### PR TITLE
Fix 'supported services' NPM package names in config wizard

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -213,7 +213,7 @@ WDIO Configuration Helper
         name: 'services',
         message: 'Do you want to add a service to your test setup?',
         choices: SUPPORTED_SERVICES,
-        filter: (services) => services.map((service) => `wdio-${service}-service`)
+        filter: (services) => services.map((service) => `wdio-${service.split(/\- /)[0].trim()}-service`)
     }, {
         type: 'confirm',
         name: 'installServices',


### PR DESCRIPTION
## Proposed changes
The config wizard fails when trying to install services. It just looks like the package name isn't stripped properly:
```
Installing wdio packages:
pkg: wdio-mocha-framework
pkg: wdio- testingbot - https://github.com/testingbot/wdio-testingbot-service-service
Error: Command failed: /bin/sh -c npm i -D wdio-mocha-framework wdio- testingbot - https://github.com/testingbot/wdio-testingbot-service-service
```

## Types of changes

What types of changes does your code introduce to WebdriverIO?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

### Reviewers: @christian-bromann

