### PR TITLE
screenshotOnReject: Ability to specify connection retry options

### DIFF
--- a/docs/guide/getstarted/configuration.md
+++ b/docs/guide/getstarted/configuration.md
@@ -122,12 +122,26 @@ Type: `String`|`null`<br>
 Default: *null*
 
 ### screenshotOnReject
-Attaches a screenshot of a current page to the error if the Selenium driver crashes
+Attaches a screenshot of a current page to the error if the Selenium driver crashes.
+Can be specified as object to set the timeout and count of retries on the attempt to take screenshot.
 
-Type: `Boolean`<br>
+Type: `Boolean`|`Object`<br>
 Default: *false*
 
 **Note**: Attaching screenshot to the error uses extra time to get screenshot and extra memory to store it. So for the sake of performance it is disabled by default.
+
+**Example:**
+
+```js
+// take screenshot on reject
+screenshotOnReject: true
+
+// take screenshot on reject and set some options
+screenshotOnReject: {
+    connectionRetryTimeout: 30000,
+    connectionRetryCount: 0
+}
+```
 
 ### waitforTimeout
 Default timeout for all waitForXXX commands.

--- a/lib/webdriverio.js
+++ b/lib/webdriverio.js
@@ -212,6 +212,10 @@ let WebdriverIO = function (args, modifier) {
         const client = unit()
         const failDate = new Date()
 
+        if (typeof options.screenshotOnReject === 'object') {
+            client.requestHandler = createRequestHandlerDecorator(options.screenshotOnReject)
+        }
+
         // don't take a new screenshot if we already got one from Selenium
         const getScreenshot = typeof err.screenshot === 'string'
             ? () => err.screenshot
@@ -228,6 +232,14 @@ let WebdriverIO = function (args, modifier) {
                     client.emit('screenshot', { data: screenshot, filename })
                 }
             })
+    }
+
+    function createRequestHandlerDecorator (opts) {
+        return Object.create(requestHandler, {
+            defaultOptions: {
+                value: Object.assign({}, requestHandler.defaultOptions, opts)
+            }
+        })
     }
 
     function saveScreenshotSync (screenshot, date) {

--- a/test/spec/unit/remote.js
+++ b/test/spec/unit/remote.js
@@ -157,5 +157,66 @@ describe('remote method', () => {
 
             return assert.isRejected(client.getUrl(), /some-error/)
         })
+
+        describe('connection retry options', () => {
+            var mkRequest_ = (client) => {
+                var requestOpts
+
+                RequestHandler.prototype.create.restore()
+                sandbox.stub(RequestHandler.prototype, 'create', function () {
+                    requestOpts = this.defaultOptions
+                })
+
+                return client.getUrl()
+                    .catch(() => requestOpts)
+            }
+
+            it('should take screenshot with default connection retry options', () => {
+                var client = remote({
+                    connectionRetryTimeout: 100500,
+                    connectionRetryCount: 10,
+                    screenshotOnReject: true
+                })
+
+                return mkRequest_(client)
+                    .then((requestOpts) => {
+                        assert.equal(requestOpts.connectionRetryTimeout, 100500)
+                        assert.equal(requestOpts.connectionRetryCount, 10)
+                    })
+            })
+
+            it('should take screenshot with specified connection retry options', () => {
+                var client = remote({
+                    connectionRetryTimeout: 100500,
+                    connectionRetryCount: 10,
+                    screenshotOnReject: {
+                        connectionRetryTimeout: 5000,
+                        connectionRetryCount: 0
+                    }
+                })
+
+                return mkRequest_(client)
+                    .then((requestOpts) => {
+                        assert.equal(requestOpts.connectionRetryTimeout, 5000)
+                        assert.equal(requestOpts.connectionRetryCount, 0)
+                    })
+            })
+
+            it('should use default connection retry option for not specified options', () => {
+                var client = remote({
+                    connectionRetryTimeout: 100500,
+                    connectionRetryCount: 10,
+                    screenshotOnReject: {
+                        connectionRetryCount: 0
+                    }
+                })
+
+                return mkRequest_(client)
+                    .then((requestOpts) => {
+                        assert.equal(requestOpts.connectionRetryTimeout, 100500)
+                        assert.equal(requestOpts.connectionRetryCount, 0)
+                    })
+            })
+        })
     })
 })


### PR DESCRIPTION
## Proposed changes

This PR adds ability to specify `connectionRetryTimeout` and `connectionRetryCount` on request to take screenshot after test is failed. This changes is intended to reduce waiting time. 
When test failed and Selenium trying to take screenshot quite often ie11 waiting for a response for 90000ms * 3 = 4.5 minutes (at worst). It's too long.

## Types of changes

What types of changes does your code introduce to WebdriverIO?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

### Reviewers: @christian-bromann

