### PR TITLE
Add timestamp field to commandList.

### DIFF
--- a/lib/commands/getCommandHistory.js
+++ b/lib/commands/getCommandHistory.js
@@ -1,6 +1,6 @@
 /**
  *
- * Returns a list of previous called commands + their arguments.
+ * Returns a list of previous called commands + their arguments and execution timestamp.
  *
  * <example>
     :getCommandHistoryAsync.js
@@ -13,11 +13,12 @@
         .getCommandHistory().then(function(history){
             console.log(history);
             // outputs:
-            // [ { name: 'init', args: [] },
-            //   { name: 'url', args: [ 'http://www.google.com' ] },
-            //   { name: 'click', args: [ 'body' ] },
+            // [ { name: 'init', args: [], timestamp: 1487078962707 },
+            //   { name: 'url', args: [ 'http://www.google.com' ], timestamp: 1487078962707 },
+            //   { name: 'click', args: [ 'body' ], timestamp: 1487078962707 },
             //   { name: 'element',
             //     args: [ 'body' ],
+            //     timestamp: 1487078962707,
             //     result:
             //      { state: 'success',
             //        sessionId: 'c2aea856-ba18-48c0-8745-aa292f6394bc',
@@ -28,6 +29,7 @@
             //        selector: 'body' } },
             //   { name: 'elementIdClick',
             //     args: [ '0' ],
+            //     timestamp: 1487078962707,
             //     result:
             //      { state: 'success',
             //        sessionId: 'c2aea856-ba18-48c0-8745-aa292f6394bc',
@@ -35,9 +37,10 @@
             //        value: null,
             //        class: 'org.openqa.selenium.remote.Response',
             //        status: 0 } },
-            //   { name: 'addValue', args: [ '#lst-ib', 'webdriverio' ] },
+            //   { name: 'addValue', args: [ '#lst-ib', 'webdriverio' ], timestamp: 1487078962707 },
             //   { name: 'elements',
             //     args: [ '#lst-ib' ],
+            //     timestamp: 1487078962707,
             //     result:
             //      { state: 'success',
             //        sessionId: 'c2aea856-ba18-48c0-8745-aa292f6394bc',
@@ -48,6 +51,7 @@
             //        selector: '#lst-ib' } },
             //   { name: 'elementIdValue',
             //     args: [ '1', 'webdriverio' ],
+            //     timestamp: 1487078962707,
             //     result:
             //      { state: 'success',
             //        sessionId: 'c2aea856-ba18-48c0-8745-aa292f6394bc',
@@ -55,7 +59,7 @@
             //        value: null,
             //        class: 'org.openqa.selenium.remote.Response',
             //        status: 0 } },
-            //   { name: 'pause', args: [ 2000 ] } ]
+            //   { name: 'pause', args: [ 2000 ], timestamp: 1487078962707 } ]
         })
         .end();
  * </example>

--- a/lib/webdriverio.js
+++ b/lib/webdriverio.js
@@ -337,7 +337,8 @@ let WebdriverIO = function (args, modifier) {
                 /**
                  * store command into command list so `getHistory` can return it
                  */
-                commandList.push({name, args})
+                const timestamp = Date.now()
+                commandList.push({name, args, timestamp})
 
                 /**
                  * allow user to leave out selector argument if they have already queried an element before

--- a/test/spec/functional/getCommandHistory.js
+++ b/test/spec/functional/getCommandHistory.js
@@ -1,17 +1,27 @@
+const sinon = require('sinon')
+
 describe('getCommandHistory', () => {
     it('text should be visible after clicking on .btn1', async function () {
-        await this.client.getTitle()
+        const clock = sinon.useFakeTimers()
+
+        await this.client.getTitle().then(() => clock.tick(100))
         await this.client.click('body')
 
         const commandList = (await this.client.getCommandHistory()).slice(-5)
         commandList[0].name.should.be.equal('getTitle')
         commandList[0].args.should.have.length(0)
+        commandList[0].timestamp.should.be.equal(0)
         commandList[1].name.should.be.equal('title')
-        commandList[0].args.should.have.length(0)
+        commandList[1].args.should.have.length(0)
+        commandList[1].timestamp.should.be.equal(0)
         commandList[2].name.should.be.equal('click')
         commandList[2].args[0].should.be.equal('body')
         commandList[3].name.should.be.equal('element')
         commandList[3].args[0].should.be.equal('body')
+        commandList[3].timestamp.should.be.equal(100)
         commandList[4].name.should.be.equal('elementIdClick')
+        commandList[4].timestamp.should.be.equal(100)
+
+        clock.restore()
     })
 })


### PR DESCRIPTION
## Proposed changes

getCommandHistory() now returns a list of previous called commands + their arguments and execution timestamp.

Example output from getCommandHistory()
```
[ { name: 'init', args: [], timestamp: 1487078962707 },
  { name: 'url', args: [ 'http://example.com' ], timestamp: 1487078962708 }
]
```

Execution timestamps are usefull for profiling and logging. I need this functionality to sync in-browser console-api messages with executed commands in webdriver.io.

## Types of changes

What types of changes does your code introduce to WebdriverIO?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

### Reviewers: @christian-bromann
