### PR TITLE
Allow comments in functions passed to execute/executeAsync.

### DIFF
--- a/lib/scripts/createSelectorScript.js
+++ b/lib/scripts/createSelectorScript.js
@@ -59,7 +59,7 @@ let createSelectorScript = function (fn, selectors, args) {
     strArgs.push(JSON.stringify(foundSel))
     strArgs.push(getArgs(args, this.inMultibrowserMode))
 
-    return (`return (${executeClientSide})(${strArgs.join(',')}, arguments[arguments.length - 1]);`).replace(/(\s{4}|\t)+/g, ' ')
+    return (`return (${executeClientSide})(${strArgs.join(',')}, arguments[arguments.length - 1]);`).replace(/( {4}|\t)+/g, ' ')
 }
 
 /**

--- a/test/spec/functional/selectorExecute.js
+++ b/test/spec/functional/selectorExecute.js
@@ -57,6 +57,13 @@ describe('selectorExecute', () => {
         )).should.be.equal('githubRepo with an argument')
     })
 
+    it('should be able to contain JS single-line comments', async function () {
+        (await this.client.selectorExecute('[class="sometext"]', (arr) => {
+            return arr[0].innerHTML
+            // comment test
+        })).should.be.equal('some text')
+    })
+
     it('should be able to accept multiple selectors', async function () {
         (await this.client.selectorExecute(['*=GitHub ', '//*[@class="sometext"]'], (links, divs, arg) => {
             var returnStr = 'Returning '

--- a/test/spec/functional/selectorExecuteAsync.js
+++ b/test/spec/functional/selectorExecuteAsync.js
@@ -72,6 +72,16 @@ describe('selectorExecuteAsync', () => {
         )).should.be.equal('githubRepo with an argument')
     })
 
+    it('should be able to contain JS single-line comments', async function () {
+        (await this.client.selectorExecuteAsync(
+            '[class="sometext"]',
+            (arr, cb) => {
+                setTimeout(() => cb(arr[0].innerHTML), 100)
+                // comment test
+            }
+        )).should.be.equal('some text')
+    })
+
     it('should be able to accept multiple selectors', async function () {
         (await this.client.selectorExecuteAsync(
             ['*=GitHub ', '//html/body/section/h1'],


### PR DESCRIPTION
## Proposed changes

This fixes https://github.com/webdriverio/webdriverio/issues/2172.

I'm guessing that the string replacement that occurs in `createSelectorScript()` is intended to replace 4 *spaces*, or a tab, with a single space. But the `\s` shorthand class includes newlines, which makes it impossible to include `//` comments in the functions. This modifies the string replacement to only match spaces.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- n/a I have added necessary documentation (if appropriate)


### Reviewers: @christian-bromann
