### PR TITLE
Assume JsonWP if platform cap is given

### DIFF
--- a/packages/webdriver/src/utils.js
+++ b/packages/webdriver/src/utils.js
@@ -198,10 +198,11 @@ export function isW3C (capabilities) {
      * assume session to be a WebDriver session when
      * - capabilities are returned
      *   (https://w3c.github.io/webdriver/#dfn-new-sessions)
-     * - platformName is returned which is not defined in the JSONWire protocol
+     * - a `platform` capability is not given but a platformName is returned
+     *   which is not defined in the JSONWire protocol
      */
     const isAppium = capabilities.automationName || capabilities.deviceName
-    return Boolean(capabilities.platformName || isAppium)
+    return Boolean((!capabilities.platform && capabilities.platformName) || isAppium)
 }
 
 /**

--- a/packages/webdriver/tests/__fixtures__/safaridriver.legacy.response.json
+++ b/packages/webdriver/tests/__fixtures__/safaridriver.legacy.response.json
@@ -1,0 +1,20 @@
+{
+  "status": 0,
+  "sessionId": "22AFB3C2-6E4D-419B-8509-49F72F9CDCC0",
+  "value": {
+    "version": "13606.4.5.3.1",
+    "rotatable": false,
+    "applicationCacheEnabled": true,
+    "databaseEnabled": true,
+    "handlesAlerts": true,
+    "cleanSession": true,
+    "browserName": "safari",
+    "javascriptEnabled": true,
+    "locationContextEnabled": false,
+    "platform": "macOS",
+    "webStorageEnabled": true,
+    "cssSelectorsEnabled": true,
+    "nativeEvents": true,
+    "platformName": "macOS"
+  }
+}

--- a/packages/webdriver/tests/__fixtures__/safaridriver.response.json
+++ b/packages/webdriver/tests/__fixtures__/safaridriver.response.json
@@ -1,0 +1,12 @@
+{
+  "value": {
+    "sessionId": "867A8C76-537F-4F2B-897C-85F87DF2C995",
+    "capabilities": {
+      "browserVersion": "12.0.3",
+      "platformName": "macOS",
+      "acceptInsecureCerts": false,
+      "setWindowRect": true,
+      "browserName": "Safari"
+    }
+  }
+}

--- a/packages/webdriver/tests/utils.test.js
+++ b/packages/webdriver/tests/utils.test.js
@@ -6,6 +6,8 @@ import {
 import appiumResponse from './__fixtures__/appium.response.json'
 import chromedriverResponse from './__fixtures__/chromedriver.response.json'
 import geckodriverResponse from './__fixtures__/geckodriver.response.json'
+import safaridriverResponse from './__fixtures__/safaridriver.response.json'
+import safaridriverLegacyResponse from './__fixtures__/safaridriver.legacy.response.json'
 
 describe('utils', () => {
     it('isSuccessfulResponse', () => {
@@ -116,12 +118,16 @@ describe('utils', () => {
         const chromeCaps = chromedriverResponse.value
         const appiumCaps = appiumResponse.value.capabilities
         const geckoCaps = geckodriverResponse.value.capabilities
+        const safariCaps = safaridriverResponse.value.capabilities
+        const safariLegacyCaps = safaridriverLegacyResponse.value
 
         it('isW3C', () => {
             const requestedCapabilities = { w3cCaps: { alwaysMatch: {} } }
             expect(environmentDetector({ capabilities: appiumCaps, requestedCapabilities }).isW3C).toBe(true)
             expect(environmentDetector({ capabilities: chromeCaps, requestedCapabilities }).isW3C).toBe(false)
             expect(environmentDetector({ capabilities: geckoCaps, requestedCapabilities }).isW3C).toBe(true)
+            expect(environmentDetector({ capabilities: safariCaps, requestedCapabilities }).isW3C).toBe(true)
+            expect(environmentDetector({ capabilities: safariLegacyCaps, requestedCapabilities }).isW3C).toBe(false)
             expect(isW3C()).toBe(false)
         })
 


### PR DESCRIPTION
## Proposed changes

If we find a `platform` capability in the session response we should refer to it as a jsonwp session.

Fixes #3611

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
