### PR TITLE
Decide to read from stdin using a parameter rather than magic

### DIFF
--- a/docs/guide/testrunner/gettingstarted.md
+++ b/docs/guide/testrunner/gettingstarted.md
@@ -41,6 +41,7 @@ Options:
   --reporters, -r       reporters to print out the results on stdout
   --suite               runs the defined suite, can be combined with --spec
   --spec                runs a certain spec file, can be combined with --suite - overrides specs piped from stdin
+  --stdin, -            reads specs from stdin (a single dash is the abbrevated version)
   --cucumberOpts.*      Cucumber options, see the full list options at https://github.com/webdriverio/wdio-cucumber-framework#cucumberopts-options
   --jasmineOpts.*       Jasmine options, see the full list options at https://github.com/webdriverio/wdio-jasmine-framework#jasminenodeopts-options
   --mochaOpts.*         Mocha options, see the full list options at http://mochajs.org

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -107,7 +107,8 @@ optimist
     .default({coloredLogs: true})
 
     .check((arg) => {
-        if (arg._.length > 1 && arg._[0] !== 'repl') {
+        let readStdIn = (arg._[0] === '-' || arg._[1] === '-') && arg._.length === 2
+        if (arg._.length > 1 && arg._[0] !== 'repl' && !readStdIn) {
             throw new Error('Error: more than one config file specified')
         }
     })
@@ -128,6 +129,12 @@ if (argv.version) {
  * use wdio.conf.js default file name if no config was specified
  * otherwise run config sequenz
  */
+if (argv._[0] === '-') {
+    // Remove the dash from argv so it doesn't try to load a file named - as the config
+    // and set the stdin parameter so we still read stdin
+    argv._.shift()
+    argv.stdin = true
+}
 let configFile = argv._[0]
 if (!configFile) {
     if (fs.existsSync('./wdio.conf.js')) {
@@ -431,13 +438,10 @@ const launch = () => {
 }
 
 /**
- * if stdin.isTTY, then no piped input is present and launcher should be
- * called immediately, otherwise piped input is processed, expecting
- * a list of files to process.
+ * if --stdin or a single dash is passed as an argument, piped
+ * input is processed, expecting a list of files to process.
  */
-if (process.stdin.isTTY) {
-    launch()
-} else {
+if (argv.stdin || Object.values(process.argv).includes('-')) {
     let stdinData = ''
     /*
      * get a list of spec files to run from stdin, overriding any other
@@ -454,4 +458,6 @@ if (process.stdin.isTTY) {
         }
         launch()
     })
+} else {
+    launch()
 }


### PR DESCRIPTION
## Proposed changes

This changes webdriverio to read from stdin if `--stdin` or `-` is provided as an option as a fix to #2624. (Note: This is backwards breaking of #2617 but restores functionality closer to #2477.  The conversation in #2624 seemed to decide a new option was the best way to implement this.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works (see comments below)
- [x] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

I could not find any tests which exercise `cli.js` so I didn't add any tests, but let me know if there is a spot to add them.

The single dash `-` is read in as a file (`argv._`) rather than an option so I had to alter the reading of the config to ensure it didn't try to read in dash as the config file.

### Reviewers: @christian-bromann
