### PR TITLE
Run custom commands in fiber context

### DIFF
--- a/packages/wdio-config/src/shim.js
+++ b/packages/wdio-config/src/shim.js
@@ -46,15 +46,9 @@ export let executeHooksWithArgs = async function executeHooksWithArgsShim (hooks
 }
 
 export let runTestInFiberContext = NOOP
-export let runFnInFiberContext = (fn, done) => {
+export let runFnInFiberContext = (fn) => {
     return function (...args) {
-        const result = fn.apply(this, args)
-
-        if (typeof done === 'function') {
-            return done(result)
-        }
-
-        return result
+        return Promise.resolve(fn.apply(this, args))
     }
 }
 export let wrapCommand = (_, origFn) => origFn

--- a/packages/wdio-config/tests/__mocks__/@wdio/config.js
+++ b/packages/wdio-config/tests/__mocks__/@wdio/config.js
@@ -61,3 +61,8 @@ export const wrapCommand = (_, origFn) => origFn
 export const ConfigParser = ConfigParserMock
 export const runTestInFiberContext = jest.fn()
 export const executeHooksWithArgs = jest.fn()
+export const runFnInFiberContext = (fn) => {
+    return function (...args) {
+        return Promise.resolve(fn.apply(this, args))
+    }
+}

--- a/packages/wdio-repl/src/index.js
+++ b/packages/wdio-repl/src/index.js
@@ -66,9 +66,8 @@ export default class WDIORepl {
 
         /* istanbul ignore if */
         if (hasWdioSyncSupport) {
-            return runFnInFiberContext(() => {
-                return this._runCmd(cmd, context, callback)
-            })()
+            return runFnInFiberContext(
+                () => this._runCmd(cmd, context, callback))()
         }
 
         return this._runCmd(cmd, context, callback)

--- a/packages/wdio-sync/src/runFnInFiberContext.js
+++ b/packages/wdio-sync/src/runFnInFiberContext.js
@@ -5,14 +5,11 @@ import Fiber from 'fibers'
  * @param  {Function} fn  function to wrap around
  * @return {Function}     wrapped around function
  */
-export default function runFnInFiberContext (fn, done) {
+export default function runFnInFiberContext (fn) {
     return function (...args) {
-        return Fiber(() => {
+        return new Promise((resolve) => Fiber(() => {
             const result = fn.apply(this, args)
-
-            if (typeof done === 'function') {
-                done(result)
-            }
-        }).run()
+            resolve(result)
+        }).run())
     }
 }

--- a/packages/webdriver/src/monad.js
+++ b/packages/webdriver/src/monad.js
@@ -64,10 +64,13 @@ export default function WebDriver (options, modifier, propertiesObject = {}) {
         }
 
         client.addCommand = function (name, func, attachToElement = false, proto) {
+            const customCommand = typeof commandWrapper === 'function'
+                ? commandWrapper(name, func)
+                : func
             if (attachToElement) {
-                this.__propertiesObject__[name] = { value: func }
+                this.__propertiesObject__[name] = { value: customCommand }
             } else {
-                unit.lift(name, func, proto)
+                unit.lift(name, customCommand, proto)
             }
         }
 

--- a/packages/webdriverio/src/commands/browser/$$.js
+++ b/packages/webdriverio/src/commands/browser/$$.js
@@ -41,7 +41,7 @@
  *
  */
 import { webdriverMonad } from 'webdriver'
-import { wrapCommand } from '@wdio/config'
+import { wrapCommand, runFnInFiberContext } from '@wdio/config'
 import merge from 'lodash.merge'
 
 import { findElements, getPrototype as getWDIOPrototype, getElementFromResponse } from '../../utils'
@@ -86,7 +86,7 @@ export default async function $$ (selector) {
         const origAddCommand = ::elementInstance.addCommand
         elementInstance.addCommand = (name, fn) => {
             this.__propertiesObject__[name] = { value: fn }
-            origAddCommand(name, fn)
+            origAddCommand(name, runFnInFiberContext(fn))
         }
         return elementInstance
     })

--- a/packages/webdriverio/src/commands/browser/$.js
+++ b/packages/webdriverio/src/commands/browser/$.js
@@ -41,7 +41,7 @@
  *
  */
 import { webdriverMonad } from 'webdriver'
-import { wrapCommand } from '@wdio/config'
+import { wrapCommand, runFnInFiberContext } from '@wdio/config'
 import merge from 'lodash.merge'
 
 import { findElement, getPrototype as getWDIOPrototype, getElementFromResponse } from '../../utils'
@@ -84,7 +84,7 @@ export default async function $ (selector) {
     const origAddCommand = ::elementInstance.addCommand
     elementInstance.addCommand = (name, fn) => {
         this.__propertiesObject__[name] = { value: fn }
-        origAddCommand(name, fn)
+        origAddCommand(name, runFnInFiberContext(fn))
     }
     return elementInstance
 }

--- a/packages/webdriverio/src/commands/element/$$.js
+++ b/packages/webdriverio/src/commands/element/$$.js
@@ -38,7 +38,7 @@
  *
  */
 import { webdriverMonad } from 'webdriver'
-import { wrapCommand } from '@wdio/config'
+import { wrapCommand, runFnInFiberContext } from '@wdio/config'
 import merge from 'lodash.merge'
 
 import {findElements, getBrowserObject, getPrototype as getWDIOPrototype, getElementFromResponse} from '../../utils'
@@ -84,7 +84,7 @@ export default async function $$ (selector) {
         const origAddCommand = ::elementInstance.addCommand
         elementInstance.addCommand = (name, fn) => {
             browser.__propertiesObject__[name] = { value: fn }
-            origAddCommand(name, fn)
+            origAddCommand(name, runFnInFiberContext(fn))
         }
         return elementInstance
     })

--- a/packages/webdriverio/src/commands/element/$.js
+++ b/packages/webdriverio/src/commands/element/$.js
@@ -22,7 +22,7 @@
         const text = $('#menu');
         console.log(text.$$('li')[2].$('a').getText()); // outputs: "API"
     });
