### PR TITLE
webdriver: Change getTitle to getCurrentTitle

### DIFF
--- a/docs/CustomCommands.md
+++ b/docs/CustomCommands.md
@@ -8,8 +8,8 @@ If you want to extend the browser instance with your own set of commands there i
 ```js
 browser.addCommand("getUrlAndTitle", (customVar) => {
     return {
-        url: this.getUrl(),
-        title: this.getTitle(),
+        url: this.getCurrentUrl(),
+        title: this.getCurrentTitle(),
         customVar: customVar
     };
 });

--- a/docs/Frameworks.md
+++ b/docs/Frameworks.md
@@ -31,7 +31,7 @@ Once that is done you can write beautiful assertions like:
 describe('my awesome website', () => {
     it('should do some chai assertions', () => {
         browser.url('https://webdriver.io');
-        browser.getTitle().should.be.equal('WebdriverIO - WebDriver bindings for Node.js');
+        browser.getCurrentTitle().should.be.equal('WebdriverIO - WebDriver bindings for Node.js');
     });
 });
 ```
@@ -42,7 +42,7 @@ WebdriverIO supports Mochas `BDD` (default), `TDD` and `QUnit` [interface](https
 suite('my awesome website', () => {
     test('should do some chai assertions', () => {
         browser.url('https://webdriver.io');
-        browser.getTitle().should.be.equal('WebdriverIO - WebDriver bindings for Node.js');
+        browser.getCurrentTitle().should.be.equal('WebdriverIO - WebDriver bindings for Node.js');
     });
 });
 ```

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -75,7 +75,7 @@ const { remote } = require('webdriverio');
 
     await browser.url('https://webdriver.io');
 
-    const title = await browser.getTitle();
+    const title = await browser.getCurrentTitle();
     console.log('Title was: ' + title);
 
     await browser.deleteSession();
@@ -175,7 +175,7 @@ const assert = require('assert');
 describe('webdriver.io page', () => {
     it('should have the right title', () => {
         browser.url('https://webdriver.io');
-        const title = browser.getTitle();
+        const title = browser.getCurrentTitle();
         assert.equal(title, 'WebdriverIO - WebDriver bindings for Node.js');
     });
 });

--- a/docs/SetupTypes.md
+++ b/docs/SetupTypes.md
@@ -28,7 +28,7 @@ const { remote } = require('webdriverio');
     const submitBtn = await browser.$('#search_button_homepage')
     await submitBtn.click()
 
-    console.log(await browser.getTitle()) // outputs: "Title is: WebdriverIO (Software) at DuckDuckGo"
+    console.log(await browser.getCurrentTitle()) // outputs: "Title is: WebdriverIO (Software) at DuckDuckGo"
 
     await browser.deleteSession()
 })().catch((e) => console.error(e))
@@ -48,7 +48,7 @@ describe('DuckDuckGo search', () => {
         $('#search_form_input_homepage').setValue('WebdriverIO')
         $('#search_button_homepage').click()
 
-        const title = browser.getTitle()
+        const title = browser.getCurrentTitle()
         console.log('Title is: ' + title)
         // outputs: "Title is: WebdriverIO (Software) at DuckDuckGo"
     })

--- a/docs/Timeouts.md
+++ b/docs/Timeouts.md
@@ -78,7 +78,7 @@ it('should login into the application', () => {
     password.setValue('******');
     form.submit();
 
-    expect(browser.getTitle()).to.be.equal('Admin Area');
+    expect(browser.getCurrentTitle()).to.be.equal('Admin Area');
 });
 ```
 

--- a/examples/cloudservices/browserstack.js
+++ b/examples/cloudservices/browserstack.js
@@ -26,7 +26,7 @@ import { remote } from '../../packages/webdriverio/build'
 
     await browser.pause(1000)
 
-    const title = await browser.getTitle()
+    const title = await browser.getCurrentTitle()
     // eslint-disable-next-line
     console.log(title) // returns "should return "WebdriverIO - click""
 

--- a/examples/cloudservices/kobiton.js
+++ b/examples/cloudservices/kobiton.js
@@ -31,7 +31,7 @@ import { remote } from '../../packages/webdriverio/build'
 
     await browser.pause(1000)
 
-    const title = await browser.getTitle()
+    const title = await browser.getCurrentTitle()
     // eslint-disable-next-line
     console.log(title) // returns "should return "WebdriverIO - click""
 

--- a/examples/cloudservices/saucelabs.js
+++ b/examples/cloudservices/saucelabs.js
@@ -32,7 +32,7 @@ import { remote } from '../../packages/webdriverio/build'
 
     await browser.pause(1000)
 
-    const title = await browser.getTitle()
+    const title = await browser.getCurrentTitle()
     // eslint-disable-next-line
     console.log(title) // returns "should return "WebdriverIO - click""
 

--- a/examples/cloudservices/testingbot.js
+++ b/examples/cloudservices/testingbot.js
@@ -25,7 +25,7 @@ import { remote } from '../../packages/webdriverio/build'
 
     await browser.pause(1000)
 
-    const title = await browser.getTitle()
+    const title = await browser.getCurrentTitle()
     // eslint-disable-next-line
     console.log(title) // returns "should return "WebdriverIO - click""
 

--- a/examples/wdio/cucumber/step-definitions.js
+++ b/examples/wdio/cucumber/step-definitions.js
@@ -23,7 +23,7 @@ module.exports = () => {
     })
 
     this.Then(/^should the title of the page be "([^"]*)"$/, (expectedTitle) => {
