### PR TITLE
wdio-allure-reporter: fix test skip

### DIFF
--- a/packages/wdio-allure-reporter/src/index.js
+++ b/packages/wdio-allure-reporter/src/index.js
@@ -89,10 +89,10 @@ class AllureReporter extends WDIOReporter {
     }
 
     onTestSkip(test) {
-        if (this.allure.getCurrentTest() && this.allure.getCurrentTest().status !== testStatuses.PENDING) {
-            this.allure.endCase(testStatuses.PENDING)
-        } else {
+        if (!this.allure.getCurrentTest() || this.allure.getCurrentTest().name !== test.title) {
             this.allure.pendingCase(test.title)
+        } else {
+            this.allure.endCase(testStatuses.PENDING)
         }
     }
 


### PR DESCRIPTION
## Proposed changes

mark proper test as skipped

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

#3520

situation here was like following:

1. test1 starts, allure.currentTest is now test1
2. test1 finishes (pass/fail/...), allure.currentTest is still test1
3. test2 is skipped, allure.currentTest is still test1 because test2 was not actually started
4. test1 is marked as skipped, test2 details are lost.

### Reviewers: @webdriverio/technical-committee
