### PR TITLE
Fixes typo in config file name

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -132,7 +132,7 @@ describe('webdriver.io page', function() {
 The last step is to execute the test runner. To do so just run:
 
 ```sh
-$ ./node_modules/.bin/wdio wdio.config.js
+$ ./node_modules/.bin/wdio wdio.conf.js
 ```
 
 Hurray! The test should pass and your can start writing integration tests with WebdriverIO.


### PR DESCRIPTION
## Proposed changes
In the docs it asks to run the command:
```sh
$ ./node_modules/.bin/wdio wdio.config.js
```
as the config file generated is `wdio.conf.js`, the command should be:
```sh
$ ./node_modules/.bin/wdio wdio.conf.js
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

I'm using webdriver.io for the first time, I saw this while I was trying to get started.

### Reviewers: @christian-bromann

