### PR TITLE
Add ability to run geckodriver without selenium

### DIFF
--- a/lib/commands/addValue.js
+++ b/lib/commands/addValue.js
@@ -56,7 +56,7 @@ let addValue = function (selector, value) {
         let elementIdValueCommands = []
 
         for (let elem of res.value) {
-            elementIdValueCommands.push(self.elementIdValue(elem.ELEMENT, value))
+            elementIdValueCommands.push(self.elementIdValue(elem[Object.keys(elem)[0]], value))
         }
 
         return this.unify(elementIdValueCommands)

--- a/lib/commands/clearElement.js
+++ b/lib/commands/clearElement.js
@@ -38,7 +38,7 @@ let clearElement = function (selector) {
 
         let elementIdClearCommands = []
         for (let elem of res.value) {
-            elementIdClearCommands.push(this.elementIdClear(elem.ELEMENT, 'value'))
+            elementIdClearCommands.push(this.elementIdClear(elem[Object.keys(elem)[0]], 'value'))
         }
 
         return this.unify(elementIdClearCommands)

--- a/lib/commands/click.js
+++ b/lib/commands/click.js
@@ -46,7 +46,7 @@ let click = function (selector) {
             throw new RuntimeError(7)
         }
 
-        return this.elementIdClick(elem.value.ELEMENT)
+        return this.elementIdClick(elem.value[Object.keys(elem.value)[0]])
     })
 }
 

--- a/lib/commands/doubleClick.js
+++ b/lib/commands/doubleClick.js
@@ -38,7 +38,7 @@ let doubleClick = function (selector) {
                 throw new RuntimeError(7)
             }
 
-            return this.touchDoubleClick(res.value.ELEMENT)
+            return this.touchDoubleClick(res.value[Object.keys(res.value)[0]])
         })
     }
 
@@ -50,7 +50,7 @@ let doubleClick = function (selector) {
             throw new RuntimeError(7)
         }
 
-        return this.moveTo(res.value.ELEMENT)
+        return this.moveTo(res.value[Object.keys(res.value)[0]])
     }).doDoubleClick()
 }
 

