### PR TITLE
set logLevel per logger and disable driver logger

### DIFF
--- a/docs/ConfigurationFile.md
+++ b/docs/ConfigurationFile.md
@@ -105,7 +105,11 @@ exports.config = {
         "moz:firefoxOptions": {
           // flag to activate Firefox headless mode (see https://github.com/mozilla/geckodriver/blob/master/README.md#firefox-capabilities for more details about moz:firefoxOptions)
           // args: ['-headless']
-        }
+        },
+        // If outputDir is provided WebdriverIO can capture driver session logs
+        // it is possible to configure which logTypes to exclude.
+        // excludeDriverLogs: ['*'], // pass '*' to exclude all driver session logs
+        excludeDriverLogs: ['bugreport', 'server'],
     }],
     //
     // Additional list of node arguments to use when starting child processes
@@ -118,6 +122,16 @@ exports.config = {
     //
     // Level of logging verbosity: trace | debug | info | warn | error
     logLevel: 'info',
+    //
+    // Set specific log levels per logger
+    // use 'silent' level to disable logger
+    logLevels: {
+        webdriver: 'info',
+        'wdio-applitools-service': 'info'
+    },
+    //
+    // Set directory to store all logs into
+    outputDir: __dirname,
     //
     // If you only want to run your tests until a specific amount of tests have failed use
     // bail (default is 0 - don't bail, run all tests).

--- a/packages/wdio-cli/src/launcher.js
+++ b/packages/wdio-cli/src/launcher.js
@@ -27,6 +27,8 @@ class Launcher {
             process.env.WDIO_LOG_PATH = path.join(config.outputDir, 'wdio.log')
         }
 
+        logger.setLogLevelsConfig(config.logLevels)
+
         const totalWorkerCnt = Array.isArray(capabilities)
             ? capabilities
                 .map((c) => this.configParser.getSpecs(c.specs, c.exclude).length)

--- a/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
+++ b/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
@@ -84,7 +84,11 @@ exports.config = {
         // 5 instances get started at a time.
         maxInstances: 5,
         //
-        browserName: 'firefox'
+        browserName: 'firefox',
+        // If outputDir is provided WebdriverIO can capture driver session logs
+        // it is possible to configure which logTypes to include/exclude.
+        // excludeDriverLogs: ['*'], // pass '*' to exclude all driver session logs
+        // excludeDriverLogs: ['bugreport', 'server'],
     }],
     //
     // ===================
