### PR TITLE
Limit very long results in the log output

### DIFF
--- a/lib/helpers/sanitize.js
+++ b/lib/helpers/sanitize.js
@@ -69,6 +69,9 @@ let css = function (value) {
  * @return {Any}     Limited var of same type
  */
 let limit = function (val) {
+    // Ensure we're working with a copy
+    val = JSON.parse(stringify(val))
+
     switch (Object.prototype.toString.call(val)) {
     case '[object String]':
         if (val.length > 100 && validator.isBase64(val)) {
@@ -98,8 +101,8 @@ let limit = function (val) {
                 removed.push(keys[i])
             }
         }
-        if (keys.length > OBJLENGTH) {
-            val._ = (keys.length - OBJLENGTH) + ' more keys: ' + stringify(removed)
+        if (removed.length) {
+            val._ = (keys.length - OBJLENGTH) + ' more keys: ' + JSON.stringify(removed)
         }
         return val
     }

--- a/lib/helpers/sanitize.js
+++ b/lib/helpers/sanitize.js
@@ -3,7 +3,7 @@ import validator from 'validator'
 
 const OBJLENGTH = 10
 const ARRLENGTH = 10
-const STRINGLIMIT = 10000
+const STRINGLIMIT = 1000
 const STRINGTRUNCATE = 200
 
 let sanitizeString = function (str) {
@@ -64,11 +64,13 @@ let css = function (value) {
 }
 
 /**
- * Limit the length of an arbritrary variable of any type, suitable for being logged or displayed
+ * Limit the length of an arbitrary variable of any type, suitable for being logged or displayed
  * @param  {Any} val Any variable
  * @return {Any}     Limited var of same type
  */
 let limit = function (val) {
+    if (!val) return val
+
     // Ensure we're working with a copy
     val = JSON.parse(stringify(val))
 
@@ -87,7 +89,7 @@ let limit = function (val) {
         const length = val.length
         if (length > ARRLENGTH) {
             val = val.slice(0, ARRLENGTH)
-            val.push(' ... (' + (length - ARRLENGTH) + ' more items)')
+            val.push('(' + (length - ARRLENGTH) + ' more items)')
         }
         return val.map(limit)
     case '[object Object]':
@@ -106,6 +108,7 @@ let limit = function (val) {
         }
         return val
     }
+    return val
 }
 
 export default {

--- a/lib/helpers/sanitize.js
+++ b/lib/helpers/sanitize.js
@@ -71,7 +71,7 @@ let css = function (value) {
 let limit = function (val) {
     switch (Object.prototype.toString.call(val)) {
     case '[object String]':
-        if (validator.isBase64(val)) {
+        if (val.length > 100 && validator.isBase64(val)) {
             return '[base64] ' + val.length + ' bytes'
         }
 

--- a/lib/helpers/sanitize.js
+++ b/lib/helpers/sanitize.js
@@ -1,3 +1,11 @@
+import stringify from 'json-stringify-safe'
+import validator from 'validator'
+
+const OBJLENGTH = 10
+const ARRLENGTH = 10
+const STRINGLIMIT = 10000
+const STRINGTRUNCATE = 200
+
 let sanitizeString = function (str) {
     if (!str) {
         return ''
@@ -55,8 +63,51 @@ let css = function (value) {
     return value.trim().replace(/'/g, '').replace(/"/g, '').toLowerCase()
 }
 
+/**
+ * Limit the length of an arbritrary variable of any type, suitable for being logged or displayed
+ * @param  {Any} val Any variable
+ * @return {Any}     Limited var of same type
+ */
+let limit = function (val) {
+    switch (Object.prototype.toString.call(val)) {
+    case '[object String]':
+        if (validator.isBase64(val)) {
+            return '[base64] ' + val.length + ' bytes'
+        }
+
+        if (val.length > STRINGLIMIT) {
+            return val.substr(0, STRINGTRUNCATE) + ' ... (' + (val.length - STRINGTRUNCATE) + ' more bytes)'
+        }
+
+        return val
+    case '[object Array]':
+        const length = val.length
+        if (length > ARRLENGTH) {
+            val = val.slice(0, ARRLENGTH)
+            val.push(' ... (' + (length - ARRLENGTH) + ' more items)')
+        }
+        return val.map(limit)
+    case '[object Object]':
+        const keys = Object.keys(val)
+        const removed = []
+        for (let i = 0, l = keys.length; i < l; i++) {
+            if (i < OBJLENGTH) {
+                val[keys[i]] = limit(val[keys[i]])
+            } else {
+                delete val[keys[i]]
+                removed.push(keys[i])
+            }
+        }
+        if (keys.length > OBJLENGTH) {
+            val._ = (keys.length - OBJLENGTH) + ' more keys: ' + stringify(removed)
+        }
+        return val
+    }
+}
+
 export default {
     css,
     args,
-    caps
+    caps,
+    limit
 }

--- a/lib/utils/BaseReporter.js
+++ b/lib/utils/BaseReporter.js
@@ -2,7 +2,6 @@ import tty from 'tty'
 import events from 'events'
 import supportsColor from 'supports-color'
 import sanitize from '../helpers/sanitize'
-import validator from 'validator'
 import { ReporterStats } from './ReporterStats'
 
 const ISATTY = tty.isatty(1) && tty.isatty(2)
@@ -42,8 +41,6 @@ const SYMBOLS = {
     dot: '․',
     error: 'F'
 }
-
-const STRINGLIMIT = 10000
 
 class BaseReporter extends events.EventEmitter {
     constructor () {
@@ -162,25 +159,7 @@ class BaseReporter extends events.EventEmitter {
     }
 
     limit (val) {
-        switch (Object.prototype.toString.call(val)) {
-        case '[object String]':
-            if (validator.isBase64(val)) {
-                return '[base64] ' + val.length + ' bytes'
-            } else if (val.length > STRINGLIMIT) {
-                return val.slice(0, STRINGLIMIT) + '... (' + (val.length - STRINGLIMIT) + ' more bytes)'
-            }
-            return val
-        case '[object Array]':
-            return val.map(this.limit.bind(this))
-        case '[object Object]':
-            const copy = {}
-            for (let key of Object.keys(val)) {
-                copy[key] = this.limit(val[key])
-            }
-            return copy
-        default:
-            return val
-        }
+        return sanitize.limit(val)
     }
 
     /**

--- a/lib/utils/Logger.js
+++ b/lib/utils/Logger.js
@@ -13,6 +13,8 @@ For a complete list of commands, visit ${COLORS.lime}http://webdriver.io/docs.ht
 ${COLORS.yellow}=======================================================================================${COLORS.reset}
 `
 
+const STRINGLIMIT = 1000
+
 /**
  * Logger module
  *
@@ -179,7 +181,7 @@ class Logger {
     data (data) {
         data = JSON.stringify(data)
 
-        if (data.length > 1000) {
+        if (data.length > STRINGLIMIT) {
             data = '[String Buffer]'
         }
 
@@ -197,6 +199,7 @@ class Logger {
             result = '[base64] ' + result.length + ' bytes'
         } else if (typeof result === 'object') {
             result = JSON.stringify(result)
+            if (result.length > STRINGLIMIT) result = `${result.substr(0, STRINGLIMIT)}... (${result.length - STRINGLIMIT} more bytes)`
         }
 
         this.log(`${COLORS.teal}RESULT\t\t${COLORS.reset}${result}`)

--- a/lib/utils/Logger.js
+++ b/lib/utils/Logger.js
@@ -1,7 +1,6 @@
 import fs from 'fs'
 import path from 'path'
 import mkdirp from 'mkdirp'
-import validator from 'validator'
 
 import { COLORS, ERROR_CODES } from '../helpers/constants'
 import sanitize from '../helpers/sanitize'
@@ -12,8 +11,6 @@ Selenium 2.0 / webdriver protocol bindings implementation with helper commands i
 For a complete list of commands, visit ${COLORS.lime}http://webdriver.io/docs.html${COLORS.reset}.
 ${COLORS.yellow}=======================================================================================${COLORS.reset}
 `
-
-const STRINGLIMIT = 1000
 
 /**
  * Logger module
@@ -150,7 +147,7 @@ class Logger {
         if (!content) {
             this.write(preamble, message)
         } else {
-            this.write(preamble, message, '\t', JSON.stringify(content))
+            this.write(preamble, message, '\t', JSON.stringify(sanitize.limit(content)))
         }
     }
 
@@ -179,13 +176,8 @@ class Logger {
      * @param  {Object} data  data object
      */
     data (data) {
-        data = JSON.stringify(data)
-
-        if (data.length > STRINGLIMIT) {
-            data = '[String Buffer]'
-        }
-
-        if (data && keySize(data) !== 0 && (this.logLevel === 'data' || this.logLevel === 'verbose')) {
+        data = JSON.stringify(sanitize.limit(data))
+        if (data && (this.logLevel === 'data' || this.logLevel === 'verbose')) {
             this.log(`${COLORS.brown}DATA\t\t${COLORS.reset}${data}`)
         }
     }
@@ -195,13 +187,7 @@ class Logger {
      * @param  {Object} result  result object
      */
     result (result) {
-        if (typeof result === 'string' && validator.isBase64(result)) {
-            result = '[base64] ' + result.length + ' bytes'
-        } else if (typeof result === 'object') {
-            result = JSON.stringify(result)
-            if (result.length > STRINGLIMIT) result = `${result.substr(0, STRINGLIMIT)}... (${result.length - STRINGLIMIT} more bytes)`
-        }
-
+        result = sanitize.limit(JSON.stringify(result))
         this.log(`${COLORS.teal}RESULT\t\t${COLORS.reset}${result}`)
     }
 
@@ -239,21 +225,6 @@ class Logger {
         this.write(COLORS.dkred + (type || 'Error') + ': ' + message + COLORS.reset, null)
         this.write(COLORS.dkgray + stacktrace.reverse().join('\n') + COLORS.reset, null)
     }
-}
-
-/**
- * helper method to check size of object
- * @param   {Object}   obj  object you like to check
- * @return  {Integer}       number of own properties
- */
-let keySize = function (obj) {
-    let size = 0
-
-    for (let key in obj) {
-        if (obj.hasOwnProperty(key)) size++
-    }
-
-    return size
 }
 
 export default Logger

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "ejs": "^2.3.1",
     "glob": "^5.0.10",
     "inquirer": "^0.8.5",
+    "json-stringify-safe": "^5.0.1",
     "mkdirp": "^0.5.1",
     "npm-install-package": "^1.0.2",
     "optimist": "^0.6.1",

--- a/test/spec/unit/sanitize.js
+++ b/test/spec/unit/sanitize.js
@@ -1,0 +1,111 @@
+import Sanitize from '../../../lib/helpers/sanitize'
+import {deepEqual, AssertionError} from 'assert'
+
+const MEDIUM_BASE64 = 'aGVsbG8gbXkgbmFtZSBpcyBnZW9yZ2UgYW5kIEkgcmVhbGx5IGxvdmUgd2ViZHJpdmVyaW8uIGhlbGxvIG15IG5hbWUgaXMgZ2VvcmdlIGFuZCBJIHJlYWxseSBsb3ZlIHdlYmRyaXZlcmlvLiBoZWxsbyBteSBuYW1lIGlzIGdlb3JnZSBhbmQgSSByZWFsbHkgbG92ZSB3ZWJkcml2ZXJpby4K'
+const SHORT_BASE64 = 'Webdriverio4'
+const MEDIUM_STRING = Array(201).join('$')
+const LONG_STRING = Array(2001).join('$')
+
+const SHORT_ARRAY = fillArray(3)
+const LONG_ARRAY = fillArray(200)
+const ARRAY_OF_LONG_STRINGS = fillArray(3, LONG_STRING)
+
+const SHORT_OBJECT = fillObject(3)
+const LONG_OBJECT = fillObject(20)
+const OBJECT_OF_LONG_STRINGS = fillObject(3, LONG_STRING)
+
+function fillArray (length, val) {
+    return Array.apply(0, Array(length)).map((val, i) => val || i)
+}
+
+function fillObject (length, val) {
+    const o = {}
+    for (let i = 0; i < length; i++) {
+        o[i] = val || i
+    }
+    return o
+}
+
+// Seems like non-strict equal doesn't exist in Chai BDD:
+// https://github.com/chaijs/chai/issues/280
+function compare (expected, actual) {
+    return () => {
+        deepEqual(expected, actual)
+    }
+}
+
+describe('Sanitize', () => {
+    it.skip('should sanitize capabilities')
+    it.skip('should sanitize arguments')
+    it.skip('should sanitize css')
+
+    describe.only('Sanitize an arbitrary variable', () => {
+        it('should return simple values unchanged', () => {
+            expect(Sanitize.limit(undefined)).to.be.undefined
+            expect(Sanitize.limit(null)).to.be.null
+            expect(Sanitize.limit('')).to.be.equal('')
+        })
+
+        it('should highlight a base64 string', () => {
+            const limited = Sanitize.limit(MEDIUM_BASE64)
+            limited.should.be.equal('[base64] 220 bytes')
+        })
+
+        it('should not change a short base64-like string', () => {
+            const limited = Sanitize.limit(SHORT_BASE64)
+            limited.should.be.equal(SHORT_BASE64)
+        })
+
+        it('should not change a medium length non-base64 string', () => {
+            const limited = Sanitize.limit(MEDIUM_STRING)
+            limited.should.be.equal(MEDIUM_STRING)
+        })
+
+        it('should truncate a long non-base64 string', () => {
+            const limited = Sanitize.limit(LONG_STRING)
+            limited.should.be.equal(`${Array(201).join('$')} ... (1800 more bytes)`)
+        })
+
+        it('should not change a short simple array', () => {
+            const limited = Sanitize.limit(SHORT_ARRAY)
+            expect(compare(SHORT_ARRAY, limited)).to.not.throw(AssertionError)
+        })
+
+        it('should truncate a long simple array', () => {
+            const limited = Sanitize.limit(LONG_ARRAY)
+
+            const expected = fillArray(10)
+            expected.push('(190 more items)')
+
+            expect(compare(expected, limited)).to.not.throw(AssertionError)
+        })
+
+        it('should map array values to limit', () => {
+            const limited = Sanitize.limit(ARRAY_OF_LONG_STRINGS)
+            const expected = fillArray(3, `${Array(201).join('$')} ... (1800 more bytes)`)
+
+            expect(compare(expected, limited)).to.not.throw(AssertionError)
+        })
+
+        it('should not change a short simple object', () => {
+            const limited = Sanitize.limit(SHORT_OBJECT)
+            expect(compare(SHORT_OBJECT, limited)).to.not.throw(AssertionError)
+        })
+
+        it('should truncate a long simple object and list keys', () => {
+            const limited = Sanitize.limit(LONG_OBJECT)
+
+            const expected = fillObject(10)
+            expected._ = '10 more keys: ["10","11","12","13","14","15","16","17","18","19"]'
+
+            expect(compare(expected, limited)).to.not.throw(AssertionError)
+        })
+
+        it('should map object values to limit', () => {
+            const limited = Sanitize.limit(OBJECT_OF_LONG_STRINGS)
+            const expected = fillObject(3, `${Array(201).join('$')} ... (1800 more bytes)`)
+
+            expect(compare(expected, limited)).to.not.throw(AssertionError)
+        })
+    })
+})


### PR DESCRIPTION
I'm using `browser.log('performance')` which returns a huge result string. It needs limiting in the console output.