### PR TITLE
Don't access undefined errorCode

### DIFF
--- a/node_modules/webdriverjs/lib/webdriverjs.js
+++ b/node_modules/webdriverjs/lib/webdriverjs.js
@@ -49,7 +49,8 @@ var errorCodes = {
     "29": {id: "InvalidElementCoordinates", message: "The coordinates provided to an interactions operation are invalid."},
     "30": {id: "IMENotAvailable", message: "IME was not available."},
     "31": {id : "IMEEngineActivationFailed", message: "An IME engine could not be started."},
-    "32": {id: "InvalidSelector", message: "Argument was an invalid selector (e.g. XPath/CSS)."}
+    "32": {id: "InvalidSelector", message: "Argument was an invalid selector (e.g. XPath/CSS)."},
+    "34": {id: "ElementNotScrollable", message: "Element cannot be scrolled into view."}
 };
 
 


### PR DESCRIPTION
errorCodes[result.status] is checked, but nevertheless accessed if undefined/false.
This patch adds a generic Unknown  state with id "-1" to prevent test deaths.

The unknown state in my case was 34, Element cannot be scrolled into view.

Of course I added the specific code also, but I'm not sure about the wording, and what the missing "33" would be - my first priority was to stop the dying processes.
