### PR TITLE
doc: fix xpath position

### DIFF
--- a/docs/Selectors.md
+++ b/docs/Selectors.md
@@ -121,7 +121,7 @@ It is also possible to query elements via a specific [xPath](https://developer.m
 You can query the second paragraph by calling:
 
 ```js
-const paragraph = $('//BODY/P[1]');
+const paragraph = $('//BODY/P[2]');
 console.log(paragraph.getText()); // outputs: "barfoo"
 ```
 


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

When using XPath, positions starts with 1. In order to select an element according to the description (`You can query the second paragraph`), the position should be 2.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
