### PR TITLE
apply wdioLogLevel before starting workers

### DIFF
--- a/packages/wdio-cli/src/launcher.js
+++ b/packages/wdio-cli/src/launcher.js
@@ -29,7 +29,7 @@ class Launcher {
             process.env.WDIO_LOG_PATH = path.join(config.outputDir, 'wdio.log')
         }
 
-        logger.setLogLevelsConfig(config.logLevels)
+        logger.setLogLevelsConfig(config.logLevels, config.logLevel)
 
         const totalWorkerCnt = Array.isArray(capabilities)
             ? capabilities

--- a/packages/wdio-local-runner/src/worker.js
+++ b/packages/wdio-local-runner/src/worker.js
@@ -50,7 +50,6 @@ export default class WorkerInstance extends EventEmitter {
         const argv = process.argv.slice(2)
 
         const runnerEnv = Object.assign(process.env, this.config.runnerEnv, {
-            WDIO_LOG_LEVEL: this.config.logLevel,
             WDIO_WORKER: true
         })
 

--- a/packages/wdio-logger/src/node.js
+++ b/packages/wdio-logger/src/node.js
@@ -153,7 +153,7 @@ getLogger.setLogLevelsConfig = (logLevels = {}, wdioLogLevel = DEFAULT_LEVEL) =>
         /**
          * either apply log level from logLevels object or use global logLevel
          */
-        const logLevel = logLevelsConfig[logLevelName] !== undefined ? logLevelsConfig[logLevelName] : process.env.WDIO_LOG_LEVEL
+        const logLevel = typeof logLevelsConfig[logLevelName] !== 'undefined' ? logLevelsConfig[logLevelName] : process.env.WDIO_LOG_LEVEL
 
         loggers[logName].setLevel(logLevel)
     })

--- a/packages/wdio-logger/tests/node.test.js
+++ b/packages/wdio-logger/tests/node.test.js
@@ -108,6 +108,15 @@ describe('wdio-logger node', () => {
             expect(log.getLevel()).toEqual(0)
         })
 
+        it('should set wdio logLevel passed as argument', () => {
+            const log = nodeLogger('test-wdio-log-level')
+            expect(log.getLevel()).toEqual(0)
+
+            nodeLogger.setLogLevelsConfig(undefined, 'info')
+
+            expect(log.getLevel()).toEqual(2)
+        })
+
         afterEach(() => {
             delete process.env.WDIO_LOG_LEVEL
         })

--- a/packages/wdio-runner/src/index.js
+++ b/packages/wdio-runner/src/index.js
@@ -55,7 +55,7 @@ export default class Runner extends EventEmitter {
         this.configParser.merge(server)
 
         this.config = this.configParser.getConfig()
-        logger.setLogLevelsConfig(this.config.logLevels)
+        logger.setLogLevelsConfig(this.config.logLevels, this.config.logLevel)
         this.isMultiremote = !Array.isArray(this.configParser.getCapabilities())
         initialiseServices(this.config, caps).map(::this.configParser.addService)
 


### PR DESCRIPTION
## Proposed changes

Want to change current behaviour of applying `logLevel`.

Current:
1. Initialise loggers with default `logLevel` (because config is not yet parsed)
2. Set `logLevels`
3. Set `logLevel` when workers start

As a result `logLevel` is ignored for some loggers and it is not possible to override `logLevel` in conf file using ENV variable.

New:
1. Initialise loggers with default `logLevel` (because config is not yet parsed)
2. Set `logLevel` if was not provided by user with ENV var `WDIO_LOG_LEVEL`
3. Set `logLevels`

In such case `logLevel` is applied before printing any messages to log

---

fixes some more issues mentioned in #3867 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

Output example having only `logLevel` set to silent:

```
Test Suites:     1 passed, 1 total (100% completed)
Time:            🕐  8.02s
```

### Reviewers: @webdriverio/technical-committee
