### PR TITLE
fix multiremote instances spawning

### DIFF
--- a/packages/wdio-cli/tests/launcher.test.js
+++ b/packages/wdio-cli/tests/launcher.test.js
@@ -43,12 +43,12 @@ describe('launcher', () => {
         })
 
         it('should start instance in multiremote', () => {
-            launcher.startInstance = jest.fn()
+            launcher.runSpecs = jest.fn()
             launcher.isMultiremote = true
             launcher.runMode({ specs: './' }, [{ browserName: 'multiremote' }])
 
             expect(typeof launcher.resolve).toBe('function')
-            expect(launcher.startInstance).toBeCalledTimes(1)
+            expect(launcher.runSpecs).toBeCalledTimes(1)
         })
     })
 

--- a/packages/wdio-runner/src/index.js
+++ b/packages/wdio-runner/src/index.js
@@ -270,11 +270,12 @@ export default class Runner extends EventEmitter {
      * within a hook by the user
      */
     async endSession (shutdown) {
+        const hasSessionId = global.browser && (this.isMultiremote ? global.browser.instances.some(i => global.browser[i] && global.browser[i].sessionId) : global.browser.sessionId)
         /**
          * don't do anything if test framework returns after SIGINT
          * if endSession is called without shutdown flag we expect a session id
          */
-        if (!shutdown && (!global.browser || !global.browser.sessionId)) {
+        if (!shutdown && (!global.browser || !hasSessionId)) {
             return
         }
 
@@ -282,14 +283,29 @@ export default class Runner extends EventEmitter {
          * if shutdown was called but no session was created, wait until it was
          * and try to end it
          */
-        if (shutdown && (!global.browser || !global.browser.sessionId)) {
+        if (shutdown && (!global.browser || !hasSessionId)) {
             await new Promise((resolve) => setTimeout(resolve, 250))
             return this.endSession(shutdown)
         }
 
-        const capabilities = global.browser.capabilities
+        /**
+         * store capabilities for afterSession hook
+         */
+        let capabilities = global.browser.capabilities || {}
+        if (this.isMultiremote) {
+            global.browser.instances.forEach(i => { capabilities[i] = global.browser[i] ? global.browser[i].capabilities : {} })
+        }
+
         await global.browser.deleteSession()
-        delete global.browser.sessionId
+
+        /**
+         * delete session(s)
+         */
+        if (this.isMultiremote) {
+            global.browser.instances.forEach(i => { global.browser[i] && delete global.browser[i].sessionId })
+        } else {
+            delete global.browser.sessionId
+        }
 
         await runHook('afterSession', global.browser.config, capabilities, this.specs)
 

--- a/packages/wdio-runner/src/index.js
+++ b/packages/wdio-runner/src/index.js
@@ -271,14 +271,23 @@ export default class Runner extends EventEmitter {
      */
     async endSession (shutdown) {
         /**
-         * For Multiremote - make sure that all the instances have sessionId
+         * make sure instance(s) exist and have `sessionId`
          */
-        const hasSessionId = global.browser && (this.isMultiremote ? !global.browser.instances.some(i => global.browser[i] && !global.browser[i].sessionId) : global.browser.sessionId)
+        const hasSessionId = global.browser && (this.isMultiremote
+            /**
+             * every multiremote instance should exist and should have `sessionId`
+             */
+            ? !global.browser.instances.some(i => global.browser[i] && !global.browser[i].sessionId)
+            /**
+             * browser object should have `sessionId` in regular mode
+             */
+            : global.browser.sessionId)
+
         /**
          * don't do anything if test framework returns after SIGINT
          * if endSession is called without shutdown flag we expect a session id
          */
-        if (!shutdown && (!global.browser || !hasSessionId)) {
+        if (!shutdown && !hasSessionId) {
             return
         }
 
@@ -286,7 +295,7 @@ export default class Runner extends EventEmitter {
          * if shutdown was called but no session was created, wait until it was
          * and try to end it
          */
-        if (shutdown && (!global.browser || !hasSessionId)) {
+        if (shutdown && !hasSessionId) {
             await new Promise((resolve) => setTimeout(resolve, 250))
             return this.endSession(shutdown)
         }
@@ -296,7 +305,7 @@ export default class Runner extends EventEmitter {
          */
         let capabilities = global.browser.capabilities || {}
         if (this.isMultiremote) {
-            global.browser.instances.forEach(i => { capabilities[i] = global.browser[i] ? global.browser[i].capabilities : {} })
+            global.browser.instances.forEach(i => { capabilities[i] = global.browser[i].capabilities })
         }
 
         await global.browser.deleteSession()
@@ -305,7 +314,7 @@ export default class Runner extends EventEmitter {
          * delete session(s)
          */
         if (this.isMultiremote) {
-            global.browser.instances.forEach(i => { global.browser[i] && delete global.browser[i].sessionId })
+            global.browser.instances.forEach(i => { delete global.browser[i].sessionId })
         } else {
             delete global.browser.sessionId
         }

--- a/packages/wdio-runner/src/index.js
+++ b/packages/wdio-runner/src/index.js
@@ -270,7 +270,10 @@ export default class Runner extends EventEmitter {
      * within a hook by the user
      */
     async endSession (shutdown) {
-        const hasSessionId = global.browser && (this.isMultiremote ? global.browser.instances.some(i => global.browser[i] && global.browser[i].sessionId) : global.browser.sessionId)
+        /**
+         * For Multiremote - make sure that all the instances have sessionId
+         */
+        const hasSessionId = global.browser && (this.isMultiremote ? !global.browser.instances.some(i => global.browser[i] && !global.browser[i].sessionId) : global.browser.sessionId)
         /**
          * don't do anything if test framework returns after SIGINT
          * if endSession is called without shutdown flag we expect a session id

--- a/packages/wdio-runner/tests/index.test.js
+++ b/packages/wdio-runner/tests/index.test.js
@@ -104,7 +104,7 @@ describe('wdio-runner', () => {
     })
 
     describe('endSession', () => {
-        it ('should work normally when called after framework run', async () => {
+        it('should work normally when called after framework run', async () => {
             const hook = jest.fn()
             const runner = new WDIORunner()
             runner._shutdown = jest.fn()
@@ -150,7 +150,7 @@ describe('wdio-runner', () => {
             expect(end - start).toBeGreaterThanOrEqual(200)
         })
 
-        it ('should work normally when called after framework run in multiremote', async () => {
+        it('should work normally when called after framework run in multiremote', async () => {
             const hook = jest.fn()
             const runner = new WDIORunner()
             runner.isMultiremote = true

--- a/packages/wdio-webdriver-mock-service/src/index.js
+++ b/packages/wdio-webdriver-mock-service/src/index.js
@@ -28,6 +28,7 @@ export default class WebdriverMockService {
         // in case run with multiremote
         this.command.newSession().reply(200, newSession)
         this.command.getTitle().reply(200, { value: 'Mock Page Other Title' })
+        this.command.deleteSession().reply(200, deleteSession)
     }
 
     before () {


### PR DESCRIPTION
## Proposed changes

Change way how multiremote mode spawns instances.

**Current behaviour**
- all the spec files are running in same worker. This causing issues with reporters and limits spawning of instances (so parallelization works bad)
- instances are not killed in the very end, browsers are hanging opened

**New behaviour**
- another worker spawned for each spec file
- spec files can run in parallel
- browser instances are killed after every spec file (same as in non multiremote mode)

fixes #2825

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

### Reviewers: @webdriverio/technical-committee
