### PR TITLE
webdriverio: updating screenshot call to handle backslash

### DIFF
--- a/packages/webdriverio/src/commands/browser/saveScreenshot.js
+++ b/packages/webdriverio/src/commands/browser/saveScreenshot.js
@@ -32,7 +32,7 @@ export default async function saveScreenshot (filepath) {
         throw new Error('saveScreenshot expects a filepath of type string and ".png" file ending')
     }
 
-    const absoluteFilepath = filepath.startsWith('/')
+    const absoluteFilepath = filepath.startsWith('/') | filepath.startsWith('\\')
         ? filepath
         : path.join(process.cwd(), filepath)
 

--- a/packages/webdriverio/src/commands/browser/saveScreenshot.js
+++ b/packages/webdriverio/src/commands/browser/saveScreenshot.js
@@ -32,7 +32,7 @@ export default async function saveScreenshot (filepath) {
         throw new Error('saveScreenshot expects a filepath of type string and ".png" file ending')
     }
 
-    const absoluteFilepath = filepath.startsWith('/') | filepath.startsWith('\\')
+    const absoluteFilepath = filepath.startsWith('/') || filepath.startsWith('\\')
         ? filepath
         : path.join(process.cwd(), filepath)
 

--- a/packages/webdriverio/tests/__mocks__/fs.js
+++ b/packages/webdriverio/tests/__mocks__/fs.js
@@ -1,4 +1,4 @@
 const fs = jest.genMockFromModule('fs')
-fs.writeFileSync = (path, data, options) => path
+fs.writeFileSync = (path, data, options) => {path, data, options}
 fs.existsSync = () => true
 export default fs

--- a/packages/webdriverio/tests/__mocks__/fs.js
+++ b/packages/webdriverio/tests/__mocks__/fs.js
@@ -1,4 +1,4 @@
 const fs = jest.genMockFromModule('fs')
-fs.writeFileSync = (path, data, options) => {path, data, options}
-fs.existsSync = () => true
+fs.writeFileSync = jest.fn()
+fs.existsSync = jest.fn(() => true)
 export default fs

--- a/packages/webdriverio/tests/__mocks__/fs.js
+++ b/packages/webdriverio/tests/__mocks__/fs.js
@@ -1,4 +1,4 @@
 const fs = jest.genMockFromModule('fs')
-fs.writeFileSync = jest.fn()
+fs.writeFileSync = (path, data, options) => path
 fs.existsSync = () => true
 export default fs

--- a/packages/webdriverio/tests/commands/browser/saveScreenshot.test.js
+++ b/packages/webdriverio/tests/commands/browser/saveScreenshot.test.js
@@ -1,5 +1,6 @@
 import request from 'request'
 import { remote } from '../../../src'
+import path from 'path'
 
 describe('saveScreenshot', () => {
     jest.mock('fs')
@@ -75,9 +76,9 @@ describe('saveScreenshot', () => {
         fs.existsSync = () => true
         spy = jest.spyOn(fs, 'writeFileSync')
 
-        await browser.saveScreenshot('packages\\bar.png')
+        await browser.saveScreenshot('packages/bar.png')
 
         expect(spy).toHaveBeenCalledTimes(1)
-        expect(spy).toHaveBeenCalledWith(process.cwd() + '\\packages\\bar.png', expect.any(Buffer))
+        expect(spy).toHaveBeenCalledWith(path.join(process.cwd(), 'packages/bar.png'), expect.any(Buffer))
     })
 })

--- a/packages/webdriverio/tests/commands/browser/saveScreenshot.test.js
+++ b/packages/webdriverio/tests/commands/browser/saveScreenshot.test.js
@@ -4,6 +4,8 @@ import path from 'path'
 
 describe('saveScreenshot', () => {
     jest.mock('fs')
+    const fs = require('fs').default
+
     let browser
     let spy
 
@@ -14,6 +16,9 @@ describe('saveScreenshot', () => {
                 browserName: 'foobar'
             }
         })
+
+        spy = jest.spyOn(fs, 'writeFileSync')
+        fs.existsSync.mockReturnValue(true)
     })
 
     afterEach(() => {
@@ -41,8 +46,7 @@ describe('saveScreenshot', () => {
     })
 
     it('should fail if not existing directory', async () => {
-        const fs = require('fs').default
-        fs.existsSync = () => false
+        fs.existsSync.mockReturnValue(false)
 
         await expect(
             browser.saveScreenshot('/i/dont/exist.png')
@@ -50,10 +54,6 @@ describe('saveScreenshot', () => {
     })
 
     it('should not change filepath if starts with forward slash', async () => {
-        const fs = require('fs').default
-        fs.existsSync = () => true
-        spy = jest.spyOn(fs, 'writeFileSync')
-
         await browser.saveScreenshot('/packages/bar.png')
 
         expect(spy).toHaveBeenCalledTimes(1)
@@ -61,10 +61,6 @@ describe('saveScreenshot', () => {
     })
 
     it('should not change filepath if starts with backslash slash', async () => {
-        const fs = require('fs').default
-        fs.existsSync = () => true
-        spy = jest.spyOn(fs, 'writeFileSync')
-
         await browser.saveScreenshot('\\packages\\bar.png')
 
         expect(spy).toHaveBeenCalledTimes(1)
@@ -72,10 +68,6 @@ describe('saveScreenshot', () => {
     })
 
     it('should change filepath if does not start with forward or back slash', async () => {
-        const fs = require('fs').default
-        fs.existsSync = () => true
-        spy = jest.spyOn(fs, 'writeFileSync')
-
         await browser.saveScreenshot('packages/bar.png')
 
         expect(spy).toHaveBeenCalledTimes(1)


### PR DESCRIPTION
## Proposed changes

Updating the ```saveScreenshot``` method to be able to start with a backslash.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

 I wanted to introduce this because when trying to save a screenshot to a network location the filepath starts with ```\\\\``` (Two backslashes and two escape characters). Before this, it would just append the server path to the current directory.

### Reviewers: @webdriverio/technical-committee
