### PR TITLE
typings: fix promise return type

### DIFF
--- a/packages/webdriverio/webdriverio.d.ts
+++ b/packages/webdriverio/webdriverio.d.ts
@@ -7,7 +7,7 @@ type ElementPromise = Omit<WebdriverIO.Element, 'addCommand'>;
 
 // Element commands wrapper with Promise
 type ElementAsync = {
-    [K in keyof ElementPromise]: WrapWithPromise<WebdriverIO.Element[K]>
+    [K in keyof ElementPromise]: WrapWithPromise<ElementPromise[K], ReturnType<ElementPromise[K]>>
 }
 // Element commands that should not be wrapper with promise
 type ElementStatic = Pick<WebdriverIO.Element, 'addCommand'>
@@ -17,7 +17,7 @@ type BrowserPromise = Omit<WebdriverIO.Browser, 'addCommand' | 'options'>;
 
 // Browser commands wrapper with Promise
 type BrowserAsync = {
-    [K in keyof BrowserPromise]: WrapWithPromise<WebdriverIO.Browser[K]>
+    [K in keyof BrowserPromise]: WrapWithPromise<BrowserPromise[K], ReturnType<BrowserPromise[K]>>
 }
 
 // Browser commands that should not be wrapper with promise

--- a/scripts/templates/webdriver.tpl.d.ts
+++ b/scripts/templates/webdriver.tpl.d.ts
@@ -7,7 +7,7 @@
 type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 
 type ArgumentTypes<T> = T extends (...args: infer U) => infer R ? U : never;
-type WrapWithPromise<T> = (...args: ArgumentTypes<T>) => Promise<T>;
+type WrapWithPromise<T, R> = (...args: ArgumentTypes<T>) => Promise<R>;
 
 declare namespace WebDriver {
     type PageLoadingStrategy = 'none' | 'eager' | 'normal';
@@ -254,7 +254,7 @@ declare namespace WebDriver {
 }
 
 type AsyncClient = {
-    [K in keyof WebDriver.Client]: WrapWithPromise<WebDriver.Client[K]>
+    [K in keyof WebDriver.Client]: WrapWithPromise<WebDriver.Client[K], ReturnType<WebDriver.Client[K]>>
 }
 
 declare module "webdriver" {


### PR DESCRIPTION
## Proposed changes

fix return type of async commands that was previously type of function itself instead of function return type.

fix #3607

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

browser async
![image](https://user-images.githubusercontent.com/25589559/53337030-778ca500-3900-11e9-940f-e87ec3c069be.png)


client async
![image](https://user-images.githubusercontent.com/25589559/53337071-97bc6400-3900-11e9-9719-0bbb1b1dd1ac.png)


element async
![image](https://user-images.githubusercontent.com/25589559/53337103-b4589c00-3900-11e9-89e1-6c37c0bce86e.png)


### Reviewers: @webdriverio/technical-committee
