### PR TITLE
Removed 2nd SIGINT

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -12,7 +12,6 @@ class Runner {
         this.sigintWasCalled = false
         this.hasSessionID = false
         this.failures = 0
-        this.forceKillingProcess = false
         this.isRunning = false
         this.fileTriggeredWhileRunning = null
     }
@@ -461,13 +460,6 @@ process.on('message', (m) => {
  * catches ctrl+c event
  */
 process.on('SIGINT', () => {
-    /**
-     * force killing process when 2nd SIGINT comes in
-     */
-    if (runner.forceKillingProcess) {
-        return process.exit(1)
-    }
-
-    runner.forceKillingProcess = true
     runner.sigintHandler()
+    process.exit(1)
 })


### PR DESCRIPTION
## Proposed changes

The 2nd SIGINT is not an evident way to interrupt test running and not usable with `maxInstances` at all.

Less pain, please.

### Before

![img-2017-02-09-14-10-52](https://cloud.githubusercontent.com/assets/803674/22780960/9eb008f0-eed1-11e6-90dd-77eede2857e3.png)

### After

![img-2017-02-09-14-10-23](https://cloud.githubusercontent.com/assets/803674/22780961/9eb4bc42-eed1-11e6-8251-5626a1d2d19e.png)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)


### Reviewers: @christian-bromann
