### PR TITLE
wdio-sync: Cleanup stacktraces

### DIFF
--- a/packages/wdio-sync/src/constants.js
+++ b/packages/wdio-sync/src/constants.js
@@ -4,8 +4,8 @@ const STACKTRACE_FILTER = [
     // exclude @wdio/sync from stack traces
     'node_modules/@wdio/sync/',
 
-    // exclude middlewares
-    'node_modules/webdriverio/build/middlewares.js',
+    // exclude webdriverio stack traces
+    'node_modules/webdriverio/build/',
 
     // exclude Request emit
     ' (events.js:',


### PR DESCRIPTION
## Proposed changes

Remove stacktraces from webdriverio files.

Before:
```
element ("body") still not displayed after 30000ms
Error: element ("body") still not displayed after 30000ms
    at timer.catch.e (/focus/node_modules/webdriverio/build/commands/browser/waitUntil.js:69:15)
    at Element.waitForDisplayed (/focus/node_modules/webdriverio/build/commands/element/waitForDisplayed.js:51:15)
    at FinalGrades.waitForDisplayed [as openTemplate] (/focus/sis/modules/Grades/FinalGrades/page-classes/FinalGrades.js:137:23)
    at Context.openTemplate (/focus/sis/modules/Users/Profiles/tests/FOCUS-19414.js:102:15)
```

After:
```
element ("body") still not displayed after 30000ms
Error: element ("body") still not displayed after 30000ms
    at FinalGrades.waitForDisplayed [as openTemplate] (/focus/sis/modules/Grades/FinalGrades/page-classes/FinalGrades.js:137:23)
    at Context.openTemplate (/focus/sis/modules/Users/Profiles/tests/FOCUS-19414.js:102:15)
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

### Reviewers: @webdriverio/technical-committee
