### PR TITLE
cli: fix handling of cucumber tags when given through CLI

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -330,7 +330,7 @@ if (argv.reporters) {
  */
 if (argv.cucumberOpts) {
     if (argv.cucumberOpts.tags) {
-        argv.cucumberOpts.tags = argv.cucumberOpts.tags.split(',')
+        argv.cucumberOpts.tags = typeof argv.cucumberOpts.tags === 'string' ? [argv.cucumberOpts.tags] : argv.cucumberOpts.tags
     }
     if (argv.cucumberOpts.ignoreUndefinedDefinitions) {
         argv.cucumberOpts.ignoreUndefinedDefinitions = argv.cucumberOpts.ignoreUndefinedDefinitions === 'true'


### PR DESCRIPTION
## Proposed changes
Fixes [following bug](https://github.com/webdriverio/wdio-cucumber-framework/issues/53) (initially reported in the wdio-cucumber-framework repo).

The fix aligns wdio behavior with cucumber js.
You give OR-ed tags in a string
```
$ wdio --cucumberOpts.tags=@tag1,@tag2
```
And you give AND-ed tags as follow
```
$ wdio --cucumberOpts.tags=@tag1 --cucumberOpts.tags=@tag2
```


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

To be honest that's my first PR and while I'm confident the fix works, I'm unsure how to implement the test. Let me know if that's absolutely mandatory and I'll do my best to add a test.

I ran a build and all the tests, but a recent change broke them because of a file rename (lib/helpers/depcrecationWarning.js). The tests pass localy if I revert the file name back to its previous value, but I didn't commit that change.

Regarding the documentation, I've made a PR here:
https://github.com/webdriverio/cucumber-boilerplate/pull/83

### Reviewers: @christian-bromann
