### PR TITLE
Add appWaitPackage/Activity to startActivity

### DIFF
--- a/lib/protocol/startActivity.js
+++ b/lib/protocol/startActivity.js
@@ -10,24 +10,33 @@
     });
  * </example>
  *
- * @param {String} appPackage   name of app
- * @param {String} appActivity  name of activity
+ * @param {String} appPackage       name of app
+ * @param {String} appActivity      name of activity
+ * @param {String=} appWaitPackage  name of app to wait for
+ * @param {String=} appWaitActivity name of activity to wait for
  * @type mobile
  * @for android
  *
  */
-
 import { ProtocolError } from '../utils/ErrorHandler'
-
-export default function startActivity (appPackage, appActivity) {
+export default function startActivity (appPackage, appActivity, appWaitPackage, appWaitActivity) {
     if (typeof appPackage !== 'string' || typeof appActivity !== 'string') {
         throw new ProtocolError(
             'startActivity command requires two parameter (appPackage, appActivity) from type string'
         )
     }
 
+    let data = { appPackage, appActivity }
+
+    if (typeof appWaitPackage === 'string') {
+        data.appWaitPackage = appWaitPackage
+    }
+    if (typeof appWaitActivity === 'string') {
+        data.appWaitActivity = appWaitActivity
+    }
+
     return this.requestHandler.create(
         '/session/:sessionId/appium/device/start_activity',
-        { appPackage, appActivity }
+        data
     )
 }


### PR DESCRIPTION
## Proposed changes

Add appWaitPackage and appWaitActivity as optional parameters to startActivity(). This change allows appium to wait for a different package and activity then the launched one prior to returning a success message. These changes were made based off of the [Appium Android Driver source](https://github.com/appium/appium-android-driver/blob/08eedc58a88c1bbffa1fa050e71b711c314f9815/lib/commands/general.js#L170)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # 

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

I've tried for a few days to get `npm run test:android` to pass, the last issue I had ran into related to the device not being able to unlock. I also noticed startActivity() also had no tests currently 😢  I was hoping to piggy back off of something. To test this personally I used the pressKeyCode(3) to kill the app and startActivity() to relaunch. I tested various combinations of parameters and believe this code change improves startActivity() without breaking any of its current functionality.

### Reviewers: @christian-bromann
