### PR TITLE
Fix attach to session w3c handling

### DIFF
--- a/packages/webdriver/src/index.js
+++ b/packages/webdriver/src/index.js
@@ -88,8 +88,8 @@ export default class WebDriver {
         logger.setLevel('webdriver', options.logLevel)
 
         options.capabilities = options.capabilities || {}
-        options.isW3C = options.isW3C || true
-        const prototype = Object.assign(getPrototype(options.isW3C), userPrototype)
+        options.isW3C = options.isW3C === false ? false : true
+        const prototype = Object.assign(getPrototype({ isW3C: options.isW3C }), userPrototype)
         const monad = webdriverMonad(options, modifier, prototype)
         return monad(options.sessionId, commandWrapper)
     }

--- a/packages/webdriver/src/index.js
+++ b/packages/webdriver/src/index.js
@@ -71,7 +71,7 @@ export default class WebDriver {
             isChrome: { value: isChrome }
         }
 
-        const protocolCommands = getPrototype({ isW3C, isMobile, isIOS, isAndroid, isChrome, isSauce })
+        const protocolCommands = getPrototype({ isW3C, isChrome, isMobile, isSauce })
         const prototype = merge(protocolCommands, environmentFlags, userPrototype)
         const monad = webdriverMonad(params, modifier, prototype)
         return monad(response.value.sessionId || response.sessionId, commandWrapper)
@@ -89,7 +89,7 @@ export default class WebDriver {
 
         options.capabilities = options.capabilities || {}
         options.isW3C = options.isW3C === false ? false : true
-        const prototype = Object.assign(getPrototype({ isW3C: options.isW3C }), userPrototype)
+        const prototype = Object.assign(getPrototype({ ...options, isW3C: options.isW3C }), userPrototype)
         const monad = webdriverMonad(options, modifier, prototype)
         return monad(options.sessionId, commandWrapper)
     }

--- a/packages/webdriver/src/index.js
+++ b/packages/webdriver/src/index.js
@@ -89,7 +89,7 @@ export default class WebDriver {
 
         options.capabilities = options.capabilities || {}
         options.isW3C = options.isW3C === false ? false : true
-        const prototype = Object.assign(getPrototype({ ...options, isW3C: options.isW3C }), userPrototype)
+        const prototype = Object.assign(getPrototype({ ...options }), userPrototype)
         const monad = webdriverMonad(options, modifier, prototype)
         return monad(options.sessionId, commandWrapper)
     }

--- a/packages/webdriver/tests/index.test.js
+++ b/packages/webdriver/tests/index.test.js
@@ -3,6 +3,14 @@ import logger from '@wdio/logger'
 
 import WebDriver from '../src'
 
+const sessionOptions = {
+    protocol: 'http',
+    hostname: 'localhost',
+    port: 4444,
+    path: '/',
+    sessionId: 'foobar'
+}
+
 test('should allow to create a new session using jsonwire caps', async () => {
     await WebDriver.newSession({
         path: '/',
@@ -61,37 +69,52 @@ test('should be possible to set logLevel', async () => {
     expect(logger.setLevel).toBeCalled()
 })
 
-test('should allow to attach to existing session W3C', async () => {
-    const client = WebDriver.attachToSession({
-        protocol: 'http',
-        hostname: 'localhost',
-        port: 4444,
-        path: '/',
-        sessionId: 'foobar'
-    })
-
+test('should allow to attach to existing session', async () => {
+    const client = WebDriver.attachToSession({ ...sessionOptions })
     await client.getUrl()
     const req = request.mock.calls[0][0]
     expect(req.uri.href).toBe('http://localhost:4444/session/foobar/url')
-    expect(client.getApplicationCacheStatus).toBeFalsy()
-    expect(client.takeElementScreenshot).toBeTruthy()
 })
 
-test('should allow to attach to existing session non W3C', async () => {
-    const client = WebDriver.attachToSession({
-        protocol: 'http',
-        hostname: 'localhost',
-        port: 4444,
-        path: '/',
-        sessionId: 'foobar',
-        isW3C: false
+test('should allow to attach to existing session - W3C', async () => {
+    const client = WebDriver.attachToSession({ ...sessionOptions })
+    await client.getUrl()
+
+    expect(client.options.isChrome).toBeFalsy()
+    expect(client.options.isMobile).toBeFalsy()
+    expect(client.options.isSauce).toBeFalsy()
+    expect(client.getApplicationCacheStatus).toBeFalsy()
+    expect(client.takeElementScreenshot).toBeTruthy()
+    expect(client.getDeviceTime).toBeFalsy()
+})
+
+test('should allow to attach to existing session - non W3C', async () => {
+    const client = WebDriver.attachToSession({ ...sessionOptions,
+        isW3C: false,
+        isSauce: true,
     })
 
     await client.getUrl()
-    const req = request.mock.calls[0][0]
-    expect(req.uri.href).toBe('http://localhost:4444/session/foobar/url')
+
+    expect(client.options.isSauce).toBe(true)
     expect(client.getApplicationCacheStatus).toBeTruthy()
     expect(client.takeElementScreenshot).toBeFalsy()
+    expect(client.getDeviceTime).toBeFalsy()
+})
+
+test('should allow to attach to existing session - mobile', async () => {
+    const client = WebDriver.attachToSession({ ...sessionOptions,
+        isChrome: true,
+        isMobile: true
+    })
+
+    await client.getUrl()
+
+    expect(client.options.isChrome).toBe(true)
+    expect(client.options.isMobile).toBe(true)
+    expect(client.getApplicationCacheStatus).toBeTruthy()
+    expect(client.takeElementScreenshot).toBeTruthy()
+    expect(client.getDeviceTime).toBeTruthy()
 })
 
 test('should fail attaching to session if sessionId is not given', () => {

--- a/packages/webdriver/tests/index.test.js
+++ b/packages/webdriver/tests/index.test.js
@@ -61,7 +61,7 @@ test('should be possible to set logLevel', async () => {
     expect(logger.setLevel).toBeCalled()
 })
 
-test('should allow to attach to existing session', async () => {
+test('should allow to attach to existing session W3C', async () => {
     const client = WebDriver.attachToSession({
         protocol: 'http',
         hostname: 'localhost',
@@ -73,6 +73,25 @@ test('should allow to attach to existing session', async () => {
     await client.getUrl()
     const req = request.mock.calls[0][0]
     expect(req.uri.href).toBe('http://localhost:4444/session/foobar/url')
+    expect(client.getApplicationCacheStatus).toBeFalsy()
+    expect(client.takeElementScreenshot).toBeTruthy()
+})
+
+test('should allow to attach to existing session non W3C', async () => {
+    const client = WebDriver.attachToSession({
+        protocol: 'http',
+        hostname: 'localhost',
+        port: 4444,
+        path: '/',
+        sessionId: 'foobar',
+        isW3C: false
+    })
+
+    await client.getUrl()
+    const req = request.mock.calls[0][0]
+    expect(req.uri.href).toBe('http://localhost:4444/session/foobar/url')
+    expect(client.getApplicationCacheStatus).toBeTruthy()
+    expect(client.takeElementScreenshot).toBeFalsy()
 })
 
 test('should fail attaching to session if sessionId is not given', () => {


### PR DESCRIPTION
## Proposed changes

Currently `attachToSession` ignores W3C option and assumes that it is always **false**.

This PR fixes it.
`isW3C` default value is now true and `attachToSession` respects isW3C passed value.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist


- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

fixes #3933

### Reviewers: @webdriverio/technical-committee
