### PR TITLE
Updated waitForExist documentation to be more clear.  Made slight code change

### DIFF
--- a/lib/commands/waitForExist.js
+++ b/lib/commands/waitForExist.js
@@ -1,15 +1,14 @@
 /**
  *
  * Wait for an element (selected by css selector) for the provided amount of
- * milliseconds to be existent within DOM. If multiple elements get queryied by given
- * selector, it returns true (or false if reverse flag is set) if at least one
- * element is visible.
+ * milliseconds to be present within the DOM. Returns true if the selector
+ * matches at least one element. If the reverse flag is true, the command will
+ * instead return true if the selector does not match any elements.
  *
- * @param {String}   selector element to wait for
+ * @param {String}   selector CSS selector to query
  * @param {Number=}  ms       time in ms (default: 500)
- * @param {Boolean=} reverse  if true it waits for the opposite (default: false)
+ * @param {Boolean=} reverse  if true it instead waits for the selector to not match any elements (default: false)
  *
- * @uses action/selectorExecuteAsync, protocol/timeoutsAsyncScript
  * @type utility
  *
  */
@@ -57,9 +56,11 @@ module.exports = function waitForExist(selector, ms, reverse) {
             function(res, cb) {
                 response.elements.push(res);
 
-                var isExistent = res.value.length > 0;
-                if(res && res.value && ((!reverse && isExistent) || (reverse && !isExistent))) {
-                    return cb(null, true);
+                if (res && res.value) {
+                    var isExistent = res.value.length > 0;
+                    if ((!reverse && isExistent) || (reverse && !isExistent)) {
+                        return cb(null, true);
+                    }
                 }
 
                 var now = new Date().getTime();


### PR DESCRIPTION
Slight code change because the check to see that 'res' and 'res.value' existed was in the line after res.value.length was accessed.  If operating under the presumption that 'res' and 'res.value' may not exist, the line accessing 'res.value.length' before it would throw an exception.

Note: this is unrelated to issue 419