### PR TITLE
webdriverio: fix isDisplayed

### DIFF
--- a/packages/webdriverio/src/commands/element/isDisplayed.js
+++ b/packages/webdriverio/src/commands/element/isDisplayed.js
@@ -70,7 +70,7 @@ export default async function isDisplayed() {
      * no longer dictates it. In those instances, we pass the element through a script
      * that was provided by Brian Burg of safaridriver.
      */
-    return browser.isW3C && noW3CEndpoint.includes(browser.capabilities.browserName.toLowerCase()) ?
+    return browser.isW3C && !browser.isMobile && noW3CEndpoint.includes(browser.capabilities.browserName.toLowerCase()) ?
         await browser.execute(isElementDisplayedScript, {
             [ELEMENT_KEY]: this.elementId, // w3c compatible
             ELEMENT: this.elementId // jsonwp compatible

--- a/packages/webdriverio/src/middlewares.js
+++ b/packages/webdriverio/src/middlewares.js
@@ -15,7 +15,19 @@ export const elementErrorHandler = (fn) => (commandName, commandFn) => {
             this.elementId = element.elementId
 
             try {
-                return await fn(commandName, commandFn).apply(this, args)
+                const result = await fn(commandName, commandFn).apply(this, args)
+
+                /**
+                 * assume Safari responses like { error: 'no such element', message: '', stacktrace: '' }
+                 * as `stale element reference`
+                 */
+                if (result && result.error === 'no such element') {
+                    const err = new Error()
+                    err.name = 'stale element reference'
+                    throw err
+                }
+
+                return result
             } catch (error) {
                 if (error.name === 'stale element reference') {
                     const element = await refetchElement(this, commandName)

--- a/packages/webdriverio/src/utils/implicitWait.js
+++ b/packages/webdriverio/src/utils/implicitWait.js
@@ -11,7 +11,7 @@ const log = logger('webdriverio')
  */
 export default async function implicitWait (currentElement, commandName) {
 
-    if (!currentElement.elementId && !commandName.match(/(waitUntil|waitFor|isExisting|isDisplayed)/)) {
+    if (!currentElement.elementId && !commandName.match(/(waitUntil|waitFor|isExisting|is?\w+Displayed)/)) {
         log.debug(
             `command ${commandName} was called on an element ("${currentElement.selector}") ` +
             'that wasn\'t found, waiting for it...'

--- a/packages/webdriverio/tests/__mocks__/request.js
+++ b/packages/webdriverio/tests/__mocks__/request.js
@@ -50,7 +50,7 @@ const requestMock = jest.fn().mockImplementation((params, cb) => {
     case '/wd/hub/session':
         value = sessionResponse
 
-        if (params.body.capabilities.alwaysMatch.browserName.includes('noW3C')) {
+        if (params.body.capabilities.alwaysMatch.browserName && params.body.capabilities.alwaysMatch.browserName.includes('noW3C')) {
             value.desiredCapabilities = { browserName: 'mockBrowser' }
             delete value.capabilities
         }
@@ -239,8 +239,13 @@ const requestMock = jest.fn().mockImplementation((params, cb) => {
     /**
      * overwrite if manual response is set
      */
+    let statusCode = 200
     if (Array.isArray(manualMockResponse)) {
         value = manualMockResponse.shift() || value
+
+        if (typeof value.statusCode === 'number') {
+            statusCode = value.statusCode
+        }
 
         if (manualMockResponse.length === 0) {
             manualMockResponse = null
@@ -257,7 +262,7 @@ const requestMock = jest.fn().mockImplementation((params, cb) => {
 
     cb(null, {
         headers: { foo: 'bar' },
-        statusCode: 200,
+        statusCode,
         body: response
     }, response)
 })

--- a/packages/webdriverio/tests/commands/element/isDisplayed.test.js
+++ b/packages/webdriverio/tests/commands/element/isDisplayed.test.js
@@ -26,12 +26,45 @@ describe('isDisplayed test', () => {
         expect(request.mock.calls[0][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/displayed')
     })
 
+    it('should allow to check if element is displayed in mobile mode without browserName', async () => {
+        browser = await remote({
+            baseUrl: 'http://foobar.com',
+            capabilities: {
+                keepBrowserName: true,
+                mobileMode: true
+            }
+        })
+        elem = await browser.$('#foo')
+        request.mockClear()
+        expect(await elem.isDisplayed()).toBe(true)
+        expect(request).toBeCalledTimes(1)
+        expect(request.mock.calls[0][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/displayed')
+    })
+
     it('should refetch element if non existing', async () => {
         delete elem.elementId
         expect(await elem.isDisplayed()).toBe(true)
         expect(request).toBeCalledTimes(2)
         expect(request.mock.calls[0][0].uri.path).toBe('/wd/hub/session/foobar-123/element')
         expect(request.mock.calls[1][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/displayed')
+    })
+
+    it('should return false if element is not existing anymore', async () => {
+        browser = await remote({
+            baseUrl: 'http://foobar.com',
+            capabilities: {
+                browserName: 'safari',
+                keepBrowserName: true
+            }
+        })
+        elem = await browser.$('#foo')
+
+        expect(await elem.isDisplayed()).toBe(true)
+
+        elem.selector = '#nonexisting'
+        request.setMockResponse([ { error: 'no such element', statusCode: 404 }])
+
+        expect(await elem.isDisplayed()).toBe(false)
     })
 
     it('should return false if element can\'t be found after refetching it', async () => {

--- a/packages/webdriverio/tests/middleware.test.js
+++ b/packages/webdriverio/tests/middleware.test.js
@@ -67,6 +67,15 @@ describe('middleware', () => {
         request.retryCnt = 0
     })
 
+    it('should successfully getAttribute of an element that falls stale after being re-found in Safari', async () => {
+        const elem = await browser.$('#foo')
+        elem.selector = '#nonexisting'
+        request.setMockResponse([ { error: 'no such element', statusCode: 404 }, undefined, undefined, 'bar' ])
+        expect(await elem.getAttribute('foo')).toEqual('bar')
+        expect(waitForExist.default.mock.calls).toHaveLength(1)
+        request.mockClear()
+    })
+
     it('should successfully click on a stale element', async () => {
         const elem = await browser.$('#foo')
         const subElem = await elem.$('#subfoo')
@@ -91,6 +100,9 @@ describe('middleware', () => {
             'waitUntil',
             'waitForDisplayed',
             'waitForEnabled',
+            'isElementDisplayed',
+            'isDisplayed',
+            'isExisting',
 
             // custom commands
             'waitUntilFoo',


### PR DESCRIPTION
## Proposed changes

fix #3699 #3700 #3645 #3709 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

code for testing PR
```
browser.url("http://adam.goucher.ca/parkcalc/")
const inputSelector = "input[type='submit']"

// already not existing
$("not-existing").waitForDisplayed(2000, true)
const el = $(inputSelector)
console.log(el.isDisplayed()) // true

// remove element in 3 seconds
browser.execute(function (selector) {
    const window = this
    window.setTimeout(() => {
        window.document.querySelector(selector).remove()
    }, 3000);
}, inputSelector)

// first existing, then not existing
$(inputSelector).waitForDisplayed(8000, true)
console.log(el.isDisplayed()) // false
```

### Reviewers: @webdriverio/technical-committee
