### PR TITLE
Add jsdoc to test runner configuration hooks

### DIFF
--- a/docs/guide/testrunner/configurationfile.md
+++ b/docs/guide/testrunner/configurationfile.md
@@ -227,65 +227,105 @@ exports.config = {
     // methods. If one of them returns with a promise, WebdriverIO will wait until that promise got
     // resolved to continue.
     //
-    // Gets executed once before all workers get launched.
+
+    /**
+     * Gets executed once before all workers get launched.
+     * @param {Object} config wdio configuration object
+     * @param {Array.<Object>} capabilities list of capabilities details
+     */
     onPrepare: function (config, capabilities) {
     },
-    //
-    // Gets executed just before initialising the webdriver session and test framework. It allows you
-    // to manipulate configurations depending on the capability or spec.
+    /**
+     * Gets executed just before initialising the webdriver session and test framework. It allows you
+     * to manipulate configurations depending on the capability or spec.
+     * @param {Object} config wdio configuration object
+     * @param {Array.<Object>} capabilities list of capabilities details
+     * @param {Array.<String>} specs List of spec file paths that are to be run
+     */
     beforeSession: function (config, capabilities, specs) {
-    },
-    //
-    // Gets executed before test execution begins. At this point you can access to all global
-    // variables like `browser`. It is the perfect place to define custom commands.
+    },  
+    /**
+     * Gets executed before test execution begins. At this point you can access to all global
+     * variables like `browser`. It is the perfect place to define custom commands.
+     * @param {Array.<Object>} capabilities list of capabilities details
+     * @param {Array.<String>} specs List of spec file paths that are to be run
+     */
     before: function (capabilities, specs) {
     },
-    //
-    // Hook that gets executed before the suite starts
+    /**
+     * Hook that gets executed before the suite starts
+     * @param {Object} suite suite details
+     */
     beforeSuite: function (suite) {
     },
-    //
-    // Hook that gets executed _before_ a hook within the suite starts (e.g. runs before calling
-    // beforeEach in Mocha)
+    /**
+     * Hook that gets executed _before_ a hook within the suite starts (e.g. runs before calling
+     * beforeEach in Mocha)
+     */
     beforeHook: function () {
     },
-    //
-    // Hook that gets executed _after_ a hook within the suite starts (e.g. runs after calling
-    // afterEach in Mocha)
+    /**
+     * Hook that gets executed _after_ a hook within the suite starts (e.g. runs after calling
+     * afterEach in Mocha)
+     */
     afterHook: function () {
     },
-    //
-    // Function to be executed before a test (in Mocha/Jasmine) or a step (in Cucumber) starts.
+    /**
+     * Function to be executed before a test (in Mocha/Jasmine) or a step (in Cucumber) starts.
+     * @param {Object} test test details
+     */
     beforeTest: function (test) {
     },
-    //
-    // Runs before a WebdriverIO command gets executed.
+    /**
+     * Runs before a WebdriverIO command gets executed.
+     * @param {String} commandName hook command name
+     * @param {Array} args arguments that command would receive
+     */
     beforeCommand: function (commandName, args) {
     },
-    //
-    // Runs after a WebdriverIO command gets executed
+    /**
+     * Runs after a WebdriverIO command gets executed
+     * @param {String} commandName hook command name
+     * @param {Array} args arguments that command would receive
+     * @param {Number} result 0 - command success, 1 - command error
+     * @param {Object} error error object if any
+     */
     afterCommand: function (commandName, args, result, error) {
     },
-    //
-    // Function to be executed after a test (in Mocha/Jasmine) or a step (in Cucumber) starts.
+    /**
+     * Function to be executed after a test (in Mocha/Jasmine) or a step (in Cucumber) starts.
+     * @param {Object} test test details
+     */
     afterTest: function (test) {
     },
-    //
-    // Hook that gets executed after the suite has ended
+    /**
+     * Hook that gets executed after the suite has ended
+     * @param {Object} suite suite details
+     */
     afterSuite: function (suite) {
     },
