### PR TITLE
Port of #992

### DIFF
--- a/lib/commands/waitForEnabled.js
+++ b/lib/commands/waitForEnabled.js
@@ -14,7 +14,7 @@
  *
  */
 
-import { CommandError } from '../utils/ErrorHandler'
+import { CommandError, isTimeoutError } from '../utils/ErrorHandler'
 
 let waitForEnabled = function (selector, ms, reverse = false) {
     /*!
@@ -42,7 +42,7 @@ let waitForEnabled = function (selector, ms, reverse = false) {
             return result !== reverse
         })
     }, ms).catch((e) => {
-        if (e.message === 'Promise never resolved with an truthy value') {
+        if (isTimeoutError(e)) {
             let isReversed = reverse ? '' : 'not'
             throw new CommandError(`element (${selector}) still ${isReversed} enabled after ${ms}ms`)
         }

--- a/lib/commands/waitForExist.js
+++ b/lib/commands/waitForExist.js
@@ -14,7 +14,7 @@
  *
  */
 
-import { CommandError } from '../utils/ErrorHandler'
+import { CommandError, isTimeoutError } from '../utils/ErrorHandler'
 
 let waitForExist = function (selector, ms, reverse = false) {
     /*!
@@ -42,7 +42,7 @@ let waitForExist = function (selector, ms, reverse = false) {
             return result !== reverse
         })
     }, ms).catch((e) => {
-        if (e.message === 'Promise never resolved with an truthy value') {
+        if (isTimeoutError(e)) {
             let isReversed = reverse ? '' : 'not'
             throw new CommandError(`element (${selector}) still ${isReversed} existing after ${ms}ms`)
         }

--- a/lib/commands/waitForSelected.js
+++ b/lib/commands/waitForSelected.js
@@ -13,7 +13,7 @@
  *
  */
 
-import { CommandError } from '../utils/ErrorHandler'
+import { CommandError, isTimeoutError } from '../utils/ErrorHandler'
 
 let waitForSelected = function (selector, ms, reverse = false) {
     /*!
@@ -41,7 +41,7 @@ let waitForSelected = function (selector, ms, reverse = false) {
             return result !== reverse
         })
     }, ms).catch((e) => {
-        if (e.message === 'Promise never resolved with an truthy value') {
+        if (isTimeoutError(e)) {
             let isReversed = reverse ? '' : 'not'
             throw new CommandError(`element (${selector}) still ${isReversed} selected after ${ms}ms`)
         }

--- a/lib/commands/waitForText.js
+++ b/lib/commands/waitForText.js
@@ -14,7 +14,7 @@
  *
  */
 
-import { CommandError } from '../utils/ErrorHandler'
+import { CommandError, isTimeoutError } from '../utils/ErrorHandler'
 
 let waitForText = function (selector, ms, reverse = false) {
     /*!
@@ -42,7 +42,7 @@ let waitForText = function (selector, ms, reverse = false) {
             return result !== reverse
         })
     }, ms).catch((e) => {
-        if (e.message === 'Promise never resolved with an truthy value') {
+        if (isTimeoutError(e)) {
             let isReversed = reverse ? 'with' : 'without'
             throw new CommandError(`element (${selector}) still ${isReversed} text after ${ms}ms`)
         }

--- a/lib/commands/waitForValue.js
+++ b/lib/commands/waitForValue.js
@@ -14,7 +14,7 @@
  *
  */
 
-import { CommandError } from '../utils/ErrorHandler'
+import { CommandError, isTimeoutError } from '../utils/ErrorHandler'
 
 let waitForValue = function (selector, ms, reverse = false) {
     /*!
@@ -42,7 +42,7 @@ let waitForValue = function (selector, ms, reverse = false) {
             return result !== reverse
         })
     }, ms).catch((e) => {
-        if (e.message === 'Promise never resolved with an truthy value') {
+        if (isTimeoutError(e)) {
             let isReversed = reverse ? 'with' : 'without'
             throw new CommandError(`element (${selector}) still ${isReversed} a value after ${ms}ms`)
         }

--- a/lib/commands/waitForVisible.js
+++ b/lib/commands/waitForVisible.js
@@ -19,7 +19,7 @@
  *
  */
 
-import { CommandError } from '../utils/ErrorHandler'
+import { CommandError, isTimeoutError } from '../utils/ErrorHandler'
 
 let waitForVisible = function (selector, ms, reverse = false) {
     /*!
@@ -47,7 +47,7 @@ let waitForVisible = function (selector, ms, reverse = false) {
             return result !== reverse
         })
     }, ms).catch((e) => {
-        if (e.message === 'Promise never resolved with an truthy value') {
+        if (isTimeoutError(e)) {
             let isReversed = reverse ? '' : 'not'
             throw new CommandError(`element (${selector}) still ${isReversed} visible after ${ms}ms`)
         }

--- a/lib/commands/waitUntil.js
+++ b/lib/commands/waitUntil.js
@@ -36,47 +36,7 @@
  */
 
 import { CommandError } from '../utils/ErrorHandler'
-
-const REJECT_MESSAGE = 'Promise never resolved with an truthy value'
-
-function waitUntilPrivate (condition, timeout, interval, starttime) {
-    let promise
-
-    var now = new Date().getTime()
-    var timeLeft = timeout - (now - starttime)
-    timeLeft = timeLeft < 0 ? 0 : timeLeft
-
-    if (!timeLeft) {
-        return Promise.reject(new CommandError(REJECT_MESSAGE))
-    }
-
-    if (typeof condition === 'function') {
-        promise = condition.call(this)
-    } else {
-        promise = Promise.resolve(condition)
-    }
-
-    return new Promise((resolve, reject) => {
-        let timeoutId = setTimeout(() => {
-            reject(new CommandError(REJECT_MESSAGE))
-        }, timeLeft)
-
-        promise.then((res) => {
-            clearTimeout(timeoutId)
-
-            if (!res) {
-                return resolve(this.pause(interval).then(
-                    waitUntilPrivate.bind(this, condition, timeout, interval, starttime)
-                ))
-            }
-
-            resolve(res)
-        }, (err) => {
-            clearTimeout(timeoutId)
-            reject(new CommandError(`Promise was fulfilled but got rejected with the following reason: ${err}`))
-        })
-    })
-}
+import Timer from '../utils/Timer'
 
 export default function (condition, timeout, interval) {
     /*!
@@ -90,6 +50,17 @@ export default function (condition, timeout, interval) {
         interval = this.options.waitforInterval
     }
 
-    let starttime = new Date().getTime()
-    return waitUntilPrivate.call(this, condition, timeout, interval, starttime)
+    let fn
+
+    if (typeof condition === 'function') {
+        fn = condition
+    } else {
+        fn = () => Promise.resolve(condition)
+    }
+
+    let timer = new Timer(interval, timeout, fn, true)
+
+    return timer.catch(function (e) {
+        throw new CommandError(`Promise was rejected with the following reason: ${e}`)
+    })
 }

--- a/lib/utils/ErrorHandler.js
+++ b/lib/utils/ErrorHandler.js
@@ -91,10 +91,20 @@ let RuntimeError = function (msg) {
     return new ErrorHandler('RuntimeError', msg)
 }
 
+/**
+ * Check if current error is caused by timeout
+ * @param {Object} err
+ * @returns {Boolean}
+ */
+let isTimeoutError = function (e) {
+    return e.message === 'Promise was rejected with the following reason: timeout'
+}
+
 export {
     ErrorHandler,
     CommandError,
     ProtocolError,
-    RuntimeError
+    RuntimeError,
+    isTimeoutError
 }
 export default ErrorHandler

--- a/lib/utils/Timer.js
+++ b/lib/utils/Timer.js
@@ -1,0 +1,81 @@
+
+/**
+ * Promise-based Timer. Execute fn every tick.
+ * When fn is resolved — timer will stop
+ * @param {Number} delay - delay between ticks
+ * @param {Number} timeout - after that time timer will stop
+ * @param {Function} fn - function that returns promise. will execute every tick
+ * @param {Boolean} leading - should be function invoked on start
+ * @returns {promise}
+ */
+class Timer {
+    constructor (delay, timeout, fn, leading) {
+        this._delay = delay
+        this._timeout = timeout
+        this._fn = fn
+        this._leading = leading
+
+        this.start()
+
+        return new Promise((resolve, reject) => {
+            this._resolve = resolve
+            this._reject = reject
+        })
+    }
+
+    start () {
+        this._start = Date.now()
+        this._ticks = 0
+        if (this._leading) {
+            this.tick()
+        } else {
+            this._timeoutId = setTimeout(this.tick.bind(this), this._delay)
+        }
+
+        setTimeout(() => {
+            this._reject('timeout')
+            this.stop()
+        }, this._timeout)
+    }
+
+    stop () {
+        if (this._timeoutId) {
+            clearTimeout(this._timeoutId)
+        }
+        this._timeoutId = null
+    }
+
+    tick () {
+        this._fn().then((res) => {
+            // resolve timer only on truthy values
+            if (res) {
+                this._resolve(res)
+                this.stop()
+                return
+            }
+
+            // autocorrect timer
+            let diff = (Date.now() - this._start) - (this._ticks++ * this._delay)
+            let delay = Math.max(0, this._delay - diff)
+
+            // clear old timeoutID
+            this.stop()
+
+            // check if we have time to one more tick
+            if (this.hasTime(delay)) {
+                this._timeoutId = setTimeout(this.tick.bind(this), delay)
+            } else {
+                this._reject('timeout')
+            }
+        }).catch((err) => {
+            this.stop()
+            this._reject(err)
+        })
+    }
+
+    hasTime (delay) {
+        return (Date.now() - this._start + delay) <= this._timeout
+    }
+}
+
+export default Timer

--- a/test/spec/unit/timer.js
+++ b/test/spec/unit/timer.js
@@ -1,0 +1,81 @@
+import Timer from '../../../lib/utils/Timer.js'
+import sinon from 'sinon'
+
+describe('timer', function() {
+
+    describe('ticks', function() {
+
+        let timer
+        let spy
+        let clock
+
+        beforeEach(function() {
+            sinon.stub(process, 'nextTick').yields()
+            clock = sinon.useFakeTimers(Date.now())
+
+            spy = sinon.spy(() => Promise.resolve())
+            timer = new Timer(20, 100, spy, false)
+        })
+
+        afterEach(function() {
+            process.nextTick.restore()
+            clock.restore()
+        })
+
+        it('should tick once', function() {
+            clock.tick(20)
+            expect(spy.calledOnce).to.be.true
+        })
+
+        it('should tick many times', function() {
+            clock.tick(80)
+            expect(spy.callCount).to.be.equal(5)
+        })
+
+        it('should not tick after timeout', function() {
+            clock.tick(300)
+            expect(spy.callCount).to.be.equal(5)
+        })
+
+    })
+
+    describe('promise', function() {
+
+        it('should be rejected by timeout', function() {
+            let timer = new Timer(20, 30, () => Promise.resolve(false))
+
+            return timer.then(assert.fail, function(msg) {
+                expect(msg).to.be.equal('timeout')
+            })
+        })
+
+        it('should be fulfilled when resolved with true value', function() {
+            let timer = new Timer(20, 30, () => Promise.resolve(true))
+
+            return timer.then(assert.isTrue, assert.fail)
+        })
+
+        it('should not be fulfilled when resolved with false value', function() {
+            let timer = new Timer(20, 30, () => Promise.resolve(false))
+
+            return timer.then(assert.fail, assert.ok)
+        })
+
+        it('should be rejected', function() {
+            let timer = new Timer(20, 30, () => Promise.reject('err'))
+
+            return timer.then(assert.fail).catch(function(msg) {
+                expect(msg).to.be.equal('err')
+            })
+        })
+
+    })
+
+    it('should have leading fn call', function() {
+        let spy = sinon.spy(() => Promise.resolve(true))
+        let timer = new Timer(100, 100, spy, true)
+
+        return timer.then(assert.isTrue)
+    })
+
+})

--- a/test/spec/unit/waitUntil.js
+++ b/test/spec/unit/waitUntil.js
@@ -15,7 +15,7 @@ describe('waitUntil', () => {
         } catch (e) {
             error = e
         } finally {
-            error.message.should.match(/Promise never resolved with an truthy value/)
+            error.message.should.be.equal('Promise was rejected with the following reason: timeout')
         }
     })
 
@@ -26,7 +26,7 @@ describe('waitUntil', () => {
         } catch (e) {
             error = e
         } finally {
-            error.message.should.match(/Promise was fulfilled but got rejected/)
+            error.message.should.match(/Promise was rejected with the following reason/)
         }
     })
 
@@ -37,7 +37,7 @@ describe('waitUntil', () => {
         } catch (e) {
             error = e
         } finally {
-            error.message.should.match(/Promise never resolved with an truthy value/)
+            error.message.should.be.equal('Promise was rejected with the following reason: timeout')
         }
     })
 
@@ -55,7 +55,7 @@ describe('waitUntil', () => {
         try {
             await this.client.waitUntil(() => new Promise((r) => setTimeout(() => r('foobar'), 50)), 100, 250)
         } catch (error) {
-            error.message.should.match(/Promise never resolved with an truthy value/)
+            error.message.should.be.equal('Promise was rejected with the following reason: timeout')
         }
     })
 })

--- a/test/spec/waitFor.js
+++ b/test/spec/waitFor.js
@@ -12,7 +12,7 @@ describe('waitFor', () => {
                 .should.be.equal(true)
         })
 
-        it('should return with an error if the element never becomes visible', function () {
+        it('should return with an error if the element never becomes enabled', function () {
             return expect(this.client.waitForEnabled('.waitForValueEnabledReverse', 10))
                 .to.be.rejectedWith('element (.waitForValueEnabledReverse) still not enabled after 10ms')
         })


### PR DESCRIPTION
In #992 
> @sbmaxx I can't port this feature into the v4 branch. Tests didn't pass and I think it is because of your changes. One big difference between your attempt and the current implementation is that the timer is waiting until the condition promise has resolved. The problem with that is if the condition for some reasons never resolves the test stops without any notifications.

> Could you create a new PR on the v4 branch (or master if already merged) with this issue addressed? Thanks!

I run many tests on master/timer branch, and sometime `phantomjs` hangs. Chrome works fine. I think that `mocha`'s big timeout can be the issue. 

Also, i'm not sure about `await` in tests. Why just not return promise always?
