### PR TITLE
Runner not closing gracefully

### DIFF
--- a/packages/wdio-cli/package.json
+++ b/packages/wdio-cli/package.json
@@ -38,6 +38,7 @@
     "@wdio/config": "5.0.0-beta.5",
     "@wdio/interface": "5.0.0-beta.5",
     "@wdio/logger": "5.0.0-beta.5",
+    "async-exit-hook": "^2.0.1",
     "chalk": "^2.3.2",
     "chokidar": "^2.0.4",
     "cli-spinners": "^1.1.0",

--- a/packages/wdio-cli/src/interface.js
+++ b/packages/wdio-cli/src/interface.js
@@ -16,6 +16,7 @@ export default class WDIOCLInterface extends EventEmitter {
         this.specs = specs
         this.config = config
         this.totalWorkerCnt = totalWorkerCnt
+        this.sigintTriggered = false
 
         this.interface = new CLInterface()
         this.on('job:start', ::this.addJob)
@@ -82,6 +83,11 @@ export default class WDIOCLInterface extends EventEmitter {
             this.messages[params.origin][params.name] = []
         }
         this.messages[params.origin][params.name].push(params.content)
+    }
+
+    sigintTrigger () {
+        this.sigintTriggered = true
+        this.updateView()
     }
 
     updateView (wasJobCleared) {
@@ -182,6 +188,16 @@ export default class WDIOCLInterface extends EventEmitter {
         )
 
         this.updateClock()
+
+        if (this.sigintTriggered) {
+            clearTimeout(this.interval)
+            this.interface.log('\n')
+            this.interface.log(!isFinished
+                ? 'Ending WebDriver sessions gracefully ...\n' +
+                  '(press ctrl+c again to hard kill the runner)'
+                : 'Ended WebDriver sessions gracefully after a SIGINT signal was received!'
+            )
+        }
 
         if (isFinished) {
             clearTimeout(this.interval)

--- a/packages/wdio-cli/tests/__mocks__/async-exit-hook.js
+++ b/packages/wdio-cli/tests/__mocks__/async-exit-hook.js
@@ -1,0 +1,1 @@
+export default jest.fn()

--- a/packages/wdio-cli/tests/interface.test.js
+++ b/packages/wdio-cli/tests/interface.test.js
@@ -134,6 +134,12 @@ describe('cli interface', () => {
             .toContain('(60% completed)')
 
         wdioClInterface.interface.log.mockClear()
+        wdioClInterface.sigintTrigger()
+        let output = flatten(wdioClInterface.interface.log.mock.calls)
+        expect(output).toContain(
+            'Ending WebDriver sessions gracefully ...\n(press ctrl+c again to hard kill the runner)')
+
+        wdioClInterface.interface.log.mockClear()
         wdioClInterface.jobs.delete('0-0')
         wdioClInterface.jobs.delete('0-1')
         wdioClInterface.jobs.delete('0-2')
@@ -153,11 +159,21 @@ describe('cli interface', () => {
         })
         wdioClInterface.updateView()
 
-        const output = flatten(wdioClInterface.interface.log.mock.calls)
+        output = flatten(wdioClInterface.interface.log.mock.calls)
         expect(output).toContain('black "foo" Reporter:')
         expect(output).toContain('black Stdout:\nfoobar')
         expect(output).toContain('black Stderr:\nbarfoo')
         expect(output).toContain('black Worker Error:\nfoobar\n')
         expect(output).toContain('(100% completed)')
+        expect(output).toContain('Ended WebDriver sessions gracefully after a SIGINT signal was received!')
+    })
+
+    it('should be able to mark display when SIGINT is called', () => {
+        wdioClInterface.updateView = jest.fn()
+        expect(wdioClInterface.sigintTriggered).toBe(false)
+        expect(wdioClInterface.updateView).toBeCalledTimes(0)
+        wdioClInterface.sigintTrigger()
+        expect(wdioClInterface.sigintTriggered).toBe(true)
+        expect(wdioClInterface.updateView).toBeCalledTimes(1)
     })
 })

