### PR TITLE
Should log Command Result even if falsy

### DIFF
--- a/lib/utils/Logger.js
+++ b/lib/utils/Logger.js
@@ -168,7 +168,7 @@ Logger.prototype.result = function (result) {
     }
 
     // prevent screenshot data output
-    if(result.length > 1000) {
+    if(result && result.length > 1000) {
         result = '[Buffer] screenshot data';
     }
 


### PR DESCRIPTION
I am deep in troubleshooting some intermittent issues with webdriverio and I am finding it necessary to hack this change into my local version. 

The 3.2.0 output looks something like 

```sh
[00:17:18]:  COMMAND	POST 	 "/wd/hub/session/95d4b88bb2f06ac45af6ca4d4b88d839/url"
[00:17:18]:  DATA		 {"url":"http://github.com/cucumber/cucumber-js/"}
[00:17:20]:  COMMAND	POST 	 "/wd/hub/session/95d4b88bb2f06ac45af6ca4d4b88d839/element"
[00:17:20]:  DATA		 {"using":"css selector","value":"a[href=\"/cucumber/cucumber-js\"]"}
[00:17:20]:  COMMAND	POST 	 "/wd/hub/session/95d4b88bb2f06ac45af6ca4d4b88d839/element/0.8255703393369913-1/click"
[00:17:20]:  DATA		 {}
[00:17:20]:  COMMAND	POST 	 "/wd/hub/session/95d4b88bb2f06ac45af6ca4d4b88d839/element"
[00:17:20]:  DATA		 {"using":"css selector","value":"a[href=\"/cucumber/cucumber-js\"]"}
[00:17:20]:  COMMAND	POST 	 "/wd/hub/session/95d4b88bb2f06ac45af6ca4d4b88d839/element/0.8255703393369913-1/click"
[00:17:20]:  DATA		 {}
[00:17:20]:  COMMAND	POST 	 "/wd/hub/session/95d4b88bb2f06ac45af6ca4d4b88d839/element"
[00:17:20]:  DATA		 {"using":"css selector","value":"a[href=\"/cucumber/cucumber-js\"]"}
[00:17:20]:  COMMAND	POST 	 "/wd/hub/session/95d4b88bb2f06ac45af6ca4d4b88d839/element/0.8255703393369913-1/click"
[00:17:20]:  DATA		 {}
```
Which leaves me unsure if the previous COMMAND finished before the COMMAND starts. 

With this patch, the output looks like 
```sh
[00:17:18]:  COMMAND	POST 	 "/wd/hub/session/95d4b88bb2f06ac45af6ca4d4b88d839/url"
[00:17:18]:  DATA		 {"url":"http://github.com/cucumber/cucumber-js/"}
[00:17:20]:  RESULT		 null
[00:17:20]:  COMMAND	POST 	 "/wd/hub/session/95d4b88bb2f06ac45af6ca4d4b88d839/element"
[00:17:20]:  DATA		 {"using":"css selector","value":"a[href=\"/cucumber/cucumber-js\"]"}
[00:17:20]:  RESULT		 {"ELEMENT":"0.8255703393369913-1"}
[00:17:20]:  COMMAND	POST 	 "/wd/hub/session/95d4b88bb2f06ac45af6ca4d4b88d839/element/0.8255703393369913-1/click"
[00:17:20]:  DATA		 {}
[00:17:20]:  RESULT		 null
[00:17:20]:  COMMAND	POST 	 "/wd/hub/session/95d4b88bb2f06ac45af6ca4d4b88d839/element"
[00:17:20]:  DATA		 {"using":"css selector","value":"a[href=\"/cucumber/cucumber-js\"]"}
[00:17:20]:  RESULT		 {"ELEMENT":"0.8255703393369913-1"}
[00:17:20]:  COMMAND	POST 	 "/wd/hub/session/95d4b88bb2f06ac45af6ca4d4b88d839/element/0.8255703393369913-1/click"
[00:17:20]:  DATA		 {}
[00:17:20]:  RESULT		 null
[00:17:20]:  COMMAND	POST 	 "/wd/hub/session/95d4b88bb2f06ac45af6ca4d4b88d839/element"
[00:17:20]:  DATA		 {"using":"css selector","value":"a[href=\"/cucumber/cucumber-js\"]"}
[00:17:20]:  RESULT		 {"ELEMENT":"0.8255703393369913-1"}
[00:17:20]:  COMMAND	POST 	 "/wd/hub/session/95d4b88bb2f06ac45af6ca4d4b88d839/element/0.8255703393369913-1/click"
[00:17:20]:  DATA		 {}
[00:17:20]:  RESULT		 null
```
So now I can see that a response was returned from Selenium. 

`npm run-script test-functional` - PASSED
`npm run-script test-desktop` - PASSED

let me know if there is anything else I should do