### PR TITLE
wdio-cli: Fix #3003 package installing hangs on windows

### DIFF
--- a/packages/wdio-cli/package.json
+++ b/packages/wdio-cli/package.json
@@ -44,7 +44,7 @@
     "cli-spinners": "^1.1.0",
     "deepmerge": "^2.0.1",
     "ejs": "^2.5.7",
-    "inquirer": "^4.0.1",
+    "inquirer": "^6.2.1",
     "lodash.flattendeep": "^4.4.0",
     "lodash.pickby": "^4.6.0",
     "lodash.union": "^4.6.0",


### PR DESCRIPTION
## Proposed changes

I found that #3003 issue related to `inquirer` library. If I remove it from wdio-cli and replace with stub string wdio-cli doesn't hang. I did't find that issue in inquirer bug tracker. I check that update to `inquirer 6.2.1` fixes issue

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

### Reviewers: @webdriverio/technical-committee
