### PR TITLE
Debugging w/ node inspector

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ to know that you have a clean state.
 
   or install it with npm package [selenium-standalone](https://github.com/vvo/selenium-standalone)
   ```sh
-  $ npm install -g selenium-standalone
+  $ npm install -g selenium-standalone phantomjs
   $ selenium-standalone install
   $ selenium-standalone start
   ```

--- a/docs/guide/getstarted/configuration.md
+++ b/docs/guide/getstarted/configuration.md
@@ -109,6 +109,18 @@ Default interval for all waitForXXX commands.
 Type: `Number`<br>
 Default: *250*
 
+## debug
+Enables node debugging
+
+Type: `Boolean`<br>
+Default: *false*
+
+## execArgv
+Node arguments to specify when launching child processes
+
+Type: `Array of String`<br>
+Default: *null*
+
 ## Setup [Babel](https://babeljs.io/) to write tests using next generation JavaScript
 
 There are multiple ways to setup Babel using the wdio testrunner. If you are running Cucumber or Jasmine test you just need

--- a/docs/guide/testrunner/configurationfile.md
+++ b/docs/guide/testrunner/configurationfile.md
@@ -62,6 +62,7 @@ exports.config = {
     // sessions. Within your capabilities you can overwrite the spec and exclude option in
     // order to group specific specs to a specific capability.
     //
+    //
     // First you can define how many instances should be started at the same time. Let's
     // say you have 3 different capabilities (Chrome, Firefox and Safari) and you have
     // set maxInstances to 1, wdio will spawn 3 processes. Therefor if you have 10 spec
@@ -94,6 +95,16 @@ exports.config = {
         ]
     }],
     //
+    // When enabled opens a debug port for node-inspector and pauses execution
+    // on `debugger` statements. The node-inspector can be attached with:
+    // `node-inspector --debug-port 5859 --no-preload`
+    // When debugging it is also recommended to change the timeout interval of
+    // test runner (eg. jasmineNodeOpts.defaultTimeoutInterval) to a very high
+    // value and setting maxInstances to 1.
+    debug: false
+    //
+    // Additional list node arguments to use when starting child processes
+    execArgv: null
     //
     //
     // ===================

