### PR TITLE
serialize getLocation requests for multiple elements

### DIFF
--- a/lib/commands/getLocation.js
+++ b/lib/commands/getLocation.js
@@ -37,25 +37,44 @@ let getLocation = function (selector, prop) {
             throw new CommandError(7)
         }
 
-        let elementIdLocationCommands = []
-        for (let elem of res.value) {
-            elementIdLocationCommands.push(this.elementIdLocation(elem.ELEMENT))
-        }
+        let results = []
+        let that = this
+        return new Promise((resolve, reject) => {
+            let hasError = false
 
-        return Promise.all(elementIdLocationCommands)
-    }).then((locations) => {
-        locations = locations.map((location) => {
-            if (typeof prop === 'string' && prop.match(/(x|y)/)) {
-                return location.value[prop]
+            function processNext () {
+                let current = res.value.pop()
+
+                return that
+                    .elementIdLocation(current.ELEMENT)
+                    .catch((err) => {
+                        hasError = true
+                        reject(err)
+                    })
+                    .then((location) => {
+                        if (hasError) {
+                            return
+                        }
+
+                        if (prop === 'x' || prop === 'y') {
+                            results.push(location.value[prop])
+                        } else {
+                            results.push({
+                                x: location.value.x,
+                                y: location.value.y
+                            })
+                        }
+
+                        if (res.value.length) {
+                            return processNext()
+                        } else {
+                            resolve((results.length === 1) ? results[0] : results)
+                        }
+                    })
             }
 
-            return {
-                x: location.value.x,
-                y: location.value.y
-            }
+            return processNext()
         })
-
-        return locations.length === 1 ? locations[0] : locations
     })
 }
 


### PR DESCRIPTION
fixes #1357 

## Proposed changes

Instead of calling `elementIdLocation()` in parallel this change lets each location wait for the previous one to finish.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

### Reviewers: @christian-bromann
