### PR TITLE
Unified the deprecated tags, warnings, and docs

### DIFF
--- a/lib/protocol/applicationCacheStatus.js
+++ b/lib/protocol/applicationCacheStatus.js
@@ -9,6 +9,7 @@
  *
  * @see  https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidapplication_cachestatus
  * @type protocol
+ * @deprecated
  *
  */
 

--- a/lib/protocol/buttonDown.js
+++ b/lib/protocol/buttonDown.js
@@ -12,6 +12,7 @@
  *
  * @see  https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidbuttondown
  * @type protocol
+ * @deprecated
  *
  */
 

--- a/lib/protocol/buttonPress.js
+++ b/lib/protocol/buttonPress.js
@@ -9,6 +9,7 @@
  *
  * @param {Number} button  Which button, enum: *{LEFT = 0, MIDDLE = 1 , RIGHT = 2}*. Defaults to the left mouse button if not specified.
  * @type protocol
+ * @deprecated
  *
  */
 

--- a/lib/protocol/buttonUp.js
+++ b/lib/protocol/buttonUp.js
@@ -11,6 +11,7 @@
  *
  * @see  https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidbuttonup
  * @type protocol
+ * @deprecated
  *
  */
 

--- a/lib/protocol/doDoubleClick.js
+++ b/lib/protocol/doDoubleClick.js
@@ -7,6 +7,7 @@
  *
  * @see  https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessioniddoubleclick
  * @type protocol
+ * @deprecated
  *
  */
 

--- a/lib/protocol/elementIdLocation.js
+++ b/lib/protocol/elementIdLocation.js
@@ -4,7 +4,9 @@
  * upper-left corner of the page. The element's coordinates are returned as a
  * JSON object with x and y properties.
  *
