### PR TITLE
Fixes type generation for URL variables

### DIFF
--- a/scripts/type-generation/webdriver-generate-typings.js
+++ b/scripts/type-generation/webdriver-generate-typings.js
@@ -19,11 +19,15 @@ for (const [protocolName, definition] of Object.entries(PROTOCOLS)) {
 
     for (const [, methods] of Object.entries(definition)) {
         for (const [, description] of Object.entries(methods)) {
-            const { command, parameters = [], returns } = description
+            const { command, parameters = [], variables = [], returns } = description
+            const vars = variables
+                .filter((v) => v.name != "sessionId" && v.name != "elementId")
+                .map((v) => `${v.name}: string`)
             const params = parameters.map((p) => `${p.name}${p.required === false ? '?' : ''}: ${p.type.toLowerCase()}`)
+            const paramsAndVars = params.concat(vars);
             let returnValue = returns ? returns.type.toLowerCase() : 'undefined'
             returnValue = returnValue === '*' ? 'any' : returnValue
-            lines.push(`        ${command}(${params.join(', ')}): ${returnValue};`)
+            lines.push(`        ${command}(${paramsAndVars.join(', ')}): ${returnValue};`)
         }
     }
 

--- a/scripts/type-generation/webdriver-generate-typings.js
+++ b/scripts/type-generation/webdriver-generate-typings.js
@@ -21,10 +21,10 @@ for (const [protocolName, definition] of Object.entries(PROTOCOLS)) {
         for (const [, description] of Object.entries(methods)) {
             const { command, parameters = [], variables = [], returns } = description
             const vars = variables
-                .filter((v) => v.name != "sessionId" && v.name != "elementId")
+                .filter((v) => v.name != 'sessionId' && v.name != 'elementId')
                 .map((v) => `${v.name}: string`)
             const params = parameters.map((p) => `${p.name}${p.required === false ? '?' : ''}: ${p.type.toLowerCase()}`)
-            const paramsAndVars = params.concat(vars);
+            const paramsAndVars = params.concat(vars)
             let returnValue = returns ? returns.type.toLowerCase() : 'undefined'
             returnValue = returnValue === '*' ? 'any' : returnValue
             lines.push(`        ${command}(${paramsAndVars.join(', ')}): ${returnValue};`)

--- a/scripts/type-generation/webdriver-generate-typings.js
+++ b/scripts/type-generation/webdriver-generate-typings.js
@@ -24,10 +24,10 @@ for (const [protocolName, definition] of Object.entries(PROTOCOLS)) {
                 .filter((v) => v.name != 'sessionId' && v.name != 'elementId')
                 .map((v) => `${v.name}: string`)
             const params = parameters.map((p) => `${p.name}${p.required === false ? '?' : ''}: ${p.type.toLowerCase()}`)
-            const paramsAndVars = params.concat(vars)
+            const varsAndParams = vars.concat(params)
             let returnValue = returns ? returns.type.toLowerCase() : 'undefined'
             returnValue = returnValue === '*' ? 'any' : returnValue
-            lines.push(`        ${command}(${paramsAndVars.join(', ')}): ${returnValue};`)
+            lines.push(`        ${command}(${varsAndParams.join(', ')}): ${returnValue};`)
         }
     }
 


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

This PR fixes the webdriver type generation. When there were more URL variables than `sessionId` or `elementId` they would not end up in the typings as input parameters.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)
Since the variables are in the url, they are always of type `string` and can not be optional.

### Reviewers: @webdriverio/technical-committee
