### PR TITLE
webdriverio: fix appium getvalue

### DIFF
--- a/packages/webdriverio/src/commands/element/getValue.js
+++ b/packages/webdriverio/src/commands/element/getValue.js
@@ -23,7 +23,8 @@
  */
 
 export default function getValue () {
-    if (this.isW3C) {
+    // `!this.isMobile` added to workaround https://github.com/appium/appium/issues/12218
+    if (this.isW3C && !this.isMobile) {
         return this.getElementProperty(this.elementId, 'value')
     }
 

--- a/packages/webdriverio/tests/commands/element/getValue.test.js
+++ b/packages/webdriverio/tests/commands/element/getValue.test.js
@@ -33,4 +33,18 @@ describe('getValue', () => {
         await elem.getValue()
         expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/attribute/value')
     })
+
+    it('should get value in mobile mode', async () => {
+        const browser = await remote({
+            baseUrl: 'http://foobar.com',
+            capabilities: {
+                browserName: 'foobar',
+                mobileMode: true
+            }
+        })
+        const elem = await browser.$('#foo')
+
+        await elem.getValue()
+        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/attribute/value')
+    })
 })


### PR DESCRIPTION
## Proposed changes

fix #3515
use non W3C method to getValue

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

most likely we have to submit ticket to Appium if there are no such
iOS
```
session/{sessionId}/element/5000/property/value
Method has not yet been implemented
```
Android
```
404 - "unknown command: 
session/{sessionId}/element/0.12642389298468348-1/property/value"
```

### Reviewers: @webdriverio/technical-committee
