### PR TITLE
Add session failure hook to allow retries

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -162,7 +162,23 @@ class Runner {
         global.$$ = (selector) => global.browser.elements(selector).value
 
         try {
-            let res = await global.browser.init()
+            let retries = 0
+            let retry = true
+            let res
+            while (retry) {
+                try {
+                    res = await global.browser.init()
+                    retry = false
+                } catch (e) {
+                    let shouldRetry = await this.runHook('sessionFailure', config, this.caps, this.specs, retries, e)
+                    retry = shouldRetry.some(x => x) // If any hook returned true, we retry.
+                    if (!retry) {
+                        throw e
+                    }
+                }
+                retries++
+            }
+
             global.browser.sessionId = res.sessionId
             this.haltSIGINT = false
 
@@ -443,13 +459,13 @@ class Runner {
     /**
      * run before/after session hook
      */
-    runHook (hookName, config, caps, specs) {
+    runHook (hookName, config, caps, specs, retries = 0, exception = null) {
         const catchFn = (e) => console.error(`Error in ${hookName}: ${e.stack}`)
 
         return Promise.all(
             config[hookName].map((hook) => {
                 try {
-                    return hook(config, caps, specs)
+                    return hook(config, caps, specs, retries, exception)
                 } catch (e) {
                     return catchFn(e)
                 }

--- a/lib/utils/ConfigParser.js
+++ b/lib/utils/ConfigParser.js
@@ -6,7 +6,7 @@ import merge from 'deepmerge'
 import detectSeleniumBackend from '../helpers/detectSeleniumBackend'
 
 const HOOKS = [
-    'before', 'beforeSession', 'beforeSuite', 'beforeHook', 'beforeTest', 'beforeCommand',
+    'before', 'beforeSession', 'sessionFailure', 'beforeSuite', 'beforeHook', 'beforeTest', 'beforeCommand',
     'afterCommand', 'afterTest', 'afterHook', 'afterSuite', 'afterSession', 'after',
     'beforeFeature', 'beforeScenario', 'beforeStep', 'afterFeature',
     'afterScenario', 'afterStep', 'onError', 'onReload'
@@ -52,6 +52,7 @@ const DEFAULT_CONFIGS = {
     onPrepare: NOOP,
     before: [],
     beforeSession: [],
+    sessionFailure: [],
     beforeSuite: [],
     beforeHook: [],
     beforeTest: [],


### PR DESCRIPTION
## Proposed changes

This implements the feature suggested in #2447. It's a callback to allow retries when session creation fails.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

As mentioned in #2447, we are already using this, since we urgently needed to improve our run rate. It's too early to evaluate the impact of this change, since we don't have enough runs yet, but it has allowed us to successfully recover when the session creation failed.

I haven't added any tests or any documentation yet, because I figured you might have opinions on the name of the hook, parameters, etc. and it's better to add the documentation when the implementation has been agreed upon.

### Reviewers: @christian-bromann
