### PR TITLE
avoid sauce:contexts calls being made for Sauce RDC tests

### DIFF
--- a/packages/wdio-sauce-service/src/service.js
+++ b/packages/wdio-sauce-service/src/service.js
@@ -48,7 +48,7 @@ export default class SauceService {
     }
 
     beforeTest (test) {
-        if (!this.isServiceEnabled) {
+        if (!this.isServiceEnabled || this.isRDC) {
             return
         }
 
@@ -80,7 +80,7 @@ export default class SauceService {
     }
 
     beforeFeature (feature) {
-        if (!this.isServiceEnabled) {
+        if (!this.isServiceEnabled || this.isRDC) {
             return
         }
 
@@ -108,7 +108,7 @@ export default class SauceService {
     }
 
     beforeScenario (scenario) {
-        if (!this.isServiceEnabled) {
+        if (!this.isServiceEnabled || this.isRDC) {
             return
         }
 

--- a/packages/wdio-sauce-service/tests/service.test.js
+++ b/packages/wdio-sauce-service/tests/service.test.js
@@ -47,6 +47,24 @@ test('beforeTest should set context for test', () => {
     expect(global.browser.execute).toBeCalledWith('sauce:context=foobar')
 })
 
+test('beforeTest should not set context for RDC test', () => {
+
+    // not for RDC since sauce:context is not available there
+    const rdcService = new SauceService()
+    rdcService.beforeSession({}, { testobject_api_key: 'foobar' })
+    rdcService.beforeTest({
+        parent: 'my test',
+        title: 'can do something'
+    })
+    expect(global.browser.execute).not.toBeCalled()
+
+    rdcService.beforeTest({
+        fullName: 'foobar',
+        parent: 'Jasmine__TopLevel__Suite'
+    })
+    expect(global.browser.execute).not.toBeCalled()
+})
+
 test('beforeTest should not set context if user does not use sauce', () => {
     const service = new SauceService()
     service.beforeSession({}, {})
@@ -92,6 +110,15 @@ test('beforeFeature should set context', () => {
     expect(global.browser.execute).toBeCalledWith('sauce:context=Feature: barfoo')
 })
 
+test('beforeFeature should set context if RDC test', () => {
+    const rdcService = new SauceService()
+    rdcService.beforeSession({}, { testobject_api_key: 'foobar' })
+    rdcService.beforeFeature({ name: 'foobar' })
+    expect(global.browser.execute).not.toBeCalled()
+    rdcService.beforeFeature({ getName: () => 'barfoo' })
+    expect(global.browser.execute).not.toBeCalled()
+})
+
 test('beforeFeature should not set context if no sauce user was applied', () => {
     const service = new SauceService()
     service.beforeSession({}, {})
@@ -125,6 +152,13 @@ test('beforeScenario should set context', () => {
     expect(global.browser.execute).toBeCalledWith('sauce:context=Scenario: foobar')
     service.beforeScenario({ getName: () => 'barfoo' })
     expect(global.browser.execute).toBeCalledWith('sauce:context=Scenario: barfoo')
+})
+
+test('beforeScenario should not set context if RDC test', () => {
+    const rdcService = new SauceService()
+    rdcService.beforeSession({}, { testobject_api_key: 'foobar' })
+    rdcService.beforeScenario({ name: 'foobar' })
+    expect(global.browser.execute).not.toBeCalledWith('sauce:context=Scenario: foobar')
 })
 
 test('beforeScenario should not set context if no sauce user was applied', () => {


### PR DESCRIPTION
## Proposed changes

Prior to this change, all RDC tests were sending a sauce:context to Sauce RDC.
Sauce RDC tests do not have this capability.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
