### PR TITLE
Allowing to specify a feature file with a scenario line number

### DIFF
--- a/docs/guide/testrunner/organizesuite.md
+++ b/docs/guide/testrunner/organizesuite.md
@@ -111,6 +111,12 @@ or run multiple specs at once:
 $ wdio wdio.conf.js --spec ./test/specs/signup.js,./test/specs/forgot-password.js
 ```
 
+In case of a feature (Cucumber) you can specify a single scenario by adding a line number:
+
+```sh
+$ wdio wdio.conf.js --spec ./test/specs/login.feature:6
+```
+
 If the spec passed in is not a path to a spec file, it is used as a filter for the spec file names defined in your configuration file. To run all specs with the word 'dialog' in the spec file names, you could use:
 
 ```sh

--- a/lib/utils/ConfigParser.js
+++ b/lib/utils/ConfigParser.js
@@ -1,7 +1,7 @@
-import fs from 'fs'
-import path from 'path'
-import glob from 'glob'
 import merge from 'deepmerge'
+import fs from 'fs'
+import glob from 'glob'
+import path from 'path'
 
 import detectSeleniumBackend from '../helpers/detectSeleniumBackend'
 
@@ -77,6 +77,8 @@ const DEFAULT_CONFIGS = {
     afterStep: []
 }
 const FILE_EXTENSIONS = ['.js', '.ts', '.feature', '.coffee', '.es6']
+
+const FEATURE_FILE_SPEC_REGEX = /^(.+\.feature):[0-9]+$/
 
 class ConfigParser {
     constructor () {
@@ -273,7 +275,18 @@ class ConfigParser {
         const filePathList = ConfigParser.getFilePaths(config)
 
         for (let file of fileList) {
-            if (fs.existsSync(file) && fs.lstatSync(file).isFile()) {
+            const match = file.match(FEATURE_FILE_SPEC_REGEX)
+            let filename
+            /*
+             * check whether a file is a feature file specifying a scenario by its line number
+             * if this is the case extract filename part
+             */
+            if (match) {
+                filename = match[1]
+            } else {
+                filename = file
+            }
+            if (fs.existsSync(filename) && fs.lstatSync(filename).isFile()) {
                 filesToFilter.add(path.resolve(process.cwd(), file))
                 continue
             }
@@ -309,15 +322,24 @@ class ConfigParser {
         }
 
         for (let pattern of patterns) {
-            let filenames = glob.sync(pattern)
+            let filenames
+            /*
+             * check whether a pattern is a feature file specifying a scenario by its line number
+             * if this is the case don't glob the pattern
+            */
+            if (pattern.match(FEATURE_FILE_SPEC_REGEX)) {
+                filenames = [path.isAbsolute(pattern) ? path.normalize(pattern) : path.resolve(process.cwd(), pattern)]
+            } else {
+                filenames = glob.sync(pattern)
 
-            filenames = filenames.filter(filename => FILE_EXTENSIONS.includes(path.extname(filename)))
+                filenames = filenames.filter(filename => FILE_EXTENSIONS.includes(path.extname(filename)))
 
-            filenames = filenames.map(filename =>
-                path.isAbsolute(filename) ? path.normalize(filename) : path.resolve(process.cwd(), filename))
+                filenames = filenames.map(filename =>
+                    path.isAbsolute(filename) ? path.normalize(filename) : path.resolve(process.cwd(), filename))
 
-            if (filenames.length === 0 && !omitWarnings) {
-                console.warn('pattern', pattern, 'did not match any file')
+                if (filenames.length === 0 && !omitWarnings) {
+                    console.warn('pattern', pattern, 'did not match any file')
+                }
             }
 
             files = merge(files, filenames, MERGE_OPTIONS)

--- a/test/spec/unit/configparser.js
+++ b/test/spec/unit/configparser.js
@@ -52,6 +52,15 @@ describe('ConfigParser', () => {
         specs.should.include(path.resolve(__dirname, '..', 'functional/end.js'))
     })
 
+    it('should allow to specify a feature file with a scenario line number', () => {
+        let configParser = new ConfigParser()
+        configParser.addConfigFile(path.resolve(FIXTURES_PATH, 'exclude.conf.js'))
+        let featureFileSpec = path.resolve(FIXTURES_PATH, 'dummy.feature:6')
+        configParser.merge({ specs: featureFileSpec })
+        let specs = configParser.getSpecs()
+        specs.should.include(featureFileSpec)
+    })
+
     it('should throw when suite is not defined', () => {
         let configParser = new ConfigParser()
         configParser.addConfigFile(path.resolve(FIXTURES_PATH, 'exclude.conf.js'))


### PR DESCRIPTION
## Proposed changes

I would like it to be possible to run a single feature scenario (Cucumber) from a command line. This changed allows to specify a feature file with a scenario line number:

```sh
$ wdio wdio.conf.js --spec ./test/specs/login.feature:6
```
A request for that functionality has been already reported in #2832 and marked as a duplicate of https://github.com/webdriverio/wdio-cucumber-framework/issues/78. Nevertheless I was able to make it work by applying changes to `webdriverio` only.

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee