### PR TITLE
 browserstack-service: fixes #3648 modifying name and reason

### DIFF
--- a/packages/wdio-browserstack-service/src/service.js
+++ b/packages/wdio-browserstack-service/src/service.js
@@ -9,8 +9,6 @@ export default class BrowserstackService {
     constructor (config) {
         this.config = config
         this.failures = 0
-        this.fullTitle
-        this.failReason
     }
 
     before() {
@@ -89,7 +87,7 @@ export default class BrowserstackService {
         return {
             status: this.failures === 0 ? 'completed' : 'error',
             name: this.fullTitle,
-            reason: this.failReason || ''
+            reason: this.failReason
         }
     }
 

--- a/packages/wdio-browserstack-service/src/service.js
+++ b/packages/wdio-browserstack-service/src/service.js
@@ -88,7 +88,7 @@ export default class BrowserstackService {
     _getBody() {
         return {
             status: this.failures === 0 ? 'completed' : 'error',
-            name: this.name,
+            name: this.fullTitle,
             reason: this.failReason
         }
     }

--- a/packages/wdio-browserstack-service/src/service.js
+++ b/packages/wdio-browserstack-service/src/service.js
@@ -33,7 +33,7 @@ export default class BrowserstackService {
 
         if (!test.passed) {
             this.failures++
-            this.failReason = test.error.message
+            this.failReason = (test.error.message === undefined ? 'Error' : test.error.message)
         }
     }
 

--- a/packages/wdio-browserstack-service/src/service.js
+++ b/packages/wdio-browserstack-service/src/service.js
@@ -33,7 +33,7 @@ export default class BrowserstackService {
 
         if (!test.passed) {
             this.failures++
-            this.failReason = (test.error.message === undefined ? 'Error' : test.error.message)
+            this.failReason = (test.error && test.error.message ? test.error.message : 'Unknown Error')
         }
     }
 

--- a/packages/wdio-browserstack-service/src/service.js
+++ b/packages/wdio-browserstack-service/src/service.js
@@ -9,6 +9,8 @@ export default class BrowserstackService {
     constructor (config) {
         this.config = config
         this.failures = 0
+        this.fullTitle = ''
+        this.failReason = ''
     }
 
     before() {
@@ -27,8 +29,11 @@ export default class BrowserstackService {
     }
 
     afterTest(test) {
+        this.fullTitle = test.parent + ' - ' + test.title
+
         if (!test.passed) {
             this.failures++
+            this.failReason = test.error.message
         }
     }
 
@@ -59,6 +64,8 @@ export default class BrowserstackService {
         this.sessionId = newSessionId
         await this._update(oldSessionId, this._getBody())
         this.failures = 0
+        this.fullTitle = ''
+        this.failReason = ''
         this._printSessionURL()
     }
 
@@ -80,7 +87,9 @@ export default class BrowserstackService {
 
     _getBody() {
         return {
-            status: this.failures === 0 ? 'completed' : 'error'
+            status: this.failures === 0 ? 'completed' : 'error',
+            name: this.name,
+            reason: this.failReason
         }
     }
 

--- a/packages/wdio-browserstack-service/src/service.js
+++ b/packages/wdio-browserstack-service/src/service.js
@@ -9,8 +9,8 @@ export default class BrowserstackService {
     constructor (config) {
         this.config = config
         this.failures = 0
-        this.fullTitle = ''
-        this.failReason = ''
+        this.fullTitle
+        this.failReason
     }
 
     before() {
@@ -64,8 +64,8 @@ export default class BrowserstackService {
         this.sessionId = newSessionId
         await this._update(oldSessionId, this._getBody())
         this.failures = 0
-        this.fullTitle = ''
-        this.failReason = ''
+        delete this.fullTitle
+        delete this.failReason
         this._printSessionURL()
     }
 
@@ -89,7 +89,7 @@ export default class BrowserstackService {
         return {
             status: this.failures === 0 ? 'completed' : 'error',
             name: this.fullTitle,
-            reason: this.failReason
+            reason: this.failReason || ''
         }
     }
 

--- a/packages/wdio-browserstack-service/tests/service.test.js
+++ b/packages/wdio-browserstack-service/tests/service.test.js
@@ -202,22 +202,6 @@ describe('afterTest', () => {
         expect(service.failures).toBe(0)
         expect(service.fullTitle).toBe('foo - bar')
     })
-
-    it('should contain or not reason value on pases or fails', () => {
-        service.failures = 0
-        service.fullTitle = ''
-        service.failReason = ''
-
-        service.afterTest({ passed: true, parent: 'foo', title: 'bar' })
-        expect(service.failReason).toBe('')
-
-        service.failures = 0
-        service.fullTitle = ''
-        service.failReason = ''
-        
-        service.afterTest({ passed: false, parent: 'foo', title: 'bar', error: {message: 'error message'} })
-        expect(service.failReason).toBe('error message')
-    })
 })
 
 describe('afterStep', () => {

--- a/packages/wdio-browserstack-service/tests/service.test.js
+++ b/packages/wdio-browserstack-service/tests/service.test.js
@@ -189,6 +189,8 @@ describe('afterTest', () => {
 
         service.afterTest({ passed: false, parent: 'foo', title: 'bar', error: {message: 'error message'}  })
         expect(service.failures).toBe(1)
+        expect(service.fullTitle).toBe('foo - bar')
+        expect(service.failReason).toBe('error message')
     })
 
     it('should not increment failures on passes', () => {
@@ -196,8 +198,9 @@ describe('afterTest', () => {
         service.fullTitle = ''
         service.failReason = ''
 
-        service.afterTest({ passed: true, parent: 'foo', title: 'bar', error: {message: 'error message'} })
+        service.afterTest({ passed: true, parent: 'foo', title: 'bar' })
         expect(service.failures).toBe(0)
+        expect(service.fullTitle).toBe('foo - bar')
     })
 
     it('should not increment failures on passes', () => {
@@ -205,7 +208,7 @@ describe('afterTest', () => {
         service.fullTitle = ''
         service.failReason = ''
 
-        service.afterTest({ passed: true, parent: 'foo', title: 'bar', error: {message: 'error message'} })
+        service.afterTest({ passed: true, parent: 'foo', title: 'bar' })
         expect(service.failures).toBe(0)
     })
 
@@ -214,29 +217,18 @@ describe('afterTest', () => {
         service.fullTitle = ''
         service.failReason = ''
 
-        service.afterTest({ passed: true, parent: 'foo', title: 'bar', error: {message: 'error message'} })
+        service.afterTest({ passed: true, parent: 'foo', title: 'bar' })
         expect(service.fullTitle).toBe('foo - bar')
     })
 
-    it('should add test name parameter on fails', () => {
+    it('should contain or not reason value on pases or fails', () => {
         service.failures = 0
         service.fullTitle = ''
         service.failReason = ''
 
-        service.afterTest({ passed: false, parent: 'foo', title: 'bar', error: {message: 'error message'} })
-        expect(service.fullTitle).toBe('foo - bar')
-    })
-
-    it('should not contain reason value on pases', () => {
-        service.failures = 0
-        service.fullTitle = ''
-        service.failReason = ''
-
-        service.afterTest({ passed: true, parent: 'foo', title: 'bar', error: {message: 'error message'} })
+        service.afterTest({ passed: true, parent: 'foo', title: 'bar' })
         expect(service.failReason).toBe('')
-    })
 
-    it('should contain reason value on pases', () => {
         service.failures = 0
         service.fullTitle = ''
         service.failReason = ''

--- a/packages/wdio-browserstack-service/tests/service.test.js
+++ b/packages/wdio-browserstack-service/tests/service.test.js
@@ -208,6 +208,42 @@ describe('afterTest', () => {
         service.afterTest({ passed: true, parent: 'foo', title: 'bar', error: {message: 'error message'} })
         expect(service.failures).toBe(0)
     })
+
+    it('should add test name parameter on pases', () => {
+        service.failures = 0
+        service.fullTitle = ''
+        service.failReason = ''
+
+        service.afterTest({ passed: true, parent: 'foo', title: 'bar', error: {message: 'error message'} })
+        expect(service.fullTitle).toBe('foo - bar')
+    })
+
+    it('should add test name parameter on fails', () => {
+        service.failures = 0
+        service.fullTitle = ''
+        service.failReason = ''
+
+        service.afterTest({ passed: false, parent: 'foo', title: 'bar', error: {message: 'error message'} })
+        expect(service.fullTitle).toBe('foo - bar')
+    })
+
+    it('should not contain reason value on pases', () => {
+        service.failures = 0
+        service.fullTitle = ''
+        service.failReason = ''
+
+        service.afterTest({ passed: true, parent: 'foo', title: 'bar', error: {message: 'error message'} })
+        expect(service.failReason).toBe('')
+    })
+
+    it('should contain reason value on pases', () => {
+        service.failures = 0
+        service.fullTitle = ''
+        service.failReason = ''
+        
+        service.afterTest({ passed: false, parent: 'foo', title: 'bar', error: {message: 'error message'} })
+        expect(service.failReason).toBe('error message')
+    })
 })
 
 describe('afterStep', () => {

--- a/packages/wdio-browserstack-service/tests/service.test.js
+++ b/packages/wdio-browserstack-service/tests/service.test.js
@@ -203,24 +203,6 @@ describe('afterTest', () => {
         expect(service.fullTitle).toBe('foo - bar')
     })
 
-    it('should not increment failures on passes', () => {
-        service.failures = 0
-        service.fullTitle = ''
-        service.failReason = ''
-
-        service.afterTest({ passed: true, parent: 'foo', title: 'bar' })
-        expect(service.failures).toBe(0)
-    })
-
-    it('should add test name parameter on pases', () => {
-        service.failures = 0
-        service.fullTitle = ''
-        service.failReason = ''
-
-        service.afterTest({ passed: true, parent: 'foo', title: 'bar' })
-        expect(service.fullTitle).toBe('foo - bar')
-    })
-
     it('should contain or not reason value on pases or fails', () => {
         service.failures = 0
         service.fullTitle = ''
@@ -270,15 +252,15 @@ describe('_getBody', () => {
     it('should return "error" if failures', () => {
         service.failures = 1
         service.failReason = 'error message'
-        service.fullTitle = 'foo bar',
+        service.fullTitle = 'foo - bar',
         
-        expect(service._getBody()).toEqual({ status: 'error', reason: 'error message', name: 'foo bar' })
+        expect(service._getBody()).toEqual({ status: 'error', reason: 'error message', name: 'foo - bar' })
     })
 
     it('should return "completed" if no errors', () => {
         service.failures = 0
-        service.fullTitle = 'foo bar'
+        service.fullTitle = 'foo - bar'
 
-        expect(service._getBody()).toEqual({ status: 'completed', name: 'foo bar', reason: '' })
+        expect(service._getBody()).toEqual({ status: 'completed', name: 'foo - bar', reason: '' })
     })
 })

--- a/packages/wdio-browserstack-service/tests/service.test.js
+++ b/packages/wdio-browserstack-service/tests/service.test.js
@@ -270,14 +270,14 @@ describe('_getBody', () => {
     it('should return "error" if failures', () => {
         service.failures = 1
         service.failReason = 'error message'
-        service.name = 'foo bar',
+        service.fullTitle = 'foo bar',
         
         expect(service._getBody()).toEqual({ status: 'error', reason: 'error message', name: 'foo bar' })
     })
 
     it('should return "completed" if no errors', () => {
         service.failures = 0
-        service.name = 'foo bar'
+        service.fullTitle = 'foo bar'
 
         expect(service._getBody()).toEqual({ status: 'completed', name: 'foo bar', reason: '' })
     })

--- a/packages/wdio-browserstack-service/tests/service.test.js
+++ b/packages/wdio-browserstack-service/tests/service.test.js
@@ -185,8 +185,15 @@ describe('afterTest', () => {
     it('should increment failures on fails', () => {
         service.failures = 0
 
-        service.afterTest({ passed: false })
+        service.afterTest({ passed: false, parent: 'foo', title: 'bar', error: {message: 'error message'}  })
         expect(service.failures).toBe(1)
+    })
+
+    it('should not increment failures on passes', () => {
+        service.failures = 0
+
+        service.afterTest({ passed: true })
+        expect(service.failures).toBe(0)
     })
 
     it('should not increment failures on passes', () => {
@@ -228,11 +235,16 @@ describe('after', () => {
 describe('_getBody', () => {
     it('should return "error" if failures', () => {
         service.failures = 1
-        expect(service._getBody()).toEqual({ status: 'error' })
+        service.failReason = 'error message'
+        service.name = 'foo bar',
+        
+        expect(service._getBody()).toEqual({ status: 'error', reason: 'error message', name: 'foo bar' })
     })
 
     it('should return "completed" if no errors', () => {
         service.failures = 0
-        expect(service._getBody()).toEqual({ status: 'completed' })
+        service.name = 'foo bar'
+
+        expect(service._getBody()).toEqual({ status: 'completed', name: 'foo bar', reason: '' })
     })
 })

--- a/packages/wdio-browserstack-service/tests/service.test.js
+++ b/packages/wdio-browserstack-service/tests/service.test.js
@@ -245,6 +245,6 @@ describe('_getBody', () => {
         service.failures = 0
         service.fullTitle = 'foo - bar'
 
-        expect(service._getBody()).toEqual({ status: 'completed', name: 'foo - bar', reason: '' })
+        expect(service._getBody()).toEqual({ status: 'completed', name: 'foo - bar', reason: undefined })
     })
 })

--- a/packages/wdio-browserstack-service/tests/service.test.js
+++ b/packages/wdio-browserstack-service/tests/service.test.js
@@ -192,14 +192,14 @@ describe('afterTest', () => {
     it('should not increment failures on passes', () => {
         service.failures = 0
 
-        service.afterTest({ passed: true })
+        service.afterTest({ passed: true, parent: 'foo', title: 'bar', error: {message: 'error message'} })
         expect(service.failures).toBe(0)
     })
 
     it('should not increment failures on passes', () => {
         service.failures = 0
 
-        service.afterTest({ passed: true })
+        service.afterTest({ passed: true, parent: 'foo', title: 'bar', error: {message: 'error message'} })
         expect(service.failures).toBe(0)
     })
 })

--- a/packages/wdio-browserstack-service/tests/service.test.js
+++ b/packages/wdio-browserstack-service/tests/service.test.js
@@ -184,6 +184,8 @@ describe('afterSuite', () => {
 describe('afterTest', () => {
     it('should increment failures on fails', () => {
         service.failures = 0
+        service.fullTitle = ''
+        service.failReason = ''
 
         service.afterTest({ passed: false, parent: 'foo', title: 'bar', error: {message: 'error message'}  })
         expect(service.failures).toBe(1)
@@ -191,6 +193,8 @@ describe('afterTest', () => {
 
     it('should not increment failures on passes', () => {
         service.failures = 0
+        service.fullTitle = ''
+        service.failReason = ''
 
         service.afterTest({ passed: true, parent: 'foo', title: 'bar', error: {message: 'error message'} })
         expect(service.failures).toBe(0)
@@ -198,6 +202,8 @@ describe('afterTest', () => {
 
     it('should not increment failures on passes', () => {
         service.failures = 0
+        service.fullTitle = ''
+        service.failReason = ''
 
         service.afterTest({ passed: true, parent: 'foo', title: 'bar', error: {message: 'error message'} })
         expect(service.failures).toBe(0)


### PR DESCRIPTION
## Proposed changes
 Browserstack supports modifying the name of the session as well as the reason for the failure as described in #3648 

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)
I added new parameters for Browserstack update request.
it fixes #3648 and contains small changes.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee