### PR TITLE
Add more special selector characters to CSS detection.

### DIFF
--- a/lib/helpers/findElementStrategy.js
+++ b/lib/helpers/findElementStrategy.js
@@ -25,7 +25,7 @@ let findStrategy = function (...args) {
 
     // check value type
     // use id strategy if value starts with # and doesnt contain any other CSS selector-relevant character
-    if (value.indexOf('#') === 0 && value.search(/(\s|>|\.|[|])/) === -1) {
+    if (value.indexOf('#') === 0 && value.search(/(\s|>|\.|\[|\]|:|\+|~)/) === -1) {
         using = 'id'
         value = value.slice(1)
 

--- a/test/spec/unit/selectors.js
+++ b/test/spec/unit/selectors.js
@@ -145,4 +145,24 @@ describe('selector strategies helper', () => {
         element.using.should.be.equal('accessibility id')
         element.value.should.be.equal('foo')
     })
+
+    it('should find an element by css selector with id and attribute', () => {
+        const element = findStrategy('#purplebox[data-foundBy]')
+        element.using.should.be.equal('css selector')
+    })
+
+    it('should find an element by css selector with id and immediately preceded operator', () => {
+        const element = findStrategy('#purplebox+div')
+        element.using.should.be.equal('css selector')
+    })
+
+    it('should find an element by css selector with id and preceded operator', () => {
+        const element = findStrategy('#purplebox~div')
+        element.using.should.be.equal('css selector')
+    })
+
+    it('should find an element by css selector with id and pseudo class', () => {
+        const element = findStrategy('#purplebox:before')
+        element.using.should.be.equal('css selector')
+    })
 })


### PR DESCRIPTION
'[' and ']' weren't escaped properly and there were several CSS special characters missing.

Ref:
https://www.w3.org/TR/css3-selectors/

Aside 1: I can't get all unit tests to run locally. It seems to only run one of the spec files (sanitize.js). I had to manually run just the selectors.js file.

Aside 2: I personally would prefer if matching always defaulted to css selectors and if I wanted to use a special syntax I'd explicitly call another function or pass in an argument saying that.