### PR TITLE
Fixed a wrong name on a local variable reference

### DIFF
--- a/lib/protocol/frame.js
+++ b/lib/protocol/frame.js
@@ -10,6 +10,6 @@ exports.command = function (frameId, callback) {
         frameId  = null;
     }
 
-    this.requestHandler.create(requestOptions,{"id":frameId},callback);
+    this.requestHandler.create(commandOptions,{"id":frameId},callback);
 
 };


### PR DESCRIPTION
The call to `this.requestHandler.create` used a non-existing variable (`requestOptions`) as the first argument. I think that the intention was to use the local var called `commandOptions` in the call ?
