### PR TITLE
Cli enhancement

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -82,11 +82,15 @@ module.exports = function (grunt) {
             }
         },
         copy: {
-            main: {
+            packagejson: {
                 src: 'package.json',
-                dest: 'build/',
+                dest: 'build/'
             },
-        },
+            ejstemplate: {
+                src: 'lib/helpers/wdio.conf.ejs',
+                dest: 'build/'
+            }
+        }
     })
 
     require('load-grunt-tasks')(grunt)

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -202,7 +202,8 @@ WDIO Configuration Helper
         type: 'confirm',
         name: 'installReporter',
         message: 'Shall I install the reporter library for you?',
-        default: true
+        default: true,
+        when: (answers) => answers.reporter.length > 0
     }, {
         type: 'checkbox',
         name: 'services',

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -92,6 +92,19 @@ if (argv.version) {
     process.exit(0)
 }
 
+/**
+ * use wdio.conf.js default file name if no config was specified
+ * otherwise run config sequenz
+ */
+let configFile = argv._[0]
+if (!configFile) {
+    if (fs.existsSync('./wdio.conf.js')) {
+        configFile = './wdio.conf.js'
+    } else {
+        argv._[0] = 'config'
+    }
+}
+
 let configMode = false
 if (argv._[0] === 'config') {
     configMode = true
@@ -244,13 +257,13 @@ WDIO Configuration Helper
         }
 
         if (packagesToInstall.length > 0) {
-            console.log('Installing wdio packages:')
+            console.log('\nInstalling wdio packages:')
             return npmInstallPackage(packagesToInstall, { saveDev: true }, (err) => {
                 if (err) {
                     throw err
                 }
 
-                console.log('Packages installed successfully, creating configuration file...')
+                console.log('\nPackages installed successfully, creating configuration file...')
                 renderConfigurationFile(answers)
             })
         }
@@ -308,14 +321,6 @@ if (argv.mochaOpts) {
     }
     if (argv.mochaOpts.require) {
         argv.mochaOpts.require = argv.mochaOpts.require.split(',')
-    }
-}
-
-// Use default configuration, if it exists.
-let configFile = argv._[0]
-if (!configFile) {
-    if (fs.existsSync('./wdio.conf.js')) {
-        configFile = './wdio.conf.js'
     }
 }
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -3,11 +3,31 @@
 import path from 'path'
 import fs from 'fs'
 import ejs from 'ejs'
+import npmInstallPackage from 'npm-install-package'
 import inquirer from 'inquirer'
 import optimist from 'optimist'
 
 import Launcher from './launcher'
 import pkg from '../package.json'
