### PR TITLE
fix: cloud services examples readme typo

### DIFF
--- a/examples/cloudservices/README.md
+++ b/examples/cloudservices/README.md
@@ -26,7 +26,7 @@ export TESTINGBOT_SECRET="XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
 node ./examples/cloudservices/webdriverio.testingbot.js
 ```
 
-#### webdriverio.kobiton.js
+## webdriverio.kobiton.js
 ```sh
 export KOBITON_USERNAME="XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
 export KOBITON_ACCESS_KEY="XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"


### PR DESCRIPTION
## Proposed changes

There is an typo which cause inconsistency in `examples/cloudservices/README.md`

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

### Reviewers: @christian-bromann
