### PR TITLE
Issue 3416: Allow the spec reporter to expose multiple errors if present

### DIFF
--- a/packages/wdio-spec-reporter/src/index.js
+++ b/packages/wdio-spec-reporter/src/index.js
@@ -228,14 +228,19 @@ class SpecReporter extends WDIOReporter {
                 }
 
                 const testTitle = test.title
-
+                const errors = test.errors || [test.error]
                 // If we get here then there is a failed test
                 output.push(
                     '',
                     `${++failureLength}) ${suiteTitle} ${testTitle}`,
-                    this.chalk.red(test.error.message),
-                    ...test.error.stack.split(/\n/g).map(value => this.chalk.gray(value))
+
                 )
+                for (let error of errors) {
+                    output.push(
+                        this.chalk.red(error.message),
+                        ...error.stack.split(/\n/g).map(value => this.chalk.gray(value))
+                    )
+                }
             }
         }
 

--- a/packages/wdio-spec-reporter/tests/__fixtures__/testdata.js
+++ b/packages/wdio-spec-reporter/tests/__fixtures__/testdata.js
@@ -71,6 +71,53 @@ export const SUITES = [
     }
 ]
 
+export const SUITES_MULTIPLE_ERRORS = [
+    {
+        uid : SUITE_UIDS[0],
+        title : SUITE_UIDS[0].slice(0, -1),
+        hooks: [],
+        tests : [
+            {
+                uid : 'foo1',
+                title : 'foo',
+                state : 'passed',
+            },
+            {
+                uid : 'bar1',
+                title : 'bar',
+                state : 'passed',
+            }
+        ],
+    },
+    {
+        uid : SUITE_UIDS[1],
+        title : SUITE_UIDS[1].slice(0, -1),
+        hooks: [],
+        tests : [
+            {
+                uid : 'some test1',
+                title : 'some test',
+                state : 'passed',
+            },
+            {
+                uid : 'a failed test',
+                title : 'a test with two failures',
+                state : 'failed',
+                errors : [
+                    {
+                        message : 'expected the party on the first part to be the party on the first part',
+                        stack : 'First failed stack trace'
+                    },
+                    {
+                        message : 'expected the party on the second part to be the party on the second part',
+                        stack : 'Second failed stack trace'
+                    }
+                ]
+            }
+        ],
+    },
+]
+
 export const SUITES_NO_TESTS = [
     {
         uid: SUITE_UIDS[0],

--- a/packages/wdio-spec-reporter/tests/index.test.js
+++ b/packages/wdio-spec-reporter/tests/index.test.js
@@ -7,7 +7,8 @@ import {
     SUITES_NO_TESTS,
     REPORT,
     SAUCELABS_REPORT,
-    SUITES_NO_TESTS_WITH_HOOK_ERROR
+    SUITES_NO_TESTS_WITH_HOOK_ERROR,
+    SUITES_MULTIPLE_ERRORS
 } from './__fixtures__/testdata'
 
 const reporter = new SpecReporter({})
@@ -294,6 +295,20 @@ describe('SpecReporter', () => {
             const result = tmpReporter.getFailureDisplay()
 
             expect(result.length).toBe(0)
+        })
+
+        it('should return mutliple failing results if they exist', () => {
+            tmpReporter.getOrderedSuites = jest.fn(() => SUITES_MULTIPLE_ERRORS)
+            tmpReporter.suites = SUITES_MULTIPLE_ERRORS
+
+            const result = tmpReporter.getFailureDisplay()
+            expect(result.length).toBe(6)
+            expect(result[0]).toBe('')
+            expect(result[1]).toBe('1) Bar test a test with two failures')
+            expect(result[2]).toBe('red expected the party on the first part to be the party on the first part')
+            expect(result[3]).toBe('gray First failed stack trace')
+            expect(result[4]).toBe('red expected the party on the second part to be the party on the second part')
+            expect(result[5]).toBe('gray Second failed stack trace')
         })
     })
 


### PR DESCRIPTION
## Proposed changes

Continuing on [https://github.com/webdriverio/webdriverio/pull/3672](https://github.com/webdriverio/webdriverio/pull/3672)

This PR prints out multiple errors with the spec reporter if they are present. It pretty well emulates the behavior of other spec-style Jasmine reporters. 

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

### Reviewers: @webdriverio/technical-committee
