### PR TITLE
Document default value for browser.pause()

### DIFF
--- a/lib/commands/pause.js
+++ b/lib/commands/pause.js
@@ -15,7 +15,7 @@
  * </example>
  *
  * @alias browser.pause
- * @param {Number} milliseconds time in ms
+ * @param {Number=1000} milliseconds time in ms
  * @type utility
  *
  */


### PR DESCRIPTION
## Proposed changes

browser.pause() takes a "milliseconds" parameter with a default value of 1000. This change simply documents the default value. I saw someone use the function without any params and it wasn't clear to me if the function would pause indefinitely or if it had a default value so I had to look at the source code to find out.

### Reviewers: @christian-bromann