### PR TITLE
Await error screenshot before promise rejection

### DIFF
--- a/lib/webdriverio.js
+++ b/lib/webdriverio.js
@@ -173,23 +173,32 @@ let WebdriverIO = function (args, modifier) {
         if (!options.isWDIO && typeof onRejected === 'function') {
             delete err.screenshot
             return onRejected(err)
-        } else if (typeof onRejected === 'function') {
-            onRejected(err)
-        }
-
-        if (!this) {
-            throw err
-        } else if (this.depth !== 0) {
-            return this.promise
         }
 
         /**
-         * take screenshot only if screenshotPath is given
+         * take screenshot only if screenshotPath is given and we are on top of promise chain
          */
-        if (typeof options.screenshotPath !== 'string' || err.shotTaken) {
-            return throwException(err, stacktrace)
+        if (!this || this.depth !== 0 || typeof options.screenshotPath !== 'string' || err.shotTaken) {
+            if (typeof onRejected === 'function') {
+                onRejected(err)
+            }
+            if (this && this.depth !== 0) {
+                return this.promise
+            } else {
+                return throwException(err, stacktrace)
+            }
         }
 
+        err.shotTaken = true
+        return saveErrorScreenshot(err)
+            .then(() => typeof onRejected === 'function' && onRejected(err))
+            .then(() => {
+                let stack = stacktrace.slice()
+                return throwException(err, stack)
+            })
+    }
+
+    function saveErrorScreenshot (err) {
         let screenshotPath = path.isAbsolute(options.screenshotPath)
             ? options.screenshotPath : path.join(process.cwd(), options.screenshotPath)
 
@@ -221,11 +230,7 @@ let WebdriverIO = function (args, modifier) {
         }
         client.logger.log(`\tSaved screenshot: ${filename}`)
 
-        err.shotTaken = true
-        return screenshotPromise.then(() => {
-            let stack = stacktrace.slice()
-            return throwException(err, stack)
-        })
+        return screenshotPromise
     }
 
     function throwException (e, stack) {

--- a/test/spec/unit/reject.js
+++ b/test/spec/unit/reject.js
@@ -1,0 +1,61 @@
+import { remote } from '../../../index'
+import { tmpdir } from 'os'
+
+describe('rejection', () => {
+    before(async function() {
+        this.client = remote({
+            screenshotPath: tmpdir()
+        })
+
+        const createSession = global.mock('post', '/session')
+        await this.client.init()
+        createSession.isDone().should.be.true
+    })
+
+    it('should not take screenshot if rejection handler is provided', function () {
+        mock('post', '/session/123ABC/element', { status: 7 })
+
+        let screenshot
+        this.client.on('screenshot', data => {
+            screenshot = data
+        })
+
+        return this.client.click('.missing')
+            .catch(e => {
+                expect(screenshot).to.be.undefined
+                expect(e.message).to.match(/An element could not be located/)
+            })
+    })
+
+    it('should take screenshot if there is no error handler', function () {
+        mock('post', '/session/123ABC/element', { status: 7 })
+        mock('get', '/session/123ABC/screenshot', { status: 0, value: '' })
+
+        let screenshot
+        this.client.on('screenshot', data => {
+            screenshot = data
+        })
+
+        return this.client.click('.missing')
+            .then(() => { throw new Error('Unexpected success') })
+            .catch(e => {
+                expect(screenshot).to.be.defined
+            })
+    })
+
+    it('should prevent infinite loop when screenhot attempt has failed', function () {
+        mock('post', '/session/123ABC/element', { status: 7 })
+        mock('get', '/session/123ABC/screenshot', { status: 6 })
+
+        let screenshot
+        this.client.on('screenshot', data => {
+            screenshot = data
+        })
+
+        return this.client.click('.missing')
+            .then(() => { throw new Error('Unexpected success') })
+            .catch(e => {
+                expect(screenshot).to.be.undefined
+            })
+    })
+})


### PR DESCRIPTION
## Proposed changes

This change is intended to fix https://github.com/webdriverio/wdio-allure-reporter/issues/24
After that, screenshot command will be part of test workflow and will be finished before the test framework will get the failure.

Also, I am aware of https://github.com/webdriverio/webdriverio/pull/1441, which contains similar changes, but I think that this is not necessary to introduce new configuration option.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

*Note*. According to currently existing  tests, there are nobody relied on current behavior. So, I consider this as bugfix to resolve a mess between `test:fail` and `runner:command` events.

## Checklist

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)


### Reviewers: @christian-bromann

