### PR TITLE
fix typing data for waitFor*

### DIFF
--- a/packages/webdriverio/src/commands/element/waitForDisplayed.js
+++ b/packages/webdriverio/src/commands/element/waitForDisplayed.js
@@ -28,6 +28,7 @@
  * @param {Number=}  ms       time in ms (default: 500)
  * @param {Boolean=} reverse  if true it waits for the opposite (default: false)
  * @param {String=}  error    if exists it overrides the default error message
+ * @return {Boolean} true     if element is displayed (or doesn't if flag is set)
  * @uses utility/waitUntil, state/isDisplayed
  * @type utility
  *

--- a/packages/webdriverio/src/commands/element/waitForEnabled.js
+++ b/packages/webdriverio/src/commands/element/waitForEnabled.js
@@ -2,8 +2,7 @@
  *
  * Wait for an element (selected by css selector) for the provided amount of
  * milliseconds to be (dis/en)abled. If multiple elements get queried by given
- * selector, it returns true (or false if reverse flag is set) if at least one
- * element is (dis/en)abled.
+ * selector, it returns true if at least one element is (dis/en)abled.
  *
  * <example>
     :index.html
@@ -28,6 +27,7 @@
  * @param {Number=}  ms       time in ms (default: 500)
  * @param {Boolean=} reverse  if true it waits for the opposite (default: false)
  * @param {String=}  error    if exists it overrides the default error message
+ * @return {Boolean} true     if element is (dis/en)abled
  * @uses utility/waitUntil, state/isEnabled
  * @type utility
  *

--- a/packages/webdriverio/src/commands/element/waitForExist.js
+++ b/packages/webdriverio/src/commands/element/waitForExist.js
@@ -29,6 +29,7 @@
  * @param {Number=}  ms       time in ms (default: 500)
  * @param {Boolean=} reverse  if true it instead waits for the selector to not match any elements (default: false)
  * @param {String=}  error    if exists it overrides the default error message
+ * @return {Boolean} true     if element exists (or doesn't if flag is set)
  * @uses utility/waitUntil, state/isExisting
  * @type utility
  *


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

The typing data for the `waitFor` commands was missing the `return` documentation, which would result in errors if you tried to get the return value from a `waitFor` command as a boolean. This fixes that.

Did some local testing to confirm this resolves the error.

Hat tip @justinewalt

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
