### PR TITLE
`browserName === undefined` should not indicate mobile

### DIFF
--- a/lib/helpers/mobileDetector.js
+++ b/lib/helpers/mobileDetector.js
@@ -12,7 +12,7 @@ let mobileDetector = function (caps) {
             (typeof caps.deviceName !== 'undefined') ||
             // Check browserName for specific values
             (caps.browserName === '' ||
-                 (caps.browserName !== undefined && (caps.browserName.toLowerCase() === 'ipad' || caps.browserName.toLowerCase() === 'iphone' || caps.browserName.toLowerCase() === 'android') ))
+                 (caps.browserName !== undefined && (caps.browserName.toLowerCase() === 'ipad' || caps.browserName.toLowerCase() === 'iphone' || caps.browserName.toLowerCase() === 'android')))
     )
 
     let isIOS = !!(

--- a/lib/helpers/mobileDetector.js
+++ b/lib/helpers/mobileDetector.js
@@ -10,7 +10,9 @@ let mobileDetector = function (caps) {
             (typeof caps['device-type'] !== 'undefined') || (typeof caps['deviceType'] !== 'undefined') ||
             (typeof caps['device-orientation'] !== 'undefined') || (typeof caps['deviceOrientation'] !== 'undefined') ||
             (typeof caps.deviceName !== 'undefined') ||
-            (!caps.browserName || caps.browserName === '' || caps.browserName.toLowerCase() === 'ipad' || caps.browserName.toLowerCase() === 'iphone' || caps.browserName.toLowerCase() === 'android')
+            // Check browserName for specific values
+            (caps.browserName === '' ||
+                 (caps.browserName !== undefined && (caps.browserName.toLowerCase() === 'ipad' || caps.browserName.toLowerCase() === 'iphone' || caps.browserName.toLowerCase() === 'android') ))
     )
 
     let isIOS = !!(

--- a/test/spec/unit/mobileDetector.js
+++ b/test/spec/unit/mobileDetector.js
@@ -1,0 +1,59 @@
+import mobileDetector from '../../../lib/helpers/mobileDetector';
+
+describe('mobileDetector helper', () => {
+    it('should not detect mobile app for browserName===undefined', function () {
+        const {isMobile, isIOS, isAndroid} = mobileDetector({});
+        expect( isMobile ).to.be.false;
+        expect( isIOS ).to.be.false;
+        expect( isAndroid ).to.be.false;
+    })
+
+    it('should not detect mobile app for browserName==="firefox"', function () {
+        const {isMobile, isIOS, isAndroid} = mobileDetector({browserName:"firefox"});
+        expect( isMobile ).to.be.false;
+        expect( isIOS ).to.be.false;
+        expect( isAndroid ).to.be.false;
+    })
+
+    it('should not detect mobile app for browserName==="chrome"', function () {
+        const {isMobile, isIOS, isAndroid} = mobileDetector({browserName:"chrome"});
+        expect( isMobile ).to.be.false;
+        expect( isIOS ).to.be.false;
+        expect( isAndroid ).to.be.false;
+    })
+
+    it('should detect mobile app for browserName===""', function () {
+        const {isMobile, isIOS, isAndroid} = mobileDetector({browserName:''});
+        expect( isMobile ).to.be.true;
+        expect( isIOS ).to.be.false;
+        expect( isAndroid ).to.be.false;
+    })
+
+    it('should detect Android mobile app', function () {
+        const {isMobile, isIOS, isAndroid} = mobileDetector({
+                platformName: 'Android',
+                platformVersion: '4.4',
+                deviceName: 'LGVS450PP2a16334',
+                app: 'foo.apk',
+            });
+        expect( isMobile ).to.be.true;
+        expect( isIOS ).to.be.false;
+        expect( isAndroid ).to.be.true;
+    })
+
+    it('should detect Android mobile app without upload', function () {
+        const {isMobile, isIOS, isAndroid} = mobileDetector({
+                platformName: 'Android',
+                platformVersion: '4.4',
+                deviceName: 'LGVS450PP2a16334',
+                appPackage: 'com.example',
+                appActivity: 'com.example.gui.LauncherActivity',
+                noReset: true,
+                appWaitActivity: 'com.example.gui.LauncherActivity',
+            });
+        expect( isMobile ).to.be.true;
+        expect( isIOS ).to.be.false;
+        expect( isAndroid ).to.be.true;
+    })
+
+})

--- a/test/spec/unit/remote.js
+++ b/test/spec/unit/remote.js
@@ -24,4 +24,17 @@ describe('remote method', () => {
         var client = remote({ desiredCapabilities: { browserName: '', app: 'xyz' } })
         client.desiredCapabilities.browserName.should.be.equal('')
     })
+
+    it('should default to firefox if caps are empty', () => {
+        var client = remote({ desiredCapabilities: { } })
+        client.desiredCapabilities.browserName.should.be.equal('firefox')
+    })
+
+    // This allows testing a native Android app via appium using an
+    // already-installed app rather than uploading and installing from an apk.
+    it('should not force firefox when app is undefined but appPackage is not', () => {
+        var client = remote({ desiredCapabilities: {browserName: '', appPackage: 'com.example' } })
+        client.desiredCapabilities.browserName.should.be.equal('')
+    })
+
 })


### PR DESCRIPTION
## Proposed changes

Fixes an issue revealed by PR #1325:  when `caps.browserName` is left undefined
the mobileDetector() function returned `isMobile===true`.  This PR updates the `mobileDetector()` function so that a falsey `browserName` is not considered to indicate driving a mobile app.

## Types of changes

- [x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Reviewers: @christian-bromann

Fixes an issue revealed by PR #1325:  when browserName is left undefined
the mobileDetector function returned `isMobile===true`.  This affects
tests that do not specify any capabilities
(eg `var client = require('webdriverio').remote(); client.init()...`)