### PR TITLE
Wrap stats logging in try...catch but print errors, so runner doesn't crash

### DIFF
--- a/lib/utils/BaseReporter.js
+++ b/lib/utils/BaseReporter.js
@@ -55,64 +55,64 @@ class BaseReporter extends events.EventEmitter {
         })
 
         this.on('runner:start', (runner) => {
-            this.stats.runnerStart(runner)
-            this.stats.specStart(runner)
+            this.log('runnerStart', runner)
+            this.log('specStart', runner)
         })
 
         this.on('runner:init', (runner) => {
-            this.stats.setSessionId(runner)
+            this.log('setSessionId', runner)
         })
 
         this.on('runner:beforecommand', (command) => {
-            this.stats.output('beforecommand', command)
+            this.log('output', 'beforecommand', command)
         })
 
         this.on('runner:command', (command) => {
-            this.stats.output('command', command)
+            this.log('output', 'command', command)
         })
 
         this.on('runner:aftercommand', (command) => {
-            this.stats.output('aftercommand', command)
+            this.log('output', 'aftercommand', command)
         })
 
         this.on('runner:result', (result) => {
-            this.stats.output('result', result)
+            this.log('output', 'result', result)
         })
 
         this.on('runner:screenshot', (screenshot) => {
-            this.stats.output('screenshot', screenshot)
+            this.log('output', 'screenshot', screenshot)
         })
 
         this.on('runner:log', (log) => {
-            this.stats.output('log', log)
+            this.log('output', 'log', log)
         })
 
         this.on('suite:start', (suite) => {
-            this.stats.suiteStart(suite)
+            this.log('suiteStart', suite)
         })
 
         this.on('test:start', (test) => {
-            this.stats.testStart(test)
+            this.log('testStart', test)
         })
 
         this.on('test:pass', (test) => {
-            this.stats.testPass(test)
+            this.log('testPass', test)
         })
 
         this.on('test:fail', (test) => {
-            this.stats.testFail(test)
+            this.log('testFail', test)
         })
 
         this.on('test:pending', (test) => {
-            this.stats.testPending(test)
+            this.log('testPending', test)
         })
 
         this.on('test:end', (test) => {
-            this.stats.testEnd(test)
+            this.log('testEnd', test)
         })
 
         this.on('suite:end', (runner) => {
-            this.stats.suiteEnd(runner)
+            this.log('suiteEnd', runner)
         })
 
         this.on('error', (runner) => {
@@ -133,13 +133,21 @@ class BaseReporter extends events.EventEmitter {
         })
 
         this.on('runner:end', (runner) => {
-            this.stats.runnerEnd(runner)
+            this.log('runnerEnd', runner)
         })
 
         this.on('end', (args) => {
-            this.stats.complete()
+            this.log('complete')
             this.printEpilogue = this.printEpilogue && !args.sigint
         })
+    }
+
+    log (type, ...args) {
+        try {
+            this.stats[type].apply(this.stats, args)
+        } catch (e) {
+            console.log(e.stack)
+        }
     }
 
     /**


### PR DESCRIPTION
This doesn't address cases where a `Unrecognised suite [] for runner` error is encountered, which still need fixing, but at least won't let the runner crash in such cases.