### PR TITLE
Fix ConfigParser.merge bug where capabilities weren't getting updated

### DIFF
--- a/lib/utils/ConfigParser.js
+++ b/lib/utils/ConfigParser.js
@@ -138,6 +138,11 @@ class ConfigParser {
         this._config = merge(this._config, object)
 
         /**
+         * merge capabilities
+         */
+        this._capabilities = merge(this._capabilities, this._config.capabilities || {})
+
+        /**
          * run single spec file only
          */
         if (typeof object.spec === 'string') {

--- a/test/spec/unit/configparser.js
+++ b/test/spec/unit/configparser.js
@@ -137,4 +137,21 @@ describe('ConfigParser', () => {
         configParser.getConfig().beforeSession.should.be.an('array').and.have.a.lengthOf(1)
         configParser.getConfig().afterSession.should.be.an('array').and.have.a.lengthOf(1)
     })
+
+    describe('merge', () => {
+        it('should update capabilities based on merged config', () => {
+            let configParser = new ConfigParser()
+            configParser.addConfigFile(path.resolve(FIXTURES_PATH, 'exclude.conf.js'))
+            configParser.merge({
+                capabilities: {
+                    someNewCapability: 'I should be included in ConfigParser capabilities!'
+                }
+            })
+
+            configParser.getCapabilities().should.have.property('browserName', 'chrome')
+            configParser.getCapabilities().should.have.property('someNewCapability',
+                'I should be included in ConfigParser capabilities!'
+            )
+        })
+    })
 })


### PR DESCRIPTION
## Proposed changes

This PR resolves #2108.


`merge` function now updates ConfigParser's internal `_capabilities` property, since it wasn't getting updated previously and was causing unexpected behavior when launching wdio programmatically with the `Launcher` class.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @christian-bromann
