### PR TITLE
webdriverio: user friendly waitUntil messages

### DIFF
--- a/packages/webdriverio/src/commands/browser/waitUntil.js
+++ b/packages/webdriverio/src/commands/browser/waitUntil.js
@@ -56,10 +56,13 @@ export default function (condition, timeout, timeoutMsg, interval) {
     let timer = new Timer(interval, timeout, fn, true)
 
     return timer.catch((e) => {
-        if (e.message === 'timeout' && typeof timeoutMsg === 'string') {
-            throw new Error(timeoutMsg)
+        if (e.message === 'timeout') {
+            if (typeof timeoutMsg === 'string') {
+                throw new Error(timeoutMsg)
+            }
+            throw new Error(`waitUntil condition timed out after ${timeout}ms`)
         }
 
-        throw new Error(`Promise was rejected with the following reason: ${e}`)
+        throw new Error(`waitUntil condition failed with the following reason: ${(e && e.message) || e}`)
     })
 }

--- a/packages/webdriverio/tests/commands/browser/waitUntil.test.js
+++ b/packages/webdriverio/tests/commands/browser/waitUntil.test.js
@@ -57,7 +57,18 @@ describe('waitUntil', () => {
         } catch(e) {
             error = e
         } finally{
-            expect(error.message).toContain('Promise was rejected with the following reason: Error: foobar')
+            expect(error.message).toContain('waitUntil condition failed with the following reason: foobar')
+        }
+    })
+
+    it('Should throw an error when the promise is rejected without error message', async () => {
+        expect.assertions(1)
+        try {
+            await browser.waitUntil(() => new Promise((resolve,reject) => 
+                setTimeout(() => reject(new Error()), 200)),
+            500)
+        } catch(e) {
+            expect(e.message).toContain('waitUntil condition failed with the following reason: Error')
         }
     })
 
@@ -70,11 +81,11 @@ describe('waitUntil', () => {
                     setTimeout(
                         () => resolve(false),
                         500)),
-            'blah','Timed Out',200)
+            'blah', undefined, 200)
         } catch(e) {
             error = e
         } finally{
-            expect(error.message).toContain('Timed Out')
+            expect(error.message).toMatch(/waitUntil condition timed out after \d+ms/)
         }
     })
 


### PR DESCRIPTION
## Proposed changes

Make waitUntil messages more user friendly, no more frightening "Promise was rejected" :)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

examples

```
Error: waitUntil condition timed out after 60ms
     at timer.catch.e (/.../e2e/node_modules/webdriverio/build/commands/browser/waitUntil.js:71:13)
```
```
Error: waitUntil user message
     at timer.catch.e (/.../e2e/node_modules/webdriverio/build/commands/browser/waitUntil.js:69:17)
```
```
Error: waitUntil condition failed with the following reason: user exception in waitUntil
     at timer.catch.e (/.../e2e/node_modules/webdriverio/build/commands/browser/waitUntil.js:74:11)
```

### Reviewers: @webdriverio/technical-committee
