### PR TITLE
wdio-browerstack-service: fixing auth issue

### DIFF
--- a/packages/wdio-browserstack-service/src/service.js
+++ b/packages/wdio-browserstack-service/src/service.js
@@ -5,7 +5,7 @@ const log = logger('wdio-browserstack-service');
 
 export default class BrowserstackService {
     constructor (config) {
-        this.config = config || {};
+        this.config = config;
         this.failures = 0;
     }
 

--- a/packages/wdio-browserstack-service/src/service.js
+++ b/packages/wdio-browserstack-service/src/service.js
@@ -5,13 +5,16 @@ const log = logger('wdio-browserstack-service');
 
 export default class BrowserstackService {
     constructor (config) {
-        this.config = config;
+        this.config = config || {};
         this.failures = 0;
     }
 
     before() {
         this.sessionId = global.browser.sessionId;
-        this.auth = (global.browser.requestHandler && global.browser.requestHandler.auth) || {};
+        this.auth = {
+            user: this.config.user || 'NotSetUser',
+            pass: this.config.key || 'NotSetKey'
+        };
         return this._printSessionURL();
     }
 

--- a/packages/wdio-browserstack-service/tests/service.test.js
+++ b/packages/wdio-browserstack-service/tests/service.test.js
@@ -119,33 +119,43 @@ describe('before', () => {
 
     });
 
-    it('should set auth to empty object if requestHandler is falsey', () => {
+    it('should set auth to default values if not provided', () => {
         let beforeService = new BrowserstackService();
 
         beforeService.before();
 
         expect(beforeService.sessionId).toEqual(12);
         expect(beforeService.failures).toEqual(0);
-        expect(beforeService.auth).toEqual({});
+        expect(beforeService.auth).toEqual({
+            user: 'NotSetUser',
+            pass: 'NotSetKey'
+        });
 
-        beforeService = new BrowserstackService();
-        global.browser.requestHandler = {};
+        beforeService = new BrowserstackService({ user: 'blah'});
         beforeService.before();
 
         expect(beforeService.sessionId).toEqual(12);
         expect(beforeService.failures).toEqual(0);
-        expect(beforeService.auth).toEqual({});
+        expect(beforeService.auth).toEqual({
+            user: 'blah',
+            pass: 'NotSetKey'
+        });
+        beforeService = new BrowserstackService({ key: 'blah'});
+        beforeService.before();
+
+        expect(beforeService.sessionId).toEqual(12);
+        expect(beforeService.failures).toEqual(0);
+        expect(beforeService.auth).toEqual({
+            user: 'NotSetUser',
+            pass: 'blah'
+        });
     });
 
     it('should initialize correctly', () => {
-        const beforeService = new BrowserstackService();
-        global.browser.requestHandler = {
-            auth: {
-                user: 'foo',
-                pass: 'bar'
-            }
-        };
-
+        const beforeService = new BrowserstackService({
+            user: 'foo',
+            key: 'bar'
+        });
         beforeService.before();
 
         expect(beforeService.sessionId).toEqual(12);

--- a/packages/wdio-browserstack-service/tests/service.test.js
+++ b/packages/wdio-browserstack-service/tests/service.test.js
@@ -19,11 +19,11 @@ beforeAll(() => {
         }
     };
     global.browser.sessionId = 12;
-    service = new BrowserstackService()
+    service = new BrowserstackService({})
 });
 
 it('should initialize correctly', () => {
-    service = new BrowserstackService();
+    service = new BrowserstackService({});
 
     expect(service.failures).toEqual(0);
 });
@@ -120,7 +120,7 @@ describe('before', () => {
     });
 
     it('should set auth to default values if not provided', () => {
-        let beforeService = new BrowserstackService();
+        let beforeService = new BrowserstackService({});
 
         beforeService.before();
 
@@ -168,7 +168,7 @@ describe('before', () => {
 
     it('should log the url', () => {
         const logInfoSpy = jest.spyOn(log, 'info').mockImplementation((string) => string);
-        const beforeService = new BrowserstackService();
+        const beforeService = new BrowserstackService({});
 
         beforeService.before();
         expect(logInfoSpy).toHaveBeenCalled();


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

The global.requestHander.auth object no longer exist in v5, and so the restAPI calls to update the status are not working as expected. I am updating the package to directly access the username and key from the config.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

### Reviewers: @webdriverio/technical-committee
