### PR TITLE
webdriverio: Allow selectByVisibleText to work with newlines

### DIFF
--- a/packages/webdriverio/src/commands/element/selectByVisibleText.js
+++ b/packages/webdriverio/src/commands/element/selectByVisibleText.js
@@ -48,8 +48,17 @@ export default async function selectByVisibleText (text) {
     const formatted = /"/.test(normalized)
         ? 'concat("' + normalized.split('"').join('", \'"\', "') + '")'
         : `"${normalized}"`
-    const value = `[. = ${formatted}]`
-    const optionElement = await this.findElementFromElement(this.elementId, 'xpath', `./option${value}|./optgroup/option${value}`)
+    const dotFormat = `[. = ${formatted}]`
+    const spaceFormat = `[normalize-space(text()) = ${formatted}]`
+
+    const selections = [
+        `./option${dotFormat}`,
+        `./option${spaceFormat}`,
+        `./optgroup/option${dotFormat}`,
+        `./optgroup/option${spaceFormat}`,
+    ]
+
+    const optionElement = await this.findElementFromElement(this.elementId, 'xpath', selections.join('|'))
 
     /**
     * select option

--- a/packages/webdriverio/tests/commands/element/selectByVisibleText.test.js
+++ b/packages/webdriverio/tests/commands/element/selectByVisibleText.test.js
@@ -25,10 +25,12 @@ describe('selectByVisibleText test', () => {
 
     it('should select value by visible text', async () => {
         await elem.selectByVisibleText(' someValue1 ')
+        const optionSelection = './option[. = "someValue1"]|./option[normalize-space(text()) = "someValue1"]'
+        const optgroupSelection = './optgroup/option[. = "someValue1"]|./optgroup/option[normalize-space(text()) = "someValue1"]'
 
         expect(request.mock.calls[1][0].uri.path).toBe('/wd/hub/session/foobar-123/element')
         expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/element')
-        expect(request.mock.calls[2][0].body.value).toBe('./option[. = "someValue1"]|./optgroup/option[. = "someValue1"]')
+        expect(request.mock.calls[2][0].body.value).toBe(`${optionSelection}|${optgroupSelection}`)
         expect(request.mock.calls[3][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-sub-elem-321/click')
         expect(getElementFromResponseSpy).toBeCalledWith({
             [ELEMENT_KEY]: 'some-sub-elem-321'
@@ -37,10 +39,12 @@ describe('selectByVisibleText test', () => {
 
     it('should select value by visible text with spaces', async () => {
         await elem.selectByVisibleText('some Value1')
+        const optionSelection = './option[. = "some Value1"]|./option[normalize-space(text()) = "some Value1"]'
+        const optgroupSelection = './optgroup/option[. = "some Value1"]|./optgroup/option[normalize-space(text()) = "some Value1"]'
 
         expect(request.mock.calls[1][0].uri.path).toBe('/wd/hub/session/foobar-123/element')
         expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/element')
-        expect(request.mock.calls[2][0].body.value).toBe('./option[. = "some Value1"]|./optgroup/option[. = "some Value1"]')
+        expect(request.mock.calls[2][0].body.value).toBe(`${optionSelection}|${optgroupSelection}`)
         expect(request.mock.calls[3][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-sub-elem-321/click')
         expect(getElementFromResponseSpy).toBeCalledWith({
             [ELEMENT_KEY]: 'some-sub-elem-321'
@@ -49,10 +53,12 @@ describe('selectByVisibleText test', () => {
 
     it('should select value by visible text with leading and trailing white-space', async () => {
         await elem.selectByVisibleText(' someValue1 ')
+        const optionSelection = './option[. = "someValue1"]|./option[normalize-space(text()) = "someValue1"]'
+        const optgroupSelection = './optgroup/option[. = "someValue1"]|./optgroup/option[normalize-space(text()) = "someValue1"]'
 
         expect(request.mock.calls[1][0].uri.path).toBe('/wd/hub/session/foobar-123/element')
         expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/element')
-        expect(request.mock.calls[2][0].body.value).toBe('./option[. = "someValue1"]|./optgroup/option[. = "someValue1"]')
+        expect(request.mock.calls[2][0].body.value).toBe(`${optionSelection}|${optgroupSelection}`)
         expect(request.mock.calls[3][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-sub-elem-321/click')
         expect(getElementFromResponseSpy).toBeCalledWith({
             [ELEMENT_KEY]: 'some-sub-elem-321'
@@ -61,10 +67,12 @@ describe('selectByVisibleText test', () => {
 
     it('should select value by visible text with sequences of whitespace characters', async () => {
         await elem.selectByVisibleText('some    Value1')
+        const optionSelection = './option[. = "some Value1"]|./option[normalize-space(text()) = "some Value1"]'
+        const optgroupSelection = './optgroup/option[. = "some Value1"]|./optgroup/option[normalize-space(text()) = "some Value1"]'
 
         expect(request.mock.calls[1][0].uri.path).toBe('/wd/hub/session/foobar-123/element')
         expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/element')
-        expect(request.mock.calls[2][0].body.value).toBe('./option[. = "some Value1"]|./optgroup/option[. = "some Value1"]')
+        expect(request.mock.calls[2][0].body.value).toBe(`${optionSelection}|${optgroupSelection}`)
         expect(request.mock.calls[3][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-sub-elem-321/click')
         expect(getElementFromResponseSpy).toBeCalledWith({
             [ELEMENT_KEY]: 'some-sub-elem-321'
@@ -73,10 +81,12 @@ describe('selectByVisibleText test', () => {
 
     it('should select value by visible text with quotes', async () => {
         await elem.selectByVisibleText('"someValue1""')
+        const optionSelection = './option[. = concat("", \'"\', "someValue1", \'"\', "", \'"\', "")]|./option[normalize-space(text()) = concat("", \'"\', "someValue1", \'"\', "", \'"\', "")]'
+        const optgroupSelection = './optgroup/option[. = concat("", \'"\', "someValue1", \'"\', "", \'"\', "")]|./optgroup/option[normalize-space(text()) = concat("", \'"\', "someValue1", \'"\', "", \'"\', "")]'
 
         expect(request.mock.calls[1][0].uri.path).toBe('/wd/hub/session/foobar-123/element')
         expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/element')
-        expect(request.mock.calls[2][0].body.value).toBe('./option[. = concat("", \'"\', "someValue1", \'"\', "", \'"\', "")]|./optgroup/option[. = concat("", \'"\', "someValue1", \'"\', "", \'"\', "")]')
+        expect(request.mock.calls[2][0].body.value).toBe(`${optionSelection}|${optgroupSelection}`)
         expect(request.mock.calls[3][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-sub-elem-321/click')
         expect(getElementFromResponseSpy).toBeCalledWith({
             [ELEMENT_KEY]: 'some-sub-elem-321'
@@ -85,10 +95,12 @@ describe('selectByVisibleText test', () => {
 
     it('should convert number to string when selecting', async () => {
         await elem.selectByVisibleText(123)
+        const optionSelection = './option[. = "123"]|./option[normalize-space(text()) = "123"]'
+        const optgroupSelection = './optgroup/option[. = "123"]|./optgroup/option[normalize-space(text()) = "123"]'
 
         expect(request.mock.calls[1][0].uri.path).toBe('/wd/hub/session/foobar-123/element')
         expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/element')
-        expect(request.mock.calls[2][0].body.value).toBe('./option[. = "123"]|./optgroup/option[. = "123"]')
+        expect(request.mock.calls[2][0].body.value).toBe(`${optionSelection}|${optgroupSelection}`)
         expect(request.mock.calls[3][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-sub-elem-321/click')
         expect(getElementFromResponseSpy).toBeCalledWith({
             [ELEMENT_KEY]: 'some-sub-elem-321'


### PR DESCRIPTION
With the addition of #3540 selectByVisibleText will not match options like the following example. This adds back the ```normalize-space``` selection while keeping the current selections.

Although I think this should probably be handled/fixed by the users app, this returns the functionality of how it previously acted. We have quite a few places in our app where we have options formatted like this.

```
$(`.test`).selectByVisibleText(`foo`)

<option>Foo
</option>
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

### Reviewers: @webdriverio/technical-committee
