### PR TITLE
changed 'returns' to 'return', added throws to alerts docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,8 +117,8 @@ The source code for various API methods is located in the `lib/` folder.  To fin
  * </example>
  *
  * @param   {String}           selector   element with requested tag name
- * @returns {String|String[]}             the element's tag name, as a lowercase string
- *
+ * @return {String|String[]}             the element's tag name, as a lowercase string
+ * 
  * @uses protocol/elements, protocol/elementIdName
  * @type property
  *
@@ -137,7 +137,9 @@ Here's a quick cheat-sheet:
 
 5. **Type:** The `@type` attribute corresponds to the sections on the API page.  Currently in use are `action`, `appium`, `cookie`, `mobile`, `property`, `protocol`, `state`, `utility`, `window`.  You probably will not ever need to change this.
 
-6. **Returns:** Identifies the data type returned and a short description.
+6. **Return:** Identifies the data type returned and a short description.
+
+7. **Throws:** Identifies common exceptions that may be thrown.
 
 
 When you have completed your updates to the documentation, push to your fork and submit a pull request.

--- a/lib/commands/getAttribute.js
+++ b/lib/commands/getAttribute.js
@@ -29,7 +29,7 @@
  * @alias browser.getAttribute
  * @param {String} selector      element with requested attribute
  * @param {String} attributeName requested attribute
- * @returns {String|String[]|null} The value of the attribute(s), or null if it is not set on the element.
+ * @return {String|String[]|null} The value of the attribute(s), or null if it is not set on the element.
  * @uses protocol/elements, protocol/elementIdAttribute
  * @type property
  *

--- a/lib/commands/getCommandHistory.js
+++ b/lib/commands/getCommandHistory.js
@@ -65,7 +65,7 @@
  * </example>
  *
  * @alias browser.getCommandHistory
- * @returns {Object[]} list of recent called commands + their arguments
+ * @return {Object[]} list of recent called commands + their arguments
  * @type utility
  *
  */

--- a/lib/commands/getCookie.js
+++ b/lib/commands/getCookie.js
@@ -25,7 +25,7 @@
  *
  * @alias browser.getCookie
  * @param {String=} name name of requested cookie
- * @returns {Object|null} requested cookie if existing
+ * @return {Object|null} requested cookie if existing
  * @uses protocol/cookie
  * @type cookie
  *

--- a/lib/commands/getCurrentTabId.js
+++ b/lib/commands/getCurrentTabId.js
@@ -15,7 +15,7 @@
  * </example>
  *
  * @alias browser.getCurrentTabId
- * @returns {String} the window handle URL of the current focused window
+ * @return {String} the window handle URL of the current focused window
  * @uses protocol/windowHandle
  * @type window
  *

--- a/lib/commands/getElementSize.js
+++ b/lib/commands/getElementSize.js
@@ -28,7 +28,7 @@
  * @alias browser.getElementSize
  * @param   {String}  selector element with requested size
  * @param   {String*} prop     size to receive (optional "width|height")
- * @returns {Object|Number}    requested element size (`{ width: <Number>, height: <Number> }`) or actual width/height as number if prop param is given
+ * @return {Object|Number}    requested element size (`{ width: <Number>, height: <Number> }`) or actual width/height as number if prop param is given
  * @uses protocol/elements, protocol/elementIdSize
  * @type property
  *

--- a/lib/commands/getGeoLocation.js
+++ b/lib/commands/getGeoLocation.js
@@ -17,7 +17,7 @@
  * </example>
  *
  * @alias browser.getGeoLocation
- * @returns {Object} the current geo location (`{latitude: number, longitude: number, altitude: number}`)
+ * @return {Object} the current geo location (`{latitude: number, longitude: number, altitude: number}`)
  * @uses protocol/location
  * @type mobile
  *

--- a/lib/commands/getLocation.js
+++ b/lib/commands/getLocation.js
@@ -22,7 +22,7 @@
  * @alias browser.getLocation
  * @param {String} selector    element with requested position offset
  * @param {String} property    can be "x" or "y" to get a result value directly for easier assertions
