### PR TITLE
Add support for filtering specs

### DIFF
--- a/docs/guide/testrunner/organizesuite.md
+++ b/docs/guide/testrunner/organizesuite.md
@@ -85,30 +85,36 @@ exports.config = {
 }
 ```
 
-If you now want to run a single suite only you can pass the suite name as cli argument like
+Now, if you want to only run a single suite, you can pass the suite name as cli argument like:
 
 ```sh
 $ wdio wdio.conf.js --suite login
 ```
 
-or run multiple suites at once
+or run multiple suites at once:
 
 ```sh
 $ wdio wdio.conf.js --suite login,otherFeature
 ```
 
-## Run Single Test Specs
+## Run Selected Tests
 
-If you are working on your WebdriverIO tests you don't want to execute your whole suite everytime you added an assertion or any other code. With the `--spec` parameter you can specify which suite (Mocha, Jasmine) or feature (Cucumber) should be run. For example if you only want to run your login test, do:
+In some cases, you may wish to only execute a single test or a subset of your suites. With the `--spec` parameter you can specify which suite (Mocha, Jasmine) or feature (Cucumber) should be run. For example if you only want to run your login test, do:
 
 ```sh
 $ wdio wdio.conf.js --spec ./test/specs/e2e/login.js
 ```
 
-or run multiple specs at once
+or run multiple specs at once:
 
 ```sh
 $ wdio wdio.conf.js --spec ./test/specs/signup.js,./test/specs/forgot-password.js
+```
+
+If the spec passed in is not a path to a spec file, it is used as a filter for the specs defined in your configuration file. To run all specs with the word 'dialog' in them, you could use:
+
+```sh
+$ wdio wdio.conf.js --spec dialog
 ```
 
 Note that each test file is running in a single test runner process. Since we don't scan files in advance (see the next section for information on piping filenames to `wdio`) you _can't_ use for example `describe.only` at the top of your spec file to say Mocha to only run that suite. This feature will help you though to do that in the same way.

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -94,7 +94,7 @@ optimist
     .describe('reporters', 'reporters to print out the results on stdout')
     .alias('reporters', 'r')
     .describe('suite', 'overwrites the specs attribute and runs the defined suite')
-    .describe('spec', 'specifies spec file(s) or filter(s) for specs piped from stdin')
+    .describe('spec', 'specifies spec file(s) to run or filter(s) for specs defined in the specs attribute')
     .describe('cucumberOpts.*', 'Cucumber options, see the full list options at https://github.com/webdriverio/wdio-cucumber-framework#cucumberopts-options')
     .describe('jasmineOpts.*', 'Jasmine options, see the full list options at https://github.com/webdriverio/wdio-jasmine-framework#jasminenodeopts-options')
     .describe('mochaOpts.*', 'Mocha options, see the full list options at http://mochajs.org')

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -94,7 +94,7 @@ optimist
     .describe('reporters', 'reporters to print out the results on stdout')
     .alias('reporters', 'r')
     .describe('suite', 'overwrites the specs attribute and runs the defined suite')
-    .describe('spec', 'run only a certain spec file - overrides specs piped from stdin')
+    .describe('spec', 'specifies spec file(s) or filter(s) for specs piped from stdin')
     .describe('cucumberOpts.*', 'Cucumber options, see the full list options at https://github.com/webdriverio/wdio-cucumber-framework#cucumberopts-options')
     .describe('jasmineOpts.*', 'Jasmine options, see the full list options at https://github.com/webdriverio/wdio-jasmine-framework#jasminenodeopts-options')
     .describe('mochaOpts.*', 'Mocha options, see the full list options at http://mochajs.org')

--- a/lib/utils/ConfigParser.js
+++ b/lib/utils/ConfigParser.js
@@ -152,23 +152,32 @@ class ConfigParser {
         this._capabilities = merge(this._capabilities, this._config.capabilities || defaultTo, MERGE_OPTIONS)
 
         /**
-         * run single spec file only, regardless of multiple-spec specification
+         * run only specified spec files, regardless of multiple-spec specification
+         * If spec is a file on disk, it is set as the current spec, if it is not, it
+         * is treated as a string match filter for the multiple-spec specification.
          */
         if (typeof object.spec === 'string') {
-            const specs = []
+            const specs = new Set()
             const specList = object.spec.split(/,/g)
+            const specsList = ConfigParser.getFilePaths(this._config.specs)
 
             for (let spec of specList) {
                 if (fs.existsSync(spec)) {
-                    specs.push(path.resolve(process.cwd(), spec))
+                    specs.add(path.resolve(process.cwd(), spec))
+                } else {
+                    specsList.forEach(file => {
+                        if (file.match(spec)) {
+                            specs.add(file)
+                        }
+                    })
                 }
             }
 
-            if (specs.length === 0) {
+            if (specs.size === 0) {
                 throw new Error(`spec file ${object.spec} not found`)
             }
 
-            this._config.specs = specs
+            this._config.specs = [...specs]
         }
 
         /**

--- a/test/spec/unit/launcher.js
+++ b/test/spec/unit/launcher.js
@@ -43,7 +43,7 @@ describe('launcher', () => {
             expect(() => launcher.configParser.getSpecs()).to.throw(/The suite\(s\) "foo" you specified don't exist/)
         })
 
-        it('should allow to pass spec as cli argument to run only once test file', () => {
+        it('should allow to pass spec as cli argument to run only one test file', () => {
             let launcher = new Launcher(path.join(FIXTURE_ROOT, 'suite.wdio.conf.js'), {
                 spec: './test/spec/unit/launcher.js'
             })
@@ -60,6 +60,15 @@ describe('launcher', () => {
             specs.should.have.length(2)
             specs[0].should.endWith(path.resolve('test', 'spec', 'unit', 'launcher.js'))
             specs[1].should.endWith(path.resolve('lib', 'webdriverio.js'))
+        })
+
+        it('should filter specs with spec as a cli argument', () => {
+            let launcher = new Launcher(path.join(FIXTURE_ROOT, 'suite.wdio.conf.js'), {
+                spec: 'index'
+            })
+            let specs = launcher.configParser.getSpecs()
+            specs.should.have.length(1)
+            specs[0].should.contain('index.js')
         })
 
         it('should throw if specified spec file doesnt exist', () => {


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

This change modifies the `--spec` command line option to treat any of the specified strings as a regex to apply against the set of specs defined in the configuration file. This makes it possible to easily execute a subset of specs without specifying the full path.  This should be fully backwards compatible .  For example:

```sh
$ wdio wdio.conf.js --spec dialog
```

This will execute any spec file whose name contains the word 'dialog'.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

One (possible?) downside to this change is that when `--spec` is supplied on the command line, the runner will glob the files twice.  The second time, it should only be globbing against actual filenames so this doesn't seem like a bad trade-off. It is possible this could be done through a different command line option, but it seems a natural fit for the existing `--spec` option.

### Reviewers: @christian-bromann
