### PR TITLE
Use exact package versions

### DIFF
--- a/packages/wdio-allure-reporter/package.json
+++ b/packages/wdio-allure-reporter/package.json
@@ -31,7 +31,7 @@
     "url": "https://github.com/webdriverio/webdriverio/issues"
   },
   "dependencies": {
-    "@wdio/reporter": "^5.0.0-beta.5",
+    "@wdio/reporter": "5.0.0-beta.5",
     "allure-js-commons": "^1.3.2"
   },
   "devDependencies": {

--- a/packages/wdio-applitools-service/package.json
+++ b/packages/wdio-applitools-service/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@applitools/eyes.webdriverio": "^2.0.0",
-    "@wdio/logger": "^5.0.0-beta.5"
+    "@wdio/logger": "5.0.0-beta.5"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/wdio-cli/package.json
+++ b/packages/wdio-cli/package.json
@@ -35,9 +35,9 @@
     "url": "https://github.com/webdriverio/webdriverio/issues"
   },
   "dependencies": {
-    "@wdio/config": "^5.0.0-beta.5",
-    "@wdio/interface": "^5.0.0-beta.5",
-    "@wdio/logger": "^5.0.0-beta.5",
+    "@wdio/config": "5.0.0-beta.5",
+    "@wdio/interface": "5.0.0-beta.5",
+    "@wdio/logger": "5.0.0-beta.5",
     "chalk": "^2.3.2",
     "chokidar": "^2.0.4",
     "cli-spinners": "^1.1.0",
@@ -48,7 +48,7 @@
     "lodash.union": "^4.6.0",
     "npm-install-package": "^2.1.0",
     "source-map-support": "^0.5.6",
-    "webdriverio": "^5.0.0-beta.5",
+    "webdriverio": "5.0.0-beta.5",
     "yargs": "^11.1.0"
   },
   "devDependencies": {

--- a/packages/wdio-concise-reporter/package.json
+++ b/packages/wdio-concise-reporter/package.json
@@ -30,7 +30,7 @@
     "url": "https://github.com/webdriverio/webdriverio/issues"
   },
   "dependencies": {
-    "@wdio/reporter": "^5.0.0-beta.5",
+    "@wdio/reporter": "5.0.0-beta.5",
     "chalk": "^2.4.1",
     "pretty-ms": "^3.2.0"
   },

--- a/packages/wdio-config/package.json
+++ b/packages/wdio-config/package.json
@@ -30,7 +30,7 @@
     "url": "https://github.com/webdriverio/webdriverio/issues"
   },
   "dependencies": {
-    "@wdio/logger": "^5.0.0-beta.5",
+    "@wdio/logger": "5.0.0-beta.5",
     "deepmerge": "^2.0.1",
     "glob": "^7.1.2"
   },

--- a/packages/wdio-devtools-service/package.json
+++ b/packages/wdio-devtools-service/package.json
@@ -34,7 +34,7 @@
     "url": "https://github.com/webdriverio/webdriverio/issues"
   },
   "dependencies": {
-    "@wdio/logger": "^5.0.0-beta.5",
+    "@wdio/logger": "5.0.0-beta.5",
     "chrome-remote-interface": "^0.25.5",
     "speedline": "^1.4.1",
     "stable": "^0.1.8"

--- a/packages/wdio-dot-reporter/package.json
+++ b/packages/wdio-dot-reporter/package.json
@@ -30,7 +30,7 @@
     "url": "https://github.com/webdriverio/webdriverio/issues"
   },
   "dependencies": {
-    "@wdio/reporter": "^5.0.0-beta.5",
+    "@wdio/reporter": "5.0.0-beta.5",
     "chalk": "^2.3.0"
   },
   "devDependencies": {

--- a/packages/wdio-jasmine-framework/package.json
+++ b/packages/wdio-jasmine-framework/package.json
@@ -33,12 +33,12 @@
     "url": "https://github.com/webdriverio/webdriverio/issues"
   },
   "dependencies": {
-    "@wdio/config": "^5.0.0-beta.5",
-    "@wdio/logger": "^5.0.0-beta.5",
+    "@wdio/config": "5.0.0-beta.5",
+    "@wdio/logger": "5.0.0-beta.5",
     "jasmine": "^3.1.0"
   },
   "peerDependencies": {
-    "webdriverio": "^5.0.0"
+    "webdriverio": "5"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/wdio-lambda-runner/package.json
+++ b/packages/wdio-lambda-runner/package.json
@@ -32,8 +32,8 @@
     "url": "https://github.com/webdriverio/webdriverio/issues"
   },
   "dependencies": {
-    "@wdio/logger": "^5.0.0-beta.5",
-    "@wdio/runner": "^5.0.0-beta.5",
+    "@wdio/logger": "5.0.0-beta.5",
+    "@wdio/runner": "5.0.0-beta.5",
     "find-node-modules": "^1.0.4",
     "serverless": "^1.25.0",
     "shelljs": "^0.7.8",

--- a/packages/wdio-local-runner/package.json
+++ b/packages/wdio-local-runner/package.json
@@ -31,8 +31,8 @@
     "url": "https://github.com/webdriverio/webdriverio/issues"
   },
   "dependencies": {
-    "@wdio/logger": "^5.0.0-beta.5",
-    "@wdio/runner": "^5.0.0-beta.5"
+    "@wdio/logger": "5.0.0-beta.5",
+    "@wdio/runner": "5.0.0-beta.5"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/wdio-mocha-framework/package.json
+++ b/packages/wdio-mocha-framework/package.json
@@ -30,12 +30,12 @@
     "url": "https://github.com/webdriverio/webdriverio/issues"
   },
   "dependencies": {
-    "@wdio/config": "^5.0.0-beta.5",
-    "@wdio/logger": "^5.0.0-beta.5",
+    "@wdio/config": "5.0.0-beta.5",
+    "@wdio/logger": "5.0.0-beta.5",
     "mocha": "^5.0.0"
   },
   "peerDependencies": {
-    "webdriverio": "^5.0.0"
+    "webdriverio": "5"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/wdio-runner/package.json
+++ b/packages/wdio-runner/package.json
@@ -30,11 +30,11 @@
     "url": "https://github.com/webdriverio/webdriverio/issues"
   },
   "dependencies": {
-    "@wdio/config": "^5.0.0-beta.5",
-    "@wdio/logger": "^5.0.0-beta.5",
+    "@wdio/config": "5.0.0-beta.5",
+    "@wdio/logger": "5.0.0-beta.5",
     "deepmerge": "^2.0.1",
     "gaze": "^1.1.2",
-    "webdriverio": "^5.0.0-beta.5"
+    "webdriverio": "5.0.0-beta.5"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/wdio-sauce-service/package.json
+++ b/packages/wdio-sauce-service/package.json
@@ -31,7 +31,7 @@
     "url": "https://github.com/webdriverio/webdriverio/issues"
   },
   "dependencies": {
-    "@wdio/logger": "^5.0.0-beta.5",
+    "@wdio/logger": "5.0.0-beta.5",
     "request": "^2.85.0",
     "sauce-connect-launcher": "^1.2.3"
   },

