### PR TITLE
moveTo: do not set offset to 0 by default

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,6 +7,7 @@
   },
   "globals": {
     "expect": true,
+    "assert": true,
     "describe": true,
     "before": true,
     "beforeEach": true,
@@ -16,6 +17,7 @@
     "should": true,
     "browser": true,
     "browserA": true,
-    "mock": true
+    "mock": true,
+    "sinon": true
   }
 }

--- a/lib/protocol/moveTo.js
+++ b/lib/protocol/moveTo.js
@@ -19,7 +19,7 @@
 import { ProtocolError } from '../utils/ErrorHandler'
 import eventSimulator from '../scripts/eventSimulator'
 
-let moveTo = function (element, xoffset = 0, yoffset = 0) {
+let moveTo = function (element, xoffset, yoffset) {
     let data = {}
 
     if (typeof element === 'string') {
@@ -45,6 +45,9 @@ let moveTo = function (element, xoffset = 0, yoffset = 0) {
      * simulate event in safari
      */
     if (this.desiredCapabilities.browserName === 'safari') {
+        xoffset = xoffset || 0
+        yoffset = yoffset || 0
+
         let target = { x: xoffset, y: yoffset }
         return this.elementIdLocation(element).then((res) => {
             target = { x: res.value.x + xoffset, y: res.value.y + yoffset }

--- a/test/setup-unit.js
+++ b/test/setup-unit.js
@@ -3,6 +3,7 @@ import nock from 'nock'
 import chai from 'chai'
 import merge from 'deepmerge'
 import chaiString from 'chai-string'
+import sinon from 'sinon'
 
 /**
  * setup chai
@@ -11,6 +12,12 @@ chai.should()
 chai.use(chaiString)
 global.assert = chai.assert
 global.expect = chai.expect
+
+/**
+ * setup sinon
+ */
+global.sinon = sinon
+sinon.assert.expose(chai.assert, {prefix: ''})
 
 /**
  * provide simplified mock interface

--- a/test/spec/unit/moveTo.js
+++ b/test/spec/unit/moveTo.js
@@ -1,0 +1,19 @@
+import { remote } from '../../../index.js'
+import RequestHandler from '../../../lib/utils/RequestHandler'
+import q from 'q'
+
+describe('moveTo command', () => {
+    const sandbox = sinon.sandbox.create()
+
+    afterEach(() => sandbox.restore())
+
+    it('should not set any offset by default', () => {
+        sandbox.stub(RequestHandler.prototype, 'create').returns(q())
+        const client = remote({})
+
+        return client.moveTo('some-element')
+            .then(() => {
+                assert.calledWith(RequestHandler.prototype.create, '/session/:sessionId/moveto', {element: 'some-element'})
+            })
+    })
+})


### PR DESCRIPTION
## Proposed changes

moveTo behaviour was broken in webdriverio@4.2.2
[Spec](https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidmoveto) says that **if offset is not specified than mouse will be moved to the middle of the element**, but  [this commit](https://github.com/webdriverio/webdriverio/commit/79ff992e302676f014c24297278f3e832aa39b61) sets default offset value to 0. So now by default mouse will be moved to the top left corner of the element.

## Types of changes

What types of changes does your code introduce to WebdriverIO?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

### Reviewers: @christian-bromann

