### PR TITLE
adding explicit check from false loggingPrefs

### DIFF
--- a/lib/webdriverio.js
+++ b/lib/webdriverio.js
@@ -33,7 +33,8 @@ module.exports = function WebdriverIO(args, modifier) {
         waitforTimeout: 500,
         coloredLogs: true,
         logLevel: 'silent',
-        baseUrl: null
+        baseUrl: null,
+        desiredCapabilities: {}
     }, typeof args !== 'string' ? args : {});
 
     /**
@@ -72,6 +73,15 @@ module.exports = function WebdriverIO(args, modifier) {
         }
     }, options.desiredCapabilities || {});
     var isMobile = isMobileHelper(desiredCapabilities);
+
+    /**
+     * Some implementations of Selenium have not implemented loggingPrefs and will throw
+     * exceptions if an object, boolean, or empty string is passed. Sending the value
+     * `false` will remove the object entirely.
+     */
+    if (options.desiredCapabilities.loggingPrefs === false) {
+        delete desiredCapabilities.loggingPrefs;
+    }
 
     var resolve = function(result, hasExceptionQueue, isRejectionNotHandled) {
         if(typeof result === 'function') {


### PR DESCRIPTION
Addressing an issue with Saucelabs Android webdriver not implementing the LoggingPreferences object, passing a JSON object, string, or boolean to it throws an exception.

This allows for a `false` loggingPrefs value to be excluded from sending to Selenium.

https://github.com/webdriverio/webdriverio/issues/590#issuecomment-127332580