### PR TITLE
webdriver: Add strictSSL option

### DIFF
--- a/docs/Proxy.md
+++ b/docs/Proxy.md
@@ -18,6 +18,15 @@ $ export HTTPS_PROXY=https://my.corp.proxy.com:9090
 $ wdio wdio.conf.js
 ```
 
+Additionally, if you run into errors concerning SSL certificates during test execution, you can set the `STRICT_SSL` environment variable to `false`, which will turn off SSL key validation when making requests with https:
+
+```sh
+$ export HTTP_PROXY=http://my.corp.proxy.com:9090
+$ export HTTPS_PROXY=https://my.corp.proxy.com:9090
+$ export STRICT_SSL=false
+$ wdio wdio.conf.js
+```
+
 If you use [Sauce Connect Proxy](https://wiki.saucelabs.com/display/DOCS/Sauce+Connect+Proxy) start it via:
 
 ```sh

--- a/packages/webdriver/src/request.js
+++ b/packages/webdriver/src/request.js
@@ -83,6 +83,11 @@ export default class WebDriverRequest extends EventEmitter {
                 pass: options.key
             }
         }
+        
+        /**
+         * if the environment variable "STRICT_SSL" is defined as "false", it doesn't require SSL certificates to be valid.
+         */
+		requestOptions.strictSSL = process.env.STRICT_SSL !== "false" || process.env.strict_ssl !== "false";
 
         return requestOptions
     }

--- a/packages/webdriver/src/request.js
+++ b/packages/webdriver/src/request.js
@@ -87,7 +87,7 @@ export default class WebDriverRequest extends EventEmitter {
         /**
          * if the environment variable "STRICT_SSL" is defined as "false", it doesn't require SSL certificates to be valid.
          */
-        requestOptions.strictSSL = process.env.STRICT_SSL !== 'false' || process.env.strict_ssl !== 'false'
+        requestOptions.strictSSL = !(process.env.STRICT_SSL === 'false' || process.env.strict_ssl === 'false')
 
         return requestOptions
     }

--- a/packages/webdriver/src/request.js
+++ b/packages/webdriver/src/request.js
@@ -87,7 +87,7 @@ export default class WebDriverRequest extends EventEmitter {
         /**
          * if the environment variable "STRICT_SSL" is defined as "false", it doesn't require SSL certificates to be valid.
          */
-		requestOptions.strictSSL = process.env.STRICT_SSL !== "false" || process.env.strict_ssl !== "false";
+        requestOptions.strictSSL = process.env.STRICT_SSL !== 'false' || process.env.strict_ssl !== 'false'
 
         return requestOptions
     }

