### PR TITLE
Fix build

### DIFF
--- a/packages/webdriverio/webdriverio.d.ts
+++ b/packages/webdriverio/webdriverio.d.ts
@@ -5,7 +5,7 @@ type $ = (selector: string | Function) => Promise<WebdriverIOAsync.Element>;
 type $$ = (selector: string | Function) => Promise<WebdriverIOAsync.Element[]>;
 
 // Element commands that should be wrapper with Promise
-type ElementPromise = Omit<WebdriverIO.Element, 'addCommand' | '$' | '$$'>;
+type ElementPromise = WdioOmit<WebdriverIO.Element, 'addCommand' | '$' | '$$'>;
 
 // Methods which return async element(s) so non-async equivalents cannot just be promise-wrapped
 interface AsyncSelectors {
@@ -22,7 +22,7 @@ type ElementAsync = {
 type ElementStatic = Pick<WebdriverIO.Element, 'addCommand'>
 
 // Browser commands that should be wrapper with Promise
-type BrowserPromise = Omit<WebdriverIO.Browser, 'addCommand' | 'options' | '$' | '$$'>;
+type BrowserPromise = WdioOmit<WebdriverIO.Browser, 'addCommand' | 'options' | '$' | '$$'>;
 
 // Browser commands wrapper with Promise
 type BrowserAsync = {

--- a/scripts/templates/webdriver.tpl.d.ts
+++ b/scripts/templates/webdriver.tpl.d.ts
@@ -4,8 +4,6 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 /// <reference types="node"/>
 
-type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
-
 type ArgumentTypes<T> = T extends (...args: infer U) => infer R ? U : never;
 type WrapWithPromise<T, R> = (...args: ArgumentTypes<T>) => Promise<R>;
 

--- a/scripts/templates/webdriver.tpl.d.ts
+++ b/scripts/templates/webdriver.tpl.d.ts
@@ -4,6 +4,8 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 /// <reference types="node"/>
 
+type WdioOmit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+
 type ArgumentTypes<T> = T extends (...args: infer U) => infer R ? U : never;
 type WrapWithPromise<T, R> = (...args: ArgumentTypes<T>) => Promise<R>;
 

--- a/scripts/templates/webdriverio.tpl.d.ts
+++ b/scripts/templates/webdriverio.tpl.d.ts
@@ -179,5 +179,5 @@ declare namespace WebdriverIO {
         // ... browser commands ...
     }
 
-    interface Config extends Options, Omit<WebDriver.Options, "capabilities">, Hooks {}
+    interface Config extends Options, WdioOmit<WebDriver.Options, "capabilities">, Hooks {}
 }


### PR DESCRIPTION
Our typescript tests fail due to:

```
../../../node_modules/typescript/lib/lib.es5.d.ts:1469:6 - error TS2300: Duplicate identifier 'Omit'.

1469 type Omit<T, K extends keyof any> = Pick<T, Exclude<keyof T, K>>;
          ~~~~

  node_modules/webdriver/webdriver.d.ts:7:6
    7 type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
           ~~~~
    'Omit' was also declared here.

node_modules/webdriver/webdriver.d.ts:7:6 - error TS2300: Duplicate identifier 'Omit'.

7 type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
       ~~~~

  ../../../node_modules/typescript/lib/lib.es5.d.ts:1469:6
    1469 type Omit<T, K extends keyof any> = Pick<T, Exclude<keyof T, K>>;
              ~~~~
    'Omit' was also declared here.


Found 2 errors.
```

This removes the definition of `Omit` which is not used anyway.