### PR TITLE
Implement protocol binding for DELETE /session/:sessionId/cookie

### DIFF
--- a/lib/commands/deleteCookie.js
+++ b/lib/commands/deleteCookie.js
@@ -1,21 +1,15 @@
 module.exports = function deleteCookie (name, callback) {
 
-    if(typeof name == 'function') {
+    if(typeof name === 'function') {
         callback = name;
         name = null;
     }
 
-    var requestOptions = {
-        path: '/session/:sessionId/cookie' + (name ? '/:name' : ''),
-        method: 'DELETE'
-    };
+    this.cookie('DELETE', name, function(err,result) {
 
-    var self = this;
+        if(typeof callback === 'function') {
+            callback(err, result);
+        }
 
-    if(name) {
-        requestOptions.path = requestOptions.path.replace(/:name/, name);
-    }
-
-    this.requestHandler.create(requestOptions,{},callback);
-
+    });
 };

--- a/lib/commands/getCookie.js
+++ b/lib/commands/getCookie.js
@@ -5,7 +5,7 @@ module.exports = function getCookie (name, callback) {
         name = null;
     }
 
-    this.cookie(function(err,result) {
+    this.cookie('GET', null, function(err,result) {
 
         if(err === null && result.value) {
 

--- a/lib/commands/setCookie.js
+++ b/lib/commands/setCookie.js
@@ -1,5 +1,16 @@
 module.exports = function setCookie (cookieObj, callback) {
-    this.cookie(cookieObj, function(err, result) {
-        callback(err, result && result.value);
+
+    // throw error if no cookie object is given
+    if(typeof cookieObj !== 'object') {
+        throw 'Please specify a cookie object to set (see http://code.google.com/p/selenium/wiki/JsonWireProtocol#Cookie_JSON_Object for documentation.';
+    }
+
+    this.cookie('POST', cookieObj, function(err, result) {
+
+        if(typeof callback === 'function') {
+           callback(err, result && result.value);
+        }
+
     });
+
 };

--- a/lib/protocol/cookie.js
+++ b/lib/protocol/cookie.js
@@ -1,21 +1,29 @@
-module.exports = function cookie (cookieObj, callback) {
+/**
+ * protocol bindings for all cookie operations
+ * @ref http://code.google.com/p/selenium/wiki/JsonWireProtocol#/session/:sessionId/cookie
+ */
 
-    if(typeof cookieObj === 'function') {
-        callback = cookieObj;
-        cookieObj = null;
+module.exports = function cookie (method, args, callback) {
+    
+    // set default options
+    var data = {},
+        requestOptions = {
+            path: '/session/:sessionId/cookie',
+            method: method.toUpperCase()
+        };
+
+
+    // set cookie param for POST method
+    if(requestOptions.method === 'POST' && typeof args === 'object') {
+        data.cookie = args;
     }
 
-    var requestOptions = {
-        path: '/session/:sessionId/cookie',
-        method: cookieObj ? 'POST' : 'GET'
-    };
-
-    if(cookieObj && !('secure' in cookieObj)) {
-        cookieObj.secure = false;
+    // add cookie name tp path URL to delete a specific cookie object
+    if(requestOptions.method === 'DELETE' && typeof args === 'string') {
+        requestOptions.path += '/' + args;
     }
 
-    var data = cookieObj ? { cookie: cookieObj } : {};
-
+    // create request
     this.requestHandler.create(requestOptions,data,callback);
 
 };

--- a/test/spec/cookies.js
+++ b/test/spec/cookies.js
@@ -1,44 +1,47 @@
-/*module.exports = function(testpageURL,testpageTitle,assert,should,expect){
+describe.only('test cookie functionality',function() {
+    before(h.setup);
 
-    describe('test cookie functionality',function() {
-
-        it('should set a cookie and read its content afterwards', function(done){
-            client
-                .setCookie({name: 'test',value: 'cookie saved!'})
-                .getCookie('test', function(err,result) {
-                    assert.equal(null, err)
-                    assert.strictEqual(result.name,'test');
-                    assert.strictEqual(result.value,'cookie saved!');
-                })
-                .call(done);
-        });
-
-        it('should delete created cookie and is not able to read its content', function(done){
-            client
-                .deleteCookie('test')
-                .getCookie('test', function(err,result) {
-                    assert.equal(null, err)
-                    assert.strictEqual(result,null);
-                })
-                .call(done);
-        });
-
-        it('should create two cookies and delete all at once', function(done){
-            client
-                .setCookie({name: 'test',value: 'cookie saved!'})
-                .setCookie({name: 'test2',value: 'cookie2 saved!'})
-                .deleteCookie()
-                .getCookie('test', function(err,result) {
-                    assert.equal(null, err)
-                    assert.strictEqual(result,null);
-                })
-                .getCookie('test2', function(err,result) {
-                    assert.equal(null, err)
-                    assert.strictEqual(result,null);
-                })
-                .call(done);
-        });
-
+    it('should set a cookie and read its content afterwards', function(done){
+        this.client
+            .setCookie({name: 'test',value: 'cookie saved!'})
+            .getCookie('test', function(err,result) {
+                assert.equal(null, err);
+                assert.strictEqual(result.name,'test');
+                assert.strictEqual(result.value,'cookie saved!');
+            })
+            .call(done);
     });
 
-};*/
+    it('should delete created cookie and is not able to read its content', function(done){
+        this.client
+            .deleteCookie('test')
+            .getCookie('test', function(err,result) {
+                assert.equal(null, err);
+                assert.strictEqual(result,null);
+            })
+            .call(done);
+    });
+
+    it('should set two cookies and read all at once', function(done){
+        this.client
+            .setCookie({name: 'test',value: 'cookie saved!'})
+            .setCookie({name: 'test2',value: 'cookie2 saved!'})
+            .getCookie(function(err,result) {
+                assert.equal(null, err);
+                assert.strictEqual(2,result.length);
+                assert.strictEqual('cookie saved!',result[0].value);
+                assert.strictEqual('cookie2 saved!',result[1].value);
+            })
+            .call(done);
+    });
+
+    it('should delete all previous created cookies at once', function(done){
+        this.client
+            .deleteCookie()
+            .getCookie(function(err,result) {
+                assert.equal(null, err);
+                assert.strictEqual(0,result.length);
+            })
+            .call(done);
+    });
+});


### PR DESCRIPTION
This is missing in the current protocol implementation (protocol/cookie.js). Maybe it would be great to have to have a command like `deleteAllCookies()`.

**exerpt from JsonWire-Protocol**

```
DELETE /session/:sessionId/cookie
    Delete all cookies visible to the current page.

URL Parameters:
    :sessionId - ID of the session to route the command to.

Potential Errors:
    InvalidCookieDomain - If the cookie's domain is not visible from the current page.
    NoSuchWindow - If the currently selected window has been closed.
    UnableToSetCookie - If attempting to set a cookie on a page that does not support cookies (e.g. pages with mime-type text/plain).
```
