### PR TITLE
webdriverio: fix options in multiremote

### DIFF
--- a/packages/webdriverio/src/index.js
+++ b/packages/webdriverio/src/index.js
@@ -61,9 +61,13 @@ export const multiremote = async function (params = {}) {
      */
     await Promise.all(
         browserNames.map((browserName) => {
-            validateConfig(WDIO_DEFAULTS, params[browserName])
+            const config = validateConfig(WDIO_DEFAULTS, params[browserName])
+            const modifier = (client, options) => {
+                Object.assign(options, config)
+                return client
+            }
             const prototype = getPrototype('browser')
-            const instance = WebDriver.newSession(params[browserName], null, prototype, wrapCommand)
+            const instance = WebDriver.newSession(params[browserName], modifier, prototype, wrapCommand)
             return multibrowser.addInstance(browserName, instance)
         })
     )

--- a/packages/webdriverio/tests/module.test.js
+++ b/packages/webdriverio/tests/module.test.js
@@ -10,10 +10,12 @@ jest.mock('webdriver', () => {
     }
     const newSessionMock = jest.fn()
     newSessionMock.mockReturnValue(new Promise((resolve) => resolve(client)))
-    newSessionMock.mockImplementation((params, cb) => cb ? cb(client, params) : {
-        ...client,
-        ...params,
-        ...{ options: { logLevel: 'error' } }
+    newSessionMock.mockImplementation((params, cb) => {
+        let result = cb(client, params)
+        if (params.test_multiremote) {
+            result.options = { logLevel: 'error' }
+        }
+        return result
     })
 
     return {
@@ -68,8 +70,8 @@ describe('WebdriverIO module interface', () => {
     describe('multiremote', () => {
         it('register multiple clients', async () => {
             await multiremote({
-                browserA: { capabilities: { browserName: 'chrome' } },
-                browserB: { capabilities: { browserName: 'firefox' } }
+                browserA: { test_multiremote: true, capabilities: { browserName: 'chrome' } },
+                browserB: { test_multiremote: true, capabilities: { browserName: 'firefox' } }
             })
             expect(WebDriver.attachToSession).toBeCalled()
             expect(WebDriver.newSession.mock.calls).toHaveLength(2)


### PR DESCRIPTION
## Proposed changes

Fix for #3683 

Original problem:
- Timer is failing because interval is undefined and causing some calculations to return NaN.
https://github.com/webdriverio/webdriverio/blob/master/packages/webdriverio/src/utils/Timer.js#L105

- Interval is undefined because it's default value (and other config values) is missing in options object.
https://github.com/webdriverio/webdriverio/blob/master/packages/webdriverio/src/commands/browser/waitUntil.js#L52

So I came up with following solution:
- there should be default values in this.options in multiremote mode. 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

Please validate if approach is valid

### Reviewers: @webdriverio/technical-committee
