### PR TITLE
Fix xpath selector start

### DIFF
--- a/packages/webdriverio/src/utils/findStrategy.js
+++ b/packages/webdriverio/src/utils/findStrategy.js
@@ -4,7 +4,7 @@ import isPlainObject from 'lodash.isplainobject'
 const DEFAULT_STRATEGY = 'css selector'
 const DIRECT_SELECTOR_REGEXP = /^(id|css selector|xpath|link text|partial link text|name|tag name|class name|-android uiautomator|-android datamatcher|-ios uiautomation|-ios predicate string|-ios class chain|accessibility id):(.+)/
 const XPATH_SELECTORS_START = [
-    '/', '(', '\'../\'', './', '*/'
+    '/', '(', '../', './', '*/'
 ]
 const NAME_MOBILE_SELECTORS_START = [
     'uia', 'xcuielementtype', 'android.widget', 'cyi'

--- a/packages/webdriverio/tests/findStrategy.test.js
+++ b/packages/webdriverio/tests/findStrategy.test.js
@@ -198,6 +198,8 @@ describe('selector strategies helper', () => {
         expect(element.using).toBe('xpath')
         element = findStrategy('.')
         expect(element.using).toBe('xpath')
+        element = findStrategy('../')
+        expect(element.using).toBe('xpath')
     })
 
     it('should find an element by ui automator strategy (android only)', () => {


### PR DESCRIPTION
## Proposed changes

There was a typo (redundant `'\`) in `'\'../\''` vs `'../'`

Fix #3982

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments


### Reviewers: @webdriverio/technical-committee
