### PR TITLE
RequestHandler: fix retries logic

### DIFF
--- a/docs/guide/getstarted/configuration.md
+++ b/docs/guide/getstarted/configuration.md
@@ -97,6 +97,18 @@ Shorten `url` command calls by setting a base url. If your `url` parameter start
 Type: `String`<br>
 Default: *null*
 
+### connectionRetryTimeout
+Timeout for any request to the Selenium server
+
+Type: `Number`<br>
+Default: *90000*
+
+### connectionRetryCount
+Count of request retries to the Selenium server
+
+Type: `Number`<br>
+Default: *3*
+
 ### coloredLogs
 Enables colors for log output
 

--- a/lib/utils/RequestHandler.js
+++ b/lib/utils/RequestHandler.js
@@ -163,8 +163,6 @@ class RequestHandler {
     }
 
     request (fullRequestOptions, totalRetryCount, retryCount = 0) {
-        retryCount += 1
-
         return new Promise((resolve, reject) => {
             request(fullRequestOptions, (err, response, body) => {
                 /**
@@ -214,7 +212,7 @@ class RequestHandler {
                     return reject(new RuntimeError(error))
                 }
 
-                if (retryCount === totalRetryCount) {
+                if (retryCount >= totalRetryCount) {
                     let error = null
 
                     if (err && err.message.indexOf('Nock') > -1) {
@@ -232,7 +230,7 @@ class RequestHandler {
                     return reject(error)
                 }
 
-                this.request(fullRequestOptions, totalRetryCount, retryCount)
+                this.request(fullRequestOptions, totalRetryCount, ++retryCount)
                     .then(resolve)
                     .catch(reject)
             })

--- a/test/spec/functional/connectionRetries.js
+++ b/test/spec/functional/connectionRetries.js
@@ -15,10 +15,10 @@ describe('connection retries', () => {
     afterEach(() => nock.cleanAll())
 
     it('should retry connection 3 times if network error occurs', async function () {
-        // mock 2 request errors and third successful
+        // mock 3 request errors and 4th successful
         nock('http://localhost:4444')
             .post('/wd/hub/session')
-                .twice()
+                .thrice()
                 .replyWithError('some error')
             .post('/wd/hub/session')
                 .reply(200, FAKE_SUCCESS_RESPONSE)
@@ -27,10 +27,10 @@ describe('connection retries', () => {
     })
 
     it('should fail with ECONNREFUSED if all connection attempts failed', async function () {
-        // mock 3 request errors
+        // mock 4 request errors (3 of them retries)
         nock('http://localhost:4444')
             .post('/wd/hub/session')
-            .thrice()
+            .times(4)
             .replyWithError('some error')
 
         await WebdriverIO.remote(conf).init().catch(err => {
@@ -38,6 +38,37 @@ describe('connection retries', () => {
             expect(err.message).to.equal('Couldn\'t connect to selenium server')
             expect(err.seleniumStack.type).to.equal('ECONNREFUSED')
         })
+    })
+
+    it('should fail with ECONNREFUSED on first attempt if connectionRetryCount is set as zero', async function () {
+        // mock 1 request error
+        nock('http://localhost:4444')
+            .post('/wd/hub/session')
+            .replyWithError('some error')
+
+        const localConf = merge({}, conf)
+        localConf.connectionRetryCount = 0
+
+        await WebdriverIO.remote(localConf).init().catch(err => {
+            expect(err).not.to.be.undefined
+            expect(err.message).to.equal('Couldn\'t connect to selenium server')
+            expect(err.seleniumStack.type).to.equal('ECONNREFUSED')
+        })
+    })
+
+    it('should use connectionRetryCount option in requests retrying', async function () {
+        // mock 12 request errors
+        nock('http://localhost:4444')
+            .post('/wd/hub/session')
+                .times(12)
+                .replyWithError('some error')
+            .post('/wd/hub/session')
+                .reply(200, FAKE_SUCCESS_RESPONSE)
+
+        const localConf = merge({}, conf)
+        localConf.connectionRetryCount = 15
+
+        await WebdriverIO.remote(localConf).init()
     })
 
     it('should use connectionRetryTimeout option in requests retrying', async function () {
@@ -60,20 +91,5 @@ describe('connection retries', () => {
             expect(connectionTime).to.be.above(3000)
             expect(connectionTime).to.be.below(4000)
         })
-    })
-
-    it('should use connectionRetryCount option in requests retrying', async function () {
-        // mock 12 request errors
-        nock('http://localhost:4444')
-            .post('/wd/hub/session')
-                .times(12)
-                .replyWithError('some error')
-            .post('/wd/hub/session')
-                .reply(200, FAKE_SUCCESS_RESPONSE)
-
-        const localConf = merge({}, conf)
-        localConf.connectionRetryCount = 15
-
-        await WebdriverIO.remote(localConf).init()
     })
 })


### PR DESCRIPTION
## Proposed changes

This PR is intended to fix logic of repeated requests to Selenium server.
Currently retries do not work properly, because first request included in the amount of retries, but it's wrong. If I set `connectionRetryCount = 0` I want to see only one request without retries.

## Types of changes

What types of changes does your code introduce to WebdriverIO?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

### Reviewers: @christian-bromann

