### PR TITLE
Change setImmediateValue @for to iOS

### DIFF
--- a/lib/protocol/setImmediateValue.js
+++ b/lib/protocol/setImmediateValue.js
@@ -8,7 +8,7 @@
  * </example>
  *
  * @type mobile
- * @for android
+ * @for ios
  *
  */
 


### PR DESCRIPTION
As pointed out on #1092 thread, `setImmediateValue` top documentation block includes @for android. Using Appium 1.4.16, it returns a 501 (a "Not yet implemented" RuntimeError) with the Android driver but it works on iOS.