### PR TITLE
Fixed test from webdriverjs to webdriverio syntax

### DIFF
--- a/examples/webdriverjs.with.mocha.and.chai.js
+++ b/examples/webdriverjs.with.mocha.and.chai.js
@@ -17,17 +17,17 @@ describe('my webdriverjs tests', function(){
         client
             .url('https://github.com/')
             .getElementSize('.header-logo-wordmark', function(err, result) {
-                assert.equal(null, err);
+                assert.equal(undefined, err);
                 assert.strictEqual(result.height , 32);
                 assert.strictEqual(result.width, 89);
             })
             .getTitle(function(err, title) {
-                assert.equal(null, err);
+                assert.equal(undefined, err);
                 assert.strictEqual(title,'GitHub · Build software better, together.');
             })
             .getCssProperty('a[href="/plans"]', 'color', function(err, result){
-                assert.equal(null, err);
-                assert.strictEqual(result, 'rgba(65,131,196,1)');
+                assert.equal(undefined, err);
+                assert.strictEqual(result.value, 'rgba(65,131,196,1)');
             })
             .call(done);
     });


### PR DESCRIPTION
The value of err used to be null in webdriverjs, but I see that webdriverio returns undefined.
Please note that client.execute still returns a null error - quite confusing
CSS color used to be a string in webdriverjs, but now webdriverio returns an obj, which must be opened to extract the value prop.
