### PR TITLE
webdriverio: add ios predicate and class chain direct selectors

### DIFF
--- a/docs/Selectors.md
+++ b/docs/Selectors.md
@@ -184,7 +184,7 @@ With iOS 10 and above (using the XCUITest driver), you can use [predicate string
 
 ```js
 const selector = 'type == \'XCUIElementTypeSwitch\' && name CONTAINS \'Allow\'';
-const Switch = $(`ios=predicate=${selector}`);
+const Switch = $(`-ios predicate string:${selector}`);
 Switch.click();
 ```
 
@@ -192,7 +192,7 @@ And [class chains](https://github.com/facebook/WebDriverAgent/wiki/Class-Chain-Q
 
 ```js
 const selector = '**/XCUIElementTypeCell[`name BEGINSWITH "D"`]/**/XCUIElementTypeButton';
-const Button = $(`ios=chain=${selector}`);
+const Button = $(`-ios class chain:${selector}`);
 Button.click();
 ```
 

--- a/packages/webdriverio/src/utils.js
+++ b/packages/webdriverio/src/utils.js
@@ -7,7 +7,7 @@ import GraphemeSplitter from 'grapheme-splitter'
 import { ELEMENT_KEY, W3C_SELECTOR_STRATEGIES, UNICODE_CHARACTERS } from './constants'
 
 const DEFAULT_SELECTOR = 'css selector'
-const DIRECT_SELECTOR_REGEXP = /^(id|css selector|xpath|link text|partial link text|name|tag name|class name|-android uiautomator|-ios uiautomation|accessibility id):(.+)/
+const DIRECT_SELECTOR_REGEXP = /^(id|css selector|xpath|link text|partial link text|name|tag name|class name|-android uiautomator|-ios uiautomation|-ios predicate string|-ios class chain|accessibility id):(.+)/
 const INVALID_SELECTOR_ERROR = new Error('selector needs to be typeof `string` or `function`')
 
 export const findStrategy = function (value, isW3C, isMobile) {

--- a/packages/webdriverio/tests/utils.test.js
+++ b/packages/webdriverio/tests/utils.test.js
@@ -179,7 +179,7 @@ describe('utils', () => {
             expect(element.using).toBe('xpath')
             expect(element.value).toBe('.//*[contains(@some-attribute, "some-value") and contains(., "some random text with "§$%&/()div=or others")]')
         })
-        
+
         it('should find an custom element by tag name + content', () => {
             const element = findStrategy('custom-element-with-multiple-dashes=some random text with "§$%&/()div=or others')
             expect(element.using).toBe('xpath')
@@ -203,6 +203,18 @@ describe('utils', () => {
             const element = findStrategy('ios=foo')
             expect(element.using).toBe('-ios uiautomation')
             expect(element.value).toBe('foo')
+        })
+
+        it('should find an element by predicate strategy (ios only)', () => {
+            const element = findStrategy('-ios predicate string:type == \'XCUIElementTypeSwitch\' && name CONTAINS \'Allow\'')
+            expect(element.using).toBe('-ios predicate string')
+            expect(element.value).toBe('type == \'XCUIElementTypeSwitch\' && name CONTAINS \'Allow\'')
+        })
+
+        it('should find an element by class chain strategy (ios only)', () => {
+            const element = findStrategy('-ios class chain:**/XCUIElementTypeCell[`name BEGINSWITH "D"`]/**/XCUIElementTypeButton')
+            expect(element.using).toBe('-ios class chain')
+            expect(element.value).toBe('**/XCUIElementTypeCell[`name BEGINSWITH "D"`]/**/XCUIElementTypeButton')
         })
 
         it('should find an element by accessibility id', () => {


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

iOS predicate and class chain selector as described in the docs were not working with XCUITest driver since everything starting with `ios=` would be rewritten to `-ios uiautomation` which is not available on iOS 10 and above. This adds the corresponding direct selectors to use predicate and class chain strategies.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
