### PR TITLE
typo fix and cleaner global usage

### DIFF
--- a/test/spec/unit/launcher.js
+++ b/test/spec/unit/launcher.js
@@ -1,5 +1,4 @@
 import path from 'path'
-import sinon from 'sinon'
 import Launcher from '../../../build/lib/launcher'
 import mock from 'mock-require'
 

--- a/test/spec/unit/launcher.js
+++ b/test/spec/unit/launcher.js
@@ -111,23 +111,23 @@ describe('launcher', () => {
             browserName: 'phantomjs'
         }]
 
-        function getLauncer (args, numberOfSpecs = 20) {
+        function getLauncher (args, numberOfSpecs = 20) {
             launcher = new Launcher(path.join(FIXTURE_ROOT, 'runspec.wdio.conf.js'), args)
             launcher.configParser.getSpecs = () => Object.assign('/foo/bar.js,'.repeat(numberOfSpecs).split(',').slice(0, -1))
             launcher.configParser.getCapabilities = () => Object.assign(caps)
-            launcher.startInstance = sinon.spy()
+            launcher.startInstance = global.sinon.spy()
             return launcher
         }
 
         it('should run all specs if no limitations are given (full concurrency)', async () => {
-            launcher = getLauncer()
+            launcher = getLauncher()
             setTimeout(() => launcher.resolve(0), 10)
             await launcher.run()
             launcher.startInstance.callCount.should.be.equal(100)
         })
 
         it('should run max maxInstances', async () => {
-            launcher = getLauncer({
+            launcher = getLauncher({
                 maxInstances: 10
             }, 4)
             setTimeout(() => launcher.resolve(0), 10)
@@ -165,7 +165,7 @@ describe('launcher', () => {
         })
 
         it('should respect maxInstances property of a single capabiltiy', async () => {
-            launcher = getLauncer({}, 5)
+            launcher = getLauncher({}, 5)
             launcher.configParser.getCapabilities = () => Object.assign(caps).map((a, i) => {
                 a.maxInstances = i + 1
                 return a
@@ -191,7 +191,7 @@ describe('launcher', () => {
         })
 
         it('should stop launching runners after bail number is reached', async () => {
-            launcher = getLauncer({
+            launcher = getLauncher({
                 maxInstances: 1,
                 bail: 2
             }, 5)

--- a/test/spec/unit/touchAction.js
+++ b/test/spec/unit/touchAction.js
@@ -4,8 +4,8 @@ let performMultiAction, performTouchAction, scope, elementCalls
 
 describe('touchAction', () => {
     beforeEach(() => {
-        performMultiAction = sinon.spy()
-        performTouchAction = sinon.spy()
+        performMultiAction = global.sinon.spy()
+        performTouchAction = global.sinon.spy()
         elementCalls = 0
 
         scope = {


### PR DESCRIPTION
## Proposed changes

We set `sinon` to be global and refer to it in touchAction implicitly, however in launcher we reimport it specifically and use it. I cleaned it up by referring to `global.sinon` anywhere it was being used in `spec/unit`

I also fixed a typo: `getLauncer` to `getLauncher` 

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ x] I have added tests that prove my fix is effective or that my feature works
- [x ] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @christian-bromann
