### PR TITLE
fix(dependency): remove lodash.merge dependency hell

### DIFF
--- a/lib/protocol/init.js
+++ b/lib/protocol/init.js
@@ -1,5 +1,5 @@
 module.exports = function init (desiredCapabilities, callback) {
-    var merge = require('lodash.merge');
+    var merge = require('deepmerge');
 
     var commandOptions = {
         path:"/session",

--- a/lib/utils/RequestHandler.js
+++ b/lib/utils/RequestHandler.js
@@ -6,7 +6,7 @@
 
 var request    = require('request'),
     log        = require('./log'),
-    merge      = require('lodash.merge'),
+    merge      = require('deepmerge'),
     errorCodes = require('./errorCodes');
 
 module.exports = RequestHandler;
@@ -19,8 +19,10 @@ function RequestHandler(options) {
 
     // Wdjs calls RequestHandler with `host` badly set
     // A host is an hostname+port
-    options.hostname = options.host;
-    delete options.host;
+    if (options.host !== undefined) {
+        options.hostname = options.host;
+        delete options.host;
+    }
 
     // default request options
     this.defaultOptions = {

--- a/lib/webdriverjs.js
+++ b/lib/webdriverjs.js
@@ -13,7 +13,7 @@ var Wdjs =
     chainIt(WebdriverJs);
 
 function WebdriverJs(options) {
-    var merge = require('lodash.merge');
+    var merge = require('deepmerge');
     var log = require('./utils/log.js');
     var RequestHandler = require('./utils/RequestHandler.js');
 

--- a/package.json
+++ b/package.json
@@ -67,9 +67,9 @@
   ],
   "dependencies": {
     "chainit": "~1.1.2",
-    "lodash.merge": "~2.4.1",
     "pragma-singleton": "~1.0.3",
     "archiver": "~0.5.2",
-    "request": "~2.33.0"
+    "request": "~2.33.0",
+    "deepmerge": "~0.2.7"
   }
 }

--- a/test/conf/index.js
+++ b/test/conf/index.js
@@ -1,4 +1,4 @@
-var merge = require('lodash.merge');
+var merge = require('deepmerge');
 
 var env = process.env.TRAVIS && process.env._BROWSER !== 'phantomjs' ? 'travis-ci' : 'local';
 

--- a/test/spec/singleton.js
+++ b/test/spec/singleton.js
@@ -5,7 +5,7 @@ describe.skip('singleton option', function() {
 
     before(function(done) {
         var webdriverjs = require('../../index.js');
-        var merge = require('lodash.merge');
+        var merge = require('deepmerge');
 
         c1 = webdriverjs.remote(merge(conf, {
             singleton: true


### PR DESCRIPTION
Single lodash packages eats too much dependency ressources and downloads
for such a simple package like lodash.merge.

fixes #157
