### PR TITLE
Add missing logLevel

### DIFF
--- a/docs/ConfigurationFile.md
+++ b/docs/ConfigurationFile.md
@@ -116,7 +116,7 @@ exports.config = {
     // ===================
     // Define all options that are relevant for the WebdriverIO instance here
     //
-    // Level of logging verbosity: trace | debug | info | warn | error
+    // Level of logging verbosity: trace | debug | info | warn | error | silent
     logLevel: 'info',
     //
     // If you only want to run your tests until a specific amount of tests have failed use

--- a/examples/pageobject/wdio.conf.js
+++ b/examples/pageobject/wdio.conf.js
@@ -31,7 +31,7 @@ exports.config = {
     // ===================
     // Define all options that are relevant for the WebdriverIO instance here
     //
-    // Level of logging verbosity: trace | debug | info | warn | error
+    // Level of logging verbosity: trace | debug | info | warn | error | silent
     logLevel: 'trace',
     outputDir: __dirname,
     //

--- a/examples/wdio.conf.js
+++ b/examples/wdio.conf.js
@@ -100,7 +100,7 @@ exports.config = {
     // e.g. using promises you can set the sync option to false.
     sync: true,
     //
-    // Level of logging verbosity: trace | debug | info | warn | error
+    // Level of logging verbosity: trace | debug | info | warn | error | silent
     logLevel: 'info',
     //
     // Set directory to store all logs into

--- a/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
+++ b/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
@@ -92,7 +92,7 @@ exports.config = {
     // ===================
     // Define all options that are relevant for the WebdriverIO instance here
     //
-    // Level of logging verbosity: trace | debug | info | warn | error
+    // Level of logging verbosity: trace | debug | info | warn | error | silent
     logLevel: '<%= answers.logLevel %>',
     //
     // If you only want to run your tests until a specific amount of tests have failed use

--- a/packages/webdriver/README.md
+++ b/packages/webdriver/README.md
@@ -54,7 +54,7 @@ Level of logging verbosity.
 
 Type: `String`<br>
 Default: *info*<br>
-Options: *trace* | *debug* | *info* | *warn* | *error*
+Options: *trace* | *debug* | *info* | *warn* | *error* | *silent*
 
 ### logOutput
 Pipe logs into a file.

--- a/scripts/templates/webdriver.tpl.d.ts
+++ b/scripts/templates/webdriver.tpl.d.ts
@@ -7,7 +7,7 @@
 declare namespace WebDriver {
     type PageLoadingStrategy = 'none' | 'eager' | 'normal';
     type ProxyTypes = 'pac' | 'noproxy' | 'autodetect' | 'system' | 'manual';
-    type WebDriverLogTypes = 'trace' | 'debug' | 'info' | 'warn' | 'error';
+    type WebDriverLogTypes = 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'silent';
     type LoggingPreferenceType =
         'OFF' | 'SEVERE' | 'WARNING' |
         'INFO' | 'CONFIG' | 'FINE' |


### PR DESCRIPTION
## Proposed changes

I believe that webdriver accepts the following logLevels: 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'silent'
Silent was missing from this list and it has been added in all the places needed.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

### Reviewers: @webdriverio/technical-committee
