### PR TITLE
Properly implement 'setTimeout' function and /timeouts endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -238,7 +238,7 @@ This version comes with a variety of technical changes that might affect the fun
         * `session` → `getSession`, `deleteSession` (JsonWireProtocol only)
         * `sessions` → `getSessions`
         * `submit` → `elementSubmit`
-        * `timeouts` → `getTimeouts`, `setTimeout`
+        * `timeouts` → `getTimeouts`, `setTimeouts`
         * `window`, `switchToWindow` → `switchWindow`
         * `windowHandle` → `closeWindow`, `getWindowHandle`
         * `windowHandles` → `getWindowHandles`

--- a/packages/webdriver/protocol/jsonwp.json
+++ b/packages/webdriver/protocol/jsonwp.json
@@ -64,7 +64,7 @@
   },
   "/session/:sessionId/timeouts": {
     "POST": {
-      "command": "setTimeout",
+      "command": "setTimeouts",
       "description": "Configure the amount of time that a particular type of operation can execute for before they are aborted and a |Timeout| error is returned to the client.",
       "ref": "https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidtimeouts",
       "parameters": [{

--- a/packages/webdriver/protocol/webdriver.json
+++ b/packages/webdriver/protocol/webdriver.json
@@ -51,7 +51,7 @@
       }
     },
     "POST": {
-      "command": "setTimeout",
+      "command": "setTimeouts",
       "description": "The Set Timeouts command sets timeout durations associated with the current session. The timeouts that can be controlled are listed in the table of session timeouts below.",
       "ref": "https://w3c.github.io/webdriver/#dfn-timeouts",
       "parameters": [{

--- a/packages/webdriver/protocol/webdriver.json
+++ b/packages/webdriver/protocol/webdriver.json
@@ -46,7 +46,7 @@
       "parameters": [],
       "returns": {
         "type": "Object",
-        "name": "status",
+        "name": "timeouts",
         "description": "Object containing timeout durations for `script`, `pageLoad` and `implicit` timeouts."
       }
     },
@@ -55,10 +55,20 @@
       "description": "The Set Timeouts command sets timeout durations associated with the current session. The timeouts that can be controlled are listed in the table of session timeouts below.",
       "ref": "https://w3c.github.io/webdriver/#dfn-timeouts",
       "parameters": [{
-        "name": "timeouts",
-        "type": "Object",
-        "description": "Object containing timeout values for at least one of the following keys: \"script\", \"pageLoad\" and/or \"implicit\"",
-        "required": true
+        "name": "implicit",
+        "type": "number",
+        "description": "integer in ms for session implicit wait timeout",
+        "required": false
+      }, {
+        "name": "pageLoad",
+        "type": "number",
+        "description": "integer in ms for session page load timeout",
+        "required": false
+      }, {
+        "name": "script",
+        "type": "number",
+        "description": "integer in ms for session script timeout",
+        "required": false
       }]
     }
   },

--- a/packages/webdriverio/src/commands/browser/setTimeout.js
+++ b/packages/webdriverio/src/commands/browser/setTimeout.js
@@ -1,0 +1,76 @@
+/**
+ *
+ * Sets the timeouts associated with the current session, timeout durations control such
+ * behaviour as timeouts on script injection, document navigation, and element retrieval.
+ * For more information and examples, see [timeouts guide](https://webdriver.io/docs/timeouts.html#selenium-timeouts).
+ *
+ * <example>
+    :setTimeout.js
+    it('should change timeout duration for session with long code duration', () => {
+        browser.setTimeout({
+            'pageLoad': 10000,
+            'script': 60000
+        });
+        // Execute code which takes a long time
+        browser.executeAsync((done) => {
+            console.log('Wake me up before you go!');
+            setTimeout(done, 59000);
+        });
+    });
+ * </example>
+ *
+ * @param {Object} timeouts  Object containing session timeout values
+ * @param {Number} timeouts.implicit  (Optional) Time in milliseconds to retry the element location strategy when finding an element.
+ * @param {Number} timeouts.pageLoad  (Optional) Time in milliseconds to wait for the document to finish loading.
+ * @param {Number} timeouts.script  (Optional) Scripts injected with [`execute`](https://webdriver.io/docs/api/browser/execute.html) or [`executeAsync`](https://webdriver.io/docs/api/browser/executeAsync.html) will run until they hit the script timeout duration, which is also given in milliseconds.
+ * @see https://w3c.github.io/webdriver/#set-timeouts
+ *
+ */
+
+export default async function setTimeout(timeouts) {
+    if (!(timeouts instanceof Object)) {
+        return Promise.reject(new Error('Parameter for "setTimeout" command needs to be an object'))
+    }
+    // If value is not an integer, or it is less than 0 or greater than the maximum safe integer, return error with error code invalid argument.
+    const timeoutValues = Object.values(timeouts)
+    if (timeoutValues.length && timeoutValues.every(timeout => typeof timeout !== 'number' || timeout < 0 || timeout > Number.MAX_SAFE_INTEGER)) {
+        return Promise.reject(new Error('Specified timeout values are not valid integer (see https://webdriver.io/docs/api/browser/setTimeout.html for documentation).'))
+    }
+
+    let implicit
+    let pageLoad
+    let script
+
+    if (typeof timeouts.implicit !== 'undefined') {
+        implicit = timeouts.implicit
+    }
+    // Previously also known as `page load` with JsonWireProtocol
+    if (!this.isW3C && typeof timeouts['page load'] !== 'undefined') {
+        pageLoad = timeouts['page load']
+    }
+    if (typeof timeouts.pageLoad !== 'undefined') {
+        pageLoad = timeouts.pageLoad
+    }
+    if (typeof timeouts.script !== 'undefined') {
+        script = timeouts.script
+    }
+
+    /**
+     * JsonWireProtocol action
+     */
+    if (!this.isW3C) {
+        let setTimeoutsResponse
+        if (typeof implicit === 'number') {
+            setTimeoutsResponse = await this.setTimeouts('implicit', implicit)
+        }
+        if (typeof pageLoad === 'number') {
+            setTimeoutsResponse = await this.setTimeouts('page load', pageLoad)
+        }
+        if (typeof script === 'number') {
+            setTimeoutsResponse = await this.setTimeouts('script', script)
+        }
+        return Promise.resolve(setTimeoutsResponse)
+    }
+
+    return this.setTimeouts(implicit, pageLoad, script)
+}

--- a/packages/webdriverio/tests/commands/browser/setTimeout.test.js
+++ b/packages/webdriverio/tests/commands/browser/setTimeout.test.js
@@ -1,0 +1,136 @@
+import request from 'request'
+import { remote } from '../../../src'
+
+describe('setTimeout', () => {
+
+    it('should set timeout', async () => {
+        const browser = await remote({
+            baseUrl: 'http://foobar.com',
+            capabilities: {
+                browserName: 'foobar'
+            }
+        })
+
+        await browser.setTimeout({ implicit: 5000 })
+        expect(request.mock.calls.length).toBe(2)
+        expect(request.mock.calls[1][0].method).toBe('POST')
+        expect(request.mock.calls[1][0].uri.path).toBe('/wd/hub/session/foobar-123/timeouts')
+        expect(request.mock.calls[1][0].body).toEqual({ 'implicit': 5000 })
+
+        await browser.setTimeout({ pageLoad: 10000 })
+        expect(request.mock.calls.length).toBe(3)
+        expect(request.mock.calls[2][0].method).toBe('POST')
+        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/timeouts')
+        expect(request.mock.calls[2][0].body).toEqual({ 'pageLoad': 10000 })
+
+        await browser.setTimeout({ script: 60000 })
+        expect(request.mock.calls.length).toBe(4)
+        expect(request.mock.calls[3][0].method).toBe('POST')
+        expect(request.mock.calls[3][0].uri.path).toBe('/wd/hub/session/foobar-123/timeouts')
+        expect(request.mock.calls[3][0].body).toEqual({ 'script': 60000 })
+
+        await browser.setTimeout({
+            implicit: 0,
+            pageLoad: 300000,
+            script: 30000,
+        })
+        expect(request.mock.calls.length).toBe(5)
+        expect(request.mock.calls[4][0].method).toBe('POST')
+        expect(request.mock.calls[4][0].uri.path).toBe('/wd/hub/session/foobar-123/timeouts')
+        expect(request.mock.calls[4][0].body).toEqual({
+            'implicit': 0,
+            'pageLoad': 300000,
+            'script': 30000,
+        })
+
+        await browser.setTimeout({})
+        expect(request.mock.calls.length).toBe(6)
+        expect(request.mock.calls[5][0].method).toBe('POST')
+        expect(request.mock.calls[5][0].uri.path).toBe('/wd/hub/session/foobar-123/timeouts')
+        expect(request.mock.calls[5][0].body).toEqual({})
+    })
+
+    it('should set timeout (no w3c)', async () => {
+        const browser = await remote({
+            baseUrl: 'http://foobar.com',
+            capabilities: {
+                browserName: 'foobar-noW3C'
+            }
+        })
+
+        await browser.setTimeout({ implicit: 5000 })
+        expect(request.mock.calls.length).toBe(2)
+        expect(request.mock.calls[1][0].method).toBe('POST')
+        expect(request.mock.calls[1][0].uri.path).toBe('/wd/hub/session/foobar-123/timeouts')
+        expect(request.mock.calls[1][0].body).toEqual({ 'type': 'implicit', 'ms': 5000 })
+
+        await browser.setTimeout({ 'page load': 10000 })
+        expect(request.mock.calls.length).toBe(3)
+        expect(request.mock.calls[2][0].method).toBe('POST')
+        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/timeouts')
+        expect(request.mock.calls[2][0].body).toEqual({ 'type': 'page load', 'ms': 10000 })
+
+        await browser.setTimeout({ script: 60000 })
+        expect(request.mock.calls.length).toBe(4)
+        expect(request.mock.calls[3][0].method).toBe('POST')
+        expect(request.mock.calls[3][0].uri.path).toBe('/wd/hub/session/foobar-123/timeouts')
+        expect(request.mock.calls[3][0].body).toEqual({ 'type': 'script', 'ms': 60000 })
+
+        await browser.setTimeout({
+            implicit: 0,
+            pageLoad: 300000,
+            script: 30000,
+        })
+        expect(request.mock.calls.length).toBe(7)
+        expect(request.mock.calls[4][0].method).toBe('POST')
+        expect(request.mock.calls[4][0].uri.path).toBe('/wd/hub/session/foobar-123/timeouts')
+        expect(request.mock.calls[4][0].body).toEqual({ 'type': 'implicit', 'ms': 0 })
+        expect(request.mock.calls[5][0].method).toBe('POST')
+        expect(request.mock.calls[5][0].uri.path).toBe('/wd/hub/session/foobar-123/timeouts')
+        expect(request.mock.calls[5][0].body).toEqual({ 'type': 'page load', 'ms': 300000 })
+        expect(request.mock.calls[6][0].method).toBe('POST')
+        expect(request.mock.calls[6][0].uri.path).toBe('/wd/hub/session/foobar-123/timeouts')
+        expect(request.mock.calls[6][0].body).toEqual({ 'type': 'script', 'ms': 30000 })
+
+        await browser.setTimeout({})
+        expect(request.mock.calls.length).toBe(7)
+    })
+
+    it('should throw error on setting invalid timeout', async () => {
+        const browser = await remote({
+            baseUrl: 'http://foobar.com',
+            capabilities: {
+                browserName: 'foobar-noW3C'
+            }
+        })
+
+        const invalidTimeoutParameterError = new Error('Parameter for "setTimeout" command needs to be an object')
+        await expect(browser.setTimeout('0'))
+            .rejects
+            .toEqual(invalidTimeoutParameterError)
+        await expect(browser.setTimeout(5000))
+            .rejects
+            .toEqual(invalidTimeoutParameterError)
+
+        const invalidTimeoutValueError = new Error('Specified timeout values are not valid integer (see https://webdriver.io/docs/api/browser/setTimeout.html for documentation).')
+        await expect(browser.setTimeout({ implicit: Number.MAX_SAFE_INTEGER + 1 }))
+            .rejects
+            .toEqual(invalidTimeoutValueError)
+        await expect(browser.setTimeout({ pageLoad: -2000 }))
+            .rejects
+            .toEqual(invalidTimeoutValueError)
+        await expect(browser.setTimeout({ 'page load': null }))
+            .rejects
+            .toEqual(invalidTimeoutValueError)
+        await expect(browser.setTimeout({ script: '4000' }))
+            .rejects
+            .toEqual(invalidTimeoutValueError)
+        await expect(browser.setTimeout({ timeouts: { script: 5000 } }))
+            .rejects
+            .toEqual(invalidTimeoutValueError)
+    })
+
+    afterEach(() => {
+        request.mockClear()
+    })
+})


### PR DESCRIPTION
## Proposed changes

* Address incorrect parameters/return definition for __/session/:sessionId/timeouts__ endpoint.
* Rename `setTimeout` command to `setTimeouts` to be consistent with `getTimeouts`.
* Introduce unified `setTimeout` browser command that proxies values to respective `setTimeouts` command, which takes different parameters depending on protocol.

Fixes #3214.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments
Initially reverted changes made in 690fd66f02678e76270b333acbd99393c4afc3cd, due to the fact that it initially not even recognized ["Object" type](https://github.com/webdriverio/webdriverio/blob/972e66725ae71e1bb9c235b5c3dad304d1506827/packages/webdriver/protocol/webdriver.json#L59) when [validating parameters against "object" type](https://github.com/webdriverio/webdriverio/blob/972e66725ae71e1bb9c235b5c3dad304d1506827/packages/webdriver/tests/utils.test.js#L30-L42), which is apparently case sensitive.

In Firefox and Safari this command:
```js
browser.setTimeout({ script: 1000 })
```
Would result in the following error:
```
Error: Malformed type for "timeouts" parameter of command setTimeout
Expected: Object
Actual: object

For more info see https://w3c.github.io/webdriver/webdriver-spec.html#dfn-timeouts

    at Browser.<anonymous> (/Users/profile/.npm/lib/node_modules/webdriverio/node_modules/webdriver/src/command.js:55:23)
    at /Users/profile/project/webdriverio.js:15:19
    at process._tickCallback (internal/process/next_tick.js:68:7)
```

Noticed later on that Chrome actually also does not work with the above mentioned command, due to the fact that JsonWireProtocol takes different parameters than the W3C definition.
```
Error: Wrong parameters applied for setTimeout
Usage: setTimeout(type, ms)

Property Description:
  "type" (string): The type of operation to set the timeout for. Valid values are: "script" for script timeouts, "implicit" for modifying the implicit wait timeout and "page load" for setting a page load timeout.
  "ms" (number): The amount of time, in milliseconds, that time-limited commands are permitted to run

For more info see https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidtimeouts

    at Browser.<anonymous> (/Users/profile/.npm/lib/node_modules/webdriverio/node_modules/webdriver/src/command.js:33:19)
    at /Users/profile/project/webdriverio.js:15:19
    at process._tickCallback (internal/process/next_tick.js:68:7)
```

Based on that I've decided to rename `setTimeout` to `setTimeouts` and introduce a unified `setTimeout` (proxy) command, which works with both protocols.

### Reviewers: @webdriverio/technical-committee