- * @returns {Object|Object[]}  The X and Y coordinates for the element on the page (`{x:number, y:number}`)
+ * @return {Object|Object[]}  The X and Y coordinates for the element on the page (`{x:number, y:number}`)
  * @uses protocol/elements, protocol/elementIdLocation
  * @type property
  *

--- a/lib/commands/getLocationInView.js
+++ b/lib/commands/getLocationInView.js
@@ -20,7 +20,7 @@
  *
  * @alias browser.getLocationInView
  * @param {String} selector    element with requested position offset
- * @returns {Object|Object[]}  The X and Y coordinates for the element on the page (`{x:number, y:number}`)
+ * @return {Object|Object[]}  The X and Y coordinates for the element on the page (`{x:number, y:number}`)
  *
  * @uses protocol/elements, protocol/elementIdLocationInView
  * @type property

--- a/lib/commands/getOrientation.js
+++ b/lib/commands/getOrientation.js
@@ -12,7 +12,7 @@
  * </example>
  *
  * @alias browser.getOrientation
- * @returns {String} device orientation (`landscape/portrait`)
+ * @return {String} device orientation (`landscape/portrait`)
  * @uses protocol/orientation
  * @for android, ios
  * @type mobile

--- a/lib/commands/getSource.js
+++ b/lib/commands/getSource.js
@@ -14,7 +14,7 @@
  * </example>
  *
  * @alias browser.getSource
- * @returns {String} source code of current website
+ * @return {String} source code of current website
  * @uses protocol/source
  * @type property
  *

--- a/lib/commands/getTabIds.js
+++ b/lib/commands/getTabIds.js
@@ -18,7 +18,7 @@
  * </example>
  *
  * @alias browser.getTabIds
- * @returns {String[]} a list of window handles
+ * @return {String[]} a list of window handles
  * @uses protocol/windowHandles
  * @type window
  *

--- a/lib/commands/getTagName.js
+++ b/lib/commands/getTagName.js
@@ -17,7 +17,7 @@
  *
  * @alias browser.getTagName
  * @param   {String}           selector   element with requested tag name
- * @returns {String|String[]}             the element's tag name, as a lowercase string
+ * @return {String|String[]}             the element's tag name, as a lowercase string
  * @uses protocol/elements, protocol/elementIdName
  * @type property
  *

--- a/lib/commands/getText.js
+++ b/lib/commands/getText.js
@@ -36,7 +36,7 @@
  *
  * @alias browser.getText
  * @param   {String}           selector   element with requested text
- * @returns {String|String[]}             content of selected element (all HTML tags are removed)
+ * @return {String|String[]}             content of selected element (all HTML tags are removed)
  * @uses protocol/elements, protocol/elementIdText
  * @type property
  *

--- a/lib/commands/getTitle.js
+++ b/lib/commands/getTitle.js
@@ -16,7 +16,7 @@
  * </example>
  *
  * @alias browser.getTitle
- * @returns {String} current page title
+ * @return {String} current page title
  * @uses protocol/title
  * @type property
  *

--- a/lib/commands/getUrl.js
+++ b/lib/commands/getUrl.js
@@ -15,7 +15,7 @@
  * </example>
  *
  * @alias browser.getUrl
- * @returns {String} current page url
+ * @return {String} current page url
  * @uses protocol/url
  * @type property
  *

--- a/lib/commands/getValue.js
+++ b/lib/commands/getValue.js
@@ -17,7 +17,7 @@
  *
  * @alias browser.getValue
  * @param   {String} selector input, textarea, or select element
- * @returns {String}          requested input value
+ * @return {String}          requested input value
  * @uses protocol/elements, protocol/elementIdAttribute
  * @type property
  *

--- a/lib/commands/getViewportSize.js
+++ b/lib/commands/getViewportSize.js
@@ -21,7 +21,7 @@
  *
  * @alias browser.getViewportSize
  * @param {String} property  if "width" or "height" is set it returns only that property
- * @returns {Object}  viewport width and height of the browser
+ * @return {Object}  viewport width and height of the browser
  * @uses protocol/execute
  * @type window
  *

--- a/lib/commands/hasFocus.js
+++ b/lib/commands/hasFocus.js
@@ -20,7 +20,7 @@
  *
  * @alias browser.hasFocus
  * @param {String} selector   select active element
