### PR TITLE
Don't let jasmine swallow errors by ignoring its expectationResultHandler

### DIFF
--- a/packages/wdio-jasmine-framework/src/index.js
+++ b/packages/wdio-jasmine-framework/src/index.js
@@ -67,11 +67,7 @@ class JasmineAdapter {
         /**
          * enable expectHandler
          */
-        const { expectationResultHandler } = this.jasmineNodeOpts
-        const handler = typeof expectationResultHandler === 'function'
-            ? expectationResultHandler
-            : jasmine.Spec.prototype.addExpectationResult
-        jasmine.Spec.prototype.addExpectationResult = handler
+        jasmine.Spec.prototype.addExpectationResult = this.getExpectationResultHandler(jasmine)
 
         /**
          * wrap commands with wdio-sync
@@ -193,6 +189,17 @@ class JasmineAdapter {
         return message
     }
 
+    getExpectationResultHandler (jasmine) {
+        let { expectationResultHandler } = this.jasmineNodeOpts
+        const origHandler = jasmine.Spec.prototype.addExpectationResult
+
+        if (typeof expectationResultHandler !== 'function') {
+            return origHandler
+        }
+
+        return this.expectationResultHandler(origHandler)
+    }
+
     expectationResultHandler (origHandler) {
         const { expectationResultHandler } = this.jasmineNodeOpts
         return function (passed, data) {
@@ -201,12 +208,14 @@ class JasmineAdapter {
             } catch (e) {
                 /**
                  * propagate expectationResultHandler error if actual assertion passed
+                 * but the custom handler decides to throw
                  */
                 if (passed) {
                     passed = false
                     data = {
                         passed: false,
-                        message: 'expectationResultHandlerError: ' + e.message
+                        message: 'expectationResultHandlerError: ' + e.message,
+                        error: e
                     }
                 }
             }


### PR DESCRIPTION
## Proposed changes

Currently Jasmine is swallowing errors if an `expectationResultHandler` is set without doing anything. This patch fixes this. It will ensure that the original handler is always called but the user still has the ability to change the assertion outcome.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
