### PR TITLE
Fixed contradiction in the "Retry flaky tests" docs

### DIFF
--- a/docs/guide/testrunner/retry.md
+++ b/docs/guide/testrunner/retry.md
@@ -62,7 +62,7 @@ describe('my flaky app', function () {
 });
 ```
 
-It is __not__ possible to rerun whole suites, only hooks or test blocks. To use this you have to have the [wdio-mocha-framework](https://github.com/webdriverio/wdio-mocha-framework) adapter installed with `v0.3.0` or greater or the [wdio-jasmine-framework](https://github.com/webdriverio/wdio-jasmine-framework) adapter with `v0.2.0` or greater.
+It is __not__ possible to rerun whole suites with Jasmine, only hooks or test blocks. To use this you have to have the [wdio-mocha-framework](https://github.com/webdriverio/wdio-mocha-framework) adapter installed with `v0.3.0` or greater or the [wdio-jasmine-framework](https://github.com/webdriverio/wdio-jasmine-framework) adapter with `v0.2.0` or greater.
 
 ## Rerun Step Definitions in Cucumber
 


### PR DESCRIPTION
## Proposed changes

The docs are misleading, indicating it is not possible to re-run whole suites, while the previous paragraph says it's possible to do it with Mocha.

So I assume it's only impossible with Jasmine? Correct me if I'm wrong.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

### Reviewers: @christian-bromann
