### PR TITLE
webdriverio: Update types for attach and remote methods

### DIFF
--- a/packages/webdriverio/webdriverio.d.ts
+++ b/packages/webdriverio/webdriverio.d.ts
@@ -33,12 +33,12 @@ type BrowserAsync = {
 type BrowserStatic = Pick<WebdriverIO.Browser, 'addCommand' | 'options'>;
 declare namespace WebdriverIOAsync {
     function remote(
-        options?: WebDriver.Options,
+        options?: WebDriver.Options & WebdriverIO.Options,
         modifier?: (...args: any[]) => any
     ): BrowserObject;
 
     function attach(
-        options?: WebDriver.Options,
+        options?: WebDriver.AttachSessionOptions,
     ): BrowserObject;
 
     function multiremote(

--- a/scripts/templates/webdriver.tpl.d.ts
+++ b/scripts/templates/webdriver.tpl.d.ts
@@ -232,8 +232,20 @@ declare namespace WebDriver {
         key?: string;
     }
 
+    interface AttachSessionOptions extends Options {
+        sessionId: string,
+        isW3C?: boolean
+    }
+
     function newSession(
         options?: Options,
+        modifier?: (...args: any[]) => any,
+        proto?: object,
+        commandWrapper?: (commandName: string, fn: (...args: any[]) => any) => any
+    ): Promise<Client>;
+
+    function attachToSession(
+        options: AttachSessionOptions,
         modifier?: (...args: any[]) => any,
         proto?: object,
         commandWrapper?: (commandName: string, fn: (...args: any[]) => any) => any


### PR DESCRIPTION
## Proposed changes

This is a proposal to address some part of #3942

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] **N/A** I have added tests that prove my fix is effective or that my feature works
- [ ] **N/A** I have added necessary documentation (if appropriate)

## Further comments

This PR contains solution where we suggest passing merged options (WebdriverIO and WebDriver) to the `remote()` function, since this is what code is expecting on the input.

The other option would be to re-engineer the way we work with `options`, but this most probably will lead to a breaking change in public API.

### Reviewers: @webdriverio/technical-committee