- * @returns {Boolean}         true if element has focus
+ * @return {Boolean}         true if element has focus
  * @uses protocol/execute
  * @type state
  *

--- a/lib/commands/isEnabled.js
+++ b/lib/commands/isEnabled.js
@@ -23,7 +23,7 @@
  *
  * @alias browser.isEnabled
  * @param   {String}             selector  DOM-element
- * @returns {Boolean|Boolean[]}            true if element(s)* (is|are) enabled
+ * @return {Boolean|Boolean[]}            true if element(s)* (is|are) enabled
  * @uses protocol/elements, protocol/elementIdEnabled
  * @type state
  *

--- a/lib/commands/isExisting.js
+++ b/lib/commands/isExisting.js
@@ -31,7 +31,7 @@
  *
  * @alias browser.isExisting
  * @param   {String}             selector  DOM-element
- * @returns {Boolean|Boolean[]}            true if element(s)* [is|are] existing
+ * @return {Boolean|Boolean[]}            true if element(s)* [is|are] existing
  * @uses protocol/elements
  * @type state
  *

--- a/lib/commands/isSelected.js
+++ b/lib/commands/isSelected.js
@@ -23,7 +23,7 @@
  *
  * @alias browser.isSelected
  * @param   {String}             selector  option element or input of type checkbox or radio
- * @returns {Boolean|Boolean[]}            true if element is selected
+ * @return {Boolean|Boolean[]}            true if element is selected
  * @uses protocol/elements, protocol/elementIdSelected
  * @type state
  *

--- a/lib/commands/isVisible.js
+++ b/lib/commands/isVisible.js
@@ -30,7 +30,7 @@
  *
  * @alias browser.isVisible
  * @param   {String}             selector  DOM-element
- * @returns {Boolean|Boolean[]}            true if element(s)* [is|are] visible
+ * @return {Boolean|Boolean[]}            true if element(s)* [is|are] visible
  * @uses protocol/elements, protocol/elementIdDisplayed
  * @type state
  *

--- a/lib/commands/isVisibleWithinViewport.js
+++ b/lib/commands/isVisibleWithinViewport.js
@@ -31,7 +31,7 @@
  *
  * @alias browser.isVisibleWithinViewport
  * @param   {String}             selector  DOM-element
- * @returns {Boolean|Boolean[]}            true if element(s)* [is|are] visible
+ * @return {Boolean|Boolean[]}            true if element(s)* [is|are] visible
  * @uses protocol/selectorExecute, protocol/timeoutsAsyncScript
  * @type state
  *

--- a/lib/helpers/getImplementedCommands.js
+++ b/lib/helpers/getImplementedCommands.js
@@ -6,7 +6,7 @@ const COMMAND_TYPES = ['protocol', 'commands']
 /**
  * helper to find all implemented commands
  *
- * @returns {String[]} list of implemented command names
+ * @return {String[]} list of implemented command names
  */
 let getImplementedCommands = function () {
     let commands = {}

--- a/lib/protocol/alertAccept.js
+++ b/lib/protocol/alertAccept.js
@@ -13,6 +13,8 @@
     });
  * </example>
  *
+ * @throws {RuntimeError}   If no alert is present. The seleniumStack.type parameter will equal 'NoAlertOpenError'.
+ *
  * @see  https://w3c.github.io/webdriver/webdriver-spec.html#accept-alert
  * @type protocol
  *

--- a/lib/protocol/alertDismiss.js
+++ b/lib/protocol/alertDismiss.js
@@ -14,6 +14,8 @@
     });
  * </example>
  *
+ * @throws {RuntimeError}   If no alert is present. The seleniumStack.type parameter will equal 'NoAlertOpenError'.
+ *
  * @see  https://w3c.github.io/webdriver/webdriver-spec.html#dismiss-alert
  * @type protocol
  *

--- a/lib/protocol/alertText.js
+++ b/lib/protocol/alertText.js
@@ -13,7 +13,8 @@
  * </example>
  *
  * @param {String=} text  Keystrokes to send to the prompt() dialog.
- * @returns {String}      The text of the currently displayed alert.
+ * @return {String}      The text of the currently displayed alert.
+ * @throws {RuntimeError}   If no alert is present. The seleniumStack.type parameter will equal 'NoAlertOpenError'.
  *
  * @see  https://w3c.github.io/webdriver/webdriver-spec.html#get-alert-text
  * @see  https://w3c.github.io/webdriver/webdriver-spec.html#send-alert-text

