### PR TITLE
Fixes incompatibility with PhantomJS 1.9 Ghostdriver mode (fixes #594)

### DIFF
--- a/lib/utils/RequestHandler.js
+++ b/lib/utils/RequestHandler.js
@@ -7,6 +7,7 @@
 var Q = require('q'),
     url = require('url'),
     request = require('request'),
+    merge = require('deepmerge'),
     errorCodes = require('./errorCodes'),
     ErrorHandler = require('./ErrorHandler'),
     packageDotJson  = require('../../package.json');
@@ -106,9 +107,13 @@ RequestHandler.prototype.createOptions = function(requestOptions, data) {
     };
 
     if (Object.keys(data).length > 0) {
-        newOptions.body = data;
+        var requestData = JSON.stringify(data);
+        newOptions.body = requestData;
         newOptions.method = 'POST';
-        newOptions.json = true;
+        newOptions.headers = merge(newOptions.headers, {
+            'Content-Type': 'application/json; charset=UTF-8',
+            'Content-Length': Buffer.byteLength(requestData, 'UTF-8')
+        });
     }
 
     return newOptions;

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "inquirer": "^0.8.5",
     "optimist": "^0.6.1",
     "q": "~1.3.0",
-    "request": "~2.55.0",
+    "request": "2.49.0",
     "rgb2hex": "~0.1.0",
     "supports-color": "^1.3.1",
     "url": "~0.10.3",


### PR DESCRIPTION
The core problem seems to be that PhantomJS 1.9 has problems with some lowercase headers.
request 2.49.0 is the latest version that works correctly in addition to setting
the Content-Type and Content-Length header with uppercase.

Relevant issues:

* PhantomJS issue: https://github.com/ariya/phantomjs/issues/11421