### PR TITLE
Capture stacktrace after message modifying in ErrorHandler

### DIFF
--- a/lib/utils/ErrorHandler.js
+++ b/lib/utils/ErrorHandler.js
@@ -3,7 +3,6 @@ import { ERROR_CODES } from '../helpers/constants'
 class ErrorHandler extends Error {
     constructor (type, msg, details) {
         super()
-        Error.captureStackTrace(this, this.constructor)
 
         if (typeof msg === 'number') {
             // if ID is not known error throw UnknownError
@@ -72,6 +71,8 @@ class ErrorHandler extends Error {
                 this.seleniumStack = seleniumStack
             }
         }
+
+        Error.captureStackTrace(this, this.constructor)
     }
 
     /**

--- a/lib/utils/ErrorHandler.js
+++ b/lib/utils/ErrorHandler.js
@@ -72,7 +72,7 @@ class ErrorHandler extends Error {
             }
         }
 
-        Error.captureStackTrace(this, this.constructor)
+        Error.captureStackTrace(this, ErrorHandler)
     }
 
     /**

--- a/test/spec/unit/errorHandler.js
+++ b/test/spec/unit/errorHandler.js
@@ -25,4 +25,10 @@ describe('ErrorHandler', () => {
         error.name.should.be.equal('Error')
         error.message.should.be.equal('Some error in runtime')
     })
+
+    it('should capture stacktrace after message modifying', () => {
+        const error = new RuntimeError(1)
+
+        error.stack.should.match(/An unknown server-side error occurred while processing the command/)
+    })
 })

--- a/test/spec/unit/errorHandler.js
+++ b/test/spec/unit/errorHandler.js
@@ -26,6 +26,12 @@ describe('ErrorHandler', () => {
         error.message.should.be.equal('Some error in runtime')
     })
 
+    it('should have full stacktrace in error', () => {
+        const error = new ErrorHandler('some-error')
+
+        error.stack.should.match(new RegExp(process.cwd()))
+    })
+
     it('should capture stacktrace after message modifying', () => {
         const error = new RuntimeError(1)
 


### PR DESCRIPTION
## Proposed changes

[//]: `capturestacktrace` is unnecessary here and after babel processing stacktrace is lost. I left more information about this problem in issue https://github.com/webdriverio/webdriverio/issues/2275

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

### Reviewers: @christian-bromann
