### PR TITLE
Add support for find by attribute and content

### DIFF
--- a/packages/webdriverio/src/utils.js
+++ b/packages/webdriverio/src/utils.js
@@ -43,12 +43,12 @@ export const findStrategy = function (value, isW3C) {
                value.indexOf('*/') === 0) {
         using = 'xpath'
 
-    // use link text strategy if value startes with =
+    // use link text strategy if value starts with =
     } else if (value.indexOf('=') === 0) {
         using = 'link text'
         value = value.slice(1)
 
-    // use partial link text strategy if value startes with *=
+    // use partial link text strategy if value starts with *=
     } else if (value.indexOf('*=') === 0) {
         using = 'partial link text'
         value = value.slice(2)
@@ -86,50 +86,54 @@ export const findStrategy = function (value, isW3C) {
         using = 'name'
         value = value.match(/^\[name=("|')([a-zA-z0-9\-_. ]+)("|')]$/)[2]
 
-    // any element with given text e.g. h1=Welcome
-    } else if (value.search(/^[a-z0-9]*=(.)+$/) >= 0) {
-        let query = value.split(/=/)
-        let tag = query.shift()
-
-        using = 'xpath'
-        value = `.//${tag.length ? tag : '*'}[normalize-space() = "${query.join('=')}"]`
-
-    // any element containing given text
-    } else if (value.search(/^[a-z0-9]*\*=(.)+$/) >= 0) {
-        let query = value.split(/\*=/)
-        let tag = query.shift()
-
-        using = 'xpath'
-        value = `.//${tag.length ? tag : '*'}[contains(., "${query.join('*=')}")]`
-
-    // any element with certain class or id + given content
-    } else if (value.search(/^[a-z0-9]*(\.|#)-?[_a-zA-Z]+[_a-zA-Z0-9-]*=(.)+$/) >= 0) {
-        let query = value.split(/=/)
-        let tag = query.shift()
-
-        let classOrId = tag.substr(tag.search(/(\.|#)/), 1) === '#' ? 'id' : 'class'
-        let classOrIdName = tag.slice(tag.search(/(\.|#)/) + 1)
-
-        tag = tag.substr(0, tag.search(/(\.|#)/))
-        using = 'xpath'
-        value = `.//${tag.length ? tag : '*'}[contains(@${classOrId}, "${classOrIdName}") and normalize-space() = "${query.join('=')}"]`
-
-    // any element with certain class or id + has certain content
-    } else if (value.search(/^[a-z0-9]*(\.|#)-?[_a-zA-Z]+[_a-zA-Z0-9-]*\*=(.)+$/) >= 0) {
-        let query = value.split(/\*=/)
-        let tag = query.shift()
-
-        let classOrId = tag.substr(tag.search(/(\.|#)/), 1) === '#' ? 'id' : 'class'
-        let classOrIdName = tag.slice(tag.search(/(\.|#)/) + 1)
-
-        tag = tag.substr(0, tag.search(/(\.|#)/))
-        using = 'xpath'
-        value = './/' + (tag.length ? tag : '*') + '[contains(@' + classOrId + ', "' + classOrIdName + '") and contains(., "' + query.join('*=') + '")]'
-        value = `.//${tag.length ? tag : '*'}[contains(@${classOrId}, "${classOrIdName}") and contains(., "${query.join('*=')}")]`
 
     // allow to move up to the parent or select current element
     } else if (value === '..' || value === '.') {
         using = 'xpath'
+
+    // any element with given class, id, or attribute and content
+    // e.g. h1.header=Welcome or [data-name=table-row]=Item or #content*=Intro
+    } else {
+        const match = value.match(new RegExp([
+            // HTML tag
+            /^([a-z0-9]*)/,
+            // optional . or # + class or id
+            /(?:(\.|#)(-?[_a-zA-Z]+[_a-zA-Z0-9-]*))?/,
+            // optional [attribute-name="attribute-value"]
+            /(?:\[(-?[_a-zA-Z]+[_a-zA-Z0-9-]*)(?:=(?:"|')([a-zA-z0-9\-_. ]+)(?:"|'))?\])?/,
+            // *=query or =query
+            /(\*)?=(.+)$/,
+        ].map(rx => rx.source).join('')))
+
+        if (match) {
+            const PREFIX_NAME = { '.': 'class', '#': 'id' }
+            const conditions = []
+            const [
+                tag,
+                prefix, name,
+                attrName, attrValue,
+                partial, query
+            ] =  match.slice(1)
+
+            if (prefix) {
+                conditions.push(`contains(@${PREFIX_NAME[prefix]}, "${name}")`)
+            }
+            if (attrName) {
+                conditions.push(
+                    attrValue
+                        ? `contains(@${attrName}, "${attrValue}")`
+                        : `@${attrName}`
+                );
+            }
+            if (partial) {
+                conditions.push(`contains(., "${query}")`)
+            } else {
+                conditions.push(`normalize-space() = "${query}"`)
+            }
+
+            using = 'xpath'
+            value = `.//${tag || '*'}[${conditions.join(' and ')}]`
+        }
     }
 
     /**
@@ -171,7 +175,7 @@ export const getPrototype = (scope) => {
  */
 export const getElementFromResponse = (res) => {
     /**
-     * depcrecated JSONWireProtocol response
+     * deprecated JSONWireProtocol response
      */
     if (res.ELEMENT) {
         return res.ELEMENT

--- a/packages/webdriverio/tests/utils.test.js
+++ b/packages/webdriverio/tests/utils.test.js
@@ -146,6 +146,36 @@ describe('utils', () => {
             expect(element.value).toBe('.//*[contains(@id, "What-is-WebdriverIO") and contains(., "What")]')
         })
 
+        it('should find an element by tag name + attribute + content', () => {
+            const element = findStrategy('div[some-attribute="some-value"]=some random text with "§$%&/()div=or others')
+            expect(element.using).toBe('xpath')
+            expect(element.value).toBe('.//div[contains(@some-attribute, "some-value") and normalize-space() = "some random text with "§$%&/()div=or others"]')
+        })
+
+        it('should find an element by attribute + content', () => {
+            const element = findStrategy('[some-attribute="some-value"]=some random text with "§$%&/()div=or others')
+            expect(element.using).toBe('xpath')
+            expect(element.value).toBe('.//*[contains(@some-attribute, "some-value") and normalize-space() = "some random text with "§$%&/()div=or others"]')
+        })
+
+        it('should find an element by attribute existence + content', () => {
+            const element = findStrategy('[some-attribute]=some random text with "§$%&/()div=or others')
+            expect(element.using).toBe('xpath')
+            expect(element.value).toBe('.//*[@some-attribute and normalize-space() = "some random text with "§$%&/()div=or others"]')
+        })
+
+        it('should find an element by tag name + attribute + similar content', () => {
+            const element = findStrategy('div[some-attribute="some-value"]*=some random text with "§$%&/()div=or others')
+            expect(element.using).toBe('xpath')
+            expect(element.value).toBe('.//div[contains(@some-attribute, "some-value") and contains(., "some random text with "§$%&/()div=or others")]')
+        })
+
+        it('should find an element by attribute + similar content', () => {
+            const element = findStrategy('[some-attribute="some-value"]*=some random text with "§$%&/()div=or others')
+            expect(element.using).toBe('xpath')
+            expect(element.value).toBe('.//*[contains(@some-attribute, "some-value") and contains(., "some random text with "§$%&/()div=or others")]')
+        })
+
         it('should allow to go up and down the DOM tree with xpath', () => {
             let element = findStrategy('..')
             expect(element.using).toBe('xpath')


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)
Add support for selecting elements by attribute as well as content.
Before this change it was only possible to select some element by a given tag name, id or class and a certain content, like `div#main*=Hello`.
After this change it will be also possible to select by attribute, like `div[data-test-name="main"]*=Hello`

### Motivation
In our project we are using `data-test-name` attributes for marking elements that will be consumed by our tests. Since we are using [styled components](https://github.com/styled-components) which already generate random class names for elements, we avoid polluting the class attribute by using this specific attribute for tests element targeting.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)
I have taken this as an opportunity for removing some repeated code, so now all the id class or attribute + content cases are handled by a single regular expression.

### Reviewers: @webdriverio/technical-committee
