### PR TITLE
Take care of failures when parsing execArgv that were causing crashes

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -305,12 +305,19 @@ class Launcher {
         let debugHost = ''
         let debugPort = process.debugPort
         for (let i in process.execArgv) {
-            let [, type, host] = process.execArgv[i].match('--(debug|inspect)(?:-brk)?(?:=(.*):)?')
-            if (type) {
-                debugType = type
-            }
-            if (host) {
-                debugHost = `${host}:`
+            try {
+                let [, type, host] = process.execArgv[i].match('--(debug|inspect)(?:-brk)?(?:=(.*):)?')
+                if (type) {
+                    debugType = type
+                }
+                if (host) {
+                    debugHost = `${host}:`
+                }
+            } catch (e) {
+                // There are currently two known failures:
+                // 1. process.execArgv[i] is not a string and match doesn't exist
+                // 2. match returns null and using it as an array fails
+                // We don't need to do anything about this and the loop can continue.
             }
         }
         if (debugType) {


### PR DESCRIPTION
## Proposed changes

Catch exceptions when parsing `execArgv` to prevent crashes.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

This addresses the issue raised by @tarun in #2467 and the issue raised by @alippai in #2459. It also makes #2461 redundant.

### Reviewers: @christian-bromann