+
+/**
+ * 💌 Dear contributors 💌
+ * ========================================================================
+ * If you are awesome and have created a new reporter, service or framework
+ * adaption feel free to add it to this list and make a PR so people know
+ * that your add-on is available and supported. Thanks, you 🚀!
+ * ========================================================================
+ */
+const SUPPORTED_FRAMEWORKS = ['mocha', 'jasmine']
+const SUPPORTED_REPORTER = [
+    ' dot - https://github.com/webdriverio/wdio-dot-reporter',
+    ' junit - https://github.com/webdriverio/wdio-junit-reporter',
+    ' allure - https://github.com/webdriverio/wdio-allure-reporter'
+]
+const SUPPORTED_SERVICES = [
+    ' sauce - https://github.com/webdriverio/wdio-sauce-service',
+    ' selenium-standalone - https://github.com/webdriverio/wdio-selenium-standalone-service'
+]
 
 const VERSION = pkg.version
 const ALLOWED_ARGV = ['host', 'port', 'path', 'user', 'key', 'updateJob', 'logLevel', 'coloredLogs', 'screenshotPath',
@@ -72,7 +92,9 @@ if (argv.version) {
     process.exit(0)
 }
 
+let configMode = false
 if (argv._[0] === 'config') {
+    configMode = true
     console.log(`
 =========================
 WDIO Configuration Helper
@@ -92,77 +114,100 @@ WDIO Configuration Helper
         type: 'input',
         name: 'host',
         message: 'What is the host address of that cloud service?',
-        when: answers => answers.backend.indexOf('different service') > -1
+        when: (answers) => answers.backend.indexOf('different service') > -1
     }, {
         type: 'input',
         name: 'port',
         message: 'What is the port on which that service is running?',
         default: '80',
-        when: answers => answers.backend.indexOf('different service') > -1
+        when: (answers) => answers.backend.indexOf('different service') > -1
     }, {
         type: 'input',
         name: 'env_user',
-        message: 'Environment letiable for username',
+        message: 'Environment variable for username',
         default: 'SAUCE_USERNAME',
-        when: answers => answers.backend.indexOf('In the cloud') > -1
+        when: (answers) => answers.backend.indexOf('In the cloud') > -1
     }, {
         type: 'input',
         name: 'env_key',
-        message: 'Environment letiable for access key',
+        message: 'Environment variable for access key',
         default: 'SAUCE_ACCESS_KEY',
-        when: answers => answers.backend.indexOf('In the cloud') > -1
+        when: (answers) => answers.backend.indexOf('In the cloud') > -1
     }, {
         type: 'input',
         name: 'host',
         message: 'What is the IP or URI to your Selenium standalone server?',
         default: '0.0.0.0',
-        when: answers => answers.backend.indexOf('own Selenium cloud') > -1
+        when: (answers) => answers.backend.indexOf('own Selenium cloud') > -1
     }, {
         type: 'input',
         name: 'port',
         message: 'What is the port which your Selenium standalone server is running on?',
         default: '4444',
-        when: answers => answers.backend.indexOf('own Selenium cloud') > -1
+        when: (answers) => answers.backend.indexOf('own Selenium cloud') > -1
     }, {
         type: 'input',
         name: 'path',
         message: 'What is the path to your Selenium standalone server?',
         default: '/wd/hub',
-        when: answers => answers.backend.indexOf('own Selenium cloud') > -1
+        when: (answers) => answers.backend.indexOf('own Selenium cloud') > -1
     }, {
         type: 'list',
         name: 'framework',
         message: 'Which framework do you want to use?',
-        choices: ['mocha', 'jasmine', 'cucumber']
+        choices: SUPPORTED_FRAMEWORKS
+    }, {
+        type: 'confirm',
+        name: 'installFramework',
+        message: 'Shall I install the framework adapter for you?',
+        default: true
     }, {
         type: 'input',
         name: 'specs',
         message: 'Where are your test specs located?',
         default: './test/specs/**/*.js',
-        when: answers => answers.framework.match(/(mocha|jasmine)/)
+        when: (answers) => answers.framework.match(/(mocha|jasmine)/)
     }, {
         type: 'input',
         name: 'specs',
         message: 'Where are your feature files located?',
         default: './features/**/*.feature',
-        when: answers => answers.framework === 'cucumber'
+        when: (answers) => answers.framework === 'cucumber'
     }, {
         type: 'input',
         name: 'stepDefinitions',
         message: 'Where are your step definitions located?',
         default: './features/step-definitions/**/*.js',
-        when: answers => answers.framework === 'cucumber'
+        when: (answers) => answers.framework === 'cucumber'
     }, {
-        type: 'list',
+        type: 'checkbox',
         name: 'reporter',
-        message: 'Which reporter do you want to use? (see http://webdriver.io/guide/testrunner/reporters.html)',
-        choices: ['dot', 'spec', 'xunit']
+        message: 'Which reporter do you want to use?',
+        choices: SUPPORTED_REPORTER,
+        filter: (reporters) => reporters.map((reporter) => `wdio-${reporter.split(/\-/)[0].trim()}-reporter`)
+    }, {
+        type: 'confirm',
+        name: 'installReporter',
+        message: 'Shall I install the reporter library for you?',
+        default: true
+    }, {
+        type: 'checkbox',
+        name: 'services',
+        message: 'Do you want to add a service to your test setup?',
+        choices: SUPPORTED_SERVICES,
+        filter: (services) => services.map((service) => `wdio-${service.split(/\-/)[0].trim()}-service`)
+    }, {
+        type: 'confirm',
+        name: 'installServices',
+        message: 'Shall I install the services for you?',
+        default: true,
+        when: (answers) => answers.services.length > 0
     }, {
         type: 'input',
         name: 'outputDir',
         message: 'In which directory should the xunit reports get stored?',
         default: './',
-        when: answers => answers.reporter === 'xunit'
+        when: (answers) => answers.reporter === 'xunit'
     }, {
         type: 'list',
         name: 'logLevel',
@@ -187,20 +232,46 @@ WDIO Configuration Helper
         message: 'What is the base url?',
         default: 'http://localhost'
     }], (answers) => {
-        let tpl = fs.readFileSync(__dirname + '/helpers/wdio.conf.ejs', 'utf8')
-        let renderedTpl = ejs.render(tpl, {
-            answers: answers
-        })
+        let packagesToInstall = []
+        if (answers.installFramework) {
+            packagesToInstall.push(`wdio-${answers.framework}-framework`)
+        }
+        if (answers.installReporter) {
+            packagesToInstall = packagesToInstall.concat(answers.reporter)
+        }
+        if (answers.installServices) {
+            packagesToInstall = packagesToInstall.concat(answers.services)
+        }
 
-        fs.writeFileSync(path.join(process.cwd(), 'wdio.conf.js'), renderedTpl)
-        console.log(`
+        if (packagesToInstall.length > 0) {
+            console.log('Installing wdio packages:')
+            return npmInstallPackage(packagesToInstall, { saveDev: true }, (err) => {
+                if (err) {
+                    throw err
+                }
+
+                console.log('Packages installed successfully, creating configuration file...')
+                renderConfigurationFile(answers)
+            })
+        }
+
+        renderConfigurationFile(answers)
+        process.exit(0)
+    })
+}
+
+function renderConfigurationFile (answers) {
+    let tpl = fs.readFileSync(__dirname + '/helpers/wdio.conf.ejs', 'utf8')
+    let renderedTpl = ejs.render(tpl, {
+        answers: answers
+    })
+    fs.writeFileSync(path.join(process.cwd(), 'wdio.conf.js'), renderedTpl)
+    console.log(`
 Configuration file was created successfully!
 To run your tests, execute:
 
-    $ wdio wdio.conf.js
+$ wdio wdio.conf.js
 `)
-        process.exit(0)
-    })
 }
 
 /**
@@ -255,7 +326,12 @@ for (let key of ALLOWED_ARGV) {
     }
 }
 
-let launcher = new Launcher(configFile, args)
-launcher.run().then(
-    () => process.exit(),
-    (e) => process.nextTick(() => { throw e }))
+/**
+ * run launch sequenz if config command wasn't called
+ */
+if (!configMode) {
+    let launcher = new Launcher(configFile, args)
+    launcher.run().then(
+        () => process.exit(),
+        (e) => process.nextTick(() => { throw e }))
+}

