### PR TITLE
Fail test if sauce service is used but no credentials are provided

### DIFF
--- a/packages/wdio-browserstack-service/src/service.js
+++ b/packages/wdio-browserstack-service/src/service.js
@@ -11,11 +11,23 @@ export default class BrowserstackService {
         this.failures = 0
     }
 
+    beforeSession (config) {
+        /**
+         * if no user and key is specified even though a sauce service was
+         * provided set user and key with values so that the session request
+         * will fail
+         */
+        if (!config.user)
+            config.user = 'NotSetUser'
+        if (!config.key)
+            config.key = 'NotSetKey'
+    }
+
     before() {
         this.sessionId = global.browser.sessionId
         this.auth = {
-            user: this.config.user || 'NotSetUser',
-            pass: this.config.key || 'NotSetKey'
+            user: this.config.user,
+            pass: this.config.key
         }
         return this._printSessionURL()
     }

--- a/packages/wdio-browserstack-service/src/service.js
+++ b/packages/wdio-browserstack-service/src/service.js
@@ -11,16 +11,22 @@ export default class BrowserstackService {
         this.failures = 0
     }
 
+    /**
+     * if no user and key is specified even though a sauce service was
+     * provided set user and key with values so that the session request
+     * will fail
+     */
     beforeSession (config) {
-        /**
-         * if no user and key is specified even though a sauce service was
-         * provided set user and key with values so that the session request
-         * will fail
-         */
-        if (!config.user)
+        if (!config.user) {
             config.user = 'NotSetUser'
-        if (!config.key)
+        }
+
+        if (!config.key) {
             config.key = 'NotSetKey'
+        }
+
+        this.config.user = config.user
+        this.config.key = config.key
     }
 
     before() {

--- a/packages/wdio-browserstack-service/tests/service.test.js
+++ b/packages/wdio-browserstack-service/tests/service.test.js
@@ -109,52 +109,52 @@ describe('_printSessionURL', () => {
 })
 
 describe('before', () => {
-    beforeAll(() => {
-        global.browser.sessionId = 12
-    })
-
     it('should set auth to default values if not provided', () => {
-        let beforeService = new BrowserstackService({})
+        let service = new BrowserstackService({})
 
-        beforeService.before()
+        service.beforeSession({})
+        service.before()
 
-        expect(beforeService.sessionId).toEqual(12)
-        expect(beforeService.failures).toEqual(0)
-        expect(beforeService.auth).toEqual({
+        expect(service.sessionId).toEqual(12)
+        expect(service.failures).toEqual(0)
+        expect(service.auth).toEqual({
             user: 'NotSetUser',
             pass: 'NotSetKey'
         })
 
-        beforeService = new BrowserstackService({ user: 'blah' })
-        beforeService.before()
+        service = new BrowserstackService({})
+        service.beforeSession({ user: 'blah' })
+        service.before()
 
-        expect(beforeService.sessionId).toEqual(12)
-        expect(beforeService.failures).toEqual(0)
-        expect(beforeService.auth).toEqual({
+        expect(service.sessionId).toEqual(12)
+        expect(service.failures).toEqual(0)
+
+        expect(service.auth).toEqual({
             user: 'blah',
             pass: 'NotSetKey'
         })
-        beforeService = new BrowserstackService({ key: 'blah' })
-        beforeService.before()
+        service = new BrowserstackService({})
+        service.beforeSession({ key: 'blah' })
+        service.before()
 
-        expect(beforeService.sessionId).toEqual(12)
-        expect(beforeService.failures).toEqual(0)
-        expect(beforeService.auth).toEqual({
+        expect(service.sessionId).toEqual(12)
+        expect(service.failures).toEqual(0)
+        expect(service.auth).toEqual({
             user: 'NotSetUser',
             pass: 'blah'
         })
     })
 
     it('should initialize correctly', () => {
-        const beforeService = new BrowserstackService({
+        const service = new BrowserstackService({
             user: 'foo',
             key: 'bar'
         })
-        beforeService.before()
+        service.before()
 
-        expect(beforeService.sessionId).toEqual(12)
-        expect(beforeService.failures).toEqual(0)
-        expect(beforeService.auth).toEqual({
+        expect(service.sessionId).toEqual(12)
+        expect(service.failures).toEqual(0)
+        expect(service.auth).toEqual({
             user: 'foo',
             pass: 'bar'
         })
@@ -162,9 +162,9 @@ describe('before', () => {
 
     it('should log the url', () => {
         const logInfoSpy = jest.spyOn(log, 'info').mockImplementation((string) => string)
-        const beforeService = new BrowserstackService({})
+        const service = new BrowserstackService({})
 
-        beforeService.before()
+        service.before()
         expect(logInfoSpy).toHaveBeenCalled()
     })
 })

--- a/packages/wdio-config/src/utils.js
+++ b/packages/wdio-config/src/utils.js
@@ -27,7 +27,7 @@ export function detectBackend (options = {}, isRDC = false) {
      * browserstack
      * e.g. zHcv9sZ39ip8ZPsxBVJ2
      */
-    if (typeof user === 'string' && key.length === 20) {
+    if (typeof user === 'string' && typeof key === 'string' && key.length === 20) {
         return {
             protocol: 'https',
             hostname: 'hub-cloud.browserstack.com',
@@ -39,7 +39,7 @@ export function detectBackend (options = {}, isRDC = false) {
      * testingbot
      * e.g. ec337d7b677720a4dde7bd72be0bfc67
      */
-    if (typeof user === 'string' && key.length === 32) {
+    if (typeof user === 'string' && typeof key === 'string' && key.length === 32) {
         return {
             hostname: 'hub.testingbot.com',
             port: 80
@@ -50,7 +50,7 @@ export function detectBackend (options = {}, isRDC = false) {
      * Sauce Labs
      * e.g. 50aa152c-1932-B2f0-9707-18z46q2n1mb0
      */
-    if ((typeof user === 'string' && key.length === 36) ||
+    if ((typeof user === 'string' && typeof key === 'string' && key.length === 36) ||
         // When SC is used a user needs to be provided and `isRDC` needs to be true
         (typeof user === 'string' && isRDC) ||
         // Or only RDC
@@ -64,6 +64,14 @@ export function detectBackend (options = {}, isRDC = false) {
             hostname: hostname || (preFix + getSauceEndpoint(region, isRDC)),
             port: port || 443
         }
+    }
+
+    if (typeof user === 'string' || typeof key === 'string') {
+        throw new Error(
+            'A "user" or "key" was provided but could not be connected to a ' +
+            'known cloud service (SauceLabs, Browerstack or Testingbot). ' +
+            'Please check if given user and key properties are correct!'
+        )
     }
 
     /**

--- a/packages/wdio-config/src/utils.js
+++ b/packages/wdio-config/src/utils.js
@@ -66,7 +66,16 @@ export function detectBackend (options = {}, isRDC = false) {
         }
     }
 
-    if (typeof user === 'string' || typeof key === 'string') {
+    if (
+        /**
+         * user and key are set in config
+         */
+        (typeof user === 'string' || typeof key === 'string') &&
+        /**
+         * but no custom WebDriver endpoint was configured
+         */
+        !hostname
+    ) {
         throw new Error(
             'A "user" or "key" was provided but could not be connected to a ' +
             'known cloud service (SauceLabs, Browerstack or Testingbot). ' +

--- a/packages/wdio-config/tests/detectBackend.test.js
+++ b/packages/wdio-config/tests/detectBackend.test.js
@@ -132,4 +132,14 @@ describe('detectBackend', () => {
             key: 'barfoo'
         })).toThrow()
     })
+
+    it('should not throw if user and key are invalid but a custom host was set', () => {
+        const caps = detectBackend({
+            user: 'foobar',
+            key: 'barfoo',
+            hostname: 'foobar.com'
+        })
+        expect(caps.hostname).toBe('foobar.com')
+        expect(caps.port).toBe(4444)
+    })
 })

--- a/packages/wdio-config/tests/detectBackend.test.js
+++ b/packages/wdio-config/tests/detectBackend.test.js
@@ -125,4 +125,11 @@ describe('detectBackend', () => {
         expect(caps.port).toBe(443)
         expect(caps.protocol).toBe('https')
     })
+
+    it('should throw if user and key are given but can not be connected to a cloud', () => {
+        expect(() => detectBackend({
+            user: 'foobar',
+            key: 'barfoo'
+        })).toThrow()
+    })
 })

--- a/packages/wdio-sauce-service/src/service.js
+++ b/packages/wdio-sauce-service/src/service.js
@@ -14,6 +14,23 @@ export default class SauceService {
     }
 
     /**
+     * if no user and key is specified even though a sauce service was
+     * provided set user and key with values so that the session request
+     * will fail
+     */
+    beforeSession (config) {
+        if (!config.user) {
+            config.user = 'unknown_user'
+        }
+        if (!config.key) {
+            config.key = 'unknown_key'
+        }
+
+        this.config.user = config.user
+        this.config.key = config.key
+    }
+
+    /**
      * gather information about runner
      */
     before (capabilities) {
@@ -31,18 +48,6 @@ export default class SauceService {
             return `https://app.testobject.com/api/rest/v2/appium/session/${sessionId}/test`
         }
         return `https://${this.hostname}/rest/v1/${this.sauceUser}/jobs/${sessionId}`
-    }
-
-    beforeSession (config) {
-        /**
-         * if no user and key is specified even though a sauce service was
-         * provided set user and key with values so that the session request
-         * will fail
-         */
-        if (!config.user)
-            config.user = 'unknown_user'
-        if (!config.key)
-            config.key = 'unknown_key'
     }
 
     beforeSuite (suite) {

--- a/packages/wdio-sauce-service/src/service.js
+++ b/packages/wdio-sauce-service/src/service.js
@@ -26,11 +26,16 @@ export default class SauceService {
         this.isRDC = 'testobject_api_key' in this.capabilities
     }
 
-    getSauceRestUrl (sessionId) {
-        if (this.isRDC){
-            return `https://app.testobject.com/api/rest/v2/appium/session/${sessionId}/test`
-        }
-        return `https://${this.hostname}/rest/v1/${this.sauceUser}/jobs/${sessionId}`
+    beforeSession (config) {
+        /**
+         * if no user and key is specified even though a sauce service was
+         * provided set user and key with values so that the session request
+         * will fail
+         */
+        if (!config.user)
+            config.user = 'unknown_user'
+        if (!config.key)
+            config.key = 'unknown_key'
     }
 
     beforeSuite (suite) {

--- a/packages/wdio-sauce-service/src/service.js
+++ b/packages/wdio-sauce-service/src/service.js
@@ -26,6 +26,13 @@ export default class SauceService {
         this.isRDC = 'testobject_api_key' in this.capabilities
     }
 
+    getSauceRestUrl (sessionId) {
+        if (this.isRDC){
+            return `https://app.testobject.com/api/rest/v2/appium/session/${sessionId}/test`
+        }
+        return `https://${this.hostname}/rest/v1/${this.sauceUser}/jobs/${sessionId}`
+    }
+
     beforeSession (config) {
         /**
          * if no user and key is specified even though a sauce service was

--- a/packages/wdio-sauce-service/tests/service.test.js
+++ b/packages/wdio-sauce-service/tests/service.test.js
@@ -37,12 +37,13 @@ test('getSauceRestUrl', () => {
 
 test('beforeSession', () => {
     const config = {}
-    const service = new SauceService({})
+    const service = new SauceService(config)
     service.beforeSession({})
-    expect(service.sauceUser).toBe('unknown_user')
-    expect(service.sauceKey).toBe('unknown_key')
     expect(config.user).toBe('unknown_user')
     expect(config.key).toBe('unknown_key')
+    service.before({})
+    expect(service.sauceUser).toBe('unknown_user')
+    expect(service.sauceKey).toBe('unknown_key')
 })
 
 test('beforeSuite', () => {

--- a/packages/wdio-sauce-service/tests/service.test.js
+++ b/packages/wdio-sauce-service/tests/service.test.js
@@ -35,6 +35,16 @@ test('getSauceRestUrl', () => {
         .toBe('https://app.testobject.com/api/rest/v2/appium/session/12345/test')
 })
 
+test('beforeSession', () => {
+    const config = {}
+    const service = new SauceService({})
+    service.beforeSession({})
+    expect(service.sauceUser).toBe('unknown_user')
+    expect(service.sauceKey).toBe('unknown_key')
+    expect(config.user).toBe('unknown_user')
+    expect(config.key).toBe('unknown_key')
+})
+
 test('beforeSuite', () => {
     const service = new SauceService({})
     expect(service.suiteTitle).toBeUndefined()


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
Currently if you have the sauce services defined within your config but don't provide any sauce credentials the testrunner will try to run against a local instance without letting anyone know why.

**Describe the solution you'd like**
I think it should be better propagated with at least a dominant warning that sauce service is used without sauce credentials. I am not sure if I want to break tests of people that already do it the wrong way. Therefor we should show that error somewhere explicit.

**Describe alternatives you've considered**
Just having the test fail completely but then again this could throw off tests from people that already use the sauce service even though they run locally.

**Additional context**
This should also be applied to the browserstack and testingbot service.
