### PR TITLE
added getCurrentPackage method

### DIFF
--- a/lib/protocol/getCurrentPackage.js
+++ b/lib/protocol/getCurrentPackage.js
@@ -1,0 +1,26 @@
+/**
+ *
+ * Get current device package.
+ *
+ * <example>
+    :getCurrentPackage.js
+    it('should get current Android package', function () {
+        var package = browser.getCurrentPackage();
+        console.log(package); // returns "io.webdriver.guineapig"
+    });
+ * </example>
+ *
+ * @see  https://github.com/appium/appium/blob/master/docs/en/appium-bindings.md#current-package
+ * @type mobile
+ * @for android
+ *
+ */
+
+export default function getCurrentPackage () {
+    return this.unify(this.requestHandler.create({
+        path: '/session/:sessionId/appium/device/current_package',
+        method: 'GET'
+    }), {
+        extractValue: true
+    })
+}

--- a/test/fixtures/labels.js
+++ b/test/fixtures/labels.js
@@ -10,6 +10,7 @@ if (BUILD_ENV === 'android') {
     labels = merge(labels, {
         WEBVIEW_CONTEXT: 'WEBVIEW_io.webdriver.guineapig',
         ACTIVITY: '.MainActivity',
+        PACKAGE: 'io.webdriver.guineapig',
         HITAREA: '//android.widget.LinearLayout[1]/android.widget.FrameLayout[1]/android.webkit.WebView[1]/android.webkit.WebView[1]/android.widget.ListView[1]'
     })
 }

--- a/test/spec/mobile/android/package.js
+++ b/test/spec/mobile/android/package.js
@@ -1,0 +1,7 @@
+import labels from '../../../fixtures/labels'
+
+describe('package', () => {
+    it('should get current package', async function () {
+        (await this.client.getCurrentPackage()).should.be.equal(labels.PACKAGE)
+    })
+})


### PR DESCRIPTION
* Gets the current package
* Mirrors the implementation and tests of the getCurrentDeviceActivity method

## Proposed changes

[//]: # Added getCurrentPackage method which calls the `/current_package` endpoint (similar to `/current_activity`

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @christian-bromann
