### PR TITLE
webdriver: (W3C) Remove invalid capabilities from alwaysMatch

### DIFF
--- a/packages/webdriver/src/constants.js
+++ b/packages/webdriver/src/constants.js
@@ -86,5 +86,13 @@ export const DEFAULTS = {
      */
     headers: {
         type: 'object'
-    }
+    },
+
+    /**
+     * w3c allowed capabilities
+     */
+    w3cAllowedCaps: [
+        'browserName', 'browserVersion', 'platformName', 'acceptInsecureCerts', 'pageLoadStrategy', 'proxy',
+        'setWindowRect', 'timeouts', 'strictFileInteractability', 'unhandledPromptBehavior'
+    ]
 }

--- a/packages/webdriver/src/constants.js
+++ b/packages/webdriver/src/constants.js
@@ -93,5 +93,6 @@ export const DEFAULTS = {
  */
 export const W3C_ALLOWED_CAPABILITIES = [
     'browserName', 'browserVersion', 'platformName', 'acceptInsecureCerts', 'pageLoadStrategy', 'proxy',
-    'setWindowRect', 'timeouts', 'strictFileInteractability', 'unhandledPromptBehavior'
+    'setWindowRect', 'timeouts', 'strictFileInteractability', 'unhandledPromptBehavior', 'keepBrowserName',
+    'mobileMode', 'baseUrl', 'jsonwpMode'
 ]

--- a/packages/webdriver/src/constants.js
+++ b/packages/webdriver/src/constants.js
@@ -86,13 +86,12 @@ export const DEFAULTS = {
      */
     headers: {
         type: 'object'
-    },
-
-    /**
-     * w3c allowed capabilities
-     */
-    w3cAllowedCaps: [
-        'browserName', 'browserVersion', 'platformName', 'acceptInsecureCerts', 'pageLoadStrategy', 'proxy',
-        'setWindowRect', 'timeouts', 'strictFileInteractability', 'unhandledPromptBehavior'
-    ]
+    }
 }
+/**
+ * w3c allowed capabilities
+ */
+export const W3C_ALLOWED_CAPABILITIES = [
+    'browserName', 'browserVersion', 'platformName', 'acceptInsecureCerts', 'pageLoadStrategy', 'proxy',
+    'setWindowRect', 'timeouts', 'strictFileInteractability', 'unhandledPromptBehavior'
+]

--- a/packages/webdriver/src/index.js
+++ b/packages/webdriver/src/index.js
@@ -4,7 +4,7 @@ import { validateConfig } from '@wdio/config'
 
 import webdriverMonad from './monad'
 import WebDriverRequest from './request'
-import { DEFAULTS } from './constants'
+import { DEFAULTS, W3C_ALLOWED_CAPABILITIES } from './constants'
 import { getPrototype, environmentDetector } from './utils'
 
 import WebDriverProtocol from '../protocol/webdriver.json'
