### PR TITLE
guard against bad console method access in web version of logger

### DIFF
--- a/packages/wdio-logger/src/web.js
+++ b/packages/wdio-logger/src/web.js
@@ -1,7 +1,12 @@
 export default function getLogger (component) {
     return ['error', 'warn', 'info', 'debug', 'trace', 'silent'].reduce((acc, cur) => {
+        // check if the method is available on console (web doesn't have
+        // 'silent', for example) before adding to acc
         // eslint-disable-next-line no-console
-        acc[cur] = console[cur].bind(console, `${component}:`)
+        if (console[cur]) {
+            // eslint-disable-next-line no-console
+            acc[cur] = console[cur].bind(console, `${component}:`)
+        }
         return acc
     }, {})
 }


### PR DESCRIPTION
web doesn't have console.silent, so logger shouldn't assume it exists