### PR TITLE
setViewpoertSize: added type parameter according to documentation

### DIFF
--- a/lib/commands/setViewportSize.js
+++ b/lib/commands/setViewportSize.js
@@ -8,12 +8,12 @@
  :setViewportSize.js
  client
  .setViewportSize({
-            width: 500,
-            height: 500
-        })
+    width: 500,
+    height: 500
+ })
  .windowHandleSize(function(err, res) {
-            console.log(res.value); // outputs: "{ width: 500, height: 602 }"
-        })
+    console.log(res.value); // outputs: "{ width: 500, height: 602 }"
+ })
  * </example>
  *
  * @param {Object}   size  window width/height
@@ -24,11 +24,10 @@
  *
  */
 
-
 var getViewportSizeHelper = require('../helpers/_getViewportSize'),
     ErrorHandler = require('../utils/ErrorHandler.js');
 
-module.exports = function setViewportSize(size) {
+module.exports = function setViewportSize(size, type) {
 
     /**
      * parameter check
@@ -37,16 +36,19 @@ module.exports = function setViewportSize(size) {
         throw new ErrorHandler.CommandError('number or type of arguments don\'t agree with setViewportSize command');
     }
 
-    return setSize(this);
+    var shouldIndent = typeof(type) === 'undefined' ? true : type;
+
+    return shouldIndent ? setViewportSize(this) : this.windowHandleSize(size);
 
     /**
      * to set viewport size properly we need to execute the process multiple times
      * since the difference between the inner and outer size changes when browser
      * switch between fullscreen modes or visibility of scrollbar
      */
-    function setSize(client, retryNo) {
+    function setViewportSize(client, retryNo) {
 
         const MAX_TRIES = 5;
+
         if (typeof retryNo === 'undefined') retryNo = 0;
 
         /**
@@ -57,26 +59,27 @@ module.exports = function setViewportSize(size) {
             /**
              * get viewport size
              */
-            return this.execute(getViewportSizeHelper).then(function(viewportSize) {
+            return this.execute(getViewportSizeHelper).then(function (viewportSize) {
 
                 var widthDiff = windowHandleSize.value.width - viewportSize.value.screenWidth,
                     heightDiff = windowHandleSize.value.height - viewportSize.value.screenHeight;
 
                 /**
-                 * change window size
+                 * change window size with indent
                  */
                 return this.windowHandleSize({
                     width: size.width + widthDiff,
                     height: size.height + heightDiff
                 });
 
-            }).execute(getViewportSizeHelper).then(function(res) {
+            }).execute(getViewportSizeHelper).then(function (res) {
 
                 /**
                  * if viewport size not equals desired size, execute process again
                  */
-                if (retryNo < MAX_TRIES && (res.value.screenWidth !== size.width || res.value.screenHeight !== size.height)) {
-                    return setSize(client, ++retryNo);
+                if (retryNo < MAX_TRIES
+                    && (res.value.screenWidth !== size.width || res.value.screenHeight !== size.height)) {
+                    return setViewportSize(client, ++retryNo);
                 }
 
             });

--- a/lib/commands/setViewportSize.js
+++ b/lib/commands/setViewportSize.js
@@ -5,13 +5,13 @@
  * window size will always be bigger since it includes the height of any menu or status bars.
  *
  * <example>
-    :setViewportSize.js
-    client
-        .setViewportSize({
+ :setViewportSize.js
+ client
+ .setViewportSize({
             width: 500,
             height: 500
         })
-        .windowHandleSize(function(err, res) {
+ .windowHandleSize(function(err, res) {
             console.log(res.value); // outputs: "{ width: 500, height: 602 }"
         })
  * </example>
@@ -28,55 +28,58 @@
 var getViewportSizeHelper = require('../helpers/_getViewportSize'),
     ErrorHandler = require('../utils/ErrorHandler.js');
 
-module.exports = function setViewportSize (size) {
+module.exports = function setViewportSize(size) {
 
     /**
      * parameter check
      */
-    if(typeof size !== 'object' || typeof size.width !== 'number' || typeof size.height !== 'number') {
+    if (typeof size !== 'object' || typeof size.width !== 'number' || typeof size.height !== 'number') {
         throw new ErrorHandler.CommandError('number or type of arguments don\'t agree with setViewportSize command');
     }
 
-    var maxExecutionTime = 5;
+    return setSize(this);
 
     /**
      * to set viewport size properly we need to execute the process multiple times
      * since the difference between the inner and outer size changes when browser
      * switch between fullscreen modes or visibility of scrollbar
      */
+    function setSize(client, retryNo) {
 
-    /**
-     * get window size
-     */
-    return this.windowHandleSize().then(function(windowHandleSize) {
+        const MAX_TRIES = 5;
+        if (typeof retryNo === 'undefined') retryNo = 0;
 
         /**
-         * get viewport size
+         * get window size
          */
-        return this.execute(getViewportSizeHelper).then(function(viewportSize) {
-
-            var widthDiff = windowHandleSize.value.width - viewportSize.value.screenWidth,
-                heightDiff = windowHandleSize.value.height - viewportSize.value.screenHeight;
+        return client.windowHandleSize().then(function(windowHandleSize) {
 
             /**
-             * change window size
+             * get viewport size
              */
-            return this.windowHandleSize({
-                width: size.width + widthDiff,
-                height: size.height + heightDiff
+            return this.execute(getViewportSizeHelper).then(function(viewportSize) {
+
+                var widthDiff = windowHandleSize.value.width - viewportSize.value.screenWidth,
+                    heightDiff = windowHandleSize.value.height - viewportSize.value.screenHeight;
+
+                /**
+                 * change window size
+                 */
+                return this.windowHandleSize({
+                    width: size.width + widthDiff,
+                    height: size.height + heightDiff
+                });
+
+            }).execute(getViewportSizeHelper).then(function(res) {
+
+                /**
+                 * if viewport size not equals desired size, execute process again
+                 */
+                if (retryNo < MAX_TRIES && (res.value.screenWidth !== size.width || res.value.screenHeight !== size.height)) {
+                    return setSize(client, ++retryNo);
+                }
+
             });
-
-        }).execute(getViewportSizeHelper).then(function(res) {
-
-            /**
-             * if viewport size not equals desired size, execute process again
-             */
-            if(--maxExecutionTime && (res.value.screenWidth !== size.width || res.value.screenHeight !== size.height)) {
-                return this.setViewportSize(size);
-            }
-
         });
-
-    });
-
+    }
 };

--- a/lib/commands/setViewportSize.js
+++ b/lib/commands/setViewportSize.js
@@ -17,7 +17,7 @@
  * </example>
  *
  * @param {Object}   size  window width/height
- * @param {Boolean}  type  set to `false` to change window size, `true` (default) to change viewport size
+ * @param {Boolean}  type  set to `false` to change window size, `true` (default)  to change viewport size
  *
  * @uses protocol/execute, protocol/windowHandleSize
  * @type window
@@ -32,7 +32,10 @@ module.exports = function setViewportSize(size, type) {
     /**
      * parameter check
      */
-    if (typeof size !== 'object' || typeof size.width !== 'number' || typeof size.height !== 'number') {
+    if (typeof size !== 'object'
+        || typeof size.width !== 'number'
+        || typeof size.height !== 'number'
+        || (typeof type !== 'undefined' && typeof type !== 'boolean')) {
         throw new ErrorHandler.CommandError('number or type of arguments don\'t agree with setViewportSize command');
     }
 

--- a/test/spec/desktop/viewportSize.js
+++ b/test/spec/desktop/viewportSize.js
@@ -21,4 +21,14 @@ describe('setViewportSize/getViewportSize', function() {
         });
     });
 
+    it('should set window size exactly when parameter \'type\' is false', function() {
+        return this.client.setViewportSize({
+            width: 500,
+            height: 500
+        }, false).windowHandleSize().then(function(res) {
+            res.value.width.should.be.exactly(500);
+            res.value.height.should.be.exactly(500);
+        });
+    })
+
 });

--- a/test/spec/desktop/viewportSize.js
+++ b/test/spec/desktop/viewportSize.js
@@ -29,6 +29,5 @@ describe('setViewportSize/getViewportSize', function() {
             res.value.width.should.be.exactly(500);
             res.value.height.should.be.exactly(500);
         });
-    })
-
+    });
 });


### PR DESCRIPTION
According to documentation, ```setViewpoertSize``` should have the boolean parameter ```type```. When ```type``` is set to ```false```, ```setViewpoertSize``` will change window(not viewport) size without indentation and retries.
@christian-bromann did you mean this indentation problem?