### PR TITLE
How to contribute documentation changes, a few examples added

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,13 @@
-### We love pull requests. Here's a quick guide:
+# Contributing
+
+## Code
+
+We love pull requests. Here's a quick guide:
 
 1. Fork the repo.
 
 2. Run the tests. We only take pull requests with passing tests, and it's great
-to know that you have a clean state
+to know that you have a clean state.
 
 3. Add a test for your change. Only refactoring and documentation changes
 require no new tests. If you are adding functionality or fixing a bug, we need
@@ -16,11 +20,11 @@ a test!
 ### How to run tests
 
 1. Download the latest Selenium [standalone server](http://selenium-release.storage.googleapis.com/index.html)
-   and run it via
+    and run it via
 
-   ```sh
-   $ java -jar selenium-server-standalone-2.41.0.jar
-   ```
+    ```sh
+    $ java -jar selenium-server-standalone-2.41.0.jar
+    ```
 
 2. Make sure you have all the dependencies installed
 
@@ -28,43 +32,43 @@ a test!
    $ npm install
    ```
 
-   also all Bower packages required by our testpage
+also all Bower packages required by our testpage
 
-   ```sh
-   $ cd test/site/www && bower install && cd ../../..
-   ```
+    ```sh
+    $ cd test/site/www && bower install && cd ../../..
+    ```
 
-3. Start a local server that delivers our test page to the browser. We recommend to
-   use [http-server](https://www.npmjs.org/package/http-server)
+3. Start a local server that delivers our test page to the browser. We recommend using 
+[http-server](https://www.npmjs.org/package/http-server)
 
-   ```sh
-   $ cd /root/dir/of/webdriverio
-   $ http-server -p 8080
-   ```
+    ```sh
+    $ cd /root/dir/of/webdriverio
+    $ http-server -p 8080
+    ```
 
 4. Depending on your feature/fix/patch make sure it gets covered by a test.
-   To ensure that you can run one of the following commands:
+    To ensure that you can run one of the following commands:
 
-   ```sh
-   # if your patch is browser specific
-   # (e.g. upload files)
-   npm run-script test-desktop
+    ```sh
+    # if your patch is browser specific
+    # (e.g. upload files)
+    npm run-script test-desktop
 
-   # if your patch is mobile specific
-   # (e.g. flick or swipe tests)
-   npm run-script test-mobile
+    # if your patch is mobile specific
+    # (e.g. flick or swipe tests)
+    npm run-script test-mobile
 
-   # if your patch is functional and hasn't something to do with Selenium
-   # (e.g. library specific fixes like changes within EventHandler.js)
-   npm run-script test-functional
-   ```
+    # if your patch is functional and hasn't something to do with Selenium
+    # (e.g. library specific fixes like changes within EventHandler.js)
+    npm run-script test-functional
+    ```
 
-   While developing you can run tests on specific specs by passing another
-   environment variable `_SPEC`, e.g.
+    While developing you can run tests on specific specs by passing another
+    environment variable `_SPEC`, e.g.
 
-   ```sh
-   $ _SPEC=test/spec/YOURSPEC.js npm run-script test-desktop
-   ```
+    ```sh
+    $ _SPEC=test/spec/YOURSPEC.js npm run-script test-desktop
+    ```
 
 ### Syntax rules
 
@@ -81,3 +85,75 @@ Please pay attention on the following syntax rules:
 * Follow the conventions you see used in the source already.
 
 And in case we didn't emphasize it enough: we love tests!
+
+------------------------------------------
+
+## Documentation
+
+For convenience and ease of maintenance, our project's documentation pages are generated partly from markdown files in 
+the `docs/` directory and partly from comments in the source code.
+
+### Markdown Pages
+
+Pages in the `docs/` directory follow a common markdown syntax.  In lieu of detailed definitions of this syntax, it's 
+easiest to imitate the format in the existing pages.  Some page attributes can be defined in a YAML block at the 
+beginning of each document, terminated with three or more dashes (i.e. a horizontal line in markdown), for example:
+
+```
+layout: guide
+name: guide
+title: WebdriverIO - Developer Guide
+---
+```
+
+### API Methods
+
+The source code for various API methods is located in the `lib/` folder.  To find the source of any API method listed 
+on http://webdriver.io/api.html, you can find the corresponding `.js` file.  For example the 
+[dragAndDrop](http://webdriver.io/api/action/dragAndDrop.html) method is defined in the `lib/commands/dragAndDrop.js` 
+file.  The documentation for each method is generated from documentation blocks in each file.  The syntax relies on 
+block-level comments (e.g. `/** multi-line comment */`, comment-tags for the parameters 
+(e.g. `@param {String=} windowHandle the window to change focus to`), and code samples contained in example tags, 
+(e.g. `<example>...</example>`).  As with the markdown pages, it's easiest to imitate the format of the existing 
+documents.  For example:
+
+    ```
+    /**
+     *
+     * Get tag name of a DOM-element found by given selector.
+     *
+     * <example>
+        :index.html
+        <div id="elem">Lorem ipsum</div>
+    
+        :getTagName.js
+        client.getTagName('#elem').then(function(tagName) {
+            console.log(tagName); // outputs: "div"
+        });
+     * </example>
+     *
+     * @param   {String}           selector   element with requested tag name
+     * @returns {String|String[]}             the element's tag name, as a lowercase string
+     *
+     * @uses protocol/elements, protocol/elementIdName
+     * @type property
+     *
+     */
+    ```
+
+Here's a quick cheat-sheet:
+
+1. **Description:** The first few lines of the comment are typically used to provide a concise description of the method.
+
+2. **Examples:** The `<example>` block omits asterisks (`*`) -- see above example.
+
+3. **File Names:** For examples that reference multiple files, infer the file name in the `<example>` block by prefixing 
+its name with a colon.  See `:index.html` and `:getTagName.js` in the above example.
+
+4. **Parameters:** Parameters should type-hint using curly braces, e.g. `{String}` or `{Number}` and may include default 
+arguments following and equals sign, e.g. `{Number=42}`
+
+5. **Type:** The `@type` attribute corresponds to the sections on the API page.  Currently in use are `action`, `appium`, 
+`cookie`, `mobile`, `property`, `protocol`, `state`, `utility`, `window`.  You probably will not ever need to change this.
+
+6. **Returns:** Identifies the data type returned and a short description.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,7 +91,9 @@ And in case we didn't emphasize it enough: we love tests!
 ## Documentation
 
 For convenience and ease of maintenance, our project's documentation pages are generated partly from markdown files in 
-the `docs/` directory and partly from comments in the source code.
+the `docs/` directory and partly from comments in the source code.  
+
+As with code contributions, your first step should be to fork the repo.
 
 ### Markdown Pages
 
@@ -157,3 +159,6 @@ arguments following and equals sign, e.g. `{Number=42}`
 `cookie`, `mobile`, `property`, `protocol`, `state`, `utility`, `window`.  You probably will not ever need to change this.
 
 6. **Returns:** Identifies the data type returned and a short description.
+
+
+When you have completed your updates to the documentation, push to your fork and submit a pull request.

--- a/lib/commands/getCurrentTabId.js
+++ b/lib/commands/getCurrentTabId.js
@@ -2,6 +2,16 @@
  *
  * Retrieve the current window handle.
  *
+ * <example>
+    :getCurrenteTabId.js
+    client
+        .url('http://webdriver.io')
+        .getCurrentTabId().then(function(tabid) {
+            console.log(tabid);
+            // outputs something like the following:
+            // "CDwindow-C43FB686-949D-4232-828B-583398FBD0C0"
+        });
+ * </example>
  * @returns {String} the window handle URL of the current focused window
  * @uses protocol/windowHandle
  * @type window

--- a/lib/protocol/title.js
+++ b/lib/protocol/title.js
@@ -1,8 +1,26 @@
 /**
  *
- * Get the current page title.
+ * Gets an object containing the current page title.
  *
- * @returns {String} The current page title.
+ * <example>
+    :title.js
+    client
+        .url('http://webdriver.io')
+        .title().then(function(title) {
+            console.log(title);
+            // outputs the following:
+            //  {
+            //      state: 'success',
+            //      sessionId: '0c49951c-eb15-4053-96af-c1ebc79fb8b7',
+            //      hCode: 388233301,
+            //      value: 'WebdriverIO - Selenium 2.0 javascript bindings for nodejs',
+            //      class: 'org.openqa.selenium.remote.Response',
+            //      status: 0
+            //  }
+        });
+ * </example>
+ *
+ * @returns {Object} Object containing the current page title
  *
  * @see  https://code.google.com/p/selenium/wiki/JsonWireProtocol#/session/:sessionId/title
  * @type protocol

--- a/lib/protocol/windowHandle.js
+++ b/lib/protocol/windowHandle.js
@@ -3,7 +3,26 @@
  *
  * @returns {String} the current window handle
  *
+ * <example>
+    :windowHandle.js
+    client
+        .url('http://webdriver.io')
+        .windowHandle().then(function(handle) {
+            console.log(handle);
+            // outputs something like the following:
+            //  {
+            //      state: 'success',
+            //      sessionId: 'e6782264-9eb1-427b-9250-d8302ac35161',
+            //      hCode: 988127308,
+            //      value: 'CDwindow-849D79B1-5CCB-4A1D-A217-5BA809D935F3',
+            //      class: 'org.openqa.selenium.remote.Response',
+            //      status: 0
+            //  }
+        });
+ * </example>
+ *
  * @see https://code.google.com/p/selenium/wiki/JsonWireProtocol#/session/:sessionId/window_handle
+ * @returns {Object} the window handle object of the current focused window
  * @type protocol
  *
  */

--- a/lib/protocol/windowHandles.js
+++ b/lib/protocol/windowHandles.js
@@ -2,7 +2,27 @@
  *
  * Retrieve the list of all window handles available to the session.
  *
- * @returns {String[]} a list of window handles
+ * <example>
+    browser
+        .url('http://localhost/one.html')
+        .newWindow('http://localhost/two.html')
+        .windowHandles().then(function(windowHandles) {
+            console.log('windowHandles:');
+            // Outputs something like
+            // {
+            //    state: 'success',
+            //    sessionId: '31dc8253-a27e-4bae-8d20-338d6b0541c9',
+            //    hCode: 273402755,
+            //    value:
+            //    [ 'CDwindow-CBFE1412-8D46-495C-96B4-42E04F9153C0',
+            //        'CDwindow-BD7BE568-52F2-4552-B834-FE2D041DCE5B' ],
+            //    class: 'org.openqa.selenium.remote.Response',
+            //    status: 0
+            // }
+        })
+ * </example>
+ *
+ * @returns {Object} Contains a list of window handles
  *
  * @see https://code.google.com/p/selenium/wiki/JsonWireProtocol#/session/:sessionId/window_handles
  * @type protocol


### PR DESCRIPTION
1. Added a section to the CONTRIBUTING.md file that attempts to outline how the community can submit updates to the documentation.  (Also applied the recommended style guide to that page).

2. Included examples with sample output for several functions including getCurrentTabId, title, windowHandle, and windowHandles.

Note that currently the `@return` declarations are sometimes inaccurately typed and are not visible anywhere in the generated documentation plages.  This makes it more critical that the examples include sample output.