### PR TITLE
strict array type checking removed

### DIFF
--- a/lib/protocol/elementIdValue.js
+++ b/lib/protocol/elementIdValue.js
@@ -36,7 +36,7 @@ module.exports = function elementIdValue (id, value) {
         // replace key with corresponding unicode character
         key = checkUnicode(value);
 
-    } else if(value instanceof Array) {
+    } else if(value.forEach) {
 
         value.forEach(function(charSet) {
             key = key.concat(checkUnicode(charSet));

--- a/lib/protocol/keys.js
+++ b/lib/protocol/keys.js
@@ -31,7 +31,8 @@ module.exports = function keys (value) {
         // replace key with corresponding unicode character
         key = checkUnicode(value);
 
-    } else if(value instanceof Array) {
+    }
+    else if(value.forEach) {
 
         value.forEach(function(charSet) {
             key = key.concat(checkUnicode(charSet));


### PR DESCRIPTION
I am using arguments and since arguments are not arrays it fails. 