### PR TITLE
Improve command definitions for available protocols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -207,7 +207,7 @@ This version comes with a variety of technical changes that might affect the fun
         * `elementIdDisplayed` → `isElementDisplayed`
         * `elementIdElement` → `findElementFromElement`
         * `elementIdElements` → `findElementsFromElement`
-        * `elementIdEnabled` → `getElementEnabled`
+        * `elementIdEnabled` → `isElementEnabled`
         * `elementIdLocation` → `getElementLocation`
         * `elementIdLocationInView` → `getElementLocationInView` (JsonWireProtocol only)
         * `elementIdName` → `getElementTagName`

--- a/packages/webdriver/protocol/chromium.json
+++ b/packages/webdriver/protocol/chromium.json
@@ -161,7 +161,7 @@
   },
   "/session/:sessionId/touch/pinch": {
     "POST": {
-      "command": "launchApp",
+      "command": "touchPinch",
       "description": "Trigger a pinch zoom effect.",
       "ref": "https://github.com/bayandin/chromedriver/blob/master/window_commands.cc#L903-L917",
       "parameters": [{

--- a/packages/webdriver/protocol/chromium.json
+++ b/packages/webdriver/protocol/chromium.json
@@ -159,20 +159,6 @@
       }]
     }
   },
-  "/session/:sessionId/element/:elementId/equals/:otherElementId": {
-    "POST": {
-      "command": "elementEquals",
-      "description": "Compare elements with each other.",
-      "ref": "https://github.com/bayandin/chromedriver/blob/2b5b43101967a01bb1d18259d946e796be3ca134/session_commands.cc#L521-L539",
-      "variables": [{
-        "name": "elementId",
-        "description": "element id to compare other element to"
-      }, {
-        "name": "otherElementId",
-        "description": "other element id to compare element to"
-      }]
-    }
-  },
   "/session/:sessionId/touch/pinch": {
     "POST": {
       "command": "launchApp",

--- a/packages/webdriver/protocol/jsonwp.json
+++ b/packages/webdriver/protocol/jsonwp.json
@@ -916,6 +916,19 @@
       }]
     }
   },
