### PR TITLE
Add fixed footer warning to click documentation

### DIFF
--- a/lib/commands/click.js
+++ b/lib/commands/click.js
@@ -1,6 +1,13 @@
 /**
  *
- * Click on an element based on given selector.
+ * Click on an element based on the given selector (unless the element is covered up).
+ *
+ * Note: This issues a Webdriver `click` command for the selected element, which generally scrolls to and then clicks the
+ * selected element.  However, if you have fixed-position elements (such as a fixed header or footer) that cover up the
+ * selected element after it is scrolled within the viewport, the click will be issued at the given coordinates, but will
+ * be received by your fixed element.
+ *
+ * To work around this, you can scroll to the element yourself using `scroll` with an offset appropriate for your scenario.
  *
  * <example>
     :example.html


### PR DESCRIPTION
As discussed in https://github.com/webdriverio/webdriverio/issues/2067#issuecomment-301535856

## Proposed changes

Documents a known issue in selenium (https://github.com/SeleniumHQ/selenium-google-code-issue-archive/issues/4175)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other: Documentation

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- (N/A) I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

I don't know if there's a good way to link to the scroll function documentation here (might be appropriate)?

### Reviewers: @christian-bromann
