### PR TITLE
Add another UnknownCommand indicator

### DIFF
--- a/lib/helpers/utilities.js
+++ b/lib/helpers/utilities.js
@@ -55,6 +55,7 @@ export function isUnknownCommand (err) {
         err.message.match(/did not match a known command/) ||
         err.message.match(/unknown command/) ||
         err.message.match(/Driver info: driver\.version: unknown/) ||
+        err.message.match(/Method has not yet been implemented/) ||
         err.message.match(/did not map to a valid resource/)
     ) {
         return true


### PR DESCRIPTION
Error message "Method has not yet been implemented" was added, has seen with Appium 1.7.2 while running on iOS

## Proposed changes

# To solve issue #2574 I added the message "Method has not yet been implemented" as a message indicating that this is an unknown command

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments
I wanted to add unit test for my change but i could not figure out how to run the mobile tests (which I assume I'd need, since I can only reproduce this issue in a specific case with Appium on iOS).  Anyway, I tried the change with my existing test that was erroring out and it passed with flying colors. For a one line change, I hope this is sufficient.

### Reviewers: @christian-bromann
