### PR TITLE
keys.js: Use unicode segmentation instead of character segmentation

### DIFF
--- a/lib/protocol/keys.js
+++ b/lib/protocol/keys.js
@@ -18,6 +18,8 @@
  *
  */
 
+import GraphemeSplitter from 'grapheme-splitter'
+
 import { UNICODE_CHARACTERS } from '../helpers/constants'
 import { isUnknownCommand } from '../helpers/utilities'
 import { ProtocolError } from '../utils/ErrorHandler'
@@ -63,5 +65,5 @@ module.exports = function keys (value) {
  * @return {Array}         set of characters or unicode symbols
  */
 function checkUnicode (value) {
-    return UNICODE_CHARACTERS.hasOwnProperty(value) ? [UNICODE_CHARACTERS[value]] : value.split('')
+    return UNICODE_CHARACTERS.hasOwnProperty(value) ? [UNICODE_CHARACTERS[value]] : new GraphemeSplitter().splitGraphemes(value)
 }

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "ejs": "~2.5.6",
     "gaze": "~1.1.2",
     "glob": "~7.1.1",
+    "grapheme-splitter": "^1.0.2",
     "inquirer": "~3.3.0",
     "json-stringify-safe": "~5.0.1",
     "mkdirp": "~0.5.1",


### PR DESCRIPTION
## Proposed changes

Currently when using unicode characters like emojis that require more than one characters for representation in javascript strings are sent separately, leading them to not be rendered correctly. This patch proposes [segmentation of unicode text by visibility](http://unicode.org/reports/tr29/) using the grapheme-splitter library.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have proposed the same patch to the new [v5](https://github.com/webdriverio/v5) repository

### Reviewers: @christian-bromann