@@ -37,12 +37,10 @@ export default class WebDriver {
              */
             : [{ alwaysMatch: params.capabilities, firstMatch: [{}] }, params.capabilities]
 
-        if (w3cCaps.alwaysMatch) {
-            w3cCaps.alwaysMatch = JSON.parse(JSON.stringify(w3cCaps.alwaysMatch))
-            Object.keys(w3cCaps.alwaysMatch)
-                .filter(key => !DEFAULTS.w3cAllowedCaps.includes(key) && !key.match(/^[\w-]+:.*$/))
-                .forEach(key => delete w3cCaps.alwaysMatch[key])
-        }
+        w3cCaps.alwaysMatch = JSON.parse(JSON.stringify(w3cCaps.alwaysMatch))
+        Object.keys(w3cCaps.alwaysMatch)
+            .filter(key => !W3C_ALLOWED_CAPABILITIES.includes(key) && !key.match(/^[\w-]+:.*$/))
+            .forEach(key => delete w3cCaps.alwaysMatch[key])
 
         const sessionRequest = new WebDriverRequest(
             'POST',

--- a/packages/webdriver/src/index.js
+++ b/packages/webdriver/src/index.js
@@ -36,15 +36,21 @@ export default class WebDriver {
             /**
              * otherwise assume they passed in jsonwp-style caps (flat object)
              */
-            : [{ alwaysMatch: params.capabilities, firstMatch: [{}] }, params.capabilities]
-
-        w3cCaps.alwaysMatch = JSON.parse(JSON.stringify(w3cCaps.alwaysMatch))
-        Object.keys(w3cCaps.alwaysMatch)
-            .filter(key => !W3C_ALLOWED_CAPABILITIES.includes(key) && !key.match(/^[\w-]+:.*$/))
-            .forEach(key => {
-                log.warn(`Dropping capability ${key} from alwaysMatch.`)
-                delete w3cCaps.alwaysMatch[key]
-            })
+            : [{
+                alwaysMatch: Object.keys(params.capabilities)
+                    .filter(key => {
+                        if (W3C_ALLOWED_CAPABILITIES.includes(key) || key.match(/^[\w-]+:.*$/)) {
+                            return true
+                        } else {
+                            log.warn(`Skipping capability ${key} from alwaysMatch.`)
+                            return false
+                        }
+                    })
+                    .reduce((obj, key) => {
+                        obj[key] = params.capabilities[key]
+                        return obj
+                    }, {}), firstMatch: [{}]
+            }, params.capabilities]
 
         const sessionRequest = new WebDriverRequest(
             'POST',

--- a/packages/webdriver/src/index.js
+++ b/packages/webdriver/src/index.js
@@ -13,6 +13,7 @@ import MJsonWProtocol from '../protocol/mjsonwp.json'
 import AppiumProtocol from '../protocol/appium.json'
 import ChromiumProtocol from '../protocol/chromium.json'
 
+const log = logger('webdriver')
 export default class WebDriver {
     static async newSession (options = {}, modifier, userPrototype = {}, commandWrapper) {
         const params = validateConfig(DEFAULTS, options)
@@ -40,7 +41,10 @@ export default class WebDriver {
         w3cCaps.alwaysMatch = JSON.parse(JSON.stringify(w3cCaps.alwaysMatch))
         Object.keys(w3cCaps.alwaysMatch)
             .filter(key => !W3C_ALLOWED_CAPABILITIES.includes(key) && !key.match(/^[\w-]+:.*$/))
-            .forEach(key => delete w3cCaps.alwaysMatch[key])
+            .forEach(key => {
+                log.warn(`Dropping capability ${key} from alwaysMatch.`)
+                delete w3cCaps.alwaysMatch[key]
+            })
 
         const sessionRequest = new WebDriverRequest(
             'POST',

--- a/packages/webdriver/src/index.js
+++ b/packages/webdriver/src/index.js
@@ -37,6 +37,13 @@ export default class WebDriver {
              */
             : [{ alwaysMatch: params.capabilities, firstMatch: [{}] }, params.capabilities]
 
+        if (w3cCaps.alwaysMatch) {
+            w3cCaps.alwaysMatch = JSON.parse(JSON.stringify(w3cCaps.alwaysMatch))
+            Object.keys(w3cCaps.alwaysMatch)
+                .filter(key => !DEFAULTS.w3cAllowedCaps.includes(key) && !key.match(/^[\w-]+:.*$/))
+                .forEach(key => delete w3cCaps.alwaysMatch[key])
+        }
+
         const sessionRequest = new WebDriverRequest(
             'POST',
             '/session',

--- a/packages/webdriver/tests/index.test.js
+++ b/packages/webdriver/tests/index.test.js
@@ -43,7 +43,7 @@ test('should allow to create a new session using w3c compliant caps', async () =
 test('should skip invalid caps from alwaysMatch using jsonwire caps', async () => {
     await WebDriver.newSession({
         path: '/',
-        capabilities: { 
+        capabilities: {
             browserName: 'firefox',
             'browserstack.debug': true
         }
@@ -56,7 +56,7 @@ test('should skip invalid caps from alwaysMatch using jsonwire caps', async () =
             alwaysMatch: { browserName: 'firefox' },
             firstMatch: [{}]
         },
-        desiredCapabilities: { 
+        desiredCapabilities: {
             browserName: 'firefox',
             'browserstack.debug': true
         }
@@ -67,8 +67,8 @@ test('should skip invalid caps from alwaysMatch using w3c compliant caps', async
     await WebDriver.newSession({
         path: '/',
         capabilities: {
-            alwaysMatch: { 
-                browserName: 'firefox', 
+            alwaysMatch: {
+                browserName: 'firefox',
                 'browserstack.debug': true
             },
             firstMatch: [{}]
@@ -82,7 +82,7 @@ test('should skip invalid caps from alwaysMatch using w3c compliant caps', async
             alwaysMatch: { browserName: 'firefox' },
             firstMatch: [{}]
         },
-        desiredCapabilities: { 
+        desiredCapabilities: {
             browserName: 'firefox',
             'browserstack.debug': true
         }

--- a/packages/webdriver/tests/index.test.js
+++ b/packages/webdriver/tests/index.test.js
@@ -40,6 +40,55 @@ test('should allow to create a new session using w3c compliant caps', async () =
     })
 })
 
+test('should skip invalid caps from alwaysMatch using jsonwire caps', async () => {
+    await WebDriver.newSession({
+        path: '/',
+        capabilities: { 
+            browserName: 'firefox',
+            'browserstack.debug': true
+        }
+    })
+
+    const req = request.mock.calls[0][0]
+    expect(req.uri.pathname).toBe('/session')
+    expect(req.body).toEqual({
+        capabilities: {
+            alwaysMatch: { browserName: 'firefox' },
+            firstMatch: [{}]
+        },
+        desiredCapabilities: { 
+            browserName: 'firefox',
+            'browserstack.debug': true
+        }
+    })
+})
+
+test('should skip invalid caps from alwaysMatch using w3c compliant caps', async () => {
+    await WebDriver.newSession({
+        path: '/',
+        capabilities: {
+            alwaysMatch: { 
+                browserName: 'firefox', 
+                'browserstack.debug': true
+            },
+            firstMatch: [{}]
+        }
+    })
+
+    const req = request.mock.calls[0][0]
+    expect(req.uri.pathname).toBe('/session')
+    expect(req.body).toEqual({
+        capabilities: {
+            alwaysMatch: { browserName: 'firefox' },
+            firstMatch: [{}]
+        },
+        desiredCapabilities: { 
+            browserName: 'firefox',
+            'browserstack.debug': true
+        }
+    })
+})
+
 test('should be possible to skip setting logLevel', async () => {
     logger.setLevel.mockClear()
     await WebDriver.newSession({

--- a/packages/webdriver/tests/index.test.js
+++ b/packages/webdriver/tests/index.test.js
@@ -79,7 +79,10 @@ test('should skip invalid caps from alwaysMatch using w3c compliant caps', async
     expect(req.uri.pathname).toBe('/session')
     expect(req.body).toEqual({
         capabilities: {
-            alwaysMatch: { browserName: 'firefox' },
+            alwaysMatch: {
+                browserName: 'firefox',
+                'browserstack.debug': true
+            },
             firstMatch: [{}]
         },
         desiredCapabilities: {


### PR DESCRIPTION
## Proposed changes

In `alwaysMatch` section of W3C capabilities we should only use the capabilities defined [here](https://w3c.github.io/webdriver/#capabilities) and the [extension capabilities](https://w3c.github.io/webdriver/#dfn-extension-capability). This PR will help in running tests on selenium servers where this validation is enforced.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

Signed-off-by: Varun Garg <varun.ga@browserstack.com>

### Reviewers: @webdriverio/technical-committee