### PR TITLE
Fixed 1591, when a screenshot is created the results are now displayed

### DIFF
--- a/lib/webdriverio.js
+++ b/lib/webdriverio.js
@@ -200,7 +200,7 @@ let WebdriverIO = function (args, modifier) {
         err.shotTaken = true
         return takeScreenshot(err)
             .catch((e) => logger.log('\tFailed to take screenshot on reject:', e))
-            .then(() => fail(err, onRejected))
+            .then(() => { throw err })
     }
 
     function insideCommand (command, unit) {


### PR DESCRIPTION
## Proposed changes

Fixed issue #1591 If a screenshot is generated for a failed test the results are now being displayed. (as expected)

## Types of changes

What types of changes does your code introduce to WebdriverIO?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

Small fix, the fail handle prevented the error from bubbling up to the point of displaying the results.

### Reviewers: @christian-bromann