### PR TITLE
Updated the isUnknownCommand to match on Unknown for IE Drivers

### DIFF
--- a/lib/helpers/utilities.js
+++ b/lib/helpers/utilities.js
@@ -53,8 +53,7 @@ export function isUnknownCommand (err) {
     /**
      * when running browser driver directly
      */
-    if (err.message.match(/405/) ||
-        err.message.match(/Invalid Command Method/) ||
+    if (err.message.match(/Invalid Command Method/) ||
         err.message.match(/did not match a known command/) ||
         err.message.match(/unknown command/) ||
         err.message.match(/Driver info: driver\.version: unknown/) ||
@@ -67,7 +66,7 @@ export function isUnknownCommand (err) {
     /**
      * when running via selenium standalone
      */
-    if (err.seleniumStack && (err.seleniumStack.type === 'UnknownCommand' || err.seleniumStack.type === 'Unknown')) {
+    if (err.seleniumStack && err.seleniumStack.type.match(/Unknown/)) {
         return true
     }
 

--- a/lib/helpers/utilities.js
+++ b/lib/helpers/utilities.js
@@ -53,7 +53,8 @@ export function isUnknownCommand (err) {
     /**
      * when running browser driver directly
      */
-    if (err.message.match(/Invalid Command Method/) ||
+    if (err.message.match(/405/) ||
+        err.message.match(/Invalid Command Method/) ||
         err.message.match(/did not match a known command/) ||
         err.message.match(/unknown command/) ||
         err.message.match(/Driver info: driver\.version: unknown/) ||

--- a/test/spec/unit/utilities.js
+++ b/test/spec/unit/utilities.js
@@ -110,7 +110,7 @@ describe('utilities', () => {
                 message: 'did not map to a valid resource'
             })).to.be.equal(true)
         })
-        
+
         it('should recognise unknown server-side error response', () => {
             expect(isUnknownCommand({
                 message: 'java.io.IOException: Server returned HTTP response code: 405 for URL:',
@@ -119,7 +119,7 @@ describe('utilities', () => {
                     message: 'An unknown server-side error occurred while processing the command.'
                 }
             })).to.be.equal(true)
-        });
+        })
     })
 
     describe('formatHostname', () => {

--- a/test/spec/unit/utilities.js
+++ b/test/spec/unit/utilities.js
@@ -110,6 +110,16 @@ describe('utilities', () => {
                 message: 'did not map to a valid resource'
             })).to.be.equal(true)
         })
+        
+        it('should recognise unknown server-side error response', () => {
+            expect(isUnknownCommand({
+                message: 'java.io.IOException: Server returned HTTP response code: 405 for URL:',
+                seleniumStack: {
+                    type: 'UnknownError',
+                    message: 'An unknown server-side error occurred while processing the command.'
+                }
+            })).to.be.equal(true)
+        });
     })
 
     describe('formatHostname', () => {


### PR DESCRIPTION
## Proposed changes
Updated the `isUnknownCommand` to match on `Unknown` instead of  specifically checking for `Unknown` or `UnknownCommand`. Closes https://github.com/webdriverio/webdriverio/issues/2983.

This issue was discovered while running tests against a 3.14.0 selenium grid with IE nodes. The IE driver  returned the following error message when `browser.execute()` attempted the JsonWireframeProtocol execute endpoint before attempting the `W3C` endpoint syntax. This version of the IE driver must have changed the error message returned.

```
{ Error: java.io.IOException: Server returned HTTP response code: 405 for URL: http://localhost:37890/session/00d90918-cbba-4131-a274-cb40bf1d0608/execute
    at .....
  details: undefined,
  message: 'java.io.IOException: Server returned HTTP response code: 405 for URL: http://localhost:37890/session/00d90918-cbba-4131-a274-cb40bf1d0608/execute',
  type: 'RuntimeError',
  seleniumStack: 
   { type: 'UnknownError',
     message: 'An unknown server-side error occurred while processing the command.',
     orgStatusMessage: 'java.io.IOException: Server returned HTTP response code: 405 for URL: http://localhost:37890/session/00d90918-cbba-4131-a274-cb40bf1d0608/execute' } }
```


## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)


### Reviewers: @webdriverio/technical-committee
