### PR TITLE
setImmediateValue always throws an exception

### DIFF
--- a/lib/protocol/setImmediateValue.js
+++ b/lib/protocol/setImmediateValue.js
@@ -15,7 +15,7 @@
 import { ProtocolError } from '../utils/ErrorHandler'
 
 let setImmediateValue = function (id, value) {
-    if (typeof id !== 'string' || typeof id !== 'number') {
+    if (typeof id !== 'string' && typeof id !== 'number') {
         throw new ProtocolError('setImmediateValue requires two parameters (id, value) from type string')
     }
 


### PR DESCRIPTION
The assertion to throw the `ProtocolError` was wrong.