### PR TITLE
Allow for optional arguments in addCommand

### DIFF
--- a/lib/webdriverio.js
+++ b/lib/webdriverio.js
@@ -4,6 +4,7 @@ var buildPrototype = require('./utils/buildPrototype'),
     EventHandler   = require('./utils/EventHandler'),
     PromiseHandler = require('./utils/PromiseHandler'),
     isMobileHelper = require('./helpers/isMobile');
+    vargsCallback  = require('vargs-callback');
 
 buildPrototype(
     WebdriverIO.prototype,
@@ -74,6 +75,7 @@ function WebdriverIO(options) {
      * to be added to asynchronous chain.
      */
     this.addCommand = function(name, fn) {
+        fn = vargsCallback(fn);
         chainIt.add(this, name, fn);
 
         /**

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "request": "~2.34.0",
     "rgb2hex": "^0.1.0",
     "url": "^0.10.1",
+    "vargs-callback": "^0.2.4",
     "wgxpath": "^0.23.0"
   },
   "devDependencies": {

--- a/test/spec/functional/addCommand.js
+++ b/test/spec/functional/addCommand.js
@@ -3,6 +3,7 @@ describe('addCommand', function() {
     before(h.setup());
 
     before(function() {
+        var Url = require('url');
 
         this.client.addCommand('getUrlAndTitle', function(callback) {
 
@@ -21,6 +22,22 @@ describe('addCommand', function() {
 
         });
 
+        this.client.addCommand('checkArgumentsLength', function(a, b, c, d, callback) {
+
+            var result,
+                error;
+            callback = arguments[arguments.length - 1];
+
+            if (arguments.length < 5) {
+                error = new Error('Fn signature has 5 arguments, received only ' + arguments.length.toString() + ' arguments.');
+            } else {
+                result = (a || 0) + (b || 0) + (c || 0) + (d || 0);
+            }
+
+            this.call(callback.bind(this, error, result));
+
+        });
+
     });
 
     it('added a `getUrlAndTitle` command', function(done) {
@@ -33,6 +50,15 @@ describe('addCommand', function() {
             })
             .call(done);
 
+    });
+    it('calls checkArgumentsLength with proper number of args', function(done) {
+
+        this.client
+            .checkArgumentsLength(2, 3, 4, function(err, result) {
+                assert.ifError(err);
+                assert.strictEqual(result, (2 + 3 + 4))
+            })
+            .call(done);
     });
 
 });


### PR DESCRIPTION
# Background
The addCommand method allows custom functions to be added to the webdriverio client. When the custom command is called, webdriverio will call the custom function with `this` equal to the client, and it will append a callback to the arguments passed to the custom command.
Example:
```js
var customFunc = function(a) {...};
client.addCommand('customCommand', customFunc);
client.customCommand('foo');
// This will essentially call
// customFunc.call(client, ['foo'].push(nextWaterfall));
```
# Problem
Appending the callback to the arguments passed to the customCommand makes it difficult to gracefully handle optional arguments. For example, if the `customCommand` above were invoked with no arguments, the callback would be the first and only argument. This makes it challenging to use standard techniques to set default values for optional arguments (e.g. `optionalArg = optionalArg || 'default';`).

# Solution
Wrapping the `customFunc` in an argument padding function will cause the number of arguments passed to the customFunc is always the same as the function signature. The library vargs-callback(https://www.npmjs.com/package/vargs-callback) provides an easy way to do this. 

# Example
Place the script below in the root directory of webdriverio as `testOptionalArgs.js`. Run the script with node testOptionalArgs.js (after starting selenium server). 

```js
/**
 * test script to highlight the shortcomings of 
 * simply appending the chaining callback
 * to the list of input args.
 * 
 * Place this script in the webdriverio root directory.
 * Run this script with `node testOptionalArgs.js`.
 */
'use strict';

var webdriverio = require('./index.js');
var client;

var options = {
    desiredCapabilities: {
        browserName: 'chrome'
    }
};

/**
 * example function with optional input params
 * Note that it IS possible to use the `arguments` var 
 * to more safely test for the existance of `text` and `waitTime`.
 * However, even this approach becomes unwieldy and confusing with
 * two or more optional parameters.
 */
var typeExampleText = function(text, waitTime, cb) {
    text = text || 'Example text courtesy of webdriverio';
    waitTime = waitTime || 10000;
    cb = arguments[arguments.length - 1];
    this
        .click('input[name="q"]')
        .keys([text])
        .pause(10000)
        .waitForExist('input[name="q"]')
        .call(cb);
};

client = webdriverio.remote(options);
client.addCommand('typeExampleText',typeExampleText);

client
    .init()
    .url('https://google.com')
    .typeExampleText()//pass no arguments (just use defaults)
    .getValue('input[name="q"]', function(err, res) {
        console.log('You typed: `%s`',res)

    })
    .end();
```
# Test
I added a test :-)

# Discussion
I realize that it is common practice to pass a callback as the last argument to a function. However, in this case, I think that maintaining the number of arguments in the signature makes the addCommand system more intuitive. Since webdriverio is quietly appending the callback, it is very easy for a developer to forget that the callback will be added after the arguments that they pass to the customCommand. Further, handling the possible variations of optional callbacks is greatly simplified with vargs-callback. 

If you're opposed to adding this to the webdriverio library, I understand, but I suggest at least mentioning it in the docs. Let me know if you prefer to go that route, and I will happily add a couple sentences to the docs.