### PR TITLE
Correction to afterTest description

### DIFF
--- a/docs/guide/testrunner/configurationfile.md
+++ b/docs/guide/testrunner/configurationfile.md
@@ -285,7 +285,7 @@ exports.config = {
     afterHook: function () {
     },
     /**
-     * Function to be executed before a test (in Mocha/Jasmine) or a step (in Cucumber) starts.
+     * Function to be executed before a test (in Mocha/Jasmine) or a step (in Cucumber) ends.
      * @param {Object} test test details
      */
     beforeTest: function (test) {

--- a/docs/guide/testrunner/configurationfile.md
+++ b/docs/guide/testrunner/configurationfile.md
@@ -279,13 +279,13 @@ exports.config = {
     beforeHook: function () {
     },
     /**
-     * Hook that gets executed _after_ a hook within the suite starts (e.g. runs after calling
+     * Hook that gets executed _after_ a hook within the suite ends (e.g. runs after calling
      * afterEach in Mocha)
      */
     afterHook: function () {
     },
     /**
-     * Function to be executed before a test (in Mocha/Jasmine) or a step (in Cucumber) ends.
+     * Function to be executed before a test (in Mocha/Jasmine) or a step (in Cucumber) starts.
      * @param {Object} test test details
      */
     beforeTest: function (test) {

--- a/docs/guide/testrunner/configurationfile.md
+++ b/docs/guide/testrunner/configurationfile.md
@@ -307,7 +307,7 @@ exports.config = {
     afterCommand: function (commandName, args, result, error) {
     },
     /**
-     * Function to be executed after a test (in Mocha/Jasmine) or a step (in Cucumber) starts.
+     * Function to be executed after a test (in Mocha/Jasmine) or a step (in Cucumber) ends.
      * @param {Object} test test details
      */
     afterTest: function (test) {

--- a/examples/pageobject/wdio.conf.js
+++ b/examples/pageobject/wdio.conf.js
@@ -129,7 +129,7 @@ exports.config = {
     // beforeHook: function () {
     // },
     //
-    // Hook that gets executed _after_ a hook within the suite starts (e.g. runs after calling
+    // Hook that gets executed _after_ a hook within the suite ends (e.g. runs after calling
     // afterEach in Mocha)
     // afterHook: function () {
     // },
@@ -146,7 +146,7 @@ exports.config = {
     // afterCommand: function (commandName, args, result, error) {
     // },
     //
-    // Function to be executed after a test (in Mocha/Jasmine) or a step (in Cucumber) starts.
+    // Function to be executed after a test (in Mocha/Jasmine) or a step (in Cucumber) ends.
     // afterTest: function (test) {
     // },
     //

--- a/examples/wdio.conf.js
+++ b/examples/wdio.conf.js
@@ -246,7 +246,7 @@ exports.config = {
     beforeHook: function () {
     },
     /**
-     * Hook that gets executed _after_ a hook within the suite starts (e.g. runs after calling
+     * Hook that gets executed _after_ a hook within the suite ends (e.g. runs after calling
      * afterEach in Mocha)
      */
     afterHook: function () {
@@ -275,7 +275,7 @@ exports.config = {
     afterCommand: function (commandName, args, result, error) {
     },
     /**
-     * Function to be executed after a test (in Mocha/Jasmine) or a step (in Cucumber) starts.
+     * Function to be executed after a test (in Mocha/Jasmine) or a step (in Cucumber) ends.
      * @param {Object} test test details
      */
     afterTest: function (test) {

--- a/lib/helpers/wdio.conf.ejs
+++ b/lib/helpers/wdio.conf.ejs
@@ -273,13 +273,13 @@ exports.config = {
     // beforeHook: function () {
     // },
     /**
-     * Hook that gets executed _after_ a hook within the suite starts (e.g. runs after calling
+     * Hook that gets executed _after_ a hook within the suite ends (e.g. runs after calling
      * afterEach in Mocha)
      */
     // afterHook: function () {
     // },
     /**
-     * Function to be executed after a test (in Mocha/Jasmine) or a step (in Cucumber) starts.
+     * Function to be executed after a test (in Mocha/Jasmine) or a step (in Cucumber) ends.
      * @param {Object} test test details
      */
     // afterTest: function (test) {


### PR DESCRIPTION
afterTest previous described as to be executed after a test "starts"; should be after the test ends of course.

## Proposed changes

[//]: #Minor documentation fix to docs/guide/testrunner/configurationfile.md

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments



### Reviewers: @christian-bromann
