### PR TITLE
Add request timeout to init call

### DIFF
--- a/lib/protocol/init.js
+++ b/lib/protocol/init.js
@@ -16,11 +16,15 @@ var ErrorHandler = require('../utils/ErrorHandler.js'),
     packageDotJson = require('../../package.json'),
     merge = require('deepmerge');
 
-module.exports = function init (desiredCapabilities) {
+module.exports = function init (desiredCapabilities, timeout) {
     var commandOptions = {
         path: '/session',
         method: 'POST'
     };
+
+    if (typeof timeout === 'number' && timeout > 0) {
+        commandOptions.timeout = timeout;
+    }
 
     desiredCapabilities = desiredCapabilities || {};
 

--- a/lib/utils/RequestHandler.js
+++ b/lib/utils/RequestHandler.js
@@ -94,6 +94,10 @@ RequestHandler.prototype.createOptions = function(requestOptions, data) {
         });
     }
 
+    if (typeof requestOptions.timeout === 'number' && requestOptions.timeout > 0) {
+        newOptions.timeout = requestOptions.timeout;
+    }
+
     return newOptions;
 };
 


### PR DESCRIPTION
Call to init sometimes hangs forever in my testing environment. Wouldn't it be useful to be able to set request timeout? 