@@ -94,6 +98,20 @@ exports.config = {
     //
     // Level of logging verbosity: trace | debug | info | warn | error
     logLevel: '<%= answers.logLevel %>',
+    //
+    // Set specific log levels per logger
+    // loggers:
+    // - webdriver, webdriverio
+    // - wdio-applitools-service, wdio-browserstack-service, wdio-devtools-service, wdio-sauce-service
+    // - wdio-mocha-framework, wdio-jasmine-framework
+    // - wdio-local-runner, wdio-lambda-runner
+    // - wdio-sumologic-reporter
+    // - wdio-cli, wdio-config, wdio-sync, wdio-utils
+    // Level of logging verbosity: trace | debug | info | warn | error | silent
+    // logLevels: {
+        // webdriver: 'info',
+        // 'wdio-applitools-service': 'info'
+    // },
     //
     // If you only want to run your tests until a specific amount of tests have failed use
     // bail (default is 0 - don't bail, run all tests).

--- a/packages/wdio-cli/tests/__mocks__/chalk.js
+++ b/packages/wdio-cli/tests/__mocks__/chalk.js
@@ -9,6 +9,7 @@ chalkMock.red = jest.fn().mockImplementation((msg) => `red ${msg}`)
 chalkMock.gray = jest.fn().mockImplementation((msg) => `gray ${msg}`)
 chalkMock.black = jest.fn().mockImplementation((msg) => `black ${msg}`)
 chalkMock.yellow = jest.fn().mockImplementation((msg) => `yellow ${msg}`)
+chalkMock.magenta = jest.fn().mockImplementation((msg) => `magenta ${msg}`)
 chalkMock.supportsColor = { hasBasic: true }
 chalkMock.bgYellow = chalkMock
 chalkMock.bgRed = chalkMock

--- a/packages/wdio-config/src/constants.js
+++ b/packages/wdio-config/src/constants.js
@@ -10,6 +10,8 @@ export const DEFAULT_CONFIGS = {
     exclude: [],
     outputDir: undefined,
     logLevel: 'info',
+    logLevels: {},
+    excludeDriverLogs: [],
     baseUrl: undefined,
     bail: 0,
     waitforInterval: 500,

--- a/packages/wdio-devtools-service/src/lighthouse/tabTraces.js
+++ b/packages/wdio-devtools-service/src/lighthouse/tabTraces.js
@@ -15,7 +15,7 @@ import TraceProcessor from './tracingProcessor'
 import LHError from './errors'
 
 const ACCEPTABLE_NAVIGATION_URL_REGEX = /^(chrome|https?):/
-const log = logger('TraceOfTab')
+const log = logger('wdio-devtools-service:TraceOfTab')
 
 export default class TraceOfTab {
     /**

--- a/packages/wdio-devtools-service/src/lighthouse/tracingProcessor.js
+++ b/packages/wdio-devtools-service/src/lighthouse/tracingProcessor.js
@@ -24,7 +24,7 @@ const SCHEDULABLE_TASK_TITLE_ALT2 = 'ThreadControllerImpl::DoWork'
 // m65 and earlier
 const SCHEDULABLE_TASK_TITLE_ALT3 = 'TaskQueueManager::ProcessTaskFromWorkQueue'
 
-const log = logger('TraceProcessor')
+const log = logger('wdio-devtools-service:TraceProcessor')
 
 /**
  * @typedef ToplevelEvent

--- a/packages/wdio-logger/src/web.js
+++ b/packages/wdio-logger/src/web.js
@@ -13,3 +13,4 @@ export default function getLogger (component) {
 
 // logging interface expects a 'setLevel' method
 getLogger.setLevel = () => {}
+getLogger.setLogLevelsConfig = () => {}

--- a/packages/wdio-logger/tests/__mocks__/@wdio/logger.js
+++ b/packages/wdio-logger/tests/__mocks__/@wdio/logger.js
@@ -1,5 +1,6 @@
 const mock = () => logMock
 mock.setLevel = jest.fn()
+mock.setLogLevelsConfig = jest.fn()
 export const logMock = {
     error: jest.fn(),
     debug: jest.fn(),

--- a/packages/wdio-logger/tests/node.test.js
+++ b/packages/wdio-logger/tests/node.test.js
@@ -1,0 +1,189 @@
+import fs from 'fs'
+import nodeLogger from '../src/node'
+
+describe('wdio-logger node', () => {
+    describe('log level', () => {
+        const log = nodeLogger('test:setLevel')
+
+        it('DEFAULT_LEVEL', () => {
+            expect(log.getLevel()).toEqual(0)
+        })
+
+        const scenarios = [{
+            level: 'trace',
+            logLevel: 0
+        }, {
+            level: 'debug',
+            logLevel: 1
+        }, {
+            level: 'info',
+            logLevel: 2
+        }, {
+            level: 'warn',
+            logLevel: 3
+        }, {
+            level: 'error',
+            logLevel: 4
+        }, {
+            level: 'silent',
+            logLevel: 5
+        }]
+
+        scenarios.forEach((scenario) => {
+            it(`should be possible to set ${scenario.level} logLevel`, () => {
+                nodeLogger.setLevel('test:setLevel', scenario.level)
+                expect(log.getLevel()).toEqual(scenario.logLevel)
+            })
+        })
+    })
+
+    describe('getLogger', () => {
+        const sameLog1 = nodeLogger('test:getLogger')
+        const sameLog2 = nodeLogger('test:getLogger')
+        const anotherLog = nodeLogger('test:getLogger:test')
+
+        it('should be possible to get same instance of logger', () => {
+            expect(sameLog1).toEqual(sameLog2)
+        })
+        it('should be possible to create new instance', () => {
+            expect(sameLog1).not.toEqual(anotherLog)
+        })
+    })
+
+    describe('setLogLevelsConfig', () => {
+        const scenarios = [{
+            name: 'should be possible to set logLevel in config',
+            logger: 'test-setLogLevelsConfig-3',
+            config: { 'test-setLogLevelsConfig-3': 'silent' },
+            logLevel: 5
+        }, {
+            name: 'should be possible to set logLevel in WDIO_LOG_LEVEL',
+            logger: 'test-setLogLevelsConfig-4',
+            get config() {
+                process.env.WDIO_LOG_LEVEL = 'info'
+                return undefined
+            },
+            logLevel: 2
+        }, {
+            name: 'should be possible to override WDIO_LOG_LEVEL in config',
+            logger: 'test-setLogLevelsConfig-5',
+            get config() {
+                process.env.WDIO_LOG_LEVEL = 'info'
+                return { 'test-setLogLevelsConfig-5': 'warn' }
+            },
+            logLevel: 3
+        }, {
+            name: 'should be possible to set logLevel in config for all sub levels',
+            logger: 'test-setLogLevelsConfig-6:foo',
+            config: { 'test-setLogLevelsConfig-6:bar': 'error' },
+            logLevel: 4
+        }]
+
+        scenarios.forEach((scenario) => {
+            it(scenario.name, () => {
+                nodeLogger.setLogLevelsConfig(scenario.config)
+                const log = nodeLogger(scenario.logger)
+                expect(log.getLevel()).toEqual(scenario.logLevel)
+            })
+        })
+
+        it('should apply logLevels after loggers are created', () => {
+            const log1 = nodeLogger('test-applyLogLevelsConfig1')
+            const log2 = nodeLogger('test-applyLogLevelsConfig2')
+            expect(log1.getLevel()).toEqual(0)
+            expect(log2.getLevel()).toEqual(0)
+
+            nodeLogger.setLogLevelsConfig({
+                'test-applyLogLevelsConfig1': 'error',
+                'test-applyLogLevelsConfig2': 'debug'
+            })
+
+            expect(log1.getLevel()).toEqual(4)
+            expect(log2.getLevel()).toEqual(1)
+        })
+
+        it('should not change logLevel if not provided in config', () => {
+            const log = nodeLogger('test-applyLogLevelsConfig')
+            expect(log.getLevel()).toEqual(0)
+
+            nodeLogger.setLogLevelsConfig(undefined)
+
+            expect(log.getLevel()).toEqual(0)
+        })
+
+        afterEach(() => {
+            delete process.env.WDIO_LOG_LEVEL
+        })
+    })
+
+    describe('logFile', () => {
+        const write = jest.fn(logText => logText)
+        const logInfoSpy = jest.spyOn(fs, 'createWriteStream')
+        const logCacheAddSpy = jest.spyOn(Set.prototype, 'add')
+        const logCacheForEachSpy = jest.spyOn(Set.prototype, 'forEach')
+        logInfoSpy.mockImplementation((path) => ({
+            path,
+            write
+        }))
+
+        it('should be possible to add to cache', () => {
+            const log = nodeLogger('test-logFile1')
+            log.info('', 'DATA')
+            log.info('', 'RESULT')
+
+            const logCache = logCacheAddSpy.mock.results[0].value
+
+            expect(logCacheAddSpy).toBeCalledTimes(2)
+            expect(logCache.size).toBe(2)
+
+            const it = logCache.values()
+            expect(it.next().value).toContain('test-logFile1:  yellow DATA')
+            expect(it.next().value).toContain('test-logFile1:  cyan RESULT')
+
+            // after
+            logCache.clear()
+        })
+
+        it('should be possible to create and write to logFile, with cache', () => {
+            const log = nodeLogger('test-logFile3')
+            log.info('foo')
+            const logCache = logCacheAddSpy.mock.results[0].value
+
+            process.env.WDIO_LOG_PATH = 'wdio.test.log'
+
+            log.info('bar')
+
+            expect(logInfoSpy).toBeCalledTimes(1)
+            expect(logCache.size).toBe(0)
+            expect(logCacheForEachSpy).toBeCalledTimes(1)
+        })
+
+        it('should be possible to create and write to logFile, no cache', () => {
+            process.env.WDIO_LOG_PATH = 'wdio.test.log'
+
+            const log = nodeLogger('test-logFile2')
+            log.info('', 'COMMAND')
+            log.info(new Error('bar'))
+
+            expect(write.mock.calls.length).toBe(2)
+            expect(write.mock.results[0].value).toContain('test-logFile2:  magenta COMMAND')
+            expect(write.mock.results[1].value).toContain('test-logFile2: Error: bar')
+            expect(write.mock.results[1].value).not.toContain('test-logFile2:  magenta COMMAND')
+
+            expect(logCacheForEachSpy).toBeCalledTimes(0)
+        })
+
+        beforeEach(() => {
+            delete process.env.WDIO_LOG_PATH
+        })
+        afterEach(() => {
+            logCacheForEachSpy.mockClear()
+            logCacheAddSpy.mockClear()
+            logInfoSpy.mockClear()
+            write.mockClear()
+        })
+        afterAll(() => {
+            logInfoSpy.mockRestore()
+        })
+    })
+})

--- a/packages/wdio-runner/src/utils.js
+++ b/packages/wdio-runner/src/utils.js
@@ -77,3 +77,27 @@ export async function initialiseInstance (config, capabilities, isMultiremote) {
 
     return browser
 }
+
+/**
+ * Filter logTypes based on filter
+ * @param  {string[]} excludeDriverLogs logTypes filter
+ * @param  {string[]} driverLogTypes    available driver log types
+ * @return {string[]}                   logTypes
+ */
+export function filterLogTypes(excludeDriverLogs, driverLogTypes) {
+    let logTypes = [...driverLogTypes]
+
+    if (Array.isArray(excludeDriverLogs)) {
+        log.debug('filtering logTypes', logTypes)
+
+        if (excludeDriverLogs.length === 1 && excludeDriverLogs[0] === '*') { // exclude all logTypes
+            logTypes = []
+        } else {
+            logTypes = logTypes.filter(x => !excludeDriverLogs.includes(x)) // exclude specific logTypes
+        }
+
+        log.debug('filtered logTypes', logTypes)
+    }
+
+    return logTypes
+}

--- a/packages/wdio-runner/tests/index-initSession.test.js
+++ b/packages/wdio-runner/tests/index-initSession.test.js
@@ -1,0 +1,54 @@
+import WDIORunner from '../src'
+
+jest.mock('../src/utils', () => ({
+    __esModule: true,
+    initialiseInstance(err) {
+        if (err) {
+            throw new Error(err)
+        }
+        return {
+            '$'() { },
+            '$$'() { },
+            sessionId: 'id',
+            events: {},
+            on(eventName, callback) {
+                this.events[eventName] = callback
+            }
+        }
+    }
+}))
+
+describe('wdio-runner', () => {
+    describe('_initSession', () => {
+        let runner
+
+        beforeEach(() => {
+            runner = new WDIORunner()
+            runner.reporter = {
+                emit: jest.fn()
+            }
+        })
+
+        it('command event', async () => {
+            const browser = await runner._initSession()
+
+            const command = { foo: 'bar' }
+            browser.events.command(command)
+
+            expect(command).toEqual({ foo: 'bar', sessionId: 'id' })
+        })
+
+        it('result event', async () => {
+            const browser = await runner._initSession()
+
+            const result = { bar: 'foo' }
+            browser.events.result(result)
+
+            expect(result).toEqual({ bar: 'foo', sessionId: 'id' })
+        })
+
+        it('throw error', () => {
+            expect(runner._initSession('err')).rejects.toThrow('err')
+        })
+    })
+})

--- a/packages/wdio-runner/tests/index.test.js
+++ b/packages/wdio-runner/tests/index.test.js
@@ -7,18 +7,45 @@ jest.mock('util', () => ({ promisify: (fn) => fn }))
 
 describe('wdio-runner', () => {
     describe('_fetchDriverLogs', () => {
+        let runner
+        beforeEach(() => {
+            runner = new WDIORunner()
+            runner.cid = '0-1'
+        })
         it('not do anything if driver does not support log commands', async () => {
-            const runner = new WDIORunner()
             global.browser = { sessionId: '123' }
 
-            const result = await runner._fetchDriverLogs({ outputDir: '/foo/bar' })
+            const result = await runner._fetchDriverLogs({ outputDir: '/foo/bar' }, ['*'])
             expect(result).toBe(undefined)
         })
 
-        it('should fetch logs', async () => {
-            const runner = new WDIORunner()
-            runner.cid = '0-1'
+        it('should not write to file if all logs excluded', async () => {
+            global.browser = {
+                getLogTypes: () => Promise.resolve(['foo', 'bar']),
+                getLogs: (type) => Promise.resolve([`#1 ${type} log`, `#2 ${type} log`]),
+                sessionId: '123'
+            }
 
+            await runner._fetchDriverLogs({ outputDir: '/foo/bar' }, ['*'])
+
+            expect(fs.writeFile).toHaveBeenCalledTimes(0)
+        })
+
+        it('should not write to file excluded logTypes', async () => {
+            global.browser = {
+                getLogTypes: () => Promise.resolve(['foo', 'bar']),
+                getLogs: (type) => Promise.resolve([`#1 ${type} log`, `#2 ${type} log`]),
+                sessionId: '123'
+            }
+
+            await runner._fetchDriverLogs({ outputDir: '/foo/bar' }, ['bar'])
+
+            expect(fs.writeFile).toHaveBeenCalledTimes(1)
+
+            expect(fs.writeFile.mock.calls[0]).toEqual(['/foo/bar/wdio-0-1-foo.log', '"#1 foo log"\n"#2 foo log"', 'utf-8'])
+        })
+
+        it('should fetch logs', async () => {
             global.browser = {
                 getLogTypes: () => Promise.resolve(['foo', 'bar']),
                 getLogs: (type) => Promise.resolve([`#1 ${type} log`, `#2 ${type} log`]),
@@ -28,13 +55,9 @@ describe('wdio-runner', () => {
             await runner._fetchDriverLogs({ outputDir: '/foo/bar' })
             expect(fs.writeFile.mock.calls[0]).toEqual(['/foo/bar/wdio-0-1-foo.log', '"#1 foo log"\n"#2 foo log"', 'utf-8'])
             expect(fs.writeFile.mock.calls[1]).toEqual(['/foo/bar/wdio-0-1-bar.log', '"#1 bar log"\n"#2 bar log"', 'utf-8'])
-            fs.writeFile.mockClear()
         })
 
         it('should not fail if logs can not be received', async () => {
-            const runner = new WDIORunner()
-            runner.cid = '0-1'
-
             global.browser = {
                 getLogTypes: () => Promise.resolve(['corrupt']),
                 getLogs: () => Promise.reject(new Error('boom')),
@@ -46,9 +69,6 @@ describe('wdio-runner', () => {
         })
 
         it('should not write to file if no logs exist', async () => {
-            const runner = new WDIORunner()
-            runner.cid = '0-1'
-
             global.browser = {
                 getLogTypes: () => Promise.resolve(['foo', 'bar']),
                 getLogs: () => Promise.resolve([]),
@@ -60,7 +80,7 @@ describe('wdio-runner', () => {
         })
 
         afterEach(() => {
-            delete global.browser
+            fs.writeFile.mockClear()
         })
     })
 
@@ -145,6 +165,52 @@ describe('wdio-runner', () => {
             expect(runner._shutdown).toBeCalledWith(1)
             expect(beforeSession).toBeCalledWith(config, caps, specs)
         })
+
+        it('should return failures count', async () => {
+            const runner = new WDIORunner()
+            const config = {
+                framework: 'testNoFailures',
+                reporters: [],
+                beforeSession: []
+            }
+            runner.configParser.getConfig = jest.fn().mockReturnValue(config)
+            runner._initSession = jest.fn().mockReturnValue({ options: { capabilities: {} } })
+            const failures = await runner.run({ argv: {}, caps: {} })
+
+            expect(failures).toBe(0)
+        })
+
+        it('should call browser url if args watch', async () => {
+            const runner = new WDIORunner()
+            const config = {
+                framework: 'testNoFailures',
+                reporters: [],
+                beforeSession: []
+            }
+            runner.configParser.getConfig = jest.fn().mockReturnValue(config)
+            global.browser = { url: jest.fn(url => url) }
+            runner._initSession = jest.fn().mockReturnValue({ options: { capabilities: {} } })
+            const failures = await runner.run({ argv: { watch: true }, caps: {} })
+
+            expect(failures).toBe(0)
+            expect(global.browser.url).toBeCalledWith('about:blank')
+        })
+
+        it('should set failures to 1 in case of error', async () => {
+            const runner = new WDIORunner()
+            const config = {
+                framework: 'testThrows',
+                reporters: [],
+                beforeSession: []
+            }
+            runner.configParser.getConfig = jest.fn().mockReturnValue(config)
+            runner._initSession = jest.fn().mockReturnValue({ options: { capabilities: {} } })
+            runner.emit = jest.fn()
+            const failures = await runner.run({ argv: {}, caps: {} })
+
+            expect(failures).toBe(1)
+            expect(runner.emit.mock.calls[0]).toEqual([ 'error', new Error('framework testThrows failed') ])
+        })
     })
 
     describe('_shutdown', () => {
@@ -158,5 +224,9 @@ describe('wdio-runner', () => {
             expect(runner.reporter.waitForSync).toBeCalledTimes(1)
             expect(runner.emit).toBeCalledWith('exit', 1)
         })
+    })
+
+    afterEach(() => {
+        delete global.browser
     })
 })

--- a/packages/wdio-utils/tests/__mocks__/@wdio/utils.js
+++ b/packages/wdio-utils/tests/__mocks__/@wdio/utils.js
@@ -20,6 +20,14 @@ const pluginMocks = {
     },
     runner: {
         local: RunnerMock
+    },
+    framework: {
+        testNoFailures: {
+            run() { return 0 }
+        },
+        testThrows: {
+            run() { throw new Error('framework testThrows failed') }
+        }
     }
 }
 

--- a/packages/webdriver/src/index.js
+++ b/packages/webdriver/src/index.js
@@ -16,7 +16,10 @@ import ChromiumProtocol from '../protocol/chromium.json'
 export default class WebDriver {
     static async newSession (options = {}, modifier, userPrototype = {}, commandWrapper) {
         const params = validateConfig(DEFAULTS, options)
-        logger.setLevel('webdriver', params.logLevel)
+
+        if (!options.logLevels || !options.logLevels['webdriver']) {
+            logger.setLevel('webdriver', params.logLevel)
+        }
 
         /**
          * the user could have passed in either w3c style or jsonwp style caps

--- a/packages/webdriver/tests/index.test.js
+++ b/packages/webdriver/tests/index.test.js
@@ -1,4 +1,5 @@
 import request from 'request'
+import logger from '@wdio/logger'
 
 import WebDriver from '../src'
 
@@ -37,6 +38,27 @@ test('should allow to create a new session using w3c compliant caps', async () =
         },
         desiredCapabilities: { browserName: 'firefox' }
     })
+})
+
+test('should be possible to skip setting logLevel', async () => {
+    logger.setLevel.mockClear()
+    await WebDriver.newSession({
+        capabilities: { browserName: 'chrome' },
+        logLevel: 'info',
+        logLevels: { webdriver: 'silent' }
+    })
+    
+    expect(logger.setLevel).not.toBeCalled()
+})
+
+test('should be possible to set logLevel', async () => {
+    logger.setLevel.mockClear()
+    await WebDriver.newSession({
+        capabilities: { browserName: 'chrome' },
+        logLevel: 'info'
+    })
+    
+    expect(logger.setLevel).toBeCalled()
 })
 
 test('should allow to attach to existing session', async () => {


### PR DESCRIPTION
## Proposed changes

ability to set log level per logger and disable driver logger
```
  outputDir: __dirname,
  logLevel: 'info',
  
  logLevels: {
    webdriver: 'warn',
    webdriverio: 'debug',
  },

  // extremely helpful with Appium if outputDir is provided
  capabilities: [{
      deviceName: 'Pixel 3',
      excludeDriverLogs: ['bugreport', 'server'] // '*' to exclude all logs
  }]
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

resolve #3440

### Reviewers: @webdriverio/technical-committee
