### PR TITLE
webdriverio: return promise-wrapped async elements from $/$$ in async mode

### DIFF
--- a/packages/webdriverio/webdriverio.d.ts
+++ b/packages/webdriverio/webdriverio.d.ts
@@ -3,21 +3,36 @@
 type BrowserObject = WebDriver.ClientOptions & WebDriver.ClientAsync & WebdriverIOAsync.Browser;
 
 // Element commands that should be wrapper with Promise
-type ElementPromise = Omit<WebdriverIO.Element, 'addCommand'>;
+type ElementPromise = Omit<WebdriverIO.Element, 'addCommand' | '$' | '$$'>;
 
 // Element commands wrapper with Promise
 type ElementAsync = {
     [K in keyof ElementPromise]: WrapWithPromise<ElementPromise[K], ReturnType<ElementPromise[K]>>
+} & {
+  $(
+    selector: string | Function
+  ): Promise<WebdriverIOAsync.Element>;
+  $$(
+    selector: string | Function
+  ): Promise<WebdriverIOAsync.Element[]>;
 }
+
 // Element commands that should not be wrapper with promise
 type ElementStatic = Pick<WebdriverIO.Element, 'addCommand'>
 
 // Browser commands that should be wrapper with Promise
-type BrowserPromise = Omit<WebdriverIO.Browser, 'addCommand' | 'options'>;
+type BrowserPromise = Omit<WebdriverIO.Browser, 'addCommand' | 'options' | '$' | '$$'>;
 
 // Browser commands wrapper with Promise
 type BrowserAsync = {
     [K in keyof BrowserPromise]: WrapWithPromise<BrowserPromise[K], ReturnType<BrowserPromise[K]>>
+} & {
+  $(
+    selector: string | Function
+  ): Promise<WebdriverIOAsync.Element>;
+  $$(
+    selector: string | Function
+  ): Promise<WebdriverIOAsync.Element[]>;
 }
 
 // Browser commands that should not be wrapper with promise

--- a/packages/webdriverio/webdriverio.d.ts
+++ b/packages/webdriverio/webdriverio.d.ts
@@ -1,18 +1,16 @@
 /// <reference types="webdriverio/webdriverio-core"/>
 
 type BrowserObject = WebDriver.ClientOptions & WebDriver.ClientAsync & WebdriverIOAsync.Browser;
+type $ = (selector: string | Function) => Promise<WebdriverIOAsync.Element>;
+type $$ = (selector: string | Function) => Promise<WebdriverIOAsync.Element[]>;
 
 // Element commands that should be wrapper with Promise
 type ElementPromise = Omit<WebdriverIO.Element, 'addCommand' | '$' | '$$'>;
 
 // Methods which return async element(s) so non-async equivalents cannot just be promise-wrapped
 interface AsyncSelectors {
-    $(
-        selector: string | Function
-    ): Promise<WebdriverIOAsync.Element>;
-    $$(
-        selector: string | Function
-    ): Promise<WebdriverIOAsync.Element[]>;
+    $: $;
+    $$: $$;
 }
 
 // Element commands wrapper with Promise
@@ -48,8 +46,8 @@ declare namespace WebdriverIOAsync {
 }
 
 declare var browser: BrowserObject;
-declare function $(selector: string | Function): Promise<WebdriverIOAsync.Element>;
-declare function $$(selector: string | Function): Promise<WebdriverIOAsync.Element[]>;
+declare var $: $;
+declare var $$: $$;
 
 declare module "webdriverio" {
     export = WebdriverIOAsync

--- a/packages/webdriverio/webdriverio.d.ts
+++ b/packages/webdriverio/webdriverio.d.ts
@@ -5,17 +5,20 @@ type BrowserObject = WebDriver.ClientOptions & WebDriver.ClientAsync & Webdriver
 // Element commands that should be wrapper with Promise
 type ElementPromise = Omit<WebdriverIO.Element, 'addCommand' | '$' | '$$'>;
 
+// Methods which return async element(s) so non-async equivalents cannot just be promise-wrapped
+interface AsyncSelectors {
+    $(
+        selector: string | Function
+    ): Promise<WebdriverIOAsync.Element>;
+    $$(
+        selector: string | Function
+    ): Promise<WebdriverIOAsync.Element[]>;
+}
+
 // Element commands wrapper with Promise
 type ElementAsync = {
     [K in keyof ElementPromise]: WrapWithPromise<ElementPromise[K], ReturnType<ElementPromise[K]>>
-} & {
-  $(
-    selector: string | Function
-  ): Promise<WebdriverIOAsync.Element>;
-  $$(
-    selector: string | Function
-  ): Promise<WebdriverIOAsync.Element[]>;
-}
+} & AsyncSelectors;
 
 // Element commands that should not be wrapper with promise
 type ElementStatic = Pick<WebdriverIO.Element, 'addCommand'>
@@ -26,14 +29,7 @@ type BrowserPromise = Omit<WebdriverIO.Browser, 'addCommand' | 'options' | '$' |
 // Browser commands wrapper with Promise
 type BrowserAsync = {
     [K in keyof BrowserPromise]: WrapWithPromise<BrowserPromise[K], ReturnType<BrowserPromise[K]>>
-} & {
-  $(
-    selector: string | Function
-  ): Promise<WebdriverIOAsync.Element>;
-  $$(
-    selector: string | Function
-  ): Promise<WebdriverIOAsync.Element[]>;
-}
+} & AsyncSelectors;
 
 // Browser commands that should not be wrapper with promise
 type BrowserStatic = Pick<WebdriverIO.Browser, 'addCommand' | 'options'>;


### PR DESCRIPTION
## Proposed changes

`WebdriverIO.Async` types are updated so that the `$` and `$$` methods on `Element` and `Browser` return one or an array of `WebdriverIOAsync.Element` objects wrapped in a promise, rather than one of an array of `WebdriverIO.Element` objects wrapped in a promise (which is inconsistent with the API).

Resolves #3760 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

N/A

### Reviewers: @webdriverio/technical-committee
