### PR TITLE
Test runner should able to set remote.path by environment variable _PATH

### DIFF
--- a/test/conf/local.js
+++ b/test/conf/local.js
@@ -1,6 +1,7 @@
 var local = {
     host: 'localhost',
     port: process.env._PORT || 4444,
+    path: process.env._PATH,
     logLevel: 'silent',
     waitforTimeout: 1000,
     desiredCapabilities: {


### PR DESCRIPTION
This enable test runner to run against Edge.

If `_PATH` is not set (`undefined`), will default to `/wd/hub`, see https://github.com/webdriverio/webdriverio/commit/4eb6585f2ef6fc02ac22489b96960c0c7959203b.