-        var title = browser.getTitle()
+        var title = browser.getCurrentTitle()
         assert.equal(title, expectedTitle, ' title is "'+ title + '" but should be "'+ expectedTitle)
     })
 

--- a/examples/wdio/jasmine/jasmine.spec.js
+++ b/examples/wdio/jasmine/jasmine.spec.js
@@ -1,7 +1,7 @@
 describe('webdriver.io page', () => {
     it('should have the right title', () => {
         browser.url('https://webdriver.io')
-        const title = browser.getTitle()
+        const title = browser.getCurrentTitle()
         expect(title).toBe('WebdriverIO - WebDriver bindings for Node.js')
     })
 })

--- a/examples/wdio/mocha/mocha.test.js
+++ b/examples/wdio/mocha/mocha.test.js
@@ -5,7 +5,7 @@ describe('webdriver.io page', () => {
 
     it('should have the right title - the fancy generator way', () => {
         browser.url('https://webdriver.io')
-        const title = browser.getTitle()
+        const title = browser.getCurrentTitle()
         assert.equal(title, 'WebdriverIO - WebDriver bindings for Node.js')
     })
 })

--- a/package.json
+++ b/package.json
@@ -54,7 +54,10 @@
     "testMatch": [
       "/**/tests/**/*.test.js"
     ],
-    "testPathIgnorePatterns": ["<rootDir>/tests/", "<rootDir>/node_modules/"],
+    "testPathIgnorePatterns": [
+      "<rootDir>/tests/",
+      "<rootDir>/node_modules/"
+    ],
     "coverageDirectory": "./coverage/",
     "collectCoverage": true,
     "coverageThreshold": {

--- a/packages/wdio-webdriver-mock-service/src/index.js
+++ b/packages/wdio-webdriver-mock-service/src/index.js
@@ -20,7 +20,7 @@ export default class WebdriverMockService {
         // define required responses
         this.command.newSession().reply(200, newSession)
         this.command.deleteSession().reply(200, deleteSession)
-        this.command.getTitle().reply(200, { value: 'Mock Page Title' })
+        this.command.getCurrentTitle().reply(200, { value: 'Mock Page Title' })
     }
 
     before () {

--- a/packages/webdriver/README.md
+++ b/packages/webdriver/README.md
@@ -26,7 +26,7 @@ import WebDriver from 'webdriver'
     const searchBtn = await client.findElement('css selector', 'input[value="Google Search"]')
     await client.elementClick(searchBtn['element-6066-11e4-a52e-4f735466cecf'])
 
-    console.log(await client.getTitle()) // outputs "WebDriver - Google Search"
+    console.log(await client.getCurrentTitle()) // outputs "WebDriver - Google Search"
 
     await client.deleteSession()
 })()