--- a/lib/protocol/applicationCacheStatus.js
+++ b/lib/protocol/applicationCacheStatus.js
@@ -5,7 +5,7 @@
  * This command is depcrecated and will be removed soon. Make sure you don't use it in your
  * automation/test scripts anymore to avoid errors.
  *
- * @returns {Number} Status code for application cache: **{UNCACHED = 0, IDLE = 1, CHECKING = 2, DOWNLOADING = 3, UPDATE_READY = 4, OBSOLETE = 5}**
+ * @return {Number} Status code for application cache: **{UNCACHED = 0, IDLE = 1, CHECKING = 2, DOWNLOADING = 3, UPDATE_READY = 4, OBSOLETE = 5}**
  *
  * @see  https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidapplication_cachestatus
  * @type protocol

--- a/lib/protocol/cookie.js
+++ b/lib/protocol/cookie.js
@@ -22,7 +22,7 @@
  * @param {String=}         method  request method
  * @param {Object=|String=} args    contains cookie information if you want to set a cookie or contains name of cookie if you want to delete it
  *
- * @returns {Object}  cookie data
+ * @return {Object}  cookie data
  *
  * @see  https://w3c.github.io/webdriver/webdriver-spec.html#cookies
  * @type protocol

--- a/lib/protocol/element.js
+++ b/lib/protocol/element.js
@@ -7,7 +7,7 @@
  * @see  https://w3c.github.io/webdriver/webdriver-spec.html#find-element
  *
  * @param {String} selector selector to query the element
- * @returns {String} A WebElement JSON object for the located element.
+ * @return {String} A WebElement JSON object for the located element.
  *
  * @type protocol
  *

--- a/lib/protocol/elementActive.js
+++ b/lib/protocol/elementActive.js
@@ -2,7 +2,7 @@
  *
  * Get the element on the page that currently has focus. The element will be returned as a WebElement JSON object.
  *
- * @returns {String} A WebElement JSON object for the active element.
+ * @return {String} A WebElement JSON object for the active element.
  *
  * @see  https://w3c.github.io/webdriver/webdriver-spec.html#get-active-element
  * @type protocol

--- a/lib/protocol/elementIdAttribute.js
+++ b/lib/protocol/elementIdAttribute.js
@@ -5,7 +5,7 @@
  * @param {String} ID             ID of a WebElement JSON object to route the command to
  * @param {String} attributeName  attribute name of element you want to receive
  *
- * @returns {String|null} The value of the attribute, or null if it is not set on the element.
+ * @return {String|null} The value of the attribute, or null if it is not set on the element.
  *
  * @see  https://w3c.github.io/webdriver/webdriver-spec.html#dfn-get-element-attribute
  * @type protocol

--- a/lib/protocol/elementIdCssProperty.js
+++ b/lib/protocol/elementIdCssProperty.js
@@ -7,7 +7,7 @@
  * @param {String} ID                ID of a WebElement JSON object to route the command to
  * @param  {String} cssPropertyName  CSS property
  *
- * @returns {String} The value of the specified CSS property.
+ * @return {String} The value of the specified CSS property.
  *
  * @see  https://w3c.github.io/webdriver/webdriver-spec.html#get-element-property
  * @type protocol

--- a/lib/protocol/elementIdDisplayed.js
+++ b/lib/protocol/elementIdDisplayed.js
@@ -3,7 +3,7 @@
  * Determine if an element is currently displayed.
  *
  * @param {String} ID ID of a WebElement JSON object to route the command to
- * @returns {Boolean} true if the element is displayed
+ * @return {Boolean} true if the element is displayed
  *
  * @see  https://w3c.github.io/webdriver/webdriver-spec.html#element-displayedness
  * @type protocol

--- a/lib/protocol/elementIdElement.js
+++ b/lib/protocol/elementIdElement.js
@@ -7,7 +7,7 @@
  *
  * @param {String} ID ID of a WebElement JSON object to route the command to
  * @param {String} selector selector to query the element
