### PR TITLE
Allow spaces in CSS Name selector

### DIFF
--- a/lib/helpers/find-element-strategy.js
+++ b/lib/helpers/find-element-strategy.js
@@ -39,9 +39,9 @@ module.exports = function findStrategy(args) {
 
     // use name strategy if value queries elements with name attributes
     // e.g. "[name='myName']" or '[name="myName"]'
-    } else if(value.search(/^\[name=("|')([a-zA-z0-9-_]+)("|')\]$/) >= 0) {
+    } else if(value.search(/^\[name=("|')([a-zA-z0-9-_ ]+)("|')\]$/) >= 0) {
         using = 'name';
-        value = value.match(/^\[name=("|')([a-zA-z0-9-_]+)("|')\]$/)[2];
+        value = value.match(/^\[name=("|')([a-zA-z0-9-_ ]+)("|')\]$/)[2];
 
     // if nothing fits with the supported strategies we fall back to the css selector strategy
     } else {


### PR DESCRIPTION
I was doing `.click("[name='btn confirm normal']")` and it kept failing.
Allowing spaces in the find-element strategy made it work.

P.S. The 'magic' of this logic, might want some explanation in the docs.
