### PR TITLE
Print error message on test and "before/after all" hooks failure

### DIFF
--- a/packages/wdio-cli/src/interface.js
+++ b/packages/wdio-cli/src/interface.js
@@ -91,6 +91,15 @@ export default class WDIOCLInterface extends EventEmitter {
         return this.log(...details)
     }
 
+    onTestError(payload) {
+        let error = { type: 'Error', message: typeof payload.error === 'string' ? payload.error : 'Uknown error.' }
+        if (payload.error) {
+            error.type = payload.error.type || error.type
+            error.message = payload.error.message || error.message
+        }
+        return this.log(`[${payload.cid}]`, `${chalk.red(error.type)} in "${payload.fullTitle}"\n${chalk.red(error.message)}`)
+    }
+
     getFilenames(specs = []) {
         if (specs.length > 0) {
             return '- ' + specs.join(', ').replace(new RegExp(`${process.cwd()}`, 'g'), '')
@@ -162,6 +171,10 @@ export default class WDIOCLInterface extends EventEmitter {
 
         if (event.origin !== 'reporter') {
             return this.log(event.cid, event.origin, event.name, event.content)
+        }
+
+        if (event.name === 'printFailureMessage') {
+            return this.onTestError(event.content)
         }
 
         if (!this.messages[event.origin][event.name]) {

--- a/packages/wdio-cli/tests/interface.test.js
+++ b/packages/wdio-cli/tests/interface.test.js
@@ -76,6 +76,17 @@ describe('cli interface', () => {
         expect(wdioClInterface.messages).toEqual({ reporter: { foo: ['123', '456'] } })
     })
 
+    it('should print test error', () => {
+        wdioClInterface.onTestError = jest.fn()
+        wdioClInterface.onMessage({
+            origin: 'reporter',
+            name: 'printFailureMessage',
+            content: 'printFailureMessage'
+        })
+        expect(wdioClInterface.onTestError).toBeCalledWith('printFailureMessage')
+        expect(wdioClInterface.messages).toEqual({ reporter: {} })
+    })
+
     it('should print reporter messages in watch mode', () => {
         wdioClInterface.isWatchMode = true
         wdioClInterface.printReporters = jest.fn()
@@ -319,6 +330,45 @@ describe('cli interface', () => {
         it('percentCompleted without workers', () => {
             wdioClInterface.totalWorkerCnt = 0
             expect(wdioClInterface.printSummary().some(x => x.includes(0))).toBe(true)
+        })
+    })
+
+    describe('onTestError', () => {
+        it('onTestError', () => {
+            const result = wdioClInterface.onTestError({
+                cid: 'CID',
+                fullTitle: 'FULL_TITLE',
+                error: {
+                    type: 'ERROR_TYPE',
+                    message: 'ERROR_MESSAGE'
+                }
+            })
+
+            expect(result[0]).toContain('CID')
+            expect(result[1]).toContain('ERROR_TYPE')
+            expect(result[1]).toContain('ERROR_MESSAGE')
+            expect(result[1]).toContain('FULL_TITLE')
+        })
+
+        it('no error', () => {
+            const result = wdioClInterface.onTestError({
+                cid: 'CID',
+                fullTitle: 'FULL_TITLE'
+            })
+
+            expect(result[1]).toContain('Error')
+            expect(result[1]).toContain('Uknown error.')
+        })
+
+        it('string error', () => {
+            const result = wdioClInterface.onTestError({
+                cid: 'CID',
+                fullTitle: 'FULL_TITLE',
+                error: 'STRING_ERROR'
+            })
+
+            expect(result[1]).toContain('Error')
+            expect(result[1]).toContain('STRING_ERROR')
         })
     })
 })

--- a/packages/wdio-runner/src/reporter.js
+++ b/packages/wdio-runner/src/reporter.js
@@ -1,6 +1,7 @@
 import path from 'path'
 import logger from '@wdio/logger'
 import { initialisePlugin } from '@wdio/utils'
+import { sendFailureMessage } from './utils'
 
 const log = logger('@wdio/runner')
 
@@ -38,6 +39,12 @@ export default class BaseReporter {
      */
     emit (e, payload) {
         payload.cid = this.cid
+
+        /**
+         * Send failure message (only once) in case of test or hook failure
+         */
+        sendFailureMessage(e, payload)
+
         this.reporters.forEach((reporter) => reporter.emit(e, payload))
     }
 

--- a/packages/wdio-runner/src/utils.js
+++ b/packages/wdio-runner/src/utils.js
@@ -6,6 +6,7 @@ import { DEFAULT_CONFIGS } from '@wdio/config'
 const log = logger('@wdio/local-runner:utils')
 
 const MERGE_OPTIONS = { clone: false }
+const mochaAllHooks = ['"before all" hook', '"after all" hook']
 
 /**
  * run before/after session hook
@@ -100,4 +101,19 @@ export function filterLogTypes(excludeDriverLogs, driverLogTypes) {
     }
 
     return logTypes
+}
+
+/**
+ * Send event to WDIOCLInterface if test or before/after all hook failed
+ * @param {string} e        event
+ * @param {object} payload  payload
+ */
+export function sendFailureMessage(e, payload) {
+    if (e === 'test:fail' || (e === 'hook:end' && payload.error && mochaAllHooks.some(hook => payload.title.startsWith(hook)))) {
+        process.send({
+            origin: 'reporter',
+            name: 'printFailureMessage',
+            content: payload
+        })
+    }
 }


### PR DESCRIPTION
## Proposed changes

Currently test and before/after all hooks failures are printed in the very end within reporter.

Change: print error immediately, even if there are no or multiple reporters.
This doesn't affect printing errors in reporters anyhow.

**dot + spec** before each
![image](https://user-images.githubusercontent.com/25589559/58058610-dcefdb00-7b69-11e9-9119-a98a3ada6399.png)

**no reporters** before all
![image](https://user-images.githubusercontent.com/25589559/58058636-f7c24f80-7b69-11e9-8b0b-e36862eb22c1.png)

**dot** regular test failure
![image](https://user-images.githubusercontent.com/25589559/58058531-9dc18a00-7b69-11e9-9965-6f0b19521410.png)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

After recent changes in logge PR https://github.com/webdriverio/webdriverio/pull/3589 is no longer valid. 
I suppose current PR does something similar.

### Reviewers: @webdriverio/technical-committee
