### PR TITLE
wdio-reporter: updating pending test uid if existing

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   },
   "jest": {
     "testMatch": [
-      "<rootDir>/**/tests/**/*.test.js"
+      "/**/tests/**/*.test.js"
     ],
     "testPathIgnorePatterns": [
       "<rootDir>/tests/",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   },
   "jest": {
     "testMatch": [
-      "/**/tests/**/*.test.js"
+      "<rootDir>/**/tests/**/*.test.js"
     ],
     "testPathIgnorePatterns": [
       "<rootDir>/tests/",

--- a/packages/wdio-reporter/src/index.js
+++ b/packages/wdio-reporter/src/index.js
@@ -111,6 +111,8 @@ export default class WDIOReporter extends EventEmitter {
             const currentSuite = this.currentSuites[this.currentSuites.length - 1]
             currentTest = new TestStats(test)
 
+            currentTest.uid = test.uid in this.tests ? 'skipped-' + this.counts.skipping : currentTest.uid;
+
             /**
              * In Mocha: tests that are skipped don't have a start event but a test end.
              * In Jasmine: tests have a start event, therefor we need to replace the

--- a/packages/wdio-reporter/src/index.js
+++ b/packages/wdio-reporter/src/index.js
@@ -111,13 +111,14 @@ export default class WDIOReporter extends EventEmitter {
             const currentSuite = this.currentSuites[this.currentSuites.length - 1]
             currentTest = new TestStats(test)
 
-            currentTest.uid = test.uid in this.tests ? 'skipped-' + this.counts.skipping : currentTest.uid
-
             /**
              * In Mocha: tests that are skipped don't have a start event but a test end.
              * In Jasmine: tests have a start event, therefor we need to replace the
              * test instance with the pending test here
              */
+            if (test.uid in this.tests && this.tests[test.uid].state !== 'pending') {
+                currentTest.uid = test.uid in this.tests ? 'skipped-' + this.counts.skipping : currentTest.uid
+            }
             const suiteTests = currentSuite.tests
             if (!suiteTests.length || currentTest.uid !== suiteTests[suiteTests.length - 1].uid) {
                 currentSuite.tests.push(currentTest)
@@ -125,7 +126,7 @@ export default class WDIOReporter extends EventEmitter {
                 suiteTests[suiteTests.length - 1] = currentTest
             }
 
-            this.tests[test.uid] = currentTest
+            this.tests[currentTest.uid] = currentTest
             currentTest.skip()
             this.counts.skipping++
             this.counts.tests++

--- a/packages/wdio-reporter/src/index.js
+++ b/packages/wdio-reporter/src/index.js
@@ -111,7 +111,7 @@ export default class WDIOReporter extends EventEmitter {
             const currentSuite = this.currentSuites[this.currentSuites.length - 1]
             currentTest = new TestStats(test)
 
-            currentTest.uid = test.uid in this.tests ? 'skipped-' + this.counts.skipping : currentTest.uid;
+            currentTest.uid = test.uid in this.tests ? 'skipped-' + this.counts.skipping : currentTest.uid
 
             /**
              * In Mocha: tests that are skipped don't have a start event but a test end.

--- a/packages/wdio-reporter/src/index.js
+++ b/packages/wdio-reporter/src/index.js
@@ -107,7 +107,7 @@ export default class WDIOReporter extends EventEmitter {
             this.onTestFail(testStat)
         })
 
-        this.on('test:pending',  /* istanbul ignore next */ (test) => {
+        this.on('test:pending', (test) => {
             const currentSuite = this.currentSuites[this.currentSuites.length - 1]
             currentTest = new TestStats(test)
 

--- a/packages/wdio-reporter/tests/reporter.listeners.test.js
+++ b/packages/wdio-reporter/tests/reporter.listeners.test.js
@@ -1,0 +1,143 @@
+import WDIOReporter from "../src"
+import tmp from 'tmp'
+import TestStats from "../src/stats/test";
+
+describe('WDIOReporter Listeners', () => {
+    let stat
+    let reporter
+    let spy
+    let spy2
+
+    beforeEach(() => {
+        stat = { type: 'test:start',
+            title: 'should can do something',
+            parent: 'My awesome feature',
+            fullTitle: 'My awesome feature should can do something',
+            pending: false,
+            cid: '0-0',
+            specs: [ '/path/to/test/specs/sync.spec.js' ],
+            uid: '0-0'
+        }
+
+        stat.complete = jest.fn()
+    })
+
+    beforeEach(() => {
+        const tmpobj = tmp.fileSync()
+        reporter = new WDIOReporter({ logFile: tmpobj.name })
+    })
+
+    describe('Pending Listener', () => {
+        beforeEach(() => {
+            spy = jest.spyOn(WDIOReporter.prototype, 'onTestSkip')
+            spy2 = jest.spyOn(TestStats.prototype, 'skip')
+        })
+        
+        afterEach(() => {
+            spy.mockClear()
+            spy2.mockClear()
+        })
+
+        it('should add a pending test to the test list', () => {
+            reporter.emit('test:pending', stat)
+            expect(reporter.tests).toHaveProperty(stat.uid)
+            expect(reporter.counts.skipping).toEqual(1)
+            expect(reporter.counts.tests).toEqual(1)
+            expect(spy).toHaveBeenCalledTimes(1)
+            expect(spy2).toHaveBeenCalledTimes(1)
+        })
+    
+        it('should allow Mocha pending tests with same UID to be added to other tests ', () => {
+            const stats = []
+            stat.uid = '0-0-0'
+            stats.push(Object.assign({}, stat))
+            stat.uid = '0-0-1'
+            stats.push(Object.assign({}, stat))
+            stat.uid = '0-0-2'
+            stats.push(Object.assign({}, stat))
+    
+            reporter.emit('test:start', stats[0])
+            reporter.emit('test:pass', stats[0])
+            reporter.emit('test:start', stats[1])
+            reporter.emit('test:fail', stats[1])
+    
+            // If new uid is not generated for pending test
+            reporter.emit('test:pending', stats[1])
+
+            reporter.emit('test:pending', stats[2])
+
+            expect(spy).toHaveBeenCalledTimes(2)
+            expect(spy2).toHaveBeenCalledTimes(2)
+
+            // Make sure all tests are present
+            expect(reporter.tests).toHaveProperty(stats[0].uid)
+            expect(reporter.tests).toHaveProperty(stats[1].uid)
+            expect(reporter.tests).toHaveProperty('skipped-0')
+            expect(reporter.tests).toHaveProperty(stats[2].uid)
+
+            // Make sure there are only 4 tests
+            expect(Object.keys(reporter.tests).length).toEqual(4)
+    
+            // Make sure all tests have the right state
+            expect(reporter.tests[stats[0].uid].state).toEqual('passed')
+            expect(reporter.tests[stats[1].uid].state).toEqual('failed')
+            expect(reporter.tests['skipped-0'].state).toEqual('skipped')
+            expect(reporter.tests[stats[2].uid].state).toEqual('skipped')
+
+            // Make sure all tests are in the suite
+            expect(reporter.currentSuites[0].tests.length).toEqual(4)
+            expect(reporter.currentSuites[0].tests[0].uid).toEqual(stats[0].uid)
+            expect(reporter.currentSuites[0].tests[1].uid).toEqual(stats[1].uid)
+            expect(reporter.currentSuites[0].tests[2].uid).toEqual('skipped-0')
+            expect(reporter.currentSuites[0].tests[3].uid).toEqual(stats[2].uid)
+    
+            // Make sure the counts are updated
+            expect(reporter.counts.skipping).toEqual(2)
+            expect(reporter.counts.tests).toEqual(4)
+        })
+
+        it('should allow Jasmine pending tests to be added to the test list', () => {
+            const stats = []
+            stat.uid = '0-0-0'
+            stats.push(Object.assign({}, stat))
+            stat.uid = '0-0-1'
+            stats.push(Object.assign({}, stat))
+            stat.uid = '0-0-2'
+            stats.push(Object.assign({}, stat))
+    
+            reporter.emit('test:start', stats[0])
+            reporter.emit('test:pass', stats[0])
+            reporter.emit('test:start', stats[1])
+            reporter.emit('test:fail', stats[1])
+            reporter.emit('test:start', stats[2])
+            reporter.emit('test:pending', stats[2])
+
+            expect(spy).toHaveBeenCalledTimes(1)
+            expect(spy2).toHaveBeenCalledTimes(1)
+
+            // Make sure all tests are present
+            expect(reporter.tests).toHaveProperty(stats[0].uid)
+            expect(reporter.tests).toHaveProperty(stats[1].uid)
+            expect(reporter.tests).toHaveProperty(stats[2].uid)
+
+            // Make sure there are only 4 tests
+            expect(Object.keys(reporter.tests).length).toEqual(3)
+            expect(reporter.tests).not.toHaveProperty('skipped-0')
+
+            // Make sure all tests have the right state
+            expect(reporter.tests[stats[0].uid].state).toEqual('passed')
+            expect(reporter.tests[stats[1].uid].state).toEqual('failed')
+            expect(reporter.tests[stats[2].uid].state).toEqual('skipped')
+
+            // Make sure all tests are in the suite
+            expect(reporter.currentSuites[0].tests.length).toEqual(3)
+            expect(reporter.currentSuites[0].tests[0].uid).toEqual(stats[0].uid)
+            expect(reporter.currentSuites[0].tests[1].uid).toEqual(stats[1].uid)
+            expect(reporter.currentSuites[0].tests[2].uid).toEqual(stats[2].uid)
+
+            // Make sure the counts are updated
+            expect(reporter.counts.skipping).toEqual(1)
+            expect(reporter.counts.tests).toEqual(3)
+        })
+    })
+})

--- a/packages/wdio-reporter/tests/reporter.listeners.test.js
+++ b/packages/wdio-reporter/tests/reporter.listeners.test.js
@@ -47,14 +47,12 @@ describe('WDIOReporter Listeners', () => {
             expect(spy2).toHaveBeenCalledTimes(1)
         })
     
-        it('should allow Mocha pending tests with same UID to be added to other tests ', () => {
+        it.only('should allow Mocha pending tests with same UID to be added to other tests ', () => {
             const stats = []
-            stat.uid = '0-0-0'
-            stats.push(Object.assign({}, stat))
-            stat.uid = '0-0-1'
-            stats.push(Object.assign({}, stat))
-            stat.uid = '0-0-2'
-            stats.push(Object.assign({}, stat))
+            stats.push({ ...stat, uid: '0-0-0' })
+            stats.push({ ...stat, uid: '0-0-1' })
+            stats.push({ ...stat, uid: '0-0-2' })
+            stats.push({ ...stat, uid: '0-0-3' })
     
             reporter.emit('test:start', stats[0])
             reporter.emit('test:pass', stats[0])
@@ -63,47 +61,52 @@ describe('WDIOReporter Listeners', () => {
     
             // If new uid is not generated for pending test
             reporter.emit('test:pending', stats[1])
+            reporter.emit('test:pending', stats[1])
 
             reporter.emit('test:pending', stats[2])
+            reporter.emit('test:pending', stats[3])
 
-            expect(spy).toHaveBeenCalledTimes(2)
-            expect(spy2).toHaveBeenCalledTimes(2)
+            expect(spy).toHaveBeenCalledTimes(4)
+            expect(spy2).toHaveBeenCalledTimes(4)
 
             // Make sure all tests are present
             expect(reporter.tests).toHaveProperty(stats[0].uid)
             expect(reporter.tests).toHaveProperty(stats[1].uid)
             expect(reporter.tests).toHaveProperty('skipped-0')
+            expect(reporter.tests).toHaveProperty('skipped-1')
             expect(reporter.tests).toHaveProperty(stats[2].uid)
+            expect(reporter.tests).toHaveProperty(stats[3].uid)
 
             // Make sure there are only 4 tests
-            expect(Object.keys(reporter.tests).length).toEqual(4)
+            expect(Object.keys(reporter.tests).length).toEqual(6)
     
             // Make sure all tests have the right state
             expect(reporter.tests[stats[0].uid].state).toEqual('passed')
             expect(reporter.tests[stats[1].uid].state).toEqual('failed')
             expect(reporter.tests['skipped-0'].state).toEqual('skipped')
+            expect(reporter.tests['skipped-1'].state).toEqual('skipped')
             expect(reporter.tests[stats[2].uid].state).toEqual('skipped')
+            expect(reporter.tests[stats[3].uid].state).toEqual('skipped')
 
             // Make sure all tests are in the suite
-            expect(reporter.currentSuites[0].tests.length).toEqual(4)
+            expect(reporter.currentSuites[0].tests.length).toEqual(6)
             expect(reporter.currentSuites[0].tests[0].uid).toEqual(stats[0].uid)
             expect(reporter.currentSuites[0].tests[1].uid).toEqual(stats[1].uid)
             expect(reporter.currentSuites[0].tests[2].uid).toEqual('skipped-0')
-            expect(reporter.currentSuites[0].tests[3].uid).toEqual(stats[2].uid)
+            expect(reporter.currentSuites[0].tests[3].uid).toEqual('skipped-1')
+            expect(reporter.currentSuites[0].tests[4].uid).toEqual(stats[2].uid)
+            expect(reporter.currentSuites[0].tests[5].uid).toEqual(stats[3].uid)
     
             // Make sure the counts are updated
-            expect(reporter.counts.skipping).toEqual(2)
-            expect(reporter.counts.tests).toEqual(4)
+            expect(reporter.counts.skipping).toEqual(4)
+            expect(reporter.counts.tests).toEqual(6)
         })
 
         it('should allow Jasmine pending tests to be added to the test list', () => {
             const stats = []
-            stat.uid = '0-0-0'
-            stats.push(Object.assign({}, stat))
-            stat.uid = '0-0-1'
-            stats.push(Object.assign({}, stat))
-            stat.uid = '0-0-2'
-            stats.push(Object.assign({}, stat))
+            stats.push({ ...stat, uid: '0-0-0' })
+            stats.push({ ...stat, uid: '0-0-1' })
+            stats.push({ ...stat, uid: '0-0-2' })
     
             reporter.emit('test:start', stats[0])
             reporter.emit('test:pass', stats[0])

--- a/packages/wdio-reporter/tests/reporter.listeners.test.js
+++ b/packages/wdio-reporter/tests/reporter.listeners.test.js
@@ -47,7 +47,7 @@ describe('WDIOReporter Listeners', () => {
             expect(spy2).toHaveBeenCalledTimes(1)
         })
     
-        it.only('should allow Mocha pending tests with same UID to be added to other tests ', () => {
+        it('should allow Mocha pending tests with same UID to be added to other tests ', () => {
             const stats = []
             stats.push({ ...stat, uid: '0-0-0' })
             stats.push({ ...stat, uid: '0-0-1' })

--- a/packages/wdio-reporter/tests/reporter.listeners.test.js
+++ b/packages/wdio-reporter/tests/reporter.listeners.test.js
@@ -1,6 +1,6 @@
-import WDIOReporter from "../src"
+import WDIOReporter from '../src'
 import tmp from 'tmp'
-import TestStats from "../src/stats/test";
+import TestStats from '../src/stats/test'
 
 describe('WDIOReporter Listeners', () => {
     let stat

--- a/packages/wdio-reporter/tests/reporter.listeners.test.js
+++ b/packages/wdio-reporter/tests/reporter.listeners.test.js
@@ -32,7 +32,7 @@ describe('WDIOReporter Listeners', () => {
             spy = jest.spyOn(WDIOReporter.prototype, 'onTestSkip')
             spy2 = jest.spyOn(TestStats.prototype, 'skip')
         })
-        
+
         afterEach(() => {
             spy.mockClear()
             spy2.mockClear()
@@ -120,7 +120,7 @@ describe('WDIOReporter Listeners', () => {
             expect(reporter.tests).toHaveProperty(stats[1].uid)
             expect(reporter.tests).toHaveProperty(stats[2].uid)
 
-            // Make sure there are only 4 tests
+            // Make sure there are only 3 tests
             expect(Object.keys(reporter.tests).length).toEqual(3)
             expect(reporter.tests).not.toHaveProperty('skipped-0')
 


### PR DESCRIPTION
## Proposed changes

When using a package like ```mocha-steps``` that sets the remaining tests to pending after a failure, Mocha does not generate a new UID for the test. This was causing it to get overwritten and only showing the tests that passed and the last test to be skipped like this:
![capture](https://user-images.githubusercontent.com/31546234/50707362-32e23d00-1026-11e9-9a7a-aabfb9b252f7.PNG)

This fix changes the skipped tests UID if it already exists so it does not overwrite the previous test.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

### Reviewers: @webdriverio/technical-committee
