### PR TITLE
wdio.conf.ejs: minor correction

### DIFF
--- a/docs/guide/testrunner/configurationfile.md
+++ b/docs/guide/testrunner/configurationfile.md
@@ -44,8 +44,10 @@ exports.config = {
     // ==================
     // Specify Test Files
     // ==================
-    // Define which test specs should run. The pattern is relative to the location of this
-    // file.
+    // Define which test specs should run. The pattern is relative to the directory
+    // from which `wdio` was called. Notice that, if you are calling `wdio` from an
+    // NPM script (see https://docs.npmjs.com/cli/run-script) then the current working
+    // directory is where your package.json resides, so `wdio` will be called from there.
     //
     specs: [
         'test/spec/**'

--- a/examples/wdio.conf.js
+++ b/examples/wdio.conf.js
@@ -31,8 +31,10 @@ exports.config = {
     // ==================
     // Specify Test Files
     // ==================
-    // Define which test specs should run. The pattern is relative to the location of this
-    // file.
+    // Define which test specs should run. The pattern is relative to the directory
+    // from which `wdio` was called. Notice that, if you are calling `wdio` from an
+    // NPM script (see https://docs.npmjs.com/cli/run-script) then the current working
+    // directory is where your package.json resides, so `wdio` will be called from there.
     //
     specs: [
         'test/spec/**'

--- a/lib/helpers/wdio.conf.ejs
+++ b/lib/helpers/wdio.conf.ejs
@@ -36,8 +36,10 @@ exports.config = {
     // ==================
     // Specify Test Files
     // ==================
-    // Define which test specs should run. The pattern is relative to the location of this
-    // file.
+    // Define which test specs should run. The pattern is relative to the directory
+    // from which `wdio` was called. Notice that, if you are calling `wdio` from an
+    // NPM script (see https://docs.npmjs.com/cli/run-script) then the current working
+    // directory is where your package.json resides, so `wdio` will be called from there.
     //
     specs: [
         '<%= answers.specs %>'


### PR DESCRIPTION
Spec paths are relative to the directory fro which `wdio` was called,
which is not necessarily the location of wdio.conf.js.

On a side note, one might encounter further problems when calling `wdio` from an npm script, as those are run from the project root (you can explicitly `cd` back to where you wanted, in the script). Shall I include a notice for that in the same comment?