### PR TITLE
Updated Contributing to latest Se3, and npm run instead of grunt

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ to know that you have a clean state.
 1. Download and install the latest Selenium [standalone server](http://selenium-release.storage.googleapis.com/index.html) and run it via
 
   ```sh
-  $ java -jar selenium-server-standalone-2.53.0.jar
+  $ java -jar selenium-server-standalone-3.4.0.jar
   ```
 
   or install it with npm package [selenium-standalone](https://github.com/vvo/selenium-standalone)
@@ -41,27 +41,31 @@ to know that you have a clean state.
   ```sh
   # if your patch is browser specific
   # (e.g. upload files)
-  grunt test:desktop
+  npm run test:desktop
 
   # if your patch is mobile specific
   # (e.g. flick or swipe tests)
-  grunt test:ios test:android
+  npm run test:mobile
+  # or to run each individually
+  npm run test:ios
+  npm run test:android
+  
 
   # if your patch is functional and hasn't something to do with Selenium
   # (e.g. library specific fixes like changes within EventHandler.js)
-  grunt test:functional
+  npm run test:functional
 
   # changes to multibrowser functionality
   # (e.g. actually only changes to /lib/multibrowser.js)
-  grunt test:functional
+  npm run test:multibrowser
 
   # wdio test runner changes
   # (e.g. any changes that reflect the behavior of the test runner e.g. in lib/launcher.js)
-  grunt test:wdio
+  npm run test:wdio
 
   # anything else unittestable
   # (e.g. changes to utils and classes)
-  grunt test:unit
+  npm run test:unit
   ```
 
 ### Syntax rules

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "test:desktop": "mocha test/setup.js test/spec/*.js test/spec/desktop/*.js",
     "test:functional": "mocha test/setup.js test/spec/functional/**/*.js",
     "test:ios": "mocha test/setup.js test/spec/mobile/*.js test/spec/mobile/ios/*.js",
+    "test:mobile": "run-s test:ios test:android",
     "test:multibrowser": "mocha test/setup.js test/spec/multibrowser/**/*.js",
     "test:snyk": "snyk auth $SNYK_AUTH_TOKEN && snyk test",
     "test:unit": "mocha test/setup-unit.js test/spec/unit/*.js",


### PR DESCRIPTION
## Proposed changes

- Updated the Selenium Standalone Jar command to reflect the latest version, 3.4 (chore).
- Updated the example test commands to use `npm run` instead of `grunt`.
- Added `npm run test:mobile` to package.json, which runs `test:ios` and `test:android` sequentially.

## Types of changes

What types of changes does your code introduce to WebdriverIO?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue): #2022
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

I added the `test:mobile` npm script for ease of use, instead of people running `test:ios` and forgetting to run `test:android` after. The two original scripts still exist, as this script just does `run-s test:ios test:android`, and the original scripts are needed for travis.

### Reviewers: @christian-bromann
