### PR TITLE
update documentation for getValue/select

### DIFF
--- a/lib/commands/getValue.js
+++ b/lib/commands/getValue.js
@@ -1,6 +1,6 @@
 /**
  *
- * Get the value of a `<textarea>` or text `<input>` found by given selector.
+ * Get the value of a `<textarea>`, `<select>` or text `<input>` found by given selector.
  *
  * <example>
     :index.html
@@ -16,7 +16,7 @@
  * </example>
  *
  * @alias browser.getValue
- * @param   {String} selector input or textarea element
+ * @param   {String} selector input, textarea, or select element
  * @returns {String}          requested input value
  * @uses protocol/elements, protocol/elementIdAttribute
  * @type property


### PR DESCRIPTION
## Proposed changes

`select` elements work with `.getValue()`. This documentation is slightly misleading, as it shows that it would only work for `textarea` or `input`.

As a reference, [this page](http://webdriver.io/api/action/selectByValue.html) in the `selectByValue.js` example on line 6, it shows `.getValue()` being used with a `select` element.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

Minor doc tweak but figured it was worth mentioning. Thanks for an awesome tool! :)

### Reviewers: @christian-bromann
