### PR TITLE
Launcher generates unlimited runner IDs

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -4,7 +4,6 @@ import child from 'child_process'
 import ConfigParser from './utils/ConfigParser'
 import BaseReporter from './utils/BaseReporter'
 
-
 class Launcher {
     constructor (configFile, argv) {
         this.configParser = new ConfigParser()

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -319,13 +319,11 @@ class Launcher {
      * @return {String}     runner id (combination of cid and test id e.g. 0a, 0b, 1a, 1b ...)
      */
     getRunnerId (cid) {
+        let delimiter = '-'
         if (!this.rid[cid]) {
-            this.rid[cid] = 'a'
-            return cid + this.rid[cid]
+            this.rid[cid] = 0
         }
-
-        this.rid[cid] = String.fromCharCode(this.rid[cid].charCodeAt(0) + 1)
-        return cid + this.rid[cid]
+        return [cid, delimiter, this.rid[cid]++].join('')
     }
 
     /**

--- a/lib/utils/ConfigParser.js
+++ b/lib/utils/ConfigParser.js
@@ -207,8 +207,8 @@ class ConfigParser {
             }
 
             if (suiteSpecs.length === 0) {
-                throw new Error(`The suite(s) "${suites.join('", "')}" you specified don\'t exist ` +
-                                'in your config file or doesn\'t contain any files!')
+                throw new Error(`The suite(s) "${suites.join('", "')}" you specified does not exist ` +
+                                'in your config file or does not contain any files!')
             }
 
             specs = suiteSpecs


### PR DESCRIPTION
## Proposed changes

When running more than 26 suites on a single instance, the rid pattern turns from letters to special characters (`y`, `z`, `{`, `|`, `}`, ...). A problem occurs when reporters like wdio-junit-reporter include that identifier in an output file name.

Here is an example that outlines the problem:
```
> var rid = 'a'
undefined
> rid = String.fromCharCode(rid.charCodeAt(0)+1)
'b'
> rid = String.fromCharCode(rid.charCodeAt(0)+1)
'c'
> rid = 'z'
'z'
> rid = String.fromCharCode(rid.charCodeAt(0)+1)
'{'
> rid = String.fromCharCode(rid.charCodeAt(0)+1)
'|'
> rid = String.fromCharCode(rid.charCodeAt(0)+1)
'}'
> rid = String.fromCharCode(rid.charCodeAt(0)+1)
'~'
> rid = String.fromCharCode(rid.charCodeAt(0)+1)
''
> rid = String.fromCharCode(rid.charCodeAt(0)+1)
'
```

With the changes from this pull-request both the cid and the rid are numeric values separated by a delimiter.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)