### PR TITLE
Print reporters after/below stdout in final output

### DIFF
--- a/packages/wdio-cli/src/interface.js
+++ b/packages/wdio-cli/src/interface.js
@@ -298,8 +298,8 @@ export default class WDIOCLInterface extends EventEmitter {
 
     finalise () {
         this.interface.clearAll()
-        this.printReporters()
         this.printStdout()
+        this.printReporters()
         this.printSummary()
         this.updateClock()
         this.reset()


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

Many times I want to see the reporter information (especially from 'spec' reporter) more than I want to see Stdout info. This change will show the reporter details below the stdout in the final output, making it easier to get to. This really helps when there's a lot of stdout in the way of getting to the reporter information.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
