### PR TITLE
Fixes exception when getValue() returns an error.

### DIFF
--- a/lib/commands/getValue.js
+++ b/lib/commands/getValue.js
@@ -16,7 +16,7 @@ module.exports = function getValue (cssSelector, callback) {
 
             if(typeof callback === 'function') {
                 /* istanbul ignore next */
-                callback(err, result.value);
+                callback(err, result);
             }
 
         }

--- a/test/spec/desktop/get.js
+++ b/test/spec/desktop/get.js
@@ -125,4 +125,13 @@ describe('get commands should return the evaluated value', function() {
             });
     });
 
+    it('getValue: value of non-existent element should be null', function(done){
+        this.client
+            .getValue('#non-existent-element', function(err,result) {
+                assert.notEqual(null, err);
+                assert.equal(null, result);
+                done();
+            });
+    });
+
 });


### PR DESCRIPTION
Exception was being thrown about accessing properties on a null object instead of returning the proper error. I fixed this and added a test for it as well.
