### PR TITLE
Q storing all unhandled rejections leads to major memory leaks when webd...

### DIFF
--- a/lib/webdriverio.js
+++ b/lib/webdriverio.js
@@ -5,6 +5,9 @@ var buildPrototype = require('./utils/buildPrototype'),
     PromiseHandler = require('./utils/PromiseHandler'),
     isMobileHelper = require('./helpers/isMobile');
 
+// Stop Q from tracking unhandled rejections
+require('q').stopUnhandledRejectionTracking();
+
 buildPrototype(
     WebdriverIO.prototype,
     ['commands', 'protocol'].map(realPath(__dirname))


### PR DESCRIPTION
...riverio runs for a long time. This change should stop this behavior.

This is mostly debug behavior - https://github.com/kriskowal/q/wiki/API-Reference#qstopunhandledrejectiontracking