### PR TITLE
stop support for node < v4.8.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "wdio": "bin/wdio"
   },
   "engines": {
-    "node": ">= 0.12.0"
+    "node": ">= 4.8.5"
   },
   "scripts": {
     "build": "run-s clean compile copy",


### PR DESCRIPTION
Commit 91be48880989588d78d55dcc99ef7d1b3353df0a drops support for node < 4.8.5. This commit just updates package.json to match.

### Reviewers: @christian-bromann
