### PR TITLE
update broken google code links to github wiki

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -6,5 +6,5 @@ title: WebdriverIO - API Docs
 # WebdriverIO API Docs
 
 Welcome to the WebdriverIO docs page. These pages contain reference materials for all implemented selenium
-bindings and commands. Since `v2.0.0` WebdriverIO has all [JSONWire protocol](https://code.google.com/p/selenium/wiki/JsonWireProtocol)
+bindings and commands. Since `v2.0.0` WebdriverIO has all [JSONWire protocol](https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol)
 commands implemented and also supports special bindings for [Appium](http://appium.io).

--- a/docs/guide/getstarted/configuration.md
+++ b/docs/guide/getstarted/configuration.md
@@ -18,7 +18,7 @@ var client = webdriverio.remote(options);
 you need to pass in an object that should contain the following properties:
 
 ### desiredCapabilities
-Defines the capabilities you want to run in your Selenium session. See the [Selenium documentation](https://code.google.com/p/selenium/wiki/DesiredCapabilities)
+Defines the capabilities you want to run in your Selenium session. See the [Selenium documentation](https://github.com/SeleniumHQ/selenium/wiki/DesiredCapabilities)
 for a list of the available `capabilities`. Also useful is Sauce Labs [Automated Test Configurator](https://wiki.saucelabs.com/display/DOCS/Platform+Configurator#/)
 that helps you to create this object by clicking together your desired capabilities.
 

--- a/docs/guide/usage/bindingscommands.md
+++ b/docs/guide/usage/bindingscommands.md
@@ -10,7 +10,7 @@ Bindings & Commands
 
 WebdriverIO differentiates between two different method types: protocol bindings and commands. Protocol bindings
 are the exact representation of the JSONWire protocol interface. They expect the same parameters as described
-in the [protocol docs](https://code.google.com/p/selenium/wiki/JsonWireProtocol#Command_Detail).
+in the [protocol docs](https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#Command_Detail).
 
 ```js
 client.element().then(function(result) {

--- a/docs/index.md
+++ b/docs/index.md
@@ -136,7 +136,7 @@ create your config file in less than a minute. It also gives and overview of all
             test framework. Even Cucumber tests are supported.
         </p>
         <p>
-            It basically sends requests to a Selenium server via the <a href="https://code.google.com/p/selenium/wiki/JsonWireProtocol#Command_Reference">WebDriver Wire Protocol</a>
+            It basically sends requests to a Selenium server via the <a href="https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#Command_Reference">WebDriver Wire Protocol</a>
             and handles its response. These requests are wrapped in useful commands, which
             provide callbacks to test several aspects of your site in an automated way.
         </p>


### PR DESCRIPTION
Can point to their [new docs](https://seleniumhq.github.io/docs/) when these pages get added, but for now the links all redirected to project root on github