### PR TITLE
Documentation fix - Update pageobjects.md

### DIFF
--- a/docs/guide/testrunner/pageobjects.md
+++ b/docs/guide/testrunner/pageobjects.md
@@ -24,10 +24,10 @@ function Page () {
 }
 
 Page.prototype.open = function (path) {
-    browser.url(path)
+    browser.url(path);
 }
 
-module.exports = new Page()
+module.exports = new Page();
 ```
 Or, using ES6 class:
 ```js
@@ -44,7 +44,7 @@ class Page {
 	}
 
 }
-module.exports = new Page();
+module.exports = Page;
 ```
 
 We will always export an instance of a page object and never create that instance in the test. Since we are writing end to end tests we always see the page as a stateless construct the same way as each http request is a stateless construct. Sure, the browser can carry session information and therefore can display different pages based on different sessions, but this shouldn't be reflected within a page object. These state changes should emerge from your actual tests.


### PR DESCRIPTION
Using ES6 Page class should be treated as abstract (base) class. We need to export class definition instead of class instance in order to be able to extend this class. Right now class instance is exported what causes errors when we are trying to extend this class. For example: 
```
var Page = require('./page')
class LoginPage extends Page {
}
```
will throw error "ERROR: Class extends value #<Page> is not a constructor or null".

## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @christian-bromann
