### PR TITLE
Replace all instances of rm -rf with rimraf

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "babel-preset-env": "^1.3.3",
     "babel-register": "^6.24.1",
     "codecov": "^3.0.0",
+    "copyfiles": "^2.1.0",
     "eslint": "^4.7.2",
     "eslint-plugin-import": "^2.8.0",
     "inquirer": "^5.1.0",

--- a/packages/wdio-allure-reporter/package.json
+++ b/packages/wdio-allure-reporter/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "build": "run-s clean compile",
-    "clean": "rm -rf ./build",
+    "clean": "rimraf ./build",
     "compile": "babel src/ -d build/",
     "test": "run-s test:*",
     "test:eslint": "eslint src test",

--- a/packages/wdio-applitools-service/package.json
+++ b/packages/wdio-applitools-service/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "build": "run-s clean compile",
-    "clean": "rm -rf ./build",
+    "clean": "rimraf ./build",
     "compile": "babel src/ -d build/",
     "test": "run-s test:*",
     "test:eslint": "eslint src test",

--- a/packages/wdio-cli/package.json
+++ b/packages/wdio-cli/package.json
@@ -14,9 +14,9 @@
   },
   "scripts": {
     "build": "run-s clean compile copy",
-    "clean": "rm -rf ./build",
+    "clean": "rimraf ./build",
     "compile": "babel src/ -d build/",
-    "copy": "cp -r src/templates build/",
+    "copy": "copyfiles src/templates/*.ejs ./build/",
     "test": "run-s test:*",
     "test:eslint": "eslint src test",
     "test:unit": "jest"

--- a/packages/wdio-concise-reporter/package.json
+++ b/packages/wdio-concise-reporter/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "build": "run-s clean compile",
-    "clean": "rm -rf ./build",
+    "clean": "rimraf ./build",
     "compile": "babel src/ -d build/",
     "test": "run-s test:*",
     "test:eslint": "eslint src test",

--- a/packages/wdio-config/package.json
+++ b/packages/wdio-config/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "build": "run-s clean compile",
-    "clean": "rm -rf ./build",
+    "clean": "rimraf ./build",
     "compile": "babel src/ -d build/",
     "test": "run-s test:*",
     "test:eslint": "eslint src test",

--- a/packages/wdio-devtools-service/package.json
+++ b/packages/wdio-devtools-service/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "build": "run-s clean compile",
-    "clean": "rm -rf ./build",
+    "clean": "rimraf ./build",
     "compile": "babel src/ -d build/",
     "test": "run-s test:*",
     "test:eslint": "eslint src test",

--- a/packages/wdio-dot-reporter/package.json
+++ b/packages/wdio-dot-reporter/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "build": "run-s clean compile",
-    "clean": "rm -rf ./build",
+    "clean": "rimraf ./build",
     "compile": "babel src/ -d build/",
     "test": "run-s test:*",
     "test:eslint": "eslint src test",

--- a/packages/wdio-firefox-profile-service/package.json
+++ b/packages/wdio-firefox-profile-service/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "build": "run-s clean compile",
-    "clean": "rm -rf ./build",
+    "clean": "rimraf ./build",
     "compile": "babel src/ -d build/",
     "test": "run-s test:*",
     "test:eslint": "eslint src test",

--- a/packages/wdio-interface/package.json
+++ b/packages/wdio-interface/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "build": "run-s clean compile",
-    "clean": "rm -rf ./build",
+    "clean": "rimraf ./build",
     "compile": "babel src/ -d build/",
     "test": "run-s test:*",
     "test:eslint": "eslint src test",

--- a/packages/wdio-jasmine-framework/package.json
+++ b/packages/wdio-jasmine-framework/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "build": "run-s clean compile",
-    "clean": "rm -rf ./build",
+    "clean": "rimraf ./build",
     "compile": "babel src/ -d build/",
     "test": "run-s test:*",
     "test:eslint": "eslint src test",

--- a/packages/wdio-junit-reporter/package.json
+++ b/packages/wdio-junit-reporter/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "build": "run-s clean compile",
-    "clean": "rm -rf ./build",
+    "clean": "rimraf ./build",
     "compile": "babel src/ -d build/",
     "test": "run-s test:*",
     "test:eslint": "eslint src test",

--- a/packages/wdio-lambda-runner/package.json
+++ b/packages/wdio-lambda-runner/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "build": "run-s clean compile",
-    "clean": "rm -rf ./build",
+    "clean": "rimraf ./build",
     "compile": "babel src/ -d build/",
     "test": "run-s test:*",
     "test:eslint": "eslint src test",

--- a/packages/wdio-local-runner/package.json
+++ b/packages/wdio-local-runner/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "build": "run-s clean compile",
-    "clean": "rm -rf ./build",
+    "clean": "rimraf ./build",
     "compile": "babel src/ -d build/",
     "test": "run-s test:*",
     "test:eslint": "eslint src test",

--- a/packages/wdio-logger/package.json
+++ b/packages/wdio-logger/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "build": "run-s clean compile",
-    "clean": "rm -rf ./build",
+    "clean": "rimraf ./build",
     "compile": "babel src/ -d build/",
     "test": "run-s test:*",
     "test:eslint": "eslint src test",

--- a/packages/wdio-mocha-framework/package.json
+++ b/packages/wdio-mocha-framework/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "build": "run-s clean compile",
-    "clean": "rm -rf ./build",
+    "clean": "rimraf ./build",
     "compile": "babel src/ -d build/",
     "test": "run-s test:*",
     "test:eslint": "eslint src test",

--- a/packages/wdio-reporter/package.json
+++ b/packages/wdio-reporter/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "build": "run-s clean compile",
-    "clean": "rm -rf ./build",
+    "clean": "rimraf ./build",
     "compile": "babel src/ -d build/",
     "test": "run-s test:*",
     "test:eslint": "eslint src test",

--- a/packages/wdio-runner/package.json
+++ b/packages/wdio-runner/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "build": "run-s clean compile",
-    "clean": "rm -rf ./build",
+    "clean": "rimraf ./build",
     "compile": "babel src/ -d build/",
     "test": "run-s test:*",
     "test:eslint": "eslint src test",

--- a/packages/wdio-sauce-service/package.json
+++ b/packages/wdio-sauce-service/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "build": "run-s clean compile",
-    "clean": "rm -rf ./build",
+    "clean": "rimraf ./build",
     "compile": "babel src/ -d build/",
     "test": "run-s test:*",
     "test:eslint": "eslint src test",

--- a/packages/wdio-selenium-standalone-service/package.json
+++ b/packages/wdio-selenium-standalone-service/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "build": "run-s clean compile",
-    "clean": "rm -rf ./build",
+    "clean": "rimraf ./build",
     "compile": "babel src/ -d build/",
     "test": "run-s test:*",
     "test:eslint": "eslint src test",

--- a/packages/wdio-spec-reporter/package.json
+++ b/packages/wdio-spec-reporter/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "build": "run-s clean compile",
-    "clean": "rm -rf ./build",
+    "clean": "rimraf ./build",
     "compile": "babel src/ -d build/",
     "test": "run-s test:*",
     "test:eslint": "eslint src test",

--- a/packages/wdio-sumologic-reporter/package.json
+++ b/packages/wdio-sumologic-reporter/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "build": "run-s clean compile",
-    "clean": "rm -rf ./build",
+    "clean": "rimraf ./build",
     "compile": "babel src/ -d build/",
     "test": "run-s test:*",
     "test:eslint": "eslint src test",

--- a/packages/wdio-sync/package.json
+++ b/packages/wdio-sync/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "build": "run-s clean compile",
-    "clean": "rm -rf ./build",
+    "clean": "rimraf ./build",
     "compile": "babel src/ -d build/",
     "test": "run-s test:*",
     "test:eslint": "eslint src test",

--- a/packages/wdio-testingbot-service/package.json
+++ b/packages/wdio-testingbot-service/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "build": "run-s clean compile",
-    "clean": "rm -rf ./build",
+    "clean": "rimraf ./build",
     "compile": "babel src/ -d build/",
     "test": "run-s test:*",
     "test:eslint": "eslint src test",

--- a/packages/webdriver/package.json
+++ b/packages/webdriver/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "build": "run-s clean compile",
-    "clean": "rm -rf ./build",
+    "clean": "rimraf ./build",
     "compile": "babel src/ -d build/",
     "test": "run-s test:*",
     "test:eslint": "eslint src test",

--- a/packages/webdriver/src/request.js
+++ b/packages/webdriver/src/request.js
@@ -58,7 +58,7 @@ export default class WebDriverRequest extends EventEmitter {
         requestOptions.uri = url.parse(
             `${options.protocol}://` +
             `${options.hostname}:${options.port}` +
-            path.resolve(`${options.path}${this.endpoint.replace(':sessionId', sessionId)}`)
+            path.join(`${options.path}${this.endpoint.replace(':sessionId', sessionId)}`)
         )
 
         /**

--- a/packages/webdriverio/package.json
+++ b/packages/webdriverio/package.json
@@ -46,7 +46,7 @@
   ],
   "scripts": {
     "build": "run-s clean compile",
-    "clean": "rm -rf ./build",
+    "clean": "rimraf ./build",
     "compile": "babel src/ -d build/",
     "test": "run-s test:*",
     "test:eslint": "eslint src test",

--- a/scripts/generate-sub-package.js
+++ b/scripts/generate-sub-package.js
@@ -50,7 +50,7 @@ inquirer.prompt(questions).then(answers => {
   },
   "scripts": {
     "build": "run-s clean compile",
-    "clean": "rm -rf ./build",
+    "clean": "rimraf ./build",
     "compile": "babel src/ -d build/",
     "test": "run-s test:*",
     "test:eslint": "eslint src test",


### PR DESCRIPTION
## Proposed changes
Fix for [this issue](https://github.com/webdriverio/webdriverio/issues/2973). It uses rimraf to replace all of the ```rm -rf``` commands, and it uses a package called ```copyfile``` to replace the ```cp -r``` command. 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

This works on Windows but has not been tested on Mac. It should work just fine though.

### Reviewers: @webdriverio/technical-committee
