### PR TITLE
Expose sessionId and capabilities to the after() hook

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -164,7 +164,7 @@ process.on('message', function(m) {
                 return global.browser.end();
             }).then(function(res) {
                 if(!config.updateJob || config.host.indexOf('saucelabs') === -1 || !res || !res.sessionId) {
-                    return;
+                    return res.sessionId;
                 }
 
                 /**
@@ -185,14 +185,14 @@ process.on('message', function(m) {
                         'custom-data': capabilities['custom-data']
                     }
                 });
-            }).finally(function() {
+            }).then(function(sessionId) {
                 process.send({
                     event: 'runner:end',
                     failures: failures,
                     pid: process.pid
                 });
 
-                return q(config.after(failures, process.pid));
+                return q(config.after(failures, sessionId, capabilities));
             }).finally(function() {
                 process.exit(failures === 0 ? 0 : 1);
             });


### PR DESCRIPTION
Ok, I will need a bit of help here.

1. Was `sessionId` already reachable to `after` somehow?
2. In which order should the arguments go?
3. Is there a way to expose it in both cases?

I needed `sessionId` for updating the job status in my service.

Once this either gets merged and released, or I find out about an existing way to reach `sessionId`, I can add a CrossBrowserTesting `wdio.config.js` to your examples. I finally mastered the crap out of it.