### PR TITLE
Allow stdout to be overwritten in Spec and Dot reporters

### DIFF
--- a/packages/wdio-dot-reporter/src/index.js
+++ b/packages/wdio-dot-reporter/src/index.js
@@ -9,7 +9,7 @@ export default class DotReporter extends WDIOReporter {
         /**
          * make dot reporter to write to output stream by default
          */
-        options = Object.assign(options, { stdout: true })
+        options = Object.assign({ stdout: true }, options)
         super(options)
     }
 

--- a/packages/wdio-spec-reporter/src/index.js
+++ b/packages/wdio-spec-reporter/src/index.js
@@ -5,9 +5,9 @@ import prettyMs from 'pretty-ms'
 class SpecReporter extends WDIOReporter {
     constructor (options) {
         /**
-         * make dot reporter to write to output stream by default
+         * make spec reporter to write to output stream by default
          */
-        options = Object.assign(options, { stdout: true })
+        options = Object.assign({ stdout: true }, options)
         super(options)
 
         // Keep track of the order that suites were called


### PR DESCRIPTION
## Proposed changes

The stdio object should be passed in first to Object.assign so that it can be overwritten from a config file. Currently the stdio property will always be true.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

### Reviewers: @webdriverio/technical-committee
