### PR TITLE
Custom Command alignment

### DIFF
--- a/packages/wdio-reporter/README.md
+++ b/packages/wdio-reporter/README.md
@@ -117,6 +117,26 @@ test "some other test" passed
 
 If `stdout` is set to `false` WebdriverIO will automatically write to a filestream at a location where other logs are stored as well.
 
+## Synchronization
+
+If your reporter needs to do some async computation after the test (e.g. upload logs to a server) you can overwrite the `isSynchronised` getter method to manage this. By default this property always returns true as most of the reporters don't require to do any async work. However in case you need to handle this overwrite the getter method with an custom implementation (e.g. [wdio-sumologic-reporter](https://github.com/webdriverio/webdriverio/tree/master/packages/wdio-sumologic-reporter)).
+
+```js
+class MyReporter extends WDIOReporter {
+    constructor (options) {
+        // ...
+    }
+
+    get isSynchronised (test) {
+        return this.unsyncedMessages.length === 0
+    }
+
+    // ...
+}
+```
+
+The wdio testrunner will wait to kill the runner process until every reporter has the `isSynchronised` property set to `true`.
+
 ## Events
 
 During a test run in WebdriverIO several events are thrown and can be captured by your event functions. The following events are propagated:

--- a/packages/wdio-reporter/package.json
+++ b/packages/wdio-reporter/package.json
@@ -28,5 +28,8 @@
   ],
   "bugs": {
     "url": "https://github.com/webdriverio/webdriverio/issues"
+  },
+  "devDependencies": {
+    "tmp": "^0.0.33"
   }
 }

