### PR TITLE
Changed writeFile to asynchronous and made options an Object.

### DIFF
--- a/lib/utils/log.js
+++ b/lib/utils/log.js
@@ -197,7 +197,7 @@ log.error = function(msg) {
 
 // saves screenshot to file
 log.writeFile = function(fileName, data, callback) {
-	fs.writeFileSync(fileName, data, "base64", function(err) {
+    fs.writeFile(fileName, data, {encoding:"base64"}, function(err) {
 		callback(err);
 	});
 };

--- a/lib/webdriverjs.js
+++ b/lib/webdriverjs.js
@@ -84,7 +84,7 @@ WebdriverJs.prototype.addCommand = function(commandName, command) {
 
 // saves screenshot to file
 WebdriverJs.prototype.writeFile = function(fileName, data, callback) {
-    fs.writeFileSync(fileName, data, "base64", function(err) {
+    fs.writeFile(fileName, data, {encoding:"base64"}, function(err) {
         callback(err);
     });
 };


### PR DESCRIPTION
I was getting a timeout in my Mocha test using takeScreenshot, probably due to an exception being thrown.  Making these changes resolved the issue.  Since fs.writeFileSync doesn't accept a callback parameter I changed it to asynchronous fs.writeFile.
