### PR TITLE
Garbage in npm wdio packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "clean": "run-p clean:*",
     "clean:build": "rimraf ./packages/*/build",
     "clean:pkglock": "rimraf ./packages/*/package-lock.json",
+    "clean:tgz": "rimraf ./packages/*/*.tgz",
     "clean:node_modules": "rimraf ./packages/*/node_modules ./packages/node_modules",
     "clean:website": "rimraf docs/api/**/*.md && rimraf website/sidebars.json",
     "link": "node ./scripts/link",


### PR DESCRIPTION
**Describe the bug**
After `npm i` I found in every `@wdio/*` module folder under node_modules archive `%modulename%-5.0.0-beta.4.tgz`
E.g see my file tree in `node_modules/wdio/`
https://gist.github.com/BorisOsipov/c0e76346871ca1ab7ca48f1039d08cb8

**To Reproduce**
Run wdio config and look at node_modules.

**Environment (please complete the following information):**
 - **WebdriverIO version:** [e.g. 5.0.5]
 - **Node.js version:** [e.g. 10 LTS]
 - **NPM version:** [e.g. 5.8.0]
 - **Browser name and version:** [e.g. Chrome 68]
 - **Additional wdio packages used (if applicable):** [e.g. @wdio/spec reporter, @wdio/selenium-standalone service]

