### PR TITLE
missing lodash in dependencies require('lodash') node_modules/webdriverio/build/commands/element/$$.js

### DIFF
--- a/packages/webdriverio/src/commands/element/$$.js
+++ b/packages/webdriverio/src/commands/element/$$.js
@@ -39,7 +39,7 @@
  */
 import { webdriverMonad } from 'webdriver'
 import { wrapCommand } from '@wdio/config'
-import { merge } from 'lodash'
+import merge from 'lodash.merge'
 
 import {findElements, getBrowserObject, getPrototype as getWDIOPrototype, getElementFromResponse} from '../../utils'
 import { elementErrorHandler } from '../../middlewares'


### PR DESCRIPTION
```
npm ls webdriverio
└── webdriverio@5.3.2

lodash is not in package.json
missing lodash in dependencies require('lodash') node_modules/webdriverio/build/commands/element/$$.js

const webdriverio = require('webdriverio');
...		const browser = await webdriverio.remote(opts);
... throws when using:

scenarios.js:120 Error: Cannot find module 'lodash'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
    at Function.Module._load (internal/modules/cjs/loader.js:507:25)
    at Module.require (internal/modules/cjs/loader.js:637:17)
    at require (internal/modules/cjs/helpers.js:22:18)
    at Object.<anonymous> (/usr/local/lib/node_modules/webdriverio/build/commands/element/$$.js:12:15) as follows:
(function (exports, require, module, __filename, __dirname) { "use strict";

Object.defineProperty(exports, "__esModule", {
  value: true
});
exports.default = $$;

var _webdriver = require("webdriver");

var _config = require("@wdio/config");

var _lodash = require("lodash");
```