### PR TITLE
fix logging target determination

### DIFF
--- a/packages/wdio-logger/src/index.js
+++ b/packages/wdio-logger/src/index.js
@@ -1,6 +1,6 @@
 /**
  * environment check to allow to use this package in a web context
  */
-export default (typeof process !== 'undefined' && process.release.name === 'node')
+export default (typeof process !== 'undefined' &&  && typeof process.release !== 'undefined' && process.release.name === 'node')
     ? require('./node').default
     : require('./web').default


### PR DESCRIPTION
we might wind up in a webpack environment where 'process'
is defined but fake, in which case we can't rely on
'process.release' existing