### PR TITLE
wdio-allure-reporter: Add support for additional test arguments

### DIFF
--- a/packages/wdio-allure-reporter/README.md
+++ b/packages/wdio-allure-reporter/README.md
@@ -50,6 +50,7 @@ exports.config = {
 * `testId(value)` – assign TMS test id to test
 * `addEnvironment(name, value)` – save environment value
 * `addAttachment(name, content, [type])` – save attachment to test.
+* `addArgument(name, value)` - add additional argument to test
     * `name` (*String*) - attachment name.
     * `content` – attachment content.
     * `type` (*String*, optional) – attachment MIME-type, `text/plain` by default

--- a/packages/wdio-allure-reporter/src/constants.js
+++ b/packages/wdio-allure-reporter/src/constants.js
@@ -25,7 +25,8 @@ const events = {
     addEnvironment: 'allure:addEnvironment',
     addDescription: 'allure:addDescription',
     addAttachment: 'allure:addAttachment',
-    addStep: 'allure:addStep'
+    addStep: 'allure:addStep',
+    addArgument: 'allure:addArgument'
 }
 
 const mochaIgnoredHooks = ['"before all" hook', '"after all" hook', '"before each" hook', '"after each" hook']

--- a/packages/wdio-allure-reporter/src/index.js
+++ b/packages/wdio-allure-reporter/src/index.js
@@ -23,6 +23,7 @@ class AllureReporter extends WDIOReporter {
         process.on(events.addAttachment, ::this.addAttachment)
         process.on(events.addDescription, ::this.addDescription)
         process.on(events.addStep, ::this.addStep)
+        process.on(events.addArgument, ::this.addArgument)
     }
 
     onRunnerStart(runner) {
@@ -225,6 +226,14 @@ class AllureReporter extends WDIOReporter {
             this.addAttachment(step.attachment)
         }
         this.allure.endStep(step.status)
+    }
+
+    addArgument({name, value}) {
+        if (!this.isAnyTestRunning()) {
+            return false
+        }
+        const test = this.allure.getCurrentTest()
+        test.addParameter('argument', name, value)
     }
 
     isAnyTestRunning() {

--- a/packages/wdio-allure-reporter/src/runtime.js
+++ b/packages/wdio-allure-reporter/src/runtime.js
@@ -91,3 +91,12 @@ export const addStep = (title, {content, name = 'attachment'}, status = stepStat
     }
     tellReporter(events.addStep, {step})
 }
+
+/**
+ * Add additional argument to test
+ * @param {string} name - argument name
+ * @param {string} value - argument value
+ */
+export const addArgument = (name, value) => {
+    tellReporter(events.addArgument, {name, value})
+}

--- a/packages/wdio-allure-reporter/tests/allureFeatures.test.js
+++ b/packages/wdio-allure-reporter/tests/allureFeatures.test.js
@@ -233,6 +233,22 @@ describe('reporter runtime implementation', () => {
         expect(startStep).toHaveBeenCalledWith(step.step.title)
         expect(endStep).toHaveBeenCalledWith(step.step.status)
     })
+
+    it('should correctly add argument', () => {
+        const reporter = new AllureReporter({stdout: true})
+        const addParameter = jest.fn()
+        const mock = jest.fn(() => {
+            return {addParameter}
+        })
+        reporter.allure = {
+            getCurrentSuite: mock,
+            getCurrentTest: mock,
+        }
+
+        reporter.addArgument({name: 'os', value: 'osx'})
+        expect(addParameter).toHaveBeenCalledTimes(1)
+        expect(addParameter).toHaveBeenCalledWith('argument', 'os', 'osx')
+    })
 })
 
 describe('reporter runtime implementation', () => {
@@ -247,6 +263,7 @@ describe('reporter runtime implementation', () => {
         expect(reporter.addDescription({})).toEqual(false)
         expect(reporter.addAttachment({})).toEqual(false)
         expect(reporter.addStep({})).toEqual(false)
+        expect(reporter.addArgument({})).toEqual(false)
     })
 })
 

--- a/packages/wdio-allure-reporter/tests/constants.test.js
+++ b/packages/wdio-allure-reporter/tests/constants.test.js
@@ -18,7 +18,7 @@ describe('Important constants', () => {
     })
 
     it('should have correct step statuses', () => {
-        expect(Object.values(events)).toHaveLength(9)
+        expect(Object.values(events)).toHaveLength(10)
         expect(events.addSeverity).toEqual("allure:addSeverity")
         expect(events.addIssue).toEqual("allure:addIssue")
         expect(events.addTestId).toEqual("allure:addTestId")
@@ -28,5 +28,6 @@ describe('Important constants', () => {
         expect(events.addEnvironment).toEqual("allure:addEnvironment")
         expect(events.addFeature).toEqual("allure:addFeature")
         expect(events.addStory).toEqual("allure:addStory")
+        expect(events.addArgument).toEqual("allure:addArgument")
     })
 })

--- a/packages/wdio-allure-reporter/tests/runtime.test.js
+++ b/packages/wdio-allure-reporter/tests/runtime.test.js
@@ -90,4 +90,9 @@ describe('reporter runtime api', () => {
         expect(cb).toThrowError('Step status must be passed or failed or broken. You tried to set "canceled"')
     })
 
+    it('should pass correct data from addArgument', () => {
+        runtime.addArgument('os', 'osx')
+        expect(utils.tellReporter).toHaveBeenCalledTimes(1)
+        expect(utils.tellReporter).toHaveBeenCalledWith(events.addArgument, {name: 'os', value: 'osx'})
+    })
 })

--- a/packages/wdio-allure-reporter/tests/suite.test.js
+++ b/packages/wdio-allure-reporter/tests/suite.test.js
@@ -24,6 +24,7 @@ describe('Passing tests', () => {
         reporter.addEnvironment({name: 'jenkins', value: '1.2.3'})
         reporter.addDescription({description: 'functions', type: 'html'})
         reporter.addAttachment({name: 'My attachment', content: '99thoughtz', type: 'text/plain'})
+        reporter.addArgument({name: 'os', value: 'osx'})
         const step = {'step': {'attachment': {'content': 'baz', 'name': 'attachment'}, 'status': 'failed', 'title': 'foo'}}
         reporter.addStep(step)
         reporter.onTestPass(testPassed())
@@ -56,7 +57,7 @@ describe('Passing tests', () => {
     })
 
     it('should add browser name as test argument', () => {
-        expect(allureXml('test-case parameter[kind="argument"]')).toHaveLength(1)
+        expect(allureXml('test-case parameter[kind="argument"]')).toHaveLength(2)
         expect(allureXml('test-case parameter[name="browser"]').eq(0).attr('value')).toEqual('chrome-68')
     })
 
@@ -83,6 +84,11 @@ describe('Passing tests', () => {
 
     it('should add attachment', () => {
         expect(allureXml('test-case attachment[title="My attachment"]')).toHaveLength(1)
+    })
+
+    it('should add additional argument', () => {
+        expect(allureXml('test-case parameter[kind="argument"]')).toHaveLength(2)
+        expect(allureXml('test-case parameter[name="os"]').eq(0).attr('value')).toEqual('osx')
     })
 })
 


### PR DESCRIPTION
## Proposed changes

Adds ability to add additional argument to the test to distinguish run of same test on different OSes or resolutions for example.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
