### PR TITLE
Update snyk config to allow Travis master and PR builds again

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,9 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.7.0
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  'npm:shelljs:20140723':
+    - grunt-eslint > eslint > shelljs:
+        reason: Issue open since 2014, no fix yet: https://snyk.io/vuln/npm:shelljs:20140723
+        expires: '2017-04-16T17:17:13.719Z'
+patch: {}

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,10 @@ before_script:
   - cd test/site/www && bower install && cd ../../../
   - phantomjs --webdriver=4444 2>&1 >/dev/null &
 
-script: "sleep 5 && npm run test-snyk && npm run test"
+script:
+    - sleep 5
+    - 'if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then npm run test-snyk; fi'
+    - npm run test
 
 addons:
   sauce_connect: true


### PR DESCRIPTION
## Proposed changes

This PR fixes two issues with snyk
- runs snyk only when no PR is created (i.e. master, branches from contributors - since auth token is a secret in Travis and could be exposed)
- ignores vulnerable shelljs dependency for 30 days, so master runs the testsuite again  
(side note: this happens due to npm@2 peerDependency resolving)

## Types of changes

What types of changes does your code introduce to WebdriverIO?

- [x] Change to build pipeline

## Checklist

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

The CONTRIBUTING doc links to a GitHub page, **not** the one in the project root. I'm fine with both, since OSS is <3

### Reviewers: @christian-bromann