--- a/lib/commands/getAttribute.js
+++ b/lib/commands/getAttribute.js
@@ -56,7 +56,7 @@ let getAttribute = function (selector, attributeName) {
         let elementIdAttributeCommands = []
 
         for (let elem of res.value) {
-            elementIdAttributeCommands.push(this.elementIdAttribute(elem.ELEMENT, attributeName))
+            elementIdAttributeCommands.push(this.elementIdAttribute(elem[Object.keys(elem)[0]], attributeName))
         }
 
         return this.unify(elementIdAttributeCommands, {

--- a/lib/commands/getCssProperty.js
+++ b/lib/commands/getCssProperty.js
@@ -86,7 +86,7 @@ let getCssProperty = function (selector, cssProperty) {
 
         let elementIdCssPropertyCommands = []
         for (let elem of res.value) {
-            elementIdCssPropertyCommands.push(this.elementIdCssProperty(elem.ELEMENT, cssProperty))
+            elementIdCssPropertyCommands.push(this.elementIdCssProperty(elem[Object.keys(elem)[0]], cssProperty))
         }
 
         return Promise.all(elementIdCssPropertyCommands)

--- a/lib/commands/getElementSize.js
+++ b/lib/commands/getElementSize.js
@@ -46,7 +46,7 @@ let getElementSize = function (selector, prop) {
 
         let elementIdSizeCommands = []
         for (let elem of res.value) {
-            elementIdSizeCommands.push(this.elementIdSize(elem.ELEMENT))
+            elementIdSizeCommands.push(this.elementIdSize(elem[Object.keys(elem)[0]]))
         }
 
         return Promise.all(elementIdSizeCommands)

--- a/lib/commands/getLocation.js
+++ b/lib/commands/getLocation.js
@@ -48,7 +48,7 @@ let getLocation = function (selector, prop) {
                 let current = res.value.pop()
 
                 return that
-                    .elementIdLocation(current.ELEMENT)
+                    .elementIdLocation(current[Object.keys(current)[0]])
                     .catch((err) => {
                         hasError = true
                         reject(err)

--- a/lib/commands/getLocationInView.js
+++ b/lib/commands/getLocationInView.js
@@ -40,7 +40,7 @@ let getLocationInView = function (selector, prop) {
 
         let elementIdLocationInViewCommands = []
         for (let elem of res.value) {
-            elementIdLocationInViewCommands.push(this.elementIdLocationInView(elem.ELEMENT))
+            elementIdLocationInViewCommands.push(this.elementIdLocationInView(elem[Object.keys(elem)[0]]))
         }
 
         return Promise.all(elementIdLocationInViewCommands)

--- a/lib/commands/getTagName.js
+++ b/lib/commands/getTagName.js
@@ -36,7 +36,7 @@ let getTagName = function (selector) {
 
         let elementIdNameCommands = []
         for (let elem of res.value) {
-            elementIdNameCommands.push(this.elementIdName(elem.ELEMENT))
+            elementIdNameCommands.push(this.elementIdName(elem[Object.keys(elem)[0]]))
         }
 
         return this.unify(elementIdNameCommands, {

--- a/lib/commands/getText.js
+++ b/lib/commands/getText.js
@@ -55,7 +55,7 @@ let getText = function (selector) {
 
         let elementIdTextCommands = []
         for (let elem of res.value) {
-            elementIdTextCommands.push(this.elementIdText(elem.ELEMENT))
+            elementIdTextCommands.push(this.elementIdText(elem[Object.keys(elem)[0]]))
         }
 
         return this.unify(elementIdTextCommands, {

--- a/lib/commands/getValue.js
+++ b/lib/commands/getValue.js
@@ -36,7 +36,7 @@ let getValue = function (selector) {
 
         let elementIdAttributeCommands = []
         for (let elem of res.value) {
-            elementIdAttributeCommands.push(this.elementIdAttribute(elem.ELEMENT, 'value'))
+            elementIdAttributeCommands.push(this.elementIdAttribute(elem[Object.keys(elem)[0]], 'value'))
         }
 
         return this.unify(elementIdAttributeCommands, {

--- a/lib/commands/hold.js
+++ b/lib/commands/hold.js
@@ -21,7 +21,7 @@ let hold = function (selector) {
             throw new RuntimeError(7)
         }
 
-        return this.touchLongClick(res.value.ELEMENT)
+        return this.touchLongClick(res.value[Object.keys(res.value)[0]])
     })
 }
 

--- a/lib/commands/isEnabled.js
+++ b/lib/commands/isEnabled.js
@@ -42,7 +42,7 @@ let isEnabled = function (selector) {
 
         let elementIdEnabledCommands = []
         for (let elem of res.value) {
-            elementIdEnabledCommands.push(this.elementIdEnabled(elem.ELEMENT))
+            elementIdEnabledCommands.push(this.elementIdEnabled(elem[Object.keys(elem)[0]]))
         }
 
         return this.unify(elementIdEnabledCommands, {

--- a/lib/commands/isSelected.js
+++ b/lib/commands/isSelected.js
@@ -42,7 +42,7 @@ let isSelected = function (selector) {
 
         let elementIdSelectedCommands = []
         for (let elem of res.value) {
-            elementIdSelectedCommands.push(this.elementIdSelected(elem.ELEMENT))
+            elementIdSelectedCommands.push(this.elementIdSelected(elem[Object.keys(elem)[0]]))
         }
 
         return this.unify(elementIdSelectedCommands, {

--- a/lib/commands/isVisible.js
+++ b/lib/commands/isVisible.js
@@ -47,7 +47,7 @@ let isVisible = function (selector) {
 
         let elementIdDisplayedCommands = []
         for (let elem of res.value) {
-            elementIdDisplayedCommands.push(this.elementIdDisplayed(elem.ELEMENT))
+            elementIdDisplayedCommands.push(this.elementIdDisplayed(elem[Object.keys(elem)[0]]))
         }
 
         return this.unify(elementIdDisplayedCommands, {

--- a/lib/commands/moveToObject.js
+++ b/lib/commands/moveToObject.js
@@ -33,8 +33,8 @@ let moveToObject = function (selector, xoffset, yoffset) {
                 throw new RuntimeError(7)
             }
 
-            return this.elementIdSize(res.value.ELEMENT).then((size) =>
-                this.elementIdLocation(res.value.ELEMENT).then((location) => {
+            return this.elementIdSize(res.value[Object.keys(res.value)[0]]).then((size) =>
+                this.elementIdLocation(res.value[Object.keys(res.value)[0]]).then((location) => {
                     return { size, location }
                 })
             )
@@ -59,7 +59,7 @@ let moveToObject = function (selector, xoffset, yoffset) {
             throw new RuntimeError(7)
         }
 
-        return this.moveTo(res.value.ELEMENT, xoffset, yoffset)
+        return this.moveTo(res.value[Object.keys(res.value)[0]], xoffset, yoffset)
     })
 }
 

--- a/lib/commands/scroll.js
+++ b/lib/commands/scroll.js
@@ -62,7 +62,7 @@ let scroll = function (selector, xoffset, yoffset) {
             }
 
             if (typeof res !== 'undefined') {
-                selector = res.value.ELEMENT
+                selector = res.value[Object.keys(res.value)[0]]
             }
 
             return this.touchScroll(selector, xoffset, yoffset)
@@ -78,7 +78,7 @@ let scroll = function (selector, xoffset, yoffset) {
                 throw new RuntimeError(7)
             }
 
-            return this.elementIdLocation(res.value.ELEMENT)
+            return this.elementIdLocation(res.value[Object.keys(res.value)[0]])
         }).then((location) =>
             this.execute(scrollHelper, location.value.x + xoffset, location.value.y + yoffset)
         )

--- a/lib/commands/setValue.js
+++ b/lib/commands/setValue.js
@@ -51,7 +51,7 @@ let setValue = function (selector, value) {
 
         let elementIdValueCommands = []
         for (let elem of res.value) {
-            elementIdValueCommands.push(this.elementIdClear(elem.ELEMENT).elementIdValue(elem.ELEMENT, value))
+            elementIdValueCommands.push(this.elementIdClear(elem[Object.keys(elem)[0]]).elementIdValue(elem[Object.keys(elem)[0]], value))
         }
 
         return this.unify(elementIdValueCommands)

--- a/lib/commands/submitForm.js
+++ b/lib/commands/submitForm.js
@@ -39,7 +39,7 @@ let submitForm = function (selector) {
             throw new RuntimeError(7)
         }
 
-        return this.submit(res.value.ELEMENT)
+        return this.submit(res.value[Object.keys(res.value)[0]])
     })
 }
 

--- a/lib/commands/swipe.js
+++ b/lib/commands/swipe.js
@@ -40,7 +40,7 @@ let swipe = function (selector, xoffset, yoffset, speed) {
             throw new RuntimeError(7)
         }
 
-        return this.touchFlick(res.value.ELEMENT.toString(), xoffset, yoffset, speed)
+        return this.touchFlick(res.value[Object.keys(res.value)[0]].toString(), xoffset, yoffset, speed)
     })
 }
 

--- a/lib/commands/touchAction.js
+++ b/lib/commands/touchAction.js
@@ -151,7 +151,7 @@ let formatArgs = function (selector, actions) {
             // don't propagate if user has x and y set
             !(isFinite(action.x) && isFinite(action.y))
         ) {
-            formattedAction.options.element = selector.value.ELEMENT
+            formattedAction.options.element = selector.value[Object.keys(selector.value)[0]]
         }
 
         if (typeof action === 'string') {
@@ -274,7 +274,7 @@ let replaceSelectorsById = function (actions, elements) {
 
         elements.forEach((element) => {
             if (action.options.selector === element.selector) {
-                action.options.element = element.value.ELEMENT
+                action.options.element = element.value
                 delete action.options.selector
             }
         })

--- a/lib/commands/touchAction.js
+++ b/lib/commands/touchAction.js
@@ -274,7 +274,7 @@ let replaceSelectorsById = function (actions, elements) {
 
         elements.forEach((element) => {
             if (action.options.selector === element.selector) {
-                action.options.element = element.value
+                action.options.element = element.value[Object.keys(element.value)[0]]
                 delete action.options.selector
             }
         })

--- a/lib/helpers/handleMouseButtonCommand.js
+++ b/lib/helpers/handleMouseButtonCommand.js
@@ -30,13 +30,13 @@ let handleMouseButtonCommand = function (selector, button, xoffset, yoffset) {
          * simulate event in safari
          */
         if (this.desiredCapabilities.browserName === 'safari') {
-            return this.moveTo(res.value.ELEMENT, xoffset, yoffset).execute((elem, x, y, button) => {
+            return this.moveTo(res.value[Object.keys(res.value)[0]], xoffset, yoffset).execute((elem, x, y, button) => {
                 return window._wdio_simulate(elem, 'mousedown', 0, 0, button) &&
                        window._wdio_simulate(elem, 'mouseup', 0, 0, button)
             }, res.value, xoffset, yoffset, button)
         }
 
-        return this.moveTo(res.value.ELEMENT, xoffset, yoffset).buttonPress(button)
+        return this.moveTo(res.value[Object.keys(res.value)[0]], xoffset, yoffset).buttonPress(button)
     })
 }
 

--- a/lib/protocol/alertAccept.js
+++ b/lib/protocol/alertAccept.js
@@ -26,7 +26,7 @@ let alertAccept = function () {
         method: 'POST'
     }
 
-    return this.requestHandler.create(requestOptions, {dummy: "dummy"})
+    return this.requestHandler.create(requestOptions, {dummy: 'dummy'})
 }
 
 export default alertAccept

--- a/lib/protocol/alertAccept.js
+++ b/lib/protocol/alertAccept.js
@@ -26,7 +26,7 @@ let alertAccept = function () {
         method: 'POST'
     }
 
-    return this.requestHandler.create(requestOptions)
+    return this.requestHandler.create(requestOptions, {dummy: "dummy"})
 }
 
 export default alertAccept

--- a/lib/protocol/alertDismiss.js
+++ b/lib/protocol/alertDismiss.js
@@ -27,7 +27,7 @@ let alertDismiss = function () {
         method: 'POST'
     }
 
-    return this.requestHandler.create(requestOptions, {dummy: "dummy"})
+    return this.requestHandler.create(requestOptions, {dummy: 'dummy'})
 }
 
 export default alertDismiss

--- a/lib/protocol/alertDismiss.js
+++ b/lib/protocol/alertDismiss.js
@@ -27,7 +27,7 @@ let alertDismiss = function () {
         method: 'POST'
     }
 
-    return this.requestHandler.create(requestOptions)
+    return this.requestHandler.create(requestOptions, {dummy: "dummy"})
 }
 
 export default alertDismiss

--- a/lib/protocol/back.js
+++ b/lib/protocol/back.js
@@ -11,8 +11,8 @@ let back = function () {
     if (this.desiredCapabilities.browserName === 'safari') {
         /*!
          * helper for safaridriver which doesn not support forward
-         * Reason: "Yikes! Safari history navigation does not work. We can go forward or back,
-         * but once we do, we can no longer communicate with the page"
+         * Reason: 'Yikes! Safari history navigation does not work. We can go forward or back,
+         * but once we do, we can no longer communicate with the page'
          */
         return this.execute('history.go(-1)')
     }
@@ -20,7 +20,7 @@ let back = function () {
     return this.requestHandler.create({
         path: '/session/:sessionId/back',
         method: 'POST'
-    }, {dummy: "dummy"})
+    }, {dummy: 'dummy'})
 }
 
 export default back

--- a/lib/protocol/back.js
+++ b/lib/protocol/back.js
@@ -20,7 +20,7 @@ let back = function () {
     return this.requestHandler.create({
         path: '/session/:sessionId/back',
         method: 'POST'
-    })
+    }, {dummy: "dummy"})
 }
 
 export default back

--- a/lib/protocol/doDoubleClick.js
+++ b/lib/protocol/doDoubleClick.js
@@ -11,7 +11,7 @@ let doDoubleClick = function () {
     return this.requestHandler.create({
         path: '/session/:sessionId/doubleclick',
         method: 'POST'
-    }, {dummy: "dummy"})
+    }, {dummy: 'dummy'})
 }
 
 export default doDoubleClick

--- a/lib/protocol/doDoubleClick.js
+++ b/lib/protocol/doDoubleClick.js
@@ -11,7 +11,7 @@ let doDoubleClick = function () {
     return this.requestHandler.create({
         path: '/session/:sessionId/doubleclick',
         method: 'POST'
-    })
+    }, {dummy: "dummy"})
 }
 
 export default doDoubleClick

--- a/lib/protocol/elementActive.js
+++ b/lib/protocol/elementActive.js
@@ -13,7 +13,7 @@ let elementActive = function () {
     return this.requestHandler.create({
         path: '/session/:sessionId/element/active',
         method: 'POST'
-    }, {dummy: "dummy"})
+    }, {dummy: 'dummy'})
 }
 
 export default elementActive

--- a/lib/protocol/elementActive.js
+++ b/lib/protocol/elementActive.js
@@ -13,7 +13,7 @@ let elementActive = function () {
     return this.requestHandler.create({
         path: '/session/:sessionId/element/active',
         method: 'POST'
-    })
+    }, {dummy: "dummy"})
 }
 
 export default elementActive

--- a/lib/protocol/elementIdAttribute.js
+++ b/lib/protocol/elementIdAttribute.js
@@ -25,7 +25,7 @@ let elementIdAttribute = function (id, attributeName) {
         command = '/property/'
     }
 
-    return this.requestHandler.create(`/session/:sessionId/element/${id}/attribute/${attributeName}`)
+    return this.requestHandler.create(`/session/:sessionId/element/${id}${command}${attributeName}`)
 }
 
 export default elementIdAttribute

--- a/lib/protocol/elementIdAttribute.js
+++ b/lib/protocol/elementIdAttribute.js
@@ -19,6 +19,12 @@ let elementIdAttribute = function (id, attributeName) {
         throw new ProtocolError('number or type of arguments don\'t agree with elementIdAttribute protocol command')
     }
 
+    var command = '/attribute/'
+
+    if (this.options.useW3C && this.desiredCapabilities.browserName === 'firefox' && attributeName === 'value') {
+        command = '/property/'
+    }
+
     return this.requestHandler.create(`/session/:sessionId/element/${id}/attribute/${attributeName}`)
 }
 

--- a/lib/protocol/elementIdClear.js
+++ b/lib/protocol/elementIdClear.js
@@ -19,7 +19,7 @@ let elementIdClear = function (id) {
     return this.requestHandler.create({
         path: `/session/:sessionId/element/${id}/clear`,
         method: 'POST'
-    }, {dummy: "dummy"})
+    }, {dummy: 'dummy'})
 }
 
 export default elementIdClear

--- a/lib/protocol/elementIdClear.js
+++ b/lib/protocol/elementIdClear.js
@@ -19,7 +19,7 @@ let elementIdClear = function (id) {
     return this.requestHandler.create({
         path: `/session/:sessionId/element/${id}/clear`,
         method: 'POST'
-    })
+    }, {dummy: "dummy"})
 }
 
 export default elementIdClear

