### PR TITLE
Add transferPromiseness support, and write test cases for use of chai-as-promised (#510)

### DIFF
--- a/lib/webdriverio.js
+++ b/lib/webdriverio.js
@@ -13,7 +13,7 @@ var Q = require('q'),
  */
 var WebdriverIO = module.exports = function WebdriverIO(args) {
 
-    var prototype = Object.create(null),
+    var prototype = Object.create(Object.prototype),
         eventHandler = new EventEmitter(),
         noop = function() {},
         fulFilledPromise = Q();
@@ -194,6 +194,22 @@ var WebdriverIO = module.exports = function WebdriverIO(args) {
                     return result;
 
                 });
+        };
+
+        client.transferPromiseness = function(target, promise) {
+            /**
+             * transfer WebdriverIO commands
+             */
+
+            var clientFunctions =  Object.keys(prototype);
+            var promiseFunctions = ['then', 'catch', 'finally'];
+            var functionsToTranfer = clientFunctions.concat(promiseFunctions);
+
+            functionsToTranfer.forEach(function(fnName) {
+                if(typeof promise[fnName] === 'function') {
+                    target[fnName] = promise[fnName].bind(promise);
+                }
+            });
         };
 
         if (typeof modifier === 'function') {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   },
   "devDependencies": {
     "chai": "~2.3.0",
+    "chai-as-promised": "^5.0.0",
     "coveralls": "~2.11.2",
     "glob": "~5.0.5",
     "istanbul": "^0.3.13",

--- a/test/spec/functional/chaiPromises.js
+++ b/test/spec/functional/chaiPromises.js
@@ -1,0 +1,62 @@
+var Q = require('q');
+
+describe('chai-as-promised', function() {
+
+    /**
+     *  Remove the `should` global on Object.prototype to allow chai.should for these tests,
+     *  and set up chai, chai-as-promised and chai.should properly
+     */
+
+    require('should').noConflict();
+
+    var chai = require('chai');
+    var chaiAsPromised = require('chai-as-promised');
+
+    chai.should();
+    chai.use(chaiAsPromised);
+
+    before(h.setup());
+
+    beforeEach(function() {
+        chaiAsPromised.transferPromiseness = this.client.transferPromiseness;
+    });
+
+    after(function() {
+        /**
+         *  Restore the original `should` library to allow other tests to use it
+         */
+        var should = require('should');
+        should.extend('should', Object.prototype);
+    });
+
+    it('should handle a single promise', function() {
+
+        return this.client.getTitle()
+            .should.eventually.equal('WebdriverJS Testpage');
+
+    });
+
+    it('should allow chaining of further promises', function() {
+
+        return this.client
+            .isVisible('body').should.eventually.be.true
+            .getTitle().should.eventually.equal('WebdriverJS Testpage');
+
+    });
+
+    it('should handle failed assertions', function() {
+
+        return this.client
+            .isVisible('body').should.eventually.be.true
+            .getTitle().should.eventually.equal('some other title')
+            .catch(function(e) {
+                e.should.be.an.instanceof(Error);
+            });
+
+    });
+
+    it('should support deep comparisons', function() {
+        return this.client.getText('#selectbox option').should.become(['1', '2', '3']);
+    })
+
+});

--- a/test/spec/functional/chaiPromises.js
+++ b/test/spec/functional/chaiPromises.js
@@ -1,5 +1,3 @@
-var Q = require('q');
-
 describe('chai-as-promised', function() {
 
     /**


### PR DESCRIPTION
- Adds a `transferPromiseness` function to webdriverio.js for chai-as-promised support
- Extend the webdriverio client from `Object.prototype` to support `chai.should`
- Ådds test cases for chai-as-promised usage

@christian-bromann -- let me know if this looks ok, or if there's anything that I'm missing. thanks!