### PR TITLE
wdio-local-runner: unpipe streams in the end

### DIFF
--- a/packages/wdio-local-runner/src/transformStream.js
+++ b/packages/wdio-local-runner/src/transformStream.js
@@ -19,12 +19,8 @@ export default class RunnerTransformStream extends Transform {
         callback()
     }
 
-    _final () {
-        /**
-         * we don't want to do anything here otherwise we would end the
-         * stream of the local runner that captures stdout/stderr or all
-         * runners and therefor would loose all incoming messages after
-         * the first runner finishes.
-         */
+    _final (callback) {
+        this.unpipe()
+        callback()
     }
 }

--- a/packages/wdio-local-runner/tests/transformStream.test.js
+++ b/packages/wdio-local-runner/tests/transformStream.test.js
@@ -1,27 +1,38 @@
 import RunnerTransformStream from '../src/transformStream'
 import { DEBUGGER_MESSAGES } from '../src/constants'
 
-jest.mock('stream', () => {
-    class TransformMock {
-        constructor () {
-            this.push = jest.fn()
-        }
-    }
-
-    return { Transform: TransformMock }
-})
-
 test('should add cid to message', () => {
     const stream = new RunnerTransformStream('0-5')
     const cb = jest.fn()
+    const pushSpy = jest.spyOn(stream, 'push')
+
     stream._transform('foobar', null, cb)
-    expect(stream.push).toBeCalledWith('[0-5] foobar')
+    expect(pushSpy).toBeCalledWith('[0-5] foobar')
     expect(cb).toBeCalled()
 })
 
 test('should ignore debugger messages', () => {
     const stream = new RunnerTransformStream('0-5')
     const cb = jest.fn()
+    const pushSpy = jest.spyOn(stream, 'push')
+
     DEBUGGER_MESSAGES.forEach(m => stream._transform(`${m} foobar`, null, cb))
-    expect(stream.push).toBeCalledTimes(0)
+    expect(pushSpy).toBeCalledTimes(0)
+})
+
+test('should ignore debugger messages', (done) => {
+    const stream = new RunnerTransformStream('0-5')
+    const stream2 = new RunnerTransformStream('0-6')
+
+    stream2.pipe(stream)
+    const cb = jest.fn()
+    stream.on('unpipe', cb)
+
+    const finalSpy = jest.spyOn(stream, '_final')
+
+    stream.end(() => {
+        expect(cb).toBeCalled()
+        expect(finalSpy).toBeCalled()
+        done()
+    })
 })


### PR DESCRIPTION
## Proposed changes

Previously **RunnerTransformStream** streams were closed. 
After recent changes closing stream was causing `Error [ERR_STREAM_WRITE_AFTER_END]: write after end` because `end` was triggered while streams were in pipe.

Added `unpipe` and restored stream closing functionality.

fixes #3877 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

I have some problems with covering this functionality with proper tests.
Just added test to ensure `unpipe` was called.

### Reviewers: @webdriverio/technical-committee
