### PR TITLE
Developer Guide → Copy Edits → Move one line after the heading

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -43,9 +43,10 @@ $ curl -L https://github.com/mozilla/geckodriver/releases/download/v0.16.0/gecko
 
 Note: Other geckodriver releases are available [here](https://github.com/mozilla/geckodriver/releases).
 
+** 4. Start selenium standalone server**
+
 Start the server by executing the following:
 
-** 4. Start selenium standalone server**
 ```sh
 $ java -jar -Dwebdriver.gecko.driver=./geckodriver selenium-server-standalone-3.5.3.jar
 ```


### PR DESCRIPTION
The line "Start the server by executing the following" should have been after the heading "Start selenium standalone server"

## Proposed changes

Small tweak to [Developer Guide](http://webdriver.io/guide.html) page, where one of the lines was in the incorrect heading section.

| `currently` | `proposed` |
| ---------- | ---------- |
| <img src="https://cl.ly/161E250F3u2g/Image%202018-02-01%20at%2012.11.58%20AM.png" /> | <img src="https://cl.ly/2X1w103c433g/Image%202018-02-01%20at%2012.14.35%20AM.png" /> |

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [ ] ~I have added necessary documentation (if appropriate)~

### Reviewers: @christian-bromann
