### PR TITLE
Distinguish between timeout errors and other errors.

### DIFF
--- a/lib/commands/waitForEnabled.js
+++ b/lib/commands/waitForEnabled.js
@@ -45,8 +45,12 @@ module.exports = function waitForEnabled(selector, ms, reverse) {
 
             return isEnabled !== reverse;
         });
-    }, ms).catch(function() {
-        throw new Error('element (' + selector + ') still ' + (reverse ? '' : 'not') + ' enabled after ' + ms + 'ms');
+    }, ms).catch(function(err) {
+        if(err.message === 'Promise never resolved with an truthy value') {
+            throw new Error('element (' + selector + ') still ' + (reverse ? '' : 'not') + ' enabled after ' + ms + 'ms');
+        } else {
+            throw err;
+        }
     });
 
 };

--- a/lib/commands/waitForExist.js
+++ b/lib/commands/waitForExist.js
@@ -45,8 +45,12 @@ module.exports = function waitForExist(selector, ms, reverse) {
 
             return isExisting !== reverse;
         });
-    }, ms).catch(function() {
-        throw new Error('element (' + selector + ') still ' + (reverse ? '' : 'not') + ' existing after ' + ms + 'ms');
+    }, ms).catch(function(err) {
+        if(err.message === 'Promise never resolved with an truthy value') {
+            throw new Error('element (' + selector + ') still ' + (reverse ? '' : 'not') + ' existing after ' + ms + 'ms');
+        } else {
+            throw err;
+        }
     });
 
 };

--- a/lib/commands/waitForSelected.js
+++ b/lib/commands/waitForSelected.js
@@ -44,8 +44,12 @@ module.exports = function waitForSelected(selector, ms, reverse) {
 
             return isSelected !== reverse;
         });
-    }, ms).catch(function() {
-        throw new Error('element (' + selector + ') still ' + (reverse ? '' : 'not') + ' selected after ' + ms + 'ms');
+    }, ms).catch(function(err) {
+        if(err.message === 'Promise never resolved with an truthy value') {
+            throw new Error('element (' + selector + ') still ' + (reverse ? '' : 'not') + ' selected after ' + ms + 'ms');
+        } else {
+            throw err;
+        }
     });
 
 };

--- a/lib/commands/waitForText.js
+++ b/lib/commands/waitForText.js
@@ -45,7 +45,11 @@ module.exports = function waitForText(selector, ms, reverse) {
 
             return (text !== '') !== reverse;
         });
-    }, ms).catch(function() {
-        throw new Error('element (' + selector + ') still ' + (reverse ? 'with' : 'without') + ' text after ' + ms + 'ms');
+    }, ms).catch(function(err) {
+        if(err.message === 'Promise never resolved with an truthy value') {
+            throw new Error('element (' + selector + ') still ' + (reverse ? 'with' : 'without') + ' text after ' + ms + 'ms');
+        } else {
+            throw err;
+        }
     });
 };

--- a/lib/commands/waitForValue.js
+++ b/lib/commands/waitForValue.js
@@ -45,8 +45,12 @@ module.exports = function waitForValue(selector, ms, reverse) {
 
             return (value !== '') !== reverse;
         });
-    }, ms).catch(function() {
-        throw new Error('element (' + selector + ') still ' + (reverse ? 'with' : 'without') + ' a value after ' + ms + 'ms');
+    }, ms).catch(function(err) {
+        if(err.message === 'Promise never resolved with an truthy value') {
+            throw new Error('element (' + selector + ') still ' + (reverse ? 'with' : 'without') + ' a value after ' + ms + 'ms');
+        } else {
+            throw err;
+        }
     });
 
 };

--- a/lib/commands/waitForVisible.js
+++ b/lib/commands/waitForVisible.js
@@ -51,8 +51,12 @@ module.exports = function waitForVisible(selector, ms, reverse) {
 
             return isVisible !== reverse;
         });
