### PR TITLE
The last example getText tests wrong string

### DIFF
--- a/docs/guide/usage/transferpromises.md
+++ b/docs/guide/usage/transferpromises.md
@@ -50,6 +50,6 @@ it('should contain a certain text after clicking', function() {
     return client
         .click('button=Send')
         .isVisible('#status_message').should.eventually.be.true
-        .getText('#status_message').should.eventually.be.equal('wrong status message');
+        .getText('#status_message').should.eventually.be.equal('Message sent!');
 });
 ```


### PR DESCRIPTION
The last example getText tests against the error text instead of the expected text. To match the earlier example, it should be changed from 'wrong status message' to 'Message sent!'.