### PR TITLE
wdio-reporter: Output error messages on failure

### DIFF
--- a/packages/wdio-dot-reporter/src/index.js
+++ b/packages/wdio-dot-reporter/src/index.js
@@ -48,6 +48,6 @@ export default class DotReporter extends WDIOReporter {
             return
         }
 
-        this.write(`${results.join('\n')}\n`)
+        this.writeEnd(`${results.join('\n')}\n`)
     }
 }

--- a/packages/wdio-dot-reporter/src/index.js
+++ b/packages/wdio-dot-reporter/src/index.js
@@ -38,6 +38,10 @@ export default class DotReporter extends WDIOReporter {
      * Test run is complete
      */
     onRunnerEnd () {
+        this.printErrors()
+    }
+
+    printErrors() {
         const results = this.getFailureDisplay()
 
         if(results.length === 0) {

--- a/packages/wdio-dot-reporter/src/index.js
+++ b/packages/wdio-dot-reporter/src/index.js
@@ -33,4 +33,17 @@ export default class DotReporter extends WDIOReporter {
     onTestFail () {
         this.write(chalk.redBright('F'))
     }
+
+    /**
+     * Test run is complete
+     */
+    onRunnerEnd () {
+        const results = this.getFailureDisplay()
+
+        if(results.length === 0) {
+            return
+        }
+
+        this.write(`${results.join('\n')}\n`)
+    }
 }

--- a/packages/wdio-dot-reporter/tests/index.test.js
+++ b/packages/wdio-dot-reporter/tests/index.test.js
@@ -35,4 +35,37 @@ describe('Dot Reporter', () => {
         reporter.write(1)
         expect(reporter.outputStream.write.mock.calls[0]).toEqual([1])
     })
+
+    describe('onRunnerEnd', () => {
+        const reporter = new DotReporter({})
+
+        it('should call printReport method', () => {
+            reporter.printErrors = jest.fn()
+            reporter.onRunnerEnd({})
+
+            expect(reporter.printErrors.mock.calls.length).toBe(1)
+        })
+    })
+
+    describe('printErrors', () => {
+        let reporter
+
+        beforeEach(() => {
+            reporter = new DotReporter({})
+        })
+
+        it('should not return any errors', () => {
+            reporter.getFailureDisplay = jest.fn(() => [])
+
+            expect(reporter.printErrors()).toBe(undefined)
+        })
+
+        it('should return errors', () => {
+            reporter.getFailureDisplay = jest.fn(() => ['foo', 'bar'])
+            reporter.write = jest.fn()
+            reporter.printErrors()
+
+            expect(reporter.write).toHaveBeenCalled()
+        })
+    })
 })

--- a/packages/wdio-reporter/src/index.js
+++ b/packages/wdio-reporter/src/index.js
@@ -238,7 +238,14 @@ export default class WDIOReporter extends EventEmitter {
      * function to write to reporters output stream
      */
     write (content) {
-        this.outputStream.write(content)
+        this.outputStream.write(content, 'standard')
+    }
+
+    /**
+     * Write data at the end of the report
+     */
+    writeEnd (content) {
+        this.outputStream.write(content, 'end')
     }
 
     /* istanbul ignore next */

--- a/packages/wdio-reporter/tests/__fixtures__/testdata.js
+++ b/packages/wdio-reporter/tests/__fixtures__/testdata.js
@@ -1,0 +1,72 @@
+export const SUITE_UIDS = [
+    'Foo test1',
+    'Bar test2',
+    'Baz test3',
+]
+
+export const SUITES = [
+    {
+        uid : SUITE_UIDS[0],
+        title : SUITE_UIDS[0].slice(0, -1),
+        hooks: [],
+        tests : [
+            {
+                uid : 'foo1',
+                title : 'foo',
+                state : 'passed',
+            },
+            {
+                uid : 'bar1',
+                title : 'bar',
+                state : 'passed',
+            }
+        ],
+    },
+    {
+        uid : SUITE_UIDS[1],
+        title : SUITE_UIDS[1].slice(0, -1),
+        hooks: [{ error : false }],
+        tests : [
+            {
+                uid : 'some test1',
+                title : 'some test',
+                state : 'passed',
+            },
+            {
+                uid : 'a failed test2',
+                title : 'a failed test',
+                state : 'failed',
+                error : {
+                    message : 'expected foo to equal bar',
+                    stack : 'Failed test stack trace'
+                }
+            }
+        ],
+    },
+    {
+        uid : SUITE_UIDS[2],
+        title : SUITE_UIDS[2].slice(0, -1),
+        hooks: [{ error : true }],
+        tests : [
+            {
+                uid : 'foo bar baz1',
+                title : 'foo bar baz',
+                state : 'passed',
+            },
+            {
+                uid : 'a skipped test2',
+                title : 'a skipped test',
+                state : 'skipped',
+            }],
+    }
+]
+
+export const SUITES_NO_TESTS = [
+    {
+        uid: SUITE_UIDS[0],
+        title: SUITE_UIDS[0].slice(0, -1),
+        tests: [],
+        suites: [],
+        hooks: []
+    },
+]

--- a/packages/wdio-reporter/tests/__mocks__/@wdio/reporter.js
+++ b/packages/wdio-reporter/tests/__mocks__/@wdio/reporter.js
@@ -25,47 +25,6 @@ export default class WDIOReporter extends EventEmitter {
         return true
     }
 
-    getEventsToReport (suite) {
-        return [
-            /**
-             * report all tests
-             */
-            ...suite.tests,
-            /**
-             * and only hooks that failed
-             */
-            ...suite.hooks
-                .filter((hook) => Boolean(hook.error))
-        ]
-    }
-
-    getFailureDisplay () {
-        let failureLength = 0
-        const output = []
-
-        for (const [ , suite ] of Object.entries(this.all_suites)) {
-            const suiteTitle = suite.title
-            const eventsToReport = this.getEventsToReport(suite)
-            for (const test of eventsToReport) {
-                if(test.state !== 'failed') {
-                    continue
-                }
-
-                const testTitle = test.title
-
-                // If we get here then there is a failed test
-                output.push(
-                    '',
-                    `${++failureLength}) ${suiteTitle} ${testTitle}`,
-                    chalk.red(test.error.message),
-                    ...test.error.stack.split(/\n/g).map(value => chalk.gray(value))
-                )
-            }
-        }
-
-        return output
-    }
-
     write (content) {
         this.outputStream.write(content)
     }

--- a/packages/wdio-reporter/tests/reporter.test.js
+++ b/packages/wdio-reporter/tests/reporter.test.js
@@ -5,6 +5,11 @@ import path from 'path'
 
 import WDIOReporter from '../src'
 
+import {
+    SUITES,
+    SUITES_NO_TESTS,
+} from './__fixtures__/testdata'
+
 jest.mock('events', () => {
     class EventEmitterMock {
         constructor () {
@@ -98,5 +103,45 @@ describe('WDIOReporter', () => {
         expect(() => {
             new WDIOReporter({ outputDir: true })
         }).toThrow()
+    })
+
+    describe('getFailureDisplay', () => {
+        const reporter = new WDIOReporter({})
+
+        it('should return failing results', () => {
+            reporter.all_suites = SUITES
+
+            const result = reporter.getFailureDisplay()
+
+            expect(result.length).toBe(4)
+            expect(result[0]).toBe('')
+            expect(result[1]).toBe('1) Bar test a failed test')
+            expect(result[2]).toBe('red expected foo to equal bar')
+            expect(result[3]).toBe('gray Failed test stack trace')
+        })
+
+        it('should return no results', () => {
+            reporter.all_suites = SUITES_NO_TESTS
+
+            const result = reporter.getFailureDisplay()
+
+            expect(result.length).toBe(0)
+        })
+    })
+
+    describe('getEventsToReport', () => {
+        const reporter = new WDIOReporter({})
+
+        it('should return all tests and hook errors to report', () => {
+            expect(reporter.getEventsToReport({
+                tests: [1, 2, 3],
+                hooks: [4, 5, 6]
+            })).toEqual([1, 2, 3])
+
+            expect(reporter.getEventsToReport({
+                tests: [1, 2, 3],
+                hooks: [{ error: 1 }, 5, { error: 2 }]
+            })).toEqual([1, 2, 3, { error: 1 }, { error: 2 }])
+        })
     })
 })

--- a/packages/wdio-runner/src/reporter.js
+++ b/packages/wdio-runner/src/reporter.js
@@ -74,11 +74,12 @@ export default class BaseReporter {
      */
     getWriteStreamObject (reporter) {
         return {
-            write: /* istanbul ignore next */ (content) => process.send({
+            write: /* istanbul ignore next */ (content, outputType = 'standard') => process.send({
                 origin: 'reporter',
                 name: reporter,
+                outputType,
                 content
-            })
+            }),
         }
     }
 

--- a/packages/wdio-spec-reporter/src/index.js
+++ b/packages/wdio-spec-reporter/src/index.js
@@ -121,25 +121,6 @@ class SpecReporter extends WDIOReporter {
     }
 
     /**
-     * returns everything worth reporting from a suite
-     * @param  {Object}    suite  test suite containing tests and hooks
-     * @return {Object[]}         list of events to report
-     */
-    getEventsToReport (suite) {
-        return [
-            /**
-             * report all tests
-             */
-            ...suite.tests,
-            /**
-             * and only hooks that failed
-             */
-            ...suite.hooks
-                .filter((hook) => Boolean(hook.error))
-        ]
-    }
-
-    /**
      * Get the results from the tests
      * @param  {Array} suites Runner suites
      * @return {Array}        Display output list
@@ -205,38 +186,6 @@ class SpecReporter extends WDIOReporter {
         if(this.stateCounts.skipped > 0) {
             const text = `${this.stateCounts.skipped} skipped ${duration}`.trim()
             output.push(this.chalk[this.getColor('skipped')](text))
-        }
-
-        return output
-    }
-
-    /**
-     * Get display for failed tests, e.g. stack trace
-     * @return {Array} Stack trace output
-     */
-    getFailureDisplay () {
-        let failureLength = 0
-        const output = []
-        const suites = this.getOrderedSuites()
-
-        for (const suite of suites) {
-            const suiteTitle = suite.title
-            const eventsToReport = this.getEventsToReport(suite)
-            for (const test of eventsToReport) {
-                if(test.state !== 'failed') {
-                    continue
-                }
-
-                const testTitle = test.title
-
-                // If we get here then there is a failed test
-                output.push(
-                    '',
-                    `${++failureLength}) ${suiteTitle} ${testTitle}`,
-                    this.chalk.red(test.error.message),
-                    ...test.error.stack.split(/\n/g).map(value => this.chalk.gray(value))
-                )
-            }
         }
 
         return output

--- a/packages/wdio-spec-reporter/tests/index.test.js
+++ b/packages/wdio-spec-reporter/tests/index.test.js
@@ -63,19 +63,6 @@ describe('SpecReporter', () => {
         })
     })
 
-    describe('getEventsToReport', () => {
-        it('should return all tests and hook errors to report', () => {
-            expect(tmpReporter.getEventsToReport({
-                tests: [1, 2, 3],
-                hooks: [4, 5, 6]
-            })).toEqual([1, 2, 3])
-            expect(tmpReporter.getEventsToReport({
-                tests: [1, 2, 3],
-                hooks: [{ error: 1 }, 5, { error: 2 }]
-            })).toEqual([1, 2, 3, { error: 1 }, { error: 2 }])
-        })
-    })
-
     describe('onTestPass', () => {
         beforeAll(() => {
             reporter.onTestPass()
@@ -143,6 +130,7 @@ describe('SpecReporter', () => {
         it('should print the report to the console', () => {
             printReporter.suiteUids = SUITE_UIDS
             printReporter.suites = SUITES
+            printReporter.all_suites = SUITES
             printReporter.stateCounts = {
                 passed : 4,
                 failed : 1,
@@ -157,6 +145,7 @@ describe('SpecReporter', () => {
         it('should print link to SauceLabs job details page', () => {
             printReporter.suiteUids = SUITE_UIDS
             printReporter.suites = SUITES
+            printReporter.all_suites = SUITES
             printReporter.stateCounts = {
                 passed : 4,
                 failed : 1,
@@ -273,51 +262,30 @@ describe('SpecReporter', () => {
         })
     })
 
-    describe('getFailureDisplay', () => {
-        it('should return failing results', () => {
-            tmpReporter.getOrderedSuites = jest.fn(() => SUITES)
-            tmpReporter.suites = SUITES
-
-            const result = tmpReporter.getFailureDisplay()
-
-            expect(result.length).toBe(4)
-            expect(result[0]).toBe('')
-            expect(result[1]).toBe('1) Bar test a failed test')
-            expect(result[2]).toBe('red expected foo to equal bar')
-            expect(result[3]).toBe('gray Failed test stack trace')
-        })
-
-        it('should return no results', () => {
-            tmpReporter.getOrderedSuites = jest.fn(() => SUITES_NO_TESTS)
-            tmpReporter.suites = SUITES_NO_TESTS
-
-            const result = tmpReporter.getFailureDisplay()
-
-            expect(result.length).toBe(0)
-        })
-    })
-
     describe('getOrderedSuites', () => {
-        it('should return the suites in order based on uids', () => {
-            tmpReporter.foo = 'hellooo'
-            tmpReporter.suiteUids = [5, 3, 8]
-            tmpReporter.suites = [{ uid : 3 }, { uid : 5 }]
+        const reporter = new SpecReporter({})
 
-            const result = tmpReporter.getOrderedSuites()
+        it('should return the suites in order based on uids', () => {
+            reporter.foo = 'hellooo'
+            reporter.suiteUids = [5, 3, 8]
+            reporter.suites = [{ uid : 3 }, { uid : 5 }]
+            reporter.all_suites = [{ uid : 3 }, { uid : 5 }]
+
+            const result = reporter.getOrderedSuites()
 
             expect(result.length).toBe(2)
             expect(result[0]).toEqual({ uid : 5 })
             expect(result[1]).toEqual({ uid : 3 })
 
-            expect(tmpReporter.orderedSuites.length).toBe(2)
-            expect(tmpReporter.orderedSuites[0]).toEqual({ uid : 5 })
-            expect(tmpReporter.orderedSuites[1]).toEqual({ uid : 3 })
+            expect(reporter.orderedSuites.length).toBe(2)
+            expect(reporter.orderedSuites[0]).toEqual({ uid : 5 })
+            expect(reporter.orderedSuites[1]).toEqual({ uid : 3 })
         })
 
         it('should return the cached ordered suites', () => {
-            tmpReporter.foo = 'hellooo boo'
-            tmpReporter.orderedSuites = ['foo', 'bar']
-            const result = tmpReporter.getOrderedSuites()
+            reporter.foo = 'hellooo boo'
+            reporter.orderedSuites = ['foo', 'bar']
+            const result = reporter.getOrderedSuites()
 
             expect(result.length).toBe(2)
             expect(result[0]).toBe('foo')
@@ -325,7 +293,9 @@ describe('SpecReporter', () => {
         })
 
         it('should return no suites', () => {
-            expect(tmpReporter.getOrderedSuites().length).toBe(0)
+            reporter.suites = []
+            reporter.orderedSuites = []
+            expect(reporter.getOrderedSuites().length).toBe(0)
         })
     })
 


### PR DESCRIPTION
## Proposed changes

When using the dot reporter and an error occurs there is no information about the error.

Adds error messages to the dot reporter.

Adds a function to wdio-reporter that will return the error messages that other reporters can use.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

### Reviewers: @webdriverio/technical-committee
