### PR TITLE
Updated ConfigParser waitforTimeout default to match docs

### DIFF
--- a/lib/utils/ConfigParser.js
+++ b/lib/utils/ConfigParser.js
@@ -24,7 +24,7 @@ const DEFAULT_CONFIGS = {
     baseUrl: null,
     bail: 0,
     waitforInterval: 500,
-    waitforTimeout: 1000,
+    waitforTimeout: 500,
     framework: 'mocha',
     reporters: [],
     reporterOptions: {},


### PR DESCRIPTION
## Proposed changes

The default value for waitforTimeout in ConfigParser differed from everywhere else in the codebase. This change should correct that.

## Types of changes

What types of changes does your code introduce to WebdriverIO?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

### Reviewers: @christian-bromann