- * Deprecated command, please use [`elementIdRect`](http://webdriver.io/api/protocol/elementIdRect.html).
+ * This command is deprecated and will be removed soon. Make sure you don't use it in your
+ * automation/test scripts anymore to avoid errors. Please use the
+ * [`elementIdRect`](http://webdriver.io/api/protocol/elementIdRect.html) command instead.
  *
  * @param {String} ID ID of a WebElement JSON object to route the command to
  * @return {Object} The X and Y coordinates for the element on the page (`{x:number, y:number}`)
@@ -16,12 +18,13 @@
  */
 
 import { ProtocolError } from '../utils/ErrorHandler'
+import deprecate from '../helpers/deprecationWarning'
 
 export default function elementIdLocation (id) {
     if (typeof id !== 'string' && typeof id !== 'number') {
         throw new ProtocolError('number or type of arguments don\'t agree with elementIdLocation protocol command')
     }
-
+    deprecate('elementIdLocation', this.options)
     return this.requestHandler.create(`/session/:sessionId/element/${id}/location`).catch((err) => {
         /**
          * jsonwire command not supported try webdriver endpoint

--- a/lib/protocol/elementIdLocationInView.js
+++ b/lib/protocol/elementIdLocationInView.js
@@ -5,7 +5,9 @@
  * *Note:* This is considered an internal command and should only be used to determine
  * an element's location for correctly generating native events.
  *
- * Deprecated command, please use `elementIdRect`.
+ * This command is deprecated and will be removed soon. Make sure you don't use it in your
+ * automation/test scripts anymore to avoid errors. Please use the
+ * [`elementIdRect`](http://webdriver.io/api/protocol/elementIdRect.html) command instead.
  *
  * @param {String} ID ID of a WebElement JSON object to route the command to
  * @return {Object} The X and Y coordinates for the element (`{x:number, y:number}`)

--- a/lib/protocol/elementIdSize.js
+++ b/lib/protocol/elementIdSize.js
@@ -3,7 +3,9 @@
  * Determine an element's size in pixels. The size will be returned as a JSON object
  * with width and height properties.
  *
- * Deprecated command, please use [`elementIdRect`](http://webdriver.io/api/protocol/elementIdRect.html).
+ * This command is deprecated and will be removed soon. Make sure you don't use it in your
+ * automation/test scripts anymore to avoid errors. Please use the
+ * [`elementIdRect`](http://webdriver.io/api/protocol/elementIdRect.html) command instead.
  *
  * @param {String} ID ID of a WebElement JSON object to route the command to
  * @return {Object} The width and height of the element, in pixels (`{width:number, height:number}`)
@@ -15,11 +17,13 @@
  */
 
 import { ProtocolError } from '../utils/ErrorHandler'
+import deprecate from '../helpers/deprecationWarning'
 
 export default function elementIdSize (id) {
     if (typeof id !== 'string' && typeof id !== 'number') {
         throw new ProtocolError('number or type of arguments don\'t agree with elementIdSize protocol command')
     }
+    deprecate('elementIdSize', this.options)
 
     return this.requestHandler.create(`/session/:sessionId/element/${id}/size`).catch((err) => {
         /**

--- a/lib/protocol/imeActivate.js
+++ b/lib/protocol/imeActivate.js
@@ -4,12 +4,15 @@
  * After this call, the engine will be added to the list of engines loaded in the IME daemon and the
  * input sent using sendKeys will be converted by the active engine. Note that this is a
  * platform-independent method of activating IME (the platform-specific way being using keyboard shortcuts.
- * (Not part of the official Webdriver specification)
+ *
+ * This command is deprecated and will be removed soon. Make sure you don't use it in your
+ * automation/test scripts anymore to avoid errors.
  *
  * @param {String} engine   Name of the engine to activate.
  *
  * @see  https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidimeactive_engine
  * @type protocol
+ * @deprecated
  *
  */
 

--- a/lib/protocol/imeActivated.js
+++ b/lib/protocol/imeActivated.js
@@ -1,12 +1,15 @@
 /**
  *
- * Indicates whether IME input is active at the moment (not if it's available.
- * (Not part of the official Webdriver specification)
+ * Indicates whether IME input is active at the moment (not if it's available).
+ *
+ * This command is deprecated and will be removed soon. Make sure you don't use it in your
+ * automation/test scripts anymore to avoid errors.
  *
  * @return {boolean}  true if IME input is available and currently active, false otherwise
  *
  * @see  https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidimeactivated
  * @type protocol
+ * @deprecated
  *
  */
 

--- a/lib/protocol/imeActiveEngine.js
+++ b/lib/protocol/imeActiveEngine.js
@@ -1,12 +1,15 @@
 /**
  *
- * Get the name of the active IME engine. The name string is platform specific. (Not part of the
- * official Webdriver specification)
+ * Get the name of the active IME engine. The name string is platform specific.
+ *
+ * This command is deprecated and will be removed soon. Make sure you don't use it in your
+ * automation/test scripts anymore to avoid errors.
  *
  * @return {String} engine   The name of the active IME engine.
  *
  * @see  https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidimeactive_engine
  * @type protocol
+ * @deprecated
  *
  */
 

--- a/lib/protocol/imeAvailableEngines.js
+++ b/lib/protocol/imeAvailableEngines.js
@@ -1,12 +1,16 @@
 /**
  *
  * List all available engines on the machine. To use an engine, it has to be present
- * in this list. (Not part of the official Webdriver specification)
+ * in this list.
+ *
+ * This command is deprecated and will be removed soon. Make sure you don't use it in your
+ * automation/test scripts anymore to avoid errors.
  *
  * @return {Object[]} engines   A list of available engines
  *
  * @see  https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidimeavailable_engines
  * @type protocol
+ * @deprecated
  *
  */
 

--- a/lib/protocol/imeDeactivated.js
+++ b/lib/protocol/imeDeactivated.js
@@ -1,9 +1,13 @@
 /**
  *
- * De-activates the currently-active IME engine. (Not part of the official Webdriver specification)
+ * De-activates the currently-active IME engine.
+ *
+ * This command is deprecated and will be removed soon. Make sure you don't use it in your
+ * automation/test scripts anymore to avoid errors.
  *
  * @see  https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidimedeactivate
  * @type protocol
+ * @deprecated
  *
  */
 

--- a/lib/protocol/keys.js
+++ b/lib/protocol/keys.js
@@ -10,6 +10,9 @@
  * [here](https://w3c.github.io/webdriver/webdriver-spec.html#keyboard-actions).
  * To do that, the value has to correspond to a key from the table.
  *
+ * This command is deprecated and will be removed soon. Make sure you don't use it in your
+ * automation/test scripts anymore to avoid errors.
+ *
  * @param {String|String[]} value  The sequence of keys to type. An array must be provided. The server should flatten the array items to a single string to be typed.
  *
  * @see  https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidkeys

--- a/lib/protocol/location.js
+++ b/lib/protocol/location.js
@@ -1,6 +1,9 @@
 /**
  *
- * Protocol bindings for all geolocation operations. (Not part of the official Webdriver specification).
+ * Protocol bindings for all geolocation operations.
+ *
+ * This command is deprecated and will be removed soon. Make sure you don't use it in your
+ * automation/test scripts anymore to avoid errors.
  *
  * <example>
     :location.js
@@ -18,6 +21,7 @@
  *
  * @see  https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidlocation
  * @type protocol
+ * @deprecated
  *
  */
 

--- a/lib/protocol/moveTo.js
+++ b/lib/protocol/moveTo.js
@@ -5,7 +5,8 @@
  * no offset, the mouse will be moved to the center of the element. If the element
  * is not visible, it will be scrolled into view.
  *
- * (Not part of the official Webdriver specification).
+ * This command is deprecated and will be removed soon. Make sure you don't use it in your
+ * automation/test scripts anymore to avoid errors.
  *
  * @param {String} element  Opaque ID assigned to the element to move to, as described in the WebElement JSON Object. If not specified or is null, the offset is relative to current position of the mouse.
  * @param {Number} xoffset  X offset to move to, relative to the top-left corner of the element. If not specified, the mouse will move to the middle of the element.
@@ -13,6 +14,7 @@
  *
  * @see  https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidmoveto
  * @type protocol
+ * @deprecated
  *
  */
 

--- a/lib/protocol/sessions.js
+++ b/lib/protocol/sessions.js
@@ -8,7 +8,8 @@
  * | id           | string | The session ID |
  * | capabilities | object | An object describing the [session capabilities](https://w3c.github.io/webdriver/webdriver-spec.html#capabilities) |
  *
- * (Not part of the official Webdriver specification).
+ * This command is deprecated and will be removed soon. Make sure you don't use it in your
+ * automation/test scripts anymore to avoid errors.
  *
  * @return {Object[]} a list of the currently active sessions
  *
@@ -18,7 +19,10 @@
  *
  */
 
+import deprecate from '../helpers/deprecationWarning'
+
 export default function sessions () {
+    deprecate('sessions', this.options)
     return this.requestHandler.create({
         path: '/sessions',
         method: 'GET',

--- a/lib/protocol/submit.js
+++ b/lib/protocol/submit.js
@@ -1,12 +1,16 @@
 /**
  *
  * Submit a FORM element. The submit command may also be applied to any element
- * that is a descendant of a FORM element. (Not part of the official Webdriver specification).
+ * that is a descendant of a FORM element.
+ *
+ * This command is deprecated and will be removed soon. Make sure you don't use it in your
+ * automation/test scripts anymore to avoid errors.
  *
  * @param {String} ID ID of a `<form />` WebElement JSON object to route the command to
  *
  * @see  https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidelementidsubmit
  * @type protocol
+ * @deprecated
  *
  */
 

--- a/lib/protocol/timeoutsAsyncScript.js
+++ b/lib/protocol/timeoutsAsyncScript.js
@@ -4,7 +4,9 @@
  * by /session/:sessionId/execute_async are permitted to run before they are
  * aborted and a |Timeout| error is returned to the client.
  *
- * Deprecated! Please use the `timeouts` command instead.
+ * This command is deprecated and will be removed soon. Make sure you don't use it in your
+ * automation/test scripts anymore to avoid errors. Please use the
+ * [`timeouts`](http://webdriver.io/api/protocol/timeouts.html) command instead.
  *
  * @see https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidtimeoutsasync_script
  *

--- a/lib/protocol/timeoutsImplicitWait.js
+++ b/lib/protocol/timeoutsImplicitWait.js
@@ -7,12 +7,15 @@
  *
  * If this command is never sent, the driver should default to an implicit wait of 0ms.
  *
- * Deprecated! Please use the `timeouts` command instead.
+ * This command is deprecated and will be removed soon. Make sure you don't use it in your
+ * automation/test scripts anymore to avoid errors. Please use the
+ * [`timeouts`](http://webdriver.io/api/protocol/timeouts.html) command instead.
  *
  * @param {Number} ms   The amount of time to wait, in milliseconds. This value has a lower bound of 0.
  *
  * @see https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidtimeoutsimplicit_wait
  * @type protocol
+ * @deprecated
  *
  */
 

--- a/lib/protocol/touchClick.js
+++ b/lib/protocol/touchClick.js
@@ -1,6 +1,10 @@
 /**
  *
- * Single tap on the touch enabled device. Deprecated! Please use `touchPerform` instead.
+ * Single tap on the touch enabled device.
+ *
+ * This command is deprecated and will be removed soon. Make sure you don't use it in your
+ * automation/test scripts anymore to avoid errors. Please use the
+ * [`touchPerform`](http://webdriver.io/api/mobile/touchPerform.html) command instead.
  *
  * @param {String} ID ID of a WebElement JSON object to route the command to
  *
@@ -12,11 +16,13 @@
  */
 
 import { ProtocolError } from '../utils/ErrorHandler'
+import deprecate from '../helpers/deprecationWarning'
 
 export default function touchClick (id) {
     if (typeof id !== 'string' && typeof id !== 'number') {
         throw new ProtocolError('number or type of arguments don\'t agree with elementIdCssProperty protocol command')
     }
+    deprecate('touchClick', this.options)
 
     return this.requestHandler.create('/session/:sessionId/touch/click', {
         element: id.toString()

--- a/lib/protocol/touchDown.js
+++ b/lib/protocol/touchDown.js
@@ -1,21 +1,28 @@
 /**
  *
- * Finger down on the screen. Deprecated! Please use `touchPerform` instead.
+ * Finger down on the screen.
+ *
+ * This command is deprecated and will be removed soon. Make sure you don't use it in your
+ * automation/test scripts anymore to avoid errors. Please use the
+ * [`touchPerform`](http://webdriver.io/api/mobile/touchPerform.html) command instead.
  *
  * @param {Number} x  X coordinate on the screen
  * @param {Number} y  Y coordinate on the screen
  *
  * @see  https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidtouchdown
  * @type protocol
+ * @deprecated
  *
  */
 
 import { ProtocolError } from '../utils/ErrorHandler'
+import deprecate from '../helpers/deprecationWarning'
 
 export default function touchDown (x, y) {
     if (typeof x !== 'number' || typeof y !== 'number') {
         throw new ProtocolError('number or type of arguments don\'t agree with touchDown command')
     }
+    deprecate('touchDown', this.options)
 
     return this.requestHandler.create('/session/:sessionId/touch/down', { x, y })
 }

--- a/lib/protocol/touchFlick.js
+++ b/lib/protocol/touchFlick.js
@@ -1,6 +1,10 @@
 /**
  * Flick on the touch screen using finger motion events. This flick command starts
- * at a particular screen location. Deprecated! Please use `touchPerform` instead.
+ * at a particular screen location.
+ *
+ * This command is deprecated and will be removed soon. Make sure you don't use it in your
+ * automation/test scripts anymore to avoid errors. Please use the
+ * [`touchPerform`](http://webdriver.io/api/mobile/touchPerform.html) command instead.
  *
  * @param {String} ID      ID of the element where the flick starts
  * @param {Number} xoffset the x offset in pixels to flick by
@@ -9,10 +13,12 @@
  *
  * @see  https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidtouchflick
  * @type protocol
+ * @deprecated
  *
  */
 
 import { ProtocolError } from '../utils/ErrorHandler'
+import deprecate from '../helpers/deprecationWarning'
 
 export default function touchFlick (id, xoffset, yoffset, speed) {
     let data = {}
@@ -29,6 +35,7 @@ export default function touchFlick (id, xoffset, yoffset, speed) {
     } else {
         throw new ProtocolError('number or type of arguments don\'t agree with touchFlick command')
     }
+    deprecate('touchFlick', this.options)
 
     return this.requestHandler.create('/session/:sessionId/touch/flick', data)
 }

--- a/lib/protocol/touchLongClick.js
+++ b/lib/protocol/touchLongClick.js
@@ -1,21 +1,28 @@
 /**
  *
- * Long press on the touch screen using finger motion events. Deprecated! Please use `touchPerform` instead.
+ * Long press on the touch screen using finger motion events.
+ *
+ * This command is deprecated and will be removed soon. Make sure you don't use it in your
+ * automation/test scripts anymore to avoid errors. Please use the
+ * [`touchPerform`](http://webdriver.io/api/mobile/touchPerform.html) command instead.
  *
  * @param {String} id ID of the element to long press on
  *
  * @see https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidtouchlongclick
  * @type protocol
  * @for android
+ * @deprecated
  *
  */
 
 import { ProtocolError } from '../utils/ErrorHandler'
+import deprecate from '../helpers/deprecationWarning'
 
 export default function touchLongClick (id) {
     if (typeof id !== 'string' && typeof id !== 'number') {
         throw new ProtocolError('number or type of arguments don\'t agree with touchLongClick protocol command')
     }
+    deprecate('touchLongClick', this.options)
 
     return this.requestHandler.create('/session/:sessionId/touch/longclick', {
         element: id.toString()

--- a/lib/protocol/touchMove.js
+++ b/lib/protocol/touchMove.js
@@ -1,7 +1,10 @@
 /**
  *
- * Finger move on the screen. Deprecated! Please use `touchPerform` instead.
- * Deprecated! Please use `touchPerform` instead.
+ * Finger move on the screen.
+ *
+ * This command is deprecated and will be removed soon. Make sure you don't use it in your
+ * automation/test scripts anymore to avoid errors. Please use the
+ * [`touchPerform`](http://webdriver.io/api/mobile/touchPerform.html) command instead.
  *
  * @param {Number} x  coordinate on the screen
  * @param {Number} y  coordinate on the screen
@@ -13,11 +16,13 @@
  */
 
 import { ProtocolError } from '../utils/ErrorHandler'
+import deprecate from '../helpers/deprecationWarning'
 
 export default function touchMove (x, y) {
     if (typeof x !== 'number' || typeof y !== 'number') {
         throw new ProtocolError('number or type of arguments don\'t agree with touchMove command')
     }
+    deprecate('touchMove', this.options)
 
     return this.requestHandler.create('/session/:sessionId/touch/move', { x, y })
 }

--- a/lib/protocol/touchScroll.js
+++ b/lib/protocol/touchScroll.js
@@ -2,7 +2,9 @@
  * Scroll on the touch screen using finger based motion events. If
  * element ID is given start scrolling at a particular screen location.
  *
- * Deprecated! Please use `touchPerform` instead.
+ * This command is deprecated and will be removed soon. Make sure you don't use it in your
+ * automation/test scripts anymore to avoid errors. Please use the
+ * [`touchPerform`](http://webdriver.io/api/mobile/touchPerform.html) command instead.
  *
  * @param {String} id       the element where the scroll starts.
  * @param {Number} xoffset  in pixels to scroll by
@@ -15,6 +17,7 @@
  */
 
 import { ProtocolError } from '../utils/ErrorHandler'
+import deprecate from '../helpers/deprecationWarning'
 
 export default function touchScroll (id, xoffset, yoffset) {
     let data = {}
@@ -42,6 +45,7 @@ export default function touchScroll (id, xoffset, yoffset) {
     } else {
         throw new ProtocolError('number or type of arguments don\'t agree with touchScroll command')
     }
+    deprecate('touchScroll', this.options)
 
     return this.requestHandler.create('/session/:sessionId/touch/scroll', data)
 }

--- a/lib/protocol/touchUp.js
+++ b/lib/protocol/touchUp.js
@@ -1,6 +1,10 @@
 /**
  *
- * Finger up on the screen. Deprecated! Please use `touchPerform` instead.
+ * Finger up on the screen.
+ *
+ * This command is deprecated and will be removed soon. Make sure you don't use it in your
+ * automation/test scripts anymore to avoid errors. Please use the
+ * [`touchPerform`](http://webdriver.io/api/mobile/touchPerform.html) command instead.
  *
  * @param {Number} x  coordinate on the screen
  * @param {Number} y  coordinate on the screen
@@ -12,11 +16,13 @@
  */
 
 import { ProtocolError } from '../utils/ErrorHandler'
+import deprecate from '../helpers/deprecationWarning'
 
 export default function touchUp (x, y) {
     if (typeof x !== 'number' || typeof y !== 'number') {
         throw new ProtocolError('number or type of arguments don\'t agree with touchUp command')
     }
+    deprecate('touchUp', this.options)
 
     return this.requestHandler.create('/session/:sessionId/touch/up', { x, y })
 }


### PR DESCRIPTION
## Proposed changes

I updated the deprecated tags (`@deprecated`), warnings, and jsdocs to all be the same.

- `@deprecated` tags were added to deprecated commands that did not already have the tag, in case the wddoc project is updated to handle these tags
- warnings were added to deprecated commands that did not already have the warning
- jsdocs were unified so that the verbiage is the same across deprecated commands, including links to alternative commands when alternatives were already present.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

### Reviewers: @christian-bromann
