### PR TITLE
webdriver: hack to make chrome support element.saveScreenshot()

### DIFF
--- a/packages/webdriver/protocol/chromium.json
+++ b/packages/webdriver/protocol/chromium.json
@@ -392,5 +392,27 @@
       "ref": "https://github.com/bayandin/chromedriver/blob/2.45/session_commands.cc#L489-L498",
       "parameters": []
     }
+  },
+  "/session/:sessionId/element/:elementId/screenshot": {
+    "GET": {
+      "command": "takeElementScreenshot",
+      "description": "The Take Element Screenshot command takes a screenshot of the visible region encompassed by the bounding rectangle of an element.",
+      "ref": "https://w3c.github.io/webdriver/#dfn-take-element-screenshot",
+      "variables": [{
+        "name": "elementId",
+        "description": "the id of an element returned in a previous call to Find Element(s)"
+      }],
+      "parameters": [{
+        "name": "scroll",
+        "type": "boolean",
+        "description": "scroll into view the element. Default: true",
+        "required": false
+      }],
+      "returns": {
+        "type": "String",
+        "name": "screenshot",
+        "description": "The base64-encoded PNG image data comprising the screenshot of the visible region of an element’s bounding rectangle after it has been scrolled into view."
+      }
+    }
   }
 }


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

Currently, the webdriverio element.saveScreenshot() command does not work in chrome:
<img width="724" alt="screen shot 2019-02-05 at 4 24 04 pm" src="https://user-images.githubusercontent.com/4043890/52311111-7dc7db00-296b-11e9-9976-f1defa62a6ff.png">

As a temporary workaround, I'd like to use the the chromium protocol to hold this command

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
