### PR TITLE
Emit log lines using browser, and add to reporter stats

### DIFF
--- a/docs/guide/usage/eventhandling.md
+++ b/docs/guide/usage/eventhandling.md
@@ -30,7 +30,7 @@ client
     .init()
     .log('Before my method')
     .click('h2.subheading a')
-    .log('After my method', {more: 'data'})
+    .emit('log', 'After my method', {more: 'data'})
     .end();
 ```
 

--- a/docs/guide/usage/eventhandling.md
+++ b/docs/guide/usage/eventhandling.md
@@ -24,11 +24,11 @@ client.on('error', function(e) {
 })
 ```
 
-Use the `log()` method to log arbitrary data, which can then be logged or displayed by a reporter:
+Use the `log()` event to log arbitrary data, which can then be logged or displayed by a reporter:
 ```js
 client
     .init()
-    .log('Before my method')
+    .emit('log', 'Before my method')
     .click('h2.subheading a')
     .emit('log', 'After my method', {more: 'data'})
     .end();

--- a/docs/guide/usage/eventhandling.md
+++ b/docs/guide/usage/eventhandling.md
@@ -10,10 +10,10 @@ Eventhandling
 
 The following functions are supported: `on`,`once`,`emit`,`removeListener`,`removeAllListeners`.
 They behave exactly as described in the official NodeJS [docs](http://nodejs.org/api/events.html).
-There are some predefined events (`error`,`init`,`end`, `command`) which cover important
+There are some predefined events (`error`,`init`,`end`, `command`, `log`) which cover important
 WebdriverIO events.
 
-## Example
+## Examples
 
 ```js
 client.on('error', function(e) {
@@ -22,6 +22,16 @@ client.on('error', function(e) {
     console.log(e.body.value.class);   // -> "org.openqa.selenium.NoSuchElementException"
     console.log(e.body.value.message); // -> "no such element ..."
 })
+```
+
+Use the `log()` method to log arbitrary data, which can then be logged or displayed by a reporter:
+```js
+client
+    .init()
+    .log('Before my method')
+    .click('h2.subheading a')
+    .log('After my method', {more: 'data'})
+    .end();
 ```
 
 All commands are chainable, so you can use them while chaining your commands

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -98,6 +98,16 @@ class Runner {
             process.send(this.addTestDetails(details))
         })
 
+        global.browser.on('log', (data) => {
+            const details = {
+                event: 'runner:log',
+                cid: m.cid,
+                specs: this.specs,
+                data
+            }
+            process.send(this.addTestDetails(details))
+        })
+
         process.on('test:start', (test) => {
             this.currentTest = test
         })

--- a/lib/utils/BaseReporter.js
+++ b/lib/utils/BaseReporter.js
@@ -86,6 +86,10 @@ class BaseReporter extends events.EventEmitter {
             this.stats.output('screenshot', screenshot)
         })
 
+        this.on('runner:log', (log) => {
+            this.stats.output('log', log)
+        })
+
         this.on('suite:start', (suite) => {
             this.stats.suiteStart(suite)
         })


### PR DESCRIPTION
This enables a user to add useful information to the test output available to a runner:
```js

	browser.addCommand('getSectionTitle', function () {
		browser.emit('log', 'getSectionTitle log line');
		return browser.getText(articleSectionTitleSelector).toLowerCase();
	});

	it('should throw an error', function() {
		browser.emit('log', 'before log');
		browser.emit('log', {complex: 'george'});
		browser.getSectionTitle();
	});
```
For example, it can be displayed in the debug log output using the Allure reporter:
![screenshot 2016-01-12 15 54 24](https://cloud.githubusercontent.com/assets/84737/12268469/de9c13fa-b944-11e5-91b3-acf140022d32.png)
