### PR TITLE
Update doc: update selenium download url

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -23,14 +23,14 @@ Then let's download the current [selenium standalone server](http://docs.seleniu
 
 ** 2. Download selenium standalone server**
 ```sh
-$ curl -O http://selenium-release.storage.googleapis.com/2.45/selenium-server-standalone-2.45.0.jar
+$ curl -O http://selenium-release.storage.googleapis.com/2.46/selenium-server-standalone-2.46.0.jar
 ```
 
 Start the server by executing the following:
 
 ** 3. Start selenium standalone server**
 ```sh
-$ java -jar selenium-server-standalone-2.45.0.jar
+$ java -jar selenium-server-standalone-2.46.0.jar
 ```
 
 Keep this running in the background and open a new terminal window. Next step is to download WebdriverIO via


### PR DESCRIPTION
Selenium 2.45 seems does not work with Firefox 38+ on MacOS. Since people usually copy&paste the command, it might be better to keep it up-to-date.