--- a/lib/protocol/elementIdClick.js
+++ b/lib/protocol/elementIdClick.js
@@ -19,7 +19,7 @@ let elementIdClick = function (id) {
     return this.requestHandler.create({
         path: `/session/:sessionId/element/${id}/click`,
         method: 'POST'
-    })
+    }, {dummy: "dummy"})
 }
 
 export default elementIdClick

--- a/lib/protocol/elementIdClick.js
+++ b/lib/protocol/elementIdClick.js
@@ -19,7 +19,7 @@ let elementIdClick = function (id) {
     return this.requestHandler.create({
         path: `/session/:sessionId/element/${id}/click`,
         method: 'POST'
-    }, {dummy: "dummy"})
+    }, {dummy: 'dummy'})
 }
 
 export default elementIdClick

--- a/lib/protocol/forward.js
+++ b/lib/protocol/forward.js
@@ -9,8 +9,8 @@
 let forward = function () {
     /*!
      * helper for safaridriver which doesn not support forward
-     * Reason: "Yikes! Safari history navigation does not work. We can go forward or back,
-     * but once we do, we can no longer communicate with the page"
+     * Reason: 'Yikes! Safari history navigation does not work. We can go forward or back,
+     * but once we do, we can no longer communicate with the page'
      */
     if (this.desiredCapabilities.browserName === 'safari') {
         return this.execute('history.go(+1)').waitForExist('body', 5000)
@@ -19,7 +19,7 @@ let forward = function () {
     return this.requestHandler.create({
         path: '/session/:sessionId/forward',
         method: 'POST'
-    }, {dummy: "dummy"})
+    }, {dummy: 'dummy'})
 }
 
 export default forward

