### PR TITLE
Webdriver: Fix endpoint for Appium sendSms

### DIFF
--- a/packages/webdriver/protocol/appium.json
+++ b/packages/webdriver/protocol/appium.json
@@ -974,7 +974,7 @@
       }
     }
   },
-  "/session/:sessionId/appium/device/gsm_voice": {
+  "/session/:sessionId/appium/device/send_sms": {
     "POST": {
       "command": "sendSms",
       "description": "Simulate an SMS message (Emulator only).",


### PR DESCRIPTION
## Proposed changes

Fix sendSms endpoint, it was pointing to gsm_voice

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
Current tests don't verify that the correct endpoint is called only that the various protocol `json` files are correctly interpreted, so I didn't add a test to do that as I'm not sure what testing philosophy is being followed. Though basic double-entry accounting type testing might prevent issues like this...

### Reviewers: @webdriverio/technical-committee