### PR TITLE
wdio-cli: ignore services without launcher

### DIFF
--- a/packages/wdio-cli/src/utils.js
+++ b/packages/wdio-cli/src/utils.js
@@ -27,6 +27,14 @@ export function getLauncher (config) {
 
         try {
             const Launcher = initialisePlugin(serviceName, 'service', 'launcher')
+
+            /**
+             * abort if service has no launcher
+             */
+            if (!Launcher) {
+                continue
+            }
+
             launcher = new Launcher()
         } catch (e) {
             if (!e.message.match(`Couldn't find plugin`)) {

--- a/packages/wdio-cli/tests/utils.test.js
+++ b/packages/wdio-cli/tests/utils.test.js
@@ -13,7 +13,7 @@ jest.mock('@wdio/config', () => {
             .mockImplementationOnce(
                 () => LauncherMock)
             .mockImplementationOnce(
-                () => LauncherMock)
+                () => undefined)
             .mockImplementationOnce(
                 () => { throw new Error(`Couldn't find plugin`) })
             .mockImplementationOnce(() => { throw new Error('buhh') })
@@ -49,7 +49,7 @@ test('getLauncher', () => {
             'scoped',
             'non-existing'
         ]
-    })).toHaveLength(3)
+    })).toHaveLength(2)
 })
 
 test('getLauncher failing if syntax error', () => {


### PR DESCRIPTION
## Proposed changes

If a service exports no launcher an error is thrown. This patch fixes this.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

### Reviewers: @webdriverio/technical-committee
