### PR TITLE
Resolving xUnit null value errors

### DIFF
--- a/lib/reporter/xunit.js
+++ b/lib/reporter/xunit.js
@@ -1,7 +1,6 @@
 /**
  * Module dependencies.
  */
-
 var util = require('util'),
     Base = require('./base'),
     fs = require('fs'),
@@ -164,7 +163,6 @@ XUnit.prototype.findParentSuite = function(title, suite) {
  * generate junit report
  */
 XUnit.prototype.genTestsuites = function(tests, pid) {
-
     var caps = this.stats.runner[pid].capabilities,
         options = this.options.reporterOptions,
         filename = 'WDIO.xunit.' + sanitizeCaps(caps) + '.' + pid + '.xml';
@@ -231,11 +229,9 @@ XUnit.prototype.printLogTags = function(data, tagName, type, iter) {
  * generate testsuites markup
  */
 XUnit.prototype.genTestsuite = function(tests) {
-
     var self = this;
 
     tests.forEach(function(test) {
-
         /**
          * write test suite
          */
@@ -260,7 +256,7 @@ XUnit.prototype.genTestsuite = function(tests) {
             self.write('</testsuite>');
             return;
         }
-
+        
         /**
          * write testcase
          */
@@ -270,7 +266,7 @@ XUnit.prototype.genTestsuite = function(tests) {
             time: test.time / 1000,
             id: test.id,
             file: test.file,
-            status: test.err && Object.getOwnPropertyNames(test.err).length === 0 ? 'passed' : 'failed',
+            status: !!test.err && Object.getOwnPropertyNames(test.err).length === 0 ? 'passed' : 'failed',
             classname: sanitizeCaps(self.stats.runner[test.pid].capabilities)
         }));
 
@@ -289,7 +285,7 @@ XUnit.prototype.genTestsuite = function(tests) {
         /**
          * print failure tags
          */
-        } else if(Object.getOwnPropertyNames(test.err).length > 0) {
+        } else if(!!test.err && Object.getOwnPropertyNames(test.err).length > 0) {
             var content = cdata((test.err.stack || '').slice(0, self.errorLogCharacterLimitation));
 
             self.indents++;
@@ -298,7 +294,6 @@ XUnit.prototype.genTestsuite = function(tests) {
                 message: escape(test.err.message)
             }, false, content));
             self.indents--;
-
         }
 
         /**
@@ -328,8 +323,6 @@ XUnit.prototype.genTestsuite = function(tests) {
 
         self.write('</testcase>');
     });
-
-
 };
 
 /**
@@ -364,7 +357,6 @@ function tag(name, attrs, close, content) {
 /**
  * Return cdata escaped CDATA `str`.
  */
-
 function cdata(str) {
     return '<![CDATA[' + str + ']]>';
 }


### PR DESCRIPTION
This resolves #817 by adding falsy value check for test.err.

Note: I did not see any unit tests for the reporters, so I wasn't sure where to put one to validate this reporter's functionality.