### PR TITLE
Fix runFnInFiberContext to allow wrapped commands to run in try/catch

### DIFF
--- a/packages/wdio-sync/src/runFnInFiberContext.js
+++ b/packages/wdio-sync/src/runFnInFiberContext.js
@@ -7,9 +7,13 @@ import Fiber from 'fibers'
  */
 export default function runFnInFiberContext (fn) {
     return function (...args) {
-        return new Promise((resolve) => Fiber(() => {
-            const result = fn.apply(this, args)
-            resolve(result)
+        return new Promise((resolve, reject) => Fiber(() => {
+            try {
+                const result = fn.apply(this, args)
+                return resolve(result)
+            } catch (err) {
+                return reject(err)
+            }
         }).run())
     }
 }

--- a/packages/wdio-sync/tests/__mocks__/fibers.js
+++ b/packages/wdio-sync/tests/__mocks__/fibers.js
@@ -1,0 +1,5 @@
+const FiberMock = jest.fn().mockImplementation((fn) => {
+    return { run: fn }
+})
+
+export default FiberMock

--- a/packages/wdio-sync/tests/runFnInFibersContext.test.js
+++ b/packages/wdio-sync/tests/runFnInFibersContext.test.js
@@ -1,0 +1,18 @@
+import runFnInFiberContext from '../src/runFnInFiberContext'
+
+test('should wrap a successful running command', async () => {
+    const wrappedFn = runFnInFiberContext(function (arg) {
+        return this.scopedVar + arg
+    })
+
+    expect(await wrappedFn.call({ scopedVar: 'foo' }, 'bar')).toBe('foobar')
+})
+
+test('should wrap a failing running command', async () => {
+    const wrappedFn = runFnInFiberContext(function (arg) {
+        throw new Error(this.scopedVar + arg)
+    })
+
+    await expect(wrappedFn.call({ scopedVar: 'foo' }, 'bar'))
+        .rejects.toThrow(new Error('foobar'))
+})


### PR DESCRIPTION
## Proposed changes

Fix behavior where wrapped Fiber commands would throw even though they are within try/catch.

closes #3815

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
