### PR TITLE
wdio-browserstack-service: Remove erroneous call to resolve

### DIFF
--- a/packages/wdio-browserstack-service/src/launcher.js
+++ b/packages/wdio-browserstack-service/src/launcher.js
@@ -37,7 +37,6 @@ export default class BrowserstackLauncherService {
                     }
                     resolve()
                 })
-                resolve()
             }),
             new Promise((resolve, reject) => {
                 /* istanbul ignore next */


### PR DESCRIPTION
## Proposed changes

The BrowserStack service got an extra call to resolve() when the launcher was ported. It causes the launcher to resolve prematurely, before the local tunnel has actually started.


## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

While the unit tests don't disclose the bug, it's not immediately obvious to me how the tests could be improved.

### Reviewers: @webdriverio/technical-committee
