### PR TITLE
Update examples to pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ describe('my webdriverjs tests', function(){
             .getElementSize('.header-logo-wordmark', function(err, result) {
                 expect(err).to.be.null;
                 assert.strictEqual(result.height , 30);
-                assert.strictEqual(result.width, 68);
+                assert.strictEqual(result.width, 94);
             })
             .getTitle(function(err, title) {
                 expect(err).to.be.null;

--- a/examples/webdriverjs.with.buster.js
+++ b/examples/webdriverjs.with.buster.js
@@ -16,7 +16,7 @@ buster.testCase("my webdriverjs tests", {
             .getElementSize('.header-logo-wordmark', function(err, result) {
                 assert(err === null);
                 assert(result.height === 30);
-                assert(result.width  === 68);
+                assert(result.width  === 94);
             })
             .getTitle(function(err, title) {
                 assert(err === null);

--- a/examples/webdriverjs.with.jasmine.spec.js
+++ b/examples/webdriverjs.with.jasmine.spec.js
@@ -16,7 +16,7 @@ describe('my webdriverjs tests', function() {
             .getElementSize('.header-logo-wordmark', function(err, result) {
                 expect(err).toBe(null);
                 expect(result.height).toBe(30);
-                expect(result.width).toBe(68);
+                expect(result.width).toBe(94);
             })
             .getTitle(function(err, title) {
                 expect(err).toBe(null);

--- a/examples/webdriverjs.with.mocha.and.chai.js
+++ b/examples/webdriverjs.with.mocha.and.chai.js
@@ -3,7 +3,6 @@
 
 var chai        = require('chai'),
     assert      = chai.assert,
-    should      = chai.should(),
     expect      = chai.expect,
     webdriverjs = require('../index');
 
@@ -23,7 +22,7 @@ describe('my webdriverjs tests', function(){
             .getElementSize('.header-logo-wordmark', function(err, result) {
                 expect(err).to.be.null;
                 assert.strictEqual(result.height , 30);
-                assert.strictEqual(result.width, 68);
+                assert.strictEqual(result.width, 94);
             })
             .getTitle(function(err, title) {
                 expect(err).to.be.null;

--- a/examples/webdriverjs.with.mocha.js
+++ b/examples/webdriverjs.with.mocha.js
@@ -20,7 +20,7 @@ describe('my webdriverjs tests', function(){
             .getElementSize('.header-logo-wordmark', function(err, result) {
                 assert(err === null);
                 assert(result.height === 30);
-                assert(result.width  === 68);
+                assert(result.width  === 94);
             })
             .getTitle(function(err, title) {
                 assert(err === null);

--- a/examples/webdriverjs.with.nodeunit.js
+++ b/examples/webdriverjs.with.nodeunit.js
@@ -18,7 +18,7 @@ module.exports = {
             .getElementSize('.header-logo-wordmark', function(err, result) {
                 test.ok(err === null, 'getElementSize() should cause no error');
                 test.ok(result.height === 30, 'logo height should be 30px');
-                test.ok(result.width  === 68, 'logo width should be 68px');
+                test.ok(result.width  === 94, 'logo width should be 94px');
             })
             .getTitle(function(err, title) {
                 test.ok(err === null, 'getTitle() should cause no error');

--- a/examples/webdriverjs.with.vows.js
+++ b/examples/webdriverjs.with.vows.js
@@ -37,8 +37,8 @@ vows.describe('my github tests').addBatch({
                     assert(result.height === 30);
                 },
 
-                'width is 68px': function(err,result) {
-                    assert(result.width === 68);
+                'width is 94px': function(err,result) {
+                    assert(result.width === 94);
                 }
 
             },


### PR DESCRIPTION
GitHub word-logo width appears to have changed; example tests updated
to pass. README sample code updated as well.
