### PR TITLE
Check type of argument before calling match on it

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -305,12 +305,15 @@ class Launcher {
         let debugHost = ''
         let debugPort = process.debugPort
         for (let i in process.execArgv) {
-            let [, type, host] = process.execArgv[i].match('--(debug|inspect)(?:-brk)?(?:=(.*):)?')
-            if (type) {
-                debugType = type
-            }
-            if (host) {
-                debugHost = `${host}:`
+            let arg = process.execArgv[i]
+            if (typeof (arg) === 'string') {
+                let [, type, host] = arg.match('--(debug|inspect)(?:-brk)?(?:=(.*):)?')
+                if (type) {
+                    debugType = type
+                }
+                if (host) {
+                    debugHost = `${host}:`
+                }
             }
         }
         if (debugType) {


### PR DESCRIPTION
## Proposed changes

Potentially fixes problem described in #2459.

> Something went wrong: TypeError: `process.execArgv[i].match` is not a function

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

I still need to test this with our project, but I thought I'd make a PR, so that @alippai can verify if this solves his problem.

### Reviewers: @christian-bromann
