### PR TITLE
Fix for error handling on before/after hooks

### DIFF
--- a/lib/utils/BaseReporter.js
+++ b/lib/utils/BaseReporter.js
@@ -162,7 +162,7 @@ class BaseReporter extends events.EventEmitter {
      * @api private
      */
     color (type, str) {
-        if (!supportsColor) return String(str)
+        if (!supportsColor.stdout) return String(str)
         return `\u001b[${COLORS[type]}m${str}\u001b[0m`
     }
 

--- a/lib/utils/BaseReporter.js
+++ b/lib/utils/BaseReporter.js
@@ -162,7 +162,7 @@ class BaseReporter extends events.EventEmitter {
      * @api private
      */
     color (type, str) {
-        if (!supportsColor.stdout) return String(str)
+        if (!supportsColor) return String(str)
         return `\u001b[${COLORS[type]}m${str}\u001b[0m`
     }
 

--- a/lib/utils/ReporterStats.js
+++ b/lib/utils/ReporterStats.js
@@ -307,14 +307,13 @@ class ReporterStats extends RunnableStats {
             runner.err.stack = runner.err.stack.replace(message, replacement)
         }
 
-        testStats = this.getTestStats(runner)
-
-        /**
-         * if before block fails that is located before any describe block (Mocha specific)
-         * register failure on previous beforeAll hook
-         */
-        if (!testStats && Object.keys(this.runners).length === 1) {
-            testStats = this.runners
+        try {
+            testStats = this.getTestStats(runner) || {};
+        } catch (e) {
+            // If a test fails during the before() or beforeEach() hook, it will not yet
+            // have been 'started', so start now
+            this.testStart(runner);
+            testStats = this.getTestStats(runner);
         }
 
         testStats.state = 'fail'

--- a/lib/utils/ReporterStats.js
+++ b/lib/utils/ReporterStats.js
@@ -308,12 +308,12 @@ class ReporterStats extends RunnableStats {
         }
 
         try {
-            testStats = this.getTestStats(runner) || {};
+            testStats = this.getTestStats(runner) || {}
         } catch (e) {
             // If a test fails during the before() or beforeEach() hook, it will not yet
             // have been 'started', so start now
-            this.testStart(runner);
-            testStats = this.getTestStats(runner);
+            this.testStart(runner)
+            testStats = this.getTestStats(runner)
         }
 
         testStats.state = 'fail'


### PR DESCRIPTION
## Proposed changes

In reference to https://github.com/webdriverio/webdriverio/issues/2494

Tested on mocha and jasmine. It seems to be working when the hooks are before or inside of describe.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

### Reviewers: @christian-bromann