--- a/lib/protocol/forward.js
+++ b/lib/protocol/forward.js
@@ -19,7 +19,7 @@ let forward = function () {
     return this.requestHandler.create({
         path: '/session/:sessionId/forward',
         method: 'POST'
-    })
+    }, {dummy: "dummy"})
 }
 
 export default forward

--- a/lib/protocol/frameParent.js
+++ b/lib/protocol/frameParent.js
@@ -11,7 +11,7 @@ let frameParent = function () {
     return this.requestHandler.create({
         path: '/session/:sessionId/frame/parent',
         method: 'POST'
-    })
+    }, {dummy: "dummy"})
 }
 
 export default frameParent

--- a/lib/protocol/frameParent.js
+++ b/lib/protocol/frameParent.js
@@ -11,7 +11,7 @@ let frameParent = function () {
     return this.requestHandler.create({
         path: '/session/:sessionId/frame/parent',
         method: 'POST'
-    }, {dummy: "dummy"})
+    }, {dummy: 'dummy'})
 }
 
 export default frameParent

--- a/lib/protocol/refresh.js
+++ b/lib/protocol/refresh.js
@@ -11,7 +11,7 @@ let refresh = function () {
     return this.requestHandler.create({
         path: '/session/:sessionId/refresh',
         method: 'POST'
-    })
+    }, {dummy: "dummy"})
 }
 
 export default refresh

