### PR TITLE
Fix selectByVisibleText when element has multiple textNodes

### DIFF
--- a/packages/webdriverio/src/commands/element/selectByVisibleText.js
+++ b/packages/webdriverio/src/commands/element/selectByVisibleText.js
@@ -44,7 +44,7 @@ export default async function selectByVisibleText (text) {
     const formatted = /"/.test(text)
         ? 'concat("' + text.trim().split('"').join('", \'"\', "') + '")'
         : `"${text.trim()}"`
-    const normalized = `[normalize-space(text()) = ${formatted}]`
+    const normalized = `[. = ${formatted}]`
     const optionElement = await this.findElementFromElement(this.elementId, 'xpath', `./option${normalized}|./optgroup/option${normalized}`)
 
     /**

--- a/packages/webdriverio/src/commands/element/selectByVisibleText.js
+++ b/packages/webdriverio/src/commands/element/selectByVisibleText.js
@@ -38,14 +38,14 @@ export default async function selectByVisibleText (text) {
         ? text.toString()
         : text
 
-    /**
-    * find option element using xpath
-    */
 
     const normalized = text
         .trim() // strip leading and trailing white-space characters
         .replace(/\s+/, ' ') // replace sequences of whitespace characters by a single space
 
+    /**
+    * find option element using xpath
+    */
     const formatted = /"/.test(normalized)
         ? 'concat("' + normalized.split('"').join('", \'"\', "') + '")'
         : `"${normalized}"`

--- a/packages/webdriverio/src/commands/element/selectByVisibleText.js
+++ b/packages/webdriverio/src/commands/element/selectByVisibleText.js
@@ -47,8 +47,8 @@ export default async function selectByVisibleText (text) {
         .replace(/\s+/, ' ') // replace sequences of whitespace characters by a single space
 
     const formatted = /"/.test(normalized)
-        ? 'concat("' + normalized.trim().split('"').join('", \'"\', "') + '")'
-        : `"${normalized.trim()}"`
+        ? 'concat("' + normalized.split('"').join('", \'"\', "') + '")'
+        : `"${normalized}"`
     const value = `[. = ${formatted}]`
     const optionElement = await this.findElementFromElement(this.elementId, 'xpath', `./option${value}|./optgroup/option${value}`)
 

--- a/packages/webdriverio/src/commands/element/selectByVisibleText.js
+++ b/packages/webdriverio/src/commands/element/selectByVisibleText.js
@@ -38,7 +38,6 @@ export default async function selectByVisibleText (text) {
         ? text.toString()
         : text
 
-
     const normalized = text
         .trim() // strip leading and trailing white-space characters
         .replace(/\s+/, ' ') // replace sequences of whitespace characters by a single space

--- a/packages/webdriverio/src/commands/element/selectByVisibleText.js
+++ b/packages/webdriverio/src/commands/element/selectByVisibleText.js
@@ -41,9 +41,14 @@ export default async function selectByVisibleText (text) {
     /**
     * find option element using xpath
     */
-    const formatted = /"/.test(text)
-        ? 'concat("' + text.trim().split('"').join('", \'"\', "') + '")'
-        : `"${text.trim()}"`
+
+    const normalized = text
+        .trim() // strip leading and trailing white-space characters
+        .replace(/\s+/, ' ') // replace sequences of whitespace characters by a single space
+
+    const formatted = /"/.test(normalized)
+        ? 'concat("' + normalized.trim().split('"').join('", \'"\', "') + '")'
+        : `"${normalized.trim()}"`
     const value = `[. = ${formatted}]`
     const optionElement = await this.findElementFromElement(this.elementId, 'xpath', `./option${value}|./optgroup/option${value}`)
 

--- a/packages/webdriverio/src/commands/element/selectByVisibleText.js
+++ b/packages/webdriverio/src/commands/element/selectByVisibleText.js
@@ -44,8 +44,8 @@ export default async function selectByVisibleText (text) {
     const formatted = /"/.test(text)
         ? 'concat("' + text.trim().split('"').join('", \'"\', "') + '")'
         : `"${text.trim()}"`
-    const normalized = `[. = ${formatted}]`
-    const optionElement = await this.findElementFromElement(this.elementId, 'xpath', `./option${normalized}|./optgroup/option${normalized}`)
+    const value = `[. = ${formatted}]`
+    const optionElement = await this.findElementFromElement(this.elementId, 'xpath', `./option${value}|./optgroup/option${value}`)
 
     /**
     * select option

--- a/packages/webdriverio/tests/commands/element/selectByVisibleText.test.js
+++ b/packages/webdriverio/tests/commands/element/selectByVisibleText.test.js
@@ -28,7 +28,7 @@ describe('selectByVisibleText test', () => {
 
         expect(request.mock.calls[1][0].uri.path).toBe('/wd/hub/session/foobar-123/element')
         expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/element')
-        expect(request.mock.calls[2][0].body.value).toBe('./option[normalize-space(text()) = "someValue1"]|./optgroup/option[normalize-space(text()) = "someValue1"]')
+        expect(request.mock.calls[2][0].body.value).toBe('./option[. = "someValue1"]|./optgroup/option[. = "someValue1"]')
         expect(request.mock.calls[3][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-sub-elem-321/click')
         expect(getElementFromResponseSpy).toBeCalledWith({
             [ELEMENT_KEY]: 'some-sub-elem-321'
@@ -40,7 +40,7 @@ describe('selectByVisibleText test', () => {
 
         expect(request.mock.calls[1][0].uri.path).toBe('/wd/hub/session/foobar-123/element')
         expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/element')
-        expect(request.mock.calls[2][0].body.value).toBe('./option[normalize-space(text()) = "some Value1"]|./optgroup/option[normalize-space(text()) = "some Value1"]')
+        expect(request.mock.calls[2][0].body.value).toBe('./option[. = "some Value1"]|./optgroup/option[. = "some Value1"]')
         expect(request.mock.calls[3][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-sub-elem-321/click')
         expect(getElementFromResponseSpy).toBeCalledWith({
             [ELEMENT_KEY]: 'some-sub-elem-321'
@@ -52,7 +52,7 @@ describe('selectByVisibleText test', () => {
 
         expect(request.mock.calls[1][0].uri.path).toBe('/wd/hub/session/foobar-123/element')
         expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/element')
-        expect(request.mock.calls[2][0].body.value).toBe('./option[normalize-space(text()) = concat("", \'"\', "someValue1", \'"\', "", \'"\', "")]|./optgroup/option[normalize-space(text()) = concat("", \'"\', "someValue1", \'"\', "", \'"\', "")]')
+        expect(request.mock.calls[2][0].body.value).toBe('./option[. = concat("", \'"\', "someValue1", \'"\', "", \'"\', "")]|./optgroup/option[. = concat("", \'"\', "someValue1", \'"\', "", \'"\', "")]')
         expect(request.mock.calls[3][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-sub-elem-321/click')
         expect(getElementFromResponseSpy).toBeCalledWith({
             [ELEMENT_KEY]: 'some-sub-elem-321'
@@ -64,7 +64,7 @@ describe('selectByVisibleText test', () => {
 
         expect(request.mock.calls[1][0].uri.path).toBe('/wd/hub/session/foobar-123/element')
         expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/element')
-        expect(request.mock.calls[2][0].body.value).toBe('./option[normalize-space(text()) = "123"]|./optgroup/option[normalize-space(text()) = "123"]')
+        expect(request.mock.calls[2][0].body.value).toBe('./option[. = "123"]|./optgroup/option[. = "123"]')
         expect(request.mock.calls[3][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-sub-elem-321/click')
         expect(getElementFromResponseSpy).toBeCalledWith({
             [ELEMENT_KEY]: 'some-sub-elem-321'

--- a/packages/webdriverio/tests/commands/element/selectByVisibleText.test.js
+++ b/packages/webdriverio/tests/commands/element/selectByVisibleText.test.js
@@ -47,8 +47,32 @@ describe('selectByVisibleText test', () => {
         })
     })
 
+    it('should select value by visible text with leading and trailing white-space', async () => {
+        await elem.selectByVisibleText(' someValue1 ')
+
+        expect(request.mock.calls[1][0].uri.path).toBe('/wd/hub/session/foobar-123/element')
+        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/element')
+        expect(request.mock.calls[2][0].body.value).toBe('./option[. = "someValue1"]|./optgroup/option[. = "someValue1"]')
+        expect(request.mock.calls[3][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-sub-elem-321/click')
+        expect(getElementFromResponseSpy).toBeCalledWith({
+            [ELEMENT_KEY]: 'some-sub-elem-321'
+        })
+    })
+
+    it('should select value by visible text with sequences of whitespace characters', async () => {
+        await elem.selectByVisibleText('some    Value1')
+
+        expect(request.mock.calls[1][0].uri.path).toBe('/wd/hub/session/foobar-123/element')
+        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/element')
+        expect(request.mock.calls[2][0].body.value).toBe('./option[. = "some Value1"]|./optgroup/option[. = "some Value1"]')
+        expect(request.mock.calls[3][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-sub-elem-321/click')
+        expect(getElementFromResponseSpy).toBeCalledWith({
+            [ELEMENT_KEY]: 'some-sub-elem-321'
+        })
+    })
+
     it('should select value by visible text with quotes', async () => {
-        await elem.selectByVisibleText(' "someValue1"" ')
+        await elem.selectByVisibleText('"someValue1""')
 
         expect(request.mock.calls[1][0].uri.path).toBe('/wd/hub/session/foobar-123/element')
         expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/element')


### PR DESCRIPTION
## Proposed changes

Change the way we query the options in order to fix #3529 

Consider this HTML:
```
<option value="1">
    "foo"
    "bar"
</option>
```

When querying the element using:
`$('option').selectByVisibleText('foobar')`

Before fix: it would not select the option because it would only check the first textNode

After fix: it will select the option by the text that is actually visible to the user

IMPORTANT: This also fixes the normalization that should have been applied but wasn't. Although I do not agree that we should normalize the input/ouput this is what the code should do but didn't apperently. Can we decide on if we really should be doing do this (I can live with the trim though)?

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x ] I have added tests that prove my fix is effective or that my feature works
- [x ] I have added necessary documentation (if appropriate)

### Reviewers: @webdriverio/technical-committee
