### PR TITLE
Move reporter directory creation up

### DIFF
--- a/packages/wdio-reporter/src/index.js
+++ b/packages/wdio-reporter/src/index.js
@@ -15,6 +15,12 @@ export default class WDIOReporter extends EventEmitter {
     constructor (options) {
         super()
         this.options = options
+
+        // ensure the report directory exists
+        if (this.options.outputDir) {
+            fse.ensureDirSync(this.options.outputDir)
+        }
+        
         this.outputStream = this.options.stdout || !this.options.logFile
             ? options.writeStream
             : fs.createWriteStream(this.options.logFile)
@@ -30,11 +36,6 @@ export default class WDIOReporter extends EventEmitter {
             passes: 0,
             skipping: 0,
             failures: 0
-        }
-
-        // ensure the report directory exists
-        if (this.options.outputDir) {
-            fse.ensureDirSync(this.options.outputDir)
         }
 
         let currentTest


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

#3510 was supposed to fix errors caused by the reporter directory not being available, but it occurs too late in the code. It needs to occur before `fs.createWriteStream(this.options.logFile)` is run, so that the directory is available for the file to be written to.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
