### PR TITLE
Expose the process number to the child processes

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -21,6 +21,7 @@ class Launcher {
         this.processes = []
         this.schedule = []
         this.rid = []
+        this.processesStarted = 0
     }
 
     /**
@@ -249,7 +250,7 @@ class Launcher {
         let config = this.configParser.getConfig()
         let debug = caps.debug || config.debug
         let rid = this.getRunnerId(cid)
-        let processNumber = this.getNumberOfRunningInstances() + 1
+        let processNumber = this.processesStarted + 1
 
         // process.debugPort defaults to 5858 and is set even when process
         // is not being debugged.
@@ -290,6 +291,8 @@ class Launcher {
             specs,
             isMultiremote: this.isMultiremote()
         })
+
+        this.processesStarted++
     }
 
     /**

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -249,11 +249,12 @@ class Launcher {
         let config = this.configParser.getConfig()
         let debug = caps.debug || config.debug
         let rid = this.getRunnerId(cid)
+        let processNumber = this.getNumberOfRunningInstances() + 1
 
         // process.debugPort defaults to 5858 and is set even when process
         // is not being debugged.
         let debugArgs = (debug)
-          ? [`--debug=${(process.debugPort + cid + 1)}`]
+          ? [`--debug=${(process.debugPort + processNumber)}`]
           : []
 
         // if you would like to add --debug-brk, use a different port, etc...
@@ -285,7 +286,7 @@ class Launcher {
             command: 'run',
             configFile: this.configFile,
             argv: this.argv,
-            caps,
+            caps: { ...caps, processNumber },
             specs,
             isMultiremote: this.isMultiremote()
         })


### PR DESCRIPTION
## Proposed changes

This change provides the child process a unique incrementing instance number.

## Types of changes

What types of changes does your code introduce to WebdriverIO?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

Our tests startup mock services which need a unique port number, we have been randomly generating this, but we are running into few issues with this.  We would perhaps like this to be more deterministic and allocate within a given port range for each service.  Unfortunately there doesn't seem to be a way to determine how much we should offset from the start port.  

Additionally, due to parallelism log output from child processes can be interleaved which makes it difficult to correlate messages from test runner.  We can use process.pid for this but a sequential test runner name might be easier for human reader to correlate than a pid. 

I attached this value to the browser.desiredCapabilities object as this is available from within the tests setup and didn't want to add another global, but open to other suggestions on how to expose this to child runner plugins/service/setup methods. 

I did see that cid was recently changed to be 1a, 1b, etc... but the the cid doesn't appear to be available to plugins, hooks, etc... so not sure if there is a way to get it.  But the partitioning here by capability isn't desired and we would need to convert alpha value back to numeric offset and leave gaps in address range to account for unknown number runners per capability.  Also not sure how this behaves if there are more than 26 processes? and we think we will probably exceed this as we scale up.  

### Reviewers: @christian-bromann
