### PR TITLE
Update cloud job as failed if mocha.bail is set

### DIFF
--- a/packages/wdio-browserstack-service/src/service.js
+++ b/packages/wdio-browserstack-service/src/service.js
@@ -51,7 +51,15 @@ export default class BrowserstackService {
         }
     }
 
-    after() {
+    after(result) {
+        /**
+         * set failures if user has bail option set in which case afterTest and
+         * afterSuite aren't executed before after hook
+         */
+        if (global.browser.config.mochaOpts && global.browser.config.mochaOpts.bail && Boolean(result)) {
+            this.failures = 1
+        }
+
         return this._update(this.sessionId, this._getBody())
     }
 

--- a/packages/wdio-browserstack-service/tests/service.test.js
+++ b/packages/wdio-browserstack-service/tests/service.test.js
@@ -12,6 +12,7 @@ let service
 
 beforeAll(() => {
     global.browser = {
+        config: {},
         capabilities: {
             device: '',
             os: 'OS X',
@@ -219,7 +220,17 @@ describe('after', () => {
         const updateSpy = jest.spyOn(service, '_update')
 
         service.after()
+        expect(service.failures).toBe(0)
         expect(updateSpy).toHaveBeenCalled()
+    })
+
+    it('should set failures if error happend and bail is set', () => {
+        global.browser.config.bail = true
+        const updateSpy = jest.spyOn(service, '_update')
+
+        service.after(1)
+        expect(updateSpy).toHaveBeenCalled()
+        expect(service.failures).toBe(1)
     })
 })
 

--- a/packages/wdio-browserstack-service/tests/service.test.js
+++ b/packages/wdio-browserstack-service/tests/service.test.js
@@ -10,7 +10,7 @@ jest.mock('request', () => ({
 const log = logger('test')
 let service
 
-beforeAll(() => {
+beforeEach(() => {
     global.browser = {
         config: {},
         capabilities: {
@@ -225,7 +225,7 @@ describe('after', () => {
     })
 
     it('should set failures if error happend and bail is set', () => {
-        global.browser.config.bail = true
+        global.browser.config.mochaOpts = { bail: true }
         const updateSpy = jest.spyOn(service, '_update')
 
         service.after(1)

--- a/packages/wdio-mocha-framework/package.json
+++ b/packages/wdio-mocha-framework/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@wdio/config": "^5.0.0-beta.15",
     "@wdio/logger": "^5.0.0-beta.15",
-    "mocha": "^5.0.0"
+    "mocha": "^5.2.0"
   },
   "peerDependencies": {
     "webdriverio": "^5.0.0"

--- a/packages/wdio-sauce-service/tests/service.test.js
+++ b/packages/wdio-sauce-service/tests/service.test.js
@@ -1,6 +1,7 @@
 import SauceService from '../src'
 
 global.browser = {
+    config: {},
     execute: jest.fn(),
     chromeA: { sessionId: 'sessionChromeA' },
     chromeB: { sessionId: 'sessionChromeB' },
@@ -160,7 +161,7 @@ test('after with bail set', () => {
 
     global.browser.isMultiremote = false
     global.browser.sessionId = 'foobar'
-    global.browser.config = { bail: 1 }
+    global.browser.config = { mochaOpts: { bail: 1 } }
     service.after(1)
 
     expect(service.updateJob).toBeCalledWith('foobar', 1)

--- a/packages/wdio-sauce-service/tests/service.test.js
+++ b/packages/wdio-sauce-service/tests/service.test.js
@@ -152,6 +152,20 @@ test('after', () => {
     expect(service.updateJob).toBeCalledWith('foobar', 5)
 })
 
+test('after with bail set', () => {
+    const service = new SauceService({ user: 'foobar', key: '123' })
+    service.before()
+    service.failures = 5
+    service.updateJob = jest.fn()
+
+    global.browser.isMultiremote = false
+    global.browser.sessionId = 'foobar'
+    global.browser.config = { bail: 1 }
+    service.after(1)
+
+    expect(service.updateJob).toBeCalledWith('foobar', 1)
+})
+
 test('beforeScenario should not set context if no sauce user was applied', () => {
     const service = new SauceService({})
     service.before()


### PR DESCRIPTION
## Proposed changes

Set failure state in after hook given the result because Mocha doesn't execute afterTest nor afterSuite if bail is set. Otherwise the job would have been marked as passed even though it failed

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)
This resolves https://github.com/webdriverio/webdriverio/issues/2954
### Reviewers: @webdriverio/technical-committee
