### PR TITLE
Wdio hangs if mocha before hooks throws exception and any reporter is active

### DIFF
--- a/packages/wdio-mocha-framework/src/index.js
+++ b/packages/wdio-mocha-framework/src/index.js
@@ -156,6 +156,13 @@ class MochaAdapter {
                 expected: params.err.expected,
                 actual: params.err.actual
             }
+
+            /**
+             * hook failures are emitted as "test:fail"
+             */
+            if (params.payload && params.payload.title.match(/^"(before|after)( all)*" hook$/g)) {
+                message.type = 'hook:end'
+            }
         }
 
         if (params.payload) {
@@ -227,7 +234,7 @@ class MochaAdapter {
             this.lastError = message.error
         }
 
-        this.reporter.emit(event, message)
+        this.reporter.emit(message.type, message)
     }
 
     generateUID (message) {

--- a/packages/wdio-reporter/src/constants.js
+++ b/packages/wdio-reporter/src/constants.js
@@ -1,0 +1,4 @@
+export const MOCHA_TIMEOUT_MESSAGE = 'Ensure the done() callback is being called in this test.'
+export const MOCHA_TIMEOUT_MESSAGE_REPLACEMENT = `
+    The execution in the test "%s %s" took too long. Try to reduce the run time or
+    increase your timeout for test specs (http://webdriver.io/docs/timeouts.html).`

--- a/packages/wdio-reporter/src/stats/hook.js
+++ b/packages/wdio-reporter/src/stats/hook.js
@@ -1,8 +1,10 @@
+import TestStats from './test'
 import RunnableStats from './runnable'
 
-export default class HookStats extends RunnableStats {
+export default class HookStats extends TestStats {
     constructor (runner) {
-        super('hook')
+        runner.type = 'hook'
+        super(runner)
         this.uid = RunnableStats.getIdentifier(runner)
         this.cid = runner.cid
         this.title = runner.title

--- a/packages/wdio-reporter/src/stats/test.js
+++ b/packages/wdio-reporter/src/stats/test.js
@@ -6,7 +6,7 @@ import RunnableStats from './runnable'
  */
 export default class TestStats extends RunnableStats {
     constructor (runner) {
-        super('test')
+        super(runner.type || 'test')
         this.uid = RunnableStats.getIdentifier(runner)
         this.cid = runner.cid
         this.title = runner.title


### PR DESCRIPTION
_From @BorisOsipov on August 5, 2018 11:13_

## The problem
If some exception throws in mocha before hooks wdio runner hangs without reporting error.
```
describe('webdriver.io page', () => {
    before("setup smth", () => {
        browser.url('http://webdriver.io')
        throw new Error("")
    })

    it('should have the right title - the fancy generator way', () => {
        const title = browser.getTitle()
        assert.equal(title, 'WebdriverIO - WebDriver bindings for Node.js')
    })
})
```
## Environment
* WebdriverIO version:5.0.0-alpha.13
* Node.js version:v8.11.3
* [Standalone mode or wdio testrunner](http://webdriver.io/guide/getstarted/modes.html): wdio testrunner
* if wdio testrunner, running synchronous or asynchronous tests: sync
* Additional wdio packages used (if applicable): spec reporter

## Link to Selenium/WebdriverIO logs

```
 RUNNING  0-0 in chrome - /mocha/mocha.test.js

Test Suites:     0 passed, 1 total (0% completed)
Time:            🕘  16.60s
```


_Copied from original issue: webdriverio/v5#109_