### PR TITLE
feat: make url act like url.resolve

### DIFF
--- a/lib/protocol/url.js
+++ b/lib/protocol/url.js
@@ -1,3 +1,5 @@
+const nodeUrl = require('url')
+
 /**
  *
  * Protocol binding to load or get the URL of the browser.
@@ -23,8 +25,8 @@ let url = function (uri) {
 
     if (typeof uri === 'string') {
         data.url = uri
-        if (typeof this.options.baseUrl === 'string' && /^(\/|\?)/.test(data.url)) {
-            data.url = this.options.baseUrl + data.url
+        if (typeof this.options.baseUrl === 'string') {
+            data.url = nodeUrl.resolve(this.options.baseUrl, data.url)
         }
     }
 

--- a/test/site/www/base-url/index.html
+++ b/test/site/www/base-url/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>WebdriverIO Testpage</title>
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+    <meta name="viewport" content="user-scalable=no, width=device-width, initial-scale=1, maximum-scale=1">
+</head>
+<body>
+
+    <header>
+        <h1>WebdriverIO Testpage</h1>
+    </header>
+
+</body>
+</html>

--- a/test/site/www/base-url/two.html
+++ b/test/site/www/base-url/two.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>two</title>
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+    <meta name="viewport" content="user-scalable=no, width=device-width, initial-scale=1, maximum-scale=1">
+</head>
+<body>
+
+    <header>
+        <h1>WebdriverIO Testpage</h1>
+    </header>
+
+    <div class="page">
+    	Second page
+    </div>
+
+</body>
+</html>

--- a/test/spec/functional/baseUrl.js
+++ b/test/spec/functional/baseUrl.js
@@ -1,7 +1,19 @@
+const url = require('url')
+
 describe('baseUrl', () => {
-    it('should get prepended if url starts with /', async function () {
+    let baseUrl
+
+    before(async function() {
+        this.client.options.baseUrl += '/base-url/'
+        baseUrl = url.parse(this.client.options.baseUrl)
+    })
+
+    it('should get prepended and replace pathname if url starts with /', async function () {
         await this.client.url('/two.html');
         (await this.client.getTitle()).should.be.equal('two')
+
+        const actualUrl = await this.client.getUrl()
+        url.parse(actualUrl).pathname.should.be.equal('/two.html')
     })
 
     it('should get prepended if url starts with ?', async function () {
@@ -10,7 +22,16 @@ describe('baseUrl', () => {
         const title = await this.client.getTitle()
         title.should.be.equal('WebdriverIO Testpage')
 
-        const url = await this.client.getUrl()
-        url.should.contain('?foo=bar')
+        const actualUrl = url.parse(await this.client.getUrl())
+
+        actualUrl.pathname.should.be.equal(baseUrl.pathname)
+        actualUrl.query.should.be.equal('foo=bar')
+    })
+
+    it('should get prepended if url dont starts with / or ?', async function () {
+        await this.client.url('two.html')
+
+        const actualUrl = url.parse(await this.client.getUrl())
+        actualUrl.pathname.should.be.equal(`${baseUrl.pathname}two.html`)
     })
 })


### PR DESCRIPTION
## Proposed changes

I suggest to change browser.url interaction with baseUrl. It will be more clear and useful if it acts like 
url.resolve.

For example

basePath = https://base_path/baz
pass /foo/bar => https://base_path/foo/bar
pass foo/bar => https://base_path/baz/foo/bar
pass https://foo.bar => https://foo.bar

## Types of changes

What types of changes does your code introduce to WebdriverIO?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

Maybe I should create alternative url command and mark existing url as deprecated? Or add optional behaviour to url with this functionality?

Have to mention that I need this functionality in my project.

### Reviewers: @christian-bromann
