### PR TITLE
runner.err can be an empty object (thus lacking the message prop.)

### DIFF
--- a/lib/utils/ReporterStats.js
+++ b/lib/utils/ReporterStats.js
@@ -275,7 +275,7 @@ class ReporterStats extends RunnableStats {
          * message
          */
         let message = 'Ensure the done() callback is being called in this test.'
-        if (runner.err && runner.err.message.indexOf(message) > -1) {
+        if (runner.err && runner.err.message && runner.err.message.indexOf(message) > -1) {
             let replacement = `The execution in the test "${runner.parent} ${runner.title}" took ` +
                                 'too long. Try to reduce the run time or increase your timeout for ' +
                                 'test specs (http://webdriver.io/guide/testrunner/timeouts.html).'
@@ -284,7 +284,7 @@ class ReporterStats extends RunnableStats {
         }
 
         message = 'For async tests and hooks, ensure "done()" is called;'
-        if (runner.err && runner.err.message.indexOf(message) > -1) {
+        if (runner.err && runner.err.message && runner.err.message.indexOf(message) > -1) {
             let replacement = 'Try to reduce the run time or increase your timeout for ' +
                                 'test specs (http://webdriver.io/guide/testrunner/timeouts.html);'
             runner.err.message = runner.err.message.replace(message, replacement)


### PR DESCRIPTION
## Proposed changes

Fix for #1770

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
Small fix, runner.err can be an empty object thus lacking the property `message`

### Reviewers: @christian-bromann