### PR TITLE
wedbdriverio & webdriver: initial stale element handler work

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -11,7 +11,7 @@ module.exports = {
         '@babel/plugin-proposal-export-default-from',
         '@babel/plugin-proposal-class-properties',
         '@babel/plugin-proposal-optional-catch-binding'
-],
+    ],
     env: {
         development: {
             sourceMaps: 'inline',

--- a/babel.config.js
+++ b/babel.config.js
@@ -9,8 +9,9 @@ module.exports = {
     plugins: [
         '@babel/plugin-proposal-function-bind',
         '@babel/plugin-proposal-export-default-from',
-        '@babel/plugin-proposal-class-properties'
-    ],
+        '@babel/plugin-proposal-class-properties',
+        '@babel/plugin-proposal-optional-catch-binding'
+],
     env: {
         development: {
             sourceMaps: 'inline',

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@babel/plugin-proposal-class-properties": "^7.1.0",
     "@babel/plugin-proposal-export-default-from": "^7.0.0",
     "@babel/plugin-proposal-function-bind": "^7.0.0",
+    "@babel/plugin-proposal-optional-catch-binding": "^7.2.0",
     "@babel/plugin-syntax-export-default-from": "^7.0.0",
     "@babel/preset-env": "^7.1.0",
     "@babel/register": "^7.0.0",

--- a/packages/webdriver/src/request.js
+++ b/packages/webdriver/src/request.js
@@ -94,6 +94,17 @@ export default class WebDriverRequest extends EventEmitter {
             }
 
             /**
+             *  stop retrying as this will never be successful.
+             *  we will handle this at the elementErrorHandler
+             */
+
+            if(error.message.includes("stale element reference")) {
+                log.warn(`Request encountered a stale element - terminating request`);
+                this.emit('response', { error })
+                return reject(error)
+            }
+
+            /**
              * stop retrying if totalRetryCount was exceeded or there is no reason to
              * retry, e.g. if sessionId is invalid
              */

--- a/packages/webdriverio/src/middlewares.js
+++ b/packages/webdriverio/src/middlewares.js
@@ -27,7 +27,7 @@ export const elementErrorHandler = (fn) => (commandName, commandFn) => {
              */
             try {
                 await this.waitForExist()
-            } catch (error) {
+            } catch {
                 throw new Error(
                     `Can't call ${commandName} on element with selector "${this.selector}" because element wasn't found`)
             }

--- a/packages/webdriverio/src/utils/refetchElement.js
+++ b/packages/webdriverio/src/utils/refetchElement.js
@@ -1,0 +1,16 @@
+export default async function refetchElement (currentElement) {
+    let selectors = [];
+
+    //Crawl back to the browser object, and cache all selectors
+    while(currentElement.elementId && currentElement.parent) {
+        selectors.push(currentElement.selector);
+        currentElement = currentElement.parent;
+    }
+    selectors.reverse();
+
+    // Beginning with the browser object, rechain
+    return selectors.reduce(async (elementPromise, selector) => {
+        const resolvedElement = await elementPromise;
+        return resolvedElement.$(selector);
+    }, Promise.resolve(currentElement));
+}

--- a/packages/webdriverio/tests/__mocks__/request.js
+++ b/packages/webdriverio/tests/__mocks__/request.js
@@ -156,34 +156,6 @@ const requestMock = jest.fn().mockImplementation((params, cb) => {
         }, {});
     }
 
-
-    /**
-     * Simulate a stale element
-     */
-
-    if (params.uri.path === `/wd/hub/session/${sessionId}/element/${genericSubSubElementId}/click`) {
-        ++requestMock.retryCnt
-
-        if (requestMock.retryCnt > 1) {
-            const response = { value: null }
-            return cb(null, {
-                headers: { foo: 'bar' },
-                statusCode: 200,
-                body: response
-            }, response)
-        }
-
-        let error = new Error('element is not attached to the page document')
-        error.name = 'stale element reference';
-
-        return cb(error, {
-            headers: { foo: 'bar' },
-            statusCode: 404,
-            body: {}
-        }, {});
-    }
-
-
     /**
      * simulate failing response
      */

--- a/packages/webdriverio/tests/__mocks__/request.js
+++ b/packages/webdriverio/tests/__mocks__/request.js
@@ -131,6 +131,60 @@ const requestMock = jest.fn().mockImplementation((params, cb) => {
     }
 
     /**
+     * Simulate a stale element
+     */
+
+    if (params.uri.path === `/wd/hub/session/${sessionId}/element/${genericSubSubElementId}/click`) {
+        ++requestMock.retryCnt
+
+        if (requestMock.retryCnt > 1) {
+            const response = { value: null }
+            return cb(null, {
+                headers: { foo: 'bar' },
+                statusCode: 200,
+                body: response
+            }, response)
+        }
+
+        let error = new Error('element is not attached to the page document')
+        error.name = 'stale element reference';
+
+        return cb(error, {
+            headers: { foo: 'bar' },
+            statusCode: 404,
+            body: {}
+        }, {});
+    }
+
+
+    /**
+     * Simulate a stale element
+     */
+
+    if (params.uri.path === `/wd/hub/session/${sessionId}/element/${genericSubSubElementId}/click`) {
+        ++requestMock.retryCnt
+
+        if (requestMock.retryCnt > 1) {
+            const response = { value: null }
+            return cb(null, {
+                headers: { foo: 'bar' },
+                statusCode: 200,
+                body: response
+            }, response)
+        }
+
+        let error = new Error('element is not attached to the page document')
+        error.name = 'stale element reference';
+
+        return cb(error, {
+            headers: { foo: 'bar' },
+            statusCode: 404,
+            body: {}
+        }, {});
+    }
+
+
+    /**
      * simulate failing response
      */
     if (params.uri.path === '/wd/hub/failing') {

--- a/packages/webdriverio/tests/commands/element/touchAction.test.js
+++ b/packages/webdriverio/tests/commands/element/touchAction.test.js
@@ -148,18 +148,18 @@ describe('touchAction element test', () => {
         })
 
         it('should throw an error if "release" has invalid params', async () => {
-            await expect(() => elem.touchAction({ action: 'release', ms: 123 }))
-                .toThrow('action "release" doesn\'t accept any options ("ms" found)')
+            await expect(elem.touchAction({ action: 'release', ms: 123 }))
+                .rejects.toThrow('action "release" doesn\'t accept any options ("ms" found)')
         })
 
         it('should throw an error if "wait" has invalid params', async () => {
-            await expect(() => elem.touchAction({ action: 'wait', x: 123 }))
-                .toThrow('action "wait" doesn\'t accept x or y options')
+            await expect(elem.touchAction({ action: 'wait', x: 123 }))
+                .rejects.toThrow('action "wait" doesn\'t accept x or y options')
         })
 
         it('should throw error if other actions contains something different than x or y', async () => {
-            await expect(() => elem.touchAction({ action: 'press', ms: 123 }))
-                .toThrow('action "press" doesn\'t accept "ms" as option')
+            await expect(elem.touchAction({ action: 'press', ms: 123 }))
+                .rejects.toThrow('action "press" doesn\'t accept "ms" as option')
         })
 
         it('should ignore unknown options', async () => {

--- a/packages/webdriverio/tests/middleware.test.js
+++ b/packages/webdriverio/tests/middleware.test.js
@@ -1,7 +1,9 @@
 import logger from '@wdio/logger'
 import { remote } from '../src'
+import request from 'request'
 
 const { warn  } = logger()
+const waitForExist = require('../src/commands/element/waitForExist')
 
 describe('middleware', () => {
     let browser;
@@ -15,6 +17,34 @@ describe('middleware', () => {
             waitforInterval: 20,
             waitforTimeout: 100
         })
+    })
+
+    it('should throw an error if the element is never found', async () => {
+        waitForExist.default =
+            jest.fn().mockImplementation ( ( ) => { throw new Error(`Promise was rejected with the following reason`)});
+
+        const elem = await browser.$('#foo')
+        elem.elementId = undefined
+
+        await expect(elem.click())
+            .rejects.toThrow(`Can't call click on element with selector "#foo" because element wasn't found`)
+    });
+
+    it('should succesfully click on an element that falls stale after being refound', async () => {
+        waitForExist.default =
+            jest.fn().mockImplementation (( ) => { return true });
+
+        const elem = await browser.$('#foo')
+        const subElem = await elem.$('#subfoo')
+        const subSubElem = await subElem.$('#subsubfoo');
+        subSubElem.elementId = undefined
+
+        //Success returns a null
+        expect(await subSubElem.click()).toEqual(null)
+        expect(warn.mock.calls).toHaveLength(1)
+        expect(warn.mock.calls).toEqual([['Request encountered a stale element - terminating request']])
+        warn.mockClear();
+        request.retryCnt = 0
     })
 
     it('should succesfully click on a stale element', async () => {

--- a/packages/webdriverio/tests/middleware.test.js
+++ b/packages/webdriverio/tests/middleware.test.js
@@ -1,0 +1,31 @@
+import logger from '@wdio/logger'
+import { remote } from '../src'
+
+const { warn  } = logger()
+
+describe('middleware', () => {
+    let browser;
+
+    beforeAll( async () => {
+        browser = await remote({
+            baseUrl: 'http://foobar.com',
+            capabilities: {
+                browserName: 'foobar'
+            },
+            waitforInterval: 20,
+            waitforTimeout: 100
+        })
+    })
+
+    it('should succesfully click on a stale element', async () => {
+        const elem = await browser.$('#foo')
+        const subElem = await elem.$('#subfoo')
+        const subSubElem = await subElem.$('#subsubfoo');
+
+        //Success returns a null
+        expect(await subSubElem.click()).toEqual(null)
+        expect(warn.mock.calls).toHaveLength(1)
+        expect(warn.mock.calls).toEqual([['Request encountered a stale element - terminating request']])
+    })
+    
+})

--- a/packages/webdriverio/tests/middleware.test.js
+++ b/packages/webdriverio/tests/middleware.test.js
@@ -1,9 +1,13 @@
+jest.mock('../src/commands/element/waitForExist', () => ({
+    __esModule: true,
+    default: jest.fn().mockImplementation(() => { return true })
+}));
+import waitForExist from '../src/commands/element/waitForExist';
 import logger from '@wdio/logger'
 import { remote } from '../src'
 import request from 'request'
 
 const { warn  } = logger()
-const waitForExist = require('../src/commands/element/waitForExist')
 
 describe('middleware', () => {
     let browser;
@@ -20,8 +24,7 @@ describe('middleware', () => {
     })
 
     it('should throw an error if the element is never found', async () => {
-        waitForExist.default =
-            jest.fn().mockImplementation ( ( ) => { throw new Error(`Promise was rejected with the following reason`)});
+        waitForExist.mockImplementationOnce (( ) => { throw new Error(`Promise was rejected with the following reason`)});
 
         const elem = await browser.$('#foo')
         elem.elementId = undefined
@@ -31,9 +34,6 @@ describe('middleware', () => {
     });
 
     it('should succesfully click on an element that falls stale after being refound', async () => {
-        waitForExist.default =
-            jest.fn().mockImplementation (( ) => { return true });
-
         const elem = await browser.$('#foo')
         const subElem = await elem.$('#subfoo')
         const subSubElem = await subElem.$('#subsubfoo');

--- a/packages/webdriverio/tests/utils/refetchElement.test.js
+++ b/packages/webdriverio/tests/utils/refetchElement.test.js
@@ -1,0 +1,35 @@
+import { remote } from '../../src'
+import refetchElement from '../../src/utils/refetchElement'
+
+describe('refetchElement', () => {
+    let browser;
+
+    beforeAll( async () => {
+        browser = await remote({
+            baseUrl: 'http://foobar.com',
+            capabilities: {
+                browserName: 'foobar'
+            },
+            waitforInterval: 20,
+            waitforTimeout: 100
+        })
+    })
+
+    it('should successfully refetch a non chained element', async () => {
+        const elem = await browser.$('#foo')
+        expect(refetchElement(elem)).resolves.toEqual(elem);
+    })
+
+    it('should successfully refetch a chained element', async () => {
+        const elem = await browser.$('#foo')
+        const subElem = await elem.$('#subfoo')
+        expect(refetchElement(subElem)).resolves.toEqual(subElem)
+    })
+
+    it('should successfully refetch a deeply chained element', async () => {
+        const elem = await browser.$('#foo')
+        const subElem = await elem.$('#subfoo')
+        const subSubElem = await subElem.$('#subsubfoo');
+        expect(refetchElement(subSubElem)).resolves.toEqual(subSubElem)
+    })
+})


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)
I am adding a handler to refetch an element in the event of a stale element, and then retry the failed command.

This resolves https://github.com/webdriverio/webdriverio/issues/3097

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
