### PR TITLE
add elementIdProperty W3C command and use it in getValue

### DIFF
--- a/lib/commands/getValue.js
+++ b/lib/commands/getValue.js
@@ -18,7 +18,7 @@
  * @alias browser.getValue
  * @param   {String} selector input, textarea, or select element
  * @return {String}          requested input value
- * @uses protocol/elements, protocol/elementIdAttribute
+ * @uses protocol/elements, protocol/elementIdProperty
  * @type property
  *
  */
@@ -34,12 +34,12 @@ let getValue = function (selector) {
             throw new CommandError(7, selector || this.lastResult.selector)
         }
 
-        let elementIdAttributeCommands = []
+        let elementIdPropertyCommands = []
         for (let elem of res.value) {
-            elementIdAttributeCommands.push(this.elementIdAttribute(elem.ELEMENT, 'value'))
+            elementIdPropertyCommands.push(this.elementIdProperty(elem.ELEMENT, 'value'))
         }
 
-        return this.unify(elementIdAttributeCommands, {
+        return this.unify(elementIdPropertyCommands, {
             extractValue: true
         })
     })

--- a/lib/protocol/elementIdProperty.js
+++ b/lib/protocol/elementIdProperty.js
@@ -1,0 +1,33 @@
+/**
+ *
+ * Get the value of an element's property.
+ *
+ * @param {String} ID             ID of a WebElement JSON object to route the command to
+ * @param {String} propertyName  property name of element you want to receive
+ *
+ * @return {String|null} The value of the property, or null if it is not set on the element.
+ *
+ * @see  https://w3c.github.io/webdriver/webdriver-spec.html#dfn-get-element-property
+ * @type protocol
+ *
+ */
+
+import { ProtocolError } from '../utils/ErrorHandler'
+import { isUnknownCommand } from '../helpers/utilities'
+
+export default function elementIdProperty (id, propertyName) {
+    if ((typeof id !== 'string' && typeof id !== 'number') || typeof propertyName !== 'string') {
+        throw new ProtocolError('number or type of arguments don\'t agree with elementIdProperty protocol command')
+    }
+
+    return this.requestHandler.create(`/session/:sessionId/element/${id}/property/${propertyName}`).catch((err) => {
+        /**
+         * use old path if W3C path failed
+         */
+        if (isUnknownCommand(err)) {
+            return this.requestHandler.create(`/session/:sessionId/element/${id}/attribute/${propertyName}`)
+        }
+
+        throw err
+    })
+}


### PR DESCRIPTION
## Proposed changes

DOM properties and HTML attributes are not the same. Currently `browser.getValue` command uses W3C protocol command `/attribute` which is wrong because getValue should return current value of the DOM property and not a value of HTML attribute. 

In geckodriver `/attribute` returns null while `/property` works fine.
In chromedriver `/attribute` somehow mashes up this terms. Currently `/property` is not implemented in chromedriver but they have an open issue to implement it.

The change is to add `/property` command and use it in getValue but fallback to `/attribute` command in case `/property` is not supported.

I run test:desktop with both chrome and firefox.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @christian-bromann
