### PR TITLE
Added instructions for using geckdriver

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -23,21 +23,39 @@ Then let's download the latest [selenium standalone server](http://docs.selenium
 $ curl -O http://selenium-release.storage.googleapis.com/3.0/selenium-server-standalone-3.0.1.jar
 ```
 
+** 3. Download the latest version geckdriver for your environment and unpack it in your project directory**
+
+Linux 64 bit
+
+```sh
+$ curl -L https://github.com/mozilla/geckodriver/releases/download/v0.11.1/geckodriver-v0.11.1-linux64.tar.gz | tar xz
+```
+
+OSX
+
+```sh
+$ curl -L https://github.com/mozilla/geckodriver/releases/download/v0.11.1/geckodriver-v0.11.1-macos.tar.gz | tar xz
+```
+
+Note: Other geckodriver releases are available [here](https://github.com/mozilla/geckodriver/releases).
+
 Start the server by executing the following:
 
-** 3. Start selenium standalone server**
+** 4. Start selenium standalone server**
 ```sh
-$ java -jar selenium-server-standalone-3.0.1.jar
+$ java -jar -Dwebdriver.geckodriver.driver=./geckodriver selenium-server-standalone-3.0.1.jar
 ```
+
+Note that this command sets webdriver path variable so that Selenium uses the geckdriver binary that was added to the project directory and also starts Selenium standalone server.
 
 Keep this running in the background and open a new terminal window. Next step is to download WebdriverIO via NPM:
 
-** 4. Download WebdriverIO**
+** 5. Download WebdriverIO**
 ```sh
 $ npm install webdriverio
 ```
 
-** 5. Create a test file (test.js) with the following content**
+** 6. Create a test file (test.js) with the following content**
 ```js
 var webdriverio = require('webdriverio');
 var options = {
@@ -56,7 +74,7 @@ webdriverio
     .end();
 ```
 
-** 6. Run your test file**
+** 7. Run your test file**
 ```sh
 $ node test.js
 ```


### PR DESCRIPTION
## Proposed changes

This is a proposal to update the guide.md file to instruct the user to download and use geckodriver with selenium standalone server.  The goal is to make it easy for users to get started using webdriverIO by providing the information they need to use the required dependencies.

## Types of changes

What types of changes does your code introduce to WebdriverIO?
_Put an `x` in the boxes that apply_

- [x] Help doc update
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x ] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x ] I have added tests that prove my fix is effective or that my feature works
- [x ] I have added necessary documentation (if appropriate)

## Further comments

Hey Christian,

Here is the PR that I promised.  I found a better solution to improving the guide.md than what I proposed before.  I set up an example to which can easily be executed using Vagrant with a couple of commands.  https://github.com/jcreager/webdriverio-getting-started

The readme explains how to run the test.  In addition to the test, there is a counter-example which which demonstrates the results that the user gets when they do not use geckodriver or specify the path to geckodriver.

### Reviewers: @christian-bromann

In Selenium Standalone Server 3.0.1, Marionette is set to true by default.  Marionette requires a driver for each browser.  Geckodriver is Mozilla's driver for firefox.  I added instructions to download and unpack geckodriver in the project directory, and to specify the driver path when launching Selenium Standalone Server.  If the user does not do this, they will get the error:

Driver info: driver.version: unknown
...
WARN - Exception: The path to the driver executable must be set by the webdriver.gecko.driver system property; for more information, see https://github.com/mozilla/geckodriver. The latest version can be downloaded from https://github.com/mozilla/geckodriver/releases

Please see my test scripts which demonstrate what happens when your run the code in the getting started guide with geckodriver, and without geckodriver at https://github.com/jcreager/webdriverio-getting-started.

I hope this helps, but please let me know if you need additional info.

Thank you,
Joe