### PR TITLE
fix: Two functions in launcher were missing 2nd argument in reduce fn

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -277,7 +277,7 @@ class Launcher {
      * @return {number} number of running instances
      */
     getNumberOfRunningInstances () {
-        return this.schedule.map((a) => a.runningInstances).reduce((a, b) => a + b)
+        return this.schedule.map((a) => a.runningInstances).reduce((a, b) => a + b, 0)
     }
 
     /**
@@ -285,7 +285,7 @@ class Launcher {
      * @return {number} specs left to complete suite
      */
     getNumberOfSpecsLeft () {
-        return this.schedule.map((a) => a.specs.length).reduce((a, b) => a + b)
+        return this.schedule.map((a) => a.specs.length).reduce((a, b) => a + b, 0)
     }
 
     /**


### PR DESCRIPTION
## Proposed changes

When I am running webdriverio on jenkins, I can see error 
```
TypeError: Reduce of empty array with no initial value
    at Array.reduce (native)
    at Launcher.getNumberOfRunningInstances (/mnt/jenkins/workspace/encore-wdio-tests/encore/node_modules/webdriverio/build/lib/launcher.js:522:16)
    at Launcher.runSpecs (/mnt/jenkins/workspace/encore-wdio-tests/encore/node_modules/webdriverio/build/lib/launcher.js:453:25)
    at /mnt/jenkins/workspace/encore-wdio-tests/encore/node_modules/webdriverio/build/lib/launcher.js:354:47

```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @christian-bromann
