### PR TITLE
emit test:end in Jasmine

### DIFF
--- a/lib/frameworks/jasmine.js
+++ b/lib/frameworks/jasmine.js
@@ -28,6 +28,7 @@ JasmineReporter.prototype.specDone = function(test) {
     test.duration = new Date() - this._testStart;
     this.emit(e, test);
     this._failedCount += test.status === 'failed' ? 1 : 0;
+    this.emit('test:end', test);
 };
 
 JasmineReporter.prototype.suiteDone = function(suite) {


### PR DESCRIPTION
Hi, the "test:end" event was not emitted when using Jasmine framework