### PR TITLE
webdriverio: remove redundant [T] -> T

### DIFF
--- a/scripts/templates/webdriver.tpl.d.ts
+++ b/scripts/templates/webdriver.tpl.d.ts
@@ -7,7 +7,7 @@
 type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 
 type ArgumentTypes<T> = T extends (...args: infer U) => infer R ? U : never;
-type WrapWithPromise<T> = (...args: ArgumentTypes<T>) => Promise<[T]>;
+type WrapWithPromise<T> = (...args: ArgumentTypes<T>) => Promise<T>;
 
 declare namespace WebDriver {
     type PageLoadingStrategy = 'none' | 'eager' | 'normal';


### PR DESCRIPTION
## Proposed changes
Currently, I see that `Browser` and `Element` methods that have `Promise` look like:
```
Promise<[T]>
```
For example `.click()` has such return type `Promise<[() => undefined]>`. `[ ]` this is redundant here. So, from my perspective I aware to see something like this:
```
Promise<T>
```
From example above `.click()` will return `Promise<() => undefined>`

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
