### PR TITLE
Updated docs to reflect #1946

### DIFF
--- a/docs/guide/getstarted/configuration.md
+++ b/docs/guide/getstarted/configuration.md
@@ -92,7 +92,7 @@ Type: `String`<br>
 Default: */wd/hub*
 
 ### baseUrl
-Shorten `url` command calls by setting a base url. If your `url` parameter starts with `/`, the base url gets prepended.
+Shorten `url` command calls by setting a base url. If your `url` parameter starts with `/`, the base url gets prepended, not including the path portion of your baseUrl. If your `url` parameter starts without a scheme or `/` (like `some/path`), the base url gets prepended directly.
 
 Type: `String`<br>
 Default: *null*

--- a/docs/guide/testrunner/configurationfile.md
+++ b/docs/guide/testrunner/configurationfile.md
@@ -130,8 +130,10 @@ exports.config = {
     // Saves a screenshot to a given path if a command fails.
     screenshotPath: 'shots',
     //
-    // Set a base URL in order to shorten url command calls. If your url parameter starts
-    //  with "/", the base url gets prepended.
+    // Set a base URL in order to shorten url command calls. If your `url` parameter starts 
+    // with `/`, the base url gets prepended, not including the path portion of your baseUrl. 
+    // If your `url` parameter starts without a scheme or `/` (like `some/path`), the base url 
+    // gets prepended directly.
     baseUrl: 'http://localhost:8080',
     //
     // Default timeout for all waitForXXX commands.

--- a/docs/guide/testrunner/pageobjects.md
+++ b/docs/guide/testrunner/pageobjects.md
@@ -24,7 +24,7 @@ function Page () {
 }
 
 Page.prototype.open = function (path) {
-    browser.url('/' + path)
+    browser.url(path)
 }
 
 module.exports = new Page()
@@ -40,7 +40,7 @@ class Page {
 	}
 
 	open(path) {
-		browser.url('/' + path);
+		browser.url(path);
 	}
 
 }

--- a/examples/pageobject/pageobjects/page.js
+++ b/examples/pageobject/pageobjects/page.js
@@ -2,7 +2,7 @@ function Page () {
 }
 
 Page.prototype.open = function (path) {
-    browser.url('/' + path);
+    browser.url(path);
 };
 
 module.exports = new Page();

--- a/examples/pageobject/wdio.conf.js
+++ b/examples/pageobject/wdio.conf.js
@@ -43,8 +43,10 @@ exports.config = {
     // Saves a screenshot to a given path if a command fails.
     screenshotPath: './errorShots/',
     //
-    // Set a base URL in order to shorten url command calls. If your url parameter starts
-    // with "/", the base url gets prepended.
+    // Set a base URL in order to shorten url command calls. If your `url` parameter starts
+    // with `/`, the base url gets prepended, not including the path portion of your baseUrl.
+    // If your `url` parameter starts without a scheme or `/` (like `some/path`), the base url
+    // gets prepended directly.
     baseUrl: 'http://the-internet.herokuapp.com',
     //
     // Default timeout for all waitForXXX commands.

--- a/examples/wdio.conf.js
+++ b/examples/wdio.conf.js
@@ -102,8 +102,10 @@ exports.config = {
     // Saves a screenshot to a given path if a command fails.
     screenshotPath: 'shots',
     //
-    // Set a base URL in order to shorten url command calls. If your url parameter starts
-    // with "/", then the base url gets prepended.
+    // Set a base URL in order to shorten url command calls. If your `url` parameter starts
+    // with `/`, the base url gets prepended, not including the path portion of your baseUrl.
+    // If your `url` parameter starts without a scheme or `/` (like `some/path`), the base url
+    // gets prepended directly.
     baseUrl: 'http://localhost:8080',
     //
     // If you only want to run your tests until a specific amount of tests have failed use

--- a/lib/helpers/wdio.conf.ejs
+++ b/lib/helpers/wdio.conf.ejs
@@ -98,8 +98,10 @@ exports.config = {
     // Saves a screenshot to a given path if a command fails.
     screenshotPath: '<%= answers.screenshotPath %>',
     //
-    // Set a base URL in order to shorten url command calls. If your url parameter starts
-    // with "/", then the base url gets prepended.
+    // Set a base URL in order to shorten url command calls. If your `url` parameter starts
+    // with `/`, the base url gets prepended, not including the path portion of your baseUrl.
+    // If your `url` parameter starts without a scheme or `/` (like `some/path`), the base url
+    // gets prepended directly.
     baseUrl: '<%= answers.baseUrl %>',
     //
     // Default timeout for all waitFor* commands.

--- a/lib/protocol/url.js
+++ b/lib/protocol/url.js
@@ -1,6 +1,8 @@
 /**
  *
- * Protocol binding to load or get the URL of the browser.
+ * Protocol binding to load or get the URL of the browser. If a baseUrl is
+ * specified in the config, it will be prepended to the url parameter using
+ * node's url.resolve() method.
  *
  * <example>
     :url.js
@@ -8,12 +10,24 @@
     browser.url('http://webdriver.io');
     // receive url
     console.log(browser.getUrl()); // outputs: "http://webdriver.io"
+    :baseUrlResolutions.js
+    // With a base URL of http://example.com/site, the following url parameters resolve as such:
+    // When providing a scheme:
+    // http://webdriver.io
+    browser.url('http://webdriver.io');
+    // When not starting with a slash, the URL resolves relative to the baseUrl
+    // http://example.com/site/relative
+    browser.url('relative');
+    // When starting with a slash, the URL resolves relative to the root path of the baseUrl
+    // http://example.com/rootRelative
+    browser.url('/rootRelative');
  * </example>
  *
  * @param {String=} url  the URL to navigate to
  * @return {String}     the current URL
  *
  * @see  https://w3c.github.io/webdriver/webdriver-spec.html#dfn-get
+ * @see  https://nodejs.org/api/url.html#url_url_resolve_from_to
  * @type protocol
  *
  */


### PR DESCRIPTION
## Proposed changes

I have updated the docs to reflect the change in #1946, as suites with a baseUrl that includes a path would have broken.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

- I have updated the documentation regarding the baseUrl config parameter in both the docs and the comments of the example config (where applicable).
- I have updated the POM example to use relative paths, as appropriate.
- I have added an example to the url() command to show how the URL resolves in three common use cases.

### Reviewers: @christian-bromann
