### PR TITLE
wdio-junit-reporter: include before and after all failures

### DIFF
--- a/packages/wdio-junit-reporter/src/index.js
+++ b/packages/wdio-junit-reporter/src/index.js
@@ -55,6 +55,21 @@ class JunitReporter extends WDIOReporter {
                 .property('capabilities', runner.sanitizedCapabilities)
                 .property('file', specFileName.replace(process.cwd(), '.'))
 
+            /**
+             * Add failed before and after all hooks to suite as tests.
+             */
+            const failedHooks = suite.hooks.filter(hook => hook.error && (hook.title === '"before all" hook' || hook.title === '"after all" hook'))
+            failedHooks.forEach(hook => {
+                const { title, _duration, error, state } = hook
+                suite.tests.push({
+                    _duration,
+                    title,
+                    error,
+                    state,
+                    output: []
+                })
+            })
+
             for (let testKey of Object.keys(suite.tests)) {
                 if (testKey !== 'undefined') { // fix cucumber hooks crashing reporter
                     const test = suite.tests[testKey]

--- a/packages/wdio-junit-reporter/tests/__fixtures__/suites-hooks.json
+++ b/packages/wdio-junit-reporter/tests/__fixtures__/suites-hooks.json
@@ -1,0 +1,48 @@
+{
+  "My awesome hooks": {
+    "type": "suite",
+    "start": "2019-04-17T09:10:10.255Z",
+    "_duration": 745,
+    "uid": "My awesome hooks",
+    "cid": "0-0",
+    "title": "My awesome feature",
+    "fullTitle": "My awesome feature",
+    "tests": [],
+    "hooks": [
+      {
+        "type": "hook",
+        "start": "2019-04-17T09:10:11.003Z",
+        "_duration": 0.002,
+        "uid": "\"before all\" hook11",
+        "cid": "0-0",
+        "title": "\"before all\" hook",
+        "parent": "My awesome feature",
+        "end": "2019-04-17T09:10:11.005Z",
+        "error": {
+          "message": "before all",
+          "stack": "Error: before all stacktrace",
+          "type": "Error"
+        },
+        "state": "failed"
+      },
+      {
+        "type": "hook",
+        "start": "2019-04-17T09:10:11.001Z",
+        "_duration": 0.001,
+        "uid": "\"after all\" hook10",
+        "cid": "0-0",
+        "title": "\"after all\" hook",
+        "parent": "My awesome feature",
+        "end": "2019-04-17T09:10:11.002Z",
+        "error": {
+          "message": "after all",
+          "stack": "Error: after all stacktrace",
+          "type": "Error"
+        },
+        "state": "failed"
+      }
+    ],
+    "suites": [],
+    "end": "2019-04-17T09:10:11.000Z"
+  }
+}

--- a/packages/wdio-junit-reporter/tests/__fixtures__/wdio-0-0-junit-reporter-hooks.txt
+++ b/packages/wdio-junit-reporter/tests/__fixtures__/wdio-0-0-junit-reporter-hooks.txt
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="My_awesome_feature" timestamp="2019-04-17T09:10:10.255Z" time="0.745" tests="2" failures="0" errors="2" skipped="0">
+    <properties>
+      <property name="specId" value="0"/>
+      <property name="suiteName" value="My awesome feature"/>
+      <property name="capabilities" value="chrome.65_0_3325_181.macosx"/>
+      <property name="file" value="/path/to/project/test/specs/sync.spec.js"/>
+    </properties>
+    <testcase classname="chrome.65_0_3325_181.macosx.My_awesome_feature" name="before_all_hook" time="0.000002">
+      <error message="before all"/>
+      <system-err>
+        <![CDATA[
+Error: before all stacktrace
+]]>
+      </system-err>
+    </testcase>
+    <testcase classname="chrome.65_0_3325_181.macosx.My_awesome_feature" name="after_all_hook" time="0.000001">
+      <error message="after all"/>
+      <system-err>
+        <![CDATA[
+Error: after all stacktrace
+]]>
+      </system-err>
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/packages/wdio-junit-reporter/tests/reporter.test.js
+++ b/packages/wdio-junit-reporter/tests/reporter.test.js
@@ -4,9 +4,11 @@ import WDIOJunitReporter from '../src'
 
 import runnerLog from './__fixtures__/runner.json'
 import suitesLog from './__fixtures__/suites.json'
+import suitesHooksLog from './__fixtures__/suites-hooks.json'
 import suitesMultipleLog from './__fixtures__/suites-multiple.json'
 
 const testLog = fs.readFileSync(path.join(__dirname, '__fixtures__', 'wdio-0-0-junit-reporter.txt'))
+const testHooksLog = fs.readFileSync(path.join(__dirname, '__fixtures__', 'wdio-0-0-junit-reporter-hooks.txt'))
 const testMultipleLog = fs.readFileSync(path.join(__dirname, '__fixtures__', 'wdio-0-0-junit-reporter-multiple-suites.txt'))
 const testErrorOptionsSetLog = fs.readFileSync(path.join(__dirname, '__fixtures__', 'wdio-0-0-junit-reporter-error-options-used.txt'))
 
@@ -71,6 +73,13 @@ describe('wdio-junit-reporter', () => {
 
         // verifies the content of the report but omits format by stripping all whitespace and new lines
         expect(reporter.prepareXml(runnerLog).replace(/\s/g, '')).toBe(testLog.toString().replace(/\s/g, ''))
+    })
+
+    it('generates xml output if before all hook failed', () => {
+        reporter.suites = suitesHooksLog
+
+        // verifies the content of the report but omits format by stripping all whitespace and new lines
+        expect(reporter.prepareXml(runnerLog).replace(/\s/g, '')).toBe(testHooksLog.toString().replace(/\s/g, ''))
     })
 
     it('generates xml output for multiple describe blocks', () => {


### PR DESCRIPTION
## Proposed changes

Capture **before all** and **after all** failures as test failures in **junit-reporter**.

Fix #3517

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

### Reviewers: @webdriverio/technical-committee
