### PR TITLE
fix(launcher): force send SIGINT when spawned via subprocess

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -286,6 +286,13 @@ class Launcher {
              */
             return this.resolve(1)
         }
+        
+        // When spawned as a subprocess,
+        // SIGINT will not be forwarded to childs.
+        // Thus for the child to exit cleanly, we must force send SIGINT
+        if (!process.stdin.isTTY) {
+            processes.forEach(p => p.kill('SIGINT'));
+        }
 
         console.log(`
 


### PR DESCRIPTION
So basically, when doing a wrapper that will spawn wdio, if you do CTRL+C on wrapper or if you send SIGINT to the spawned wdio then the child runners will not get killed and selenium sessions will not be cleaned.

With this fix I am able to do a simple watch/relaunch runner on top of wdio, code:

```js
import webpack from 'webpack';
import config from './webpack.config.jsdelivr.babel.js';
import debounce from 'lodash/function/debounce';

import {spawn} from 'child_process';

const compiler = webpack(config);
let wdio;
const launch = debounce(() => {
  if (wdio) {
    console.log('Restarting tests');
    wdio.kill('SIGINT');
    wdio.kill('SIGINT');
  }

  wdio = spawn('wdio', ['functional-tests/wdio.conf.js'], {stdio: [null, process.stdout, null]});
}, 1500, {
  leading: true,
  trailing: true
});

compiler.watch({
  aggregateTimeout: 300,
  usePolling: true
}, compilationDone);

function compilationDone(err) {
  if (err) {
    throw err;
  }

  console.log('Got webpack compilation event');

  launch();
}
```