### PR TITLE
Jim D | Support context being passed from wdio-mocha-framework

### DIFF
--- a/lib/utils/ReporterStats.js
+++ b/lib/utils/ReporterStats.js
@@ -341,7 +341,7 @@ class ReporterStats extends RunnableStats {
     testEnd (runner) {
         this.getTestStats(runner).complete()
         this.counts.tests++
-        if(runner.context) { this.getTestStats(runner).context = runner.context }
+        if (runner.context) { this.getTestStats(runner).context = runner.context }
     }
 
     suiteEnd (runner) {

--- a/lib/utils/ReporterStats.js
+++ b/lib/utils/ReporterStats.js
@@ -341,6 +341,7 @@ class ReporterStats extends RunnableStats {
     testEnd (runner) {
         this.getTestStats(runner).complete()
         this.counts.tests++
+        if(runner.context) { this.getTestStats(runner).context = runner.context }
     }
 
     suiteEnd (runner) {


### PR DESCRIPTION
## Proposed changes

This change adds support for passing a customizable ```context``` key that was implemented in [wdio-mocha-framework issue 114](https://github.com/webdriverio/wdio-mocha-framework/issues/114)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

I wasn't able to find any unit tests for ```ReporterStats.js``` as part of the v5 effort I'd be more than happy to figure out how we can get some setup.

### Reviewers: @christian-bromann
