### PR TITLE
webdriverio: workaround for Safari to moveTo, getLocation, dragAndDrop, getSize

### DIFF
--- a/packages/webdriverio/src/commands/element/dragAndDrop.js
+++ b/packages/webdriverio/src/commands/element/dragAndDrop.js
@@ -10,6 +10,8 @@
  *
  */
 
+import { getElementRect } from '../../utils'
+
 const ACTION_BUTTON = 0
 
 export default async function dragAndDrop (target, duration = 100) {
@@ -27,8 +29,8 @@ export default async function dragAndDrop (target, duration = 100) {
     /**
      * get coordinates to drag and drop
      */
-    const sourceRect = await this.getElementRect(this.elementId)
-    const targetRect = await this.getElementRect(target.elementId)
+    const sourceRect = await getElementRect(this)
+    const targetRect = await getElementRect(target)
     const sourceX = parseInt(sourceRect.x + (sourceRect.width / 2), 10)
     const sourceY = parseInt(sourceRect.y + (sourceRect.height / 2), 10)
     const targetX = parseInt(targetRect.x + (targetRect.width / 2), 10) - sourceX

--- a/packages/webdriverio/src/commands/element/getLocation.js
+++ b/packages/webdriverio/src/commands/element/getLocation.js
@@ -25,11 +25,14 @@
  * @uses protocol/elementIdLocation
  * @type property
  */
+
+import { getElementRect } from '../../utils'
+
 export default async function getLocation (prop) {
     let location = {}
 
     if (this.isW3C) {
-        location = await this.getElementRect(this.elementId)
+        location = await getElementRect(this)
         delete location.width
         delete location.height
     } else {

--- a/packages/webdriverio/src/commands/element/getSize.js
+++ b/packages/webdriverio/src/commands/element/getSize.js
@@ -27,11 +27,13 @@
  *
  */
 
+import { getElementRect } from '../../utils'
+
 export default async function getSize(prop = null) {
     let rect = {}
 
     if (this.isW3C) {
-        rect = await this.getElementRect(this.elementId)
+        rect = await getElementRect(this)
     } else {
         rect = await this.getElementSize(this.elementId)
     }

--- a/packages/webdriverio/src/commands/element/moveTo.js
+++ b/packages/webdriverio/src/commands/element/moveTo.js
@@ -11,6 +11,9 @@
  * @see  https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidmoveto
  * @type protocol
  */
+
+import { getElementRect } from '../../utils'
+
 export default async function moveTo (xoffset, yoffset) {
     if (!this.isW3C) {
         return this.moveToElement(this.elementId, xoffset, yoffset)
@@ -19,7 +22,7 @@ export default async function moveTo (xoffset, yoffset) {
     /**
      * get rect of element
      */
-    const { x, y, width, height } = await this.getElementRect(this.elementId)
+    const { x, y, width, height } = await getElementRect(this)
     const newXoffset = parseInt(x + (typeof xoffset === 'number' ? xoffset : (width / 2)), 10)
     const newYoffset = parseInt(y + (typeof yoffset === 'number' ? yoffset : (height / 2)), 10)
 

--- a/packages/webdriverio/src/utils.js
+++ b/packages/webdriverio/src/utils.js
@@ -3,9 +3,11 @@ import path from 'path'
 import cssValue from 'css-value'
 import rgb2hex from 'rgb2hex'
 import GraphemeSplitter from 'grapheme-splitter'
+import logger from '@wdio/logger'
 
 import { ELEMENT_KEY, W3C_SELECTOR_STRATEGIES, UNICODE_CHARACTERS } from './constants'
 
+const log = logger('webdriverio')
 const DEFAULT_SELECTOR = 'css selector'
 const DIRECT_SELECTOR_REGEXP = /^(id|css selector|xpath|link text|partial link text|name|tag name|class name|-android uiautomator|-ios uiautomation|-ios predicate string|-ios class chain|accessibility id):(.+)/
 const INVALID_SELECTOR_ERROR = new Error('selector needs to be typeof `string` or `function`')
@@ -392,4 +394,46 @@ export function verifyArgsAndStripIfElement(args) {
     }
 
     return !Array.isArray(args) ? verify(args) : args.map(verify)
+}
+
+/**
+ * getElementRect
+ */
+export async function getElementRect(scope) {
+    const rect = await scope.getElementRect(scope.elementId)
+
+    let defaults = { x: 0, y: 0, width: 0, height: 0 }
+
+    /**
+     * getElementRect workaround for Safari 12.0.3
+     * if one of [x, y, height, width] is undefined get rect with javascript
+     */
+    if (Object.keys(defaults).some(key => rect[key] == null)) {
+        /* istanbul ignore next */
+        const rectJs = await getBrowserObject(scope).execute(function (el) {
+            if (!el || !el.getBoundingClientRect) {
+                return
+            }
+            const { left, top, width, height } = el.getBoundingClientRect()
+            return {
+                x: left + this.scrollX,
+                y: top + this.scrollY,
+                width,
+                height
+            }
+        }, scope)
+
+        // try set proper value
+        Object.keys(defaults).forEach(key => {
+            if (rect[key] == null && typeof rectJs[key] === 'number') {
+                rect[key] = Math.floor(rectJs[key])
+            } else {
+                log.error('getElementRect', rect)
+                log.error('getBoundingClientRect', rectJs)
+                throw new Error('Failed to receive element rects via execute command')
+            }
+        })
+    }
+
+    return rect
 }

--- a/packages/webdriverio/tests/commands/element/moveTo.test.js
+++ b/packages/webdriverio/tests/commands/element/moveTo.test.js
@@ -35,6 +35,34 @@ describe('moveTo', () => {
             .toEqual({ type: 'pointerMove', duration: 0, x: 20, y: 30 })
     })
 
+    it('should do a moveTo with params if getElementRect returned empty object', async () => {
+        const browser = await remote({
+            baseUrl: 'http://foobar.com',
+            capabilities: {
+                browserName: 'foobar'
+            }
+        })
+
+        const elem = await browser.$('#elem')
+        request.setMockResponse([{}, { x: 5, y: 10, height: 33, width: 44 }])
+        await elem.moveTo(5, 10)
+        expect(request.mock.calls[4][0].body.actions[0].actions[0])
+            .toEqual({ type: 'pointerMove', duration: 0, x: 10, y: 20 })
+    })
+
+    it('should do a moveTo with params if getElementRect and getBoundingClientRect returned empty object', async () => {
+        const browser = await remote({
+            baseUrl: 'http://foobar.com',
+            capabilities: {
+                browserName: 'foobar'
+            }
+        })
+
+        const elem = await browser.$('#elem')
+        request.setMockResponse([{}, {}])
+        expect(elem.moveTo(5, 10)).rejects.toThrow('Failed to getElementRect')
+    })
+
     it('should do a moveTo without params (no-w3c)', async () => {
         const browser = await remote({
             baseUrl: 'http://foobar.com',


### PR DESCRIPTION
## Proposed changes

Because of defect in safari https://github.com/SeleniumHQ/selenium/issues/6637 `getElementRect` is not return `y`.
We are calculating x and y offset so that is one of x, y, width, height is not defined will get `NaN` as a result.

Proposal: try get rect with javascript or set 0 as default value in case on of x, y, width, height is not defined

Affected browser: Safari 12
Affected commands: moveTo, getLocation, dragAndDrop, getSize

fix for #3608 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments


### Reviewers: @webdriverio/technical-committee
