### PR TITLE
webdriverio: Fix space in output of waitFor* commands

### DIFF
--- a/packages/webdriverio/src/commands/element/waitForDisplayed.js
+++ b/packages/webdriverio/src/commands/element/waitForDisplayed.js
@@ -42,8 +42,8 @@ export default async function waitForDisplayed (ms, reverse = false) {
         ms = this.options.waitforTimeout
     }
 
-    const isReversed = reverse ? '' : 'not'
-    const errorMsg = `element ("${this.selector}") still ${isReversed} displayed after ${ms}ms`
+    const isReversed = reverse ? '' : 'not '
+    const errorMsg = `element ("${this.selector}") still ${isReversed}displayed after ${ms}ms`
 
     return this.waitUntil(async () => {
         const isVisible = await this.isElementDisplayed(this.elementId)

--- a/packages/webdriverio/src/commands/element/waitForEnabled.js
+++ b/packages/webdriverio/src/commands/element/waitForEnabled.js
@@ -49,8 +49,8 @@ export default async function waitForEnabled(ms, reverse = false) {
         ms = this.options.waitforTimeout
     }
 
-    const isReversed = reverse ? '' : 'not'
-    const errorMessage = `element ("${this.selector}") still ${isReversed} enabled after ${ms}ms`
+    const isReversed = reverse ? '' : 'not '
+    const errorMessage = `element ("${this.selector}") still ${isReversed}enabled after ${ms}ms`
 
     return this.waitUntil(async () => {
         const isEnabled = await this.isEnabled()

--- a/packages/webdriverio/src/commands/element/waitForExist.js
+++ b/packages/webdriverio/src/commands/element/waitForExist.js
@@ -34,8 +34,8 @@ export default function waitForExist (ms, reverse = false) {
         ms = this.options.waitforTimeout
     }
 
-    const isReversed = reverse ? '' : 'not'
-    const errorMsg = `element ("${this.selector}") still ${isReversed} existing after ${ms}ms`
+    const isReversed = reverse ? '' : 'not '
+    const errorMsg = `element ("${this.selector}") still ${isReversed}existing after ${ms}ms`
 
     return this.waitUntil(function async () {
         return this.isExisting().then((isExisting) => isExisting !== reverse)

--- a/packages/webdriverio/tests/commands/element/waitForDisplayed.test.js
+++ b/packages/webdriverio/tests/commands/element/waitForDisplayed.test.js
@@ -122,6 +122,6 @@ describe('waitForDisplayed', () => {
         await elem.waitForDisplayed(null, true)
 
         expect(elem.waitUntil.mock.calls[0][1]).toBe(elem.options.waitforTimeout)
-        expect(elem.waitUntil.mock.calls[0][2]).toBe(`element ("#foo") still ${``} displayed after ${elem.options.waitforTimeout}ms`)
+        expect(elem.waitUntil.mock.calls[0][2]).toBe(`element ("#foo") still displayed after ${elem.options.waitforTimeout}ms`)
     })
 })

--- a/packages/webdriverio/tests/commands/element/waitForEnabled.test.js
+++ b/packages/webdriverio/tests/commands/element/waitForEnabled.test.js
@@ -114,6 +114,6 @@ describe('waitForEnabled', () => {
         await elem.waitForEnabled(null, true)
 
         expect(elem.waitUntil.mock.calls[0][1]).toBe(elem.options.waitforTimeout)
-        expect(elem.waitUntil.mock.calls[0][2]).toBe(`element ("#foo") still ${``} enabled after ${elem.options.waitforTimeout}ms`)
+        expect(elem.waitUntil.mock.calls[0][2]).toBe(`element ("#foo") still enabled after ${elem.options.waitforTimeout}ms`)
     })
 })


### PR DESCRIPTION
## Proposed changes

When a waitFor* command throws its error message there is an extra space in the display.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

### Reviewers: @webdriverio/technical-committee
