### PR TITLE
Issue 3416: pass multiple errors through to test stats for reporting if available

### DIFF
--- a/packages/wdio-reporter/src/index.js
+++ b/packages/wdio-reporter/src/index.js
@@ -3,6 +3,8 @@ import fse from 'fs-extra'
 import { format } from 'util'
 import EventEmitter from 'events'
 
+import { getErrorsFromEvent } from './utils'
+
 import SuiteStats from './stats/suite'
 import HookStats from './stats/hook'
 import TestStats from './stats/test'
@@ -74,7 +76,7 @@ export default class WDIOReporter extends EventEmitter {
 
         this.on('hook:end',  /* istanbul ignore next */ (hook) => {
             const hookStat = this.hooks[hook.uid]
-            hookStat.complete(hook.error)
+            hookStat.complete(getErrorsFromEvent(hook))
             this.counts.hooks++
             this.onHookEnd(hookStat)
         })
@@ -108,7 +110,7 @@ export default class WDIOReporter extends EventEmitter {
                 test.error.stack = test.error.stack.replace(MOCHA_TIMEOUT_MESSAGE, replacement)
             }
 
-            testStat.fail(test.error)
+            testStat.fail(getErrorsFromEvent(test))
             this.counts.failures++
             this.counts.tests++
             this.onTestFail(testStat)

--- a/packages/wdio-reporter/src/stats/hook.js
+++ b/packages/wdio-reporter/src/stats/hook.js
@@ -9,9 +9,10 @@ export default class HookStats extends RunnableStats {
         this.parent = runner.parent
     }
 
-    complete (error) {
-        if (error) {
-            this.error = error
+    complete (errors) {
+        this.errors = errors
+        if (errors && errors.length) {
+            this.error = errors[0]
             this.state = 'failed'
         }
 

--- a/packages/wdio-reporter/src/stats/suite.js
+++ b/packages/wdio-reporter/src/stats/suite.js
@@ -4,12 +4,12 @@ import RunnableStats from './runnable'
  * Class describing statistics about a single suite.
  */
 export default class SuiteStats extends RunnableStats {
-    constructor (runner) {
+    constructor (suite) {
         super('suite')
-        this.uid = RunnableStats.getIdentifier(runner)
-        this.cid = runner.cid
-        this.title = runner.title
-        this.fullTitle = runner.fullTitle
+        this.uid = RunnableStats.getIdentifier(suite)
+        this.cid = suite.cid
+        this.title = suite.title
+        this.fullTitle = suite.fullTitle
         this.tests = []
         this.hooks = []
         this.suites = []

--- a/packages/wdio-reporter/src/stats/test.js
+++ b/packages/wdio-reporter/src/stats/test.js
@@ -5,12 +5,12 @@ import RunnableStats from './runnable'
  * captures data on a test.
  */
 export default class TestStats extends RunnableStats {
-    constructor (runner) {
+    constructor (test) {
         super('test')
-        this.uid = RunnableStats.getIdentifier(runner)
-        this.cid = runner.cid
-        this.title = runner.title
-        this.fullTitle = runner.fullTitle
+        this.uid = RunnableStats.getIdentifier(test)
+        this.cid = test.cid
+        this.title = test.title
+        this.fullTitle = test.fullTitle
         this.output = []
 
         /**
@@ -29,9 +29,13 @@ export default class TestStats extends RunnableStats {
         this.state = 'skipped'
     }
 
-    fail (error) {
+    fail (errors) {
         this.complete()
         this.state = 'failed'
-        this.error = error
+        this.errors = errors
+
+        if (errors && errors.length) {
+            this.error = errors[0]
+        }
     }
 }

--- a/packages/wdio-reporter/src/utils.js
+++ b/packages/wdio-reporter/src/utils.js
@@ -48,3 +48,17 @@ export function sanitizeCaps (caps) {
     result = result.filter(n => n !== undefined && n !== '')
     return result.join('.')
 }
+
+/**
+ * Takes a event emitted by a framework and extracts
+ * an array of errors representing test or hook failures.
+ * This exists to maintain compatibility between frameworks
+ * with have a soft assertion model (Jasmine) and those that
+ * have a hard assertion model (Mocha)
+ * @param {*} e  An event emitted by a framework adapter
+ */
+export function getErrorsFromEvent(e) {
+    if (e.errors) return e.errors
+    if (e.error) return [e.error]
+    return []
+}

--- a/packages/wdio-reporter/tests/reporter.listeners.test.js
+++ b/packages/wdio-reporter/tests/reporter.listeners.test.js
@@ -3,24 +3,7 @@ import tmp from 'tmp'
 import TestStats from '../src/stats/test'
 
 describe('WDIOReporter Listeners', () => {
-    let stat
     let reporter
-    let spy
-    let spy2
-
-    beforeEach(() => {
-        stat = { type: 'test:start',
-            title: 'should can do something',
-            parent: 'My awesome feature',
-            fullTitle: 'My awesome feature should can do something',
-            pending: false,
-            cid: '0-0',
-            specs: [ '/path/to/test/specs/sync.spec.js' ],
-            uid: '0-0'
-        }
-
-        stat.complete = jest.fn()
-    })
 
     beforeEach(() => {
         const tmpobj = tmp.fileSync()
@@ -28,9 +11,24 @@ describe('WDIOReporter Listeners', () => {
     })
 
     describe('Pending Listener', () => {
+        let stat
+        let spy
+        let spy2
+
         beforeEach(() => {
             spy = jest.spyOn(WDIOReporter.prototype, 'onTestSkip')
             spy2 = jest.spyOn(TestStats.prototype, 'skip')
+            stat = { type: 'test:start',
+                title: 'should can do something',
+                parent: 'My awesome feature',
+                fullTitle: 'My awesome feature should can do something',
+                pending: false,
+                cid: '0-0',
+                specs: [ '/path/to/test/specs/sync.spec.js' ],
+                uid: '0-0'
+            }
+
+            stat.complete = jest.fn()
         })
 
         afterEach(() => {
@@ -141,6 +139,452 @@ describe('WDIOReporter Listeners', () => {
             // Make sure the counts are updated
             expect(reporter.counts.skipping).toEqual(1)
             expect(reporter.counts.tests).toEqual(3)
+        })
+    })
+
+
+    describe('handling runner:start', () => {
+
+        let runnerStartEvent
+
+        beforeEach(() => {
+            runnerStartEvent = {
+                cid: 'runnerid',
+                capabilities: {
+                    browserName: 'Chrome'
+                }
+            }
+            reporter.onRunnerStart = jest.fn()
+        })
+
+        it('should set the root suite id', () => {
+            reporter.emit('runner:start', runnerStartEvent)
+            expect(reporter.currentSuites[0].cid).toBe(runnerStartEvent.cid)
+        })
+
+        it('should set the runner stat', () => {
+            reporter.emit('runner:start', runnerStartEvent)
+            expect(reporter.runnerStat).toBeDefined()
+            expect(reporter.runnerStat.capabilities).toEqual(runnerStartEvent.capabilities)
+        })
+
+        it('should call onRunnerStart', () => {
+            reporter.emit('runner:start', runnerStartEvent)
+            expect(reporter.onRunnerStart).toBeCalledWith(reporter.runnerStat)
+        })
+    })
+
+    describe('handling suite:start', () => {
+        let suiteStartEvent
+        let runnerStartEvent
+        beforeEach(() => {
+            runnerStartEvent = {
+                cid: 'runnerid',
+                capabilities: {
+                    browserName: 'Chrome'
+                }
+            }
+            suiteStartEvent = {
+                uid: 'suiteid',
+                title: 'the software'
+            }
+            reporter.onSuiteStart = jest.fn()
+        })
+
+        it('should set the suite as sub suite of the current suite', () => {
+            reporter.emit('runner:start', runnerStartEvent)
+            reporter.emit('suite:start', suiteStartEvent)
+
+            expect(reporter.currentSuites[0].suites.length).toBe(1)
+            expect(reporter.currentSuites[0].suites[0].title).toBe(suiteStartEvent.title)
+        })
+
+        it('should add the suite to the stack of current suites', () => {
+            reporter.emit('runner:start', runnerStartEvent)
+            reporter.emit('suite:start', suiteStartEvent)
+
+            expect(reporter.currentSuites.length).toBe(2)
+            expect(reporter.currentSuites[1].title).toBe(suiteStartEvent.title)
+        })
+
+        it('should add the suite stats to the lookup object of suite stats', () => {
+            reporter.emit('runner:start', runnerStartEvent)
+            reporter.emit('suite:start', suiteStartEvent)
+
+            expect(reporter.suites[suiteStartEvent.uid]).toBeDefined()
+            expect(reporter.suites[suiteStartEvent.uid].title).toBe(suiteStartEvent.title)
+        })
+
+        it('should call onSuiteStart with the suite stat', () => {
+            reporter.emit('runner:start', runnerStartEvent)
+            reporter.emit('suite:start', suiteStartEvent)
+
+            expect(reporter.onSuiteStart).toBeCalledWith(reporter.suites[suiteStartEvent.uid])
+        })
+    })
+
+    describe('handling hook:start', () => {
+        let hookStartEvent
+        let suiteStartEvent
+        let runnerStartEvent
+
+        const emitEvents = () => {
+            reporter.emit('runner:start', runnerStartEvent)
+            reporter.emit('suite:start', suiteStartEvent)
+            reporter.emit('hook:start', hookStartEvent)
+        }
+
+        beforeEach(() => {
+            runnerStartEvent = {
+                cid: 'runnerid',
+                capabilities: {
+                    browserName: 'Chrome'
+                }
+            }
+            suiteStartEvent = {
+                uid: 'suiteid',
+                title: 'the software'
+            }
+            hookStartEvent = {
+                uid: 'hookid',
+                title: 'beforeAll'
+            }
+        })
+
+        it('should attach the hook stats to the current suite stats', () => {
+            emitEvents()
+            expect(reporter.currentSuites[1].hooks).toHaveLength(1)
+            expect(reporter.currentSuites[1].hooks[0].uid).toEqual(hookStartEvent.uid)
+        })
+
+        it('should add the hook stats to the lookup object of hook stats', () => {
+            emitEvents()
+            expect(reporter.hooks[hookStartEvent.uid].title).toBe(hookStartEvent.title)
+        })
+
+        it('should call on hook start with the hook stat', () => {
+            reporter.onHookStart = jest.fn()
+            emitEvents()
+            expect(reporter.onHookStart).toBeCalledWith(reporter.hooks[hookStartEvent.uid])
+        })
+    })
+
+    describe('handling hook:end', () => {
+
+        let hookEndEvent
+        let hookStartEvent
+        let suiteStartEvent
+        let runnerStartEvent
+
+        const emitEvents = () => {
+            reporter.emit('runner:start', runnerStartEvent)
+            reporter.emit('suite:start', suiteStartEvent)
+            reporter.emit('hook:start', hookStartEvent)
+            reporter.emit('hook:end', hookEndEvent)
+        }
+
+        beforeEach(() => {
+            runnerStartEvent = {
+                cid: 'runnerid',
+                capabilities: {
+                    browserName: 'Chrome'
+                }
+            }
+            suiteStartEvent = {
+                uid: 'suiteid',
+                title: 'the software'
+            }
+            hookStartEvent = {
+                uid: 'hookid',
+                title: 'beforeAll'
+            }
+            hookEndEvent = {
+                uid: 'hookid',
+                title: 'beforeAll'
+            }
+        })
+
+
+        it('should complete the hook if the hook passes', () => {
+            emitEvents()
+
+            expect(reporter.hooks[hookStartEvent.uid]).toBeDefined()
+            expect(reporter.hooks[hookStartEvent.uid].end instanceof Date).toBe(true)
+            expect(reporter.hooks[hookStartEvent.uid].state).not.toBe('failed')
+        })
+
+        it('should complete the hook if the hook if the hook passes and has an empty errors property', () => {
+            hookEndEvent.errors = []
+            emitEvents()
+
+            expect(reporter.hooks[hookStartEvent.uid]).toBeDefined()
+            expect(reporter.hooks[hookStartEvent.uid].end instanceof Date).toBe(true)
+            expect(reporter.hooks[hookStartEvent.uid].state).not.toBe('failed')
+            expect(reporter.hooks[hookStartEvent.uid].error).toBeUndefined()
+        })
+
+        it('should complete the hook if the hook fails with a single error and mark it failed (Mocha-style)', () => {
+            hookEndEvent.error = new Error('Boom')
+            emitEvents()
+
+            expect(reporter.hooks[hookStartEvent.uid]).toBeDefined()
+            expect(reporter.hooks[hookStartEvent.uid].end instanceof Date).toBe(true)
+            expect(reporter.hooks[hookStartEvent.uid].state).toBe('failed')
+            expect(reporter.hooks[hookStartEvent.uid].error.message).toBe('Boom')
+            expect(reporter.hooks[hookStartEvent.uid].errors.length).toBe(1)
+            expect(reporter.hooks[hookStartEvent.uid].errors[0].message).toBe('Boom')
+        })
+
+        it('should complete the hook if the hook fails with multiple errors and mark it failed (Jasmine-style)', () => {
+            hookEndEvent.errors = [{message: 'SoftFail'}, {message: 'anotherfail'}]
+            emitEvents()
+
+            expect(reporter.hooks[hookStartEvent.uid]).toBeDefined()
+            expect(reporter.hooks[hookStartEvent.uid].end instanceof Date).toBe(true)
+            expect(reporter.hooks[hookStartEvent.uid].state).toBe('failed')
+            expect(reporter.hooks[hookStartEvent.uid].error.message).toBe('SoftFail')
+            expect(reporter.hooks[hookStartEvent.uid].errors.length).toBe(2)
+            expect(reporter.hooks[hookStartEvent.uid].errors[0].message).toBe('SoftFail')
+            expect(reporter.hooks[hookStartEvent.uid].errors[1].message).toBe('anotherfail')
+        })
+
+        it('should call onHookEnd with the hook stats', () => {
+            reporter.onHookEnd = jest.fn()
+            emitEvents()
+
+            expect(reporter.onHookEnd).toHaveBeenCalledWith(reporter.hooks[hookStartEvent.uid])
+        })
+
+        it('should increment the hook count', () => {
+            emitEvents()
+            expect(reporter.counts.hooks).toBe(1)
+        })
+    })
+
+    describe('handling test:start', () => {
+
+        let testStartEvent
+        let suiteStartEvent
+        let runnerStartEvent
+
+        const emitEvents = () => {
+            reporter.emit('runner:start', runnerStartEvent)
+            reporter.emit('suite:start', suiteStartEvent)
+            reporter.emit('test:start', testStartEvent)
+        }
+
+        beforeEach(() => {
+            runnerStartEvent = {
+                cid: 'runnerid',
+                capabilities: {
+                    browserName: 'Chrome'
+                }
+            }
+            suiteStartEvent = {
+                uid: 'suiteid',
+                title: 'the software'
+            }
+            testStartEvent = {
+                uid: 'testid',
+                title: 'should do the needful'
+            }
+        })
+
+        it('should add the test stat to the current suite stat', () => {
+            emitEvents()
+            expect(reporter.suites[suiteStartEvent.uid].tests.length).toBe(1)
+            expect(reporter.suites[suiteStartEvent.uid].tests[0].title).toBe(testStartEvent.title)
+        })
+
+        it('should add the test stat to the lookup object of test stats', () => {
+            emitEvents()
+            expect(reporter.tests[testStartEvent.uid].title).toBe(testStartEvent.title)
+        })
+
+        it('should call onTestStart with the test stat', () => {
+            reporter.onTestStart = jest.fn()
+            emitEvents()
+            expect(reporter.onTestStart).toHaveBeenCalledWith(reporter.tests[testStartEvent.uid])
+        })
+    })
+
+    describe('handling test:pass', () => {
+
+        let testPassEvent
+        let testStartEvent
+        let suiteStartEvent
+        let runnerStartEvent
+
+        const emitEvents = () => {
+            reporter.emit('runner:start', runnerStartEvent)
+            reporter.emit('suite:start', suiteStartEvent)
+            reporter.emit('test:start', testStartEvent)
+            reporter.emit('test:pass', testPassEvent)
+        }
+
+        beforeEach(() => {
+            runnerStartEvent = {
+                cid: 'runnerid',
+                capabilities: {
+                    browserName: 'Chrome'
+                }
+            }
+            suiteStartEvent = {
+                uid: 'suiteid',
+                title: 'the software'
+            }
+            testStartEvent = {
+                uid: 'testid',
+                title: 'should do the needful'
+            }
+            testPassEvent = {
+                uid: 'testid',
+            }
+        })
+
+        it('should flag the test stat as passed and complete', () => {
+            emitEvents()
+
+            expect(reporter.tests[testStartEvent.uid].state).toBe('passed')
+            expect(reporter.tests[testStartEvent.uid].end instanceof Date).toBe(true)
+        })
+
+        it('should increment the test and passes counts', () => {
+            emitEvents()
+
+            expect(reporter.counts.tests).toBe(1)
+            expect(reporter.counts.passes).toBe(1)
+        })
+
+        it('should call onTestPass with the test stat', () => {
+            reporter.onTestPass = jest.fn()
+            emitEvents()
+
+            expect(reporter.onTestPass).toHaveBeenCalledWith(reporter.tests[testStartEvent.uid])
+        })
+    })
+
+    describe('handling test:fail', () => {
+
+        let testStartEvent
+        let testFailEvent
+        let suiteStartEvent
+        let runnerStartEvent
+
+        const emitEvents = () => {
+            reporter.emit('runner:start', runnerStartEvent)
+            reporter.emit('suite:start', suiteStartEvent)
+            reporter.emit('test:start', testStartEvent)
+            reporter.emit('test:fail', testFailEvent)
+        }
+
+        beforeEach(() => {
+            runnerStartEvent = {
+                cid: 'runnerid',
+                capabilities: {
+                    browserName: 'Chrome'
+                }
+            }
+            suiteStartEvent = {
+                uid: 'suiteid',
+                title: 'the softare'
+            }
+            testStartEvent = {
+                uid: 'testid',
+                title: 'should do the needful'
+            }
+
+            testFailEvent = {
+                uid: 'testid'
+            }
+        })
+
+        it('Should flag the test as failed and complete if the test somehow has no error', () => {
+            emitEvents()
+            expect(reporter.tests[testStartEvent.uid].state).toBe('failed')
+            expect(reporter.tests[testStartEvent.uid].end instanceof Date).toBe(true)
+        })
+
+        it('shoud flag the test as failed and complete if the test has one error (Mocha style)', () => {
+            testFailEvent.error = new Error('Boom')
+            emitEvents()
+
+            expect(reporter.tests[testStartEvent.uid].state).toBe('failed')
+            expect(reporter.tests[testStartEvent.uid].end instanceof Date).toBe(true)
+            expect(reporter.tests[testStartEvent.uid].error.message).toBe('Boom')
+            expect(reporter.tests[testStartEvent.uid].errors.length).toBe(1)
+            expect(reporter.tests[testStartEvent.uid].errors[0].message).toBe('Boom')
+        })
+
+        it('should flag the test as failed and complete the test if the test has multiple errors (Jasmine style)', () => {
+            testFailEvent.errors = [{message: 'SoftFail'}, {message: 'anotherfail'}]
+            emitEvents()
+
+            expect(reporter.tests[testStartEvent.uid].state).toBe('failed')
+            expect(reporter.tests[testStartEvent.uid].end instanceof Date).toBe(true)
+            expect(reporter.tests[testStartEvent.uid].error.message).toBe('SoftFail')
+            expect(reporter.tests[testStartEvent.uid].errors.length).toBe(2)
+            expect(reporter.tests[testStartEvent.uid].errors[0].message).toBe('SoftFail')
+            expect(reporter.tests[testStartEvent.uid].errors[1].message).toBe('anotherfail')
+        })
+
+        it('should call onTestFail with the test stat', () => {
+            reporter.onTestFail = jest.fn()
+            emitEvents()
+
+            expect(reporter.onTestFail).toBeCalledWith(reporter.tests[testStartEvent.uid])
+        })
+
+        it('Should increment the test and failure counts', () => {
+            emitEvents()
+            expect(reporter.counts.tests).toBe(1)
+            expect(reporter.counts.failures).toBe(1)
+        })
+    })
+
+    describe('handling test:end', () => {
+
+        let testPassEvent
+        let testStartEvent
+        let suiteStartEvent
+        let runnerStartEvent
+        let testEndEvent
+
+        const emitEvents = () => {
+            reporter.emit('runner:start', runnerStartEvent)
+            reporter.emit('suite:start', suiteStartEvent)
+            reporter.emit('test:start', testStartEvent)
+            reporter.emit('test:pass', testPassEvent)
+            reporter.emit('test:end', testEndEvent)
+        }
+
+        beforeEach(() => {
+            runnerStartEvent = {
+                cid: 'runnerid',
+                capabilities: {
+                    browserName: 'Chrome'
+                }
+            }
+            suiteStartEvent = {
+                uid: 'suiteid',
+                title: 'the software'
+            }
+            testStartEvent = {
+                uid: 'testid',
+                title: 'should do the needful'
+            }
+            testPassEvent = {
+                uid: 'testid',
+            },
+            testEndEvent = {
+                uid: 'testid'
+            }
+        })
+
+        it('should call test end with the test stat', () => {
+            reporter.onTestEnd = jest.fn()
+            emitEvents()
+            expect(reporter.onTestEnd).toHaveBeenCalledWith(reporter.tests[testStartEvent.uid])
         })
     })
 })

--- a/packages/wdio-reporter/tests/stats/hook.test.js
+++ b/packages/wdio-reporter/tests/stats/hook.test.js
@@ -23,13 +23,28 @@ test('should allow to be called complete', () => {
     expect(hook.end).toBeInstanceOf(Date)
 })
 
-test('should mark hook as failed if onComplete has error', () => {
+test('should mark hook as failed if onComplete has errors', () => {
     const hook = new HookStats({
         cid: '0-0',
         title: 'foobar',
         parent: 'barfoo'
     })
-    const error = new Error('boom')
-    hook.complete(error)
-    expect(hook.error).toBe(error)
+    const errors = [new Error('boom')]
+    hook.complete(errors)
+    expect(hook.errors).toBe(errors)
+    expect(hook.error.message).toBe('boom')
+    expect(hook.state).toBe('failed')
+})
+
+test('Should not mark hook as failed if onComplete has no errors', () => {
+    const hook = new HookStats({
+        cid: '0-0',
+        title: 'foobar',
+        parent: 'barfoo'
+    })
+    const errors = []
+    hook.complete(errors)
+    expect(hook.errors).toBe(errors)
+    expect(hook.error).toBeUndefined()
+    expect(hook.state).not.toBe('failed')
 })

--- a/packages/wdio-reporter/tests/test.stats.test.js
+++ b/packages/wdio-reporter/tests/test.stats.test.js
@@ -38,10 +38,25 @@ describe('TestStats', () => {
     })
 
     it('can fail', () => {
-        stat.fail(new Error('oh oh'))
+        stat.fail([new Error('oh oh')])
         expect(stat.state).toBe('failed')
+        expect(stat.errors.length).toBe(1)
+        expect(stat.errors[0].message).toBe('oh oh')
+
         expect(stat.error.message).toBe('oh oh')
         expect(stat.complete.mock.calls).toHaveLength(1)
+
         stat.complete.mockReset()
+    })
+
+    it('should not throw if it fails with no errors somehow', () => {
+        stat.fail([])
+        expect(stat.errors.length).toBe(0)
+        expect(stat.state).toBe('failed')
+    })
+
+    it('should not throw if it fails with undefined errors somehow', () => {
+        stat.fail(undefined)
+        expect(stat.state).toBe('failed')
     })
 })


### PR DESCRIPTION

## Proposed changes
Continuing the work started in [https://github.com/webdriverio/webdriverio/pull/3669](https://github.com/webdriverio/webdriverio/pull/3669). That PR allowed Jasmine to pass along more than one error on test run events. Here, we're handling more than one error in the base reporter, and assigning them to test stats for consumption by reporters. In packages/wdio-reporter/src/index.js we pass multiple errors if available to the test stats, and otherwise wrap the 'error' property of the event. Then in, the test/hook stats, we assign both a 'errors' property and an 'error' property (just the first element of the passed errors array). This should maintain backwards compatibility with any existing reporters/frameworks, while allowing reporters to optionally report multiple failures from a single tests.

There's also a lot of added test coverage in this PR, since I wanted to be very careful not to break anything. While we executed all of the event handlers in packages/wdio-reporter/src/index.js, a lot of the event handling behavior wasn't asserted against. Open to reducing the volume of tests if anyone thinks we're over-testing there.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)


### Reviewers: @webdriverio/technical-committee
