### PR TITLE
Better error handling when config file is corrupted

### DIFF
--- a/packages/wdio-config/src/lib/ConfigParser.js
+++ b/packages/wdio-config/src/lib/ConfigParser.js
@@ -57,7 +57,7 @@ export default class ConfigParser {
              */
             this._config = merge(detectBackend(this._config), this._config, MERGE_OPTIONS)
         } catch (e) {
-            log.error(`Failed loading configuration file: ${filePath}`)
+            log.error(`Failed loading configuration file: ${filePath}:`, e.message)
             throw e
         }
     }

--- a/packages/wdio-runner/src/index.js
+++ b/packages/wdio-runner/src/index.js
@@ -36,7 +36,11 @@ export default class Runner extends EventEmitter {
         /**
          * add config file
          */
-        this.configParser.addConfigFile(configFile)
+        try {
+            this.configParser.addConfigFile(configFile)
+        } catch (e) {
+            return this._shutdown(1)
+        }
 
         /**
          * merge cli arguments into config
@@ -137,8 +141,7 @@ export default class Runner extends EventEmitter {
             cid: this.cid
         })
 
-        await this._shutdown(failures)
-        return failures
+        return this._shutdown(failures)
     }
 
     /**
@@ -236,6 +239,7 @@ export default class Runner extends EventEmitter {
     async _shutdown (failures) {
         await this.reporter.waitForSync()
         this.emit('exit', failures === 0 ? 0 : 1)
+        return failures
     }
 
     /**
@@ -266,7 +270,7 @@ export default class Runner extends EventEmitter {
         await runHook('afterSession', global.browser.config, this.caps, this.specs)
 
         if (shutdown) {
-            await this._shutdown()
+            return this._shutdown()
         }
     }
 }

--- a/packages/wdio-runner/tests/index.test.js
+++ b/packages/wdio-runner/tests/index.test.js
@@ -97,4 +97,52 @@ describe('wdio-runner', () => {
             expect(end - start).toBeGreaterThanOrEqual(200)
         })
     })
+
+    describe('run', () => {
+        it('should fail if log file is corrupted', async () => {
+            const runner = new WDIORunner()
+            runner._shutdown = jest.fn()
+            runner.configParser.addConfigFile = jest.fn().mockImplementation(
+                () => { throw new Error('boom') })
+            await runner.run({})
+
+            expect(runner._shutdown).toBeCalledWith(1)
+        })
+
+        it('should fail if init session fails', async () => {
+            const runner = new WDIORunner()
+            const beforeSession = jest.fn()
+            const caps = { browserName: '123' }
+            const specs = ['foobar']
+            const config = {
+                reporters: [],
+                beforeSession: [beforeSession]
+            }
+            runner.configParser.getConfig = jest.fn().mockReturnValue(config)
+            runner._shutdown = jest.fn()
+            runner._initSession = jest.fn().mockReturnValue(null)
+            await runner.run({
+                argv: { reporters: [] },
+                cid: '0-0',
+                caps,
+                specs
+            })
+
+            expect(runner._shutdown).toBeCalledWith(1)
+            expect(beforeSession).toBeCalledWith(config, caps, specs)
+        })
+    })
+
+    describe('_shutdown', () => {
+        it('should emit exit', async () => {
+            const runner = new WDIORunner()
+            runner.reporter = { waitForSync: jest.fn()
+                .mockReturnValue(Promise.resolve()) }
+            runner.emit = jest.fn()
+
+            expect(await runner._shutdown(123)).toBe(123)
+            expect(runner.reporter.waitForSync).toBeCalledTimes(1)
+            expect(runner.emit).toBeCalledWith('exit', 1)
+        })
+    })
 })


### PR DESCRIPTION
## Proposed changes

Properly shutdown worker in case the config file is corrupted (e.g. if import is used but the worker is running without babel).

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
