### PR TITLE
docs: Remove reference to wdio-screenshot that is not compatible with v5

### DIFF
--- a/packages/webdriverio/src/commands/browser/saveScreenshot.js
+++ b/packages/webdriverio/src/commands/browser/saveScreenshot.js
@@ -1,10 +1,8 @@
 /**
  *
  * Save a screenshot of the current browsing context to a PNG file on your OS. Be aware that
- * some browser driver take screenshots of the whole document (e.g. Geckodriver with Firefox)
- * and others only of the current viewport (e.g. Chromedriver with Chrome). If you want to
- * always be sure that the screenshot has the size of the whole document, use [wdio-screenshot](https://www.npmjs.com/package/wdio-screenshot)
- * to enhance this command with that functionality.
+ * some browser drivers take screenshots of the whole document (e.g. Geckodriver with Firefox)
+ * and others only of the current viewport (e.g. Chromedriver with Chrome).
  *
  * <example>
     :saveScreenshot.js


### PR DESCRIPTION
## Proposed changes

Remove reference to old wdio-screenshot.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

### Reviewers: @webdriverio/technical-committee
