### PR TITLE
fixed xunit report status attribute in the testcase tag

### DIFF
--- a/lib/reporter/xunit.js
+++ b/lib/reporter/xunit.js
@@ -270,7 +270,7 @@ XUnit.prototype.genTestsuite = function(tests) {
             time: test.time / 1000,
             id: test.id,
             file: test.file,
-            status: test.err ? 'failed' : 'passed',
+            status: Object.getOwnPropertyNames(test.err).length === 0 ? 'passed' : 'failed',
             classname: sanitizeCaps(self.stats.runner[test.pid].capabilities)
         }));
 


### PR DESCRIPTION
Small fix in the xunit reporter.  When writing the <code>testcase</code> tag, if there were no errors then <code>test.err</code> would be {}, which evaluates to <code>true</code> and ends up marking the status of all tests as 'failed'.

I haven't seen tests for the reporters, if I missed them please point me to them and I'll be glad to add a test.
