### PR TITLE
Issue #419: Add SelectorTimeoutError for waitForVisible and waitForExist

### DIFF
--- a/lib/commands/waitForExist.js
+++ b/lib/commands/waitForExist.js
@@ -67,7 +67,7 @@ module.exports = function waitForExist(selector, ms, reverse) {
                 if(now - start > ms) {
                     var checkType = reverse ? 'not in the DOM' : 'in the DOM';
                     var err = ErrorHandler.SelectorTimeoutError('waitForExist', selector, checkType);
-                    return cb(err, false);
+                    return cb(err);
                 }
 
                 return cb();

--- a/lib/commands/waitForExist.js
+++ b/lib/commands/waitForExist.js
@@ -65,7 +65,9 @@ module.exports = function waitForExist(selector, ms, reverse) {
 
                 var now = new Date().getTime();
                 if(now - start > ms) {
-                    return cb(null, false);
+                    var checkType = reverse ? 'not in the DOM' : 'in the DOM';
+                    var err = ErrorHandler.SelectorTimeoutError('waitForExist', selector, checkType);
+                    return cb(err, false);
                 }
 
                 return cb();

--- a/lib/commands/waitForVisible.js
+++ b/lib/commands/waitForVisible.js
@@ -62,7 +62,11 @@ module.exports = function waitForVisible(selector, ms, reverse) {
             cb();
         }
     ], function(err) {
-
+        // Check if error is because of script timeout
+        if (err && err.isScriptTimeoutError && err.isScriptTimeoutError()) {
+            var checkType = reverse ? 'invisible' : 'visible';
+            err = ErrorHandler.SelectorTimeoutError('waitForVisible', selector, checkType);
+        }
         callback(err, response.selectorExecuteAsync && response.selectorExecuteAsync.executeAsync ? response.selectorExecuteAsync.executeAsync.value : false, response);
 
     });

--- a/lib/utils/ErrorHandler.js
+++ b/lib/utils/ErrorHandler.js
@@ -33,6 +33,7 @@ function ErrorHandler(type, msg) {
         this.message = [];
 
         if(seleniumStack.message && seleniumStack.type && seleniumStack.status) {
+            this.status = seleniumStack.status;
             this.message.push(pad('', 6) + '(' + seleniumStack.type + ':' + seleniumStack.status + ') ' + seleniumStack.message);
         }
 
@@ -108,6 +109,15 @@ ErrorHandler.prototype.addToCallStack = function(cmd) {
     this.message += pad('-> ', 9) + cmd.name + cmd.args + '\n';
 };
 
+/**
+ * Checks the status code saved to this error handler and determines if this is a timeout error
+ * @see https://code.google.com/p/selenium/wiki/JsonWireProtocol#Response_Status_Codes
+ * @returns {Boolean} - true if ErrorHandler has status code of timeout error
+ */
+ErrorHandler.prototype.isScriptTimeoutError = function () {
+    return this.status === 28;
+};
+
 ErrorHandler.CommandError = function(msg) {
     return new ErrorHandler('CommandError',msg);
 };
@@ -116,6 +126,22 @@ ErrorHandler.ProtocolError = function(msg) {
 };
 ErrorHandler.RuntimeError = function(msg) {
     return new ErrorHandler('RuntimeError',msg);
+};
+
+/**
+ * @desc Human readable error format in case an async check for a selector fails
+ * @param {String} commandName - Name of the command used to (e.g. 'waitForVisible')
+ * @param {String} selector - Selector used
+ * @param {String} checkType - Type of check performed.  E.g. 'waitForVisible'
+ * would specify 'visible' (or 'invisible' if reverse was true)
+ * @returns {ErrorHandler} - error handler containing human readable string
+ */
+ErrorHandler.SelectorTimeoutError = function (commandName, selector, checkType) {
+    commandName = commandName || 'Unknown command';
+    selector = selector || 'Unknown selector';
+    checkType = checkType || 'Unkown check type';
+    var message = commandName + ' failed.  Selector: ' + selector + ' failed to find element that was ' + checkType;
+    return new ErrorHandler('SelectorTimeoutError', message);
 };
 
 function pad(str, width) {


### PR DESCRIPTION
Closes #419 

```
  1) Checks to see if passwordz exists:
     Uncaught SelectorTimeoutError
     Problem: waitForExist failed.  Selector: #passwordz failed to find element that was in the DOM

     Callstack:
     -> waitForExist("#passwordz",1000)
```

```
  2) Checks to see if passwordz is visible:
     Uncaught SelectorTimeoutError
     Problem: waitForVisible failed.  Selector: #passwordz failed to find element that was visible

     Callstack:
     -> waitForVisible("#passwordz",1000)
```
Note: this did not implement the SelectorTimeoutError for the other waitFor<X> functions

---
(Sorry for the trailing newline added to the ErrorHandler, I had trouble getting an editor to save the file without it.)