### PR TITLE
Remove undefined argument from after()

### DIFF
--- a/docs/guide/testrunner/configurationfile.md
+++ b/docs/guide/testrunner/configurationfile.md
@@ -201,7 +201,7 @@ exports.config = {
     //
     // Gets executed after all tests are done. You still have access to all global variables from
     // the test.
-    after: function() {
+    after: function(failures, pid) {
         console.log('finish up the tests');
     },
     //

--- a/examples/wdio.conf.js
+++ b/examples/wdio.conf.js
@@ -188,7 +188,7 @@ exports.config = {
     //
     // Gets executed after all tests are done. You still have access to all global variables from
     // the test.
-    after: function() {
+    after: function(failures, pid) {
         console.log('finish up the tests');
     },
     //

--- a/lib/helpers/wdio.conf.ejs
+++ b/lib/helpers/wdio.conf.ejs
@@ -185,7 +185,7 @@ exports.config = {
     //
     // Gets executed after all tests are done. You still have access to all global variables from
     // the test.
-    after: function() {
+    after: function(failures, pid) {
         // do something
     },
     //

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -192,7 +192,7 @@ process.on('message', function(m) {
                     pid: process.pid
                 });
 
-                return q(config.after(undefined, failures, process.pid));
+                return q(config.after(failures, process.pid));
             }).finally(function() {
                 process.exit(failures === 0 ? 0 : 1);
             });


### PR DESCRIPTION
I don't know if there was a reason behind this. Also, I added these arguments to generated and example configs.