### PR TITLE
Don't resume stdin if not paused

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -158,7 +158,9 @@ class Launcher {
         /**
          * make sure the program will not close instantly
          */
-        process.stdin.resume()
+        if (process.stdin.isPaused()) {
+            process.stdin.resume()
+        }
 
         let exitCode = await new Promise((resolve) => {
             this.resolve = resolve


### PR DESCRIPTION
May seem redundant, but it keeps Node from hanging (at least) on Windows for some reason.

I inspected `process._getActiveHandles()` after a `Launcher#run()` and found out that there was a `ReadStream` still open where `isTTY=true`. Thus, I looked for `stdin` in the code and found this line. Took a wild guess by adding the `if` and it worked.

Tested with gulp-webdriver 2.0.1 + Node 4.4.4 + Windows 10 x64.