### PR TITLE
Updating docs for wdio-junit-reporter

### DIFF
--- a/packages/wdio-junit-reporter/README.md
+++ b/packages/wdio-junit-reporter/README.md
@@ -18,6 +18,7 @@ The easiest way is to keep `@wdio/junit-reporter` as a devDependency in your `pa
 You can simple do it by:
 
 ```bash
+npm install @wdio/reporter --save-dev
 npm install @wdio/junit-reporter --save-dev
 ```
 


### PR DESCRIPTION
Updating doc, user need to install ```@wdio/reporter``` as well

## Proposed changes

Need to update one more line to guide user to install ```@wdio/repoter``` package to avoid error ```Error: Cannot find module '@wdio/reporter'```

### Reviewers: @webdriverio/technical-committee
