### PR TITLE
webdriver: set log level when attaching to existing session

### DIFF
--- a/packages/webdriver/src/index.js
+++ b/packages/webdriver/src/index.js
@@ -43,6 +43,8 @@ export default class WebDriver {
             throw new Error('sessionId is required to attach to existing session')
         }
 
+        logger.setLevel('webdriver', options.logLevel)
+
         options.capabilities = options.capabilities || {}
         options.isW3C = options.isW3C || true
         const prototype = Object.assign(getPrototype(options.isW3C), proto)


### PR DESCRIPTION
## Proposed changes

When attaching to an existing session, after e.g. the session details where stored in a json or something like that, the logLevel isn't properly set.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

This fixes https://github.com/webdriverio/webdriverio/issues/3102

### Reviewers: @webdriverio/technical-committee
