### PR TITLE
Returned object type to switchToFram under webdriver protocol

### DIFF
--- a/packages/webdriver/protocol/webdriver.json
+++ b/packages/webdriver/protocol/webdriver.json
@@ -201,7 +201,7 @@
       "ref": "https://w3c.github.io/webdriver/#dfn-switch-to-frame",
       "parameters": [{
         "name": "id",
-        "type": "(number|string|null)",
+        "type": "(number|string|object|null)",
         "description": "one of three possible types: null: this represents the top-level browsing context (i.e., not an iframe), a Number, representing the index of the window object corresponding to a frame, a string representing an element id that can be received using `findElement`.",
         "required": true
       }]


### PR DESCRIPTION
Related to Bug: 
https://github.com/webdriverio/webdriverio/issues/3860

Based on: 
https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidframe