### PR TITLE
Fixed info about timeouts

### DIFF
--- a/lib/protocol/timeouts.js
+++ b/lib/protocol/timeouts.js
@@ -2,10 +2,10 @@
  * Configure the amount of time that a particular type of operation can execute
  * for before they are aborted and a |Timeout| error is returned to the client.
  *
- * @param {String} type The type of operation to set the timeout for. Valid values are:<br>- **script** for script timeouts<br>- **implicit** for modifying the implicit wait timeout<br>- **page load** for setting a page load timeout.
- * @param {Number} ms   The amount of time, in milliseconds, that time-limited commands are permitted to run.
+ * @param {String} type The type of operation to set the timeout for. Valid values are:<br>- **script** Determines when to interrupt a script that is being [evaluated](https://www.w3.org/TR/webdriver/#executing-script).<br>- **implicit** Gives the timeout of when to abort [locating an element](https://www.w3.org/TR/webdriver/#element-retrieval).<br>- **pageLoad** Provides the timeout limit used to interrupt [navigation](https://html.spec.whatwg.org/#navigate) of the [browsing context](https://html.spec.whatwg.org/#browsing-context).
+ * @param {Number} ms The amount of time, in milliseconds, that time-limited commands are permitted to run.
  *
- * @see https://w3c.github.io/webdriver/webdriver-spec.html#dfn-set-timeout
+ * @see https://www.w3.org/TR/webdriver/#dfn-get-timeouts
  * @type protocol
  *
  */


### PR DESCRIPTION
## Proposed changes

1. The `page load` parameter has been renamed to `pageLoad`
2. https://w3c.github.io/webdriver/webdriver-spec.html#dfn-set-timeout is no longer available
3. Fixed texts

## Types of changes

What types of changes does your code introduce to WebdriverIO?

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have added necessary documentation (if appropriate)

### Reviewers: @christian-bromann
