### PR TITLE
log about screenshot capturing on errors

### DIFF
--- a/lib/webdriverio.js
+++ b/lib/webdriverio.js
@@ -116,9 +116,12 @@ module.exports = function WebdriverIO(args, modifier) {
             }
 
             var client = unit();
+            var screenshotName = getScreenshotFilename();
             client.next(prototype.saveScreenshot, [
-                path.join(screenshotPath, 'ERROR_' + sanitize.caps(desiredCapabilities) + '_' + new Date().toJSON().replace(/:/g,"-")  + '.png')
+                path.join(screenshotPath, screenshotName)
             ], 'saveScreenshot');
+
+            this.logger.info('\t' + screenshotName);
 
             var stack = stacktrace.slice();
             return throwException.bind(null, result, stack);
@@ -126,6 +129,10 @@ module.exports = function WebdriverIO(args, modifier) {
 
         return this.promise;
     };
+
+    function getScreenshotFilename() {
+        return 'ERROR_' + sanitize.caps(desiredCapabilities) + '_' + new Date().toJSON().replace(/:/g,"-")  + '.png'
+    }
 
     function throwException(e, stack) {
         stack = stack.slice(0, -1).map(function(trace) {
@@ -263,7 +270,6 @@ module.exports = function WebdriverIO(args, modifier) {
                     return result.map(function(res) {
                         return res.value && typeof res.value === 'string' ? res.value.trim() : res.value;
                     });
-
                 /**
                  * sanitize result for better assertion
                  */


### PR DESCRIPTION
Just add some filename of captured screenshot after error was happen. Can be helpful on debagging.

Log will look like:

```
[14:33:58]:  COMMAND	POST 	 "/wd/hub/session/6559afe1-661c-4001-9ae3-801eabdba63a/elements"
[14:33:58]:  DATA		 {"using":"css selector","value":".distro"}
[14:33:58]:  RESULT		 []
[14:33:59]:  COMMAND	POST 	 "/wd/hub/session/6559afe1-661c-4001-9ae3-801eabdba63a/elements"
[14:33:59]:  DATA		 {"using":"css selector","value":".distro"}
[14:33:59]:  RESULT		 []
[14:33:59]:  ERROR	ServerError	Promise was rejected with the following reason: timeout
CommandError: Promise was rejected with the following reason: timeout
    at elements(".distro") - isVisible.js:43:17
    at isVisible(".distro") - waitForVisible.js:37:21
[14:33:59]:  INFO		ERROR_chrome.any_2016-01-09T11-33-59.115Z.png
```

Also, does anyone working to make logs more readable and helpful? 