### PR TITLE
webdriver: add missed return types for jsonwp

### DIFF
--- a/packages/webdriver/protocol/jsonwp.json
+++ b/packages/webdriver/protocol/jsonwp.json
@@ -688,7 +688,12 @@
       "command": "getPageSource",
       "description": "",
       "ref": "https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidsource",
-      "parameters": []
+      "parameters": [],
+      "returns": {
+        "type": "String",
+        "name": "source",
+        "description": "The current page source."
+      }
     }
   },
   "/session/:sessionId/execute": {
@@ -706,7 +711,12 @@
         "type": "(string|object|number|boolean|undefined)[]",
         "description": "the script arguments",
         "required": true
-      }]
+      }],
+      "returns": {
+        "type": "*",
+        "name": "result",
+        "description": "The script result."
+      }
     }
   },
   "/session/:sessionId/execute_async": {
@@ -724,7 +734,12 @@
         "type": "(string|object|number|boolean|undefined)[]",
         "description": "the script arguments",
         "required": true
-      }]
+      }],
+      "returns": {
+        "type": "*",
+        "name": "result",
+        "description": "The script result."
+      }
     }
   },
   "/session/:sessionId/cookie": {
@@ -732,7 +747,12 @@
       "command": "getAllCookies",
       "description": "",
       "ref": "https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#get-sessionsessionidcookie",
-      "parameters": []
+      "parameters": [],
+      "returns": {
+        "type": "Object[]",
+        "name": "cookies",
+        "description": "A list of cookies."
+      }
     },
     "POST": {
       "command": "addCookie",
@@ -817,7 +837,12 @@
       "command": "getAvailableEngines",
       "description": "",
       "ref": "https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidimeavailable_engines",
-      "parameters": []
+      "parameters": [],
+      "returns": {
+        "type": "String[]",
+        "name": "engines",
+        "description": "A list of available engines"
+      }
     }
   },
   "/session/:sessionId/ime/active_engine": {
@@ -825,7 +850,12 @@
       "command": "getActiveEngine",
       "description": "",
       "ref": "https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidimeactive_engine",
-      "parameters": []
+      "parameters": [],
+      "returns": {
+        "type": "String",
+        "name": "engine",
+        "description": "The name of the active IME engine"
+      }
     }
   },
   "/session/:sessionId/ime/activated": {
@@ -833,7 +863,12 @@
       "command": "isIMEActivated",
       "description": "",
       "ref": "https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidimeactivated",
-      "parameters": []
+      "parameters": [],
+      "returns": {
+        "type": "Boolean",
+        "name": "isActive",
+        "description": "true if IME input is available and currently active, false otherwise"
+      }
     }
   },
   "/session/:sessionId/ime/deactivate": {
@@ -862,7 +897,12 @@
       "command": "getOrientation",
       "description": "",
       "ref": "https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#get-sessionsessionidorientation",
-      "parameters": []
+      "parameters": [],
+      "returns": {
+        "type": "String",
+        "name": "orientation",
+        "description": "The current browser orientation corresponding to a value defined in ScreenOrientation: {LANDSCAPE|PORTRAIT}."
+      }
     },
     "POST": {
       "command": "setOrientation",
@@ -1256,7 +1296,12 @@
       "command": "getSessionStorageSize",
       "description": "Get the number of items in the storage.",
       "ref": "https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidsession_storagesize",
-      "parameters": []
+      "parameters": [],
+      "returns": {
+        "type": "Number",
+        "name": "itemCnt",
+        "description": "The number of items in the storage."
+      }
     }
   },
   "/session/:sessionId/log": {


### PR DESCRIPTION
## Proposed changes
Some return types were missed in jsonwp. But `https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol` when I make search by `Returns:` I see 43 findings. In our jsonwp.json 47 matches. But when I started searching I found that some returns missed on the site, so I decided not check again all our commands with returns. 

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
