### PR TITLE
fix(typo): Literals had wrong numbers.

### DIFF
--- a/examples/webdriverjs.with.vows.js
+++ b/examples/webdriverjs.with.vows.js
@@ -31,11 +31,11 @@ vows.describe('my github tests').addBatch({
                     assert(err === null);
                 },
 
-                'height is 30px': function(err,result) {
+                'height is 32px': function(err,result) {
                     assert(result.height === 32);
                 },
 
-                'width is 94px': function(err,result) {
+                'width is 89px': function(err,result) {
                     assert(result.width === 89);
                 }
 


### PR DESCRIPTION
Commit 2ccd3a1 updates the values but misses the strings.
