### PR TITLE
junit-reporter: fix log file names

### DIFF
--- a/packages/wdio-junit-reporter/README.md
+++ b/packages/wdio-junit-reporter/README.md
@@ -32,7 +32,7 @@ are examples of XML output given different scenarios in the spec file.
 ```javascript
 describe('a test suite', () => {
     it('a test case', function () {
-      // do something 
+      // do something
       // assert something
     });
 });
@@ -57,7 +57,7 @@ becomes
 describe('a test suite', () => {
     describe('a nested test suite', function() {
         it('a test case', function () {
-          // do something 
+          // do something
           // assert something
         });
     });
@@ -90,13 +90,13 @@ becomes
 ```javascript
 describe('a test suite', () => {
     it('a test case', function () {
-      // do something 
+      // do something
       // assert something
     });
 });
 describe('a second test suite', () => {
     it('a second test case', function () {
-      // do something 
+      // do something
       // assert something
     });
 });
@@ -153,8 +153,8 @@ module.exports = {
         'dot',
         ['junit', {
             outputDir: './',
-            outputFileFormat: function(opts) { // optional
-                return `results-${opts.cid}.${opts.capabilities}.xml`
+            outputFileFormat: function(options) { // optional
+                return `results-${options.cid}.${options.capabilities}.xml`
             }
         }]
     ],
@@ -174,15 +174,16 @@ Required
 Define the xml files created after the test execution.
 
 Type: `Object`<br>
-Default: ``function(opts){return `WDIO.xunit.${opts.capabilities}.${opts.cid}.xml`}``
+Default: ``function(opts){return `wdio-${this.cid}-${name}-reporter.log`}``
 
 ```
 outputFileFormat: {
-    single: function (config) {
+    single: function (options) {
         return 'mycustomfilename.xml';
     }
 }
 ```
+> Note: `options.capabilities` is your capabilities object for that runner, so specifying `${options.capabilities}` in your string will return [Object object]. You must specify which properties of capabilities you want in your filename.
 
 ### suiteNameFormat
 

--- a/packages/wdio-runner/src/reporter.js
+++ b/packages/wdio-runner/src/reporter.js
@@ -17,7 +17,6 @@ export default class BaseReporter {
     constructor (config, cid, caps) {
         this.config = config
         this.cid = cid
-        this.reporters = config.reporters.map(::this.initReporter)
         this.caps = caps
 
         /**
@@ -25,6 +24,10 @@ export default class BaseReporter {
          */
         this.reporterSyncInterval = this.config.reporterSyncInterval || DEFAULT_SYNC_INTERVAL
         this.reporterSyncTimeout = this.config.reporterSyncTimeout || DEFAULT_SYNC_TIMEOUT
+
+        // ensure all properties are set before initializing the reporters
+        this.reporters = config.reporters.map(::this.initReporter)
+
     }
 
     /**
@@ -39,7 +42,8 @@ export default class BaseReporter {
     }
 
     getLogFile(name) {
-        let options = this.config
+        // clone the config to avoid changing original properties
+        let options = Object.assign({}, this.config)
         let filename = `wdio-${this.cid}-${name}-reporter.log`
 
         const reporterOptions = this.config.reporters.find((reporter) => (

--- a/packages/wdio-runner/tests/reporter.test.js
+++ b/packages/wdio-runner/tests/reporter.test.js
@@ -42,7 +42,6 @@ describe('BaseReporter', () => {
         const reporter = new BaseReporter({
             outputDir: '/foo/bar',
             reporters: [
-                'dot',
                 ['dot', {
                     foo: 'bar',
                     outputDir: '/foo/bar/baz'
@@ -50,7 +49,7 @@ describe('BaseReporter', () => {
             ]
         }, '0-0')
 
-        expect(reporter.getLogFile('foobar')).toBe('/foo/bar/baz/wdio-0-0-foobar-reporter.log')
+        expect(reporter.getLogFile('dot')).toBe('/foo/bar/baz/wdio-0-0-dot-reporter.log')
     })
 
     it('should return custom log file name', () => {


### PR DESCRIPTION
## Proposed changes

In response to https://github.com/webdriverio/webdriverio/issues/3879 I made the following changes:

- Ensure that the this.caps is set in wdio-runner reporter.js before the reporters are initialized inside the constructor.
- Ensure that this.config.outputDir is not modified when initializing the reporters.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

### Reviewers: @webdriverio/technical-committee
