### PR TITLE
Issue 3416: pass all failed expectations through from wdio-jasmine-framework

### DIFF
--- a/packages/wdio-jasmine-framework/src/index.js
+++ b/packages/wdio-jasmine-framework/src/index.js
@@ -168,7 +168,7 @@ class JasmineAdapter {
             message.file = params.payload.file
 
             if (params.payload.failedExpectations && params.payload.failedExpectations.length) {
-                message.failedExpectations = params.payload.failedExpectations
+                message.errors = params.payload.failedExpectations
                 message.error = params.payload.failedExpectations[0]
             }
 

--- a/packages/wdio-jasmine-framework/src/reporter.js
+++ b/packages/wdio-jasmine-framework/src/reporter.js
@@ -43,10 +43,15 @@ export default class JasmineReporter {
         }
 
         if (test.failedExpectations.length) {
-            test.error = test.failedExpectations[0]
+            let errors = test.failedExpectations
             if (this.shouldCleanStack) {
-                test.error = this.cleanStack(test.error)
+                errors = test.failedExpectations.map(x => this.cleanStack(x))
             }
+            test.errors = errors
+            // We maintain the single error property for backwards compatibility with reporters
+            // However, any reporter wanting to make use of Jasmine's 'soft assertion' type expects
+            // should default to looking at 'errors' if they are available
+            test.error = errors[0]
         }
 
         const e = 'test:' + test.status.replace(/ed/, '')
@@ -97,10 +102,14 @@ export default class JasmineReporter {
             pending: payload.status === 'pending',
             parent: this.parent.length ? this.getUniqueIdentifier(this.parent[this.parent.length - 1]) : null,
             type: payload.type,
+            // We maintain the single error property for backwards compatibility with reporters
+            // However, any reporter wanting to make use of Jasmine's 'soft assertion' type expects
+            // should default to looking at 'errors' if they are available
             error: payload.error,
+            errors: payload.errors,
             duration: payload.duration || 0,
             specs: this.specs,
-            start: payload.start
+            start: payload.start,
         }
 
         this.reporter.emit(event, message)

--- a/packages/wdio-jasmine-framework/tests/adapter.test.js
+++ b/packages/wdio-jasmine-framework/tests/adapter.test.js
@@ -256,6 +256,25 @@ test('formatMessage', () => {
     expect(message.duration).toBe(123)
 })
 
+test('formatMessage should pass all failedExpectations as errors', () => {
+    const adapter = new JasmineAdapter(
+        '0-2',
+        {},
+        ['/foo/bar.test.js'],
+        { browserName: 'chrome' },
+        wdioReporter
+    )
+    const message = adapter.formatMessage({
+        type: 'foobar',
+        payload: {
+            failedExpectations: [new Error('foobar'), {message: 'I am also a failed expectation but not an exception'}]
+        }
+    })
+
+    expect(message.errors.length).toBe(2)
+    expect(message.errors[1].message).toBe('I am also a failed expectation but not an exception')
+})
+
 test('getExpectationResultHandler returns origHandler if none is given', () => {
     const jasmine = { Spec: { prototype: { addExpectationResult: 'foobar' } } }
     const config = { jasmineNodeOpts: {} }

--- a/packages/wdio-jasmine-framework/tests/reporter.test.js
+++ b/packages/wdio-jasmine-framework/tests/reporter.test.js
@@ -80,6 +80,19 @@ test('specDone', () => {
     expect(runnerReporter.emit.mock.calls[9][1].uid).toBe('some excluded test spec27')
 })
 
+test('specDone should pass multiple failed expectations as errors', () => {
+    jasmineReporter.suiteStarted({ id: 23, description: 'some test suite' })
+    jasmineReporter.specStarted({ id: 24, description: 'some test spec' })
+    jasmineReporter.specDone({ id: 24, description: 'some test spec', failedExpectations: [{message: 'I failed'}, {message: 'I failed too!'}], status: 'failed' })
+
+    expect(runnerReporter.emit.mock.calls[2][0]).toBe('test:fail')
+    // We still assign the first failedExpectation to 'error' for backwrds compatibility
+    expect(runnerReporter.emit.mock.calls[2][1].error.message).toBe('I failed')
+    expect(runnerReporter.emit.mock.calls[2][1].errors.length).toBe(2)
+    expect(runnerReporter.emit.mock.calls[2][1].errors[0].message).toBe('I failed')
+    expect(runnerReporter.emit.mock.calls[2][1].errors[1].message).toBe('I failed too!')
+})
+
 test('suiteDone', () => {
     jasmineReporter.suiteStarted({ id: 23, description: 'some test suite' })
     jasmineReporter.specStarted({ id: 24, description: 'some test spec' })


### PR DESCRIPTION
## Proposed changes

[issue 3416](https://github.com/webdriverio/webdriverio/issues/3416) was introduced, because the framework-independent reporting model wdio uses assumes a failed spec has one and only one failure. This makes sense for frameworks like Mocha, where expectations or assertions throw exceptions and stop execution of a particular test. But Jasmine uses a 'soft assertion' model. Jasmine expectations don't end test execution. Instead, Jasmine runs all expectations and accumulates any failures. This model is particularly helpful in e2e tests, where feedback loops are longer and you want to know about all failures you might have.

The proposed solution introduces support for multiple errors from a test case or hook, while maintaining backwards compatibility with existing reporters. It comes in 3 basic steps, each of which should be completely non-breaking

1. Have wdio-jasmine-framework pass along an array of errors as well as the single error property, which is always just the first error in the array.
2. Update wdio-reporter to handle multiple errors in test stats and pass multiple errors to the reporter hook methods, while still maintaining current behavior if the events emitted from the framework only have a single error
3. Update any reporters to handle multiple errors in an appropriate way (e.g. printing more than one error in spec-reporter, aggregating errors in allure-reporter) etc. etc. 

This PR is step one. I broke it up into multiple PRs so each could be small, self-contained, and easy to reason about, and to minimize the chance I accidentally introduced a breaking change.

## Types of changes
- [X] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)

### Reviewers: @webdriverio/technical-committee
