### PR TITLE
Added support for IEDriver without Selenium

### DIFF
--- a/docs/guide/services/iedriver.md
+++ b/docs/guide/services/iedriver.md
@@ -1,0 +1,79 @@
+name: iedriver
+category: services
+tags: guide
+index: 12
+title: WebdriverIO - IEDriver Service
+---
+
+WDIO IEDriver Service
+================================
+
+(Based entirely on [wdio-selenium-standalone-service](https://github.com/webdriverio/wdio-selenium-standalone-service).)
+
+----
+
+This service helps you to run IEDriver seamlessly when running tests with the [WDIO testrunner](http://webdriver.io/guide/testrunner/gettingstarted.html). It uses the [IEdriver](https://www.npmjs.com/package/iedriver) NPM package that wraps the IEDriver for you.
+
+Note - this service does not require a Selenium server, but uses IEDriver to communicate with the browser directly.
+Obvisously, it only supports:
+
+```js
+capabilities: [{
+        browserName: 'internet explorer'
+    }]
+```
+
+## Installation
+
+The easiest way is to keep `wdio-iedriver-service` as a devDependency in your `package.json`.
+
+```json
+{
+  "devDependencies": {
+    "wdio-iedriver-service": "~0.1"
+  }
+}
+```
+
+You can simple do it by:
+
+```bash
+npm install wdio-iedriver-service --save-dev
+```
+
+Instructions on how to install `WebdriverIO` can be found [here.](http://webdriver.io/guide/getstarted/install.html)
+
+## Configuration
+
+By design, only Internet Explorer is available (when installed on the host system). Make sure to read up on [InternetExplorerDriver](https://github.com/SeleniumHQ/selenium/wiki/InternetExplorerDriver) regarding required configuration. `Protected Mode`-setting can be tweaked by using `ignoreProtectedModeSettings: true` in capabilities.
+
+
+In order to use the service you need to add `iedriver` to your service array:
+
+```js
+// wdio.conf.js
+export.config = {
+  port: '5555',
+  path: '/',
+  // ...
+  services: ['iedriver'],
+  // ...
+};
+```
+
+## Options
+
+### ieDriverLogs
+Path where all logs from the IEDriver server should be stored.
+
+Type: `String`
+
+### killInstances
+Whether to force all instances of Internet Explorer to be closed after the test. Please note that this option will kill all instances, not only those spawned by IEDriverServer!
+
+Type: `Boolean`
+Default: `false`
+
+----
+
+For more information on WebdriverIO see the [homepage](http://webdriver.io).

--- a/docs/guide/services/visual-regression.md
+++ b/docs/guide/services/visual-regression.md
@@ -1,7 +1,7 @@
 name: Visual Regression
 category: services
 tags: guide
-index: 8
+index: 11
 title: WebdriverIO - Visual Regression Service
 ---
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -44,7 +44,8 @@ const SUPPORTED_SERVICES = [
     ' visual-regression - https://github.com/zinserjan/wdio-visual-regression-service',
     ' webpack - https://github.com/leadpages/wdio-webpack-service',
     ' webpack-dev-server - https://gitlab.com/Vinnl/wdio-webpack-dev-server-service',
-    ' chromedriver - https://github.com/atti187/wdio-chromedriver-service'
+    ' chromedriver - https://github.com/atti187/wdio-chromedriver-service',
+    ' iedriver - https://github.com/atti187/wdio-iedriver-service'
 ]
 
 const VERSION = pkg.version


### PR DESCRIPTION
## Proposed changes

Added support for IEDriver without Selenium - for fast and easy local testing before using other services like Browserstack etc - similar to https://github.com/webdriverio/webdriverio/pull/2059

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

Note that I also fixed the faulty index on visual-regression/webpack (both 8). I guess these are the basis for the website [documentation](http://webdriver.io/guide.html) - which lacks some services today?

Published to [npm](https://www.npmjs.com/package/wdio-iedriver-service)

### Reviewers: @christian-bromann