--- a/lib/protocol/refresh.js
+++ b/lib/protocol/refresh.js
@@ -11,7 +11,7 @@ let refresh = function () {
     return this.requestHandler.create({
         path: '/session/:sessionId/refresh',
         method: 'POST'
-    }, {dummy: "dummy"})
+    }, {dummy: 'dummy'})
 }
 
 export default refresh

--- a/lib/protocol/submit.js
+++ b/lib/protocol/submit.js
@@ -20,7 +20,7 @@ let submit = function (id) {
     return this.requestHandler.create({
         path: `/session/:sessionId/element/${id}/submit`,
         method: 'POST'
-    }, {dummy: "dummy"})
+    }, {dummy: 'dummy'})
 }
 
 export default submit

--- a/lib/protocol/submit.js
+++ b/lib/protocol/submit.js
@@ -20,7 +20,7 @@ let submit = function (id) {
     return this.requestHandler.create({
         path: `/session/:sessionId/element/${id}/submit`,
         method: 'POST'
-    })
+    }, {dummy: "dummy"})
 }
 
 export default submit

--- a/lib/protocol/window.js
+++ b/lib/protocol/window.js
@@ -31,8 +31,10 @@ let window = function (windowHandle) {
     }
 
     if (typeof windowHandle === 'string') {
-        data = { name: windowHandle }
-        requestOptions.method = 'POST'
+        if (this.options.useW3C && this.desiredCapabilities.browserName === 'firefox') {
+            data = { handle: windowHandle }
+        } else data = { name: windowHandle };
+        requestOptions.method = 'POST';
     }
 
     return this.requestHandler.create(requestOptions, data)

