### PR TITLE
Fix example .babelrc in the getting started guide

### DIFF
--- a/docs/guide/getstarted/configuration.md
+++ b/docs/guide/getstarted/configuration.md
@@ -125,6 +125,6 @@ For generator support, add a file called `.babelrc` to your project root directo
 
 ```
 {
-    blacklist: ['regenerator']
+    "blacklist": ["regenerator"]
 }
 ```


### PR DESCRIPTION
It seems that Babel (tested using v5.8.23) expects the .babelrc file to be valid JSON. This patch changes the example .babelrc file content to conform to JSON spec.