### PR TITLE
add waitUntil interval

### DIFF
--- a/lib/commands/waitUntil.js
+++ b/lib/commands/waitUntil.js
@@ -93,7 +93,7 @@ function waitUntilPrivate(condition, timeout, interval, starttime) {
 
 module.exports = function waitUntil(condition, timeout, interval) {
     /*!
-     * ensure that ms and interval are set properly
+     * ensure that timeout and interval are set properly
      */
     if (typeof timeout !== 'number') {
         timeout = this.options.waitforTimeout;

--- a/lib/commands/waitUntil.js
+++ b/lib/commands/waitUntil.js
@@ -27,7 +27,8 @@
  *
  *
  * @param {Function|Promise} condition  condition to wait on
- * @param {Number=}          ms         timeout in ms (default: 500)
+ * @param {Number=}          timeout    timeout in ms (default: 500)
+ * @param {Number=}          interval   interval between condition checks (default: 250)
  *
  * @uses utility/pause
  * @type utility
@@ -40,17 +41,7 @@ var q = require('q'),
         d.reject(new ErrorHandler.CommandError('Promise never resolved with an truthy value'));
     };
 
-module.exports = function waitUntil(condition, ms, starttime) {
-
-    starttime = starttime || new Date().getTime();
-
-    /*!
-     * ensure that ms is set properly
-     */
-    if (typeof ms !== 'number') {
-        ms = this.options.waitforTimeout;
-    }
-
+function waitUntilPrivate(condition, timeout, interval, starttime) {
     var self = this,
         defer = q.defer(),
         promise;
@@ -64,7 +55,7 @@ module.exports = function waitUntil(condition, ms, starttime) {
     }
 
     var now = new Date().getTime();
-    var timeLeft = ms - (now - starttime);
+    var timeLeft = timeout - (now - starttime);
     timeLeft = timeLeft < 0 ? 0 : timeLeft;
 
     if(!timeLeft) {
@@ -72,19 +63,19 @@ module.exports = function waitUntil(condition, ms, starttime) {
         return defer.promise;
     }
 
-    var timeout = setTimeout(function() {
+    var timeoutId = setTimeout(function() {
         reject(defer);
     }, timeLeft < 0 ? 0 : timeLeft);
 
     promise.then(function(res) {
-        clearTimeout(timeout);
+        clearTimeout(timeoutId);
 
         if(!res) {
             if(q.isPromiseAlike(condition)) {
                 defer.reject(new ErrorHandler.CommandError('Promise was fulfilled with a falsy value'));
             }
-
-            return defer.resolve(self.pause(250).waitUntil(condition, ms, starttime));
+            return defer.resolve(self.pause(interval)
+                .then(waitUntilPrivate.bind(self, condition, timeout, interval, starttime)));
         }
 
         defer.resolve(res);
@@ -98,4 +89,21 @@ module.exports = function waitUntil(condition, ms, starttime) {
 
     return defer.promise;
 
+}
+
+module.exports = function waitUntil(condition, timeout, interval) {
+    /*!
+     * ensure that ms and interval are set properly
+     */
+    if (typeof timeout !== 'number') {
+        timeout = this.options.waitforTimeout;
+    }
+
+    if (typeof interval !== 'number') {
+        interval = this.options.waitforInterval;
+    }
+
+    var starttime = new Date().getTime();
+
+    return waitUntilPrivate.call(this, condition, timeout, interval, starttime);
 };

--- a/lib/commands/waitUntil.js
+++ b/lib/commands/waitUntil.js
@@ -81,7 +81,7 @@ function waitUntilPrivate(condition, timeout, interval, starttime) {
         defer.resolve(res);
 
     }, function(err) {
-        clearTimeout(timeout);
+        clearTimeout(timeoutId);
 
         defer.reject(new ErrorHandler.CommandError('Promise was fulfilled but got rejected with the following reason: ' + err));
 

--- a/lib/webdriverio.js
+++ b/lib/webdriverio.js
@@ -31,6 +31,7 @@ module.exports = function WebdriverIO(args, modifier) {
     var options = merge({
         protocol: 'http',
         waitforTimeout: 500,
+        waitforInterval: 250,
         coloredLogs: true,
         logLevel: 'silent',
         baseUrl: null

--- a/test/spec/functional/waitUntil.js
+++ b/test/spec/functional/waitUntil.js
@@ -60,6 +60,34 @@ describe('waitUntil', function() {
         });
     });
 
+    it('should pass fast with a short waitfor interval', function() {
+        var defer = q.defer();
+
+        setTimeout(function() {
+            defer.resolve('foobar');
+        }, 50);
+
+        return this.client.waitUntil(function() {
+            return defer.promise;
+        }, 100, 20).then(function(res) {
+            res.should.be.equal('foobar');
+        });
+    });
+
+    it('should timeout with a long waitfor interval', function() {
+        var defer = q.defer();
+
+        setTimeout(function() {
+            defer.resolve('foobar');
+        }, 50);
+
+        return this.client.waitUntil(function() {
+            return defer.promise;
+        }, 100, 250).catch(function(err) {
+            err.message.should.match(/Promise never resolved with an truthy value/);
+        });
+    });
+
     it('should allow a promise condition', function() {
         var defer = q.defer();
 
@@ -69,6 +97,26 @@ describe('waitUntil', function() {
 
         return this.client.waitUntil(defer.promise, 1000).then(function(res) {
             res.should.be.equal('foobar');
+        });
+    });
+
+
+    it('should check a condition multiple times', function() {
+        var defer = q.defer(),
+            flag = false,
+            conditionCalledCount = 0,
+            testCondition = function () {
+                conditionCalledCount += 1;
+                return q(flag);
+            };
+
+        setTimeout(function() {
+            flag = 'foobar';
+        }, 50);
+
+        return this.client.waitUntil(testCondition, 100, 20).then(function(res) {
+            res.should.equal('foobar');
+            conditionCalledCount.should.equal(4);
         });
     });
 


### PR DESCRIPTION
Adds a configuration: `option.waitforInterval` and a parameter to `waitUntil` for setting the polling interval for `waitUntil`.

Resolves: https://github.com/webdriverio/webdriverio/issues/806
