### PR TITLE
Fix #3460

### DIFF
--- a/packages/webdriver/src/request.js
+++ b/packages/webdriver/src/request.js
@@ -37,7 +37,7 @@ export default class WebDriverRequest extends EventEmitter {
     }
 
     makeRequest (options, sessionId) {
-        const fullRequestOptions = merge(this.defaultOptions, this._createOptions(options, sessionId))
+        const fullRequestOptions = merge({}, this.defaultOptions, this._createOptions(options, sessionId))
         this.emit('request', fullRequestOptions)
         return this._request(fullRequestOptions, options.connectionRetryCount)
     }
@@ -54,7 +54,7 @@ export default class WebDriverRequest extends EventEmitter {
          */
         if (this.body && (Object.keys(this.body).length || this.method === 'POST')) {
             requestOptions.body = this.body
-            requestOptions.headers = merge(requestOptions.headers, {
+            requestOptions.headers = merge({}, requestOptions.headers, {
                 'Content-Length': Buffer.byteLength(JSON.stringify(requestOptions.body), 'UTF-8')
             })
         }


### PR DESCRIPTION
## Proposed changes

Lodash#merge modifies the first object provided as argument therefore it was modifying the default options in WebDriverRequest. This caused headers like 'Content-length' to propagate across requests causing problems such as a 'socket hang up' because the server is expecting more bytes than what the client is sending.

Should fix #3460 

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
