### PR TITLE
Fix instance prototype and enable custom commands for elements

### DIFF
--- a/docs/CustomCommands.md
+++ b/docs/CustomCommands.md
@@ -28,6 +28,19 @@ it('should use my custom command', () => {
 });
 ```
 
+__Note:__ if you register a custom command to the browser scope the command won't be accessible for elements. If you want to create custom commands for elements you need to call `addCommand` to an element instance:
+
+```js
+browser.addCommand("myCustomBrowserCommand", (customVar) => ...);
+
+const elem = $('body')
+elem.addCommand("myCustomElementCommand", function (customVar) {
+    return this.getTagName() + ' - ' + this.selector + ' - ' + customVar;
+});
+console.log(typeof browser.myCustomElementCommand); // outputs "undefined"
+console.log(elem.myCustomElementCommand('foobar')); // outputs "body - body - foobar"
+```
+
 Be careful to not overload the `browser` scope with custom commands. It is advised to rather define custom logic into page objects so they are bound to a specific page.
 
 ## Integrate 3rd party libraries

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "collectCoverage": true,
     "coverageThreshold": {
       "global": {
-        "branches": 94,
+        "branches": 95,
         "functions": 96,
         "lines": 96,
         "statements": 96

--- a/packages/wdio-cli/src/utils.js
+++ b/packages/wdio-cli/src/utils.js
@@ -37,8 +37,9 @@ export function getLauncher (config) {
 
             launcher = new Launcher()
         } catch (e) {
-            if (!e.message.match('Couldn\'t find plugin')) {
-                throw new Error(`Couldn't initialise launcher from service "${serviceName}".\n${e.stack}`)
+            if (e.message.startsWith('Couldn\'t find plugin')) {
+                log.error(`Couldn't initialise launcher from service "${serviceName}".\n${e.stack}`)
+                continue
             }
         }
 

--- a/packages/wdio-cli/tests/utils.test.js
+++ b/packages/wdio-cli/tests/utils.test.js
@@ -1,3 +1,5 @@
+import logger from '@wdio/logger'
+
 import { filterPackageName, getLauncher, runServiceHook } from '../src/utils'
 
 jest.mock('@wdio/config', () => {
@@ -52,10 +54,11 @@ test('getLauncher', () => {
     })).toHaveLength(2)
 })
 
