### PR TITLE
Fix incorrect mocha option in docs

### DIFF
--- a/docs/guide/getstarted/configuration.md
+++ b/docs/guide/getstarted/configuration.md
@@ -173,6 +173,6 @@ Similarly for mocha:
     mochaOpts: {
         ui: 'bdd',
         compilers: ['ts:ts-node/register'],
-        require: ['./test/helpers/common.js']
+        requires: ['./test/helpers/common.js']
     },
 ```


### PR DESCRIPTION
## Proposed changes

[wdio-mocha-framework](https://github.com/webdriverio/wdio-mocha-framework/blob/fbbaada5cefafdd209212f46384b50c551abce59/lib/adapter.js#L51) looks for `mochaOpts.requires` but the [docs say `require`](http://webdriver.io/guide/getstarted/configuration.html). Unlike `mocha.opts` which only supports one module per require, wdio accepts an array. So I assume it's a mistake in the docs rather than `wdio-mocha-framework`.

## Types of changes

What types of changes does your code introduce to WebdriverIO?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

I have not cloned or run anything (as in CONTRIBUTING.md) because this is such a tiny change.
If this breaks anything, I will quit my job.

### Reviewers: @christian-bromann

