### PR TITLE
wdio-cli: Don't error out when initializing config file

### DIFF
--- a/packages/wdio-cli/src/run.js
+++ b/packages/wdio-cli/src/run.js
@@ -26,7 +26,7 @@ export default function run (params) {
      * if no default wdio.conf was found and no path to a wdio config was specified
      * run the setup
      */
-    if (!wdioConf) {
+    if (!wdioConf || firstArgument === 'config') {
         return setup()
     }
 


### PR DESCRIPTION
## Proposed changes

When running the following command to setup the config file it will error out. The command will work fine without specifying config but the docs say to use config. We could even just update the docs to just run the command without the config argument. 

`./node_modules/.bin/wdio config`

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

### Reviewers: @webdriverio/technical-committee
