### PR TITLE
fix runOnCompleteHook to respect async functions

### DIFF
--- a/packages/wdio-cli/src/utils.js
+++ b/packages/wdio-cli/src/utils.js
@@ -52,9 +52,9 @@ export async function runOnCompleteHook(onCompleteHook, config, capabilities, ex
         onCompleteHook = [onCompleteHook]
     }
 
-    return Promise.all(onCompleteHook.map((hook) => {
+    return Promise.all(onCompleteHook.map(async (hook) => {
         try {
-            hook(exitCode, config, capabilities, results)
+            await hook(exitCode, config, capabilities, results)
             return 0
         } catch (e) {
             log.error(`Error in onCompleteHook: ${e.stack}`)

--- a/packages/wdio-cli/tests/utils.test.js
+++ b/packages/wdio-cli/tests/utils.test.js
@@ -37,6 +37,14 @@ test('runOnPrepareHook handles array of functions', () => {
     expect(hookFailing).toBeCalledTimes(1)
 })
 
+test('runOnPrepareHook handles async functions', async () => {
+    const hookSuccess = () => new Promise(resolve => setTimeout(resolve, 30))
+
+    const start = Date.now()
+    await runOnPrepareHook([hookSuccess], {}, {})
+    expect(Date.now() - start).toBeGreaterThanOrEqual(30)
+})
+
 test('runOnPrepareHook handles a single function', () => {
     const hookSuccess = jest.fn()
 
@@ -51,6 +59,14 @@ test('runOnCompleteHook handles array of functions', () => {
     runOnCompleteHook([hookSuccess, secondHook], {}, {})
     expect(hookSuccess).toBeCalledTimes(1)
     expect(secondHook).toBeCalledTimes(1)
+})
+
+test('runOnCompleteHook handles async functions', async () => {
+    const hookSuccess = () => new Promise(resolve => setTimeout(resolve, 30))
+
+    const start = Date.now()
+    await runOnCompleteHook([hookSuccess], {}, {})
+    expect(Date.now() - start).toBeGreaterThanOrEqual(30)
 })
 
 test('runOnCompleteHook handles a single function', () => {


### PR DESCRIPTION
## Proposed changes

runOnCompleteHook doesn't respect async functions, this PR fixes that

closes #4042 

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments


### Reviewers: @webdriverio/technical-committee
