### PR TITLE
fix element old syntax API

### DIFF
--- a/lib/protocol/element.js
+++ b/lib/protocol/element.js
@@ -6,41 +6,47 @@ module.exports = function element (value, callback) {
         method:"POST"
     };
 
-    // check value type
-    // use id strategy if value starts with # and doesnt contain any other CSS selector-relevant character
-    if(value.indexOf('#') === 0 && value.search(/(\s|>|\.|[|])/) === -1) {
-        using = 'id';
-        value = value.slice(1);
-
-    // use xPath startegy if value startes with //
-    } else if(value.indexOf('//') === 0) {
-        using = 'xpath';
-
-    // use link text startegy if value startes with =
-    } else if(value.indexOf('=') === 0) {
-        using = 'link text';
-        value = value.slice(1);
-
-    // use partial link text startegy if value startes with =*
-    } else if(value.indexOf('*=') === 0) {
-        using = 'partial link text';
-        value = value.slice(2);
-
-    // use tag name strategy if value contains a tag
-    // e.g. "<div>" or "<div />"
-    } else if(value.search(/<[a-zA-Z-]+( \/)*>/g) >= 0) {
-        using = 'tag name';
-        value = value.replace(/<|>|\/|\s/g,'');
-
-    // use name strategy if value queries elements with name attributes
-    // e.g. "[name='myName']" or '[name="myName"]'
-    } else if(value.search(/\[name=("|')([a-zA-z0-9-_]+)("|')\]/) >= 0) {
-        using = 'name';
-        value = value.match(/\[name=("|')([a-zA-z0-9-_]+)("|')\]/)[2];
-
-    // if nothing fits with the supported strategies we fall back to the css selector strategy
+    if (arguments.length === 3) {
+        using = arguments[0];
+        value = arguments[1];
+        callback = arguments[2];
     } else {
-        using = 'css selector';
+        // check value type
+        // use id strategy if value starts with # and doesnt contain any other CSS selector-relevant character
+        if(value.indexOf('#') === 0 && value.search(/(\s|>|\.|[|])/) === -1) {
+            using = 'id';
+            value = value.slice(1);
+
+        // use xPath startegy if value startes with //
+        } else if(value.indexOf('//') === 0) {
+            using = 'xpath';
+
+        // use link text startegy if value startes with =
+        } else if(value.indexOf('=') === 0) {
+            using = 'link text';
+            value = value.slice(1);
+
+        // use partial link text startegy if value startes with =*
+        } else if(value.indexOf('*=') === 0) {
+            using = 'partial link text';
+            value = value.slice(2);
+
+        // use tag name strategy if value contains a tag
+        // e.g. "<div>" or "<div />"
+        } else if(value.search(/<[a-zA-Z-]+( \/)*>/g) >= 0) {
+            using = 'tag name';
+            value = value.replace(/<|>|\/|\s/g,'');
+
+        // use name strategy if value queries elements with name attributes
+        // e.g. "[name='myName']" or '[name="myName"]'
+        } else if(value.search(/\[name=("|')([a-zA-z0-9-_]+)("|')\]/) >= 0) {
+            using = 'name';
+            value = value.match(/\[name=("|')([a-zA-z0-9-_]+)("|')\]/)[2];
+
+        // if nothing fits with the supported strategies we fall back to the css selector strategy
+        } else {
+            using = 'css selector';
+        }
     }
 
     this.requestHandler.create(requestOptions,{'using':using, 'value':value},callback);

--- a/test/spec/element.js
+++ b/test/spec/element.js
@@ -1,0 +1,27 @@
+describe('dsalkjdslakjdlksadsa element', function() {
+    before(h.setup);
+
+    describe('using the old syntax', function() {
+        it('returns an element', function(done) {
+            this
+                .client
+                .element('css selector', '.box.red', function(err, res) {
+                    assert.equal(err, null);
+                    assert.ok(res.value.ELEMENT);
+                    done(err);
+                })
+        });
+    });
+
+    describe('using the new syntax', function () {
+        it('returns an element', function(done) {
+            this
+                .client
+                .element('.box.red', function(err, res) {
+                    assert.equal(err, null);
+                    assert.ok(res.value.ELEMENT);
+                    done(err);
+                })
+        });
+    });
+});


### PR DESCRIPTION
HOTFIX to be merged in 1.0.x and 1.1.x

we should test all element selectors in element.js and not using higher
methods like .getValue or .isVisible (selectors.js).
