### PR TITLE
fix moveToObject() to work with touchMove()

### DIFF
--- a/lib/commands/moveToObject.js
+++ b/lib/commands/moveToObject.js
@@ -47,7 +47,7 @@ let moveToObject = function (selector, xoffset, yoffset) {
                 y = res.location.value.y + yoffset
             }
 
-            return this.touchMove(x, y)
+            return this.touchMove(Math.round(x), Math.round(y))
         })
     }
 


### PR DESCRIPTION
## Proposed changes

found a minor bug in moveToObject when building specs against mobile android -- touchMove must receive integers so i fixed moveToObject to round locations to an integer before attempting pass to touchMove

## Types of changes

- [x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
