### PR TITLE
Fixes dead links to multiple Webdriver.io "Guide" resources across multiple README.md files, as well as SUPPORT.md

### DIFF
--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -18,7 +18,7 @@ The WebdriverIO Community is also active on Stack Overflow, you can post your qu
 
 ## User Documentation
 
-* [User Documentation](http://webdriver.io/docs/gettingstarted.html)
+* [User Documentation](http://webdriver.io/guide/getstarted/install.html)
 * [API Documentation](http://webdriver.io/docs/api.html)
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 <p align="center">
     <a href="http://webdriver.io">Homepage</a> |
-    <a href="http://webdriver.io/guide/getstarted/install.html">Developer Guide</a> |
+    <a href="http://webdriver.io/guide.html">Developer Guide</a> |
     <a href="http://webdriver.io/docs/api.html">API Reference</a> |
     <a href="https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md">Contribute</a>
 </p>

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 <p align="center">
     <a href="http://webdriver.io">Homepage</a> |
-    <a href="http://webdriver.io/docs/gettingstarted.html">Developer Guide</a> |
+    <a href="http://webdriver.io/guide/getstarted/install.html">Developer Guide</a> |
     <a href="http://webdriver.io/docs/api.html">API Reference</a> |
     <a href="https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md">Contribute</a>
 </p>

--- a/packages/wdio-applitools-service/README.md
+++ b/packages/wdio-applitools-service/README.md
@@ -21,7 +21,7 @@ You can simple do it by:
 npm install @wdio/applitools-service --save-dev
 ```
 
-Instructions on how to install `WebdriverIO` can be found [here.](http://webdriver.io/docs/gettingstarted.html)
+Instructions on how to install `WebdriverIO` can be found [here.](http://webdriver.io/guide/getstarted/install.html)
 
 ## Configuration
 

--- a/packages/wdio-concise-reporter/README.md
+++ b/packages/wdio-concise-reporter/README.md
@@ -21,7 +21,7 @@ You can simple do it by:
 $ npm install @wdio/concise-reporter --save-dev
 ```
 
-Instructions on how to install `WebdriverIO` can be found [here](http://webdriver.io/docs/gettingstarted.html).
+Instructions on how to install `WebdriverIO` can be found [here](http://webdriver.io/guide/getstarted/install.html).
 
 ## Configuration
 

--- a/packages/wdio-devtools-service/README.md
+++ b/packages/wdio-devtools-service/README.md
@@ -25,7 +25,7 @@ You can simple do it by:
 npm install @wdio/devtools-service --save-dev
 ```
 
-Instructions on how to install `WebdriverIO` can be found [here.](http://webdriver.io/docs/gettingstarted.html)
+Instructions on how to install `WebdriverIO` can be found [here.](http://webdriver.io/guide/getstarted/install.html)
 
 ## Configuration
 

--- a/packages/wdio-firefox-profile-service/README.md
+++ b/packages/wdio-firefox-profile-service/README.md
@@ -1,7 +1,7 @@
 WDIO Firefox Profile Service
 ============================
 
-You want to run your Firefox browser with a specific extension or need to set couple preferences? Selenium allows you to use a profile for the Firefox browser by passing this profile as `base64` string to the `firefox_profile` property in your desired capabilities. This requires to build that profile and convert it into `base64`. This service for the [wdio testrunner](http://webdriver.io/docs/gettingstarted.html) takes the work of compiling the profile out of your hand and let's you define your desired options comfortable from the `wdio.conf.js` file.
+You want to run your Firefox browser with a specific extension or need to set couple preferences? Selenium allows you to use a profile for the Firefox browser by passing this profile as `base64` string to the `firefox_profile` property in your desired capabilities. This requires to build that profile and convert it into `base64`. This service for the [wdio testrunner](http://webdriver.io/guide/testrunner/gettingstarted.html) takes the work of compiling the profile out of your hand and let's you define your desired options comfortable from the `wdio.conf.js` file.
 
 To find all possible options just open [about:config](about:config) in your Firefox browser or go to [mozillaZine](http://kb.mozillazine.org/About:config_entries) website to find the whole documentation about each setting. In Addition to that you can define compiled (as `*.xpi`) Firefox extensions that should get installed before the test starts.
 
@@ -23,7 +23,7 @@ You can simple do it by:
 npm install @wdio/firefox-profile-service --save-dev
 ```
 
-Instructions on how to install `WebdriverIO` can be found [here.](http://webdriver.io/docs/gettingstarted.html)
+Instructions on how to install `WebdriverIO` can be found [here.](http://webdriver.io/guide/getstarted/install.html)
 
 ## Configuration
 

--- a/packages/wdio-jasmine-framework/README.md
+++ b/packages/wdio-jasmine-framework/README.md
@@ -21,7 +21,7 @@ You can simple do it by:
 npm install @wdio/jasmine-framework --save-dev
 ```
 
-Instructions on how to install `WebdriverIO` can be found [here.](http://webdriver.io/docs/gettingstarted.html)
+Instructions on how to install `WebdriverIO` can be found [here.](http://webdriver.io/guide/getstarted/install.html)
 
 ## Configuration
 

--- a/packages/wdio-junit-reporter/README.md
+++ b/packages/wdio-junit-reporter/README.md
@@ -21,7 +21,7 @@ You can simple do it by:
 npm install @wdio/junit-reporter --save-dev
 ```
 
-Instructions on how to install `WebdriverIO` can be found [here](http://webdriver.io/docs/gettingstarted.html).
+Instructions on how to install `WebdriverIO` can be found [here](http://webdriver.io/guide/getstarted/install.html).
 
 ## Configuration
 

--- a/packages/wdio-mocha-framework/README.md
+++ b/packages/wdio-mocha-framework/README.md
@@ -21,7 +21,7 @@ You can simple do it by:
 npm install @wdio/mocha-framework --save-dev
 ```
 
-Instructions on how to install `WebdriverIO` can be found [here.](http://webdriver.io/docs/gettingstarted.html)
+Instructions on how to install `WebdriverIO` can be found [here.](http://webdriver.io/guide/getstarted/install.html)
 
 ## Configuration
 

--- a/packages/wdio-sauce-service/README.md
+++ b/packages/wdio-sauce-service/README.md
@@ -21,7 +21,7 @@ You can simple do it by:
 npm install @wdio/sauce-service --save-dev
 ```
 
-Instructions on how to install `WebdriverIO` can be found [here.](http://webdriver.io/docs/gettingstarted.html)
+Instructions on how to install `WebdriverIO` can be found [here.](http://webdriver.io/guide/getstarted/install.html)
 
 ## Configuration
 

--- a/packages/wdio-selenium-standalone-service/README.md
+++ b/packages/wdio-selenium-standalone-service/README.md
@@ -1,7 +1,7 @@
 WebdriverIO Selenium Standalone Service
 =======================================
 
-Handling the Selenium server is out of scope of the actual WebdriverIO project. This service helps you to run Selenium seamlessly when running tests with the [WDIO testrunner](http://webdriver.io/docs/gettingstarted.html). It uses the well know [selenium-standalone](https://www.npmjs.com/package/selenium-standalone) NPM package that automatically sets up the standalone server and all required driver for you.
+Handling the Selenium server is out of scope of the actual WebdriverIO project. This service helps you to run Selenium seamlessly when running tests with the [WDIO testrunner](http://webdriver.io/guide/testrunner/gettingstarted.html). It uses the well know [selenium-standalone](https://www.npmjs.com/package/selenium-standalone) NPM package that automatically sets up the standalone server and all required driver for you.
 
 ## Installation
 
@@ -21,7 +21,7 @@ You can simple do it by:
 npm install @wdio/selenium-standalone-service --save-dev
 ```
 
-Instructions on how to install `WebdriverIO` can be found [here.](http://webdriver.io/docs/gettingstarted.html)
+Instructions on how to install `WebdriverIO` can be found [here.](http://webdriver.io/guide/getstarted/install.html)
 
 ## Configuration
 

--- a/packages/wdio-spec-reporter/README.md
+++ b/packages/wdio-spec-reporter/README.md
@@ -23,7 +23,7 @@ You can simple do it by:
 $ npm install @wdio/spec-reporter --save-dev
 ```
 
-Instructions on how to install `WebdriverIO` can be found [here](http://webdriver.io/docs/gettingstarted.html).
+Instructions on how to install `WebdriverIO` can be found [here](http://webdriver.io/guide/getstarted/install.html).
 
 ## Configuration
 

--- a/packages/wdio-sumologic-reporter/README.md
+++ b/packages/wdio-sumologic-reporter/README.md
@@ -23,7 +23,7 @@ You can simple do it by:
 $ npm install @wdio/sumologic-reporter --save-dev
 ```
 
-Instructions on how to install `WebdriverIO` can be found [here](http://webdriver.io/docs/gettingstarted.html).
+Instructions on how to install `WebdriverIO` can be found [here](http://webdriver.io/guide/getstarted/install.html).
 
 ## Configuration
 

--- a/packages/wdio-testingbot-service/README.md
+++ b/packages/wdio-testingbot-service/README.md
@@ -21,7 +21,7 @@ You can simple do it by:
 npm install @wdio/testingbot-service --save-dev
 ```
 
-Instructions on how to install `WebdriverIO` can be found [here.](http://webdriver.io/docs/gettingstarted.html)
+Instructions on how to install `WebdriverIO` can be found [here.](http://webdriver.io/guide/getstarted/install.html)
 
 ## Configuration
 


### PR DESCRIPTION
## Proposed changes
There were dead links to various Webdriver.io "Guide" resources within multiple *README.md* files throughout the project, as well as *SUPPORT.md*. This fixes those references.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc

### Reviewers: @webdriverio/technical-committee
