### PR TITLE
added default args to execute

### DIFF
--- a/lib/protocol/execute.js
+++ b/lib/protocol/execute.js
@@ -1,5 +1,9 @@
 module.exports = function execute (script, args, callback) {
 
+    if (typeof args === 'undefined') {
+        args = [];
+    }
+
     if (typeof args === 'function') {
         callback = args;
         args = [];


### PR DESCRIPTION
This is so we can run `browser.execute(someFunc)` without having to pass an empty arg list like `browser.execute(someFunc, [])`.

PS I tried running `npm test` but the tests seem to fail from a fresh repo after doing `npm install`: http://i.imgur.com/FXyRRyb.png
