### PR TITLE
Add wdio-testingbot-service service to SUPPORTED_SERVICES

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -29,7 +29,8 @@ const SUPPORTED_REPORTER = [
     ' allure - https://github.com/webdriverio/wdio-allure-reporter'
 ]
 const SUPPORTED_SERVICES = [
-    ' sauce - https://github.com/webdriverio/wdio-sauce-service'
+    ' sauce - https://github.com/webdriverio/wdio-sauce-service',
+    ' testingbot - https://github.com/webdriverio/wdio-testingbot-service'
 ]
 
 const VERSION = pkg.version

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -30,7 +30,7 @@ const SUPPORTED_REPORTER = [
 ]
 const SUPPORTED_SERVICES = [
     ' sauce - https://github.com/webdriverio/wdio-sauce-service',
-    ' testingbot - https://github.com/webdriverio/wdio-testingbot-service'
+    ' testingbot - https://github.com/testingbot/wdio-testingbot-service'
 ]
 
 const VERSION = pkg.version


### PR DESCRIPTION
## Proposed changes

We've created a `wdio-testingbot-service` service, which can be used to update test details after a test has run on TestingBot.

The URL is set to https://github.com/webdriverio/wdio-testingbot-service - so if you guys like you can fork https://github.com/testingbot/wdio-testingbot-service and NPM push. Or if you'd rather have us maintain this?

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

### Reviewers: @christian-bromann
