### PR TITLE
Better error handling for webdriver responses

### DIFF
--- a/packages/webdriver/src/request.js
+++ b/packages/webdriver/src/request.js
@@ -106,8 +106,7 @@ export default class WebDriverRequest extends EventEmitter {
              *  stop retrying as this will never be successful.
              *  we will handle this at the elementErrorHandler
              */
-
-            if(error.message.includes('stale element reference')) {
+            if(error.stack.includes('stale element reference')) {
                 log.warn('Request encountered a stale element - terminating request')
                 this.emit('response', { error })
                 return reject(error)

--- a/packages/webdriver/src/request.js
+++ b/packages/webdriver/src/request.js
@@ -8,7 +8,7 @@ import EventEmitter from 'events'
 
 import logger from '@wdio/logger'
 
-import { isSuccessfulResponse } from './utils'
+import { isSuccessfulResponse, getErrorFromResponseBody } from './utils'
 import pkg from '../package.json'
 
 const log = logger('webdriver')
@@ -92,7 +92,7 @@ export default class WebDriverRequest extends EventEmitter {
         }
 
         return new Promise((resolve, reject) => request(fullRequestOptions, (err, response, body) => {
-            const error = new Error(err || (body && body.value ? body.value.message : body))
+            const error = err || getErrorFromResponseBody(body)
 
             /**
              * Resolve only if successful response

--- a/packages/webdriver/src/utils.js
+++ b/packages/webdriver/src/utils.js
@@ -290,3 +290,24 @@ export function environmentDetector ({ hostname, capabilities, requestedCapabili
         isSauce: isSauce(hostname, requestedCapabilities.w3cCaps.alwaysMatch)
     }
 }
+
+/**
+ * helper method to determine the error from webdriver response
+ * @param  {Object} body body object
+ * @return {String}      error message
+ */
+export function getErrorFromResponseBody (body) {
+    if (!body) {
+        return null
+    }
+
+    if (typeof body !== 'object' || !body.value) {
+        return new Error('unknown error')
+    }
+
+    return new Error(
+        body.value.message ||
+        body.value.class ||
+        'unknown error'
+    )
+}

--- a/packages/webdriver/tests/request.test.js
+++ b/packages/webdriver/tests/request.test.js
@@ -98,8 +98,14 @@ describe('webdriver request', () => {
             const opts = Object.assign(req.defaultOptions, {
                 uri: { path: '/wd/hub/session/foobar-123/element/some-sub-sub-elem-231/click' }, body: { foo: 'bar' } })
 
-            expect(req._request(opts)).rejects.toEqual(
-                new Error('stale element reference: element is not attached to the page document'))
+            let error
+            try {
+                await req._request(opts)
+            } catch (e) {
+                error = e
+            }
+
+            expect(error.message).toBe('element is not attached to the page document')
             expect(req.emit.mock.calls).toHaveLength(1)
             expect(warn.mock.calls).toHaveLength(1)
             expect(warn.mock.calls).toEqual([['Request encountered a stale element - terminating request']])
@@ -114,7 +120,7 @@ describe('webdriver request', () => {
             req.emit = jest.fn()
 
             const opts = Object.assign(req.defaultOptions, { uri: { path: '/wd/hub/failing' } })
-            expect(req._request(opts, 2)).rejects.toEqual(new Error('Error: Could not send request'))
+            await expect(req._request(opts, 2)).rejects.toEqual(new Error('Could not send request'))
             expect(req.emit.mock.calls).toHaveLength(3)
             expect(warn.mock.calls).toHaveLength(2)
             expect(error.mock.calls).toHaveLength(1)

--- a/packages/webdriver/tests/utils.test.js
+++ b/packages/webdriver/tests/utils.test.js
@@ -1,6 +1,6 @@
 import {
     isSuccessfulResponse, isValidParameter, getArgumentType, getPrototype, commandCallStructure,
-    environmentDetector
+    environmentDetector, getErrorFromResponseBody
 } from '../src/utils'
 
 import appiumResponse from './__fixtures__/appium.response.json'
@@ -212,5 +212,21 @@ describe('utils', () => {
             expect(isIOS).toEqual(false)
             expect(isAndroid).toEqual(true)
         })
+    })
+
+    it('getErrorFromResponseBody', () => {
+        expect(getErrorFromResponseBody()).toBe(null)
+        expect(getErrorFromResponseBody('')).toBe(null)
+        expect(getErrorFromResponseBody(null)).toBe(null)
+
+        const unknownError = new Error('unknown error')
+        expect(getErrorFromResponseBody('foobar')).toEqual(unknownError)
+        expect(getErrorFromResponseBody({})).toEqual(unknownError)
+
+        const expectedError = new Error('expected')
+        expect(getErrorFromResponseBody({ value: { message: 'expected' } }))
+            .toEqual(expectedError)
+        expect(getErrorFromResponseBody({ value: { class: 'expected' } }))
+            .toEqual(expectedError)
     })
 })


### PR DESCRIPTION
## Proposed changes

Sauce Labs returned an invalid response for Firefox tests. We should better cover this.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
