### PR TITLE
mochaOpts.require after wrapping functions with Fibers

### DIFF
--- a/packages/wdio-mocha-framework/src/index.js
+++ b/packages/wdio-mocha-framework/src/index.js
@@ -97,7 +97,6 @@ class MochaAdapter {
         const match = MOCHA_UI_TYPE_EXTRACTOR.exec(options.ui)
         const type = (match && INTERFACES[match[1]] && match[1]) || DEFAULT_INTERFACE_TYPE
 
-        this.options(options, { context, file, mocha, options })
         INTERFACES[type].forEach((fnName) => {
             let testCommand = INTERFACES[type][0]
 
@@ -108,6 +107,7 @@ class MochaAdapter {
                 fnName
             )
         })
+        this.options(options, { context, file, mocha, options })
     }
 
     /**

--- a/packages/webdriverio/src/constants.js
+++ b/packages/webdriverio/src/constants.js
@@ -68,7 +68,7 @@ export const WDIO_DEFAULTS = {
                 if (typeof param === 'object') {
                     return true
                 }
-                
+
                 throw new Error('the "capabilities" options needs to be an object or a list of objects')
             }
 
@@ -79,10 +79,10 @@ export const WDIO_DEFAULTS = {
                 if (typeof option === 'object') { // Check does not work recursively
                     continue
                 }
-    
+
                 throw new Error('expected every item of a list of capabilities to be of type object')
             }
-    
+
             return true
         },
         required: true
@@ -193,14 +193,14 @@ export const WDIO_DEFAULTS = {
              * with arrays and/or strings
              */
             for (const option of param) {
-                if (!Array.isArray(option)) {         
+                if (!Array.isArray(option)) {
                     if (typeof option === 'string') {
                         continue
                     }
                     throw new Error('the "services" options needs to be a list of strings and/or arrays')
                 }
             }
-    
+
             return true
         },
         default: []


### PR DESCRIPTION
## Proposed changes

trigger mochaOpts.require after wrapping framework functions with Fibers in order to be able to decorate mocha's functions.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

outcome of https://github.com/webdriverio/webdriverio/pull/3644

### Reviewers: @webdriverio/technical-committee
