### PR TITLE
Bind `this` in waitUntil

### DIFF
--- a/lib/commands/waitUntil.js
+++ b/lib/commands/waitUntil.js
@@ -53,7 +53,7 @@ export default function (condition, timeout, interval) {
     let fn
 
     if (typeof condition === 'function') {
-        fn = condition
+        fn = condition.bind(this)
     } else {
         fn = () => Promise.resolve(condition)
     }

--- a/test/spec/unit/waitUntil.js
+++ b/test/spec/unit/waitUntil.js
@@ -58,4 +58,13 @@ describe('waitUntil', () => {
             error.message.should.be.equal('Promise was rejected with the following reason: timeout')
         }
     })
+
+    it('should bind `this` to the waitUntil function', async function() {
+        (await this.client.waitUntil(
+            function () {
+              return Promise.resolve(this.waitUntil)
+            },
+            1000
+        )).should.be.equal(this.client.waitUntil)
+    })
 })


### PR DESCRIPTION
This corrects a regression from #1048 where `this` was no longer bound to the condition function passed to `waitUntil`.

See discussion in https://github.com/webdriverio/webdriverio/pull/1048#issuecomment-191350224 for more details.

Previous `this` binding behavior was removed via https://github.com/webdriverio/webdriverio/pull/1048/files#diff-ed6f436d089f3a915b30044657956373L54