### PR TITLE
webdriverio: handle null returned by function selectors

### DIFF
--- a/packages/webdriverio/src/utils.js
+++ b/packages/webdriverio/src/utils.js
@@ -166,10 +166,16 @@ export const getPrototype = (scope) => {
 
 /**
  * get element id from WebDriver response
- * @param  {object} res         body object from response
- * @return {string|undefined}   element id or null if element couldn't be found
+ * @param  {?Object|undefined} res         body object from response or null
+ * @return {?string}   element id or null if element couldn't be found
  */
 export const getElementFromResponse = (res) => {
+    /**
+    * a function selector can return null
+    */
+    if (res === null || res === undefined) {
+        return null
+    }
     /**
      * deprecated JSONWireProtocol response
      */

--- a/packages/webdriverio/src/utils.js
+++ b/packages/webdriverio/src/utils.js
@@ -173,9 +173,10 @@ export const getElementFromResponse = (res) => {
     /**
     * a function selector can return null
     */
-    if (res === null || res === undefined) {
+    if (!res) {
         return null
     }
+    
     /**
      * deprecated JSONWireProtocol response
      */

--- a/packages/webdriverio/tests/utils.test.js
+++ b/packages/webdriverio/tests/utils.test.js
@@ -334,6 +334,14 @@ describe('utils', () => {
     })
 
     describe('getElementFromResponse', () => {
+        it('should return null if response is null', () => {
+            expect(getElementFromResponse(null)).toBe(null)
+        })
+
+        it('should return null if response is undfined', () => {
+            expect(getElementFromResponse()).toBe(null)
+        })
+
         it('should find element from JSONWireProtocol response', () => {
             expect(getElementFromResponse({ ELEMENT: 'foobar' })).toBe('foobar')
         })


### PR DESCRIPTION
## Proposed changes
Adds a `null` check to utils.getElementFromResponse so that commands like waitForExist, waitForDisplayed, etc can be used when $ is used with a function selector that returns null. This typically happens when the function selector uses `querySelector` and does not find an element.

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