--- a/lib/protocol/window.js
+++ b/lib/protocol/window.js
@@ -33,8 +33,8 @@ let window = function (windowHandle) {
     if (typeof windowHandle === 'string') {
         if (this.options.useW3C && this.desiredCapabilities.browserName === 'firefox') {
             data = { handle: windowHandle }
-        } else data = { name: windowHandle };
-        requestOptions.method = 'POST';
+        } else data = { name: windowHandle }
+        requestOptions.method = 'POST'
     }
 
     return this.requestHandler.create(requestOptions, data)

--- a/lib/protocol/windowHandleFullscreen.js
+++ b/lib/protocol/windowHandleFullscreen.js
@@ -17,7 +17,7 @@ let windowHandleMaximize = function () {
     return this.requestHandler.create({
         path: '/session/:sessionId/window/fullscreen',
         method: 'POST'
-    })
+    }, {dummy: "dummy"})
 }
 
 export default windowHandleMaximize

--- a/lib/protocol/windowHandleFullscreen.js
+++ b/lib/protocol/windowHandleFullscreen.js
@@ -17,7 +17,7 @@ let windowHandleMaximize = function () {
     return this.requestHandler.create({
         path: '/session/:sessionId/window/fullscreen',
         method: 'POST'
-    }, {dummy: "dummy"})
+    }, {dummy: 'dummy'})
 }
 
 export default windowHandleMaximize

--- a/lib/protocol/windowHandleMaximize.js
+++ b/lib/protocol/windowHandleMaximize.js
@@ -1,6 +1,6 @@
 /**
  *
- * Maximize the specified window if not already maximized. If the :windowHandle URL parameter is "current",
+ * Maximize the specified window if not already maximized. If the :windowHandle URL parameter is 'current',
  * the currently active window will be maximized.
  *
  * @param {String=} windowHandle window to maximize (if parameter is falsy the currently active window will be maximized)
@@ -11,7 +11,6 @@
  */
 
 let windowHandleMaximize = function (windowHandle = 'current') {
-
     var path = `/session/:sessionId/window/${windowHandle}/maximize`
 
     if (this.options.useW3C && this.desiredCapabilities.browserName === 'firefox') {
@@ -21,7 +20,7 @@ let windowHandleMaximize = function (windowHandle = 'current') {
     return this.requestHandler.create({
         path: path,
         method: 'POST'
-    }, {dummy: "dummy"})
+    }, {dummy: 'dummy'})
 }
 
 export default windowHandleMaximize

--- a/lib/protocol/windowHandleMaximize.js
+++ b/lib/protocol/windowHandleMaximize.js
@@ -11,10 +11,17 @@
  */
 
 let windowHandleMaximize = function (windowHandle = 'current') {
+
+    var path = `/session/:sessionId/window/${windowHandle}/maximize`
+
+    if (this.options.useW3C && this.desiredCapabilities.browserName === 'firefox') {
+        path = '/session/:sessionId/window/maximize'
+    }
+
     return this.requestHandler.create({
-        path: `/session/:sessionId/window/${windowHandle}/maximize`,
+        path: path,
         method: 'POST'
-    })
+    }, {dummy: "dummy"})
 }
 
 export default windowHandleMaximize