--- a/docs/guide/testrunner/debugging.md
+++ b/docs/guide/testrunner/debugging.md
@@ -1,0 +1,87 @@
+name: Debugging
+category: testrunner
+tags: guide
+index: 8
+title: WebdriverIO - Test Runner Frameworks
+---
+
+Debugging
+==========
+
+Debugging is significantly more difficult when there are several of processes spawning dozens of tests in multiple browsers.
+
+For starters, it is extremely helpful to limit parallelism by setting `maxInstances` to 1 and targeting only those specs and browsers that need to be debugged.
+
+
+In `wdio.conf`:
+```
+maxInstances: 1,
+specs: ['**/myspec.spec.js'],
+capabilities: [{browserName: 'firefox'}]
+```
+
+In many cases, you can use `browser.debug()` to pause your test and inspect the browser.
+When using `browser.debug()` you will likely need to increase the timeout of the test runner to prevent the test runner from failing the test for taking to long.  For example:
+
+In `wdio.conf`:
+```
+jasmineNodeOpts: {
+  defaultTimeoutInterval: (24 * 60 * 60 * 1000);
+}
+```
+
+## Node Inspector
+
+For a more comprehensive debugging experience you can enable debug flag to start the test runner processes with an open debugger port.  
+
+This will allow attaching the node-inspector and pausing test execution with `debugger`.  Each child process will be assigned a new debugging port starting at `5859`.
+
+This feature can be enabled by enabling the `debug` flag in wdio.conf:
+
+```
+{
+  debug: true
+}
+```
+
+Once enabled tests will pause at `debugger` statements. You then must attach the debugger to continue.
+
+If you do not already have `node-inspector` installed, install it with:
+```
+npm install -g node-inspector
+```
+
+And attach to the process with:
+```
+node-inspector --debug-port 5859 --no-preload
+```
+
+The `no-preload` option defers loading source file until needed, this helps performance significantly when project contains a large number of node_modules, but you may need to remove this if you need to navigate your source and add additional breakpoints after attaching the debugger.  
+
+## Dynamic configuration
+
+
+Note that `wdio.conf` can contain javascript. Since you probably do not want to permanently change your timeout value to 1 day, it can be often helpful to change these settings from the commanedline using an environment variable. This can used to dynamically change the configuration:
+
+```
+var debug = process.env.DEBUG;
+var defaultCapabilities = ...;
+var defaultTimeoutInterval = ...;
+var defaultSpecs = ...;
+
+
+exports.config = {
+debug: debug,
+maxInstances: debug ? 1 : 100,
+capabilities: debug ? [{browserName: 'chrome'}] : defaultCapabilities,
+specs:  process.env.SPEC ? [process.env.SPEC] : defaultSepcs,
+jasmineNodeOpts: {
+  defaultTimeoutInterval: debug ? (24 * 60 * 60 * 1000) : defaultTimeoutInterval
+}
+
+```
+
+You can then prefix the `wdio` command with your desired values:
+```
+DEBUG=true SPEC=myspec ./node_modules/.bin/wdio wdio.conf
+```

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -244,12 +244,26 @@ class Launcher {
      */
     startInstance (specs, caps, cid) {
         let config = this.configParser.getConfig()
-        let debug = config.debug || process.execArgv.indexOf('--debug')
+        let debug = caps.debug || config.debug
 
-        let execArgv
-        if (debug) {
-            execArgv = [ ...process.execArgv, `--debug=${(process.debugPort + cid + 1)}` ]
-        }
+        // process.debugPort defaults to 5858 and is set even when process
+        // is not being debugged.
+        let debugArgs = (debug)
+          ? [`--debug=${(process.debugPort + cid + 1)}`]
+          : []
+
+        // if you would like to add --debug-brk, use a different port, etc...
+        let capExecArgs = [
+            ...(config.execArgv || []),
+            ...(caps.execArgv || [])
+        ]
+
+        // The default value for child.fork execArgs is process.execArgs,
+        // so continue to use this unless another value is specified in config.
+        let defaultArgs = (capExecArgs.length) ? process.execArgv : []
+
+        // If an arg appears multiple times the last occurence is used
+        let execArgv = [ ...defaultArgs, ...debugArgs, ...capExecArgs ]
 
         let childProcess = child.fork(__dirname + '/runner.js', process.argv.slice(2), {
             cwd: process.cwd(),

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -243,8 +243,17 @@ class Launcher {
      * @param  {Number} cid  Capabilities ID
      */
     startInstance (specs, caps, cid) {
+        let config = this.configParser.getConfig()
+        let debug = config.debug || process.execArgv.indexOf('--debug')
+
+        let execArgv
+        if (debug) {
+            execArgv = [ ...process.execArgv, `--debug=${(process.debugPort + cid + 1)}` ]
+        }
+
         let childProcess = child.fork(__dirname + '/runner.js', process.argv.slice(2), {
-            cwd: process.cwd()
+            cwd: process.cwd(),
+            execArgv
         })
 
         this.processes.push(childProcess)

--- a/lib/utils/ConfigParser.js
+++ b/lib/utils/ConfigParser.js
@@ -27,6 +27,8 @@ const DEFAULT_CONFIGS = {
     maxInstancesPerCapability: 100,
     connectionRetryTimeout: 90000,
     connectionRetryCount: 3,
+    debug: false,
+    execArgv: null,
 
     /**
      * framework defaults


### PR DESCRIPTION
## Proposed changes

This enables forking child processes with a different debugger port for each node process to enable the use of node-debugger. It is loosely based on the gitter code referenced in this issue https://github.com/webdriverio/webdriverio/issues/459.

 The config.debug flag is used so that it is not necessary debug the launcher process to debug child processes. I also choose to use `--debug` only and not `--debug-brk` as it appears that adding debugger in my code was sufficient to pause until debugger was attached and you can just leave the debug flag on if desired.

Port is based on capability index so first child process would be on 5859 and second child process on 5860.  When using this it is often useful to set config.maxInstances to 1 as you're unlikely to try and debug them all at the same time. I thought about doing this automatically when debug option was specified, but decided to handle that when in my own config generation, such as:

```
debug: !!process.env.DEBUG,
maxInstances: process.env.DEBUG ? 1 : 100,
```

Then run:
```node-inspector --debug-port 5859```

It also often helps to use `--no-preload` to load faster when adding `debugger` in the test itself.

I was also pleasantly surprised that when sync is true that async commands actually behave synchronously in the node-inspector console which makes for a pretty nice repl as well.

If you want to add `--debug-brk`, explicitly specify a different port, or add other options you can do so in using `execArgv` config option.


## Types of changes

What types of changes does your code introduce to WebdriverIO?

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

### Reviewers: @christian-bromann
