### PR TITLE
Support '.es6' files

### DIFF
--- a/lib/utils/ConfigParser.js
+++ b/lib/utils/ConfigParser.js
@@ -290,12 +290,22 @@ class ConfigParser {
 
         for (let pattern of patterns) {
             let filenames = glob.sync(pattern)
+            
+            let patternExtension = ''
+            if (pattern.indexOf('.') !== -1) {
+                let patternParts = pattern.split('.')
+                patternExtension = '.' + patternParts.pop()
+                if (patternExtension.indexOf('*') !== -1) {
+                    patternExtension = ''
+                }
+            }
 
             filenames = filenames.filter(filename =>
                 filename.slice(-3) === '.js' ||
                 filename.slice(-3) === '.ts' ||
                 filename.slice(-8) === '.feature' ||
-                filename.slice(-7) === '.coffee')
+                filename.slice(-7) === '.coffee' ||
+                (patternExtension.length > 0 && filename.slice(-patternExtension.length) === patternExtension))
 
             filenames = filenames.map(filename =>
                 path.isAbsolute(filename) ? path.normalize(filename) : path.resolve(process.cwd(), filename))


### PR DESCRIPTION
In our project, we are suffixing all module files targeting ecmascript 6 with '.es6', because of several reasons, mainly because our IDE will interpret '.js' as ecmascript 5 and give many error messages.

I tried to set the pattern to '*.spec.es6' but it would not work. I think that, if I have specified an extension in the pattern, it should be allowed through. But if the extension is a star, or contains a star, you should only pick JS-files, as before.

## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @christian-bromann
