### PR TITLE
Don't set a default browserName when isMobile

### DIFF
--- a/lib/webdriverio.js
+++ b/lib/webdriverio.js
@@ -89,14 +89,14 @@ let WebdriverIO = function (args, modifier) {
         rotatable: true
     }, options.desiredCapabilities || {})
 
+    let { isMobile, isIOS, isAndroid } = mobileDetector(desiredCapabilities)
+
     /**
      * if no caps are specified fall back to firefox
      */
-    if (!desiredCapabilities.browserName && !desiredCapabilities.app) {
+    if (!desiredCapabilities.browserName && !isMobile) {
         desiredCapabilities.browserName = 'firefox'
     }
-
-    let { isMobile, isIOS, isAndroid } = mobileDetector(desiredCapabilities)
 
     if (!isMobile && typeof desiredCapabilities.loggingPrefs === 'undefined') {
         desiredCapabilities.loggingPrefs = {


### PR DESCRIPTION
## Proposed changes

I want to test an Android app using appium.  In `desiredCapaiblities`, I set `browserName=''` and left `app` undefined.  appium rejected the session due to unsupported browser `'firefox'`.  I consciously left `app` undefined because I want to run my test on the already-installed app rather than installing a new version.  This PR removes the test for truthiness of `desiredCapabilities.app`, instead utilizing the existing `mobileDetector()` function to identify when a mobile app is being tested so that `browserName` can be left as an empty string or undefined.

## Types of changes

What types of changes does your code introduce to WebdriverIO?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Reviewers: @christian-bromann

Test `isMoble` rather than `desiredCapabilities.app` when determining to
set a default value for `desiredCapabilities.browserName`.  This allows
allows `desiredCapabilities.app` to be blank, which instructs appium to
skip the upload and installation of an app, instead using the
already-installed copy.