### PR TITLE
Fix link to contributing.md in pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,7 +15,7 @@ _Put an `x` in the boxes that apply_
 
 _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
 
-- [ ] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
+- [ ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] I have added necessary documentation (if appropriate)
 


### PR DESCRIPTION
## Proposed changes

The link in this `PULL_REQUEST_TEMPLATE.md` to the `CONTRIBUTING.md` is invalid.  
The problem with relative paths from the PR URL is, that it's something like `pulls/123` or when writing the in the editor `compare/master...fork:branch`
This would require a relative URL that's really ugly (like `../../blob/master/`)  
Let's make the link absolute instead, since it's not that likely that the URL changes

## Types of changes

- [x] Workflow/documentation

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc

### Reviewers: @christian-bromann
