### PR TITLE
Add a reference to the webpack-dev-server service

### DIFF
--- a/docs/guide/services/webpack-dev-server
+++ b/docs/guide/services/webpack-dev-server
@@ -1,0 +1,63 @@
+name: Webpack Dev Server
+category: services
+tags: guide
+index: 9
+title: WebdriverIO - Webpack Dev Server Service
+---
+
+WDIO Webpack Dev Server Service
+====================
+
+This allows you to run a local server with your built static assets using Webpack Dev Server before testing.
+
+## Installation
+
+``bash
+npm install wdio-webpack-dev-server-service --save-dev
+```
+
+## Configuration
+
+This assumes you have:
+
+- [set up WebdriverIO](https://webdriver.io/guide.html).
+- [set up Webpack Dev Server](https://webpack.js.org/guides/development/#webpack-dev-server) - the example will use `webpack.dev.config.js` as the configuration file.
+
+Add the Webpack Dev Server service to your WebdriverIO services list:
+
+```js
+// wdio.conf.js
+export.config = {
+  // ...
+  services: ['webpack-dev-server'],
+  // ...
+};
+```
+
+Options are set directly on your WebdriverIO config as well, e.g.
+
+```js
+// wdio.conf.js
+export.config = {
+  // ...
+  webpackConfig: require('webpack.dev.config.js'),
+  webpackPort: 8080,
+  // ...
+};
+```
+
+## Options
+
+### `webpackConfig`
+Type: `String` | `Object`
+
+Default: `webpack.config.js`
+
+Either the absolute path to your Webpack configuration, or your actual Webpack configuration.
+
+### `webpackPort`
+Type: Number
+
+Default: `8080`
+
+The port the Dev Server should be run on. You'll want to set this same port in the `baseUrl` option of your WebdriverIO configuration.

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -44,7 +44,8 @@ const SUPPORTED_SERVICES = [
     ' phantomjs - https://github.com/cognitom/wdio-phantomjs-service',
     ' static-server - https://github.com/LeadPages/wdio-static-server-service',
     ' visual-regression - https://github.com/zinserjan/wdio-visual-regression-service',
-    ' webpack - https://github.com/leadpages/wdio-webpack-service'
+    ' webpack - https://github.com/leadpages/wdio-webpack-service',
+    ' webpack-dev-server - https://gitlab.com/Vinnl/wdio-webpack-dev-server-service'
 ]
 
 const VERSION = pkg.version


### PR DESCRIPTION
## Proposed changes

I wanted to run my wdio tests locally, but had to run a server beforehand for wdio to visit. Since I already had the infrastructure for that in place using Webpack Dev Server, I created a service for wdio to start that ahead of the tests and shut it down afterwards.

This PR adds documentation on it.

## Types of changes

What types of changes does your code introduce to WebdriverIO?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

(Insofar as updated documentation is a new feature.)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] N/A I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

### Reviewers: @christian-bromann
