### PR TITLE
Retries per specfile

### DIFF
--- a/docs/ConfigurationFile.md
+++ b/docs/ConfigurationFile.md
@@ -160,6 +160,9 @@ exports.config = {
     // Make sure you have the wdio adapter package for the specific framework installed before running any tests.
     framework: 'mocha',
     //
+    // The number of times to retry the entire specfile when it fails as a whole
+    specFileRetries: 1,
+    //
     // Test reporter for stdout.
     // The only one supported by default is 'dot'
     // see also: https://webdriver.io/docs/dot-reporter.html and click on "Reporters" in left column

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -140,6 +140,12 @@ If you only want to run your tests until a specific amount of tests have failed 
 Type: `Number`<br>
 Default: `0` (don't bail, run all tests)
 
+### specFileRetries
+The number of times to retry an entire specfile when it fails as a whole
+
+Type: `Number`<br>
+Default: `0`
+
 ### waitforTimeout
 Default timeout for all waitForXXX commands. Note the lowercase `f`. This timeout __only__ affects commands starting with waitForXXX and their default wait time. To increase the timeout of the test please see the framework docs.
 

--- a/docs/Retry.md
+++ b/docs/Retry.md
@@ -76,3 +76,15 @@ module.exports = function () {
 ```
 
 Reruns can only be defined in your step definitions file and not in your feature file.
+
+## Add retries on a per-specfile basis
+Previously only test-level and suite-level retries were available, which are fine in most cases. In any test which involves state, such as on a server or in a db, the state may be left invalid once the test fails the first time. Any subsequent retries may have no chance of passing due to the invalid state they would have to start with.
+A new browser instance is created for each specfile, which makes this an ideal place to hook and setup any other states (server, db). Retries on this level mean that the whole setup process will simply be repeated as if it were for a new specfile.
+```js
+module.exports = function () {
+    /**
+     * The number of times to retry the entire specfile when it fails as a whole
+     */
+    specFileRetries: 1
+}
+```

--- a/examples/wdio.conf.js
+++ b/examples/wdio.conf.js
@@ -130,6 +130,9 @@ exports.config = {
     // installed before running any tests.
     framework: 'mocha',
     //
+    // The number of times to retry the entire specfile when it fails as a whole
+    specFileRetries: 1,
+    //
     // Test reporter for stdout.
     // The only one supported by default is 'dot'
     // see also: https://webdriver.io/docs/dot-reporter.html

--- a/packages/wdio-cli/src/launcher.js
+++ b/packages/wdio-cli/src/launcher.js
@@ -333,13 +333,12 @@ class Launcher {
         const passed = exitCode === 0
 
         if (!passed && retries > 0) {
-            this.interface.totalWorkerCnt++
             this.schedule[parseInt(cid)].specs.push({ files: specs, retries: retries - 1, rid: cid })
         } else {
             this.exitCode = this.exitCode || exitCode
             this.runnerFailed += !passed ? 1 : 0
         }
-        this.interface.emit('job:end', { cid, passed })
+        this.interface.emit('job:end', { cid, passed, retries })
 
         // Update schedule now this process has ended
         if (!this.isMultiremote) {

--- a/packages/wdio-cli/src/launcher.js
+++ b/packages/wdio-cli/src/launcher.js
@@ -124,7 +124,7 @@ class Launcher {
             this.schedule.push({
                 cid: cid++,
                 caps: capabilities,
-                specs: this.configParser.getSpecs(capabilities.specs, capabilities.exclude),
+                specs: this.configParser.getSpecs(capabilities.specs, capabilities.exclude).map(s => ({ files: [s], retries: config.specFileRetries })),
                 availableInstances: capabilities.maxInstances || config.maxInstancesPerCapability,
                 runningInstances: 0,
                 seleniumServer: { hostname: config.hostname, port: config.port, protocol: config.protocol }
@@ -208,11 +208,14 @@ class Launcher {
                 break
             }
 
+            let specs = schedulableCaps[0].specs.shift()
             this.startInstance(
-                [schedulableCaps[0].specs.shift()],
+                specs.files,
                 schedulableCaps[0].caps,
                 schedulableCaps[0].cid,
-                schedulableCaps[0].seleniumServer
+                schedulableCaps[0].seleniumServer,
+                specs.rid,
+                specs.retries
             )
             schedulableCaps[0].availableInstances--
             schedulableCaps[0].runningInstances++
@@ -241,10 +244,14 @@ class Launcher {
      * Start instance in a child process.
      * @param  {Array} specs  Specs to run
      * @param  {Number} cid  Capabilities ID
+     * @param  {String} rid  Runner ID override
+     * @param  {Number} retries  Number of retries remaining
      */
-    startInstance (specs, caps, cid, server) {
+    startInstance (specs, caps, cid, server, rid, retries) {
         let config = this.configParser.getConfig()
-        cid = this.getRunnerId(cid)
+        // Retried tests receive the cid of the failing test as rid
+        // so they can run with the same cid of the failing test.
+        cid = rid || this.getRunnerId(cid)
         let processNumber = this.runnerStarted + 1
 
         // process.debugPort defaults to 5858 and is set even when process
@@ -292,7 +299,8 @@ class Launcher {
             caps,
             specs,
             server,
-            execArgv
+            execArgv,
+            retries
         })
         worker.on('message', ::this.interface.onMessage)
         worker.on('error', ::this.interface.onMessage)
@@ -318,11 +326,19 @@ class Launcher {
      * Close test runner process once all child processes have exited
      * @param  {Number} cid       Capabilities ID
      * @param  {Number} exitCode  exit code of child process
+     * @param  {Array} specs      Specs that were run
+     * @param  {Number} retries   Number or retries remaining
      */
-    endHandler ({ cid, exitCode }) {
+    endHandler ({ cid, exitCode, specs, retries }) {
         const passed = exitCode === 0
-        this.exitCode = this.exitCode || exitCode
-        this.runnerFailed += !passed ? 1 : 0
+
+        if (!passed && retries > 0) {
+            this.interface.totalWorkerCnt++
+            this.schedule[parseInt(cid)].specs.push({ files: specs, retries: retries - 1, rid: cid })
+        } else {
+            this.exitCode = this.exitCode || exitCode
+            this.runnerFailed += !passed ? 1 : 0
+        }
         this.interface.emit('job:end', { cid, passed })
 
         // Update schedule now this process has ended

--- a/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
+++ b/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
@@ -151,6 +151,9 @@ exports.config = {
     // before running any tests.
     framework: '<%= answers.framework %>',
     //
+    // The number of times to retry the entire specfile when it fails as a whole
+    // specFileRetries: 1,
+    //
     // Test reporter for stdout.
     // The only one supported by default is 'dot'
     // see also: https://webdriver.io/docs/dot-reporter.html

--- a/packages/wdio-cli/tests/interface.test.js
+++ b/packages/wdio-cli/tests/interface.test.js
@@ -37,6 +37,36 @@ describe('cli interface', () => {
         expect(wdioClInterface.result.failed).toBe(1)
     })
 
+    it('should mark jobs as retried when failing', () => {
+        wdioClInterface.updateView = jest.fn()
+        wdioClInterface.emit('job:start', { cid: '0-0' })
+        wdioClInterface.emit('job:start', { cid: '0-1' })
+        expect(wdioClInterface.result.finished).toBe(0)
+        expect(wdioClInterface.result.passed).toBe(0)
+        expect(wdioClInterface.result.retries).toBe(0)
+        expect(wdioClInterface.result.failed).toBe(0)
+        wdioClInterface.emit('job:end', { cid: '0-0', passed: false, retries: 1 })
+        expect(wdioClInterface.result.finished).toBe(0)
+        expect(wdioClInterface.result.passed).toBe(0)
+        expect(wdioClInterface.result.retries).toBe(1)
+        expect(wdioClInterface.result.failed).toBe(0)
+        wdioClInterface.emit('job:end', { cid: '0-0', passed: true, retries: 0 })
+        expect(wdioClInterface.result.finished).toBe(1)
+        expect(wdioClInterface.result.passed).toBe(1)
+        expect(wdioClInterface.result.retries).toBe(1)
+        expect(wdioClInterface.result.failed).toBe(0)
+        wdioClInterface.emit('job:end', { cid: '0-1', passed: false, retries: 1 })
+        expect(wdioClInterface.result.finished).toBe(1)
+        expect(wdioClInterface.result.passed).toBe(1)
+        expect(wdioClInterface.result.retries).toBe(2)
+        expect(wdioClInterface.result.failed).toBe(0)
+        wdioClInterface.emit('job:end', { cid: '0-1', passed: false, retries: 0 })
+        expect(wdioClInterface.result.finished).toBe(2)
+        expect(wdioClInterface.result.passed).toBe(1)
+        expect(wdioClInterface.result.retries).toBe(2)
+        expect(wdioClInterface.result.failed).toBe(1)
+    })
+
     it('should allow to store reporter messages', () => {
         wdioClInterface.onMessage({
             origin: 'reporter',

--- a/packages/wdio-cli/tests/interface.test.js
+++ b/packages/wdio-cli/tests/interface.test.js
@@ -119,6 +119,7 @@ describe('cli interface', () => {
         wdioClInterface.result = {
             finished: 3,
             passed: 1,
+            retries: 0,
             failed: 2
         }
         wdioClInterface.updateView()
@@ -133,6 +134,7 @@ describe('cli interface', () => {
         wdioClInterface.result = {
             finished: 3,
             passed: 1,
+            retries: 0,
             failed: 2
         }
         wdioClInterface.updateView(true)
@@ -152,6 +154,7 @@ describe('cli interface', () => {
         wdioClInterface.result = {
             finished: 3,
             passed: 1,
+            retries: 0,
             failed: 2
         }
 

--- a/packages/wdio-local-runner/src/worker.js
+++ b/packages/wdio-local-runner/src/worker.js
@@ -23,9 +23,10 @@ export default class WorkerInstance extends EventEmitter {
      * @param  {object}   caps        capability object
      * @param  {string[]} specs       list of paths to test files to run in this worker
      * @param  {object}   server      configuration details about automation backend this session is using
+     * @param  {number}   retries     number of retries remaining
      * @param  {object}   execArgv    execution arguments for the test run
      */
-    constructor (config, { cid, configFile, caps, specs, server, execArgv }) {
+    constructor (config, { cid, configFile, caps, specs, server, execArgv, retries }) {
         super()
         this.cid = cid
         this.config = config
@@ -34,6 +35,7 @@ export default class WorkerInstance extends EventEmitter {
         this.specs = specs
         this.server = server || {}
         this.execArgv = execArgv
+        this.retries = retries
         this.isBusy = false
     }
 
@@ -128,7 +130,7 @@ export default class WorkerInstance extends EventEmitter {
     }
 
     _handleExit (exitCode) {
-        const { cid, childProcess } = this
+        const { cid, childProcess, specs, retries } = this
 
         /**
          * delete process of worker
@@ -137,7 +139,7 @@ export default class WorkerInstance extends EventEmitter {
         this.isBusy = false
 
         log.debug(`Runner ${cid} finished with exit code ${exitCode}`)
-        this.emit('exit', { cid, exitCode })
+        this.emit('exit', { cid, exitCode, specs, retries })
         childProcess.kill('SIGTERM')
     }
 
@@ -148,7 +150,7 @@ export default class WorkerInstance extends EventEmitter {
      * @return null
      */
     postMessage (command, argv) {
-        const { cid, configFile, caps, specs, server, isBusy } = this
+        const { cid, configFile, caps, specs, server, retries, isBusy } = this
 
         if (isBusy && command !== 'endSession') {
             return log.info(`worker with cid ${cid} already busy and can't take new commands`)
@@ -162,7 +164,7 @@ export default class WorkerInstance extends EventEmitter {
             this.childProcess = this.startProcess()
         }
 
-        this.childProcess.send({ cid, command, configFile, argv, caps, specs, server })
+        this.childProcess.send({ cid, command, configFile, argv, caps, specs, server, retries })
         this.isBusy = true
     }
 }

--- a/packages/wdio-reporter/README.md
+++ b/packages/wdio-reporter/README.md
@@ -313,7 +313,8 @@ RunnerStats {
      timeouts: { implicit: 0, pageLoad: 300000, script: 30000 } },
   sanitizedCapabilities: 'firefox.59_0.darwin',
   config: [Object],
-  specs: [ '/path/to/project/test/my.test.js' ] }
+  specs: [ '/path/to/project/test/my.test.js' ] },
+  retry: 0
 ```
 
 ##### onRunnerEnd
@@ -330,6 +331,7 @@ RunnerStats {
   config: [Object],
   specs: [ '/path/to/project/test/my.test.js' ],
   failures: 1,
+  retries: 1,
   end: '2018-02-09T14:30:21.417Z' } }
 ```
 

