### PR TITLE
Unify logic for mobile device detection in webdriver(io)

### DIFF
--- a/packages/webdriver/src/index.js
+++ b/packages/webdriver/src/index.js
@@ -4,7 +4,7 @@ import { validateConfig } from '@wdio/config'
 import webdriverMonad from './monad'
 import WebDriverRequest from './request'
 import { DEFAULTS } from './constants'
-import { getPrototype, isW3CSession, isChromiumSession } from './utils'
+import { getPrototype, isW3CSession, isChromiumSession, isMobile, isAndroid, isIOS } from './utils'
 
 import WebDriverProtocol from '../protocol/webdriver.json'
 import JsonWProtocol from '../protocol/jsonwp.json'
@@ -53,10 +53,15 @@ export default class WebDriver {
          */
         params.capabilities = response.value.capabilities || response.value
         params.isW3C = isW3CSession(params.capabilities)
+        /**
+         * apply mobile check flags to browser scope
+         */
+        params.isAndroid = isAndroid(params.capabilities)
+        params.isIOS = isIOS(params.capabilities)
+        params.isMobile = isMobile(params.capabilities)
 
-        const isMobile = Boolean(params.capabilities.deviceName || params.capabilities.platformVersion)
         const prototype = Object.assign(
-            getPrototype(params.isW3C, isChromiumSession(params.capabilities), isMobile),
+            getPrototype(params.isW3C, isChromiumSession(params.capabilities), params.isMobile),
             proto)
         const monad = webdriverMonad(params, modifier, prototype)
         return monad(response.value.sessionId || response.sessionId, commandWrapper)

--- a/packages/webdriver/src/index.js
+++ b/packages/webdriver/src/index.js
@@ -78,8 +78,11 @@ export default class WebDriver {
         logger.setLevel('webdriver', options.logLevel)
 
         options.capabilities = options.capabilities || {}
-        options.isW3C = options.isW3C || true
-        const prototype = Object.assign(getPrototype(options.isW3C), proto)
+        options.isAndroid = typeof options.isAndroid === 'boolean' ? options.isAndroid : false
+        options.isIOS = typeof options.isIOS === 'boolean' ? options.isIOS : false
+        options.isMobile = typeof options.isMobile === 'boolean' ? options.isMobile : false
+        options.isW3C = typeof options.isW3C === 'boolean' ? options.isW3C : true
+        const prototype = Object.assign(getPrototype(options.isW3C, isChromiumSession(options.capabilities), options.isMobile), proto)
         const monad = webdriverMonad(options, modifier, prototype)
         return monad(options.sessionId, commandWrapper)
     }

--- a/packages/webdriver/src/monad.js
+++ b/packages/webdriver/src/monad.js
@@ -18,6 +18,9 @@ export default function WebDriver (options, modifier, propertiesObject = {}) {
     delete propertiesObject.scope
 
     const prototype = Object.create(scopeType.prototype, {
+        isAndroid: { value: options.isAndroid },
+        isIOS: { value: options.isIOS },
+        isMobile: { value: options.isMobile },
         isW3C: { value: options.isW3C }
     })
     const log = logger('webdriver')

--- a/packages/webdriver/src/utils.js
+++ b/packages/webdriver/src/utils.js
@@ -175,6 +175,50 @@ export function commandCallStructure (commandName, args) {
     return `${commandName}(${callArgs})`
 }
 
+
+/**
+ * check if session is run on Android device
+ * @param  {Object}  capabilities  caps of session response
+ * @return {Boolean}               true if run on Android device
+ */
+export function isAndroid (capabilities = {}) {
+    return Boolean(
+        (capabilities.platformName && capabilities.platformName.match(/Android/i)) ||
+        (capabilities.browserName && capabilities.browserName.match(/Android/i))
+    )
+}
+
+/**
+ * check if session is run on iOS device
+ * @param  {Object}  capabilities  caps of session response
+ * @return {Boolean}               true if run on iOS device
+ */
+export function isIOS (capabilities = {}) {
+    return Boolean(
+        (capabilities.platformName && capabilities.platformName.match(/iOS/i)) ||
+        (capabilities.deviceName && capabilities.deviceName.match(/(iPad|iPhone)/i))
+    )
+}
+
+/**
+ * check if session is run on mobile
+ * @param  {Object}  capabilities  caps of session response
+ * @return {Boolean}               true if run on mobile
+ */
+export function isMobile (capabilities = {}) {
+    return Boolean(
+        (typeof capabilities['appium-version'] !== 'undefined') ||
+        (typeof capabilities['device-type'] !== 'undefined') || (typeof capabilities['deviceType'] !== 'undefined') ||
+        (typeof capabilities['device-orientation'] !== 'undefined') || (typeof capabilities['deviceOrientation'] !== 'undefined') ||
+        (typeof capabilities.deviceName !== 'undefined') ||
+        // Check browserName for specific values
+        (capabilities.browserName === '' ||
+             (capabilities.browserName !== undefined && (capabilities.browserName.toLowerCase() === 'ipad' ||
+                                                         capabilities.browserName.toLowerCase() === 'iphone' ||
+                                                         capabilities.browserName.toLowerCase() === 'android')))
+    )
+}
+
 /**
  * check if session is based on W3C protocol based on the /session response
  * @param  {Object}  capabilities  caps of session response
@@ -204,7 +248,7 @@ export function isW3CSession (capabilities) {
  * @param  {Object}  capabilities  caps of session response
  * @return {Boolean}               true if run by Chromedriver
  */
-export function isChromiumSession (capabilities) {
+export function isChromiumSession (capabilities = {}) {
     return (
         Boolean(capabilities.chrome) ||
         Boolean(capabilities['goog:chromeOptions'])

--- a/packages/webdriver/tests/index.test.js
+++ b/packages/webdriver/tests/index.test.js
@@ -45,8 +45,16 @@ test('should allow to attach to existing session', async () => {
         hostname: 'localhost',
         port: 4444,
         path: '/',
-        sessionId: 'foobar'
+        sessionId: 'foobar',
+        isIOS: true,
+        isMobile: true,
+        isW3C: false
     })
+
+    expect(client.isAndroid).toBe(false)
+    expect(client.isIOS).toBe(true)
+    expect(client.isMobile).toBe(true)
+    expect(client.isW3C).toBe(false)
 
     await client.getUrl()
     const req = request.mock.calls[0][0]

--- a/packages/webdriver/tests/monad.test.js
+++ b/packages/webdriver/tests/monad.test.js
@@ -8,13 +8,16 @@ const sessionId = 'c5fa4320-07d5-48f5-b7c2-922d4405e17f'
 describe('monad', () => {
     it('should be able to initialize client with prototype with commands', () => {
         const modifier = jest.fn()
-        const monad = webdriverMonad({ isW3C: true }, (client) => {
+        const monad = webdriverMonad({ isAndroid: true, isIOS: false, isMobile: false, isW3C: true }, (client) => {
             modifier()
             return client
         }, prototype)
         const client = monad(sessionId)
 
         expect(client.sessionId).toBe(sessionId)
+        expect(client.isAndroid).toBe(true)
+        expect(client.isIOS).toBe(false)
+        expect(client.isMobile).toBe(false)
         expect(client.isW3C).toBe(true)
         expect(client.commandList).toHaveLength(1)
         expect(client.commandList[0]).toBe('someFunc')

--- a/packages/webdriver/tests/utils.test.js
+++ b/packages/webdriver/tests/utils.test.js
@@ -1,6 +1,6 @@
 import {
-    isSuccessfulResponse, isValidParameter, getArgumentType, getPrototype, commandCallStructure, isW3CSession,
-    isChromiumSession
+    isSuccessfulResponse, isValidParameter, getArgumentType, getPrototype, commandCallStructure,
+    isAndroid, isIOS, isMobile, isW3CSession, isChromiumSession
 } from '../src/utils'
 
 import appiumResponse from './__fixtures__/appium.response.json'
@@ -105,6 +105,12 @@ describe('utils', () => {
             .toBe('foobar("param", 1, true, <object>, <fn>, null, undefined)')
     })
 
+    it('isMobile', function() {
+        expect(isMobile(appiumResponse.value.capabilities)).toBe(true)
+        expect(isMobile(chromedriverResponse.value.capabilities)).toBe(false)
+        expect(isMobile(geckodriverResponse.value.capabilities)).toBe(false)
+    })
+
     it('isW3CSession', () => {
         expect(isW3CSession(appiumResponse.value.capabilities)).toBe(true)
         expect(isW3CSession(chromedriverResponse.value.capabilities)).toBe(false)
@@ -115,5 +121,62 @@ describe('utils', () => {
         expect(isChromiumSession(appiumResponse.value.capabilities)).toBe(false)
         expect(isChromiumSession(chromedriverResponse.value)).toBe(true)
         expect(isChromiumSession(geckodriverResponse.value.capabilities)).toBe(false)
+    })
+
+    describe('mobile detection', () => {
+        it('should not detect mobile app for browserName===undefined', function () {
+            const capabilities = {}
+            expect(isMobile(capabilities)).toEqual(false)
+            expect(isIOS(capabilities)).toEqual(false)
+            expect(isAndroid(capabilities)).toEqual(false)
+        })
+
+        it('should not detect mobile app for browserName==="firefox"', function () {
+            const capabilities = {browserName: 'firefox'}
+            expect(isMobile(capabilities)).toEqual(false)
+            expect(isIOS(capabilities)).toEqual(false)
+            expect(isAndroid(capabilities)).toEqual(false)
+        })
+
+        it('should not detect mobile app for browserName==="chrome"', function () {
+            const capabilities = {browserName: 'chrome'}
+            expect(isMobile(capabilities)).toEqual(false)
+            expect(isIOS(capabilities)).toEqual(false)
+            expect(isAndroid(capabilities)).toEqual(false)
+        })
+
+        it('should detect mobile app for browserName===""', function () {
+            const capabilities = {browserName: ''}
+            expect(isMobile(capabilities)).toEqual(true)
+            expect(isIOS(capabilities)).toEqual(false)
+            expect(isAndroid(capabilities)).toEqual(false)
+        })
+
+        it('should detect Android mobile app', function () {
+            const capabilities = {
+                platformName: 'Android',
+                platformVersion: '4.4',
+                deviceName: 'LGVS450PP2a16334',
+                app: 'foo.apk'
+            }
+            expect(isMobile(capabilities)).toEqual(true)
+            expect(isIOS(capabilities)).toEqual(false)
+            expect(isAndroid(capabilities)).toEqual(true)
+        })
+
+        it('should detect Android mobile app without upload', function () {
+            const capabilities = {
+                platformName: 'Android',
+                platformVersion: '4.4',
+                deviceName: 'LGVS450PP2a16334',
+                appPackage: 'com.example',
+                appActivity: 'com.example.gui.LauncherActivity',
+                noReset: true,
+                appWaitActivity: 'com.example.gui.LauncherActivity'
+            }
+            expect(isMobile(capabilities)).toEqual(true)
+            expect(isIOS(capabilities)).toEqual(false)
+            expect(isAndroid(capabilities)).toEqual(true)
+        })
     })
 })

--- a/packages/webdriverio/src/commands/browser/newWindow.js
+++ b/packages/webdriverio/src/commands/browser/newWindow.js
@@ -31,7 +31,6 @@
  */
 
 import newWindowHelper from '../../scripts/newWindow'
-import { mobileDetector } from '../../utils'
 
 export default async function newWindow (url, windowName = 'New Window', windowFeatures = '') {
     /*!
@@ -44,8 +43,7 @@ export default async function newWindow (url, windowName = 'New Window', windowF
     /*!
      * mobile check
      */
-    const { isMobile } = mobileDetector(this.capabilities)
-    if (isMobile) {
+    if (this.isMobile) {
         throw new Error('newWindow command is not supported on mobile platforms')
     }
 

--- a/packages/webdriverio/src/index.js
+++ b/packages/webdriverio/src/index.js
@@ -58,6 +58,9 @@ export const multiremote = async function (params = {}) {
     const prototype = getPrototype('browser')
     const sessionParams = {
         sessionId: '',
+        isAndroid: multibrowser.instances[browserNames[0]].isAndroid,
+        isIOS: multibrowser.instances[browserNames[0]].isIOS,
+        isMobile: multibrowser.instances[browserNames[0]].isMobile,
         isW3C: multibrowser.instances[browserNames[0]].isW3C
     }
     const driver = WebDriver.attachToSession(sessionParams, ::multibrowser.modifier, prototype, wrapCommand)

--- a/packages/webdriverio/src/index.js
+++ b/packages/webdriverio/src/index.js
@@ -3,7 +3,7 @@ import { validateConfig, wrapCommand, detectBackend } from '@wdio/config'
 
 import MultiRemote from './multiremote'
 import { WDIO_DEFAULTS } from './constants'
-import { getPrototype, mobileDetector } from './utils'
+import { getPrototype } from './utils'
 
 /**
  * A method to create a new session with WebdriverIO
@@ -28,16 +28,6 @@ export const remote = function (params = {}, remoteModifier) {
     }
 
     const prototype = getPrototype('browser')
-
-    /**
-     * apply mobile check flags to browser scope
-     */
-    const mobileDetection = mobileDetector(params.capabilities)
-    Object.assign(prototype, Object.keys(mobileDetection).reduce((proto, flag) => {
-        proto[flag] = { value: mobileDetection[flag] }
-        return proto
-    }, {}))
-
     return WebDriver.newSession(params, modifier, prototype, wrapCommand)
 }
 

--- a/packages/webdriverio/src/multiremote.js
+++ b/packages/webdriverio/src/multiremote.js
@@ -1,5 +1,5 @@
 import zip from 'lodash.zip'
-import { webdriverMonad, getPrototype as getWebdriverPrototype } from 'webdriver'
+import { webdriverMonad } from 'webdriver'
 import { wrapCommand } from '@wdio/config'
 
 import { multiremoteHandler } from './middlewares'
@@ -66,9 +66,7 @@ export default class MultiRemote {
          * we can't handle multi browser with different protocol support, therefor check only the
          * first registered browser and handle it similar to other browser
          */
-        const isW3C = instances[Object.keys(instances)[0]].isW3C
-
-        const prototype = Object.assign(getWebdriverPrototype(isW3C), getPrototype('element'), { scope: 'element' })
+        const prototype = Object.assign(instances[Object.keys(instances)[0]].__propertiesObject__, getPrototype('element'), { scope: 'element' })
         const element = webdriverMonad({}, (client) => {
             /**
              * attach instances to wrapper client

--- a/packages/webdriverio/src/utils.js
+++ b/packages/webdriverio/src/utils.js
@@ -188,36 +188,6 @@ export const getElementFromResponse = (res) => {
 }
 
 /**
- * check if current platform is mobile device
- *
- * @param  {Object}  caps  capabilities
- * @return {Boolean}       true if platform is mobile device
- */
-export function mobileDetector (caps) {
-    let isMobile = Boolean(
-        (typeof caps['appium-version'] !== 'undefined') ||
-        (typeof caps['device-type'] !== 'undefined') || (typeof caps['deviceType'] !== 'undefined') ||
-        (typeof caps['device-orientation'] !== 'undefined') || (typeof caps['deviceOrientation'] !== 'undefined') ||
-        (typeof caps.deviceName !== 'undefined') ||
-        // Check browserName for specific values
-        (caps.browserName === '' ||
-             (caps.browserName !== undefined && (caps.browserName.toLowerCase() === 'ipad' || caps.browserName.toLowerCase() === 'iphone' || caps.browserName.toLowerCase() === 'android')))
-    )
-
-    let isIOS = Boolean(
-        (caps.platformName && caps.platformName.match(/iOS/i)) ||
-        (caps.deviceName && caps.deviceName.match(/(iPad|iPhone)/i))
-    )
-
-    let isAndroid = Boolean(
-        (caps.platformName && caps.platformName.match(/Android/i)) ||
-        (caps.browserName && caps.browserName.match(/Android/i))
-    )
-
-    return { isMobile, isIOS, isAndroid }
-}
-
-/**
  * traverse up the scope chain until browser element was reached
  */
 export function getBrowserObject (elem) {

--- a/packages/webdriverio/tests/commands/browser/newWindow.test.js
+++ b/packages/webdriverio/tests/commands/browser/newWindow.test.js
@@ -39,10 +39,18 @@ describe('newWindow', () => {
 
     it('should fail if browser is a mobile device', async () => {
         expect.hasAssertions()
-        browser.capabilities.browserName = 'ipad'
+
+        const mobileBrowser = await remote({
+            baseUrl: 'http://foobar.com',
+            capabilities: {
+                browserName: 'foobar',
+                mobileMode: true,
+                'appium-version': '1.9.2'
+            }
+        })
 
         try {
-            await browser.newWindow('https://webdriver.io', 'some name', 'some params')
+            await mobileBrowser.newWindow('https://webdriver.io', 'some name', 'some params')
         } catch (e) {
             expect(e.message).toContain('not supported on mobile')
         }

--- a/packages/webdriverio/tests/utils.test.js
+++ b/packages/webdriverio/tests/utils.test.js
@@ -2,7 +2,6 @@ import { ELEMENT_KEY } from '../src/constants'
 import {
     findStrategy,
     getElementFromResponse,
-    mobileDetector,
     getBrowserObject,
     transformToCharString,
     parseCSS,
@@ -327,63 +326,6 @@ describe('utils', () => {
 
         it('should throw otherwise', () => {
             expect(getElementFromResponse({ invalid: 'response '})).toBe(null)
-        })
-    })
-
-    describe('mobileDetector', () => {
-        it('should not detect mobile app for browserName===undefined', function () {
-            const {isMobile, isIOS, isAndroid} = mobileDetector({})
-            expect(isMobile).toEqual(false)
-            expect(isIOS).toEqual(false)
-            expect(isAndroid).toEqual(false)
-        })
-
-        it('should not detect mobile app for browserName==="firefox"', function () {
-            const {isMobile, isIOS, isAndroid} = mobileDetector({browserName: 'firefox'})
-            expect(isMobile).toEqual(false)
-            expect(isIOS).toEqual(false)
-            expect(isAndroid).toEqual(false)
-        })
-
-        it('should not detect mobile app for browserName==="chrome"', function () {
-            const {isMobile, isIOS, isAndroid} = mobileDetector({browserName: 'chrome'})
-            expect(isMobile).toEqual(false)
-            expect(isIOS).toEqual(false)
-            expect(isAndroid).toEqual(false)
-        })
-
-        it('should detect mobile app for browserName===""', function () {
-            const {isMobile, isIOS, isAndroid} = mobileDetector({browserName: ''})
-            expect(isMobile).toEqual(true)
-            expect(isIOS).toEqual(false)
-            expect(isAndroid).toEqual(false)
-        })
-
-        it('should detect Android mobile app', function () {
-            const {isMobile, isIOS, isAndroid} = mobileDetector({
-                platformName: 'Android',
-                platformVersion: '4.4',
-                deviceName: 'LGVS450PP2a16334',
-                app: 'foo.apk'
-            })
-            expect(isMobile).toEqual(true)
-            expect(isIOS).toEqual(false)
-            expect(isAndroid).toEqual(true)
-        })
-
-        it('should detect Android mobile app without upload', function () {
-            const {isMobile, isIOS, isAndroid} = mobileDetector({
-                platformName: 'Android',
-                platformVersion: '4.4',
-                deviceName: 'LGVS450PP2a16334',
-                appPackage: 'com.example',
-                appActivity: 'com.example.gui.LauncherActivity',
-                noReset: true,
-                appWaitActivity: 'com.example.gui.LauncherActivity'
-            })
-            expect(isMobile).toEqual(true)
-            expect(isIOS).toEqual(false)
-            expect(isAndroid).toEqual(true)
         })
     })
 


### PR DESCRIPTION
## Proposed changes

* Define `isAndroid`, `isIOS`, `isMobile` flags in webdriver along with the `isW3C` flag instead of in webdriverio, having a unified approach for mobile checks.
* Check whether values passed into `attachToSession` are boolean instead of setting flags always to `true`, as `false` will pipe through to fallback/default value.
* Attach protocol to multiremote session by using `__propertiesObject__` reference.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

### Reviewers: @webdriverio/technical-committee
