### PR TITLE
Adding a standard header 'Content-Length' to the headers list to support testing some additional applications like Qt which expects these header in their request payload.

### DIFF
--- a/packages/webdriver/src/request.js
+++ b/packages/webdriver/src/request.js
@@ -54,6 +54,9 @@ export default class WebDriverRequest extends EventEmitter {
          */
         if (this.body && (Object.keys(this.body).length || this.method === 'POST')) {
             requestOptions.body = this.body
+            requestOptions.headers = merge(requestOptions.headers, {
+                'Content-Length': Buffer.byteLength(JSON.stringify(requestOptions.body), 'UTF-8')
+            })
         }
 
         /**

--- a/packages/webdriver/tests/request.test.js
+++ b/packages/webdriver/tests/request.test.js
@@ -77,6 +77,28 @@ describe('webdriver request', () => {
             const options = req._createOptions({ path: '/' })
             expect(options.body).toEqual({})
         })
+
+        it('should add the Content-Length header when a request object has a body', () => {
+            const req = new WebDriverRequest('POST', '/session', { foo: 'bar' })
+            const options = req._createOptions({ path: '/' })
+            expect(Object.keys(options.headers)).toContain('Content-Length')
+            expect(options.headers['Content-Length']).toBe(13)
+        })
+
+        it('should add Content-Length as well any other header provided in the request options if there is body in the request object', () => {
+            const req = new WebDriverRequest('POST', '/session', { foo: 'bar' })
+            const options = req._createOptions({ path: '/', headers: { foo: 'bar' }})
+            expect(Object.keys(options.headers)).toContain('Content-Length')
+            expect(options.headers.foo).toContain('bar')
+            expect(options.headers['Content-Length']).toBe(13)
+        })
+
+        it('should add only the headers provided if the request body is empty', () => {
+            const req = new WebDriverRequest('POST', '/session')
+            const options = req._createOptions({ path: '/', headers: { foo: 'bar' }})
+            expect(Object.keys(options.headers)).not.toContain('Content-Length')
+            expect(options.headers.foo).toContain('bar')
+        })
     })
 
     describe('_request', () => {


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
