### PR TITLE
wdio-allure-reporter: start end step

### DIFF
--- a/packages/wdio-allure-reporter/src/constants.js
+++ b/packages/wdio-allure-reporter/src/constants.js
@@ -25,6 +25,8 @@ const events = {
     addEnvironment: 'allure:addEnvironment',
     addDescription: 'allure:addDescription',
     addAttachment: 'allure:addAttachment',
+    startStep: 'allure:startStep',
+    endStep: 'allure:endStep',
     addStep: 'allure:addStep',
     addArgument: 'allure:addArgument'
 }

--- a/packages/wdio-allure-reporter/src/index.js
+++ b/packages/wdio-allure-reporter/src/index.js
@@ -150,7 +150,7 @@ class AllureReporter extends WDIOReporter {
             }
             return
         }
-        
+
         // add hook as test to suite
         this.onTestStart(hook)
     }
@@ -259,16 +259,29 @@ class AllureReporter extends WDIOReporter {
         }
     }
 
+    startStep(title) {
+        if (!this.isAnyTestRunning()) {
+            return false
+        }
+        this.allure.startStep(title)
+    }
+
+    endStep(status) {
+        if (!this.isAnyTestRunning()) {
+            return false
+        }
+        this.allure.endStep(status)
+    }
+
     addStep({step}) {
         if (!this.isAnyTestRunning()) {
             return false
         }
-
-        this.allure.startStep(step.title)
+        this.startStep(step.title)
         if (step.attachment) {
             this.addAttachment(step.attachment)
         }
-        this.allure.endStep(step.status)
+        this.endStep(step.status)
     }
 
     addArgument({name, value}) {
@@ -368,6 +381,28 @@ class AllureReporter extends WDIOReporter {
     static addAttachment = (name, content, type = 'text/plain') => {
         tellReporter(events.addAttachment, {name, content, type})
     }
+
+    /**
+     * Start allure step
+     * @name startStep
+     * @param {string} title - step name in report
+     */
+    static startStep = (title) => {
+        tellReporter(events.startStep, title)
+    }
+
+    /**
+     * End current allure step
+     * @name endStep
+     * @param {string} [status='passed'] - step status
+     */
+    static endStep = (status = stepStatuses.PASSED) => {
+        if (!Object.values(stepStatuses).includes(status)) {
+            throw new Error(`Step status must be ${Object.values(stepStatuses).join(' or ')}. You tried to set "${status}"`)
+        }
+        tellReporter(events.endStep, status)
+    }
+
     /**
      * Create allure step
      * @name addStep

--- a/packages/wdio-allure-reporter/tests/allureFeatures.test.js
+++ b/packages/wdio-allure-reporter/tests/allureFeatures.test.js
@@ -151,6 +151,26 @@ describe('reporter runtime implementation', () => {
         expect(dumpJSON).toHaveBeenCalledWith('foo', 'bar')
     })
 
+    it('should allow to start end step', () => {
+        const reporter = new AllureReporter({stdout: true})
+        const startStep = jest.fn()
+        const endStep = jest.fn()
+        reporter.allure = {
+            getCurrentSuite: jest.fn(() => true),
+            getCurrentTest: jest.fn(() => true),
+            startStep,
+            endStep
+        }
+        reporter.startStep('bar')
+        reporter.endStep('failed')
+
+        expect(startStep).toHaveBeenCalledTimes(1)
+        expect(endStep).toHaveBeenCalledTimes(1)
+
+        expect(startStep).toHaveBeenCalledWith('bar')
+        expect(endStep).toHaveBeenCalledWith('failed')
+    })
+
     it('should correct add step with attachment', () => {
         const reporter = new AllureReporter({stdout: true})
         const startStep = jest.fn()
@@ -232,6 +252,8 @@ describe('reporter runtime implementation', () => {
         expect(reporter.addEnvironment({})).toEqual(false)
         expect(reporter.addDescription({})).toEqual(false)
         expect(reporter.addAttachment({})).toEqual(false)
+        expect(reporter.startStep({})).toEqual(false)
+        expect(reporter.endStep({})).toEqual(false)
         expect(reporter.addStep({})).toEqual(false)
         expect(reporter.addArgument({})).toEqual(false)
     })

--- a/packages/wdio-allure-reporter/tests/constants.test.js
+++ b/packages/wdio-allure-reporter/tests/constants.test.js
@@ -18,10 +18,12 @@ describe('Important constants', () => {
     })
 
     it('should have correct step statuses', () => {
-        expect(Object.values(events)).toHaveLength(10)
+        expect(Object.values(events)).toHaveLength(12)
         expect(events.addSeverity).toEqual('allure:addSeverity')
         expect(events.addIssue).toEqual('allure:addIssue')
         expect(events.addTestId).toEqual('allure:addTestId')
+        expect(events.startStep).toEqual('allure:startStep')
+        expect(events.endStep).toEqual('allure:endStep')
         expect(events.addStep).toEqual('allure:addStep')
         expect(events.addAttachment).toEqual('allure:addAttachment')
         expect(events.addDescription).toEqual('allure:addDescription')

--- a/packages/wdio-allure-reporter/tests/runtime.test.js
+++ b/packages/wdio-allure-reporter/tests/runtime.test.js
@@ -85,6 +85,18 @@ describe('reporter reporter api', () => {
         expect(utils.tellReporter).toHaveBeenCalledWith(events.addStep, step)
     })
 
+    it('should support start step', () => {
+        reporter.startStep('foo')
+        expect(utils.tellReporter).toHaveBeenCalledTimes(1)
+        expect(utils.tellReporter).toHaveBeenCalledWith(events.startStep, 'foo')
+    })
+
+    it('should support end step', () => {
+        reporter.endStep('passed')
+        expect(utils.tellReporter).toHaveBeenCalledTimes(1)
+        expect(utils.tellReporter).toHaveBeenCalledWith(events.endStep, 'passed')
+    })
+
     it('should support addStep without attachment', () => {
         reporter.addStep('foo')
         expect(utils.tellReporter).toHaveBeenCalledTimes(1)
@@ -101,6 +113,11 @@ describe('reporter reporter api', () => {
 
     it('should throw exception for incorrect status for addStep', () => {
         const cb = () => { reporter.addStep('foo', {content: 'baz'}, 'canceled')}
+        expect(cb).toThrowError('Step status must be passed or failed or broken. You tried to set "canceled"')
+    })
+
+    it('should throw exception for incorrect status for endStep', () => {
+        const cb = () => { reporter.endStep('canceled') }
         expect(cb).toThrowError('Step status must be passed or failed or broken. You tried to set "canceled"')
     })
 

--- a/packages/wdio-allure-reporter/tests/suite.test.js
+++ b/packages/wdio-allure-reporter/tests/suite.test.js
@@ -35,6 +35,8 @@ describe('Passing tests', () => {
         reporter.addDescription({description: 'functions', type: 'html'})
         reporter.addAttachment({name: 'My attachment', content: '99thoughtz', type: 'text/plain'})
         reporter.addArgument({name: 'os', value: 'osx'})
+        reporter.startStep('bar')
+        reporter.endStep('passed')
         const step = {'step': {'attachment': {'content': 'baz', 'name': 'attachment'}, 'status': 'failed', 'title': 'foo'}}
         reporter.addStep(step)
         reporter.onTestPass(testPassed())
@@ -85,11 +87,17 @@ describe('Passing tests', () => {
         expect(allureXml('test-case parameter[name="jenkins"]').eq(0).attr('value')).toEqual('1.2.3')
     })
 
+    it('should start end custom step', () => {
+        expect(allureXml('step > name').eq(0).text()).toEqual('bar')
+        expect(allureXml('step > title').eq(0).text()).toEqual('bar')
+        expect(allureXml('step').eq(0).attr('status')).toEqual('passed')
+    })
+
     it('should add custom step', () => {
-        expect(allureXml('step > name').eq(0).text()).toEqual('foo')
-        expect(allureXml('step > title').eq(0).text()).toEqual('foo')
+        expect(allureXml('step > name').eq(1).text()).toEqual('foo')
+        expect(allureXml('step > title').eq(1).text()).toEqual('foo')
         expect(allureXml('test-case attachment[title="attachment"]')).toHaveLength(1)
-        expect(allureXml('step').eq(0).attr('status')).toEqual('failed')
+        expect(allureXml('step').eq(1).attr('status')).toEqual('failed')
     })
 
     it('should add attachment', () => {


### PR DESCRIPTION
## Proposed changes

- it should be possible to create stepFunc like it is described in allure doc https://docs.qameta.io/allure/#_steps_6
- it should be possible to add step with duration

To be able to do it we need to have start and end step events.

```
allure.startStep('long running wait for foo')
$('foo').waitForExist()
allure.endStep('passed')
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

Another usage example:
```
const step = (step, func, attachment) => {
  allure.startStep(step)

  if (attachment) {
    allure.addAttachment(attachment)
  }

  let status
  try {
    func()
  } catch (error) {
    allure.addAttachment(error)
    if (error && error.name === 'AssertionError') {
      status = 'failed'
    } else {
      status = 'broken'
    }
  } finally {
    allure.endStep(status) // undefined => passed
  }
}

it('my test', () => {
  const el = $('foo')
  step('wait for foo', () => el.waitForExist())
  step('foo has modal class', () => assert.equals(el.getAttribute('class'), 'modal'))
})
```

### Reviewers: @webdriverio/technical-committee