-    }, ms).catch(function() {
-        throw new Error('element (' + selector + ') still ' + (reverse ? '' : 'not') + ' visible after ' + ms + 'ms');
+    }, ms).catch(function(err) {
+        if(err.message === 'Promise never resolved with an truthy value') {
+            throw new Error('element (' + selector + ') still ' + (reverse ? '' : 'not') + ' visible after ' + ms + 'ms');
+        } else {
+            throw err;
+        }
     });
 
 };

--- a/test/runner.js
+++ b/test/runner.js
@@ -19,6 +19,7 @@ var mocha = new Mocha({
 conf = require('./conf/index.js');
 assert = require('chai').assert;
 expect = require('chai').expect;
+require('chai').use(require('chai-as-promised'));
 
 if(specDir) {
     // only test functional test spec if required

--- a/test/spec/functional/chaiPromises.js
+++ b/test/spec/functional/chaiPromises.js
@@ -2,16 +2,14 @@ describe('chai-as-promised', function() {
 
     /**
      *  Remove the `should` global on Object.prototype to allow chai.should for these tests,
-     *  and set up chai, chai-as-promised and chai.should properly
+     *  and set up chai and chai.should properly
      */
 
     require('should').noConflict();
 
     var chai = require('chai');
-    var chaiAsPromised = require('chai-as-promised');
 
     chai.Should();
-    chai.use(chaiAsPromised);
 
     before(h.setup());
 

--- a/test/spec/waitFor.js
+++ b/test/spec/waitFor.js
@@ -48,7 +48,7 @@ describe('waitFor',function() {
 
         it('should pass through an error from isExisting()', function() {
             var client = this.client;
-            restore = function() {client.addCommand('isExisting', require('../../lib/commands/isExisting'), true);}
+            var restore = function() {client.addCommand('isExisting', require('../../lib/commands/isExisting'), true);}
             this.client.addCommand('isExisting', function() {throw new Error("My error")}, true);
 
             return expect(this.client.waitForExist('#notExisting', duration))
@@ -151,7 +151,7 @@ describe('waitFor',function() {
 
         it('should pass through an error from isVisible()', function() {
             var client = this.client;
-            restore = function() {client.addCommand('isVisible', require('../../lib/commands/isVisible'), true);}
+            var restore = function() {client.addCommand('isVisible', require('../../lib/commands/isVisible'), true);}
             this.client.addCommand('isVisible', function() {throw new Error("My error")}, true);
 
             return expect(this.client.waitForVisible('#notExisting', duration))

--- a/test/spec/waitFor.js
+++ b/test/spec/waitFor.js
@@ -17,6 +17,16 @@ describe('waitFor',function() {
             return this.client.waitForEnabled('.waitForValueEnabledReverse', duration, true).then(checkTime);
         });
 
+        it('should return with an error if the element never becomes visible', function() {
+            return expect(this.client.waitForEnabled('.waitForValueEnabledReverse', 10))
+            .to.be.rejectedWith('element (.waitForValueEnabledReverse) still not enabled after 10ms');
+        });
+
+        it('should pass through an error from isEnabled()', function() {
+            return expect(this.client.waitForEnabled('#notExisting', duration, true))
+            .to.be.rejectedWith("An element could not be located on the page using the given search parameters")
+        });
+
     });
 
     describe('Exist', function() {
@@ -29,6 +39,22 @@ describe('waitFor',function() {
 
         it('(reverse) should return w/o err after element was removed from the DOM', function() {
             return this.client.waitForExist('.goAway', duration, true).then(checkTime);
+        });
+
+        it('should return with an error if the element never exists', function() {
+            return expect(this.client.waitForExist('#notExisting', 10))
+            .to.be.rejectedWith('element (#notExisting) still not existing after 10ms');
+        });
+
+        it('should pass through an error from isExisting()', function() {
+            var client = this.client;
+            restore = function() {client.addCommand('isExisting', require('../../lib/commands/isExisting'), true);}
+            this.client.addCommand('isExisting', function() {throw new Error("My error")}, true);
+
+            return expect(this.client.waitForExist('#notExisting', duration))
+            .to.be.rejectedWith("My error")
+            .then(restore)
+            .catch(function(err) {restore(); throw err;});
         });
 
     });
@@ -45,6 +71,16 @@ describe('waitFor',function() {
             return this.client.waitForSelected('.option2', duration, true).then(checkTime);
         });
 
+        it('should return with an error if the element never becomes visible', function() {
+            return expect(this.client.waitForSelected('.option2', 10))
+            .to.be.rejectedWith('element (.option2) still not selected after 10ms');
+        });
+
+        it('should pass through an error from isSelected()', function() {
+            return expect(this.client.waitForSelected('#notExisting', duration, true))
+            .to.be.rejectedWith("An element could not be located on the page using the given search parameters")
+        });
+
     });
 
     describe('Text', function() {
@@ -57,6 +93,16 @@ describe('waitFor',function() {
 
         it('(reverse) should return w/o err after text/content element was removed', function() {
             return this.client.waitForText('.sometext', duration, true).then(checkTime);
+        });
+
+        it('should return with an error if the text never appears', function() {
+            return expect(this.client.waitForText('.sometext', 10))
+            .to.be.rejectedWith('element (.sometext) still without text after 10ms');
+        });
+
+        it('should pass through an error from getText()', function() {
+            return expect(this.client.waitForText('#notExisting', duration, true))
+            .to.be.rejectedWith("An element could not be located on the page using the given search parameters")
         });
 
     });
@@ -73,9 +119,20 @@ describe('waitFor',function() {
             return this.client.waitForValue('.waitForValueEnabled', duration, true).then(checkTime);
         });
 
+        it('should return with an error if the text never appears', function() {
+            return expect(this.client.waitForValue('.sometext', 10))
+            .to.be.rejectedWith('element (.sometext) still without a value after 10ms');
+        });
+
+        it('should pass through an error from getValue()', function() {
+            return expect(this.client.waitForValue('#notExisting', duration, true))
+            .to.be.rejectedWith("An element could not be located on the page using the given search parameters")
+        });
+
     });
 
     describe('Visible', function() {
+        var origIsVisible = null;
 
         beforeEach(h.setup());
 
@@ -85,6 +142,22 @@ describe('waitFor',function() {
 
         it('(reverse) should return w/o err after element left document bounderies', function() {
             return this.client.waitForVisible('.onMyWay', duration, true).then(checkTime);
+        });
+
+        it('should return with an error if the element never becomes visible', function() {
+            return expect(this.client.waitForVisible('#notExisting', 10))
+            .to.be.rejectedWith('element (#notExisting) still not visible after 10ms');
+        });
+
+        it('should pass through an error from isVisible()', function() {
+            var client = this.client;
+            restore = function() {client.addCommand('isVisible', require('../../lib/commands/isVisible'), true);}
+            this.client.addCommand('isVisible', function() {throw new Error("My error")}, true);
+
+            return expect(this.client.waitForVisible('#notExisting', duration))
+            .to.be.rejectedWith("My error")
+            .then(restore)
+            .catch(function(err) {restore(); throw err;});
         });
 
     });


### PR DESCRIPTION
Wondering if you're interested in taking a patch along these lines - same needs to be done for other `waitFor*()` functions if you are.

The case I'm trying to address here is, if you call `waitForVisible()`, and, say, there's an alert showing, then you'll get an "Unexpected alert open" error when `waitForVisible()` [calls `isVisible()`](https://github.com/webdriverio/webdriverio/blob/c02ae25adfd72c5fbec2901a458bd5083c950bc1/lib/commands/waitForVisible.js#L37), but this exception gets eaten and turned into an 'element still not visible...' error, which is a little misleading.

Is this a good way to fix this?  Better ideas?