### PR TITLE
fix #1778 fatal error when "before all" hook fails

### DIFF
--- a/lib/utils/ReporterStats.js
+++ b/lib/utils/ReporterStats.js
@@ -168,12 +168,6 @@ class ReporterStats extends RunnableStats {
     getSuiteStats (runner, suiteTitle) {
         let specStats = this.getSpecStats(runner)
 
-        // The "before all" hook runs before the context of the suite is defined
-        // to prevent the creation of incorrect suite details always skip reporting for this hook
-        if (runner.title === '"before all" hook') {
-            return
-        }
-
         /**
          * if error occurs in root level hooks we haven't created any suites yet, so
          * create one here if so


### PR DESCRIPTION
fixes #1778

Revert commit https://github.com/webdriverio/webdriverio/commit/b7e3a6e976a5feb42a643759ab040e4daf9331c6

Issue #1778 was caused at https://github.com/webdriverio/webdriverio/blob/f029d4563ac7258b6c33c11449503624595e8edf/lib/utils/ReporterStats.js#L301-L310 when `getTestStats()` returns undefined for "before all" hooks.