### PR TITLE
Fetch element by JS function

### DIFF
--- a/docs/Selectors.md
+++ b/docs/Selectors.md
@@ -134,7 +134,7 @@ console.log(parent.getTagName()); // outputs: "body"
 
 ## JS Function
 
-You can also use a JS functions to fetch elements using web native APIs. This of course is only supported in an web environment (e.g. browser or web context in mobile). Given the following HTML structure:
+You can also use JS functions to fetch elements using web native APIs. This of course is only supported in a web environment (e.g. browser or web context in mobile). Given the following HTML structure:
 
 ```html
 <html>
@@ -145,7 +145,7 @@ You can also use a JS functions to fetch elements using web native APIs. This of
 </html>
 ```
 
-You can query the sibline element of `#elem` as follows:
+You can query the sibling element of `#elem` as follows:
 
 ```js
 const elem = $('#elem') // or $(() => document.getElementById('elem'))

--- a/docs/Selectors.md
+++ b/docs/Selectors.md
@@ -132,6 +132,26 @@ const parent = paragraph.$('..');
 console.log(parent.getTagName()); // outputs: "body"
 ```
 
+## JS Function
+
+You can also use a JS functions to fetch elements using web native APIs. This of course is only supported in an web environment (e.g. browser or web context in mobile). Given the following HTML structure:
+
+```html
+<html>
+    <body>
+        <p id="elem">foobar</p>
+        <p>barfoo</p>
+    </body>
+</html>
+```
+
+You can query the sibline element of `#elem` as follows:
+
+```js
+const elem = $('#elem') // or $(() => document.getElementById('elem'))
+elem.$(() => this.nextSibling.nextSibling) // (first sibling is #text with value ("↵"))
+```
+
 ## Mobile Selectors
 
 For (hybrid/native) mobile testing you have to use mobile strategies and use the underlying device automation technology directly. This is especially useful when a test needs some fine-grained control over finding elements.

