### PR TITLE
Also clear protocol if not set

### DIFF
--- a/packages/wdio-config/src/lib/ConfigParser.js
+++ b/packages/wdio-config/src/lib/ConfigParser.js
@@ -110,9 +110,14 @@ export default class ConfigParser {
          * if host and port are default, remove them to get new values
          */
         let defaultBackend = detectBackend({})
-        if (this._config.hostname === defaultBackend.hostname && this._config.port === defaultBackend.port) {
+        if (
+            (this._config.hostname === defaultBackend.hostname) &&
+            (this._config.port === defaultBackend.port) &&
+            (this._config.protocol === defaultBackend.protocol)
+        ) {
             delete this._config.hostname
             delete this._config.port
+            delete this._config.protocol
         }
 
         this._config = merge(detectBackend(this._config), this._config, MERGE_OPTIONS)

--- a/packages/wdio-config/tests/configparser.test.js
+++ b/packages/wdio-config/tests/configparser.test.js
@@ -138,6 +138,7 @@ describe('ConfigParser', () => {
             const config = configParser.getConfig()
             expect(config.hostname).toBe('ondemand.saucelabs.com')
             expect(config.port).toBe(443)
+            expect(config.protocol).toBe('https')
             expect(config.user).toBe('barfoo')
             expect(config.key).toBe('50fa1411-3121-4gb0-9p07-8q326vvbq7b0')
         })


### PR DESCRIPTION
closes #3671

## Proposed changes

When passing in user and key as cli argument WebdriverIO couldn't properly connect to the backend as protocol was still set as `http`.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers 
