### PR TITLE
Documentation: output `spanText` instead of `text`

### DIFF
--- a/lib/commands/getText.js
+++ b/lib/commands/getText.js
@@ -22,7 +22,7 @@
         // "Lorem ipsum dolor sit amet,consetetur sadipscing elitr"
 
         var spanText = browser.getText('span');
-        console.log(text);
+        console.log(spanText);
         // outputs "" (empty string) since element is not interactable
     });
 


### PR DESCRIPTION
Since `spanText` is the most recently assigned variable and `text` has already been outputted, I assume outputting `spanText` here is correct.

## Proposed changes

Fixes a mistake in documentation.

## Types of changes

- [x] Documentation
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

### Reviewers: @christian-bromann
