### PR TITLE
CLI: Fix setup and installation of services with hyphenated names

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -213,7 +213,7 @@ WDIO Configuration Helper
         name: 'services',
         message: 'Do you want to add a service to your test setup?',
         choices: SUPPORTED_SERVICES,
-        filter: (services) => services.map((service) => `wdio-${service.split(/\-/)[0].trim()}-service`)
+        filter: (services) => services.map((service) => `wdio-${service}-service`)
     }, {
         type: 'confirm',
         name: 'installServices',


### PR DESCRIPTION
## Proposed changes

This fixes an issue in the CLI (when running `wdio config`) where services with hyphenated names are not set up correctly. Fixes #1378.

Prior to this fix, the CLI resolves services like so:

```javascript
> ['sauce', 'testingbot', 'firefox-profile', 'selenium-standalone'].map((service) => `wdio-${service.split(/\-/)[0].trim()}-service`)
[ 'wdio-sauce-service',
  'wdio-testingbot-service',
  'wdio-firefox-service',
  'wdio-selenium-service' ]
```
Neither `wdio-firefox-service` nor `wdio-selenium-service` exist.

Removing the call to `split()` results in resolving service names correctly:

```javascript
> ['sauce', 'testingbot', 'firefox-profile', 'selenium-standalone'].map((service) => `wdio-${service}-service`)
[ 'wdio-sauce-service',
  'wdio-testingbot-service',
  'wdio-firefox-profile-service',
  'wdio-selenium-standalone-service' ]
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

### Reviewers: @christian-bromann

