### PR TITLE
Added selectByName action and fixed a bug

### DIFF
--- a/lib/commands/selectByName.js
+++ b/lib/commands/selectByName.js
@@ -1,0 +1,78 @@
+/**
+ *
+ * Select option with a specific name.
+ *
+ * <example>
+    :example.html
+    <select id="selectbox">
+        <option name="someName0" value="someValue0">uno</option>
+        <option name="someName1" value="someValue1">dos</option>
+        <option name="someName2" value="someValue2">tres</option>
+        <option name="someName3" value="someValue3">cuatro</option>
+        <option name="someName4" value="someValue4">cinco</option>
+        <option name="someName5" value="someValue5">seis</option>
+    </select>
+
+    :selectByName.js
+    client
+        .getValue('#selectbox').then(function(value) {
+            console.log(value);
+            // returns "someValue0"
+        })
+        .selectByName('#selectbox', 'someName3')
+        .getValue('#selectbox').then(function(value) {
+            console.log(value);
+            // returns "someValue3"
+        });
+ * </example>
+ *
+ * @param {String} selectElem select element that contains the options
+ * @param {String} name      name of option element to get selected
+ *
+ * @uses protocol/element, protocol/elementIdClick, protocol/elementIdElement
+ * @type action
+ *
+ */
+
+var ErrorHandler = require('../utils/ErrorHandler.js');
+var staleElementRetry = require('../helpers/staleElementRetry');
+
+module.exports = function selectByName (selectElem, name) {
+
+    /**
+     * convert name into string
+     */
+    if(typeof name === 'number') {
+        name = name.toString();
+    }
+
+    /*!
+     * parameter check
+     */
+    if(typeof selectElem !== 'string' || typeof name !== 'string') {
+        throw new ErrorHandler.CommandError('number or type of arguments don\'t agree with selectByName command');
+    }
+
+    /**
+     * get options element by xpath
+     */
+    return this.element(selectElem).then(function(res) {
+
+        /**
+         * find option elem using xpath
+         */
+        var normalized = '[normalize-space(@name) = "' + name.trim() + '"]';
+        return this.elementIdElement(res.value.ELEMENT, './option' + normalized + '|./optgroup/option' + normalized);
+
+    }).then(function(res) {
+
+        /**
+         * select option
+         */
+        return this.elementIdClick(res.value.ELEMENT);
+
+    })
+    .catch(staleElementRetry.bind(this, 'selectByName', arguments));
+
+};
+

--- a/lib/commands/selectByVisibleText.js
+++ b/lib/commands/selectByVisibleText.js
@@ -54,7 +54,13 @@ module.exports = function selectByVisibleText (selectElem, text) {
         /**
          * find option elem using xpath
          */
-        var normalized = '[normalize-space(.) = "' + text.trim() + '"]';
+        if(/"/.test(text)) {
+            var formatted = 'concat("' + text.trim().split('"').join('", \'"\', "') + '")'; // escape quotes
+        } else {
+            var formatted = '"' + text.trim() + '"';
+        }
+
+        var normalized = '[normalize-space(.) = ' + formatted + ']';
         return this.elementIdElement(res.value.ELEMENT, './option' + normalized + '|./optgroup/option' + normalized);
 
     }).then(function(res) {

--- a/test/site/www/index.html
+++ b/test/site/www/index.html
@@ -73,6 +73,12 @@
                 <option value="someValue5">cinco</option>
                 <option value="someValue6">seis</option>
             </optgroup>
+            <optgroup>
+                <option name="someName7" value="someValue7">"siete"</option>
+                <option name="someName8" value="someValue8">ocho "huit" (otto)</option>
+                <option name="   someName9   " value="someValue9">nu"eve</option>
+                <option name="someName10" value="someValue10">diez"</option>
+            </optgroup>
         </select>
         <hr>
         <input type="search" class="searchinput" name="searchinput" data-foundBy="name">

--- a/test/spec/selectBy.js
+++ b/test/spec/selectBy.js
@@ -23,6 +23,30 @@ describe('selectBy', function() {
             });
         });
 
+        it('should find element with quotes around the text', function() {
+             return this.client.selectByVisibleText('#selectTest', '"siete"').getValue('#selectTest').then(function (value) {
+                value.should.be.exactly('someValue7');
+            });
+        });
+
+        it('should find element with quotes in the text', function() {
+            return this.client.selectByVisibleText('#selectTest', 'ocho "huit" (otto)').getValue('#selectTest').then(function (value) {
+                value.should.be.exactly('someValue8');
+            });
+        });
+
+        it('should find element with a quote in the text', function() {
+            return this.client.selectByVisibleText('#selectTest', 'nu"eve').getValue('#selectTest').then(function (value) {
+                value.should.be.exactly('someValue9');
+            });
+        });
+
+        it('should find element with a quote at the end of the text', function() {
+            return this.client.selectByVisibleText('#selectTest', 'diez"').getValue('#selectTest').then(function (value) {
+                value.should.be.exactly('someValue10');
+            });
+        });
+
     });
 
     describe('Index', function() {
@@ -42,6 +66,28 @@ describe('selectBy', function() {
         it('should throw error if index is higher than number of options', function() {
             return this.client.selectByIndex('#selectTest', 99).catch(function(err) {
                 assert.ifError(!!!err);
+            });
+        });
+
+    });
+
+    describe('Name', function() {
+
+        it('should find element without special conditions', function() {
+            return this.client.selectByName('#selectTest',  'someName7').getValue('#selectTest').then(function (value) {
+                value.should.be.exactly('someValue7');
+            });
+        });
+
+        it('should find element with spaces before and after the name', function() {
+            return this.client.selectByName('#selectTest',  'someName9').getValue('#selectTest').then(function (value) {
+                value.should.be.exactly('someValue9');
+            });
+        });
+
+        it('should find element with spaces before and after the name parameter', function() {
+            return this.client.selectByName('#selectTest', '    someName8    ').getValue('#selectTest').then(function (value) {
+                value.should.be.exactly('someValue8');
             });
         });
 


### PR DESCRIPTION
Fixed a bug where `selectByVisibleText` did not properly escape quotes.

The bug is only specific to `selectByVisibleText` because element [attributes](http://www.w3.org/TR/html401/intro/sgmltut.html#h-3.2.2) (such as value or name) cannot have quotes inside them by default:

> The attribute value may only contain letters (a-z and A-Z), digits (0-9), hyphens (ASCII decimal 45), periods (ASCII decimal 46), underscores (ASCII decimal 95), and colons (ASCII decimal 58).

The only way to solve this issue in a satisfactory way is to use the Xpath [concat](http://www.w3.org/TR/xpath/#function-concat) function. A useful reference can be found [here](http://kushalm.com/the-perils-of-xpath-expressions-specifically-escaping-quotes).

Also added `selectByName` so that `option` elements can be selected by their `name` attribute.
