### PR TITLE
404 on isExisting callback should be handled and same as element not found

### DIFF
--- a/lib/protocol/elements.js
+++ b/lib/protocol/elements.js
@@ -35,5 +35,11 @@ module.exports = function elements(selector) {
     return this.requestHandler.create(
         requestPath,
         { using: found.using, value: found.value }
-    );
+    ).catch(function (err) {
+        if (err.message === 'no such element') {
+            return [];
+        } else {
+            throw err;
+        }
+    });
 };


### PR DESCRIPTION
If `elements` command return `404 no such element`, it means the element does not exist and `isExisting` should return `false`.

Spec at https://w3c.github.io/webdriver/webdriver-spec.html#handling-errors.