### PR TITLE
Fix broken Browserstack Tunnel link

### DIFF
--- a/docs/guide/services/browserstack.md
+++ b/docs/guide/services/browserstack.md
@@ -20,7 +20,7 @@ npm install --save-dev wdio-browserstack-service
 
 ## Configuration
 
-WebdriverIO has Browserstack support out of the box. You should simply set `user` and `key` in your `wdio.conf.js` file. This service plugin provdies supports for [Browserstack Tunnel](https://wiki.saucelabs.com/display/DOCS/Using+Sauce+Connect+for+Testing+Behind+the+Firewall+or+on+Localhost). Set `browserstackLocal: true` also to activate this feature.
+WebdriverIO has Browserstack support out of the box. You should simply set `user` and `key` in your `wdio.conf.js` file. This service plugin provdies supports for [Browserstack Tunnel](https://www.browserstack.com/automate/node#setting-local-tunnel). Set `browserstackLocal: true` also to activate this feature.
 
 ```js
 // wdio.conf.js


### PR DESCRIPTION
## Proposed changes

Previously the Browserstack Tunnel link went to a broken Sauce Labs
link, now it goes to the appropriate Browserstack Tunnel link. 

ref: http://webdriver.io/guide/services/browserstack.html

## Types of changes

What types of changes does your code introduce to WebdriverIO?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

N/A

### Reviewers: @christian-bromann
