### PR TITLE
Strip Element objects from execute and executeAsync arguments

### DIFF
--- a/packages/webdriverio/src/commands/browser/execute.js
+++ b/packages/webdriverio/src/commands/browser/execute.js
@@ -1,3 +1,4 @@
+import { verifyArgsAndStripIfElement } from '../../utils'
 /**
  *
  * Inject a snippet of JavaScript into the page for execution in the context of the currently selected frame.
@@ -52,5 +53,5 @@ export default function execute (...args) {
         script = `return (${script}).apply(null, arguments)`
     }
 
-    return this.executeScript(script, args)
+    return this.executeScript(script, verifyArgsAndStripIfElement(args))
 }

--- a/packages/webdriverio/src/commands/browser/executeAsync.js
+++ b/packages/webdriverio/src/commands/browser/executeAsync.js
@@ -1,3 +1,4 @@
+import { verifyArgsAndStripIfElement } from '../../utils'
 /**
  *
  * Inject a snippet of JavaScript into the page for execution in the context of the currently selected
@@ -60,5 +61,5 @@ export default function executeAsync (...args) {
         script = `return (${script}).apply(null, arguments)`
     }
 
-    return this.executeAsyncScript(script, args)
+    return this.executeAsyncScript(script, verifyArgsAndStripIfElement(args))
 }

--- a/packages/webdriverio/src/utils.js
+++ b/packages/webdriverio/src/utils.js
@@ -379,7 +379,7 @@ export function verifyArgsAndStripIfElement(args) {
     function verify(arg) {
         if (arg.constructor.name === 'Element') {
             if (!arg.elementId) {
-              throw new Error('property "elementId" missing')
+                throw new Error(`The element with selector "${arg.selector}" you trying to pass into the execute method wasn't found`)
             }
 
             return {

--- a/packages/webdriverio/src/utils.js
+++ b/packages/webdriverio/src/utils.js
@@ -370,3 +370,11 @@ export async function findElements(selector) {
 
     throw INVALID_SELECTOR_ERROR
 }
+
+/**
+ * Strip element object of all propeties except `elementId`
+ */
+
+export function verifyArgsAndStripIfElement(args) {
+    return args.map(a => a.elementId ? { elementId: a.elementId } : a)
+}

--- a/packages/webdriverio/src/utils.js
+++ b/packages/webdriverio/src/utils.js
@@ -372,9 +372,24 @@ export async function findElements(selector) {
 }
 
 /**
- * Strip element object of all propeties except `elementId`
+ * Strip element object and return w3c and jsonwp compatible keys
  */
 
 export function verifyArgsAndStripIfElement(args) {
-    return args.map(a => a.elementId ? { elementId: a.elementId } : a)
+    function verify(arg) {
+        if (arg.constructor.name === 'Element') {
+            if (!arg.elementId) {
+              throw new Error('property "elementId" missing')
+            }
+
+            return {
+                [ELEMENT_KEY]: arg.elementId,
+                ELEMENT: arg.elementId
+            }
+        }
+
+        return arg
+    }
+
+    return !Array.isArray(args) ? verify(args) : args.map(verify)
 }

--- a/packages/webdriverio/tests/utils.test.js
+++ b/packages/webdriverio/tests/utils.test.js
@@ -667,7 +667,7 @@ describe('utils', () => {
         class Element {
             constructor({ elementId, ...otherProps }) {
                 this.elementId = elementId
-                Object.keys(otherProps).forEach(key => this[key] = otherProps[key]);
+                Object.keys(otherProps).forEach(key => this[key] = otherProps[key])
             }
         }
 
@@ -705,10 +705,11 @@ describe('utils', () => {
         it('throws error if element object is missing element id', () => {
             const fakeObj = new Element({
                 someProp: 123,
-                anotherProp: 'abc'
+                anotherProp: 'abc',
+                selector: 'div'
             })
 
-            expect(() => verifyArgsAndStripIfElement(fakeObj)).toThrow('property "elementId" missing')
+            expect(() => verifyArgsAndStripIfElement(fakeObj)).toThrow('The element with selector "div" you trying to pass into the execute method wasn\'t found')
         })
     })
 })

