### PR TITLE
Increase default test timeout for all frameworks to 60 seconds

### DIFF
--- a/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
+++ b/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
@@ -169,7 +169,8 @@ exports.config = {
     // Options to be passed to Mocha.
     // See the full list at http://mochajs.org/
     mochaOpts: {
-        ui: 'bdd'
+        ui: 'bdd',
+        timeout: 60000
     },<% }
     if(answers.framework === 'jasmine') { %>
     //
@@ -177,7 +178,7 @@ exports.config = {
     jasmineNodeOpts: {
         //
         // Jasmine default timeout
-        defaultTimeoutInterval: 10000,
+        defaultTimeoutInterval: 60000,
         //
         // The Jasmine framework allows interception of each assertion in order to log the state of the application
         // or website depending on the result. For example, it is pretty handy to take a screenshot every time
@@ -202,7 +203,7 @@ exports.config = {
         profile: [],        // <string[]> (name) specify the profile to use
         strict: false,      // <boolean> fail if there are any undefined or pending steps
         tags: [],           // <string[]> (expression) only execute the features or scenarios with tags matching the expression
-        timeout: 20000,     // <number> timeout for step definitions
+        timeout: 60000,     // <number> timeout for step definitions
         ignoreUndefinedDefinitions: false, // <boolean> Enable this config to treat undefined definitions as warnings.
     },
     <% } %>


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

The default timeout of 10 seconds for Mocha/Jasmine (20 for Cucumber) is almost always too short for the majority of WebdriverIO tests. 

Even the most basic of test suites can easily take over 10 seconds just loading the page.

This change updates the configuration template settings for the test framework, so they all allow for 60 seconds of test execution before timing out. This should work for the majority of test cases.

This also resolves an issue with error messaging in the following scenario (v5):
- I run a test that tries to find a non-existent element on the page
- The element command waits for 10 seconds for the element to appear
- The element is never found, but before that happens, the test framework timeout triggers, resulting in the following error:
![image](https://user-images.githubusercontent.com/706039/48026110-ce306200-e10a-11e8-9d97-13e4f339d025.png)

The expected (more useful) error would be the "element not found" error that occurs when WebdriverIO triggers the error:
![image](https://user-images.githubusercontent.com/706039/48026183-fae47980-e10a-11e8-9a44-a318ebbb3fd9.png)

By increasing the default test framework timeout, we can ensure that the default `waitForTimeout` setting is triggered in such cases. 

Note: It'd be a good idea to update all the various places the `wdio.conf.js` file is shown in the documentation to reflect this change. I wanted to run it by the contributors first to get their thoughts before spending the time hunting down where these settings are documented.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works: **n/a I think**
- [ ] I have added necessary documentation (if appropriate) **see comments above**

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
