### PR TITLE
wdio-allure-reporter: make step attachments optional

### DIFF
--- a/packages/wdio-allure-reporter/src/index.js
+++ b/packages/wdio-allure-reporter/src/index.js
@@ -46,7 +46,7 @@ class AllureReporter extends WDIOReporter {
 
         const currentTest = this.allure.getCurrentTest()
 
-        const { browserName, deviceName } = this.config.capabilities
+        const {browserName, deviceName} = this.config.capabilities
         const targetName = browserName || deviceName || test.cid
         const version = this.config.capabilities.version || this.config.capabilities.platformVersion || ''
         const paramName = deviceName ? 'device' : 'browser'
@@ -240,7 +240,7 @@ class AllureReporter extends WDIOReporter {
         return this.allure.getCurrentSuite() && this.allure.getCurrentTest()
     }
 
-    isScreenshotCommand(command){
+    isScreenshotCommand(command) {
         const isScrenshotEndpoint = /\/session\/[^/]*\/screenshot/
         return isScrenshotEndpoint.test(command.endpoint)
     }
@@ -320,24 +320,18 @@ class AllureReporter extends WDIOReporter {
     /**
      * Create allure step
      * @param {string} title - step name in report
-     * @param {Object} attachmentObject - attachment for step
+     * @param {Object} [attachmentObject={}] - attachment for step
      * @param {string} attachmentObject.content - attachment content
      * @param {string} [attachmentObject.name='attachment'] - attachment name
+     * @param {string} [attachmentObject.type='text/plain'] - attachment type
      * @param {string} [status='passed'] - step status
      */
-    static addStep = (title, {content, name = 'attachment'}, status = stepStatuses.PASSED) => {
+    static addStep = (title, {content, name = 'attachment', type = 'text/plain'} = {}, status = stepStatuses.PASSED) => {
         if (!Object.values(stepStatuses).includes(status)) {
             throw new Error(`Step status must be ${Object.values(stepStatuses).join(' or ')}. You tried to set "${status}"`)
         }
 
-        const step = {
-            title,
-            attachment: {
-                content,
-                name
-            },
-            status
-        }
+        const step = content ? {title, attachment: {content, name, type}, status} : {title, status}
         tellReporter(events.addStep, {step})
     }
 

--- a/packages/wdio-allure-reporter/tests/runtime.test.js
+++ b/packages/wdio-allure-reporter/tests/runtime.test.js
@@ -65,23 +65,37 @@ describe('reporter reporter api', () => {
     })
 
     it('should pass correct data from addStep', () => {
-        reporter.addStep('foo', {name: 'bar', content: 'baz'}, stepStatuses.FAILED )
+        reporter.addStep('foo', {name: 'bar', content: 'baz', type: 'text/plain'}, stepStatuses.FAILED )
         expect(utils.tellReporter).toHaveBeenCalledTimes(1)
-        const step = {'step': {'attachment': {'content': 'baz', 'name': 'bar'}, 'status': 'failed', 'title': 'foo'}}
+        const step = {'step': {'attachment': {'content': 'baz', 'name': 'bar', 'type': 'text/plain'}, 'status': 'failed', 'title': 'foo'}}
         expect(utils.tellReporter).toHaveBeenCalledWith(events.addStep, step)
     })
 
     it('should support default attachment name for addStep', () => {
         reporter.addStep('foo', {content: 'baz'}, stepStatuses.FAILED )
         expect(utils.tellReporter).toHaveBeenCalledTimes(1)
-        const step = {'step': {'attachment': {'content': 'baz', 'name': 'attachment'}, 'status': 'failed', 'title': 'foo'}}
+        const step = {'step': {'attachment': {'content': 'baz', 'name': 'attachment', 'type': 'text/plain'}, 'status': 'failed', 'title': 'foo'}}
+        expect(utils.tellReporter).toHaveBeenCalledWith(events.addStep, step)
+    })
+
+    it('should support default attachment type for addStep', () => {
+        reporter.addStep('foo', {content: 'baz'})
+        expect(utils.tellReporter).toHaveBeenCalledTimes(1)
+        const step = {'step': {'attachment': {'content': 'baz', 'name': 'attachment', 'type': 'text/plain'}, 'status': 'passed', 'title': 'foo'}}
+        expect(utils.tellReporter).toHaveBeenCalledWith(events.addStep, step)
+    })
+
+    it('should support addStep without attachment', () => {
+        reporter.addStep('foo')
+        expect(utils.tellReporter).toHaveBeenCalledTimes(1)
+        const step = {'step': {'status': 'passed', 'title': 'foo'}}
         expect(utils.tellReporter).toHaveBeenCalledWith(events.addStep, step)
     })
 
     it('should support default step status for addStep', () => {
         reporter.addStep('foo', {content: 'baz'} )
         expect(utils.tellReporter).toHaveBeenCalledTimes(1)
-        const step = {'step': {'attachment': {'content': 'baz', 'name': 'attachment'}, 'status': 'passed', 'title': 'foo'}}
+        const step = {'step': {'attachment': {'content': 'baz', 'name': 'attachment', 'type': 'text/plain'}, 'status': 'passed', 'title': 'foo'}}
         expect(utils.tellReporter).toHaveBeenCalledWith(events.addStep, step)
     })
 


### PR DESCRIPTION
## Proposed changes

Current addStep signature has no default value for attachmentObject. It forces users to add attachment for each step. Moreover, even if we ignore it, and pass just a single title arg, step processing logic still assumes attachment presence. If content is undefined we're getting a runtime exception. This update relaxes attachment rules for steps, making attachmentObject optional. Apart from that, there was added an explicit content type, so that users could add not only text attachments to steps.

METADATA: fixes #3316

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

### Reviewers: @webdriverio/technical-committee @BorisOsipov 
