### PR TITLE
Fix package name and fix typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,7 +96,7 @@ Commits that affect all packages or are not related to any (e.g. changes to NPM 
 
 ## Release New Version
 
-Package releases are made using Lerna's release capabilities and executed by [the technical committee](https://github.com/webdriverio/webdriverio/blob/master/GOVERNANCE.md#the-technical-committee) only. Before you can start please export an `GITHUB_AUTH` token into your environment in order to allow [`lerna-changelog`](https://www.npmjs.com/package/lerna-changelog#github-token) to gather data about the upcomming release and autogenerate the [CHANGELOG.md](/CHANGELOG.md). Go to your [personal access token](https://github.com/settings/tokens) settings page and generate such token with only having the `public_repo` field enabled. Then export it into your environment:
+Package releases are made using Lerna's release capabilities and executed by [the technical committee](https://github.com/webdriverio/webdriverio/blob/master/GOVERNANCE.md#the-technical-committee) only. Before you can start please export an `GITHUB_AUTH` token into your environment in order to allow [`lerna-changelog`](https://www.npmjs.com/package/lerna-changelog#github-token) to gather data about the upcoming release and autogenerate the [CHANGELOG.md](/CHANGELOG.md). Go to your [personal access token](https://github.com/settings/tokens) settings page and generate such token with only having the `public_repo` field enabled. Then export it into your environment:
 
 ```sh
 export GITHUB_AUTH=...
@@ -111,4 +111,4 @@ $ git pull origin master
 $ npm run release
 ```
 
-and choose the appropiate version upgrade based on the [Semantic Versioning](https://semver.org/).
+and choose the appropriate version upgrade based on the [Semantic Versioning](https://semver.org/).

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -5,7 +5,7 @@ title: WDIO CLI Options
 
 WebdriverIO comes with its own test runner to help you get started with integration testing as quickly as possible. All the fiddling around hooking up WebdriverIO with a test framework belongs to the past. The WebdriverIO runner does all the work for you and helps you to run your tests as efficiently as possible.
 
-Starting with v5 of WebdriverIO the testrunner will be bundled as a seperated NPM package `@wdio/cli`. To see the command line interface help just type the following command in your terminal:
+Starting with v5 of WebdriverIO the testrunner will be bundled as a separate NPM package `@wdio/cli`. To see the command line interface help just type the following command in your terminal:
 
 ```sh
 $ npm install @wdio/cli

--- a/packages/wdio-config/src/shim.js
+++ b/packages/wdio-config/src/shim.js
@@ -66,7 +66,7 @@ export let hasWdioSyncSupport = false
 try {
     // eslint-disable-next-line import/no-unresolved
     const wdioSync = require('@wdio/sync')
-    log.debug('wdio-sync found, running tests synchronous')
+    log.debug('@wdio/sync found, running tests synchronous')
 
     hasWdioSyncSupport = true
     runFnInFiberContext = wdioSync.runFnInFiberContext
@@ -74,5 +74,5 @@ try {
     wrapCommand = wdioSync.wrapCommand
     executeHooksWithArgs = wdioSync.executeHooksWithArgs
 } catch (e) {
-    log.debug('wdio-sync not found, running tests asynchronous')
+    log.debug('@wdio/sync not found, running tests asynchronous')
 }

--- a/scripts/generate-sub-package.js
+++ b/scripts/generate-sub-package.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * This script generates new sub package with intial structure and files
+ * This script generates new sub package with initial structure and files
  */
 
 const fs = require('fs')

--- a/website/blog/2018-12-19-webdriverio-v5-released.md
+++ b/website/blog/2018-12-19-webdriverio-v5-released.md
@@ -28,7 +28,7 @@ We wanted to start this effort completely community driven, and began to gather 
 
 As we moved to a monolithic system we scoped all WebdriverIO packages into the [`@wdio`](https://www.npmjs.com/org/wdio) NPM organization. This would make it simpler to onboard contributors to release new package versions, and better clarifies which packages are "officially" maintained by the organization or are 3rd party community packages.<br>
 <br>
-If you have been using `wdio-mocha-framework` or `wdio-spec-reporter` in your project please update the packages to use the ones built for v5: `@wdio/mocha-framework` or `@wdio/spec-reporter`. Going foward the version number of all packages are now pinned to each other; meaning that you should always have the same versions for all "official" WebdriverIO packages that you use.
+If you have been using `wdio-mocha-framework` or `wdio-spec-reporter` in your project please update the packages to use the ones built for v5: `@wdio/mocha-framework` or `@wdio/spec-reporter`. Going forward the version number of all packages are now pinned to each other; meaning that you should always have the same versions for all "official" WebdriverIO packages that you use.
 
 ## We Did Some Spring Cleaning
 


### PR DESCRIPTION
I found an old logger debug printout that refers to "wdio-sync" and I changed it to say @wdio/sync instead. Also fixed a few typos in the docs etc in a separate commit.

### Reviewers: @webdriverio/technical-committee
