### PR TITLE
Fixed misleading docs on Selenium Standalone Service seleniumArgs option

### DIFF
--- a/docs/guide/services/selenium-standalone.md
+++ b/docs/guide/services/selenium-standalone.md
@@ -54,10 +54,10 @@ Path where all logs from the Selenium server should be stored.
 Type: `String`
 
 ### seleniumArgs
-Array of arguments for the Selenium server, passed directly to `child_process.spawn`.
+Object configuration for selenium-standalone.start().
 
-Type: `String[]`<br>
-Default: `[]`
+Type: `Object`<br>
+Default: `{}`
 
 ### seleniumInstallArgs
 Object configuration for selenium-standalone.install().


### PR DESCRIPTION
The current documentation on that is wrong, as in code there is:
```
return _seleniumStandalone2.default.start(_this.seleniumArgs, function (err, process) {
```
so clearly `seleniumArgs` property taken from `wdio.conf.js` is passed as opts for selenium-standalone `selenium.start([opts,] cb)` method.

Obviously seleniumArgs configuration object can contain `opts.seleniumArgs` property too, which will be passed directly to `child_process.spawn` (as stated in selenium-standalone [docs](https://www.npmjs.com/package/selenium-standalone)).