--- a/packages/wdio-devtools-service/src/commands.js
+++ b/packages/wdio-devtools-service/src/commands.js
@@ -122,6 +122,7 @@ export default class CommandHandler {
         this.cdp('Tracing', 'end')
         const stream = await new Promise((resolve, reject) => {
             const timeout = setTimeout(
+                /* istanbul ignore next */
                 () => reject('Did not receive a Tracing.tracingComplete event'),
                 5000)
 

--- a/packages/webdriverio/src/commands/browser/$$.js
+++ b/packages/webdriverio/src/commands/browser/$$.js
@@ -31,13 +31,12 @@
 import { webdriverMonad, getPrototype as getWebdriverPrototype } from 'webdriver'
 import { wrapCommand } from 'wdio-config'
 
-import { findStrategy, getPrototype as getWDIOPrototype, getElementFromResponse } from '../../utils'
+import { findElements, getPrototype as getWDIOPrototype, getElementFromResponse } from '../../utils'
 import { elementErrorHandler } from '../../middlewares'
 import { ELEMENT_KEY } from '../../constants'
 
 export default async function $$ (selector) {
-    const { using, value } = findStrategy(selector, this.isW3C)
-    const res = await this.findElements(using, value)
+    const res = await findElements.call(this, selector)
     const prototype = Object.assign(getWebdriverPrototype(this.isW3C), getWDIOPrototype('element'), { scope: 'element' })
 
     const elements = res.map((res, i) => {

--- a/packages/webdriverio/src/commands/browser/$$.js
+++ b/packages/webdriverio/src/commands/browser/$$.js
@@ -6,7 +6,8 @@
  *
  * Using the wdio testrunner this command is a global variable else it will be located on the browser object instead.
  *
- * You can chain `$` or `$$` together in order to walk down the DOM tree.
+ * You can chain `$` or `$$` together in order to walk down the DOM tree. For more information on how
+ * to select specific elements, see [`Selectors`](/docs/selectors.html).
  *
  * <example>
     :index.html

--- a/packages/webdriverio/src/commands/browser/$.js
+++ b/packages/webdriverio/src/commands/browser/$.js
@@ -31,13 +31,12 @@
 import { webdriverMonad, getPrototype as getWebdriverPrototype } from 'webdriver'
 import { wrapCommand } from 'wdio-config'
 
-import { findStrategy, getPrototype as getWDIOPrototype, getElementFromResponse } from '../../utils'
+import { findElement, getPrototype as getWDIOPrototype, getElementFromResponse } from '../../utils'
 import { elementErrorHandler } from '../../middlewares'
 import { ELEMENT_KEY } from '../../constants'
 
 export default async function $ (selector) {
-    const { using, value } = findStrategy(selector, this.isW3C)
-    const res = await this.findElement(using, value)
+    const res = await findElement.call(this, selector)
     const prototype = Object.assign(getWebdriverPrototype(this.isW3C), getWDIOPrototype('element'), { scope: 'element' })
 
     const element = webdriverMonad(this.options, (client) => {

--- a/packages/webdriverio/src/commands/browser/$.js
+++ b/packages/webdriverio/src/commands/browser/$.js
@@ -6,7 +6,8 @@
  *
  * Using the wdio testrunner this command is a global variable else it will be located on the browser object instead.
  *
- * You can chain `$` or `$$` together in order to walk down the DOM tree.
+ * You can chain `$` or `$$` together in order to walk down the DOM tree. For more information on how
+ * to select specific elements, see [`Selectors`](/docs/selectors.html).
  *
  * <example>
     :index.html

--- a/packages/webdriverio/src/commands/element/$$.js
+++ b/packages/webdriverio/src/commands/element/$$.js
@@ -3,6 +3,8 @@
  * to fetch multiple elements on the page similar to the `$$` command from the browser scope. The difference when calling
  * it from an element scope is that the driver will look within the children of that element.
  *
+ * For more information on how to select specific elements, see [`Selectors`](/docs/selectors.html).
+ *
  * <example>
     :index.html
     <ul id="menu">

--- a/packages/webdriverio/src/commands/element/$$.js
+++ b/packages/webdriverio/src/commands/element/$$.js
@@ -28,13 +28,12 @@
 import { webdriverMonad, getPrototype as getWebdriverPrototype } from 'webdriver'
 import { wrapCommand } from 'wdio-config'
 
-import { findStrategy, getPrototype as getWDIOPrototype, getElementFromResponse } from '../../utils'
+import { findElements, getPrototype as getWDIOPrototype, getElementFromResponse } from '../../utils'
 import { elementErrorHandler } from '../../middlewares'
 import { ELEMENT_KEY } from '../../constants'
 
 export default async function $$ (selector) {
-    const { using, value } = findStrategy(selector, this.isW3C)
-    const res = await this.findElementsFromElement(this.elementId, using, value)
+    const res = await findElements.call(this, selector)
     const prototype = Object.assign(getWebdriverPrototype(this.isW3C), getWDIOPrototype('element'), { scope: 'element' })
 
     const elements = res.map((res, i) => {

--- a/packages/webdriverio/src/commands/element/$.js
+++ b/packages/webdriverio/src/commands/element/$.js
@@ -7,6 +7,8 @@
  * make unnecessary requests that slow down the test (e.g. `$('body').$('div')` will trigger two request whereas
  * `$('body div')` does literary the same with just one request)
  *
+ * For more information on how to select specific elements, see [`Selectors`](/docs/selectors.html).
+ *
  * <example>
     :index.html
     <ul id="menu">

--- a/packages/webdriverio/src/commands/element/$.js
+++ b/packages/webdriverio/src/commands/element/$.js
@@ -32,13 +32,12 @@
 import { webdriverMonad, getPrototype as getWebdriverPrototype } from 'webdriver'
 import { wrapCommand } from 'wdio-config'
 
-import { findStrategy, getPrototype as getWDIOPrototype, getElementFromResponse } from '../../utils'
+import { findElement, getPrototype as getWDIOPrototype, getElementFromResponse } from '../../utils'
 import { elementErrorHandler } from '../../middlewares'
 import { ELEMENT_KEY } from '../../constants'
 
 export default async function $ (selector) {
-    const { using, value } = findStrategy(selector, this.isW3C)
-    const res = await this.findElementFromElement(this.elementId, using, value)
+    const res = await findElement.call(this, selector)
     const prototype = Object.assign(getWebdriverPrototype(this.isW3C), getWDIOPrototype('element'), { scope: 'element' })
 
     const element = webdriverMonad(this.options, (client) => {

--- a/packages/webdriverio/src/utils.js
+++ b/packages/webdriverio/src/utils.js
@@ -329,7 +329,7 @@ export function checkUnicode (value) {
 
 function fetchElementByJSFunction (selector, scope) {
     if (!scope.elementId) {
-        return this.execute(selector)
+        return scope.execute(selector)
     }
 
     const script = ((elem) => (selector).call(elem)).toString().replace('selector', `(${selector.toString()})`)

--- a/packages/webdriverio/src/utils.js
+++ b/packages/webdriverio/src/utils.js
@@ -15,10 +15,6 @@ export const findStrategy = function (value, isW3C) {
      */
     let using = DEFAULT_SELECTOR
 
-    if (typeof value !== 'string') {
-        throw new Error('selector needs to be typeof `string`')
-    }
-
     /**
      * check if user has specified locator strategy directly
      */
@@ -328,4 +324,69 @@ export function parseCSS (cssPropertyValue, cssProperty) {
  */
 export function checkUnicode (value) {
     return UNICODE_CHARACTERS.hasOwnProperty(value) ? [UNICODE_CHARACTERS[value]] : new GraphemeSplitter().splitGraphemes(value)
+}
+
+/**
+ * logic to find an element
+ */
+export async function findElement(selector) {
+    /**
+     * fetch element using regular protocol command
+     */
+    if (typeof selector === 'string') {
+        const { using, value } = findStrategy(selector, this.isW3C)
+        return this.elementId
+            ? this.findElementFromElement(this.elementId, using, value)
+            : this.findElement(using, value)
+    }
+
+    /**
+     * fetch element with JS function
+     */
+    if (typeof selector === 'function') {
+        const script = ((elem) => (selector).call(elem)).toString().replace('selector', `(${selector.toString()})`)
+        const notFoundError = new Error(`Function selector "${selector.toString()}" did not return an HTMLElement`)
+
+        let elem = await (
+            this.elementId
+                ? getBrowserObject(this).execute(`return (${script}).apply(null, arguments)`, this)
+                : this.execute(selector)
+        )
+        elem = Array.isArray(elem) ? elem[0] : elem
+        return getElementFromResponse(elem) ? elem : notFoundError
+    }
+
+    throw new Error('selector needs to be typeof `string` or `function`')
+}
+
+/**
+ * logic to find a elements
+ */
+export async function findElements(selector) {
+    /**
+     * fetch element using regular protocol command
+     */
+    if (typeof selector === 'string') {
+        const { using, value } = findStrategy(selector, this.isW3C)
+        return this.elementId
+            ? this.findElementsFromElement(this.elementId, using, value)
+            : this.findElements(using, value)
+    }
+
+    /**
+     * fetch element with JS function
+     */
+    if (typeof selector === 'function') {
+        const script = ((elem) => (selector).call(elem)).toString().replace('selector', `(${selector.toString()})`)
+
+        let elems = await (
+            this.elementId
+                ? getBrowserObject(this).execute(`return (${script}).apply(null, arguments)`, this)
+                : this.execute(selector)
+        )
+        elems = Array.isArray(elems) ? elems : [elems]
+        return elems.filter((elem) => elem && getElementFromResponse(elem))
+    }
+
+    throw new Error('selector needs to be typeof `string` or `function`')
 }

--- a/packages/webdriverio/src/utils.js
+++ b/packages/webdriverio/src/utils.js
@@ -8,6 +8,7 @@ import { ELEMENT_KEY, W3C_SELECTOR_STRATEGIES, UNICODE_CHARACTERS } from './cons
 
 const DEFAULT_SELECTOR = 'css selector'
 const DIRECT_SELECTOR_REGEXP = /^(id|css selector|xpath|link text|partial link text|name|tag name|class name|-android uiautomator|-ios uiautomation|accessibility id):(.+)/
+const INVALID_SELECTOR_ERROR = new Error('selector needs to be typeof `string` or `function`')
 
 export const findStrategy = function (value, isW3C) {
     /**
@@ -326,6 +327,15 @@ export function checkUnicode (value) {
     return UNICODE_CHARACTERS.hasOwnProperty(value) ? [UNICODE_CHARACTERS[value]] : new GraphemeSplitter().splitGraphemes(value)
 }
 
+function fetchElementByJSFunction (selector, scope) {
+    if (!scope.elementId) {
+        return this.execute(selector)
+    }
+
+    const script = ((elem) => (selector).call(elem)).toString().replace('selector', `(${selector.toString()})`)
+    return getBrowserObject(scope).execute(`return (${script}).apply(null, arguments)`, scope)
+}
+
 /**
  * logic to find an element
  */
@@ -344,19 +354,13 @@ export async function findElement(selector) {
      * fetch element with JS function
      */
     if (typeof selector === 'function') {
-        const script = ((elem) => (selector).call(elem)).toString().replace('selector', `(${selector.toString()})`)
         const notFoundError = new Error(`Function selector "${selector.toString()}" did not return an HTMLElement`)
-
-        let elem = await (
-            this.elementId
-                ? getBrowserObject(this).execute(`return (${script}).apply(null, arguments)`, this)
-                : this.execute(selector)
-        )
+        let elem = await fetchElementByJSFunction(selector, this)
         elem = Array.isArray(elem) ? elem[0] : elem
         return getElementFromResponse(elem) ? elem : notFoundError
     }
 
-    throw new Error('selector needs to be typeof `string` or `function`')
+    throw INVALID_SELECTOR_ERROR
 }
 
 /**
@@ -377,16 +381,10 @@ export async function findElements(selector) {
      * fetch element with JS function
      */
     if (typeof selector === 'function') {
-        const script = ((elem) => (selector).call(elem)).toString().replace('selector', `(${selector.toString()})`)
-
-        let elems = await (
-            this.elementId
-                ? getBrowserObject(this).execute(`return (${script}).apply(null, arguments)`, this)
-                : this.execute(selector)
-        )
+        let elems = await fetchElementByJSFunction(selector, this)
         elems = Array.isArray(elems) ? elems : [elems]
         return elems.filter((elem) => elem && getElementFromResponse(elem))
     }
 
-    throw new Error('selector needs to be typeof `string` or `function`')
+    throw INVALID_SELECTOR_ERROR
 }

--- a/packages/webdriverio/tests/utils.test.js
+++ b/packages/webdriverio/tests/utils.test.js
@@ -1,3 +1,4 @@
+import { ELEMENT_KEY } from '../src/constants'
 import {
     findStrategy,
     getElementFromResponse,
@@ -6,14 +7,12 @@ import {
     transformToCharString,
     parseCSS,
     checkUnicode,
+    findElement,
+    findElements
 } from '../src/utils'
 
 describe('utils', () => {
     describe('selector strategies helper', () => {
-        it('should throw when not a string', () => {
-            expect(() => findStrategy(123)).toThrow('selector needs to be typeof `string`')
-        })
-
         it('should find an element using "css selector" method', () => {
             const element = findStrategy('.red')
             expect(element.using).toBe('css selector')
@@ -471,6 +470,172 @@ describe('utils', () => {
             expect(result[0]).toBe('f')
             expect(result[1]).toBe('o')
             expect(result[2]).toBe('o')
+        })
+    })
+
+    describe('findElement', () => {
+        const malformedElementResponse = { foo: 'bar' }
+        const elementResponse = { [ELEMENT_KEY]: 'foobar' }
+        const elementsResponse = [
+            { [ELEMENT_KEY]: 'foobar' },
+            { [ELEMENT_KEY]: 'barfoo' }
+        ]
+        let scope
+
+        beforeEach(() => {
+            scope = {
+                findElementsFromElement: jest.fn(),
+                findElementFromElement: jest.fn(),
+                findElements: jest.fn(),
+                findElement: jest.fn(),
+                execute: jest.fn()
+            }
+        })
+
+        it('fetches element using a selector string with browser scope', async () => {
+            await findElement.call(scope, '.elem')
+            expect(scope.findElement).toBeCalledWith('css selector', '.elem')
+            expect(scope.findElementFromElement).not.toBeCalled()
+        })
+
+        it('fetches element using a selector string with element scope', async () => {
+            scope.elementId = 'foobar'
+            await findElement.call(scope, '.elem')
+            expect(scope.findElement).not.toBeCalled()
+            expect(scope.findElementFromElement)
+                .toBeCalledWith('foobar', 'css selector', '.elem')
+        })
+
+        it('fetches element using a function with browser scope', async () => {
+            scope.execute.mockReturnValue(elementResponse)
+            const elem = await findElement.call(scope, () => { return global.document.body })
+            expect(scope.findElement).not.toBeCalled()
+            expect(scope.findElementFromElement).not.toBeCalled()
+            expect(scope.execute).toBeCalled()
+            expect(elem[ELEMENT_KEY]).toBe('foobar')
+        })
+
+        it('fetches element using a function with element scope', async () => {
+            scope.elementId = 'foobar'
+            scope.execute.mockReturnValue(elementResponse)
+            const elem = await findElement.call(scope, () => { return global.document.body })
+            expect(scope.findElement).not.toBeCalled()
+            expect(scope.findElementFromElement).not.toBeCalled()
+            expect(scope.execute).toBeCalled()
+            expect(elem[ELEMENT_KEY]).toBe('foobar')
+            expect(scope.execute.mock.calls[0][1]).toEqual(scope)
+        })
+
+        it('should return only one element if multiple are returned', async () => {
+            scope.execute.mockReturnValue(elementsResponse)
+            const elem = await findElement.call(scope, () => { return global.document.body })
+            expect(scope.findElement).not.toBeCalled()
+            expect(scope.findElementFromElement).not.toBeCalled()
+            expect(scope.execute).toBeCalled()
+            expect(elem[ELEMENT_KEY]).toBe('foobar')
+        })
+
+        it('throws if element response is malformed', async () => {
+            scope.execute.mockReturnValue(malformedElementResponse)
+            const res = await findElement.call(scope, () => { return global.document.body })
+            expect(res instanceof Error)
+            expect(res.message).toMatch('did not return an HTMLElement')
+        })
+
+        it('throws if selector is neither string nor function', async () => {
+            const expectedMatch = 'selector needs to be typeof `string` or `function`'
+            await expect(findElement.call(scope, null)).rejects.toEqual(new Error(expectedMatch))
+            await expect(findElement.call(scope, 123)).rejects.toEqual(new Error(expectedMatch))
+            await expect(findElement.call(scope, false)).rejects.toEqual(new Error(expectedMatch))
+            await expect(findElement.call(scope)).rejects.toEqual(new Error(expectedMatch))
+        })
+    })
+
+    describe('findElements', () => {
+        const malformedElementResponse = { foo: 'bar' }
+        const elementResponse = { [ELEMENT_KEY]: 'foobar' }
+        const elementsResponse = [
+            { [ELEMENT_KEY]: 'foobar' },
+            { [ELEMENT_KEY]: 'barfoo' }
+        ]
+        let scope
+
+        beforeEach(() => {
+            scope = {
+                findElementsFromElement: jest.fn(),
+                findElementFromElement: jest.fn(),
+                findElements: jest.fn(),
+                findElement: jest.fn(),
+                execute: jest.fn()
+            }
+        })
+
+        it('fetches element using a selector string with browser scope', async () => {
+            await findElements.call(scope, '.elem')
+            expect(scope.findElements).toBeCalledWith('css selector', '.elem')
+            expect(scope.findElementsFromElement).not.toBeCalled()
+        })
+
+        it('fetches element using a selector string with element scope', async () => {
+            scope.elementId = 'foobar'
+            await findElements.call(scope, '.elem')
+            expect(scope.findElements).not.toBeCalled()
+            expect(scope.findElementsFromElement)
+                .toBeCalledWith('foobar', 'css selector', '.elem')
+        })
+
+        it('fetches element using a function with browser scope', async () => {
+            scope.execute.mockReturnValue(elementResponse)
+            const elem = await findElements.call(scope, () => { return global.document.body })
+            expect(scope.findElements).not.toBeCalled()
+            expect(scope.findElementsFromElement).not.toBeCalled()
+            expect(scope.execute).toBeCalled()
+            expect(elem).toHaveLength(1)
+            expect(elem[0][ELEMENT_KEY]).toBe('foobar')
+        })
+
+        it('fetches element using a function with element scope', async () => {
+            scope.elementId = 'foobar'
+            scope.execute.mockReturnValue(elementResponse)
+            const elem = await findElements.call(scope, () => { return global.document.body })
+            expect(scope.findElements).not.toBeCalled()
+            expect(scope.findElementsFromElement).not.toBeCalled()
+            expect(scope.execute).toBeCalled()
+            expect(elem).toHaveLength(1)
+            expect(elem[0][ELEMENT_KEY]).toBe('foobar')
+            expect(scope.execute.mock.calls[0][1]).toEqual(scope)
+        })
+
+        it('should return multiple elements if multiple are returned', async () => {
+            scope.execute.mockReturnValue(elementsResponse)
+            const elem = await findElements.call(scope, () => { return global.document.body })
+            expect(scope.findElement).not.toBeCalled()
+            expect(scope.findElementFromElement).not.toBeCalled()
+            expect(scope.execute).toBeCalled()
+            expect(elem).toEqual(elementsResponse)
+        })
+
+        it('should filter out malformed responses', async () => {
+            scope.execute.mockReturnValue([...elementsResponse, 'foobar'])
+            const elem = await findElements.call(scope, () => { return global.document.body })
+            expect(scope.findElement).not.toBeCalled()
+            expect(scope.findElementFromElement).not.toBeCalled()
+            expect(scope.execute).toBeCalled()
+            expect(elem).toEqual(elementsResponse)
+        })
+
+        it('throws if element response is malformed', async () => {
+            scope.execute.mockReturnValue(malformedElementResponse)
+            const res = await findElements.call(scope, () => { return global.document.body })
+            expect(res).toHaveLength(0)
+        })
+
+        it('throws if selector is neither string nor function', async () => {
+            const expectedMatch = 'selector needs to be typeof `string` or `function`'
+            await expect(findElements.call(scope, null)).rejects.toEqual(new Error(expectedMatch))
+            await expect(findElements.call(scope, 123)).rejects.toEqual(new Error(expectedMatch))
+            await expect(findElements.call(scope, false)).rejects.toEqual(new Error(expectedMatch))
+            await expect(findElements.call(scope)).rejects.toEqual(new Error(expectedMatch))
         })
     })
 })


### PR DESCRIPTION
## The problem

Sometimes given selector strategies won't work and you need to use some JS to fetch an element. You can already use that via `browser.execute` in v4 today. However it won't convert that element into an element object.

## Proposal

Allow to pass in a function to the `$` and `$$` commands which will fetch an element and wrap it into an element object.