-    
+
     it('should get text a menu link - JS Function', () => {
         const text = $('#menu');
         console.log(text.$$('li')[2].$(function() { // Arrow function is not allowed here.
@@ -42,7 +42,7 @@
  *
  */
 import { webdriverMonad } from 'webdriver'
-import { wrapCommand } from '@wdio/config'
+import { wrapCommand, runFnInFiberContext } from '@wdio/config'
 import merge from 'lodash.merge'
 
 import { findElement, getBrowserObject, getPrototype as getWDIOPrototype, getElementFromResponse } from '../../utils'
@@ -86,7 +86,7 @@ export default async function $ (selector) {
     const origAddCommand = ::elementInstance.addCommand
     elementInstance.addCommand = (name, fn) => {
         browser.__propertiesObject__[name] = { value: fn }
-        origAddCommand(name, fn)
+        origAddCommand(name, runFnInFiberContext(fn))
     }
     return elementInstance
 }

--- a/packages/webdriverio/src/index.js
+++ b/packages/webdriverio/src/index.js
@@ -1,5 +1,5 @@
 import WebDriver from 'webdriver'
-import { validateConfig, wrapCommand, detectBackend } from '@wdio/config'
+import { validateConfig, wrapCommand, runFnInFiberContext, detectBackend } from '@wdio/config'
 
 import MultiRemote from './multiremote'
 import { WDIO_DEFAULTS } from './constants'
@@ -12,7 +12,7 @@ import { getPrototype } from './utils'
  * @param  {function} remoteModifier  Modifier function to change the monad object
  * @return {object}                   browser object with sessionId
  */
-export const remote = function (params = {}, remoteModifier) {
+export const remote = async function (params = {}, remoteModifier) {
     const config = validateConfig(WDIO_DEFAULTS, params)
     const modifier = (client, options) => {
         if (typeof remoteModifier === 'function') {
@@ -28,7 +28,18 @@ export const remote = function (params = {}, remoteModifier) {
     }
 
     const prototype = getPrototype('browser')
-    return WebDriver.newSession(params, modifier, prototype, wrapCommand)
+    const instance = await WebDriver.newSession(params, modifier, prototype, wrapCommand)
+
+    /**
+     * we need to overwrite the original addCommand in order to wrap the
+     * function within Fibers
+     */
+    const origAddCommand = ::instance.addCommand
+    instance.addCommand = (name, fn, attachToElement) => (
+        origAddCommand(name, runFnInFiberContext(fn), attachToElement)
+    )
+
+    return instance
 }
 
 export const attach = function (params) {

--- a/tests/mocha/test.js
+++ b/tests/mocha/test.js
@@ -86,5 +86,37 @@ describe('smoke test', () => {
 
             assert.equal(browser.customFn($('body')), '2-body')
         })
+
+        it('should respect promises', () => {
+            browser.addCommand('customFn', () => {
+                return Promise.resolve('foobar')
+            })
+
+            assert.equal(browser.customFn(), 'foobar')
+        })
+
+        it('should throw if promise rejects', () => {
+            browser.addCommand('customFn', () => {
+                return Promise.reject('Boom!')
+            })
+
+            let err = null
+            try {
+                browser.customFn()
+            } catch (e) {
+                err = e
+            }
+            assert.equal(err.message, 'Boom!')
+        })
+
+        it('allows to create custom commands on elements that respects promises', () => {
+            browser.customCommandScenario()
+            browser.addCommand('myCustomPromiseCommand', function () {
+                return Promise.resolve('foobar')
+            }, true)
+            const elem = $('elem')
+
+            assert.equal(elem.myCustomPromiseCommand(), 'foobar')
+        })
     })
 })


### PR DESCRIPTION
## Proposed changes

We broke custom commands by letting them not respect promises anymore, e.g. 
```js
            browser.addCommand('customFn', () => {
                return Promise.resolve('foobar')
            })
```

## Types of changes

Wrap custom commands in Fibers.

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
