### PR TITLE
Fix chaining selectors with deep matches

### DIFF
--- a/lib/helpers/findElementStrategy.js
+++ b/lib/helpers/findElementStrategy.js
@@ -5,7 +5,7 @@ const DEFAULT_SELECTOR = 'css selector'
 let findStrategy = function (...args) {
     let value = args[0]
     let relative = (args.length > 1 ? args[1] : false)
-    let xpathPrefix = relative ? './' : '//'
+    let xpathPrefix = relative ? './/' : '//'
 
     /**
      * set default selector

--- a/test/spec/functional/selectorChaining.js
+++ b/test/spec/functional/selectorChaining.js
@@ -23,6 +23,11 @@ describe('selectorChaining', () => {
             (elements) => elements.should.be.equal('MORE NESTED'))
     })
 
+    it('should find deeply nested element using selector chaining', function () {
+        return this.client.element('.nested').element('span=nested span').getText().then(
+            (elements) => elements.should.be.equal('NESTED SPAN'))
+    })
+
     it('should select cell using context of row', function () {
         return this.client.elements('tr').then((rows) => {
             var foundRows = []


### PR DESCRIPTION
## Proposed changes

Slightly change the xpath selector used when chaining selectors to match a deeply nested element in the descendant tree.   Addresses issue #1465 

## Types of changes

What types of changes does your code introduce to WebdriverIO?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate) 

## Further comments

none

### Reviewers: @christian-bromann

Use xpath select `.//` instead of `./` to match elements anywhere in the descendant tree, instead of just in the first level of children.

Issue #1465