### PR TITLE
Update sauce labs job when host set to localhost for use with sauce connect.

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -163,7 +163,7 @@ process.on('message', function(m) {
                 failures = 1;
                 return global.browser.end();
             }).then(function(res) {
-                if(!config.updateJob || config.host.indexOf('saucelabs') === -1 || !res || !res.sessionId) {
+                if(!config.updateJob || !res || !res.sessionId) {
                     return res.sessionId;
                 }
 
@@ -184,6 +184,11 @@ process.on('message', function(m) {
                         'build': capabilities.build,
                         'custom-data': capabilities['custom-data']
                     }
+                }).catch(function() {
+                    // Ignore errors because they are likely caused by jobs
+                    // that aren't running on SauceLabs.
+                }).then(function() {
+                    return res.sessionId;
                 });
             }).then(function(sessionId) {
                 process.send({


### PR DESCRIPTION
Fixes #848. Sorry it took me so long to get to it!

Per discussion on the issue, I haven't added a test.

When a user is using sauce connect, they may set the host to localhost. The
check for saucelabs in the host name prevented these jobs from updating.

Per discussion on the issue, this throws away errors from the sauce labs api
because they will often be caused by tests that don't use sauce labs.

This commit also modifies this block of code to properly pass along the session
id after calling the sauce labs api. I noticed it wasn't working properly when testing
my fix. 