### PR TITLE
handle a case when error is created with details

### DIFF
--- a/lib/utils/ErrorHandler.js
+++ b/lib/utils/ErrorHandler.js
@@ -17,7 +17,8 @@ class ErrorHandler extends Error {
             if (msg === 7 && details) {
                 this.message = `${this.message.slice(0, -1)} ("${details}").`
             }
-        } else if (arguments.length === 2) {
+        } else if (arguments.length > 1) {
+            this.details = details
             this.message = msg
             this.type = type
         } else if (arguments.length === 1) {

--- a/test/spec/unit/errorHandler.js
+++ b/test/spec/unit/errorHandler.js
@@ -1,4 +1,5 @@
 import { ErrorHandler } from '../../../index'
+import { CommandError, RuntimeError } from '../../../lib/utils/ErrorHandler'
 
 describe('ErrorHandler', () => {
     it('should accessible through module object', () => {
@@ -7,7 +8,21 @@ describe('ErrorHandler', () => {
     })
 
     it('should throw selenium error when passing specific error ID', () => {
-        const error = new ErrorHandler(17)
+        const error = new CommandError(17)
         error.name.should.be.equal('Error')
+        error.message.should.be.equal('An error occurred while executing user supplied JavaScript.')
+    })
+
+    it('should report command error', () => {
+        const error = new CommandError('Some error in command', 'extra info')
+        error.name.should.be.equal('Error')
+        error.message.should.be.equal('Some error in command')
+        error.details.should.be.equal('extra info')
+    })
+
+    it('should report runtime error', () => {
+        const error = new RuntimeError('Some error in runtime')
+        error.name.should.be.equal('Error')
+        error.message.should.be.equal('Some error in runtime')
     })
 })


### PR DESCRIPTION
## Proposed changes

There is [a line](https://github.com/webdriverio/webdriverio/blob/master/lib/utils/ErrorHandler.js#L89) that creates and ErrorHandler with 3 arguments. Currently this case is not handled, so we are receiving an empty Error object at the end.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

Here is a code to reproduce the issue

```js
const webdriverio = require('webdriverio');
const browser = webdriverio.remote();

browser
    .init()
    .url('https://google.com')
    .setValue('[name="q"]', undefined) // I give invalid value and expect to see an error message, that `setValue` has for me
    .catch(error => console.log(error)) // log error message
    .end();
```

With the latest webdriver.io version you will see an empty `Error` without any message. After that change you will see `Error: number or type of arguments don't agree with setValue command` as it was expected.

### Reviewers: @christian-bromann