--- a/packages/wdio-reporter/src/index.js
+++ b/packages/wdio-reporter/src/index.js
@@ -37,13 +37,13 @@ export default class WDIOReporter extends EventEmitter {
         this.on('client:beforeCommand', ::this.onBeforeCommand)
         this.on('client:afterCommand', ::this.onAfterCommand)
 
-        this.on('runner:start', (runner) => {
+        this.on('runner:start',  /* istanbul ignore next */ (runner) => {
             rootSuite.cid = runner.cid
             this.runnerStat = new RunnerStats(runner)
             this.onRunnerStart(this.runnerStat)
         })
 
-        this.on('suite:start', (params) => {
+        this.on('suite:start',  /* istanbul ignore next */ (params) => {
             const suite = new SuiteStats(params)
             const currentSuite = this.currentSuites[this.currentSuites.length - 1]
             currentSuite.suites.push(suite)
@@ -52,7 +52,7 @@ export default class WDIOReporter extends EventEmitter {
             this.onSuiteStart(suite)
         })
 
-        this.on('hook:start', (hook) => {
+        this.on('hook:start',  /* istanbul ignore next */ (hook) => {
             const hookStat = new HookStats(hook)
             const currentSuite = this.currentSuites[this.currentSuites.length - 1]
             currentSuite.hooks.push(hookStat)
@@ -60,14 +60,14 @@ export default class WDIOReporter extends EventEmitter {
             this.onHookStart(hookStat)
         })
 
-        this.on('hook:end', (hook) => {
+        this.on('hook:end',  /* istanbul ignore next */ (hook) => {
             const hookStat = this.hooks[hook.uid]
             hookStat.complete()
             this.counts.hooks++
             this.onHookEnd(hookStat)
         })
 
-        this.on('test:start', (test) => {
+        this.on('test:start',  /* istanbul ignore next */ (test) => {
             currentTest = new TestStats(test)
             const currentSuite = this.currentSuites[this.currentSuites.length - 1]
             currentSuite.tests.push(currentTest)
@@ -75,7 +75,7 @@ export default class WDIOReporter extends EventEmitter {
             this.onTestStart(currentTest)
         })
 
-        this.on('test:pass', (test) => {
+        this.on('test:pass',  /* istanbul ignore next */ (test) => {
             const testStat = this.tests[test.uid]
             testStat.pass()
             this.counts.passes++
@@ -83,7 +83,7 @@ export default class WDIOReporter extends EventEmitter {
             this.onTestPass(testStat)
         })
 
-        this.on('test:fail', (test) => {
+        this.on('test:fail',  /* istanbul ignore next */ (test) => {
             const testStat = this.tests[test.uid]
             testStat.fail(test.error)
             this.counts.failures++
@@ -91,7 +91,7 @@ export default class WDIOReporter extends EventEmitter {
             this.onTestFail(testStat)
         })
 
-        this.on('test:pending', (test) => {
+        this.on('test:pending',  /* istanbul ignore next */ (test) => {
             const currentSuite = this.currentSuites[this.currentSuites.length - 1]
             currentTest = new TestStats(test)
 
@@ -114,19 +114,19 @@ export default class WDIOReporter extends EventEmitter {
             this.onTestSkip(currentTest)
         })
 
-        this.on('test:end', (test) => {
+        this.on('test:end',  /* istanbul ignore next */ (test) => {
             const testStat = this.tests[test.uid]
             this.onTestEnd(testStat)
         })
 
-        this.on('suite:end', (suite) => {
+        this.on('suite:end',  /* istanbul ignore next */ (suite) => {
             const suiteStat = this.suites[suite.uid]
             suiteStat.complete()
             this.currentSuites.pop()
             this.onSuiteEnd(suiteStat)
         })
 
-        this.on('runner:end', (runner) => {
+        this.on('runner:end',  /* istanbul ignore next */ (runner) => {
             rootSuite.complete()
             this.runnerStat.failures = runner.failures
             this.runnerStat.complete()
@@ -136,18 +136,26 @@ export default class WDIOReporter extends EventEmitter {
         /**
          * browser client event handlers
          */
-        this.on('client:command', (payload) => {
+        this.on('client:command',  /* istanbul ignore next */ (payload) => {
             if (!currentTest) {
                 return
             }
             currentTest.output.push(Object.assign(payload, { type: 'command' }))
         })
-        this.on('client:result', (payload) => {
+        this.on('client:result',  /* istanbul ignore next */ (payload) => {
             if (!currentTest) {
                 return
             }
             currentTest.output.push(Object.assign(payload, { type: 'result' }))
         })
+    }
+
+    /**
+     * allows reporter to stale process shutdown process until required sync work
+     * is done (e.g. when having to send data to some server or any other async work)
+     */
+    get isSynchronised () {
+        return true
     }
 
     /**
@@ -157,18 +165,32 @@ export default class WDIOReporter extends EventEmitter {
         this.outputStream.write(content)
     }
 
+    /* istanbul ignore next */
     onRunnerStart () {}
+    /* istanbul ignore next */
     onBeforeCommand () {}
+    /* istanbul ignore next */
     onAfterCommand () {}
+    /* istanbul ignore next */
     onScreenshot () {}
+    /* istanbul ignore next */
     onSuiteStart () {}
+    /* istanbul ignore next */
     onHookStart () {}
+    /* istanbul ignore next */
     onHookEnd () {}
+    /* istanbul ignore next */
     onTestStart () {}
+    /* istanbul ignore next */
     onTestPass () {}
+    /* istanbul ignore next */
     onTestFail () {}
+    /* istanbul ignore next */
     onTestSkip () {}
+    /* istanbul ignore next */
     onTestEnd () {}
+    /* istanbul ignore next */
     onSuiteEnd () {}
+    /* istanbul ignore next */
     onRunnerEnd () {}
 }

--- a/packages/wdio-reporter/tests/reporter.test.js
+++ b/packages/wdio-reporter/tests/reporter.test.js
@@ -1,0 +1,67 @@
+import fs from 'fs'
+import tmp from 'tmp'
+
+import WDIOReporter from '../src'
+
+jest.mock('events', () => {
+    class EventEmitterMock {
+        constructor () {
+            this.on = jest.fn()
+        }
+    }
+
+    return EventEmitterMock
+})
+
+describe('WDIOReporter', () => {
+    it('constructor', () => {
+        const tmpobj = tmp.fileSync();
+        const reporter = new WDIOReporter({ logFile: tmpobj.name })
+        expect(reporter.on).toBeCalledWith('client:beforeCommand', expect.any(Function))
+        expect(reporter.on).toBeCalledWith('client:afterCommand', expect.any(Function))
+        expect(reporter.on).toBeCalledWith('runner:start', expect.any(Function))
+        expect(reporter.on).toBeCalledWith('suite:start', expect.any(Function))
+        expect(reporter.on).toBeCalledWith('hook:start', expect.any(Function))
+        expect(reporter.on).toBeCalledWith('hook:end', expect.any(Function))
+        expect(reporter.on).toBeCalledWith('test:start', expect.any(Function))
+        expect(reporter.on).toBeCalledWith('test:pass', expect.any(Function))
+        expect(reporter.on).toBeCalledWith('test:fail', expect.any(Function))
+        expect(reporter.on).toBeCalledWith('test:pending', expect.any(Function))
+        expect(reporter.on).toBeCalledWith('test:end', expect.any(Function))
+        expect(reporter.on).toBeCalledWith('suite:end', expect.any(Function))
+        expect(reporter.on).toBeCalledWith('runner:end', expect.any(Function))
+        expect(reporter.on).toBeCalledWith('client:command', expect.any(Function))
+        expect(reporter.on).toBeCalledWith('client:result', expect.any(Function))
+    })
+
+    it('should be by default synchronised', () => {
+        const tmpobj = tmp.fileSync();
+        const reporter = new WDIOReporter({ logFile: tmpobj.name })
+        expect(reporter.isSynchronised).toBe(true)
+    })
+
+    it('should provide a function to write to output stream', () => {
+        expect.assertions(1)
+
+        const tmpobj = tmp.fileSync();
+        const reporter = new WDIOReporter({ logFile: tmpobj.name })
+        reporter.write('foobar')
+
+        return new Promise((resolve) => reporter.outputStream.end(() => {
+            expect(reporter.outputStream.bytesWritten).toBe(6)
+            resolve()
+        }))
+    })
+
+    it('should allow an own writeable stream', () => {
+        const tmpobj = tmp.fileSync()
+        const customLogStream = fs.createWriteStream(tmpobj.name)
+        const reporter = new WDIOReporter({ stdout: true, writeStream: customLogStream })
+        reporter.write('foobar')
+
+        return new Promise((resolve) => reporter.outputStream.end(() => {
+            expect(reporter.outputStream.bytesWritten).toBe(6)
+            resolve()
+        }))
+    })
+})

--- a/packages/wdio-runner/src/index.js
+++ b/packages/wdio-runner/src/index.js
@@ -167,6 +167,7 @@ export default class Runner extends EventEmitter {
             })
         }
 
+        await this.reporter.waitForSync()
         this.emit('exit', failures === 0 ? 0 : 1)
     }
 

--- a/packages/wdio-runner/src/reporter.js
+++ b/packages/wdio-runner/src/reporter.js
@@ -1,7 +1,12 @@
 import path from 'path'
+import logger from 'wdio-logger'
 import { initialisePlugin } from 'wdio-config'
 
+const log = logger('wdio-runner')
+
 const NOOP = () => {}
+const DEFAULT_SYNC_TIMEOUT = 5000 // 5s
+const DEFAULT_SYNC_INTERVAL = 100 // 100ms
 
 /**
  * BaseReporter
@@ -13,6 +18,12 @@ export default class BaseReporter {
         this.config = config
         this.cid = cid
         this.reporters = config.reporters.map(::this.initReporter)
+
+        /**
+         * these configurations are not publicly documented as there should be no desire for it
+         */
+        this.reporterSyncInterval = this.config.reporterSyncInterval || DEFAULT_SYNC_INTERVAL
+        this.reporterSyncTimeout = this.config.reporterSyncTimeout || DEFAULT_SYNC_TIMEOUT
     }
 
     /**
@@ -41,12 +52,43 @@ export default class BaseReporter {
      */
     getWriteStreamObject (reporter) {
         return {
-            write: (content) => process.send({
+            write: /* istanbul ignore next */ (content) => process.send({
                 origin: 'reporter',
                 name: reporter,
                 content
             })
         }
+    }
+
+    /**
+     * wait for reporter to finish synchronization, e.g. when sending data asynchronous
+     * to a server (e.g. sumo reporter)
+     */
+    waitForSync () {
+        const startTime = Date.now()
+        return new Promise((resolve, reject) => {
+            const interval = setInterval(() => {
+                const unsyncedReporter = this.reporters
+                    .filter((reporter) => !reporter.isSynchronised)
+                    .map((reporter) => reporter.constructor.name)
+
+                if ((Date.now() - startTime) > this.reporterSyncTimeout && unsyncedReporter.length) {
+                    clearInterval(interval)
+                    return reject(new Error(`Some reporter are still unsynced: ${unsyncedReporter.join(', ')}`))
+                }
+
+                /**
+                 * no reporter are in need to sync anymore, continue
+                 */
+                if (!unsyncedReporter.length) {
+                    clearInterval(interval)
+                    return resolve(true)
+                }
+
+                log.info(`Wait for ${unsyncedReporter.length} reporter to synchronise`)
+                // wait otherwise
+            }, this.reporterSyncInterval)
+        })
     }
 
     /**

--- a/packages/wdio-sumologic-reporter/src/index.js
+++ b/packages/wdio-sumologic-reporter/src/index.js
@@ -15,13 +15,16 @@ const DATE_FORMAT = 'yyyy-mm-dd HH:mm:ss,l o'
  */
 export default class SumoLogicReporter extends WDIOReporter {
     constructor (options) {
-        super(options)
-        this.options = Object.assign({
+        options = Object.assign({
+            // don't create a log file
+            stdout: true,
             // define sync interval how often logs get pushed to Sumologic
             syncInterval: 100,
             // endpoint of collector source
             sourceAddress: process.env.SUMO_SOURCE_ADDRESS
         }, options)
+        super(options)
+        this.options = options
 
         if (typeof this.options.sourceAddress !== 'string') {
             log.error('Sumo Logic requires "sourceAddress" paramater')
@@ -35,6 +38,10 @@ export default class SumoLogicReporter extends WDIOReporter {
         this.specs = {}
         this.results = {}
         this.interval = setInterval(::this.sync, this.options.syncInterval)
+    }
+
+    get isSynchronised () {
+        return this.unsynced.length === 0
     }
 
     onRunnerStart (runner) {
@@ -126,26 +133,29 @@ export default class SumoLogicReporter extends WDIOReporter {
          * set `isSynchronising` to true so we don't sync when a request is being made
          */
         this.isSynchronising = true
+        log.debug('start synchronization')
 
         request({
             method: 'POST',
             uri: this.options.sourceAddress,
             body: logLines
         }, (err, resp) => {
-            const failed = Boolean(err) || resp.status < 200 || resp.status >= 400
+            const failed = Boolean(err) || resp.statusCode < 200 || resp.statusCode >= 400
 
+            /* istanbul ignore if  */
             if (failed) {
                 return log.error('failed send data to Sumo Logic:\n', err.stack ? err.stack : err)
-            } else {
-                /**
-                 * remove transfered logs from log bucket
-                 */
-                this.unsynced.splice(0, MAX_LINES)
             }
+
+            /**
+             * remove transfered logs from log bucket
+             */
+            this.unsynced.splice(0, MAX_LINES)
 
             /**
              * reset sync flag so we can sync again
              */
+            log.debug(`synchronised collector data, server status: ${resp.statusCode}`)
             this.isSynchronising = false
         })
     }

--- a/packages/wdio-sumologic-reporter/tests/reporter.test.js
+++ b/packages/wdio-sumologic-reporter/tests/reporter.test.js
@@ -10,7 +10,7 @@ describe('wdio-sumologic-reporter', () => {
 
     beforeEach(() => {
         logger().error.mockClear()
-        reporter = new SumoLogicReporter({ stdout: true })
+        reporter = new SumoLogicReporter()
     })
 
     it('it should start sync when reporter gets initiated', () => {
@@ -104,5 +104,13 @@ describe('wdio-sumologic-reporter', () => {
         request.mock.calls[0][1](new Error('ups'))
         expect(logger().error.mock.calls).toHaveLength(1)
         expect(logger().error.mock.calls[0][0]).toContain('failed send data to Sumo Logic')
+    })
+
+    it('should be synchronised when no unsynced messages', () => {
+        reporter = new SumoLogicReporter({ sourceAddress: 'foobar' })
+        reporter.onRunnerStart('onRunnerStart')
+        expect(reporter.isSynchronised).toBe(false)
+        reporter.sync()
+        expect(reporter.isSynchronised).toBe(true)
     })
 })

--- a/packages/webdriver/src/command.js
+++ b/packages/webdriver/src/command.js
@@ -1,6 +1,6 @@
 import logger from 'wdio-logger'
 import WebDriverRequest from './request'
-import { isValidParameter } from './utils'
+import { isValidParameter, commandCallStructure } from './utils'
 
 const log = logger('webdriver')
 
@@ -76,6 +76,7 @@ export default function (method, endpointUri, commandInfo) {
 
         const request = new WebDriverRequest(method, endpoint, body)
         this.emit('command', { method, endpoint, body })
+        log.info('COMMAND', commandCallStructure(command, args))
         return request.makeRequest(this.options, this.sessionId).then((result) => {
             if (result.value) {
                 log.info('RESULT', result.value)

--- a/packages/webdriver/src/monad.js
+++ b/packages/webdriver/src/monad.js
@@ -78,7 +78,18 @@ export default function WebDriver (options, modifier, propertiesObject = {}) {
             Object.defineProperty(func, 'name', { writable: true })
             func.name = name
 
-            return func.apply(client, args)
+            const result = func.apply(client, args)
+
+            /**
+             * always transform result into promise as we don't know whether or not
+             * the user is running tests with wdio-sync or not
+             */
+            Promise.resolve(result).then((res) => {
+                log.info('RESULT', res)
+                this.emit('result', { name, result: res })
+            })
+
+            return result
         }
     }
 

--- a/packages/webdriver/src/monad.js
+++ b/packages/webdriver/src/monad.js
@@ -1,6 +1,8 @@
 import { EventEmitter } from 'events'
 import logger from 'wdio-logger'
 
+import { commandCallStructure } from './utils'
+
 const SCOPE_TYPES = {
     'browser': function Browser () {},
     'element': function Element () {}
@@ -68,7 +70,7 @@ export default function WebDriver (options, modifier, propertiesObject = {}) {
     unit.lift = function (name, func) {
         prototype[name] = function next (...args) {
             const client = unit(this.sessionId)
-            log.info('COMMAND', `${name}(${args.join(', ')})`)
+            log.info('COMMAND', commandCallStructure(name, args))
 
             /**
              * set name of function for better error stack

--- a/packages/webdriver/src/utils.js
+++ b/packages/webdriver/src/utils.js
@@ -123,3 +123,27 @@ export function getPrototype (isW3C) {
 
     return prototype
 }
+
+/**
+ * get command call structure
+ * (for logging purposes)
+ */
+export function commandCallStructure (commandName, args) {
+    const callArgs = args.map((arg) => {
+        if (typeof arg === 'string') {
+            arg = `"${arg}"`
+        } else if (typeof arg === 'function') {
+            arg = '<fn>'
+        } else if (arg === null) {
+            arg = 'null'
+        } else if (typeof arg === 'object') {
+            arg = '<object>'
+        } else if (typeof arg === 'undefined') {
+            arg = typeof arg
+        }
+
+        return arg
+    }).join(', ')
+
+    return `${commandName}(${callArgs})`
+}

--- a/packages/webdriver/tests/utils.test.js
+++ b/packages/webdriver/tests/utils.test.js
@@ -1,4 +1,4 @@
-import { isSuccessfulResponse, isValidParameter, getPrototype } from '../src/utils'
+import { isSuccessfulResponse, isValidParameter, getPrototype, commandCallStructure } from '../src/utils'
 
 describe('utils', () => {
     it('isSuccessfulResponse', () => {
@@ -63,5 +63,10 @@ describe('utils', () => {
         expect(webdriverPrototype instanceof Object).toBe(true)
         expect(typeof webdriverPrototype.sendKeys).toBe('undefined')
         expect(typeof webdriverPrototype.performActions.value).toBe('function')
+    })
+
+    it('commandCallStructure', () => {
+        expect(commandCallStructure('foobar', ['param', 1, true, { a: 123 }, () => true, null, undefined]))
+            .toBe('foobar("param", 1, true, <object>, <fn>, null, undefined)')
     })
 })


### PR DESCRIPTION
## Proposed changes

I wanted to allow the Sumologic reporter to capture the results of the performance commands (implemented in #2918). I realised, that the custom command implementation was missing an result event emit for that to happen. I implemented that.

Additionally I experienced that reporter that need to do async stuff after the test (e.g. Sumologic reporter has to upload the data) can't do so because the process is killed before. Therefor I implemented a waitFor command to ensure all reporters are in sync.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
