### PR TITLE
Ensure ms edge runs on w3c on Sauce

### DIFF
--- a/packages/webdriver/src/utils.js
+++ b/packages/webdriver/src/utils.js
@@ -198,11 +198,19 @@ export function isW3C (capabilities) {
      * assume session to be a WebDriver session when
      * - capabilities are returned
      *   (https://w3c.github.io/webdriver/#dfn-new-sessions)
-     * - a `platform` capability is not given but a platformName is returned
-     *   which is not defined in the JSONWire protocol
+     * - it is an Appium session (since Appium is full W3C compliant)
      */
     const isAppium = capabilities.automationName || capabilities.deviceName
-    return Boolean((!capabilities.platform && capabilities.platformName) || isAppium)
+    const hasW3CCaps = (
+        capabilities.platformName &&
+        capabilities.browserVersion &&
+        /**
+         * local safari doesn't provide platformVersion therefor
+         * check also for setWindowRect
+         */
+        (capabilities.platformVersion || capabilities.setWindowRect)
+    )
+    return Boolean(hasW3CCaps || isAppium)
 }
 
 /**

--- a/packages/webdriver/tests/__fixtures__/edgedriver.response.json
+++ b/packages/webdriver/tests/__fixtures__/edgedriver.response.json
@@ -1,0 +1,25 @@
+{
+  "value": {
+    "sessionId": "867A8C76-537F-4F2B-897C-85F87DF2C995",
+    "capabilities": {
+      "ms:inPrivate": false,
+      "browserVersion": "44.17763.1.0",
+      "takesScreenshot": true,
+      "acceptSslCerts": true,
+      "cssSelectorsEnabled": true,
+      "javascriptEnabled": true,
+      "browserName": "MicrosoftEdge",
+      "locationContextEnabled": true,
+      "platform": "ANY",
+      "takesElementScreenshot": true,
+      "webdriver.remote.sessionid": "199008b1e1e64a039d45e534d71b1e32",
+      "hasMetadata": true,
+      "applicationCacheEnabled": true,
+      "webStorageEnabled": true,
+      "pageLoadStrategy": "normal",
+      "platformName": "windows",
+      "platformVersion": "10",
+      "unhandledPromptBehavior": "dismiss and notify"
+    }
+  }
+}

--- a/packages/webdriver/tests/utils.test.js
+++ b/packages/webdriver/tests/utils.test.js
@@ -8,6 +8,7 @@ import chromedriverResponse from './__fixtures__/chromedriver.response.json'
 import geckodriverResponse from './__fixtures__/geckodriver.response.json'
 import safaridriverResponse from './__fixtures__/safaridriver.response.json'
 import safaridriverLegacyResponse from './__fixtures__/safaridriver.legacy.response.json'
+import edgedriverResponse from './__fixtures__/edgedriver.response.json'
 
 describe('utils', () => {
     it('isSuccessfulResponse', () => {
@@ -118,6 +119,7 @@ describe('utils', () => {
         const chromeCaps = chromedriverResponse.value
         const appiumCaps = appiumResponse.value.capabilities
         const geckoCaps = geckodriverResponse.value.capabilities
+        const edgeCaps = edgedriverResponse.value.capabilities
         const safariCaps = safaridriverResponse.value.capabilities
         const safariLegacyCaps = safaridriverLegacyResponse.value
 
@@ -127,6 +129,7 @@ describe('utils', () => {
             expect(environmentDetector({ capabilities: chromeCaps, requestedCapabilities }).isW3C).toBe(false)
             expect(environmentDetector({ capabilities: geckoCaps, requestedCapabilities }).isW3C).toBe(true)
             expect(environmentDetector({ capabilities: safariCaps, requestedCapabilities }).isW3C).toBe(true)
+            expect(environmentDetector({ capabilities: edgeCaps, requestedCapabilities }).isW3C).toBe(true)
             expect(environmentDetector({ capabilities: safariLegacyCaps, requestedCapabilities }).isW3C).toBe(false)
             expect(isW3C()).toBe(false)
         })

--- a/packages/webdriverio/tests/__mocks__/request.js
+++ b/packages/webdriverio/tests/__mocks__/request.js
@@ -14,7 +14,9 @@ const requestMock = jest.fn().mockImplementation((params, cb) => {
         sessionId,
         capabilities: {
             browserName: 'mockBrowser',
-            platformName: 'node'
+            platformName: 'node',
+            browserVersion: '1234',
+            setWindowRect: true
         }
     }
 


### PR DESCRIPTION
## Proposed changes

Seems that `webdriver` doesn't properly determine MS Edge sessions on Sauce as W3C sessions.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
