### PR TITLE
Remove app path from sanitize.caps() so it fixes #1104

### DIFF
--- a/lib/helpers/sanitize.js
+++ b/lib/helpers/sanitize.js
@@ -29,7 +29,7 @@ let caps = function (caps) {
      * mobile caps
      */
     if (caps.deviceName) {
-        result = [sanitizeString(caps.deviceName), sanitizeString(caps.platformName), sanitizeString(caps.platformVersion)]
+        result = [sanitizeString(caps.deviceName), sanitizeString(caps.platformName), sanitizeString(caps.platformVersion), sanitizeString(caps.app)]
     } else {
         result = [sanitizeString(caps.browserName), sanitizeString(caps.version), sanitizeString(caps.platform), sanitizeString(caps.app)]
     }

--- a/lib/helpers/sanitize.js
+++ b/lib/helpers/sanitize.js
@@ -12,6 +12,7 @@ let sanitizeString = function (str) {
     }
 
     return String(str)
+        .replace(/^.*\/([^\/]+)\/?$/, '$1')
         .replace(/\./g, '_')
         .replace(/\s/g, '')
         .toLowerCase()
@@ -30,7 +31,7 @@ let caps = function (caps) {
     if (caps.deviceName) {
         result = [sanitizeString(caps.deviceName), sanitizeString(caps.platformName), sanitizeString(caps.platformVersion)]
     } else {
-        result = [sanitizeString(caps.browserName), sanitizeString(caps.version), sanitizeString(caps.platform), sanitizeString(caps.app.replace(/^.*\/([^\/]+)\/?$/, '$1'))]
+        result = [sanitizeString(caps.browserName), sanitizeString(caps.version), sanitizeString(caps.platform), sanitizeString(caps.app)]
     }
 
     result = result.filter(n => n !== undefined && n !== '')

--- a/lib/helpers/sanitize.js
+++ b/lib/helpers/sanitize.js
@@ -30,7 +30,7 @@ let caps = function (caps) {
     if (caps.deviceName) {
         result = [sanitizeString(caps.deviceName), sanitizeString(caps.platformName), sanitizeString(caps.platformVersion)]
     } else {
-        result = [sanitizeString(caps.browserName), sanitizeString(caps.version), sanitizeString(caps.platform)]
+        result = [sanitizeString(caps.browserName), sanitizeString(caps.version), sanitizeString(caps.platform), sanitizeString(caps.app.replace(/^.*\/([^\/]+)\/?$/, '$1'))]
     }
 
     result = result.filter(n => n !== undefined && n !== '')

--- a/lib/helpers/sanitize.js
+++ b/lib/helpers/sanitize.js
@@ -28,7 +28,7 @@ let caps = function (caps) {
      * mobile caps
      */
     if (caps.deviceName) {
-        result = [sanitizeString(caps.deviceName), sanitizeString(caps.platformName), sanitizeString(caps.platformVersion), sanitizeString(caps.app)]
+        result = [sanitizeString(caps.deviceName), sanitizeString(caps.platformName), sanitizeString(caps.platformVersion)]
     } else {
         result = [sanitizeString(caps.browserName), sanitizeString(caps.version), sanitizeString(caps.platform)]
     }


### PR DESCRIPTION
Quickfix for #1104 as the app name is polluting the log file name. Unless you run parallel tests on different applications (Is that common?), it will not lead to file name conflicts.