### PR TITLE
Fix misnamed jasmine opts CLI param

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -57,7 +57,7 @@ const VERSION = pkg.version
 const ALLOWED_ARGV = [
     'host', 'port', 'path', 'user', 'key', 'logLevel', 'coloredLogs', 'screenshotPath',
     'baseUrl', 'waitforTimeout', 'framework', 'reporters', 'suite', 'spec', 'cucumberOpts',
-    'jasmineOpts', 'mochaOpts', 'connectionRetryTimeout', 'connectionRetryCount', 'watch'
+    'jasmineNodeOpts', 'mochaOpts', 'connectionRetryTimeout', 'connectionRetryCount', 'watch'
 ]
 
 optimist
@@ -99,7 +99,7 @@ optimist
     .describe('suite', 'overwrites the specs attribute and runs the defined suite')
     .describe('spec', 'specifies spec file(s) to run or filter(s) for specs defined in the specs attribute')
     .describe('cucumberOpts.*', 'Cucumber options, see the full list options at https://github.com/webdriverio/wdio-cucumber-framework#cucumberopts-options')
-    .describe('jasmineOpts.*', 'Jasmine options, see the full list options at https://github.com/webdriverio/wdio-jasmine-framework#jasminenodeopts-options')
+    .describe('jasmineNodeOpts.*', 'Jasmine options, see the full list options at https://github.com/webdriverio/wdio-jasmine-framework#jasminenodeopts-options')
     .describe('mochaOpts.*', 'Mocha options, see the full list options at http://mochajs.org')
 
     .string(['host', 'path', 'user', 'key', 'logLevel', 'screenshotPath', 'baseUrl', 'framework', 'reporters', 'suite', 'spec'])
@@ -355,10 +355,10 @@ if (argv.cucumberOpts) {
 }
 
 /**
- * sanitize jasmineOpts
+ * sanitize jasmineNodeOpts
  */
-if (argv.jasmineOpts && argv.jasmineOpts.defaultTimeoutInterval) {
-    argv.jasmineOpts.defaultTimeoutInterval = parseInt(argv.jasmineOpts.defaultTimeoutInterval, 10)
+if (argv.jasmineNodeOpts && argv.jasmineNodeOpts.defaultTimeoutInterval) {
+    argv.jasmineNodeOpts.defaultTimeoutInterval = parseInt(argv.jasmineNodeOpts.defaultTimeoutInterval, 10)
 }
 
 /**


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

When passing in Jasmine options via the command line, they are currently ignored.

For example, running:
`wdio --jasmineOpts.defaultTimeoutInterval=10000`

with our config file being:
```
jasmineNodeOpts: {
  defaultTimeoutInterval: 1,
},
```

it will stick with the `defaultTimeoutInterval: 1`. 

The same is true for using the `grep` option.

I believe this is caused by the property name of the command line argument not matching the property name that `wdio-jasmine-framework` is looking for.
https://github.com/webdriverio/webdriverio/blob/7bac02e4e9de5b4bc7fb3b3e65a7cb7c5c0a2db9/lib/cli.js#L102
https://github.com/webdriverio/wdio-jasmine-framework/blob/master/lib/adapter.js#L20

This change updates the CLI param to match what wdio-jasmine-framework is expecting.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

There was a PR open for this previously (#1442), but was closed for an undisclosed reason (one could venture a guess that the person was paid off by [the Sundance Beverage Company](https://en.wikipedia.org/wiki/La_Croix_Sparkling_Water), although no evidence is provided to prove this).

### Reviewers: @christian-bromann
