### PR TITLE
Suggested gm overwrite

### DIFF
--- a/lib/commands/saveScreenshot.js
+++ b/lib/commands/saveScreenshot.js
@@ -28,6 +28,10 @@ var async = require('async'),
     rimraf = require('rimraf'),
     ErrorHandler = require('../utils/ErrorHandler.js');
 
+gm.prototype.write = function(fileName, callback) {
+	fs.writeFile(fileName, this.sourceBuffer, callback);
+};
+
 module.exports = function saveScreenshot(fileName, totalScreen) {
 
     /*!


### PR DESCRIPTION
This admittedly evil overwrite fixes the fatal error that gm throws (it happens at `gm.write()` by the way) - for me. I do not know if any functionality is lost, because `npm test` does not work properly on my machine. I did compare `master` with my branch for my local Chrome, Firefox and PhantomJS and I only gained functionality. 

Please review and consider merging. Being able to make screenshots is quite a central feature to using selenium - at least for me. 
