### PR TITLE
Fix "unknown command" exception handling for IE

### DIFF
--- a/lib/helpers/utilities.js
+++ b/lib/helpers/utilities.js
@@ -66,7 +66,7 @@ export function isUnknownCommand (err) {
     /**
      * when running via selenium standalone
      */
-    if (err.seleniumStack && err.seleniumStack.type === 'UnknownCommand') {
+    if (err.seleniumStack && (err.seleniumStack.type === 'UnknownCommand' || err.seleniumStack.type === 'Unknown')) {
         return true
     }
 

--- a/lib/protocol/alertAccept.js
+++ b/lib/protocol/alertAccept.js
@@ -22,6 +22,8 @@
  *
  */
 
+import { isUnknownCommand } from '../helpers/utilities'
+
 export default function alertAccept () {
     const requestOptions = {
         path: '/session/:sessionId/accept_alert',
@@ -32,7 +34,7 @@ export default function alertAccept () {
         /**
          * jsonwire command not supported try webdriver endpoint
          */
-        if (err.message.match(/did not match a known command/)) {
+        if (isUnknownCommand(err)) {
             requestOptions.path = '/session/:sessionId/alert/accept'
             return this.requestHandler.create(requestOptions)
         }

--- a/lib/protocol/alertDismiss.js
+++ b/lib/protocol/alertDismiss.js
@@ -23,6 +23,8 @@
  *
  */
 
+import { isUnknownCommand } from '../helpers/utilities'
+
 export default function alertDismiss () {
     const requestOptions = {
         path: '/session/:sessionId/dismiss_alert',
@@ -33,7 +35,7 @@ export default function alertDismiss () {
         /**
          * jsonwire command not supported try webdriver endpoint
          */
-        if (err.message.match(/did not match a known command/)) {
+        if (isUnknownCommand(err)) {
             requestOptions.path = '/session/:sessionId/alert/dismiss'
             return this.requestHandler.create(requestOptions)
         }

--- a/lib/protocol/alertText.js
+++ b/lib/protocol/alertText.js
@@ -21,6 +21,8 @@
  *
  */
 
+import { isUnknownCommand } from '../helpers/utilities'
+
 let alertText = function (text) {
     const requestOptions = {
         path: '/session/:sessionId/alert_text',
@@ -37,7 +39,7 @@ let alertText = function (text) {
         /**
          * jsonwire command not supported try webdriver endpoint
          */
-        if (err.message.match(/did not match a known command/)) {
+        if (isUnknownCommand(err)) {
             requestOptions.path = '/session/:sessionId/alert/text'
             return this.requestHandler.create(requestOptions, data)
         }

--- a/lib/protocol/elementActive.js
+++ b/lib/protocol/elementActive.js
@@ -9,6 +9,8 @@
  *
  */
 
+import { isUnknownCommand } from '../helpers/utilities'
+
 export default function elementActive () {
     const requestOptions = {
         path: '/session/:sessionId/element/active',
@@ -19,7 +21,7 @@ export default function elementActive () {
         /**
          * jsonwire command not supported try webdriver endpoint
          */
-        if (err.message.match(/(did not match a known command|is not supported for command)/)) {
+        if (isUnknownCommand(err)) {
             requestOptions.method = 'GET'
             return this.requestHandler.create(requestOptions)
         }

--- a/lib/protocol/elementIdLocation.js
+++ b/lib/protocol/elementIdLocation.js
@@ -18,6 +18,7 @@
  */
 
 import { ProtocolError } from '../utils/ErrorHandler'
+import { isUnknownCommand } from '../helpers/utilities'
 
 export default function elementIdLocation (id) {
     if (typeof id !== 'string' && typeof id !== 'number') {
@@ -28,7 +29,7 @@ export default function elementIdLocation (id) {
         /**
          * jsonwire command not supported try webdriver endpoint
          */
-        if (err.message.match(/did not match a known command/)) {
+        if (isUnknownCommand(err)) {
             return this.elementIdRect(id).then((result) => {
                 const { x, y } = result.value
                 result.value = { x, y }

--- a/lib/protocol/elementIdSize.js
+++ b/lib/protocol/elementIdSize.js
@@ -17,6 +17,7 @@
  */
 
 import { ProtocolError } from '../utils/ErrorHandler'
+import { isUnknownCommand } from '../helpers/utilities'
 
 export default function elementIdSize (id) {
     if (typeof id !== 'string' && typeof id !== 'number') {
@@ -27,7 +28,7 @@ export default function elementIdSize (id) {
         /**
          * jsonwire command not supported try webdriver endpoint
          */
-        if (err.message.match(/did not match a known command/)) {
+        if (isUnknownCommand(err)) {
             return this.elementIdRect(id).then((result) => {
                 const { width, height } = result.value
                 result.value = { width, height }

--- a/lib/protocol/execute.js
+++ b/lib/protocol/execute.js
@@ -36,6 +36,7 @@
  */
 
 import { ProtocolError } from '../utils/ErrorHandler'
+import { isUnknownCommand } from '../helpers/utilities'
 
 export default function execute (...args) {
     let script = args.shift()
@@ -59,7 +60,7 @@ export default function execute (...args) {
         /**
          * jsonwire command not supported try webdriver endpoint
          */
-        if (err.message.match(/did not match a known command/)) {
+        if (isUnknownCommand(err)) {
             return this.requestHandler.create('/session/:sessionId/execute/sync', { script, args })
         }
 

--- a/lib/protocol/executeAsync.js
+++ b/lib/protocol/executeAsync.js
@@ -45,6 +45,7 @@
  */
 
 import { ProtocolError } from '../utils/ErrorHandler'
+import { isUnknownCommand } from '../helpers/utilities'
 
 export default function executeAsync (...args) {
     let script = args.shift()
@@ -68,7 +69,7 @@ export default function executeAsync (...args) {
         /**
          * jsonwire command not supported try webdriver endpoint
          */
-        if (err.message.match(/did not match a known command/)) {
+        if (isUnknownCommand(err)) {
             return this.requestHandler.create('/session/:sessionId/execute/async', { script, args })
         }
 

--- a/lib/protocol/windowHandle.js
+++ b/lib/protocol/windowHandle.js
@@ -27,12 +27,14 @@
  *
  */
 
+import { isUnknownCommand } from '../helpers/utilities'
+
 export default function windowHandle () {
     return this.requestHandler.create('/session/:sessionId/window_handle').catch((err) => {
         /**
          * jsonwire command not supported try webdriver endpoint
          */
-        if (err.message.match(/did not match a known command/)) {
+        if (isUnknownCommand(err)) {
             return this.requestHandler.create('/session/:sessionId/window')
         }
 

--- a/lib/protocol/windowHandlePosition.js
+++ b/lib/protocol/windowHandlePosition.js
@@ -31,6 +31,8 @@
  *
  */
 
+import { isUnknownCommand } from '../helpers/utilities'
+
 let windowHandlePosition = function (windowHandle, position) {
     let data = {}
     let requestOptions = {
@@ -61,7 +63,7 @@ let windowHandlePosition = function (windowHandle, position) {
         /**
          * jsonwire command not supported try webdriver endpoint
          */
-        if (err.message.match(/did not match a known command/)) {
+        if (isUnknownCommand(err)) {
             requestOptions.path = '/session/:sessionId/window/rect'
             return this.requestHandler.create(requestOptions, data)
         }

--- a/lib/protocol/windowHandles.js
+++ b/lib/protocol/windowHandles.js
@@ -38,12 +38,14 @@
  *
  */
 
+import { isUnknownCommand } from '../helpers/utilities'
+
 let windowHandles = function () {
     return this.requestHandler.create('/session/:sessionId/window_handles').catch((err) => {
         /**
          * jsonwire command not supported try webdriver endpoint
          */
-        if (err.message.match(/did not match a known command/)) {
+        if (isUnknownCommand(err)) {
             return this.requestHandler.create('/session/:sessionId/window/handles')
         }
 

--- a/test/spec/unit/utilities.js
+++ b/test/spec/unit/utilities.js
@@ -96,6 +96,13 @@ describe('utilities', () => {
                     type: 'UnknownCommand'
                 }
             })).to.be.equal(true)
+
+            expect(isUnknownCommand({
+                message: 'foobar',
+                seleniumStack: {
+                    type: 'Unknown'
+                }
+            })).to.be.equal(true)
         })
 
         it('should recognise unknown command when using chromedriver', () => {


### PR DESCRIPTION
## Proposed changes
Fix #2828 and #2833 - allow the fallback to W3C WebDriver APIs to happen when using newer versions of IE Driver.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have proposed the same patch to the new [v5](https://github.com/webdriverio/v5) repository

### Reviewers: @christian-bromann
