### PR TITLE
Adjust test to match hasFocus implementation

### DIFF
--- a/test/spec/desktop/hasFocus.js
+++ b/test/spec/desktop/hasFocus.js
@@ -23,8 +23,8 @@ describe('hasFocus', () => {
         (await this.client.elements('input').hasFocus()).should.be.true
     })
 
-    it('should return true when one of the elements collection is active and is using `element()`', async function () {
-        (await this.client.element('input').hasFocus()).should.be.true
+    it('should return false when using `element()` with non-matching result', async function () {
+        (await this.client.element('input').hasFocus()).should.be.false
     })
 
     it('should return true when body has focus', async function () {


### PR DESCRIPTION
## Proposed changes

The desktop `hasFocus` test did not make sense.  Chaining a single element into a function that can accept one or more elements should only test the one element that was passed to it.

## Types of changes

What types of changes does your code introduce to WebdriverIO?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

An argument could be made that this is breaking existing functionality.  However, I view this as a bug in the test.  No other method besides `hasFocus()` behaves this way and given that `hasFocus()` was somewhat broken with chaining before anyhow I would suggest this move forward as a bug fix.  Perhaps worth calling out in the changelog if it's a concern.

### Reviewers: @christian-bromann
