### PR TITLE
chain each instance separately

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,4 +15,30 @@
  *     Vincent Voyer <vincent@zeroload.net>
  */
 
-module.exports = require('./lib/webdriverjs.js');
+var createSingleton = require('pragma-singleton'),
+    WebdriverJS = require('./lib/webdriverjs.js'),
+    package = require('./package.json');
+    chainIt = require('chainit'),
+
+// expose version number
+module.exports.version = package.version;
+
+// use the chained API reference to add static methods
+module.exports.remote = function remote(options, Constructor) {
+    if (typeof options === 'function') {
+        Constructor = options;
+        options = {};
+    } else {
+        options = options || {};
+
+        // allows easy webdriverjs-$framework creation (like webdriverjs-angular)
+        Constructor = Constructor || chainIt(WebdriverJS);
+    }
+
+    var singleton = createSingleton(Constructor);
+    if (options.singleton) {
+        return new singleton(options);
+    } else {
+        return new Constructor(options);
+    }
+};

--- a/lib/webdriverjs.js
+++ b/lib/webdriverjs.js
@@ -8,9 +8,7 @@ buildPrototype(
 );
 
 // save a reference to the chained API
-var Wdjs =
-    module.exports =
-    chainIt(WebdriverJs);
+var Wdjs = module.exports = WebdriverJs;
 
 function WebdriverJs(options) {
     var merge = require('lodash.merge');
@@ -43,37 +41,13 @@ function WebdriverJs(options) {
     this.use = function(commandModule) {
         commandModule.call(self);
     }
+
+    // addCommand added here because it's synchronous and thus does not need
+    // to be added to asynchronous chain.
+    this.addCommand = function(name, fn) {
+        chainIt.add(this, name, fn);
+
+        // we still returns the instance so that we can continue chaining
+        return this;
+    };
 }
-
-Wdjs.use = function(module) {
-
-}
-
-// use the chained API reference to add static methods
-Wdjs.remote = function remote(options, Constructor) {
-    if (typeof options === 'function') {
-        Constructor = options;
-        options = {};
-    } else {
-        options = options || {};
-
-        // allows easy webdriverjs-$framework creation (like webdriverjs-angular)
-        Constructor = Constructor || Wdjs;
-    }
-
-    var singleton = require('pragma-singleton')(Constructor);
-    if (options.singleton) {
-        return new singleton(options);
-    } else {
-        return new Constructor(options);
-    }
-};
-
-// addCommand added here because it's synchronous and thus does not need
-// to be added to asynchronous chain.
-Wdjs.prototype.addCommand = function(name, fn) {
-    chainIt.add(this, name, fn);
-
-    // we still returns the instance so that we can continue chaining
-    return this;
-};

--- a/test/runner.js
+++ b/test/runner.js
@@ -74,7 +74,7 @@ h = {
             if (client) {
                 this.client = client;
             } else {
-                this.client = client = new wdjs(conf).init();
+                this.client = client = wdjs.remote(conf).init();
             }
 
             this.client.url(conf.testPage.start, done);


### PR DESCRIPTION
With this patch the following isn't possible anymore:

```
var WebdriverJS = require('webdriverjs');
var client = new WebdriverJS({...});
```

but we've never advised people to use it like that. I separated the `remote` function from main library to avoid confusion. It will enable to create multiple instances and run them in parellel.
