### PR TITLE
Pass custom agent and headers in every request

### DIFF
--- a/docs/Options.md
+++ b/docs/Options.md
@@ -86,6 +86,18 @@ Count of request retries to the Selenium server
 Type: `Number`<br>
 Default: `3`
 
+### agent
+Allows to use a custom http/https agent when making requests.
+
+Type: `Object`<br>
+Default: `new http(s).Agent({ keepAlive: true })`
+
+### headers
+Provide custom headers to pass into every request.
+
+Type: `Object`<br>
+Default: `{}`
+
 ---
 
 ## WDIO Options

--- a/packages/webdriver/src/constants.js
+++ b/packages/webdriver/src/constants.js
@@ -74,5 +74,17 @@ export const DEFAULTS = {
      */
     key: {
         type: 'string'
+    },
+    /**
+     * Override default agent
+     */
+    agent: {
+        type: 'object'
+    },
+    /**
+     * Pass custom headers
+     */
+    headers: {
+        type: 'object'
     }
 }

--- a/packages/webdriver/src/request.js
+++ b/packages/webdriver/src/request.js
@@ -44,7 +44,7 @@ export default class WebDriverRequest extends EventEmitter {
 
     _createOptions (options, sessionId) {
         const requestOptions = {
-            agent: agents[options.protocol],
+            agent: options.agent || agents[options.protocol],
             headers: typeof options.headers === 'object' ? options.headers : {},
             qs: typeof options.queryParams === 'object' ? options.queryParams : {}
         }

--- a/packages/webdriver/tests/request.test.js
+++ b/packages/webdriver/tests/request.test.js
@@ -1,5 +1,6 @@
 import logger from '@wdio/logger'
 import request from 'request'
+import https from 'https'
 
 import WebDriverRequest from '../src/request'
 
@@ -47,6 +48,21 @@ describe('webdriver request', () => {
             expect(options.agent.protocol).toBe('https:')
             expect(options.uri.href).toBe('https://localhost:4445/wd/hub/session/foobar12345/element')
             expect(options.headers.foo).toBe('bar')
+        })
+
+        it('passes a custom agent', () => {
+            const req = new WebDriverRequest('POST', 'session/:sessionId/element')
+            const agent = new https.Agent({ keepAlive: true })
+            const options = req._createOptions({
+                protocol: 'https',
+                hostname: 'localhost',
+                port: 4445,
+                path: '/wd/hub/',
+                agent
+            }, 'foobar12345')
+
+            expect(options.agent.protocol).toBe('https:')
+            expect(options.agent).toBe(agent)
         })
 
         it('should add auth if user and key is given', () => {


### PR DESCRIPTION
## Proposed changes

In v4 we could pass a custom agent to allow for example a self-signed certificate chain. We could also pass some custom headers to each request to provide, for example, custom authentication information.
This PR allows passing a custom agent and custom headers.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
