### PR TITLE
Terminals without color support

### DIFF
--- a/packages/wdio-cli/src/interface.js
+++ b/packages/wdio-cli/src/interface.js
@@ -11,7 +11,7 @@ const clockSpinner = cliSpinners['clock']
 export default class WDIOCLInterface extends EventEmitter {
     constructor (config, specs) {
         super()
-        this.hasAnsiSupport = chalk.supportsColor.hasBasic
+        this.hasAnsiSupport = !!chalk.supportsColor.hasBasic
         this.clockTimer = 0
         this.specs = specs
         this.config = config

--- a/packages/wdio-cli/src/launcher.js
+++ b/packages/wdio-cli/src/launcher.js
@@ -23,7 +23,7 @@ class Launcher {
         }
 
         this.interface = new CLInterface(config, specs)
-        config.runnerEnv.FORCE_COLOR = this.interface.hasAnsiSupport
+        config.runnerEnv.FORCE_COLOR = Number(this.interface.hasAnsiSupport)
 
         const Runner = initialisePlugin(config.runner, 'runner')
         this.runner = new Runner(configFile, config)

--- a/packages/wdio-local-runner/src/index.js
+++ b/packages/wdio-local-runner/src/index.js
@@ -28,14 +28,6 @@ export default class LocalRunner extends EventEmitter {
             runnerEnv.WDIO_LOG_PATH = path.join(this.config.logDir, `wdio-${cid}.log`)
         }
 
-        /**
-         * ensure that logs are colored in wdio-cli interface
-         * (only set if not set by user or wdio-cli package)
-         */
-        if (Object.keys(runnerEnv).includes('FORCE_COLOR')) {
-            runnerEnv.FORCE_COLOR = true
-        }
-
         log.info(`Start worker ${cid} with arg: ${process.argv.slice(2)}`)
         const childProcess = child.fork(path.join(__dirname, 'run.js'), process.argv.slice(2), {
             cwd: process.cwd(),

--- a/packages/wdio-local-runner/tests/localRunner.test.js
+++ b/packages/wdio-local-runner/tests/localRunner.test.js
@@ -16,7 +16,7 @@ jest.mock('child_process', () => {
 test('should fork a new process', () => {
     const runner = new LocalRunner('/path/to/wdio.conf.js', {
         logDir: '/foo/bar',
-        runnerEnv: { FORCE_COLOR: false }
+        runnerEnv: { FORCE_COLOR: 1 }
     })
     const childProcess = runner.run({
         cid: '0-5',
@@ -34,7 +34,7 @@ test('should fork a new process', () => {
 
     const { env } = child.fork.mock.calls[0][2]
     expect(env.WDIO_LOG_PATH).toBe('/foo/bar/wdio-0-5.log')
-    expect(env.FORCE_COLOR).toBe('true')
+    expect(env.FORCE_COLOR).toBe('1')
     expect(childProcess.on).toBeCalled()
 
     expect(childProcess.send).toBeCalledWith({


### PR DESCRIPTION
## Proposed changes

Terminals without color support are printing out ansi characters. 

1) FORCE_COLOR expects a value to be 0 for no color support but was getting `undefined`.

https://github.com/chalk/supports-color/blob/master/index.js#L19

2) In `wdio-local-runner/src/index.js` i'm not sure exactly why that is always forcing color output so I might be missing the reasoning behind it. 

Screenshot from Jenkins:

![ansi-support](https://user-images.githubusercontent.com/1300981/44945791-ca582a80-adbd-11e8-9e58-9263a6c2deec.png)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

### Reviewers: @webdriverio/technical-committee
