### PR TITLE
Add notice about modifier keys

### DIFF
--- a/packages/webdriverio/src/commands/browser/keys.js
+++ b/packages/webdriverio/src/commands/browser/keys.js
@@ -5,6 +5,8 @@
  * characters. You’ll find all supported characters [here](https://w3c.github.io/webdriver/webdriver-spec.html#keyboard-actions).
  * To do that, the value has to correspond to a key from the table.
  *
+ * Modifier like Ctrl, Shift, Alt and Meta will stay pressed so you need to trigger them again to release them.
+ *
  * <example>
     :keys.js
     it('copies text out of active element', () => {


### PR DESCRIPTION
## Proposed changes

As this seems normal behavior the docs shouldhint about this pitfall.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
