### PR TITLE
process.stdin.isTTY is false when running commands from a Node script

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -424,8 +424,9 @@ const launch = () => {
  * if stdin.isTTY, then no piped input is present and launcher should be
  * called immediately, otherwise piped input is processed, expecting
  * a list of files to process.
+ * stdin.isTTY is false when command is from nodes spawn since it's treated as a pipe
  */
-if (process.stdin.isTTY) {
+if (process.stdin.isTTY || !process.stdout.isTTY) {
     launch()
 } else {
     let stdinData = ''


### PR DESCRIPTION
## Proposed changes

Adding !process.stdout.isTTY which will allow launch() to be ran when called from a node script. Node's child_process spawn is treated as a pipe so the original process.stdin.isTTY is false and launch() would never get called.

Doing something like the following will never launch with just process.stdin.isTTY.

```
const { spawn } = require(`child_process`);

spawn(`./node_modules/.bin/wdio wdio.config.js --spec ./some/test/spec.js`);
```

## Types of changes

- [ x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc

## Further comments

If there is a better solution let me know.

### Reviewers: @christian-bromann
