### PR TITLE
Docs: fix Getting Started guide (part 2)

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -124,7 +124,7 @@ A: _local_<br>
 __Q: Shall I install the runner plugin for you?__<br>
 A: _Yes_<br>
 <br>
-__Q: Where do you want to execute your tests?__<br>
+__Q: Where is your automation backend located?__<br>
 A: _On my local machine_<br>
 <br>
 __Q: Which framework do you want to use?__<br>
@@ -149,15 +149,21 @@ __Q: Do you want to add a service to your test setup?__<br>
 A: none (just press enter, let's skip this for simplicity)<br>
 <br>
 __Q: Level of logging verbosity:__<br>
-A: _trace_ (just press enter)<br>
-<br>
-__Q: In which directory should screenshots gets saved if a command fails?__<br>
-A: _./errorShots/_ (just press enter)<br>
+A: _trace_<br>
 <br>
 __Q: What is the base url?__<br>
 A: _http://localhost_ (just press enter)<br>
 
-That's it! The configurator now installs all required packages for you and creates a config file with the name `wdio.conf.js`. Next step is to create your first spec file (test file).
+That's it! The configurator now installs all required packages for you and creates a config file with the name `wdio.conf.js`. As we're using Geckodriver, we need to override the default path (which uses the Selenium's default of `/wd/hub`). Then, we'll be ready to create your first spec file (test file).
+
+### Configure the path
+Edit the `wdio.conf.js` file to specify the path (e.g. right after the baseUrl setting):
+
+```
+    // Override the default path of /wd/hub
+    path: '/',
+```
+
 
 ### Create Spec Files
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -160,6 +160,7 @@ That's it! The configurator now installs all required packages for you and creat
 Edit the `wdio.conf.js` file to specify the path (e.g. right after the baseUrl setting):
 
 ```
+    //
     // Override the default path of /wd/hub
     path: '/',
 ```


### PR DESCRIPTION
## Proposed changes

1. Fixed the transcript describing how the configuration wizard works
2. Adds a section describing the needed change to tweak the generated configuration file to override the default path (which seems to be the Selenium default of `/wd/hub`

Fixes #3183 

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
