### PR TITLE
Only set body if a body is required

### DIFF
--- a/packages/webdriver/package.json
+++ b/packages/webdriver/package.json
@@ -31,6 +31,7 @@
     "@wdio/config": "^5.0.3",
     "@wdio/logger": "^5.0.3",
     "deepmerge": "^2.0.1",
+    "lodash.merge": "^4.6.1",
     "request": "^2.83.0"
   }
 }

--- a/packages/webdriver/src/request.js
+++ b/packages/webdriver/src/request.js
@@ -52,7 +52,7 @@ export default class WebDriverRequest extends EventEmitter {
         /**
          * only apply body property if existing
          */
-        if (Object.keys(this.body).length) {
+        if (this.body && Object.keys(this.body).length) {
             requestOptions.body = this.body
         }
 

--- a/packages/webdriver/src/request.js
+++ b/packages/webdriver/src/request.js
@@ -2,9 +2,11 @@ import url from 'url'
 import http from 'http'
 import path from 'path'
 import https from 'https'
+import merge from 'lodash.merge'
 import request from 'request'
-import logger from '@wdio/logger'
 import EventEmitter from 'events'
+
+import logger from '@wdio/logger'
 
 import { isSuccessfulResponse } from './utils'
 import pkg from '../package.json'
@@ -18,12 +20,12 @@ const agents = {
 export default class WebDriverRequest extends EventEmitter {
     constructor (method, endpoint, body) {
         super()
+        this.body = body
         this.method = method
         this.endpoint = endpoint
         this.requiresSessionId = this.endpoint.match(/:sessionId/)
         this.defaultOptions = {
             method,
-            body,
             followAllRedirects: true,
             json: true,
             headers: {
@@ -35,7 +37,7 @@ export default class WebDriverRequest extends EventEmitter {
     }
 
     makeRequest (options, sessionId) {
-        const fullRequestOptions = Object.assign(this.defaultOptions, this._createOptions(options, sessionId))
+        const fullRequestOptions = merge(this.defaultOptions, this._createOptions(options, sessionId))
         this.emit('request', fullRequestOptions)
         return this._request(fullRequestOptions, options.connectionRetryCount)
     }
@@ -44,7 +46,14 @@ export default class WebDriverRequest extends EventEmitter {
         const requestOptions = {
             agent: agents[options.protocol],
             headers: typeof options.headers === 'object' ? options.headers : {},
-            qs: typeof this.defaultOptions.queryParams === 'object' ? options.queryParams : {}
+            qs: typeof options.queryParams === 'object' ? options.queryParams : {}
+        }
+
+        /**
+         * only apply body property if existing
+         */
+        if (Object.keys(this.body).length) {
+            requestOptions.body = this.body
         }
 
         /**
@@ -88,7 +97,7 @@ export default class WebDriverRequest extends EventEmitter {
             /**
              * Resolve only if successful response
              */
-            if (!err && isSuccessfulResponse(response)) {
+            if (!err && isSuccessfulResponse(response.statusCode, body)) {
                 this.emit('response', { result: body })
                 return resolve(body)
             }

--- a/packages/webdriver/src/utils.js
+++ b/packages/webdriver/src/utils.js
@@ -13,7 +13,7 @@ const log = logger('webdriver')
  * @param  {Object}  body  body payload of response
  * @return {Boolean}       true if request was successful
  */
-export function isSuccessfulResponse ({ body, statusCode } = {}) {
+export function isSuccessfulResponse (statusCode, body) {
     /**
      * response contains a body
      */

--- a/packages/webdriver/tests/request.test.js
+++ b/packages/webdriver/tests/request.test.js
@@ -50,12 +50,19 @@ describe('webdriver request', () => {
         })
 
         it('should add auth if user and key is given', () => {
-            const req = new WebDriverRequest('POST', '/session')
+            const req = new WebDriverRequest('POST', '/session', { some: 'body' })
             const options = req._createOptions({
                 user: 'foo',
                 key: 'bar'
             })
-            expect(options.auth).toEqual({pass: 'bar', user: 'foo'})
+            expect(options.auth).toEqual({ pass: 'bar', user: 'foo' })
+            expect(options.body).toEqual({ some: 'body' })
+        })
+
+        it('should not attach a body if none is needed', () => {
+            const req = new WebDriverRequest('POST', '/status', {})
+            const options = req._createOptions({})
+            expect(Boolean(options.body)).toEqual(false)
         })
     })
 

--- a/packages/webdriver/tests/utils.test.js
+++ b/packages/webdriver/tests/utils.test.js
@@ -7,36 +7,17 @@ import geckodriverResponse from './__fixtures__/geckodriver.response.json'
 describe('utils', () => {
     it('isSuccessfulResponse', () => {
         expect(isSuccessfulResponse()).toBe(false)
-        expect(isSuccessfulResponse({})).toBe(false)
-        expect(isSuccessfulResponse({
-            body: undefined,
-            statusCode: 200
-        })).toBe(false)
-        expect(isSuccessfulResponse({
-            body: { value: { some: 'result' } },
-            statusCode: 200
-        })).toBe(true)
-        expect(isSuccessfulResponse({
-            body: { value: { error: new Error('foobar' )} },
-            statusCode: 404
-        })).toBe(false)
-        expect(isSuccessfulResponse({
-            body: { value: { error: 'no such element' } },
-            statusCode: 404
-        })).toBe(true)
-        expect(isSuccessfulResponse({
-            body: { status: 7 },
-            statusCode: 200
-        })).toBe(false)
-        expect(isSuccessfulResponse({
-            body: { status: 7, value: {} }
-        })).toBe(false)
-        expect(isSuccessfulResponse({
-            body: { status: 0, value: {} }
-        })).toBe(true)
-        expect(isSuccessfulResponse({
-            body: { status: 7, value: { message: 'no such element: foobar' } }
-        })).toBe(true)
+        expect(isSuccessfulResponse(200)).toBe(false)
+        expect(isSuccessfulResponse(200, { value: { some: 'result' } })).toBe(true)
+        expect(isSuccessfulResponse(404, { value: { error: new Error('foobar' )} })).toBe(false)
+        expect(isSuccessfulResponse(404, { value: { error: 'no such element' } })).toBe(true)
+        expect(isSuccessfulResponse(200, { status: 7 })).toBe(false)
+        expect(isSuccessfulResponse(undefined, { status: 7, value: {} })).toBe(false)
+        expect(isSuccessfulResponse(undefined, { status: 0, value: {} })).toBe(true)
+        expect(isSuccessfulResponse(
+            undefined,
+            { status: 7, value: { message: 'no such element: foobar' } }
+        )).toBe(true)
     })
 
     it('isValidParameter', () => {


### PR DESCRIPTION
## Proposed changes

We have been setting the body of a request even though it is not required. This fails with Safaridriver.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

closes #3187

### Reviewers: @webdriverio/technical-committee
