### PR TITLE
Timer: clear main timeout on end

### DIFF
--- a/lib/utils/Timer.js
+++ b/lib/utils/Timer.js
@@ -32,7 +32,7 @@ class Timer {
             this._timeoutId = setTimeout(this.tick.bind(this), this._delay)
         }
 
-        setTimeout(() => {
+        this._mainTimeoutId = setTimeout(() => {
             this._reject('timeout')
             this.stop()
         }, this._timeout)
@@ -45,12 +45,17 @@ class Timer {
         this._timeoutId = null
     }
 
+    stopMain () {
+        clearTimeout(this._mainTimeoutId)
+    }
+
     tick () {
         this._fn().then((res) => {
             // resolve timer only on truthy values
             if (res) {
                 this._resolve(res)
                 this.stop()
+                this.stopMain()
                 return
             }
 
@@ -65,10 +70,12 @@ class Timer {
             if (this.hasTime(delay)) {
                 this._timeoutId = setTimeout(this.tick.bind(this), delay)
             } else {
+                this.stopMain()
                 this._reject('timeout')
             }
         }).catch((err) => {
             this.stop()
+            this.stopMain()
             this._reject(err)
         })
     }


### PR DESCRIPTION
the function registered to nodejs's event queue with setTimeout
is never terminated. therefore nodejs process never ends
even after the promise is resolved and it'll wait untill the callback
function get executed. this a fix to this issue.