### PR TITLE
Preserve mocha `this` in testrunner-wrapped generators

### DIFF
--- a/examples/wdio/runner-specs/mocha.test.js
+++ b/examples/wdio/runner-specs/mocha.test.js
@@ -34,4 +34,10 @@ describe('webdriver.io page', function() {
 
     });
 
+    it('should be skippable (pending) from within a generator spec', function* () {
+        yield browser.pause(100);
+        this.skip();
+        throw new Error("this should not be reached");
+    });
+
 });

--- a/examples/wdio/runner-specs/mocha.test.js
+++ b/examples/wdio/runner-specs/mocha.test.js
@@ -34,6 +34,14 @@ describe('webdriver.io page', function() {
 
     });
 
+    it('should have mocha’s normal `this` context within a generator spec', function* () {
+        yield browser.pause(100);
+        assert(this);
+        assert(this.test);
+        assert(this.test.title);
+        assert(this.test.fullTitle());
+    });
+
     it('should be skippable (pending) from within a generator spec', function* () {
         yield browser.pause(100);
         this.skip();

--- a/lib/frameworks/mocha.js
+++ b/lib/frameworks/mocha.js
@@ -112,15 +112,11 @@ var runInGenerator = function (ui, fnName) {
         interfaceTestFnName = interfaces[ui][2];
 
     var runSpec = function(specTitle, specFn) {
-        return origFn.call(null, specTitle, function(done) {
-            co(specFn).then(done.bind(null, null), done.bind(null));
-        });
+        return origFn.call(null, specTitle, co.wrap(specFn));
     };
 
-    var runHook = function(specFn) {
-        return origFn.call(null, function(done) {
-            co(specFn).then(done.bind(null, null), done.bind(null));
-        });
+    var runHook = function(hookFn) {
+        return origFn.call(null, co.wrap(hookFn));
     };
 
     global[fnName] = function() {


### PR DESCRIPTION
Hi! Normally, mocha provides a `this` context to spec and hook functions, which lets you do things like `this.skip()` a test. This p.r. makes this context available to generator functions wrapped for mocha by the testrunner. As a small bonus, I think we’re able to dispense with the adapter between co and mocha’s async `done()` callback, since mocha natively “does the right thing” with promises returned from 0-ary specs/hooks.

Feedback welcome!