### PR TITLE
wdio-cli: Fix output of reporters/services when generating config file

### DIFF
--- a/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
+++ b/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
@@ -141,9 +141,7 @@ exports.config = {
     // your test setup with almost no effort. Unlike plugins, they don't add new
     // commands. Instead, they hook themselves up into the test process.
     <% if(answers.services.length) {
-    %>services: ['<%- answers.services.map(function(service) {
-        return service.slice(0, -8);
-    }).join("','") %>'],
+    %>services: ['<%- answers.services.join("','") %>'],
     <% } else {
     %>// services: [],<% } %>//
     // Framework you want to run your specs with.
@@ -158,11 +156,9 @@ exports.config = {
     // The only one supported by default is 'dot'
     // see also: http://webdriver.io/docs/dot-reporter.html
     <% if(answers.reporters.length) {
-    %>reporters: ['<%- answers.reporters.map(function(reporter) {
-        return reporter.slice(0, -9);
-    }).join("','") %>'],
+    %>reporters: ['<%- answers.reporters.join("','") %>'],
     <% } else {
-    %>// reporters: ['@wdio/dot'],<%
+    %>// reporters: ['@wdio/dot-reporter'],<%
     }
     if(answers.framework === 'mocha') { %>
     //


### PR DESCRIPTION
## Proposed changes

When generating the wdio.conf.js file from that startup questions it's putting them in like below which does not work when it tries to require the package:

```reporters : ['@wdio/spec']```

It should be listed as the actual package name like:

```reporters : ['@wdio/spec-reporter']```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

### Reviewers: @webdriverio/technical-committee
