### PR TITLE
Documentation - pageobjects.md Fix ES6 Page Object

### DIFF
--- a/docs/guide/testrunner/pageobjects.md
+++ b/docs/guide/testrunner/pageobjects.md
@@ -44,7 +44,7 @@ class Page {
 	}
 
 }
-module.exports = new Page();
+module.exports = Page;
 ```
 
 We will always export an instance of a page object and never create that instance in the test. Since we are writing end to end tests we always see the page as a stateless construct the same way as each http request is a stateless construct. Sure, the browser can carry session information and therefore can display different pages based on different sessions, but this shouldn't be reflected within a page object. These state changes should emerge from your actual tests.


### PR DESCRIPTION
Fixing ES6 page.js error on exported module

## Proposed changes

The ES6 sample page objects provided in the documentation `pageobjects.md` do not work in Node 8.0.0

The export of `page.js` will cause an error when extended in the sample `login.js` of
`TypeError: Class extends value #<Page> is not a constructor or null`

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

### Reviewers: @christian-bromann
