### PR TITLE
fix: isW3C flag

### DIFF
--- a/packages/webdriver/src/index.js
+++ b/packages/webdriver/src/index.js
@@ -4,7 +4,7 @@ import { validateConfig } from '@wdio/config'
 import webdriverMonad from './monad'
 import WebDriverRequest from './request'
 import { DEFAULTS } from './constants'
-import { getPrototype } from './utils'
+import { getPrototype, isW3CSession } from './utils'
 
 import WebDriverProtocol from '../protocol/webdriver.json'
 import JsonWProtocol from '../protocol/jsonwp.json'
@@ -28,7 +28,7 @@ export default class WebDriver {
         const response = await sessionRequest.makeRequest(params)
         params.requestedCapabilities = params.capabilities
         params.capabilities = response.value.capabilities || response.value
-        params.isW3C = Boolean(response.value.capabilities || response.value.platformName)
+        params.isW3C = isW3CSession(params.capabilities)
 
         const prototype = Object.assign(getPrototype(params.isW3C), proto)
         const monad = webdriverMonad(params, modifier, prototype)

--- a/packages/webdriver/src/utils.js
+++ b/packages/webdriver/src/utils.js
@@ -9,6 +9,15 @@ import AppiumProtocol from '../protocol/appium.json'
 const log = logger('webdriver')
 
 /**
+ * check if WebDriver request is W3C (browser or native app)
+ * @param  {Object}       capabilities of session response
+ * @return {Boolean}       true if W3C (browser)
+ */
+export function isW3CSession(capabilities) {
+    return capabilities.browserName !== ""
+}
+
+/**
  * check if WebDriver requests was successful
  * @param  {Object}  body  body payload of response
  * @return {Boolean}       true if request was successful

--- a/packages/webdriver/tests/fixture/sessionResponse.js
+++ b/packages/webdriver/tests/fixture/sessionResponse.js
@@ -1,0 +1,70 @@
+const iosSessionResponse = {
+  "value": {
+    "capabilities": {
+      "webStorageEnabled": false,
+      "locationContextEnabled": false,
+      "browserName": "",
+      "platform": "MAC",
+      "javascriptEnabled": true,
+      "databaseEnabled": false,
+      "takesScreenshot": true,
+      "networkConnectionEnabled": false,
+      "platformName": "ios",
+      "server:CONFIG_UUID": "XXXXXXXX-0000-0000-XXXX-XXXXXXXXXXXX",
+      "app": "AppLocation/iosAppName.app",
+      "automationName": "XCUITest",
+      "deviceName": "iPhone Simulator",
+      "newCommandTimeout": 3000,
+      "noReset": true,
+      "platformVersion": "12.1",
+      "resetOnSessionStartOnly": false,
+      "simpleIsVisibleCheck": true,
+      "updatedWDABundleId": "com.yamsafer.driverAgent",
+      "wdaLocalPort": 8102,
+      "xcodeOrgId": "YUC5LW8F44",
+      "xcodeSigningId": "iPhone Developer",
+      "udid": "XXXXXXXX-0000-0000-XXXX-XXXXXXXXXXXX"
+    },
+    "sessionId": "XXXXXXXX-0000-0000-XXXX-XXXXXXXXXXXX"
+  }
+};
+
+const w3cSessionResponse = {
+  "status": 0,
+  "sessionId": "XXXXXXXX00000000XXXXXXXXXXXXXXXX",
+  "value": {
+    "applicationCacheEnabled": false,
+    "rotatable": false,
+    "mobileEmulationEnabled": false,
+    "networkConnectionEnabled": false,
+    "chrome": {
+      "chromedriverVersion": "2.38.552522 (437e6fbedfa8762dec75e2c5b3ddb86763dc9dcb)",
+      "userDataDir": "/tmp/.org.chromium.Chromium.QN56NN"
+    },
+    "takesHeapSnapshot": true,
+    "pageLoadStrategy": "normal",
+    "databaseEnabled": false,
+    "handlesAlerts": true,
+    "hasTouchScreen": false,
+    "version": "66.0.3359.117",
+    "platform": "Linux",
+    "browserConnectionEnabled": false,
+    "nativeEvents": true,
+    "acceptSslCerts": false,
+    "acceptInsecureCerts": false,
+    "locationContextEnabled": true,
+    "webStorageEnabled": true,
+    "browserName": "chrome",
+    "takesScreenshot": true,
+    "javascriptEnabled": true,
+    "cssSelectorsEnabled": true,
+    "setWindowRect": true,
+    "unexpectedAlertBehaviour": "",
+    "webdriver.remote.sessionid": "XXXXXXXX00000000XXXXXXXXXXXXXXXX"
+  }
+}
+
+module.exports = {
+  iosSessionResponse,
+  w3cSessionResponse,
+}

--- a/packages/webdriver/tests/utils.test.js
+++ b/packages/webdriver/tests/utils.test.js
@@ -1,4 +1,5 @@
 import { isSuccessfulResponse, isValidParameter, getPrototype, commandCallStructure } from '../src/utils'
+import { iosSessionResponse, w3cSessionResponse } from './fixture/SessionResponse'
 
 describe('utils', () => {
     it('isSuccessfulResponse', () => {
@@ -68,5 +69,12 @@ describe('utils', () => {
     it('commandCallStructure', () => {
         expect(commandCallStructure('foobar', ['param', 1, true, { a: 123 }, () => true, null, undefined]))
             .toBe('foobar("param", 1, true, <object>, <fn>, null, undefined)')
+    })
+
+    it('isW3C', () => {
+        const iosCapabilities = iosSessionResponse.value.capabilities
+        const w3cCapabilities = w3cSessionResponse.value
+        expect(isW3CSession(w3cCapabilities)).to.be.true
+        expect(isW3CSession(iosCapabilities)).to.be.false
     })
 })


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

`params.isW3C` flag returns `true` even when connecting to a native app. This causes the native selectors to fail, throwing an error that the selector strategies are not supported since webdriver is expecting to be working on a browser, although it is connected to a native node.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
