### PR TITLE
Fix: Removing wdio-cli duplicate peer dependency

### DIFF
--- a/packages/wdio-browserstack-service/package.json
+++ b/packages/wdio-browserstack-service/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@wdio/logger": "^5.0.0-beta.12",
-    "browserstack-local": "^1.3.5",
+    "browserstack-local": "1.3.7",
     "request": "^2.85.0"
   },
   "peerDependencies": {

--- a/packages/wdio-cli/package.json
+++ b/packages/wdio-cli/package.json
@@ -53,9 +53,6 @@
     "webdriverio": "^5.0.0-beta.12",
     "yargs": "^11.1.0"
   },
-  "peerDependencies": {
-    "webdriverio": "^5.0.0"
-  },
   "publishConfig": {
     "access": "public"
   }


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)
@wdio/cli has both a peer dependency and an explicit dependency in in webdriverio, which then chains an older version of webdriver (5.0.0-rc1).

I'm also ninja updating the BSLocal version (it looks like they fixed a critical vulnerability).

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
