### PR TITLE
fix the scroll error when using mobile browser

### DIFF
--- a/lib/commands/scroll.js
+++ b/lib/commands/scroll.js
@@ -50,13 +50,13 @@ module.exports = function scroll (selector, xoffset, yoffset) {
             queue = this.element(selector);
         }
 
-        return queue.then(function(res) {
+        return queue.then((function(res) {
             if(typeof res !== 'undefined') {
                 selector = res.value.ELEMENT;
             }
 
             return this.touchScroll(selector, xoffset, yoffset);
-        })
+        }).bind(this))
         .catch(staleElementRetry.bind(this, 'scroll', arguments));
 
     }


### PR DESCRIPTION
When using scroll with out a selector.the callback in Q() object will get the wrong "this",therefor cause a TypeError "this.touchScroll is not a function".
bind this will fix it.