### PR TITLE
Updating stale element handling

### DIFF
--- a/packages/webdriver/src/request.js
+++ b/packages/webdriver/src/request.js
@@ -106,7 +106,7 @@ export default class WebDriverRequest extends EventEmitter {
              *  stop retrying as this will never be successful.
              *  we will handle this at the elementErrorHandler
              */
-            if(error.stack.includes('stale element reference')) {
+            if(error.stack.includes('stale')) {
                 log.warn('Request encountered a stale element - terminating request')
                 this.emit('response', { error })
                 return reject(error)

--- a/packages/webdriver/tests/request.test.js
+++ b/packages/webdriver/tests/request.test.js
@@ -106,7 +106,7 @@ describe('webdriver request', () => {
                 error = e
             }
 
-            expect(error.message).toBe('element is not attached to the page document')
+            expect(error.message).toBe('stale element reference: element is not attached to the page document')
             expect(req.emit.mock.calls).toHaveLength(1)
             expect(warn.mock.calls).toHaveLength(1)
             expect(warn.mock.calls).toEqual([['Request encountered a stale element - terminating request']])

--- a/packages/webdriverio/src/middlewares.js
+++ b/packages/webdriverio/src/middlewares.js
@@ -12,62 +12,48 @@ const log = logger('webdriverio')
  */
 export const elementErrorHandler = (fn) => (commandName, commandFn) => {
     return function (...args) {
-        /**
-         * wait on element if:
-         *  - elementId couldn't be fetched in the first place
-         *  - command is not explicit wait command for existance or displayedness
-         */
-        if (!this.elementId && !commandName.match(/(wait(Until|ForDisplayed|ForExist|ForEnabled)|isExisting|isDisplayed)/)) {
-            log.debug(
-                `command ${commandName} was called on an element ("${this.selector}") ` +
-                'that wasn\'t found, waiting for it...'
-            )
+        return fn(commandName, async () => {
+            /**
+             * wait on element if:
+             *  - elementId couldn't be fetched in the first place
+             *  - command is not explicit wait command for existance or displayedness
+             */
+            if (!this.elementId && !commandName.match(/(wait(Until|ForDisplayed|ForExist|ForEnabled)|isExisting|isDisplayed)/)) {
+                log.debug(
+                    `command ${commandName} was called on an element ("${this.selector}") ` +
+                    'that wasn\'t found, waiting for it...'
+                )
 
-            return fn(commandName, () => {
                 /**
                  * create new promise so we can apply a custom error message in cases waitForExist fails
                  */
-                return new Promise((resolve, reject) => this.waitForExist().then(resolve, reject)).then(
+                try {
+                    await this.waitForExist()
                     /**
                      * if waitForExist was successful requery element and assign elementId to the scope
                      */
-                    () => {
-                        return this.parent.$(this.selector).then((elem) => {
-                            this.elementId = elem.elementId
-                            return fn(commandName, commandFn).apply(this, args)
-                        })
-                    },
-                    /**
-                     * if waitForExist failes throw custom error
-                     */
-                    () => {
-                        throw new Error(`Can't call ${commandName} on element with selector "${this.selector}" because element wasn't found`)
-                    }
-                )
-            }).apply(this)
-        }
+                    const element = await this.parent.$(this.selector)
+                    this.elementId = element.elementId
+                } catch {
+                    throw new Error(
+                        `Can't call ${commandName} on element with selector "${this.selector}" because element wasn't found`)
+                }
+            }
 
-        try {
-            return fn(commandName, commandFn).apply(this, args)
-        } catch (error) {
-            /**
-             * refetch element ids when stale element reference execption was thrown
-             */
-            if (error.message.includes('stale element reference')) {
-                return refetchElement(this).then((element) => {
+            try {
+                return await fn(commandName, commandFn).apply(this, args)
+            } catch (error) {
+                if (error.message.includes('stale')) {
+                    const element = await refetchElement(this)
                     this.elementId = element.elementId
                     this.parent = element.parent
 
-                    return fn(commandName, commandFn).apply(this, args)
-                })
+                    return await fn(commandName, commandFn).apply(this, args)
+                }
+                throw error
             }
+        }).apply(this)
 
-            /**
-             * add other post command handlings here
-             */
-
-            throw error
-        }
     }
 }
 

--- a/packages/webdriverio/tests/__mocks__/request.js
+++ b/packages/webdriverio/tests/__mocks__/request.js
@@ -162,14 +162,19 @@ const requestMock = jest.fn().mockImplementation((params, cb) => {
             }, response)
         }
 
-        let error = new Error('element is not attached to the page document')
-        error.name = 'stale element reference'
+        // https://www.w3.org/TR/webdriver1/#handling-errors
+        let error = {
+            value: {
+                'error': 'stale element reference',
+                'message': 'stale element reference: element is not attached to the page document'
+            }
+        }
 
-        return cb(error, {
+        return cb(null, {
             headers: { foo: 'bar' },
             statusCode: 404,
-            body: {}
-        }, {})
+            body: error
+        }, error)
     }
 
     /**

--- a/packages/webdriverio/tests/commands/element/touchAction.test.js
+++ b/packages/webdriverio/tests/commands/element/touchAction.test.js
@@ -149,18 +149,18 @@ describe('touchAction element test', () => {
         })
 
         it('should throw an error if "release" has invalid params', () => {
-            expect(() => elem.touchAction({ action: 'release', ms: 123 }))
-                .toThrow('action "release" doesn\'t accept any options ("ms" found)')
+            expect(elem.touchAction({ action: 'release', ms: 123 }))
+                .rejects.toThrow('action "release" doesn\'t accept any options ("ms" found)')
         })
 
         it('should throw an error if "wait" has invalid params', () => {
-            expect(() => elem.touchAction({ action: 'wait', x: 123 }))
-                .toThrow('action "wait" doesn\'t accept x or y options')
+            expect(elem.touchAction({ action: 'wait', x: 123 }))
+                .rejects.toThrow('action "wait" doesn\'t accept x or y options')
         })
 
         it('should throw error if other actions contains something different than x or y', () => {
-            expect(() => elem.touchAction({ action: 'press', ms: 123 }))
-                .toThrow('action "press" doesn\'t accept "ms" as option')
+            expect(elem.touchAction({ action: 'press', ms: 123 }))
+                .rejects.toThrow('action "press" doesn\'t accept "ms" as option')
         })
 
         it('should ignore unknown options', async () => {

--- a/packages/webdriverio/tests/middleware.test.js
+++ b/packages/webdriverio/tests/middleware.test.js
@@ -44,7 +44,7 @@ describe('middleware', () => {
     /**
      * skipped because they don't work after refactoring
      */
-    it.skip('should succesfully click on an element that falls stale after being refound', async () => {
+    it('should succesfully click on an element that falls stale after being refound', async () => {
         const elem = await browser.$('#foo')
         const subElem = await elem.$('#subfoo')
         const subSubElem = await subElem.$('#subsubfoo')
@@ -60,7 +60,7 @@ describe('middleware', () => {
     /**
      * skipped because they don't work after refactoring
      */
-    it.skip('should succesfully click on a stale element', async () => {
+    it('should succesfully click on a stale element', async () => {
         const elem = await browser.$('#foo')
         const subElem = await elem.$('#subfoo')
         const subSubElem = await subElem.$('#subsubfoo')


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)
1.) Firefox is not passing stale elements per the wc3 spec. Widening the scope of errors that we refetch so that we can handle firefox
2.) Flattening the middleware (this also adds the refetch to the edge case of an element falling stale after waiting for it to exist)
3.) Fixing the stale element mock
4.) Updating the UTs that expect a function toThrow to be .rejects.toThrow()

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [X] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