-test('getLauncher failing if syntax error', () => {
+test('getLauncher not failing on syntax error', () => {
     expect(() => getLauncher({
         services: ['other-unscoped']
-    })).toThrow('buhh')
+    })).toHaveLength(0)
+    expect(logger().error).toBeCalledTimes(1)
 })
 
 test('runServiceHook', () => {

--- a/packages/wdio-webdriver-mock-service/src/WebDriverMock.js
+++ b/packages/wdio-webdriver-mock-service/src/WebDriverMock.js
@@ -5,10 +5,19 @@ import webdriver from 'webdriver'
 
 import { SESSION_ID } from './constants'
 
-const protocol = new Map()
-for (const [endpoint, methods] of Object.entries(webdriver.WebDriverProtocol)) {
-    for (const [method, commandData] of Object.entries(methods)) {
-        protocol.set(commandData.command, { method, endpoint, commandData })
+const protocols = [
+    webdriver.JsonWProtocol,
+    webdriver.MJsonWProtocol,
+    webdriver.AppiumProtocol,
+    webdriver.ChromiumProtocol
+]
+
+const protocolFlattened = new Map()
+for (const protocol of protocols) {
+    for (const [endpoint, methods] of Object.entries(protocol)) {
+        for (const [method, commandData] of Object.entries(methods)) {
+            protocolFlattened.set(commandData.command, { method, endpoint, commandData })
+        }
     }
 }
 
@@ -20,7 +29,7 @@ export default class WebDriverMock {
     }
 
     get (obj, commandName) {
-        const { method, endpoint, commandData } = protocol.get(commandName)
+        const { method, endpoint, commandData } = protocolFlattened.get(commandName)
 
         return (...args) => {
             let urlPath = path.join(this.path, endpoint).replace(':sessionId', SESSION_ID)

--- a/packages/wdio-webdriver-mock-service/src/index.js
+++ b/packages/wdio-webdriver-mock-service/src/index.js
@@ -21,6 +21,7 @@ export default class WebdriverMockService {
         this.command.newSession().reply(200, newSession)
         this.command.deleteSession().reply(200, deleteSession)
         this.command.getTitle().reply(200, { value: 'Mock Page Title' })
+        this.command.getLogTypes().reply(200, { value: [] })
     }
 
     before () {

--- a/packages/wdio-webdriver-mock-service/src/index.js
+++ b/packages/wdio-webdriver-mock-service/src/index.js
@@ -21,6 +21,8 @@ export default class WebdriverMockService {
         this.command.newSession().reply(200, newSession)
         this.command.deleteSession().reply(200, deleteSession)
         this.command.getTitle().reply(200, { value: 'Mock Page Title' })
+        this.command.getUrl().reply(200, { value: 'https://mymockpage.com' })
+        this.command.getElementRect(ELEMENT_ID).reply(200, { value: { width: 1, height: 2, x: 3, y: 4 } })
         this.command.getLogTypes().reply(200, { value: [] })
     }
 
@@ -37,6 +39,7 @@ export default class WebdriverMockService {
         global.browser.addCommand('isNeverDisplayedScenario', ::this.isNeverDisplayedScenario)
         global.browser.addCommand('isEventuallyDisplayedScenario', ::this.isEventuallyDisplayedScenario)
         global.browser.addCommand('staleElementRefetchScenario', ::this.staleElementRefetchScenario)
+        global.browser.addCommand('customCommandScenario', ::this.customCommandScenario)
     }
 
     waitForElementScenario () {
@@ -86,6 +89,11 @@ export default class WebdriverMockService {
             message: 'stale element reference error'
         } })
         this.command.elementClick(ELEMENT_REFETCHED).once().reply(200, { value: null })
+    }
+
+    customCommandScenario () {
+        const elemResponse = { 'element-6066-11e4-a52e-4f735466cecf': ELEMENT_ID }
+        this.command.findElement().once().reply(200, { value: elemResponse })
     }
 
     nockReset () {

--- a/packages/webdriver/src/index.js
+++ b/packages/webdriver/src/index.js
@@ -54,7 +54,10 @@ export default class WebDriver {
         params.capabilities = response.value.capabilities || response.value
         params.isW3C = isW3CSession(params.capabilities)
 
-        const prototype = Object.assign(getPrototype(params.isW3C, isChromiumSession(params.capabilities)), proto)
+        const isMobile = Boolean(params.capabilities.deviceName || params.capabilities.platformVersion)
+        const prototype = Object.assign(
+            getPrototype(params.isW3C, isChromiumSession(params.capabilities), isMobile),
+            proto)
         const monad = webdriverMonad(params, modifier, prototype)
         return monad(response.value.sessionId || response.sessionId, commandWrapper)
     }

--- a/packages/webdriver/src/monad.js
+++ b/packages/webdriver/src/monad.js
@@ -46,6 +46,11 @@ export default function WebDriver (options, modifier, propertiesObject = {}) {
             }
         }
 
+        /**
+         * assign propertiesObject to itself so the client can be recreated
+         */
+        propertiesObject['__propertiesObject__'] = { value: propertiesObject }
+
         let client = Object.create(prototype, propertiesObject)
         client.sessionId = sessionId
 

--- a/packages/webdriver/src/monad.js
+++ b/packages/webdriver/src/monad.js
@@ -66,7 +66,7 @@ export default function WebDriver (options, modifier, propertiesObject = {}) {
         }
 
         client.addCommand = function (name, func, proto) {
-            unit.lift(name, commandWrapper(name, func), proto)
+            unit.lift(name, func, proto)
         }
 
         return client

--- a/packages/webdriver/src/utils.js
+++ b/packages/webdriver/src/utils.js
@@ -117,13 +117,29 @@ export function getArgumentType (arg) {
 /**
  * creates the base prototype for the webdriver monad
  */
-export function getPrototype (isW3C, isChrome) {
+export function getPrototype (isW3C, isChrome, isMobile) {
     const prototype = {}
     const ProtocolCommands = merge(
-        isW3C ? WebDriverProtocol : JsonWProtocol,
-        MJsonWProtocol,
-        AppiumProtocol,
-        isChrome ? ChromiumProtocol : {}
+        /**
+         * if mobile apply JSONWire and WebDriver protocol because
+         * some legacy JSONWire commands are still used in Appium
+         * (e.g. set/get geolocation)
+         */
+        isMobile
+            ? merge(JsonWProtocol, WebDriverProtocol)
+            : isW3C ? WebDriverProtocol : JsonWProtocol,
+        /**
+         * only apply mobile protocol if session is actually for mobile
+         */
+        isMobile
+            ? merge(MJsonWProtocol, AppiumProtocol)
+            : {},
+        /**
+         * only apply special Chrome commands if session is using Chrome
+         */
+        isChrome
+            ? ChromiumProtocol
+            : {}
     )
 
     for (const [endpoint, methods] of Object.entries(ProtocolCommands)) {

--- a/packages/webdriver/tests/monad.test.js
+++ b/packages/webdriver/tests/monad.test.js
@@ -40,7 +40,6 @@ describe('monad', () => {
 
         client.addCommand('foo', fn)
         expect(client.foo()).toBe('bar')
-        expect(commandWrapperMock).toBeCalledWith('foo', fn)
     })
 
     it('allows to use custom command wrapper', () => {

--- a/packages/webdriver/tests/utils.test.js
+++ b/packages/webdriver/tests/utils.test.js
@@ -68,18 +68,36 @@ describe('utils', () => {
         expect(jsonWireProtocolPrototype instanceof Object).toBe(true)
         expect(typeof jsonWireProtocolPrototype.sendKeys.value).toBe('function')
         expect(typeof jsonWireProtocolPrototype.sendCommand).toBe('undefined')
+        expect(typeof jsonWireProtocolPrototype.lock).toBe('undefined')
 
         const webdriverPrototype = getPrototype(true)
         expect(webdriverPrototype instanceof Object).toBe(true)
         expect(typeof webdriverPrototype.sendKeys).toBe('undefined')
         expect(typeof webdriverPrototype.sendCommand).toBe('undefined')
         expect(typeof webdriverPrototype.performActions.value).toBe('function')
+        expect(typeof webdriverPrototype.lock).toBe('undefined')
 
         const chromiumPrototype = getPrototype(false, true)
         expect(chromiumPrototype instanceof Object).toBe(true)
         expect(typeof chromiumPrototype.sendCommand.value).toBe('function')
         expect(typeof chromiumPrototype.getElementValue.value).toBe('function')
         expect(typeof chromiumPrototype.elementSendKeys.value).toBe('function')
+        expect(typeof chromiumPrototype.lock).toBe('undefined')
+
+        const mobilePrototype = getPrototype(true, false, true)
+        expect(mobilePrototype instanceof Object).toBe(true)
+        expect(typeof mobilePrototype.performActions.value).toBe('function')
+        expect(typeof mobilePrototype.sendKeys.value).toBe('function')
+        expect(typeof mobilePrototype.lock.value).toBe('function')
+        expect(typeof mobilePrototype.getNetworkConnection.value).toBe('function')
+
+        const mobileChromePrototype = getPrototype(true, true, true)
+        expect(mobileChromePrototype instanceof Object).toBe(true)
+        expect(typeof mobileChromePrototype.sendCommand.value).toBe('function')
+        expect(typeof mobileChromePrototype.performActions.value).toBe('function')
+        expect(typeof mobileChromePrototype.sendKeys.value).toBe('function')
+        expect(typeof mobileChromePrototype.lock.value).toBe('function')
+        expect(typeof mobileChromePrototype.getNetworkConnection.value).toBe('function')
     })
 
     it('commandCallStructure', () => {

--- a/packages/webdriverio/src/commands/browser/$$.js
+++ b/packages/webdriverio/src/commands/browser/$$.js
@@ -38,7 +38,7 @@ import { ELEMENT_KEY } from '../../constants'
 
 export default async function $$ (selector) {
     const res = await findElements.call(this, selector)
-    const prototype = Object.assign(this.__propertiesObject__, getWDIOPrototype('element'), { scope: 'element' })
+    const prototype = Object.assign({}, this.__propertiesObject__, getWDIOPrototype('element'), { scope: 'element' })
 
     const elements = res.map((res, i) => {
         const element = webdriverMonad(this.options, (client) => {
@@ -69,7 +69,14 @@ export default async function $$ (selector) {
             return client
         }, prototype)
 
-        return element(this.sessionId, elementErrorHandler(wrapCommand))
+        const elementInstance = element(this.sessionId, elementErrorHandler(wrapCommand))
+
+        const origAddCommand = ::elementInstance.addCommand
+        elementInstance.addCommand = (name, fn) => {
+            this.__propertiesObject__[name] = { value: fn }
+            origAddCommand(name, fn)
+        }
+        return elementInstance
     })
 
     return elements

--- a/packages/webdriverio/src/commands/browser/$$.js
+++ b/packages/webdriverio/src/commands/browser/$$.js
@@ -29,7 +29,7 @@
  * @type utility
  *
  */
-import { webdriverMonad, getPrototype as getWebdriverPrototype } from 'webdriver'
+import { webdriverMonad } from 'webdriver'
 import { wrapCommand } from '@wdio/config'
 
 import { findElements, getPrototype as getWDIOPrototype, getElementFromResponse } from '../../utils'
@@ -38,7 +38,7 @@ import { ELEMENT_KEY } from '../../constants'
 
 export default async function $$ (selector) {
     const res = await findElements.call(this, selector)
-    const prototype = Object.assign(getWebdriverPrototype(this.isW3C), getWDIOPrototype('element'), { scope: 'element' })
+    const prototype = Object.assign(this.__propertiesObject__, getWDIOPrototype('element'), { scope: 'element' })
 
     const elements = res.map((res, i) => {
         const element = webdriverMonad(this.options, (client) => {

--- a/packages/webdriverio/src/commands/browser/$.js
+++ b/packages/webdriverio/src/commands/browser/$.js
@@ -29,7 +29,7 @@
  * @type utility
  *
  */
-import { webdriverMonad, getPrototype as getWebdriverPrototype } from 'webdriver'
+import { webdriverMonad } from 'webdriver'
 import { wrapCommand } from '@wdio/config'
 
 import { findElement, getPrototype as getWDIOPrototype, getElementFromResponse } from '../../utils'
@@ -38,7 +38,7 @@ import { ELEMENT_KEY } from '../../constants'
 
 export default async function $ (selector) {
     const res = await findElement.call(this, selector)
-    const prototype = Object.assign(getWebdriverPrototype(this.isW3C), getWDIOPrototype('element'), { scope: 'element' })
+    const prototype = Object.assign(this.__propertiesObject__, getWDIOPrototype('element'), { scope: 'element' })
 
     const element = webdriverMonad(this.options, (client) => {
         const elementId = getElementFromResponse(res)

--- a/packages/webdriverio/src/commands/browser/$.js
+++ b/packages/webdriverio/src/commands/browser/$.js
@@ -38,7 +38,7 @@ import { ELEMENT_KEY } from '../../constants'
 
 export default async function $ (selector) {
     const res = await findElement.call(this, selector)
-    const prototype = Object.assign(this.__propertiesObject__, getWDIOPrototype('element'), { scope: 'element' })
+    const prototype = Object.assign({}, this.__propertiesObject__, getWDIOPrototype('element'), { scope: 'element' })
 
     const element = webdriverMonad(this.options, (client) => {
         const elementId = getElementFromResponse(res)
@@ -67,5 +67,12 @@ export default async function $ (selector) {
         return client
     }, prototype)
 
-    return element(this.sessionId, elementErrorHandler(wrapCommand))
+    const elementInstance = element(this.sessionId, elementErrorHandler(wrapCommand))
+
+    const origAddCommand = ::elementInstance.addCommand
+    elementInstance.addCommand = (name, fn) => {
+        this.__propertiesObject__[name] = { value: fn }
+        origAddCommand(name, fn)
+    }
+    return elementInstance
 }

--- a/packages/webdriverio/src/commands/element/$$.js
+++ b/packages/webdriverio/src/commands/element/$$.js
@@ -27,7 +27,7 @@
  * @type utility
  *
  */
-import { webdriverMonad, getPrototype as getWebdriverPrototype } from 'webdriver'
+import { webdriverMonad } from 'webdriver'
 import { wrapCommand } from '@wdio/config'
 
 import { findElements, getPrototype as getWDIOPrototype, getElementFromResponse } from '../../utils'
@@ -36,7 +36,7 @@ import { ELEMENT_KEY } from '../../constants'
 
 export default async function $$ (selector) {
     const res = await findElements.call(this, selector)
-    const prototype = Object.assign(getWebdriverPrototype(this.isW3C), getWDIOPrototype('element'), { scope: 'element' })
+    const prototype = Object.assign(this.__propertiesObject__, getWDIOPrototype('element'), { scope: 'element' })
 
     const elements = res.map((res, i) => {
         const element = webdriverMonad(this.options, (client) => {

--- a/packages/webdriverio/src/commands/element/$$.js
+++ b/packages/webdriverio/src/commands/element/$$.js
@@ -36,7 +36,7 @@ import { ELEMENT_KEY } from '../../constants'
 
 export default async function $$ (selector) {
     const res = await findElements.call(this, selector)
-    const prototype = Object.assign(this.__propertiesObject__, getWDIOPrototype('element'), { scope: 'element' })
+    const prototype = Object.assign({}, this.__propertiesObject__, getWDIOPrototype('element'), { scope: 'element' })
 
     const elements = res.map((res, i) => {
         const element = webdriverMonad(this.options, (client) => {
@@ -67,7 +67,14 @@ export default async function $$ (selector) {
             return client
         }, prototype)
 
-        return element(this.sessionId, elementErrorHandler(wrapCommand))
+        const elementInstance = element(this.sessionId, elementErrorHandler(wrapCommand))
+
+        const origAddCommand = ::elementInstance.addCommand
+        elementInstance.addCommand = (name, fn) => {
+            this.__propertiesObject__[name] = { value: fn }
+            origAddCommand(name, fn)
+        }
+        return elementInstance
     })
 
     return elements

--- a/packages/webdriverio/src/commands/element/$.js
+++ b/packages/webdriverio/src/commands/element/$.js
@@ -40,7 +40,7 @@ import { ELEMENT_KEY } from '../../constants'
 
 export default async function $ (selector) {
     const res = await findElement.call(this, selector)
-    const prototype = Object.assign(this.__propertiesObject__, getWDIOPrototype('element'), { scope: 'element' })
+    const prototype = Object.assign({}, this.parent.__propertiesObject__, getWDIOPrototype('element'), { scope: 'element' })
 
     const element = webdriverMonad(this.options, (client) => {
         const elementId = getElementFromResponse(res)
@@ -69,5 +69,12 @@ export default async function $ (selector) {
         return client
     }, prototype)
 
-    return element(this.sessionId, elementErrorHandler(wrapCommand))
+    const elementInstance = element(this.sessionId, elementErrorHandler(wrapCommand))
+
+    const origAddCommand = ::elementInstance.addCommand
+    elementInstance.addCommand = (name, fn) => {
+        this.parent.__propertiesObject__[name] = { value: fn }
+        origAddCommand(name, fn)
+    }
+    return elementInstance
 }

--- a/packages/webdriverio/src/commands/element/$.js
+++ b/packages/webdriverio/src/commands/element/$.js
@@ -31,7 +31,7 @@
  * @type utility
  *
  */
-import { webdriverMonad, getPrototype as getWebdriverPrototype } from 'webdriver'
+import { webdriverMonad } from 'webdriver'
 import { wrapCommand } from '@wdio/config'
 
 import { findElement, getPrototype as getWDIOPrototype, getElementFromResponse } from '../../utils'
@@ -40,7 +40,8 @@ import { ELEMENT_KEY } from '../../constants'
 
 export default async function $ (selector) {
     const res = await findElement.call(this, selector)
-    const prototype = Object.assign(getWebdriverPrototype(this.isW3C), getWDIOPrototype('element'), { scope: 'element' })
+    const prototype = Object.assign(this.__propertiesObject__, getWDIOPrototype('element'), { scope: 'element' })
+
     const element = webdriverMonad(this.options, (client) => {
         const elementId = getElementFromResponse(res)
 

--- a/packages/webdriverio/src/commands/element/getSize.js
+++ b/packages/webdriverio/src/commands/element/getSize.js
@@ -27,7 +27,7 @@
  *
  */
 
-export default async function getElementSize(prop = null) {
+export default async function getSize(prop = null) {
     let rect = {}
 
     if (this.isW3C) {

--- a/packages/webdriverio/tests/__mocks__/request.js
+++ b/packages/webdriverio/tests/__mocks__/request.js
@@ -27,6 +27,14 @@ const requestMock = jest.fn().mockImplementation((params, cb) => {
         }
     }
 
+    if (
+        params.body &&
+        params.body.capabilities &&
+        params.body.capabilities.alwaysMatch.mobileMode
+    ) {
+        sessionResponse.capabilities.deviceName = 'iNode'
+    }
+
     switch (params.uri.path) {
     case '/wd/hub/session':
         value = sessionResponse

--- a/packages/webdriverio/tests/__mocks__/request.js
+++ b/packages/webdriverio/tests/__mocks__/request.js
@@ -49,6 +49,11 @@ const requestMock = jest.fn().mockImplementation((params, cb) => {
         value = {
             [ELEMENT_KEY]: genericElementId
         }
+
+        if (params.body.value === '#nonexisting') {
+            value = { elementId: null }
+        }
+
         break
     case `/wd/hub/session/${sessionId}/element/some-elem-123/element`:
         value = {
@@ -87,6 +92,9 @@ const requestMock = jest.fn().mockImplementation((params, cb) => {
             x: 15,
             y: 20
         }
+        break
+    case `/wd/hub/session/${sessionId}/element/${genericElementId}/displayed`:
+        value = true
         break
     case `/wd/hub/session/${sessionId}/elements`:
         value = [

--- a/packages/webdriverio/tests/__mocks__/request.js
+++ b/packages/webdriverio/tests/__mocks__/request.js
@@ -50,7 +50,7 @@ const requestMock = jest.fn().mockImplementation((params, cb) => {
             [ELEMENT_KEY]: genericElementId
         }
 
-        if (params.body.value === '#nonexisting') {
+        if (params.body && params.body.value === '#nonexisting') {
             value = { elementId: null }
         }
 

--- a/packages/webdriverio/tests/addCommand.test.js
+++ b/packages/webdriverio/tests/addCommand.test.js
@@ -1,0 +1,176 @@
+import { remote, multiremote } from '../src'
+
+const remoteConfig = {
+    baseUrl: 'http://foobar.com',
+    capabilities: {
+        browserName: 'foobar-noW3C'
+    }
+}
+
+const multiremoteConfig = {
+    browserA: {
+        logLevel: 'debug',
+        capabilities: {
+            browserName: 'chrome'
+        }
+    },
+    browserB: {
+        logLevel: 'debug',
+        port: 4445,
+        capabilities: {
+            browserName: 'firefox'
+        }
+    }
+}
+
+const customCommand = async () => {
+    const result = await new Promise(
+        (resolve) => setTimeout(() => resolve('foo'), 1))
+    return result + 'bar'
+}
+
+describe('addCommand', () => {
+    describe('remote', () => {
+        test('should be able to handle async', async () => {
+            const browser = await remote(remoteConfig)
+
+            browser.addCommand('mytest', customCommand)
+            expect(typeof browser.mytest).toBe('function')
+            expect(await browser.mytest()).toBe('foobar')
+        })
+
+        test('should not allow to call custom browser commands on elements', async () => {
+            const browser = await remote(remoteConfig)
+
+            browser.addCommand('mytest', customCommand)
+            const elem = await browser.$('#foo')
+            expect(typeof elem.mytest).toBe('undefined')
+        })
+
+        test('should allow to add custom commands to elements', async () => {
+            const browser = await remote(remoteConfig)
+            const elem = await browser.$('#foo')
+            elem.addCommand('myCustomElementCommand', async function () {
+                const result = await new Promise(
+                    (resolve) => setTimeout(() => resolve('foo'), 1))
+                return result + 'bar-' + this.selector
+            })
+
+            expect(typeof browser.myCustomElementCommand).toBe('undefined')
+            expect(typeof elem.myCustomElementCommand).toBe('function')
+            expect(await elem.myCustomElementCommand()).toBe('foobar-#foo')
+
+            const elem2 = await browser.$('#bar')
+            expect(typeof elem2.myCustomElementCommand).toBe('function')
+            expect(await elem2.myCustomElementCommand()).toBe('foobar-#bar')
+        })
+
+        test('should propagate custom element commands for all prototypes', async () => {
+            const browser = await remote(remoteConfig)
+            const elem = await browser.$('#foo')
+
+            expect(typeof elem.myCustomElementCommand).toBe('undefined')
+            elem.addCommand('myCustomElementCommand', async function () {
+                const result = await new Promise(
+                    (resolve) => setTimeout(() => resolve('foo'), 1))
+                return result + 'bar-' + this.selector + this.index
+            })
+
+            const elems = await browser.$$('.someRandomElement')
+            expect(typeof elems[0].myCustomElementCommand).toBe('function')
+            expect(typeof elems[1].myCustomElementCommand).toBe('function')
+            expect(typeof elems[2].myCustomElementCommand).toBe('function')
+            expect(await elems[0].myCustomElementCommand()).toBe('foobar-.someRandomElement0')
+            expect(await elems[1].myCustomElementCommand()).toBe('foobar-.someRandomElement1')
+            expect(await elems[2].myCustomElementCommand()).toBe('foobar-.someRandomElement2')
+        })
+
+        test('should propagate custom element commands to sub elements', async () => {
+            const browser = await remote(remoteConfig)
+            const elem = await browser.$('#foo')
+
+            expect(typeof elem.myCustomElementCommand).toBe('undefined')
+            elem.addCommand('myCustomElementCommand', async function () {
+                const result = await new Promise(
+                    (resolve) => setTimeout(() => resolve('foo'), 1))
+                return result + 'bar-' + this.selector
+            })
+
+            const subElem = await elem.$('.subElem')
+            expect(typeof subElem.myCustomElementCommand).toBe('function')
+            expect(await subElem.myCustomElementCommand()).toBe('foobar-.subElem')
+        })
+
+        test('should propagate custom sub element command back to element', async () => {
+            const browser = await remote(remoteConfig)
+            const elem = await browser.$('#foo')
+            const subElem = await elem.$('.subElem')
+
+            expect(typeof elem.myCustomElementCommand).toBe('undefined')
+            expect(typeof subElem.myCustomElementCommand).toBe('undefined')
+            subElem.addCommand('myCustomElementCommand', async function () {
+                const result = await new Promise(
+                    (resolve) => setTimeout(() => resolve('foo'), 1))
+                return result + 'bar-' + this.selector
+            })
+
+            expect(typeof elem.myCustomElementCommand).toBe('undefined')
+            expect(typeof subElem.myCustomElementCommand).toBe('function')
+            expect(await subElem.myCustomElementCommand()).toBe('foobar-.subElem')
+
+            const otherElem = await browser.$('#otherFoo')
+            expect(typeof otherElem.myCustomElementCommand).toBe('function')
+            expect(await otherElem.myCustomElementCommand()).toBe('foobar-#otherFoo')
+            const otherSubElem = await otherElem.$('.otherSubElem')
+            expect(typeof otherSubElem.myCustomElementCommand).toBe('function')
+            expect(await otherSubElem.myCustomElementCommand()).toBe('foobar-.otherSubElem')
+        })
+    })
+
+    describe('multiremote', () => {
+        test('should allow to register custom commands to multiremote instance', async () => {
+            const browser = await multiremote(multiremoteConfig)
+
+            expect(typeof browser.myCustomCommand).toBe('undefined')
+            browser.addCommand('myCustomCommand', async function (param) {
+                const commandResult = await this.execute(() => 'foobar')
+                return { param, commandResult }
+            })
+
+            expect(typeof browser.myCustomCommand).toBe('function')
+            const { param, commandResult } = await browser.myCustomCommand('barfoo')
+            expect(param).toBe('barfoo')
+            expect(commandResult).toEqual(['foobar', 'foobar'])
+        })
+
+        test('should allow to register custom commands to a single multiremote instance', async () => {
+            const browser = await multiremote(multiremoteConfig)
+
+            expect(typeof browser.myOtherCustomCommand).toBe('undefined')
+            browser.browserA.addCommand('myOtherCustomCommand', async function (param) {
+                const commandResult = await this.execute(() => 'foobar')
+                return { param, commandResult }
+            })
+
+            expect(typeof browser.myOtherCustomCommand).toBe('undefined')
+            expect(typeof browser.browserB.myOtherCustomCommand).toBe('undefined')
+            expect(typeof browser.browserA.myOtherCustomCommand).toBe('function')
+            const { param, commandResult } = await browser.browserA.myOtherCustomCommand('barfoo')
+            expect(param).toBe('barfoo')
+            expect(commandResult).toEqual('foobar')
+        })
+
+        test('should not allow to call custom multi browser commands on elements', async () => {
+            const browser = await multiremote(multiremoteConfig)
+            browser.addCommand('myCustomOtherOtherCommand', async function (param) {
+                const commandResult = await this.execute(() => 'foobar')
+                return { param, commandResult }
+            })
+
+            const elem = await browser.$('#foo')
+            expect(typeof elem.myCustomOtherOtherCommand).toBe('undefined')
+            expect(typeof elem.browserA.myCustomOtherOtherCommand).toBe('undefined')
+            expect(typeof elem.browserB.myCustomOtherOtherCommand).toBe('undefined')
+        })
+    })
+})

--- a/packages/webdriverio/tests/addCommand.test.js
+++ b/packages/webdriverio/tests/addCommand.test.js
@@ -101,6 +101,40 @@ describe('addCommand', () => {
             expect(await subElem.myCustomElementCommand()).toBe('foobar-.subElem')
         })
 
+        test('should propagate custom element commands to sub elements of elements call', async () => {
+            const browser = await remote(remoteConfig)
+            const elems = await browser.$$('.someRandomElement')
+            const elem = elems[0]
+
+            expect(typeof elem.myCustomElementCommand).toBe('undefined')
+            elem.addCommand('myCustomElementCommand', async function () {
+                const result = await new Promise(
+                    (resolve) => setTimeout(() => resolve('foo'), 1))
+                return result + 'bar-' + this.selector
+            })
+
+            const subElem = await elem.$('.subElem')
+            expect(typeof subElem.myCustomElementCommand).toBe('function')
+            expect(await subElem.myCustomElementCommand()).toBe('foobar-.subElem')
+        })
+
+        test('should propagate custom element commands to sub elements of elements call', async () => {
+            const browser = await remote(remoteConfig)
+            const elem = await browser.$('#foo')
+            const elems = await elem.$$('.someRandomElement')
+            const subElem = elems[0]
+
+            expect(typeof subElem.myCustomElementCommand).toBe('undefined')
+            subElem.addCommand('myCustomElementCommand', async function () {
+                const result = await new Promise(
+                    (resolve) => setTimeout(() => resolve('foo'), 1))
+                return result + 'bar-' + this.selector
+            })
+
+            expect(typeof subElem.myCustomElementCommand).toBe('function')
+            expect(await subElem.myCustomElementCommand()).toBe('foobar-.someRandomElement')
+        })
+
         test('should propagate custom sub element command back to element', async () => {
             const browser = await remote(remoteConfig)
             const elem = await browser.$('#foo')

--- a/packages/webdriverio/tests/commands/browser/$$.test.js
+++ b/packages/webdriverio/tests/commands/browser/$$.test.js
@@ -3,8 +3,6 @@ import { remote } from '../../../src'
 import { ELEMENT_KEY } from '../../../src/constants'
 
 describe('elements', () => {
-    let elems
-
     it('should fetch elements', async () => {
         const browser = await remote({
             baseUrl: 'http://foobar.com',
@@ -13,7 +11,7 @@ describe('elements', () => {
             }
         })
 
-        elems = await browser.$$('.foo')
+        const elems = await browser.$$('.foo')
         expect(request.mock.calls[1][0].method).toBe('POST')
         expect(request.mock.calls[1][0].uri.path).toBe('/wd/hub/session/foobar-123/elements')
         expect(request.mock.calls[1][0].body).toEqual({ using: 'css selector', value: '.foo' })
@@ -44,7 +42,7 @@ describe('elements', () => {
             }
         })
 
-        elems = await browser.$$('.foo')
+        const elems = await browser.$$('.foo')
         expect(elems).toHaveLength(3)
         expect(elems[0][ELEMENT_KEY]).toBe(undefined)
         expect(elems[0].ELEMENT).toBe('some-elem-123')
@@ -52,6 +50,22 @@ describe('elements', () => {
         expect(elems[1].ELEMENT).toBe('some-elem-456')
         expect(elems[2][ELEMENT_KEY]).toBe(undefined)
         expect(elems[2].ELEMENT).toBe('some-elem-789')
+    })
+
+    it('keeps prototype from browser object', async () => {
+        const browser = await remote({
+            baseUrl: 'http://foobar.com',
+            capabilities: {
+                browserName: 'foobar',
+                mobileMode: true,
+                'appium-version': '1.9.2'
+            }
+        })
+
+        const elems = await browser.$$('.foo')
+        expect(elems[0].isMobile).toBe(true)
+        expect(elems[1].isMobile).toBe(true)
+        expect(elems[2].isMobile).toBe(true)
     })
 
     afterEach(() => {

--- a/packages/webdriverio/tests/commands/browser/$.test.js
+++ b/packages/webdriverio/tests/commands/browser/$.test.js
@@ -3,8 +3,6 @@ import { remote } from '../../../src'
 import { ELEMENT_KEY } from '../../../src/constants'
 
 describe('element', () => {
-    let elem
-
     it('should fetch an element', async () => {
         const browser = await remote({
             baseUrl: 'http://foobar.com',
@@ -13,7 +11,7 @@ describe('element', () => {
             }
         })
 
-        elem = await browser.$('#foo')
+        const elem = await browser.$('#foo')
         expect(request.mock.calls[1][0].method).toBe('POST')
         expect(request.mock.calls[1][0].uri.path).toBe('/wd/hub/session/foobar-123/element')
         expect(request.mock.calls[1][0].body).toEqual({ using: 'css selector', value: '#foo' })
@@ -30,9 +28,24 @@ describe('element', () => {
             }
         })
 
-        elem = await browser.$('#foo')
+        const elem = await browser.$('#foo')
         expect(elem[ELEMENT_KEY]).toBe(undefined)
         expect(elem.ELEMENT).toBe('some-elem-123')
+    })
+
+    it('keeps prototype from browser object', async () => {
+        const browser = await remote({
+            baseUrl: 'http://foobar.com',
+            capabilities: {
+                browserName: 'foobar',
+                mobileMode: true,
+                'appium-version': '1.9.2'
+            }
+        })
+
+        expect(browser.isMobile).toBe(true)
+        const elem = await browser.$('#foo')
+        expect(elem.isMobile).toBe(true)
     })
 
     afterEach(() => {

--- a/packages/webdriverio/tests/commands/browser/touchAction.test.js
+++ b/packages/webdriverio/tests/commands/browser/touchAction.test.js
@@ -9,7 +9,8 @@ describe('touchAction test', () => {
         browser = await remote({
             baseUrl: 'http://foobar.com',
             capabilities: {
-                browserName: 'foobar'
+                browserName: 'foobar',
+                mobileMode: true
             }
         })
         elem = await browser.$('#foo')

--- a/packages/webdriverio/tests/commands/element/$$.test.js
+++ b/packages/webdriverio/tests/commands/element/$$.test.js
@@ -58,6 +58,23 @@ describe('element', () => {
         expect(elems[2].ELEMENT).toBe('some-elem-789')
     })
 
+    it('keeps prototype from browser object', async () => {
+        const browser = await remote({
+            baseUrl: 'http://foobar.com',
+            capabilities: {
+                browserName: 'foobar',
+                mobileMode: true,
+                'appium-version': '1.9.2'
+            }
+        })
+
+        const elem = await browser.$('#foo')
+        const elems = await elem.$$('.foo')
+        expect(elems[0].isMobile).toBe(true)
+        expect(elems[1].isMobile).toBe(true)
+        expect(elems[2].isMobile).toBe(true)
+    })
+
     afterEach(() => {
         request.mockClear()
     })

--- a/packages/webdriverio/tests/commands/element/$.test.js
+++ b/packages/webdriverio/tests/commands/element/$.test.js
@@ -43,6 +43,21 @@ describe('element', () => {
         expect(subElem.ELEMENT).toBe('some-sub-elem-321')
     })
 
+    it('keeps prototype from browser object', async () => {
+        const browser = await remote({
+            baseUrl: 'http://foobar.com',
+            capabilities: {
+                browserName: 'foobar',
+                mobileMode: true,
+                'appium-version': '1.9.2'
+            }
+        })
+
+        const elem = await browser.$('#foo')
+        const subElem = await elem.$('#subfoo')
+        expect(subElem.isMobile).toBe(true)
+    })
+
     afterEach(() => {
         request.mockClear()
     })

--- a/packages/webdriverio/tests/commands/element/isDisplayed.test.js
+++ b/packages/webdriverio/tests/commands/element/isDisplayed.test.js
@@ -5,7 +5,7 @@ describe('isDisplayed test', () => {
     let browser
     let elem
 
-    beforeAll(async () => {
+    beforeEach(async () => {
         browser = await remote({
             baseUrl: 'http://foobar.com',
             capabilities: {
@@ -13,14 +13,26 @@ describe('isDisplayed test', () => {
             }
         })
         elem = await browser.$('#foo')
+        request.mockClear()
     })
 
     it('should allow to check if element is displayed', async () => {
-        await elem.isDisplayed()
-        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/displayed')
+        expect(await elem.isDisplayed()).toBe(true)
+        expect(request).toBeCalledTimes(1)
+        expect(request.mock.calls[0][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/displayed')
     })
 
-    afterEach(() => {
-        request.mockClear()
+    it('should refetch element if non existing', async () => {
+        delete elem.elementId
+        expect(await elem.isDisplayed()).toBe(true)
+        expect(request).toBeCalledTimes(2)
+        expect(request.mock.calls[0][0].uri.path).toBe('/wd/hub/session/foobar-123/element')
+        expect(request.mock.calls[1][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/displayed')
+    })
+
+    it('should return false if element can\'t be found after refetching it', async () => {
+        const elem = await browser.$('#nonexisting')
+        expect(await elem.isDisplayed()).toBe(false)
+        expect(request).toBeCalledTimes(2)
     })
 })

--- a/packages/webdriverio/tests/commands/element/touchAction.test.js
+++ b/packages/webdriverio/tests/commands/element/touchAction.test.js
@@ -9,7 +9,8 @@ describe('touchAction element test', () => {
         browser = await remote({
             baseUrl: 'http://foobar.com',
             capabilities: {
-                browserName: 'foobar'
+                browserName: 'foobar',
+                mobileMode: true
             }
         })
         elem = await browser.$('#foo')

--- a/packages/webdriverio/tests/commands/element/waitForDisplayed.test.js
+++ b/packages/webdriverio/tests/commands/element/waitForDisplayed.test.js
@@ -5,7 +5,7 @@ describe('waitForDisplayed', () => {
     const duration = 1000
     let browser
 
-    beforeAll(async () => {
+    beforeEach(async () => {
         request.mockClear()
 
         browser = await remote({
@@ -38,7 +38,7 @@ describe('waitForDisplayed', () => {
         const result = await elem.waitForDisplayed(duration)
 
         expect(result).toBe(true)
-        expect(request.mock.calls[3][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/displayed')
+        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/displayed')
     })
 
     test('should call isDisplayed and return true if eventually true', async () => {
@@ -60,6 +60,7 @@ describe('waitForDisplayed', () => {
     })
 
     test('should call isDisplayed and return false', async () => {
+        expect.assertions(1)
         const tmpElem = await browser.$('#foo')
         const elem = {
             selector : '#foo',
@@ -114,6 +115,7 @@ describe('waitForDisplayed', () => {
     })
 
     test('should call isDisplayed and return false with custom error', async () => {
+        expect.assertions(1)
         const tmpElem = await browser.$('#foo')
         const elem = {
             selector : '#foo',

--- a/packages/webdriverio/tests/commands/element/waitForExist.test.js
+++ b/packages/webdriverio/tests/commands/element/waitForExist.test.js
@@ -1,0 +1,71 @@
+import request from 'request'
+import { remote } from '../../../src'
+
+describe('waitForExists', () => {
+    const duration = 1000
+    let browser
+
+    beforeEach(async () => {
+        request.mockClear()
+
+        browser = await remote({
+            baseUrl: 'http://foobar.com',
+            capabilities: {
+                browserName: 'foobar'
+            }
+        })
+    })
+
+    test('should wait for the element to exist', async () => {
+        const tmpElem = await browser.$('#foo')
+        const elem = {
+            selector: 'foobar',
+            waitForExist : tmpElem.waitForExist,
+            isExisting: jest.fn().mockReturnValueOnce(Promise.resolve(true)),
+            elementId : null,
+            waitUntil : jest.fn().mockImplementation(
+                (condition) => condition.call(elem)),
+            isElementDisplayed : jest.fn(() => Promise.resolve())
+        }
+
+        await elem.waitForExist(duration)
+        expect(elem.isExisting).toBeCalled()
+        expect(elem.waitUntil.mock.calls[0][1]).toBe(1000)
+        expect(elem.waitUntil.mock.calls[0][2]).toBe('element ("foobar") still not existing after 1000ms')
+    })
+
+    test('should use default waitFor duration', async () => {
+        const tmpElem = await browser.$('#foo')
+        const elem = {
+            options: { waitforTimeout: 1234 },
+            waitForExist : tmpElem.waitForExist,
+            isExisting: jest.fn().mockReturnValueOnce(Promise.resolve(true)),
+            elementId : null,
+            waitUntil : jest.fn().mockImplementation(
+                (condition) => condition.call(elem)),
+            isElementDisplayed : jest.fn(() => Promise.resolve())
+        }
+
+        await elem.waitForExist()
+        expect(elem.isExisting).toBeCalled()
+        expect(elem.waitUntil.mock.calls[0][1]).toBe(1234)
+    })
+
+    test('should allow to set custom error', async () => {
+        const tmpElem = await browser.$('#foo')
+        const elem = {
+            selector: 'barfoo',
+            options: { waitforTimeout: 1234 },
+            waitForExist : tmpElem.waitForExist,
+            isExisting: jest.fn().mockReturnValueOnce(Promise.resolve(true)),
+            elementId : null,
+            waitUntil : jest.fn().mockImplementation(
+                (condition) => condition.call(elem)),
+            isElementDisplayed : jest.fn(() => Promise.resolve())
+        }
+
+        await elem.waitForExist(duration, true, 'my custom error')
+        expect(elem.isExisting).toBeCalled()
+        expect(elem.waitUntil.mock.calls[0][2]).toBe('my custom error')
+    })
+})

--- a/packages/webdriverio/tests/multiremote.test.js
+++ b/packages/webdriverio/tests/multiremote.test.js
@@ -91,35 +91,6 @@ test('should be able to fetch multiple elements', async () => {
     expect(size).toEqual([{ width: 50, height: 30 }, { width: 50, height: 30 }])
 })
 
-test('should allow to register custom commands to multiremote instance', async () => {
-    const browser = await multiremote({
-        browserA: {
-            logLevel: 'debug',
-            capabilities: {
-                browserName: 'chrome'
-            }
-        },
-        browserB: {
-            logLevel: 'debug',
-            port: 4445,
-            capabilities: {
-                browserName: 'firefox'
-            }
-        }
-    })
-
-    expect(typeof browser.myCustomCommand).toBe('undefined')
-    browser.addCommand('myCustomCommand', async function (param) {
-        const commandResult = await this.execute(() => 'foobar')
-        return { param, commandResult }
-    })
-
-    expect(typeof browser.myCustomCommand).toBe('function')
-    const { param, commandResult } = await browser.myCustomCommand('barfoo')
-    expect(param).toBe('barfoo')
-    expect(commandResult).toEqual(['foobar', 'foobar'])
-})
-
 afterEach(() => {
     request.mockClear()
 })

--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -38,4 +38,44 @@ describe('smoke test', () => {
             assert.equal(elem.isDisplayed(), true)
         })
     })
+
+    describe('customCommands', () => {
+        it('should allow to call nested custom commands', () => {
+            browser.addCommand('myCustomCommand', function (param) {
+                const result = {
+                    url: browser.getUrl(),
+                    title: browser.getTitle()
+                }
+
+                return { param, ...result }
+            })
+
+            assert.equal(
+                JSON.stringify(browser.myCustomCommand('foobar')),
+                JSON.stringify({
+                    param: 'foobar',
+                    url: 'https://mymockpage.com',
+                    title: 'Mock Page Title'
+                })
+            )
+        })
+
+        it('allows to create custom commands on elements', () => {
+            browser.customCommandScenario()
+            const elem = $('elem')
+            elem.addCommand('myCustomCommand', function (param) {
+                const result = this.getSize()
+                return { selector: this.selector, result, param }
+            })
+
+            assert.equal(
+                JSON.stringify(elem.myCustomCommand('foobar')),
+                JSON.stringify({
+                    selector: 'elem',
+                    result: { width: 1, height: 2 },
+                    param: 'foobar'
+                })
+            )
+        })
+    })
 })


### PR DESCRIPTION

**Environment (please complete the following information):**
 - **WebdriverIO version:** 5.2.2
 - **Mode:** Standalone mode
 - **Node.js version:** 10.14.2
 - **NPM version:** 6.4.1
 - **Platform name and version:** Appium 1.10 and Android emulator

**Config of WebdriverIO**
Running Cucumber over standalone Wdio connected to Appium that talks to an Amdroid emulator 

**Describe the bug**
driver.getGeoLocation is not a function
driver.setGeoLocation is not a function

**To Reproduce**
```
async function crash(){
let a = await wdio.remote({
        host : "localhost",
        port : 4723,
        capabilities : {
            appiumVersion : '1.10.0',
            platformName: "Android",
            platformVersion: opts.platformVersion,
            deviceName: "Android Emulator",
            app: opts.app,
            automationName: "UiAutomator2",
            newCommandTimeout : 600
        }
    });
return a.getGeoLocation();
}
```

could be related to webdriverio/webdriverio#3120