### PR TITLE
Pass config object to runner, so that users can pass simple values between processes

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -78,7 +78,7 @@ class Launcher {
          * if it is an object run multiremote test
          */
         if (this.isMultiremote()) {
-            return this.startInstance(this.configParser.getSpecs(), caps)
+            return this.startInstance(this.configParser.getSpecs(), caps, config)
         }
 
         /**
@@ -104,7 +104,7 @@ class Launcher {
 
         let exitCode = await new Promise((resolve, reject) => {
             this.resolve = resolve
-            this.runSpecs()
+            this.runSpecs(config)
         })
 
         try {
@@ -118,7 +118,7 @@ class Launcher {
     /**
      * run multiple single remote tests
      */
-    runSpecs () {
+    runSpecs (config) {
         let specsLeft = 0
         let isRunning = false
 
@@ -127,7 +127,7 @@ class Launcher {
             specsLeft += specFiles
 
             for (let i = 0; i < capability.availableInstances && i < specFiles; i++) {
-                this.startInstance([capability.specs.pop()], cid)
+                this.startInstance([capability.specs.pop()], cid, config)
                 capability.availableInstances--
                 capability.runningInstances++
             }
@@ -141,7 +141,8 @@ class Launcher {
      * Start instance in a child process.
      * @param  {Object|Object[]} capabilities  desired capabilities of instance
      */
-    startInstance (specs, i) {
+    startInstance (specs, i, config) {
+
         let childProcess = child.fork(__dirname + '/runner.js', [], {
             cwd: process.cwd()
         })
@@ -156,6 +157,7 @@ class Launcher {
             cid: i,
             command: 'run',
             configFile: this.configFile,
+            config: config,
             argv: this.argv,
             specs: specs,
             isMultiremote: this.isMultiremote()

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -17,6 +17,7 @@ class Runner {
         this.configParser = new ConfigParser()
         this.configParser.addConfigFile(m.configFile)
         this.configParser.merge(m.argv)
+        this.configParser.merge(m.config)
 
         let config = this.configParser.getConfig()
         let capabilities = this.configParser.getCapabilities(m.cid)


### PR DESCRIPTION
I found that there were a couple of use cases where it'd be nice to be able to set up a dynamic variable in wdio.conf.js, and have it propagated to the child processes. For example, I'd like each test run to create a timestamped directory in which to save log files, screenshots, etc.

As a user, I'd expect to be able to export the path of my log directory in `onPrepare`, and to be able to use it in `before` and other defined commands. With this PR, I can do this:

wdio.conf.js
```
		onPrepare: function(config, capabilities) {
			config.outputDirs = utils.getOutputDirs();
		},
```

```
		const screenshotFile = `${browser.options.outputDirs.screenshots}/${Date.now()}-${message}.png`;
		browser.saveScreenshot(screenshotFile);
```