+  "/session/:sessionId/click": {
+    "POST": {
+      "command": "positionClick",
+      "description": "Clicks at the current mouse coordinates (set by moveto).",
+      "ref": "https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidclick",
+      "parameters": [{
+        "name": "button",
+        "type": "number",
+        "description": "which button, enum: LEFT = 0, RIGHT = 2, defaults to the left mouse button if not specified",
+        "required": false
+      }]
+    }
+  },
   "/session/:sessionId/doubleclick": {
     "POST": {
       "command": "positionDoubleClick",
@@ -960,6 +973,24 @@
       "command": "touchUp",
       "description": "Finger up on the screen.",
       "ref": "https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidtouchup",
+      "parameters": [{
+        "name": "x",
+        "type": "number",
+        "description": "x coordinate on the screen",
+        "required": false
+      }, {
+        "name": "y",
+        "type": "number",
+        "description": "y coordinate on the screen",
+        "required": false
+      }]
+    }
+  },
+  "/session/:sessionId/touch/move": {
+    "POST": {
+      "command": "touchMove",
+      "description": "Finger move on the screen.",
+      "ref": "https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidtouchmove",
       "parameters": [{
         "name": "x",
         "type": "number",

--- a/packages/webdriver/protocol/jsonwp.json
+++ b/packages/webdriver/protocol/jsonwp.json
@@ -578,7 +578,7 @@
   },
   "/session/:sessionId/element/:elementId/enabled": {
     "GET": {
-      "command": "getElementEnabled",
+      "command": "isElementEnabled",
       "description": "Determine if an element is currently enabled.",
       "ref": "https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidelementidenabled",
       "variables": [{

--- a/packages/webdriver/protocol/jsonwp.json
+++ b/packages/webdriver/protocol/jsonwp.json
@@ -605,6 +605,26 @@
       "parameters": []
     }
   },
+  "/session/:sessionId/element/:elementId/equals/:otherElementId": {
+    "GET": {
+      "command": "elementEquals",
+      "description": "Compare elements with each other.",
+      "ref": "https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidelementidequalsother",
+      "variables": [{
+        "name": "elementId",
+        "description": "ID of the element to route the command to"
+      }, {
+        "name": "otherElementId",
+        "description": "ID of the element to compare against"
+      }],
+      "parameters": [],
+      "returns": {
+        "type": "Boolean",
+        "name": "isEqual",
+        "description": "Whether the two IDs refer to the same element."
+      }
+    }
+  },
   "/session/:sessionId/element/:elementId/submit": {
     "POST": {
       "command": "elementSubmit",

--- a/packages/webdriver/protocol/webdriver.json
+++ b/packages/webdriver/protocol/webdriver.json
@@ -530,7 +530,7 @@
   },
   "/session/:sessionId/element/:elementId/enabled": {
     "GET": {
-      "command": "getElementEnabled",
+      "command": "isElementEnabled",
       "description": "Is Element Enabled determines if the referenced element is enabled or not. This operation only makes sense on form controls.",
       "ref": "https://w3c.github.io/webdriver/webdriver-spec.html#dfn-is-element-enabled",
       "variables": [{

--- a/packages/webdriver/protocol/webdriver.json
+++ b/packages/webdriver/protocol/webdriver.json
@@ -3,7 +3,7 @@
     "POST": {
       "command": "newSession",
       "description": "The New Session command creates a new WebDriver session with the endpoint node. If the creation fails, a session not created error is returned.",
-      "ref": "https://w3c.github.io/webdriver/webdriver-spec.html#dfn-creating-a-new-session",
+      "ref": "https://w3c.github.io/webdriver/#dfn-new-sessions",
       "parameters": [{
         "name": "capabilities",
         "type": "object",
@@ -21,7 +21,7 @@
     "DELETE": {
       "command": "deleteSession",
       "description": "The Delete Session command closes any top-level browsing contexts associated with the current session, terminates the connection, and finally closes the current session.",
-      "ref": "https://w3c.github.io/webdriver/webdriver-spec.html#dfn-delete-session",
+      "ref": "https://w3c.github.io/webdriver/#dfn-delete-session",
       "parameters": []
     }
   },
@@ -29,7 +29,7 @@
     "GET": {
       "command": "status",
       "description": "The Status command returns information about whether a remote end is in a state in which it can create new sessions and can additionally include arbitrary meta information that is specific to the implementation.",
-      "ref": "https://w3c.github.io/webdriver/webdriver-spec.html#dfn-status",
+      "ref": "https://w3c.github.io/webdriver/#dfn-status",
       "parameters": [],
       "returns": {
         "type": "Object",
@@ -42,7 +42,7 @@
     "GET": {
       "command": "getTimeouts",
       "description": "The Get Timeouts command gets timeout durations associated with the current session.",
-      "ref": "https://w3c.github.io/webdriver/webdriver-spec.html#dfn-get-timeouts",
+      "ref": "https://w3c.github.io/webdriver/#dfn-get-timeouts",
       "parameters": [],
       "returns": {
         "type": "Object",
@@ -53,7 +53,7 @@
     "POST": {
       "command": "setTimeout",
       "description": "The Set Timeouts command sets timeout durations associated with the current session. The timeouts that can be controlled are listed in the table of session timeouts below.",
-      "ref": "https://w3c.github.io/webdriver/webdriver-spec.html#dfn-timeouts",
+      "ref": "https://w3c.github.io/webdriver/#dfn-timeouts",
       "parameters": [{
         "name": "timeouts",
         "type": "Object",
@@ -66,13 +66,13 @@
     "GET": {
       "command": "getUrl",
       "description": "The Get Current URL command returns the URL of the current top-level browsing context.",
-      "ref": "https://w3c.github.io/webdriver/webdriver-spec.html#dfn-get-current-url",
+      "ref": "https://w3c.github.io/webdriver/#dfn-get-current-url",
       "parameters": []
     },
     "POST": {
       "command": "navigateTo",
       "description": "The navigateTo (go) command is used to cause the user agent to navigate the current top-level browsing context a new location.",
-      "ref": "https://w3c.github.io/webdriver/webdriver-spec.html#dfn-navigate-to",
+      "ref": "https://w3c.github.io/webdriver/#dfn-navigate-to",
       "parameters": [{
         "name": "url",
         "type": "string",
@@ -90,7 +90,7 @@
     "POST": {
       "command": "back",
       "description": "The Back command causes the browser to traverse one step backward in the joint session history of the current top-level browsing context. This is equivalent to pressing the back button in the browser chrome or calling `window.history.back`.",
-      "ref": "https://w3c.github.io/webdriver/webdriver-spec.html#dfn-back",
+      "ref": "https://w3c.github.io/webdriver/#dfn-back",
       "parameters": []
     }
   },
@@ -98,7 +98,7 @@
     "POST": {
       "command": "forward",
       "description": "The Forward command causes the browser to traverse one step forwards in the joint session history of the current top-level browsing context.",
-      "ref": "https://w3c.github.io/webdriver/webdriver-spec.html#dfn-forward",
+      "ref": "https://w3c.github.io/webdriver/#dfn-forward",
       "parameters": []
     }
   },
@@ -106,7 +106,7 @@
     "POST": {
       "command": "refresh",
       "description": "The Refresh command causes the browser to reload the page in current top-level browsing context.",
-      "ref": "https://w3c.github.io/webdriver/webdriver-spec.html#dfn-refresh",
+      "ref": "https://w3c.github.io/webdriver/#dfn-refresh",
       "parameters": []
     }
   },
@@ -114,7 +114,7 @@
     "GET": {
       "command": "getTitle",
       "description": "The Get Title command returns the document title of the current top-level browsing context, equivalent to calling `document.title`.",
-      "ref": "https://w3c.github.io/webdriver/webdriver-spec.html#dfn-get-title",
+      "ref": "https://w3c.github.io/webdriver/#dfn-get-title",
       "parameters": [],
       "returns": {
         "type": "String",
@@ -127,7 +127,7 @@
     "GET": {
       "command": "getWindowHandle",
       "description": "The Get Window Handle command returns the window handle for the current top-level browsing context. It can be used as an argument to Switch To Window.",
-      "ref": "https://w3c.github.io/webdriver/webdriver-spec.html#dfn-get-window-handle",
+      "ref": "https://w3c.github.io/webdriver/#dfn-get-window-handle",
       "parameters": [],
       "returns": {
         "type": "String",
@@ -138,13 +138,13 @@
     "DELETE": {
       "command": "closeWindow",
       "description": "The Close Window command closes the current top-level browsing context. Once done, if there are no more top-level browsing contexts open, the WebDriver session itself is closed.",
-      "ref": "https://w3c.github.io/webdriver/webdriver-spec.html#dfn-close-window",
+      "ref": "https://w3c.github.io/webdriver/#dfn-close-window",
       "parameters": []
     },
     "POST": {
       "command": "switchToWindow",
       "description": "The Switch To Window command is used to select the current top-level browsing context for the current session, i.e. the one that will be used for processing commands.",
-      "ref": "https://w3c.github.io/webdriver/webdriver-spec.html#dfn-switch-to-window",
+      "ref": "https://w3c.github.io/webdriver/#dfn-switch-to-window",
       "parameters": [{
         "name": "handle",
         "type": "string",
@@ -157,7 +157,7 @@
     "GET": {
       "command": "getWindowHandles",
       "description": "The Get Window Handles command returns a list of window handles for every open top-level browsing context. The order in which the window handles are returned is arbitrary.",
-      "ref": "https://w3c.github.io/webdriver/webdriver-spec.html#dfn-get-window-handles",
+      "ref": "https://w3c.github.io/webdriver/#dfn-get-window-handles",
       "parameters": [],
       "returns": {
         "type": "String[]",
@@ -170,7 +170,7 @@
     "POST": {
       "command": "switchToFrame",
       "description": "The Switch To Frame command is used to select the current top-level browsing context or a child browsing context of the current browsing context to use as the current browsing context for subsequent commands.",
-      "ref": "https://w3c.github.io/webdriver/webdriver-spec.html#dfn-switch-to-frame",
+      "ref": "https://w3c.github.io/webdriver/#dfn-switch-to-frame",
       "parameters": [{
         "name": "id",
         "type": "(number|string|object)",
@@ -183,7 +183,7 @@
     "POST": {
       "command": "switchToParentFrame",
       "description": "The Switch to Parent Frame command sets the current browsing context for future commands to the parent of the current browsing context.",
-      "ref": "https://w3c.github.io/webdriver/webdriver-spec.html#dfn-switch-to-parent-frame",
+      "ref": "https://w3c.github.io/webdriver/#dfn-switch-to-parent-frame",
       "parameters": []
     }
   },
@@ -191,7 +191,7 @@
     "GET": {
       "command": "getWindowRect",
       "description": "The Get Window Rect command returns the size and position on the screen of the operating system window corresponding to the current top-level browsing context.",
-      "ref": "https://w3c.github.io/webdriver/webdriver-spec.html#dfn-get-window-rect",
+      "ref": "https://w3c.github.io/webdriver/#dfn-get-window-rect",
       "parameters": [],
       "returns": {
         "type": "Object",
@@ -202,7 +202,7 @@
     "POST": {
       "command": "setWindowRect",
       "description": "The Set Window Rect command alters the size and the position of the operating system window corresponding to the current top-level browsing context.",
-      "ref": "https://w3c.github.io/webdriver/webdriver-spec.html#dfn-set-window-rect",
+      "ref": "https://w3c.github.io/webdriver/#dfn-set-window-rect",
       "parameters": [{
         "name": "x",
         "type": "(number|null)",
@@ -235,7 +235,7 @@
     "POST": {
       "command": "maximizeWindow",
       "description": "The Maximize Window command invokes the window manager-specific \"maximize\" operation, if any, on the window containing the current top-level browsing context. This typically increases the window to the maximum available size without going full-screen.",
-      "ref": "https://w3c.github.io/webdriver/webdriver-spec.html#dfn-maximize-window",
+      "ref": "https://w3c.github.io/webdriver/#dfn-maximize-window",
       "parameters": [],
       "returns": {
         "type": "Object",
@@ -248,7 +248,7 @@
     "POST": {
       "command": "minimizeWindow",
       "description": "The Minimize Window command invokes the window manager-specific \"minimize\" operation, if any, on the window containing the current top-level browsing context. This typically hides the window in the system tray.",
-      "ref": "https://w3c.github.io/webdriver/webdriver-spec.html#dfn-minimize-window",
+      "ref": "https://w3c.github.io/webdriver/#dfn-minimize-window",
       "parameters": [],
       "returns": {
         "type": "Object",
@@ -261,7 +261,7 @@
     "POST": {
       "command": "fullscreenWindow",
       "description": "The Fullscreen Window command invokes the window manager-specific “full screen” operation, if any, on the window containing the current top-level browsing context. This typically increases the window to the size of the physical display and can hide browser chrome elements such as toolbars.",
-      "ref": "https://w3c.github.io/webdriver/webdriver-spec.html#dfn-fullscreen-window",
+      "ref": "https://w3c.github.io/webdriver/#dfn-fullscreen-window",
       "parameters": [],
       "returns": {
         "type": "Object",
@@ -274,7 +274,7 @@
     "POST": {
       "command": "findElement",
       "description": "The Find Element command is used to find an element in the current browsing context that can be used for future commands.",
-      "ref": "https://w3c.github.io/webdriver/webdriver-spec.html#dfn-find-element",
+      "ref": "https://w3c.github.io/webdriver/#dfn-find-element",
       "parameters": [{
         "name": "using",
         "type": "string",
@@ -297,7 +297,7 @@
     "POST": {
       "command": "findElements",
       "description": "The Find Elements command is used to find elements in the current browsing context that can be used for future commands.",
-      "ref": "https://w3c.github.io/webdriver/webdriver-spec.html#dfn-find-elements",
+      "ref": "https://w3c.github.io/webdriver/#dfn-find-elements",
       "parameters": [{
         "name": "using",
         "type": "string",
@@ -320,7 +320,7 @@
     "POST": {
       "command": "findElementFromElement",
       "description": "The Find Element From Element command is used to find an element from a web element in the current browsing context that can be used for future commands.",
-      "ref": "https://w3c.github.io/webdriver/webdriver-spec.html#dfn-find-element-from-element",
+      "ref": "https://w3c.github.io/webdriver/#dfn-find-element-from-element",
       "variables": [{
         "name": "elementId",
         "description": "the id of an element returned in a previous call to Find Element(s)"
@@ -347,7 +347,7 @@
     "POST": {
       "command": "findElementsFromElement",
       "description": "The Find Elements From Element command is used to find elements from a web element in the current browsing context that can be used for future commands.",
-      "ref": "https://w3c.github.io/webdriver/webdriver-spec.html#dfn-find-elements-from-element",
+      "ref": "https://w3c.github.io/webdriver/#dfn-find-elements-from-element",
       "variables": [{
         "name": "elementId",
         "description": "the id of an element returned in a previous call to Find Element(s)"
@@ -374,7 +374,7 @@
     "POST": {
       "command": "getActiveElement",
       "description": "Get Active Element returns the active element of the current browsing context’s document element.",
-      "ref": "https://w3c.github.io/webdriver/webdriver-spec.html#dfn-get-active-element",
+      "ref": "https://w3c.github.io/webdriver/#dfn-get-active-element",
       "parameters": [],
       "returns": {
         "type": "String",
@@ -387,7 +387,7 @@
     "GET": {
       "command": "isElementSelected",
       "description": "Is Element Selected determines if the referenced element is selected or not. This operation only makes sense on input elements of the Checkbox- and Radio Button states, or option elements.",
-      "ref": "https://w3c.github.io/webdriver/webdriver-spec.html#dfn-is-element-selected",
+      "ref": "https://w3c.github.io/webdriver/#dfn-is-element-selected",
       "variables": [{
         "name": "elementId",
         "description": "the id of an element returned in a previous call to Find Element(s)"
@@ -404,7 +404,7 @@
     "GET": {
       "command": "isElementDisplayed",
       "description": "Is Element Displayed determines the visibility of an element which is guided by what is perceptually visible to the human eye. In this context, an element's displayedness does not relate to the `visibility` or `display` style properties.",
-      "ref": "https://w3c.github.io/webdriver/webdriver-spec.html#c-element-displayedness",
+      "ref": "https://w3c.github.io/webdriver/#element-displayedness",
       "variables": [{
         "name": "elementId",
         "description": "the id of an element returned in a previous call to Find Element(s)"
@@ -421,7 +421,7 @@
     "GET": {
       "command": "getElementAttribute",
       "description": "The Get Element Attribute command will return the attribute of a web element.",
-      "ref": "https://w3c.github.io/webdriver/webdriver-spec.html#dfn-get-element-attribute",
+      "ref": "https://w3c.github.io/webdriver/#dfn-get-element-attribute",
       "variables": [{
         "name": "elementId",
         "description": "the id of an element returned in a previous call to Find Element(s)"
@@ -441,7 +441,7 @@
     "GET": {
       "command": "getElementProperty",
       "description": "The Get Element Property command will return the result of getting a property of an element.",
-      "ref": "https://w3c.github.io/webdriver/webdriver-spec.html#dfn-get-element-property",
+      "ref": "https://w3c.github.io/webdriver/#dfn-get-element-property",
       "variables": [{
         "name": "elementId",
         "description": "the id of an element returned in a previous call to Find Element(s)"
@@ -461,7 +461,7 @@
     "GET": {
       "command": "getElementCSSValue",
       "description": "The Get Element CSS Value command retrieves the computed value of the given CSS property of the given web element.",
-      "ref": "https://w3c.github.io/webdriver/webdriver-spec.html#dfn-get-element-css-value",
+      "ref": "https://w3c.github.io/webdriver/#dfn-get-element-css-value",
       "variables": [{
         "name": "elementId",
         "description": "the id of an element returned in a previous call to Find Element(s)"
@@ -481,7 +481,7 @@
     "GET": {
       "command": "getElementText",
       "description": "The Get Element Text command intends to return an element’s text \"as rendered\". An element's rendered text is also used for locating a elements by their link text and partial link text.",
-      "ref": "https://w3c.github.io/webdriver/webdriver-spec.html#dfn-get-element-text",
+      "ref": "https://w3c.github.io/webdriver/#dfn-get-element-text",
       "variables": [{
         "name": "elementId",
         "description": "the id of an element returned in a previous call to Find Element(s)"
@@ -498,7 +498,7 @@
     "GET": {
       "command": "getElementTagName",
       "description": "The Get Element Tag Name command returns the qualified element name of the given web element.",
-      "ref": "https://w3c.github.io/webdriver/webdriver-spec.html#dfn-get-element-tag-name",
+      "ref": "https://w3c.github.io/webdriver/#dfn-get-element-tag-name",
       "variables": [{
         "name": "elementId",
         "description": "the id of an element returned in a previous call to Find Element(s)"
@@ -515,7 +515,7 @@
     "GET": {
       "command": "getElementRect",
       "description": "The Get Element Rect command returns the dimensions and coordinates of the given web element.",
-      "ref": "https://w3c.github.io/webdriver/webdriver-spec.html#dfn-get-element-rect",
+      "ref": "https://w3c.github.io/webdriver/#dfn-get-element-rect",
       "variables": [{
         "name": "elementId",
         "description": "the id of an element returned in a previous call to Find Element(s)"
@@ -532,7 +532,7 @@
     "GET": {
       "command": "isElementEnabled",
       "description": "Is Element Enabled determines if the referenced element is enabled or not. This operation only makes sense on form controls.",
-      "ref": "https://w3c.github.io/webdriver/webdriver-spec.html#dfn-is-element-enabled",
+      "ref": "https://w3c.github.io/webdriver/#dfn-is-element-enabled",
       "variables": [{
         "name": "elementId",
         "description": "the id of an element returned in a previous call to Find Element(s)"
@@ -549,7 +549,7 @@
     "POST": {
       "command": "elementClick",
       "description": "The Element Click command scrolls into view the element if it is not already pointer-interactable, and clicks its in-view center point. If the element's center point is obscured by another element, an element click intercepted error is returned. If the element is outside the viewport, an element not interactable error is returned.",
-      "ref": "https://w3c.github.io/webdriver/webdriver-spec.html#dfn-element-click",
+      "ref": "https://w3c.github.io/webdriver/#dfn-element-click",
       "variables": [{
         "name": "elementId",
         "description": "the id of an element returned in a previous call to Find Element(s)"
@@ -561,7 +561,7 @@
     "POST": {
       "command": "elementClear",
       "description": "The Element Clear command scrolls into view an editable or resettable element and then attempts to clear its selected files or text content.",
-      "ref": "https://w3c.github.io/webdriver/webdriver-spec.html#dfn-element-clear",
+      "ref": "https://w3c.github.io/webdriver/#dfn-element-clear",
       "variables": [{
         "name": "elementId",
         "description": "the id of an element returned in a previous call to Find Element(s)"
@@ -573,7 +573,7 @@
     "POST": {
       "command": "elementSendKeys",
       "description": "The Element Send Keys command scrolls into view the form control element and then sends the provided keys to the element. In case the element is not keyboard-interactable, an element not interactable error is returned.<br><br>The key input state used for input may be cleared mid-way through \"typing\" by sending the null key, which is U+E000 (NULL).",
-      "ref": "https://w3c.github.io/webdriver/webdriver-spec.html#dfn-element-send-keys",
+      "ref": "https://w3c.github.io/webdriver/#dfn-element-send-keys",
       "variables": [{
         "name": "elementId",
         "description": "the id of an element returned in a previous call to Find Element(s)"
@@ -590,7 +590,7 @@
     "GET": {
       "command": "getPageSource",
       "description": "The Get Page Source command returns a string serialization of the DOM of the current browsing context active document.",
-      "ref": "https://w3c.github.io/webdriver/webdriver-spec.html#dfn-get-page-source",
+      "ref": "https://w3c.github.io/webdriver/#dfn-get-page-source",
       "parameters": []
     }
   },
@@ -598,7 +598,7 @@
     "POST": {
       "command": "executeScript",
       "description": "The Execute Script command executes a JavaScript function in the context of the current browsing context and returns the return value of the function.",
-      "ref": "https://w3c.github.io/webdriver/webdriver-spec.html#dfn-execute-script",
+      "ref": "https://w3c.github.io/webdriver/#dfn-execute-script",
       "parameters": [{
         "name": "script",
         "type": "string",
@@ -621,7 +621,7 @@
     "POST": {
       "command": "executeAsyncScript",
       "description": "The Execute Async Script command causes JavaScript to execute as an anonymous function. Unlike the Execute Script command, the result of the function is ignored. Instead an additional argument is provided as the final argument to the function. This is a function that, when called, returns its first argument as the response.",
-      "ref": "https://w3c.github.io/webdriver/webdriver-spec.html#dfn-execute-async-script",
+      "ref": "https://w3c.github.io/webdriver/#dfn-execute-async-script",
       "parameters": [{
         "name": "script",
         "type": "string",
@@ -644,7 +644,7 @@
     "GET": {
       "command": "getAllCookies",
       "description": "The Get All Cookies command returns all cookies associated with the address of the current browsing context’s active document.",
-      "ref": "https://w3c.github.io/webdriver/webdriver-spec.html#dfn-get-all-cookies",
+      "ref": "https://w3c.github.io/webdriver/#dfn-get-all-cookies",
       "parameters": [],
       "returns": {
         "type": "Object[]",
@@ -655,7 +655,7 @@
     "POST": {
       "command": "addCookie",
       "description": "The Add Cookie command adds a single cookie to the cookie store associated with the active document's address.",
-      "ref": "https://w3c.github.io/webdriver/webdriver-spec.html#dfn-adding-a-cookie",
+      "ref": "https://w3c.github.io/webdriver/#dfn-adding-a-cookie",
       "parameters": [{
         "name": "cookie",
         "type": "object",
@@ -666,7 +666,7 @@
     "DELETE": {
       "command": "deleteAllCookies",
       "description": "The Delete All Cookies command allows deletion of all cookies associated with the active document's address.",
-      "ref": "https://w3c.github.io/webdriver/webdriver-spec.html#dfn-delete-all-cookies",
+      "ref": "https://w3c.github.io/webdriver/#dfn-delete-all-cookies",
       "parameters": []
     }
   },
@@ -674,7 +674,7 @@
     "GET": {
       "command": "getNamedCookie",
       "description": "The Get Named Cookie command returns the cookie with the requested name from the associated cookies in the cookie store of the current browsing context's active document. If no cookie is found, a no such cookie error is returned.",
-      "ref": "https://w3c.github.io/webdriver/webdriver-spec.html#dfn-get-named-cookie",
+      "ref": "https://w3c.github.io/webdriver/#dfn-get-named-cookie",
       "variables": [{
         "name": "name",
         "description": "name of the cookie to retrieve"
@@ -689,7 +689,7 @@
     "DELETE": {
       "command": "deleteCookie",
       "description": "The Delete Cookie command allows you to delete either a single cookie by parameter name, or all the cookies associated with the active document's address if name is undefined.",
-      "ref": "https://w3c.github.io/webdriver/webdriver-spec.html#dfn-delete-cookie",
+      "ref": "https://w3c.github.io/webdriver/#dfn-delete-cookie",
       "variables": [{
         "name": "name",
         "description": "name of the cookie to retrieve"
@@ -701,7 +701,7 @@
     "POST": {
       "command": "performActions",
       "description": "The Perform Actions command is used to execute complex user actions. See [spec](https://github.com/jlipps/simple-wd-spec#perform-actions) for more details.",
-      "ref": "https://w3c.github.io/webdriver/webdriver-spec.html#dfn-perform-actions",
+      "ref": "https://w3c.github.io/webdriver/#dfn-perform-actions",
       "parameters": [{
         "name": "actions",
         "type": "object[]",
@@ -712,7 +712,7 @@
     "DELETE": {
       "command": "releaseActions",
       "description": "The Release Actions command is used to release all the keys and pointer buttons that are currently depressed. This causes events to be fired as if the state was released by an explicit series of actions. It also clears all the internal state of the virtual devices.",
-      "ref": "https://w3c.github.io/webdriver/webdriver-spec.html#dfn-release-actions",
+      "ref": "https://w3c.github.io/webdriver/#dfn-release-actions",
       "parameters": []
     }
   },
@@ -720,7 +720,7 @@
     "POST": {
       "command": "dismissAlert",
       "description": "The Dismiss Alert command dismisses a simple dialog if present. A request to dismiss an alert user prompt, which may not necessarily have a dismiss button, has the same effect as accepting it.",
-      "ref": "https://w3c.github.io/webdriver/webdriver-spec.html#dfn-dismiss-alert",
+      "ref": "https://w3c.github.io/webdriver/#dfn-dismiss-alert",
       "parameters": []
     }
   },
@@ -728,7 +728,7 @@
     "POST": {
       "command": "acceptAlert",
       "description": "The Accept Alert command accepts a simple dialog if present.",
-      "ref": "https://w3c.github.io/webdriver/webdriver-spec.html#dfn-accept-alert",
+      "ref": "https://w3c.github.io/webdriver/#dfn-accept-alert",
       "parameters": []
     }
   },
@@ -736,7 +736,7 @@
     "GET": {
       "command": "getAlertText",
       "description": "The Get Alert Text command returns the message of the current user prompt. If there is no current user prompt, it returns an error.",
-      "ref": "https://w3c.github.io/webdriver/webdriver-spec.html#dfn-get-alert-text",
+      "ref": "https://w3c.github.io/webdriver/#dfn-get-alert-text",
       "parameters": [],
       "returns": {
         "type": "String",
@@ -747,7 +747,7 @@
     "POST": {
       "command": "sendAlertText",
       "description": "The Send Alert Text command sets the text field of a window.prompt user prompt to the given value.",
-      "ref": "https://w3c.github.io/webdriver/webdriver-spec.html#dfn-send-alert-text",
+      "ref": "https://w3c.github.io/webdriver/#dfn-send-alert-text",
       "parameters": [{
         "name": "text",
         "type": "string",
@@ -760,7 +760,7 @@
     "GET": {
       "command": "takeScreenshot",
       "description": "The Take Screenshot command takes a screenshot of the top-level browsing context's viewport.",
-      "ref": "https://w3c.github.io/webdriver/webdriver-spec.html#dfn-take-screenshot",
+      "ref": "https://w3c.github.io/webdriver/#dfn-take-screenshot",
       "parameters": [],
       "returns": {
         "type": "String",
@@ -773,7 +773,7 @@
     "GET": {
       "command": "takeElementScreenshot",
       "description": "The Take Element Screenshot command takes a screenshot of the visible region encompassed by the bounding rectangle of an element.",
-      "ref": "https://w3c.github.io/webdriver/webdriver-spec.html#dfn-take-element-screenshot",
+      "ref": "https://w3c.github.io/webdriver/#dfn-take-element-screenshot",
       "variables": [{
         "name": "elementId",
         "description": "the id of an element returned in a previous call to Find Element(s)"

--- a/packages/webdriver/protocol/webdriver.json
+++ b/packages/webdriver/protocol/webdriver.json
@@ -403,7 +403,7 @@
   "/session/:sessionId/element/:elementId/displayed": {
     "GET": {
       "command": "isElementDisplayed",
-      "description": "The visibility of an element is guided by what is perceptually visible to the human eye. In this context, an element's displayedness does not relate to the visibility or display style properties.",
+      "description": "Is Element Displayed determines the visibility of an element which is guided by what is perceptually visible to the human eye. In this context, an element's displayedness does not relate to the `visibility` or `display` style properties.",
       "ref": "https://w3c.github.io/webdriver/webdriver-spec.html#c-element-displayedness",
       "variables": [{
         "name": "elementId",
@@ -700,7 +700,7 @@
   "/session/:sessionId/actions": {
     "POST": {
       "command": "performActions",
-      "description": "Execute complex user actions. See [spec](https://github.com/jlipps/simple-wd-spec#perform-actions) for more details.",
+      "description": "The Perform Actions command is used to execute complex user actions. See [spec](https://github.com/jlipps/simple-wd-spec#perform-actions) for more details.",
       "ref": "https://w3c.github.io/webdriver/webdriver-spec.html#dfn-perform-actions",
       "parameters": [{
         "name": "actions",
@@ -746,7 +746,7 @@
     },
     "POST": {
       "command": "sendAlertText",
-      "description": "",
+      "description": "The Send Alert Text command sets the text field of a window.prompt user prompt to the given value.",
       "ref": "https://w3c.github.io/webdriver/webdriver-spec.html#dfn-send-alert-text",
       "parameters": [{
         "name": "text",
@@ -759,15 +759,20 @@
   "/session/:sessionId/screenshot": {
     "GET": {
       "command": "takeScreenshot",
-      "description": "The Send Alert Text command sets the text field of a window.prompt user prompt to the given value.",
+      "description": "The Take Screenshot command takes a screenshot of the top-level browsing context's viewport.",
       "ref": "https://w3c.github.io/webdriver/webdriver-spec.html#dfn-take-screenshot",
-      "parameters": []
+      "parameters": [],
+      "returns": {
+        "type": "String",
+        "name": "screenshot",
+        "description": "The base64-encoded PNG image data comprising the screenshot of the initial viewport."
+      }
     }
   },
   "/session/:sessionId/element/:elementId/screenshot": {
     "GET": {
       "command": "takeElementScreenshot",
-      "description": "The Take Screenshot command takes a screenshot of the top-level browsing context's viewport.",
+      "description": "The Take Element Screenshot command takes a screenshot of the visible region encompassed by the bounding rectangle of an element.",
       "ref": "https://w3c.github.io/webdriver/webdriver-spec.html#dfn-take-element-screenshot",
       "variables": [{
         "name": "elementId",
@@ -777,7 +782,7 @@
       "returns": {
         "type": "String",
         "name": "screenshot",
-        "description": "The base64-encoded PNG image data comprising the screenshot of the initial viewport."
+        "description": "The base64-encoded PNG image data comprising the screenshot of the visible region of an element’s bounding rectangle after it has been scrolled into view."
       }
     }
   }

--- a/packages/webdriverio/src/commands/element/isEnabled.js
+++ b/packages/webdriverio/src/commands/element/isEnabled.js
@@ -32,5 +32,5 @@
  */
 
 export default function isEnabled() {
-    return this.getElementEnabled(this.elementId)
+    return this.isElementEnabled(this.elementId)
 }


### PR DESCRIPTION
## Proposed changes

* Moved `elementEquals` command definition from Chromium to JsonWireProtocol, changing method from POST to GET.
* Added missing definitions for JsonWireProtocol `positionClick` and `touchMove` commands.
* Renamed duplicate Chromium command definition (`launchApp`) to `touchPinch`.
* Corrected missing/improper documentation for WebDriver command definitions.
* Renamed `getElementEnabled` to `isElementEnabled` to be consistent with other Boolean return type functions (closes #3221).
* Changed references to latest Living Standard, without redirect, for WebDriver command definitions, using updated definition link for new session.

## Types of changes
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

### Reviewers: @webdriverio/technical-committee