### PR TITLE
Allow to pick dc to run tests in

### DIFF
--- a/docs/ConfigurationFile.md
+++ b/docs/ConfigurationFile.md
@@ -33,8 +33,10 @@ exports.config = {
     key:  'xxxxxxxxxxxxxxxx-xxxxxx-xxxxx-xxxxxxxxx',
     //
     // If you run your tests on SauceLabs you can specify the region you want to run your tests
-    // in via the `region` property.
-    region: 'eu', // for eu-central-1
+    // in via the `region` property. Available short handles for regions are:
+    // us: us-west-1 (default)
+    // eu: eu-central-1
+    region: 'us',
     //
     // ==================
     // Specify Test Files

--- a/docs/ConfigurationFile.md
+++ b/docs/ConfigurationFile.md
@@ -32,6 +32,10 @@ exports.config = {
     user: 'webdriverio',
     key:  'xxxxxxxxxxxxxxxx-xxxxxx-xxxxx-xxxxxxxxx',
     //
+    // If you run your tests on SauceLabs you can specify the region you want to run your tests
+    // in via the `region` property.
+    region: 'eu', // for eu-central-1
+    //
     // ==================
     // Specify Test Files
     // ==================

--- a/examples/wdio.conf.js
+++ b/examples/wdio.conf.js
@@ -27,8 +27,10 @@ exports.config = {
     key:  'xxxxxxxxxxxxxxxx-xxxxxx-xxxxx-xxxxxxxxx',
     //
     // If you run your tests on SauceLabs you can specify the region you want to run your tests
-    // in via the `region` property.
-    region: 'eu', // for eu-central-1
+    // in via the `region` property. Available short handles for regions are:
+    // us: us-west-1 (default)
+    // eu: eu-central-1
+    region: 'us',
     //
     // ==================
     // Specify Test Files

--- a/examples/wdio.conf.js
+++ b/examples/wdio.conf.js
@@ -26,6 +26,10 @@ exports.config = {
     user: 'webdriverio',
     key:  'xxxxxxxxxxxxxxxx-xxxxxx-xxxxx-xxxxxxxxx',
     //
+    // If you run your tests on SauceLabs you can specify the region you want to run your tests
+    // in via the `region` property.
+    region: 'eu', // for eu-central-1
+    //
     // ==================
     // Specify Test Files
     // ==================

--- a/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
+++ b/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
@@ -32,6 +32,10 @@ exports.config = {
     //
     user: process.env.<%= answers.env_user %>,
     key: process.env.<%= answers.env_key %>,
+    //
+    // If you run your tests on SauceLabs you can specify the region you want to run your tests
+    // in via the `region` property.
+    // region: 'eu', // for eu-central-1
     <% }
     if(answers.backend.indexOf('In the cloud') > -1) { %>
     <% } %>

--- a/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
+++ b/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
@@ -34,8 +34,9 @@ exports.config = {
     key: process.env.<%= answers.env_key %>,
     //
     // If you run your tests on SauceLabs you can specify the region you want to run your tests
-    // in via the `region` property.
-    // region: 'eu', // for eu-central-1
+    // in via the `region` property. Available short handles for regions are:
+    // us: us-west-1 (default)
+    // eu: eu-central-1
     <% }
     if(answers.backend.indexOf('In the cloud') > -1) { %>
     <% } %>

--- a/packages/wdio-config/src/index.js
+++ b/packages/wdio-config/src/index.js
@@ -1,5 +1,5 @@
 import ConfigParser from './lib/ConfigParser'
-import { validateConfig, detectBackend, initialisePlugin } from './utils'
+import { validateConfig, getSauceEndpoint, detectBackend, initialisePlugin } from './utils'
 import {
     wrapCommand, runFnInFiberContext, runTestInFiberContext, executeHooksWithArgs,
     hasWdioSyncSupport
@@ -7,6 +7,7 @@ import {
 
 export {
     validateConfig,
+    getSauceEndpoint,
     detectBackend,
     initialisePlugin,
     ConfigParser,

--- a/packages/wdio-config/src/utils.js
+++ b/packages/wdio-config/src/utils.js
@@ -2,11 +2,20 @@ const DEFAULT_HOSTNAME = '127.0.0.1'
 const DEFAULT_PORT = 4444
 const DEFAULT_PROTOCOL = 'http'
 
+const REGION_MAPPING = {
+    'eu': 'eu-central-1'
+}
+
+export function getSauceEndpoint (region) {
+    const dc = region ? (REGION_MAPPING[region] || region) + '.' : ''
+    return `${dc}saucelabs.com`
+}
+
 /**
  * helper to detect the Selenium backend according to given capabilities
  */
 export function detectBackend (options = {}) {
-    const { port, hostname, user, key, protocol } = options
+    const { port, hostname, user, key, protocol, region } = options
 
     /**
      * browserstack
@@ -37,7 +46,7 @@ export function detectBackend (options = {}) {
     if (typeof user === 'string' && key.length === 36) {
         return {
             protocol: protocol || 'https',
-            hostname: hostname || 'ondemand.saucelabs.com',
+            hostname: hostname || `ondemand.${getSauceEndpoint(region)}`,
             port: port || 443
         }
     }

--- a/packages/wdio-config/src/utils.js
+++ b/packages/wdio-config/src/utils.js
@@ -3,11 +3,12 @@ const DEFAULT_PORT = 4444
 const DEFAULT_PROTOCOL = 'http'
 
 const REGION_MAPPING = {
-    'eu': 'eu-central-1'
+    'us': '', // default endpoint
+    'eu': 'eu-central-1.'
 }
 
 export function getSauceEndpoint (region) {
-    const dc = region ? (REGION_MAPPING[region] || region) + '.' : ''
+    const dc = region ? REGION_MAPPING[region] || (region + '.') : ''
     return `${dc}saucelabs.com`
 }
 

--- a/packages/wdio-config/src/utils.js
+++ b/packages/wdio-config/src/utils.js
@@ -8,7 +8,10 @@ const REGION_MAPPING = {
 }
 
 export function getSauceEndpoint (region) {
-    const dc = region ? REGION_MAPPING[region] || (region + '.') : ''
+    const dc = region ?
+        typeof REGION_MAPPING[region] !== 'undefined' ?
+            REGION_MAPPING[region] : (region + '.')
+        : ''
     return `${dc}saucelabs.com`
 }
 

--- a/packages/wdio-config/tests/__mocks__/@wdio/config.js
+++ b/packages/wdio-config/tests/__mocks__/@wdio/config.js
@@ -1,4 +1,5 @@
 import { DEFAULT_CONFIGS } from '../../../src/constants'
+import { getSauceEndpoint as getSauceEndpointMock } from '../../../src/utils'
 
 class DotReporter {
     constructor (options) {
@@ -45,6 +46,7 @@ const pluginMocks = {
     }
 }
 
+export const getSauceEndpoint = getSauceEndpointMock
 export const initialisePlugin = jest.fn().mockImplementation(
     (name, type) => pluginMocks[type][name])
 export const validateConfig = jest.fn().mockImplementation(

--- a/packages/wdio-config/tests/detectBackend.test.js
+++ b/packages/wdio-config/tests/detectBackend.test.js
@@ -58,6 +58,17 @@ describe('detectBackend', () => {
         expect(caps.protocol).toBe('https')
     })
 
+    it('should detect saucelabs user running in the default DC', () => {
+        const caps = detectBackend({
+            user: 'foobar',
+            key: '50aa152c-1932-B2f0-9707-18z46q2n1mb0',
+            region: 'us'
+        })
+        expect(caps.hostname).toBe('ondemand.saucelabs.com')
+        expect(caps.port).toBe(443)
+        expect(caps.protocol).toBe('https')
+    })
+
     it('should detect saucelabs user running in an EU DC', () => {
         const caps = detectBackend({
             user: 'foobar',

--- a/packages/wdio-config/tests/detectBackend.test.js
+++ b/packages/wdio-config/tests/detectBackend.test.js
@@ -58,6 +58,28 @@ describe('detectBackend', () => {
         expect(caps.protocol).toBe('https')
     })
 
+    it('should detect saucelabs user running in an EU DC', () => {
+        const caps = detectBackend({
+            user: 'foobar',
+            key: '50aa152c-1932-B2f0-9707-18z46q2n1mb0',
+            region: 'eu'
+        })
+        expect(caps.hostname).toBe('ondemand.eu-central-1.saucelabs.com')
+        expect(caps.port).toBe(443)
+        expect(caps.protocol).toBe('https')
+    })
+
+    it('should detect saucelabs user running on a random DC', () => {
+        const caps = detectBackend({
+            user: 'foobar',
+            key: '50aa152c-1932-B2f0-9707-18z46q2n1mb0',
+            region: 'foobar'
+        })
+        expect(caps.hostname).toBe('ondemand.foobar.saucelabs.com')
+        expect(caps.port).toBe(443)
+        expect(caps.protocol).toBe('https')
+    })
+
     it('should detect saucelabs user but recognise custom endpoint properties', () => {
         const caps = detectBackend({
             user: 'foobar',

--- a/packages/wdio-sauce-service/package.json
+++ b/packages/wdio-sauce-service/package.json
@@ -31,6 +31,7 @@
     "url": "https://github.com/webdriverio/webdriverio/issues"
   },
   "dependencies": {
+    "@wdio/config": "^5.0.0-beta.10",
     "@wdio/logger": "^5.0.0-beta.10",
     "request": "^2.85.0",
     "sauce-connect-launcher": "^1.2.3"

--- a/packages/wdio-sauce-service/src/service.js
+++ b/packages/wdio-sauce-service/src/service.js
@@ -1,5 +1,6 @@
 import request from 'request'
 import logger from '@wdio/logger'
+import { getSauceEndpoint } from '@wdio/config'
 
 const jobDataProperties = ['name', 'tags', 'public', 'build', 'custom-data']
 
@@ -19,12 +20,13 @@ export default class SauceService {
         this.capabilities = capabilities
         this.sauceUser = this.config.user
         this.sauceKey = this.config.key
+        this.hostname = getSauceEndpoint(this.config.region)
         this.testCnt = 0
         this.failures = 0 // counts failures between reloads
     }
 
     getSauceRestUrl (sessionId) {
-        return `https://saucelabs.com/rest/v1/${this.sauceUser}/jobs/${sessionId}`
+        return `https://${this.hostname}/rest/v1/${this.sauceUser}/jobs/${sessionId}`
     }
 
     beforeSuite (suite) {

--- a/packages/wdio-sauce-service/tests/service.test.js
+++ b/packages/wdio-sauce-service/tests/service.test.js
@@ -22,6 +22,11 @@ test('getSauceRestUrl', () => {
     euService.before()
     expect(euService.getSauceRestUrl('12345'))
         .toBe('https://eu-central-1.saucelabs.com/rest/v1/foobar/jobs/12345')
+
+    const usService = new SauceService({ user: 'foobar', region: 'us' })
+    usService.before()
+    expect(usService.getSauceRestUrl('12345'))
+        .toBe('https://saucelabs.com/rest/v1/foobar/jobs/12345')
 })
 
 test('beforeSuite', () => {

--- a/packages/wdio-sauce-service/tests/service.test.js
+++ b/packages/wdio-sauce-service/tests/service.test.js
@@ -17,6 +17,11 @@ test('getSauceRestUrl', () => {
     service.before()
     expect(service.getSauceRestUrl('12345'))
         .toBe('https://saucelabs.com/rest/v1/foobar/jobs/12345')
+
+    const euService = new SauceService({ user: 'foobar', region: 'eu' })
+    euService.before()
+    expect(euService.getSauceRestUrl('12345'))
+        .toBe('https://eu-central-1.saucelabs.com/rest/v1/foobar/jobs/12345')
 })
 
 test('beforeSuite', () => {


### PR DESCRIPTION
## Proposed changes

SauceLabs is expanding their services to other regions in the world. WebdriverIO wants to allow user to easily pick between DCs. 

## Types of changes

This change allows user to define the WebDriver backend region from sauce via the `region` property, e.g. 

```js
    user: process.env.SAUCE_USERNAME,
    key: process.env.SAUCE_ACCESS_KEY,
    region: 'eu',
```

Will run the test against https://ondemand.eu-central-1.saucelabs.com:443/wd/hub/. Any additional regions will be supported, e.g.

```js
    user: process.env.SAUCE_USERNAME,
    key: process.env.SAUCE_ACCESS_KEY,
    region: 'us-east-1',
```

Will run the test against https://ondemand.us-east-1.saucelabs.com:443/wd/hub/

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)


### Reviewers: @webdriverio/technical-committee
