### PR TITLE
Don't write colon after date in logs

### DIFF
--- a/lib/utils/Logger.js
+++ b/lib/utils/Logger.js
@@ -117,9 +117,9 @@ Logger.prototype.log = function(message, content) {
     var dateString = currentDate.toString().match(/\d\d:\d\d:\d\d/)[0];
 
     if (!content) {
-        this.write(colors.dkgray + '[' + dateString + ']: ' + colors.reset, message);
+        this.write(colors.dkgray + '[' + dateString + '] ' + colors.reset, message);
     } else {
-        this.write(colors.dkgray +'[' + dateString + ']: ' + colors.reset, message, '\t', JSON.stringify(content));
+        this.write(colors.dkgray +'[' + dateString + '] ' + colors.reset, message, '\t', JSON.stringify(content));
     }
 
 };


### PR DESCRIPTION
We already have date inside square bracket. This should be enough.