- * @returns {String} A WebElement JSON object for the located element.
+ * @return {String} A WebElement JSON object for the located element.
  *
  * @see  https://w3c.github.io/webdriver/webdriver-spec.html#find-element-from-element
  * @type protocol

--- a/lib/protocol/elementIdElements.js
+++ b/lib/protocol/elementIdElements.js
@@ -7,7 +7,7 @@
  *
  * @param {String} ID ID of a WebElement JSON object to route the command to
  * @param {String} selector selector to query the elements
- * @returns {Object[]} A list of WebElement JSON objects for the located elements.
+ * @return {Object[]} A list of WebElement JSON objects for the located elements.
  *
  * @see  https://w3c.github.io/webdriver/webdriver-spec.html#find-elements-from-element
  * @type protocol

--- a/lib/protocol/elementIdEnabled.js
+++ b/lib/protocol/elementIdEnabled.js
@@ -3,7 +3,7 @@
  * Determine if an element is currently enabled.
  *
  * @param {String} ID ID of a WebElement JSON object to route the command to
- * @returns {Boolean} true if the element is enabled
+ * @return {Boolean} true if the element is enabled
  *
  * @see  https://w3c.github.io/webdriver/webdriver-spec.html#is-element-enabled
  * @type protocol

--- a/lib/protocol/elementIdLocation.js
+++ b/lib/protocol/elementIdLocation.js
@@ -7,7 +7,7 @@
  * Depcrecated command, please use [`elementIdRect`](http://webdriver.io/api/protocol/elementIdRect.html).
  *
  * @param {String} ID ID of a WebElement JSON object to route the command to
- * @returns {Object} The X and Y coordinates for the element on the page (`{x:number, y:number}`)
+ * @return {Object} The X and Y coordinates for the element on the page (`{x:number, y:number}`)
  *
  * @see  https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidelementidlocation
  * @type protocol

--- a/lib/protocol/elementIdLocationInView.js
+++ b/lib/protocol/elementIdLocationInView.js
@@ -8,7 +8,7 @@
  * Depcrecated command, please use `elementIdRect`.
  *
  * @param {String} ID ID of a WebElement JSON object to route the command to
- * @returns {Object} The X and Y coordinates for the element (`{x:number, y:number}`)
+ * @return {Object} The X and Y coordinates for the element (`{x:number, y:number}`)
  *
  * @see  https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidelementidlocation_in_view
  * @type protocol

--- a/lib/protocol/elementIdName.js
+++ b/lib/protocol/elementIdName.js
@@ -3,7 +3,7 @@
  * Query for an element's tag name.
  *
  * @param {String} ID ID of a WebElement JSON object to route the command to
- * @returns {String}  the element's tag name, as a lowercase string
+ * @return {String}  the element's tag name, as a lowercase string
  *
  * @see  https://w3c.github.io/webdriver/webdriver-spec.html#get-element-tag-name
  * @type protocol

--- a/lib/protocol/elementIdScreenshot.js
+++ b/lib/protocol/elementIdScreenshot.js
@@ -4,7 +4,7 @@
  * by the bounding rectangle of an element. If given a parameter argument scroll that
  * evaluates to false, the element will not be scrolled into view.
  *
- * @returns {String} screenshot   The screenshot as a base64 encoded PNG.
+ * @return {String} screenshot   The screenshot as a base64 encoded PNG.
  *
  * @see  https://w3c.github.io/webdriver/webdriver-spec.html#take-screenshot
  * @type protocol

--- a/lib/protocol/elementIdSelected.js
+++ b/lib/protocol/elementIdSelected.js
@@ -4,7 +4,7 @@
  * radiobutton is currently selected.
  *
  * @param {String} ID ID of a WebElement JSON object to route the command to
- * @returns {Boolean} true if the element is selected.
+ * @return {Boolean} true if the element is selected.
  *
  * @see  https://w3c.github.io/webdriver/webdriver-spec.html#is-element-selected
  * @type protocol

--- a/lib/protocol/elementIdSize.js
+++ b/lib/protocol/elementIdSize.js
@@ -6,7 +6,7 @@
  * Depcrecated command, please use [`elementIdRect`](http://webdriver.io/api/protocol/elementIdRect.html).
  *
  * @param {String} ID ID of a WebElement JSON object to route the command to
- * @returns {Object} The width and height of the element, in pixels (`{width:number, height:number}`)
+ * @return {Object} The width and height of the element, in pixels (`{width:number, height:number}`)
  *
  * @see  https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidelementidsize
  * @type protocol

--- a/lib/protocol/elementIdText.js
+++ b/lib/protocol/elementIdText.js
@@ -3,7 +3,7 @@
  * Returns the visible text for the element.
  *
  * @param {String} ID ID of a WebElement JSON object to route the command to
- * @returns {String} visible text for the element
+ * @return {String} visible text for the element
  *
  * @see  https://w3c.github.io/webdriver/webdriver-spec.html#getelementtext
  * @type protocol

--- a/lib/protocol/elements.js
+++ b/lib/protocol/elements.js
@@ -10,7 +10,7 @@
  * using the '.ELEMENT' method.
  *
  * @param {String} selector selector to query the elements
- * @returns {Object[]} A list of WebElement JSON objects for the located elements.
+ * @return {Object[]} A list of WebElement JSON objects for the located elements.
  *
  * @see  https://w3c.github.io/webdriver/webdriver-spec.html#find-elements
  * @type protocol

--- a/lib/protocol/execute.js
+++ b/lib/protocol/execute.js
@@ -28,7 +28,7 @@
  * @param {String|Function} script                     The script to execute.
  * @param {*}               [argument1,...,argumentN]  script arguments
  *
- * @returns {*}             The script result.
+ * @return {*}             The script result.
  *
  * @see  https://w3c.github.io/webdriver/webdriver-spec.html#dfn-execute-script
  * @type protocol

--- a/lib/protocol/executeAsync.js
+++ b/lib/protocol/executeAsync.js
@@ -37,7 +37,7 @@
  * @param {String|Function} script     The script to execute.
  * @param {*}               arguments  script arguments
  *
- * @returns {*}             The script result.
+ * @return {*}             The script result.
  *
  * @see  https://w3c.github.io/webdriver/webdriver-spec.html#dfn-execute-async-script
  * @type protocol

--- a/lib/protocol/imeActivated.js
+++ b/lib/protocol/imeActivated.js
@@ -3,7 +3,7 @@
  * Indicates whether IME input is active at the moment (not if it's available.
  * (Not part of the official Webdriver specification)
  *
- * @returns {boolean}  true if IME input is available and currently active, false otherwise
+ * @return {boolean}  true if IME input is available and currently active, false otherwise
  *
  * @see  https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidimeactivated
  * @type protocol

--- a/lib/protocol/imeActiveEngine.js
+++ b/lib/protocol/imeActiveEngine.js
@@ -3,7 +3,7 @@
  * Get the name of the active IME engine. The name string is platform specific. (Not part of the
  * official Webdriver specification)
  *
- * @returns {String} engine   The name of the active IME engine.
+ * @return {String} engine   The name of the active IME engine.
  *
  * @see  https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidimeactive_engine
  * @type protocol

--- a/lib/protocol/imeAvailableEngines.js
+++ b/lib/protocol/imeAvailableEngines.js
@@ -3,7 +3,7 @@
  * List all available engines on the machine. To use an engine, it has to be present
  * in this list. (Not part of the official Webdriver specification)
  *
- * @returns {Object[]} engines   A list of available engines
+ * @return {Object[]} engines   A list of available engines
  *
  * @see  https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidimeavailable_engines
  * @type protocol

--- a/lib/protocol/localStorageSize.js
+++ b/lib/protocol/localStorageSize.js
@@ -3,7 +3,7 @@
  * protocol bindings to get local_storage size. This command is not part of the official Webdriver
  * specification and might not be supported for your browser.
  *
- * @returns {Number} The number of items in the storage.
+ * @return {Number} The number of items in the storage.
  *
  * @see  https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidlocal_storagesize
  * @type protocol

--- a/lib/protocol/location.js
+++ b/lib/protocol/location.js
@@ -14,7 +14,7 @@
  * </example>
  *
  * @param {Object} location  the new location
- * @returns {Object}         the current geo location
+ * @return {Object}         the current geo location
  *
  * @see  https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidlocation
  * @type protocol

--- a/lib/protocol/log.js
+++ b/lib/protocol/log.js
@@ -4,7 +4,7 @@
  * (Not part of the official Webdriver specification).
  *
  * @param {String} type  The [log type](https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#log-type). This must be provided.
- * @returns {Object[]} The list of [log entries](https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#log-entry-json-object)
+ * @return {Object[]} The list of [log entries](https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#log-entry-json-object)
  *
  * @see  https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidlog
  * @type protocol

--- a/lib/protocol/logTypes.js
+++ b/lib/protocol/logTypes.js
@@ -12,7 +12,7 @@
     });
  * </example>
  *
- * @returns {Strings[]}  The list of available [log types](https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#log-type)
+ * @return {Strings[]}  The list of available [log types](https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#log-type)
  *
  * @see  https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidlogtypes
  * @type protocol

--- a/lib/protocol/orientation.js
+++ b/lib/protocol/orientation.js
@@ -18,7 +18,7 @@
  * </example>
  *
  * @param   {String=} deviceOrientation  The new browser orientation as defined in ScreenOrientation: `{LANDSCAPE|PORTRAIT}`
- * @returns {String}                     device orientation (`LANDSCAPE/PORTRAIT`)
+ * @return {String}                     device orientation (`LANDSCAPE/PORTRAIT`)
  *
  * @see  https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidorientation
  * @type mobile

--- a/lib/protocol/screenshot.js
+++ b/lib/protocol/screenshot.js
@@ -3,7 +3,7 @@
  * Take a screenshot of the current viewport. To get the screenshot of the whole page
  * use the action command `saveScreenshot`
  *
- * @returns {String} screenshot   The screenshot as a base64 encoded PNG.
+ * @return {String} screenshot   The screenshot as a base64 encoded PNG.
  *
  * @see  https://w3c.github.io/webdriver/webdriver-spec.html#take-screenshot
  * @type protocol

--- a/lib/protocol/sessionStorageSize.js
+++ b/lib/protocol/sessionStorageSize.js
@@ -3,7 +3,7 @@
  * Protocol bindings to get the session storage size. (Not part of the official
  * Webdriver specification).
  *
- * @returns {Number} The number of items in the storage.
+ * @return {Number} The number of items in the storage.
  *
  * @see  https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidsession_storagesize
  * @type protocol

--- a/lib/protocol/sessions.js
+++ b/lib/protocol/sessions.js
@@ -10,7 +10,7 @@
  *
  * (Not part of the official Webdriver specification).
  *
- * @returns {Object[]} a list of the currently active sessions
+ * @return {Object[]} a list of the currently active sessions
  *
  * @see  https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessions
  * @type protocol

--- a/lib/protocol/settings.js
+++ b/lib/protocol/settings.js
@@ -16,7 +16,7 @@
  *
  * @type mobile
  * @param {Object=}  settings  key/value pairs defining settings on the device
- * @returns {Object} current settings (only if method was called without parameters)
+ * @return {Object} current settings (only if method was called without parameters)
  *
  */
 

--- a/lib/protocol/source.js
+++ b/lib/protocol/source.js
@@ -2,7 +2,7 @@
  *
  * Get the current page source.
  *
- * @returns {String} The current page source.
+ * @return {String} The current page source.
  *
  * @see  https://w3c.github.io/webdriver/webdriver-spec.html#get-page-source
  * @type protocol

--- a/lib/protocol/status.js
+++ b/lib/protocol/status.js
@@ -19,7 +19,7 @@
  *
  * (Not part of the official Webdriver specification).
  *
- * @returns {Object} An object describing the general status of the server
+ * @return {Object} An object describing the general status of the server
  *
  * @see  https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#status
  * @type protocol

--- a/lib/protocol/title.js
+++ b/lib/protocol/title.js
@@ -21,7 +21,7 @@
     });
  * </example>
  *
- * @returns {String} The current page title.
+ * @return {String} The current page title.
  *
  * @see  https://w3c.github.io/webdriver/webdriver-spec.html#get-title
  * @type protocol

--- a/lib/protocol/url.js
+++ b/lib/protocol/url.js
@@ -11,7 +11,7 @@
  * </example>
  *
  * @param {String=} url  the URL to navigate to
- * @returns {String}     the current URL
+ * @return {String}     the current URL
  *
  * @see  https://w3c.github.io/webdriver/webdriver-spec.html#dfn-get
  * @type protocol

--- a/lib/protocol/windowHandle.js
+++ b/lib/protocol/windowHandle.js
@@ -20,7 +20,7 @@
     });
  * </example>
  *
- * @returns {String} the current window handle
+ * @return {String} the current window handle
  *
  * @see https://w3c.github.io/webdriver/webdriver-spec.html#dfn-get-window-handle
  * @type protocol

--- a/lib/protocol/windowHandlePosition.js
+++ b/lib/protocol/windowHandlePosition.js
@@ -24,7 +24,7 @@
  * @param {String=} windowHandle the window to receive/change the position
  * @param {Object=} position     the X and Y coordinates to position the window at, relative to the upper left corner of the screen
  *
- * @returns {Object} the X and Y coordinates for the window, relative to the upper left corner of the screen (`{x: number, y: number}`)
+ * @return {Object} the X and Y coordinates for the window, relative to the upper left corner of the screen (`{x: number, y: number}`)
  *
  * @see  https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidwindowwindowhandleposition
  * @type protocol

--- a/lib/protocol/windowHandleSize.js
+++ b/lib/protocol/windowHandleSize.js
@@ -22,7 +22,7 @@
  * @param {String=} windowHandle the window to receive/change the size
  * @param {Object=} dimension    the new size of the window
  *
- * @returns {Object} the size of the window (`{width: number, height: number}`)
+ * @return {Object} the size of the window (`{width: number, height: number}`)
  *
  * @see  https://w3c.github.io/webdriver/webdriver-spec.html#dfn-set-window-size
  * @type protocol

--- a/lib/protocol/windowHandles.js
+++ b/lib/protocol/windowHandles.js
@@ -24,7 +24,7 @@
     });
  * </example>
  *
