### PR TITLE
Use Buffer.byteLength instead of string length for Content-Length header

### DIFF
--- a/node_modules/webdriverjs/lib/webdriverjs.js
+++ b/node_modules/webdriverjs/lib/webdriverjs.js
@@ -640,7 +640,7 @@ WebdriverJs.prototype.createRequest = function(requestOptions, data, callback)
 	// we need to set the requests content-length. either from the data that is sent or 0 if nothing is sent
 	if (data != "")
 	{
-		fullRequestOptions.headers['content-length'] = JSON.stringify(data).length;
+		fullRequestOptions.headers['content-length'] = Buffer.byteLength(JSON.stringify(data);
 	}
 	else
 	{


### PR DESCRIPTION
This prevents Content-Length mismatches when sending multi-byte characters.

See https://groups.google.com/forum/?fromgroups=#!topic/nodejs/LAxACfj5_KI.
