### PR TITLE
screenshotOnReject: Ability to extend error with current page screenshot

### DIFF
--- a/docs/guide/getstarted/configuration.md
+++ b/docs/guide/getstarted/configuration.md
@@ -97,6 +97,14 @@ Saves a screenshot to a given path if the Selenium driver crashes
 Type: `String`|`null`<br>
 Default: *null*
 
+### screenshotOnReject
+Attaches a screenshot of a current page to the error if the Selenium driver crashes
+
+Type: `Boolean`<br>
+Default: *false*
+
+**Note**: Attaching screenshot to the error uses extra time to get screenshot and extra memory to store it. So for the sake of performance it is disabled by default.
+
 ### waitforTimeout
 Default timeout for all waitForXXX commands.
 

--- a/lib/webdriverio.js
+++ b/lib/webdriverio.js
@@ -189,18 +189,29 @@ let WebdriverIO = function (args, modifier) {
             }
         }
 
-        err.shotTaken = true
-        return saveErrorScreenshot(err)
-            .then(() => typeof onRejected === 'function' && onRejected(err))
-            .then(() => {
-                let stack = stacktrace.slice()
-                return throwException(err, stack)
-            })
+        const client = unit()
+        const failDate = new Date()
+
+        // don't take a new screenshot if we already got one from Selenium
+        let screenshotPromise = typeof err.screenshot === 'string'
+            ? Promise.resolve(err.screenshot)
+            : client.next(prototype.screenshot, [], 'screenshot').then((res) => res.value)
+
+        return screenshotPromise.then((screenshot) => {
+            err.shotTaken = true
+            const filename = saveScreenshot(screenshot, failDate)
+
+            client.emit('screenshot', { data: screenshot, filename })
+
+            const stack = stacktrace.slice()
+            return throwException(err, stack)
+        })
     }
 
