### PR TITLE
Fixing Refetch to handle slow rerenders

### DIFF
--- a/packages/wdio-webdriver-mock-service/src/index.js
+++ b/packages/wdio-webdriver-mock-service/src/index.js
@@ -85,18 +85,27 @@ export default class WebdriverMockService {
         const elemResponse = { 'element-6066-11e4-a52e-4f735466cecf': ELEMENT_ID }
         const elem2Response = { 'element-6066-11e4-a52e-4f735466cecf': ELEMENT_REFETCHED }
 
+        //Found initially
         this.command.findElement().once().reply(200, { value: elemResponse })
+        //Initiate refetch, but its not ready
         this.command.findElement().once().reply(404, NO_SUCH_ELEMENT)
-        this.command.findElements().once().reply(200, { value: []})
-        this.command.findElements().reply(200, { value: [ elem2Response ]})
-        this.command.findElement().reply(200, { value: elem2Response })
+        //Always return the new element after
+        this.command.findElement().times(4).reply(200, { value: elem2Response })
 
+        //First click works
         this.command.elementClick(ELEMENT_ID).once().reply(200, { value: null })
+        //Additional clicks won't for the original element
         this.command.elementClick(ELEMENT_ID).times(4).reply(500, { value: {
             error: 'stale element reference',
             message: 'element is not attached to the page document'
         } })
-        this.command.elementClick(ELEMENT_REFETCHED).once().reply(200, { value: null })
+        //Clicks on the new element are successful
+        this.command.elementClick(ELEMENT_REFETCHED).times(4).reply(200, { value: null })
+
+        //Wait for it to exist - but 2 failed iterations
+        this.command.findElements().times(2).reply(200, { value: []})
+        //Always appears thereafter
+        this.command.findElements().times(4).reply(200, { value: [ elem2Response ]})
     }
 
     customCommandScenario () {

--- a/packages/wdio-webdriver-mock-service/src/index.js
+++ b/packages/wdio-webdriver-mock-service/src/index.js
@@ -86,7 +86,10 @@ export default class WebdriverMockService {
         const elem2Response = { 'element-6066-11e4-a52e-4f735466cecf': ELEMENT_REFETCHED }
 
         this.command.findElement().once().reply(200, { value: elemResponse })
-        this.command.findElement().twice().reply(200, { value: elem2Response })
+        this.command.findElement().once().reply(404, NO_SUCH_ELEMENT)
+        this.command.findElements().once().reply(200, { value: []})
+        this.command.findElements().reply(200, { value: [ elem2Response ]})
+        this.command.findElement().reply(200, { value: elem2Response })
 
         this.command.elementClick(ELEMENT_ID).once().reply(200, { value: null })
         this.command.elementClick(ELEMENT_ID).times(4).reply(500, { value: {

--- a/packages/webdriverio/src/utils/refetchElement.js
+++ b/packages/webdriverio/src/utils/refetchElement.js
@@ -17,6 +17,12 @@ export default async function refetchElement (currentElement) {
     // Beginning with the browser object, rechain
     return selectors.reduce(async (elementPromise, selector) => {
         const resolvedElement = await elementPromise
-        return resolvedElement.$(selector)
+        let nextElement = await resolvedElement.$(selector)
+        //If the element wasn't found, we should wait for it
+        if (!nextElement.elementId) {
+            await nextElement.waitForExist()
+            nextElement = await resolvedElement.$(selector)
+        }
+        return nextElement
     }, Promise.resolve(currentElement))
 }

--- a/packages/webdriverio/tests/__mocks__/request.js
+++ b/packages/webdriverio/tests/__mocks__/request.js
@@ -49,12 +49,21 @@ const requestMock = jest.fn().mockImplementation((params, cb) => {
 
         break
     case `/wd/hub/session/${sessionId}/element`:
-        value = {
-            [ELEMENT_KEY]: genericElementId
-        }
-
         if (params.body && params.body.value === '#nonexisting') {
             value = { elementId: null }
+            break
+        }
+
+        if (params.body && params.body.value === '#slowRerender') {
+            ++requestMock.retryCnt
+            if (requestMock.retryCnt === 2) {
+                ++requestMock.retryCnt
+                value = {elementId: null}
+                break
+            }
+        }
+        value = {
+            [ELEMENT_KEY]: genericElementId
         }
 
         break

--- a/packages/webdriverio/tests/utils/refetchElement.test.js
+++ b/packages/webdriverio/tests/utils/refetchElement.test.js
@@ -1,5 +1,14 @@
 import { remote } from '../../src'
+import request from 'request'
 import refetchElement from '../../src/utils/refetchElement'
+
+jest.mock('../../src/commands/element/waitForExist', () => ({
+    __esModule: true,
+    default: jest.fn().mockImplementation(() => { return true })
+}))
+const waitForExist = require('../../src/commands/element/waitForExist')
+
+
 
 describe('refetchElement', () => {
     let browser
@@ -34,5 +43,14 @@ describe('refetchElement', () => {
         const subSubElem = await subElem.$('#subsubfoo')
         const refetchedElement = await refetchElement(subSubElem)
         expect(JSON.stringify(refetchedElement)).toBe(JSON.stringify(subSubElem))
+    })
+
+    it('should successfully refetch an element that isn\'t immediately present', async () => {
+        const elem = await browser.$('#foo')
+        request.retryCnt = 0
+        const notFound = await browser.$('#slowRerender')
+        const refetchedElement = await refetchElement(notFound)
+        expect(waitForExist.default.mock.calls).toHaveLength(1)
+        expect(refetchedElement.elementId).toBe(elem.elementId)
     })
 })

--- a/tests/mocha/test.js
+++ b/tests/mocha/test.js
@@ -10,7 +10,7 @@ describe('smoke test', () => {
         assert($('elem').waitForDisplayed(), true)
     })
 
-    describe.only('middleware', () => {
+    describe('middleware', () => {
         it('should wait for elements if not found immediately', () => {
             browser.waitForElementScenario()
             const elem = $('elem')

--- a/tests/mocha/test.js
+++ b/tests/mocha/test.js
@@ -10,7 +10,7 @@ describe('smoke test', () => {
         assert($('elem').waitForDisplayed(), true)
     })
 
-    describe('middleware', () => {
+    describe.only('middleware', () => {
         it('should wait for elements if not found immediately', () => {
             browser.waitForElementScenario()
             const elem = $('elem')


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

In the case that an element is removed from the DOM prior to being readded, we were returning a No Such Element Found object from refetch; This meant that subsequent commands would always fail.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
