### PR TITLE
wdio-sauce-service: Add ability to detect step failure for cucumber v3 and above

### DIFF
--- a/packages/wdio-sauce-service/src/index.js
+++ b/packages/wdio-sauce-service/src/index.js
@@ -81,7 +81,11 @@ export default class SauceService {
             /**
              * Cucumber v2
              */
-            (typeof feature.getFailureException === 'function' && feature.getFailureException())
+            (typeof feature.getFailureException === 'function' && feature.getFailureException()) ||
+            /**
+             * Cucumber v3, v4
+             */
+            (feature.status === 'failed')
         ) {
             ++this.failures
         }

--- a/packages/wdio-sauce-service/tests/service.test.js
+++ b/packages/wdio-sauce-service/tests/service.test.js
@@ -108,6 +108,9 @@ test('afterStep', () => {
 
     service.afterStep({ getFailureException: () => 'whatever' })
     expect(service.failures).toBe(2)
+
+    service.afterStep({ status: 'failed' })
+    expect(service.failures).toBe(3)
 })
 
 test('beforeScenario should set context', () => {


### PR DESCRIPTION
## Proposed changes
The cucumber API has changed again on v3, thus sauce plugin is currently enable to detect failures when using wdio-cucumber-framework v2.x (which upgrades from cucumber v2 to v3-v4).
This fixes that problem by adding the proper failure condition.

[V4 PR](https://github.com/webdriverio-boneyard/wdio-sauce-service/pull/55)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)
I have followed the instructions to setup the project as per CONTRIBUTING.md, unfortunately I walked into a bunch of errors during the setup phase and gave up after an hour.
I could not run the tests locally, though the changes are pretty much straight forward and have already been approved in v4. I hope that's ok.

### Reviewers: @webdriverio/technical-committee
