### PR TITLE
Fix spacing in `waitForExist` if `reverse` is set

### DIFF
--- a/lib/commands/waitForExist.js
+++ b/lib/commands/waitForExist.js
@@ -43,8 +43,8 @@ let waitForExist = function (selector, ms, reverse = false) {
         })
     }, ms).catch((e) => {
         if (isTimeoutError(e)) {
-            let isReversed = reverse ? '' : 'not'
-            throw new CommandError(`element (${selector}) still ${isReversed} existing after ${ms}ms`)
+            let isReversed = reverse ? '' : 'not '
+            throw new CommandError(`element (${selector}) still ${isReversed}existing after ${ms}ms`)
         }
         throw e
     })


### PR DESCRIPTION
The previous version would return `"still  existing"` with two blanks.