### PR TITLE
wdio-runner: Fix looking at caps as an array

### DIFF
--- a/packages/wdio-runner/src/utils.js
+++ b/packages/wdio-runner/src/utils.js
@@ -86,7 +86,7 @@ export async function initialiseInstance (config, capabilities, isMultiremote) {
 
     if (!isMultiremote) {
         log.debug('init remote session')
-        config.capabilities = capabilities.map(sanitizeCaps)
+        config.capabilities = sanitizeCaps(capabilities)
         return remote(config)
     }
 

--- a/packages/wdio-runner/tests/utils.test.js
+++ b/packages/wdio-runner/tests/utils.test.js
@@ -98,17 +98,16 @@ describe('utils', () => {
         it('should create normal remote session', () => {
             initialiseInstance({
                 foo: 'bar'
-            }, [
-                {
-                    browserName: 'chrome',
-                    maxInstances: 123
-                }
-            ])
+            },
+            {
+                browserName: 'chrome',
+                maxInstances: 123
+            })
             expect(attach).toHaveBeenCalledTimes(0)
             expect(multiremote).toHaveBeenCalledTimes(0)
             expect(remote).toBeCalledWith({
                 foo: 'bar',
-                capabilities: [{ browserName: 'chrome' }]
+                capabilities: { browserName: 'chrome' }
             })
         })
 


### PR DESCRIPTION
## Proposed changes

map is being used on capabilities when it's an object. See below error.

The error comes up after a basic install and running a single test.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

```
Stderr:
[0-0] 2018-12-21T19:35:29.698Z ERROR wdio-runner: TypeError: capabilities.map is not a function
    at map (/Users/pmerwin/Projects/qa/WDIO-5/lib-webdriverio5-nodejs/node_modules/@wdio/runner/src/utils.js:89:44)
    at Runner._initSession (/Users/pmerwin/Projects/qa/WDIO-5/lib-webdriverio5-nodejs/node_modules/@wdio/runner/src/index.js:152:62)
    at Runner._initSession [as run] (/Users/pmerwin/Projects/qa/WDIO-5/lib-webdriverio5-nodejs/node_modules/@wdio/runner/src/index.js:58:36)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:188:7)
[0-0] 2018-12-21T19:35:29.713Z ERROR wdio-local-runner: Failed launching test session: TypeError: Cannot read property 'isMultiremote' of null
    at Runner.isMultiremote [as run] (/Users/pmerwin/Projects/qa/WDIO-5/lib-webdriverio5-nodejs/node_modules/@wdio/runner/src/index.js:59:47)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:188:7)

Worker Error:
TypeError: capabilities.map is not a function
    at map (/Users/pmerwin/Projects/qa/WDIO-5/lib-webdriverio5-nodejs/node_modules/@wdio/runner/src/utils.js:89:44)
    at Runner._initSession (/Users/pmerwin/Projects/qa/WDIO-5/lib-webdriverio5-nodejs/node_modules/@wdio/runner/src/index.js:152:62)
    at Runner._initSession [as run] (/Users/pmerwin/Projects/qa/WDIO-5/lib-webdriverio5-nodejs/node_modules/@wdio/runner/src/index.js:58:36)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:188:7)
```


### Reviewers: @webdriverio/technical-committee
