### PR TITLE
Accept custom reporter as constructor

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -47,13 +47,18 @@ class Launcher {
             return reporter
         }
 
-        for (let reporterType of config.reporter) {
-            try {
-                let Reporter = require(`wdio-${reporterType}-reporter`)
-                reporter.add(new Reporter(reporter, config))
-            } catch (e) {
-                throw new Error(`reporter "wdio-${reporterType}-reporter" is not installed. Error: ${e.stack}`)
+        for (let Reporter of config.reporter) {
+            if (typeof Reporter === 'string') {
+                try {
+                    Reporter = require(`wdio-${Reporter}-reporter`)
+                } catch (e) {
+                    throw new Error(`reporter "wdio-${Reporter}-reporter" is not installed. Error: ${e.stack}`)
+                }
             }
+            if (typeof Reporter !== 'function') {
+                throw new Error(`reporter option must be either string or function, but got: ${Reporter}`)
+            }
+            reporter.add(new Reporter(reporter, config))
         }
 
         return reporter


### PR DESCRIPTION
Example with the custom reporter doesn't work in the branch `4.0`.

I am going to use it to test my Allure integration with Webdriver.io, so it is matters for me.

So, I've fixed it.