### PR TITLE
Display link to EU platform of Sauce

### DIFF
--- a/packages/wdio-spec-reporter/src/index.js
+++ b/packages/wdio-spec-reporter/src/index.js
@@ -96,7 +96,8 @@ class SpecReporter extends WDIOReporter {
      */
     getTestLink ({ config, sessionId }) {
         if (config.hostname.includes('saucelabs')) {
-            return ['', `Check out job at https://app.saucelabs.com/tests/${sessionId}`]
+            const dc = ['eu', 'eu-central-1'].includes(config.region) ? '.eu-central-1' : ''
+            return ['', `Check out job at https://app${dc}.saucelabs.com/tests/${sessionId}`]
         }
 
         return []

--- a/packages/wdio-spec-reporter/tests/__fixtures__/testdata.js
+++ b/packages/wdio-spec-reporter/tests/__fixtures__/testdata.js
@@ -174,3 +174,7 @@ export const REPORT = `---------------------------------------------------------
 export const SAUCELABS_REPORT = REPORT + `[loremipsum #0-0]
 [loremipsum #0-0] Check out job at https://app.saucelabs.com/tests/ba86cbcb70774ef8a0757c1702c3bdf9
 `
+
+export const SAUCELABS_EU_REPORT = REPORT + `[loremipsum #0-0]
+[loremipsum #0-0] Check out job at https://app.saucelabs.com/tests/ba86cbcb70774ef8a0757c1702c3bdf9
+`

--- a/packages/wdio-spec-reporter/tests/__fixtures__/testdata.js
+++ b/packages/wdio-spec-reporter/tests/__fixtures__/testdata.js
@@ -176,5 +176,5 @@ export const SAUCELABS_REPORT = REPORT + `[loremipsum #0-0]
 `
 
 export const SAUCELABS_EU_REPORT = REPORT + `[loremipsum #0-0]
-[loremipsum #0-0] Check out job at https://app.saucelabs.com/tests/ba86cbcb70774ef8a0757c1702c3bdf9
+[loremipsum #0-0] Check out job at https://app.eu-central-1.saucelabs.com/tests/ba86cbcb70774ef8a0757c1702c3bdf9
 `

--- a/packages/wdio-spec-reporter/tests/index.test.js
+++ b/packages/wdio-spec-reporter/tests/index.test.js
@@ -7,6 +7,7 @@ import {
     SUITES_NO_TESTS,
     REPORT,
     SAUCELABS_REPORT,
+    SAUCELABS_EU_REPORT,
     SUITES_NO_TESTS_WITH_HOOK_ERROR,
     SUITES_MULTIPLE_ERRORS
 } from './__fixtures__/testdata'
@@ -171,6 +172,36 @@ describe('SpecReporter', () => {
             printReporter.printReport(runner)
 
             expect(printReporter.write).toBeCalledWith(SAUCELABS_REPORT)
+        })
+
+        it('should print link to SauceLabs EU job details page', () => {
+            printReporter.suiteUids = SUITE_UIDS
+            printReporter.suites = SUITES
+            printReporter.stateCounts = {
+                passed : 4,
+                failed : 1,
+                skipped : 1,
+            }
+
+            printReporter.printReport(Object.assign({}, RUNNER, {
+                config: {
+                    hostname: 'ondemand.saucelabs.com',
+                    region: 'eu'
+                },
+                sessionId: 'ba86cbcb70774ef8a0757c1702c3bdf9'
+            }))
+            expect(printReporter.write).toBeCalledWith(SAUCELABS_EU_REPORT)
+
+            printReporter.write.mockClear()
+
+            printReporter.printReport(Object.assign({}, RUNNER, {
+                config: {
+                    hostname: 'ondemand.saucelabs.com',
+                    region: 'eu-central-1'
+                },
+                sessionId: 'ba86cbcb70774ef8a0757c1702c3bdf9'
+            }))
+            expect(printReporter.write).toBeCalledWith(SAUCELABS_EU_REPORT)
         })
 
         it('should print report for suites with no tests but failed hooks', () => {


### PR DESCRIPTION
## Proposed changes

When running tests on Sauce EU the link in the spec reporter didn't linked to the EU platform.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
