### PR TITLE
Fix Appium reloadSession and add ability to set capabilities for next session

### DIFF
--- a/packages/wdio-runner/tests/reporter.test.js
+++ b/packages/wdio-runner/tests/reporter.test.js
@@ -159,7 +159,7 @@ describe('BaseReporter', () => {
             reporterSyncTimeout: 100
         })
 
-        setTimeout(() => (reporter.reporters[0].inSync = true), 110)
+        setTimeout(() => (reporter.reporters[0].inSync = true), 112)
         await expect(reporter.waitForSync())
             .rejects.toEqual(new Error('Some reporters are still unsynced: CustomReporter'))
     })

--- a/packages/webdriver/src/index.js
+++ b/packages/webdriver/src/index.js
@@ -3,9 +3,8 @@ import merge from 'lodash.merge'
 import { validateConfig } from '@wdio/config'
 
 import webdriverMonad from './monad'
-import WebDriverRequest from './request'
 import { DEFAULTS } from './constants'
-import { getPrototype, environmentDetector } from './utils'
+import { getPrototype, environmentDetector, buildCapabilities, buildSessionRequest } from './utils'
 
 import WebDriverProtocol from '../protocol/webdriver.json'
 import JsonWProtocol from '../protocol/jsonwp.json'
@@ -18,30 +17,8 @@ export default class WebDriver {
         const params = validateConfig(DEFAULTS, options)
         logger.setLevel('webdriver', params.logLevel)
 
-        /**
-         * the user could have passed in either w3c style or jsonwp style caps
-         * and we want to pass both styles to the server, which means we need
-         * to check what style the user sent in so we know how to construct the
-         * object for the other style
-         */
-        const [w3cCaps, jsonwpCaps] = params.capabilities && params.capabilities.alwaysMatch
-            /**
-             * in case W3C compliant capabilities are provided
-             */
-            ? [params.capabilities, params.capabilities.alwaysMatch]
-            /**
-             * otherwise assume they passed in jsonwp-style caps (flat object)
-             */
-            : [{ alwaysMatch: params.capabilities, firstMatch: [{}] }, params.capabilities]
-
-        const sessionRequest = new WebDriverRequest(
-            'POST',
-            '/session',
-            {
-                capabilities: w3cCaps, // W3C compliant
-                desiredCapabilities: jsonwpCaps // JSONWP compliant
-            }
-        )
+        const { w3cCaps, jsonwpCaps } = buildCapabilities(params.capabilities)
+        const sessionRequest = buildSessionRequest(w3cCaps, jsonwpCaps)
 
         const response = await sessionRequest.makeRequest(params)
 

--- a/packages/webdriverio/src/commands/browser/reloadSession.js
+++ b/packages/webdriverio/src/commands/browser/reloadSession.js
@@ -8,19 +8,19 @@
  *
  * <example>
     :reloadSync.js
-    it('should reload my session', () => {
+    it('should reload my session with current capabilities', () => {
         console.log(browser.sessionId) // outputs: e042b3f3cd5a479da4e171825e96e655
-        browser.reload()
+        browser.reloadSession()
         console.log(browser.sessionId) // outputs: 9a0d9bf9d4864160aa982c50cf18a573
     })
  * </example>
  *
- * @alias browser.reload
+ * @alias browser.reloadSession
  * @type utility
  *
  */
 
-import WebDriverRequest from 'webdriver/build/request'
+import { buildSessionRequest } from 'webdriver/build/utils'
 
 export default async function reloadSession () {
     const oldSessionId = this.sessionId
@@ -31,17 +31,10 @@ export default async function reloadSession () {
     await this.deleteSession()
 
     const { w3cCaps, jsonwpCaps } = this.options.requestedCapabilities
-    const sessionRequest = new WebDriverRequest(
-        'POST',
-        '/session',
-        {
-            capabilities: w3cCaps, // W3C compliant
-            desiredCapabilities: jsonwpCaps // JSONWP compliant
-        }
-    )
+    const sessionRequest = buildSessionRequest(w3cCaps, jsonwpCaps)
 
     const response = await sessionRequest.makeRequest(this.options)
-    const newSessionId = response.sessionId
+    const newSessionId = response.sessionId || (response.value && response.value.sessionId)
     this.sessionId = newSessionId
 
     if (Array.isArray(this.options.onReload) && this.options.onReload.length) {

--- a/packages/webdriverio/src/commands/browser/setNextSessionCapabilities.js
+++ b/packages/webdriverio/src/commands/browser/setNextSessionCapabilities.js
@@ -1,0 +1,38 @@
+/**
+ *
+ * Set capabilities for next session to be created by webdriverio.
+ * Useful if it is required to change capabilities within test and then restore them
+ *
+ * <example>
+    :setNextSessionCapabilities.js
+    const origCapabilities = { browserName: 'firefox' }
+
+    it('should set capabilities for next session', () => {
+        console.log(browser.capabilities.browserName) // outputs: firefox
+        browser.setNextSessionCapabilities({ browserName: 'chrome' })
+        browser.reload()
+        console.log(browser.capabilities.browserName) // outputs: chrome
+    })
+
+    after(() => {
+        browser.setNextSessionCapabilities(origCapabilities)
+    })
+ * </example>
+ *
+ * @param {object} capabilities time in ms
+ * @type utility
+ *
+ */
+
+import { buildCapabilities } from 'webdriver/build/utils'
+
+export default function setNextSessionCapabilities(capabilities) {
+    if (capabilities) {
+        let { w3cCaps, jsonwpCaps } = buildCapabilities(capabilities)
+
+        this.options.requestedCapabilities.w3cCaps = w3cCaps
+        this.options.requestedCapabilities.jsonwpCaps = jsonwpCaps
+    } else {
+        throw new Error('Capabilities object is required (see https://webdriver.io/docs/api/browser/setNextSessionCapabilities.html for documentation.')
+    }
+}

--- a/packages/webdriverio/tests/__mocks__/request.js
+++ b/packages/webdriverio/tests/__mocks__/request.js
@@ -2,12 +2,14 @@ import { ELEMENT_KEY } from '../../src/constants'
 
 let manualMockResponse
 
-const sessionId = 'foobar-123'
+const defaultSessionId = 'foobar-123'
+let sessionId = defaultSessionId
 const genericElementId = 'some-elem-123'
 const genericSubElementId = 'some-sub-elem-321'
 const genericSubSubElementId = 'some-sub-sub-elem-231'
 const requestMock = jest.fn().mockImplementation((params, cb) => {
     let value = {}
+    let jsonwpMode = false
     let sessionResponse = {
         sessionId,
         capabilities: {
@@ -21,6 +23,7 @@ const requestMock = jest.fn().mockImplementation((params, cb) => {
         params.body.capabilities &&
         params.body.capabilities.alwaysMatch.jsonwpMode
     ) {
+        jsonwpMode = true
         sessionResponse = {
             sessionId,
             browserName: 'mockBrowser'
@@ -217,7 +220,7 @@ const requestMock = jest.fn().mockImplementation((params, cb) => {
     }
 
     let response = { value }
-    if (params.jsonwpMode) {
+    if (jsonwpMode) {
         response = { value, sessionId, status: 0 }
     }
 
@@ -231,6 +234,14 @@ const requestMock = jest.fn().mockImplementation((params, cb) => {
 requestMock.retryCnt = 0
 requestMock.setMockResponse = (value) => {
     manualMockResponse = value
+}
+
+requestMock.getSessionId = () => sessionId
+requestMock.setSessionId = (newSessionId) => {
+    sessionId = newSessionId
+}
+requestMock.resetSessionId = () => {
+    sessionId = defaultSessionId
 }
 
 export default requestMock

--- a/packages/webdriverio/tests/commands/browser/reloadSession.test.js
+++ b/packages/webdriverio/tests/commands/browser/reloadSession.test.js
@@ -2,22 +2,59 @@ import request from 'request'
 import { remote } from '../../../src'
 
 describe('reloadSession test', () => {
-    it('should allow to check if an element is enabled', async () => {
-        const hook = jest.fn()
-        const browser = await remote({
-            baseUrl: 'http://foobar.com',
-            capabilities: {
-                browserName: 'foobar'
-            },
-            onReload: [hook]
+    const scenarios = [{
+        name: 'should be undefined if sessionId is missing in response',
+        sessionIdMock: 'ignored if jsonwpMode is false',
+        requestMock: [{}, {}],
+        newSessionId: undefined,
+        jsonwpMode: false
+    }, {
+        name: 'should be ok if sessionId is in response',
+        sessionIdMock: 'foobar-234',
+        requestMock: [{}, {}],
+        newSessionId: 'foobar-234',
+        jsonwpMode: true
+    }, {
+        name: 'should be ok if sessionId is in response.value',
+        sessionIdMock: undefined,
+        requestMock: [{}, { sessionId: 'foobar-345' }],
+        newSessionId: 'foobar-345',
+    }, {
+        name: 'should be sessionId if sessionId and value.sessionId are present',
+        sessionIdMock: 'foobar-456',
+        requestMock: [{}, { sessionId: 'foobar-567' }],
+        newSessionId: 'foobar-456',
+        jsonwpMode: true
+    }]
+
+    scenarios.forEach(scenario => {
+        it(scenario.name, async () => {
+            const oldSessionId = request.getSessionId()
+            const hook = jest.fn()
+            const browser = await remote({
+                baseUrl: 'http://foobar.com',
+                capabilities: {
+                    jsonwpMode: scenario.jsonwpMode,
+                    browserName: 'foobar'
+                },
+                onReload: [hook]
+            })
+
+            request.setSessionId(scenario.sessionIdMock)
+            request.setMockResponse(scenario.requestMock)
+            await browser.reloadSession()
+
+            expect(request.mock.calls[1][0].method).toBe('DELETE')
+            expect(request.mock.calls[1][0].uri.pathname).toBe(`/wd/hub/session/${oldSessionId}`)
+            expect(request.mock.calls[2][0].method).toBe('POST')
+            expect(request.mock.calls[2][0].uri.pathname).toBe('/wd/hub/session')
+            expect(hook).toBeCalledWith(oldSessionId, scenario.newSessionId)
         })
+    })
 
-        await browser.reloadSession()
-
-        expect(request.mock.calls[1][0].method).toBe('DELETE')
-        expect(request.mock.calls[1][0].uri.pathname).toBe('/wd/hub/session/foobar-123')
-        expect(request.mock.calls[2][0].method).toBe('POST')
-        expect(request.mock.calls[2][0].uri.pathname).toBe('/wd/hub/session')
-        expect(hook).toBeCalledWith('foobar-123', undefined)
+    afterEach(() => {
+        request.mockClear()
+        request.resetSessionId()
+        request.setMockResponse()
     })
 })

--- a/packages/webdriverio/tests/commands/browser/setNextSessionCapabilities.test.js
+++ b/packages/webdriverio/tests/commands/browser/setNextSessionCapabilities.test.js
@@ -1,0 +1,29 @@
+import request from 'request'
+import { remote } from '../../../src'
+
+describe('setNextSessionCapabilities test', () => {
+    let browser
+    beforeEach(async () => {
+        browser = await remote({
+            baseUrl: 'http://foobar.com',
+            capabilities: {
+                browserName: 'foo'
+            },
+            onReload: true
+        })
+    })
+    it('should be possible to pass capabilities object', async () => {
+        browser.setNextSessionCapabilities({ browserName: 'bar' })
+        await browser.reloadSession()
+
+        expect(request.mock.calls[2][0].body.capabilities.alwaysMatch.browserName).toBe('bar')
+    })
+
+    it('should throw error if no capabilities passed', () => {
+        expect(() => browser.setNextSessionCapabilities()).toThrowError(/Capabilities object is required/)
+    })
+
+    afterEach(() => {
+        request.mockClear()
+    })
+})

--- a/scripts/templates/webdriver.tpl.d.ts
+++ b/scripts/templates/webdriver.tpl.d.ts
@@ -239,6 +239,7 @@ declare namespace WebDriver {
         isAndroid: boolean;
         isMobile: boolean;
         isIOS: boolean;
+        sessionId: string;
     }
 
     // generated typings


### PR DESCRIPTION
## Proposed changes

fix #3494 and add ability to reload session with different capabilities.

It is really useful if there is a need to switch between app(s), app/browser, adjust some capability, etc.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments


### Reviewers: @webdriverio/technical-committee
