### PR TITLE
Fixed issue with moveToObject

### DIFF
--- a/lib/commands/moveToObject.js
+++ b/lib/commands/moveToObject.js
@@ -98,7 +98,12 @@ module.exports = function moveToObject(selector, xoffset, yoffset) {
             },
             function(res, cb) {
                 response.element = res;
-                self.moveTo(res.value.ELEMENT, xoffset, yoffset, cb);
+
+                if(hasOffsetParams){
+                    self.moveTo(res.value.ELEMENT, xoffset, yoffset, cb);
+                }else{
+                    self.moveTo(res.value.ELEMENT, cb);
+                }
             },
             function(res, cb) {
                 response.moveTo = res;


### PR DESCRIPTION
Fixed an issue with moveToObject where the mouse cursor was not being moved to the center by default (without providing the offset). Previously it was non-compliant with the specs of Webdriver.io(http://webdriver.io/api/action/moveToObject.html) in the API docs, where it says that if no offset is specified the default is the center.