### PR TITLE
docs(test.js): update to use .getTitle().then()

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -50,8 +50,8 @@ webdriverio
     .remote(options)
     .init()
     .url('http://www.google.com')
-    .title(function(err, res) {
-        console.log('Title was: ' + res.value);
+    .getTitle().then(function(title) {
+        console.log('Title was: ' + title);
     })
     .end();
 ```


### PR DESCRIPTION
This particular example was failing silently on node 4.2; I updated to bring it in line with the homepage example with use of `.getTitle().then()` instead of `.title()`