### PR TITLE
Fix browser documentation on getCurrentUrl

### DIFF
--- a/packages/webdriverio/src/commands/browser/url.js
+++ b/packages/webdriverio/src/commands/browser/url.js
@@ -9,7 +9,7 @@
     // navigate to a new URL
     browser.url('http://webdriver.io');
     // receive url
-    console.log(browser.getUrl()); // outputs: "http://webdriver.io"
+    console.log(browser.getCurrentUrl()); // outputs: "http://webdriver.io"
 
     :baseUrlResolutions.js
     // With a base URL of http://example.com/site, the following url parameters resolve as such:


### PR DESCRIPTION
The documentation suggests using `browser.getUrl()`.

The correct command is `browser.getCurrentUrl()`

## Proposed changes

It's a simple documentation fix. The current documentation is incorrect.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

**Added no tests because it's just documentation.**

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
