### PR TITLE
Added getUrl property

### DIFF
--- a/lib/commands/getUrl.js
+++ b/lib/commands/getUrl.js
@@ -1,0 +1,26 @@
+/**
+ *
+ * Get the url of current opened website.
+ *
+ * <example>
+    :getUrl.js
+    client
+        .url('http://webdriver.io')
+        .getUrl().then(function(url) {
+            console.log(url);
+            // outputs the following:
+            // "http://webdriver.io"
+        });
+ * </example>
+ *
+ * @returns {String} current page url
+ * @uses protocol/url
+ * @type property
+ *
+ */
+
+module.exports = function getUrl () {
+    return this.unify(this.url(), {
+        extractValue: true
+    });
+};

--- a/test/spec/getUrl.js
+++ b/test/spec/getUrl.js
@@ -1,0 +1,11 @@
+describe('getUrl', function() {
+
+    before(h.setup());
+
+    it('should return the url of the current webpage', function() {
+        return this.client.getUrl().then(function (url) {
+            url.should.be.exactly(conf.testPage.start);
+        });
+    });
+
+});


### PR DESCRIPTION
Added a getUrl property just like getTitle, to make the url() protocol work with chai promises when retreiving the current url:

    browser.getUrl().should.eventually.be.equal('http://some-url')