-    function saveErrorScreenshot (err) {
-        let screenshotPath = path.isAbsolute(options.screenshotPath)
-            ? options.screenshotPath : path.join(process.cwd(), options.screenshotPath)
+    function saveScreenshot (screenshot, date) {
+        const screenshotPath = path.isAbsolute(options.screenshotPath)
+            ? options.screenshotPath
+            : path.join(process.cwd(), options.screenshotPath)
 
         /**
         * create directory if not existing
@@ -211,26 +222,15 @@ let WebdriverIO = function (args, modifier) {
             mkdirp.sync(screenshotPath)
         }
 
-        let client = unit()
-        let capId = sanitize.caps(desiredCapabilities)
-        let timestamp = new Date().toJSON().replace(/:/g, '-')
-        let filename = `ERROR_${capId}_${timestamp}.png`
-        let filePath = path.join(screenshotPath, filename)
-        let screenshotPromise = Promise.resolve()
+        const capId = sanitize.caps(desiredCapabilities)
+        const timestamp = date.toJSON().replace(/:/g, '-')
+        const filename = `ERROR_${capId}_${timestamp}.png`
+        const filePath = path.join(screenshotPath, filename)
 
-        /**
-         * don't take a new screenshot if we already got one from Selenium
-         */
-        if (typeof err.screenshot === 'string') {
-            let screenshot = new Buffer(err.screenshot, 'base64')
-            fs.writeFileSync(filePath, screenshot)
-            client.emit('screenshot', { data: err.screenshot, filename })
-        } else {
-            screenshotPromise = client.next(prototype.saveScreenshot, [filePath], 'saveScreenshot')
-        }
-        client.logger.log(`\tSaved screenshot: ${filename}`)
+        fs.writeFileSync(filePath, new Buffer(screenshot, 'base64'))
+        logger.log(`\tSaved screenshot: ${filename}`)
 
-        return screenshotPromise
+        return filename
     }
 
     function throwException (e, stack) {

--- a/lib/webdriverio.js
+++ b/lib/webdriverio.js
@@ -28,6 +28,7 @@ let EventEmitter = events.EventEmitter
  */
 let WebdriverIO = function (args, modifier) {
     let prototype = Object.create(Object.prototype)
+    let rawCommands = {}
     let eventHandler = new EventEmitter()
     let fulFilledPromise = q()
     let stacktrace = []
@@ -170,45 +171,70 @@ let WebdriverIO = function (args, modifier) {
      * check if the last and current promise got rejected. If so we can throw the error.
      */
     let reject = function (err, onRejected) {
-        if (!options.isWDIO && typeof onRejected === 'function') {
+        if (!options.isWDIO && !options.screenshotOnReject && typeof onRejected === 'function') {
             delete err.screenshot
             return onRejected(err)
         }
 
-        /**
-         * take screenshot only if screenshotPath is given and we are on top of promise chain
-         */
-        if (!this || this.depth !== 0 || typeof options.screenshotPath !== 'string' || err.shotTaken) {
-            if (typeof onRejected === 'function') {
-                onRejected(err)
-            }
-            if (this && this.depth !== 0) {
-                return this.promise
-            } else {
-                return throwException(err, stacktrace)
-            }
+        if (typeof onRejected !== 'function') {
+            onRejected = () => {}
         }
 
+        if (!this) {
+            onRejected(err)
+            throw err
+        }
+
+        if (this.depth !== 0) {
+            onRejected(err)
+            return this.promise
+        }
+
+        const shouldTakeScreenshot = options.screenshotOnReject || typeof options.screenshotPath === 'string'
+
+        if (!shouldTakeScreenshot || err.shotTaken || insideCommand('screenshot', this)) {
+            onRejected(err)
+            return throwException(err, stacktrace)
+        }
+
+        return takeScreenshot.call(this, err)
+            .catch((e) => logger.log('\tFailed to take screenshot on reject:', e))
+            .then(() => {
+                err.shotTaken = true
+                onRejected(err)
+                const stack = stacktrace.slice()
+                return throwException(err, stack)
+            })
+    }
+
+    function insideCommand (command, unit) {
+        const commands = unit.commandList
+        return commands && commands[commands.length - 1].name === command
+    }
+
+    function takeScreenshot (err) {
         const client = unit()
         const failDate = new Date()
 
         // don't take a new screenshot if we already got one from Selenium
         let screenshotPromise = typeof err.screenshot === 'string'
             ? Promise.resolve(err.screenshot)
-            : client.next(prototype.screenshot, [], 'screenshot').then((res) => res.value)
+            : client.next(rawCommands.screenshot, [], 'screenshot').then((res) => res.value)
 
-        return screenshotPromise.then((screenshot) => {
-            err.shotTaken = true
-            const filename = saveScreenshot(screenshot, failDate)
+        return screenshotPromise
+            .then((screenshot) => {
+                if (options.screenshotOnReject) {
+                    err.screenshot = screenshot
+                }
 
-            client.emit('screenshot', { data: screenshot, filename })
-
-            const stack = stacktrace.slice()
-            return throwException(err, stack)
-        })
+                if (typeof options.screenshotPath === 'string') {
+                    const filename = saveScreenshotSync(screenshot, failDate)
+                    client.emit('screenshot', { data: screenshot, filename })
+                }
+            })
     }
 
-    function saveScreenshot (screenshot, date) {
+    function saveScreenshotSync (screenshot, date) {
         const screenshotPath = path.isAbsolute(options.screenshotPath)
             ? options.screenshotPath
             : path.join(process.cwd(), options.screenshotPath)
@@ -491,6 +517,8 @@ let WebdriverIO = function (args, modifier) {
 
             commandGroup = prototype[namespace]
         }
+
+        rawCommands[name] = func
 
         commandGroup[name] = function (...args) {
             let nextPromise = this.promise

--- a/lib/webdriverio.js
+++ b/lib/webdriverio.js
@@ -198,7 +198,7 @@ let WebdriverIO = function (args, modifier) {
         }
 
         err.shotTaken = true
-        return takeScreenshot.call(this, err)
+        return takeScreenshot(err)
             .catch((e) => logger.log('\tFailed to take screenshot on reject:', e))
             .then(() => fail(err, onRejected))
     }
@@ -213,11 +213,11 @@ let WebdriverIO = function (args, modifier) {
         const failDate = new Date()
 
         // don't take a new screenshot if we already got one from Selenium
-        let screenshotPromise = typeof err.screenshot === 'string'
-            ? Promise.resolve(err.screenshot)
-            : client.next(rawCommands.screenshot, [], 'screenshot').then((res) => res.value)
+        const getScreenshot = typeof err.screenshot === 'string'
+            ? () => err.screenshot
+            : () => rawCommands.screenshot.call(client).then((res) => res.value)
 
-        return screenshotPromise
+        return q.fcall(getScreenshot)
             .then((screenshot) => {
                 if (options.screenshotOnReject) {
                     err.screenshot = screenshot

--- a/lib/webdriverio.js
+++ b/lib/webdriverio.js
@@ -176,39 +176,35 @@ let WebdriverIO = function (args, modifier) {
             return onRejected(err)
         }
 
-        if (typeof onRejected !== 'function') {
-            onRejected = () => {}
+        const onRejectedSafe = (err) => {
+            if (typeof onRejected === 'function') {
+                onRejected(err)
+            }
         }
 
-        if (!this) {
-            onRejected(err)
+        if (!this && !options.screenshotOnReject) {
+            onRejectedSafe(err)
             throw err
         }
 
-        if (this.depth !== 0) {
-            onRejected(err)
+        if (this && this.depth !== 0) {
+            onRejectedSafe(err)
             return this.promise
         }
 
         const shouldTakeScreenshot = options.screenshotOnReject || typeof options.screenshotPath === 'string'
-
         if (!shouldTakeScreenshot || err.shotTaken || insideCommand('screenshot', this)) {
-            onRejected(err)
-            return throwException(err, stacktrace)
+            return fail(err, onRejected)
         }
 
+        err.shotTaken = true
         return takeScreenshot.call(this, err)
             .catch((e) => logger.log('\tFailed to take screenshot on reject:', e))
-            .then(() => {
-                err.shotTaken = true
-                onRejected(err)
-                const stack = stacktrace.slice()
-                return throwException(err, stack)
-            })
+            .then(() => fail(err, onRejected))
     }
 
     function insideCommand (command, unit) {
-        const commands = unit.commandList
+        const commands = unit && unit.commandList
         return commands && commands[commands.length - 1].name === command
     }
 
@@ -259,12 +255,12 @@ let WebdriverIO = function (args, modifier) {
         return filename
     }
 
-    function throwException (e, stack) {
+    function fail (e, onRejected) {
         if (!e.stack) {
-            throw new Error(e)
+            e = new Error(e)
         }
 
-        stack = stack.map(trace => '    at ' + trace)
+        let stack = stacktrace.slice().map(trace => '    at ' + trace)
         e.stack = e.type + ': ' + e.message + '\n' + stack.reverse().join('\n')
 
         /**
@@ -287,7 +283,11 @@ let WebdriverIO = function (args, modifier) {
          * })
          */
 
-        throw e
+        if (typeof onRejected !== 'function') {
+            throw e
+        }
+
+        return onRejected(e)
     }
 
     /**

--- a/test/fixtures/waitUntil.conf.js
+++ b/test/fixtures/waitUntil.conf.js
@@ -1,5 +1,8 @@
 var path = require('path')
+
 var chai = require('chai')
+var chaiString = require('chai-string')
+var chaiAsPromised = require('chai-as-promised')
 
 exports.config = {
     specs: [],
@@ -16,6 +19,8 @@ exports.config = {
     },
     before: function () {
         chai.should()
+        chai.use(chaiString)
+        chai.use(chaiAsPromised)
         global.assert = chai.assert
         global.expect = chai.expect
     }

--- a/test/setup-unit.js
+++ b/test/setup-unit.js
@@ -3,6 +3,7 @@ import nock from 'nock'
 import chai from 'chai'
 import merge from 'deepmerge'
 import chaiString from 'chai-string'
+import chaiAsPromised from 'chai-as-promised'
 import sinon from 'sinon'
 
 /**
@@ -10,6 +11,7 @@ import sinon from 'sinon'
  */
 chai.should()
 chai.use(chaiString)
+chai.use(chaiAsPromised)
 global.assert = chai.assert
 global.expect = chai.expect
 

--- a/test/spec/unit/remote.js
+++ b/test/spec/unit/remote.js
@@ -117,13 +117,25 @@ describe('remote method', () => {
                 })
         })
 
-        it('should not take screenshot again if first attempt failed', () => {
+        it('should try to take screenshot only once ', () => {
             var client = remote({screenshotOnReject: true})
 
             var takeScreenshot = RequestHandler.prototype.create.withArgs('/session/:sessionId/screenshot')
             takeScreenshot.returns(q.reject(new Error('some-error')))
 
             return client.getUrl()
+                .catch(err => assert.calledOnce(takeScreenshot)) // eslint-disable-line handle-callback-err
+        })
+
+        it('should try to take screenshot only once on assert inside `then`', () => {
+            var client = remote({screenshotOnReject: true})
+
+            var takeScreenshot = RequestHandler.prototype.create.withArgs('/session/:sessionId/screenshot')
+            takeScreenshot.throws(new Error())
+
+            return client
+                .init()
+                .then(() => q.reject(new Error()))
                 .catch(err => assert.calledOnce(takeScreenshot)) // eslint-disable-line handle-callback-err
         })
 


### PR DESCRIPTION
## Proposed changes
This PR adds ability to extend error object with current page screenshot via `screenshotOnReject` option

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

### Reviewers: @christian-bromann
