### PR TITLE
Changes formatting of param documentation for getElementSize

### DIFF
--- a/lib/commands/getElementSize.js
+++ b/lib/commands/getElementSize.js
@@ -27,7 +27,7 @@
  *
  * @alias browser.getElementSize
  * @param   {String}  selector element with requested size
- * @param   {String*} prop     size to receive (optional "width|height")
+ * @param   {String*} prop     size to receive [optional] ("width" or "height")
  * @return {Object|Number}    requested element size (`{ width: <Number>, height: <Number> }`) or actual width/height as number if prop param is given
  * @uses protocol/elements, protocol/elementIdSize
  * @type property


### PR DESCRIPTION
## Proposed changes

Currently doc for param in getElementSize uses `|` which is probably interpreted as table cell so it looks like this:

![image](https://user-images.githubusercontent.com/5216143/34484229-a9e88366-efc3-11e7-985e-4ea75d83aa7c.png)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [N/A] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

N/A

### Reviewers: @christian-bromann
