### PR TITLE
docs: Fix element commnads referencing the browser object

### DIFF
--- a/scripts/generate-docs.js
+++ b/scripts/generate-docs.js
@@ -148,7 +148,7 @@ for (const [type, [namePlural, nameSingular]] of Object.entries(plugins)) {
         const name = pkg.split('-').slice(1,-1)
         const id = `${name.join('-')}-${type}`
         const pkgName = name.map((n) => n[0].toUpperCase() + n.slice(1)).join(' ')
-        const readme = fs.readFileSync(path.join(__dirname, '..', 'packages', pkg, 'Readme.md')).toString()
+        const readme = fs.readFileSync(path.join(__dirname, '..', 'packages', pkg, 'README.md')).toString()
         const preface = [
             '---',
             `id: ${id}`,

--- a/scripts/templates/api.tpl.ejs
+++ b/scripts/templates/api.tpl.ejs
@@ -16,7 +16,11 @@ title: <?= method.command ?>
 ##### Usage
 
 ```js
-<?= method.isMobile ? 'driver' : 'browser' ?>.<?= method.command ?>(<?= method.paramString ?>)
+<? if (method.element_scope) { ?>
+    $(selector).<?= method.command ?>(<?= method.paramString ?>)
+<? } else { ?>
+    <?= method.isMobile ? 'driver' : 'browser' ?>.<?= method.command ?>(<?= method.paramString ?>)
+<? } ?>
 ```
 
 <? if (method.paramTags.length) { ?>

--- a/scripts/utils/formatter.js
+++ b/scripts/utils/formatter.js
@@ -7,7 +7,7 @@ module.exports = function (docfile) {
 
     let type = (javadoc.ctx && javadoc.ctx.type)
     const name = path.basename(docfile.filename, '.js')
-    const scope = docfile.filename.split('/').slice(-2, -1)
+    const scope = docfile.filename.split('/').slice(-2, -1)[0]
 
     let description = ''
     let paramStr = []
@@ -164,7 +164,8 @@ module.exports = function (docfile) {
         examples: files,
         customEditUrl: `${config.repoUrl}/edit/master/packages/webdriverio/src/commands/${scope}/${name}.js`,
         hasDocusaurusHeader: true,
-        originalId: `api/${scope}/${name}`
+        originalId: `api/${scope}/${name}`,
+        element_scope : scope === 'element',
     }
 
     return commandDescription


### PR DESCRIPTION
## Proposed changes

In the docs for v5 the element commands are being called like the below which is incorrect:

```browser.addValue(value)```

They should be called with something like this:

```
$(selector).clearValue()
```

This fixes the output of the generated docs for element commands.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

### Reviewers: @webdriverio/technical-committee
