### PR TITLE
Make metrics param in assertPerformance not required

### DIFF
--- a/packages/webdriver/protocol/saucelabs.json
+++ b/packages/webdriver/protocol/saucelabs.json
@@ -168,7 +168,7 @@
         "name": "metrics",
         "type": "string[]",
         "description": "Name of metrics you want to assert agains the baseline.",
-        "required": true
+        "required": false
       }],
       "returns": {
         "type": "Boolean",


### PR DESCRIPTION
## Proposed changes

The metrics parameter is not required for the `assertPerformance` command.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
