### PR TITLE
Modify description in the docs

### DIFF
--- a/lib/commands/waitForVisible.js
+++ b/lib/commands/waitForVisible.js
@@ -5,8 +5,10 @@
  * selector, it returns true (or false if reverse flag is set) if at least one
  * element is visible.
  *
- * This function checks for visibility using window.getComputedStyle and
- * checks that the element's x/y coordinates are within the viewport.
+ * This function checks for visibility using window.getComputedStyle. An
+ * element will be considered invisible if its visibility is 'none', its
+ * display is 'hidden', its opacity is 0 or its x/y coordinates are not
+ * within the viewport.
  *
  * @param {String}   selector element to wait for
  * @param {Number=}  ms       time in ms (default: 500)


### PR DESCRIPTION
[waitForVisible](http://webdriver.io/api/utility/waitForVisible.html)'s description in the docs is slightly misleading. It says that it checks for the visibility and x/y coordinates but it also checks that display is not 'hidden' and opacity is not zero.

I was a little bit confused by it today so I added specificity to the description. I think it's helpful because it's not entirely obvious that it's going to work in that way: [isVisible](http://webdriver.io/api/state/isVisible.html) for example behaves in a different way, considering an element is "visible" even when its opacity is zero.