### PR TITLE
The `chainit` module uses `setImmediate` function.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   ],
   "main": "./index.js",
   "engines": {
-    "node": ">= 0.8.0"
+    "node": ">= 0.10.0"
   },
   "scripts": {
     "test": "node ./test/runner.js",


### PR DESCRIPTION
It is available starting from node 0.10.0.