### PR TITLE
webdriver: add disableW3cCapabilities option

### DIFF
--- a/packages/webdriver/src/index.js
+++ b/packages/webdriver/src/index.js
@@ -17,6 +17,10 @@ export default class WebDriver {
     static async newSession (options = {}, modifier, userPrototype = {}, commandWrapper) {
         const params = validateConfig(DEFAULTS, options)
 
+        const disableW3cCapabilities = Object.prototype.hasOwnProperty.call(options, 'disableW3cCapabilities')
+            ? options.disableW3cCapabilities
+            : false
+
         if (!options.logLevels || !options.logLevels['webdriver']) {
             logger.setLevel('webdriver', params.logLevel)
         }
@@ -41,8 +45,8 @@ export default class WebDriver {
             'POST',
             '/session',
             {
-                capabilities: w3cCaps, // W3C compliant
-                desiredCapabilities: jsonwpCaps // JSONWP compliant
+                desiredCapabilities: jsonwpCaps, // JSONWP compliant
+                ...(disableW3cCapabilities ? {} : { capabilities: w3cCaps }), // W3C compliant
             }
         )
 

--- a/packages/webdriver/tests/index.test.js
+++ b/packages/webdriver/tests/index.test.js
@@ -40,6 +40,23 @@ test('should allow to create a new session using w3c compliant caps', async () =
     })
 })
 
+test('should allow to disable w3c caps', async () => {
+    await WebDriver.newSession({
+        path: '/',
+        capabilities: {
+            alwaysMatch: { browserName: 'firefox' },
+            firstMatch: [{}]
+        },
+        disableW3cCapabilities: true
+    })
+
+    const req = request.mock.calls[0][0]
+    expect(req.uri.pathname).toBe('/session')
+    expect(req.body).toEqual({
+        desiredCapabilities: { browserName: 'firefox' }
+    })
+})
+
 test('should be possible to skip setting logLevel', async () => {
     logger.setLevel.mockClear()
     await WebDriver.newSession({


### PR DESCRIPTION
## Proposed changes

Allow to choose whether to send W3C capabilities when creating a new session with the test runner.
Fixes #3842. 

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

### Reviewers: @webdriverio/technical-committee
