### PR TITLE
webdriverio: added error messages to the waitForExist call

### DIFF
--- a/packages/webdriverio/src/commands/element/waitForDisplayed.js
+++ b/packages/webdriverio/src/commands/element/waitForDisplayed.js
@@ -33,7 +33,7 @@ export default async function waitForDisplayed (ms, reverse = false, error) {
      * if element wasn't found in the first place wait for its existance first
      */
     if (!this.elementId && !reverse) {
-        await this.waitForExist(ms)
+        await this.waitForExist(ms, false, error)
     }
 
     /*

--- a/packages/webdriverio/src/commands/element/waitForEnabled.js
+++ b/packages/webdriverio/src/commands/element/waitForEnabled.js
@@ -36,7 +36,7 @@
 export default async function waitForEnabled(ms, reverse = false, error) {
     // If the element doesn't already exist, wait for it to exist
     if (!this.elementId && !reverse) {
-        await this.waitForExist(ms)
+        await this.waitForExist(ms, false, error)
     }
 
     if (typeof ms !== 'number') {


### PR DESCRIPTION
## Proposed changes

When I initially created the pull request I forgot to add the error message parameter to the ```waitForExist``` command. So the custom error message would not get thrown if the element did not exist.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)


### Reviewers: @webdriverio/technical-committee
