### PR TITLE
webdriverio: isDisplayed fix to return false on non existing elements

### DIFF
--- a/packages/wdio-webdriver-mock-service/src/index.js
+++ b/packages/wdio-webdriver-mock-service/src/index.js
@@ -80,7 +80,7 @@ export default class WebdriverMockService {
         this.command.findElement().twice().reply(200, { value: elem2Response })
 
         this.command.elementClick(ELEMENT_ID).once().reply(200, { value: null })
-        this.command.elementClick(ELEMENT_ID).times(1).reply(500, { value: {
+        this.command.elementClick(ELEMENT_ID).times(4).reply(500, { value: {
             error: 'stale element reference error',
             message: 'stale element reference error'
         } })

--- a/packages/wdio-webdriver-mock-service/src/index.js
+++ b/packages/wdio-webdriver-mock-service/src/index.js
@@ -33,6 +33,7 @@ export default class WebdriverMockService {
          * register request interceptors for specific scenarios
          */
         global.browser.addCommand('waitForElementScenario', ::this.waitForElementScenario)
+        global.browser.addCommand('isDisplayedScenario', ::this.isDisplayedScenario)
         global.browser.addCommand('staleElementRefetchScenario', ::this.staleElementRefetchScenario)
     }
 
@@ -47,6 +48,17 @@ export default class WebdriverMockService {
         this.command.findElements().reply(200, { value: [elemResponse] })
         this.command.elementClick(ELEMENT_ID).once().reply(200, { value: null })
     }
+
+    isDisplayedScenario() {
+        this.nockReset()
+
+        const elemResponse = { 'element-6066-11e4-a52e-4f735466cecf': ELEMENT_ID }
+
+        this.command.findElement().times(2).reply(404, NO_SUCH_ELEMENT)
+        this.command.findElement().times(2).reply(200, { value: elemResponse })
+        this.command.isElementDisplayed(ELEMENT_ID).once().reply(200, { value: true })
+    }
+
 
     staleElementRefetchScenario () {
         this.nockReset()

--- a/packages/wdio-webdriver-mock-service/src/index.js
+++ b/packages/wdio-webdriver-mock-service/src/index.js
@@ -45,7 +45,7 @@ export default class WebdriverMockService {
         this.command.findElement().times(2).reply(200, { value: elemResponse })
         this.command.findElements().times(5).reply(200, { value: [] })
         this.command.findElements().reply(200, { value: [elemResponse] })
-        this.command.isElementDisplayed(ELEMENT_ID).reply(200, { value: true })
+        this.command.elementClick(ELEMENT_ID).once().reply(200, { value: null })
     }
 
     staleElementRefetchScenario () {
@@ -58,7 +58,7 @@ export default class WebdriverMockService {
         this.command.findElement().twice().reply(200, { value: elem2Response })
 
         this.command.elementClick(ELEMENT_ID).once().reply(200, { value: null })
-        this.command.elementClick(ELEMENT_ID).times(4).reply(500, { value: {
+        this.command.elementClick(ELEMENT_ID).times(1).reply(500, { value: {
             error: 'stale element reference error',
             message: 'stale element reference error'
         } })

--- a/packages/wdio-webdriver-mock-service/src/index.js
+++ b/packages/wdio-webdriver-mock-service/src/index.js
@@ -33,7 +33,8 @@ export default class WebdriverMockService {
          * register request interceptors for specific scenarios
          */
         global.browser.addCommand('waitForElementScenario', ::this.waitForElementScenario)
-        global.browser.addCommand('isDisplayedScenario', ::this.isDisplayedScenario)
+        global.browser.addCommand('isNeverDisplayedScenario', ::this.isNeverDisplayedScenario)
+        global.browser.addCommand('isEventuallyDisplayedScenario', ::this.isEventuallyDisplayedScenario)
         global.browser.addCommand('staleElementRefetchScenario', ::this.staleElementRefetchScenario)
     }
 
@@ -49,7 +50,7 @@ export default class WebdriverMockService {
         this.command.elementClick(ELEMENT_ID).once().reply(200, { value: null })
     }
 
-    isDisplayedScenario() {
+    isNeverDisplayedScenario() {
         this.nockReset()
 
         const elemResponse = { 'element-6066-11e4-a52e-4f735466cecf': ELEMENT_ID }
@@ -59,6 +60,15 @@ export default class WebdriverMockService {
         this.command.isElementDisplayed(ELEMENT_ID).once().reply(200, { value: true })
     }
 
+    isEventuallyDisplayedScenario() {
+        this.nockReset()
+
+        const elemResponse = { 'element-6066-11e4-a52e-4f735466cecf': ELEMENT_ID }
+
+        this.command.findElement().times(1).reply(404, NO_SUCH_ELEMENT)
+        this.command.findElement().times(2).reply(200, { value: elemResponse })
+        this.command.isElementDisplayed(ELEMENT_ID).once().reply(200, { value: true })
+    }
 
     staleElementRefetchScenario () {
         this.nockReset()

--- a/packages/webdriverio/src/commands/element/isDisplayed.js
+++ b/packages/webdriverio/src/commands/element/isDisplayed.js
@@ -40,9 +40,7 @@
  *
  */
 
-export default function isDisplayed() {
-    return this.parent.$(this.selector).then((elem) => {
-        this.elementId = elem.elementId
-        return this.elementId ? this.isElementDisplayed(this.elementId) : false
-    })
+export default async function isDisplayed() {
+    this.elementId = (await this.parent.$(this.selector)).elementId
+    return this.elementId ? await this.isElementDisplayed(this.elementId) : false
 }

--- a/packages/webdriverio/src/commands/element/isDisplayed.js
+++ b/packages/webdriverio/src/commands/element/isDisplayed.js
@@ -41,6 +41,13 @@
  */
 
 export default async function isDisplayed() {
-    this.elementId = (await this.parent.$(this.selector)).elementId
+
+    /*
+     * This is only necessary as isDisplayed is on the exclusion list for the middleware
+     */
+    if (!this.elementId) {
+        this.elementId = (await this.parent.$(this.selector)).elementId
+    }
+
     return this.elementId ? await this.isElementDisplayed(this.elementId) : false
 }

--- a/packages/webdriverio/src/commands/element/isDisplayed.js
+++ b/packages/webdriverio/src/commands/element/isDisplayed.js
@@ -41,5 +41,8 @@
  */
 
 export default function isDisplayed() {
-    return this.elementId ? this.isElementDisplayed(this.elementId) : false
+    return this.parent.$(this.selector).then((elem) => {
+        this.elementId = elem.elementId
+        return this.elementId ? this.isElementDisplayed(this.elementId) : false
+    })
 }

--- a/packages/webdriverio/src/commands/element/isDisplayed.js
+++ b/packages/webdriverio/src/commands/element/isDisplayed.js
@@ -41,5 +41,5 @@
  */
 
 export default function isDisplayed() {
-    return this.isElementDisplayed(this.elementId)
+    return this.elementId ? this.isElementDisplayed(this.elementId) : false
 }

--- a/packages/webdriverio/src/middlewares.js
+++ b/packages/webdriverio/src/middlewares.js
@@ -17,7 +17,7 @@ export const elementErrorHandler = (fn) => (commandName, commandFn) => {
          *  - elementId couldn't be fetched in the first place
          *  - command is not explicit wait command for existance or displayedness
          */
-        if (!this.elementId && !commandName.match(/(wait(Until|ForDisplayed|ForExist|ForEnabled)|isExisting)/)) {
+        if (!this.elementId && !commandName.match(/(wait(Until|ForDisplayed|ForExist|ForEnabled)|isExisting|isDisplayed)/)) {
             log.debug(
                 `command ${commandName} was called on an element ("${this.selector}") ` +
                 'that wasn\'t found, waiting for it...'

--- a/packages/webdriverio/tests/commands/element/isDisplayed.test.js
+++ b/packages/webdriverio/tests/commands/element/isDisplayed.test.js
@@ -17,8 +17,7 @@ describe('isDisplayed test', () => {
 
     it('should allow to check if element is displayed', async () => {
         await elem.isDisplayed()
-        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element')
-        expect(request.mock.calls[3][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/displayed')
+        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/displayed')
     })
 
     afterEach(() => {

--- a/packages/webdriverio/tests/commands/element/isDisplayed.test.js
+++ b/packages/webdriverio/tests/commands/element/isDisplayed.test.js
@@ -17,7 +17,8 @@ describe('isDisplayed test', () => {
 
     it('should allow to check if element is displayed', async () => {
         await elem.isDisplayed()
-        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/displayed')
+        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element')
+        expect(request.mock.calls[3][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/displayed')
     })
 
     afterEach(() => {

--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -12,6 +12,13 @@ describe('smoke test', () => {
         assert.doesNotThrow(() => elem.click())
     })
 
+    it('should NOT wait for elements when isDisplayed is called', () => {
+        browser.isDisplayedScenario()
+        const elem = $('elem')
+
+        assert.equal(elem.isDisplayed(), false)
+    });
+
     it('should refetch elements', () => {
         browser.staleElementRefetchScenario()
 

--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -9,7 +9,7 @@ describe('smoke test', () => {
         browser.waitForElementScenario()
         const elem = $('elem')
         //Element will be found
-        elem.click()
+        assert.doesNotThrow(() => elem.click())
     })
 
     it('should refetch elements', () => {

--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -5,26 +5,37 @@ describe('smoke test', () => {
         assert.equal(browser.getTitle(), 'Mock Page Title')
     })
 
-    it('should wait for elements if not found immediately', () => {
-        browser.waitForElementScenario()
-        const elem = $('elem')
-        //Element will be found
-        assert.doesNotThrow(() => elem.click())
+    describe('middleware', () => {
+        it('should wait for elements if not found immediately', () => {
+            browser.waitForElementScenario()
+            const elem = $('elem')
+            //Element will be found
+            assert.doesNotThrow(() => elem.click())
+        })
+
+        it('should refetch stale elements', () => {
+            browser.staleElementRefetchScenario()
+
+            const elem = $('elem')
+            elem.click()
+            // element becomes stale
+            elem.click()
+        })
     })
 
-    it('should NOT wait for elements when isDisplayed is called', () => {
-        browser.isDisplayedScenario()
-        const elem = $('elem')
+    describe('isDisplayed', () => {
+        it('should return false if element is never found', () => {
+            browser.isNeverDisplayedScenario()
+            const elem = $('elem')
 
-        assert.equal(elem.isDisplayed(), false)
-    });
+            assert.equal(elem.isDisplayed(), false)
+        })
 
-    it('should refetch elements', () => {
-        browser.staleElementRefetchScenario()
+        it('should reFetch the element once', () => {
+            browser.isEventuallyDisplayedScenario()
+            const elem = $('elem')
 
-        const elem = $('elem')
-        elem.click()
-        // element becomes stale
-        elem.click()
+            assert.equal(elem.isDisplayed(), true)
+        })
     })
 })

--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -8,7 +8,8 @@ describe('smoke test', () => {
     it('should wait for elements if not found immediately', () => {
         browser.waitForElementScenario()
         const elem = $('elem')
-        assert.equal(elem.isDisplayed(), true)
+        //Element will be found
+        elem.click()
     })
 
     it('should refetch elements', () => {


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)
Currently isDisplayed() is being handled by the middleware, and forcing the command to waitForExist (1st problem for negative tests), as well as throwing an error if not found (2nd problem for negative tests). isDisplayed() will now properly immediately check and return false if not found or it doesn't exist.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
