### PR TITLE
Add getWindowSize command

### DIFF
--- a/packages/webdriver/protocol/jsonwp.json
+++ b/packages/webdriver/protocol/jsonwp.json
@@ -273,7 +273,7 @@
   },
   "/session/:sessionId/window/current/size": {
     "GET": {
-      "command": "getWindowSize",
+      "command": "_getWindowSize",
       "description": "Get the size of the current focused window.",
       "ref": "https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#get-sessionsessionidwindowwindowhandlesize",
       "parameters": [],

--- a/packages/webdriverio/src/commands/browser/getWindowSize.js
+++ b/packages/webdriverio/src/commands/browser/getWindowSize.js
@@ -1,0 +1,31 @@
+/**
+ *
+ * Returns browser window size (and position for drivers with W3C support).
+ *
+ * <example>
+ * :getWindowSize.js
+    it('should return browser window size', function () {
+        const windowSize = browser.getWindowSize(500, 600);
+        console.log(windowSize);
+        // outputs
+        // Firefox: { x: 4, y: 23, width: 1280, height: 767 }
+        // Chrome: { width: 1280, height: 767 }
+    });
+ * </example>
+ *
+ * @alias browser.getWindowSize
+ * @return {Object} { x, y, width, height } for W3C or { width, height } for non W3C browser
+ * @type window
+ *
+ */
+
+import { getBrowserObject } from '../../utils'
+
+export default function getWindowSize() {
+    const browser = getBrowserObject(this)
+
+    if (!browser.isW3C) {
+        return browser._getWindowSize()
+    }
+    return browser.getWindowRect()
+}

--- a/packages/webdriverio/tests/commands/browser/getWindowSize.test.js
+++ b/packages/webdriverio/tests/commands/browser/getWindowSize.test.js
@@ -1,0 +1,38 @@
+import request from 'request'
+import { remote } from '../../../src'
+
+describe('getWindowSize', () => {
+    let browser
+
+    beforeAll(async () => {
+        browser = await remote({
+            baseUrl: 'http://foobar.com',
+            capabilities: {
+                browserName: 'foobar'
+            }
+        })
+    })
+
+    it('should get size of W3C browser window', async () => {
+        await browser.getWindowSize()
+        expect(request.mock.calls[1][0].method).toBe('GET')
+        expect(request.mock.calls[1][0].uri.path).toBe('/wd/hub/session/foobar-123/window/rect')
+    })
+
+    it('should get size of NO-W3C browser window', async () => {
+        browser = await remote({
+            baseUrl: 'http://foobar.com',
+            capabilities: {
+                browserName: 'foobar-noW3C'
+            }
+        })
+
+        await browser.getWindowSize()
+        expect(request.mock.calls[1][0].method).toBe('GET')
+        expect(request.mock.calls[1][0].uri.path).toBe('/wd/hub/session/foobar-123/window/current/size')
+    })
+
+    afterEach(() => {
+        request.mockClear()
+    })
+})


### PR DESCRIPTION
## Proposed changes

Added `getWindowSize` to choosing between `getWindowSize` and `getWindowRect` commands and be consistent with `setWindowSize` command.

Fixes #3905

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist


- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

Affects **webdriver** package, requires documentation to be updated and update of **webdriver**, **webdriverio** and **@wdio/sync** typings to be generated.

### Reviewers: @webdriverio/technical-committee
