### PR TITLE
wdio-runner: Allow custom reporter options to be overridden

### DIFF
--- a/packages/wdio-runner/src/reporter.js
+++ b/packages/wdio-runner/src/reporter.js
@@ -43,7 +43,10 @@ export default class BaseReporter {
         let filename = `wdio-${this.cid}-${name}-reporter.log`
 
         const reporterOptions = this.config.reporters.find((reporter) => (
-            Array.isArray(reporter) && reporter[0] === name
+            Array.isArray(reporter) && (
+                reporter[0] === name ||
+                typeof reporter[0] === 'function' && reporter[0].name === name
+            )
         ))
 
         if(reporterOptions) {

--- a/packages/wdio-runner/tests/reporter.test.js
+++ b/packages/wdio-runner/tests/reporter.test.js
@@ -122,6 +122,17 @@ describe('BaseReporter', () => {
         expect(reporter.reporters[0].isCustom).toBe(true)
     })
 
+    it('should allow to write to output directory with custom reporter', () => {
+        const reporter = new BaseReporter({
+            outputDir: '/foo/bar',
+            reporters: [[CustomReporter, {
+                outputDir: '/foo/baz/bar'
+            }]]
+        }, '0-0')
+
+        expect(reporter.getLogFile('CustomReporter')).toBe('/foo/baz/bar/wdio-0-0-CustomReporter-reporter.log')
+    })
+
     it('should throw if reporters are in a wrong format', () => {
         expect.hasAssertions()
         try {


### PR DESCRIPTION
When setting options in a custom reporter like `outputDir` and `outputFileFormat` those options were not being used.

e.g. The below would output to the `/bar/baz` directory instead of `/foo/bar`

```
outputDir : `/bar/baz`,
reporters : [[CustomReporter, {
   outputDir : `/foo/bar`
}
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

### Reviewers: @webdriverio/technical-committee
