### PR TITLE
Fix invalid urls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,4 @@ docs/_*.md
 .gradle
 wallaby.conf.js
 tags
+tests/.retry_succeeded

--- a/packages/webdriverio/src/commands/browser/url.js
+++ b/packages/webdriverio/src/commands/browser/url.js
@@ -34,6 +34,7 @@
  */
 
 import nodeUrl from 'url'
+import { validateUrl } from '../../utils'
 
 export default function url (path) {
     if (typeof path !== 'string') {
@@ -44,16 +45,5 @@ export default function url (path) {
         path = nodeUrl.resolve(this.options.baseUrl, path)
     }
 
-    /**
-     * prepend http in front of the url to avoid invalid navigate calls
-     */
-    if (
-        path.startsWith('www.') ||
-        !path.startsWith('http://') ||
-        !path.startsWith('https://')
-    ) {
-        path = `http://${path}`
-    }
-
-    return this.navigateTo(path)
+    return this.navigateTo(validateUrl(path))
 }

--- a/packages/webdriverio/src/commands/browser/url.js
+++ b/packages/webdriverio/src/commands/browser/url.js
@@ -48,8 +48,9 @@ export default function url (path) {
      * prepend http in front of the url to avoid invalid navigate calls
      */
     if (
-        (path.startsWith('www.')) ||
-        (!path.startsWith('http://') || !path.startsWith('https://'))
+        path.startsWith('www.') ||
+        !path.startsWith('http://') ||
+        !path.startsWith('https://')
     ) {
         path = `http://${path}`
     }

--- a/packages/webdriverio/src/commands/browser/url.js
+++ b/packages/webdriverio/src/commands/browser/url.js
@@ -44,5 +44,15 @@ export default function url (path) {
         path = nodeUrl.resolve(this.options.baseUrl, path)
     }
 
+    /**
+     * prepend http in front of the url to avoid invalid navigate calls
+     */
+    if (
+        (path.startsWith('www.')) ||
+        (!path.startsWith('http://') || !path.startsWith('https://'))
+    ) {
+        path = `http://${path}`
+    }
+
     return this.navigateTo(path)
 }

--- a/packages/webdriverio/src/utils.js
+++ b/packages/webdriverio/src/utils.js
@@ -467,15 +467,18 @@ export function assertDirectoryExists(filepath) {
  * @param  {Boolean} [retryCheck=false] true if an url was already check and still failed with fix applied
  * @return {string}                     fixed url
  */
-export function validateUrl (url, retryCheck = false) {
+export function validateUrl (url, origError) {
     try {
         const urlObject = new URL(url)
         return urlObject.href
     } catch (e) {
-        if (retryCheck) {
-            throw e
+        /**
+         * if even adding http:// doesn't help, fail with original error
+         */
+        if (origError) {
+            throw origError
         }
 
-        return validateUrl(`http://${url}`, true)
+        return validateUrl(`http://${url}`, e)
     }
 }

--- a/packages/webdriverio/src/utils.js
+++ b/packages/webdriverio/src/utils.js
@@ -5,6 +5,7 @@ import rgb2hex from 'rgb2hex'
 import GraphemeSplitter from 'grapheme-splitter'
 import logger from '@wdio/logger'
 import isObject from 'lodash.isobject'
+import { URL } from 'url'
 
 import { ELEMENT_KEY, W3C_SELECTOR_STRATEGIES, UNICODE_CHARACTERS } from './constants'
 

--- a/packages/webdriverio/src/utils.js
+++ b/packages/webdriverio/src/utils.js
@@ -460,3 +460,22 @@ export function assertDirectoryExists(filepath) {
         throw new Error(`directory (${path.dirname(filepath)}) doesn't exist`)
     }
 }
+
+/**
+ * check if urls are valid and fix them if necessary
+ * @param  {string}  url                url to navigate to
+ * @param  {Boolean} [retryCheck=false] true if an url was already check and still failed with fix applied
+ * @return {string}                     fixed url
+ */
+export function validateUrl (url, retryCheck = false) {
+    try {
+        const urlObject = new URL(url)
+        return urlObject.href
+    } catch (e) {
+        if (retryCheck) {
+            throw e
+        }
+
+        return validateUrl(`http://${url}`, true)
+    }
+}

--- a/packages/webdriverio/tests/commands/browser/url.test.js
+++ b/packages/webdriverio/tests/commands/browser/url.test.js
@@ -28,6 +28,8 @@ describe('url', () => {
         delete browser.baseUrl
         await browser.url('www.google.com')
         expect(request.mock.calls[0][0].body).toEqual({ url: 'http://www.google.com' })
+        await browser.url('google.com')
+        expect(request.mock.calls[1][0].body).toEqual({ url: 'http://google.com' })
     })
 
     it('should throw an exception when a non-string value passed in', async () => {

--- a/packages/webdriverio/tests/commands/browser/url.test.js
+++ b/packages/webdriverio/tests/commands/browser/url.test.js
@@ -24,14 +24,6 @@ describe('url', () => {
         expect(request.mock.calls[0][0].body).toEqual({ url: 'http://foobar.com/foobar' })
     })
 
-    it('should fix url paths if invalid', async () => {
-        delete browser.baseUrl
-        await browser.url('www.google.com')
-        expect(request.mock.calls[0][0].body).toEqual({ url: 'http://www.google.com' })
-        await browser.url('google.com')
-        expect(request.mock.calls[1][0].body).toEqual({ url: 'http://google.com' })
-    })
-
     it('should throw an exception when a non-string value passed in', async () => {
         try {
             await browser.url(true)

--- a/packages/webdriverio/tests/commands/browser/url.test.js
+++ b/packages/webdriverio/tests/commands/browser/url.test.js
@@ -24,6 +24,12 @@ describe('url', () => {
         expect(request.mock.calls[0][0].body).toEqual({ url: 'http://foobar.com/foobar' })
     })
 
+    it('should fix url paths if invalid', async () => {
+        delete browser.baseUrl
+        await browser.url('www.google.com')
+        expect(request.mock.calls[0][0].body).toEqual({ url: 'http://www.google.com' })
+    })
+
     it('should throw an exception when a non-string value passed in', async () => {
         try {
             await browser.url(true)

--- a/packages/webdriverio/tests/utils.test.js
+++ b/packages/webdriverio/tests/utils.test.js
@@ -770,12 +770,15 @@ describe('utils', () => {
 
     describe('validateUrl', () => {
         it('should ensure url is correct', () => {
-            expect(validateUrl('http://json.org')).toEqual('http://json.org')
-            expect(validateUrl('www.json.org')).toEqual('http://www.json.org')
-            expect(validateUrl('json.org')).toEqual('http://json.org')
+            expect(validateUrl('http://json.org')).toEqual('http://json.org/')
+            expect(validateUrl('www.json.org')).toEqual('http://www.json.org/')
+            expect(validateUrl('json.org')).toEqual('http://json.org/')
             expect(validateUrl('about:blank')).toEqual('about:blank')
+            expect(validateUrl('IamInAHost')).toEqual('http://iaminahost/')
             expect(validateUrl('data:text/html, <html contenteditable>'))
                 .toEqual('data:text/html, <html contenteditable>')
+            expect(() => validateUrl('_I.am.I:nvalid'))
+                .toThrowError('Invalid URL: _I.am.I:nvalid')
         })
     })
 })

--- a/packages/webdriverio/tests/utils.test.js
+++ b/packages/webdriverio/tests/utils.test.js
@@ -12,7 +12,8 @@ import {
     verifyArgsAndStripIfElement,
     getElementRect,
     getAbsoluteFilepath,
-    assertDirectoryExists
+    assertDirectoryExists,
+    validateUrl
 } from '../src/utils'
 
 describe('utils', () => {
@@ -764,6 +765,17 @@ describe('utils', () => {
         })
         it('should not fail if directory exists', () => {
             expect(() => assertDirectoryExists('.')).not.toThrow()
+        })
+    })
+
+    describe('validateUrl', () => {
+        it('should ensure url is correct', () => {
+            expect(validateUrl('http://json.org')).toEqual('http://json.org')
+            expect(validateUrl('www.json.org')).toEqual('http://www.json.org')
+            expect(validateUrl('json.org')).toEqual('http://json.org')
+            expect(validateUrl('about:blank')).toEqual('about:blank')
+            expect(validateUrl('data:text/html, <html contenteditable>'))
+                .toEqual('data:text/html, <html contenteditable>')
         })
     })
 })


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
When navigating to pages like:
- google.com
- www.google.com
the driver will fail because the url is invalid.

**Describe the solution you'd like**
Always prepend an http in front of the url.

