### PR TITLE
Appium protocol fix

### DIFF
--- a/packages/webdriver/src/index.js
+++ b/packages/webdriver/src/index.js
@@ -4,7 +4,7 @@ import { validateConfig } from '@wdio/config'
 import webdriverMonad from './monad'
 import WebDriverRequest from './request'
 import { DEFAULTS } from './constants'
-import { getPrototype, isW3CSession } from './utils'
+import { getPrototype, isW3CSession, isAppiumSession } from './utils'
 
 import WebDriverProtocol from '../protocol/webdriver.json'
 import JsonWProtocol from '../protocol/jsonwp.json'
@@ -14,6 +14,7 @@ import AppiumProtocol from '../protocol/appium.json'
 export default class WebDriver {
     static async newSession (options = {}, modifier, proto = {}, commandWrapper) {
         const params = validateConfig(DEFAULTS, options)
+
         logger.setLevel('webdriver', params.logLevel)
 
         /**
@@ -52,8 +53,9 @@ export default class WebDriver {
          */
         params.capabilities = response.value.capabilities || response.value
         params.isW3C = isW3CSession(response.value)
+        params.isAppium = isAppiumSession(response.value)
 
-        const prototype = Object.assign(getPrototype(params.isW3C), proto)
+        const prototype = Object.assign(getPrototype(params.isW3C, params.isAppium), proto)
         const monad = webdriverMonad(params, modifier, prototype)
         return monad(response.value.sessionId || response.sessionId, commandWrapper)
     }

--- a/packages/webdriver/src/utils.js
+++ b/packages/webdriver/src/utils.js
@@ -109,11 +109,12 @@ export function isValidParameter (arg, expectedType) {
  */
 export function getPrototype (isW3C, isAppium) {
     const prototype = {}
+    let ProtocolCommands;
 
     if (isAppium) {
         // if we have the appium server, we want both w3c and jsonwp commands to
         // exist on the session, since appium allows mixing of both
-        const ProtocolCommands = Object.assign(
+        ProtocolCommands = Object.assign(
             JsonWProtocol,
             WebDriverProtocol,
             MJsonWProtocol,
@@ -121,7 +122,7 @@ export function getPrototype (isW3C, isAppium) {
         )
     } else {
         // otherwise we don't want to mix w3c and jsonwp
-        const ProtocolCommands = Object.assign(
+        ProtocolCommands = Object.assign(
             isW3C ? WebDriverProtocol : JsonWProtocol,
             MJsonWProtocol,
             AppiumProtocol


### PR DESCRIPTION
OK one more. When running an Appium test, even when using W3C caps, the prototype that comes back is the jsonwp proto because appium is specifically filtered out in the isW3C check.

with appium, we basically want both w3c and jsonwp commands to be available on the driver.

this PR makes that happen, not sure if it's the most elegant way though.