### PR TITLE
Update click workaround to a safer approach

### DIFF
--- a/lib/commands/click.js
+++ b/lib/commands/click.js
@@ -11,9 +11,8 @@
  * Element is not clickable at point (x, x). Other element would receive the click: ..."
  * ```
  *
- * To work around this, try to find the overlaying element and remove it via `execute` command so it doesn't interfere
- * the click. You also can try to scroll to the element yourself using `scroll` with an offset appropriate for your
- * scenario.
+ * To work around this, try to find the overlaying element and click on it via `execute` command. You also can try to scroll to the element yourself using `scroll` with an offset appropriate for your
+ * scenario. If you find you frequently have to do this, creating a [custom command](/api/utility/addCommand.html) is helpful.
  *
  * <example>
     :example.html


### PR DESCRIPTION
## Proposed changes

The "other element would receive click" workaround recommended using `execute` to _remove_ elements from the DOM in order to Click other elements. This is not a best practice, especially on SPA's. We should never recommend removal of elements in order to run a Webdriver test.

Instead, I have recommended executing a click on the element via `execute` command  and that users create a custom command for this, if they find themselves having to frequently do this.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

### Reviewers: @christian-bromann
