### PR TITLE
Update other commands which allow/expect 'null' as value.

### DIFF
--- a/packages/webdriver/protocol/appium.json
+++ b/packages/webdriver/protocol/appium.json
@@ -748,7 +748,7 @@
       "ref": "http://appium.io/docs/en/commands/device/app/background-app/",
       "parameters": [{
         "name": "duration",
-        "type": "number",
+        "type": "(number|null)",
         "description": "timeout to restore app, if 'null' app won't be restored",
         "default": "null"
       }],

--- a/packages/webdriver/protocol/jsonwp.json
+++ b/packages/webdriver/protocol/jsonwp.json
@@ -219,7 +219,7 @@
       "ref": "https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidframe",
       "parameters": [{
         "name": "id",
-        "type": "(string|number|object)",
+        "type": "(string|number|object|null)",
         "description": "Identifier for the frame to change focus to",
         "required": true
       }]
@@ -874,7 +874,7 @@
       "ref": "https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidmoveto",
       "parameters": [{
         "name": "element",
-        "type": "string",
+        "type": "(string|null)",
         "description": "opaque ID assigned to the element to move to, as described in the WebElement JSON Object, if not specified or is null, the offset is relative to current position of the mouse",
         "required": false
       }, {


### PR DESCRIPTION
## Proposed changes

* Resolves issue with `switchToFrame` command not accepting `null` as valid value for JsonWireProtocol.
* Allow defining of `null` value for `moveToElement` (JsonWireProtocol) command and `background` (Appium) command.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

This should be it hopefully, in #3239 I completely forgot to check other protocols for supported values.

### Reviewers: @webdriverio/technical-committee
