### PR TITLE
Enable support for both --inspect and --debug

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -295,14 +295,27 @@ class Launcher {
      */
     startInstance (specs, caps, cid, server) {
         let config = this.configParser.getConfig()
-        let debug = caps.debug || config.debug
         cid = this.getRunnerId(cid)
         let processNumber = this.processesStarted + 1
 
         // process.debugPort defaults to 5858 and is set even when process
         // is not being debugged.
-        let debugArgs = (debug)
-            ? [`--debug=${(process.debugPort + processNumber)}`] : []
+        let debugArgs = []
+        let debugType
+        let debugHost = ''
+        let debugPort = process.debugPort
+        for (let i in process.execArgv) {
+            let [, type, host] = process.execArgv[i].match('--(debug|inspect)(?:-brk)?(?:=(.*):)?')
+            if (type) {
+                debugType = type
+            }
+            if (host) {
+                debugHost = `${host}:`
+            }
+        }
+        if (debugType) {
+            debugArgs.push(`--${debugType}=${debugHost}${(debugPort + processNumber)}`)
+        }
 
         // if you would like to add --debug-brk, use a different port, etc...
         let capExecArgs = [


### PR DESCRIPTION
## Proposed changes

As promised in #2350 here's the pull request for enabling debugging for newer versions of node.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

I didn't have the chance to fully test this yet and I didn't update the documentation. The logic is put directly in `startInstance`, but could be broken out into its own function, which would make it unit testable. #2350 was done in a similar fashion, so I'm not sure unit tests are considered important for this functionality.

### Reviewers: @christian-bromann
