### PR TITLE
docs(test.js): update example to use getTitle.then

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -50,7 +50,8 @@ webdriverio
     .remote(options)
     .init()
     .url('http://www.google.com')
-    .title(function(err, res) {
+    .getTitle
+    .then(function(err, res) {
         console.log('Title was: ' + res.value);
     })
     .end();


### PR DESCRIPTION
I'm brand new to webdriver.io, and it took a few minutes to figure out that the use of `.title()` in the example code provided was causing my test.js script to silently fail. My research showed that `.getTitle().then()` is the correct approach.