### PR TITLE
Add new selector strategies from WebdriverAgent

### DIFF
--- a/docs/guide/usage/selectors.md
+++ b/docs/guide/usage/selectors.md
@@ -117,6 +117,22 @@ browser.click('ios=' + selector);
 
 You can also use predicate searching within iOS UI Automation in Appium, to control element finding even further. See [here](https://github.com/appium/appium/blob/master/docs/en/writing-running-appium/ios_predicate.md) for details.
 
+### iOS XCUITest predicate strings and class chains
+
+With iOS 10 and above (using the XCUITest driver), you can use [predicate strings](https://github.com/facebook/WebDriverAgent/wiki/Predicate-Queries-Construction-Rules):
+
+```js
+var selector = 'type == \'XCUIElementTypeSwitch\' && name CONTAINS \'Allow\'';
+browser.click('ios=predicate=' + selector);
+```
+
+And [class chains](https://github.com/facebook/WebDriverAgent/wiki/Class-Chain-Queries-Construction-Rules):
+
+```js
+var selector = '**/XCUIElementTypeCell[`name BEGINSWITH "D"`]/**/XCUIElementTypeButton';
+browser.click('ios=chain=' + selector);
+```
+
 ### Accessibility ID
 
 The `accessibility id` locator strategy is designed to read a unique identifier for a UI element. This has the benefit of not changing during localization or any other process that might change text. In addition, it can be an aid in creating cross-platform tests, if elements that are functionally the same have the same accessibility id.

--- a/lib/helpers/findElementStrategy.js
+++ b/lib/helpers/findElementStrategy.js
@@ -1,7 +1,7 @@
 import { ProtocolError } from '../utils/ErrorHandler'
 
 const DEFAULT_SELECTOR = 'css selector'
-const DIRECT_SELECTOR_REGEXP = /^(id|css selector|xpath|link text|partial link text|name|tag name|class name|-android uiautomator|-ios uiautomation|accessibility id):(.+)/
+const DIRECT_SELECTOR_REGEXP = /^(id|css selector|xpath|link text|partial link text|name|tag name|class name|-android uiautomator|-ios uiautomation|-ios predicate string|-ios class chain|accessibility id):(.+)/
 
 let findStrategy = function (...args) {
     let value = args[0]
@@ -63,10 +63,22 @@ let findStrategy = function (...args) {
         using = '-android uiautomator'
         value = value.slice(8)
 
-    // recursive element search using the UIAutomation library (iOS-only)
+    // recursive element search using the UIAutomation or XCUITest library (iOS-only)
     } else if (value.indexOf('ios=') === 0) {
-        using = '-ios uiautomation'
         value = value.slice(4)
+
+        if (value.indexOf('predicate=') === 0) {
+            // Using 'ios=predicate=' (iOS 10+ only)
+            using = '-ios predicate string'
+            value = value.slice(10)
+        } else if (value.indexOf('chain=') === 0) {
+            // Using 'ios=chain=' (iOS 10+ only)
+            using = '-ios class chain'
+            value = value.slice(6)
+        } else {
+            // Legacy iOS (<= 9.3) UIAutomation library
+            using = '-ios uiautomation'
+        }
 
     // recursive element search using accessibility id
     } else if (value.indexOf('~') === 0) {

--- a/test/spec/unit/selectors.js
+++ b/test/spec/unit/selectors.js
@@ -152,6 +152,18 @@ describe('selector strategies helper', () => {
         element.value.should.be.equal('foo')
     })
 
+    it('should find an element by predicate string strategy (ios >= 10 only)', () => {
+        const element = findStrategy('ios=predicate=foo')
+        element.using.should.be.equal('-ios predicate string')
+        element.value.should.be.equal('foo')
+    })
+
+    it('should find an element by class chain strategy (ios >= 10 only)', () => {
+        const element = findStrategy('ios=chain=foo')
+        element.using.should.be.equal('-ios class chain')
+        element.value.should.be.equal('foo')
+    })
+
     it('should find an element by accessibility id', () => {
         const element = findStrategy('~foo')
         element.using.should.be.equal('accessibility id')
@@ -185,10 +197,24 @@ describe('selector strategies helper', () => {
         element.value.should.be.equal(selector)
     })
 
-    it('should find an element by ios accessibility id', () => {
+    it('should find an element by ios UiAutomation', () => {
         const selector = 'UIATarget.localTarget().frontMostApp().mainWindow().buttons()[0]'
         const element = findStrategy('ios=' + selector)
         element.using.should.be.equal('-ios uiautomation')
+        element.value.should.be.equal(selector)
+    })
+
+    it('should find an element by ios XCUITest Predicate String', () => {
+        const selector = 'type === \'XCUITestTypeButton\' && name CONTAINS \'Enable\''
+        const element = findStrategy('ios=predicate=' + selector)
+        element.using.should.be.equal('-ios predicate string')
+        element.value.should.be.equal(selector)
+    })
+
+    it('should find an element by ios XCUITest Class Chain', () => {
+        const selector = '**/XCUIElementTypeCell[`name BEGINSWITH "B"`]'
+        const element = findStrategy('ios=chain=' + selector)
+        element.using.should.be.equal('-ios class chain')
         element.value.should.be.equal(selector)
     })
 
@@ -233,6 +259,12 @@ describe('selector strategies helper', () => {
         element = findStrategy('-ios uiautomation:foobar -ios uiautomation')
         element.using.should.be.equal('-ios uiautomation')
         element.value.should.be.equal('foobar -ios uiautomation')
+        element = findStrategy('-ios predicate string:foobar -ios predicate string')
+        element.using.should.be.equal('-ios predicate string')
+        element.value.should.be.equal('foobar -ios predicate string')
+        element = findStrategy('-ios class chain:foobar -ios class chain')
+        element.using.should.be.equal('-ios class chain')
+        element.value.should.be.equal('foobar -ios class chain')
         element = findStrategy('accessibility id:foobar accessibility id')
         element.using.should.be.equal('accessibility id')
         element.value.should.be.equal('foobar accessibility id')


### PR DESCRIPTION
## Proposed changes

Adds Predicate String and Class Chain query types from [WebDriverAgent](https://github.com/facebook/WebDriverAgent/wiki/Queries).

More info for [Predicate Strings](https://github.com/facebook/WebDriverAgent/wiki/Predicate-Queries-Construction-Rules) and [Class Chains](https://github.com/facebook/WebDriverAgent/wiki/Class-Chain-Queries-Construction-Rules)

Relates to appium/appium#8898

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

I felt it would be easier to append to the existing `ios=` selector string to retain the context that this is still iOS-specific, but still benefit from an explicitly named selector strategy, without being too wordy.

### Reviewers: @christian-bromann
