### PR TITLE
Using UID instead of title to identify runner, suite, spec and steps

### DIFF
--- a/lib/utils/ReporterStats.js
+++ b/lib/utils/ReporterStats.js
@@ -25,7 +25,7 @@ class RunnableStats {
 class RunnerStats extends RunnableStats {
     constructor (runner) {
         super('runner')
-        this.uid = runner.uid
+        this.uid = this.getIdentifier(runner)
         this.cid = runner.cid
         this.capabilities = runner.capabilities
         this.sanitizedCapabilities = runner.capabilities && sanitize.caps(runner.capabilities)
@@ -37,7 +37,7 @@ class RunnerStats extends RunnableStats {
 class SpecStats extends RunnableStats {
     constructor (runner) {
         super('spec')
-        this.uid = runner.uid
+        this.uid = this.getIdentifier(runner)
         this.files = runner.specs
         this.specHash = runner.specHash
         this.suites = {}
@@ -48,7 +48,7 @@ class SpecStats extends RunnableStats {
 class SuiteStats extends RunnableStats {
     constructor (runner) {
         super('suite')
-        this.uid = runner.uid
+        this.uid = this.getIdentifier(runner)
         this.title = runner.title
         this.tests = {}
         this.hooks = {}
@@ -58,7 +58,7 @@ class SuiteStats extends RunnableStats {
 class TestStats extends RunnableStats {
     constructor (runner) {
         super('test')
-        this.uid = runner.uid
+        this.uid = this.getIdentifier(runner)
         this.title = runner.title
         this.state = ''
         this.screenshots = []
@@ -69,7 +69,7 @@ class TestStats extends RunnableStats {
 class HookStats extends RunnableStats {
     constructor (runner) {
         super('hook')
-        this.uid = runner.uid
+        this.uid = this.getIdentifier(runner)
         this.title = runner.title
         this.parent = runner.parent
         this.currentTest = runner.currentTest
@@ -160,7 +160,7 @@ class ReporterStats extends RunnableStats {
     }
 
     suiteStart (runner) {
-        this.getSpecStats(runner).suites[runner.uid] = new SuiteStats(runner)
+        this.getSpecStats(runner).suites[this.getIdentifier(runner)] = new SuiteStats(runner)
         this.counts.suites++
     }
 
@@ -186,7 +186,7 @@ class ReporterStats extends RunnableStats {
             return
         }
 
-        suiteStat.hooks[runner.uid] = new HookStats(runner)
+        suiteStat.hooks[this.getIdentifier(runner)] = new HookStats(runner)
     }
 
     hookEnd (runner) {
@@ -201,7 +201,7 @@ class ReporterStats extends RunnableStats {
     }
 
     testStart (runner) {
-        this.getSuiteStats(runner, runner.parent).tests[runner.uid] = new TestStats(runner)
+        this.getSuiteStats(runner, runner.parent).tests[this.getIdentifier(runner)] = new TestStats(runner)
     }
     getHookStats (runner) {
         const suiteStats = this.getSuiteStats(runner, runner.parent)
@@ -212,9 +212,9 @@ class ReporterStats extends RunnableStats {
 
         // Errors encountered inside hooks (e.g. beforeEach) can be identified by looking
         // at the currentTest param (currently only applicable to the Mocha adapter).
-        let uid = runner.currentTest || runner.uid
+        let uid = runner.currentTest || this.getIdentifier(runner)
         if (!suiteStats.hooks[uid]) {
-            uid = runner.uid
+            uid = this.getIdentifier(runner)
         }
 
         if (!suiteStats.hooks[uid]) throw Error(`Unrecognised hook [${runner.title}] for suite [${runner.parent}]`)
@@ -229,9 +229,9 @@ class ReporterStats extends RunnableStats {
 
         // Errors encountered inside hooks (e.g. beforeEach) can be identified by looking
         // at the currentTest param (currently only applicable to the Mocha adapter).
-        let uid = runner.currentTest || runner.uid
+        let uid = runner.currentTest || this.getIdentifier(runner)
         if (!suiteStats.tests[uid]) {
-            uid = runner.uid
+            uid = this.getIdentifier(runner)
         }
 
         if (!suiteStats.tests[uid]) throw Error(`Unrecognised test [${runner.title}] for suite [${runner.parent}]`)
@@ -240,7 +240,7 @@ class ReporterStats extends RunnableStats {
 
     output (type, runner) {
         runner.time = new Date()
-        if (runner.uid && runner.parent) {
+        if (this.getIdentifier(runner) && runner.parent) {
             this.getTestStats(runner).output.push({
                 type,
                 payload: runner
@@ -309,7 +309,7 @@ class ReporterStats extends RunnableStats {
          */
         let duplicateError = false
         for (let failure of this.failures) {
-            if (runner.err.message !== failure.err.message || failure.uid !== runner.uid) {
+            if (runner.err.message !== failure.err.message || this.getIdentifier(failure) !== this.getIdentifier(runner)) {
                 continue
             }
             duplicateError = true
@@ -327,11 +327,15 @@ class ReporterStats extends RunnableStats {
     }
 
     suiteEnd (runner) {
-        this.getSuiteStats(runner, runner.uid).complete()
+        this.getSuiteStats(runner, this.getIdentifier(runner)).complete()
     }
 
     runnerEnd (runner) {
         this.getSpecStats(runner).complete()
+    }
+
+    getIdentifier (runner) {
+        return runner.uid || runner.title
     }
 }
 

--- a/lib/utils/ReporterStats.js
+++ b/lib/utils/ReporterStats.js
@@ -213,7 +213,7 @@ class ReporterStats extends RunnableStats {
         // Errors encountered inside hooks (e.g. beforeEach) can be identified by looking
         // at the currentTest param (currently only applicable to the Mocha adapter).
         let uid = runner.currentTest || runner.uid
-        if (!suiteStats.tests[uid]) {
+        if (!suiteStats.hooks[uid]) {
             uid = runner.uid
         }
 

--- a/lib/utils/ReporterStats.js
+++ b/lib/utils/ReporterStats.js
@@ -25,7 +25,7 @@ class RunnableStats {
 class RunnerStats extends RunnableStats {
     constructor (runner) {
         super('runner')
-        this.uid = getIdentifier(runner)
+        this.uid = ReporterStats.getIdentifier(runner)
         this.cid = runner.cid
         this.capabilities = runner.capabilities
         this.sanitizedCapabilities = runner.capabilities && sanitize.caps(runner.capabilities)
@@ -37,7 +37,7 @@ class RunnerStats extends RunnableStats {
 class SpecStats extends RunnableStats {
     constructor (runner) {
         super('spec')
-        this.uid = getIdentifier(runner)
+        this.uid = ReporterStats.getIdentifier(runner)
         this.files = runner.specs
         this.specHash = runner.specHash
         this.suites = {}
@@ -48,7 +48,7 @@ class SpecStats extends RunnableStats {
 class SuiteStats extends RunnableStats {
     constructor (runner) {
         super('suite')
-        this.uid = getIdentifier(runner)
+        this.uid = ReporterStats.getIdentifier(runner)
         this.title = runner.title
         this.tests = {}
         this.hooks = {}
@@ -58,7 +58,7 @@ class SuiteStats extends RunnableStats {
 class TestStats extends RunnableStats {
     constructor (runner) {
         super('test')
-        this.uid = getIdentifier(runner)
+        this.uid = ReporterStats.getIdentifier(runner)
         this.title = runner.title
         this.state = ''
         this.screenshots = []
@@ -69,7 +69,7 @@ class TestStats extends RunnableStats {
 class HookStats extends RunnableStats {
     constructor (runner) {
         super('hook')
-        this.uid = getIdentifier(runner)
+        this.uid = ReporterStats.getIdentifier(runner)
         this.title = runner.title
         this.parent = runner.parent
         this.currentTest = runner.currentTest
@@ -160,7 +160,7 @@ class ReporterStats extends RunnableStats {
     }
 
     suiteStart (runner) {
-        this.getSpecStats(runner).suites[getIdentifier(runner)] = new SuiteStats(runner)
+        this.getSpecStats(runner).suites[ReporterStats.getIdentifier(runner)] = new SuiteStats(runner)
         this.counts.suites++
     }
 
@@ -186,7 +186,7 @@ class ReporterStats extends RunnableStats {
             return
         }
 
-        suiteStat.hooks[getIdentifier(runner)] = new HookStats(runner)
+        suiteStat.hooks[ReporterStats.getIdentifier(runner)] = new HookStats(runner)
     }
 
     hookEnd (runner) {
@@ -201,7 +201,7 @@ class ReporterStats extends RunnableStats {
     }
 
     testStart (runner) {
-        this.getSuiteStats(runner, runner.parent).tests[getIdentifier(runner)] = new TestStats(runner)
+        this.getSuiteStats(runner, runner.parent).tests[ReporterStats.getIdentifier(runner)] = new TestStats(runner)
     }
     getHookStats (runner) {
         const suiteStats = this.getSuiteStats(runner, runner.parent)
@@ -212,9 +212,9 @@ class ReporterStats extends RunnableStats {
 
         // Errors encountered inside hooks (e.g. beforeEach) can be identified by looking
         // at the currentTest param (currently only applicable to the Mocha adapter).
-        let uid = runner.currentTest || getIdentifier(runner)
+        let uid = runner.currentTest || ReporterStats.getIdentifier(runner)
         if (!suiteStats.hooks[uid]) {
-            uid = getIdentifier(runner)
+            uid = ReporterStats.getIdentifier(runner)
         }
 
         if (!suiteStats.hooks[uid]) throw Error(`Unrecognised hook [${runner.title}] for suite [${runner.parent}]`)
@@ -229,9 +229,9 @@ class ReporterStats extends RunnableStats {
 
         // Errors encountered inside hooks (e.g. beforeEach) can be identified by looking
         // at the currentTest param (currently only applicable to the Mocha adapter).
-        let uid = runner.currentTest || getIdentifier(runner)
+        let uid = runner.currentTest || ReporterStats.getIdentifier(runner)
         if (!suiteStats.tests[uid]) {
-            uid = getIdentifier(runner)
+            uid = ReporterStats.getIdentifier(runner)
         }
 
         if (!suiteStats.tests[uid]) throw Error(`Unrecognised test [${runner.title}] for suite [${runner.parent}]`)
@@ -240,7 +240,7 @@ class ReporterStats extends RunnableStats {
 
     output (type, runner) {
         runner.time = new Date()
-        if (getIdentifier(runner) && runner.parent) {
+        if (ReporterStats.getIdentifier(runner) && runner.parent) {
             this.getTestStats(runner).output.push({
                 type,
                 payload: runner
@@ -309,7 +309,7 @@ class ReporterStats extends RunnableStats {
          */
         let duplicateError = false
         for (let failure of this.failures) {
-            if (runner.err.message !== failure.err.message || getIdentifier(failure) !== getIdentifier(runner)) {
+            if (runner.err.message !== failure.err.message || ReporterStats.getIdentifier(failure) !== ReporterStats.getIdentifier(runner)) {
                 continue
             }
             duplicateError = true
@@ -327,16 +327,16 @@ class ReporterStats extends RunnableStats {
     }
 
     suiteEnd (runner) {
-        this.getSuiteStats(runner, getIdentifier(runner)).complete()
+        this.getSuiteStats(runner, ReporterStats.getIdentifier(runner)).complete()
     }
 
     runnerEnd (runner) {
         this.getSpecStats(runner).complete()
     }
-}
 
-function getIdentifier (runner) {
-    return runner.uid || runner.title
+    static getIdentifier (runner) {
+        return runner.uid || runner.title
+    }
 }
 
 export {

--- a/lib/utils/ReporterStats.js
+++ b/lib/utils/ReporterStats.js
@@ -25,6 +25,7 @@ class RunnableStats {
 class RunnerStats extends RunnableStats {
     constructor (runner) {
         super('runner')
+        this.uid = runner.uid
         this.cid = runner.cid
         this.capabilities = runner.capabilities
         this.sanitizedCapabilities = runner.capabilities && sanitize.caps(runner.capabilities)
@@ -36,6 +37,7 @@ class RunnerStats extends RunnableStats {
 class SpecStats extends RunnableStats {
     constructor (runner) {
         super('spec')
+        this.uid = runner.uid
         this.files = runner.specs
         this.specHash = runner.specHash
         this.suites = {}
@@ -46,6 +48,7 @@ class SpecStats extends RunnableStats {
 class SuiteStats extends RunnableStats {
     constructor (runner) {
         super('suite')
+        this.uid = runner.uid
         this.title = runner.title
         this.tests = {}
         this.hooks = {}
@@ -55,6 +58,7 @@ class SuiteStats extends RunnableStats {
 class TestStats extends RunnableStats {
     constructor (runner) {
         super('test')
+        this.uid = runner.uid
         this.title = runner.title
         this.state = ''
         this.screenshots = []
@@ -65,6 +69,7 @@ class TestStats extends RunnableStats {
 class HookStats extends RunnableStats {
     constructor (runner) {
         super('hook')
+        this.uid = runner.uid
         this.title = runner.title
         this.parent = runner.parent
         this.currentTest = runner.currentTest
@@ -155,7 +160,7 @@ class ReporterStats extends RunnableStats {
     }
 
     suiteStart (runner) {
-        this.getSpecStats(runner).suites[runner.title] = new SuiteStats(runner)
+        this.getSpecStats(runner).suites[runner.uid] = new SuiteStats(runner)
         this.counts.suites++
     }
 
@@ -181,7 +186,7 @@ class ReporterStats extends RunnableStats {
             return
         }
 
-        suiteStat.hooks[runner.title] = new HookStats(runner)
+        suiteStat.hooks[runner.uid] = new HookStats(runner)
     }
 
     hookEnd (runner) {
@@ -196,7 +201,7 @@ class ReporterStats extends RunnableStats {
     }
 
     testStart (runner) {
-        this.getSuiteStats(runner, runner.parent).tests[runner.title] = new TestStats(runner)
+        this.getSuiteStats(runner, runner.parent).tests[runner.uid] = new TestStats(runner)
     }
     getHookStats (runner) {
         const suiteStats = this.getSuiteStats(runner, runner.parent)
@@ -207,13 +212,13 @@ class ReporterStats extends RunnableStats {
 
         // Errors encountered inside hooks (e.g. beforeEach) can be identified by looking
         // at the currentTest param (currently only applicable to the Mocha adapter).
-        let title = runner.title
-        if (!suiteStats.hooks[title]) {
-            title = runner.title
+        let uid = runner.currentTest || runner.uid
+        if (!suiteStats.tests[uid]) {
+            uid = runner.uid
         }
 
-        if (!suiteStats.hooks[title]) throw Error(`Unrecognised hook [${title}] for suite [${runner.parent}]`)
-        return suiteStats.hooks[title]
+        if (!suiteStats.hooks[uid]) throw Error(`Unrecognised hook [${runner.title}] for suite [${runner.parent}]`)
+        return suiteStats.hooks[uid]
     }
     getTestStats (runner) {
         const suiteStats = this.getSuiteStats(runner, runner.parent)
@@ -224,18 +229,18 @@ class ReporterStats extends RunnableStats {
 
         // Errors encountered inside hooks (e.g. beforeEach) can be identified by looking
         // at the currentTest param (currently only applicable to the Mocha adapter).
-        let title = runner.currentTest || runner.title
-        if (!suiteStats.tests[title]) {
-            title = runner.title
+        let uid = runner.currentTest || runner.uid
+        if (!suiteStats.tests[uid]) {
+            uid = runner.uid
         }
 
-        if (!suiteStats.tests[title]) throw Error(`Unrecognised test [${title}] for suite [${runner.parent}]`)
-        return suiteStats.tests[title]
+        if (!suiteStats.tests[uid]) throw Error(`Unrecognised test [${runner.title}] for suite [${runner.parent}]`)
+        return suiteStats.tests[uid]
     }
 
     output (type, runner) {
         runner.time = new Date()
-        if (runner.title && runner.parent) {
+        if (runner.uid && runner.parent) {
             this.getTestStats(runner).output.push({
                 type,
                 payload: runner
@@ -304,7 +309,7 @@ class ReporterStats extends RunnableStats {
          */
         let duplicateError = false
         for (let failure of this.failures) {
-            if (runner.err.message !== failure.err.message || failure.title !== runner.title) {
+            if (runner.err.message !== failure.err.message || failure.uid !== runner.uid) {
                 continue
             }
             duplicateError = true
@@ -322,7 +327,7 @@ class ReporterStats extends RunnableStats {
     }
 
     suiteEnd (runner) {
-        this.getSuiteStats(runner, runner.title).complete()
+        this.getSuiteStats(runner, runner.uid).complete()
     }
 
     runnerEnd (runner) {

--- a/lib/utils/ReporterStats.js
+++ b/lib/utils/ReporterStats.js
@@ -25,7 +25,7 @@ class RunnableStats {
 class RunnerStats extends RunnableStats {
     constructor (runner) {
         super('runner')
-        this.uid = this.getIdentifier(runner)
+        this.uid = getIdentifier(runner)
         this.cid = runner.cid
         this.capabilities = runner.capabilities
         this.sanitizedCapabilities = runner.capabilities && sanitize.caps(runner.capabilities)
@@ -37,7 +37,7 @@ class RunnerStats extends RunnableStats {
 class SpecStats extends RunnableStats {
     constructor (runner) {
         super('spec')
-        this.uid = this.getIdentifier(runner)
+        this.uid = getIdentifier(runner)
         this.files = runner.specs
         this.specHash = runner.specHash
         this.suites = {}
@@ -48,7 +48,7 @@ class SpecStats extends RunnableStats {
 class SuiteStats extends RunnableStats {
     constructor (runner) {
         super('suite')
-        this.uid = this.getIdentifier(runner)
+        this.uid = getIdentifier(runner)
         this.title = runner.title
         this.tests = {}
         this.hooks = {}
@@ -58,7 +58,7 @@ class SuiteStats extends RunnableStats {
 class TestStats extends RunnableStats {
     constructor (runner) {
         super('test')
-        this.uid = this.getIdentifier(runner)
+        this.uid = getIdentifier(runner)
         this.title = runner.title
         this.state = ''
         this.screenshots = []
@@ -69,7 +69,7 @@ class TestStats extends RunnableStats {
 class HookStats extends RunnableStats {
     constructor (runner) {
         super('hook')
-        this.uid = this.getIdentifier(runner)
+        this.uid = getIdentifier(runner)
         this.title = runner.title
         this.parent = runner.parent
         this.currentTest = runner.currentTest
@@ -160,7 +160,7 @@ class ReporterStats extends RunnableStats {
     }
 
     suiteStart (runner) {
-        this.getSpecStats(runner).suites[this.getIdentifier(runner)] = new SuiteStats(runner)
+        this.getSpecStats(runner).suites[getIdentifier(runner)] = new SuiteStats(runner)
         this.counts.suites++
     }
 
@@ -186,7 +186,7 @@ class ReporterStats extends RunnableStats {
             return
         }
 
-        suiteStat.hooks[this.getIdentifier(runner)] = new HookStats(runner)
+        suiteStat.hooks[getIdentifier(runner)] = new HookStats(runner)
     }
 
     hookEnd (runner) {
@@ -201,7 +201,7 @@ class ReporterStats extends RunnableStats {
     }
 
     testStart (runner) {
-        this.getSuiteStats(runner, runner.parent).tests[this.getIdentifier(runner)] = new TestStats(runner)
+        this.getSuiteStats(runner, runner.parent).tests[getIdentifier(runner)] = new TestStats(runner)
     }
     getHookStats (runner) {
         const suiteStats = this.getSuiteStats(runner, runner.parent)
@@ -212,9 +212,9 @@ class ReporterStats extends RunnableStats {
 
         // Errors encountered inside hooks (e.g. beforeEach) can be identified by looking
         // at the currentTest param (currently only applicable to the Mocha adapter).
-        let uid = runner.currentTest || this.getIdentifier(runner)
+        let uid = runner.currentTest || getIdentifier(runner)
         if (!suiteStats.hooks[uid]) {
-            uid = this.getIdentifier(runner)
+            uid = getIdentifier(runner)
         }
 
         if (!suiteStats.hooks[uid]) throw Error(`Unrecognised hook [${runner.title}] for suite [${runner.parent}]`)
@@ -229,9 +229,9 @@ class ReporterStats extends RunnableStats {
 
         // Errors encountered inside hooks (e.g. beforeEach) can be identified by looking
         // at the currentTest param (currently only applicable to the Mocha adapter).
-        let uid = runner.currentTest || this.getIdentifier(runner)
+        let uid = runner.currentTest || getIdentifier(runner)
         if (!suiteStats.tests[uid]) {
-            uid = this.getIdentifier(runner)
+            uid = getIdentifier(runner)
         }
 
         if (!suiteStats.tests[uid]) throw Error(`Unrecognised test [${runner.title}] for suite [${runner.parent}]`)
@@ -240,7 +240,7 @@ class ReporterStats extends RunnableStats {
 
     output (type, runner) {
         runner.time = new Date()
-        if (this.getIdentifier(runner) && runner.parent) {
+        if (getIdentifier(runner) && runner.parent) {
             this.getTestStats(runner).output.push({
                 type,
                 payload: runner
@@ -309,7 +309,7 @@ class ReporterStats extends RunnableStats {
          */
         let duplicateError = false
         for (let failure of this.failures) {
-            if (runner.err.message !== failure.err.message || this.getIdentifier(failure) !== this.getIdentifier(runner)) {
+            if (runner.err.message !== failure.err.message || getIdentifier(failure) !== getIdentifier(runner)) {
                 continue
             }
             duplicateError = true
@@ -327,16 +327,16 @@ class ReporterStats extends RunnableStats {
     }
 
     suiteEnd (runner) {
-        this.getSuiteStats(runner, this.getIdentifier(runner)).complete()
+        this.getSuiteStats(runner, getIdentifier(runner)).complete()
     }
 
     runnerEnd (runner) {
         this.getSpecStats(runner).complete()
     }
+}
 
-    getIdentifier (runner) {
-        return runner.uid || runner.title
-    }
+function getIdentifier (runner) {
+    return runner.uid || runner.title
 }
 
 export {


### PR DESCRIPTION
**Please note:** this PR is required for fixing issue [#11 reported in the wdio-spec-reporter](https://github.com/webdriverio/wdio-spec-reporter/issues/11) repo, please refer to that issue for more details.

## Proposed changes

I implemented an UID to identify suite/spec/steps to prevent duplicate named items forming an issue when reported back to the wdio-spec-reporter.

## Types of changes

What types of changes does your code introduce to WebdriverIO?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) *added fallback for reporters that don't report a UID*

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works **There seems to be no tests for the stats reporter util?**
- [ ] I have added necessary documentation (if appropriate) **There seems to be no documentation about the stats reporter util?**

## Further comments

For further information about this PR please refer to the issue mentioned above.

### Reviewers: @christian-bromann

