### PR TITLE
Typescript: update wait functions return types

### DIFF
--- a/packages/webdriverio/src/commands/browser/waitUntil.js
+++ b/packages/webdriverio/src/commands/browser/waitUntil.js
@@ -29,7 +29,7 @@
  * @param {Number=}  timeout    timeout in ms (default: 500)
  * @param {String=}  timeoutMsg error message to throw when waitUntil times out
  * @param {Number=}  interval   interval between condition checks (default: 500)
- * @return {Boolean} true if condition is fulfilled
+ * @return {Promise<boolean>} true if condition is fulfilled
  * @uses utility/pause
  * @type utility
  *

--- a/packages/webdriverio/src/commands/element/waitForDisplayed.js
+++ b/packages/webdriverio/src/commands/element/waitForDisplayed.js
@@ -28,7 +28,7 @@
  * @param {Number=}  ms       time in ms (default: 500)
  * @param {Boolean=} reverse  if true it waits for the opposite (default: false)
  * @param {String=}  error    if exists it overrides the default error message
- * @return {Boolean} true     if element is displayed (or doesn't if flag is set)
+ * @return {Promise<boolean>} true if element is displayed (or doesn't if flag is set)
  * @uses utility/waitUntil, state/isDisplayed
  * @type utility
  *

--- a/packages/webdriverio/src/commands/element/waitForEnabled.js
+++ b/packages/webdriverio/src/commands/element/waitForEnabled.js
@@ -27,7 +27,7 @@
  * @param {Number=}  ms       time in ms (default: 500)
  * @param {Boolean=} reverse  if true it waits for the opposite (default: false)
  * @param {String=}  error    if exists it overrides the default error message
- * @return {Boolean} true     if element is (dis/en)abled
+ * @return {Promise<boolean>} true if element is (dis/en)abled
  * @uses utility/waitUntil, state/isEnabled
  * @type utility
  *

--- a/packages/webdriverio/src/commands/element/waitForExist.js
+++ b/packages/webdriverio/src/commands/element/waitForExist.js
@@ -29,7 +29,7 @@
  * @param {Number=}  ms       time in ms (default: 500)
  * @param {Boolean=} reverse  if true it instead waits for the selector to not match any elements (default: false)
  * @param {String=}  error    if exists it overrides the default error message
- * @return {Boolean} true     if element exists (or doesn't if flag is set)
+ * @return {Promise<boolean>} true if element exists (or doesn't if flag is set)
  * @uses utility/waitUntil, state/isExisting
  * @type utility
  *

--- a/scripts/templates/webdriverio.tpl.d.ts
+++ b/scripts/templates/webdriverio.tpl.d.ts
@@ -181,7 +181,7 @@ declare namespace WebdriverIO {
             timeout?: number,
             timeoutMsg?: string,
             interval?: number
-        ): boolean
+        ): Promise<boolean>
         // ... browser commands ...
     }
 

--- a/scripts/type-generation/generate-typings-utils.js
+++ b/scripts/type-generation/generate-typings-utils.js
@@ -22,10 +22,7 @@ const changeType = (text) => {
 }
 
 const getTypes = (types, alwaysType) => {
-    types.forEach((type, index, array) => {
-        array[index] = changeType(type)
-    })
-    types = types.join(' | ')
+    types = types.map(changeType).join(' | ')
     if (types === '' && !alwaysType) {
         types = 'void'
     } else if (types === '*' || (types === '' && alwaysType)) {

--- a/scripts/type-generation/generate-typings-utils.js
+++ b/scripts/type-generation/generate-typings-utils.js
@@ -16,8 +16,12 @@ const changeType = (text) => {
     default: {
         text = text.toLowerCase()
     }
-
     }
+
+    if (text.indexOf('promise.<') === 0) {
+        text = text.replace('promise.', 'Promise')
+    }
+
     return text
 }
 
@@ -46,7 +50,7 @@ const buildCommand = (commandName, commandTags, indentation = 0) => {
 
             // skipping param with dot in name that stands for Object properties description, ex: attachmentObject.name
             if (name.indexOf('.') < 0) {
-                // get rid from default values from param name, ex: [paramName='someString'] will become paramName
+                // get rid of default values from param name, ex: [paramName='someString'] will become paramName
                 allParameters.push(`${name.split('[').pop().split('=')[0]}${optional ? '?' : ''}: ${commandTypes}`)
             }
         }

--- a/tests/typings/sync/sync.ts
+++ b/tests/typings/sync/sync.ts
@@ -2,7 +2,7 @@ import allure from '@wdio/allure-reporter'
 
 // browser
 browser.pause(1)
-const waitUntil: boolean = browser.waitUntil(() => true, 1, '', 1)
+const waitUntil: Promise<boolean> = browser.waitUntil(() => true, 1, '', 1)
 browser.getCookies()
 let res = browser.execute(function (x: number) {
     return x


### PR DESCRIPTION
## Proposed changes

Update `waitUntil` and all `waitFor*` functions to return `Promise<boolean>` instead of just `boolean`.

Fixes #3940 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] **N/A** I have added tests that prove my fix is effective or that my feature works
- [ ] **N/A** I have added necessary documentation (if appropriate)

## Further comments

All these functions return Promise of the callback that is passed to `waitUntil`.

In order to make typing generation work I had to add additional logic to work with incorrect output of `dox` module: `Promise.<boolean>` instead of `Promise<boolean>`.
I have put it in the end of `changeType` function to ensure `Promise` will be capitalised.

Additionally, `forEach` was replaced with `map` as it is more appropriate in this situation.

### Reviewers: @webdriverio/technical-committee
