### PR TITLE
return readable errors in debug mode

### DIFF
--- a/lib/commands/debug.js
+++ b/lib/commands/debug.js
@@ -91,7 +91,9 @@ let debug = function (commandTimeout = 5000, enableStdout, enableLogging) {
         }, (e) => {
             commandIsRunning = false
             clearTimeout(timeout)
-            return callback(e)
+            const commandError = new Error(e.message)
+            delete commandError.stack
+            return callback(commandError)
         })
     }
 


### PR DESCRIPTION
## Proposed changes

Before:
> browser.waitForExist(".we")
Error

Now:

> browser.waitForExist('.we')
Thrown: Error: element (".we") still not existing after 1000ms

Makes for a much easier debugging experience - otherwise it's hard to guess what's wrong. 
I also removed the stack from the message - I can't think of a situation where it would be helpful, but it surely messes up the debug. Another option would be to decrease the number of stack lines displayed.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

I don't think those internals are tested
