### PR TITLE
wdio-firefox-profile: legacy handling

### DIFF
--- a/packages/wdio-firefox-profile-service/README.md
+++ b/packages/wdio-firefox-profile-service/README.md
@@ -39,7 +39,8 @@ export.config = {
       '/path/to/extensionA.xpi', // path to .xpi file
       '/path/to/extensionB' // or path to unpacked Firefox extension
     ],
-    'browser.startup.homepage': 'https://webdriver.io'
+    'browser.startup.homepage': 'https://webdriver.io',
+    legacy: true // used for firefox <= 55
   },
   // ...
 };
@@ -48,6 +49,6 @@ export.config = {
 ## Options
 
 ### firefoxProfile
-Contains all settings as key value pair. If you want to add an extension, use the `extensions` key with an array of string paths to the extensions you want to use.
+Contains all settings as key value pair. If you want to add an extension, use the `extensions` key with an array of string paths to the extensions you want to use. If you are running a version of firefox older before 56 use `legacy: true`.
 
 Type: `Object`

--- a/packages/wdio-firefox-profile-service/src/launcher.js
+++ b/packages/wdio-firefox-profile-service/src/launcher.js
@@ -10,9 +10,6 @@ export default class FirefoxProfileLauncher {
             return
         }
 
-        this.legacy = this.config.firefoxProfile.legacy
-        this.config.firefoxProfile
-
         this.profile = new Profile()
 
         // Set preferences and proxy

--- a/packages/wdio-firefox-profile-service/src/launcher.js
+++ b/packages/wdio-firefox-profile-service/src/launcher.js
@@ -5,11 +5,13 @@ export default class FirefoxProfileLauncher {
     async onPrepare (config, capabilities) {
         this.config = config
         this.capabilities = capabilities
-
         // Return if no profile options were specified
         if (!this.config.firefoxProfile) {
             return
         }
+
+        this.legacy = this.config.firefoxProfile.legacy
+        this.config.firefoxProfile
 
         this.profile = new Profile()
 
@@ -31,7 +33,7 @@ export default class FirefoxProfileLauncher {
      */
     _setPreferences () {
         for (const [ preference, value ] of Object.entries(this.config.firefoxProfile)) {
-            if (['extensions', 'proxy'].includes(preference)) {
+            if (['extensions', 'proxy', 'legacy'].includes(preference)) {
                 continue
             }
 
@@ -70,11 +72,13 @@ export default class FirefoxProfileLauncher {
     }
 
     _setProfile(capability, zippedProfile) {
-        // for older firefox and geckodriver versions
-        capability.firefox_profile = zippedProfile
-
-        // for firefox >= 56.0 and geckodriver >= 0.19.0
-        capability['moz:firefoxOptions'] = capability['moz:firefoxOptions'] || {}
-        capability['moz:firefoxOptions'].profile = zippedProfile
+        if(this.config.firefoxProfile.legacy) {
+            // for older firefox and geckodriver versions
+            capability.firefox_profile = zippedProfile
+        } else {
+            // for firefox >= 56.0 and geckodriver >= 0.19.0
+            capability['moz:firefoxOptions'] = capability['moz:firefoxOptions'] || {}
+            capability['moz:firefoxOptions'].profile = zippedProfile
+        }
     }
 }

--- a/packages/wdio-firefox-profile-service/tests/launcher.test.js
+++ b/packages/wdio-firefox-profile-service/tests/launcher.test.js
@@ -12,7 +12,7 @@ describe('Firefox profile service', () => {
             expect(capabilities).toEqual([{}])
         })
 
-        test('should set preferences with no extensions', async () => {
+        test('should set preferences with no extensions - modern', async () => {
             const config = {
                 firefoxProfile : {
                     'browser.startup.homepage': 'https://webdriver.io',
@@ -30,8 +30,31 @@ describe('Firefox profile service', () => {
             expect(service.profile.updatePreferences).toHaveBeenCalled()
             expect(service.profile.addExtensions).not.toHaveBeenCalled()
 
-            expect(capabilities[0].firefox_profile).toBe('foobar')
+            expect(capabilities[0].firefox_profile).toBe(undefined)
             expect(capabilities[0]['moz:firefoxOptions']).toEqual({ profile : 'foobar'})
+        })
+
+        test('should set preferences with no extensions - legacy', async () => {
+            const config = {
+                firefoxProfile : {
+                    'browser.startup.homepage': 'https://webdriver.io',
+                    legacy: true
+                }
+            }
+            const capabilities = [{
+                browserName : 'firefox',
+            }]
+
+            const service = new Launcher()
+            await service.onPrepare(config, capabilities)
+
+            expect(service.profile.setPreference).toHaveBeenCalledTimes(1)
+            expect(service.profile.setPreference).toHaveBeenCalledWith('browser.startup.homepage', 'https://webdriver.io')
+            expect(service.profile.updatePreferences).toHaveBeenCalled()
+            expect(service.profile.addExtensions).not.toHaveBeenCalled()
+
+            expect(capabilities[0].firefox_profile).toBe('foobar')
+            expect(capabilities[0]['moz:firefoxOptions']).toEqual(undefined)
         })
 
         test('should amend firefox capabilities', async () => {
@@ -55,7 +78,6 @@ describe('Firefox profile service', () => {
             expect(service.profile.updatePreferences).toHaveBeenCalled()
             expect(service.profile.addExtensions).not.toHaveBeenCalled()
 
-            expect(capabilities[0].firefox_profile).toBe('foobar')
             expect(capabilities[0]['moz:firefoxOptions']).toEqual({ args: ['-headless'], profile : 'foobar'})
         })
 
@@ -72,7 +94,6 @@ describe('Firefox profile service', () => {
             const service = new Launcher()
             await service.onPrepare(config, capabilities)
 
-            expect(capabilities[0].firefox_profile).toBe('foobar')
             expect(capabilities[0]['moz:firefoxOptions']).toEqual({ profile : 'foobar'})
 
             expect(service.profile.addExtensions.mock.calls[0][0]).toBe(config.firefoxProfile.extensions)
@@ -96,7 +117,6 @@ describe('Firefox profile service', () => {
             const service = new Launcher()
             await service.onPrepare(config, capabilities)
 
-            expect(capabilities[0].firefox_profile).toBe('foobar')
             expect(capabilities[0]['moz:firefoxOptions']).toEqual({ profile : 'foobar'})
 
             expect(capabilities[1]).not.toHaveProperty('firefox_profile')
@@ -120,7 +140,6 @@ describe('Firefox profile service', () => {
             const service = new Launcher()
             await service.onPrepare(config, capabilities)
 
-            expect(capabilities.firefox.capabilities.firefox_profile).toBe('foobar')
             expect(capabilities.firefox.capabilities['moz:firefoxOptions']).toEqual({ profile : 'foobar'})
         })
 


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

@wdio/firefox-profile-service is currently broken in two ways: 
1 - anything prior to firefox 55 is throwing up due to the driver not understanding the profile key in the firefox options
2 - firefox_profile is an invalid w3c key and is causing selenium-server-standalone to throw-up

Resolves https://github.com/webdriverio/webdriverio/issues/3297

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