- * @returns {String[]} a list of window handles
+ * @return {String[]} a list of window handles
  *
  * @see https://w3c.github.io/webdriver/webdriver-spec.html#dfn-get-window-handles
  * @type protocol

--- a/lib/scripts/createSelectorScript.js
+++ b/lib/scripts/createSelectorScript.js
@@ -44,7 +44,7 @@ export function getArgs (args = [], inMultibrowserMode = false) {
  * @param {Array.<String>} selectors - the selectors to resolve and pass to fn, each in its own array
  * @param {Array} args - the arguments to pass to fn (after resolved selectors)
  * @param {Function} callback
- * @returns {string}
+ * @return {String} The script to execute in the browser, as a string.
  */
 let createSelectorScript = function (fn, selectors, args) {
     let strArgs = []
@@ -70,7 +70,7 @@ let createSelectorScript = function (fn, selectors, args) {
  * @param {Function} fn - the function to execute client side that will receive the resolved selectors
  * @param {Array.<String>} sArr - a series of usage, value pairs from find-element-strategy
  * @param {Array} args - any other arguments to pass to fn
- * @returns {*} the return value of fn
+ * @return {*} the return value of fn
  * @example
  * var helper = require('./executeClientSideSelector');
  * // Execute in the browser

--- a/lib/utils/Timer.js
+++ b/lib/utils/Timer.js
@@ -8,7 +8,7 @@ const TIMEOUT_ERROR = 'timeout'
  * @param {Function} fn - function that returns promise. will execute every tick
  * @param {Boolean} leading - should be function invoked on start
  * @param {Boolean} isSync - true if test runner runs commands synchronously
- * @returns {promise}
+ * @return {promise} Promise-based Timer.
  */
 class Timer {
     constructor (delay, timeout, fn, leading, isSync) {


### PR DESCRIPTION
## Proposed changes

- Updated instances of `@returns` to instead be `@return` in the jsdocs, as the wddoc generator only supports the `@return` tag. 
- Updated the contribution doc to reflect the change mentioned above.
- Added the `@throws` tag to the `alertDismiss`, `alertAccept`, and `alertText` protocol functions, as per #1788.

## Types of changes

What types of changes does your code introduce to WebdriverIO?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

These changes will make no visual difference to the API documentations without https://github.com/webdriverio/wddoc/pull/3

### Reviewers: @christian-bromann
