### PR TITLE
Command/configure http

### DIFF
--- a/lib/commands/configureHttp.js
+++ b/lib/commands/configureHttp.js
@@ -1,0 +1,25 @@
+/**
+ * Set http request options
+ *
+ * <example>
+    :configureHttp.js
+    client
+        .init()
+        .url('http://google.com')
+        // ... other commands
+        .configureHttp({ // configuring of next requests
+            connectionRetryCount: 1,
+            connectionRetryTimeout: 5000
+        })
+        .end() // timeout on closing of a session will be 5000 ms with 1 retry
+ * </example>
+ *
+ * @param {Object} opts request options (`{protocol: string, hostname: string, port: string, connectionRetryTimeout: number, connectionRetryCount: number}`)
+ * @type utility
+ */
+
+let configureHttp = function (opts) {
+    Object.assign(this.requestHandler.defaultOptions, opts)
+}
+
+export default configureHttp

--- a/test/spec/unit/configureHttp.js
+++ b/test/spec/unit/configureHttp.js
@@ -1,0 +1,61 @@
+import { remote } from '../../../index.js'
+import RequestHandler from '../../../lib/utils/RequestHandler'
+import q from 'q'
+
+describe('configureHttp command', () => {
+    const sandbox = sinon.sandbox.create()
+
+    const stubRequestResult = () => q({body: {sessionId: '', value: ''}})
+
+    const assertRequestUri = (key, value) => {
+        const requestOpts = RequestHandler.prototype.request.lastCall.args[0]
+
+        assert.equal(requestOpts.uri[key], value)
+    }
+
+    beforeEach(() => sandbox.stub(RequestHandler.prototype, 'request').returns(stubRequestResult()))
+
+    afterEach(() => sandbox.restore())
+
+    it('should configure request protocol', () => {
+        const client = remote({protocol: 'http'})
+
+        client.configureHttp({protocol: 'https'})
+
+        return client.init().then(() => assertRequestUri('protocol', 'https:'))
+    })
+
+    it('should configure request host', () => {
+        const client = remote({hostname: '127.0.0.1'})
+
+        client.configureHttp({hostname: 'localhost'})
+
+        return client.init().then(() => assertRequestUri('hostname', 'localhost'))
+    })
+
+    it('should configure request port', () => {
+        const client = remote({port: '4444'})
+
+        client.configureHttp({port: '8080'})
+
+        return client.init().then(() => assertRequestUri('port', '8080'))
+    })
+
+    it('should configure request timeout', () => {
+        const client = remote({connectionRetryTimeout: 90000})
+
+        client.configureHttp({connectionRetryTimeout: 5000})
+
+        return client.init()
+            .then(() => assert.calledWithMatch(RequestHandler.prototype.request, {timeout: 5000}))
+    })
+
+    it('should configure request retry count', () => {
+        const client = remote({connectionRetryCount: 3})
+
+        client.configureHttp({connectionRetryCount: 0})
+
+        return client.init()
+            .then(() => assert.calledWith(RequestHandler.prototype.request, sinon.match.any, 0))
+    })
+})


### PR DESCRIPTION
## Proposed changes

This pull request adds new command `configureHttp`. This feature is useful when you need to change http request options in runtime. For example, I set options `connectionRetryCount` and `connectionRetryTimeout` when I create instance of `wdio`:

```js
const client = webdriverio.remote({
    // ... lots of other options
    connectionRetryCount: 3,
    connectionRetryTimeout: 90000
})

client
    .init()
    .url('https://google.com')
    .end()
```

According to the code above, for all requests (`init`, `url`, `end`) http timeout will be 90000 ms and the amount of retries will be 3, but in tests there is often no need to wait for some requests for 90000 ms with 3 retries, for example, for closing of a session (`end` method), so it seems to be great to have the ability to configure http request options in runtime:

```js
const client = webdriverio.remote({
    // ... lots of other options
    connectionRetryCount: 3,
    connectionRetryTimeout: 90000
})

client
    .init()
    .url('https://google.com')
    .configureHttp({ connectionRetryCount: 1, connectionRetryTimeout: 5000 })
    .end() // timeout on closing of a session will be 5000 ms with 1 retry
```

## Types of changes

What types of changes does your code introduce to WebdriverIO?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

### Reviewers: @christian-bromann @j0tunn 
