### PR TITLE
Updated broken links to Selenium Wiki

### DIFF
--- a/lib/protocol/keys.js
+++ b/lib/protocol/keys.js
@@ -7,12 +7,12 @@
  *
  * You can also use unicode characters like Left arrow or Back space. WebdriverIO will take
  * care of translating them into unicode characters. You’ll find all supported characters
- * [here](https://code.google.com/p/selenium/wiki/JsonWireProtocol#/session/:sessionId/element/:id/value).
+ * [here](https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidelementidvalue).
  * To do that, the value has to correspond to a key from the table.
  *
  * @param {String|String[]} value  The sequence of keys to type. An array must be provided. The server should flatten the array items to a single string to be typed.
  *
- * @see  https://code.google.com/p/selenium/wiki/JsonWireProtocol#/session/:sessionId/keys
+ * @see  https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidkeys
  * @type protocol
  *
  */


### PR DESCRIPTION
The links on http://webdriver.io/api/protocol/keys.html leading to the Selenium Wiki are broken.

* https://code.google.com/p/selenium/wiki/JsonWireProtocol#/session/:sessionId/element/:id/value
* https://code.google.com/p/selenium/wiki/JsonWireProtocol#/session/:sessionId/keys