### PR TITLE
Make it easier for new users to compare reporters

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -152,7 +152,7 @@ if(argv._[0] === 'config') {
     }, {
         type: 'list',
         name: 'reporter',
-        message: 'Which reporter do you want to use?',
+        message: 'Which reporter do you want to use? (see http://webdriver.io/guide/testrunner/reporters.html)',
         choices: [
           'dot',
           'spec',


### PR DESCRIPTION
If that is too long, we could shorten to

> Which reporter to use? (see http://webdriver.io/guide/testrunner/reporters.html)