### PR TITLE
wdio-logger: fix webdriver log colors

### DIFF
--- a/packages/wdio-logger/src/node.js
+++ b/packages/wdio-logger/src/node.js
@@ -14,6 +14,12 @@ const COLORS = {
     trace: 'cyan'
 }
 
+const matches = {
+    COMMAND: 'COMMAND',
+    DATA: 'DATA',
+    RESULT: 'RESULT'
+}
+
 const SERIALIZERS = [{
     /**
      * display error stack
@@ -24,19 +30,19 @@ const SERIALIZERS = [{
     /**
      * color commands blue
      */
-    matches: (log) => log === 'COMMAND',
+    matches: (log) => log === matches.COMMAND,
     serialize: (log) => chalk.magenta(log)
 }, {
     /**
      * color data yellow
      */
-    matches: (log) => log === 'DATA',
+    matches: (log) => log === matches.DATA,
     serialize: (log) => chalk.yellow(log)
 }, {
     /**
      * color result cyan
      */
-    matches: (log) => log === 'RESULT',
+    matches: (log) => log === matches.RESULT,
     serialize: (log) => chalk.cyan(log)
 }]
 
@@ -54,6 +60,16 @@ log.methodFactory = function (methodName, logLevel, loggerName) {
          */
         if (!logFile && process.env.WDIO_LOG_PATH) {
             logFile = fs.createWriteStream(process.env.WDIO_LOG_PATH)
+        }
+
+        /**
+         * split `prefixer: value` sting to `prefixer: ` and `value`
+         * so that SERIALIZERS can match certain string
+         */
+        const match = Object.values(matches).filter(x => args[0].endsWith(`: ${x}`))[0]
+        if (match) {
+            const prefixStr = args.shift().slice(0, -match.length - 1)
+            args.unshift(prefixStr, match)
         }
 
         args = args.map((arg) => {

--- a/packages/wdio-logger/tests/node.test.js
+++ b/packages/wdio-logger/tests/node.test.js
@@ -128,8 +128,8 @@ describe('wdio-logger node', () => {
 
         it('should be possible to add to cache', () => {
             const log = nodeLogger('test-logFile1')
-            log.info('', 'DATA')
-            log.info('', 'RESULT')
+            log.info('foo')
+            log.info('bar')
 
             const logCache = logCacheAddSpy.mock.results[0].value
 
@@ -137,8 +137,8 @@ describe('wdio-logger node', () => {
             expect(logCache.size).toBe(2)
 
             const it = logCache.values()
-            expect(it.next().value).toContain('test-logFile1:  yellow DATA')
-            expect(it.next().value).toContain('test-logFile1:  cyan RESULT')
+            expect(it.next().value).toContain('test-logFile1: foo')
+            expect(it.next().value).toContain('test-logFile1: bar')
 
             // after
             logCache.clear()
@@ -162,15 +162,31 @@ describe('wdio-logger node', () => {
             process.env.WDIO_LOG_PATH = 'wdio.test.log'
 
             const log = nodeLogger('test-logFile2')
-            log.info('', 'COMMAND')
-            log.info(new Error('bar'))
+            log.info('foo')
+            log.info('bar')
 
             expect(write.mock.calls.length).toBe(2)
-            expect(write.mock.results[0].value).toContain('test-logFile2:  magenta COMMAND')
-            expect(write.mock.results[1].value).toContain('test-logFile2: Error: bar')
-            expect(write.mock.results[1].value).not.toContain('test-logFile2:  magenta COMMAND')
+            expect(write.mock.results[0].value).toContain('test-logFile2: foo')
+            expect(write.mock.results[1].value).toContain('test-logFile2: bar')
+            expect(write.mock.results[1].value).not.toContain('test-logFile2: foo')
 
             expect(logCacheForEachSpy).toBeCalledTimes(0)
+        })
+
+        it('serializers', () => {
+            process.env.WDIO_LOG_PATH = 'wdio.test.log'
+
+            const log = nodeLogger('test-logFile4')
+            log.info('DATA')
+            log.info('RESULT')
+            log.info('COMMAND')
+            log.info(new Error('bar'))
+
+            expect(write.mock.calls.length).toBe(4)
+            expect(write.mock.results[0].value).toContain('test-logFile4: yellow DATA')
+            expect(write.mock.results[1].value).toContain('test-logFile4: cyan RESULT')
+            expect(write.mock.results[2].value).toContain('test-logFile4: magenta COMMAND')
+            expect(write.mock.results[3].value).toContain('test-logFile4: Error: bar')
         })
 
         beforeEach(() => {


### PR DESCRIPTION
## Proposed changes

fix coloring of webdriver's COMMAND, DATA, RESULT

![image](https://user-images.githubusercontent.com/25589559/53759960-d4202f00-3ec1-11e9-8eeb-ed462dbd41c5.png)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

fix #3593 

### Reviewers: @webdriverio/technical-committee
