### PR TITLE
webdriverio: getCssPropertry changed to getCSSProperty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,7 @@ This version comes with a variety of technical changes that might affect the fun
         * `alertText` → `getAlertText`, `sendAlertText`
         * `applicationCacheStatus` → `getApplicationCacheStatus` (JsonWireProtocol only)
         * `cookie` → `getAllCookies`, `addCookie`, `deleteCookie`
+        * `getCssProperty` → `getCSSProperty`
         * `element` → `findElement`
         * `elements` → `findElements`
         * `elementActive` → `getActiveElement`

--- a/packages/webdriverio/src/commands/element/getCSSProperty.js
+++ b/packages/webdriverio/src/commands/element/getCSSProperty.js
@@ -11,10 +11,10 @@
  * <example>
     :example.html
     <label id="myLabel" for="input" style="color: #0088cc; font-family: helvetica, arial, freesans, clean, sans-serif, width: 100px">Some Label</label>
-    :getCssProperty.js
-    it('should demonstrate the getCssProperty command', () => {
+    :getCSSProperty.js
+    it('should demonstrate the getCSSProperty command', () => {
         const elem = $('#myLabel')
-        const color = elem.getCssProperty('color')
+        const color = elem.getCSSProperty('color')
         console.log(color)
         // outputs the following:
         // {
@@ -28,7 +28,7 @@
         //     }
         // }
 
-        const font = elem.getCssProperty('font-family')
+        const font = elem.getCSSProperty('font-family')
         console.log(font)
         // outputs the following:
         // {
@@ -41,7 +41,7 @@
         //      }
         // }
 
-        var width = elem.getCssProperty('width')
+        var width = elem.getCSSProperty('width')
         console.log(width)
         // outputs the following:
         // {
@@ -57,7 +57,7 @@
     })
  * </example>
  *
- * @alias element.getCssProperty
+ * @alias element.getCSSProperty
  * @param {String} selector    element with requested style attribute
  * @param {String} cssProperty css property name
  * @uses protocol/elements, protocol/elementIdCssProperty

--- a/packages/webdriverio/src/commands/element/getProperty.js
+++ b/packages/webdriverio/src/commands/element/getProperty.js
@@ -3,7 +3,7 @@
  *
  * <example>
     :getProperty.js
-    it('should demonstrate the getCssProperty command', () => {
+    it('should demonstrate the getCSSProperty command', () => {
         var elem = $('body')
         var color = elem.getProperty('tagName')
         console.log(color) // outputs: "BODY"


### PR DESCRIPTION
## Proposed changes

```getCssProperty``` changed to ```getCSSProperty``` but is not documented as being changed. I think this makes sense since it matches the syntax of ```getElementCSSValue```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

### Reviewers: @webdriverio/technical-committee
