### PR TITLE
fixed typo -- unused property

### DIFF
--- a/lib/utils/ReporterStats.js
+++ b/lib/utils/ReporterStats.js
@@ -72,7 +72,7 @@ class HookStats extends RunnableStats {
         this.uid = ReporterStats.getIdentifier(runner)
         this.title = runner.title
         this.parent = runner.parent
-        this.parenUid = runner.parentUid || runner.parent
+        this.parentUid = runner.parentUid || runner.parent
         this.currentTest = runner.currentTest
     }
 }


### PR DESCRIPTION
## Proposed changes

I think that you meant to use `parentUid` not `parenUid`

## Types of changes

- [ x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ x] I have added tests that prove my fix is effective or that my feature works
- [ x] I have added necessary documentation (if appropriate)

### Reviewers: @christian-bromann
