### PR TITLE
Added close.js to commands

### DIFF
--- a/lib/commands/close.js
+++ b/lib/commands/close.js
@@ -1,0 +1,10 @@
+exports.command = function(callback) {
+
+    var requestOptions = {
+        path: '/session/:sessionId/window',
+        method: 'DELETE'
+    };
+
+    this.requestHandler.create(requestOptions,{},callback);
+
+};


### PR DESCRIPTION
This allows to close the browser window.

Sometimes browsers might not be closed by their driver if the session is ended. I can reproduce this problem with Chrome on Windows. Closing the window before ending the session cleans evenything up.

I'm doing this:

``` js
client.close(function () {
  client.end(function () { /* ... */ });
});
```

I had difficulties with the test setup. Firefox had lots of failures in the build and running the tests in the cloud was terribly slow. I gave up on getting the test env to work properly, therefore no test. Sorry.
