### PR TITLE
fix: 'request' in RequestHandler should be fulfilled if body is empty

### DIFF
--- a/lib/helpers/utilities.js
+++ b/lib/helpers/utilities.js
@@ -8,7 +8,7 @@ export function isSuccessfulResponse (body) {
      * response contains a body
      */
     if (!body) {
-        return false
+        return true
     }
 
     /**

--- a/test/spec/unit/utilities.js
+++ b/test/spec/unit/utilities.js
@@ -2,8 +2,8 @@ import { isSuccessfulResponse, isUnknownCommand } from '../../../lib/helpers/uti
 
 describe('utilities', () => {
     describe('isSuccessfulResponse', () => {
-        it('should fail when there is no error', () => {
-            expect(isSuccessfulResponse()).to.be.equal(false)
+        it('should not fail when there is no error', () => {
+            expect(isSuccessfulResponse()).to.be.equal(true)
         })
 
         it('should fail when status is not 0', () => {


### PR DESCRIPTION
## Proposed changes

We have problems in opera 12 like here https://github.com/webdriverio/webdriverio/pull/2291 again. Operadriver doesn't return body on `browser.url` request, so http call that returns empty body should be successfully resolved.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

### Reviewers: @christian-bromann @DudaGod
