### PR TITLE
add return type void for Browser and Element commands

### DIFF
--- a/scripts/templates/webdriverio.tpl.d.ts
+++ b/scripts/templates/webdriverio.tpl.d.ts
@@ -153,7 +153,7 @@ declare namespace WebdriverIO {
         addCommand(
             name: string,
             func: Function
-        ): undefined;
+        ): void;
         // ... element commands ...
     }
 
@@ -171,7 +171,7 @@ declare namespace WebdriverIO {
             name: string,
             func: Function,
             attachToElement?: boolean
-        ): undefined;
+        ): void;
         execute: Execute;
         executeAsync: ExecuteAsync;
         call: Call;
@@ -181,7 +181,7 @@ declare namespace WebdriverIO {
             timeout?: number,
             timeoutMsg?: string,
             interval?: number
-        ): undefined
+        ): void
         // ... browser commands ...
     }
 

--- a/scripts/type-generation/generate-typings-utils.js
+++ b/scripts/type-generation/generate-typings-utils.js
@@ -27,7 +27,7 @@ const getTypes = (types, alwaysType) => {
     })
     types = types.join(' | ')
     if (types === '' && !alwaysType) {
-        types = 'undefined'
+        types = 'void'
     } else if (types === '*' || (types === '' && alwaysType)) {
         types = 'any'
     }
@@ -37,7 +37,7 @@ const getTypes = (types, alwaysType) => {
 
 const buildCommand = (commandName, commandTags, indentation = 0) => {
     const allParameters = []
-    let returnType = 'undefined'
+    let returnType = 'void'
 
     for (const { type, name, optional, types, string } of commandTags) {
         // dox parse {*} as string instead of types

--- a/scripts/type-generation/specific-types.json
+++ b/scripts/type-generation/specific-types.json
@@ -22,7 +22,7 @@
     "setCookies": [
         {
             "parameters": [{"name": "cookie", "type": "Cookie"}],
-            "return": "undefined"
+            "return": "void"
         }
     ],
     "getCookies": [
@@ -40,13 +40,13 @@
     "setTimeout": [
         {
             "parameters": [{"name": "timeouts", "type": "Timeouts"}],
-            "return": "undefined"
+            "return": "void"
         }
     ],
     "touchAction": [
         {
             "parameters": [{"name": "action", "type": "TouchActions"}],
-            "return": "undefined"
+            "return": "void"
         }
     ]
 }

--- a/scripts/type-generation/webdriver-generate-typings.js
+++ b/scripts/type-generation/webdriver-generate-typings.js
@@ -19,7 +19,7 @@ for (const [protocolName, definition] of Object.entries(PROTOCOLS)) {
                 .map((v) => `${v.name}: string`)
             const params = parameters.map((p) => `${p.name}${p.required === false ? '?' : ''}: ${p.type.toLowerCase()}`)
             const varsAndParams = vars.concat(params)
-            let returnValue = returns ? returns.type.toLowerCase() : 'undefined'
+            let returnValue = returns ? returns.type.toLowerCase() : 'void'
             returnValue = returnValue === '*' ? 'any' : returnValue
             lines.push(`        ${command}(${varsAndParams.join(', ')}): ${returnValue};`)
         }


### PR DESCRIPTION
## Proposed changes
Currently, Browser and Element commands miss type in case if it is `void`. So, in typings I see `undefined`. I added it for commands that I expect should return `void`

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