--- a/packages/webdriverio/tests/utils.test.js
+++ b/packages/webdriverio/tests/utils.test.js
@@ -7,7 +7,8 @@ import {
     parseCSS,
     checkUnicode,
     findElement,
-    findElements
+    findElements,
+    verifyArgsAndStripIfElement
 } from '../src/utils'
 
 describe('utils', () => {
@@ -660,6 +661,23 @@ describe('utils', () => {
             await expect(findElements.call(scope, 123)).rejects.toEqual(new Error(expectedMatch))
             await expect(findElements.call(scope, false)).rejects.toEqual(new Error(expectedMatch))
             await expect(findElements.call(scope)).rejects.toEqual(new Error(expectedMatch))
+        })
+    })
+    describe('verifyArgsAndStripIfElement', () => {
+        it('returns the same value if it is not an element object', () => {
+            expect(verifyArgsAndStripIfElement([1, 2, 3])).toEqual([1, 2, 3])
+        })
+
+        it('strips down properties if value is element object', () => {
+            const fakeObj = {
+                elementId: 'foo-bar',
+                someProp: 123,
+                anotherProps: 'abc'
+            }
+
+            expect(verifyArgsAndStripIfElement([fakeObj])).toEqual([
+                { elementId: 'foo-bar' }
+            ])
         })
     })
 })

--- a/packages/webdriverio/tests/utils.test.js
+++ b/packages/webdriverio/tests/utils.test.js
@@ -664,20 +664,51 @@ describe('utils', () => {
         })
     })
     describe('verifyArgsAndStripIfElement', () => {
+        class Element {
+            constructor({ elementId, ...otherProps }) {
+                this.elementId = elementId
+                Object.keys(otherProps).forEach(key => this[key] = otherProps[key]);
+            }
+        }
+
         it('returns the same value if it is not an element object', () => {
             expect(verifyArgsAndStripIfElement([1, 2, 3])).toEqual([1, 2, 3])
         })
 
         it('strips down properties if value is element object', () => {
-            const fakeObj = {
+            const fakeObj = new Element({ 
                 elementId: 'foo-bar',
                 someProp: 123,
-                anotherProps: 'abc'
-            }
+                anotherProp: 'abc'
+            })
 
-            expect(verifyArgsAndStripIfElement([fakeObj])).toEqual([
-                { elementId: 'foo-bar' }
+            expect(verifyArgsAndStripIfElement([fakeObj, 'abc', 123])).toMatchObject([
+                { [ELEMENT_KEY]: 'foo-bar', ELEMENT: 'foo-bar' },
+                'abc',
+                123
             ])
+        })
+
+        it('should work even if parameter is not of type Array', () => {
+            const fakeObj = new Element({ 
+                elementId: 'foo-bar',
+                someProp: 123,
+                anotherProp: 'abc'
+            })
+
+            expect(verifyArgsAndStripIfElement(fakeObj)).toMatchObject(
+                { [ELEMENT_KEY]: 'foo-bar', ELEMENT: 'foo-bar' }
+            )
+            expect(verifyArgsAndStripIfElement('foo')).toEqual('foo')
+        })
+
+        it('throws error if element object is missing element id', () => {
+            const fakeObj = new Element({
+                someProp: 123,
+                anotherProp: 'abc'
+            })
+
+            expect(() => verifyArgsAndStripIfElement(fakeObj)).toThrow('property "elementId" missing')
         })
     })
 })


### PR DESCRIPTION
## Proposed changes

Ref: #3602 

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

I'm not sure if the docs should be updated to tell the reader that Element object arguments will be stripped of all properties except `elementId`.

### Reviewers: @webdriverio/technical-committee
