### PR TITLE
Disable unsupported cli wizard options

### DIFF
--- a/packages/wdio-cli/src/config.js
+++ b/packages/wdio-cli/src/config.js
@@ -2,8 +2,8 @@ import { filterPackageName } from './utils'
 
 export const SUPPORTED_FRAMEWORKS = [
     'mocha', // https://github.com/webdriverio/webdriverio/tree/master/packages/wdio-mocha-framework
-    'jasmine', // https://github.com/webdriverio/webdriverio/tree/master/packages/wdio-jasmine-framework
-    'cucumber' // https://github.com/webdriverio/webdriverio/tree/master/packages/wdio-cucumber-framework
+    'jasmine' // https://github.com/webdriverio/webdriverio/tree/master/packages/wdio-jasmine-framework
+    // 'cucumber' not yet supported (see #2872)
 ]
 
 export const SUPPORTED_REPORTER = [
@@ -39,8 +39,8 @@ export const SUPPORTED_SERVICES = [
 ]
 
 export const SUPPORTED_RUNNERS = [
-    ' local - https://www.npmjs.com/package/@wdio/local-runner',
-    ' lambda - https://www.npmjs.com/package/@wdio/lambda-runner'
+    ' local - https://www.npmjs.com/package/@wdio/local-runner'
+    // ' lambda - https://www.npmjs.com/package/@wdio/lambda-runner'
 ]
 
 const LOG_LEVELS = ['trace', 'debug', 'info', 'warn', 'error']


### PR DESCRIPTION
## Proposed changes

The cli wizard shows options that are not supported yet (e.g. cucumber framework or lambda runner). Let's disable them until they are supported.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)


### Reviewers: @webdriverio/technical-committee
