### PR TITLE
Fix: default location for cucumber step definitions

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -200,7 +200,7 @@ WDIO Configuration Helper
         type: 'input',
         name: 'stepDefinitions',
         message: 'Where are your step definitions located?',
-        default: './features/step-definitions/**/*.js',
+        default: './features/step-definitions',
         when: (answers) => answers.framework === 'cucumber'
     }, {
         type: 'checkbox',


### PR DESCRIPTION
## Proposed changes

As mentioned in [#1565](https://github.com/webdriverio/webdriverio/issues/1565) the standard pattern for cucumber step definitions results in a not found error, even when they exist. By just specifying the directory rather than the globbing pattern the suite runs as expected.

## Types of changes

What types of changes does your code introduce to WebdriverIO?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

I couldn't find associated tests for this, but the entire suite passes with the change. So I'm guessing this part isn't covered? Please just let me know whether either that is fine as is, or where relevant tests should live. Thanks.

### Reviewers: @christian-bromann

The generated './features/step_definitions/**/*.js' throws a  not found error, just the directory path is needed ie './features/step_definitions/'