### PR TITLE
Implement react$ and react$$ command

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "npm run test:eslint",
+      "pre-commit": "git diff-index --name-only --diff-filter=d HEAD | grep -E \"(.*)\\.js$\" | xargs node_modules/eslint/bin/eslint.js -c .eslintrc.js",
       "pre-push": "npm run test:eslint"
     }
   },

--- a/packages/webdriverio/package.json
+++ b/packages/webdriverio/package.json
@@ -64,7 +64,7 @@
     "lodash.isplainobject": "^4.0.6",
     "lodash.merge": "^4.6.1",
     "lodash.zip": "^4.2.0",
-    "resq": "^1.0.0",
+    "resq": "^1.2.0",
     "rgb2hex": "^0.1.0",
     "serialize-error": "^3.0.0",
     "webdriver": "^5.7.8"

--- a/packages/webdriverio/package.json
+++ b/packages/webdriverio/package.json
@@ -64,6 +64,7 @@
     "lodash.isplainobject": "^4.0.6",
     "lodash.merge": "^4.6.1",
     "lodash.zip": "^4.2.0",
+    "resq": "^1.0.0",
     "rgb2hex": "^0.1.0",
     "serialize-error": "^3.0.0",
     "webdriver": "^5.7.8"

--- a/packages/webdriverio/src/commands/browser/$$.js
+++ b/packages/webdriverio/src/commands/browser/$$.js
@@ -40,56 +40,10 @@
  * @type utility
  *
  */
-import { webdriverMonad } from 'webdriver'
-import { wrapCommand, runFnInFiberContext } from '@wdio/config'
-import merge from 'lodash.merge'
-
-import { findElements, getPrototype as getWDIOPrototype, getElementFromResponse } from '../../utils'
-import { elementErrorHandler } from '../../middlewares'
-import { ELEMENT_KEY } from '../../constants'
+import { findElements } from '../../utils'
+import { getElements } from '../../utils/getElementObject'
 
 export default async function $$ (selector) {
     const res = await findElements.call(this, selector)
-    const prototype = merge({}, this.__propertiesObject__, getWDIOPrototype('element'), { scope: 'element' })
-
-    const elements = res.map((res, i) => {
-        const element = webdriverMonad(this.options, (client) => {
-            const elementId = getElementFromResponse(res)
-
-            if (elementId) {
-                /**
-                 * set elementId for easy access
-                 */
-                client.elementId = elementId
-
-                /**
-                 * set element id with proper key so element can be passed into execute commands
-                 */
-                if (this.isW3C) {
-                    client[ELEMENT_KEY] = elementId
-                } else {
-                    client.ELEMENT = elementId
-                }
-            } else {
-                client.error = res
-            }
-
-            client.selector = selector
-            client.parent = this
-            client.index = i
-            client.emit = ::this.emit
-            return client
-        }, prototype)
-
-        const elementInstance = element(this.sessionId, elementErrorHandler(wrapCommand))
-
-        const origAddCommand = ::elementInstance.addCommand
-        elementInstance.addCommand = (name, fn) => {
-            this.__propertiesObject__[name] = { value: fn }
-            origAddCommand(name, runFnInFiberContext(fn))
-        }
-        return elementInstance
-    })
-
-    return elements
+    return getElements.call(this, selector, res)
 }

--- a/packages/webdriverio/src/commands/browser/react$$.js
+++ b/packages/webdriverio/src/commands/browser/react$$.js
@@ -10,12 +10,8 @@
     it('should calculate 7 * 6', () => {
         browser.url('https://ahfarmer.github.io/calculator/');
 
-        browser.react$('t', { name: '7' }).click()
-        browser.react$('t', { name: 'x' }).click()
-        browser.react$('t', { name: '6' }).click()
-        browser.react$('t', { name: '=' }).click()
-
-        console.log($('.component-display').getText()); // prints "42"
+        const orangeButtons = browser.react$$('t', { orange: true })
+        console.log(orangeButtons.map((btn) => btn.getText())); // prints "[ '÷', 'x', '-', '+', '=' ]"
     });
  * </example>
  *

