### PR TITLE
Don't try to connect to localhost anymore

### DIFF
--- a/docs/ConfigurationFile.md
+++ b/docs/ConfigurationFile.md
@@ -24,7 +24,7 @@ exports.config = {
     // according to your user and key information. However if you are using a private Selenium
     // backend you should define the host address, port, and path here.
     //
-    hostname: '0.0.0.0',
+    hostname: 'localhost',
     port: 4444,
     path: '/wd/hub',
     //

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -21,7 +21,7 @@ Default: `http`
 Host of your driver server.
 
 Type: `String`<br>
-Default: `0.0.0.0`
+Default: `localhost`
 
 ### port
 Port your driver server is on.

--- a/examples/wdio.conf.js
+++ b/examples/wdio.conf.js
@@ -11,7 +11,7 @@ exports.config = {
     // according to your user and key information. However, if you are using a private Selenium
     // backend you should define the host address, port, and path here.
     //
-    hostname: '0.0.0.0',
+    hostname: 'localhost',
     port: 4444,
     path: '/wd/hub',
     //

--- a/examples/wdio/cucumber/wdio.conf.js
+++ b/examples/wdio/cucumber/wdio.conf.js
@@ -2,7 +2,7 @@ exports.config = {
     /**
      * server configurations
      */
-    hostname: '0.0.0.0',
+    hostname: 'localhost',
     port: 4444,
 
     /**

--- a/examples/wdio/custom-reporter/wdio.conf.js
+++ b/examples/wdio/custom-reporter/wdio.conf.js
@@ -5,7 +5,7 @@ exports.config = {
     /**
      * server configurations
      */
-    hostname: '0.0.0.0',
+    hostname: 'localhost',
     port: 4444,
 
     /**

--- a/examples/wdio/jasmine/wdio.conf.js
+++ b/examples/wdio/jasmine/wdio.conf.js
@@ -5,7 +5,7 @@ exports.config = {
     /**
      * server configurations
      */
-    hostname: '0.0.0.0',
+    hostname: 'localhost',
     port: 4444,
 
     /**

--- a/examples/wdio/mocha/wdio.conf.js
+++ b/examples/wdio/mocha/wdio.conf.js
@@ -4,7 +4,7 @@ exports.config = {
     /**
      * server configurations
      */
-    hostname: '0.0.0.0',
+    hostname: 'localhost',
     port: 4444,
 
     /**

--- a/examples/wdio/multiremote/wdio.conf.js
+++ b/examples/wdio/multiremote/wdio.conf.js
@@ -4,7 +4,7 @@ exports.config = {
     /**
      * server configurations
      */
-    hostname: '0.0.0.0',
+    hostname: 'localhost',
     port: 4444,
 
     /**

--- a/packages/wdio-appium-service/tests/launcher.test.js
+++ b/packages/wdio-appium-service/tests/launcher.test.js
@@ -27,7 +27,7 @@ class MockProcess {
     _eventHandler = new eventHandler()
     once() {
         this._eventHandler.trigger('data', '[Appium] Welcome to Appium v1.11.1')
-        this._eventHandler.trigger('data', '[Appium] Appium REST http interface listener started on 0.0.0.0:4723')
+        this._eventHandler.trigger('data', '[Appium] Appium REST http interface listener started on localhost:4723')
     }
     removeListener() {}
     kill() {}

--- a/packages/wdio-cli/src/config.js
+++ b/packages/wdio-cli/src/config.js
@@ -220,7 +220,7 @@ export const QUESTIONNAIRE = [{
     type: 'input',
     name: 'hostname',
     message: 'What is the IP or URI to your Selenium standalone or grid server?',
-    default: '0.0.0.0',
+    default: 'localhost',
     when: (answers) => answers.backend.indexOf('own Selenium cloud') > -1
 }, {
     type: 'input',

--- a/packages/wdio-config/tests/__mocks__/@wdio/config.js
+++ b/packages/wdio-config/tests/__mocks__/@wdio/config.js
@@ -26,7 +26,7 @@ export const getSauceEndpoint = getSauceEndpointMock
 export const validateConfig = jest.fn().mockImplementation(
     (_, config) => Object.assign(
         DEFAULT_CONFIGS_IMPORT,
-        { hostname: '0.0.0.0', port: 4444, protocol: 'http', path: '/wd/hub' },
+        { hostname: 'localhost', port: 4444, protocol: 'http', path: '/wd/hub' },
         config
     )
 )

--- a/packages/wdio-config/tests/detectBackend.test.js
+++ b/packages/wdio-config/tests/detectBackend.test.js
@@ -3,7 +3,7 @@ import { detectBackend } from '../src/utils'
 describe('detectBackend', () => {
     it('should not set anything if host is set in caps', () => {
         const caps = {
-            hostname: '0.0.0.0',
+            hostname: 'localhost',
             port: 1234,
             protocol: 'http'
         }

--- a/packages/wdio-webdriver-mock-service/src/WebDriverMock.js
+++ b/packages/wdio-webdriver-mock-service/src/WebDriverMock.js
@@ -23,9 +23,9 @@ for (const protocol of protocols) {
 }
 
 export default class WebDriverMock {
-    constructor (host = 'http://0.0.0.0', port = 4444, path = '/') {
+    constructor (host = 'localhost', port = 4444, path = '/') {
         this.path = path
-        this.scope = nock(`${host}:${port}`, { 'encodedQueryParams':true })
+        this.scope = nock(`http://${host}:${port}`, { 'encodedQueryParams':true })
         this.command = new Proxy({}, { get: ::this.get })
     }
 

--- a/packages/webdriver/README.md
+++ b/packages/webdriver/README.md
@@ -67,7 +67,7 @@ Options: *http* | *https*
 Host of your WebDriver server.
 
 Type: `String`<br>
-Default: *0.0.0.0*
+Default: *localhost*
 
 ### port
 Port your WebDriver server is on.

--- a/packages/webdriver/src/constants.js
+++ b/packages/webdriver/src/constants.js
@@ -12,7 +12,7 @@ export const DEFAULTS = {
      */
     hostname: {
         type: 'string',
-        default: '0.0.0.0'
+        default: 'localhost'
     },
     /**
      * port of automation driver

--- a/tests/helpers/config.js
+++ b/tests/helpers/config.js
@@ -2,7 +2,7 @@ exports.config = {
     /**
      * server configurations
      */
-    hostname: '0.0.0.0',
+    hostname: 'localhost',
     port: 4444,
     path: '/',
 


### PR DESCRIPTION
## Proposed changes

Latest Chromedriver fails when trying to connect to it via `0.0.0.0` as host name. Let's get rid of this in the code base.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

If you currently try to start a new session with latest Chromedriver you will receive an error response saying:

```
Host header or origin header is specified and is not localhost.
```

and Chromedriver logs having this:

```
[1556724433.499][SEVERE]: Rejecting request with host: 0.0.0.0:4444
```

### Reviewers: @webdriverio/technical-committee
