### PR TITLE
Improved doc on value property

### DIFF
--- a/lib/commands/setValue.js
+++ b/lib/commands/setValue.js
@@ -20,8 +20,8 @@
  * </example>
  *
  * @alias browser.setValue
- * @param {String}         selector   Input element
- * @param {String|Number=} values     Input element
+ * @param {String}              selector   Input element
+ * @param {String|Number|Array} values     Input element
  * @uses protocol/elements, protocol/elementIdClear, protocol/elementIdValue
  * @type action
  *


### PR DESCRIPTION
## Proposed changes

Documentation update

## Types of changes

- [ ] Documentation

## Checklist

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

None

### Reviewers: @christian-bromann

The `value` property is not optional an can also be an array. Fixed this in the documentation.