### PR TITLE
Remove screenshot data from ReporterStats payload

### DIFF
--- a/lib/utils/ReporterStats.js
+++ b/lib/utils/ReporterStats.js
@@ -245,6 +245,10 @@ class ReporterStats extends RunnableStats {
 
     output (type, runner) {
         runner.time = new Date()
+        // Remove the screenshot data to reduce RAM usage on the parent process
+        if (type === 'screenshot') {
+            runner.data = null
+        }
         if (ReporterStats.getIdentifier(runner) && runner.parent) {
             this.getTestStats(runner).output.push({
                 type,


### PR DESCRIPTION
## Proposed changes

I removed the raw screenshot data in the RunnerStats.output() function, so that it is not stored in the parent process's memory.

Addresses #1978.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

I did not see any current UTs on this function or class, let me know if I missed something...

## Further comments

I chose to remove the data from the payload specifically in the ReporterSpecs class (instead of in the process listener/runner or BaseReporter), so that any custom reporters that utilize this data have the opportunity to use the raw screenshot data before it is scrubbed.

### Reviewers: @christian-bromann
