### PR TITLE
Fix error due to empty wd response

### DIFF
--- a/packages/webdriver/src/utils.js
+++ b/packages/webdriver/src/utils.js
@@ -302,7 +302,7 @@ export function environmentDetector ({ hostname, capabilities, requestedCapabili
  */
 export function getErrorFromResponseBody (body) {
     if (!body) {
-        return new Error('unknown error')
+        return new Error('Response has empty body')
     }
 
     if (typeof body === 'string' && body.length) {

--- a/packages/webdriver/src/utils.js
+++ b/packages/webdriver/src/utils.js
@@ -302,7 +302,7 @@ export function environmentDetector ({ hostname, capabilities, requestedCapabili
  */
 export function getErrorFromResponseBody (body) {
     if (!body) {
-        return null
+        return new Error('empty response body')
     }
 
     if (typeof body === 'string' && body.length) {

--- a/packages/webdriver/src/utils.js
+++ b/packages/webdriver/src/utils.js
@@ -302,7 +302,7 @@ export function environmentDetector ({ hostname, capabilities, requestedCapabili
  */
 export function getErrorFromResponseBody (body) {
     if (!body) {
-        return new Error('empty response body')
+        return new Error('unknown error')
     }
 
     if (typeof body === 'string' && body.length) {

--- a/packages/webdriver/tests/request.test.js
+++ b/packages/webdriver/tests/request.test.js
@@ -116,6 +116,21 @@ describe('webdriver request', () => {
             request.mockClear()
         })
 
+        it('should not fail code due to an empty server response', async () => {
+            const req = new WebDriverRequest('POST', '/session')
+            req.emit = jest.fn()
+
+            const opts = Object.assign(req.defaultOptions, { uri: { path: '/wd/hub/empty' } })
+            await expect(req._request(opts)).rejects.toEqual(new Error('empty response body'))
+            expect(req.emit.mock.calls).toHaveLength(1)
+            expect(warn.mock.calls).toHaveLength(0)
+            expect(error.mock.calls).toHaveLength(1)
+
+            request.retryCnt = 0
+            warn.mockClear()
+            error.mockClear()
+        })
+
         it('should retry requests but still fail', async () => {
             const req = new WebDriverRequest('POST', '/session')
             req.emit = jest.fn()

--- a/packages/webdriver/tests/request.test.js
+++ b/packages/webdriver/tests/request.test.js
@@ -121,7 +121,7 @@ describe('webdriver request', () => {
             req.emit = jest.fn()
 
             const opts = Object.assign(req.defaultOptions, { uri: { path: '/wd/hub/empty' } })
-            await expect(req._request(opts)).rejects.toEqual(new Error('empty response body'))
+            await expect(req._request(opts)).rejects.toEqual(new Error('unknown error'))
             expect(req.emit.mock.calls).toHaveLength(1)
             expect(warn.mock.calls).toHaveLength(0)
             expect(error.mock.calls).toHaveLength(1)

--- a/packages/webdriver/tests/request.test.js
+++ b/packages/webdriver/tests/request.test.js
@@ -121,7 +121,7 @@ describe('webdriver request', () => {
             req.emit = jest.fn()
 
             const opts = Object.assign(req.defaultOptions, { uri: { path: '/wd/hub/empty' } })
-            await expect(req._request(opts)).rejects.toEqual(new Error('unknown error'))
+            await expect(req._request(opts)).rejects.toEqual(new Error('Response has empty body'))
             expect(req.emit.mock.calls).toHaveLength(1)
             expect(warn.mock.calls).toHaveLength(0)
             expect(error.mock.calls).toHaveLength(1)

--- a/packages/webdriver/tests/utils.test.js
+++ b/packages/webdriver/tests/utils.test.js
@@ -219,10 +219,12 @@ describe('utils', () => {
     })
 
     it('getErrorFromResponseBody', () => {
+        const emptyBodyError = new Error('Response has empty body')
+        expect(getErrorFromResponseBody()).toEqual(emptyBodyError)
+        expect(getErrorFromResponseBody('')).toEqual(emptyBodyError)
+        expect(getErrorFromResponseBody(null)).toEqual(emptyBodyError)
+
         const unknownError = new Error('unknown error')
-        expect(getErrorFromResponseBody()).toEqual(unknownError)
-        expect(getErrorFromResponseBody('')).toEqual(unknownError)
-        expect(getErrorFromResponseBody(null)).toEqual(unknownError)
         expect(getErrorFromResponseBody({})).toEqual(unknownError)
 
         const expectedError = new Error('expected')

--- a/packages/webdriver/tests/utils.test.js
+++ b/packages/webdriver/tests/utils.test.js
@@ -219,11 +219,10 @@ describe('utils', () => {
     })
 
     it('getErrorFromResponseBody', () => {
-        expect(getErrorFromResponseBody()).toBe(null)
-        expect(getErrorFromResponseBody('')).toBe(null)
-        expect(getErrorFromResponseBody(null)).toBe(null)
-
         const unknownError = new Error('unknown error')
+        expect(getErrorFromResponseBody()).toEqual(unknownError)
+        expect(getErrorFromResponseBody('')).toEqual(unknownError)
+        expect(getErrorFromResponseBody(null)).toEqual(unknownError)
         expect(getErrorFromResponseBody({})).toEqual(unknownError)
 
         const expectedError = new Error('expected')

--- a/packages/webdriverio/tests/__mocks__/request.js
+++ b/packages/webdriverio/tests/__mocks__/request.js
@@ -181,6 +181,17 @@ const requestMock = jest.fn().mockImplementation((params, cb) => {
     }
 
     /**
+     * empty response
+     */
+    if (params.uri.path === '/wd/hub/empty') {
+        return cb(null, {
+            headers: { foo: 'bar' },
+            statusCode: 500,
+            body: ''
+        })
+    }
+
+    /**
      * simulate failing response
      */
     if (params.uri.path === '/wd/hub/failing') {


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)
Fix #3552
Empty wd response leads to the TypeError:
```bash
Cannot read property 'name' of null
TypeError: Cannot read property 'name' of null
at Request._callback (/tests/node_modules/webdriver/build/request.js:130:17)
at Request.self.callback (/tests/node_modules/request/request.js:185:22)
at Request.emit (events.js:182:13)
at Request.EventEmitter.emit (domain.js:442:20)
at Request.<anonymous> (/tests/node_modules/request/request.js:1161:10)
at Request.emit (events.js:182:13)
at Request.EventEmitter.emit (domain.js:442:20)
at IncomingMessage.<anonymous> (/tests/node_modules/request/request.js:1083:12)
at Object.onceWrapper (events.js:273:13)
at IncomingMessage.emit (events.js:187:15)
```
Fixed issue #3552

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
