### PR TITLE
wdio-junit-reporter: fix npm run setup on OSX

### DIFF
--- a/packages/wdio-junit-reporter/package.json
+++ b/packages/wdio-junit-reporter/package.json
@@ -37,7 +37,7 @@
     "validator": "^9.4.1"
   },
   "devDependencies": {
-    "libxmljs": "^0.18.7",
+    "libxmljs": "^0.19.5",
     "rimraf": "^2.6.2"
   }
 }


### PR DESCRIPTION
## Proposed changes
When setting up the new v5 repo I kept bumping on an error at the installation of lixmljs 0.18.7
Upgrading to 0.19.5 (latest) fixes that problem.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
