### PR TITLE
Add wait command

### DIFF
--- a/lib/commands/wait.js
+++ b/lib/commands/wait.js
@@ -1,0 +1,8 @@
+exports.command = function (waitForMilliseconds, callback) {
+
+    setTimeout(function() {
+        callback();
+    }, waitForMilliseconds);
+
+};
+

--- a/test/commands-test.js
+++ b/test/commands-test.js
@@ -663,7 +663,7 @@ describe('webdriverjs API test', function(){
             });
         });
 
-        it('waitfor works when chained and wait the specified amount of time if the elemtn doesnt exist', function(done) {
+        it('waitfor works when chained and wait the specified amount of time if the element doesnt exist', function(done) {
 
             var startTime = 10000000000000;
             client
@@ -678,6 +678,21 @@ describe('webdriverjs API test', function(){
                     done();
                 });
 
+        });
+
+        it('wait should simply wait the specified amount of time', function(done) {
+            var startTime = 10000000000000;
+            client
+                .url(testpageURL)
+                .call(function() {
+                    startTime = Date.now();
+                })
+                .wait(3000)
+                .call(function() {
+                    var delta = Date.now() - startTime;
+                    delta.should.be.within(2999,10000);
+                    done();
+                });            
         });
 
         it.skip('closeAll ends all sessions', function(done) {


### PR DESCRIPTION
When testing AJAXy/single-page apps, it is often required to simply wait a specified amount of time when something happens. While it is probably possible to do it using `waitFor()` with an element that does not exist, it is not intuitively clear and feels hacky.

This PR adds a simple `wait` command that simply uses `setTimeout` to wait for the given amount in milliseconds without trying to look up any elements.
