### PR TITLE
Adding exclude spec functionality to cli arguments NextGen

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -47,6 +47,8 @@ Options:
                         suite                                            [array]
   --spec                run only a certain spec file - overrides specs piped
                         from stdin                                       [array]
+  --exclude             exclude spec file(s) from a run - overrides specs piped
+                        from stdin                                       [array]
   --mochaOpts           Mocha options
   --jasmineOpts         Jasmine options
   --cucumberOpts        Cucumber options

--- a/docs/OrganizingTestSuites.md
+++ b/docs/OrganizingTestSuites.md
@@ -114,6 +114,22 @@ $ wdio wdio.conf.js --spec dialog
 
 Note that each test file is running in a single test runner process. Since we don't scan files in advance (see the next section for information on piping filenames to `wdio`) you _can't_ use for example `describe.only` at the top of your spec file to say Mocha to only run that suite. This feature will help you though to do that in the same way.
 
+## Exclude Selected Tests
+
+ When needed, if you need to exclude particular spec file(s) from a run, you can use the `--exclude` parameter (Mocha, Jasmine) or feature (Cucumber). For example if you want to exclude your login
+test from the test run, do:
+ ```sh
+$ wdio wdio.conf.js --exclude ./test/specs/e2e/login.js
+```
+ or exclude multiple spec files:
+ ```sh
+$ wdio wdio.conf.js --exclude ./test/specs/signup.js,./test/specs/forgot-password.js
+```
+ or exclude a spec file when filtering using a suite:
+ ```sh
+$ wdio wdio.conf.js --suite login --exclude ./test/specs/e2e/login.js
+```
+
 ## Run Suites and Test Specs
 
 This will allow you to run an entire suite along with individual spec's.

--- a/docs/OrganizingTestSuites.md
+++ b/docs/OrganizingTestSuites.md
@@ -123,7 +123,7 @@ $ wdio wdio.conf.js --exclude ./test/specs/e2e/login.js
 ```
  or exclude multiple spec files:
  ```sh
-$ wdio wdio.conf.js --exclude ./test/specs/signup.js,./test/specs/forgot-password.js
+$ wdio wdio.conf.js --exclude ./test/specs/signup.js --exclude ./test/specs/forgot-password.js
 ```
  or exclude a spec file when filtering using a suite:
  ```sh

--- a/packages/wdio-cli/src/config.js
+++ b/packages/wdio-cli/src/config.js
@@ -49,7 +49,9 @@ Usage: wdio repl <browserName>
 
 config file defaults to wdio.conf.js
 The [options] object will override values from the config file.
-An optional list of spec files can be piped to wdio that will override configured specs`
+An optional list of spec files can be piped to wdio that will override configured specs.
+Same applies to the exclude option. It can take a list of specs to exclude for a given run 
+and it also overrides the exclude key from the config file.`
 
 export const CONFIG_HELPER_INTRO = `
 =========================
@@ -128,6 +130,10 @@ export const CLI_PARAMS = [{
 }, {
     name: 'spec',
     description: `run only a certain spec file - overrides specs piped from stdin`,
+    type: 'array'
+}, {
+    name: 'exclude',
+    description: `exclude certain spec file from the test run - overrides exclude piped from stdin`,
     type: 'array'
 }, {
     name: 'mochaOpts',

--- a/packages/wdio-config/tests/configparser.test.js
+++ b/packages/wdio-config/tests/configparser.test.js
@@ -137,6 +137,39 @@ describe('ConfigParser', () => {
             expect(config.hostname).toBe('ondemand.saucelabs.com')
             expect(config.port).toBe(443)
         })
+
+        it('should allow specifying a exclude file', () => {
+            const configParser = new ConfigParser()
+            configParser.addConfigFile(FIXTURES_CONF)
+            configParser.merge({ spec: [INDEX_PATH, FIXTURES_CONF] })
+            configParser.merge({ exclude: [INDEX_PATH] })
+            const specs = configParser.getSpecs()
+            expect(specs).toHaveLength(1)
+            expect(specs).toContain(FIXTURES_CONF)
+        })
+
+        it('should allow specifying multiple exclude files', () => {
+            const configParser = new ConfigParser()
+            configParser.addConfigFile(FIXTURES_CONF)
+            configParser.merge({ spec: [INDEX_PATH, FIXTURES_CONF] })
+            configParser.merge({ exclude: [INDEX_PATH, FIXTURES_CONF] })
+            const specs = configParser.getSpecs()
+            expect(specs).toHaveLength(0)
+        })
+
+        it('should throw if specified exclude file does not exist', () => {
+            const configParser = new ConfigParser()
+            configParser.addConfigFile(FIXTURES_CONF)
+            expect(() => configParser.merge({ exclude: [path.resolve(__dirname, 'foobar.js')] })).toThrow()
+        })
+
+        it('should overwrite exclude if piped into cli command', () => {
+            const configParser = new ConfigParser()
+            configParser.addConfigFile(FIXTURES_CONF)
+            configParser.merge({ exclude: [INDEX_PATH] })
+            const specs = configParser.getSpecs()
+            expect(specs).toHaveLength(4)
+        })
     })
 
     describe('addService', () => {


### PR DESCRIPTION
## Proposed changes

Adding the capability to exclude spec(s) file(s) from command line, not a very big piece of work but can be handy... I've also tested the change locally (did some exploratory testing as well and it's ok)

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ x] I have added tests that prove my fix is effective or that my feature works
- [ x] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
