### PR TITLE
wdio-allure-reporter: capture before each and all hooks

### DIFF
--- a/packages/wdio-allure-reporter/src/constants.js
+++ b/packages/wdio-allure-reporter/src/constants.js
@@ -29,6 +29,6 @@ const events = {
     addArgument: 'allure:addArgument'
 }
 
-const mochaIgnoredHooks = ['"before all" hook', '"after all" hook', '"before each" hook', '"after each" hook']
+const mochaEachHooks = ['"before each" hook', '"after each" hook']
 
-export {testStatuses, stepStatuses, events, mochaIgnoredHooks}
+export {testStatuses, stepStatuses, events, mochaEachHooks}

--- a/packages/wdio-allure-reporter/src/index.js
+++ b/packages/wdio-allure-reporter/src/index.js
@@ -1,7 +1,7 @@
 import WDIOReporter from '@wdio/reporter'
 import Allure from 'allure-js-commons'
 import Step from 'allure-js-commons/beans/step'
-import {getTestStatus, ignoredHooks, isEmpty, tellReporter} from './utils'
+import {getTestStatus, isEmpty, tellReporter, isMochaEachHooks} from './utils'
 import {events, stepStatuses, testStatuses} from './constants'
 
 class AllureReporter extends WDIOReporter {
@@ -138,22 +138,49 @@ class AllureReporter extends WDIOReporter {
     }
 
     onHookStart(hook) {
-        if (!this.allure.getCurrentSuite() || ignoredHooks(hook.title)) {
+        // ignore global hooks
+        if (!hook.parent || !this.allure.getCurrentSuite()) {
             return false
         }
 
-        this.allure.startCase(hook.title)
+        // add beforeEach / afterEach hook as step to test
+        if (isMochaEachHooks(hook.title)) {
+            if (this.allure.getCurrentTest()) {
+                this.allure.startStep(hook.title)
+            }
+            return
+        }
+        
+        // add hook as test to suite
+        this.onTestStart(hook)
     }
 
     onHookEnd(hook) {
-        if (!this.allure.getCurrentSuite() || ignoredHooks(hook.title)) {
+        // ignore global hooks
+        if (!hook.parent || !this.allure.getCurrentSuite() || !this.allure.getCurrentTest()) {
             return false
         }
 
-        this.allure.endCase(testStatuses.PASSED)
+        // set beforeEach / afterEach hook (step) status
+        if (isMochaEachHooks(hook.title)) {
+            if (hook.error) {
+                this.allure.endStep(stepStatuses.FAILED)
+            } else {
+                this.allure.endStep(stepStatuses.PASSED)
+            }
+            return
+        }
 
-        if (this.allure.getCurrentTest().steps.length === 0) {
-            this.allure.getCurrentSuite().testcases.pop()
+        // set hook (test) status
+        if (hook.error) {
+            this.onTestFail(hook)
+        } else {
+            this.onTestPass()
+
+            // remove hook from suite if it has no steps
+            if (this.allure.getCurrentTest().steps.length === 0) {
+                this.allure.getCurrentSuite().testcases.pop()
+            }
         }
     }
 

--- a/packages/wdio-allure-reporter/src/utils.js
+++ b/packages/wdio-allure-reporter/src/utils.js
@@ -1,5 +1,5 @@
 import process from 'process'
-import {testStatuses, mochaIgnoredHooks} from './constants'
+import {testStatuses, mochaEachHooks} from './constants'
 /**
  * Get allure test status by TestStat object
  * @param test {Object} - TestStat object
@@ -28,12 +28,12 @@ export const getTestStatus = (test, config) => {
 export const isEmpty = (object) => !object || Object.keys(object).length === 0
 
 /**
- * Filter unnecessary mocha hooks
+ * Is mocha beforeEach / afterEach hook
  * @param title {String} - hook title
  * @returns {boolean}
  * @private
  */
-export const ignoredHooks = title => mochaIgnoredHooks.some(hook => title.includes(hook))
+export const isMochaEachHooks = title => mochaEachHooks.some(hook => title.includes(hook))
 
 /**
  * Call reporter

--- a/packages/wdio-allure-reporter/tests/utils.test.js
+++ b/packages/wdio-allure-reporter/tests/utils.test.js
@@ -1,5 +1,5 @@
 import process from 'process'
-import {getTestStatus, ignoredHooks, isEmpty, tellReporter} from '../src/utils'
+import {getTestStatus, isEmpty, tellReporter, isMochaEachHooks} from '../src/utils'
 import {testStatuses} from '../src/constants'
 
 let processEmit
@@ -43,11 +43,11 @@ describe('utils#getTestStatus', () => {
 })
 
 describe('utils', () => {
-    it('ignoredHook filter hook by title', () => {
-        expect(ignoredHooks('"before all" hook')).toEqual(true)
-        expect(ignoredHooks('"after all" hook')).toEqual(true)
-        expect(ignoredHooks('"before each" hook')).toEqual(true)
-        expect(ignoredHooks('"after each" hook')).toEqual(true)
+    it('isMochaEachHooks filter hook by title', () => {
+        expect(isMochaEachHooks('"before all" hook')).toEqual(false)
+        expect(isMochaEachHooks('"after all" hook')).toEqual(false)
+        expect(isMochaEachHooks('"before each" hook')).toEqual(true)
+        expect(isMochaEachHooks('"after each" hook')).toEqual(true)
     })
 
     it('isEmpty filter empty objects', () => {
@@ -57,10 +57,20 @@ describe('utils', () => {
         expect(isEmpty(null)).toEqual(true)
         expect(isEmpty('')).toEqual(true)
     })
+})
 
-    it('tellReporter', () => {
+describe('utils#tellReporter', () => {
+    afterEach(() => {
+        process.emit.mockClear()
+    })
+    it('should accept message', () => {
         tellReporter('foo', {bar: 'baz'})
         expect(process.emit).toHaveBeenCalledTimes(1)
         expect(process.emit).toHaveBeenCalledWith('foo', {bar: 'baz'})
+    })
+    it('should accept no message', () => {
+        tellReporter('foo')
+        expect(process.emit).toHaveBeenCalledTimes(1)
+        expect(process.emit).toHaveBeenCalledWith('foo', {})
     })
 })

--- a/packages/wdio-mocha-framework/src/index.js
+++ b/packages/wdio-mocha-framework/src/index.js
@@ -166,16 +166,11 @@ class MochaAdapter {
         if (params.payload) {
             message.title = params.payload.title
             message.parent = params.payload.parent ? params.payload.parent.title : null
-            /**
-             * get title for hooks in root suite
-             */
-            if (message.parent === '' && params.payload.parent && params.payload.parent.suites) {
-                message.parent = params.payload.parent.suites[0].title
-            }
 
             message.fullTitle = params.payload.fullTitle ? params.payload.fullTitle() : message.parent + ' ' + message.title
             message.pending = params.payload.pending || false
             message.file = params.payload.file
+            message.duration = params.payload.duration
 
             /**
              * Add the current test title to the payload for cases where it helps to
@@ -187,7 +182,6 @@ class MochaAdapter {
 
             if (params.type.match(/Test/)) {
                 message.passed = (params.payload.state === 'passed')
-                message.duration = params.payload.duration
             }
 
             if (params.payload.context) { message.context = params.payload.context }

--- a/packages/wdio-mocha-framework/tests/adapter.test.js
+++ b/packages/wdio-mocha-framework/tests/adapter.test.js
@@ -220,7 +220,7 @@ test('formatMessage', () => {
         parent: { title: '', suites: [{ title: 'first suite' }] }
     } }
     message = adapter.formatMessage(params)
-    expect(message.parent).toEqual('first suite')
+    expect(message.parent).toEqual('')
 
     params = { type: 'foobar', payload: {
         title: 'barfoo',


### PR DESCRIPTION
## Proposed changes

Capture before all and after all hooks in Allure report as tests in case:
- hook failed
- hook has some user defined steps attached to report with allure.addStep(...)

Capture beforeEach and afterEach hooks in Allure report as test steps.

No global hooks will not appear in report.

fix for #3517 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

Allure report example with mentioned changes

example with beforeEach failure and afterEach pass as test steps

![image](https://user-images.githubusercontent.com/25589559/52528589-c58b9100-2ce2-11e9-8cef-91db0ea1fe57.png)

example with failure in the very first before

![image](https://user-images.githubusercontent.com/25589559/52528632-65491f00-2ce3-11e9-939a-32952dfa5cad.png)

more examples here https://github.com/webdriverio/webdriverio/pull/3536#issuecomment-462521067

### Reviewers: @webdriverio/technical-committee
