### PR TITLE
package.json - Fixed Jest's testMatch pattern to also work in Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   },
   "jest": {
     "testMatch": [
-      "/**/tests/**/*.test.js"
+      "**/tests/**/*.test.js"
     ],
     "testPathIgnorePatterns": [
       "<rootDir>/tests/",


### PR DESCRIPTION
## Proposed changes

Fixes issue https://github.com/webdriverio/webdriverio/issues/3283. Changes Jest's `testMatch` property in `package.json` to work both in Windows and in Linux.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

No need to add tests as this change will either make all tests run if successful or all tests fail if not.

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
