### PR TITLE
Updated onComplete documentation to reflect the permittance of promises

### DIFF
--- a/docs/guide/testrunner/configurationfile.md
+++ b/docs/guide/testrunner/configurationfile.md
@@ -322,8 +322,7 @@ exports.config = {
     afterSession: function (config, capabilities, specs) {
     },
     /**
-     * Gets executed after all workers got shut down and the process is about to exit. It is not
-     * possible to defer the end of the process using a promise.
+     * Gets executed after all workers got shut down and the process is about to exit.
      * @param {Object} exitCode 0 - success, 1 - fail
      */
     onComplete: function (exitCode) {

--- a/examples/pageobject/wdio.conf.js
+++ b/examples/pageobject/wdio.conf.js
@@ -180,8 +180,7 @@ exports.config = {
     // after: function (result, capabilities, specs) {
     // },
     //
-    // Gets executed after all workers got shut down and the process is about to exit. It is not
-    // possible to defer the end of the process using a promise.
+    // Gets executed after all workers got shut down and the process is about to exit.
     // onComplete: function(exitCode) {
     // }
 }

--- a/examples/wdio.conf.js
+++ b/examples/wdio.conf.js
@@ -300,8 +300,7 @@ exports.config = {
     afterSession: function (config, capabilities, specs) {
     },
     /**
-     * Gets executed after all workers got shut down and the process is about to exit. It is not
-     * possible to defer the end of the process using a promise.
+     * Gets executed after all workers got shut down and the process is about to exit.
      * @param {Object} exitCode 0 - success, 1 - fail
      */
     onComplete: function (exitCode) {

--- a/lib/helpers/wdio.conf.ejs
+++ b/lib/helpers/wdio.conf.ejs
@@ -351,8 +351,7 @@ exports.config = {
     // afterSession: function (config, capabilities, specs) {
     // },
     /**
-     * Gets executed after all workers got shut down and the process is about to exit. It is not
-     * possible to defer the end of the process using a promise.
+     * Gets executed after all workers got shut down and the process is about to exit.
      * @param {Object} exitCode 0 - success, 1 - fail
      */
     // onComplete: function(exitCode) {


### PR DESCRIPTION
## Proposed changes

I have updated the documentation and examples for onComplete to reflect the fact that promises are no longer prohibited on this particular hook. This hook now matches all the other hooks behaviour of resolving promises before continuing. 

The default promise-resolving behaviour is already documented at the beginning of the hooks section of the example configuration file.

## Types of changes

What types of changes does your code introduce to WebdriverIO?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

As discussed in the gitter char.

### Reviewers: @christian-bromann
