### PR TITLE
Add smoke test for custom reporters

### DIFF
--- a/docs/CustomReporter.md
+++ b/docs/CustomReporter.md
@@ -78,3 +78,16 @@ export default class CustomReporter extends WDIOReporter {
 ```
 
 Note that you can't defer the test execution in any way. All event handler should execute synchronous routines otherwise you will run into race conditions. Make sure you check out the [example section](https://github.com/webdriverio/webdriverio/tree/master/examples/wdio) where you can find an example for a custom reporter that prints the event name for each event. If you have implemented a custom reporter that can be useful for the community, don't hesitate to make a Pull Request so we can make the reporter available for the public.
+
+Also if you run the wdio testrunner via the launcher interface you can't apply a custom reporter as function as follows:
+
+```js
+import Launcher from '@wdio/cli';
+
+import CustomReporter from './reporter/my.custom.reporter';
+
+const launcher = new Launcher('/path/to/config.file.js', {
+    // this will NOT work because CustomReporter is not serializable
+    reporters: ['dot', CustomReporter]
+})
+```

--- a/packages/wdio-runner/src/reporter.js
+++ b/packages/wdio-runner/src/reporter.js
@@ -127,7 +127,7 @@ export default class BaseReporter {
          * check if reporter has custom options
          */
         if (Array.isArray(reporter)) {
-            options = Object.assign(options, reporter[1])
+            options = Object.assign({}, options, reporter[1])
             reporter = reporter[0]
         }
 

--- a/packages/wdio-smoke-test-reporter/.npmignore
+++ b/packages/wdio-smoke-test-reporter/.npmignore
@@ -1,0 +1,2 @@
+src
+tests

--- a/packages/wdio-smoke-test-reporter/.npmrc
+++ b/packages/wdio-smoke-test-reporter/.npmrc
@@ -1,0 +1,1 @@
+message = "wdio-smoke-test-reporter: bump version %s"

--- a/packages/wdio-smoke-test-reporter/README.md
+++ b/packages/wdio-smoke-test-reporter/README.md
@@ -1,2 +1,6 @@
-WebdriverIO SMOKE-TEST Reporter
-========================
+WebdriverIO Smoke-Test Reporter
+===============================
+
+> A WebdriverIO utility to smoke test reporters for internal testing purposes.
+
+__Note:__ This reporter is for internal use only and not recommended to use in production test suites. It is used by the WebbdriverIO project for testing purposes.

--- a/packages/wdio-smoke-test-reporter/README.md
+++ b/packages/wdio-smoke-test-reporter/README.md
@@ -1,0 +1,2 @@
+WebdriverIO SMOKE-TEST Reporter
+========================

--- a/packages/wdio-smoke-test-reporter/package.json
+++ b/packages/wdio-smoke-test-reporter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wdio/smoke-test-reporter",
   "version": "0.0.0",
-  "description": "A WebdriverIO reporter that <provide reporter description>",
+  "description": "A WebdriverIO utility to smoke test reporters for internal testing purposes.",
   "author": "Christian Bromann <christian@saucelabs.com>",
   "homepage": "https://github.com/webdriverio/webdriverio/tree/master/packages/wdio-smoke-test-reporter",
   "license": "MIT",

--- a/packages/wdio-smoke-test-reporter/package.json
+++ b/packages/wdio-smoke-test-reporter/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@wdio/smoke-test-reporter",
+  "version": "0.0.0",
+  "description": "A WebdriverIO reporter that <provide reporter description>",
+  "author": "Christian Bromann <christian@saucelabs.com>",
+  "homepage": "https://github.com/webdriverio/webdriverio/tree/master/packages/wdio-smoke-test-reporter",
+  "license": "MIT",
+  "main": "./build/index",
+  "engines": {
+    "node": ">= 4.8.5"
+  },
+  "scripts": {
+    "build": "run-s clean compile",
+    "clean": "rimraf ./build",
+    "compile": "babel src/ -d build/ --config-file ../../babel.config.js",
+    "test": "run-s test:*",
+    "test:eslint": "eslint src test",
+    "test:unit": "jest"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/webdriverio/webdriverio.git"
+  },
+  "bugs": {
+    "url": "https://github.com/webdriverio/webdriverio/issues"
+  },
+  "dependencies": {
+    "@wdio/reporter": "^5.6.4"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/wdio-smoke-test-reporter/src/index.js
+++ b/packages/wdio-smoke-test-reporter/src/index.js
@@ -1,0 +1,46 @@
+import WDIOReporter from '@wdio/reporter'
+
+export default class CustomSmokeTestReporter extends WDIOReporter {
+    onRunnerStart () {
+        this.write('onRunnerStart\n')
+    }
+    onBeforeCommand () {
+        this.write('onBeforeCommand\n')
+    }
+    onAfterCommand () {
+        this.write('onAfterCommand\n')
+    }
+    onScreenshot () {
+        this.write('onScreenshot\n')
+    }
+    onSuiteStart () {
+        this.write('onSuiteStart\n')
+    }
+    onHookStart () {
+        this.write('onHookStart\n')
+    }
+    onHookEnd () {
+        this.write('onHookEnd\n')
+    }
+    onTestStart () {
+        this.write('onTestStart\n')
+    }
+    onTestPass () {
+        this.write('onTestPass\n')
+    }
+    onTestFail () {
+        this.write('onTestFail\n')
+    }
+    onTestSkip () {
+        this.write('onTestSkip\n')
+    }
+    onTestEnd () {
+        this.write('onTestEnd\n')
+    }
+    onSuiteEnd () {
+        this.write('onSuiteEnd\n')
+    }
+    onRunnerEnd () {
+        this.write('onRunnerEnd\n')
+    }
+}

--- a/packages/webdriverio/src/constants.js
+++ b/packages/webdriverio/src/constants.js
@@ -68,7 +68,7 @@ export const WDIO_DEFAULTS = {
                 if (typeof param === 'object') {
                     return true
                 }
-                
+
                 throw new Error('the "capabilities" options needs to be an object or a list of objects')
             }
 
@@ -79,10 +79,10 @@ export const WDIO_DEFAULTS = {
                 if (typeof option === 'object') { // Check does not work recursively
                     continue
                 }
-    
+
                 throw new Error('expected every item of a list of capabilities to be of type object')
             }
-    
+
             return true
         },
         required: true
@@ -141,14 +141,19 @@ export const WDIO_DEFAULTS = {
                 throw new Error('the "reporters" options needs to be a list of strings')
             }
 
+            const isValidReporter = (option) => (
+                (typeof option === 'string') ||
+                (typeof option === 'function')
+            )
+
             /**
              * array elements must be:
              */
             for (const option of param) {
                 /**
-                 * either a string
+                 * either a string or a function (custom reporter)
                  */
-                if (typeof option === 'string') {
+                if (isValidReporter(option)) {
                     continue
                 }
 
@@ -159,10 +164,7 @@ export const WDIO_DEFAULTS = {
                 if (
                     Array.isArray(option) &&
                     typeof option[1] === 'object' &&
-                    (
-                        (typeof option[0] === 'string') ||
-                        (typeof option[0] === 'function')
-                    )
+                    isValidReporter(option[0])
                 ) {
                     continue
                 }
@@ -193,14 +195,14 @@ export const WDIO_DEFAULTS = {
              * with arrays and/or strings
              */
             for (const option of param) {
-                if (!Array.isArray(option)) {         
+                if (!Array.isArray(option)) {
                     if (typeof option === 'string') {
                         continue
                     }
                     throw new Error('the "services" options needs to be a list of strings and/or arrays')
                 }
             }
-    
+
             return true
         },
         default: []

--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -16,5 +16,17 @@ const PROTOCOL_NAMES = {
 }
 const MOBILE_PROTOCOLS = ['appium', 'mjsonwp']
 const VENDOR_PROTOCOLS = ['chromium']
+const IGNORED_SUBPACKAGES_FOR_DOCS = [
+    'eslint-plugin-wdio',
+    'wdio-smoke-test-service',
+    'wdio-smoke-test-reporter',
+    'wdio-webdriver-mock-service'
+]
 
-module.exports = { PROTOCOLS, PROTOCOL_NAMES, MOBILE_PROTOCOLS, VENDOR_PROTOCOLS }
+module.exports = {
+    PROTOCOLS,
+    PROTOCOL_NAMES,
+    MOBILE_PROTOCOLS,
+    VENDOR_PROTOCOLS,
+    IGNORED_SUBPACKAGES_FOR_DOCS
+}

--- a/scripts/utils/helpers.js
+++ b/scripts/utils/helpers.js
@@ -1,6 +1,8 @@
 const shell = require('shelljs')
 const path = require('path')
 
+const { IGNORED_SUBPACKAGES_FOR_DOCS } = require('../constants')
+
 const getSubPackages = () => shell.ls(path.join(__dirname, '..', '..', 'packages')).filter((pkg) => (
     /**
      * ignore node_modules directory that is created by the link script to test the
@@ -10,7 +12,7 @@ const getSubPackages = () => shell.ls(path.join(__dirname, '..', '..', 'packages
     /**
      * ignore packages that don't need to be compiled
      */
-    !['eslint-plugin-wdio', 'wdio-smoke-test-service', 'wdio-webdriver-mock-service'].includes(pkg)
+    !IGNORED_SUBPACKAGES_FOR_DOCS.includes(pkg)
 ))
 
 module.exports = { getSubPackages }

--- a/tests/helpers/fixtures.js
+++ b/tests/helpers/fixtures.js
@@ -15,3 +15,24 @@ afterSession called
 export const LAUNCHER_LOGS = `onPrepare called
 onComplete called
 `
+
+export const REPORTER_LOGS = `onRunnerStart
+onHookStart
+onHookEnd
+onSuiteStart
+onTestStart
+onHookStart
+onHookEnd
+onBeforeCommand
+onAfterCommand
+onTestPass
+onTestEnd
+onHookStart
+onHookEnd
+onSuiteEnd
+onHookStart
+onHookEnd
+onBeforeCommand
+onAfterCommand
+onRunnerEnd
+`

--- a/tests/helpers/reporter.conf.js
+++ b/tests/helpers/reporter.conf.js
@@ -1,0 +1,9 @@
+const path = require('path')
+
+const { config } = require('./config')
+const reporter = require('../../packages/wdio-smoke-test-reporter')
+
+exports.config = Object.assign({}, config, {
+    reporters: ['spec', reporter.default],
+    specs: [path.resolve(__dirname, '..', 'mocha', 'reporter.js')],
+})

--- a/tests/mocha/reporter.js
+++ b/tests/mocha/reporter.js
@@ -1,0 +1,7 @@
+import assert from 'assert'
+
+describe('my feature', () => {
+    it('should do stuff', () => {
+        assert.equal(browser.getTitle(), 'Mock Page Title')
+    })
+})

--- a/tests/smoke.runner.js
+++ b/tests/smoke.runner.js
@@ -3,7 +3,7 @@ import path from 'path'
 import assert from 'assert'
 
 import launch from './helpers/launch'
-import { SERVICE_LOGS, LAUNCHER_LOGS } from './helpers/fixtures'
+import { SERVICE_LOGS, LAUNCHER_LOGS, REPORTER_LOGS } from './helpers/fixtures'
 
 (async () => {
     /**
@@ -13,6 +13,9 @@ import { SERVICE_LOGS, LAUNCHER_LOGS } from './helpers/fixtures'
         path.resolve(__dirname, 'helpers', 'config.js'),
         { specs: [path.resolve(__dirname, 'mocha', 'test.js')] })
 
+    /**
+     * wdio test run with custom service
+     */
     await launch(
         path.resolve(__dirname, 'helpers', 'config.js'),
         {
@@ -23,6 +26,29 @@ import { SERVICE_LOGS, LAUNCHER_LOGS } from './helpers/fixtures'
     assert.equal(serviceLogs, SERVICE_LOGS)
     const launcherLogs = fs.readFileSync(path.join(__dirname, 'helpers', 'launcher.log'))
     assert.equal(launcherLogs, LAUNCHER_LOGS)
+
+    /**
+     * wdio test run with custom reporter as string
+     */
+    await launch(
+        path.resolve(__dirname, 'helpers', 'config.js'),
+        {
+            specs: [path.resolve(__dirname, 'mocha', 'reporter.js')],
+            reporters: [['smoke-test', { foo: 'bar' }]]
+        })
+    const reporterLogsPath = path.join(__dirname, 'helpers', 'wdio-0-0-smoke-test-reporter.log')
+    const reporterLogs = fs.readFileSync(reporterLogsPath)
+    assert.equal(reporterLogs, REPORTER_LOGS)
+    fs.unlinkSync(reporterLogsPath)
+
+    /**
+     * wdio test run with custom reporter as object
+     */
+    await launch(path.resolve(__dirname, 'helpers', 'reporter.conf.js'), {})
+    const reporterLogsWithReporterAsObjectPath = path.join(__dirname, 'helpers', 'wdio-0-0-CustomSmokeTestReporter-reporter.log')
+    const reporterLogsWithReporterAsObject = fs.readFileSync(reporterLogsWithReporterAsObjectPath)
+    assert.equal(reporterLogsWithReporterAsObject, REPORTER_LOGS)
+    fs.unlinkSync(reporterLogsWithReporterAsObjectPath)
 
     /**
      * multiremote wdio testrunner tests


### PR DESCRIPTION
## Proposed changes

Someone on Gitter pointed out that it was not possible to set a custom reporter as follows:

```js
reporters: ['spec', [MyCustomReporter]],
```

however it was working when doing

```js
reporters: ['spec', [MyCustomReporter, {}]],
```

This patch fixes that issue and adds a smoke test so we can ensure that custom reporter work.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
