### PR TITLE
'name' find strategy should be used if isMobile is used even when w3c is used

### DIFF
--- a/packages/webdriverio/src/utils.js
+++ b/packages/webdriverio/src/utils.js
@@ -14,6 +14,8 @@ const DIRECT_SELECTOR_REGEXP = /^(id|css selector|xpath|link text|partial link t
 const INVALID_SELECTOR_ERROR = new Error('selector needs to be typeof `string` or `function`')
 
 export const findStrategy = function (value, isW3C, isMobile) {
+    const isNameAttribute = value.search(/^\[name=("|')([a-zA-z0-9\-_. ]+)("|')]$/) >= 0
+
     /**
      * set default selector
      */
@@ -84,8 +86,8 @@ export const findStrategy = function (value, isW3C, isMobile) {
     // or if isMobile is used even when w3c is used
     // e.g. "[name='myName']" or '[name="myName"]'
     } else if (isMobile
-        ? value.search(/^\[name=("|')([a-zA-z0-9\-_. ]+)("|')]$/) >= 0
-        : !isW3C && value.search(/^\[name=("|')([a-zA-z0-9\-_. ]+)("|')]$/) >= 0) {
+        ? isNameAttribute
+        : !isW3C && isNameAttribute) {
         using = 'name'
         value = value.match(/^\[name=("|')([a-zA-z0-9\-_. ]+)("|')]$/)[2]
 

--- a/packages/webdriverio/src/utils.js
+++ b/packages/webdriverio/src/utils.js
@@ -81,8 +81,11 @@ export const findStrategy = function (value, isW3C, isMobile) {
         value = value.replace(/<|>|\/|\s/g, '')
 
     // use name strategy if value queries elements with name attributes for JSONWP
+    // or if isMobile is used even when w3c is used
     // e.g. "[name='myName']" or '[name="myName"]'
-    } else if (!isW3C && value.search(/^\[name=("|')([a-zA-z0-9\-_. ]+)("|')]$/) >= 0) {
+    } else if (isMobile
+        ? value.search(/^\[name=("|')([a-zA-z0-9\-_. ]+)("|')]$/) >= 0
+        : !isW3C && value.search(/^\[name=("|')([a-zA-z0-9\-_. ]+)("|')]$/) >= 0) {
         using = 'name'
         value = value.match(/^\[name=("|')([a-zA-z0-9\-_. ]+)("|')]$/)[2]
 

--- a/packages/webdriverio/tests/utils.test.js
+++ b/packages/webdriverio/tests/utils.test.js
@@ -47,6 +47,12 @@ describe('utils', () => {
             expect(element.value).toBe('search.input')
         })
 
+        it('should find an element using "name" method by "name" strategy if isMobile is used even when w3c is used', () => {
+            const element = findStrategy('[name="searchinput"]', true, true)
+            expect(element.using).toBe('name')
+            expect(element.value).toBe('searchinput')
+        })
+
         it('should find an element using "link text" method', () => {
             const element = findStrategy('=GitHub Repo')
             expect(element.using).toBe('link text')


### PR DESCRIPTION

## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)
Fix #3738 . Inside `findStrategy` method we have a logic that uses `css selector` in case when `w3c` is `true`. When running tests on mobile (`isMobile` is `true`) it should use `name` anyway.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
