### PR TITLE
Fixed infinite recursion in setViewportSize command

### DIFF
--- a/lib/commands/setViewportSize.js
+++ b/lib/commands/setViewportSize.js
@@ -5,13 +5,13 @@
  * window size will always be bigger since it includes the height of any menu or status bars.
  *
  * <example>
-    :setViewportSize.js
-    client
-        .setViewportSize({
+ :setViewportSize.js
+ client
+ .setViewportSize({
             width: 500,
             height: 500
         })
-        .windowHandleSize(function(err, res) {
+ .windowHandleSize(function(err, res) {
             console.log(res.value); // outputs: "{ width: 500, height: 602 }"
         })
  * </example>
@@ -28,55 +28,58 @@
 var getViewportSizeHelper = require('../helpers/_getViewportSize'),
     ErrorHandler = require('../utils/ErrorHandler.js');
 
-module.exports = function setViewportSize (size) {
+module.exports = function setViewportSize(size) {
 
     /**
      * parameter check
      */
-    if(typeof size !== 'object' || typeof size.width !== 'number' || typeof size.height !== 'number') {
+    if (typeof size !== 'object' || typeof size.width !== 'number' || typeof size.height !== 'number') {
         throw new ErrorHandler.CommandError('number or type of arguments don\'t agree with setViewportSize command');
     }
 
-    var maxExecutionTime = 5;
+    return setSize(this);
 
     /**
      * to set viewport size properly we need to execute the process multiple times
      * since the difference between the inner and outer size changes when browser
      * switch between fullscreen modes or visibility of scrollbar
      */
+    function setSize(client, retryNo) {
 
-    /**
-     * get window size
-     */
-    return this.windowHandleSize().then(function(windowHandleSize) {
+        const MAX_TRIES = 5;
+        if (typeof retryNo === 'undefined') retryNo = 0;
 
         /**
-         * get viewport size
+         * get window size
          */
-        return this.execute(getViewportSizeHelper).then(function(viewportSize) {
-
-            var widthDiff = windowHandleSize.value.width - viewportSize.value.screenWidth,
-                heightDiff = windowHandleSize.value.height - viewportSize.value.screenHeight;
+        return client.windowHandleSize().then(function(windowHandleSize) {
 
             /**
-             * change window size
+             * get viewport size
              */
-            return this.windowHandleSize({
-                width: size.width + widthDiff,
-                height: size.height + heightDiff
+            return this.execute(getViewportSizeHelper).then(function(viewportSize) {
+
+                var widthDiff = windowHandleSize.value.width - viewportSize.value.screenWidth,
+                    heightDiff = windowHandleSize.value.height - viewportSize.value.screenHeight;
+
+                /**
+                 * change window size
+                 */
+                return this.windowHandleSize({
+                    width: size.width + widthDiff,
+                    height: size.height + heightDiff
+                });
+
+            }).execute(getViewportSizeHelper).then(function(res) {
+
+                /**
+                 * if viewport size not equals desired size, execute process again
+                 */
+                if (retryNo < MAX_TRIES && (res.value.screenWidth !== size.width || res.value.screenHeight !== size.height)) {
+                    return setSize(client, ++retryNo);
+                }
+
             });
-
-        }).execute(getViewportSizeHelper).then(function(res) {
-
-            /**
-             * if viewport size not equals desired size, execute process again
-             */
-            if(--maxExecutionTime && (res.value.screenWidth !== size.width || res.value.screenHeight !== size.height)) {
-                return this.setViewportSize(size);
-            }
-
         });
-
-    });
-
+    }
 };


### PR DESCRIPTION
Sometimes we can not get desired window size due to screen size limits or etc. In this case setViewportSize was entering infinite recursion because of maxExecutionTime was always 5. 