### PR TITLE
Fix browser session close in watch mode

### DIFF
--- a/packages/wdio-cli/src/launcher.js
+++ b/packages/wdio-cli/src/launcher.js
@@ -116,6 +116,11 @@ class Launcher {
         }
 
         /**
+         * avoid retries in watch mode
+         */
+        const specFileRetries = config.watch ? 0 : config.specFileRetries
+
+        /**
          * schedule test runs
          */
         let cid = 0
@@ -126,7 +131,7 @@ class Launcher {
             this.schedule.push({
                 cid: cid++,
                 caps,
-                specs: this.configParser.getSpecs(caps.specs, caps.exclude).map(s => ({ files: [s], retries: config.specFileRetries })),
+                specs: this.configParser.getSpecs(caps.specs, caps.exclude).map(s => ({ files: [s], retries: specFileRetries })),
                 availableInstances: config.maxInstances || 1,
                 runningInstances: 0
             })
@@ -138,7 +143,7 @@ class Launcher {
                 this.schedule.push({
                     cid: cid++,
                     caps: capabilities,
-                    specs: this.configParser.getSpecs(capabilities.specs, capabilities.exclude).map(s => ({ files: [s], retries: config.specFileRetries })),
+                    specs: this.configParser.getSpecs(capabilities.specs, capabilities.exclude).map(s => ({ files: [s], retries: specFileRetries })),
                     availableInstances: capabilities.maxInstances || config.maxInstancesPerCapability,
                     runningInstances: 0,
                     seleniumServer: { hostname: config.hostname, port: config.port, protocol: config.protocol }

--- a/packages/wdio-cli/src/watcher.js
+++ b/packages/wdio-cli/src/watcher.js
@@ -15,12 +15,10 @@ export default class Watcher {
         this.argv = argv
 
         const specs = this.launcher.configParser.getSpecs()
-        this.specs = [
-            ...specs,
-            ...union(flattenDeep(
-                this.launcher.configParser.getCapabilities().map(cap => cap.specs || [])
-            ))
-        ]
+        const capSpecs = this.launcher.isMultiremote ? [] : union(flattenDeep(
+            this.launcher.configParser.getCapabilities().map(cap => cap.specs || [])
+        ))
+        this.specs = [...specs, ...capSpecs]
         this.isRunningTests = false
     }
 

--- a/packages/wdio-cli/tests/interface.test.js
+++ b/packages/wdio-cli/tests/interface.test.js
@@ -3,6 +3,7 @@ import chalk from 'chalk'
 
 const config = {}
 const specs = ['/some/path/to/test.js']
+global.console.log = jest.fn()
 
 describe('cli interface', () => {
     let wdioClInterface

--- a/packages/wdio-cli/tests/watcher.test.js
+++ b/packages/wdio-cli/tests/watcher.test.js
@@ -11,6 +11,7 @@ jest.mock('../src/launcher', () => {
             this.configParser = new ConfigParser()
             this.configParser.addConfigFile(configFile)
             this.configParser.merge(argv)
+            this.isMultiremote = argv.isMultiremote
             this.runner = {}
             this.interface = {
                 emit: jest.fn(),
@@ -39,6 +40,14 @@ describe('watcher', () => {
         expect(watcher.specs).toEqual([
             './tests/test1.js',
             './tests/test2.js'
+        ])
+    })
+
+    it('should initialise properly in Multiremote', async () => {
+        const wdioConf = path.join(__dirname, '__fixtures__', 'wdio.conf')
+        const watcher = new Watcher(wdioConf, { isMultiremote: true })
+        expect(watcher.specs).toEqual([
+            './tests/test1.js',
         ])
     })
 

--- a/packages/wdio-local-runner/src/worker.js
+++ b/packages/wdio-local-runner/src/worker.js
@@ -93,9 +93,13 @@ export default class WorkerInstance extends EventEmitter {
          * store sessionId and connection data to worker instance
          */
         if (payload.name === 'sessionStarted') {
-            this.sessionId = payload.content.sessionId
-            delete payload.content.sessionId
-            Object.assign(this.server, payload.content)
+            if (payload.content.isMultiremote) {
+                Object.assign(this, payload.content)
+            } else {
+                this.sessionId = payload.content.sessionId
+                delete payload.content.sessionId
+                Object.assign(this.server, payload.content)
+            }
             return
         }
 

--- a/packages/wdio-local-runner/tests/localRunner.test.js
+++ b/packages/wdio-local-runner/tests/localRunner.test.js
@@ -92,3 +92,104 @@ test('should shut down worker processes', async () => {
     expect(call2.cid).toBe('0-4')
     expect(call2.command).toBe('endSession')
 })
+
+test('should avoid shutting down if worker is not busy', async () => {
+    const runner = new LocalRunner('/path/to/wdio.conf.js', {
+        outputDir: '/foo/bar',
+        runnerEnv: { FORCE_COLOR: 1 }
+    })
+
+    runner.run({
+        cid: '0-8',
+        command: 'run',
+        configFile: '/path/to/wdio.conf.js',
+        argv: { sessionId: 'abc' },
+        caps: {},
+        processNumber: 231,
+        specs: ['/foo/bar2.test.js'],
+    })
+    runner.workerPool['0-8'].isBusy = false
+
+    await runner.shutdown()
+
+    expect(runner.workerPool['0-8']).toBeFalsy()
+})
+
+test('should shut down worker processes in watch mode - regular', async () => {
+    const runner = new LocalRunner('/path/to/wdio.conf.js', {
+        outputDir: '/foo/bar',
+        runnerEnv: { FORCE_COLOR: 1 },
+        watch: true,
+    })
+
+    const worker = runner.run({
+        cid: '0-6',
+        command: 'run',
+        configFile: '/path/to/wdio.conf.js',
+        argv: { sessionId: 'abc' },
+        caps: {},
+        processNumber: 231,
+        specs: ['/foo/bar2.test.js'],
+    })
+    runner.workerPool['0-6'].sessionId = 'abc'
+    runner.workerPool['0-6'].server = { host: 'foo' }
+    runner.workerPool['0-6'].caps = { browser: 'chrome' }
+
+    setTimeout(() => {
+        worker.isBusy = false
+    }, 260)
+
+    const before = Date.now()
+    await runner.shutdown()
+    const after = Date.now()
+
+    expect(after - before).toBeGreaterThanOrEqual(300)
+
+    const call2 = worker.childProcess.send.mock.calls.pop()[0]
+    expect(call2.cid).toBe('0-6')
+    expect(call2.command).toBe('endSession')
+    expect(call2.argv.watch).toBe(true)
+    expect(call2.argv.isMultiremote).toBeFalsy()
+    expect(call2.argv.config.sessionId).toBe('abc')
+    expect(call2.argv.config.host).toEqual('foo')
+    expect(call2.argv.caps).toEqual({ browser: 'chrome' })
+})
+
+test('should shut down worker processes in watch mode - mutliremote', async () => {
+    const runner = new LocalRunner('/path/to/wdio.conf.js', {
+        outputDir: '/foo/bar',
+        runnerEnv: { FORCE_COLOR: 1 },
+        watch: true,
+    })
+
+    const worker = runner.run({
+        cid: '0-7',
+        command: 'run',
+        configFile: '/path/to/wdio.conf.js',
+        argv: {},
+        caps: {},
+        processNumber: 232,
+        specs: ['/foo/bar.test.js'],
+    })
+    runner.workerPool['0-7'].isMultiremote = true
+    runner.workerPool['0-7'].instances = { foo: {} }
+    runner.workerPool['0-7'].caps = { foo: { capabilities: { browser: 'chrome' } } }
+
+    setTimeout(() => {
+        worker.isBusy = false
+    }, 260)
+
+    const before = Date.now()
+    await runner.shutdown()
+    const after = Date.now()
+
+    expect(after - before).toBeGreaterThanOrEqual(300)
+
+    const call1 = worker.childProcess.send.mock.calls.pop()[0]
+    expect(call1.cid).toBe('0-7')
+    expect(call1.command).toBe('endSession')
+    expect(call1.argv.watch).toBe(true)
+    expect(call1.argv.isMultiremote).toBe(true)
+    expect(call1.argv.instances).toEqual({ foo: {} })
+    expect(call1.argv.caps).toEqual({ foo: { capabilities: { browser: 'chrome' } } })
+})

--- a/packages/wdio-local-runner/tests/worker.test.js
+++ b/packages/wdio-local-runner/tests/worker.test.js
@@ -45,6 +45,23 @@ describe('handleMessage', () => {
         expect(worker.emit).not.toBeCalled()
     })
 
+    it('stores instances to worker instance in Multiremote mode', () => {
+        const worker = new Worker({}, {
+            cid: '0-3',
+            server: { foo: 'bar' }
+        })
+        const payload = {
+            name: 'sessionStarted',
+            content: {
+                instances: { foo: { sessionId: 'abc123' } },
+                isMultiremote: true
+            }
+        }
+        worker._handleMessage(payload)
+        expect(worker.instances).toEqual({ foo: { sessionId: 'abc123' } })
+        expect(worker.isMultiremote).toEqual(true)
+    })
+
     it('handle debug command called within worker process', async () => {
         const worker = new Worker({}, {})
         worker.emit = jest.fn()

--- a/packages/wdio-runner/src/index.js
+++ b/packages/wdio-runner/src/index.js
@@ -8,7 +8,7 @@ import { initialiseServices, initialisePlugin } from '@wdio/utils'
 import { ConfigParser } from '@wdio/config'
 
 import BaseReporter from './reporter'
-import { runHook, initialiseInstance, filterLogTypes } from './utils'
+import { runHook, initialiseInstance, filterLogTypes, getInstancesData, attachToMultiremote } from './utils'
 
 const log = logger('@wdio/runner')
 
@@ -89,6 +89,8 @@ export default class Runner extends EventEmitter {
          */
         this.framework = initialisePlugin(this.config.framework, 'framework')
 
+        const instances = getInstancesData(browser, isMultiremote)
+
         /**
          * initialisation successful, send start message
          */
@@ -115,7 +117,7 @@ export default class Runner extends EventEmitter {
         process.send({
             origin: 'worker',
             name: 'sessionStarted',
-            content: { sessionId, isW3C, protocol, hostname, port, path, queryParams }
+            content: { sessionId, isW3C, protocol, hostname, port, path, queryParams, isMultiremote, instances }
         })
 
         /**
@@ -132,12 +134,10 @@ export default class Runner extends EventEmitter {
         }
 
         /**
-         * in watch mode we don't close the session and open a blank page instead
+         * in watch mode we don't close the session and leave current page opened
          */
         if (!argv.watch) {
             await this.endSession()
-        } else {
-            await global.browser.url('about:blank')
         }
 
         this.reporter.emit('runner:end', {
@@ -269,7 +269,19 @@ export default class Runner extends EventEmitter {
      * end WebDriver session, a config object can be applied if object has changed
      * within a hook by the user
      */
-    async endSession (shutdown) {
+    async endSession (payload) {
+        /**
+         * Attach to browser session before killing it in Multiremote
+         */
+        if (!global.browser && payload && payload.argv && payload.argv.watch) {
+            if (payload.argv.isMultiremote) {
+                this.isMultiremote = true
+                global.browser = await attachToMultiremote(payload.argv.instances, payload.argv.caps)
+            } else {
+                global.browser = await initialiseInstance(payload.argv.config, payload.argv.caps, false)
+            }
+        }
+
         /**
          * make sure instance(s) exist and have `sessionId`
          */
@@ -285,19 +297,19 @@ export default class Runner extends EventEmitter {
 
         /**
          * don't do anything if test framework returns after SIGINT
-         * if endSession is called without shutdown flag we expect a session id
+         * if endSession is called without payload we expect a session id
          */
-        if (!shutdown && !hasSessionId) {
+        if (!payload && !hasSessionId) {
             return
         }
 
         /**
-         * if shutdown was called but no session was created, wait until it was
+         * if payload was called but no session was created, wait until it was
          * and try to end it
          */
-        if (shutdown && !hasSessionId) {
+        if (payload && !hasSessionId) {
             await new Promise((resolve) => setTimeout(resolve, 250))
-            return this.endSession(shutdown)
+            return this.endSession(payload)
         }
 
         /**
@@ -321,7 +333,7 @@ export default class Runner extends EventEmitter {
 
         await runHook('afterSession', global.browser.config, capabilities, this.specs)
 
-        if (shutdown) {
+        if (payload) {
             return this._shutdown()
         }
     }

--- a/packages/wdio-runner/tests/utils.test.js
+++ b/packages/wdio-runner/tests/utils.test.js
@@ -1,7 +1,7 @@
 import { logMock } from '@wdio/logger'
 import { attach, remote, multiremote } from 'webdriverio'
 
-import { runHook, initialiseInstance, sanitizeCaps, sendFailureMessage } from '../src/utils'
+import { runHook, initialiseInstance, sanitizeCaps, sendFailureMessage, getInstancesData, attachToMultiremote } from '../src/utils'
 
 process.send = jest.fn()
 
@@ -33,6 +33,12 @@ describe('utils', () => {
             expect(logMock.error.mock.calls).toHaveLength(2)
             expect(logMock.error.mock.calls[0][0]).toContain('foobar123')
             expect(logMock.error.mock.calls[1][0]).toContain('foobar321')
+        })
+
+        it('should do nothing if hook is not array', async () => {
+            expect(runHook('before', null)).toBe(undefined)
+            expect(runHook('before', { before: {} })).toBe(undefined)
+            expect(runHook('before', {})).toBe(undefined)
         })
     })
 
@@ -151,6 +157,62 @@ describe('utils', () => {
 
         afterEach(() => {
             process.send.mockClear()
+        })
+    })
+
+    describe('getInstancesData', () => {
+        it('isMultiremote = true', () => {
+            const { sessionId, isW3C, protocol, hostname, port, path, queryParams } = {
+                isW3C: true,
+                sessionId: 'bar',
+                protocol: 'http',
+                hostname: 'localhost',
+                port: 4441,
+                path: '/foo/bar',
+                queryParams: '123'
+            }
+
+            expect(getInstancesData({
+                instances: ['foo'],
+                foo: {
+                    isW3C,
+                    sessionId,
+                    options: { protocol, hostname, port, path, queryParams }
+                }
+            }, true)).toEqual({ foo: { sessionId, isW3C, protocol, hostname, port, path, queryParams } })
+        })
+
+        it('isMultiremote = false', () => {
+            expect(getInstancesData(null, false)).toEqual(undefined)
+        })
+    })
+
+    describe('attachToMultiremote', () => {
+        it('should build browser object', async () => {
+            const browser = await attachToMultiremote({
+                foo: { sessionId: 'foo' },
+                bar: { sessionId: 'bar' }
+            }, {
+                foo: { capabilities: { browserName: 'chrome' } },
+                bar: { capabilities: { browserName: 'firefox' } }
+            })
+
+            expect(attach.mock.calls[0][0]).toEqual({
+                sessionId: 'foo',
+                capabilities: { browserName: 'chrome' }
+            })
+            expect(attach.mock.calls[1][0]).toEqual({
+                sessionId: 'bar',
+                capabilities: { browserName: 'firefox' }
+            })
+
+            expect(typeof browser.deleteSession).toEqual('function')
+            expect(typeof browser.foo.deleteSession).toEqual('function')
+            expect(typeof browser.bar.deleteSession).toEqual('function')
+            expect(browser.foo.sessionId).toBeTruthy()
+            expect(browser.bar.sessionId).toBeTruthy()
+
+            expect(await browser.deleteSession()).toHaveLength(2)
         })
     })
 })

--- a/packages/webdriver/src/index.js
+++ b/packages/webdriver/src/index.js
@@ -85,7 +85,10 @@ export default class WebDriver {
             throw new Error('sessionId is required to attach to existing session')
         }
 
-        logger.setLevel('webdriver', options.logLevel)
+        // logLevel can be undefined in watch mode when SIGINT is called
+        if (options.logLevel !== undefined) {
+            logger.setLevel('webdriver', options.logLevel)
+        }
 
         options.capabilities = options.capabilities || {}
         options.isW3C = options.isW3C === false ? false : true

--- a/packages/webdriver/tests/index.test.js
+++ b/packages/webdriver/tests/index.test.js
@@ -11,126 +11,141 @@ const sessionOptions = {
     sessionId: 'foobar'
 }
 
-test('should allow to create a new session using jsonwire caps', async () => {
-    await WebDriver.newSession({
-        path: '/',
-        capabilities: { browserName: 'firefox' }
+describe('WebDriver', () => {
+    describe('newSession', () => {
+        test('should allow to create a new session using jsonwire caps', async () => {
+            await WebDriver.newSession({
+                path: '/',
+                capabilities: { browserName: 'firefox' }
+            })
+
+            const req = request.mock.calls[0][0]
+            expect(req.uri.pathname).toBe('/session')
+            expect(req.body).toEqual({
+                capabilities: {
+                    alwaysMatch: { browserName: 'firefox' },
+                    firstMatch: [{}]
+                },
+                desiredCapabilities: { browserName: 'firefox' }
+            })
+        })
+
+        test('should allow to create a new session using w3c compliant caps', async () => {
+            await WebDriver.newSession({
+                path: '/',
+                capabilities: {
+                    alwaysMatch: { browserName: 'firefox' },
+                    firstMatch: [{}]
+                }
+            })
+
+            const req = request.mock.calls[0][0]
+            expect(req.uri.pathname).toBe('/session')
+            expect(req.body).toEqual({
+                capabilities: {
+                    alwaysMatch: { browserName: 'firefox' },
+                    firstMatch: [{}]
+                },
+                desiredCapabilities: { browserName: 'firefox' }
+            })
+        })
+
+        test('should be possible to skip setting logLevel', async () => {
+            await WebDriver.newSession({
+                capabilities: { browserName: 'chrome' },
+                logLevel: 'info',
+                logLevels: { webdriver: 'silent' }
+            })
+
+            expect(logger.setLevel).not.toBeCalled()
+        })
+
+        test('should be possible to set logLevel', async () => {
+            await WebDriver.newSession({
+                capabilities: { browserName: 'chrome' },
+                logLevel: 'info'
+            })
+
+            expect(logger.setLevel).toBeCalled()
+        })
     })
 
-    const req = request.mock.calls[0][0]
-    expect(req.uri.pathname).toBe('/session')
-    expect(req.body).toEqual({
-        capabilities: {
-            alwaysMatch: { browserName: 'firefox' },
-            firstMatch: [{}]
-        },
-        desiredCapabilities: { browserName: 'firefox' }
-    })
-})
+    describe('attachToSession', () => {
 
-test('should allow to create a new session using w3c compliant caps', async () => {
-    await WebDriver.newSession({
-        path: '/',
-        capabilities: {
-            alwaysMatch: { browserName: 'firefox' },
-            firstMatch: [{}]
-        }
-    })
+        test('should allow to attach to existing session', async () => {
+            const client = WebDriver.attachToSession({ ...sessionOptions, logLevel: 'info' })
+            await client.getUrl()
+            const req = request.mock.calls[0][0]
+            expect(req.uri.href).toBe('http://localhost:4444/session/foobar/url')
+            expect(logger.setLevel).toBeCalled()
+        })
 
-    const req = request.mock.calls[0][0]
-    expect(req.uri.pathname).toBe('/session')
-    expect(req.body).toEqual({
-        capabilities: {
-            alwaysMatch: { browserName: 'firefox' },
-            firstMatch: [{}]
-        },
-        desiredCapabilities: { browserName: 'firefox' }
-    })
-})
+        test('should allow to attach to existing session2', async () => {
+            const client = WebDriver.attachToSession({ ...sessionOptions })
+            await client.getUrl()
+            const req = request.mock.calls[0][0]
+            expect(req.uri.href).toBe('http://localhost:4444/session/foobar/url')
+            expect(logger.setLevel).not.toBeCalled()
+        })
 
-test('should be possible to skip setting logLevel', async () => {
-    logger.setLevel.mockClear()
-    await WebDriver.newSession({
-        capabilities: { browserName: 'chrome' },
-        logLevel: 'info',
-        logLevels: { webdriver: 'silent' }
-    })
+        test('should allow to attach to existing session - W3C', async () => {
+            const client = WebDriver.attachToSession({ ...sessionOptions })
+            await client.getUrl()
 
-    expect(logger.setLevel).not.toBeCalled()
-})
+            expect(client.options.isChrome).toBeFalsy()
+            expect(client.options.isMobile).toBeFalsy()
+            expect(client.options.isSauce).toBeFalsy()
+            expect(client.getApplicationCacheStatus).toBeFalsy()
+            expect(client.takeElementScreenshot).toBeTruthy()
+            expect(client.getDeviceTime).toBeFalsy()
+        })
 
-test('should be possible to set logLevel', async () => {
-    logger.setLevel.mockClear()
-    await WebDriver.newSession({
-        capabilities: { browserName: 'chrome' },
-        logLevel: 'info'
-    })
+        test('should allow to attach to existing session - non W3C', async () => {
+            const client = WebDriver.attachToSession({ ...sessionOptions,
+                isW3C: false,
+                isSauce: true,
+            })
 
-    expect(logger.setLevel).toBeCalled()
-})
+            await client.getUrl()
 
-test('should allow to attach to existing session', async () => {
-    const client = WebDriver.attachToSession({ ...sessionOptions })
-    await client.getUrl()
-    const req = request.mock.calls[0][0]
-    expect(req.uri.href).toBe('http://localhost:4444/session/foobar/url')
-})
+            expect(client.options.isSauce).toBe(true)
+            expect(client.getApplicationCacheStatus).toBeTruthy()
+            expect(client.takeElementScreenshot).toBeFalsy()
+            expect(client.getDeviceTime).toBeFalsy()
+        })
 
-test('should allow to attach to existing session - W3C', async () => {
-    const client = WebDriver.attachToSession({ ...sessionOptions })
-    await client.getUrl()
+        test('should allow to attach to existing session - mobile', async () => {
+            const client = WebDriver.attachToSession({ ...sessionOptions,
+                isChrome: true,
+                isMobile: true
+            })
 
-    expect(client.options.isChrome).toBeFalsy()
-    expect(client.options.isMobile).toBeFalsy()
-    expect(client.options.isSauce).toBeFalsy()
-    expect(client.getApplicationCacheStatus).toBeFalsy()
-    expect(client.takeElementScreenshot).toBeTruthy()
-    expect(client.getDeviceTime).toBeFalsy()
-})
+            await client.getUrl()
 
-test('should allow to attach to existing session - non W3C', async () => {
-    const client = WebDriver.attachToSession({ ...sessionOptions,
-        isW3C: false,
-        isSauce: true,
+            expect(client.options.isChrome).toBe(true)
+            expect(client.options.isMobile).toBe(true)
+            expect(client.getApplicationCacheStatus).toBeTruthy()
+            expect(client.takeElementScreenshot).toBeTruthy()
+            expect(client.getDeviceTime).toBeTruthy()
+        })
+
+        test('should fail attaching to session if sessionId is not given', () => {
+            expect(() => WebDriver.attachToSession({})).toThrow(/sessionId is required/)
+        })
     })
 
-    await client.getUrl()
-
-    expect(client.options.isSauce).toBe(true)
-    expect(client.getApplicationCacheStatus).toBeTruthy()
-    expect(client.takeElementScreenshot).toBeFalsy()
-    expect(client.getDeviceTime).toBeFalsy()
-})
-
-test('should allow to attach to existing session - mobile', async () => {
-    const client = WebDriver.attachToSession({ ...sessionOptions,
-        isChrome: true,
-        isMobile: true
+    test('ensure that WebDriver interface exports protocols and other objects', () => {
+        expect(WebDriver.WebDriver).not.toBe(undefined)
+        expect(WebDriver.DEFAULTS).not.toBe(undefined)
+        expect(WebDriver.WebDriverProtocol).not.toBe(undefined)
+        expect(WebDriver.JsonWProtocol).not.toBe(undefined)
+        expect(WebDriver.MJsonWProtocol).not.toBe(undefined)
+        expect(WebDriver.AppiumProtocol).not.toBe(undefined)
+        expect(WebDriver.ChromiumProtocol).not.toBe(undefined)
     })
 
-    await client.getUrl()
-
-    expect(client.options.isChrome).toBe(true)
-    expect(client.options.isMobile).toBe(true)
-    expect(client.getApplicationCacheStatus).toBeTruthy()
-    expect(client.takeElementScreenshot).toBeTruthy()
-    expect(client.getDeviceTime).toBeTruthy()
-})
-
-test('should fail attaching to session if sessionId is not given', () => {
-    expect(() => WebDriver.attachToSession({})).toThrow(/sessionId is required/)
-})
-
-test('ensure that WebDriver interface exports protocols and other objects', () => {
-    expect(WebDriver.WebDriver).not.toBe(undefined)
-    expect(WebDriver.DEFAULTS).not.toBe(undefined)
-    expect(WebDriver.WebDriverProtocol).not.toBe(undefined)
-    expect(WebDriver.JsonWProtocol).not.toBe(undefined)
-    expect(WebDriver.MJsonWProtocol).not.toBe(undefined)
-    expect(WebDriver.AppiumProtocol).not.toBe(undefined)
-    expect(WebDriver.ChromiumProtocol).not.toBe(undefined)
-})
-
-afterEach(() => {
-    request.mockClear()
+    afterEach(() => {
+        logger.setLevel.mockClear()
+        request.mockClear()
+    })
 })

--- a/packages/webdriverio/tests/__mocks__/webdriverio.js
+++ b/packages/webdriverio/tests/__mocks__/webdriverio.js
@@ -7,11 +7,11 @@ const wdioMock = {
     sessionId: 'fakeid'
 }
 
-export const attach = jest.fn().mockImplementation(() => wdioMock)
+export const attach = jest.fn().mockImplementation(() => ({ ...wdioMock }))
 export const remote = jest.fn().mockImplementation(() => {
     if (global.throwRemoteCall) {
         throw new Error('boom')
     }
-    return wdioMock
+    return { ...wdioMock }
 })
-export const multiremote = jest.fn().mockImplementation(() => wdioMock)
+export const multiremote = jest.fn().mockImplementation(() => ({ ...wdioMock }))


### PR DESCRIPTION
## Proposed changes

Currently sessions are not closed in watch mode on termination. This PR fixes it.
Tested in regular and multiremote modes. 

Fixes #3919

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

**flow**
1. spec execution started
2. spec execution finished, child process killed, browser object no longer exists 
3. watcher is waiting for changes...
4. SIGINT

_then..._

**previous flow**
5. no attempt to call endSession because worker is marked as not busy. Even if it was, browser object doesn't exist so there is no way to interact with session.

**new flow**
5. endSession triggered, attached to session, deleted session. In multiremote mode things are a bit more complex because it is necessary to attach to every instance.

### Reviewers: @webdriverio/technical-committee
