### PR TITLE
Framework  Error: Don't know the framework "Mocha"

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -121,9 +121,9 @@ if(argv._[0] === 'config') {
         name: 'framework',
         message: 'Which framework do you want to use?',
         choices: [
-          'Mocha',
-          'Jasmine',
-          'Cucumber'
+          'mocha',
+          'jasmine',
+          'cucumber'
         ]
     }, {
         type: 'input',
@@ -131,7 +131,7 @@ if(argv._[0] === 'config') {
         message: 'Where are your test specs located?',
         default: './test/specs/**/*.js',
         when: function(answers) {
-            return answers.framework.match(/(Mocha|Jasmine)/);
+            return answers.framework.match(/(mocha|jasmine)/);
         }
     }, {
         type: 'input',
@@ -139,7 +139,7 @@ if(argv._[0] === 'config') {
         message: 'Where are your feature files located?',
         default: './features/**/*.feature',
         when: function(answers) {
-            return answers.framework === 'Cucumber';
+            return answers.framework === 'cucumber';
         }
     }, {
         type: 'input',
@@ -147,7 +147,7 @@ if(argv._[0] === 'config') {
         message: 'Where are your step definitions located?',
         default: './features/step-definitions/**/*.js',
         when: function(answers) {
-            return answers.framework === 'Cucumber';
+            return answers.framework === 'cucumber';
         }
     }, {
         type: 'list',


### PR DESCRIPTION
For initialising frameworks to run test cases. The framework names should be in small letters .
Otherwise error pop {Error: Don't know the framework "Mocha"}

Small fix!