### PR TITLE
Remove desiredCapabilities in docs

### DIFF
--- a/docs/CloudServices.md
+++ b/docs/CloudServices.md
@@ -42,7 +42,7 @@ Also if you want to have Sauce Labs group your tests by build number, you can se
 
 Lastly if you set the `name`, this changes the name of this test in Sauce Labs for this build. If you are using the WDIO testrunner combined with the [`@wdio/sauce-service`](https://github.com/webdriverio/webdriverio/tree/master/packages/wdio-sauce-service) WebdriverIO automatically sets a proper name for the test.
 
-Example `desiredCapabilities`:
+Example `capabilities`:
 
 ```javascript
 browserName: 'chrome',
@@ -92,7 +92,7 @@ sleep 3
 
 Also, you might wanna set the `build` to the Travis build number.
 
-Example `desiredCapabilities`:
+Example `capabilities`:
 
 ```javascript
 browserName: 'chrome',

--- a/docs/Multiremote.md
+++ b/docs/Multiremote.md
@@ -47,12 +47,12 @@ export.config = {
     // ...
     capabilities: {
         myChromeBrowser: {
-            desiredCapabilities: {
+            capabilities: {
                 browserName: 'chrome'
             }
         },
         myFirefoxBrowser: {
-            desiredCapabilities: {
+            capabilities: {
                 browserName: 'firefox'
             }
         }

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -42,11 +42,10 @@ Type: `Object`<br>
 Default: `null`
 
 ### capabilities
-Defines the capabilities you want to run in your WebDriver session. Check out the [WebDriver Protocol](https://w3c.github.io/webdriver/#capabilities) for more details. If you run an older driver that doesn't support WebDriver you need to apply the [JSONWireProtocol capabilities](https://github.com/SeleniumHQ/selenium/wiki/DesiredCapabilities) to successfuly run a session. Also a useful utility is the Sauce Labs [Automated Test Configurator](https://wiki.saucelabs.com/display/DOCS/Platform+Configurator#/)
-that helps you to create this object by clicking together your desired capabilities.
+Defines the capabilities you want to run in your WebDriver session. Check out the [WebDriver Protocol](https://w3c.github.io/webdriver/#capabilities) for more details. If you run an older driver that doesn't support WebDriver you need to apply the [JSONWireProtocol capabilities](https://github.com/SeleniumHQ/selenium/wiki/DesiredCapabilities) to successfuly run a session. Also a useful utility is the Sauce Labs [Automated Test Configurator](https://wiki.saucelabs.com/display/DOCS/Platform+Configurator#/) that helps you to create this object by clicking together your desired capabilities.
 
 Type: `Object`<br>
-Default: `{ browserName: 'firefox' }`
+Default: `null`
 
 **Example:**
 

--- a/examples/appium/appium-draws-its-logo.js
+++ b/examples/appium/appium-draws-its-logo.js
@@ -11,7 +11,7 @@ const webviewApp = '/path/to/app'
     const driver = await remote({
         port: 4723,
         logLevel: 'debug',
-        desiredCapabilities: {
+        capabilities: {
             platformName: 'iOS',
             platformVersion: '8.4',
             deviceName: 'iPhone 6',

--- a/packages/wdio-firefox-profile-service/src/launcher.js
+++ b/packages/wdio-firefox-profile-service/src/launcher.js
@@ -59,7 +59,7 @@ export default class FirefoxProfileLauncher {
         }
 
         for (const browser in this.capabilities) {
-            const capability = this.capabilities[browser].desiredCapabilities
+            const capability = this.capabilities[browser].capabilities
 
             if (!capability || capability.browserName !== 'firefox') {
                 continue

--- a/packages/wdio-firefox-profile-service/tests/launcher.test.js
+++ b/packages/wdio-firefox-profile-service/tests/launcher.test.js
@@ -111,7 +111,7 @@ describe('Firefox profile service', () => {
             }
             const capabilities = {
                 firefox : {
-                    desiredCapabilities : {
+                    capabilities : {
                         browserName : 'firefox',
                     }
                 }
@@ -120,8 +120,8 @@ describe('Firefox profile service', () => {
             const service = new Launcher()
             await service.onPrepare(config, capabilities)
 
-            expect(capabilities.firefox.desiredCapabilities.firefox_profile).toBe('foobar')
-            expect(capabilities.firefox.desiredCapabilities['moz:firefoxOptions']).toEqual({ profile : 'foobar'})
+            expect(capabilities.firefox.capabilities.firefox_profile).toBe('foobar')
+            expect(capabilities.firefox.capabilities['moz:firefoxOptions']).toEqual({ profile : 'foobar'})
         })
 
         test('should not set capabilities when an object and not firefox', async () => {
@@ -132,7 +132,7 @@ describe('Firefox profile service', () => {
             }
             const capabilities = {
                 foo : {
-                    desiredCapabilities : {
+                    capabilities : {
                         browserName : 'chrome',
                     }
                 }
@@ -141,8 +141,8 @@ describe('Firefox profile service', () => {
             const service = new Launcher()
             await service.onPrepare(config, capabilities)
 
-            expect(capabilities.foo.desiredCapabilities).not.toHaveProperty('firefox_profile')
-            expect(capabilities.foo.desiredCapabilities).not.toHaveProperty('moz:firefoxOptions')
+            expect(capabilities.foo.capabilities).not.toHaveProperty('firefox_profile')
+            expect(capabilities.foo.capabilities).not.toHaveProperty('moz:firefoxOptions')
         })
 
         test('should set proxy', async () => {

--- a/packages/webdriver/protocol/jsonwp.json
+++ b/packages/webdriver/protocol/jsonwp.json
@@ -22,6 +22,10 @@
         "type": "object",
         "description": "An object describing the session's desired capabilities.",
         "required": true
+      }, {
+        "name": "requiredCapabilities",
+        "type": "object",
+        "description": "An object describing the session's required capabilities (Optional)."
       }],
       "returns": {
         "type": "Object",

--- a/packages/webdriverio/src/constants.js
+++ b/packages/webdriverio/src/constants.js
@@ -60,7 +60,7 @@ export const WDIO_DEFAULTS = {
      * capabilities of WebDriver sessions
      */
     capabilities: {
-        type: 'object|object[]',
+        type: 'object',
         required: true
     },
     /**
@@ -157,14 +157,14 @@ export const WDIO_DEFAULTS = {
      * set of WDIO services to use
      */
     services: {
-        type: 'string[]|object[]',
+        type: 'object',
         default: []
     },
     /**
      * Node arguments to specify when launching child processes
      */
     execArgv: {
-        type: 'string[]',
+        type: 'object',
         default: []
     },
     /**


### PR DESCRIPTION
## Proposed changes

The option `desiredCapabilities` is not valid in v5 anymore. Remove the entirely where needed.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