--- a/packages/wdio-reporter/src/index.js
+++ b/packages/wdio-reporter/src/index.js
@@ -157,6 +157,7 @@ export default class WDIOReporter extends EventEmitter {
         this.on('runner:end',  /* istanbul ignore next */ (runner) => {
             rootSuite.complete()
             this.runnerStat.failures = runner.failures
+            this.runnerStat.retries = runner.retries
             this.runnerStat.complete()
             this.onRunnerEnd(this.runnerStat)
         })

--- a/packages/wdio-reporter/src/stats/runner.js
+++ b/packages/wdio-reporter/src/stats/runner.js
@@ -15,5 +15,6 @@ export default class RunnerStats extends RunnableStats {
         this.specs = runner.specs
         this.sessionId = runner.sessionId
         this.isMultiremote = runner.isMultiremote
+        this.retry = runner.retry
     }
 }

--- a/packages/wdio-runner/src/index.js
+++ b/packages/wdio-runner/src/index.js
@@ -27,9 +27,10 @@ export default class Runner extends EventEmitter {
      * @param  {Object}    caps           capabilities to run session with
      * @param  {String}    configFile     path to config file to get config from
      * @param  {Object}    server         modified WebDriver target
+     * @param  {Number}    retries        number of retries remaining
      * @return {Promise}                  resolves in number of failures for testrun
      */
-    async run ({ cid, argv, specs, caps, configFile, server }) {
+    async run ({ cid, argv, specs, caps, configFile, server, retries }) {
         this.cid = cid
         this.specs = specs
         this.caps = caps
@@ -102,7 +103,8 @@ export default class Runner extends EventEmitter {
                     caps[browserName] = browser[browserName].capabilities
                     return caps
                 }, {})
-                : browser.options.capabilities
+                : browser.options.capabilities,
+            retry: (this.config.specFileRetries || 0) - (retries || 0)
         })
 
         /**
@@ -140,7 +142,8 @@ export default class Runner extends EventEmitter {
 
         this.reporter.emit('runner:end', {
             failures,
-            cid: this.cid
+            cid: this.cid,
+            retries
         })
 
         return this._shutdown(failures)

--- a/tests/mocha/retry_and_fail.js
+++ b/tests/mocha/retry_and_fail.js
@@ -1,0 +1,5 @@
+describe('always fail', function () {
+    it('always fail', function () {
+        throw Error('Deliberate error.')
+    })
+})

--- a/tests/mocha/retry_and_pass.js
+++ b/tests/mocha/retry_and_pass.js
@@ -1,0 +1,10 @@
+const fs = require('fs')
+const filename = browser.config.retry_filename
+describe('fail on first run and succeed on second', function () {
+    it(`pass if ${filename} exists, otherwise create it and fail`, function () {
+        if (!fs.existsSync(filename)) {
+            fs.closeSync(fs.openSync(filename, 'w'))
+            throw Error('Deliberate error.')
+        }
+    })
+})

--- a/tests/smoke.runner.js
+++ b/tests/smoke.runner.js
@@ -43,6 +43,51 @@ import { SERVICE_LOGS, LAUNCHER_LOGS } from './helpers/fixtures'
     )
 
     /**
+     * specfile-level retries
+     */
+    let retry_failed = false
+    try {
+        await launch(
+            path.resolve(__dirname, 'helpers', 'config.js'),
+            {
+                specs: [path.resolve(__dirname, 'mocha', 'retry_and_fail.js')],
+                specFileRetries: 1
+            })
+    } catch (e) {
+        retry_failed = true
+    }
+    if (!retry_failed) {
+        throw Error('Expected retries to fail but they passed')
+    }
+
+    let retry_filename = path.join(__dirname, '.retry_succeeded')
+    let logfiles = ['wdio-0-0.log', 'wdio-0-1.log'].map(f => path.join(__dirname, f))
+    let rmfiles = [retry_filename, ...logfiles]
+    rmfiles.forEach(filename => {
+        if (fs.existsSync(filename)) {
+            fs.unlink(filename, err => {
+                if (err) {
+                    throw Error(`Unable to delete ${filename}`)
+                }
+            })
+        }
+    })
+    await launch(
+        path.resolve(__dirname, 'helpers', 'config.js'),
+        {
+            specs: [path.resolve(__dirname, 'mocha', 'retry_and_pass.js')],
+            outputDir: path.dirname(logfiles[0]),
+            specFileRetries: 1,
+            retry_filename
+        })
+    if (!fs.existsSync(logfiles[0])) {
+        throw Error(`Expected ${logfiles[0]} to exist but it does not`)
+    }
+    if (fs.existsSync(logfiles[1])) {
+        throw Error(`Expected ${logfiles[1]} to not exist but it does`)
+    }
+
+    /**
      * for some reason the process get stuck therefor exit it
      */
     process.exit(0)


