### PR TITLE
show related imports of gulp plugin code example

### DIFF
--- a/docs/guide/plugins/gulp-webdriver.md
+++ b/docs/guide/plugins/gulp-webdriver.md
@@ -21,6 +21,8 @@ npm install gulp-webdriver --save-dev
 You can run WebdriverIO locally running this simple task:
 
 ```js
+import webdriver from 'gulp-webdriver';
+
 gulp.task('test:e2e', function() {
     return gulp.src('wdio.conf.js').pipe(webdriver());
 });
@@ -32,6 +34,8 @@ You can find all available options [here](http://webdriver.io/guide/testrunner/g
 or by executing `$ wdio --help` (if you have WebdriverIO installed globally).
 
 ```js
+import webdriver from 'gulp-webdriver';
+
 gulp.task('test:e2e', function() {
     return gulp.src('wdio.conf.js').pipe(webdriver({
         logLevel: 'verbose',


### PR DESCRIPTION
minor, but for some reason it took me a couple minutes before I face-palmed

## Proposed changes

The code sample used in the gulp plugin does not explicitly note where the `webdriver` variable comes from which can lead to some confusion. It is relatively obvious, but it doesn't hurt to be explicit in the docs.

I deleted the rest of the automated form because it isn't really applicable for such a small docs change. I don't think this is a completely necessary change, but if you agree it might make the docs more clear, here is a PR!

### Reviewers: @christian-bromann
