### PR TITLE
set NODE_ENV to production to not compile source map for NPM code

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "clean:node_modules": "rimraf ./packages/*/node_modules ./packages/node_modules",
     "clean:website": "rimraf docs/api/**/*.md && rimraf website/sidebars.json",
     "link": "node ./scripts/link",
-    "release": "npm run setup && lerna publish",
+    "release": "NODE_ENV=production npm run setup && lerna publish",
     "setup": "run-s bootstrap build",
     "test": "run-s test:*",
     "test:eslint": "eslint packages examples scripts",

--- a/packages/wdio-cli/package.json
+++ b/packages/wdio-cli/package.json
@@ -49,7 +49,6 @@
     "lodash.pickby": "^4.6.0",
     "lodash.union": "^4.6.0",
     "npm-install-package": "^2.1.0",
-    "source-map-support": "^0.5.6",
     "webdriverio": "^5.2.0",
     "yargs": "^11.1.0"
   },


### PR DESCRIPTION
## Proposed changes

Currently the released code contains source maps which requires the `source-map-support` module which is not a dependency in all modules. Let's just avoid including it in NPM pushed code.

closes #3205

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
