### PR TITLE
Update touchId.js

### DIFF
--- a/lib/protocol/touchId.js
+++ b/lib/protocol/touchId.js
@@ -20,5 +20,5 @@
  */
 
 export default function touchId (match = true) {
-    return this.requestHandler.create('session/:session_id/appium/simulator/touch_id', { match })
+    return this.requestHandler.create('/session/:sessionId/appium/simulator/touch_id', { match })
 }


### PR DESCRIPTION
This is currently failing with the following error:

Error: The URL '/wd/hubsession/:session_id/appium/simulator/touch_id' did not map to a valid resource

According to the documents, you should be pointing to /wd/hub/session/{sessionId}/appium/simulator/touch_id. For more information, please visit: https://github.com/appium/appium-base-driver/blob/master/docs/mjsonwp/protocol-methods.md

Reviewers: @christian-bromann
