### PR TITLE
Fixed wrong link to Selenium Documentation

### DIFF
--- a/docs/guide/getstarted/configuration.md
+++ b/docs/guide/getstarted/configuration.md
@@ -41,7 +41,7 @@ pageLoadStrategy: 'eager' // strategy for page load
 
 **Details:**
 
-`pageLoadStrategy` is implemented in Selenium [2.46.0](https://github.com/SeleniumHQ/selenium/blob/master/java/CHANGELOG#L205), and apparently, it is only working on Firefox. The valid values are:
+`pageLoadStrategy` is implemented in Selenium [2.46.0](https://github.com/SeleniumHQ/selenium/blob/master/java/CHANGELOG#L494), and apparently, it is only working on Firefox. The valid values are:
 
  `normal` - waits for `document.readyState` to be 'complete'. This value is used by default.<br>
  `eager`  - will abort the wait when `document.readyState` is 'interactive' instead of waiting for 'complete'.<br>


### PR DESCRIPTION
## Proposed changes

The documentation currently references a wrong line in the Release Notes of the Selenium documentation.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
