### PR TITLE
Allow displaying logs in realtime

### DIFF
--- a/packages/wdio-cli/src/interface.js
+++ b/packages/wdio-cli/src/interface.js
@@ -286,7 +286,7 @@ export default class WDIOCLInterface extends EventEmitter {
     }
 
     finalise () {
-        this.clearAll()
+        this.interface.clearAll()
         this.printReporters()
         this.printStdout()
         this.printSummary()

--- a/packages/wdio-cli/src/interface.js
+++ b/packages/wdio-cli/src/interface.js
@@ -20,8 +20,10 @@ export default class WDIOCLInterface extends EventEmitter {
         this.config = config
         this.totalWorkerCnt = totalWorkerCnt
         this.sigintTriggered = false
+        this.isWatchMode = false
 
         this.interface = new CLInterface()
+        this.interface.on('bufferchange', ::this.updateView)
         this.on('job:start', ::this.addJob)
         this.on('job:end', ::this.clearJob)
 
@@ -99,6 +101,7 @@ export default class WDIOCLInterface extends EventEmitter {
             this.messages[event.origin][event.name] = []
         }
         this.messages[event.origin][event.name].push(event.content)
+        this.updateView()
     }
 
     sigintTrigger () {
@@ -190,18 +193,25 @@ export default class WDIOCLInterface extends EventEmitter {
         }
 
         /**
+         * print reporters in watch mode
+         */
+        if (this.isWatchMode) {
+            this.printReporters()
+        }
+
+        /**
          * add empty line between "pending tests" and results
          */
         if (this.jobs.size) {
             this.interface.log()
         }
 
+        this.printStdout(5)
         this.printSummary()
         this.updateClock()
     }
 
-    printReporters() {
-        this.interface.clearAll()
+    printReporters () {
         this.interface.log()
 
         /**
@@ -212,27 +222,32 @@ export default class WDIOCLInterface extends EventEmitter {
             this.interface.log(messages.join(''))
             this.interface.log()
         }
+    }
 
-        /**
-         * print stdout and stderr from runners
-         */
+    /**
+     * print stdout and stderr from runners
+     */
+    printStdout (length) {
         if (this.interface.stdoutBuffer.length) {
-            this.interface.log(chalk.bgYellow.black('Stdout:\n') + this.interface.stdoutBuffer.join(''))
+            const bufferLength = this.interface.stdoutBuffer.length
+            const maxBufferLength = !length || length > bufferLength ? bufferLength : length
+            const buffer = this.interface.stdoutBuffer.slice(bufferLength - maxBufferLength)
+            this.interface.log(chalk.bgYellow.black('Stdout:\n') + buffer.join(''))
         }
         if (this.interface.stderrBuffer.length) {
-            this.interface.log(chalk.bgRed.black('Stderr:\n') + this.interface.stderrBuffer.join(''))
+            const bufferLength = this.interface.stderrBuffer.length
+            const maxBufferLength = !length || length > bufferLength ? bufferLength : length
+            const buffer = this.interface.stderrBuffer.slice(bufferLength - maxBufferLength)
+            this.interface.log(chalk.bgRed.black('Stderr:\n') + buffer.join(''))
         }
         if (this.messages.worker.error) {
-            this.interface.log(chalk.bgRed.black('Worker Error:\n') + this.messages.worker.error.map(
+            const bufferLength = this.messages.worker.error.length
+            const maxBufferLength = !length || length > bufferLength ? bufferLength : length
+            const buffer = this.messages.worker.error.slice(bufferLength - maxBufferLength)
+            this.interface.log(chalk.bgRed.black('Worker Error:\n') + buffer.map(
                 (e) => e.stack
             ).join('\n') + '\n')
         }
-
-        this.printSummary()
-        this.interface.log('Time:\t\t ' + this.getClockSymbol() + ' ' + ((Date.now() - this.start) / 1000).toFixed(2) + 's')
-
-        clearTimeout(this.interval)
-        this.interface.log()
     }
 
     printSummary() {
@@ -260,6 +275,26 @@ export default class WDIOCLInterface extends EventEmitter {
     }
 
     reset () {
+        clearTimeout(this.interval)
+        this.interface.log('\n')
+
+        if (this.isWatchMode) {
+            return
+        }
+
         this.interface.reset()
+    }
+
+    clearAll () {
+        this.interface.clearAll()
+    }
+
+    finalise () {
+        this.clearAll()
+        this.printReporters()
+        this.printStdout()
+        this.printSummary()
+        this.updateClock()
+        this.reset()
     }
 }

--- a/packages/wdio-cli/src/interface.js
+++ b/packages/wdio-cli/src/interface.js
@@ -285,10 +285,6 @@ export default class WDIOCLInterface extends EventEmitter {
         this.interface.reset()
     }
 
-    clearAll () {
-        this.interface.clearAll()
-    }
-
     finalise () {
         this.clearAll()
         this.printReporters()

--- a/packages/wdio-cli/src/launcher.js
+++ b/packages/wdio-cli/src/launcher.js
@@ -84,7 +84,7 @@ class Launcher {
         await runServiceHook(launcher, 'onComplete', exitCode, config, caps)
         await config.onComplete(exitCode, config, caps, this.interface.result)
 
-        this.interface.updateView()
+        this.interface.finalise()
         return exitCode
     }
 
@@ -324,11 +324,7 @@ class Launcher {
             return
         }
 
-        return process.nextTick(() => {
-            this.interface.printReporters()
-            this.interface.reset()
-            setTimeout(() => this.resolve(passed ? this.exitCode : 1), 100)
-        })
+        this.resolve(passed ? this.exitCode : 1)
     }
 
     /**

--- a/packages/wdio-cli/src/watcher.js
+++ b/packages/wdio-cli/src/watcher.js
@@ -55,9 +55,7 @@ export default class Watcher {
          * clean interface once all worker finish
          */
         const workers = this.getWorkers()
-        this.launcher.interface.finalise()
         Object.values(workers).forEach((worker) => worker.on('exit', () => {
-            this.launcher.interface.finalise()
             /**
              * check if all workers have finished
              */

--- a/packages/wdio-cli/tests/interface.test.js
+++ b/packages/wdio-cli/tests/interface.test.js
@@ -188,10 +188,19 @@ describe('cli interface', () => {
 
         output = flatten(wdioClInterface.interface.log.mock.calls)
         expect(output).toContain('black "foo" Reporter:')
-        expect(output).toContain('black Stdout:\nfoobar')
-        expect(output).toContain('black Stderr:\nbarfoo')
-        expect(output).toContain('black Worker Error:\nfoobar\n')
-        expect(output).toContain('(100% completed)')
+    })
+
+    it('should allow to print stdout logs', () => {
+        wdioClInterface.interface.stdoutBuffer = ['out-1', 'out-2', 'out-3', 'out-4', 'out-5']
+        wdioClInterface.interface.stderrBuffer = ['err-1', 'err-2', 'err-3', 'err-4', 'err-5']
+        wdioClInterface.messages.worker.error = ['worker-1', 'worker-2', 'worker-3', 'worker-4', 'worker-5']
+        wdioClInterface.printStdout(3)
+        expect(wdioClInterface.interface.log.mock.calls[0][0])
+            .toBe('black Stdout:\nout-3out-4out-5')
+        expect(wdioClInterface.interface.log.mock.calls[1][0])
+            .toBe('black Stderr:\nerr-3err-4err-5')
+        expect(wdioClInterface.interface.log.mock.calls[2][0])
+            .toBe('black Worker Error:\n\n\n\n')
     })
 
     it('should be able to mark display when SIGINT is called', () => {
@@ -237,5 +246,34 @@ describe('cli interface', () => {
         expect(wdioClInterface.updateView).toHaveBeenCalledTimes(1)
         expect(wdioClInterface.interface.inDebugMode).toBe(false)
         expect(wdioClInterface.sigintTriggered).toBe(false)
+    })
+
+    it('should allow to reset', () => {
+        wdioClInterface.reset()
+        expect(wdioClInterface.interface.reset).toBeCalledTimes(1)
+        expect(wdioClInterface.interface.log).toHaveBeenCalledWith('\n')
+    })
+
+    it('should not call reset in watch mode', () => {
+        wdioClInterface.isWatchMode = true
+        wdioClInterface.reset()
+        expect(wdioClInterface.interface.reset).toBeCalledTimes(0)
+        expect(wdioClInterface.interface.log).toHaveBeenCalledWith('\n')
+    })
+
+    it('has finalise to create a final display', () => {
+        wdioClInterface.clearAll = jest.fn()
+        wdioClInterface.printReporters = jest.fn()
+        wdioClInterface.printStdout = jest.fn()
+        wdioClInterface.printSummary = jest.fn()
+        wdioClInterface.updateClock = jest.fn()
+        wdioClInterface.reset = jest.fn()
+        wdioClInterface.finalise()
+        expect(wdioClInterface.clearAll).toBeCalledTimes(1)
+        expect(wdioClInterface.printReporters).toBeCalledTimes(1)
+        expect(wdioClInterface.printStdout).toBeCalledTimes(1)
+        expect(wdioClInterface.printSummary).toBeCalledTimes(1)
+        expect(wdioClInterface.updateClock).toBeCalledTimes(1)
+        expect(wdioClInterface.reset).toBeCalledTimes(1)
     })
 })

--- a/packages/wdio-cli/tests/interface.test.js
+++ b/packages/wdio-cli/tests/interface.test.js
@@ -269,7 +269,6 @@ describe('cli interface', () => {
         wdioClInterface.updateClock = jest.fn()
         wdioClInterface.reset = jest.fn()
         wdioClInterface.finalise()
-        expect(wdioClInterface.clearAll).toBeCalledTimes(1)
         expect(wdioClInterface.printReporters).toBeCalledTimes(1)
         expect(wdioClInterface.printStdout).toBeCalledTimes(1)
         expect(wdioClInterface.printSummary).toBeCalledTimes(1)

--- a/packages/wdio-interface/src/index.js
+++ b/packages/wdio-interface/src/index.js
@@ -63,8 +63,9 @@ export default class CLInterface extends EventEmitter {
         this.out(message)
     }
 
-    reset () {
-        process.stdout.write = this.out
-        process.stderr.write = this.err
+    reset (stdout = process.stdout.write, stderr = process.stderr.write) {
+        stdout = this.out
+        stderr = this.err
+        return [stdout, stderr]
     }
 }

--- a/packages/wdio-interface/src/index.js
+++ b/packages/wdio-interface/src/index.js
@@ -1,8 +1,10 @@
 import util from 'util'
+import EventEmitter from 'events'
 import ansiEscapes from 'ansi-escapes'
 
-export default class CLInterface {
+export default class CLInterface extends EventEmitter {
     constructor () {
+        super()
         this.i = 0
         this.stdoutBuffer = []
         this.stderrBuffer = []
@@ -30,6 +32,7 @@ export default class CLInterface {
             }
 
             buffer.push(chunk)
+            this.emit('bufferchange', chunk)
             return true
         }
     }

--- a/packages/wdio-interface/src/index.js
+++ b/packages/wdio-interface/src/index.js
@@ -63,9 +63,8 @@ export default class CLInterface extends EventEmitter {
         this.out(message)
     }
 
-    reset (stdout = process.stdout.write, stderr = process.stderr.write) {
-        stdout = this.out
-        stderr = this.err
-        return [stdout, stderr]
+    reset () {
+        process.stdout.write = this.out
+        process.stderr.write = this.err
     }
 }

--- a/packages/wdio-interface/tests/__mocks__/@wdio/interface.js
+++ b/packages/wdio-interface/tests/__mocks__/@wdio/interface.js
@@ -5,6 +5,8 @@ export default class CLInterfaceMock {
         this.log = jest.fn()
         this.clearAll = jest.fn()
         this.clearBuffer = jest.fn()
+        this.on = jest.fn()
+        this.reset = jest.fn()
         this.stdoutBuffer = []
         this.stderrBuffer = []
     }

--- a/packages/wdio-interface/tests/interface.test.js
+++ b/packages/wdio-interface/tests/interface.test.js
@@ -8,6 +8,7 @@ beforeEach(() => {
     iface = new WDIOInterface()
     iface.out = jest.fn()
     iface.err = jest.fn()
+    iface.emit = jest.fn()
 })
 
 test('can clear lines', () => {
@@ -30,6 +31,7 @@ test('can wrap stdout or stderr', () => {
     const stream = { write: jest.fn() }
     iface.wrapStdio(stream, buffer)
     stream.write('foobar')
+    expect(iface.emit).toBeCalledTimes(1)
     expect(buffer).toHaveLength(1)
 })
 
@@ -40,6 +42,7 @@ test('writes to stream if in debug mode', () => {
     iface.inDebugMode = true
     stream.write('foobar')
     expect(buffer).toHaveLength(0)
+    expect(iface.emit).toBeCalledTimes(0)
 })
 
 test('clearBuffer', () => {
@@ -50,4 +53,14 @@ test('clearBuffer', () => {
     iface.clearBuffer()
     expect(iface.stdoutBuffer).toHaveLength(0)
     expect(iface.stderrBuffer).toHaveLength(0)
+})
+
+test('allows to reset stdout and stderr', () => {
+    global._stdout = jest.fn()
+    global._stderr = jest.fn()
+    iface.reset(global._stdout, global._stderr)
+    global._stdout('foo')
+    global._stderr('bar')
+    expect(iface.out).toBeCalledTimes(0)
+    expect(iface.err).toBeCalledTimes(0)
 })

--- a/packages/wdio-interface/tests/interface.test.js
+++ b/packages/wdio-interface/tests/interface.test.js
@@ -54,13 +54,3 @@ test('clearBuffer', () => {
     expect(iface.stdoutBuffer).toHaveLength(0)
     expect(iface.stderrBuffer).toHaveLength(0)
 })
-
-test('allows to reset stdout and stderr', () => {
-    global._stdout = jest.fn()
-    global._stderr = jest.fn()
-    iface.reset(global._stdout, global._stderr)
-    global._stdout('foo')
-    global._stderr('bar')
-    expect(iface.out).toBeCalledTimes(0)
-    expect(iface.err).toBeCalledTimes(0)
-})

--- a/packages/webdriverio/tests/commands/browser/keys.test.js
+++ b/packages/webdriverio/tests/commands/browser/keys.test.js
@@ -36,6 +36,36 @@ describe('keys', () => {
         expect(request.mock.calls[2][0].body.value).toEqual(['\uE007'])
     })
 
+    it('should allow send keys as array', async () => {
+        const browser = await remote({
+            baseUrl: 'http://foobar.com',
+            capabilities: {
+                browserName: 'foobar-noW3C'
+            }
+        })
+
+        await browser.keys(['f', 'o', 'Enter', 'b', 'a', 'r'])
+        expect(request.mock.calls[1][0].uri.path).toContain('/keys')
+        expect(request.mock.calls[1][0].body.value).toEqual([ 'f', 'o', '\uE007', 'b', 'a', 'r' ])
+
+        await browser.keys('Enter')
+        expect(request.mock.calls[2][0].uri.path).toContain('/keys')
+        expect(request.mock.calls[2][0].body.value).toEqual(['\uE007'])
+    })
+
+    it('should throw if invalid character was provided', async () => {
+        const browser = await remote({
+            baseUrl: 'http://foobar.com',
+            capabilities: {
+                browserName: 'foobar-noW3C'
+            }
+        })
+
+        expect(() => browser.keys()).toThrow()
+        expect(() => browser.keys(1)).toThrow()
+        expect(() => browser.keys(true)).toThrow()
+    })
+
     afterEach(() => {
         request.mockClear()
     })


### PR DESCRIPTION
## Proposed changes

Currently we can't see logs from worker showing up in the display when running the tests. This is problematic when user want to debug their tests.

Ensure that logs are propagated to the display and properly reset the display in watch mode.

## Types of changes

![aaa](https://user-images.githubusercontent.com/731337/51777858-d7025580-20b3-11e9-8a03-9712edc9ca93.gif)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

This is work in progress as tests are missing.

### Reviewers: @webdriverio/technical-committee
