### PR TITLE
Include building in setup for examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -3,12 +3,13 @@ WebdriverIO Examples
 
 Welcome to the WebdriverIO example repository. Here you can find a lot of stuff that helps you to understand
 how WebdriverIO works. It is separated into different topics. The best way to start is to clone the WebdriverIO
-repository and install its dependencies:
+repository, install its dependencies, and build it:
 
 ```sh
 git clone git@github.com:webdriverio/webdriverio.git
 cd ./webdriverio
 npm install
+npm run build
 ```
 
 Then just follow the instructions and test it out. Have fun!


### PR DESCRIPTION
## Proposed changes

To make it possible for the examples to "just work" for someone unfamiliar with the project, the instructions for examples need to include all the required steps.  Because the `build` directory only exists once the project is built, building needs to be in the example setup list.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation Update

## Checklist

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works 
(N/A)
- [X] I have added necessary documentation (if appropriate)

## Further comments

N/A

### Reviewers: @christian-bromann
