### PR TITLE
Pass merge options to prevent cloning

### DIFF
--- a/lib/webdriverio.js
+++ b/lib/webdriverio.js
@@ -19,6 +19,7 @@ import hasElementResult from './helpers/hasElementResultHelper'
 
 const INTERNAL_EVENTS = ['init', 'command', 'error', 'result', 'end', 'screenshot']
 const PROMISE_FUNCTIONS = ['then', 'catch', 'finally']
+const MERGE_OPTIONS = { clone: false }
 
 let EventEmitter = events.EventEmitter
 
@@ -49,12 +50,12 @@ let WebdriverIO = function (args, modifier) {
         onError: [],
         connectionRetryTimeout: 90000,
         connectionRetryCount: 3
-    }, typeof args !== 'string' ? args : {})
+    }, typeof args !== 'string' ? args : {}, MERGE_OPTIONS)
 
     /**
      * define Selenium backend given on user options
      */
-    options = merge(detectSeleniumBackend(args), options)
+    options = merge(detectSeleniumBackend(args), options, MERGE_OPTIONS)
 
     /**
      * only set globals we wouldn't get otherwise
@@ -88,7 +89,7 @@ let WebdriverIO = function (args, modifier) {
         locationContextEnabled: true,
         handlesAlerts: true,
         rotatable: true
-    }, options.desiredCapabilities || {})
+    }, options.desiredCapabilities || {}, MERGE_OPTIONS)
 
     let { isMobile, isIOS, isAndroid } = mobileDetector(desiredCapabilities)
 


### PR DESCRIPTION
This fixes #2432 by forcing merge() to not clone by default to maintain passivity between deepmerge 1.x -> 2.x upgrade.



## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)


### Reviewers: @christian-bromann
