### PR TITLE
edits to mobile selectors section

### DIFF
--- a/docs/Selectors.md
+++ b/docs/Selectors.md
@@ -3,7 +3,7 @@ id: selectors
 title: Selectors
 ---
 
-The JsonWireProtocol provides several selector strategies to query an element. WebdriverIO simplifies them to keep selecting elements simple. The following selector types are supported:
+The Json Wire Protocol provides several selector strategies to query an element. WebdriverIO simplifies them to keep selecting elements simple. The following selector types are supported:
 
 ## CSS Query Selector
 
@@ -154,7 +154,9 @@ elem.$(function () { return this.nextSibling.nextSibling }) // (first sibling is
 
 ## Mobile Selectors
 
-For (hybrid/native) mobile testing you have to use mobile strategies and use the underlying device automation technology directly. This is especially useful when a test needs some fine-grained control over finding elements.
+For hybrid mobile testing it's important that the automation server is in the correct *context* before executing commands. For automating gestures, the driver ideally should be set to native context. But to select elements from the DOM, the driver will need to be set to the platform's webview context, which only then the methods mentioned above can be used.
+
+Now for native mobile testing, there is no switching between contexts as you have to use mobile strategies and use the underlying device automation technology directly. This is especially useful when a test needs some fine-grained control over finding elements.
 
 ### Android UiAutomator
 


### PR DESCRIPTION
## Proposed changes

Edits to 'Mobile Selectors' section. Mentioning native and webview contexts for hybrid automation is important when selecting an element from the DOM, which this section currently lacks.

I think more clarification is needed in this section. For instance, does UiAutomator, UIAutomation, XCUITest or Accessibility ID pertain to hybrid automation when selecting an element? If not, that should be mentioned, as hybrid automation is in this section.

Let me know or help yourself to modifications to this PR. Thanks for WebdriverIO!

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
