### PR TITLE
Add files list to package.json for limiting data getting to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,14 @@
     "test-multibrowser": "grunt test:multibrowser",
     "test-snyk": "snyk test"
   },
+  "files": [
+    "bin",
+    "build",
+    "lib",
+    "index.js",
+    "package.json",
+    "README.md"
+  ],
   "dependencies": {
     "archiver": "1.0.0",
     "babel-runtime": "^6.9.2",

--- a/package.json
+++ b/package.json
@@ -35,8 +35,6 @@
   "files": [
     "bin",
     "build",
-    "lib",
-    "index.js",
     "package.json",
     "README.md"
   ],


### PR DESCRIPTION
## Proposed changes

Add files property to `package.json`, https://docs.npmjs.com/files/package.json#files, to limit the amount of data published to npm.

## Types of changes

What types of changes does your code introduce to WebdriverIO?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

Before adding the `files` property, `npm pack` created `tgz` of the size: 802 KB

After adding  the `files` property, `npm pack` created `tgz` of the size: 202 KB

### Reviewers: @christian-bromann

