### PR TITLE
protocol elementIdElement(s)

### DIFF
--- a/lib/protocol/elementIdElement.js
+++ b/lib/protocol/elementIdElement.js
@@ -1,0 +1,39 @@
+/**
+ *
+ * Search for an element on the page, starting from an element.
+ * The located element will be returned as a WebElement JSON object.
+ * The table below lists the locator strategies that each server should support.
+ * Each locator must return the first matching element located in the DOM.
+ *
+ * @param {String} ID ID of a WebElement JSON object to route the command to
+ * @param {String} selector selector to query the element
+ * @returns {String} A WebElement JSON object for the located element.
+ *
+ * @see  https://code.google.com/p/selenium/wiki/JsonWireProtocol#/session/:sessionId/element/:id/element
+ * @type protocol
+ *
+ */
+
+var ErrorHandler = require('../utils/ErrorHandler.js');
+
+module.exports = function elementIdElement (id) {
+
+    /*!
+     * make sure that callback contains chainit callback
+     */
+    var callback = arguments[arguments.length - 1];
+
+    if(typeof id !== 'string' && typeof id !== 'number') {
+        return callback(new ErrorHandler.ProtocolError('number or type of arguments don\'t agree with elementIdElement protocol command'));
+    }
+
+    var findStrategy = require('../helpers/find-element-strategy.js');
+
+    var found = findStrategy(Array.prototype.slice.call(arguments, 1));
+
+    this.requestHandler.create(
+        '/session/:sessionId/element/:id/element'.replace(/:id/gi, id),
+        { using: found.using, value: found.value },
+        found.callback
+    );
+};

--- a/lib/protocol/elementIdElements.js
+++ b/lib/protocol/elementIdElements.js
@@ -1,0 +1,39 @@
+/**
+ *
+ * Search for multiple elements on the page, starting from an element. The located
+ * elements will be returned as a WebElement JSON objects. The table below lists the
+ * locator strategies that each server should support. Elements should be returned in
+ * the order located in the DOM.
+ *
+ * @param {String} ID ID of a WebElement JSON object to route the command to
+ * @param {String} selector selector to query the elements
+ * @returns {Object[]} A list of WebElement JSON objects for the located elements.
+ *
+ * @see  https://code.google.com/p/selenium/wiki/JsonWireProtocol#/session/:sessionId/element/:id/elements
+ * @type protocol
+ *
+ */
+
+var ErrorHandler = require('../utils/ErrorHandler.js');
+
+module.exports = function elementIdElements (id) {
+
+    /*!
+     * make sure that callback contains chainit callback
+     */
+    var callback = arguments[arguments.length - 1];
+
+    if(typeof id !== 'string' && typeof id !== 'number') {
+        return callback(new ErrorHandler.ProtocolError('number or type of arguments don\'t agree with elementIdElements protocol command'));
+    }
+
+    var findStrategy = require('../helpers/find-element-strategy.js');
+
+    var found = findStrategy(Array.prototype.slice.call(arguments, 1));
+
+    this.requestHandler.create(
+        '/session/:sessionId/element/:id/elements'.replace(/:id/gi, id),
+        { using: found.using, value: found.value },
+        found.callback
+    );
+};


### PR DESCRIPTION
Adding support for protocol `elementIdElement` and `elementIdElements`.
This allows to select elements inside a container element (instead of document root).
This is a first step into supporting element scope (as mentioned in #283), alla capybara `within` or zombie.js `query`
