### PR TITLE
Fix: Use e.name instead of e.type

### DIFF
--- a/lib/webdriverio.js
+++ b/lib/webdriverio.js
@@ -261,14 +261,14 @@ let WebdriverIO = function (args, modifier) {
         }
 
         let stack = stacktrace.slice().map(trace => '    at ' + trace)
-        e.stack = e.type + ': ' + e.message + '\n' + stack.reverse().join('\n')
+        e.stack = e.name + ': ' + e.message + '\n' + stack.reverse().join('\n')
 
         /**
          * the waitUntil command can execute a lot of functions until it resolves
          * to keep the stacktrace sane we just shrink down the stacktrack and
          * only keep waitUntil in it
          */
-        if (e.type === 'WaitUntilTimeoutError') {
+        if (e.name === 'WaitUntilTimeoutError') {
             stack = e.stack.split('\n')
             stack.splice(1, stack.length - 2)
             e.stack = stack.join('\n')


### PR DESCRIPTION
## Proposed changes

For now if `screenshotOnReject` or `screenshotPath` option set, then error name in stack finally will be `undefined`, like:
```bash
undefined: expected '1' to equal '2'
    at elementIdAttribute("0", "value") - getValue.js:35:55
```

According to the [spec](http://www.ecma-international.org/ecma-262/5.1/#sec-15.11.7.9) Error object doesn't have `type` field but has `name` field.
This PR fixes this so the error will look as expected:
```bash
AssertionError: expected '1' to equal '2'
    at elementIdAttribute("0", "value") - getValue.js:35:55
```

## Types of changes

What types of changes does your code introduce to WebdriverIO?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

### Reviewers: @christian-bromann

