### PR TITLE
Updated onComplete hook to include same params as onPrepare

### DIFF
--- a/docs/guide/testrunner/configurationfile.md
+++ b/docs/guide/testrunner/configurationfile.md
@@ -324,8 +324,10 @@ exports.config = {
     /**
      * Gets executed after all workers got shut down and the process is about to exit.
      * @param {Object} exitCode 0 - success, 1 - fail
+     * @param {Object} config wdio configuration object
+     * @param {Array.<Object>} capabilities list of capabilities details
      */
-    onComplete: function (exitCode) {
+    onComplete: function (exitCode, config, capabilities) {
     },
     //
     // Cucumber specific hooks

--- a/examples/pageobject/wdio.conf.js
+++ b/examples/pageobject/wdio.conf.js
@@ -181,6 +181,6 @@ exports.config = {
     // },
     //
     // Gets executed after all workers got shut down and the process is about to exit.
-    // onComplete: function(exitCode) {
+    // onComplete: function(exitCode, config, capabilities) {
     // }
 }

--- a/examples/wdio.conf.js
+++ b/examples/wdio.conf.js
@@ -302,8 +302,10 @@ exports.config = {
     /**
      * Gets executed after all workers got shut down and the process is about to exit.
      * @param {Object} exitCode 0 - success, 1 - fail
+     * @param {Object} config wdio configuration object
+     * @param {Array.<Object>} capabilities list of capabilities details
      */
-    onComplete: function (exitCode) {
+    onComplete: function (exitCode, config, capabilities) {
     },
     //
     // Cucumber specific hooks

--- a/lib/helpers/wdio.conf.ejs
+++ b/lib/helpers/wdio.conf.ejs
@@ -353,7 +353,9 @@ exports.config = {
     /**
      * Gets executed after all workers got shut down and the process is about to exit.
      * @param {Object} exitCode 0 - success, 1 - fail
+     * @param {Object} config wdio configuration object
+     * @param {Array.<Object>} capabilities list of capabilities details
      */
-    // onComplete: function(exitCode) {
+    // onComplete: function(exitCode, config, capabilities) {
     // }
 }

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -134,8 +134,8 @@ class Launcher {
             /**
              * run onComplete hook for multiremote
              */
-            await this.runServiceHook(launcher, 'onComplete', exitCode)
-            await config.onComplete(exitCode)
+            await this.runServiceHook(launcher, 'onComplete', exitCode, config, caps)
+            await config.onComplete(exitCode, config, caps)
 
             return exitCode
         }
@@ -181,8 +181,8 @@ class Launcher {
         /**
          * run onComplete hook
          */
-        await this.runServiceHook(launcher, 'onComplete', exitCode)
-        await config.onComplete(exitCode)
+        await this.runServiceHook(launcher, 'onComplete', exitCode, config, caps)
+        await config.onComplete(exitCode, config, caps)
 
         return exitCode
     }


### PR DESCRIPTION
## Proposed changes

I have updated the onComplete hooks to include the same parameters as the onPrepare hook. I appended the parameters after the existing exitCode parameter to maintain backwards compatibility.

## Types of changes

What types of changes does your code introduce to WebdriverIO?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

Changed as per the gitter chat.

I did not see any tests currently for the onComplete hook to update.

### Reviewers: @christian-bromann
