### PR TITLE
Add `public` property to Sauce Labs example's `desiredCapabilities`.

### DIFF
--- a/examples/cloudservices/webdriverio.saucelabs.js
+++ b/examples/cloudservices/webdriverio.saucelabs.js
@@ -5,7 +5,15 @@ var webdriverio = require('../../index'),
             version: '27',
             platform: 'XP',
             tags: ['examples'],
-            name: 'This is an example test'
+            name: 'This is an example test',
+
+            // If using Open Sauce (https://saucelabs.com/opensauce/), 
+            // capabilities must be tagged as "public" for the jobs's status
+            // to update (failed/passed). If omitted on Open Sauce, the job's
+            // status will only be marked "Finished." This property can be
+            // be omitted for commerical (private) Sauce Labs accounts.
+            // Also see https://support.saucelabs.com/customer/portal/articles/2005331-why-do-my-tests-say-%22finished%22-instead-of-%22passed%22-or-%22failed%22-how-do-i-set-the-status-
+            'public': true
         },
         host: 'ondemand.saucelabs.com',
         port: 80,


### PR DESCRIPTION
I haven't found this little "gotcha" documented anywhere.