--- a/lib/helpers/wdio.conf.ejs
+++ b/lib/helpers/wdio.conf.ejs
@@ -109,9 +109,10 @@ exports.config = {
     // Services take over a specfic job you don't want to take care of. They enhance
     // your test setup with almost no self effort. Unlike plugins they don't add new
     // commands but hook themself up into the test process.
-    <% if(answers.reporter.length) {
+    <% if(answers.services.length) {
     %>services: ['<%= answers.services.join("','") %>'],
-    <% } %>//
+    <% } else {
+    %>// services: [],<% } %>//
     // Framework you want to run your specs with.
     // The following are supported: mocha, jasmine and cucumber
     // see also: http://webdriver.io/guide/testrunner/frameworks.html
@@ -128,7 +129,9 @@ exports.config = {
     // see also: http://webdriver.io/guide/testrunner/reporters.html
     <% if(answers.reporter.length) {
     %>reporter: ['<%= answers.reporter.join("','") %>'],
-    <% }
+    <% } else {
+    %>// reporter: [],<%
+    }
     if(answers.outputDir) { %>//
     // Some reporter require additional information which should get defined here
     reporterOptions: {

--- a/lib/helpers/wdio.conf.ejs
+++ b/lib/helpers/wdio.conf.ejs
@@ -1,5 +1,5 @@
 exports.config = {
-    <% if(answers.host && answers.port) { %>
+    <% if(answers.host && answers.port) { %>//
     // =====================
     // Server Configurations
     // =====================
@@ -109,8 +109,9 @@ exports.config = {
     // Services take over a specfic job you don't want to take care of. They enhance
     // your test setup with almost no self effort. Unlike plugins they don't add new
     // commands but hook themself up into the test process.
-    services: '<%= answers.services %>',
-    //
+    <% if(answers.reporter.length) {
+    %>services: ['<%= answers.services.join("','") %>'],
+    <% } %>//
     // Framework you want to run your specs with.
     // The following are supported: mocha, jasmine and cucumber
     // see also: http://webdriver.io/guide/testrunner/frameworks.html
@@ -125,9 +126,10 @@ exports.config = {
     // Test reporter for stdout.
     // The following are supported: dot (default), spec and xunit
     // see also: http://webdriver.io/guide/testrunner/reporters.html
-    reporter: <%= answers.reporter %>,
-    <% if(answers.outputDir) { %>
-    //
+    <% if(answers.reporter.length) {
+    %>reporter: ['<%= answers.reporter.join("','") %>'],
+    <% }
+    if(answers.outputDir) { %>//
     // Some reporter require additional information which should get defined here
     reporterOptions: {
         //
@@ -142,8 +144,7 @@ exports.config = {
     // See the full list at http://mochajs.org/
     mochaOpts: {
         ui: 'bdd'
-    },
-    <% }
+    },<% }
     if(answers.framework === 'jasmine') { %>
     //
     // Options to be passed to Jasmine.
@@ -231,4 +232,4 @@ exports.config = {
     // possible to defer the end of the process using a promise.
     // onComplete: function(exitCode) {
     // }
-};
+}

--- a/lib/helpers/wdio.conf.ejs
+++ b/lib/helpers/wdio.conf.ejs
@@ -105,6 +105,12 @@ exports.config = {
     //     browserevent: {}
     // },
     //
+    // Test runner services
+    // Services take over a specfic job you don't want to take care of. They enhance
+    // your test setup with almost no self effort. Unlike plugins they don't add new
+    // commands but hook themself up into the test process.
+    services: '<%= answers.services %>',
+    //
     // Framework you want to run your specs with.
     // The following are supported: mocha, jasmine and cucumber
     // see also: http://webdriver.io/guide/testrunner/frameworks.html
@@ -119,7 +125,7 @@ exports.config = {
     // Test reporter for stdout.
     // The following are supported: dot (default), spec and xunit
     // see also: http://webdriver.io/guide/testrunner/reporters.html
-    reporter: '<%= answers.reporter %>',
+    reporter: <%= answers.reporter %>,
     <% if(answers.outputDir) { %>
     //
     // Some reporter require additional information which should get defined here

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "ejs": "^2.3.1",
     "glob": "^5.0.10",
     "inquirer": "^0.8.5",
+    "npm-install-package": "^1.0.2",
     "optimist": "^0.6.1",
     "q": "~1.3.0",
     "request": "2.49.0",
@@ -71,7 +72,10 @@
     "load-grunt-tasks": "^3.2.0",
     "mocha": "^2.2.4",
     "saucelabs": "^1.0.1",
-    "should": "^6.0.1"
+    "should": "^6.0.1",
+    "wdio-dot-reporter": "0.0.4",
+    "wdio-mocha-framework": "^0.2.1",
+    "wdio-sauce-service": "0.0.1"
   },
   "tags": [
     "web",

--- a/package.json
+++ b/package.json
@@ -72,10 +72,7 @@
     "load-grunt-tasks": "^3.2.0",
     "mocha": "^2.2.4",
     "saucelabs": "^1.0.1",
-    "should": "^6.0.1",
-    "wdio-dot-reporter": "0.0.4",
-    "wdio-mocha-framework": "^0.2.1",
-    "wdio-sauce-service": "0.0.1"
+    "should": "^6.0.1"
   },
   "tags": [
     "web",


### PR DESCRIPTION
As we split up reporter and services from the main package it gets even more confusing when setting up WebdriverIO. The cli config interface should make this setup super easy. Therefor I did some tweaks in order to allow people to choose approved frameworks, services and reporters and give them the opportunity to install them right away. Example:

![wdioconfig](https://cloud.githubusercontent.com/assets/731337/11597597/ee5074a4-9abc-11e5-807e-f9295d6d3943.gif)
