### PR TITLE
Add support for 'enabled' command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,7 @@ can assert values or have more logic when the callback is called.
 - **getTitle(`Function` callback)**<br>Gets the title of the page
 - **getValue(`String` selector, `Function` callback)**<br>Gets the value of a dom obj found by selector
 - **isSelected(`String` selector, `Function` callback)**<br>Return true or false if an OPTION element, or an INPUT element of type checkbox or radiobutton is currently selected (found by selector).
+- **isEnabled(`String` selector, `Function` callback)**<br>Return true for everything but disabled input elements.
 - **isVisible(`String` selector, `Function` callback)**<br>Return true or false if the selected dom obj is visible (found by selector)
 - **leftClick(`String` selector, `Function` callback)**<br>Apply left click at an element. If selector is not provided, click at the last moved-to location.
 - **hold(`String` selector,`Function` callback)**<br>Long press on an element using finger motion events.
@@ -351,6 +352,7 @@ Here are the implemented bindings (and links to the official json protocol bindi
 - [elementIdText](http://code.google.com/p/selenium/wiki/JsonWireProtocol#GET_/session/:sessionId/element/:id/text)
 - [elementIdValue](http://code.google.com/p/selenium/wiki/JsonWireProtocol#POST_/session/:sessionId/element/:id/value)
 - [elementIdSelected](http://code.google.com/p/selenium/wiki/JsonWireProtocol#GET_/session/:sessionId/element/:id/selected)
+- [elementIdEnabled](http://code.google.com/p/selenium/wiki/JsonWireProtocol#GET_/session/:sessionId/element/:id/enabled)
 - [elements](http://code.google.com/p/selenium/wiki/JsonWireProtocol#POST_/session/:sessionId/element/:id/elements)
 - [execute](http://code.google.com/p/selenium/wiki/JsonWireProtocol#/session/:sessionId/execute)
 - [executeAsync](http://code.google.com/p/selenium/wiki/JsonWireProtocol#/session/:sessionId/execute_async)

--- a/lib/commands/isEnabled.js
+++ b/lib/commands/isEnabled.js
@@ -1,0 +1,21 @@
+module.exports = function isEnabled (cssSelector, callback) {
+
+    var self = this;
+
+    this.element(cssSelector, function(err, result) {
+
+        if(err === null && result.value) {
+
+            self.elementIdEnabled(result.value.ELEMENT, function(err, result) {
+                callback(err, result.value);
+            });
+
+        } else {
+
+            /* istanbul ignore next */
+            callback(err, result);
+
+        }
+    });
+};
+

--- a/lib/protocol/elementIdEnabled.js
+++ b/lib/protocol/elementIdEnabled.js
@@ -1,0 +1,8 @@
+module.exports = function elementIdEnabled (id, callback) {
+
+    this.requestHandler.create(
+        "/session/:sessionId/element/:id/enabled".replace(/:id/gi, id),
+        callback
+    );
+
+};


### PR DESCRIPTION
Allows a user to determine if an input element is enabled or not by calling ‘isEnabled’.
