### PR TITLE
Use fullTitle if it exists

### DIFF
--- a/lib/utils/BaseReporter.js
+++ b/lib/utils/BaseReporter.js
@@ -217,7 +217,7 @@ class BaseReporter extends events.EventEmitter {
                       this.color('error message', '%s') +
                       this.color('bright yellow', '%s') +
                       this.color('error stack', '\n%s\n')
-            var title = typeof test.parent !== 'undefined' ? test.parent + ' ' + test.title : test.title
+            var title = typeof test.fullTitle !== 'undefined' ? test.fullTitle : typeof test.parent !== 'undefined' ? test.parent + ' ' + test.title : test.title
             console.log(fmt, (i + 1), title, test.err.message, test.runningBrowser, test.err.stack)
         })
     }


### PR DESCRIPTION
## Proposed changes

This PR needs https://github.com/webdriverio/wdio-mocha-framework/pull/32 to pass first. The problem it solves mainly concerns the dot reporter. Currently, when there are nested `describe`, only the first parent's title is retrieved and displayed in the report error message. With this PR, the full title (provided by Mocha) is used, if it exists.

## Types of changes

What types of changes does your code introduce to WebdriverIO?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

Unfortunately, I could not find where to add tests.

### Reviewers: @christian-bromann