--- a/packages/wdio-local-runner/package.json
+++ b/packages/wdio-local-runner/package.json
@@ -32,7 +32,8 @@
   },
   "dependencies": {
     "@wdio/logger": "5.0.0-beta.5",
-    "@wdio/runner": "5.0.0-beta.5"
+    "@wdio/runner": "5.0.0-beta.5",
+    "async-exit-hook": "^2.0.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/wdio-local-runner/src/constants.js
+++ b/packages/wdio-local-runner/src/constants.js
@@ -1,0 +1,1 @@
+export const SHUTDOWN_TIMEOUT = 5000

--- a/packages/wdio-local-runner/src/index.js
+++ b/packages/wdio-local-runner/src/index.js
@@ -1,4 +1,9 @@
+import logger from '@wdio/logger'
+
 import WorkerInstance from './worker'
+import { SHUTDOWN_TIMEOUT } from './constants'
+
+const log = logger('wdio-local-runner')
 
 export default class LocalRunner {
     constructor (configFile, config) {
@@ -31,5 +36,40 @@ export default class LocalRunner {
         worker.postMessage(command, argv)
 
         return worker
+    }
+
+    /**
+     * shutdown all worker processes
+     *
+     * @return {Promise}  resolves when all worker have been shutdown or
+     *                    a timeout was reached
+     */
+    shutdown () {
+        log.info('Shutting down spawned worker')
+
+        for (const [cid, worker] of Object.entries(this.workerPool)) {
+            if (!worker.isBusy) {
+                delete this.workerPool[cid]
+                continue
+            }
+
+            worker.postMessage('endSession', {})
+        }
+
+        return new Promise((resolve) => {
+            const interval = setInterval(() => {
+                const busyWorker = Object.entries(this.workerPool)
+                    .filter(([, worker]) => worker.isBusy).length
+
+                log.info(`Waiting for ${busyWorker} to shut down gracefully`)
+                if (busyWorker === 0) {
+                    clearInterval(interval)
+                    log.info('shutting down')
+                    return resolve()
+                }
+            }, 250)
+
+            setTimeout(resolve, SHUTDOWN_TIMEOUT)
+        })
     }
 }

--- a/packages/wdio-local-runner/src/worker.js
+++ b/packages/wdio-local-runner/src/worker.js
@@ -66,6 +66,7 @@ export default class WorkerInstance extends EventEmitter {
             if (payload.name === 'finisedCommand') {
                 this.isBusy = false
             }
+
             /**
              * store sessionId and connection data to worker instance
              */
@@ -107,7 +108,7 @@ export default class WorkerInstance extends EventEmitter {
     postMessage (command, argv) {
         const { cid, configFile, caps, specs, server, isBusy } = this
 
-        if (isBusy) {
+        if (isBusy && command !== 'endSession') {
             return log.info(`worker with cid ${cid} already busy and can't take new commands`)
         }
 

--- a/packages/wdio-runner/tests/index.test.js
+++ b/packages/wdio-runner/tests/index.test.js
@@ -9,7 +9,7 @@ describe('wdio-runner', () => {
     describe('_fetchDriverLogs', () => {
         it('not do anything if driver does not support log commands', async () => {
             const runner = new WDIORunner()
-            global.browser = {}
+            global.browser = { sessionId: '123' }
 
             const result = await runner._fetchDriverLogs({ logDir: '/foo/bar' })
             expect(result).toBe(undefined)
@@ -21,7 +21,8 @@ describe('wdio-runner', () => {
 
             global.browser = {
                 getLogTypes: () => Promise.resolve(['foo', 'bar']),
-                getLogs: (type) => Promise.resolve([`#1 ${type} log`, `#2 ${type} log`])
+                getLogs: (type) => Promise.resolve([`#1 ${type} log`, `#2 ${type} log`]),
+                sessionId: '123'
             }
 
             await runner._fetchDriverLogs({ logDir: '/foo/bar' })
@@ -36,7 +37,8 @@ describe('wdio-runner', () => {
 
             global.browser = {
                 getLogTypes: () => Promise.resolve(['foo', 'bar']),
-                getLogs: () => Promise.resolve([])
+                getLogs: () => Promise.resolve([]),
+                sessionId: '123'
             }
 
             await runner._fetchDriverLogs({ logDir: '/foo/bar' })
@@ -45,6 +47,54 @@ describe('wdio-runner', () => {
 
         afterEach(() => {
             delete global.browser
+        })
+    })
+
+    describe('endSession', () => {
+        it ('should work normally when called after framework run', async () => {
+            const hook = jest.fn()
+            const runner = new WDIORunner()
+            runner._shutdown = jest.fn()
+            global.browser = {
+                deleteSession: jest.fn(),
+                sessionId: '123',
+                config: { afterSession: [hook] }
+            }
+            await runner.endSession()
+            expect(hook).toBeCalledTimes(1)
+            expect(global.browser.deleteSession).toBeCalledTimes(1)
+            expect(!global.browser.sessionId).toBe(true)
+            expect(runner._shutdown).toBeCalledTimes(0)
+        })
+
+        it('should do nothing when triggered by run method without session', async () => {
+            const hook = jest.fn()
+            const runner = new WDIORunner()
+            runner._shutdown = jest.fn()
+            await runner.endSession()
+            expect(hook).toBeCalledTimes(0)
+        })
+
+        it('should wait for session to be created until shutting down', async () => {
+            const hook = jest.fn()
+            const runner = new WDIORunner()
+            runner._shutdown = jest.fn()
+            global.browser = {
+                deleteSession: jest.fn(),
+                config: { afterSession: [hook] }
+            }
+            setTimeout(() => {
+                global.browser.sessionId = 123
+            }, 200)
+
+            const start = Date.now()
+            await runner.endSession(true)
+            const end = Date.now()
+            expect(hook).toBeCalledTimes(1)
+            expect(global.browser.deleteSession).toBeCalledTimes(1)
+            expect(!global.browser.sessionId).toBe(true)
+            expect(runner._shutdown).toBeCalledTimes(1)
+            expect(end - start).toBeGreaterThanOrEqual(200)
         })
     })
 })


### PR DESCRIPTION
## The problem

If the testrunner is stopped by pressing CTRL-C the whole process just shuts down. It should actually try to close all WebDriver sessions first and only if the user presses CTRL-C again exit the process.

## Environment

* WebdriverIO version: 5
* Node.js version: any
* Standalone mode or WDIO Testrunner: wdio testrunner
* if wdio testrunner, running synchronous or asynchronous tests: both
* Additional wdio packages used (if applicable): not important for this issue
