### PR TITLE
@wdio/devtools-service: updating puppeteer.connect arguments

### DIFF
--- a/packages/wdio-devtools-service/src/driver.js
+++ b/packages/wdio-devtools-service/src/driver.js
@@ -21,7 +21,7 @@ export default class DevToolsDriver {
     static async attach (url) {
         log.info(`Connect to ${url}`)
         const browser = await puppeteer.connect({
-            url,
+            browserURL: url,
             defaultViewport: null
         })
         return new DevToolsDriver(browser)

--- a/packages/wdio-devtools-service/tests/driver.test.js
+++ b/packages/wdio-devtools-service/tests/driver.test.js
@@ -1,5 +1,8 @@
 import DevToolsDriver from '../src/driver'
 
+import puppeteer from 'puppeteer-core'
+jest.mock('puppeteer-core')
+
 test('getActivePage: returns existing page if existing', async () => {
     const driver = new DevToolsDriver()
     driver.page = 'foobar'
@@ -17,4 +20,11 @@ test('send', async () => {
     driver.cdpSession = { send: jest.fn() }
     await driver.send('foo', 'bar')
     expect(driver.cdpSession.send).toBeCalledWith('foo', 'bar')
+})
+
+test('connect', async () => {
+    const url = 'https://webdriver.io'
+    const driver = await DevToolsDriver.attach(url)
+    expect(driver.browser).toBeInstanceOf(puppeteer.PuppeteerMock)
+    expect(puppeteer.connect).toBeCalledWith({ browserURL: url, defaultViewport: null })
 })


### PR DESCRIPTION
## Proposed changes

FIX #4040 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

The puppeteer documentation that lead me to the use of this option key: https://pptr.dev/#?product=Puppeteer&version=v1.17.0&show=api-puppeteerconnectoptions. Looks like `url` it not a vaild option in 1.17. 

### Reviewers: @webdriverio/technical-committee
