### PR TITLE
Added the command to install the default driver for selenium-standalone

### DIFF
--- a/docs/guide/getstarted/install.md
+++ b/docs/guide/getstarted/install.md
@@ -28,7 +28,12 @@ server and browser driver separately.
 
 The simplest way to get started is to use one of the NPM selenium standalone
 packages like: [vvo/selenium-standalone](https://github.com/vvo/selenium-standalone). After installing
-it (globally) you can run your server by executing:
+it (globally), install the default driver:
+```sh
+$  selenium-standalone install
+```
+
+and then you can run your server by executing:
 
 ```sh
 $  selenium-standalone start


### PR DESCRIPTION
## Proposed changes

I attempted to set up the webdriverio with standalone-selelnium as per the documentation but the ```selelnium-standalone start``` command fails if you've not run ```selenium-standalone install``` first.  I've added this to the documentation.

## Types of changes

What types of changes does your code introduce to WebdriverIO?  **Just a documentation update.**
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [X] ~~I have added tests that prove my fix is effective or that my feature works~~
- [X] I have added necessary documentation (if appropriate)

## Further comments

Just a documentation change 

### Reviewers: @christian-bromann

I ran through the set up for webdriver io but didn't realise I needed to run "selenium-standalone install" first - I propose updating the doc to include this step.