### PR TITLE
add "try it out" link to homepage docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -83,6 +83,8 @@ describe('webdriver.io api page', function() {
     });
 });
 ```
+    <a href="http://try.learnwebdriverio.com" class="button tryit icon-circle-arrow-right" target="_blank">Try It Out
+</a>
     </article>
 </div>
 


### PR DESCRIPTION
## Proposed changes

This adds the documentation changes needed to add a "try it out" button on the homepage documentation (which links to "try.learnwebdriverio.com"). A PR for the styles lives here: 
https://github.com/webdriverio/webdriver.io/pull/50

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Docs

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [n/a] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @christian-bromann
