### PR TITLE
Remove extra whitespace in waitFor error messages

### DIFF
--- a/lib/commands/waitForEnabled.js
+++ b/lib/commands/waitForEnabled.js
@@ -52,8 +52,8 @@ let waitForEnabled = function (selector, ms, reverse) {
         ms = this.options.waitforTimeout
     }
 
-    const isReversed = reverse ? '' : 'not'
-    const errorMsg = `element ("${selector || this.lastResult.selector}") still ${isReversed} enabled after ${ms}ms`
+    const isReversed = reverse ? '' : 'not '
+    const errorMsg = `element ("${selector || this.lastResult.selector}") still ${isReversed}enabled after ${ms}ms`
 
     return this.waitUntil(() => {
         return this.isEnabled(selector).then((isEnabled) => {

--- a/lib/commands/waitForExist.js
+++ b/lib/commands/waitForExist.js
@@ -46,8 +46,8 @@ let waitForExist = function (selector, ms, reverse) {
         ms = this.options.waitforTimeout
     }
 
-    const isReversed = reverse ? '' : 'not'
-    const errorMsg = `element ("${selector || this.lastResult.selector}") still ${isReversed} existing after ${ms}ms`
+    const isReversed = reverse ? '' : 'not '
+    const errorMsg = `element ("${selector || this.lastResult.selector}") still ${isReversed}existing after ${ms}ms`
 
     return this.waitUntil(() => {
         return this.isExisting(selector).then((isExisting) => {

--- a/lib/commands/waitForSelected.js
+++ b/lib/commands/waitForSelected.js
@@ -55,8 +55,8 @@ let waitForSelected = function (selector, ms, reverse) {
         ms = this.options.waitforTimeout
     }
 
-    const isReversed = reverse ? '' : 'not'
-    const errorMsg = `element ("${selector || this.lastResult.selector}") still ${isReversed} selected after ${ms}ms`
+    const isReversed = reverse ? '' : 'not '
+    const errorMsg = `element ("${selector || this.lastResult.selector}") still ${isReversed}selected after ${ms}ms`
 
     return this.waitUntil(() => {
         return this.isSelected(selector).then((isSelected) => {

--- a/lib/commands/waitForVisible.js
+++ b/lib/commands/waitForVisible.js
@@ -52,8 +52,8 @@ let waitForVisible = function (selector, ms, reverse) {
         ms = this.options.waitforTimeout
     }
 
-    const isReversed = reverse ? '' : 'not'
-    const errorMsg = `element ("${selector || this.lastResult.selector}") still ${isReversed} visible after ${ms}ms`
+    const isReversed = reverse ? '' : 'not '
+    const errorMsg = `element ("${selector || this.lastResult.selector}") still ${isReversed}visible after ${ms}ms`
 
     return this.waitUntil(() => {
         return this.isVisible(selector).then((isVisible) => {


### PR DESCRIPTION
## Proposed changes

Prior to this PR "reverse" error messages contained an extra space. Trivial, but it was bothering me!

Msg pre-PR: 
```
(element) still  visible after 10000ms
```
Msg post-PR:
```
(element) still visible after 10000ms
```

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

### Reviewers: @christian-bromann
