### PR TITLE
Documents thrown NoSuchElement error on protocols/element.js

### DIFF
--- a/lib/protocol/element.js
+++ b/lib/protocol/element.js
@@ -8,7 +8,7 @@
  *
  * @param {String} selector selector to query the element
  * @return {String} A WebElement JSON object for the located element.
- *
+ * @throws {NoSuchElement} if no element is found from the given selector
  * @type protocol
  *
  */


### PR DESCRIPTION
As per the lines 67-72, `element` throws`NoSuchElement` error in case no element can be found from a given selector.

## Proposed changes
This PR adds a section on the documentation comments of `protocols/element.js`. It includes the `@throws` description to inform users about the possibility of a thrown `NoSuchElement` error in case a given selector can't match any element.

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @christian-bromann
