### PR TITLE
Revert "Add process.stdout.isTTY"

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -432,9 +432,8 @@ const launch = () => {
  * if stdin.isTTY, then no piped input is present and launcher should be
  * called immediately, otherwise piped input is processed, expecting
  * a list of files to process.
- * stdin.isTTY is false when command is from nodes spawn since it's treated as a pipe
  */
-if (process.stdin.isTTY || !process.stdout.isTTY) {
+if (process.stdin.isTTY) {
     launch()
 } else {
     let stdinData = ''


### PR DESCRIPTION
## Proposed changes

This reverts the changes from PR #2477, which was described as "Adding !process.stdout.isTTY which will allow launch() to be ran when called from a node script. Node's child_process spawn is treated as a pipe so the original process.stdin.isTTY is false and launch() would never get called."

The reason I'm reverting it is that the original behavior was correct, since the `wdio` runner is documented as taking a list of spec files on stdin when stdin is not a TTY, it's completely expected that it would "block" when you run it in a way where it's stdin is not a TTY.  The current behavior however, is extremely broken, it's now impossible to pass spec files on stdin unless `process.stdout` is a TTY.

Here are some of the ways the original problem could be fixed in the calling code without making this change:
* [Run the testrunner programmatically instead of using spawn](http://webdriver.io/guide/testrunner/gettingstarted.html#Run-the-test-runner-programmatically)
* Ignore stdin when calling `spawn`: `stdio : [ 'ignore', null, null ]`
* Provide empty input when calling `spawn`: `input : ''`

This reverts commit 209fad10858a3b0c95226a8ea113f34495cc6455.

Resolves #2609.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Note that the original change in #2477 was a breaking change (although it was marked as a bugfix), but this PR is simply restoring the documented behavior.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

### Reviewers: @christian-bromann
