### PR TITLE
Fix issue with throwOnNextTick getting called too early

### DIFF
--- a/lib/webdriverio.js
+++ b/lib/webdriverio.js
@@ -114,7 +114,7 @@ module.exports = function WebdriverIO(args, modifier) {
                 'ERROR_' + sanitize.caps(desiredCapabilities) + '_' + new Date().toJSON() + '.png'
             )]);
 
-            return client.finally(throwOnNextTick.bind(null, result));
+            return client.next(throwOnNextTick, result)
         }
     };
 

--- a/lib/webdriverio.js
+++ b/lib/webdriverio.js
@@ -103,16 +103,15 @@ module.exports = function WebdriverIO(args, modifier) {
             /**
              * take screenshot only if errorScreenshotDir is given
              */
-            if(typeof options.errorScreenshotDir !== 'string') {
-                return throwOnNextTick(result);
-            }
-
             var client = unit();
-            client.next(prototype.saveScreenshot, [path.join(
-                process.cwd(),
-                options.errorScreenshotDir,
-                'ERROR_' + sanitize.caps(desiredCapabilities) + '_' + new Date().toJSON() + '.png'
-            )]);
+
+            if(options.errorScreenshotDir && typeof(options.errorScreenshotDir) === 'string') {
+                client.next(prototype.saveScreenshot, [path.join(
+                    process.cwd(),
+                    options.errorScreenshotDir,
+                    'ERROR_' + sanitize.caps(desiredCapabilities) + '_' + new Date().toJSON() + '.png'
+                )]);
+            }
 
             return client.next(throwOnNextTick, result)
         }


### PR DESCRIPTION
This seems to fix the issue mentioned in #607. The [throwOnNextTick](https://github.com/webdriverio/webdriverio/blob/master/lib/webdriverio.js#L121) function was getting returned while ```saveScreenshot``` was still processing, and I believe this will prevent that from occurring.