--- a/packages/webdriver/tests/request.test.js
+++ b/packages/webdriver/tests/request.test.js
@@ -120,7 +120,7 @@ describe('webdriver request', () => {
             beforeEach(function() {
                 delete process.env.STRICT_SSL
                 delete process.env.strict_ssl
-            });
+            })
 
             it('should contain key "strictSSL" with value "false" when environment variable "STRICT_SSL" is defined with value "false"', () => {
                 process.env['STRICT_SSL'] = 'false'

--- a/packages/webdriver/tests/request.test.js
+++ b/packages/webdriver/tests/request.test.js
@@ -115,6 +115,61 @@ describe('webdriver request', () => {
             expect(Object.keys(options.headers)).not.toContain('Content-Length')
             expect(options.headers.foo).toContain('bar')
         })
+        
+        describe('strictSSL', () => {
+            beforeEach(function() {
+                delete process.env.STRICT_SSL;
+                delete process.env.strict_ssl;
+            });
+
+            it('should contain key "strictSSL" with value "false" when environment variable "STRICT_SSL" is defined with value "false"', () => {
+                process.env["STRICT_SSL"] = "false"
+                const req = new WebDriverRequest('POST', '/session')
+                const options = req._createOptions({ path: '/', headers: { foo: 'bar' }})
+                expect(options.strictSSL).toEqual(false)
+            })
+
+            it('should contain key "strictSSL" with value "false" when environment variable "strict_ssl" is defined with value "false"', () => {
+                process.env["strict_ssl"] = "false"
+                const req = new WebDriverRequest('POST', '/session')
+                const options = req._createOptions({ path: '/', headers: { foo: 'bar' }})
+                expect(options.strictSSL).toEqual(false)
+            })
+
+            it('should contain key "strictSSL" with value "true" when environment variable "STRICT_SSL" is defined with value "true"', () => {
+                process.env["STRICT_SSL"] = "true"
+                const req = new WebDriverRequest('POST', '/session')
+                const options = req._createOptions({ path: '/', headers: { foo: 'bar' }})
+                expect(options.strictSSL).toEqual(true)
+            })
+
+            it('should contain key "strictSSL" with value "true" when environment variable "strict_ssl" is defined with value "true"', () => {
+                process.env["strict_ssl"] = "true"
+                const req = new WebDriverRequest('POST', '/session')
+                const options = req._createOptions({ path: '/', headers: { foo: 'bar' }})
+                expect(options.strictSSL).toEqual(true)
+            })
+
+            it('should contain key "strictSSL" with value "true" when environment variable "STRICT_SSL" / "strict_ssl" is not defined', () => {
+                const req = new WebDriverRequest('POST', '/session')
+                const options = req._createOptions({ path: '/', headers: { foo: 'bar' }})
+                expect(options.strictSSL).toEqual(true)
+            })
+
+            it('should contain key "strictSSL" with value "true" when environment variable "STRICT_SSL" is defined with any other value than "false"', () => {
+                process.env["STRICT_SSL"] = "foo"
+                const req = new WebDriverRequest('POST', '/session')
+                const options = req._createOptions({ path: '/', headers: { foo: 'bar' }})
+                expect(options.strictSSL).toEqual(true)
+            })
+
+            it('should contain key "strictSSL" with value "true" when environment variable "strict_ssl" is defined with any other value than "false"', () => {
+                process.env["strict_ssl"] = "foo"
+                const req = new WebDriverRequest('POST', '/session')
+                const options = req._createOptions({ path: '/', headers: { foo: 'bar' }})
+                expect(options.strictSSL).toEqual(true)
+            })
+        })
     })
 
     describe('_request', () => {

--- a/packages/webdriver/tests/request.test.js
+++ b/packages/webdriver/tests/request.test.js
@@ -118,33 +118,33 @@ describe('webdriver request', () => {
         
         describe('strictSSL', () => {
             beforeEach(function() {
-                delete process.env.STRICT_SSL;
-                delete process.env.strict_ssl;
+                delete process.env.STRICT_SSL
+                delete process.env.strict_ssl
             });
 
             it('should contain key "strictSSL" with value "false" when environment variable "STRICT_SSL" is defined with value "false"', () => {
-                process.env["STRICT_SSL"] = "false"
+                process.env['STRICT_SSL'] = 'false'
                 const req = new WebDriverRequest('POST', '/session')
                 const options = req._createOptions({ path: '/', headers: { foo: 'bar' }})
                 expect(options.strictSSL).toEqual(false)
             })
 
             it('should contain key "strictSSL" with value "false" when environment variable "strict_ssl" is defined with value "false"', () => {
-                process.env["strict_ssl"] = "false"
+                process.env['strict_ssl'] = 'false'
                 const req = new WebDriverRequest('POST', '/session')
                 const options = req._createOptions({ path: '/', headers: { foo: 'bar' }})
                 expect(options.strictSSL).toEqual(false)
             })
 
             it('should contain key "strictSSL" with value "true" when environment variable "STRICT_SSL" is defined with value "true"', () => {
-                process.env["STRICT_SSL"] = "true"
+                process.env['STRICT_SSL'] = 'true'
                 const req = new WebDriverRequest('POST', '/session')
                 const options = req._createOptions({ path: '/', headers: { foo: 'bar' }})
                 expect(options.strictSSL).toEqual(true)
             })
 
             it('should contain key "strictSSL" with value "true" when environment variable "strict_ssl" is defined with value "true"', () => {
-                process.env["strict_ssl"] = "true"
+                process.env['strict_ssl'] = 'true'
                 const req = new WebDriverRequest('POST', '/session')
                 const options = req._createOptions({ path: '/', headers: { foo: 'bar' }})
                 expect(options.strictSSL).toEqual(true)
@@ -157,14 +157,14 @@ describe('webdriver request', () => {
             })
 
             it('should contain key "strictSSL" with value "true" when environment variable "STRICT_SSL" is defined with any other value than "false"', () => {
-                process.env["STRICT_SSL"] = "foo"
+                process.env['STRICT_SSL'] = 'foo'
                 const req = new WebDriverRequest('POST', '/session')
                 const options = req._createOptions({ path: '/', headers: { foo: 'bar' }})
                 expect(options.strictSSL).toEqual(true)
             })
 
             it('should contain key "strictSSL" with value "true" when environment variable "strict_ssl" is defined with any other value than "false"', () => {
-                process.env["strict_ssl"] = "foo"
+                process.env['strict_ssl'] = 'foo'
                 const req = new WebDriverRequest('POST', '/session')
                 const options = req._createOptions({ path: '/', headers: { foo: 'bar' }})
                 expect(options.strictSSL).toEqual(true)


### PR DESCRIPTION
## Proposed changes

When executing a test behind a corporate proxy, even with correctly set `HTTP_PROXY` and `HTTPS_PROXY` environment variables, an error like:
```
Error: unable to verify the first certificate
```
or
```
Error: tunneling socket could not be established, cause=write EPROTO 8888:error:1408F10B:SSL routines:ssl3_get_record:wrong version number:openssl\ssl\record\ssl3_record.c:252:
```
can appear, if the corporate proxy is also doing SSL interception and inspection due to the certificate not being recognized as valid in https connections.

The [request node package](https://www.npmjs.com/package/request) has an option `strictSSL` which can be set to `false`, leading to SSL certificates not being validated in https connections and thus solving the issue.

The proposed change is to set the `strictSSL` option depending on the value of an environment variable `STRICT_SSL`. If it is set to `false`, `strictSSL` will also be defined as `false` and in all other cases, `strictSSL` will default to `true`.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)
The functionality of this is similar to what exists for npm already: https://docs.npmjs.com/misc/config#strict-ssl
I considered passing the flag in via parameters, but wanted to keep the definition of the flag consistent with the other already existing proxy-related settings `HTTP_PROXY` and `HTTPS_PROXY`, as described in the proxy documentation.

### Reviewers: @webdriverio/technical-committee
