### PR TITLE
Ensure GITHUB_AUTH token is set to generate changelogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,13 +15,28 @@ See [CHANGELOG - v4](https://github.com/webdriverio-boneyard/v4/blob/master/CHAN
 
 ---
 
+## v5.0.2 (2018-12-22)
+
+#### :memo: Documentation
+* [#3163](https://github.com/webdriverio/webdriverio/pull/3163) Name mobile variable "driver" instead of "browser" ([@christian-bromann](https://github.com/christian-bromann))
+
+#### Committers: 2
+- Boris Osipov ([@BorisOsipov](https://github.com/BorisOsipov))
+- Christian Bromann ([@christian-bromann](https://github.com/christian-bromann))
 
 
+## v5.0.1 (2018-12-21)
 
+#### :bug: Bug Fix
+* `wdio-runner`
+  * [#3162](https://github.com/webdriverio/webdriverio/pull/3162) wdio-runner: Fix looking at caps as an array ([@WillBrock](https://github.com/WillBrock))
 
+#### :memo: Documentation
+* [#3161](https://github.com/webdriverio/webdriverio/pull/3161) Update API.md ([@wobbleRed](https://github.com/wobbleRed))
 
-
-
+#### Committers: 2
+- Derek Allred ([@wobbleRed](https://github.com/wobbleRed))
+- Will Brock ([@WillBrock](https://github.com/WillBrock))
 
 ## v5.0.0 (2018-12-20)
 

--- a/scripts/changelog.js
+++ b/scripts/changelog.js
@@ -15,6 +15,13 @@ const root = path.resolve(__dirname, '..')
 const { version } = require(path.join(root,'lerna.json'))
 const changelogPath = path.join(root, 'CHANGELOG.md')
 
+if (!process.env.GITHUB_AUTH) {
+    throw new Error(
+        'Please export a "GITHUB_AUTH" access token to generate the changelog.\n' +
+        'See also https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md#release-new-version'
+    )
+}
+
 const config = load({ nextVersionFromMetadata: false })
 config.nextVersion = version
 const changelog = new Changelog(config)


### PR DESCRIPTION
## Proposed changes

Changelogs were not generated when releasing the package. Problem was missing env variable.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
