### PR TITLE
Bringing back selectByName

### DIFF
--- a/lib/commands/selectByName.js
+++ b/lib/commands/selectByName.js
@@ -1,0 +1,71 @@
+/**
+ *
+ * Select option with a specific name.
+ *
+ * <example>
+    :example.html
+    <select id="selectbox">
+        <option name="someName0" value="someValue0">uno</option>
+        <option name="someName1" value="someValue1">dos</option>
+        <option name="someName2" value="someValue2">tres</option>
+        <option name="someName3" value="someValue3">cuatro</option>
+        <option name="someName4" value="someValue4">cinco</option>
+        <option name="someName5" value="someValue5">seis</option>
+    </select>
+
+    :selectByName.js
+    client
+        .getValue('#selectbox').then(function(value) {
+            console.log(value);
+            // returns "someValue0"
+        })
+        .selectByName('#selectbox', 'someName3')
+        .getValue('#selectbox').then(function(value) {
+            console.log(value);
+            // returns "someValue3"
+        });
+ * </example>
+ *
+ * @param {String} selectElem select element that contains the options
+ * @param {String} name      name of option element to get selected
+ *
+ * @uses protocol/element, protocol/elementIdClick, protocol/elementIdElement
+ * @type action
+ *
+ */
+
+import { CommandError } from '../utils/ErrorHandler'
+
+let selectByName = function (selectElem, name) {
+    /**
+     * convert name into string
+     */
+    if (typeof name === 'number') {
+        name = name.toString()
+    }
+
+    /*!
+     * parameter check
+     */
+    if (typeof selectElem !== 'string' || typeof name !== 'string') {
+        throw new CommandError(`number or type of arguments don't agree with selectByValue command`)
+    }
+
+    /**
+     * get options element by xpath
+     */
+    return this.element(selectElem).then((res) => {
+        /**
+         * find option elem using xpath
+         */
+        let normalized = `[normalize-space(@name) = "${name.trim()}"]`
+        return this.elementIdElement(res.value.ELEMENT, `./option${normalized}|./optgroup/option${normalized}`)
+    }).then(function(res) {
+        /**
+         * select option
+         */
+        return this.elementIdClick(res.value.ELEMENT)
+    })
+}
+
+export default selectByName

--- a/test/spec/selectBy.js
+++ b/test/spec/selectBy.js
@@ -57,6 +57,23 @@ describe('selectBy', () => {
         })
     })
 
+    describe('Name', () => {
+        it('should find element without special conditions', async function () {
+            await this.client.selectByName('#selectTest',  'someName7');
+            (await this.client.getValue('#selectTest')).should.be.equal('someValue7')
+        })
+
+        it('should find element with spaces before and after the name', async function () {
+            await this.client.selectByName('#selectTest',  'someName9');
+            (await this.client.getValue('#selectTest')).should.be.equal('someValue9')
+        })
+
+        it('should find element with spaces before and after the name parameter', async function () {
+            await this.client.selectByName('#selectTest', '    someName8    ');
+            (await this.client.getValue('#selectTest')).should.be.equal('someValue8')
+        })
+    })
+
     describe('Value', () => {
         it('should find element without special conditions', async function () {
             await this.client.selectByValue('#selectTest', 'someValue1');


### PR DESCRIPTION
I noticed that `selectByName` got lost somehow. I updated the original code into ES6. I also did this:

```js
        let normalized = `[normalize-space(@name) = "${name.trim()}"]`
```

Template strings accept expressions within the `${}`, which differs from how the other `selectBy*` commands do it. I hope that's ok.

Props for switching to ES6 :sunglasses: