### PR TITLE
Implement react$ and react$$ command

### DIFF
--- a/packages/webdriverio/package.json
+++ b/packages/webdriverio/package.json
@@ -64,6 +64,7 @@
     "lodash.isplainobject": "^4.0.6",
     "lodash.merge": "^4.6.1",
     "lodash.zip": "^4.2.0",
+    "resq": "^1.0.0",
     "rgb2hex": "^0.1.0",
     "serialize-error": "^3.0.0",
     "webdriver": "^5.7.8"

--- a/packages/webdriverio/src/commands/browser/$$.js
+++ b/packages/webdriverio/src/commands/browser/$$.js
@@ -40,56 +40,10 @@
  * @type utility
  *
  */
-import { webdriverMonad } from 'webdriver'
-import { wrapCommand, runFnInFiberContext } from '@wdio/config'
-import merge from 'lodash.merge'
-
-import { findElements, getPrototype as getWDIOPrototype, getElementFromResponse } from '../../utils'
-import { elementErrorHandler } from '../../middlewares'
-import { ELEMENT_KEY } from '../../constants'
+import { findElements } from '../../utils'
+import { getElements } from '../../utils/getElementObject'
 
 export default async function $$ (selector) {
     const res = await findElements.call(this, selector)
-    const prototype = merge({}, this.__propertiesObject__, getWDIOPrototype('element'), { scope: 'element' })
-
-    const elements = res.map((res, i) => {
-        const element = webdriverMonad(this.options, (client) => {
-            const elementId = getElementFromResponse(res)
-
-            if (elementId) {
-                /**
-                 * set elementId for easy access
-                 */
-                client.elementId = elementId
-
-                /**
-                 * set element id with proper key so element can be passed into execute commands
-                 */
-                if (this.isW3C) {
-                    client[ELEMENT_KEY] = elementId
-                } else {
-                    client.ELEMENT = elementId
-                }
-            } else {
-                client.error = res
-            }
-
-            client.selector = selector
-            client.parent = this
-            client.index = i
-            client.emit = ::this.emit
-            return client
-        }, prototype)
-
-        const elementInstance = element(this.sessionId, elementErrorHandler(wrapCommand))
-
-        const origAddCommand = ::elementInstance.addCommand
-        elementInstance.addCommand = (name, fn) => {
-            this.__propertiesObject__[name] = { value: fn }
-            origAddCommand(name, runFnInFiberContext(fn))
-        }
-        return elementInstance
-    })
-
-    return elements
+    return getElements.call(this, selector, res)
 }

--- a/packages/webdriverio/src/commands/browser/react$.js
+++ b/packages/webdriverio/src/commands/browser/react$.js
@@ -1,0 +1,38 @@
+/**
+ *
+ * Pauses execution for a specific amount of time. It is recommended to not use this command to wait for an
+ * element to show up. In order to avoid flaky test results it is better to use commands like
+ * [`waitforExist`](/docs/api/element/waitForExist.html) or other waitFor* commands.
+ *
+ * <example>
+    :pause.js
+    it('should pause the execution', () => {
+        const starttime = new Date().getTime()
+        browser.pause(3000)
+        const endtime = new Date().getTime()
+        console.log(endtime - starttime) // outputs: 3000
+    });
+ * </example>
+ *
+ * @alias browser.pause
+ * @param {Number} milliseconds time in ms
+ * @type utility
+ *
+ */
+import fs from 'fs'
+import { getElement } from '../../utils/getElementObject'
+import { waitToLoadReact, react$ as react$Script } from '../../scripts/resq'
+
+const resqScript = fs.readFileSync(require.resolve('resq'))
+
+export default async function react$ (selector, props) {
+    await this.executeScript(resqScript.toString(), [])
+    await this.execute(waitToLoadReact)
+    const res = await this.execute(react$Script, selector, props)
+
+    if  (!res) {
+        throw new Error(`React element with selector "${selector.toString()}" wasn't found`)
+    }
+
+    return getElement.call(this, selector, res)
+}

--- a/packages/webdriverio/src/commands/element/$.js
+++ b/packages/webdriverio/src/commands/element/$.js
@@ -41,52 +41,10 @@
  * @type utility
  *
  */
-import { webdriverMonad } from 'webdriver'
-import { wrapCommand, runFnInFiberContext } from '@wdio/config'
-import merge from 'lodash.merge'
-
-import { findElement, getBrowserObject, getPrototype as getWDIOPrototype, getElementFromResponse } from '../../utils'
-import { elementErrorHandler } from '../../middlewares'
-import { ELEMENT_KEY } from '../../constants'
+import { findElement } from '../../utils'
+import { getElement } from '../../utils/getElementObject'
 
 export default async function $ (selector) {
     const res = await findElement.call(this, selector)
-    const browser = getBrowserObject(this)
-    const prototype = merge({}, browser.__propertiesObject__, getWDIOPrototype('element'), { scope: 'element' })
-
-    const element = webdriverMonad(this.options, (client) => {
-        const elementId = getElementFromResponse(res)
-
-        if (elementId) {
-            /**
-             * set elementId for easy access
-             */
-            client.elementId = elementId
-
-            /**
-             * set element id with proper key so element can be passed into execute commands
-             */
-            if (this.isW3C) {
-                client[ELEMENT_KEY] = elementId
-            } else {
-                client.ELEMENT = elementId
-            }
-        } else {
-            client.error = res
-        }
-
-        client.selector = selector
-        client.parent = this
-        client.emit = ::this.emit
-        return client
-    }, prototype)
-
-    const elementInstance = element(this.sessionId, elementErrorHandler(wrapCommand))
-
-    const origAddCommand = ::elementInstance.addCommand
-    elementInstance.addCommand = (name, fn) => {
-        browser.__propertiesObject__[name] = { value: fn }
-        origAddCommand(name, runFnInFiberContext(fn))
-    }
-    return elementInstance
+    return getElement.call(this, selector, res)
 }

