### PR TITLE
fix(waitFor): waitFor should not overwrite implicitWait globally

### DIFF
--- a/lib/commands/waitFor.js
+++ b/lib/commands/waitFor.js
@@ -1,26 +1,15 @@
 module.exports = function waitFor (cssSelector, ms, callback) {
+    if (typeof ms === 'function') {
+        callback = ms;
+        ms = 500;
+    }
 
-    var self = this;
-    var first = true;
-    var startTimer = 0;
-
-    this.implicitWait(ms)
+    this
+        .implicitWait(ms)
         .element(cssSelector, function(err, result) {
-
-            if(err === null && typeof callback === 'function') {
-
+            this.implicitWait(0, function() {
                 callback(err, result);
-
-            } else {
-
-                if (typeof callback === 'function') {
-
-                    callback(err, result);
-
-                }
-
-            }
-
+            });
         });
 
 };


### PR DESCRIPTION
Before this fix, waitFor was setting implicitWait for the whole
session.

We now set it back to the default.

A better approach would be to set it back to what it was previously.

I do not need this atm.

@christian-bromann it should be easy to review this. I had test taking wayyy too long because of this.
