### PR TITLE
Name mobile variable "driver" instead of "browser"

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "release": "npm run setup && lerna publish",
     "setup": "run-s bootstrap build",
     "test": "run-s test:*",
-    "test:eslint": "eslint packages examples",
+    "test:eslint": "eslint packages examples scripts",
     "test:coverage": "jest --coverage --detectOpenHandles",
     "test:wdio:sync": "wdio ./test/wdio.conf.js --spec=./test/specs/sync.spec.js",
     "test:wdio:async": "wdio ./test/wdio.conf.js --spec=./test/specs/async.spec.js",

--- a/scripts/generate-docs.js
+++ b/scripts/generate-docs.js
@@ -53,6 +53,7 @@ for (const [protocolName, definition] of Object.entries(PROTOCOLS)) {
             description.examples = [] // tbd
             description.returnTags = [] // tbd
             description.throwsTags = [] // tbd
+            description.protocolName = protocolName
             description.customEditUrl = `${config.repoUrl}/edit/master/packages/webdriver/protocol/${protocolName}.json`
 
             const protocolNote = `${protocol} command. More details can be found in the [official protocol docs](${description.ref}).`

--- a/scripts/generate-docs.js
+++ b/scripts/generate-docs.js
@@ -101,7 +101,7 @@ for (const [scope, files] of Object.entries(COMMANDS)) {
     for (const file of files) {
         const docDir = path.join(__dirname, '..', 'docs', 'api', scope)
         if (!fs.existsSync(docDir)){
-            fs.mkdirSync(docDir);
+            fs.mkdirSync(docDir)
         }
 
         const filepath = path.join(COMMAND_DIR, scope, file)
@@ -143,9 +143,9 @@ const packages = getSubPackages()
 for (const [type, [namePlural, nameSingular]] of Object.entries(plugins)) {
     const pkgs = packages.filter((pkg) => pkg.endsWith(`-${type}`) && pkg.split('-').length > 2)
     for (const pkg of pkgs) {
-        const name = pkg.split("-").slice(1,-1)
+        const name = pkg.split('-').slice(1,-1)
         const id = `${name.join('-')}-${type}`
-        const pkgName = name.map((n) => n[0].toUpperCase() + n.slice(1)).join(" ")
+        const pkgName = name.map((n) => n[0].toUpperCase() + n.slice(1)).join(' ')
         const readme = fs.readFileSync(path.join(__dirname, '..', 'packages', pkg, 'Readme.md')).toString()
         const preface = [
             '---',

--- a/scripts/generate-docs.js
+++ b/scripts/generate-docs.js
@@ -24,7 +24,7 @@ const PROTOCOL_NAMES = {
     mjsonwp: 'Mobile JSON Wire Protocol',
     webdriver: 'Webdriver Protocol'
 }
-
+const MOBILE_PROTOCOLS = ['appium', 'mjsonwp']
 const TEMPLATE_PATH = path.join(__dirname, 'templates', 'api.tpl.ejs')
 const MARKDOX_OPTIONS = {
     formatter: formatter,
@@ -53,7 +53,7 @@ for (const [protocolName, definition] of Object.entries(PROTOCOLS)) {
             description.examples = [] // tbd
             description.returnTags = [] // tbd
             description.throwsTags = [] // tbd
-            description.protocolName = protocolName
+            description.isMobile = MOBILE_PROTOCOLS.includes(protocolName)
             description.customEditUrl = `${config.repoUrl}/edit/master/packages/webdriver/protocol/${protocolName}.json`
 
             const protocolNote = `${protocol} command. More details can be found in the [official protocol docs](${description.ref}).`

--- a/scripts/templates/api.tpl.ejs
+++ b/scripts/templates/api.tpl.ejs
@@ -16,7 +16,7 @@ title: <?= method.command ?>
 ##### Usage
 
 ```js
-browser.<?= method.command ?>(<?= method.paramString ?>)
+<?= protocolName === 'appium' ? 'driver' : 'browser' ?>.<?= method.command ?>(<?= method.paramString ?>)
 ```
 
 <? if (method.paramTags.length) { ?>

--- a/scripts/templates/api.tpl.ejs
+++ b/scripts/templates/api.tpl.ejs
@@ -16,7 +16,7 @@ title: <?= method.command ?>
 ##### Usage
 
 ```js
-<?= protocolName === 'appium' ? 'driver' : 'browser' ?>.<?= method.command ?>(<?= method.paramString ?>)
+<?= method.isMobile ? 'driver' : 'browser' ?>.<?= method.command ?>(<?= method.paramString ?>)
 ```
 
 <? if (method.paramTags.length) { ?>

--- a/scripts/utils/formatter.js
+++ b/scripts/utils/formatter.js
@@ -5,62 +5,62 @@ const config = require('../../website/siteConfig')
 module.exports = function (docfile) {
     const javadoc = docfile.javadoc[0]
 
-    let type = (javadoc.ctx && javadoc.ctx.type);
+    let type = (javadoc.ctx && javadoc.ctx.type)
     const name = path.basename(docfile.filename, '.js')
     const scope = docfile.filename.split('/').slice(-2, -1)
 
-    let description = '';
-    let paramStr = [];
-    let propertyTags = [];
-    let paramTags = [];
-    let returnTags = [];
-    let throwsTags = [];
-    let fires = [];
-    let listens = [];
-    let tagDeprecated = false;
-    let tagSee = '';
-    let tagVersion = '';
-    let tagAuthor = '';
-    let tagType = '';
+    let description = ''
+    let paramStr = []
+    let propertyTags = []
+    let paramTags = []
+    let returnTags = []
+    let throwsTags = []
+    let fires = []
+    let listens = []
+    let tagDeprecated = false
+    let tagSee = ''
+    let tagVersion = ''
+    let tagAuthor = ''
+    let tagType = ''
 
     for (const tag of javadoc.tags) {
         if (tag.type == 'param') {
-            tag.joinedTypes = tag.types.join('|').replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;');
-            paramTags.push(tag);
-            paramStr.push(tag.name);
+            tag.joinedTypes = tag.types.join('|').replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;')
+            paramTags.push(tag)
+            paramStr.push(tag.name)
         } else if (tag.type == 'property') {
-            tag.joinedTypes = tag.types.join('|').replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;');
-            propertyTags.push(tag);
+            tag.joinedTypes = tag.types.join('|').replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;')
+            propertyTags.push(tag)
         } else if (tag.type == 'return' || tag.type == 'returns') {
-            tag.joinedTypes = tag.types.join('|').replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;');
-            returnTags.push(tag);
+            tag.joinedTypes = tag.types.join('|').replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;')
+            returnTags.push(tag)
         } else if (tag.type == 'throws') {
-            tag.joinedTypes = tag.types.join('|').replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;');
-            throwsTags.push(tag);
+            tag.joinedTypes = tag.types.join('|').replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;')
+            throwsTags.push(tag)
         } else if (tag.type == 'fires') {
-            fires.push(tag.string);
+            fires.push(tag.string)
         } else if (tag.type == 'listens') {
-            listens.push(tag.string);
+            listens.push(tag.string)
         } else if (tag.type == 'namespace') {
-            type = 'namespace';
+            type = 'namespace'
         } else if (tag.type == 'method') {
-            type = 'method';
+            type = 'method'
         } else if (tag.type == 'class') {
-            type = 'class';
+            type = 'class'
         } else if (tag.type == 'function') {
-            type = 'function';
+            type = 'function'
         } else if (tag.type == 'event') {
-            type = 'event';
+            type = 'event'
         } else if (tag.type == 'see') {
-            tagSee = tag.url ? tag.url : tag.local;
+            tagSee = tag.url ? tag.url : tag.local
         } else if (tag.type == 'version') {
-            tagVersion = tag.string;
+            tagVersion = tag.string
         } else if (tag.type == 'deprecated') {
-            tagDeprecated = true;
+            tagDeprecated = true
         } else if (tag.type == 'author') {
-            tagAuthor = tag.string;
+            tagAuthor = tag.string
         } else if (tag.type == 'type') {
-            tagType = tag.types.join('|').replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;');
+            tagType = tag.types.join('|').replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;')
         }
     }
 
@@ -82,17 +82,17 @@ module.exports = function (docfile) {
     let exampleCodeLine = []
     let example = description.match(/<example>((.|\n)*)<\/example>/g)
     let exampleFilename = ''
-    let currentLine = 0;
+    let currentLine = 0
 
     if (example && example[0]) {
         // eslint-disable-next-line no-console
         console.log('parse example section for', docfile.filename)
 
-        example = example[0].replace(/<(\/)*example>/g,'').split(/\n/g);
+        example = example[0].replace(/<(\/)*example>/g,'').split(/\n/g)
         example.forEach(function(line) {
-            ++currentLine;
+            ++currentLine
 
-            var checkForFilenameExpression = line.match(/\s\s\s\s(:(\S)*\.(\S)*)/g);
+            var checkForFilenameExpression = line.match(/\s\s\s\s(:(\S)*\.(\S)*)/g)
             if((checkForFilenameExpression && checkForFilenameExpression.length) || (currentLine === example.length)) {
 
                 if(exampleCodeLine.length) {
@@ -100,8 +100,8 @@ module.exports = function (docfile) {
                     /**
                      * remove filename expression in first line
                      */
-                    exampleFilename = exampleCodeLine.shift().trim().substr(1);
-                    var code = exampleCodeLine.join('\n');
+                    exampleFilename = exampleCodeLine.shift().trim().substr(1)
+                    var code = exampleCodeLine.join('\n')
 
                     /**
                      * add example
@@ -111,31 +111,31 @@ module.exports = function (docfile) {
                             file: exampleFilename,
                             format: exampleFilename.split(/\./)[1],
                             code: code
-                        });
+                        })
                     }
 
                     /**
                      * reset loop conditions
                      */
-                    exampleCodeLine = [];
+                    exampleCodeLine = []
                 }
 
                 /**
                  * if this is the last line of code dont proceed
                  */
                 if(currentLine === example.length) {
-                    return;
+                    return
                 }
 
             }
 
-            exampleCodeLine.push(line.substr(4));
-        });
+            exampleCodeLine.push(line.substr(4))
+        })
 
         /**
          * remove example section from description
          */
-        description = description.substr(0, description.indexOf('<example>'));
+        description = description.substr(0, description.indexOf('<example>'))
     }
 
     const commandDescription = {
@@ -168,4 +168,4 @@ module.exports = function (docfile) {
     }
 
     return commandDescription
-};
+}


### PR DESCRIPTION
## Proposed changes

When checking out the mobile commands supported in WebdriverIO it feels off that the scope variable is called `browser`. Instead let's name it `driver`.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
