### PR TITLE
Makes it more clear that --spec filtering is done on spec file names

### DIFF
--- a/docs/guide/testrunner/organizesuite.md
+++ b/docs/guide/testrunner/organizesuite.md
@@ -111,7 +111,7 @@ or run multiple specs at once:
 $ wdio wdio.conf.js --spec ./test/specs/signup.js,./test/specs/forgot-password.js
 ```
 
-If the spec passed in is not a path to a spec file, it is used as a filter for the specs defined in your configuration file. To run all specs with the word 'dialog' in them, you could use:
+If the spec passed in is not a path to a spec file, it is used as a filter for the spec file names defined in your configuration file. To run all specs with the word 'dialog' in the spec file names, you could use:
 
 ```sh
 $ wdio wdio.conf.js --spec dialog


### PR DESCRIPTION
## This change makes it clear in the doc that the filtering in --spec is done on the spec file names and not the contents of the spec file.

 # 
This was discussed in Issue https://github.com/webdriverio/webdriverio/issues/2657

## Types of changes
Document change

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [X ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc

## Further comments

### Reviewers: @christian-bromann
