### PR TITLE
Typings: wrap waitUntil condition function return type with Promise

### DIFF
--- a/packages/wdio-sync/webdriverio.d.ts
+++ b/packages/wdio-sync/webdriverio.d.ts
@@ -11,6 +11,15 @@ declare namespace WebdriverIO {
     function multiremote(
         options: WebdriverIO.MultiRemoteOptions
     ): WebDriver.Client;
+
+    interface Browser {
+        waitUntil(
+            condition: () => boolean,
+            timeout?: number,
+            timeoutMsg?: string,
+            interval?: number
+        ): boolean
+    }
 }
 
 declare var browser: BrowserObject;

--- a/packages/webdriverio/webdriverio.d.ts
+++ b/packages/webdriverio/webdriverio.d.ts
@@ -45,7 +45,15 @@ declare namespace WebdriverIOAsync {
         options: WebdriverIO.MultiRemoteOptions
     ): WebDriver.ClientAsync;
 
-    interface Browser extends BrowserAsync, BrowserStatic { }
+    interface Browser extends BrowserAsync, BrowserStatic {
+        waitUntil(
+            condition: () => Promise<boolean>,
+            timeout?: number,
+            timeoutMsg?: string,
+            interval?: number
+        ): Promise<boolean>
+    }
+
     interface Element extends ElementAsync, ElementStatic { }
     interface Config {}
 }

--- a/scripts/templates/webdriverio.tpl.d.ts
+++ b/scripts/templates/webdriverio.tpl.d.ts
@@ -176,12 +176,6 @@ declare namespace WebdriverIO {
         executeAsync: ExecuteAsync;
         call: Call;
         options: Options;
-        waitUntil(
-            condition: () => boolean,
-            timeout?: number,
-            timeoutMsg?: string,
-            interval?: number
-        ): boolean
         // ... browser commands ...
     }
 

--- a/tests/typings/webdriverio/async.ts
+++ b/tests/typings/webdriverio/async.ts
@@ -3,7 +3,7 @@ import allure from '@wdio/allure-reporter'
 async function bar() {
     // browser
     await browser.pause(1)
-    const waitUntil: boolean = await browser.waitUntil(() => true, 1, '', 1)
+    const waitUntil: boolean = await browser.waitUntil(() => Promise.resolve(true), 1, '', 1)
     await browser.getCookies()
 
     // ToDo fix typing for `execute` and `call`

--- a/tests/typings/webdriverio/tsconfig.json
+++ b/tests/typings/webdriverio/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "lib": ["es2018"],
     "types": [
       "webdriverio",
       "@wdio/allure-reporter",


### PR DESCRIPTION
## Proposed changes

wrap **waitUntil** condition function return type with Promise
`() =>  boolean` -> `() => Promise<boolean>`

fix #3940

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

### Reviewers: @webdriverio/technical-committee
