### PR TITLE
Appium saveRecordingScreen

### DIFF
--- a/packages/webdriver/protocol/appium.json
+++ b/packages/webdriver/protocol/appium.json
@@ -74,25 +74,65 @@
       "description": "Start recording the screen.",
       "ref": "http://appium.io/docs/en/commands/device/recording-screen/start-recording-screen/",
       "parameters": [{
-        "name": "filePath",
+        "name": "remotePath",
         "type": "string",
-        "description": "path to save video file",
-        "required": true
+        "description": "The path to the remote location, where the resulting video should be uploaded. The following protocols are supported http/https, ftp. This option only has an effect if there is screen recording process in progreess and forceRestart parameter is not set to true. Null or empty string value (the default setting) means the content of resulting file should be encoded as Base64.",
+        "required": false
       }, {
-        "name": "videoSize",
-        "type": "number",
-        "description": "max amount of bytes the video file should get",
-        "required": true
+        "name": "username",
+        "type": "string",
+        "description": "The name of the user for the remote authentication.",
+        "required": false
+      }, {
+        "name": "password",
+        "type": "string",
+        "description": "The password for the remote authentication.",
+        "required": false
+      }, {
+        "name": "method",
+        "type": "string",
+        "description": "The http multipart upload method name. The 'PUT' one is used by default.",
+        "required": false
+      }, {
+        "name": "forceRestart",
+        "type": "boolean",
+        "description": "Whether to try to catch and upload/return the currently running screen recording (false, the default setting on server) or ignore the result of it and start a new recording immediately (true).",
+        "required": false
       }, {
         "name": "timeLimit",
-        "type": "number",
+        "type": "string",
         "description": "max time length of video",
-        "required": true
+        "required": false
+      }, {
+        "name": "videoType",
+        "type": "string",
+        "description": "(iOS Only) The format of the screen capture to be recorded. Available formats h264, mp4 or fmp4. Default is mp4. Only works for Simulator.",
+        "required": false
+      }, {
+        "name": "videoQuality",
+        "type": "string",
+        "description": "(iOS Only) The video encoding quality (low, medium, high, photo - defaults to medium).",
+        "required": false
+      }, {
+        "name": "videoFps",
+        "type": "string",
+        "description": "(iOS Only) The Frames Per Second rate of the recorded video. Change this value if the resulting video is too slow or too fast. Defaults to 10. This can decrease the resulting file size.",
+        "required": false
       }, {
         "name": "bitRate",
-        "type": "number",
-        "description": "bit rate of video",
-        "required": true
+        "type": "string",
+        "description": "(iOS Only) The video bit rate for the video, in megabits per second. 4 Mbp/s(4000000) is by default for Android API level below 27. 20 Mb/s(20000000) for API level 27 and above.",
+        "required": false
+      }, {
+        "name": "videoSize",
+        "type": "string",
+        "description": "(Android Only) The format is widthxheight. The default value is the device's native display resolution (if supported), 1280x720 if not. For best results, use a size supported by your device's Advanced Video Coding (AVC) encoder. For example, 1280x720",
+        "required": false
+      }, {
+        "name": "bugReport",
+        "type": "string",
+        "description": "(Android Only) Set it to true in order to display additional information on the video overlay, such as a timestamp, that is helpful in videos captured to illustrate bugs. This option is only supported since API level 27 (Android O).",
+        "required": false
       }],
       "support": {
         "ios": {
@@ -109,7 +149,32 @@
       "command": "stopRecordingScreen",
       "description": "Stop recording screen",
       "ref": "http://appium.io/docs/en/commands/device/recording-screen/stop-recording-screen/",
-      "parameters": [],
+      "parameters": [{
+        "name": "remotePath",
+        "type": "string",
+        "description": "The path to the remote location, where the resulting video should be uploaded. The following protocols are supported http/https, ftp. This option only has an effect if there is screen recording process in progreess and forceRestart parameter is not set to true. Null or empty string value (the default setting) means the content of resulting file should be encoded as Base64.",
+        "required": false
+      }, {
+        "name": "username",
+        "type": "string",
+        "description": "The name of the user for the remote authentication.",
+        "required": false
+      }, {
+        "name": "password",
+        "type": "string",
+        "description": "The password for the remote authentication.",
+        "required": false
+      }, {
+        "name": "method",
+        "type": "string",
+        "description": "The http multipart upload method name. The 'PUT' one is used by default.",
+        "required": false
+      }],
+      "returns": {
+        "type": "string",
+        "name": "response",
+        "description": "Base64 encoded string. If remote_path is set, the response is empty string"
+      },
       "support": {
         "ios": {
           "XCUITest": "9.3+"

--- a/packages/webdriverio/src/commands/browser/saveRecordingScreen.js
+++ b/packages/webdriverio/src/commands/browser/saveRecordingScreen.js
@@ -1,0 +1,42 @@
+/**
+ *
+ * Appium only. Save a video started by startRecordingScreen command to file.
+ * See [Appium docs](http://appium.io/docs/en/commands/device/recording-screen/start-recording-screen/)
+ *
+ * <example>
+    :saveRecordingScreen.js
+    it('should save a video', () => {
+        browser.startRecordingScreen();
+        $('~BUTTON').click();
+        browser.saveRecordingScreen('./some/path/video.mp4');
+    });
+ * </example>
+ *
+ * @alias browser.saveRecordingScreen
+ * @param   {String}  filepath  full or relative to the execution directory path to the generated video
+ * @return  {Buffer}            video buffer
+ * @type utility
+ *
+ */
+
+import fs from 'fs'
+import { Buffer } from 'safe-buffer'
+import { getAbsoluteFilepath, assertDirectoryExists } from '../../utils'
+
+export default async function saveRecordingScreen (filepath) {
+    /**
+     * type check
+     */
+    if (typeof filepath !== 'string') {
+        throw new Error('saveRecordingScreen expects a filepath')
+    }
+
+    const absoluteFilepath = getAbsoluteFilepath(filepath)
+    assertDirectoryExists(absoluteFilepath)
+
+    const videoBuffer = await this.stopRecordingScreen()
+    const video = new Buffer(videoBuffer, 'base64')
+    fs.writeFileSync(absoluteFilepath, video)
+
+    return video
+}

--- a/packages/webdriverio/src/commands/browser/saveScreenshot.js
+++ b/packages/webdriverio/src/commands/browser/saveScreenshot.js
@@ -19,8 +19,8 @@
  */
 
 import fs from 'fs'
-import path from 'path'
 import { Buffer } from 'safe-buffer'
+import { getAbsoluteFilepath, assertDirectoryExists } from '../../utils'
 
 export default async function saveScreenshot (filepath) {
     /**
@@ -30,16 +30,8 @@ export default async function saveScreenshot (filepath) {
         throw new Error('saveScreenshot expects a filepath of type string and ".png" file ending')
     }
 
-    const absoluteFilepath = filepath.startsWith('/') || filepath.startsWith('\\') || filepath.match(/^[a-zA-Z]:\\/)
-        ? filepath
-        : path.join(process.cwd(), filepath)
-
-    /**
-     * check if directory exists
-     */
-    if (!fs.existsSync(path.dirname(absoluteFilepath))) {
-        throw new Error(`directory (${path.dirname(absoluteFilepath)}) doesn't exist`)
-    }
+    const absoluteFilepath = getAbsoluteFilepath(filepath)
+    assertDirectoryExists(absoluteFilepath)
 
     const screenBuffer = await this.takeScreenshot()
     const screenshot = new Buffer(screenBuffer, 'base64')

--- a/packages/webdriverio/src/commands/element/saveScreenshot.js
+++ b/packages/webdriverio/src/commands/element/saveScreenshot.js
@@ -18,8 +18,8 @@
  */
 
 import fs from 'fs'
-import path from 'path'
 import { Buffer } from 'safe-buffer'
+import { getAbsoluteFilepath, assertDirectoryExists } from '../../utils'
 
 export default async function saveScreenshot (filepath) {
     /**
@@ -29,16 +29,8 @@ export default async function saveScreenshot (filepath) {
         throw new Error('saveScreenshot expects a filepath of type string and ".png" file ending')
     }
 
-    const absoluteFilepath = filepath.startsWith('/')
-        ? filepath
-        : path.join(process.cwd(), filepath)
-
-    /**
-     * check if directory exists
-     */
-    if (!fs.existsSync(path.dirname(absoluteFilepath))) {
-        throw new Error(`directory (${path.dirname(absoluteFilepath)}) doesn't exist`)
-    }
+    const absoluteFilepath = getAbsoluteFilepath(filepath)
+    assertDirectoryExists(absoluteFilepath)
 
     const screenBuffer = await this.takeElementScreenshot(this.elementId)
     const screenshot = new Buffer(screenBuffer, 'base64')

--- a/packages/webdriverio/src/utils.js
+++ b/packages/webdriverio/src/utils.js
@@ -440,3 +440,18 @@ export async function getElementRect(scope) {
 
     return rect
 }
+
+export function getAbsoluteFilepath(filepath) {
+    return filepath.startsWith('/') || filepath.startsWith('\\') || filepath.match(/^[a-zA-Z]:\\/)
+        ? filepath
+        : path.join(process.cwd(), filepath)
+}
+
+/**
+ * check if directory exists
+ */
+export function assertDirectoryExists(filepath) {
+    if (!fs.existsSync(path.dirname(filepath))) {
+        throw new Error(`directory (${path.dirname(filepath)}) doesn't exist`)
+    }
+}

--- a/packages/webdriverio/tests/__mocks__/request.js
+++ b/packages/webdriverio/tests/__mocks__/request.js
@@ -142,6 +142,7 @@ const requestMock = jest.fn().mockImplementation((params, cb) => {
         value = 'WebdriverIO · Next-gen WebDriver test framework for Node.js'
         break
     case `/wd/hub/session/${sessionId}/screenshot`:
+    case `/wd/hub/session/${sessionId}/appium/stop_recording_screen`:
         value = Buffer.from('some screenshot').toString('base64')
         break
     case `/wd/hub/session/${sessionId}/element/${genericElementId}/screenshot`:

--- a/packages/webdriverio/tests/utils.test.js
+++ b/packages/webdriverio/tests/utils.test.js
@@ -1,3 +1,4 @@
+import path from 'path'
 import { ELEMENT_KEY } from '../src/constants'
 import {
     findStrategy,
@@ -9,7 +10,9 @@ import {
     findElement,
     findElements,
     verifyArgsAndStripIfElement,
-    getElementRect
+    getElementRect,
+    getAbsoluteFilepath,
+    assertDirectoryExists
 } from '../src/utils'
 
 describe('utils', () => {
@@ -677,7 +680,7 @@ describe('utils', () => {
         })
 
         it('strips down properties if value is element object', () => {
-            const fakeObj = new Element({ 
+            const fakeObj = new Element({
                 elementId: 'foo-bar',
                 someProp: 123,
                 anotherProp: 'abc'
@@ -691,7 +694,7 @@ describe('utils', () => {
         })
 
         it('should work even if parameter is not of type Array', () => {
-            const fakeObj = new Element({ 
+            const fakeObj = new Element({
                 elementId: 'foo-bar',
                 someProp: 123,
                 anotherProp: 'abc'
@@ -724,6 +727,37 @@ describe('utils', () => {
             expect(await getElementRect(fakeScope)).toEqual({x: 10, y: 22, width: 300, height: 400})
             expect(fakeScope.getElementRect).toHaveBeenCalled()
             expect(fakeScope.execute).toHaveBeenCalled()
+        })
+    })
+
+    describe('getAbsoluteFilepath', () => {
+        it('should not change filepath if starts with forward slash', () => {
+            const filepath = '/packages/bar.png'
+            expect(getAbsoluteFilepath(filepath)).toEqual(filepath)
+        })
+
+        it('should not change filepath if starts with backslash slash', () => {
+            const filepath = '\\packages\\bar.png'
+            expect(getAbsoluteFilepath(filepath)).toEqual(filepath)
+        })
+
+        it('should not change filepath if starts with windows drive letter', async () => {
+            const filepath = 'E:\\foo\\bar.png'
+            expect(getAbsoluteFilepath(filepath)).toEqual(filepath)
+        })
+
+        it('should change filepath if does not start with forward or back slash', async () => {
+            const filepath = 'packages/bar.png'
+            expect(getAbsoluteFilepath(filepath)).toEqual(path.join(process.cwd(), 'packages/bar.png'))
+        })
+    })
+
+    describe('assertDirectoryExists', () => {
+        it('should fail if not existing directory', () => {
+            expect(() => assertDirectoryExists('/i/dont/exist.png')).toThrowError(new Error('directory (/i/dont) doesn\'t exist'))
+        })
+        it('should not fail if directory exists', () => {
+            expect(() => assertDirectoryExists('.')).not.toThrow()
         })
     })
 })


### PR DESCRIPTION
## Proposed changes

fix for #3537

- fixed Appium start / stop screen recording protocol commands 
- added saveRecordingScreen command similar to saveScreenshot
- moved getAbsoluteFilepath and assertDirectoryExists to utils to reuse them later on in all 3 files. Updated save screenshot tests accordingly

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

typings should be generated for webdriver and webdriverio packages

### Reviewers: @webdriverio/technical-committee
