### PR TITLE
Only free up an available runner instance when a runner child process actually exists

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -196,9 +196,10 @@ class Launcher {
 
     /**
      * Start instance in a child process.
-     * @param  {Object|Object[]} capabilities  desired capabilities of instance
+     * @param  {Array} specs  Specs to run
+     * @param  {Number} cid  Capabilities ID
      */
-    startInstance (specs, i) {
+    startInstance (specs, cid) {
         let childProcess = child.fork(__dirname + '/runner.js', [], {
             cwd: process.cwd()
         })
@@ -207,14 +208,14 @@ class Launcher {
 
         childProcess
             .on('message', this.messageHandler.bind(this))
-            .on('exit', this.endHandler.bind(this))
+            .on('exit', this.endHandler.bind(this, cid))
 
         childProcess.send({
-            cid: i,
+            cid,
             command: 'run',
             configFile: this.configFile,
             argv: this.argv,
-            specs: specs,
+            specs,
             isMultiremote: this.isMultiremote()
         })
     }
@@ -226,14 +227,6 @@ class Launcher {
     messageHandler (m) {
         this.hasStartedAnyProcess = true
 
-        /**
-         * update schedule
-         */
-        if (m.event === 'runner:end' || m.event === 'runner:error') {
-            this.schedule[m.cid].availableInstances++
-            this.schedule[m.cid].runningInstances--
-        }
-
         if (m.event === 'runner:error') {
             this.reporters.handleEvent('error', m)
         }
@@ -242,11 +235,16 @@ class Launcher {
     }
 
     /**
-     * Closes test runner process once all instances finished and excited process.
+     * Close test runner process once all child processes have exited
+     * @param  {Number} cid  Capabilities ID
      * @param  {Number} childProcessExitCode  exit code of child process
      */
-    endHandler (childProcessExitCode) {
+    endHandler (cid, childProcessExitCode) {
         this.exitCode = this.exitCode || childProcessExitCode
+
+        // Update schedule now this process has ended
+        this.schedule[cid].availableInstances++
+        this.schedule[cid].runningInstances--
 
         if (!this.isMultiremote() && !this.runSpecs()) {
             return


### PR DESCRIPTION
I found that the launcher assumed that a runner process had exited when the `runner:error` event was received, even if the runner was still alive and sending messages. This resulted in the launcher process ending early, and Node errors as the runners attempted to send messages to a closed process. I believe this small change is enough to fix the issue.