### PR TITLE
webdriverio: fix scrollIntoView

### DIFF
--- a/packages/webdriverio/src/commands/element/scrollIntoView.js
+++ b/packages/webdriverio/src/commands/element/scrollIntoView.js
@@ -1,6 +1,7 @@
 /**
  *
  * Scroll element into viewport.
+ * https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView
  *
  * <example>
     :scrollIntoView.js
@@ -12,12 +13,19 @@
  * </example>
  *
  * @alias element.scrollIntoView
+ * @param {object|boolean=} scrollIntoViewOptions  boolean alignToTop or scrollIntoViewOptions object
  * @uses protocol/execute
  * @type utility
  *
  */
-export default function scrollIntoView () {
-    return this.parent.execute(/* istanbul ignore next */function (elem) {
-        elem.scrollIntoView()
-    }, { ELEMENT: this.elementId })
+
+import { ELEMENT_KEY } from '../../constants'
+
+export default function scrollIntoView (scrollIntoViewOptions = true) {
+    return this.parent.execute(/* istanbul ignore next */function (elem, options) {
+        elem.scrollIntoView(options)
+    }, {
+        [ELEMENT_KEY]: this.elementId, // w3c compatible
+        ELEMENT: this.elementId // jsonwp compatible
+    }, scrollIntoViewOptions)
 }

--- a/packages/webdriverio/tests/commands/element/scrollIntoView.test.js
+++ b/packages/webdriverio/tests/commands/element/scrollIntoView.test.js
@@ -18,7 +18,9 @@ describe('scrollIntoView test', () => {
     it('should allow to check if an element is enabled', async () => {
         elem.elementId = { scrollIntoView: jest.fn() }
         await elem.scrollIntoView()
-        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/execute/sync')
+        const executeCall = request.mock.calls[2][0]
+        expect(executeCall.uri.path).toBe('/wd/hub/session/foobar-123/execute/sync')
+        expect(Object.keys(executeCall.body.args[0])).toHaveLength(2)
         expect(elem.elementId.scrollIntoView.mock.calls).toHaveLength(1)
     })
 


### PR DESCRIPTION
## Proposed changes

1. fix #3621, there was a missing option of execute command `[ELEMENT_KEY]: this.elementId, // w3c compatible`
2. Added argument support for scrollIntoView command, it is sometimes useful to pass `false` instead of default `true` value in order to scroll within modal properly.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

### Reviewers: @webdriverio/technical-committee
