### PR TITLE
chore: update vulnerable eslint path

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -3,7 +3,7 @@ version: v1.7.0
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
   'npm:shelljs:20140723':
-    - grunt-eslint > eslint > shelljs:
+    - eslint > shelljs:
         reason: 'Issue open since 2014, no fix yet: https://snyk.io/vuln/npm:shelljs:20140723'
         expires: '2017-04-16T17:17:13.719Z'
 patch: {}


### PR DESCRIPTION
## Proposed changes

Due to how npm@2 resolves peerDependencies it's required to ignore the direct eslint path.  
This time, I've tested Node v4 with npm v2.15.11 🙈 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc

### Reviewers: @christian-bromann
