### PR TITLE
Add offset coords to left/middle/rightclick

### DIFF
--- a/lib/commands/leftClick.js
+++ b/lib/commands/leftClick.js
@@ -4,6 +4,8 @@
  * moved-to location.
  *
  * @param {String} selector element to click on
+ * @param {Number} xoffset  X offset to move to, relative to the top-left corner of the element.
+ * @param {Number} yoffset  Y offset to move to, relative to the top-left corner of the element.
  * @uses protocol/element, protocol/buttonPress
  * @type action
  *

--- a/lib/commands/leftClick.js
+++ b/lib/commands/leftClick.js
@@ -11,8 +11,8 @@
 
 import handleMouseButtonCommand from '../helpers/handleMouseButtonCommand'
 
-let leftClick = function (selector) {
-    return handleMouseButtonCommand.call(this, selector, 'left')
+let leftClick = function (selector, xoffset, yoffset) {
+    return handleMouseButtonCommand.call(this, selector, 'left', xoffset, yoffset)
 }
 
 export default leftClick

--- a/lib/commands/middleClick.js
+++ b/lib/commands/middleClick.js
@@ -11,8 +11,8 @@
 
 import handleMouseButtonCommand from '../helpers/handleMouseButtonCommand'
 
-let middleClick = function (selector) {
-    return handleMouseButtonCommand.call(this, selector, 'middle')
+let middleClick = function (selector, xoffset, yoffset) {
+    return handleMouseButtonCommand.call(this, selector, 'middle', xoffset, yoffset)
 }
 
 export default middleClick

--- a/lib/commands/middleClick.js
+++ b/lib/commands/middleClick.js
@@ -4,6 +4,8 @@
  * moved-to location.
  *
  * @param {String} selector element to click on
+ * @param {Number} xoffset  X offset to move to, relative to the top-left corner of the element.
+ * @param {Number} yoffset  Y offset to move to, relative to the top-left corner of the element.
  * @uses protocol/element, protocol/buttonPress
  * @type action
  *

--- a/lib/commands/rightClick.js
+++ b/lib/commands/rightClick.js
@@ -4,7 +4,8 @@
  * moved-to location.
  *
  * @param {String} selector element to click on
- *
+ * @param {Number} xoffset  X offset to move to, relative to the top-left corner of the element.
+ * @param {Number} yoffset  Y offset to move to, relative to the top-left corner of the element.
  * @uses protocol/element, protocol/buttonPress
  * @type action
  *

--- a/lib/commands/rightClick.js
+++ b/lib/commands/rightClick.js
@@ -12,8 +12,8 @@
 
 import handleMouseButtonCommand from '../helpers/handleMouseButtonCommand'
 
-let rightClick = function (selector) {
-    return handleMouseButtonCommand.call(this, selector, 'right')
+let rightClick = function (selector, xoffset, yoffset) {
+    return handleMouseButtonCommand.call(this, selector, 'right', xoffset, yoffset)
 }
 
 export default rightClick

--- a/lib/helpers/handleMouseButtonCommand.js
+++ b/lib/helpers/handleMouseButtonCommand.js
@@ -3,7 +3,7 @@ import { ProtocolError } from '../utils/ErrorHandler'
 /**
  * call must be scoped to the webdriverio client
  */
-let handleMouseButtonCommand = function (selector, button) {
+let handleMouseButtonCommand = function (selector, button, xoffset, yoffset) {
     /**
      * mobile only supports simple clicks
      */
@@ -23,7 +23,7 @@ let handleMouseButtonCommand = function (selector, button) {
     }
 
     return this.element(selector).then((res) =>
-        this.moveTo(res.value.ELEMENT).buttonPress(button))
+        this.moveTo(res.value.ELEMENT, xoffset, yoffset).buttonPress(button))
 }
 
 export default handleMouseButtonCommand


### PR DESCRIPTION
## Proposed changes

In this PR I suggest to pass **xoffset** and **yoffset** as optional arguments into left/middle/rightclick methods. I've described my case in the #1331.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

### Reviewers: @christian-bromann

