### PR TITLE
Update docs for Mochaawesome to limit generator version

### DIFF
--- a/docs/guide/reporters/mochawesome.md
+++ b/docs/guide/reporters/mochawesome.md
@@ -54,8 +54,10 @@ In summary...
 
 * Add the package to your project
 ```shell
-npm install --save mochawesome-report-generator
+npm install --save mochawesome-report-generator@2.3.2
 ```
+
+**NOTE** wdio-mochawesome-reporter is NOT compatible with the 3.x versions of the mochawesome-report-generator
 
 * Add a script to your package.json to generate the report
 ```json


### PR DESCRIPTION
The Mochaawesome report generator released a breaking change in v3 which hasn't been update in wdio-mochaawesome-reporter. This change will tie the install down to the latest supported version.

See:
https://github.com/fijijavis/wdio-mochawesome-reporter/issues/7
https://github.com/fijijavis/wdio-mochawesome-reporter/pull/20

## Proposed changes

Update docs to reflect this reality

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

### Reviewers: @christian-bromann
