### PR TITLE
Fix error in index.js var declaration

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,8 +17,8 @@
 
 var createSingleton = require('pragma-singleton'),
     WebdriverJS = require('./lib/webdriverjs.js'),
-    package = require('./package.json');
-    chainIt = require('chainit'),
+    package = require('./package.json'),
+    chainIt = require('chainit');
 
 // expose version number
 module.exports.version = package.version;


### PR DESCRIPTION
There was a wrong semicolon command combo that was throwing an error. Very simple fix.
