### PR TITLE
Add stopOnSpecFailure support

### DIFF
--- a/packages/wdio-jasmine-framework/README.md
+++ b/packages/wdio-jasmine-framework/README.md
@@ -61,20 +61,26 @@ Optional pattern to selectively select it/describe cases to run from spec files.
 Type: `RegExp | string`<br>
 Default: undefined
 
-## invertGrep
+### invertGrep
 Inverts 'grep' matches.
 
 Type: `Boolean`<br>
 Default: false
 
-## cleanStack
+### cleanStack
 Clean up stack trace and remove all traces of node module packages.
 
 Type: `Boolean`<br>
 Default: true
 
-## random
+### random
 Run specs in semi-random order.
+
+Type: `Boolean`<br>
+Default: `false`
+
+### stopOnSpecFailure
+Stops spec execution on first fail (other specs continue running)
 
 Type: `Boolean`<br>
 Default: `false`

--- a/packages/wdio-jasmine-framework/package.json
+++ b/packages/wdio-jasmine-framework/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@wdio/config": "^5.0.0-beta.10",
     "@wdio/logger": "^5.0.0-beta.10",
-    "jasmine": "^3.1.0"
+    "jasmine": "^3.2.0"
   },
   "peerDependencies": {
     "webdriverio": "5"

--- a/packages/wdio-jasmine-framework/src/index.js
+++ b/packages/wdio-jasmine-framework/src/index.js
@@ -56,6 +56,12 @@ class JasmineAdapter {
         jasmine.getEnv().specFilter = ::this.customSpecFilter
 
         /**
+         * Set whether to stop suite execution when a spec fails
+         */
+        const stopOnSpecFailure = !!this.jasmineNodeOpts.stopOnSpecFailure
+        jasmine.getEnv().stopOnSpecFailure(stopOnSpecFailure)
+
+        /**
          * enable expectHandler
          */
         const { expectationResultHandler } = this.jasmineNodeOpts


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

Since Jasmine 3.2, useful `stopOnSpecFailure` option became available: [documentation](https://jasmine.github.io/api/3.2/Env.html)

Would be really nice to support this feature.

**stopOnSpecFailure(value)**

Set whether to stop suite execution when a spec fails

Parameters:

Name | Type | Description
-- | -- | --
value | Boolean | Whether to stop suite execution when a spec fails

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee