### PR TITLE
scrollIntoView uses a arrow function which breaks in IE

### DIFF
--- a/packages/webdriverio/src/commands/element/scrollIntoView.js
+++ b/packages/webdriverio/src/commands/element/scrollIntoView.js
@@ -17,7 +17,7 @@
  *
  */
 export default function scrollIntoView () {
-    return this.parent.execute(/* istanbul ignore next */(elem) => elem.scrollIntoView(), {
-        ELEMENT: this.elementId
-    })
+    return this.parent.execute(/* istanbul ignore next */function (elem) {
+        elem.scrollIntoView()
+    }, { ELEMENT: this.elementId })
 }


### PR DESCRIPTION
Title says it all. We should replace the arrow with an actual function.