### PR TITLE
latest 5.0 beta 13 has incorrect sendKeys definition for w3c

### DIFF
--- a/packages/webdriver/protocol/webdriver.json
+++ b/packages/webdriver/protocol/webdriver.json
@@ -579,8 +579,8 @@
         "description": "the id of an element returned in a previous call to Find Element(s)"
       }],
       "parameters": [{
-        "name": "value",
-        "type": "string[]",
+        "name": "text",
+        "type": "string",
         "description": "string to send as keystrokes to the element",
         "required": true
       }]


### PR DESCRIPTION
According to [w3c spec](https://w3c.github.io/webdriver/#dfn-element-send-keys), parameter for send keys is `text` and has type `string`, but this is the definition in webdriverio's webdriver.json:

```
      "parameters": [{
        "name": "value",
        "type": "string[]",
        "description": "string to send as keystrokes to the element",
        "required": true
      }]
```

it is a parameter called `value` with type `string[]`. this is the old jsonwp format.

in an earlier version of 5.0 this was correct, and now it is incorrect; maybe a copy/paste issue?