### PR TITLE
webdriver: Changed path resolve to join for Windows support

### DIFF
--- a/packages/webdriver/src/request.js
+++ b/packages/webdriver/src/request.js
@@ -58,7 +58,7 @@ export default class WebDriverRequest extends EventEmitter {
         requestOptions.uri = url.parse(
             `${options.protocol}://` +
             `${options.hostname}:${options.port}` +
-            path.resolve(`${options.path}${this.endpoint.replace(':sessionId', sessionId)}`)
+            path.join(`${options.path}${this.endpoint.replace(':sessionId', sessionId)}`)
         )
 
         /**


### PR DESCRIPTION
## Proposed changes

[//]: # Proposed fix for [Issue 2980](https://github.com/webdriverio/webdriverio/issues/2980). Changes ```path.resolve()``` to ```path.join()``` in order to remove the ```C:/``` from being added on to the Selenium request endpoint.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

### Reviewers: @webdriverio/technical-committee