### PR TITLE
README.md: Fixed dead link to WebdriverIO installation instructions

### DIFF
--- a/packages/wdio-devtools-service/README.md
+++ b/packages/wdio-devtools-service/README.md
@@ -25,7 +25,7 @@ You can simple do it by:
 npm install @wdio/devtools-service --save-dev
 ```
 
-Instructions on how to install `WebdriverIO` can be found [here.](http://webdriver.io/docs/gettingstarted.html)
+Instructions on how to install `WebdriverIO` can be found [here.](http://webdriver.io/guide/getstarted/install.html)
 
 ## Configuration
 


### PR DESCRIPTION
URL on line 28 was 404ing.

## Proposed changes
Update link to WebdriverIO installation instructions on line 28 of README.md.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc

### Reviewers: @webdriverio/technical-committee
