### PR TITLE
ReporterStats: Split hooks into their own collection instead of grouping with tests

### DIFF
--- a/lib/utils/ReporterStats.js
+++ b/lib/utils/ReporterStats.js
@@ -47,6 +47,7 @@ class SuiteStats extends RunnableStats {
         super('suite')
         this.title = runner.title
         this.tests = {}
+        this.hooks = {}
     }
 }
 
@@ -60,6 +61,15 @@ class TestStats extends RunnableStats {
     }
 }
 
+class HookStats extends RunnableStats {
+    constructor (runner) {
+        super('hook')
+        this.title = runner.title
+        this.parent = runner.parent
+        this.currentTest = runner.currentTest
+    }
+}
+
 class ReporterStats extends RunnableStats {
     constructor () {
         super('base')
@@ -67,6 +77,7 @@ class ReporterStats extends RunnableStats {
         this.counts = {
             suites: 0,
             tests: 0,
+            hooks: 0,
             passes: 0,
             pending: 0,
             failures: 0
@@ -159,24 +170,40 @@ class ReporterStats extends RunnableStats {
             return
         }
 
-        suiteStat.tests[runner.title] = new TestStats(runner)
+        suiteStat.hooks[runner.title] = new HookStats(runner)
     }
 
     hookEnd (runner) {
-        const testStats = this.getTestStats(runner)
+        const hookStats = this.getHookStats(runner)
 
-        if (!testStats) {
+        if (!hookStats) {
             return
         }
 
-        testStats.complete()
-        this.counts.tests++
+        hookStats.complete()
+        this.counts.hooks++
     }
 
     testStart (runner) {
         this.getSuiteStats(runner, runner.parent).tests[runner.title] = new TestStats(runner)
     }
+    getHookStats (runner) {
+        const suiteStats = this.getSuiteStats(runner, runner.parent)
 
+        if (!suiteStats) {
+            return
+        }
+
+        // Errors encountered inside hooks (e.g. beforeEach) can be identified by looking
+        // at the currentTest param (currently only applicable to the Mocha adapter).
+        let title = runner.title
+        if (!suiteStats.hooks[title]) {
+            title = runner.title
+        }
+
+        if (!suiteStats.hooks[title]) throw Error(`Unrecognised hook [${title}] for suite [${runner.parent}]`)
+        return suiteStats.hooks[title]
+    }
     getTestStats (runner) {
         const suiteStats = this.getSuiteStats(runner, runner.parent)
 


### PR DESCRIPTION
## Proposed changes

The current implementation of ReporterStats.js groups all executed hooks in the Tests collection.  This change creates a Hooks collection for each Suite so there is clear differentiation between Test execution and Hook execution

## Types of changes

What types of changes does your code introduce to WebdriverIO?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
While this is not a breaking change, subsequent changes would need to be made to JSON and JUNIT reporters (at a minimum) to surface the Hooks information (today they are surfaced as if they are tests).  If this pull request is accepted I am willing to make the changes to those Reporters.

### Reviewers: @christian-bromann

