### PR TITLE
Support IPv6 address in hostname

### DIFF
--- a/lib/helpers/utilities.js
+++ b/lib/helpers/utilities.js
@@ -1,3 +1,5 @@
+import net from 'net'
+
 /**
  * check if WebDriver requests was successful
  * @param  {Object}  body  body payload of response
@@ -69,4 +71,13 @@ export function isUnknownCommand (err) {
     }
 
     return false
+}
+
+/**
+ * Prepare the hostname to properly use IPv6 address
+ * @param {string} hostname
+ * @returns {string}
+ */
+export function formatHostname (hostname) {
+    return net.isIPv6(hostname) ? `[${hostname}]` : hostname
 }

--- a/lib/utils/RequestHandler.js
+++ b/lib/utils/RequestHandler.js
@@ -5,7 +5,7 @@ import request from 'request'
 import merge from 'deepmerge'
 
 import { ERROR_CODES } from '../helpers/constants'
-import { isSuccessfulResponse } from '../helpers/utilities'
+import { isSuccessfulResponse, formatHostname } from '../helpers/utilities'
 import { RuntimeError } from './ErrorHandler'
 import pkg from '../../package.json'
 
@@ -72,7 +72,7 @@ class RequestHandler {
 
         newOptions.uri = url.parse(
             this.defaultOptions.protocol + '://' +
-            this.defaultOptions.hostname + ':' + this.defaultOptions.port +
+            formatHostname(this.defaultOptions.hostname) + ':' + this.defaultOptions.port +
             (requestOptions.gridCommand ? this.gridApiStartPath : this.startPath) +
             requestOptions.path.replace(':sessionId', this.sessionID || ''))
 

--- a/test/spec/unit/requestHandler.js
+++ b/test/spec/unit/requestHandler.js
@@ -1,0 +1,53 @@
+const WebdriverIO = require('../../../')
+
+describe('requestHandler', () => {
+    it('should properly parse hostname', async function () {
+        // create a new session with ipv4
+        let testDriver = WebdriverIO.remote({
+            host: '127.0.0.1',
+            desiredCapabilities: {
+                browserName: 'phantomjs'
+            }
+        })
+
+        // check the created request object
+        testDriver.requestHandler.createOptions({
+            path: ''
+        }, {}).uri.should.include({
+            hostname: '127.0.0.1',
+            host: '127.0.0.1:4444'
+        })
+
+        // create a new session with ipv6
+        testDriver = WebdriverIO.remote({
+            host: '::1',
+            desiredCapabilities: {
+                browserName: 'phantomjs'
+            }
+        })
+
+        // check the created request object
+        testDriver.requestHandler.createOptions({
+            path: ''
+        }, {}).uri.should.include({
+            hostname: '::1',
+            host: '[::1]:4444'
+        })
+
+        // create a new session with ipv6
+        testDriver = WebdriverIO.remote({
+            host: 'localhost',
+            desiredCapabilities: {
+                browserName: 'phantomjs'
+            }
+        })
+
+        // check the created request object
+        testDriver.requestHandler.createOptions({
+            path: ''
+        }, {}).uri.should.include({
+            hostname: 'localhost',
+            host: 'localhost:4444'
+        })
+    })
+})

--- a/test/spec/unit/utilities.js
+++ b/test/spec/unit/utilities.js
@@ -1,4 +1,4 @@
-import { isSuccessfulResponse, isUnknownCommand } from '../../../lib/helpers/utilities'
+import { isSuccessfulResponse, isUnknownCommand, formatHostname } from '../../../lib/helpers/utilities'
 
 describe('utilities', () => {
     describe('isSuccessfulResponse', () => {
@@ -102,6 +102,14 @@ describe('utilities', () => {
             expect(isUnknownCommand({
                 message: 'did not map to a valid resource'
             })).to.be.equal(true)
+        })
+    })
+
+    describe('formatHostname', () => {
+        it('should properly format hostname', () => {
+            formatHostname('::1').should.equal('[::1]')
+            formatHostname('127.0.0.1').should.equal('127.0.0.1')
+            formatHostname('localhost').should.equal('localhost')
         })
     })
 })


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

When trying to connect to an IPv6 address, the settings is ignored and the default is used. It is due to how the address is build/parsed in RequestHandler. This fix detects IPv6 address and adds [] around it, so it is properly understood by url.parse function.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @christian-bromann
