### PR TITLE
use correct parameter for switchContext command

### DIFF
--- a/packages/webdriver/protocol/mjsonwp.json
+++ b/packages/webdriver/protocol/mjsonwp.json
@@ -9,7 +9,7 @@
       "command": "switchContext",
       "ref": "https://github.com/SeleniumHQ/mobile-spec/blob/master/spec-draft.md#webviews-and-other-contexts",
       "parameters": [{
-        "name": "context",
+        "name": "name",
         "type": "string",
         "description": "a string representing an available context",
         "required": true


### PR DESCRIPTION
According to [Appium's route handler](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L325), switchContext should pass its parameter as `name`, not `context`.