--- a/packages/webdriverio/src/commands/browser/react$$.js
+++ b/packages/webdriverio/src/commands/browser/react$$.js
@@ -27,7 +27,7 @@ import { waitToLoadReact, react$$ as react$$Script } from '../../scripts/resq'
 
 const resqScript = fs.readFileSync(require.resolve('resq'))
 
-export default async function react$ (selector, props = {}, state = {}) {
+export default async function react$$ (selector, props = {}, state = {}) {
     await this.executeScript(resqScript.toString(), [])
     await this.execute(waitToLoadReact)
     const res = await this.execute(react$$Script, selector, props, state)

--- a/packages/webdriverio/src/commands/browser/react$$.js
+++ b/packages/webdriverio/src/commands/browser/react$$.js
@@ -1,7 +1,7 @@
 /**
  *
- * The `react$` command is a useful command to query React Components by their
- * actual name and filter them by props and state.
+ * The `react$$` command is a useful command to query multiple React Components
+ * by their actual name and filter them by props and state.
  *
  * <example>
     :pause.js
@@ -24,19 +24,14 @@
  *
  */
 import fs from 'fs'
-import { getElement } from '../../utils/getElementObject'
-import { waitToLoadReact, react$ as react$Script } from '../../scripts/resq'
+import { getElements } from '../../utils/getElementObject'
+import { waitToLoadReact, react$$ as react$$Script } from '../../scripts/resq'
 
 const resqScript = fs.readFileSync(require.resolve('resq'))
 
 export default async function react$ (selector, props = {}, state = {}) {
     await this.executeScript(resqScript.toString().slice(45), [])
     await this.execute(waitToLoadReact)
-    const res = await this.execute(react$Script, selector, props, state)
-
-    if  (!res) {
-        throw new Error(`React element with selector "${selector.toString()}" wasn't found`)
-    }
-
-    return getElement.call(this, selector, res)
+    const res = await this.execute(react$$Script, selector, props, state)
+    return getElements.call(this, selector, res)
 }

--- a/packages/webdriverio/src/commands/browser/react$$.js
+++ b/packages/webdriverio/src/commands/browser/react$$.js
@@ -3,6 +3,8 @@
  * The `react$$` command is a useful command to query multiple React Components
  * by their actual name and filter them by props and state.
  *
+ * **NOTE:** the command only works with applications using React v16.x
+ *
  * <example>
     :pause.js
     it('should calculate 7 * 6', () => {
@@ -30,7 +32,7 @@ import { waitToLoadReact, react$$ as react$$Script } from '../../scripts/resq'
 const resqScript = fs.readFileSync(require.resolve('resq'))
 
 export default async function react$ (selector, props = {}, state = {}) {
-    await this.executeScript(resqScript.toString().slice(45), [])
+    await this.executeScript(resqScript.toString(), [])
     await this.execute(waitToLoadReact)
     const res = await this.execute(react$$Script, selector, props, state)
     return getElements.call(this, selector, res)

--- a/packages/webdriverio/src/commands/browser/react$.js
+++ b/packages/webdriverio/src/commands/browser/react$.js
@@ -3,6 +3,8 @@
  * The `react$` command is a useful command to query React Components by their
  * actual name and filter them by props and state.
  *
+ * **NOTE:** the command only works with applications using React v16.x
+ *
  * <example>
     :pause.js
     it('should calculate 7 * 6', () => {
@@ -30,7 +32,7 @@ import { waitToLoadReact, react$ as react$Script } from '../../scripts/resq'
 const resqScript = fs.readFileSync(require.resolve('resq'))
 
 export default async function react$ (selector, props = {}, state = {}) {
-    await this.executeScript(resqScript.toString().slice(45), [])
+    await this.executeScript(resqScript.toString(), [])
     await this.execute(waitToLoadReact)
     const res = await this.execute(react$Script, selector, props, state)
 

--- a/packages/webdriverio/src/commands/browser/react$.js
+++ b/packages/webdriverio/src/commands/browser/react$.js
@@ -35,10 +35,5 @@ export default async function react$ (selector, props = {}, state = {}) {
     await this.executeScript(resqScript.toString(), [])
     await this.execute(waitToLoadReact)
     const res = await this.execute(react$Script, selector, props, state)
-
-    if  (!res) {
-        throw new Error(`React element with selector "${selector.toString()}" wasn't found`)
-    }
-
     return getElement.call(this, selector, res)
 }

--- a/packages/webdriverio/src/commands/browser/react$.js
+++ b/packages/webdriverio/src/commands/browser/react$.js
@@ -1,0 +1,38 @@
+/**
+ *
+ * Pauses execution for a specific amount of time. It is recommended to not use this command to wait for an
+ * element to show up. In order to avoid flaky test results it is better to use commands like
+ * [`waitforExist`](/docs/api/element/waitForExist.html) or other waitFor* commands.
+ *
+ * <example>
+    :pause.js
+    it('should pause the execution', () => {
+        const starttime = new Date().getTime()
+        browser.pause(3000)
+        const endtime = new Date().getTime()
+        console.log(endtime - starttime) // outputs: 3000
+    });
+ * </example>
+ *
+ * @alias browser.pause
+ * @param {Number} milliseconds time in ms
+ * @type utility
+ *
+ */
+import fs from 'fs'
+import { getElement } from '../../utils/getElementObject'
+import { waitToLoadReact, react$ as react$Script } from '../../scripts/resq'
+
+const resqScript = fs.readFileSync(require.resolve('resq'))
+
+export default async function react$ (selector, props) {
+    await this.executeScript(resqScript.toString(), [])
+    await this.execute(waitToLoadReact)
+    const res = await this.execute(react$Script, selector, props)
+
+    if  (!res) {
+        throw new Error(`React element with selector "${selector.toString()}" wasn't found`)
+    }
+
+    return getElement.call(this, selector, res)
+}

--- a/packages/webdriverio/src/commands/element/$.js
+++ b/packages/webdriverio/src/commands/element/$.js
@@ -41,52 +41,10 @@
  * @type utility
  *
  */
-import { webdriverMonad } from 'webdriver'
-import { wrapCommand, runFnInFiberContext } from '@wdio/config'
-import merge from 'lodash.merge'
-
-import { findElement, getBrowserObject, getPrototype as getWDIOPrototype, getElementFromResponse } from '../../utils'
-import { elementErrorHandler } from '../../middlewares'
-import { ELEMENT_KEY } from '../../constants'
+import { findElement } from '../../utils'
+import { getElement } from '../../utils/getElementObject'
 
 export default async function $ (selector) {
     const res = await findElement.call(this, selector)
-    const browser = getBrowserObject(this)
-    const prototype = merge({}, browser.__propertiesObject__, getWDIOPrototype('element'), { scope: 'element' })
-
-    const element = webdriverMonad(this.options, (client) => {
-        const elementId = getElementFromResponse(res)
-
-        if (elementId) {
-            /**
-             * set elementId for easy access
-             */
-            client.elementId = elementId
-
-            /**
-             * set element id with proper key so element can be passed into execute commands
-             */
-            if (this.isW3C) {
-                client[ELEMENT_KEY] = elementId
-            } else {
-                client.ELEMENT = elementId
-            }
-        } else {
-            client.error = res
-        }
-
-        client.selector = selector
-        client.parent = this
-        client.emit = ::this.emit
-        return client
-    }, prototype)
-
-    const elementInstance = element(this.sessionId, elementErrorHandler(wrapCommand))
-
-    const origAddCommand = ::elementInstance.addCommand
-    elementInstance.addCommand = (name, fn) => {
-        browser.__propertiesObject__[name] = { value: fn }
-        origAddCommand(name, runFnInFiberContext(fn))
-    }
-    return elementInstance
+    return getElement.call(this, selector, res)
 }

--- a/packages/webdriverio/src/scripts/resq.js
+++ b/packages/webdriverio/src/scripts/resq.js
@@ -1,0 +1,38 @@
+export const waitToLoadReact = function waitToLoadReact () {
+    window.resq.waitToLoadReact()
+}
+
+export const react$ = function react$ (selector, props) {
+    const elems = window.resq.resq$$(selector)
+
+    if (Object.keys(props).length === 0) {
+        return elems[0]
+    }
+
+    let elem = [...elems].find((elem) => {
+        for (const [name, value] of Object.entries(props)) {
+            // logs.push(`check ${name} and ${value} for ${elem[name]}`)
+            if (elem.props[name] === value) {
+                return true
+            }
+        }
+
+        return false
+    })
+
+    if (!elem || (!elem.node && elem.children.length === 0)) {
+        return
+    }
+
+    if (elem.node) {
+        return elem.node
+    }
+
+    elem = elem.node || elem.children[0].node
+
+    if (!elem) {
+        throw new Error('NotFound')
+    }
+
+    return elem
+}

--- a/packages/webdriverio/src/scripts/resq.js
+++ b/packages/webdriverio/src/scripts/resq.js
@@ -2,37 +2,36 @@ export const waitToLoadReact = function waitToLoadReact () {
     window.resq.waitToLoadReact()
 }
 
-export const react$ = function react$ (selector, props) {
+export const react$ = function react$ (selector, props, state) {
     const elems = window.resq.resq$$(selector)
+        .byProps(props)
+        .byState(state)
 
-    if (Object.keys(props).length === 0) {
-        return elems[0]
+    if (elems.length === 0) {
+        return null
     }
 
-    let elem = [...elems].find((elem) => {
-        for (const [name, value] of Object.entries(props)) {
-            // logs.push(`check ${name} and ${value} for ${elem[name]}`)
-            if (elem.props[name] === value) {
-                return true
-            }
-        }
-
-        return false
-    })
-
-    if (!elem || (!elem.node && elem.children.length === 0)) {
-        return
-    }
+    let elem = elems[0]
 
     if (elem.node) {
         return elem.node
     }
 
     elem = elem.node || elem.children[0].node
-
-    if (!elem) {
-        throw new Error('NotFound')
-    }
-
     return elem
+}
+
+export const react$$ = function react$ (selector, props, state) {
+    const elems = window.resq.resq$$(selector)
+        .byProps(props)
+        .byState(state)
+
+    return elems.map((elem) => {
+        if (elem.node) {
+            return elem.node
+        }
+
+        elem = elem.node || elem.children[0].node
+        return elem
+    })
 }

--- a/packages/webdriverio/src/scripts/resq.js
+++ b/packages/webdriverio/src/scripts/resq.js
@@ -4,15 +4,6 @@ export const waitToLoadReact = function waitToLoadReact () {
 
 export const react$ = function react$ (selector, props, state) {
     let elems = window.resq.resq$$(selector)
-
-    /**
-     * see https://github.com/baruchvlz/resq/issues/19
-     */
-    if (typeof elems === 'string') {
-        throw new Error(elems)
-    }
-
-    elems = elems
         .byProps(props)
         .byState(state)
 
@@ -32,15 +23,6 @@ export const react$ = function react$ (selector, props, state) {
 
 export const react$$ = function react$$ (selector, props, state) {
     let elems = window.resq.resq$$(selector)
-
-    /**
-     * see https://github.com/baruchvlz/resq/issues/19
-     */
-    if (typeof elems === 'string') {
-        throw new Error(elems)
-    }
-
-    elems = elems
         .byProps(props)
         .byState(state)
 

--- a/packages/webdriverio/src/scripts/resq.js
+++ b/packages/webdriverio/src/scripts/resq.js
@@ -3,7 +3,16 @@ export const waitToLoadReact = function waitToLoadReact () {
 }
 
 export const react$ = function react$ (selector, props, state) {
-    const elems = window.resq.resq$$(selector)
+    let elems = window.resq.resq$$(selector)
+
+    /**
+     * see https://github.com/baruchvlz/resq/issues/19
+     */
+    if (typeof elems === 'string') {
+        throw new Error(elems)
+    }
+
+    elems = elems
         .byProps(props)
         .byState(state)
 
@@ -22,7 +31,16 @@ export const react$ = function react$ (selector, props, state) {
 }
 
 export const react$$ = function react$$ (selector, props, state) {
-    const elems = window.resq.resq$$(selector)
+    let elems = window.resq.resq$$(selector)
+
+    /**
+     * see https://github.com/baruchvlz/resq/issues/19
+     */
+    if (typeof elems === 'string') {
+        throw new Error(elems)
+    }
+
+    elems = elems
         .byProps(props)
         .byState(state)
 

--- a/packages/webdriverio/src/scripts/resq.js
+++ b/packages/webdriverio/src/scripts/resq.js
@@ -3,35 +3,25 @@ export const waitToLoadReact = function waitToLoadReact () {
 }
 
 export const react$ = function react$ (selector, props, state) {
-    let elems = window.resq.resq$$(selector)
+    let element = window.resq.resq$(selector)
         .byProps(props)
         .byState(state)
 
-    if (elems.length === 0) {
+    if (!element.name) {
         return { message: `React element with selector "${selector}" wasn't found` }
     }
 
-    let elem = elems[0]
-
-    if (elem.node) {
-        return elem.node
-    }
-
-    elem = elem.node || elem.children[0].node
-    return elem
+    return element.node || element.children[0].node
 }
 
 export const react$$ = function react$$ (selector, props, state) {
-    let elems = window.resq.resq$$(selector)
+    let elements = window.resq.resq$$(selector)
         .byProps(props)
         .byState(state)
 
-    return [...elems].map((elem) => {
-        if (elem.node) {
-            return elem.node
-        }
+    if (!elements.length) {
+        return []
+    }
 
-        elem = elem.node || elem.children[0].node
-        return elem
-    })
+    return [...elements].map(element => element.node || element.children[0].node)
 }

--- a/packages/webdriverio/src/scripts/resq.js
+++ b/packages/webdriverio/src/scripts/resq.js
@@ -21,12 +21,12 @@ export const react$ = function react$ (selector, props, state) {
     return elem
 }
 
-export const react$$ = function react$ (selector, props, state) {
+export const react$$ = function react$$ (selector, props, state) {
     const elems = window.resq.resq$$(selector)
         .byProps(props)
         .byState(state)
 
-    return elems.map((elem) => {
+    return [...elems].map((elem) => {
         if (elem.node) {
             return elem.node
         }

--- a/packages/webdriverio/src/scripts/resq.js
+++ b/packages/webdriverio/src/scripts/resq.js
@@ -8,7 +8,7 @@ export const react$ = function react$ (selector, props, state) {
         .byState(state)
 
     if (elems.length === 0) {
-        return null
+        return { message: `React element with selector "${selector}" wasn't found` }
     }
 
     let elem = elems[0]

--- a/packages/webdriverio/src/utils/getElementObject.js
+++ b/packages/webdriverio/src/utils/getElementObject.js
@@ -1,0 +1,106 @@
+import { webdriverMonad } from 'webdriver'
+import { wrapCommand, runFnInFiberContext } from '@wdio/config'
+import merge from 'lodash.merge'
+
+import { getBrowserObject, getPrototype as getWDIOPrototype, getElementFromResponse } from '../utils'
+import { elementErrorHandler } from '../middlewares'
+import { ELEMENT_KEY } from '../constants'
+
+/**
+ * transforms and findElement response into a WDIO element
+ * @param  {String} selector  selector that was used to query the element
+ * @param  {Object} res       findElement response
+ * @return {Object}           WDIO element object
+ */
+export const getElement = function findElement (selector, res) {
+    const browser = getBrowserObject(this)
+    const prototype = merge({}, browser.__propertiesObject__, getWDIOPrototype('element'), { scope: 'element' })
+
+    const element = webdriverMonad(this.options, (client) => {
+        const elementId = getElementFromResponse(res)
+
+        if (elementId) {
+            /**
+             * set elementId for easy access
+             */
+            client.elementId = elementId
+
+            /**
+             * set element id with proper key so element can be passed into execute commands
+             */
+            if (this.isW3C) {
+                client[ELEMENT_KEY] = elementId
+            } else {
+                client.ELEMENT = elementId
+            }
+        } else {
+            client.error = res
+        }
+
+        client.selector = selector
+        client.parent = this
+        client.emit = ::this.emit
+        return client
+    }, prototype)
+
+    const elementInstance = element(this.sessionId, elementErrorHandler(wrapCommand))
+
+    const origAddCommand = ::elementInstance.addCommand
+    elementInstance.addCommand = (name, fn) => {
+        browser.__propertiesObject__[name] = { value: fn }
+        origAddCommand(name, runFnInFiberContext(fn))
+    }
+    return elementInstance
+}
+
+/**
+ * transforms and findElement response into a WDIO element
+ * @param  {String} selector  selector that was used to query the element
+ * @param  {Object} res       findElement response
+ * @return {Object}           WDIO element object
+ */
+export const getElements = function getElements (selector, res) {
+    const browser = getBrowserObject(this)
+    const prototype = merge({}, browser.__propertiesObject__, getWDIOPrototype('element'), { scope: 'element' })
+
+    const elements = res.map((res, i) => {
+        const element = webdriverMonad(this.options, (client) => {
+            const elementId = getElementFromResponse(res)
+
+            if (elementId) {
+                /**
+                 * set elementId for easy access
+                 */
+                client.elementId = elementId
+
+                /**
+                 * set element id with proper key so element can be passed into execute commands
+                 */
+                if (this.isW3C) {
+                    client[ELEMENT_KEY] = elementId
+                } else {
+                    client.ELEMENT = elementId
+                }
+            } else {
+                client.error = res
+            }
+
+            client.selector = selector
+            client.parent = this
+            client.index = i
+            client.emit = ::this.emit
+            return client
+        }, prototype)
+
+        const elementInstance = element(this.sessionId, elementErrorHandler(wrapCommand))
+
+        const origAddCommand = ::elementInstance.addCommand
+        elementInstance.addCommand = (name, fn) => {
+            browser.__propertiesObject__[name] = { value: fn }
+            origAddCommand(name, runFnInFiberContext(fn))
+        }
+        return elementInstance
+    })
+
+    return elements
+}

--- a/packages/webdriverio/tests/__mocks__/request.js
+++ b/packages/webdriverio/tests/__mocks__/request.js
@@ -133,9 +133,28 @@ const requestMock = jest.fn().mockImplementation((params, cb) => {
     case `/wd/hub/session/${sessionId}/execute/sync`: {
         const script = Function(params.body.script)
         const args = params.body.args.map(arg => arg.ELEMENT || arg[ELEMENT_KEY] || arg)
-        const result = script.apply(this, args)
+
+        let result = null
+        if (params.body.script.includes('resq')) {
+            if (params.body.script.includes('react$$')) {
+                result = [
+                    { [ELEMENT_KEY]: genericElementId },
+                    { [ELEMENT_KEY]: 'some-elem-456' },
+                    { [ELEMENT_KEY]: 'some-elem-789' },
+                ]
+            } else if (params.body.script.includes('react$')) {
+                result = args[0] === 'myNonExistingComp'
+                    ? null
+                    : { [ELEMENT_KEY]: genericElementId }
+            } else {
+                result = null
+            }
+        } else {
+            result = script.apply(this, args)
+        }
+
         //false and 0 are valid results
-        value = Boolean(result) || result === false || result === 0 ? result : {}
+        value = Boolean(result) || result === false || result === 0 || result === null ? result : {}
         break
     } case `/wd/hub/session/${sessionId}/element/${genericElementId}/elements`:
         value = [

--- a/packages/webdriverio/tests/__mocks__/request.js
+++ b/packages/webdriverio/tests/__mocks__/request.js
@@ -144,7 +144,7 @@ const requestMock = jest.fn().mockImplementation((params, cb) => {
                 ]
             } else if (params.body.script.includes('react$')) {
                 result = args[0] === 'myNonExistingComp'
-                    ? null
+                    ? new Error('foobar')
                     : { [ELEMENT_KEY]: genericElementId }
             } else {
                 result = null

--- a/packages/webdriverio/tests/commands/browser/reactElement.test.js
+++ b/packages/webdriverio/tests/commands/browser/reactElement.test.js
@@ -1,0 +1,52 @@
+import request from 'request'
+import { remote } from '../../../src'
+
+describe('react$', () => {
+    it('should fetch an React component', async () => {
+        const browser = await remote({
+            baseUrl: 'http://foobar.com',
+            capabilities: {
+                browserName: 'foobar'
+            }
+        })
+
+        const elem = await browser.react$(
+            'myComp',
+            { some: 'props' },
+            { some: 'state' }
+        )
+
+        expect(elem.elementId).toBe('some-elem-123')
+        expect(request).toBeCalledTimes(4)
+        expect(request.mock.calls.pop()[0].body.args)
+            .toEqual(['myComp', { some: 'props' }, { some: 'state' }])
+    })
+
+    it('should default state and props to empty object', async () => {
+        const browser = await remote({
+            baseUrl: 'http://foobar.com',
+            capabilities: {
+                browserName: 'foobar'
+            }
+        })
+
+        await browser.react$('myComp')
+        expect(request.mock.calls.pop()[0].body.args).toEqual(['myComp', {}, {}])
+    })
+
+    it('should set error object if no element could be found', async () => {
+        const browser = await remote({
+            baseUrl: 'http://foobar.com',
+            capabilities: {
+                browserName: 'foobar'
+            }
+        })
+
+        return expect(browser.react$('myNonExistingComp')).rejects.toThrow(
+            new Error('React element with selector "myNonExistingComp" wasn\'t found'))
+    })
+
+    afterEach(() => {
+        request.mockClear()
+    })
+})

--- a/packages/webdriverio/tests/commands/browser/reactElement.test.js
+++ b/packages/webdriverio/tests/commands/browser/reactElement.test.js
@@ -42,8 +42,8 @@ describe('react$', () => {
             }
         })
 
-        return expect(browser.react$('myNonExistingComp')).rejects.toThrow(
-            new Error('React element with selector "myNonExistingComp" wasn\'t found'))
+        const elem = await browser.react$('myNonExistingComp')
+        expect(elem.error).toEqual(new Error('foobar'))
     })
 
     afterEach(() => {

--- a/packages/webdriverio/tests/commands/browser/reactElements.test.js
+++ b/packages/webdriverio/tests/commands/browser/reactElements.test.js
@@ -1,0 +1,52 @@
+import request from 'request'
+import { ELEMENT_KEY } from '../../../src/constants'
+import { remote } from '../../../src'
+
+describe('react$', () => {
+    it('should fetch an React component', async () => {
+        const browser = await remote({
+            baseUrl: 'http://foobar.com',
+            capabilities: {
+                browserName: 'foobar'
+            }
+        })
+
+        const elems = await browser.react$$(
+            'myComp',
+            { some: 'props' },
+            { some: 'state' }
+        )
+
+        expect(elems.length).toBe(3)
+        expect(elems[0].elementId).toBe('some-elem-123')
+        expect(elems[0][ELEMENT_KEY]).toBe('some-elem-123')
+        expect(elems[0].ELEMENT).toBe(undefined)
+        expect(elems[0].selector).toBe('myComp')
+        expect(elems[0].index).toBe(0)
+        expect(elems[1].elementId).toBe('some-elem-456')
+        expect(elems[1][ELEMENT_KEY]).toBe('some-elem-456')
+        expect(elems[1].ELEMENT).toBe(undefined)
+        expect(elems[1].selector).toBe('myComp')
+        expect(elems[1].index).toBe(1)
+        expect(elems[2].elementId).toBe('some-elem-789')
+        expect(elems[2][ELEMENT_KEY]).toBe('some-elem-789')
+        expect(elems[2].ELEMENT).toBe(undefined)
+        expect(elems[2].selector).toBe('myComp')
+        expect(elems[2].index).toBe(2)
+        expect(request).toBeCalledTimes(4)
+        expect(request.mock.calls.pop()[0].body.args)
+            .toEqual(['myComp', { some: 'props' }, { some: 'state' }])
+    })
+
+    it('should default state and props to empty object', async () => {
+        const browser = await remote({
+            baseUrl: 'http://foobar.com',
+            capabilities: {
+                browserName: 'foobar'
+            }
+        })
+
+        await browser.react$$('myComp')
+        expect(request.mock.calls.pop()[0].body.args).toEqual(['myComp', {}, {}])
+    })
+})

--- a/packages/webdriverio/tests/module.test.js
+++ b/packages/webdriverio/tests/module.test.js
@@ -1,7 +1,7 @@
 import path from 'path'
 import { detectBackend } from '@wdio/config'
 
-import { remote, multiremote } from '../src'
+import { remote, multiremote, attach } from '../src'
 
 jest.mock('webdriver', () => {
     const client = {
@@ -75,6 +75,13 @@ describe('WebdriverIO module interface', () => {
             })
             expect(WebDriver.attachToSession).toBeCalled()
             expect(WebDriver.newSession.mock.calls).toHaveLength(2)
+        })
+    })
+
+    describe('attach', () => {
+        it('attaches', () => {
+            attach({})
+            expect(WebDriver.attachToSession).toBeCalled()
         })
     })
 

--- a/packages/webdriverio/tests/scripts/resq.test.js
+++ b/packages/webdriverio/tests/scripts/resq.test.js
@@ -1,0 +1,60 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { react$, react$$, waitToLoadReact } from '../../src/scripts/resq'
+
+class MockResq {
+    constructor() {
+        this.byProps = jest.fn().mockImplementation(() => new MockResq())
+        this.byState = jest.fn().mockImplementation(() => new MockResq())
+    }
+}
+
+beforeEach(() => {
+    global.window.resq = {
+        resq$: jest.fn().mockImplementation(() => new MockResq()),
+        resq$$: jest.fn().mockImplementation(() => new MockResq()),
+        waitToLoadReact: jest.fn(),
+    }
+})
+
+describe('resq script', () => {
+    it('should call the window resq$', () => {
+        const result = react$('Test', { foo: 'bar' }, { test: 123 })
+
+        const { resq$ } = global.window.resq
+        const { byProps } = resq$.mock.results[0].value
+        const { byState } = byProps.mock.results[0].value
+
+        expect(resq$).toBeCalledTimes(1)
+        expect(resq$).toBeCalledWith('Test')
+        expect(byProps).toBeCalledTimes(1)
+        expect(byProps).toBeCalledWith({ foo: 'bar' })
+        expect(byState).toBeCalledTimes(1)
+        expect(byState).toBeCalledWith({ test: 123 })
+        expect(result).toMatchObject({ message: 'React element with selector "Test" wasn\'t found' })
+    })
+
+    it('should call the window resq$$', () => {
+        const result = react$$('Test', { foo: 'bar' }, { test: 123 })
+
+        const { resq$$ } = global.window.resq
+        const { byProps } = resq$$.mock.results[0].value
+        const { byState } = byProps.mock.results[0].value
+
+        expect(resq$$).toBeCalledTimes(1)
+        expect(resq$$).toBeCalledWith('Test')
+        expect(byProps).toBeCalledTimes(1)
+        expect(byProps).toBeCalledWith({ foo: 'bar' })
+        expect(byState).toBeCalledTimes(1)
+        expect(byState).toBeCalledWith({ test: 123 })
+        expect(result).toMatchObject([])
+    })
+
+    it('should call window waitToLoadReact', () => {
+        waitToLoadReact()
+
+        expect(global.window.resq.waitToLoadReact).toBeCalledTimes(1)
+    })
+})


### PR DESCRIPTION
## Proposed changes

We want to simplify the way people fetch elements within React applications. This patch introduces `react$` and `react$$` that allow to query and React component bz y its actual component name and filter by prop and state properties.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

This is currently work in progress. There are some things that have to be changed in `resq` to get this working. A modified version of that package allowed to run the following test:

```js
await browser.url('https://ahfarmer.github.io/calculator/');

const btn7 = await browser.react$('t', { name: '7' })
const btn6 = await browser.react$('t', { name: '6' })
const btnMult = await browser.react$('t', { name: 'x' })
const btnEqual = await browser.react$('t', { name: '=' })
const display = await browser.$('.component-display')

await btn7.click()
await btnMult.click()
await btn6.click()
await btnEqual.click()

console.log(await display.getText()); // prints "42"
```

### Reviewers: @webdriverio/technical-committee
