### PR TITLE
wdio-cli: remove plugin type from list name, update docs

### DIFF
--- a/docs/ConfigurationFile.md
+++ b/docs/ConfigurationFile.md
@@ -138,8 +138,8 @@ exports.config = {
     // The only one supported by default is 'dot'
     // see also: http://webdriver.io/docs/dot-reporter.html and click on "Reporters" in left column
     reporters: [
-        'dot',
-        ['allure', {
+        '@wdio/dot',
+        ['@wdio/allure', {
             //
             // If you are using the "allure" reporter you should define the directory where
             // WebdriverIO should save all allure reports.

--- a/docs/JenkinsIntegration.md
+++ b/docs/JenkinsIntegration.md
@@ -12,8 +12,8 @@ First we need to define `junit` as test reporter. Also make sure you have it ins
 module.exports = {
     // ...
     reporters: [
-        'dot',
-        ['junit', {
+        '@wdio/dot',
+        ['@wdio/junit', {
             outputDir: './'
         }]
     ],

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -148,8 +148,8 @@ Default: `[]`
 Example:
 ```js
 reporters: [
-    'dot',
-    ['spec', {
+    '@wdio/dot',
+    ['@wdio/spec', {
         outputDir: __dirname + '/reports',
         otherOption: 'foobar'
     }]

--- a/docs/OrganizingTestSuites.md
+++ b/docs/OrganizingTestSuites.md
@@ -49,7 +49,7 @@ exports.config = merge(wdioConf.config, {
     // run tests on sauce instead locally
     user: process.env.SAUCE_USERNAME,
     key: process.env.SAUCE_ACCESS_KEY,
-    services: ['sauce']
+    services: ['@wdio/sauce']
 }, { clone: false });
 
 // add an additional reporter

--- a/examples/pageobject/wdio.conf.js
+++ b/examples/pageobject/wdio.conf.js
@@ -86,7 +86,7 @@ exports.config = {
     // Test reporter for stdout.
     // The only one supported by default is 'dot'
     // see also: http://webdriver.io/docs/dot-reporter.html
-    reporters: ['spec'],
+    reporters: ['@wdio/spec'],
 
     //
     // Options to be passed to Mocha.

--- a/examples/wdio.conf.js
+++ b/examples/wdio.conf.js
@@ -147,8 +147,8 @@ exports.config = {
     // The only one supported by default is 'dot'
     // see also: http://webdriver.io/docs/dot-reporter.html
     reporters: [
-        'dot',
-        ['allure', {
+        '@wdio/dot',
+        ['@wdio/allure', {
             //
             // If you are using the "allure" reporter you should define the directory where
             // WebdriverIO should save all allure reports.

--- a/examples/wdio/cucumber/wdio.conf.js
+++ b/examples/wdio/cucumber/wdio.conf.js
@@ -26,7 +26,7 @@ exports.config = {
     logLevel: 'error',
     framework: 'cucumber',
 
-    reporters: ['dot'],
+    reporters: ['@wdio/dot'],
 
     cucumberOpts: {
         require: ['./step-definitions.js']

--- a/examples/wdio/jasmine/wdio.conf.js
+++ b/examples/wdio/jasmine/wdio.conf.js
@@ -27,7 +27,7 @@ exports.config = {
     logDir: __dirname,
     framework: 'jasmine',
 
-    reporters: ['spec'],
+    reporters: ['@wdio/spec'],
 
     jasmineNodeOpts: {
         defaultTimeoutInterval: 1000 * 60 * 3

--- a/examples/wdio/mocha/wdio.conf.js
+++ b/examples/wdio/mocha/wdio.conf.js
@@ -27,7 +27,7 @@ exports.config = {
     framework: 'mocha',
     logDir: __dirname,
 
-    reporters: ['spec'],
+    reporters: ['@wdio/spec'],
 
     mochaOpts: {
         ui: 'bdd',

--- a/examples/wdio/multiremote/wdio.conf.js
+++ b/examples/wdio/multiremote/wdio.conf.js
@@ -35,7 +35,7 @@ exports.config = {
     logDir: __dirname,
     framework: 'mocha',
 
-    reporters: ['spec'],
+    reporters: ['@wdio/spec'],
 
     mochaOpts: {
         ui: 'bdd',

--- a/packages/wdio-allure-reporter/README.md
+++ b/packages/wdio-allure-reporter/README.md
@@ -30,7 +30,7 @@ Configure the output directory in your wdio.conf.js file:
 ```js
 exports.config = {
     // ...
-    reporters: [['allure', {
+    reporters: [['@wdio/allure', {
         outputDir: 'allure-results',
         disableWebdriverStepsReporting: true,
         disableWebdriverScreenshotsReporting: true,

--- a/packages/wdio-applitools-service/README.md
+++ b/packages/wdio-applitools-service/README.md
@@ -31,7 +31,7 @@ In order to use the service you need to set `applitoolsKey` in your `wdio.conf.j
 // wdio.conf.js
 export.config = {
   // ...
-  services: ['applitools'],
+  services: ['@wdio/applitools'],
   applitools: {
     // options
     // ...

--- a/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
+++ b/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
@@ -157,7 +157,7 @@ exports.config = {
         return reporter.slice(5, -9);
     }).join("','") %>'],
     <% } else {
-    %>// reporters: ['dot'],<%
+    %>// reporters: ['@wdio/dot'],<%
     }
     if(answers.framework === 'mocha') { %>
     //

--- a/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
+++ b/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
@@ -137,7 +137,7 @@ exports.config = {
     // commands. Instead, they hook themselves up into the test process.
     <% if(answers.services.length) {
     %>services: ['<%- answers.services.map(function(service) {
-        return service.slice(5, -8);
+        return service.slice(0, -8);
     }).join("','") %>'],
     <% } else {
     %>// services: [],<% } %>//
@@ -154,7 +154,7 @@ exports.config = {
     // see also: http://webdriver.io/docs/dot-reporter.html
     <% if(answers.reporters.length) {
     %>reporters: ['<%- answers.reporters.map(function(reporter) {
-        return reporter.slice(5, -9);
+        return reporter.slice(0, -9);
     }).join("','") %>'],
     <% } else {
     %>// reporters: ['@wdio/dot'],<%

--- a/packages/wdio-cli/src/utils.js
+++ b/packages/wdio-cli/src/utils.js
@@ -25,7 +25,7 @@ export function getLauncher (config) {
         }
 
         const pkgName = serviceName.startsWith('@')
-            ? `${serviceName}/launcher`
+            ? `${serviceName}-service/launcher`
             : `wdio-${serviceName}-service/launcher`
         try {
             service = require(pkgName)

--- a/packages/wdio-cli/tests/utils.test.js
+++ b/packages/wdio-cli/tests/utils.test.js
@@ -26,7 +26,7 @@ test('getLauncher', () => {
         services: [
             inlineService,
             'unscoped',
-            '@wdio/scoped-service',
+            '@wdio/scoped',
             'non-existing'
         ]
     })).toHaveLength(3)
@@ -50,15 +50,3 @@ test('runServiceHook', () => {
     expect(hookSuccess).toBeCalledTimes(1)
     expect(hookFailing).toBeCalledTimes(1)
 })
-
-// export async function runServiceHook (launcher, hookName, ...args) {
-//     try {
-//         return await Promise.all(launcher.map((service) => {
-//             if (typeof service[hookName] === 'function') {
-//                 return service[hookName](...args)
-//             }
-//         }))
-//     } catch (e) {
-//         log.error(`A service failed in the '${hookName}' hook\n${e.stack}\n\nContinue...`)
-//     }
-// }

--- a/packages/wdio-concise-reporter/README.md
+++ b/packages/wdio-concise-reporter/README.md
@@ -32,7 +32,7 @@ to the array.
 // wdio.conf.js
 module.exports = {
   // ...
-  reporters: ['dot', 'concise'],
+  reporters: ['@wdio/dot', '@wdio/concise'],
   // ...
 };
 ```

--- a/packages/wdio-devtools-service/README.md
+++ b/packages/wdio-devtools-service/README.md
@@ -35,7 +35,7 @@ In order to use the service you just need to add the service to your service lis
 // wdio.conf.js
 export.config = {
   // ...
-  services: ['devtools'],
+  services: ['@wdio/devtools'],
   // ...
 };
 ```

--- a/packages/wdio-dot-reporter/README.md
+++ b/packages/wdio-dot-reporter/README.md
@@ -34,7 +34,7 @@ to the array.
 // wdio.conf.js
 module.exports = {
   // ...
-  reporters: ['dot'],
+  reporters: ['@wdio/dot'],
   // ...
 };
 ```

--- a/packages/wdio-firefox-profile-service/README.md
+++ b/packages/wdio-firefox-profile-service/README.md
@@ -33,7 +33,7 @@ Setup your profile by adding the `firefox-profile` service to your service list.
 // wdio.conf.js
 export.config = {
   // ...
-  services: ['firefox-profile'],
+  services: ['@wdio/firefox-profile'],
   firefoxProfile: {
     extensions: [
       '/path/to/extensionA.xpi', // path to .xpi file

--- a/packages/wdio-junit-reporter/README.md
+++ b/packages/wdio-junit-reporter/README.md
@@ -33,8 +33,8 @@ to the array. To get some output during the test you can run the [WDIO Dot Repor
 module.exports = {
     // ...
     reporters: [
-        'dot',
-        ['junit', {
+        '@wdio/dot',
+        ['@wdio/junit', {
             outputDir: './',
             outputFileFormat: function(opts) { // optional
                 return `results-${opts.cid}.${opts.capabilities}.xml`
@@ -93,8 +93,8 @@ Example:
 module.exports = {
     // ...
     reporters: [
-        'dot',
-        ['junit', {
+        '@wdio/dot',
+        ['@wdio/junit', {
             outputDir: './',
             packageName: process.env.USER_ROLE // chrome.41 - administrator
         }]
@@ -130,8 +130,8 @@ Example:
 module.exports = {
     // ...
     reporters: [
-        'dot',
-        ['junit', {
+        '@wdio/dot',
+        ['@wdio/junit', {
             outputDir: './',
             errorOptions: {
                 error: 'message',

--- a/packages/wdio-reporter/README.md
+++ b/packages/wdio-reporter/README.md
@@ -57,7 +57,7 @@ User can pass in custom configurations for each reporter. Per default WebdriverI
 // wdio.conf.js
 exports.config = {
     // ...
-    reporters: ['dot', ['my-reporter', {
+    reporters: ['@wdio/dot', ['my-reporter', {
         logDir: '/some/path',
         foo: 'bar'
     }]]

--- a/packages/wdio-sauce-service/README.md
+++ b/packages/wdio-sauce-service/README.md
@@ -33,7 +33,7 @@ you just need to set `sauceConnect: true`.
 // wdio.conf.js
 export.config = {
   // ...
-  services: ['sauce'],
+  services: ['@wdio/sauce'],
   user: process.env.SAUCE_USERNAME,
   key: process.env.SAUCE_ACCESS_KEY,
   sauceConnect: true,

--- a/packages/wdio-selenium-standalone-service/README.md
+++ b/packages/wdio-selenium-standalone-service/README.md
@@ -31,7 +31,7 @@ By default, Google Chrome, Firefox and PhantomJS are available when installed on
 // wdio.conf.js
 export.config = {
   // ...
-  services: ['selenium-standalone'],
+  services: ['@wdio/selenium-standalone'],
   // ...
 };
 ```

--- a/packages/wdio-spec-reporter/README.md
+++ b/packages/wdio-spec-reporter/README.md
@@ -34,7 +34,7 @@ to the array.
 // wdio.conf.js
 module.exports = {
   // ...
-  reporters: ['dot', 'spec'],
+  reporters: ['@wdio/dot', '@wdio/spec'],
   // ...
 };
 ```

--- a/packages/wdio-sumologic-reporter/README.md
+++ b/packages/wdio-sumologic-reporter/README.md
@@ -44,8 +44,8 @@ Following code shows the default wdio test runner configuration. Just add `'sumo
 module.exports = {
   // ...
   reporters: [
-    'spec',
-    ['sumologic', {
+    '@wdio/spec',
+    ['@wdio/sumologic', {
         // define sync interval how often logs get pushed to Sumologic
         syncInterval: 100,
         // endpoint of collector source

--- a/packages/wdio-testingbot-service/README.md
+++ b/packages/wdio-testingbot-service/README.md
@@ -32,7 +32,7 @@ you just need to set `tbTunnel: true`.
 // wdio.conf.js
 export.config = {
   // ...
-  services: ['testingbot'],
+  services: ['@wdio/testingbot'],
   user: process.env.TB_KEY,
   key: process.env.TB_SECRET,
   tbTunnel: true,


### PR DESCRIPTION
## Proposed changes

Currently to add a service/reporter to the config the plugin type is required:

```js
  // ...
  reporters: ["@wdio/dot-reporter"],
  // ...
```

We used to strip the plugin type and I just ran into this and was confused too, therefor let's remote it:

```js
  // ...
  reporters: [
    "@wdio/dot", // requires: @wdio/dot-reporter
    "foobar", // requires: wdio-foobar-reporter
  ],
  // ...
```

I think this is simpler to understand.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)


### Reviewers: @webdriverio/technical-committee
