### PR TITLE
Update waitForExists docs

### DIFF
--- a/lib/commands/waitForExist.js
+++ b/lib/commands/waitForExist.js
@@ -2,9 +2,9 @@
  *
  * Wait for an element (selected by css selector) for the provided amount of
  * milliseconds to be present within the DOM. Returns true if the selector
- * matches at least one element that exists in the DOM. If the reverse flag
- * is true, the command will instead return true if the selector does not
- * match any elements.
+ * matches at least one element that exists in the DOM, otherwise throws an
+ * error. If the reverse flag is true, the command will instead return true
+ * if the selector does not match any elements.
  *
  * <example>
     :waitForExistSyncExample.js


### PR DESCRIPTION
## Proposed changes

Added 4 words to clarify documentation

### Reviewers: @christian-bromann

Under the situation that the element is never discovered, instead of false being returned, a error is thrown, thought it would be worth adding a line in the docs to explain this (tripped me up).