### PR TITLE
Fixes and tests for Protocol.windowHandlePosition

### DIFF
--- a/lib/protocol/windowHandlePosition.js
+++ b/lib/protocol/windowHandlePosition.js
@@ -32,21 +32,22 @@
 
 module.exports = function windowHandlePosition (windowHandle, position) {
 
+    var data = {},
+        requestOptions = {
+            method: 'POST'
+        },
+        callback = arguments[arguments.length - 1];
+
     if(typeof windowHandle !== 'string') {
+        position = windowHandle;
         windowHandle = 'current';
     }
 
-    var data = {},
-        requestOptions = {
-            path: '/session/:sessionId/window/' + windowHandle + '/position',
-            method: 'POST'
-        };
+    requestOptions.path = '/session/:sessionId/window/' + windowHandle + '/position';
 
     // check if arguments provide proper position parameter
     if(typeof position === 'object' && typeof position.x === 'number' && typeof position.y === 'number') {
         data = position;
-    } else if(typeof windowHandle === 'object' && typeof windowHandle.x === 'number' && typeof windowHandle.y === 'number') {
-        data = windowHandle;
     } else {
         // otherwise fall back to get operation
         requestOptions.method = 'GET';
@@ -55,7 +56,7 @@ module.exports = function windowHandlePosition (windowHandle, position) {
     this.requestHandler.create(
         requestOptions,
         data,
-        arguments[arguments.length - 1]
+        callback
     );
 
 };

--- a/test/spec/desktop/windowHandlePosition.js
+++ b/test/spec/desktop/windowHandlePosition.js
@@ -1,0 +1,61 @@
+describe('windowHandlePosition', function() {
+
+    before(h.setup());
+
+    it('should return window position', function(done) {
+
+        var self = this,
+            check = function(err, res) {
+                assert.ifError(err);
+
+                res.value.x.should.be.above(1);
+                res.value.y.should.be.above(1);
+            };
+
+        this.client
+            // use current tab id as a valid one
+            .getCurrentTabId(function(err, tabid) {
+                assert.ifError(err);
+
+                // specified window
+                self.client.windowHandlePosition(tabid, check);
+
+                // current window
+                self.client.windowHandlePosition(check);
+            })
+            .call(done);
+
+    });
+
+    it('should change window position', function(done) {
+
+        var self = this;
+
+        this.client
+            // use current tab id as a valid one
+            .getCurrentTabId(function(err, tabid) {
+                assert.ifError(err);
+
+                // specified window
+                self.client.windowHandlePosition(tabid, {x: 300, y: 150});
+                self.client.windowHandlePosition(tabid, function(err, res) {
+                    assert.ifError(err);
+
+                    res.value.x.should.be.exactly(300);
+                    res.value.y.should.be.exactly(150);
+                });
+
+                // current window
+                self.client.windowHandlePosition({x: 400, y: 250});
+                self.client.windowHandlePosition(tabid, function(err, res) {
+                    assert.ifError(err);
+
+                    res.value.x.should.be.exactly(400);
+                    res.value.y.should.be.exactly(250);
+                });
+            })
+            .call(done);
+
+    });
+
+});


### PR DESCRIPTION
Current Protocol.windowHandlePosition implementation doesn't work in cases when we don't specify tabid (assuming current window).

Examples:
-    <code>client.windowHandlePosition(function(err, res) {
      console.log(res.value);
  });</code>
  <p>expecting: object with x and y cordinates of current window</p>
  <p>receiving: TypeError: string is not a function</p>
-     <code>client.windowHandlePosition({x: 600, y: 100});</code>
  <p>expecting: current window movement to cordinates</p>
  <p>receiving: nothing happens</p>

Let me know whether something is wrong.
