### PR TITLE
Fix rendering of session param docs

### DIFF
--- a/lib/protocol/session.js
+++ b/lib/protocol/session.js
@@ -12,7 +12,7 @@
     client.session('delete');
  * </example>
  *
- * @param {String=} doWhat  session operation (`GET`*|`delete`) *default
+ * @param {String=} [doWhat=GET]  session operation (`GET`|`delete`)
  *
  * @see  https://code.google.com/p/selenium/wiki/JsonWireProtocol#/session/:sessionId
  * @type protocol


### PR DESCRIPTION
The parameter rendering for [the `session` docs is misformatted](http://webdriver.io/api/protocol/session.html):
![image](https://cloud.githubusercontent.com/assets/706039/11633975/b32bb82a-9cd3-11e5-9c04-93bc61238b29.png)

I haven't tested this locally; just went off of what the JSDoc spec mentions for [default params](http://usejsdoc.org/tags-param.html#optional-parameters-and-default-values).