### PR TITLE
Fix #2417 Use https Agent when protocol is https

### DIFF
--- a/lib/utils/RequestHandler.js
+++ b/lib/utils/RequestHandler.js
@@ -1,5 +1,6 @@
 import url from 'url'
 import http from 'http'
+import https from 'https'
 import request from 'request'
 import merge from 'deepmerge'
 
@@ -8,7 +9,8 @@ import { isSuccessfulResponse } from '../helpers/utilities'
 import { RuntimeError } from './ErrorHandler'
 import pkg from '../../package.json'
 
-const agent = new http.Agent({ keepAlive: true })
+const httpAgent = new http.Agent({ keepAlive: true })
+const httpsAgent = new https.Agent({ keepAlive: true })
 
 /**
  * RequestHandler
@@ -90,7 +92,15 @@ class RequestHandler {
         newOptions.json = true
         newOptions.followAllRedirects = true
 
-        newOptions.agent = agent
+        if (this.defaultOptions.protocol === 'http') {
+            newOptions.agent = httpAgent
+        } else if (this.defaultOptions.protocol === 'https') {
+            newOptions.agent = httpsAgent
+        } else {
+            throw new RuntimeError('Unsupported protocol, must be http or https: ' +
+                this.defaultOptions.protocol)
+        }
+
         newOptions.headers = {
             'Connection': 'keep-alive',
             'Accept': 'application/json',

--- a/test/spec/unit/remote.js
+++ b/test/spec/unit/remote.js
@@ -1,4 +1,5 @@
 import http from 'http'
+import https from 'https'
 import { remote } from '../../../index.js'
 import RequestHandler from '../../../lib/utils/RequestHandler'
 import q from 'q'
@@ -44,6 +45,16 @@ describe('remote method', () => {
         var options = remote().requestHandler.createOptions({ path: startPath }, {})
         options.agent.should.be.an.instanceof(http.Agent)
         options.agent.keepAlive.should.be.equal(true)
+    })
+
+    it('should create https.Agent with keep-alive enabled if protocol is https', () => {
+        var options = remote({ protocol: 'https' }).requestHandler.createOptions({ path: startPath }, {})
+        options.agent.should.be.an.instanceof(https.Agent)
+        options.agent.keepAlive.should.be.equal(true)
+    })
+
+    it('should fail when trying to create request handler options with a bad protocol', () => {
+        expect(() => remote({ protocol: 'foo' }).requestHandler.createOptions({ path: startPath }, {})).to.throw()
     })
 
     it('should append query parameters to remote calls', () => {


### PR DESCRIPTION
## Proposed changes

FIx regression from 4ec65160 where http agent is used for http and https requests, causing all https requests to fail.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

I did wonder if there was a cleaner way to implement this, so that I didn't have to create two agents up front, when I am likely to only need one, but I couldn't find a nice way to do this.

### Reviewers: @christian-bromann
