### PR TITLE
Update getHTML.js - update return information

### DIFF
--- a/lib/commands/getHTML.js
+++ b/lib/commands/getHTML.js
@@ -1,6 +1,6 @@
 /**
  *
- * Get source code of specified DOM element by selector.
+ * Get source code of specified DOM element(s) by selector. Returns an array if there are multiple elements with this selector.
  *
  * <example>
     :index.html


### PR DESCRIPTION
I propose to change the documentation for `getHTML()` as it was unclear to me that it returns an array of strings when there are several elements with this selector. I only found this out by trial and error and could have saved myself a lot of time if I would have known that it returns an array (I thought it would only return the string of the first element found with this selector). 