### PR TITLE
wdio-reporter: create outputDir directory if does not exist

### DIFF
--- a/packages/wdio-allure-reporter/src/index.js
+++ b/packages/wdio-allure-reporter/src/index.js
@@ -6,10 +6,16 @@ import {events, stepStatuses, testStatuses} from './constants'
 
 class AllureReporter extends WDIOReporter {
     constructor(options) {
-        super(options)
+        const outputDir = options.outputDir || 'allure-results'
+
+        super({
+            ...options,
+            outputDir
+        })
         this.config = {}
         this.allure = new Allure()
-        this.allure.setOptions({targetDir: options.outputDir || 'allure-results'})
+
+        this.allure.setOptions({targetDir: outputDir})
         this.registerListeners()
     }
 

--- a/packages/wdio-reporter/package.json
+++ b/packages/wdio-reporter/package.json
@@ -34,5 +34,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "dependencies": {
+    "fs-extra": "^7.0.1"
   }
 }

--- a/packages/wdio-reporter/src/index.js
+++ b/packages/wdio-reporter/src/index.js
@@ -1,4 +1,5 @@
 import fs from 'fs'
+import fse from 'fs-extra'
 import { format } from 'util'
 import EventEmitter from 'events'
 
@@ -31,12 +32,9 @@ export default class WDIOReporter extends EventEmitter {
             failures: 0
         }
 
-        const outputDir = this.options.outputDir
-        if (outputDir) {
-            // make sure report directory exists
-            if (!fs.existsSync(outputDir)){
-                fs.mkdirSync(outputDir)
-            }
+        // ensure the report directory exists
+        if (this.options.outputDir) {
+            fse.ensureDirSync(this.options.outputDir)
         }
 
         let currentTest

--- a/packages/wdio-reporter/src/index.js
+++ b/packages/wdio-reporter/src/index.js
@@ -31,6 +31,14 @@ export default class WDIOReporter extends EventEmitter {
             failures: 0
         }
 
+        const outputDir = this.options.outputDir
+        if (outputDir) {
+            // make sure report directory exists
+            if (!fs.existsSync(outputDir)){
+                fs.mkdirSync(outputDir)
+            }
+        }
+
         let currentTest
 
         const rootSuite = new SuiteStats({

--- a/packages/wdio-reporter/tests/reporter.test.js
+++ b/packages/wdio-reporter/tests/reporter.test.js
@@ -1,5 +1,7 @@
 import fs from 'fs'
+import fse from 'fs-extra'
 import tmp from 'tmp'
+import path from 'path'
 
 import WDIOReporter from '../src'
 
@@ -73,7 +75,7 @@ describe('WDIOReporter', () => {
     })
 
     it('should create directory if outputDir given and not existing', () => {
-        const outputDir = `./tempDir-${Date.now()}`
+        const outputDir = path.join(__dirname, `./tempDir-${Date.now()}`, 'multiLevel')
 
         // ensure directory isn't somehow there to begin with
         expect(fs.existsSync(outputDir)).toBe(false)
@@ -83,12 +85,18 @@ describe('WDIOReporter', () => {
 
         const dirExists = fs.existsSync(outputDir)
 
-        // remove directory before assertion so it doesn't pollute our tests,
+        // remove directory before assertion so it doesn't pollute the test directory,
         // even if the assertion fails
         if (dirExists){
-            fs.rmdirSync(outputDir)
+            fse.removeSync(outputDir)
         }
 
         expect(dirExists).toBe(true)
+    })
+
+    it('should handle invalid directory for outputDir', () => {
+        expect(() => {
+            new WDIOReporter({ outputDir: true })
+        }).toThrow()
     })
 })

--- a/packages/wdio-reporter/tests/reporter.test.js
+++ b/packages/wdio-reporter/tests/reporter.test.js
@@ -71,4 +71,24 @@ describe('WDIOReporter', () => {
         reporter.write('foobar')
         expect(options.writeStream.write).toBeCalledWith('foobar')
     })
+
+    it('should create directory if outputDir given and not existing', () => {
+        const outputDir = `./tempDir-${Date.now()}`
+
+        // ensure directory isn't somehow there to begin with
+        expect(fs.existsSync(outputDir)).toBe(false)
+
+        const options = { outputDir }
+        new WDIOReporter(options)
+
+        const dirExists = fs.existsSync(outputDir)
+
+        // remove directory before assertion so it doesn't pollute our tests,
+        // even if the assertion fails
+        if (dirExists){
+            fs.rmdirSync(outputDir)
+        }
+
+        expect(dirExists).toBe(true)
+    })
 })


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

This change adds a check in wdio-reporter that will create the output directory if it's defined but doesn't exist on the system. This addresses #3389

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

I don't think this really needs a documentation change, but can add something if preferred.

### Reviewers: @webdriverio/technical-committee
