### PR TITLE
Properly extend base protocol with extension command definitions.

### DIFF
--- a/packages/webdriver/src/utils.js
+++ b/packages/webdriver/src/utils.js
@@ -1,6 +1,7 @@
 import logger from '@wdio/logger'
 
 import command from './command'
+import merge from 'lodash.merge'
 import WebDriverProtocol from '../protocol/webdriver.json'
 import MJsonWProtocol from '../protocol/mjsonwp.json'
 import JsonWProtocol from '../protocol/jsonwp.json'
@@ -118,7 +119,7 @@ export function getArgumentType (arg) {
  */
 export function getPrototype (isW3C, isChrome) {
     const prototype = {}
-    const ProtocolCommands = Object.assign(
+    const ProtocolCommands = merge(
         isW3C ? WebDriverProtocol : JsonWProtocol,
         MJsonWProtocol,
         AppiumProtocol,

--- a/packages/webdriver/tests/utils.test.js
+++ b/packages/webdriver/tests/utils.test.js
@@ -78,6 +78,8 @@ describe('utils', () => {
         const chromiumPrototype = getPrototype(false, true)
         expect(chromiumPrototype instanceof Object).toBe(true)
         expect(typeof chromiumPrototype.sendCommand.value).toBe('function')
+        expect(typeof chromiumPrototype.getElementValue.value).toBe('function')
+        expect(typeof chromiumPrototype.elementSendKeys.value).toBe('function')
     })
 
     it('commandCallStructure', () => {


### PR DESCRIPTION
## Proposed changes

* Resolves issue with `elementSendKeys` command no longer being available due to Chromium definitions using same route (__/session/:sessionId/element/:elementId/value__) and overriding command definitions of base protocol.

Fixes #3265.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

### Reviewers: @webdriverio/technical-committee
