### PR TITLE
Don't log error if service only contains a launcher

### DIFF
--- a/packages/wdio-runner/src/utils.js
+++ b/packages/wdio-runner/src/utils.js
@@ -47,6 +47,14 @@ export function initialiseServices (config, caps) {
         log.debug(`initialise wdio service "${serviceName}"`)
         try {
             const Service = initialisePlugin(serviceName, 'service')
+
+            /**
+             * service only contains a launcher
+             */
+            if (!Service) {
+                continue
+            }
+
             initialisedServices.push(new Service(config, caps))
         } catch(e) {
             log.error(e)

--- a/packages/wdio-runner/tests/__mocks__/wdio-launcher-only-service.js
+++ b/packages/wdio-runner/tests/__mocks__/wdio-launcher-only-service.js
@@ -1,0 +1,1 @@
+export const launcher = class {}

--- a/packages/wdio-runner/tests/utils.test.js
+++ b/packages/wdio-runner/tests/utils.test.js
@@ -4,6 +4,10 @@ import { attach, remote, multiremote } from 'webdriverio'
 import { runHook, initialiseServices, initialiseInstance, sanitizeCaps } from '../src/utils'
 
 describe('utils', () => {
+    beforeEach(() => {
+        logMock.error.mockClear()
+    })
+
     describe('runHook', () => {
         it('should execute all hooks', async () => {
             const config = { before: [jest.fn(), jest.fn(), jest.fn()] }
@@ -11,7 +15,6 @@ describe('utils', () => {
 
             const args = [[config, 'foo', 'bar']]
             expect(config.before.map((hook) => hook.mock.calls)).toEqual([args, args, args])
-            logMock.error.mockClear()
         })
 
         it('should not fail if hooks throw', async () => {
@@ -58,6 +61,12 @@ describe('utils', () => {
             expect(typeof service.afterCommand).toBe('function')
             // not defined method
             expect(typeof service.before).toBe('undefined')
+        })
+
+        it('should ignore service with launcher only', () => {
+            const services = initialiseServices({ services: ['launcher-only'] })
+            expect(services).toHaveLength(0)
+            expect(logMock.error).toHaveBeenCalledTimes(0)
         })
     })
 


### PR DESCRIPTION
## Proposed changes

Right now you will find an error in the logs when using the firefox-profile service because the service only contains a launcher. That is irritating and should be ignored.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
