### PR TITLE
webdriverio: waitForDisplayed() now inherits isDisplayed() logic

### DIFF
--- a/packages/webdriverio/src/commands/element/waitForDisplayed.js
+++ b/packages/webdriverio/src/commands/element/waitForDisplayed.js
@@ -29,13 +29,6 @@
  */
 
 export default async function waitForDisplayed (ms, reverse = false, error) {
-    /**
-     * if element wasn't found in the first place wait for its existance first
-     */
-    if (!this.elementId && !reverse) {
-        await this.waitForExist(ms, false, error)
-    }
-
     /*
      * ensure that ms is set properly
      */
@@ -47,6 +40,15 @@ export default async function waitForDisplayed (ms, reverse = false, error) {
     const errorMsg = typeof error === 'string' ? error : `element ("${this.selector}") still ${isReversed}displayed after ${ms}ms`
 
     return this.waitUntil(async () => {
+        /*
+         * If element doesn't exist, and not a negative test
+         * check for its existence
+         */
+        if (!this.elementId && !reverse)
+        {
+            this.elementId = (await this.parent.$(this.selector)).elementId
+
+        }
         const isVisible = this.elementId ? await this.isElementDisplayed(this.elementId) : false
 
         return isVisible !== reverse

--- a/packages/webdriverio/src/commands/element/waitForDisplayed.js
+++ b/packages/webdriverio/src/commands/element/waitForDisplayed.js
@@ -39,18 +39,5 @@ export default async function waitForDisplayed (ms, reverse = false, error) {
     const isReversed = reverse ? '' : 'not '
     const errorMsg = typeof error === 'string' ? error : `element ("${this.selector}") still ${isReversed}displayed after ${ms}ms`
 
-    return this.waitUntil(async () => {
-        /*
-         * If element doesn't exist, and not a negative test
-         * check for its existence
-         */
-        if (!this.elementId && !reverse)
-        {
-            this.elementId = (await this.parent.$(this.selector)).elementId
-
-        }
-        const isVisible = this.elementId ? await this.isElementDisplayed(this.elementId) : false
-
-        return isVisible !== reverse
-    }, ms, errorMsg)
+    return this.waitUntil(async () => reverse !== await this.isDisplayed(), ms, errorMsg)
 }

--- a/packages/webdriverio/tests/commands/element/waitForDisplayed.test.js
+++ b/packages/webdriverio/tests/commands/element/waitForDisplayed.test.js
@@ -16,41 +16,12 @@ describe('waitForDisplayed', () => {
         })
     })
 
-    test('should wait for the element to exist', async () => {
-        const tmpElem = await browser.$('#foo')
-        const elem = {
-            waitForDisplayed : tmpElem.waitForDisplayed,
-            waitForExist : jest.fn(),
-            elementId : null,
-            waitUntil : jest.fn(),
-            isElementDisplayed : jest.fn(() => Promise.resolve())
-        }
-
-        await elem.waitForDisplayed(duration)
-        expect(elem.waitForExist).toBeCalled()
-    })
-
-    test('element should already exist on the page', async () => {
-        const tmpElem = await browser.$('#foo')
-        const elem = {
-            waitForDisplayed : tmpElem.waitForDisplayed,
-            waitForExist : jest.fn(),
-            elementId : 123,
-            waitUntil : jest.fn(),
-            isElementDisplayed : jest.fn(() => Promise.resolve())
-        }
-
-        await elem.waitForDisplayed(duration)
-        expect(elem.waitForExist).not.toBeCalled()
-    })
-
     test('should call waitUntil', async () => {
         const cb = jest.fn()
         const tmpElem = await browser.$('#foo')
         const elem = {
             selector : '#foo',
             waitForDisplayed : tmpElem.waitForDisplayed,
-            waitForExist : jest.fn(),
             elementId : 123,
             waitUntil : jest.fn(((cb))),
             isElementDisplayed : jest.fn(() => Promise.resolve())
@@ -63,24 +34,26 @@ describe('waitForDisplayed', () => {
         expect(elem.waitUntil.mock.calls[0][2]).toBe(`element ("#foo") still not displayed after ${duration}ms`)
     })
 
-    test('should call isElementDisplayed and return true', async () => {
+    test('should call isDisplayed and return true immediately if true', async () => {
         const elem = await browser.$('#foo')
         const result = await elem.waitForDisplayed(duration)
 
         expect(result).toBe(true)
-        expect(request.mock.calls[5][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/displayed')
+        expect(request.mock.calls[3][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/displayed')
     })
 
-    test('should call isElementDisplayed and return true', async () => {
+    test('should call isElementDisplayed and return true if eventually true', async () => {
         const tmpElem = await browser.$('#foo')
         const elem = {
             selector : '#foo',
             waitForDisplayed : tmpElem.waitForDisplayed,
-            waitForExist : jest.fn(),
             elementId : 123,
             waitUntil : tmpElem.waitUntil,
-            isElementDisplayed : jest.fn(() => true),
-            options : { waitforTimeout : 500 },
+            isDisplayed : jest.fn()
+                .mockImplementationOnce(() => false)
+                .mockImplementationOnce(() => false)
+                .mockImplementationOnce(() => true),
+            options : { waitforTimeout : 50, waitforInterval: 5 },
         }
 
         const result = await elem.waitForDisplayed(duration)
@@ -92,10 +65,27 @@ describe('waitForDisplayed', () => {
         const elem = {
             selector : '#foo',
             waitForDisplayed : tmpElem.waitForDisplayed,
-            waitForExist : jest.fn(),
             elementId : 123,
             waitUntil : tmpElem.waitUntil,
-            isElementDisplayed : jest.fn(() => false),
+            isDisplayed : jest.fn(() => false),
+            options : { waitforTimeout : 500 },
+        }
+
+        try {
+            await elem.waitForDisplayed(duration)
+        } catch (e) {
+            expect(e.message).toBe(`element ("#foo") still not displayed after ${duration}ms`)
+        }
+    })
+
+    test('should not call isElementDisplayed and return false if never found', async () => {
+        const tmpElem = await browser.$('#foo')
+        const elem = {
+            selector : '#foo',
+            parent: { $: jest.fn(() => { return elem}) },
+            waitForDisplayed : tmpElem.waitForDisplayed,
+            waitUntil : tmpElem.waitUntil,
+            isDisplayed : tmpElem.isDisplayed,
             options : { waitforTimeout : 500 },
         }
 
@@ -112,10 +102,9 @@ describe('waitForDisplayed', () => {
         const elem = {
             selector : '#foo',
             waitForDisplayed : tmpElem.waitForDisplayed,
-            waitForExist : jest.fn(),
             elementId : 123,
             waitUntil : jest.fn(((cb))),
-            isElementDisplayed : jest.fn(() => Promise.resolve()),
+            isDisplayed : jest.fn(() => true),
             options : { waitforTimeout : 500 },
         }
 
@@ -130,10 +119,9 @@ describe('waitForDisplayed', () => {
         const elem = {
             selector : '#foo',
             waitForDisplayed : tmpElem.waitForDisplayed,
-            waitForExist : jest.fn(),
             elementId : 123,
             waitUntil : tmpElem.waitUntil,
-            isElementDisplayed : jest.fn(() => false),
+            isDisplayed : jest.fn(() => false),
             options : { waitforTimeout : 500 },
         }
 

--- a/packages/webdriverio/tests/commands/element/waitForDisplayed.test.js
+++ b/packages/webdriverio/tests/commands/element/waitForDisplayed.test.js
@@ -24,7 +24,6 @@ describe('waitForDisplayed', () => {
             waitForDisplayed : tmpElem.waitForDisplayed,
             elementId : 123,
             waitUntil : jest.fn(((cb))),
-            isElementDisplayed : jest.fn(() => Promise.resolve())
         }
 
         await elem.waitForDisplayed(duration)
@@ -42,7 +41,7 @@ describe('waitForDisplayed', () => {
         expect(request.mock.calls[3][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/displayed')
     })
 
-    test('should call isElementDisplayed and return true if eventually true', async () => {
+    test('should call isDisplayed and return true if eventually true', async () => {
         const tmpElem = await browser.$('#foo')
         const elem = {
             selector : '#foo',
@@ -60,7 +59,7 @@ describe('waitForDisplayed', () => {
         expect(result).toBe(true)
     })
 
-    test('should call isElementDisplayed and return false', async () => {
+    test('should call isDisplayed and return false', async () => {
         const tmpElem = await browser.$('#foo')
         const elem = {
             selector : '#foo',
@@ -78,7 +77,7 @@ describe('waitForDisplayed', () => {
         }
     })
 
-    test('should not call isElementDisplayed and return false if never found', async () => {
+    test('should not call isDisplayed and return false if never found', async () => {
         const tmpElem = await browser.$('#foo')
         const elem = {
             selector : '#foo',


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)
waitForDisplayed as is, calls waitForExist() prior to checking displayedness.  I'm removing this check, as it causes 2 separate loops instead of the expected 1. isDisplayed and waitForDisplayed now have the same logic, and the existence check is handled within isDisplayed.
## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
