### PR TITLE
fix: 'request' in RequestHandler should be fulfilled if body.status is 0

### DIFF
--- a/lib/helpers/utilities.js
+++ b/lib/helpers/utilities.js
@@ -12,6 +12,14 @@ export function isSuccessfulResponse (body) {
     }
 
     /**
+     *
+     * if it has a status property, it should be 0
+     */
+    if (body.status === 0) {
+        return true
+    }
+
+    /**
      * if it has a status property, it should be 0
      * (just here to stay backwards compatible to the jsonwire protocol)
      */

--- a/test/spec/unit/utilities.js
+++ b/test/spec/unit/utilities.js
@@ -6,6 +6,13 @@ describe('utilities', () => {
             expect(isSuccessfulResponse()).to.be.equal(false)
         })
 
+        it('should pass if status is 0', () => {
+            expect(isSuccessfulResponse({
+                status: 0,
+                value: {error: 'some-string'}
+            })).to.be.equal(true)
+        })
+
         it('should fail when status is not 0', () => {
             expect(isSuccessfulResponse({
                 status: 7,


### PR DESCRIPTION
## Proposed changes

In some cases error field in body is not empty, but status is `0`. `isSuccessfulResponse` should return `true` if `body.status` is 0.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @christian-bromann @j0tunn @sipayRT @DudaGod 
