### PR TITLE
fix: 'request' in RequestHandler should be fulfilled if response status is 'No content'

### DIFF
--- a/lib/helpers/utilities.js
+++ b/lib/helpers/utilities.js
@@ -3,7 +3,15 @@
  * @param  {Object}  body  body payload of response
  * @return {Boolean}       true if request was successful
  */
-export function isSuccessfulResponse (body) {
+export function isSuccessfulResponse (body, response) {
+    /**
+     * If response status is "No content" response is successful
+     * Hack for operadriver which returns empty body if status is "No content"
+     */
+    if (response && response.statusCode === 204) {
+        return true
+    }
+
     /**
      * response contains a body
      */

--- a/lib/utils/RequestHandler.js
+++ b/lib/utils/RequestHandler.js
@@ -206,7 +206,7 @@ class RequestHandler {
                 /**
                  * Resolve only if successful response
                  */
-                if (!err && isSuccessfulResponse(body)) {
+                if (!err && isSuccessfulResponse(body, response)) {
                     return resolve({body, response})
                 }
 

--- a/test/spec/unit/utilities.js
+++ b/test/spec/unit/utilities.js
@@ -2,6 +2,10 @@ import { isSuccessfulResponse, isUnknownCommand } from '../../../lib/helpers/uti
 
 describe('utilities', () => {
     describe('isSuccessfulResponse', () => {
+        it('should pass if response status is "No content"', () => {
+            expect(isSuccessfulResponse({}, {statusCode: 204})).to.be.equal(true)
+        })
+
         it('should fail when there is no error', () => {
             expect(isSuccessfulResponse()).to.be.equal(false)
         })


### PR DESCRIPTION
## Proposed changes

When response status is 204 (No content), operadriver returns empty body. I agree that returning `true` in case of empty body is not correct. But I think we can check response status and support this case.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @christian-bromann @DudaGod @sipayRT
