### PR TITLE
Enable Microsoft Edge by customizable startPath

### DIFF
--- a/docs/guide/getstarted/configuration.md
+++ b/docs/guide/getstarted/configuration.md
@@ -49,6 +49,24 @@ or you can pass in writeable stream and everything gets redirected to that (last
 Type: `String|writeable stream`<br>
 Default: *null*
 
+### host
+Host of your WebDriver server.
+
+Type: `String`<br>
+Default: *127.0.0.1*
+
+### port
+Port your WebDriver server is on.
+
+Type: `Number`<br>
+Default: *4444* 
+
+### path
+Path to WebDriver server.
+
+Type: `String`<br>
+Default: */wd/hub*
+
 ### baseUrl
 Shorten `url` command calls by setting a base url. If your `url` parameter starts with `/` the base url gets prepended.
 

--- a/docs/guide/testrunner/configurationfile.md
+++ b/docs/guide/testrunner/configurationfile.md
@@ -21,10 +21,11 @@ exports.config = {
     // supported cloud services like Sauce Labs, Browserstack or Testing Bot you also don't
     // need to define host and port information because WebdriverIO can figure that our
     // according to your user and key information. However if you are using a private Selenium
-    // backend you should define the host address and port here.
+    // backend you should define the host address, port, and path here.
     //
     host: '0.0.0.0',
     port: 4444,
+    path: '/',
     //
     // =================
     // Service Providers

--- a/docs/guide/testrunner/configurationfile.md
+++ b/docs/guide/testrunner/configurationfile.md
@@ -25,7 +25,7 @@ exports.config = {
     //
     host: '0.0.0.0',
     port: 4444,
-    path: '/',
+    path: '/wd/hub',
     //
     // =================
     // Service Providers

--- a/examples/wdio.conf.js
+++ b/examples/wdio.conf.js
@@ -8,10 +8,11 @@ exports.config = {
     // supported cloud services like Sauce Labs, Browserstack or Testing Bot you also don't
     // need to define host and port information because WebdriverIO can figure that our
     // according to your user and key information. However if you are using a private Selenium
-    // backend you should define the host address and port here.
+    // backend you should define the host address, port, and path here.
     //
     host: '0.0.0.0',
     port: 4444,
+    path: '/',
     //
     // =================
     // Service Providers

--- a/examples/wdio.conf.js
+++ b/examples/wdio.conf.js
@@ -12,7 +12,7 @@ exports.config = {
     //
     host: '0.0.0.0',
     port: 4444,
-    path: '/',
+    path: '/wd/hub',
     //
     // =================
     // Service Providers

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -16,8 +16,9 @@ var path = require('path'),
     alias('help', 'h').
     describe('version', 'prints WebdriverIO version').
     alias('version', 'v').
-    describe('host', 'selenium server host address').
-    describe('port', 'selenium server port').
+    describe('host', 'Selenium server host address').
+    describe('port', 'Selenium server port').
+    describe('path', 'Selenium server path (default: /wd/hub)').
     describe('user', 'username if using a cloud service as Selenium backend').
     alias('user', 'u').
     describe('key', 'corresponding access key to the user').
@@ -103,7 +104,7 @@ if(argv._[0] === 'config') {
     }, {
         type: 'input',
         name: 'host',
-        message: 'What is the IP or URI to your selenium standalone server?',
+        message: 'What is the IP or URI to your Selenium standalone server?',
         default: '0.0.0.0',
         when: function(answers) {
             return answers.backend.indexOf('own Selenium cloud') > -1;
@@ -111,8 +112,16 @@ if(argv._[0] === 'config') {
     }, {
         type: 'input',
         name: 'port',
-        message: 'What is the port which your selenium standalone server is running on?',
+        message: 'What is the port which your Selenium standalone server is running on?',
         default: '4444',
+        when: function(answers) {
+            return answers.backend.indexOf('own Selenium cloud') > -1;
+        }
+    }, {
+        type: 'input',
+        name: 'path',
+        message: 'What is the path to your Selenium standalone server?',
+        default: '/wd/hub',
         when: function(answers) {
             return answers.backend.indexOf('own Selenium cloud') > -1;
         }
@@ -211,7 +220,7 @@ if (!configFile) {
 }
 
 var args = {},
-    allowedArgv = ['host', 'port', 'user', 'key', 'updateJob', 'logLevel', 'coloredLogs', 'screenshotPath',
+    allowedArgv = ['host', 'port', 'path', 'user', 'key', 'updateJob', 'logLevel', 'coloredLogs', 'screenshotPath',
                    'baseUrl', 'waitforTimeout', 'framework', 'reporter'];
 
 allowedArgv.forEach(function(key) {

--- a/lib/helpers/wdio.conf.ejs
+++ b/lib/helpers/wdio.conf.ejs
@@ -4,14 +4,15 @@ exports.config = {
     // Server Configurations
     // =====================
     // Host address of the running Selenium server. This information is usually obsolete as
-    // WebdriverIO automatically connects to localhost. If you are using one of the
+    // WebdriverIO automatically connects to localhost. Also if you are using one of the
     // supported cloud services like Sauce Labs, Browserstack or Testing Bot you also don't
-    // need to define the host and port information because WebdriverIO can figure that out
-    // according to your user and key information. However, if you are using a private Selenium
-    // backend, you should define the host address and port here.
+    // need to define host and port information because WebdriverIO can figure that our
+    // according to your user and key information. However if you are using a private Selenium
+    // backend you should define the host address, port, and path here.
     //
     host: '<%= answers.host %>',
     port: <%= answers.port %>,
+    path: '<%= answers.path %>',
     <% }
     if(answers.env_user && answers.env_key) { %>
     //

--- a/lib/utils/RequestHandler.js
+++ b/lib/utils/RequestHandler.js
@@ -17,7 +17,7 @@ module.exports = RequestHandler;
 function RequestHandler(options, eventHandler, logger) {
 
     this.sessionID = null;
-    this.startPath = options.startPath || '/wd/hub';
+    this.startPath = options.path === '/' ? '' : options.path || '/wd/hub';
     this.eventHandler = eventHandler;
     this.logger = logger;
     this.defaultOptions = options;

--- a/lib/utils/RequestHandler.js
+++ b/lib/utils/RequestHandler.js
@@ -17,7 +17,7 @@ module.exports = RequestHandler;
 function RequestHandler(options, eventHandler, logger) {
 
     this.sessionID = null;
-    this.startPath = '/wd/hub';
+    this.startPath = options.startPath || '/wd/hub';
     this.eventHandler = eventHandler;
     this.logger = logger;
     this.defaultOptions = options;

--- a/test/spec/functional/remote.js
+++ b/test/spec/functional/remote.js
@@ -1,6 +1,7 @@
 var webdriverjs = require('../../../index.js'),
     assert = require('assert'),
-    sessionID = 'ba8ca350-e0e3-4a73-aab5-1679559cdcd2';
+    sessionID = 'ba8ca350-e0e3-4a73-aab5-1679559cdcd2',
+    startPath = '/abc/xyz';
 
 describe('remote method', function() {
 
@@ -16,6 +17,13 @@ describe('remote method', function() {
 
         var client = webdriverjs.remote(sessionID);
         assert.strictEqual(client.requestHandler.sessionID, sessionID);
+
+    });
+
+    it('should be able to set startPath', function() {
+
+        var client = webdriverjs.remote({ startPath: startPath });
+        assert.strictEqual(client.requestHandler.startPath, startPath);
 
     });
 


### PR DESCRIPTION
To support [Microsoft Edge WebDriver server](https://msdn.microsoft.com/en-us/library/mt188085(v=vs.85).aspx), `startPath` must be customizable to `/` instead of `/wd/hub`. Currently, there is no way to run Edge WebDriver server on a different path, below is CLI help output.

```
Usage:
 MicrosoftWebDriver.exe --host=<HostName> --port=<PortNumber> --package=<Package>
```

I suggest customizing `startPath` with remote options. When unset, it will default to `/wd/hub`.

Following is a sample test that run successfully with Edge, based on `examples/webdriverio.local.js`:
* `startPath` must be set to `/`
* `host` must be set to `localhost`, Edge currently do not support `127.0.0.1` and will return HTTP 400
  * [Bug](https://connect.microsoft.com/IE/Feedback/Details/1627096) in Edge WebDriver server implementation

```
var webdriverio = require('webdriverio');
var options = {
    desiredCapabilities: {
        browserName: 'edge'
    },
    host: 'localhost',
    port: 17556,
    startPath: '/'
};

webdriverio
    .remote(options)
    .init()
    .url('http://www.google.com')
    .title().then(function (title) {
        console.log('Title was: ' + title.value);
    })
    .end();
```