### PR TITLE
webdriver: Fix link for setTimeouts

### DIFF
--- a/packages/webdriver/protocol/webdriver.json
+++ b/packages/webdriver/protocol/webdriver.json
@@ -53,7 +53,7 @@
     "POST": {
       "command": "setTimeouts",
       "description": "The Set Timeouts command sets timeout durations associated with the current session. The timeouts that can be controlled are listed in the table of session timeouts below.",
-      "ref": "https://w3c.github.io/webdriver/#dfn-timeouts",
+      "ref": "https://w3c.github.io/webdriver/#dfn-set-timeouts",
       "parameters": [{
         "name": "implicit",
         "type": "number",


### PR DESCRIPTION
## Proposed changes

Fixes the link to setTimeouts command.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

### Reviewers: @webdriverio/technical-committee
