### PR TITLE
Jasmine Framework improperly configures test randomization

### DIFF
--- a/packages/wdio-jasmine-framework/src/index.js
+++ b/packages/wdio-jasmine-framework/src/index.js
@@ -60,7 +60,7 @@ class JasmineAdapter {
         jasmineEnv.configure({
             specFilter: ::this.customSpecFilter,
             stopOnSpecFailure: stopOnSpecFailure,
-            randomizeTests: Boolean(this.jasmineNodeOpts.random),
+            random: Boolean(this.jasmineNodeOpts.random),
             failFast: this.jasmineNodeOpts.failFast
         })
 

--- a/packages/wdio-jasmine-framework/tests/adapter.test.js
+++ b/packages/wdio-jasmine-framework/tests/adapter.test.js
@@ -48,6 +48,33 @@ test('should properly set up jasmine', async () => {
     adapter.jrunner.configureDefaultReporter()
 })
 
+test('should properly configure the jasmine environment', async () => {
+    const stopOnSpecFailure = false
+    const random = false
+    const failFast = false
+
+    const adapter = new JasmineAdapter(
+        '0-2',
+        {
+            jasmineNodeOpts: {
+                stopOnSpecFailure,
+                random,
+                failFast,
+            }
+        },
+        ['/foo/bar.test.js'],
+        { browserName: 'chrome' },
+        wdioReporter
+    )
+    await adapter.run()
+    expect(adapter.jrunner.jasmine.getEnv().configure).toBeCalledWith({
+        specFilter: expect.any(Function),
+        stopOnSpecFailure,
+        random,
+        failFast,
+    })
+})
+
 test('set custom ', async () => {
     const config = {
         jasmineNodeOpts: { expectationResultHandler: jest.fn() }


### PR DESCRIPTION
[//]: # NOTE: This repository only maintains packages that are listed in the [Readme](https://github.com/webdriverio/webdriverio/blob/master/README.md#packages). Please make sure that your issue is directly caused by one of these packages and if not file an issue in the correct 3rd party package repository.

**Environment (please complete the following information):**
 - **WebdriverIO version:** 5.1.2 
 - **Mode:** WDIO
 - **If WDIO Testrunner, running sync/async:** sync
 - **Node.js version:** 8.9.4
 - **NPM version:** 6.1.0
 - **Browser name and version:** [e.g. Chrome 68]
 - **Platform name and version:** [e.g. Windows 10]
 - **Additional wdio packages used (if applicable):** 
    "@wdio/jasmine-framework": "^5.1.0",

**Config of WebdriverIO**
```
    jasmineNodeOpts: {
      random: false,
      defaultTimeoutInterval: 9999999,
    },
```

**Describe the bug**
Jasmine 3+ has test randomization enabled by default. The WDIO jasmine framework allows overriding this behaviour by specifying `random` in the `jasmineNodeOpts` section.

**To Reproduce**
Steps to reproduce the behavior:

Create a spec with at least 2 test cases.

**Expected behavior**
When setting random to false, I expect the cases to be run in the order as they appear in the file.

https://jasmine.github.io/api/3.3/Env.html
The Env object has a deprecated method `randomizeTests` to enable/disable test randomization. However, it is recommended to use `.configure()` to set the jasmine configuration, which is called by the wdio jasmine framework. However, the `configure()` method takes a configuration parameter where the test randomization field is called `random` instead of `randomizeTests`, of which the latter is the one provided by the wdio jasmine framework. 
The config parameter should be renamed to `random`.
