### PR TITLE
Run proper service hook according the argument

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -170,8 +170,8 @@ class Launcher {
     async runServiceHook (launcher, hookName, ...args) {
         try {
             return await Promise.all(launcher.map((service) => {
-                if (typeof service.onPrepare === 'function') {
-                    return service.onPrepare.apply(service, args)
+                if (typeof service[hookName] === 'function') {
+                    return service[hookName](...args)
                 }
             }))
         } catch (e) {


### PR DESCRIPTION
Now always is called `onPrepare` hook, even if `onComplete` was meant