### PR TITLE
 webdriverio: added custom error messages ability to wait commands

### DIFF
--- a/packages/webdriverio/src/commands/element/waitForDisplayed.js
+++ b/packages/webdriverio/src/commands/element/waitForDisplayed.js
@@ -22,12 +22,13 @@
  * @alias element.waitForDisplayed
  * @param {Number=}  ms       time in ms (default: 500)
  * @param {Boolean=} reverse  if true it waits for the opposite (default: false)
+ * @param {String=}  error    if exists it overrides the default error message
  * @uses utility/waitUntil, state/isDisplayed
  * @type utility
  *
  */
 
-export default async function waitForDisplayed (ms, reverse = false) {
+export default async function waitForDisplayed (ms, reverse = false, error) {
     /**
      * if element wasn't found in the first place wait for its existance first
      */
@@ -43,7 +44,7 @@ export default async function waitForDisplayed (ms, reverse = false) {
     }
 
     const isReversed = reverse ? '' : 'not '
-    const errorMsg = `element ("${this.selector}") still ${isReversed}displayed after ${ms}ms`
+    const errorMsg = typeof error === 'string' ? error : `element ("${this.selector}") still ${isReversed}displayed after ${ms}ms`
 
     return this.waitUntil(async () => {
         const isVisible = await this.isElementDisplayed(this.elementId)

--- a/packages/webdriverio/src/commands/element/waitForEnabled.js
+++ b/packages/webdriverio/src/commands/element/waitForEnabled.js
@@ -27,12 +27,13 @@
  * @alias element.waitForEnabled
  * @param {Number=}  ms       time in ms (default: 500)
  * @param {Boolean=} reverse  if true it waits for the opposite (default: false)
+ * @param {String=}  error    if exists it overrides the default error message
  * @uses utility/waitUntil, state/isEnabled
  * @type utility
  *
  */
 
-export default async function waitForEnabled(ms, reverse = false) {
+export default async function waitForEnabled(ms, reverse = false, error) {
     // If the element doesn't already exist, wait for it to exist
     if (!this.elementId && !reverse) {
         await this.waitForExist(ms)
@@ -43,7 +44,7 @@ export default async function waitForEnabled(ms, reverse = false) {
     }
 
     const isReversed = reverse ? '' : 'not '
-    const errorMessage = `element ("${this.selector}") still ${isReversed}enabled after ${ms}ms`
+    const errorMessage = typeof error === 'string' ? error : `element ("${this.selector}") still ${isReversed}enabled after ${ms}ms`
 
     return this.waitUntil(async () => {
         const isEnabled = await this.isEnabled()

--- a/packages/webdriverio/src/commands/element/waitForExist.js
+++ b/packages/webdriverio/src/commands/element/waitForExist.js
@@ -21,12 +21,13 @@
  * @alias element.waitForExist
  * @param {Number=}  ms       time in ms (default: 500)
  * @param {Boolean=} reverse  if true it instead waits for the selector to not match any elements (default: false)
+ * @param {String=}  error    if exists it overrides the default error message
  * @uses utility/waitUntil, state/isExisting
  * @type utility
  *
  */
 
-export default function waitForExist (ms, reverse = false) {
+export default function waitForExist (ms, reverse = false, error) {
     /*!
      * ensure that ms is set properly
      */
@@ -35,7 +36,7 @@ export default function waitForExist (ms, reverse = false) {
     }
 
     const isReversed = reverse ? '' : 'not '
-    const errorMsg = `element ("${this.selector}") still ${isReversed}existing after ${ms}ms`
+    const errorMsg = typeof error === 'string' ? error : `element ("${this.selector}") still ${isReversed}existing after ${ms}ms`
 
     return this.waitUntil(function async () {
         return this.isExisting().then((isExisting) => isExisting !== reverse)

--- a/packages/webdriverio/tests/commands/element/waitForDisplayed.test.js
+++ b/packages/webdriverio/tests/commands/element/waitForDisplayed.test.js
@@ -124,4 +124,23 @@ describe('waitForDisplayed', () => {
         expect(elem.waitUntil.mock.calls[0][1]).toBe(elem.options.waitforTimeout)
         expect(elem.waitUntil.mock.calls[0][2]).toBe(`element ("#foo") still displayed after ${elem.options.waitforTimeout}ms`)
     })
+
+    test('should call isDisplayed and return false with custom error', async () => {
+        const tmpElem = await browser.$(`#foo`)
+        const elem = {
+            selector : '#foo',
+            waitForDisplayed : tmpElem.waitForDisplayed,
+            waitForExist : jest.fn(),
+            elementId : 123,
+            waitUntil : tmpElem.waitUntil,
+            isElementDisplayed : jest.fn(() => false),
+            options : { waitforTimeout : 500 },
+        }
+
+        try {
+            await elem.waitForDisplayed(duration, false, 'Element foo never displayed')
+        } catch (e) {
+            expect(e.message).toBe(`Element foo never displayed`)
+        }
+    })
 })

--- a/packages/webdriverio/tests/commands/element/waitForEnabled.test.js
+++ b/packages/webdriverio/tests/commands/element/waitForEnabled.test.js
@@ -116,4 +116,23 @@ describe('waitForEnabled', () => {
         expect(elem.waitUntil.mock.calls[0][1]).toBe(elem.options.waitforTimeout)
         expect(elem.waitUntil.mock.calls[0][2]).toBe(`element ("#foo") still enabled after ${elem.options.waitforTimeout}ms`)
     })
+
+    test('should call isEnabled and return false with custom error', async () => {
+        const tmpElem = await browser.$(`#foo`)
+        const elem = {
+            selector : '#foo',
+            waitForEnabled : tmpElem.waitForEnabled,
+            waitForExist : jest.fn(),
+            elementId : 123,
+            waitUntil : tmpElem.waitUntil,
+            isEnabled : jest.fn(() => false),
+            options : { waitforTimeout : 500 },
+        }
+
+        try {
+            await elem.waitForEnabled(duration, false, 'Element foo never enabled')
+        } catch (e) {
+            expect(e.message).toBe(`Element foo never enabled`)
+        }
+    })
 })


### PR DESCRIPTION
## Proposed changes

Added the ability to add custom error messages to the wait commands

Ex:

```
    $('#foo').waitForDisplayed(10000, false, 'foo was never displayed');
```

When this fails it will throw the error ```foo was never displayed``` instead of ```element (#foo) still not existing after 10000ms```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

### Reviewers: @webdriverio/technical-committee