--- a/lib/protocol/windowHandleSize.js
+++ b/lib/protocol/windowHandleSize.js
@@ -40,7 +40,6 @@ let windowHandleSize = function (windowHandle = 'current', size) {
 
     var path = '/session/:sessionId/window/' + windowHandle + '/size'
 
-
     if (this.options.useW3C && this.desiredCapabilities.browserName === 'firefox') {
         path = '/session/:sessionId/window/size'
     }

--- a/lib/protocol/windowHandleSize.js
+++ b/lib/protocol/windowHandleSize.js
@@ -38,11 +38,18 @@ let windowHandleSize = function (windowHandle = 'current', size) {
         [windowHandle, size] = ['current', windowHandle]
     }
 
+    var path = '/session/:sessionId/window/' + windowHandle + '/size'
+
+
+    if (this.options.useW3C && this.desiredCapabilities.browserName === 'firefox') {
+        path = '/session/:sessionId/window/size'
+    }
+
     /*!
      * protocol options
      */
     let requestOptions = {
-        path: `/session/:sessionId/window/${windowHandle}/size`,
+        path: path,
         method: 'GET'
     }
 

--- a/lib/utils/RequestHandler.js
+++ b/lib/utils/RequestHandler.js
@@ -129,16 +129,23 @@ class RequestHandler {
             data: data
         })
 
