### PR TITLE
Hasfocus body fix

### DIFF
--- a/lib/commands/hasFocus.js
+++ b/lib/commands/hasFocus.js
@@ -30,7 +30,7 @@ let hasFocus = function (selector) {
     const finalSelector = selector === null ? this.lastPromise.inspect().value.selector : selector
     let result = this.execute(function (selector) {
         var focused = document.activeElement
-        if (!focused || focused === document.body) {
+        if (!focused) {
             return false
         }
 

--- a/test/spec/desktop/hasFocus.js
+++ b/test/spec/desktop/hasFocus.js
@@ -26,4 +26,9 @@ describe('hasFocus', () => {
     it('should return true when one of the elements collection is active and is using `element()`', async function () {
         (await this.client.element('input').hasFocus()).should.be.true
     })
+
+    it('should return true when body has focus', async function () {
+        await this.client.execute(() => { $('[name=login]').blur() });
+        (await this.client.hasFocus('body')).should.be.true
+    })
 })


### PR DESCRIPTION
## Proposed changes

`hasFocus` would not allow testing if the body element has focus.  This is a perfectly acceptable
element to have focus.  This change removes shortcut logic that prevented actually comparing
the selector against the active element if the active element was `document.body`

## Types of changes

What types of changes does your code introduce to WebdriverIO?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

I am blurring the input.  Hopefully the tests will not rely on DOM state to be preserved between tests.

### Reviewers: @christian-bromann
