### PR TITLE
Implement issue#4024: jasmine-framework - introduce new jasmineOpts option: stopSpecOnExpectationFailure

### DIFF
--- a/packages/wdio-jasmine-framework/README.md
+++ b/packages/wdio-jasmine-framework/README.md
@@ -80,7 +80,13 @@ Type: `Boolean`<br>
 Default: `false`
 
 ### stopOnSpecFailure
-Stops spec execution on first fail (other specs continue running)
+Stops test suite (`describe`) execution on first spec (`it`) failure (other suites continue running)
+
+Type: `Boolean`<br>
+Default: `false`
+
+### stopSpecOnExpectationFailure
+Stops a spec (`it`) execution on a first expectation failure (other specs continue running)
 
 Type: `Boolean`<br>
 Default: `false`

--- a/packages/wdio-jasmine-framework/src/index.js
+++ b/packages/wdio-jasmine-framework/src/index.js
@@ -55,8 +55,8 @@ class JasmineAdapter {
         const stopOnSpecFailure = !!this.jasmineNodeOpts.stopOnSpecFailure
 
         /**
-         * Set whether to stop suite execution when a spec fails
-         */
+         * Set whether to stop spec execution when an expectation fails
+        */
         const stopSpecOnExpectationFailure = !!this.jasmineNodeOpts.stopSpecOnExpectationFailure
 
         /**

--- a/packages/wdio-jasmine-framework/src/index.js
+++ b/packages/wdio-jasmine-framework/src/index.js
@@ -55,12 +55,18 @@ class JasmineAdapter {
         const stopOnSpecFailure = !!this.jasmineNodeOpts.stopOnSpecFailure
 
         /**
+         * Set whether to stop suite execution when a spec fails
+         */
+        const stopSpecOnExpectationFailure = !!this.jasmineNodeOpts.stopSpecOnExpectationFailure
+
+        /**
          * Filter specs to run based on jasmineNodeOpts.grep and jasmineNodeOpts.invert
          */
         jasmineEnv.configure({
             specFilter: ::this.customSpecFilter,
             stopOnSpecFailure: stopOnSpecFailure,
             random: Boolean(this.jasmineNodeOpts.random),
+            oneFailurePerSpec: stopSpecOnExpectationFailure,
             failFast: this.jasmineNodeOpts.failFast
         })
 

--- a/packages/wdio-jasmine-framework/tests/adapter.test.js
+++ b/packages/wdio-jasmine-framework/tests/adapter.test.js
@@ -50,6 +50,7 @@ test('should properly set up jasmine', async () => {
 
 test('should properly configure the jasmine environment', async () => {
     const stopOnSpecFailure = false
+    const stopSpecOnExpectationFailure = false
     const random = false
     const failFast = false
 
@@ -58,6 +59,7 @@ test('should properly configure the jasmine environment', async () => {
         {
             jasmineNodeOpts: {
                 stopOnSpecFailure,
+                stopSpecOnExpectationFailure,
                 random,
                 failFast,
             }
@@ -69,6 +71,7 @@ test('should properly configure the jasmine environment', async () => {
     await adapter.run()
     expect(adapter.jrunner.jasmine.getEnv().configure).toBeCalledWith({
         specFilter: expect.any(Function),
+        oneFailurePerSpec: stopSpecOnExpectationFailure,
         stopOnSpecFailure,
         random,
         failFast,


### PR DESCRIPTION
## Proposed changes

[//]: # This is an implementation for an issue https://github.com/webdriverio/webdriverio/issues/4024 - implement new jasmineOpts option: `stopSpecOnExpectationFailure`.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
