### PR TITLE
use jasmineNodeOpts to pass options to jasmine

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -40,7 +40,7 @@ const SUPPORTED_SERVICES = [
 
 const VERSION = pkg.version
 const ALLOWED_ARGV = ['host', 'port', 'path', 'user', 'key', 'logLevel', 'coloredLogs', 'screenshotPath',
-                      'baseUrl', 'waitforTimeout', 'framework', 'reporters', 'suite', 'cucumberOpts', 'jasmineOpts', 'mochaOpts',
+                      'baseUrl', 'waitforTimeout', 'framework', 'reporters', 'suite', 'cucumberOpts', 'jasmineNodeOpts', 'mochaOpts',
                       'connectionRetryTimeout', 'connectionRetryCount']
 
 optimist
@@ -76,7 +76,7 @@ optimist
     .alias('reporters', 'r')
     .describe('suite', 'overwrites the specs attribute and runs the defined suite')
     .describe('cucumberOpts.*', 'Cucumber options, see the full list options at https://github.com/webdriverio/wdio-cucumber-framework#cucumberopts-options')
-    .describe('jasmineOpts.*', 'Jasmine options, see the full list options at https://github.com/webdriverio/wdio-jasmine-framework#jasminenodeopts-options')
+    .describe('jasmineNodeOpts.*', 'Jasmine options, see the full list options at https://github.com/webdriverio/wdio-jasmine-framework#jasminenodeopts-options')
     .describe('mochaOpts.*', 'Mocha options, see the full list options at http://mochajs.org')
 
     .check((arg) => {
@@ -315,10 +315,10 @@ if (argv.cucumberOpts) {
 }
 
 /**
- * sanitize jasmineOpts
+ * sanitize jasmineNodeOpts
  */
-if (argv.jasmineOpts && argv.jasmineOpts.defaultTimeoutInterval) {
-    argv.jasmineOpts.defaultTimeoutInterval = parseInt(argv.jasmineOpts.defaultTimeoutInterval, 10)
+if (argv.jasmineNodeOpts && argv.jasmineNodeOpts.defaultTimeoutInterval) {
+    argv.jasmineNodeOpts.defaultTimeoutInterval = parseInt(argv.jasmineNodeOpts.defaultTimeoutInterval, 10)
 }
 
 /**


### PR DESCRIPTION
## Proposed changes

Update `cli.js` to use `jasmineNodeOpts` which is used in frameworks.jasmine[

## Types of changes

What types of changes does your code introduce to WebdriverIO?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

### Reviewers: @christian-bromann

