### PR TITLE
wdio-runner: Fix custom reporter options not being used

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,10 @@
     "testMatch": [
       "/**/tests/**/*.test.js"
     ],
-    "testPathIgnorePatterns": ["<rootDir>/tests/", "<rootDir>/node_modules/"],
+    "testPathIgnorePatterns": [
+      "<rootDir>/tests/",
+      "<rootDir>/node_modules/"
+    ],
     "coverageDirectory": "./coverage/",
     "collectCoverage": true,
     "coverageThreshold": {

--- a/packages/wdio-runner/src/index.js
+++ b/packages/wdio-runner/src/index.js
@@ -51,7 +51,7 @@ export default class Runner extends EventEmitter {
         this.config = this.configParser.getConfig()
         initialiseServices(this.config, caps).map(::this.configParser.addService)
 
-        this.reporter = new BaseReporter(this.config, this.cid)
+        this.reporter = new BaseReporter(this.config, this.cid, this.caps)
         this.inWatchMode = Boolean(this.config.watch)
 
         await runHook('beforeSession', this.config, this.caps, this.specs)

--- a/packages/wdio-runner/src/reporter.js
+++ b/packages/wdio-runner/src/reporter.js
@@ -42,23 +42,25 @@ export default class BaseReporter {
         let options = this.config
         let filename = `wdio-${this.cid}-${name}-reporter.log`
 
-        options.cid = this.cid
-        options.capabilities = this.caps
+        const reporter_options = this.config.reporters.find((reporter) => (
+            Array.isArray(reporter) && reporter[0] === name
+        ))
 
-        this.config.reporters.forEach(reporter => {
-            if (Array.isArray(reporter) && reporter[0] === name) {
-                const fileformat = reporter[1].outputFileFormat
-                options = Object.assign(options, reporter[1])
+        if(reporter_options) {
+            const fileformat = reporter_options[1].outputFileFormat
 
-                if (fileformat) {
-                    if (typeof fileformat !== 'function') {
-                        throw new Error('outputFileFormat must be a function')
-                    }
+            options.cid = this.cid
+            options.capabilities = this.caps
+            Object.assign(options, reporter_options[1])
 
-                    filename = fileformat(options)
+            if (fileformat) {
+                if (typeof fileformat !== 'function') {
+                    throw new Error('outputFileFormat must be a function')
                 }
+
+                filename = fileformat(options)
             }
-        })
+        }
 
         if (!options.outputDir) {
             return

--- a/packages/wdio-runner/src/reporter.js
+++ b/packages/wdio-runner/src/reporter.js
@@ -41,6 +41,8 @@ export default class BaseReporter {
     getLogFile(name) {
         let options = this.config
         let filename = `wdio-${this.cid}-${name}-reporter.log`
+
+        options.cid = this.cid
         options.capabilities = this.caps
 
         this.config.reporters.forEach(reporter => {

--- a/packages/wdio-runner/tests/reporter.test.js
+++ b/packages/wdio-runner/tests/reporter.test.js
@@ -38,6 +38,53 @@ describe('BaseReporter', () => {
         expect(reporter.getLogFile('foobar')).toBe('/foo/bar/wdio-0-0-foobar-reporter.log')
     })
 
+    it('should output log file to custom outputDir', () => {
+        const reporter = new BaseReporter({
+            outputDir: '/foo/bar',
+            reporters: [
+                'dot',
+                ['dot', {
+                    foo: 'bar',
+                    outputDir: '/foo/bar/baz'
+                }]
+            ]
+        }, '0-0')
+
+        expect(reporter.getLogFile('foobar')).toBe('/foo/bar/baz/wdio-0-0-foobar-reporter.log')
+    })
+
+    it('should return custom log file name', () => {
+        const reporter = new BaseReporter({
+            outputDir: '/foo/bar',
+            reporters: [
+                'dot',
+                ['dot', {
+                    foo: 'bar',
+                    outputFileFormat: (options) => {
+                        return `wdio-results-${options.cid}.xml`
+                    }
+                }]
+            ]
+        }, '0-0')
+
+        expect(reporter.getLogFile('dot')).toBe('/foo/bar/wdio-results-0-0.xml')
+    })
+
+    it('should throw error if outputFileFormat is not a function', () => {
+        expect(() => {
+            new BaseReporter({
+                outputDir: '/foo/bar',
+                reporters: [
+                    'dot',
+                    ['dot', {
+                        foo: 'bar',
+                        outputFileFormat: 'foo'
+                    }]
+                ]
+            }, '0-0')
+        }).toThrow('outputFileFormat must be a function')
+    })
+
     test('getLogFile returns undefined if outputDir is not defined', () => {
         const reporter = new BaseReporter({
             reporters: [


### PR DESCRIPTION
## Proposed changes

This fixes #3213 

When specifying custom reporter options the following is not being applied, e.g. outputDir:

```
reporters: [
    'spec',
    ['junit', {
      outputDir: __dirname +'/test-results'
    }]
  ],
``` 

I'll add tests for this tomorrow. Have to run out but wanted to submit the fix. 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

### Reviewers: @webdriverio/technical-committee
