### PR TITLE
Fixed issue #4021 - Not able to run tests with Sauce Connect and W3C caps

### DIFF
--- a/packages/wdio-sauce-service/src/launcher.js
+++ b/packages/wdio-sauce-service/src/launcher.js
@@ -23,11 +23,19 @@ export default class SauceLauncher {
         if (sauceConnectTunnelIdentifier) {
             if (Array.isArray(capabilities)) {
                 capabilities.forEach(capability => {
-                    capability.tunnelIdentifier = capability.tunnelIdentifier || sauceConnectTunnelIdentifier
+                    if (capability['sauce:options'] === undefined) {
+                        capability.tunnelIdentifier = capability.tunnelIdentifier || sauceConnectTunnelIdentifier
+                    } else {
+                        capability['sauce:options'].tunnelIdentifier = capability['sauce:options'].tunnelIdentifier || sauceConnectTunnelIdentifier
+                    }
                 })
             } else {
                 Object.keys(capabilities).forEach(browser => {
-                    capabilities[browser].capabilities.tunnelIdentifier = capabilities[browser].capabilities.tunnelIdentifier || sauceConnectTunnelIdentifier
+                    if (capabilities[browser].capabilities['sauce:options'] === undefined) {
+                        capabilities[browser].capabilities.tunnelIdentifier = capabilities[browser].capabilities.tunnelIdentifier || sauceConnectTunnelIdentifier
+                    } else {
+                        capabilities[browser].capabilities['sauce:options'].tunnelIdentifier = capabilities[browser].capabilities['sauce:options'].tunnelIdentifier || sauceConnectTunnelIdentifier
+                    }
                 })
             }
         }

--- a/packages/wdio-sauce-service/tests/launcher.test.js
+++ b/packages/wdio-sauce-service/tests/launcher.test.js
@@ -93,6 +93,205 @@ test('onPrepare if sauceTunnel is not set', () => {
     expect(SauceConnectLauncher).not.toBeCalled()
 })
 
+test('onPrepare multiremote with tunnel identifier and with w3c caps ', () => {
+    const caps = {
+        browserA: {
+            capabilities: {
+                browserName: 'chrome',
+                'sauce:options': {
+                    commandTimeout: 600
+                }
+            }
+        },
+        browserB: {
+            capabilities: {
+                browserName: 'firefox',
+                'sauce:options': {
+                    commandTimeout: 600,
+                    tunnelIdentifier: 'fish'
+                }
+            }
+        }
+    }
+    const config = {
+        user: 'foobaruser',
+        key: '12345',
+        sauceConnect: true,
+        sauceConnectOpts: {
+            port: 4446,
+            tunnelIdentifier: 'my-tunnel'
+        }
+    }
+    const service = new SauceServiceLauncher()
+    expect(service.sauceConnectProcess).toBeUndefined()
+    service.onPrepare(config, caps)
+
+    expect(caps).toEqual({
+        browserA: {
+            capabilities: {
+                browserName: 'chrome',
+                'sauce:options': {
+                    commandTimeout: 600,
+                    tunnelIdentifier: 'my-tunnel'
+                }
+            }
+        },
+        browserB: {
+            capabilities: {
+                browserName: 'firefox',
+                'sauce:options': {
+                    commandTimeout: 600,
+                    tunnelIdentifier: 'fish'
+                }
+            }
+        }
+    })
+    expect(service.sauceConnectProcess).not.toBeUndefined()
+    expect(config.port).toBe(4446)
+    expect(config.protocol).toBe('http')
+    expect(config.hostname).toBe('localhost')
+})
+
+test('onPrepare with tunnel identifier and without w3c caps ', () => {
+    const caps = [{
+        browserName: 'chrome'
+    }, {
+        browserName: 'firefox',
+        tunnelIdentifier: 'fish'
+    }]
+    const config = {
+        user: 'foobaruser',
+        key: '12345',
+        sauceConnect: true,
+        sauceConnectOpts: {
+            port: 4446,
+            tunnelIdentifier: 'my-tunnel'
+        }
+    }
+    const service = new SauceServiceLauncher()
+    expect(service.sauceConnectProcess).toBeUndefined()
+    service.onPrepare(config, caps)
+
+    expect(caps).toEqual([{
+        browserName: 'chrome',
+        tunnelIdentifier: 'my-tunnel'
+    }, {
+        browserName: 'firefox',
+        tunnelIdentifier: 'fish'
+    }])
+    expect(service.sauceConnectProcess).not.toBeUndefined()
+    expect(config.port).toBe(4446)
+    expect(config.protocol).toBe('http')
+    expect(config.hostname).toBe('localhost')
+})
+
+test('onPrepare without tunnel identifier and without w3c caps ', () => {
+    const caps = [{
+        browserName: 'chrome'
+    }, {
+        browserName: 'firefox',
+        tunnelIdentifier: 'fish'
+    }]
+    const config = {
+        user: 'foobaruser',
+        key: '12345',
+        sauceConnect: false
+    }
+    const service = new SauceServiceLauncher()
+    expect(service.sauceConnectProcess).toBeUndefined()
+    service.onPrepare(config, caps)
+
+    expect(caps).toEqual([{
+        browserName: 'chrome'
+    }, {
+        browserName: 'firefox',
+        tunnelIdentifier: 'fish'
+    }])
+    expect(service.sauceConnectProcess).toBeUndefined()
+})
+
+test('onPrepare without tunnel identifier and with w3c caps ', () => {
+    const caps = [{
+        browserName: 'chrome',
+        'sauce:options': {
+            commandTimeout: 600,
+            tunnelIdentifier: 'fish'
+        }
+    }, {
+        browserName: 'firefox',
+        'sauce:options': {
+            commandTimeout: 600
+        }
+    }]
+    const config = {
+        user: 'foobaruser',
+        key: '12345',
+        sauceConnect: false
+    }
+    const service = new SauceServiceLauncher()
+    expect(service.sauceConnectProcess).toBeUndefined()
+    service.onPrepare(config, caps)
+
+    expect(caps).toEqual([{
+        browserName: 'chrome',
+        'sauce:options': {
+            commandTimeout: 600,
+            tunnelIdentifier: 'fish'
+        }
+    }, {
+        browserName: 'firefox',
+        'sauce:options': {
+            commandTimeout: 600
+        }
+    }])
+    expect(service.sauceConnectProcess).toBeUndefined()
+})
+
+test('onPrepare with tunnel identifier and with w3c caps ', () => {
+    const caps = [{
+        browserName: 'chrome',
+        'sauce:options': {
+            commandTimeout: 600,
+            tunnelIdentifier: 'fish'
+        }
+    }, {
+        browserName: 'firefox',
+        'sauce:options': {
+            commandTimeout: 600
+        }
+    }]
+    const config = {
+        user: 'foobaruser',
+        key: '12345',
+        sauceConnect: true,
+        sauceConnectOpts: {
+            port: 4446,
+            tunnelIdentifier: 'my-tunnel'
+        }
+    }
+    const service = new SauceServiceLauncher()
+    expect(service.sauceConnectProcess).toBeUndefined()
+    service.onPrepare(config, caps)
+
+    expect(caps).toEqual([{
+        browserName: 'chrome',
+        'sauce:options': {
+            commandTimeout: 600,
+            tunnelIdentifier: 'fish'
+        }
+    }, {
+        browserName: 'firefox',
+        'sauce:options': {
+            commandTimeout: 600,
+            tunnelIdentifier: 'my-tunnel'
+        }
+    }])
+    expect(service.sauceConnectProcess).not.toBeUndefined()
+    expect(config.port).toBe(4446)
+    expect(config.protocol).toBe('http')
+    expect(config.hostname).toBe('localhost')
+})
+
 test('onComplete', () => {
     const service = new SauceServiceLauncher()
     expect(service.onComplete()).toBeUndefined()


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

Fixed the issue #4021 : While using W3C capabilities on Sauce Labs, we are currently not passing the tunnel identifier under 'sauce:options'. Hence it was not running the tests with W3C capabilities and Sauce Connect. Now I fixed the issue by passing the tunnel identifier for W3C capability.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee