### PR TITLE
Validate before attaching session to webdriver (using multiremote)

### DIFF
--- a/docs/Multiremote.md
+++ b/docs/Multiremote.md
@@ -10,7 +10,7 @@ WebdriverIO allows you to run multiple WebDriver/Appium sessions in a single tes
 Here is an example demonstrating a how to create a multiremote WebdriverIO instance in __standalone mode__:
 
 ```js
-import { multiremote } from 'webdriverio';
+const { multiremote } = require('webdriverio');
 
 (async () => {
     const browser = await multiremote({

--- a/examples/wdio/multiremote/mocha.test.js
+++ b/examples/wdio/multiremote/mocha.test.js
@@ -5,26 +5,32 @@ describe('multiremote example', () => {
 
     it('should login the browser', () => {
         const nameInput = $('.usernameInput')
-        nameInput.addValue('Browser A')
+        nameInput.addValue('Browser')
         browser.keys('Enter')
     })
 
     it('should post something in browserA', () => {
         const msgElemBrowserA = browserA.$('.inputMessage')
+
         msgElemBrowserA.addValue('Hey Whats up!')
         browser.pause(1000)
         browserA.keys('Enter')
 
         msgElemBrowserA.addValue('My name is Edgar')
+        browser.pause(1000)
         browserA.keys('Enter')
         browser.pause(200)
     })
 
     it('should read the message in browserB', () => {
-        const msgElemBrowserB = browserA.$('.inputMessage')
+        const msgElemBrowserB = browserB.$('.inputMessage')
+
         const chatLineBrowserB = browserB.$('.messageBody*=My name is')
+        chatLineBrowserB.waitForExist(5000)
+
         const message = chatLineBrowserB.getText()
-        const name = message.slice(11)
+        const name = message.split(' ').pop()
+
         msgElemBrowserB.addValue(`Hello ${name}! How are you today?`)
         browserB.keys('Enter')
         browser.pause(5000)

--- a/examples/wdio/multiremote/mocha.test.js
+++ b/examples/wdio/multiremote/mocha.test.js
@@ -4,8 +4,10 @@ describe('multiremote example', () => {
     })
 
     it('should login the browser', () => {
-        const nameInput = $('.usernameInput')
-        nameInput.addValue('Browser')
+        const browserANameInput = browserA.$('.usernameInput')
+        const browserBNameInput = browserB.$('.usernameInput')
+        browserANameInput.addValue('BrowserA')
+        browserBNameInput.addValue('BrowserB')
         browser.keys('Enter')
     })
 

--- a/packages/wdio-runner/src/index.js
+++ b/packages/wdio-runner/src/index.js
@@ -150,7 +150,7 @@ export default class Runner extends EventEmitter {
         let browser = null
 
         try {
-            browser = global.browser = global.driver = await initialiseInstance(config, caps, this.isMultiremote)
+            browser = global.browser = global.driver = await initialiseInstance(config, caps)
         } catch (e) {
             log.error(e)
             this.emit('error', e)

--- a/packages/wdio-runner/src/utils.js
+++ b/packages/wdio-runner/src/utils.js
@@ -82,9 +82,24 @@ export function sanitizeCaps (caps) {
 }
 
 /**
- * initialise browser instance depending whether remote or multiremote is requested
+ * checks whether capabilities contains multiple browser configurations
+ * @param  {Object}  capabilities  desired session capabilities
+ * @return {Boolean}               true if multiple browsers configured
  */
-export async function initialiseInstance (config, capabilities, isMultiremote) {
+export function hasMultiremoteOptions (capabilities) {
+    return Object.keys(capabilities).length > 0 &&
+           Object.values(capabilities).every(browserConfig => {
+               return browserConfig.hasOwnProperty('capabilities')
+           })
+}
+
+/**
+ * initialise browser instance depending whether remote or multiremote is requested
+ * @param  {Object}  config        configuration of sessions
+ * @param  {Object}  capabilities  desired session capabilities
+ * @return {Promise}               resolves with browser object
+ */
+export async function initialiseInstance (config, capabilities) {
     /**
      * check if config has sessionId and attach it to a running session if so
      */
@@ -96,7 +111,7 @@ export async function initialiseInstance (config, capabilities, isMultiremote) {
         })
     }
 
-    if (!isMultiremote) {
+    if (!hasMultiremoteOptions(capabilities)) {
         log.debug('init remote session')
         config.capabilities = sanitizeCaps(capabilities)
         return remote(config)

--- a/packages/wdio-runner/src/utils.js
+++ b/packages/wdio-runner/src/utils.js
@@ -86,7 +86,7 @@ export function sanitizeCaps (caps) {
  * @param  {Object}  capabilities  desired session capabilities
  * @return {Boolean}               true if multiple browsers configured
  */
-export function hasMultiremoteOptions (capabilities) {
+export function isMultiremoteConfig (capabilities) {
     return (
         Object.keys(capabilities).length > 0 &&
         Object.values(capabilities).every(
@@ -113,7 +113,7 @@ export async function initialiseInstance (config, capabilities) {
         })
     }
 
-    if (!hasMultiremoteOptions(capabilities)) {
+    if (!isMultiremoteConfig(capabilities)) {
         log.debug('init remote session')
         config.capabilities = sanitizeCaps(capabilities)
         return remote(config)

--- a/packages/wdio-runner/src/utils.js
+++ b/packages/wdio-runner/src/utils.js
@@ -87,10 +87,12 @@ export function sanitizeCaps (caps) {
  * @return {Boolean}               true if multiple browsers configured
  */
 export function hasMultiremoteOptions (capabilities) {
-    return Object.keys(capabilities).length > 0 &&
-           Object.values(capabilities).every(browserConfig => {
-               return browserConfig.hasOwnProperty('capabilities')
-           })
+    return (
+        Object.keys(capabilities).length > 0 &&
+        Object.values(capabilities).every(
+            (browserConfig) => browserConfig.hasOwnProperty('capabilities')
+        )
+    )
 }
 
 /**

--- a/packages/wdio-runner/tests/utils.test.js
+++ b/packages/wdio-runner/tests/utils.test.js
@@ -1,7 +1,7 @@
 import { logMock } from '@wdio/logger'
 import { attach, remote, multiremote } from 'webdriverio'
 
-import { runHook, initialiseServices, initialiseInstance, sanitizeCaps } from '../src/utils'
+import { runHook, initialiseServices, initialiseInstance, sanitizeCaps, hasMultiremoteOptions } from '../src/utils'
 
 describe('utils', () => {
     beforeEach(() => {
@@ -88,7 +88,7 @@ describe('utils', () => {
         })
 
         it('should run multiremote tests if flag is given', () => {
-            const capabilities = { someBrowser: { browserName: 'chrome' } }
+            const capabilities = { someBrowser: { capabilities: { browserName: 'chrome' } } }
             initialiseInstance(
                 { foo: 'bar' },
                 capabilities,
@@ -97,7 +97,9 @@ describe('utils', () => {
             expect(attach).toHaveBeenCalledTimes(0)
             expect(multiremote).toBeCalledWith({
                 someBrowser: {
-                    browserName: 'chrome',
+                    capabilities: {
+                        browserName: 'chrome'
+                    },
                     foo: 'bar'
                 }
             })
@@ -143,5 +145,27 @@ describe('utils', () => {
             ...invalidCaps,
             ...validCaps
         })).toEqual(validCaps)
+    })
+
+    it('hasMultiremoteOptions', () => {
+        const capabilities = {
+            browserName: 'safari'
+        }
+        const multipleCapabilities = {
+            myChrome: {
+                capabilities: {
+                    browserName: 'chrome'
+                }
+            },
+            myFirefox: {
+                capabilities: {
+                    browserName: 'firefox'
+                }
+            }
+        }
+
+        expect(hasMultiremoteOptions({})).toBe(false)
+        expect(hasMultiremoteOptions(capabilities)).toBe(false)
+        expect(hasMultiremoteOptions(multipleCapabilities)).toBe(true)
     })
 })

--- a/packages/wdio-runner/tests/utils.test.js
+++ b/packages/wdio-runner/tests/utils.test.js
@@ -87,18 +87,30 @@ describe('utils', () => {
             expect(remote).toHaveBeenCalledTimes(0)
         })
 
-        it('should run multiremote tests if flag is given', () => {
-            const capabilities = { someBrowser: { capabilities: { browserName: 'chrome' } } }
+        it('should run multiremote tests when configuration specified multiple browsers', () => {
+            const capabilities = {
+                someBrowser: {
+                    capabilities: { browserName: 'chrome' }
+                },
+                otherBrowser: {
+                    capabilities: { browserName: 'firefox' }
+                }
+            }
             initialiseInstance(
                 { foo: 'bar' },
-                capabilities,
-                true
+                capabilities
             )
             expect(attach).toHaveBeenCalledTimes(0)
             expect(multiremote).toBeCalledWith({
                 someBrowser: {
                     capabilities: {
                         browserName: 'chrome'
+                    },
+                    foo: 'bar'
+                },
+                otherBrowser: {
+                    capabilities: {
+                        browserName: 'firefox'
                     },
                     foo: 'bar'
                 }

--- a/packages/wdio-runner/tests/utils.test.js
+++ b/packages/wdio-runner/tests/utils.test.js
@@ -1,7 +1,7 @@
 import { logMock } from '@wdio/logger'
 import { attach, remote, multiremote } from 'webdriverio'
 
-import { runHook, initialiseServices, initialiseInstance, sanitizeCaps, hasMultiremoteOptions } from '../src/utils'
+import { runHook, initialiseServices, initialiseInstance, sanitizeCaps, isMultiremoteConfig } from '../src/utils'
 
 describe('utils', () => {
     beforeEach(() => {
@@ -147,7 +147,7 @@ describe('utils', () => {
         })).toEqual(validCaps)
     })
 
-    it('hasMultiremoteOptions', () => {
+    it('isMultiremoteConfig', () => {
         const capabilities = {
             browserName: 'safari'
         }
@@ -164,8 +164,8 @@ describe('utils', () => {
             }
         }
 
-        expect(hasMultiremoteOptions({})).toBe(false)
-        expect(hasMultiremoteOptions(capabilities)).toBe(false)
-        expect(hasMultiremoteOptions(multipleCapabilities)).toBe(true)
+        expect(isMultiremoteConfig({})).toBe(false)
+        expect(isMultiremoteConfig(capabilities)).toBe(false)
+        expect(isMultiremoteConfig(multipleCapabilities)).toBe(true)
     })
 })

--- a/packages/webdriver/src/constants.js
+++ b/packages/webdriver/src/constants.js
@@ -90,3 +90,17 @@ export const DEFAULTS = {
         type: 'string'
     }
 }
+
+export const SESSION_DEFAULTS = Object.assign({}, DEFAULTS, {
+    // Capabilities are optional when attaching session,
+    // due to the fact drivers not always return capabilities
+    // in the initial (JsonWireProtocol) session response.
+    capabilities: {
+        type: 'object',
+        required: false
+    },
+    sessionId: {
+        type: 'string',
+        required: true
+    }
+})

--- a/packages/webdriver/src/index.js
+++ b/packages/webdriver/src/index.js
@@ -4,7 +4,7 @@ import { validateConfig } from '@wdio/config'
 
 import webdriverMonad from './monad'
 import WebDriverRequest from './request'
-import { DEFAULTS } from './constants'
+import { DEFAULTS, SESSION_DEFAULTS } from './constants'
 import { getPrototype, environmentDetector } from './utils'
 
 import WebDriverProtocol from '../protocol/webdriver.json'
@@ -78,17 +78,12 @@ export default class WebDriver {
      * allows user to attach to existing sessions
      */
     static attachToSession (options = {}, modifier, userPrototype = {}, commandWrapper) {
-        if (typeof options.sessionId !== 'string') {
-            throw new Error('sessionId is required to attach to existing session')
-        }
+        const params = validateConfig(SESSION_DEFAULTS, options)
+        logger.setLevel('webdriver', params.logLevel)
 
-        logger.setLevel('webdriver', options.logLevel)
-
-        options.capabilities = options.capabilities || {}
-        options.isW3C = options.isW3C || true
-        const prototype = Object.assign(getPrototype(options.isW3C), userPrototype)
-        const monad = webdriverMonad(options, modifier, prototype)
-        return monad(options.sessionId, commandWrapper)
+        const prototype = Object.assign(getPrototype(params.isW3C), userPrototype)
+        const monad = webdriverMonad(params, modifier, prototype)
+        return monad(params.sessionId, commandWrapper)
     }
 
     static get WebDriver () {

--- a/packages/webdriver/src/index.js
+++ b/packages/webdriver/src/index.js
@@ -1,5 +1,4 @@
 import logger from '@wdio/logger'
-import merge from 'lodash.merge'
 import { validateConfig } from '@wdio/config'
 
 import webdriverMonad from './monad'
@@ -52,25 +51,14 @@ export default class WebDriver {
         params.requestedCapabilities = { w3cCaps, jsonwpCaps }
 
         /**
-         * save actual receveived session details
+         * save actual received session details
          */
         params.capabilities = response.value.capabilities || response.value
 
-        /**
-         * apply mobile flags to driver scope
-         */
-        const { isW3C, isMobile, isIOS, isAndroid, isChrome, isSauce } = environmentDetector(params)
-        const environmentFlags = {
-            isW3C: { value: isW3C },
-            isMobile: { value: isMobile },
-            isIOS: { value: isIOS },
-            isAndroid: { value: isAndroid },
-            isChrome: { value: isChrome }
-        }
 
-        const protocolCommands = getPrototype({ isW3C, isMobile, isIOS, isAndroid, isChrome, isSauce })
-        const prototype = merge(protocolCommands, environmentFlags, userPrototype)
-        const monad = webdriverMonad(params, modifier, prototype)
+        const environment = environmentDetector(params)
+        const prototype = Object.assign(getPrototype(environment), userPrototype)
+        const monad = webdriverMonad(Object.assign(params, environment), modifier, prototype)
         return monad(response.value.sessionId || response.sessionId, commandWrapper)
     }
 

--- a/packages/webdriver/src/index.js
+++ b/packages/webdriver/src/index.js
@@ -81,7 +81,7 @@ export default class WebDriver {
         const params = validateConfig(SESSION_DEFAULTS, options)
         logger.setLevel('webdriver', params.logLevel)
 
-        const prototype = Object.assign(getPrototype(params.isW3C), userPrototype)
+        const prototype = Object.assign(getPrototype(params), userPrototype)
         const monad = webdriverMonad(params, modifier, prototype)
         return monad(params.sessionId, commandWrapper)
     }

--- a/packages/webdriver/src/monad.js
+++ b/packages/webdriver/src/monad.js
@@ -17,7 +17,13 @@ export default function WebDriver (options, modifier, propertiesObject = {}) {
     const scopeType = SCOPE_TYPES[propertiesObject.scope] || SCOPE_TYPES['browser']
     delete propertiesObject.scope
 
-    const prototype = Object.create(scopeType.prototype)
+    const prototype = Object.create(scopeType.prototype, {
+        isW3C: { value: Boolean(options.isW3C) },
+        isMobile: { value: Boolean(options.isMobile) },
+        isAndroid: { value: Boolean(options.isAndroid) },
+        isIOS: { value: Boolean(options.isIOS) },
+        isChrome: { value: Boolean(options.isChrome) }
+    })
     const log = logger('webdriver')
 
     const eventHandler = new EventEmitter()

--- a/packages/webdriver/tests/index.test.js
+++ b/packages/webdriver/tests/index.test.js
@@ -41,20 +41,26 @@ test('should allow to create a new session using w3c compliant caps', async () =
 
 test('should allow to attach to existing session', async () => {
     const client = WebDriver.attachToSession({
-        protocol: 'http',
+        protocol: 'https',
         hostname: 'localhost',
-        port: 4444,
+        port: 9515,
         path: '/',
         sessionId: 'foobar'
     })
 
     await client.getUrl()
     const req = request.mock.calls[0][0]
-    expect(req.uri.href).toBe('http://localhost:4444/session/foobar/url')
+    expect(req.uri.href).toBe('https://localhost:9515/session/foobar/url')
 })
 
-test('should fail attaching to session if sessionId is not given', () => {
-    expect(() => WebDriver.attachToSession({})).toThrow(/sessionId is required/)
+test('should allow to attach to existing session by using defaults', async () => {
+    const client = WebDriver.attachToSession({
+        sessionId: 'foobar'
+    })
+
+    await client.getUrl()
+    const req = request.mock.calls[0][0]
+    expect(req.uri.href).toBe('http://0.0.0.0:4444/wd/hub/session/foobar/url')
 })
 
 test('ensure that WebDriver interface exports protocols and other objects', () => {

--- a/packages/webdriver/tests/monad.test.js
+++ b/packages/webdriver/tests/monad.test.js
@@ -27,13 +27,13 @@ describe('monad', () => {
 
     it('should allow to set element scope name', () => {
         prototype.scope = 'element'
-        const monad = webdriverMonad({ isW3C: true }, (client) => client, prototype)
+        const monad = webdriverMonad({}, (client) => client, prototype)
         const client = monad(sessionId)
         expect(client.constructor.name).toBe('Element')
     })
 
     it('should allow to extend base prototype', () => {
-        const monad = webdriverMonad({ isW3C: true }, (client) => client, prototype)
+        const monad = webdriverMonad({}, (client) => client, prototype)
         const commandWrapperMock = jest.fn().mockImplementation((name, fn) => fn)
         const client = monad(sessionId, commandWrapperMock)
         const fn = () => 'bar'
@@ -55,7 +55,7 @@ describe('monad', () => {
 
 
     it('allows to use custom command wrapper', () => {
-        const monad = webdriverMonad({ isW3C: true }, (client) => client, prototype)
+        const monad = webdriverMonad({}, (client) => client, prototype)
         const client = monad(sessionId, (commandName, commandFn) => {
             return (...args) => {
                 return `${commandName}(${args.join(', ')}) = ${commandFn(...args)}`
@@ -65,8 +65,30 @@ describe('monad', () => {
     })
 
     it('should allow empty prototype object', () => {
-        const monad = webdriverMonad({ isW3C: true }, (client) => client)
+        const monad = webdriverMonad({}, (client) => client)
         const client = monad(sessionId)
         expect(client.commandList).toHaveLength(0)
+    })
+
+    it('should respect specified environment flags', () => {
+        const monad = webdriverMonad({ isW3C: true, isMobile: true, isAndroid: true, isIOS: true, isChrome: true }, (client) => client, prototype)
+        const client = monad(sessionId)
+
+        expect(client.isW3C).toBe(true)
+        expect(client.isMobile).toBe(true)
+        expect(client.isAndroid).toBe(true)
+        expect(client.isIOS).toBe(true)
+        expect(client.isChrome).toBe(true)
+    })
+
+    it('should have default environment flags', () => {
+        const monad = webdriverMonad({}, (client) => client, prototype)
+        const client = monad(sessionId)
+
+        expect(client.isW3C).toBe(false)
+        expect(client.isMobile).toBe(false)
+        expect(client.isAndroid).toBe(false)
+        expect(client.isIOS).toBe(false)
+        expect(client.isChrome).toBe(false)
     })
 })

--- a/packages/webdriverio/src/index.js
+++ b/packages/webdriverio/src/index.js
@@ -58,7 +58,11 @@ export const multiremote = async function (params = {}) {
     const prototype = getPrototype('browser')
     const sessionParams = {
         sessionId: '',
-        isW3C: multibrowser.instances[browserNames[0]].isW3C
+        isW3C: multibrowser.instances[browserNames[0]].isW3C,
+        isMobile: multibrowser.instances[browserNames[0]].isMobile,
+        isAndroid: multibrowser.instances[browserNames[0]].isAndroid,
+        isIOS: multibrowser.instances[browserNames[0]].isIOS,
+        isChrome: multibrowser.instances[browserNames[0]].isChrome
     }
     const driver = WebDriver.attachToSession(sessionParams, ::multibrowser.modifier, prototype, wrapCommand)
 

--- a/packages/webdriverio/src/multiremote.js
+++ b/packages/webdriverio/src/multiremote.js
@@ -1,5 +1,5 @@
 import zip from 'lodash.zip'
-import { webdriverMonad, getPrototype as getWebdriverPrototype } from 'webdriver'
+import { webdriverMonad } from 'webdriver'
 import { wrapCommand } from '@wdio/config'
 
 import { multiremoteHandler } from './middlewares'
@@ -66,9 +66,9 @@ export default class MultiRemote {
          * we can't handle multi browser with different protocol support, therefor check only the
          * first registered browser and handle it similar to other browser
          */
-        const isW3C = instances[Object.keys(instances)[0]].isW3C
+        const protocolCommands = instances[Object.keys(instances)[0]].__propertiesObject__
 
-        const prototype = Object.assign(getWebdriverPrototype(isW3C), getPrototype('element'), { scope: 'element' })
+        const prototype = Object.assign(protocolCommands, getPrototype('element'), { scope: 'element' })
         const element = webdriverMonad({}, (client) => {
             /**
              * attach instances to wrapper client


### PR DESCRIPTION
## Proposed changes

* Validation of configuration when attaching multiremote to webdriver.
* Properly detect whether desired capabilities contains multiple browser configurations in wdio-runner.
* Set protocol and environment flags accordingly for multiremote session.
* Updated wdio example for multiremote configuration and standalone example in documentation.

Fixes #3257, #3342.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

Prior to validation it would return one or more of the following errors, depending on the configuration.

```
2019-01-08T22:01:30.142Z INFO webdriver: [GET] undefined://undefined/:undefinedundefined/session/1E8E4428-33B7-4C3B-B61D-E035BA14916B/url
2019-01-08T22:01:30.146Z ERROR webdriver: Request failed due to Error: Error: Invalid protocol: undefined:
```

```
2019-01-08T22:02:31.036Z INFO webdriver: [GET] http://undefined/:undefinedundefined/session/1E8E4428-33B7-4C3B-B61D-E035BA14916B/url
2019-01-08T22:02:31.057Z ERROR webdriver: Request failed due to Error: Error: getaddrinfo ENOTFOUND undefined undefined:80
```

```
2019-01-08T22:03:17.263Z INFO webdriver: [GET] http://0.0.0.0/:undefinedundefined/session/1E8E4428-33B7-4C3B-B61D-E035BA14916B/url
2019-01-08T22:03:17.274Z ERROR webdriver: Request failed due to Error: Error: connect ECONNREFUSED 0.0.0.0:80
```

Also with changes made in #3102, it would throw the following error when `logLevel` is not specified, this is now handled by validation.

```
(node:4136) UnhandledPromiseRejectionWarning: log.setLevel() called with invalid level: undefined
(node:4136) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:4136) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```


### Reviewers: @webdriverio/technical-committee