### PR TITLE
Add missing unit tests for Sanitize.caps, Sanitize.args and Sanitize.css

### DIFF
--- a/lib/helpers/sanitize.js
+++ b/lib/helpers/sanitize.js
@@ -23,6 +23,10 @@ let sanitizeString = function (str) {
  * @param {Object} caps  Selenium capabilities
  */
 let caps = function (caps) {
+    if (!caps) {
+        return ''
+    }
+
     let result
 
     /**
@@ -43,11 +47,15 @@ let caps = function (caps) {
  * @param  {Array} args arguments object
  */
 let args = function (args) {
+    if (!args || !Array.isArray(args)) {
+        return ''
+    }
+
     return args.map((arg) => {
         if (typeof arg === 'function' || (typeof arg === 'string' && arg.indexOf('return (function') === 0)) {
             return '<Function>'
         } else if (typeof arg === 'string') {
-            return '"' + arg + '"'
+            return `"${arg}"`
         } else if (Array.isArray(arg)) {
             return arg.join(', ')
         }
@@ -78,11 +86,11 @@ let limit = function (val) {
     switch (Object.prototype.toString.call(val)) {
     case '[object String]':
         if (val.length > 100 && validator.isBase64(val)) {
-            return '[base64] ' + val.length + ' bytes'
+            return `[base64] ${val.length} bytes`
         }
 
         if (val.length > STRINGLIMIT) {
-            return val.substr(0, STRINGTRUNCATE) + ' ... (' + (val.length - STRINGTRUNCATE) + ' more bytes)'
+            return val.substr(0, STRINGTRUNCATE) + ` ... (${val.length - STRINGTRUNCATE} more bytes)`
         }
 
         return val
@@ -90,7 +98,7 @@ let limit = function (val) {
         const length = val.length
         if (length > ARRLENGTH) {
             val = val.slice(0, ARRLENGTH)
-            val.push('(' + (length - ARRLENGTH) + ' more items)')
+            val.push(`(${length - ARRLENGTH} more items)`)
         }
         return val.map(limit)
     case '[object Object]':

--- a/test/spec/unit/sanitize.js
+++ b/test/spec/unit/sanitize.js
@@ -14,6 +14,26 @@ const SHORT_OBJECT = fillObject(3)
 const LONG_OBJECT = fillObject(20)
 const OBJECT_OF_LONG_STRINGS = fillObject(3, LONG_STRING)
 
+const MOBILE_CAPS = {
+    deviceName: 'iPhone 7',
+    platformName: 'iOS',
+    platformVersion: '10.2',
+    app: 'my.ipa'
+}
+
+const DESKTOP_CAPS = {
+    browserName: 'Chrome',
+    version: '57',
+    platform: 'Windows 10'
+}
+
+const ARGS = [
+    ['foo', 'bar'],
+    'test',
+    () => {},
+    {a: true}
+]
+
 function fillArray (length, val) {
     return Array.apply(0, Array(length)).map((val, i) => val || i)
 }
@@ -35,9 +55,27 @@ function compare (expected, actual) {
 }
 
 describe('Sanitize', () => {
-    it.skip('should sanitize capabilities')
-    it.skip('should sanitize arguments')
-    it.skip('should sanitize css')
+    it('should sanitize capabilities', () => {
+        expect(Sanitize.caps(undefined)).to.be.equal('')
+        expect(Sanitize.caps(null)).to.be.equal('')
+        expect(Sanitize.caps({})).to.be.equal('')
+        expect(Sanitize.caps(MOBILE_CAPS)).to.be.equal('iphone7.ios.10_2.my_ipa')
+        expect(Sanitize.caps(DESKTOP_CAPS)).to.be.equal('chrome.57.windows10')
+    })
+
+    it('should sanitize arguments', () => {
+        expect(Sanitize.args(undefined)).to.be.equal('')
+        expect(Sanitize.args(null)).to.be.equal('')
+        expect(Sanitize.args({})).to.be.equal('')
+        expect(Sanitize.args([])).to.be.equal('')
+        expect(Sanitize.args(ARGS)).to.be.equal('foo, bar, "test", <Function>, [object Object]')
+    })
+
+    it('should sanitize css', () => {
+        expect(Sanitize.css(undefined)).to.be.undefined
+        expect(Sanitize.css(null)).to.be.null
+        expect(Sanitize.css('"TEST"\'  ')).to.be.equal('test')
+    })
 
     describe('Sanitize an arbitrary variable', () => {
         it('should return simple values unchanged', () => {


### PR DESCRIPTION
## Proposed changes

This PR adds three missing unit tests for the Sanitize helper and uses template strings instead of string concatenation

## Types of changes

- [x] Missing tests

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works

### Reviewers: @christian-bromann
