### PR TITLE
Added support for ChromeDriver without Selenium

### DIFF
--- a/docs/guide/services/chromedriver.md
+++ b/docs/guide/services/chromedriver.md
@@ -1,0 +1,70 @@
+name: chromedriver
+category: services
+tags: guide
+index: 10
+title: WebdriverIO - ChromeDriver Service
+---
+
+WDIO ChromeDriver Service
+================================
+
+(Based entirely on [wdio-selenium-standalone-service](https://github.com/webdriverio/wdio-selenium-standalone-service).)
+
+----
+
+This service helps you to run ChromeDriver seamlessly when running tests with the [WDIO testrunner](http://webdriver.io/guide/testrunner/gettingstarted.html). It uses the [chromedriver](https://www.npmjs.com/package/chromedriver) NPM package that wraps the ChromeDriver for you.
+
+Note - this service does not require a Selenium server, but uses ChromeDriver to communicate with the browser directly.
+Obvisously, it only supports:
+
+```js
+capabilities: [{
+        browserName: 'chrome'
+    }]
+```
+
+## Installation
+
+The easiest way is to keep `wdio-chromedriver-service` as a devDependency in your `package.json`.
+
+```json
+{
+  "devDependencies": {
+    "wdio-chromedriver-service": "~0.1"
+  }
+}
+```
+
+You can simple do it by:
+
+```bash
+npm install wdio-chromedriver-service --save-dev
+```
+
+Instructions on how to install `WebdriverIO` can be found [here.](http://webdriver.io/guide/getstarted/install.html)
+
+## Configuration
+
+By design, only Google Chrome is available (when installed on the host system). In order to use the service you need to add `chromedriver` to your service array:
+
+```js
+// wdio.conf.js
+export.config = {
+  port: '9515',
+  path: '/',
+  // ...
+  services: ['chromedriver'],
+  // ...
+};
+```
+
+## Options
+
+### chromeDriverLogs
+Path where all logs from the ChromeDriver server should be stored.
+
+Type: `String`
+
+----
+
+For more information on WebdriverIO see the [homepage](http://webdriver.io).

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -43,7 +43,8 @@ const SUPPORTED_SERVICES = [
     ' static-server - https://github.com/LeadPages/wdio-static-server-service',
     ' visual-regression - https://github.com/zinserjan/wdio-visual-regression-service',
     ' webpack - https://github.com/leadpages/wdio-webpack-service',
-    ' webpack-dev-server - https://gitlab.com/Vinnl/wdio-webpack-dev-server-service'
+    ' webpack-dev-server - https://gitlab.com/Vinnl/wdio-webpack-dev-server-service',
+    ' chromedriver - https://github.com/atti187/wdio-chromedriver-service'
 ]
 
 const VERSION = pkg.version


### PR DESCRIPTION
## Proposed changes

Added support for ChromeDriver without Selenium - for fast and easy local testing before using other services like Browserstack etc.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

https://github.com/atti187/wdio-chromedriver-service is really a copy/paste of your setup/structure in https://github.com/webdriverio/wdio-selenium-standalone-service. If you rather want it to be part of the webdriverio ecosystem/organization I have to issues moving it there - just didn't know how to make a PR for a whole new repo.

Haven't published it to npmjs.org yet either, depending on the outcome of the question above.

### Reviewers: @christian-bromann
