### PR TITLE
[Fix documentation] allure open command

### DIFF
--- a/docs/guide/reporters/allure.md
+++ b/docs/guide/reporters/allure.md
@@ -60,7 +60,7 @@ Apply and restart the Jenkins server. All assets should now be served correctly.
 Install the [Allure command-line tool](https://www.npmjs.com/package/allure-commandline), and process the results directory:
 
 ```sh
-$ allure generate [allure_output_dir] && allure report open
+$ allure generate [allure_output_dir] && allure open
 ```
 
 This will generate a report (by default in `./allure-report`), and open it in your browser:


### PR DESCRIPTION
## Proposed changes

It seems that the allure CLI may have changed since this documentation was written. At the moment the correct command for generating and opening reports is 
`allure generate [allure_output_dir] && allure open`

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

### Reviewers: @christian-bromann
