### PR TITLE
Export Launcher

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ import WebdriverIO from './lib/webdriverio'
 import Multibrowser from './lib/multibrowser'
 import ErrorHandler from './lib/utils/ErrorHandler'
 import getImplementedCommands from './lib/helpers/getImplementedCommands'
+import Launcher from './lib/launcher'
 import pkg from './package.json'
 
 const IMPLEMENTED_COMMANDS = getImplementedCommands()
@@ -55,4 +56,4 @@ let multiremote = function (options) {
     return remote(options, multibrowser.getModifier())
 }
 
-export { remote, multiremote, VERSION, ErrorHandler }
+export { remote, multiremote, VERSION, ErrorHandler, Launcher }


### PR DESCRIPTION
## Proposed changes

I have to launch my tests in a custom grunt plugin. And I found a [way](https://github.com/webdriverio/grunt-webdriver/blob/master/src/webdriver.js#L9):

```js
import path from 'path'
import resolve from 'resolve'

const Launcher = require(path.join(path.dirname(resolve.sync('webdriverio')), 'lib/launcher'));
new Launcher(...);
```

But this code is ugly, so I think we should to export the Launcher.

```js
import WebdriverIO from 'webdriverio';

new WebdriverIO.Launcher(...);
```

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

@christian-bromann, what do you think?
