### PR TITLE
Fixed the launcher file running from wrapper context

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -305,14 +305,18 @@ class Launcher {
         let debugHost = ''
         let debugPort = process.debugPort
         for (let i in process.execArgv) {
-            let [, type, host] = process.execArgv[i].match('--(debug|inspect)(?:-brk)?(?:=(.*):)?')
-            if (type) {
-                debugType = type
-            }
-            if (host) {
-                debugHost = `${host}:`
+            const debugArgs = process.execArgv[i].match('--(debug|inspect)(?:-brk)?(?:=(.*):)?')
+            if (debugArgs) {
+                let [, type, host] = debugArgs
+                if (type) {
+                    debugType = type
+                }
+                if (host) {
+                    debugHost = `${host}:`
+                }
             }
         }
+
         if (debugType) {
             debugArgs.push(`--${debugType}=${debugHost}${(debugPort + processNumber)}`)
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "webdriverio",
-  "version": "4.9.10",
+  "version": "4.9.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

This PR fixes the issue when WDIO launcher is run programatically from the code that is run from any wrapper (e.g. `nodemon`) so the arguments are empty and `.match` returns `null` and destructuring the array is impossible.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @christian-bromann
