### PR TITLE
Fixed crash in the 'stale element reference' error handler

### DIFF
--- a/lib/helpers/errorHandler.js
+++ b/lib/helpers/errorHandler.js
@@ -20,14 +20,20 @@ export default [
             if (command.name !== 'element' && command.name !== 'elements') {
                 continue
             }
-            if (command.name === 'element' && (!command.result[0].value || command.result[0].value.ELEMENT !== failingCommand.args[0])) {
+
+            if (command.name === 'element' && (!command.result || !command.result.value || command.result.value.ELEMENT !== failingCommand.args[0])) {
                 continue
             }
 
-            for (let result of command.result.value) {
-                if (result.ELEMENT === failingCommand.args[0]) {
-                    commandToRepeat = this.commandList[i - 1]
-                    break
+            if (command.result) {
+                // Ensure an array to simply the below logic
+                const results = Array.isArray(command.result.value) ? command.result.value : command.result.value !== null ? [command.result.value] : []
+
+                for (let result of results) {
+                    if (result.ELEMENT === failingCommand.args[0]) {
+                        commandToRepeat = this.commandList[i - 1]
+                        break
+                    }
                 }
             }
 

--- a/lib/helpers/errorHandler.js
+++ b/lib/helpers/errorHandler.js
@@ -17,23 +17,25 @@ export default [
         for (let i = this.commandList.length - 1; i >= 0; --i) {
             const command = this.commandList[i]
 
+            if (!command.result || !command.result.value) {
+                continue
+            }
+
             if (command.name !== 'element' && command.name !== 'elements') {
                 continue
             }
 
-            if (command.name === 'element' && (!command.result || !command.result.value || command.result.value.ELEMENT !== failingCommand.args[0])) {
+            if (command.name === 'element' && (command.result.value.ELEMENT !== failingCommand.args[0])) {
                 continue
             }
 
-            if (command.result) {
-                // Ensure an array to simply the below logic
-                const results = Array.isArray(command.result.value) ? command.result.value : command.result.value !== null ? [command.result.value] : []
+            // Ensure an array when evaluating the result, so the logic is the same for 'element' and 'elements' commands
+            const results = Array.isArray(command.result.value) ? command.result.value : command.result.value !== null ? [command.result.value] : []
 
-                for (let result of results) {
-                    if (result.ELEMENT === failingCommand.args[0]) {
-                        commandToRepeat = this.commandList[i - 1]
-                        break
-                    }
+            for (let result of results) {
+                if (result.ELEMENT === failingCommand.args[0]) {
+                    commandToRepeat = this.commandList[i - 1]
+                    break
                 }
             }
 

--- a/test/fixtures/specs/stale.spec.js
+++ b/test/fixtures/specs/stale.spec.js
@@ -8,6 +8,13 @@ function goodElementRequest (scope, sessionId, times = 1) {
     })
 }
 
+function goodSingleElementRequest (scope, sessionId, times = 1) {
+    scope.post(`/wd/hub/session/${sessionId}/element`).times(times).delayConnection(100).reply(200, {
+        status: 0,
+        value: { ELEMENT: '0' }
+    })
+}
+
 function staleElementError (scope, sessionId, times = 1) {
     scope.get(`/wd/hub/session/${sessionId}/element/0/displayed`).times(times).delayConnection(100).reply(500, {
         status: 10,
@@ -97,6 +104,37 @@ describe('staleElementRetry', () => {
         }
 
         expect(elementIsGone).to.be.true
+        expect(scope.isDone()).to.be.true
+    })
+
+    it('correctly handles StaleElementReference errors when there are "element" commands in the command history', () => {
+        browser.url(conf.testPage.staleTest)
+
+        let sessionId = browser.requestHandler.sessionID
+        let scope = nock('http://127.0.0.1:4444', { allowUnmocked: true })
+
+        /**
+         * Return a StaleElementReference exception and then a valid result (isDisplayed === false).
+         * Then return a StaleElementReference exception and then finally the result we will be waiting for (isDisplayed === true),
+         * which occurs well within the 6 second wait time.
+         */
+
+        staleElementError(scope, sessionId, 1)
+        isDisplayed(scope, sessionId, 1, false)
+        staleElementError(scope, sessionId, 1)
+        isDisplayed(scope, sessionId, 1, true)
+
+        // Add an 'element' command into the command history to verify that the StaleElementReference error handler doesn't choke on it
+        goodSingleElementRequest(scope, sessionId, 1)
+        browser.element('.someSelector')
+
+        let elementIsDisplayed
+        browser.waitUntil(async () => {
+            elementIsDisplayed = await browser.elementIdDisplayed('0').value
+            return elementIsDisplayed
+        }, 6000)
+
+        expect(elementIsDisplayed).to.be.true
         expect(scope.isDone()).to.be.true
     })
 

--- a/test/spec/functional/staleElementRetry.js
+++ b/test/spec/functional/staleElementRetry.js
@@ -1,10 +1,6 @@
 import conf from '../../conf/index.js'
 
-/**
- * stale element retry is not working in standalone mode
- * ToDo #1469: broke with dependency update to babel6
- */
-describe.skip('staleElementRetry', () => {
+describe('staleElementRetry', () => {
     it('should not throw stale element error in standalone mode', async function () {
         let iterations = 50
         await this.client.url(conf.testPage.staleTest)


### PR DESCRIPTION
Fix for issue #1488.

## Proposed changes

Fixed crash in the 'stale element reference' error handler (lib/helpers/errorHandler.js) that occurred when an 'element' command was in the command list.

The crash occurred because it was assuming that a result value for 'element' commands was always present and then that the result was an array - when in face a result for that type of command is always a WebElement JSON object.

Added test that exercises such a scenario.

**Note**: I am in doubt whether the test I added is a good way to exercise the bug. It was difficult to build up a command list that contained an 'element' (not 'element**s**') command in a natural way and have the error condition trigger in the error handler. Feedback or comments appreciated if this approach isn't good.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

### Reviewers: @christian-bromann