### PR TITLE
Exit program on next tick

### DIFF
--- a/packages/wdio-cli/src/run.js
+++ b/packages/wdio-cli/src/run.js
@@ -71,6 +71,6 @@ function launch (wdioConf, params) {
     log.debug('Run suite with config', wdioConf, 'and params', params)
     const launcher = new Launcher(wdioConf, params)
     launcher.run().then(
-        (code) => process.exit(code),
+        (code) => process.nextTick(() => process.exit(code)),
         (e) => process.nextTick(() => { throw e }))
 }


### PR DESCRIPTION
## Proposed changes

It seems that logging everything at the end of the program can be huge and not all logs are displayed. Therefor exit program on next tick which delays this a bit.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