--- a/packages/wdio-spec-reporter/package.json
+++ b/packages/wdio-spec-reporter/package.json
@@ -30,7 +30,7 @@
     "url": "https://github.com/webdriverio/webdriverio/issues"
   },
   "dependencies": {
-    "@wdio/reporter": "^5.0.0-beta.5",
+    "@wdio/reporter": "5.0.0-beta.5",
     "chalk": "^2.3.2",
     "pretty-ms": "^3.1.0"
   },

--- a/packages/wdio-sumologic-reporter/package.json
+++ b/packages/wdio-sumologic-reporter/package.json
@@ -30,8 +30,8 @@
     "url": "https://github.com/webdriverio/webdriverio/issues"
   },
   "dependencies": {
-    "@wdio/logger": "^5.0.0-beta.5",
-    "@wdio/reporter": "^5.0.0-beta.5",
+    "@wdio/logger": "5.0.0-beta.5",
+    "@wdio/reporter": "5.0.0-beta.5",
     "dateformat": "^3.0.3",
     "json-stringify-safe": "^5.0.1",
     "request": "^2.85.0"

--- a/packages/wdio-sync/package.json
+++ b/packages/wdio-sync/package.json
@@ -32,8 +32,8 @@
     "url": "https://github.com/webdriverio/webdriverio/issues"
   },
   "dependencies": {
-    "@wdio/config": "^5.0.0-beta.5",
-    "@wdio/logger": "^5.0.0-beta.5",
+    "@wdio/config": "5.0.0-beta.5",
+    "@wdio/logger": "5.0.0-beta.5",
     "fibers": "^2.0.0"
   },
   "publishConfig": {

--- a/packages/webdriver/package.json
+++ b/packages/webdriver/package.json
@@ -28,8 +28,8 @@
     "url": "https://github.com/webdriverio/webdriverio/issues"
   },
   "dependencies": {
-    "@wdio/config": "^5.0.0-beta.5",
-    "@wdio/logger": "^5.0.0-beta.5",
+    "@wdio/config": "5.0.0-beta.5",
+    "@wdio/logger": "5.0.0-beta.5",
     "deepmerge": "^2.0.1",
     "request": "^2.83.0"
   }

--- a/packages/webdriverio/package.json
+++ b/packages/webdriverio/package.json
@@ -53,12 +53,12 @@
     "test:unit": "jest"
   },
   "dependencies": {
-    "@wdio/config": "^5.0.0-beta.5",
-    "@wdio/logger": "^5.0.0-beta.5",
+    "@wdio/config": "5.0.0-beta.5",
+    "@wdio/logger": "5.0.0-beta.5",
     "css-value": "^0.0.1",
     "grapheme-splitter": "^1.0.2",
     "lodash.zip": "^4.2.0",
     "rgb2hex": "^0.1.0",
-    "webdriver": "^5.0.0-beta.5"
+    "webdriver": "5.0.0-beta.5"
   }
 }


### PR DESCRIPTION
Using the carrot `^` for linking packages will cause unexpected bugs when trying to use older patch versions.

Currently I am trying to use version `webdriverio-beta.3` but the internal dependencies started using `beta.5` automatically because of the carrot, leading to unexpected errors.

I also updated `peerDependencies` where needed to accept all the variations of version `5` instead of only `5.0.*`.