### PR TITLE
Ensure boolean flags are actually boolean

### DIFF
--- a/lib/helpers/mobileDetector.js
+++ b/lib/helpers/mobileDetector.js
@@ -5,17 +5,23 @@
  * @return {Boolean}       true if platform is mobile device
  */
 let mobileDetector = function (caps) {
-    let isMobile = (typeof caps['appium-version'] !== 'undefined') ||
-           (typeof caps['device-type'] !== 'undefined') || (typeof caps['deviceType'] !== 'undefined') ||
-           (typeof caps['device-orientation'] !== 'undefined') || (typeof caps['deviceOrientation'] !== 'undefined') ||
-           (typeof caps.deviceName !== 'undefined') ||
-           (!caps.browserName || caps.browserName === '' || caps.browserName.toLowerCase() === 'ipad' || caps.browserName.toLowerCase() === 'iphone' || caps.browserName.toLowerCase() === 'android')
+    let isMobile = !!(
+            (typeof caps['appium-version'] !== 'undefined') ||
+            (typeof caps['device-type'] !== 'undefined') || (typeof caps['deviceType'] !== 'undefined') ||
+            (typeof caps['device-orientation'] !== 'undefined') || (typeof caps['deviceOrientation'] !== 'undefined') ||
+            (typeof caps.deviceName !== 'undefined') ||
+            (!caps.browserName || caps.browserName === '' || caps.browserName.toLowerCase() === 'ipad' || caps.browserName.toLowerCase() === 'iphone' || caps.browserName.toLowerCase() === 'android')
+    )
 
-    let isIOS = (caps.platformName && caps.platformName.match(/iOS/i)) ||
-            (caps.deviceName && caps.deviceName.match(/(iPad|iPhone)/i))
+    let isIOS = !!(
+        (caps.platformName && caps.platformName.match(/iOS/i)) ||
+        (caps.deviceName && caps.deviceName.match(/(iPad|iPhone)/i))
+    )
 
-    let isAndroid = (caps.platformName && caps.platformName.match(/Android/i)) ||
-            (caps.browserName && caps.browserName.match(/Android/i))
+    let isAndroid = !!(
+        (caps.platformName && caps.platformName.match(/Android/i)) ||
+        (caps.browserName && caps.browserName.match(/Android/i))
+    )
 
     return { isMobile, isIOS, isAndroid }
 }


### PR DESCRIPTION
I was seeing results like this, which I assume is not desired:
```js
isMobile: true
isIOS: null
isAndroid: [ 'Android', index: 0, input: 'Android' ]
```