### PR TITLE
Now displays the actual original message, as well as the message in webdriverjs

### DIFF
--- a/lib/utils/log.js
+++ b/lib/utils/log.js
@@ -130,7 +130,8 @@ log.result = function(result, data, callback) {
         error = {
             status: result.status,
             type: errorCodes[result.status].id,
-            orgStatusMessage: errorCodes[result.status].message
+            message : errorCodes[result.status].message,
+            orgStatusMessage: result.value.message
         };
         result.value = -1;
 
@@ -146,7 +147,8 @@ log.result = function(result, data, callback) {
         error = {
             status: result.status,
             type: errorCodes[result.status].id,
-            orgStatusMessage: errorCodes[result.status].message
+            message : errorCodes[result.status].message,
+            orgStatusMessage: result.value.message
         };
 
         if (process.argv.length > 1) {


### PR DESCRIPTION
The name was a bit misleading and for instance in phantomjs a 7 was reported as a 13 unknown error.

Having the original message there really helps debugging.
