### PR TITLE
Proposal: add onTestFramework hook

### DIFF
--- a/docs/ConfigurationFile.md
+++ b/docs/ConfigurationFile.md
@@ -336,6 +336,12 @@ exports.config = {
     onReload: function(oldSessionId, newSessionId) {
     },
     /**
+    * Gets executed once test framework (mocha, jasmine) has been initialised.
+    * At this moment global objects like `describe` or `it` are available.
+    */
+    onTestFramework: function() {
+    },
+    /**
      * Cucumber specific hooks
      */
     beforeFeature: function (feature) {

--- a/packages/wdio-config/src/constants.js
+++ b/packages/wdio-config/src/constants.js
@@ -59,6 +59,7 @@ export const DEFAULT_CONFIGS = {
     after: [],
     onComplete: NOOP,
     onReload: [],
+    onTestFramework: NOOP,
 
     /**
      * cucumber specific hooks
@@ -75,7 +76,7 @@ export const SUPPORTED_HOOKS = [
     'before', 'beforeSession', 'beforeSuite', 'beforeHook', 'beforeTest', 'beforeCommand',
     'afterCommand', 'afterTest', 'afterHook', 'afterSuite', 'afterSession', 'after',
     'beforeFeature', 'beforeScenario', 'beforeStep', 'afterFeature',
-    'afterScenario', 'afterStep', 'onReload'
+    'afterScenario', 'afterStep', 'onReload', 'onTestFramework'
     // the following hooks are excluded since they are part of the launcher
     // 'onPrepare', 'onComplete'
 ]

--- a/packages/wdio-jasmine-framework/src/index.js
+++ b/packages/wdio-jasmine-framework/src/index.js
@@ -80,6 +80,11 @@ class JasmineAdapter {
         ))
 
         /**
+         * framework global object are available and wrapped with Fiber
+         */
+        this.config.onTestFramework()
+
+        /**
          * for a clean stdout we need to avoid that Jasmine initialises the
          * default reporter
          */

--- a/packages/wdio-jasmine-framework/tests/adapter.test.js
+++ b/packages/wdio-jasmine-framework/tests/adapter.test.js
@@ -13,7 +13,7 @@ test('comes with a factory', async () => {
     expect(typeof JasmineAdapterFactory.run).toBe('function')
     const result = await JasmineAdapterFactory.run(
         '0-2',
-        {},
+        { onTestFramework() {} },
         ['/foo/bar.test.js'],
         { browserName: 'chrome' },
         wdioReporter
@@ -24,7 +24,7 @@ test('comes with a factory', async () => {
 test('should properly set up jasmine', async () => {
     const adapter = new JasmineAdapter(
         '0-2',
-        {},
+        { onTestFramework() {} },
         ['/foo/bar.test.js'],
         { browserName: 'chrome' },
         wdioReporter
@@ -60,7 +60,8 @@ test('should properly configure the jasmine environment', async () => {
                 stopOnSpecFailure,
                 random,
                 failFast,
-            }
+            },
+            onTestFramework() {}
         },
         ['/foo/bar.test.js'],
         { browserName: 'chrome' },
@@ -77,7 +78,8 @@ test('should properly configure the jasmine environment', async () => {
 
 test('set custom ', async () => {
     const config = {
-        jasmineNodeOpts: { expectationResultHandler: jest.fn() }
+        jasmineNodeOpts: { expectationResultHandler: jest.fn() },
+        onTestFramework() {}
     }
     const adapter = new JasmineAdapter(
         '0-2',
@@ -94,7 +96,7 @@ test('set custom ', async () => {
 test('get data from beforeAll hook', async () => {
     const adapter = new JasmineAdapter(
         '0-2',
-        {},
+        { onTestFramework() {} },
         ['/foo/bar.test.js'],
         { browserName: 'chrome' },
         wdioReporter
@@ -112,7 +114,7 @@ test('get data from beforeAll hook', async () => {
 test('get data from execute hook', async () => {
     const adapter = new JasmineAdapter(
         '0-2',
-        {},
+        { onTestFramework() {} },
         ['/foo/bar.test.js'],
         { browserName: 'chrome' },
         wdioReporter

--- a/packages/wdio-mocha-framework/src/index.js
+++ b/packages/wdio-mocha-framework/src/index.js
@@ -108,6 +108,11 @@ class MochaAdapter {
                 fnName
             )
         })
+
+        /**
+         * framework global object are available and wrapped with Fiber
+         */
+        this.config.onTestFramework()
     }
 
     /**

--- a/packages/wdio-mocha-framework/tests/adapter.test.js
+++ b/packages/wdio-mocha-framework/tests/adapter.test.js
@@ -97,7 +97,7 @@ test('preRequire', () => {
     const mochaOpts = { foo: 'bar', ui: 'tdd' }
     const adapter = new MochaAdapter(
         '0-2',
-        { mochaOpts, beforeHook: 'beforeHook123', afterHook: 'afterHook123' },
+        { mochaOpts, beforeHook: 'beforeHook123', afterHook: 'afterHook123', onTestFramework() {} },
         ['/foo/bar.test.js'],
         { browserName: 'chrome' },
         wdioReporter
@@ -114,7 +114,7 @@ test('custom ui', () => {
     const mochaOpts = { ui: 'custom-qunit' }
     const adapter = new MochaAdapter(
         '0-2',
-        { mochaOpts },
+        { mochaOpts, onTestFramework() {} },
         ['/foo/bar.test.js'],
         { browserName: 'chrome' },
         wdioReporter

--- a/packages/webdriverio/src/constants.js
+++ b/packages/webdriverio/src/constants.js
@@ -68,7 +68,7 @@ export const WDIO_DEFAULTS = {
                 if (typeof param === 'object') {
                     return true
                 }
-                
+
                 throw new Error('the "capabilities" options needs to be an object or a list of objects')
             }
 
@@ -79,10 +79,10 @@ export const WDIO_DEFAULTS = {
                 if (typeof option === 'object') { // Check does not work recursively
                     continue
                 }
-    
+
                 throw new Error('expected every item of a list of capabilities to be of type object')
             }
-    
+
             return true
         },
         required: true
@@ -193,14 +193,14 @@ export const WDIO_DEFAULTS = {
              * with arrays and/or strings
              */
             for (const option of param) {
-                if (!Array.isArray(option)) {         
+                if (!Array.isArray(option)) {
                     if (typeof option === 'string') {
                         continue
                     }
                     throw new Error('the "services" options needs to be a list of strings and/or arrays')
                 }
             }
-    
+
             return true
         },
         default: []
@@ -268,6 +268,9 @@ export const WDIO_DEFAULTS = {
         type: 'function'
     },
     onReload: HOOK_DEFINITION,
+    onTestFramework: {
+        type: 'function'
+    },
 
     /**
      * cucumber specific hooks


### PR DESCRIPTION
## Proposed changes

Proposal: add hook before test execution but after test framework is ready and its functions are wrapped with Fibers.

My use case. I'm decorating Mocha's describe and it objects to extend its functionality.
There is no place I can do it just before starting any test when test framework is initialised.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

Some tests and documentation are still missing, want to make I'm not doing something wrong before proceeding.

### Reviewers: @webdriverio/technical-committee