### PR DESCRIPTION
## Proposed changes

Add retries on a per-specfile basis, as discussed in #2484, and PR'd pre-v5 to v4 in #2556, now residing in https://github.com/webdriverio-boneyard/v4/pull/1.

Previously only test-level and suite-level retries were available, which
are fine in most cases. In any test which involves state, such as on a
server or in a db, the state may be left invalid once the test fails the
first time. Any subsequent retries may have no chance of passing due to
the invalid state they would have to start with.

A new browser instance is created for each specfile, which makes this an
ideal place to hook and setup any other states (server, db). Retries on
this level would mean that the whole setup process could simply be
repeated as if it were for a new specfile, with the results of the
failing specfile (that is to be retried) being discarded.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

The above referenced issues serve as required background as some previous discussion has already taken place.
This PR contains all (or most?) of the tests required to validate this feature. I started implementing in @wdio/cli, but then realized that even though retries worked, the reporters were getting notified multiple times. As per https://github.com/webdriverio/webdriverio/pull/2556#discussion_r172349719, a decision must be made on how to handle this. Possible options include:
1. Handle retries transparently and only notify reporters once a run succeeds, or during the final run. This way, reporters never receive a message that could possible be invalidated by a retry.
2. Notify reporters of all events, and add a retry event.
3. Like (1), but add a retry count to the reported event, possibly runner:end.

I'm still finding my way about the codebase, so if any committers feel inspired to just take this code and shove it into the right place, please do so. Alternatively, any guidance as to the proper location would also help a lot.

### Reviewers: @christian-bromann 