-        return this.request(fullRequestOptions, this.defaultOptions).then(({body, response}) => {
+        return this.request(fullRequestOptions, this.defaultOptions.connectionRetryCount).then(({body, response}) => {
             /**
              * if no session id was set before we've called the init command
              */
             if (this.sessionID === null && requestOptions.requiresSession !== false) {
                 this.sessionID = body.sessionId
 
+                var options = body.value;
+
+                if (this.defaultOptions.useW3C && this.defaultOptions.desiredCapabilities.browserName === 'firefox') {
+                    this.sessionID = body.value.sessionId;
+                    options = body.value.value
+                }
+
                 this.eventHandler.emit('init', {
                     sessionID: this.sessionID,
-                    options: body.value,
+                    options: options,
                     desiredCapabilities: data.desiredCapabilities
                 })
 
@@ -170,8 +177,7 @@ class RequestHandler {
         })
     }
 
-    request (fullRequestOptions, defaultOptions, retryCount = 0) {
-        var totalRetryCount = defaultOptions.connectionRetryCount
+    request (fullRequestOptions, totalRetryCount, retryCount = 0) {
 
         return new Promise((resolve, reject) => {
             request(fullRequestOptions, (err, response, body) => {
@@ -180,7 +186,7 @@ class RequestHandler {
                  */
 
                 if (!err && body) {
-                    if ((defaultOptions.useW3C && defaultOptions.desiredCapabilities.browserName === 'firefox' && !body.error) || body.status === 0) {
+                    if ((this.defaultOptions.useW3C && this.defaultOptions.desiredCapabilities.browserName === 'firefox' && !body.error) || body.status === 0) {
                         return resolve({body: body, response: response})
                     }
                 }

--- a/lib/utils/RequestHandler.js
+++ b/lib/utils/RequestHandler.js
@@ -13,7 +13,7 @@ class RequestHandler {
     constructor (options, eventHandler, logger) {
         this.sessionID = null
         this.startPath = options.path === '/' ? '' : options.path || '/wd/hub'
-            this.selenoid = options.selenoid
+        this.selenoid = options.selenoid
         this.gridApiStartPath = '/grid/api'
         this.eventHandler = eventHandler
         this.logger = logger
@@ -171,7 +171,7 @@ class RequestHandler {
     }
 
     request (fullRequestOptions, defaultOptions, retryCount = 0) {
-        var totalRetryCount = defaultOptions.connectionRetryCount;
+        var totalRetryCount = defaultOptions.connectionRetryCount
 
         return new Promise((resolve, reject) => {
             request(fullRequestOptions, (err, response, body) => {
@@ -181,7 +181,7 @@ class RequestHandler {
 
                 if (!err && body) {
                     if ((defaultOptions.useW3C && defaultOptions.desiredCapabilities.browserName === 'firefox' && !body.error) || body.status === 0) {
-                        return resolve({body: body, response: response});
+                        return resolve({body: body, response: response})
                     }
                 }
 

--- a/lib/utils/RequestHandler.js
+++ b/lib/utils/RequestHandler.js
@@ -136,10 +136,10 @@ class RequestHandler {
             if (this.sessionID === null && requestOptions.requiresSession !== false) {
                 this.sessionID = body.sessionId
 
-                var options = body.value;
+                var options = body.value
 
                 if (this.defaultOptions.useW3C && this.defaultOptions.desiredCapabilities.browserName === 'firefox') {
-                    this.sessionID = body.value.sessionId;
+                    this.sessionID = body.value.sessionId
                     options = body.value.value
                 }
 
@@ -178,7 +178,6 @@ class RequestHandler {
     }
 
     request (fullRequestOptions, totalRetryCount, retryCount = 0) {
-
         return new Promise((resolve, reject) => {
             request(fullRequestOptions, (err, response, body) => {
                 /**

--- a/lib/utils/RequestHandler.js
+++ b/lib/utils/RequestHandler.js
@@ -13,6 +13,7 @@ class RequestHandler {
     constructor (options, eventHandler, logger) {
         this.sessionID = null
         this.startPath = options.path === '/' ? '' : options.path || '/wd/hub'
+            this.selenoid = options.selenoid
         this.gridApiStartPath = '/grid/api'
         this.eventHandler = eventHandler
         this.logger = logger
@@ -128,7 +129,7 @@ class RequestHandler {
             data: data
         })
 
-        return this.request(fullRequestOptions, this.defaultOptions.connectionRetryCount).then(({body, response}) => {
+        return this.request(fullRequestOptions, this.defaultOptions).then(({body, response}) => {
             /**
              * if no session id was set before we've called the init command
              */
@@ -169,14 +170,19 @@ class RequestHandler {
         })
     }
 
-    request (fullRequestOptions, totalRetryCount, retryCount = 0) {
+    request (fullRequestOptions, defaultOptions, retryCount = 0) {
+        var totalRetryCount = defaultOptions.connectionRetryCount;
+
         return new Promise((resolve, reject) => {
             request(fullRequestOptions, (err, response, body) => {
                 /**
                  * Resolve with a healthy response
                  */
-                if (!err && body && body.status === 0) {
-                    return resolve({body, response})
+
+                if (!err && body) {
+                    if ((defaultOptions.useW3C && defaultOptions.desiredCapabilities.browserName === 'firefox' && !body.error) || body.status === 0) {
+                        return resolve({body: body, response: response});
+                    }
                 }
 
                 if (fullRequestOptions.gridCommand) {
@@ -205,10 +211,10 @@ class RequestHandler {
 
                 if (body) {
                     let error = {
-                        status: body.status,
+                        status: body.status || '-1',
                         type: ERROR_CODES[body.status] ? ERROR_CODES[body.status].id : 'unknown',
-                        message: ERROR_CODES[body.status] ? ERROR_CODES[body.status].message : 'unknown',
-                        orgStatusMessage: body.value ? body.value.message : ''
+                        message: body.error || (ERROR_CODES[body.status] ? ERROR_CODES[body.status].message : 'unknown'),
+                        orgStatusMessage: body.message || (body.value ? body.value.message : '')
                     }
                     let screenshot = body.value && body.value.screen
 


### PR DESCRIPTION
## Proposed changes

As you know there is ability to run tests without selenium at all. You just need to start driver and send requests to it. Selenium is just proxy, that unifies some difference between drivers and send responses to client in Selenium JSONWire format. But there is other implementation of Selenium, that don't unifies difference but they provide isolation for browsers. Here is an example: https://github.com/aandryashin/selenoid

In example above you can manage containers/browsers isolation and it's take only one role. The problem with difference should be resolved by client.

Now there is only one difference - geckodriver. It uses W3C standart and has other format of responses (don't has status code, elements return in other format etc)
example:
```
Selenium format:
{"value":[{"ELEMENT":"a815dba6-e075-964c-8aa6-2983cb893e7a”}]}
W3C geckodriver format:
{"value":[{"element-6066-11e4-a52e-4f735466cecf":"a815dba6-e075-964c-8aa6-2983cb893e7a”}]}
```

This pull request give you ability to use selenoid or geckodriver directly. There is new option `useW3C`. When it's `true` and browser is Firefox you can use geckodriver directly or use tools like selenoid.

This PR is not guarantied that everything will works great. I've just added an adhoc and hasn't much time to test it. So if you will be able to continue this theme, it would be great.

P.S.
Several thoughts why it's needed:
1. Exclude JVM from test process. If I develop tests on JS, I want to decrease amount of other frameworks, that I should use.
2. Have any alternative for hubs
3. Ability to use browser driver directly
3. Selenoid provide smaller docker containers for browsers and they starts faster than selenium containers. It's very nice for grid dockerization.

## Types of changes

What types of changes does your code introduce to WebdriverIO?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

### Reviewers: @christian-bromann