--- a/packages/webdriver/protocol/jsonwp.json
+++ b/packages/webdriver/protocol/jsonwp.json
@@ -156,7 +156,7 @@
   },
   "/session/:sessionId/title": {
     "GET": {
-      "command": "getTitle",
+      "command": "getCurrentTitle",
       "description": "Get the current page title.",
       "ref": "https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidtitle",
       "parameters": [],

--- a/packages/webdriver/protocol/webdriver.json
+++ b/packages/webdriver/protocol/webdriver.json
@@ -112,7 +112,7 @@
   },
   "/session/:sessionId/title": {
     "GET": {
-      "command": "getTitle",
+      "command": "getCurrentTitle",
       "description": "The Get Title command returns the document title of the current top-level browsing context, equivalent to calling `document.title`.",
       "ref": "https://w3c.github.io/webdriver/webdriver-spec.html#dfn-get-title",
       "parameters": [],

--- a/packages/webdriverio/src/commands/browser/newWindow.js
+++ b/packages/webdriverio/src/commands/browser/newWindow.js
@@ -10,13 +10,13 @@
     :newWindowSync.js
     it('should open a new tab', () => {
         browser.url('http://google.com')
-        console.log(browser.getTitle()) // outputs: "Google"
+        console.log(browser.getCurrentTitle()) // outputs: "Google"
 
         browser.newWindow('https://webdriver.io', 'WebdriverIO window', 'width=420,height=230,resizable,scrollbars=yes,status=1')
-        console.log(browser.getTitle()) // outputs: "WebdriverIO - WebDriver bindings for Node.js"
+        console.log(browser.getCurrentTitle()) // outputs: "WebdriverIO - WebDriver bindings for Node.js"
 
         browser.close()
-        console.log(browser.getTitle()) // outputs: "Google"
+        console.log(browser.getCurrentTitle()) // outputs: "Google"
     });
  * </example>
  *

--- a/packages/webdriverio/src/commands/browser/switchWindow.js
+++ b/packages/webdriverio/src/commands/browser/switchWindow.js
@@ -21,7 +21,7 @@
  *
  * @param {String|RegExp}  urlOrTitleToMatch  String or regular expression that matches the title or url of the page
  *
- * @uses protocol/getWindowHandles, protocol/switchToWindow, protocol/getCurrentUrl, protocol/getTitle
+ * @uses protocol/getWindowHandles, protocol/switchToWindow, protocol/getCurrentUrl, protocol/getCurrentTitle
  * @alias browser.switchTab
  * @type window
  *
@@ -51,7 +51,7 @@ export default async function switchWindow (urlOrTitleToMatch) {
         /**
          * check title
          */
-        const title = await this.getTitle()
+        const title = await this.getCurrentTitle()
         if (title.match(urlOrTitleToMatch)) {
             return tab
         }

--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -2,7 +2,7 @@ import assert from 'assert'
 
 describe('smoke test', () => {
     it('should return sync value', () => {
-        assert.equal(browser.getTitle(), 'Mock Page Title')
+        assert.equal(browser.getCurrentTitle(), 'Mock Page Title')
     })
 
     it('should wait for elements if not found immediately', () => {


### PR DESCRIPTION
## Proposed changes

In the change log and blog post it has ```title``` and ```getTitle``` changing to ```getCurrentTitle``` which I think makes sense since we now have ```getCurrentUrl``` but the protocol json files were still referencing ```getTtitle```.

This updates the json files along with other references of ```getTitle```.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

### Reviewers: @webdriverio/technical-committee
