### PR TITLE
Fix swipe is broken on Appium XCUITest driver

### DIFF
--- a/lib/commands/swipe.js
+++ b/lib/commands/swipe.js
@@ -11,7 +11,7 @@
  * @param {Number=} xoffset    x offset of swipe gesture (in pixels or relative units)
  * @param {Number=} yoffset    y offset of swipe gesture (in pixels or relative units)
  * @param {Number=} speed      time (in seconds) to spend performing the swipe
- * @uses protocol/element, protocol/touchFlick
+ * @uses protocol/element, protocol/touchFlick, protocol/touchPerform
  * @type mobile
  *
  */
@@ -32,6 +32,7 @@ let swipe = function (selector, xoffset, yoffset, speed) {
     /*!
      * command starts at a particular screen location
      */
+
     return this.element(selector).then((res) => {
         /**
          * check if element was found and throw error if not
@@ -40,7 +41,25 @@ let swipe = function (selector, xoffset, yoffset, speed) {
             throw new RuntimeError(7)
         }
 
-        return this.touchFlick(res.value.ELEMENT.toString(), xoffset, yoffset, speed)
+        let element = res.value.ELEMENT.toString()
+
+        if (this.isIOS) {
+            /**
+            * For Appium XCUITest driver, touchFlick is not available and
+            * only some combinations of actions for touchPerform are
+            * permitted.
+            * Please see appium-xcuitest-driver/lib/commands/gesture.js
+            * for more detail.
+            */
+            const actions = [
+                { action: 'press', options: { element } },
+                { action: 'moveTo', options: { x: xoffset, y: yoffset } },
+                { action: 'release' }
+            ]
+            return this.touchPerform(actions)
+        }
+
+        return this.touchFlick(element, xoffset, yoffset, speed)
     })
 }
 


### PR DESCRIPTION
## Proposed changes

webdriver.io uses touchFlick for swipe operations. But it is not supported by appium-xcuitest-driver.
Please search 'flick' on the repository https://github.com/appium/appium-xcuitest-driver 
to confirm that.

Instead, appium-xcuitest-driver accepts touchPerform command with restricted only some combinations of actions.

https://github.com/appium/appium-xcuitest-driver/blob/f834e2a2de1c5b1bf6763712496d7dcd246e779e/lib/commands/gesture.js#L71-L108

I fixed swipe operations on webdriver.io by using touchPerform on iOS to make it work with XCUITest driver.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

Could you please show me how to write tests for this change? I tried to write tests in `test/spec/mobile/ios`, but I didn't know how to do that (do I need to add some UI to test app?).

### Reviewers: @christian-bromann
