### PR TITLE
Adds wdio-phantomjs-service to the docs

### DIFF
--- a/docs/guide/services/phantomjs.md
+++ b/docs/guide/services/phantomjs.md
@@ -1,0 +1,38 @@
+name: phantomjs
+category: services
+tags: guide
+index: 2
+title: WebdriverIO - PhantomJS Service
+---
+
+PhantomJS Service
+===========================
+
+[This service](https://github.com/cognitom/wdio-phantomjs-service) helps you to run PhantomJS seamlessly when running tests with the [WDIO testrunner](http://webdriver.io/guide/testrunner/gettingstarted.html). It uses [phantom-prebuilt](https://www.npmjs.com/package/phantom-prebuilt) NPM package.
+
+## Installation
+
+From npm:
+
+```bash
+npm install --save-dev wdio-phantomjs-service
+```
+
+Instructions on how to install `WebdriverIO` can be found [here.](http://webdriver.io/guide/getstarted/install.html)
+
+## Configuration
+
+In order to use the service you need to add `phantomjs` to your service array:
+
+```js
+// wdio.conf.js
+export.config = {
+  // ...
+  services: ['phantomjs'],
+  // ...
+};
+```
+
+## Examples
+
+See full examples [here](https://github.com/cognitom/webdriverio-examples/tree/master/wdio-wo-local-selenium).

--- a/docs/guide/services/phantomjs.md
+++ b/docs/guide/services/phantomjs.md
@@ -1,7 +1,7 @@
 name: phantomjs
 category: services
 tags: guide
-index: 2
+index: 5
 title: WebdriverIO - PhantomJS Service
 ---
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -35,7 +35,8 @@ const SUPPORTED_SERVICES = [
     ' sauce - https://github.com/webdriverio/wdio-sauce-service',
     ' testingbot - https://github.com/testingbot/wdio-testingbot-service',
     ' firefox-profile - https://github.com/webdriverio/wdio-firefox-profile-service',
-    ' selenium-standalone - https://github.com/webdriverio/wdio-selenium-standalone-service'
+    ' selenium-standalone - https://github.com/webdriverio/wdio-selenium-standalone-service',
+    ' phantomjs - https://github.com/cognitom/wdio-phantomjs-service'
 ]
 
 const VERSION = pkg.version


### PR DESCRIPTION
## Proposed changes

Adds the document about [wdio-phantomjs-service](https://github.com/cognitom/wdio-phantomjs-service).

## Types of changes

Documentation.

## Further comments

Recently UI libraries need more E2E testing. But Java environment is bit heavy for each testing. I'd like to make such tests easier.

### Reviewers: @christian-bromann

wdio-phantomjs-service is a small helper to run PhantomJS seamlessly when running tests with wdio.