### PR TITLE
Wait for visible within viewport

### DIFF
--- a/lib/commands/waitForVisibleWithinViewport.js
+++ b/lib/commands/waitForVisibleWithinViewport.js
@@ -1,0 +1,103 @@
+/**
+ *
+ * Wait for an element (selected by css selector) for the provided amount of
+ * milliseconds to be (in)visible within the viewport. If multiple elements get
+ * queryied by given selector, it returns true (or false if reverse flag is set)
+ * if at least one element is visible.
+ *
+ * <example>
+    :index.html
+    <div id="elem" style="position:absolute; top: -100px; height: 50px;">
+        Hello World!
+    </div>
+    <script type="text/javascript">
+        setTimeout(function () {
+            document.getElementById('elem').style.top = '0px';
+        }, 2000);
+    </script>
+
+    :waitForVisibleExample.js
+    it(
+        'should detect when element is visible within the viewport',
+        function () {
+            browser.waitForVisibleWithinViewport('#elem', 3000);
+
+            // same as
+            elem = $('#elem');
+            elem.waitForVisibleWithinViewport(3000)
+        }
+    );
+ * </example>
+ *
+ * @alias browser.waitForVisibleWithinViewport
+ * @param {String}   selector element to wait for
+ * @param {Number=}  ms       time in ms (default: 500)
+ * @param {Boolean=} reverse  if true it waits for the opposite (default: false)
+ * @uses utility/waitUntil, state/isVisible
+ * @type utility
+ *
+ */
+
+import { WaitUntilTimeoutError, isTimeoutError } from '../utils/ErrorHandler'
+
+import isVisibleWithinViewportFunc from '../scripts/isWithinViewport'
+
+let waitForVisibleWithinViewport = function (selector, ms, reverse) {
+    /**
+     * we can't use default values for function parameter here because this would
+     * break the ability to chain the command with an element if reverse is used, like
+     *
+     * ```js
+     * var elem = $('#elem');
+     * elem.waitForXXX(10000, true);
+     * ```
+     */
+    reverse = typeof reverse === 'boolean' ? reverse : false
+
+    /*!
+     * ensure that ms is set properly
+     */
+    if (typeof ms !== 'number') {
+        ms = this.options.waitforTimeout
+    }
+
+    return this.waitUntil(() => {
+        return this.selectorExecute(selector, isVisibleWithinViewportFunc).then((isVisibleWithinViewport) => {
+            if (!Array.isArray(isVisibleWithinViewport)) {
+                return reverse
+            } else if (Array.isArray(isVisibleWithinViewport) && isVisibleWithinViewport.length === 1) {
+                return isVisibleWithinViewport[0] !== reverse
+            }
+
+            let result = reverse
+            for (let val of isVisibleWithinViewport) {
+                if (!reverse) {
+                    result = result || val
+                } else {
+                    result = result && val
+                }
+            }
+
+            return result !== reverse
+        }, (err) => {
+            /**
+             * if element does not exist it is automatically not visible :-)
+             */
+            if (err.message.indexOf('NoSuchElement') > -1 && reverse) {
+                return true
+            }
+
+            throw err
+        })
+    }, ms).catch((e) => {
+        selector = selector || this.lastResult.selector
+
+        if (isTimeoutError(e)) {
+            let isReversed = reverse ? '' : 'not'
+            throw new WaitUntilTimeoutError(`element (${selector}) still ${isReversed} visible within the viewport after ${ms}ms`)
+        }
+        throw e
+    })
+}
+
+export default waitForVisibleWithinViewport

--- a/test/site/www/index.html
+++ b/test/site/www/index.html
@@ -111,6 +111,9 @@
         <div class="sometext">some text</div>
         <div class="sometextlater"></div>
         <div class="opacity">Hello! I am not visible anyway</div>
+
+        <div class="moveIntoViewport" style="position:absolute; right: 0; top: -100px; height:50px;">I'm moving into the viewport</div>
+
         <script>
         if (qry('a') === 'a') {
             document.write('<div class="gotDataA">got data from input[name="a"]</div>')
@@ -222,6 +225,12 @@
             $('.invisibleParent').removeClass('hidden');
         },2000);
 
+        setTimeout(function() {
+            $('.moveIntoViewport').css({
+                'position': 'fixed',
+                'top': '10px'
+            });
+        }, 500);
     </script>
 
 </body>

--- a/test/spec/waitFor.js
+++ b/test/spec/waitFor.js
@@ -151,6 +151,33 @@ describe('waitFor', () => {
         })
     })
 
+    describe('VisibleWithinViewport', () => {
+        it('should return with an error if the element never becomes visible within the viewport', function () {
+            return expect(this.client.waitForVisibleWithinViewport('.notInViewports', 10))
+                .to.be.rejectedWith('Error: element (.notInViewports) still not visible within the viewport after 10ms')
+        })
+
+        it('should return with an error if the element never exists', function () {
+            return expect(this.client.waitForVisibleWithinViewport('#notExisting', 10))
+                .to.be.rejectedWith('Error: element (#notExisting) still not visible within the viewport after 10ms')
+        })
+
+        it('should return with true if the element becomes visible within the viewport', async function () {
+            (await this.client.waitForVisibleWithinViewport('.moveIntoViewport', duration))
+                .should.be.equal(true)
+        })
+
+        it('(reverse) should return w/o err after element left document bounderies', async function () {
+            (await this.client.waitForVisibleWithinViewport('.onMyWay', duration, true))
+                .should.be.equal(true)
+        })
+
+        it('(reverse) should return with true if the element never becomes visible', async function () {
+            (await this.client.waitForVisibleWithinViewport('#notExisting', 10, true))
+                .should.be.equal(true)
+        })
+    })
+
     describe('timeout', () => {
         it('should use specified timeout', function (done) {
             var startTime = Date.now()


### PR DESCRIPTION
## Proposed changes

I added a command to wait for an element to be visible within the viewport

## Types of changes

What types of changes does your code introduce to WebdriverIO?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

I created this command so I don't have to "fake" it by doing a timeout before checking if a element exists within the current viewpoint. This new command is useful for checking "sticky" menu's or "popover" elements on a page that appear after a certain timeout.

### Reviewers: @christian-bromann
