### PR TITLE
Acknowledge responses with body as string

### DIFF
--- a/packages/webdriver/src/utils.js
+++ b/packages/webdriver/src/utils.js
@@ -301,6 +301,10 @@ export function getErrorFromResponseBody (body) {
         return null
     }
 
+    if (typeof body === 'string') {
+        return new Error(body)
+    }
+
     if (typeof body !== 'object' || !body.value) {
         return new Error('unknown error')
     }

--- a/packages/webdriver/src/utils.js
+++ b/packages/webdriver/src/utils.js
@@ -301,7 +301,7 @@ export function getErrorFromResponseBody (body) {
         return null
     }
 
-    if (typeof body === 'string') {
+    if (typeof body === 'string' && body.length) {
         return new Error(body)
     }
 

--- a/packages/webdriver/tests/utils.test.js
+++ b/packages/webdriver/tests/utils.test.js
@@ -220,7 +220,6 @@ describe('utils', () => {
         expect(getErrorFromResponseBody(null)).toBe(null)
 
         const unknownError = new Error('unknown error')
-        expect(getErrorFromResponseBody('foobar')).toEqual(unknownError)
         expect(getErrorFromResponseBody({})).toEqual(unknownError)
 
         const expectedError = new Error('expected')

--- a/packages/webdriver/tests/utils.test.js
+++ b/packages/webdriver/tests/utils.test.js
@@ -224,6 +224,7 @@ describe('utils', () => {
         expect(getErrorFromResponseBody({})).toEqual(unknownError)
 
         const expectedError = new Error('expected')
+        expect(getErrorFromResponseBody('expected')).toEqual(expectedError)
         expect(getErrorFromResponseBody({ value: { message: 'expected' } }))
             .toEqual(expectedError)
         expect(getErrorFromResponseBody({ value: { class: 'expected' } }))


### PR DESCRIPTION
## Proposed changes

Chromedriver returns a string as body when a connection can't be established. The `getErrorFromResponseBody` doesn't acknowledge errors that are strings.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
