### PR TITLE
Fix a bug in windowHandleSize without explicit window handle

### DIFF
--- a/lib/protocol/windowHandleSize.js
+++ b/lib/protocol/windowHandleSize.js
@@ -6,12 +6,12 @@
     :windowHandleSize.js
     // get the size of
     // a specified window
-    client.windowHandleSize('dc30381e-e2f3-9444-8bf3-12cc44e8372a', function(err,res) { .. });
+    client.windowHandleSize('dc30381e-e2f3-9444-8bf3-12cc44e8372a');
 
     // the current window
-    client.windowHandleSize(function(err,res) { ... });
+    client.windowHandleSize();
 
-    // change the position of
+    // change the size of
     // a specified window
     client.windowHandleSize('dc30381e-e2f3-9444-8bf3-12cc44e8372a', {width: 800, height: 600});
 
@@ -34,6 +34,10 @@ import { ProtocolError } from '../utils/ErrorHandler'
 let windowHandleSize = function (windowHandle = 'current', size) {
     let data = {}
 
+    if (typeof windowHandle === 'object') {
+        [windowHandle, size] = ['current', windowHandle]
+    }
+
     /*!
      * protocol options
      */
@@ -43,21 +47,15 @@ let windowHandleSize = function (windowHandle = 'current', size) {
     }
 
     /*!
-     * otherwise change window size
+     * change window size if the new size is given
      */
-    if (typeof windowHandle === 'object' && windowHandle.width && windowHandle.height) {
+    if (typeof size === 'object' && size.width && size.height) {
         requestOptions.method = 'POST'
+        // The width and height value might return as a negative value, so
+        // we make sure to use its absolute value.
         data = {
-            // The width and height value might return as a negative value, so
-            // we make sure to use its absolute value.
-            width: Math.abs(windowHandle.width),
-            height: Math.abs(windowHandle.height)
-        }
-    } else if (typeof size === 'object' && size.width && size.height) {
-        requestOptions.method = 'POST'
-        data = {
-            width: size.width,
-            height: size.height
+            width: Math.abs(size.width),
+            height: Math.abs(size.height)
         }
     }
 

--- a/test/spec/desktop/windowHandleSize.js
+++ b/test/spec/desktop/windowHandleSize.js
@@ -2,7 +2,19 @@ import conf from '../../conf/index'
 
 describe('windowHandleSize', () => {
     it('should change window size of current window if no handle is given', async function () {
-        await this.client.windowHandleSize({ width: 500, height: 500 })
+        const requestHandler = this.client.requestHandler
+        const origHandlerCreate = requestHandler.create
+
+        this.client.requestHandler.create = function (options, data) {
+            expect(options.path).to.match(/\/window\/current\/size$/)
+            return origHandlerCreate.call(requestHandler, ...arguments)
+        }
+
+        try {
+            await this.client.windowHandleSize({ width: 500, height: 500 })
+        } finally {
+            requestHandler.create = origHandlerCreate
+        }
 
         const windowSize = await this.client.windowHandleSize()
         windowSize.value.width.should.be.equal(500)


### PR DESCRIPTION
The constructed URL contained ``window/[object Object]/size`` instead of ``window/current/size``.
Selenium server seems to ignore it and works anyway, but PhantomJS does not.