### PR TITLE
Selector handling for setImmediateValue

### DIFF
--- a/lib/protocol/setImmediateValue.js
+++ b/lib/protocol/setImmediateValue.js
@@ -3,8 +3,11 @@
  * Set immediate value in app.
  *
  * <example>
-    :setImmediateValueSync.js
-    browser.setImmediateValue(el, 'foo')
+    :setImmediateValueId.js
+    browser.setImmediateValue(42, 'foo')
+
+    :setImmediateValueSelector.js
+    browser.setImmediateValue('~myInput', 'foo')
  * </example>
  *
  * @type mobile
@@ -17,6 +20,13 @@ import { ProtocolError } from '../utils/ErrorHandler'
 let setImmediateValue = function (id, value) {
     if (typeof id !== 'string' && typeof id !== 'number') {
         throw new ProtocolError('setImmediateValue requires two parameters (id, value) from type string')
+    }
+
+    /**
+     * recursively call the method with the retrived element id when a non-number is passed
+     */
+    if (isNaN(id)) {
+        return this.element(id).then((elem) => this.setImmediateValue(elem.value.ELEMENT, value))
     }
 
     return this.requestHandler.create({


### PR DESCRIPTION
## Proposed changes

`setImmediateValue` only takes an element id as first parameter, thus an id has to be retrieved before using this command. As suggested in #1303, I implemented a handler for selectors so we can call the method directly, e.g. `setImmediateValue('~myInput', 'foo')`.

## Types of changes

What types of changes does your code introduce to WebdriverIO?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

- As my implementation involves performing 2 protocol commands call, should we move `lib/protocol/setImmediateValue.js` to `lib/commands/setImmediateValue.js`?
- I rewrote the documentation so it is clearer what kind of arguments can be passed
- I did not added tests for it (yet?)

### Reviewers: @christian-bromann