### PR TITLE
Custom HTTP Headers for selenium requests

### DIFF
--- a/docs/guide/getstarted/configuration.md
+++ b/docs/guide/getstarted/configuration.md
@@ -183,15 +183,19 @@ queryParams: {
 // http://127.0.0.1:4444/v1/session/a4ef025c69524902b77af5339017fd44/window/current/size?specialKey=d2ViZHJpdmVyaW8%3D
 ```
 
-### authorization
-A string to be used as a custom Authorization header when making requests to selenium.
-Type: `String`<br>
+### headers
+A key-value store of headers to be added to every selenium request. Values must be strings.
+Type: `Object`<br>
 Default: None
 
 **Example**
 
 ```js
-authorization: 'Basic dGVzdEtleTp0ZXN0VmFsdWU='
+headers: {
+  Authorization: 'Basic dGVzdEtleTp0ZXN0VmFsdWU='
+}
+// This adds headers based on the key
+// This would result in a header named 'Authorization' with a value of 'Basic dGVzdEtleTp0ZXN0VmFsdWU='
 ```
 
 ## debug

--- a/docs/guide/getstarted/configuration.md
+++ b/docs/guide/getstarted/configuration.md
@@ -183,6 +183,17 @@ queryParams: {
 // http://127.0.0.1:4444/v1/session/a4ef025c69524902b77af5339017fd44/window/current/size?specialKey=d2ViZHJpdmVyaW8%3D
 ```
 
+### authorization
+A string to be used as a custom Authorization header when making requests to selenium.
+Type: `String`<br>
+Default: None
+
+**Example**
+
+```js
+authorization: 'Basic dGVzdEtleTp0ZXN0VmFsdWU='
+```
+
 ## debug
 
 Enables node debugging

--- a/lib/utils/RequestHandler.js
+++ b/lib/utils/RequestHandler.js
@@ -93,8 +93,12 @@ class RequestHandler {
         }
 
         // Check for custom authorization header
-        if (typeof this.defaultOptions.authorization === 'string') {
-            newOptions.headers['Authorization'] = this.defaultOptions.authorization
+        if (typeof this.defaultOptions.headers === 'object') {
+            Object.keys(this.defaultOptions.headers).forEach(header => {
+                if (typeof this.defaultOptions.headers[header] === 'string') {
+                    newOptions.headers[header] = this.defaultOptions.headers[header]
+                }
+            })
         }
 
         if (Object.keys(data).length > 0) {

--- a/lib/utils/RequestHandler.js
+++ b/lib/utils/RequestHandler.js
@@ -92,6 +92,11 @@ class RequestHandler {
             'User-Agent': 'webdriverio/webdriverio/' + pkg.version
         }
 
+        // Check for custom authorization header
+        if (this.defaultOptions.authorization) {
+            newOptions.headers['Authorization'] = this.defaultOptions.authorization
+        }
+
         if (Object.keys(data).length > 0) {
             newOptions.json = data
             newOptions.method = 'POST'
@@ -237,7 +242,7 @@ class RequestHandler {
                         // for better unit test error output
                         return reject(err)
                     }
-                    
+
                     if (err) {
                         return reject(new RuntimeError({
                             status,
@@ -246,7 +251,7 @@ class RequestHandler {
                             message
                         }))
                     }
-                    
+
                     return reject(new RuntimeError({ status, type, message }))
                 }
 

--- a/lib/utils/RequestHandler.js
+++ b/lib/utils/RequestHandler.js
@@ -93,7 +93,7 @@ class RequestHandler {
         }
 
         // Check for custom authorization header
-        if (this.defaultOptions.authorization) {
+        if (typeof this.defaultOptions.authorization === 'string') {
             newOptions.headers['Authorization'] = this.defaultOptions.authorization
         }
 

--- a/test/spec/unit/remote.js
+++ b/test/spec/unit/remote.js
@@ -54,6 +54,11 @@ describe('remote method', () => {
         Object.keys(client.requestHandler.createOptions({ path: startPath }, {}).headers).should.not.include('Authorization')
     })
 
+    it('should not add authorization header if not present', () => {
+        var client = remote()
+        Object.keys(client.requestHandler.createOptions({ path: startPath }, {}).headers).should.not.include('Authorization')
+    })
+
     describe('on reject', () => {
         const sandbox = sinon.sandbox.create()
 

--- a/test/spec/unit/remote.js
+++ b/test/spec/unit/remote.js
@@ -49,6 +49,11 @@ describe('remote method', () => {
         client.requestHandler.createOptions({ path: startPath }, {}).headers.should.include({'Authorization': 'testValue'})
     })
 
+    it('should not add authorization header if not a string', () => {
+        var client = remote({authorization: ['testValue']})
+        Object.keys(client.requestHandler.createOptions({ path: startPath }, {}).headers).should.not.include('Authorization')
+    })
+
     describe('on reject', () => {
         const sandbox = sinon.sandbox.create()
 

--- a/test/spec/unit/remote.js
+++ b/test/spec/unit/remote.js
@@ -45,17 +45,12 @@ describe('remote method', () => {
     })
 
     it('should add authorization header if specified', () => {
-        var client = remote({authorization: 'testValue'})
+        var client = remote({headers: {Authorization: 'testValue'}})
         client.requestHandler.createOptions({ path: startPath }, {}).headers.should.include({'Authorization': 'testValue'})
     })
 
     it('should not add authorization header if not a string', () => {
-        var client = remote({authorization: ['testValue']})
-        Object.keys(client.requestHandler.createOptions({ path: startPath }, {}).headers).should.not.include('Authorization')
-    })
-
-    it('should not add authorization header if not present', () => {
-        var client = remote()
+        var client = remote({headers: {Authorization: ['testValue']}})
         Object.keys(client.requestHandler.createOptions({ path: startPath }, {}).headers).should.not.include('Authorization')
     })
 

--- a/test/spec/unit/remote.js
+++ b/test/spec/unit/remote.js
@@ -44,6 +44,11 @@ describe('remote method', () => {
         client.requestHandler.createOptions({ path: startPath }, {}).qs.should.include({testKey: 'testValue'})
     })
 
+    it('should add authorization header if specified', () => {
+        var client = remote({authorization: 'testValue'})
+        client.requestHandler.createOptions({ path: startPath }, {}).headers.should.include({'Authorization': 'testValue'})
+    })
+
     describe('on reject', () => {
         const sandbox = sinon.sandbox.create()
 


### PR DESCRIPTION
## Proposed changes

As with my previous pull request (https://github.com/webdriverio/webdriverio/pull/1977) this is to facilitate usage of a specialized tunnel or selenium instance where custom authorization may be required. This allows specifying of arbitrary HTTP headers to add on to selenium requests, our use case currently is for a custom `Authorization` header.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

I split this branch from master this afternoon, and it appears that there is a `describe.only` checked in for the `launcher.js` unit test, as well as some linting errors, I did not fix these problems, but can do so if necessary. 

### Reviewers: @christian-bromann
