### PR TITLE
bump rgb2hex dependency to 0.1.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "webdriverio",
-  "version": "4.12.0",
+  "version": "4.13.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -11253,9 +11253,9 @@
       }
     },
     "rgb2hex": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/rgb2hex/-/rgb2hex-0.1.4.tgz",
-      "integrity": "sha512-CZAhfcGLXI4DRn+rFsY8zFY5vLJ7oZLYnYeRJjpPFg3eInvFR9El0Ev4/VXzTE0FiQxoyaa9Zl3EnoqXoC5eDw=="
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/rgb2hex/-/rgb2hex-0.1.9.tgz",
+      "integrity": "sha512-32iuQzhOjyT+cv9aAFRBJ19JgHwzQwbjUhH3Fj2sWW2EEGAW8fpFrDFP5ndoKDxJaLO06x1hE3kyuIFrUQtybQ=="
     },
     "right-align": {
       "version": "0.1.3",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "optimist": "~0.6.1",
     "q": "~1.5.0",
     "request": "^2.83.0",
-    "rgb2hex": "~0.1.4",
+    "rgb2hex": "^0.1.9",
     "safe-buffer": "~5.1.1",
     "supports-color": "~5.0.0",
     "url": "~0.11.0",


### PR DESCRIPTION
I still get the `isn't a valid rgb or rgba color` error when using a fresh install of webdriverio, because it is still using version `0.1.4` but since this error was fixed upstream in version `0.1.9` of rgb2hex, I figure it would be safe to use this as the minimal default for this dependency.
