### PR TITLE
Fix: log protocol command expecting an object and not a string

### DIFF
--- a/lib/protocol/log.js
+++ b/lib/protocol/log.js
@@ -23,9 +23,11 @@ module.exports = function log (type) {
         return callback(new ErrorHandler.ProtocolError('number or type of arguments don\'t agree with log command'));
     }
 
+    var data = {type: type};
+
     this.requestHandler.create(
         '/session/:sessionId/log',
-        type,
+        data,
         callback
     );
 


### PR DESCRIPTION
Fixes log protocol command not working by passing an object instead of a string to selenium as per spec https://code.google.com/p/selenium/wiki/JsonWireProtocol#/session/:sessionId/log
