### PR TITLE
Add failing test for complex waitForVisible()

### DIFF
--- a/test/fixtures/specs/stale.spec.js
+++ b/test/fixtures/specs/stale.spec.js
@@ -1,6 +1,33 @@
 import conf from '../../conf/index.js'
 import nock from 'nock'
 
+let sessionId
+let scope
+
+function goodElementRequest (times = 1) {
+    scope.post(`/wd/hub/session/${sessionId}/elements`).times(times).delayConnection(100).reply(200, {
+        status: 0,
+        value: [{ ELEMENT: '0' }]
+    })
+}
+
+function staleElementError (times = 1) {
+    scope.get(`/wd/hub/session/${sessionId}/element/0/displayed`).times(times).delayConnection(100).reply(500, {
+        status: 10,
+        type: 'StaleElementReference',
+        value: {
+            message: 'Element is no longer attached to the DOM'
+        }
+    })
+}
+
+function isDisplayed (times = 1, value) {
+    scope.get(`/wd/hub/session/${sessionId}/element/0/displayed`).times(times).delayConnection(100).reply(200, {
+        status: 0,
+        value
+    })
+}
+
 describe('staleElementRetry', () => {
     it('can run quick commands after each other', () => {
         let iterations = 100
@@ -28,33 +55,49 @@ describe('staleElementRetry', () => {
     it('catches errors if an inner command fails', () => {
         browser.url(conf.testPage.staleTest)
 
-        let sessionId = browser.requestHandler.sessionID
-        let scope = nock('http://127.0.0.1:4444', { allowUnmocked: true })
-        scope.post(`/wd/hub/session/${sessionId}/elements`).times(4).delayConnection(100).reply(200, {
-            status: 0,
-            value: [{ ELEMENT: '0' }]
-        })
+        sessionId = browser.requestHandler.sessionID
+        scope = nock('http://127.0.0.1:4444', { allowUnmocked: true })
 
         /**
-         * return with StaleElementReference error three times in a row
+         * Allow 4 succesful elements() queries for .someSelector.
+         * Return a StaleElementReference error three times in a row,
+         * then return a valid result (isDisplayed === false).
          */
-        scope.get(`/wd/hub/session/${sessionId}/element/0/displayed`).times(3).delayConnection(100).reply(500, {
-            status: 10,
-            type: 'StaleElementReference',
-            value: {
-                message: 'Element is no longer attached to the DOM'
-            }
-        })
-
-        /**
-         * then return a valid result
-         */
-        scope.get(`/wd/hub/session/${sessionId}/element/0/displayed`).delayConnection(100).reply(200, {
-            status: 0,
-            value: false
-        })
+        goodElementRequest(4)
+        staleElementError(3)
+        isDisplayed(1, false)
 
         browser.waitForVisible('.someSelector', 2000, true)
+    })
+
+    it('correctly retries inside waitForVisible', () => {
+        browser.url(conf.testPage.staleTest)
+
+        sessionId = browser.requestHandler.sessionID
+        scope = nock('http://127.0.0.1:4444', { allowUnmocked: true })
+
+        /**
+         * Allow 10 succesful elements() queries for .someSelector.
+         * Return a mixture of StaleElementReference exceptions and valid
+         * results (isDisplayed === true), then finally (isDisplayed === false),
+         * which occurs well within the 6 second total wait time.
+         */
+        goodElementRequest(10)
+        isDisplayed(1, true)
+        staleElementError(1)
+        isDisplayed(2, true)
+        staleElementError(1)
+        isDisplayed(1, false)
+
+        let elementIsGone
+        try {
+            elementIsGone = browser.waitForVisible('.someSelector', 1000, true)
+        } catch (e) {
+            console.log('.someSelector still visible after 1 second. Will wait a bit longer.')
+            elementIsGone = browser.waitForVisible('.someSelector', 5000, true)
+        }
+
+        expect(elementIsGone).to.be.true
     })
 
     after(() => {


### PR DESCRIPTION
This test, I think covers the issue I'm seeing in my own test suite.

Debug output:
```
isVisible call count: 1
elementIdDisplayed call count: 1
elementIdDisplayed count: 1, res [object Object]
isVisible count: 1, res true
isVisible call count: 2
elementIdDisplayed call count: 2
elementIdDisplayed error count: 2, e: Element is no longer attached to the DOM
isVisible error count: 2, e: Element is no longer attached to the DOM
caught StaleElementReference
StaleElementReference. Will retry isVisible with .someSelector
isVisible call count: 3
elementIdDisplayed call count: 3
elementIdDisplayed count: 3, res [object Object]
isVisible count: 3, res true
isVisible call count: 4
.someSelector still visible after 1 second. Will wait a bit longer.
isVisible call count: 5
elementIdDisplayed call count: 4
elementIdDisplayed call count: 5
elementIdDisplayed count: 4, res [object Object]
elementIdDisplayed error count: 5, e: Element is no longer attached to the DOM
isVisible count: 4, res true
isVisible error count: 5, e: Element is no longer attached to the DOM
caught StaleElementReference
```
... at this point, there's no output for a few seconds - no commands are executed. Then:
```․

0 passing (10.50s)
1 failing

1) correctly retries inside waitForVisible:
element (.someSelector) still  visible after 5000ms
```

So the retry after the second `StaleElementReference` catch is not working as expected.

I also hit some issues with Nock which I don't understand. I get the output above only if I run the single test in isolation (`correctly retries inside waitForVisible`). If I allow `catches errors if an inner command fails` to run as well, then `correctly retries inside waitForVisible` doesn't seem to call commands as expected at all. Not sure how to fix this.