### PR TITLE
Fix typo in chooseFile

### DIFF
--- a/lib/commands/chooseFile.js
+++ b/lib/commands/chooseFile.js
@@ -46,7 +46,7 @@ let chooseFile = function (selector, localPath) {
         fs.stat(localPath, (err) => {
             /* istanbul ignore next */
             if (err) {
-                return reject(new CommandError('File to upload does not exists on your system'))
+                return reject(new CommandError('File to upload does not exist on your system'))
             }
 
             this.uploadFile(localPath).then(function (res) {


### PR DESCRIPTION
Changes 'File to upload does not exists...' to 'File to upload does not exist...' in an error message for chooseFile()

## Proposed changes

Fixes a small typo in error message for commands/chooseFile

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

### Reviewers: @christian-bromann
