### PR TITLE
Add pre-commit and pre-push hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   "husky": {
     "hooks": {
       "pre-commit": "npm run test:eslint",
-      "pre-push": "npm test"
+      "pre-push": "npm run test:eslint"
     }
   },
   "jest": {

--- a/package.json
+++ b/package.json
@@ -64,8 +64,10 @@
     "typescript": "^3.3.4000"
   },
   "husky": {
-    "pre-commit": "npm run test:eslint",
-    "pre-push": "npm test"
+    "hooks": {
+      "pre-commit": "npm run test:eslint",
+      "pre-push": "npm test"
+    }
   },
   "jest": {
     "testMatch": [

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "dox": "^0.9.0",
     "eslint": "^5.15.3",
     "eslint-plugin-import": "^2.16.0",
+    "husky": "^1.3.1",
     "inquirer": "^6.2.2",
     "jest": "^24.5.0",
     "lerna": "^3.13.1",
@@ -61,6 +62,10 @@
     "source-map-support": "^0.5.11",
     "tempy": "^0.2.1",
     "typescript": "^3.3.4000"
+  },
+  "husky": {
+    "pre-commit": "npm run test:eslint",
+    "pre-push": "npm test"
   },
   "jest": {
     "testMatch": [


### PR DESCRIPTION
## Proposed changes

Use Husky npm library to run `npm run test:eslint` before commits and pushes so it can catch lint errors.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

None of the above.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added necessary documentation (if appropriate)

## Further comment

Last PR I did I committed and pushed a lint error by accident and it delayed the PR from being merged. This will prevent that from happening.

### Reviewers: @webdriverio/technical-committee