-    //
-    // Gets executed after all tests are done. You still have access to all global variables from
-    // the test.
+    /**
+     * Gets executed after all tests are done. You still have access to all global variables from
+     * the test.
+     * @param {Number} result 0 - test pass, 1 - test fail
+     * @param {Array.<Object>} capabilities list of capabilities details
+     * @param {Array.<String>} specs List of spec file paths that are to be run
+     */
     after: function (result, capabilities, specs) {
     },
-    //
-    // Gets executed right after terminating the webdriver session.
+    /**
+     * Gets executed right after terminating the webdriver session.
+     * @param {Object} config wdio configuration object
+     * @param {Array.<Object>} capabilities list of capabilities details
+     * @param {Array.<String>} specs List of spec file paths that are to be run
+     */
     afterSession: function (config, capabilities, specs) {
     },
-    //
-    // Gets executed after all workers got shut down and the process is about to exit. It is not
-    // possible to defer the end of the process using a promise.
+    /**
+     * Gets executed after all workers got shut down and the process is about to exit. It is not
+     * possible to defer the end of the process using a promise.
+     * @param {Object} exitCode 0 - success, 1 - fail
+     */
     onComplete: function (exitCode) {
     },
     //

--- a/docs/guide/testrunner/configurationfile.md
+++ b/docs/guide/testrunner/configurationfile.md
@@ -309,7 +309,7 @@ exports.config = {
      * the test.
      * @param {Number} result 0 - test pass, 1 - test fail
      * @param {Array.<Object>} capabilities list of capabilities details
-     * @param {Array.<String>} specs List of spec file paths that are to be run
+     * @param {Array.<String>} specs List of spec file paths that ran
      */
     after: function (result, capabilities, specs) {
     },
@@ -317,7 +317,7 @@ exports.config = {
      * Gets executed right after terminating the webdriver session.
      * @param {Object} config wdio configuration object
      * @param {Array.<Object>} capabilities list of capabilities details
-     * @param {Array.<String>} specs List of spec file paths that are to be run
+     * @param {Array.<String>} specs List of spec file paths that ran
      */
     afterSession: function (config, capabilities, specs) {
     },

--- a/examples/wdio.conf.js
+++ b/examples/wdio.conf.js
@@ -205,65 +205,105 @@ exports.config = {
     // methods to it. If one of them returns with a promise, WebdriverIO will wait until that promise got
     // resolved to continue.
     //
-    // Gets executed once before all workers get launched.
+    /**
+     * Gets executed once before all workers get launched.
+     * @param {Object} config wdio configuration object
+     * @param {Array.<Object>} capabilities list of capabilities details
+     */
     onPrepare: function (config, capabilities) {
     },
-    //
-    // Gets executed just before initialising the webdriver session and test framework. It allows you
-    // to manipulate configurations depending on the capability or spec.
+    /**
+     * Gets executed just before initialising the webdriver session and test framework. It allows you
+     * to manipulate configurations depending on the capability or spec.
+     * @param {Object} config wdio configuration object
+     * @param {Array.<Object>} capabilities list of capabilities details
+     * @param {Array.<String>} specs List of spec file paths that are to be run
+     */
     beforeSession: function (config, capabilities, specs) {
     },
-    //
-    // Gets executed before test execution begins. At this point you can access to all global
-    // variables, such as `browser`. It is the perfect place to define custom commands.
+    /**
+     * Gets executed before test execution begins. At this point you can access to all global
+     * variables like `browser`. It is the perfect place to define custom commands.
+     * @param {Array.<Object>} capabilities list of capabilities details
+     * @param {Array.<String>} specs List of spec file paths that are to be run
+     */
     before: function (capabilities, specs) {
     },
-    //
-    // Hook that gets executed before the suite starts
+    /**
+     * Hook that gets executed before the suite starts
+     * @param {Object} suite suite details
+     */
     beforeSuite: function (suite) {
     },
-    //
-    // Hook that gets executed _before_ a hook within the suite starts (e.g. runs before calling
-    // beforeEach in Mocha)
+    /**
+     * Hook that gets executed _before_ a hook within the suite starts (e.g. runs before calling
+     * beforeEach in Mocha)
+     */
     beforeHook: function () {
     },
-    //
-    // Hook that gets executed _after_ a hook within the suite starts (e.g. runs after calling
-    // afterEach in Mocha)
+    /**
+     * Hook that gets executed _after_ a hook within the suite starts (e.g. runs after calling
+     * afterEach in Mocha)
+     */
     afterHook: function () {
     },
-    //
-    // Function to be executed before a test (in Mocha/Jasmine) or a step (in Cucumber) starts.
+    /**
+     * Function to be executed before a test (in Mocha/Jasmine) or a step (in Cucumber) starts.
+     * @param {Object} test test details
+     */
     beforeTest: function (test) {
     },
     //
-    // Runs before a WebdriverIO command gets executed.
+    /**
+     * Runs before a WebdriverIO command gets executed.
+     * @param {String} commandName hook command name
+     * @param {Array} args arguments that command would receive
+     */
     beforeCommand: function (commandName, args) {
     },
-    //
-    // Runs after a WebdriverIO command gets executed
+    /**
+     * Runs after a WebdriverIO command gets executed
+     * @param {String} commandName hook command name
+     * @param {Array} args arguments that command would receive
+     * @param {Number} result 0 - command success, 1 - command error
+     * @param {Object} error error object if any
+     */
     afterCommand: function (commandName, args, result, error) {
     },
-    //
-    // Function to be executed after a test (in Mocha/Jasmine) or a step (in Cucumber) starts.
+    /**
+     * Function to be executed after a test (in Mocha/Jasmine) or a step (in Cucumber) starts.
+     * @param {Object} test test details
+     */
     afterTest: function (test) {
     },
-    //
-    // Hook that gets executed after the suite has ended
+    /**
+     * Hook that gets executed after the suite has ended
+     * @param {Object} suite suite details
+     */
     afterSuite: function (suite) {
     },
-    //
-    // Gets executed after all tests are done. You still have access to all global variables from
-    // the test.
+    /**
+     * Gets executed after all tests are done. You still have access to all global variables from
+     * the test.
+     * @param {Number} result 0 - test pass, 1 - test fail
+     * @param {Array.<Object>} capabilities list of capabilities details
+     * @param {Array.<String>} specs List of spec file paths that ran
+     */
     after: function (result, capabilities, specs) {
     },
-    //
-    // Gets executed right after terminating the webdriver session.
+    /**
+     * Gets executed right after terminating the webdriver session.
+     * @param {Object} config wdio configuration object
+     * @param {Array.<Object>} capabilities list of capabilities details
+     * @param {Array.<String>} specs List of spec file paths that ran
+     */
     afterSession: function (config, capabilities, specs) {
     },
-    //
-    // Gets executed after all workers got shut down and the process is about to exit. It is not
-    // possible to defer the end of the process using a promise.
+    /**
+     * Gets executed after all workers got shut down and the process is about to exit. It is not
+     * possible to defer the end of the process using a promise.
+     * @param {Object} exitCode 0 - success, 1 - fail
+     */
     onComplete: function (exitCode) {
     },
     //

--- a/lib/helpers/wdio.conf.ejs
+++ b/lib/helpers/wdio.conf.ejs
@@ -217,66 +217,105 @@ exports.config = {
     // it and to build services around it. You can either apply a single function or an array of
     // methods to it. If one of them returns with a promise, WebdriverIO will wait until that promise got
     // resolved to continue.
-    //
-    // Gets executed once before all workers get launched.
+    /**
+     * Gets executed once before all workers get launched.
+     * @param {Object} config wdio configuration object
+     * @param {Array.<Object>} capabilities list of capabilities details
+     */
     // onPrepare: function (config, capabilities) {
     // },
-    //
-    // Gets executed just before initialising the webdriver session and test framework. It allows you
-    // to manipulate configurations depending on the capability or spec.
+    /**
+     * Gets executed just before initialising the webdriver session and test framework. It allows you
+     * to manipulate configurations depending on the capability or spec.
+     * @param {Object} config wdio configuration object
+     * @param {Array.<Object>} capabilities list of capabilities details
+     * @param {Array.<String>} specs List of spec file paths that are to be run
+     */
     // beforeSession: function (config, capabilities, specs) {
     // },
-    //
-    // Gets executed before test execution begins. At this point you can access all global
-    // variables, such as `browser`. It is the perfect place to define custom commands.
+    /**
+     * Gets executed before test execution begins. At this point you can access to all global
+     * variables like `browser`. It is the perfect place to define custom commands.
+     * @param {Array.<Object>} capabilities list of capabilities details
+     * @param {Array.<String>} specs List of spec file paths that are to be run
+     */
     // before: function (capabilities, specs) {
     // },
     //
-    // Hook that gets executed before the suite starts
+    /**
+     * Hook that gets executed before the suite starts
+     * @param {Object} suite suite details
+     */
     // beforeSuite: function (suite) {
     // },
-    //
-    // Hook that gets executed _before_ a hook within the suite starts (e.g. runs before calling
-    // beforeEach in Mocha)
+    /**
+     * Hook that gets executed _before_ a hook within the suite starts (e.g. runs before calling
+     * beforeEach in Mocha)
+     */
     // beforeHook: function () {
     // },
-    //
-    // Hook that gets executed _after_ a hook within the suite starts (e.g. runs after calling
-    // afterEach in Mocha)
+    /**
+     * Hook that gets executed _after_ a hook within the suite starts (e.g. runs after calling
+     * afterEach in Mocha)
+     */
     // afterHook: function () {
     // },
-    //
-    // Function to be executed before a test (in Mocha/Jasmine) or a step (in Cucumber) starts.
+    /**
+     * Function to be executed before a test (in Mocha/Jasmine) or a step (in Cucumber) starts.
+     * @param {Object} test test details
+     */
     // beforeTest: function (test) {
     // },
-    //
-    // Runs before a WebdriverIO command gets executed.
+    /**
+     * Runs before a WebdriverIO command gets executed.
+     * @param {String} commandName hook command name
+     * @param {Array} args arguments that command would receive
+     */
     // beforeCommand: function (commandName, args) {
     // },
-    //
-    // Runs after a WebdriverIO command gets executed
+    /**
+     * Runs after a WebdriverIO command gets executed
+     * @param {String} commandName hook command name
+     * @param {Array} args arguments that command would receive
+     * @param {Number} result 0 - command success, 1 - command error
+     * @param {Object} error error object if any
+     */
     // afterCommand: function (commandName, args, result, error) {
     // },
-    //
-    // Function to be executed after a test (in Mocha/Jasmine) or a step (in Cucumber) starts.
+    /**
+     * Function to be executed after a test (in Mocha/Jasmine) or a step (in Cucumber) starts.
+     * @param {Object} test test details
+     */
     // afterTest: function (test) {
     // },
-    //
-    // Hook that gets executed after the suite has ended
+    /**
+     * Hook that gets executed after the suite has ended
+     * @param {Object} suite suite details
+     */
     // afterSuite: function (suite) {
     // },
-    //
-    // Gets executed after all tests are done. You still have access to all global variables from
-    // the test.
+    /**
+     * Gets executed after all tests are done. You still have access to all global variables from
+     * the test.
+     * @param {Number} result 0 - test pass, 1 - test fail
+     * @param {Array.<Object>} capabilities list of capabilities details
+     * @param {Array.<String>} specs List of spec file paths that ran
+     */
     // after: function (result, capabilities, specs) {
     // },
-    //
-    // Gets executed right after terminating the webdriver session.
+    /**
+     * Gets executed right after terminating the webdriver session.
+     * @param {Object} config wdio configuration object
+     * @param {Array.<Object>} capabilities list of capabilities details
+     * @param {Array.<String>} specs List of spec file paths that ran
+     */
     // afterSession: function (config, capabilities, specs) {
     // },
-    //
-    // Gets executed after all workers got shut down and the process is about to exit. It is not
-    // possible to defer the end of the process using a promise.
+    /**
+     * Gets executed after all workers got shut down and the process is about to exit. It is not
+     * possible to defer the end of the process using a promise.
+     * @param {Object} exitCode 0 - success, 1 - fail
+     */
     // onComplete: function(exitCode) {
     // }
 }


### PR DESCRIPTION
Some of them were obvious based on the name of the parameter but others
were not as obvious. I added it to all the hooks I'm familar with.