### PR TITLE
Bugfix: take screenshots on failure

### DIFF
--- a/lib/webdriverio.js
+++ b/lib/webdriverio.js
@@ -173,8 +173,6 @@ let WebdriverIO = function (args, modifier) {
         if (!options.isWDIO && typeof onRejected === 'function') {
             delete err.screenshot
             return onRejected(err)
-        } else if (typeof onRejected === 'function') {
-            onRejected(err)
         }
 
         if (!this) {
@@ -186,43 +184,58 @@ let WebdriverIO = function (args, modifier) {
         /**
          * take screenshot only if screenshotPath is given
          */
-        if (typeof options.screenshotPath !== 'string') {
-            return throwException(err, stacktrace.slice())
-        }
+        var screenshotPromise = new Promise((resolve, reject) => {
+            if (typeof options.screenshotPath === 'string') {
 
-        let screenshotPath = path.isAbsolute(options.screenshotPath)
-            ? options.screenshotPath : path.join(process.cwd(), options.screenshotPath)
+                let screenshotPath = path.isAbsolute(options.screenshotPath)
+                    ? options.screenshotPath : path.join(process.cwd(), options.screenshotPath)
 
-        /**
-        * create directory if not existing
-        */
-        try {
-            fs.statSync(screenshotPath)
-        } catch (e) {
-            mkdirp.sync(screenshotPath)
-        }
+                /**
+                * create directory if not existing
+                */
+                try {
+                    fs.statSync(screenshotPath)
+                } catch (e) {
+                    mkdirp.sync(screenshotPath)
+                }
 
-        let client = unit()
-        let capId = sanitize.caps(desiredCapabilities)
-        let timestamp = new Date().toJSON().replace(/:/g, '-')
-        let fileName = `ERROR_${capId}_${timestamp}.png`
-        let filePath = path.join(screenshotPath, fileName)
+                let client = unit()
+                let capId = sanitize.caps(desiredCapabilities)
+                let timestamp = new Date().toJSON().replace(/:/g, '-')
+                let fileName = `ERROR_${capId}_${timestamp}.png`
+                let filePath = path.join(screenshotPath, fileName)
 
-        /**
-         * don't take a new screenshot if we already got one from Selenium
-         */
-        if (typeof err.screenshot === 'string') {
-            let screenshot = new Buffer(err.screenshot, 'base64')
-            fs.writeFileSync(filePath, screenshot)
-            this.emit('screenshot', {
-                data: err.screenshot,
-                filename: fileName,
-                path: filePath
+                /**
+                 * don't take a new screenshot if we already got one from Selenium
+                 */
+                if (typeof err.screenshot === 'string') {
+                    this.emit('screenshot', {
+                        data: err.screenshot,
+                        filename: fileName,
+                        path: filePath
+                    })
+                    let screenshot = new Buffer(err.screenshot, 'base64')
+                    fs.writeFileSync(filePath, screenshot)
+                    resolve()
+                } else {
+                    client.next(prototype.saveScreenshot, [filePath], 'saveScreenshot').then(resolve)
+                }
+
+            } else {
+                reject();
+            }
+        });
+
+        if (typeof onRejected === 'function') {
+            screenshotPromise
+            .then(() => {
+                logger.log(`\tSaved screenshot: ${fileName}`)
+                onRejected(err);
             })
-        } else {
-            client.next(prototype.saveScreenshot, [filePath], 'saveScreenshot')
+            .catch(() => {
+                onRejected(err);
+            })
         }
-        logger.log(`\tSaved screenshot: ${fileName}`)
 
         return throwException(err, stacktrace.slice())
     }

--- a/lib/webdriverio.js
+++ b/lib/webdriverio.js
@@ -214,15 +214,15 @@ let WebdriverIO = function (args, modifier) {
         if (typeof err.screenshot === 'string') {
             let screenshot = new Buffer(err.screenshot, 'base64')
             fs.writeFileSync(filePath, screenshot)
+            this.emit('screenshot', {
+                data: err.screenshot,
+                filename: fileName,
+                path: filePath
+            })
         } else {
             client.next(prototype.saveScreenshot, [filePath], 'saveScreenshot')
         }
         logger.log(`\tSaved screenshot: ${fileName}`)
-        this.emit('screenshot', {
-            data: err.screenshot,
-            filename: fileName,
-            path: filePath
-        })
 
         return throwException(err, stacktrace.slice())
     }

--- a/lib/webdriverio.js
+++ b/lib/webdriverio.js
@@ -217,7 +217,7 @@ let WebdriverIO = function (args, modifier) {
         } else {
             client.next(prototype.saveScreenshot, [filePath], 'saveScreenshot')
         }
-        this.logger.log(`\tSaved screenshot: ${fileName}`)
+        logger.log(`\tSaved screenshot: ${fileName}`)
         this.emit('screenshot', {
             data: err.screenshot,
             filename: fileName,

--- a/lib/webdriverio.js
+++ b/lib/webdriverio.js
@@ -187,7 +187,7 @@ let WebdriverIO = function (args, modifier) {
          * take screenshot only if screenshotPath is given
          */
         if (typeof options.screenshotPath !== 'string') {
-            return throwException(err, stacktrace)
+            return throwException(err, stacktrace.slice())
         }
 
         let screenshotPath = path.isAbsolute(options.screenshotPath)
@@ -224,8 +224,7 @@ let WebdriverIO = function (args, modifier) {
             path: filePath
         })
 
-        let stack = stacktrace.slice()
-        return throwException(err, stack)
+        return throwException(err, stacktrace.slice())
     }
 
     function throwException (e, stack) {


### PR DESCRIPTION
Screenshots that are taken automatically on test failure should emit the `runner:screenshot` event before `test:fail`, so that reporters can group them according to the failed test.

This fix is related to https://github.com/webdriverio/wdio-allure-reporter/pull/8 and #1230 

- fixes #1229