--- a/packages/webdriverio/src/scripts/resq.js
+++ b/packages/webdriverio/src/scripts/resq.js
@@ -1,0 +1,38 @@
+export const waitToLoadReact = function waitToLoadReact () {
+    window.resq.waitToLoadReact()
+}
+
+export const react$ = function react$ (selector, props) {
+    const elems = window.resq.resq$$(selector)
+
+    if (Object.keys(props).length === 0) {
+        return elems[0]
+    }
+
+    let elem = [...elems].find((elem) => {
+        for (const [name, value] of Object.entries(props)) {
+            // logs.push(`check ${name} and ${value} for ${elem[name]}`)
+            if (elem.props[name] === value) {
+                return true
+            }
+        }
+
+        return false
+    })
+
+    if (!elem || (!elem.node && elem.children.length === 0)) {
+        return
+    }
+
+    if (elem.node) {
+        return elem.node
+    }
+
+    elem = elem.node || elem.children[0].node
+
+    if (!elem) {
+        throw new Error('NotFound')
+    }
+
+    return elem
+}

--- a/packages/webdriverio/src/utils/getElementObject.js
+++ b/packages/webdriverio/src/utils/getElementObject.js
@@ -1,0 +1,106 @@
+import { webdriverMonad } from 'webdriver'
+import { wrapCommand, runFnInFiberContext } from '@wdio/config'
+import merge from 'lodash.merge'
+
+import { getBrowserObject, getPrototype as getWDIOPrototype, getElementFromResponse } from '../utils'
+import { elementErrorHandler } from '../middlewares'
+import { ELEMENT_KEY } from '../constants'
+
+/**
+ * transforms and findElement response into a WDIO element
+ * @param  {String} selector  selector that was used to query the element
+ * @param  {Object} res       findElement response
+ * @return {Object}           WDIO element object
+ */
+export const getElement = function findElement (selector, res) {
+    const browser = getBrowserObject(this)
+    const prototype = merge({}, browser.__propertiesObject__, getWDIOPrototype('element'), { scope: 'element' })
+
+    const element = webdriverMonad(this.options, (client) => {
+        const elementId = getElementFromResponse(res)
+
+        if (elementId) {
+            /**
+             * set elementId for easy access
+             */
+            client.elementId = elementId
+
+            /**
+             * set element id with proper key so element can be passed into execute commands
+             */
+            if (this.isW3C) {
+                client[ELEMENT_KEY] = elementId
+            } else {
+                client.ELEMENT = elementId
+            }
+        } else {
+            client.error = res
+        }
+
+        client.selector = selector
+        client.parent = this
+        client.emit = ::this.emit
+        return client
+    }, prototype)
+
+    const elementInstance = element(this.sessionId, elementErrorHandler(wrapCommand))
+
+    const origAddCommand = ::elementInstance.addCommand
+    elementInstance.addCommand = (name, fn) => {
+        browser.__propertiesObject__[name] = { value: fn }
+        origAddCommand(name, runFnInFiberContext(fn))
+    }
+    return elementInstance
+}
+
+/**
+ * transforms and findElement response into a WDIO element
+ * @param  {String} selector  selector that was used to query the element
+ * @param  {Object} res       findElement response
+ * @return {Object}           WDIO element object
+ */
+export const getElements = function getElements (selector, res) {
+    const browser = getBrowserObject(this)
+    const prototype = merge({}, browser.__propertiesObject__, getWDIOPrototype('element'), { scope: 'element' })
+
+    const elements = res.map((res, i) => {
+        const element = webdriverMonad(this.options, (client) => {
+            const elementId = getElementFromResponse(res)
+
+            if (elementId) {
+                /**
+                 * set elementId for easy access
+                 */
+                client.elementId = elementId
+
+                /**
+                 * set element id with proper key so element can be passed into execute commands
+                 */
+                if (this.isW3C) {
+                    client[ELEMENT_KEY] = elementId
+                } else {
+                    client.ELEMENT = elementId
+                }
+            } else {
+                client.error = res
+            }
+
+            client.selector = selector
+            client.parent = this
+            client.index = i
+            client.emit = ::this.emit
+            return client
+        }, prototype)
+
+        const elementInstance = element(this.sessionId, elementErrorHandler(wrapCommand))
+
+        const origAddCommand = ::elementInstance.addCommand
+        elementInstance.addCommand = (name, fn) => {
+            browser.__propertiesObject__[name] = { value: fn }
+            origAddCommand(name, runFnInFiberContext(fn))
+        }
+        return elementInstance
+    })
+
+    return elements
+}


### PR DESCRIPTION
## Proposed changes

We want to simplify the way people fetch elements within React applications. This patch introduces `react$` and `react$$` that allow to query and React component bz y its actual component name and filter by prop and state properties.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

This is currently work in progress. There are some things that have to be changed in `resq` to get this working. A modified version of that package allowed to run the following test:

```js
await browser.url('https://ahfarmer.github.io/calculator/');

const btn7 = await browser.react$('t', { name: '7' })
const btn6 = await browser.react$('t', { name: '6' })
const btnMult = await browser.react$('t', { name: 'x' })
const btnEqual = await browser.react$('t', { name: '=' })
const display = await browser.$('.component-display')

await btn7.click()
await btnMult.click()
await btn6.click()
await btnEqual.click()

console.log(await display.getText()); // prints "42"
```

### Reviewers: @webdriverio/technical-committee
