### PR TITLE
Added waitForUrl command

### DIFF
--- a/lib/commands/waitForUrl.js
+++ b/lib/commands/waitForUrl.js
@@ -1,0 +1,57 @@
+/**
+ *
+ * Waits for the current page url to match the provided value.
+ * It's useful when you have a redirection and need to wait for the final url
+ * to be loaded, before running you're next command.
+ *
+ * <example>
+    :waitForUrlExample.js
+    it('should detect the expected url', function () {
+        browser.waitForValue('https://example.com');
+    });
+ * </example>
+ *
+ * @alias browser.waitForUrl
+ * @param {Number=}  ms       time in ms (default: 500)
+ * @param {Boolean=} reverse  if true it waits for the opposite (default: false)
+ * @returns {Boolean}
+ * @uses util/waitUntil, property/getUrl
+ * @type utility
+ *
+ */
+
+import { WaitUntilTimeoutError, isTimeoutError } from '../utils/ErrorHandler'
+
+let waitForUrl = function (url, ms, reverse) {
+    /**
+     * we can't use default values for function parameter here because this would
+     * break the ability to chain the command with an element if reverse is used, like
+     *
+     * ```js
+     * var elem = browser.element('#elem');
+     * elem.waitForXXX(10000, true);
+     * ```
+     */
+    reverse = typeof reverse === 'boolean' ? reverse : false
+
+    /*!
+     * ensure that ms is set properly
+     */
+    if (typeof ms !== 'number') {
+        ms = this.options.waitforTimeout
+    }
+
+    return this.waitUntil(() => {
+        return this.getUrl().then((value) => {
+            return value && value === url && !reverse
+        })
+    }, ms).catch((e) => {
+        if (isTimeoutError(e)) {
+            let isReversed = reverse ? 'with' : 'without'
+            throw new WaitUntilTimeoutError(`url (${url}) still ${isReversed} expected value after ${ms}ms`)
+        }
+        throw e
+    })
+}
+
+export default waitForUrl

--- a/test/spec/waitFor.js
+++ b/test/spec/waitFor.js
@@ -1,3 +1,5 @@
+import conf from '../conf'
+
 describe('waitFor', () => {
     const duration = 10000
 
@@ -172,6 +174,23 @@ describe('waitFor', () => {
                 delta.should.be.above(2000)
                 done()
             })
+        })
+    })
+
+    describe('Url', () => {
+        it('should return w/o err after url got a value', async function () {
+            (await this.client.waitForUrl(conf.testPage.start, duration))
+                .should.be.equal(true)
+        })
+
+        it('(reverse) should return w/o err after url lost its value', async function () {
+            (await this.client.waitForUrl(conf.testPage.start, duration, true))
+                .should.be.equal(false)
+        })
+
+        it('should return with an error if the url never appears', function () {
+            return expect(this.client.waitForUrl(conf.testPage.start, 1))
+                .to.be.rejectedWith(`url (${conf.testPage.start}) still without expected value after 1ms`)
         })
     })
 })


### PR DESCRIPTION
## Proposed changes

`waitForUrl` command waits for the current page url to match the provided value.
It's useful when you have a redirection and need to wait for the final url
 * to be loaded, before running you're next command.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

### Reviewers: @christian-bromann

