### PR TITLE
Reverting my previous edit

### DIFF
--- a/docs/guide/testrunner/debugging.md
+++ b/docs/guide/testrunner/debugging.md
@@ -95,10 +95,7 @@ To start debugging, open the following URL in Chrome:
 ```
 You'll want to open that url, which will attach the debugger.
 
-Tests will pause at `debugger` statements, but ONLY once dev-tools has been opened and the debugger attached. That can be a little awkward, so you can also break on the first statement of the script with `--debug-brk`. This allows time to attach the debugger.
-```
-execArgv: ['--inspect','--debug-brk']
-```
+Tests will pause at `debugger` statements, but ONLY once dev-tools has been opened and the debugger attached. That can be a little awkward if you're trying to debug something close to the start of a test. You can get around that by adding a `browser.debug()` to pause long enough.
 
 Once execution has finished, the test doesn't actually finish until the devtools is closed. You'll need to do that yourself.
 


### PR DESCRIPTION
Although the `--debug-brk` switch works, due to multiple forked processes, there may be multiple paused processes. As the V8 debug URL isn't outputted for these processes, they remain invisibly paused, without a way to resume execution. This switch cannot unfortunately be used. Apologies