### PR TITLE
webdriverio: Update changelog for cli array arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -299,6 +299,25 @@ This version comes with a variety of technical changes that might affect the fun
   const elem2 = $('myOtherElem')
   console.log(typeof elem2.myElemCommand) // outputs "undefined"
   ```
+
+* spec and suite cli arguments are now passed as an array, e.g. 
+  ```js
+  // v4
+  ./node_modules/.bin/wdio wdio.conf.js --spec ./tests/foobar.js,./tests/baz.js
+
+  ./node_modules/.bin/wdio wdio.conf.js --suite FooBar,BarBaz
+
+  ./node_modules/.bin/wdio wdio.conf.js --suite FooBar
+  ```
+  ```js
+  // v5
+  ./node_modules/.bin/wdio wdio.conf.js --spec ./tests/foobar.js ./tests/baz.js
+
+  ./node_modules/.bin/wdio wdio.conf.js --suite FooBar BarBaz
+
+  ./node_modules/.bin/wdio wdio.conf.js --suite FooBar
+  ```
+
 * custom configuration for services or reporters are now directly applied to the config list, e.g.
   ```js
   // ...


### PR DESCRIPTION
## Proposed changes

```--spec``` and ```--suite``` has changed from a string argument to an array in v5. This updates the changelog with those changes.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

### Reviewers: @webdriverio/technical-committee
