### PR TITLE
Update Saucelabs example to use .then()

### DIFF
--- a/examples/cloudservices/webdriverio.saucelabs.js
+++ b/examples/cloudservices/webdriverio.saucelabs.js
@@ -27,7 +27,7 @@ client
     .setValue('*[name="q"]','webdriverio')
     .click('*[name="btnG"]')
     .pause(1000)
-    .getTitle(function(err,title) {
+    .getTitle().then(function(title) {
         console.log(title);
     })
     .end();


### PR DESCRIPTION
## Proposed changes

The example was still using the old callback-style, when it should be using `.then()` (as written it didn't output anything when run).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

### Reviewers: @christian-bromann
