### PR TITLE
Remove docs on optional selector

### DIFF
--- a/lib/commands/moveToObject.js
+++ b/lib/commands/moveToObject.js
@@ -1,7 +1,6 @@
 /**
  *
- * Move the mouse by an offset of the specificed element. If no element is specified,
- * the move is relative to the current mouse cursor. If an element is provided but no
+ * Move the mouse by an offset of the specificed element. If an element is provided but no
  * offset, the mouse will be moved to the center of the element. If the element is not
  * visible, it will be scrolled into view.
  *


### PR DESCRIPTION
`moveToObject` requires a selector to work, so getting rid of the documentation that says otherwise.