### PR TITLE
There is a bug in the jasmine example

### DIFF
--- a/docs/guide/testrunner/frameworks.md
+++ b/docs/guide/testrunner/frameworks.md
@@ -111,7 +111,7 @@ jasmineNodeOpts: {
         /**
          * only take screenshot if assertion failed
          */
-        if(!passed) {
+        if(passed) {
             return;
         }
 &nbsp;


### PR DESCRIPTION
The example was taking a screenshot when assertion passes