### PR TITLE
Throw on service launcher error

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -439,7 +439,11 @@ End selenium sessions properly ...
 
             try {
                 service = require(`wdio-${serviceName}-service/launcher`)
-            } catch (e) {}
+            } catch (e) {
+                if (!e.message.match(`Cannot find module 'wdio-${serviceName}-service/launcher'`)) {
+                    throw new Error(`Couldn't initialise launcher from service "${serviceName}".\n${e.stack}`)
+                }
+            }
 
             if (service && (typeof service.onPrepare === 'function' || typeof service.onPrepare === 'function')) {
                 launchServices.push(service)

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "istanbul": "^0.3.13",
     "load-grunt-tasks": "^3.2.0",
     "mocha": "^2.3.4",
+    "mock-require": "^2.0.0",
     "nock": "8.0.0",
     "saucelabs": "^1.0.1",
     "sinon": "^1.17.2",

--- a/test/fixtures/services/wdio-launcher-failure-service/index.js
+++ b/test/fixtures/services/wdio-launcher-failure-service/index.js
@@ -1,0 +1,1 @@
+module.exports = {}

--- a/test/fixtures/services/wdio-launcher-failure-service/launcher.js
+++ b/test/fixtures/services/wdio-launcher-failure-service/launcher.js
@@ -1,0 +1,2 @@
+require('some-missing-module')
+module.exports = {}

--- a/test/fixtures/services/wdio-launcher-missing-service/index.js
+++ b/test/fixtures/services/wdio-launcher-missing-service/index.js
@@ -1,0 +1,1 @@
+module.exports = {}

--- a/test/spec/unit/launcher.js
+++ b/test/spec/unit/launcher.js
@@ -1,6 +1,7 @@
 import path from 'path'
 import sinon from 'sinon'
 import Launcher from '../../../build/lib/launcher'
+import mock from 'mock-require'
 
 const FIXTURE_ROOT = path.join(__dirname, '..', '..', 'fixtures')
 
@@ -163,6 +164,26 @@ describe('launcher', () => {
 
         afterEach(() => {
             launcher.startInstance.reset()
+        })
+    })
+
+    describe('loads launch services', () => {
+        it('should throw if a service launcher fails', () => {
+            const launcher = path.join(FIXTURE_ROOT, 'services', 'wdio-launcher-failure-service', 'launcher')
+            mock('wdio-launcher-failure-service/launcher', launcher)
+            expect(() => {
+                Launcher.prototype.getLauncher({ services: ['launcher-failure'] })
+            }).to.throw(/Cannot find module 'some-missing-module'/)
+        })
+
+        it('should proceed if the service launcher doesn\'t exist', () => {
+            expect(() => {
+                Launcher.prototype.getLauncher({ services: ['launcher-missing'] })
+            }).to.not.throw(/Cannot find module/)
+        })
+
+        after(() => {
+            mock.stop('wdio-launcher-failure-service/launcher')
         })
     })
 })


### PR DESCRIPTION
I had a service launcher which was silently failing. Now it properly fails, like the service itself does. This means every service will need to include a `launcher.js` with at least an empty default export, I hope that's ok.

This change helped me solve the [wdio-static-server-service problem](https://github.com/LeadPages/wdio-static-server-service/pull/1).