### PR TITLE
wdio.conf.ejs: framework choices are lowercase

### DIFF
--- a/lib/helpers/wdio.conf.ejs
+++ b/lib/helpers/wdio.conf.ejs
@@ -127,7 +127,7 @@ exports.config = {
         outputDir: './'
     },
     <% }
-    if(answers.framework === 'Mocha') { %>
+    if(answers.framework === 'mocha') { %>
     //
     // Options to be passed to Mocha.
     // See the full list at http://mochajs.org/
@@ -135,7 +135,7 @@ exports.config = {
         ui: 'bdd'
     },
     <% }
-    if(answers.framework === 'Jasmine') { %>
+    if(answers.framework === 'jasmine') { %>
     //
     // Options to be passed to Jasmine.
     jasmineNodeOpts: {
@@ -151,7 +151,7 @@ exports.config = {
         }
     },
     <% }
-    if(answers.framework === 'Cucumber') { %>//
+    if(answers.framework === 'cucumber') { %>//
     // If you are using Cucumber you need to specify where your step definitions are located.
     cucumberOpts: {
         require: ['<%= answers.stepDefinitions %>'],


### PR DESCRIPTION
Framework-specific options wouldn't get rendered 
because the check for them was always false.

A possible solution is to use the exact framework names
as declared in https://github.com/webdriverio/webdriverio/blob/master/lib/cli.js#L123

This would fix #691, although in a different manner than proposed there. 