### PR TITLE
webdriverio: IE11 support in fetchElementByJSFunction

### DIFF
--- a/packages/webdriverio/src/utils.js
+++ b/packages/webdriverio/src/utils.js
@@ -176,7 +176,7 @@ export const getElementFromResponse = (res) => {
     if (!res) {
         return null
     }
-    
+
     /**
      * deprecated JSONWireProtocol response
      */
@@ -311,8 +311,10 @@ function fetchElementByJSFunction (selector, scope) {
     if (!scope.elementId) {
         return scope.execute(selector)
     }
-
-    const script = ((elem) => (selector).call(elem)).toString().replace('selector', `(${selector.toString()})`)
+    /**
+     * use a regular function because IE does not understand arrow functions
+     */
+    const script = (function (elem) { return (selector).call(elem) }).toString().replace('selector', `(${selector.toString()})`)
     return getBrowserObject(scope).execute(`return (${script}).apply(null, arguments)`, scope)
 }
 


### PR DESCRIPTION
## Proposed changes
Replaces the arrow function used with a regular function. IE11 does not understand arrow functions.
fixes: 
https://github.com/webdriverio/webdriverio/issues/3592

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
