### PR TITLE
do not throw errors when there is a user error handler

### DIFF
--- a/lib/utils/PromiseHandler.js
+++ b/lib/utils/PromiseHandler.js
@@ -140,7 +140,7 @@ module.exports = function PromiseHandler(fnName, fn) {
             var newArgs = array_slice(arguments);
             if(callback) {
                 callback.apply(self, newArgs);
-            } else if(error && !hasErrorHandling) {
+            } else if(error && !hasErrorHandling && self.eventHandler.listeners('error').length < 2) {
                 throw error;
             }
 


### PR DESCRIPTION
When a `on('error', cb)` is registered, errors shouldn't be thrown, i.e. this program shouldn't crash:

```js
var client = require('webdriverio');

client
  .remote()
  .init()
  .on('error', catcher)
  .url('http://example.com')
  .waitFor('.imaginary', 1000)
  .end();

setTimeout(function() {
  console.log('All ok');
}, 3000);

function catcher(e) {
  console.log('Caught error');
}
```
Or am I looking at this wrong?