### PR TITLE
Update retry documentation as per #4008

### DIFF
--- a/docs/Retry.md
+++ b/docs/Retry.md
@@ -27,9 +27,9 @@ describe('retries', function() {
 });
 ```
 
-## Rerun single tests in Jasmine or Mocha
+## Rerun single tests in Jasmine or Mocha (@wdio/sync only)
 
-To rerun a certain test block just apply the number of reruns as last parameter after the test block function:
+If you are using `@wdio/sync`, to rerun a certain test block you can just apply the number of reruns as last parameter after the test block function:
 
 ```js
 describe('my flaky app', () => {
@@ -56,6 +56,8 @@ describe('my flaky app', () => {
     // ...
 });
 ```
+
+If you are using Jasmine, it also means that second parameter of both *test functions* (e.g., `it`) and *hooks* (e.g., `beforeEach`) , which is a `timeout` in Jasmine, is treated as retry count.
 
 It is __not__ possible to rerun whole suites with Jasmine, only hooks or test blocks.
 


### PR DESCRIPTION
Elaborate that retry-per-block only works in `@wdio/sync` and is not expected to be working in async WebdriverIO.

## Proposed changes

Document that WDIO only treats second parameter of `it` statements and hooks if you're using `@wdio/sync`, and this is not expected to work in async


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
