### PR TITLE
Fixed Bug which causes isAppInstalled to throw error even when a stri…

### DIFF
--- a/lib/protocol/isAppInstalled.js
+++ b/lib/protocol/isAppInstalled.js
@@ -18,7 +18,7 @@
 import { ProtocolError } from '../utils/ErrorHandler'
 
 let isAppInstalled = function (bundleId) {
-    if (typeof appPath !== 'string') {
+    if (typeof bundleId !== 'string') {
         throw new ProtocolError('isAppInstalled command requires bundleId parameter from type string')
     }
 


### PR DESCRIPTION
## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

Following code would throw an ProtocolError:

```javascript
browser.isAppInstalled('com.example.calculator'); // => isAppInstalled command requires bundleId parameter from type string
```

When I looked into the sources, I found that the if statement checks if `appPath ` is a string and not if `bundleId` is a string. Therefore I changed the effected if statement. And as far as I can see `appPath` should be undefined.

## Types of changes

What types of changes does your code introduce to WebdriverIO?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

### Reviewers: @christian-bromann

…ng is provided