### PR TITLE
Add the ability to send your own events for runner's reporters

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -351,14 +351,14 @@ class Launcher {
 
     /**
      * emit event from child process to reporter
-     * @param  {String} rid Runner ID
+     * @param  {String} cid
      * @param  {Object} m event object
      */
-    messageHandler (rid, m) {
+    messageHandler (cid, m) {
         this.hasStartedAnyProcess = true
 
         if (!m.cid) {
-            m.cid = rid
+            m.cid = cid
         }
 
         if (m.event === 'runner:error') {

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -319,7 +319,7 @@ class Launcher {
         this.processes.push(childProcess)
 
         childProcess
-            .on('message', this.messageHandler.bind(this))
+            .on('message', this.messageHandler.bind(this, rid))
             .on('exit', this.endHandler.bind(this, rid))
 
         childProcess.send({
@@ -351,10 +351,15 @@ class Launcher {
 
     /**
      * emit event from child process to reporter
-     * @param  {Object} m  event object
+     * @param  {String} rid Runner ID
+     * @param  {Object} m event object
      */
-    messageHandler (m) {
+    messageHandler (rid, m) {
         this.hasStartedAnyProcess = true
+
+        if (!m.cid) {
+            m.cid = rid
+        }
 
         if (m.event === 'runner:error') {
             this.reporters.handleEvent('error', m)
@@ -365,7 +370,7 @@ class Launcher {
 
     /**
      * Close test runner process once all child processes have exited
-     * @param  {Number} cid  Capabilities ID
+     * @param  {Number} rid  Capabilities ID
      * @param  {Number} childProcessExitCode  exit code of child process
      */
     endHandler (rid, childProcessExitCode) {

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -289,7 +289,7 @@ class Launcher {
     startInstance (specs, caps, cid, server) {
         let config = this.configParser.getConfig()
         let debug = caps.debug || config.debug
-        let rid = this.getRunnerId(cid)
+	    cid = this.getRunnerId(cid)
         let processNumber = this.processesStarted + 1
 
         // process.debugPort defaults to 5858 and is set even when process
@@ -319,11 +319,11 @@ class Launcher {
         this.processes.push(childProcess)
 
         childProcess
-            .on('message', this.messageHandler.bind(this, rid))
-            .on('exit', this.endHandler.bind(this, rid))
+            .on('message', this.messageHandler.bind(this, cid))
+            .on('exit', this.endHandler.bind(this, cid))
 
         childProcess.send({
-            cid: rid,
+            cid,
             command: 'run',
             configFile: this.configFile,
             argv: this.argv,
@@ -370,17 +370,17 @@ class Launcher {
 
     /**
      * Close test runner process once all child processes have exited
-     * @param  {Number} rid  Capabilities ID
+     * @param  {Number} cid  Capabilities ID
      * @param  {Number} childProcessExitCode  exit code of child process
      */
-    endHandler (rid, childProcessExitCode) {
+    endHandler (cid, childProcessExitCode) {
         this.exitCode = this.exitCode || childProcessExitCode
         this.runnerFailed += this.exitCode !== 0 ? 1 : 0
 
         // Update schedule now this process has ended
         if (!this.isMultiremote()) {
             // get cid (capability id) from rid (runner id)
-            let cid = parseInt(rid, 10)
+            cid = parseInt(cid, 10)
 
             this.schedule[cid].availableInstances++
             this.schedule[cid].runningInstances--


### PR DESCRIPTION
## Proposed changes

With these changes, we can send custom messages from the runner process to the parent process, and to understand in the reporters process of what it was this message.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments


### Reviewers:
@christian-bromann