### PR TITLE
Don't replace line breaks in selenium stack traces

### DIFF
--- a/lib/utils/ErrorHandler.js
+++ b/lib/utils/ErrorHandler.js
@@ -50,7 +50,7 @@ class ErrorHandler extends Error {
 
                 // truncate errorMessage
                 if (problem.indexOf('(Session info:') > -1) {
-                    problem = problem.slice(0, problem.indexOf('(Session info:')).replace(/\n/g, '').trim()
+                    problem = problem.slice(0, problem.indexOf('(Session info:')).trim()
                 }
 
                 // make assumption based on experience on certain error messages


### PR DESCRIPTION
What do you think of this, @christian-bromann? It results in:
```
javascript error: george error
JavaScript stack:
Error: george error
    at Error (native)
    at eval (eval at executeAsyncScript (unknown source), <anonymous>:3:10)
    at eval (eval at executeAsyncScript (unknown source), <anonymous>:4:6)
    at eval (eval at executeAsyncScript (unknown source), <anonymous>:4:31)
    at executeAsyncScript (<anonymous>:321:26)
    at <anonymous>:337:29
    at callFunction (<anonymous>:229:33)
    at <anonymous>:239:23
    at <anonymous>:240:3
    at Object.InjectedScript._evaluateOn (<anonymous>:875:140)
```
rather than:
```
javascript error: george errorJavaScript stack:Error: george error    at Error (native)    at eval (eval at executeAsyncScript (unknown source), <anonymous>:3:10)    at eval (eval at executeAsyncScript (unknown source), <anonymous>:4:6)    at eval (eval at executeAsyncScript (unknown source), <anonymous>:4:31)    at executeAsyncScript (<anonymous>:321:26)    at <anonymous>:337:29    at callFunction (<anonymous>:229:33)    at <anonymous>:239:23    at <anonymous>:240:3    at Object.InjectedScript._evaluateOn (<anonymous>:875:140)
```