### PR TITLE
Don't do instanceof check for set cookie and rather look for type

### DIFF
--- a/packages/webdriverio/src/commands/browser/setCookies.js
+++ b/packages/webdriverio/src/commands/browser/setCookies.js
@@ -31,7 +31,7 @@
 export default async function setCookies(cookieObjs) {
     const cookieObjsList = !Array.isArray(cookieObjs) ? [cookieObjs] : cookieObjs
 
-    if (cookieObjsList.some(obj => !(obj instanceof Object))) {
+    if (cookieObjsList.some(obj => (typeof obj !== 'object'))) {
         throw new Error('Invalid input (see https://webdriver.io/docs/api/browser/setCookies.html for documentation.')
     }
 


### PR DESCRIPTION
## Proposed changes

For some reasons the instance of check doesn't work. `typeof` does the trick too.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
