### PR TITLE
Fix bug where Geckodriver requires POST requests to have a valid JSON body

### DIFF
--- a/packages/webdriver/src/request.js
+++ b/packages/webdriver/src/request.js
@@ -52,7 +52,7 @@ export default class WebDriverRequest extends EventEmitter {
         /**
          * only apply body property if existing
          */
-        if (this.body && Object.keys(this.body).length) {
+        if (this.body && (Object.keys(this.body).length || this.method === 'POST')) {
             requestOptions.body = this.body
         }
 

--- a/packages/webdriver/tests/request.test.js
+++ b/packages/webdriver/tests/request.test.js
@@ -59,8 +59,14 @@ describe('webdriver request', () => {
             expect(options.body).toEqual({ some: 'body' })
         })
 
-        it('should not attach a body if none is needed (e.g. DELETE)', () => {
+        it('sets request body to "undefined" when request object is empty and DELETE is used', () => {
             const req = new WebDriverRequest('DELETE', '/session', {})
+            const options = req._createOptions({})
+            expect(Boolean(options.body)).toEqual(false)
+        })
+
+        it('sets request body to "undefined" when request object is empty and GET is used', () => {
+            const req = new WebDriverRequest('GET', '/title', {})
             const options = req._createOptions({})
             expect(Boolean(options.body)).toEqual(false)
         })

--- a/packages/webdriver/tests/request.test.js
+++ b/packages/webdriver/tests/request.test.js
@@ -59,10 +59,16 @@ describe('webdriver request', () => {
             expect(options.body).toEqual({ some: 'body' })
         })
 
-        it('should not attach a body if none is needed', () => {
-            const req = new WebDriverRequest('POST', '/status', {})
+        it('should not attach a body if none is needed (e.g. DELETE)', () => {
+            const req = new WebDriverRequest('DELETE', '/session', {})
             const options = req._createOptions({})
             expect(Boolean(options.body)).toEqual(false)
+        })
+
+        it('should attach an empty object body when POST is used', () => {
+            const req = new WebDriverRequest('POST', '/status', {})
+            const options = req._createOptions({})
+            expect(options.body).toEqual({})
         })
     })
 


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

Fixes issue #3203. In #3187 it was mentioned that the fixed problem just occurred in SafariDriver with GET and DELETE requests but not for POST and GeckoDriver requires to have a valid JSON body for POST. The fix ensures that POST requests will always have a body even if the body contains an empty object. For other request types it keeps the existing logic to not set the body when an empty object is given.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
