### PR TITLE
webdriverio: Correct deleteCookies example

### DIFF
--- a/packages/webdriverio/src/commands/browser/deleteCookies.js
+++ b/packages/webdriverio/src/commands/browser/deleteCookies.js
@@ -17,7 +17,7 @@
         //     { name: 'test3', value: '789' }
         // ]
 
-        browser.deleteCookie(['test3'])
+        browser.deleteCookies(['test3'])
         cookies = browser.getCookies()
         console.log(cookies)
         // outputs:
@@ -25,7 +25,7 @@
         //     { name: 'test', value: '123' },
         //     { name: 'test2', value: '456' }
         // ]
-        
+
         browser.deleteCookies()
         cookies = browser.getCookies()
         console.log(cookies) // outputs: []


### PR DESCRIPTION
## Proposed changes

The current example has ```browser.deleteCookie(['test3'])``` which doesn't work because it doesn't accept an array. Changing it to ```browser.deleteCookies(['test3'])``` since that is what the example is for anyways.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

### Reviewers: @webdriverio/technical-committee
