### PR TITLE
Fixed promise handler

### DIFF
--- a/lib/utils/PromiseHandler.js
+++ b/lib/utils/PromiseHandler.js
@@ -85,7 +85,7 @@ module.exports = function PromiseHandler(fnName, fn) {
                  * queue up next "then" if existing
                  */
                 if(returnPromise && returnPromise.then) {
-                    lastThenable.push(returnPromise.getPromise());
+                    lastThenable.push(returnPromise.getPromise ? returnPromise.getPromise() : returnPromise);
                 } else if(typeof returnPromise !== 'undefined') {
                     var newDeferred = Q.defer();
                     lastThenable.push(newDeferred.promise);


### PR DESCRIPTION
The current promise handler throws the following error when I trying to chain promise. I found that it requires `getPromise` method, which is not a standard in promise and not implemented by most libraries. This problem can be solved by detecting whether the returned promise supports `getPromise` method.

```
TypeError: Object [object Promise] has no method 'getPromise'
  at .../node_modules/webdriverio/lib/utils/PromiseHandler.js:84:53
  at process._tickDomainCallback (node.js:486:13)
```