### PR TITLE
Use 'currentTest' name to identify tests which fail during a beforeEach hook

### DIFF
--- a/lib/utils/ReporterStats.js
+++ b/lib/utils/ReporterStats.js
@@ -159,8 +159,12 @@ class ReporterStats extends RunnableStats {
 
     getTestStats (runner) {
         const suiteStats = this.getSuiteStats(runner, runner.parent)
-        if (!suiteStats.tests[runner.title]) throw Error(`Unrecognised test [${runner.title}] for suite [${runner.parent}]`)
-        return suiteStats.tests[runner.title]
+
+        // Errors encountered inside hooks (e.g. beforeEach) can be identified by looking
+        // at the currentTest param
+        const title = runner.currentTest || runner.title
+        if (!suiteStats.tests[title]) throw Error(`Unrecognised test [${title}] for suite [${runner.parent}]`)
+        return suiteStats.tests[title]
     }
 
     output (type, runner) {

--- a/lib/utils/ReporterStats.js
+++ b/lib/utils/ReporterStats.js
@@ -161,7 +161,7 @@ class ReporterStats extends RunnableStats {
         const suiteStats = this.getSuiteStats(runner, runner.parent)
 
         // Errors encountered inside hooks (e.g. beforeEach) can be identified by looking
-        // at the currentTest param
+        // at the currentTest param (currently only applicable to the Mocha adapter).
         const title = runner.currentTest || runner.title
         if (!suiteStats.tests[title]) throw Error(`Unrecognised test [${title}] for suite [${runner.parent}]`)
         return suiteStats.tests[title]


### PR DESCRIPTION
Works in combination with https://github.com/webdriverio/wdio-mocha-framework/pull/13