### PR TITLE
wdio-appium-service: Better handling of exit code = 2

### DIFF
--- a/packages/wdio-appium-service/src/launcher.js
+++ b/packages/wdio-appium-service/src/launcher.js
@@ -49,7 +49,11 @@ export class AppiumLauncher {
         })
 
         process.once('exit', (exitCode) => {
-            callback(new Error(`Appium exited before timeout (exit code: ${exitCode})`), null)
+            let errorMessage = `Appium exited before timeout (exit code: ${exitCode})`
+            if (exitCode == 2) {
+                errorMessage += ' - Check that you don\'t already have a running Appium service.'
+            }
+            callback(new Error(errorMessage), null)
         })
     }
 

--- a/packages/wdio-appium-service/tests/launcher.test.js
+++ b/packages/wdio-appium-service/tests/launcher.test.js
@@ -36,9 +36,14 @@ class MockProcess {
 }
 
 class MockFailingProcess extends MockProcess {
+    constructor(exitCode = 2) {
+        super()
+        this.exitCode = exitCode
+    }
+
     once(event, callback) {
         if (event === 'exit') {
-            callback(2)
+            callback(this.exitCode)
         }
     }
 }
@@ -93,7 +98,7 @@ describe('Appium launcher', () => {
         })
 
         test('should fail if Appium exits', async () => {
-            childProcess.spawn.mockReturnValue(new MockFailingProcess())
+            childProcess.spawn.mockReturnValue(new MockFailingProcess(1))
 
             let error
             try {
@@ -101,7 +106,20 @@ describe('Appium launcher', () => {
             } catch (e) {
                 error = e
             }
-            const expectedError = new Error('Appium exited before timeout (exit code: 2)')
+            const expectedError = new Error('Appium exited before timeout (exit code: 1)')
+            expect(error).toEqual(expectedError)
+        })
+
+        test('should fail and error message if Appium already runs', async () => {
+            childProcess.spawn.mockReturnValue(new MockFailingProcess(2))
+
+            let error
+            try {
+                await launcher.onPrepare({})
+            } catch (e) {
+                error = e
+            }
+            const expectedError = new Error("Appium exited before timeout (exit code: 2) - Check that you don't already have a running Appium service.")
             expect(error).toEqual(expectedError)
         })
     })


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)
I can't find it documented anywhere, but my experience is that when Appium exits with code 2 it means that it couldn't start listening on the default port. This happens when another Appium service is already running on the system. This pull request gives some more info in the error message to help the user figure out why Appium couldn't start.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

### Reviewers: @webdriverio/technical-committee
