### PR TITLE
Overwrite native commands

### DIFF
--- a/docs/CustomCommands.md
+++ b/docs/CustomCommands.md
@@ -3,6 +3,8 @@ id: customcommands
 title: Custom Commands
 ---
 
+### Adding custom commands
+
 If you want to extend the browser instance with your own set of commands there is a method called `addCommand` available from the browser object. You can write your command in a synchronous (default) way the same way as in your specs or asynchronous (like when using WebdriverIO in standalone mode). The following example shows how to add a new command that returns the current url and title as one result only using synchronous commands:
 
 ```js
@@ -96,3 +98,71 @@ it('execute external library in a sync way', () => {
 ```
 
 Note that the result of your custom command will be the result of the promise you return. Also there is no support for synchronous commands in standalone mode therefore you always have to handle asynchronous commands using promises.
+
+### Overwriting native commands
+
+You can also overwrite native commands with `overwriteCommand`. It is highly unrecommended to do that because it may lead to unpredictable behavior of framework! Overall approach is similar to `addCommand`, the only difference is that first argument in command function is original function, please see some examples below.
+
+NOTE: examples below assumes sync mode. If you are not using it don't forget to add async/await.
+
+#### Overwriting browser commands
+
+```js
+/**
+ * print milliseconds before pause and return its value.
+ */
+// "pause"            - command to be overwritten
+// origPauseFunction  - original pause function
+browser.overwriteCommand("pause", function (origPauseFunction, ms) {
+    console.log(`sleeping for ${ms}`);
+    origPauseFunction(ms);
+    return ms;
+});
+
+// then use it as before
+console.log(`was sleeping for ${browser.pause(1000)}`);
+```
+
+#### Overwriting element commands
+
+Overwriting commands on element level is almost the same, simply pass `true` as 3rd argument to `overwriteCommand`
+
+```js
+/**
+ * Attempt to scroll to element if it is not clickable.
+ * Pass { force: true } to click with JS even if element is not visible or clickable.
+ */
+// "click"            - command to be overwritten
+// origClickFunction  - original click function
+browser.overwriteCommand("click", function (origClickFunction, { force = false } = {}) {
+    if (!force) {
+        try {
+            // attempt to click
+            return origClickFunction();
+        } catch (err) {
+            if (err.message.includes('not clickable at point')) {
+                console.warn('WARN: Element', this.selector, 'is not clickable.',
+                    'Scrolling to it before clicking again.');
+
+                // scroll to element and click again
+                this.scrollIntoView();
+                return origClickFunction();
+            }
+            throw err;
+        }
+    }
+
+    // clicking with js
+    console.warn('WARN: Using force click for', this.selector)
+    browser.execute(function (el) {
+        el.click();
+    }, this);
+}, true); // don't forget to pass `true` as 3rd argument
+
+// then use it as before
+const elem = $('body')
+elem.click()
+
+// or pass params
+elem.click({ force: true })
+```

--- a/docs/CustomCommands.md
+++ b/docs/CustomCommands.md
@@ -101,7 +101,7 @@ Note that the result of your custom command will be the result of the promise yo
 
 ### Overwriting native commands
 
-You can also overwrite native commands with `overwriteCommand`. It is highly unrecommended to do that because it may lead to unpredictable behavior of framework! Overall approach is similar to `addCommand`, the only difference is that first argument in command function is original function, please see some examples below.
+You can also overwrite native commands with `overwriteCommand`. It is not recommended to do this because it may lead to unpredictable behavior of the framework! The overall approach is similar to `addCommand`, the only difference is that the first argument in the command function is the original function that you are about to overwrite. Please see some examples below:
 
 NOTE: examples below assumes sync mode. If you are not using it don't forget to add async/await.
 
@@ -111,9 +111,9 @@ NOTE: examples below assumes sync mode. If you are not using it don't forget to 
 /**
  * print milliseconds before pause and return its value.
  */
-// "pause"            - command to be overwritten
+// 'pause'            - name of command to be overwritten
 // origPauseFunction  - original pause function
-browser.overwriteCommand("pause", function (origPauseFunction, ms) {
+browser.overwriteCommand('pause', function (origPauseFunction, ms) {
     console.log(`sleeping for ${ms}`);
     origPauseFunction(ms);
     return ms;
@@ -132,9 +132,9 @@ Overwriting commands on element level is almost the same, simply pass `true` as 
  * Attempt to scroll to element if it is not clickable.
  * Pass { force: true } to click with JS even if element is not visible or clickable.
  */
-// "click"            - command to be overwritten
+// 'click'            - name of command to be overwritten
 // origClickFunction  - original click function
-browser.overwriteCommand("click", function (origClickFunction, { force = false } = {}) {
+browser.overwriteCommand('click', function (origClickFunction, { force = false } = {}) {
     if (!force) {
         try {
             // attempt to click

--- a/packages/wdio-webdriver-mock-service/src/index.js
+++ b/packages/wdio-webdriver-mock-service/src/index.js
@@ -18,17 +18,12 @@ export default class WebdriverMockService {
         this.command = this.mock.command
 
         // define required responses
-        this.command.newSession().reply(200, newSession)
-        this.command.deleteSession().reply(200, deleteSession)
-        this.command.getTitle().reply(200, { value: 'Mock Page Title' })
-        this.command.getUrl().reply(200, { value: 'https://mymockpage.com' })
-        this.command.getElementRect(ELEMENT_ID).reply(200, { value: { width: 1, height: 2, x: 3, y: 4 } })
+        this.command.newSession().times(2).reply(200, newSession)
+        this.command.deleteSession().times(2).reply(200, deleteSession)
+        this.command.getTitle().times(2).reply(200, { value: 'Mock Page Title' })
+        this.command.getUrl().times(2).reply(200, { value: 'https://mymockpage.com' })
+        this.command.getElementRect(ELEMENT_ID).times(2).reply(200, { value: { width: 1, height: 2, x: 3, y: 4 } })
         this.command.getLogTypes().reply(200, { value: [] })
-
-        // in case run with multiremote
-        this.command.newSession().reply(200, newSession)
-        this.command.getTitle().reply(200, { value: 'Mock Page Other Title' })
-        this.command.deleteSession().reply(200, deleteSession)
     }
 
     before () {
@@ -115,6 +110,9 @@ export default class WebdriverMockService {
         const elemResponse = { 'element-6066-11e4-a52e-4f735466cecf': ELEMENT_ID }
         this.command.findElement().times(times).reply(200, { value: elemResponse })
         this.command.executeScript().times(times).reply(200, { value: '2' })
+
+        // overwrite
+        this.command.deleteAllCookies().times(times).reply(200, { value: 'deleteAllCookies' })
     }
 
     waitForDisplayedScenario () {

--- a/packages/webdriver/src/monad.js
+++ b/packages/webdriver/src/monad.js
@@ -94,6 +94,15 @@ export default function WebDriver (options, modifier, propertiesObject = {}) {
             }
         }
 
+        /**
+         * overwriteCommand
+         * @param  {String}   name              command name to be overwritten
+         * @param  {Function} func              function to replace original command with;
+         *                                      takes original function as first argument.
+         * @param  {boolean=} attachToElement   overwrite browser command (false) or element command (true)
+         * @param  {Object=}  proto             prototype to add function to (optional)
+         * @param  {Object=}  instances         multiremote instances
+         */
         client.overwriteCommand = function (name, func, attachToElement = false, proto, instances) {
             let customCommand = typeof commandWrapper === 'function'
                 ? commandWrapper(name, func)

--- a/packages/webdriver/src/monad.js
+++ b/packages/webdriver/src/monad.js
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'events'
 import logger from '@wdio/logger'
 
-import { commandCallStructure } from './utils'
+import { commandCallStructure, overwriteElementCommands } from './utils'
 
 const SCOPE_TYPES = {
     'browser': /* istanbul ignore next */ function Browser () {},
@@ -23,6 +23,8 @@ export default function WebDriver (options, modifier, propertiesObject = {}) {
     const eventHandler = new EventEmitter()
     const EVENTHANDLER_FUNCTIONS = Object.getPrototypeOf(eventHandler)
 
+    const origCommands = {}
+
     /**
      * WebDriver monad
      */
@@ -41,8 +43,15 @@ export default function WebDriver (options, modifier, propertiesObject = {}) {
                 }
 
                 propertiesObject[commandName].value = commandWrapper(commandName, value)
+                propertiesObject[commandName].configurable = true
+                origCommands[commandName] = propertiesObject[commandName].value
             }
         }
+
+        /**
+         * overwrite native element commands with user defined
+         */
+        overwriteElementCommands.call(this, propertiesObject)
 
         /**
          * assign propertiesObject to itself so the client can be recreated
@@ -68,6 +77,9 @@ export default function WebDriver (options, modifier, propertiesObject = {}) {
                 ? commandWrapper(name, func)
                 : func
             if (attachToElement) {
+                /**
+                 * add command to every multiremote instance
+                 */
                 if (instances) {
                     Object.values(instances).forEach(instance => {
                         instance.__propertiesObject__[name] = {
@@ -75,9 +87,36 @@ export default function WebDriver (options, modifier, propertiesObject = {}) {
                         }
                     })
                 }
+
                 this.__propertiesObject__[name] = { value: customCommand }
             } else {
                 unit.lift(name, customCommand, proto)
+            }
+        }
+
+        client.overwriteCommand = function (name, func, attachToElement = false, proto, instances) {
+            let customCommand = typeof commandWrapper === 'function'
+                ? commandWrapper(name, func)
+                : func
+            if (attachToElement) {
+                if (instances) {
+                    /**
+                     * add command to every multiremote instance
+                     */
+                    Object.values(instances).forEach(instance => {
+                        instance.__propertiesObject__.__elementOverrides__.value[name] = customCommand
+                    })
+                } else {
+                    /**
+                     * regular mode
+                     */
+                    this.__propertiesObject__.__elementOverrides__.value[name] = customCommand
+                }
+            } else if (client[name] && origCommands[name]) {
+                delete client[name]
+                unit.lift(name, customCommand, proto, (...args) => origCommands[name].apply(this, args))
+            } else {
+                throw new Error('overwriteCommand: no command to be overwritten ' + name)
             }
         }
 
@@ -86,12 +125,12 @@ export default function WebDriver (options, modifier, propertiesObject = {}) {
 
     /**
      * Enhance monad prototype with function
-     * @param  {String}   name   name of function to attach to prototype
-     * @param  {Function} func   function to be added to prototype
-     * @param  {Object}   proto  prototype to add function to (optional)
+     * @param  {String}   name          name of function to attach to prototype
+     * @param  {Function} func          function to be added to prototype
+     * @param  {Object}   proto         prototype to add function to (optional)
+     * @param  {Function} origCommand   original command to be passed to custom command as first argument
      */
-    unit.lift = function (name, func, proto) {
-
+    unit.lift = function (name, func, proto, origCommand) {
         (proto || prototype)[name] = function next (...args) {
             log.info('COMMAND', commandCallStructure(name, args))
 
@@ -103,7 +142,7 @@ export default function WebDriver (options, modifier, propertiesObject = {}) {
                 writable: false,
             })
 
-            const result = func.apply(this, args)
+            const result = func.apply(this, origCommand ? [origCommand, ...args] : args)
 
             /**
              * always transform result into promise as we don't know whether or not

--- a/packages/webdriver/src/monad.js
+++ b/packages/webdriver/src/monad.js
@@ -23,8 +23,6 @@ export default function WebDriver (options, modifier, propertiesObject = {}) {
     const eventHandler = new EventEmitter()
     const EVENTHANDLER_FUNCTIONS = Object.getPrototypeOf(eventHandler)
 
-    const origCommands = {}
-
     /**
      * WebDriver monad
      */
@@ -44,7 +42,6 @@ export default function WebDriver (options, modifier, propertiesObject = {}) {
 
                 propertiesObject[commandName].value = commandWrapper(commandName, value)
                 propertiesObject[commandName].configurable = true
-                origCommands[commandName] = propertiesObject[commandName].value
             }
         }
 
@@ -121,9 +118,10 @@ export default function WebDriver (options, modifier, propertiesObject = {}) {
                      */
                     this.__propertiesObject__.__elementOverrides__.value[name] = customCommand
                 }
-            } else if (client[name] && origCommands[name]) {
+            } else if (client[name]) {
+                const origCommand = client[name]
                 delete client[name]
-                unit.lift(name, customCommand, proto, (...args) => origCommands[name].apply(this, args))
+                unit.lift(name, customCommand, proto, (...args) => origCommand.apply(this, args))
             } else {
                 throw new Error('overwriteCommand: no command to be overwritten: ' + name)
             }

--- a/packages/webdriver/src/monad.js
+++ b/packages/webdriver/src/monad.js
@@ -116,7 +116,7 @@ export default function WebDriver (options, modifier, propertiesObject = {}) {
                 delete client[name]
                 unit.lift(name, customCommand, proto, (...args) => origCommands[name].apply(this, args))
             } else {
-                throw new Error('overwriteCommand: no command to be overwritten ' + name)
+                throw new Error('overwriteCommand: no command to be overwritten: ' + name)
             }
         }
 

--- a/packages/webdriver/tests/monad.test.js
+++ b/packages/webdriver/tests/monad.test.js
@@ -52,6 +52,16 @@ describe('monad', () => {
         expect(client.someFunc()).toBe('bar')
     })
 
+    it('should throw if there is no command to be overwritten', () => {
+        const monad = webdriverMonad({ isW3C: true }, (client) => client, { ...prototype })
+        const commandWrapperMock = jest.fn().mockImplementation((name, fn) => fn)
+        const client = monad(sessionId, commandWrapperMock)
+        const fn = () => 'bar'
+
+        expect(() => client.overwriteCommand('someFunc2', fn))
+            .toThrow('overwriteCommand: no command to be overwritten: someFunc2')
+    })
+
     it('should add element commands to the __propertiesObject__ cache', () => {
         const monad = webdriverMonad({ isW3C: true }, (client) => client, prototype)
         const client = monad(sessionId)
@@ -61,6 +71,16 @@ describe('monad', () => {
         client.addCommand('myCustomElementCommand', func, true)
         expect(typeof client.__propertiesObject__.myCustomElementCommand).toBe('object')
         expect(client.__propertiesObject__.myCustomElementCommand.value).toBe(func)
+    })
+
+    it('should add element commands for override to the __propertiesObject__.__elementOverrides__ cache', () => {
+        const monad = webdriverMonad({ isW3C: true }, (client) => client, { ...prototype })
+        const client = monad(sessionId)
+
+        const func = function (x, y) { return x + y }
+
+        client.overwriteCommand('someFunc', func, true)
+        expect(client.__propertiesObject__.__elementOverrides__.value.someFunc(2, 3)).toBe(5)
     })
 
     it('should add element commands to the __propertiesObject__ cache in multiremote', () => {
@@ -73,6 +93,17 @@ describe('monad', () => {
         client.addCommand('myCustomElementCommand', func, true, undefined, instances)
         expect(typeof instances.foo.__propertiesObject__.myCustomElementCommand).toBe('object')
         expect(instances.foo.__propertiesObject__.myCustomElementCommand.value).toBe(func)
+    })
+
+    it('should add element commands for override to the __propertiesObject__.__elementOverrides__ cache in multiremote', () => {
+        const monad = webdriverMonad({ isW3C: true }, (client) => client, { ...prototype })
+        const client = monad(sessionId)
+        const instances = { foo: { __propertiesObject__: { __elementOverrides__: { value: {} } } } }
+
+        const func = function (x, y) { return x + y }
+
+        client.overwriteCommand('someFunc', func, true, undefined, instances)
+        expect(instances.foo.__propertiesObject__.__elementOverrides__.value.someFunc(4, 5)).toBe(9)
     })
 
     it('allows to use custom command wrapper', () => {

--- a/packages/webdriver/tests/monad.test.js
+++ b/packages/webdriver/tests/monad.test.js
@@ -42,6 +42,16 @@ describe('monad', () => {
         expect(client.foo()).toBe('bar')
     })
 
+    it('should allow to overwrite command in base prototype', () => {
+        const monad = webdriverMonad({ isW3C: true }, (client) => client, { ...prototype })
+        const commandWrapperMock = jest.fn().mockImplementation((name, fn) => fn)
+        const client = monad(sessionId, commandWrapperMock)
+        const fn = () => 'bar'
+
+        client.overwriteCommand('someFunc', fn)
+        expect(client.someFunc()).toBe('bar')
+    })
+
     it('should add element commands to the __propertiesObject__ cache', () => {
         const monad = webdriverMonad({ isW3C: true }, (client) => client, prototype)
         const client = monad(sessionId)

--- a/packages/webdriver/tests/utils.test.js
+++ b/packages/webdriver/tests/utils.test.js
@@ -1,6 +1,6 @@
 import {
     isSuccessfulResponse, isValidParameter, getArgumentType, getPrototype, commandCallStructure,
-    environmentDetector, getErrorFromResponseBody, isW3C, CustomRequestError
+    environmentDetector, getErrorFromResponseBody, isW3C, CustomRequestError, overwriteElementCommands
 } from '../src/utils'
 
 import appiumResponse from './__fixtures__/appium.response.json'
@@ -275,5 +275,49 @@ describe('utils', () => {
         error = new CustomRequestError({ value: { } } )
         expect(error.name).toBe('Error')
         expect(error.message).toBe('unknown error')
+    })
+
+    describe('overwriteElementCommands', () => {
+        it('should overwrite command', function () {
+            const context = {}
+            const propertiesObject = {
+                foo: { value() { return 1 } },
+                __elementOverrides__: {
+                    value: { foo(origCmd, arg) { return [origCmd(), arg] } }
+                }
+            }
+            overwriteElementCommands.call(context, propertiesObject)
+            expect(propertiesObject.foo.value(5)).toEqual([1, 5])
+        })
+
+        it('should create __elementOverrides__ if not exists', function () {
+            const propertiesObject = {}
+            overwriteElementCommands.call(null, propertiesObject)
+            expect(propertiesObject.__elementOverrides__).toBeTruthy()
+        })
+
+        it('should throw if user command is not a function', function () {
+            const propertiesObject = { __elementOverrides__: { value: {
+                foo: 'bar'
+            } } }
+            expect(() => overwriteElementCommands.call(null, propertiesObject))
+                .toThrow('overwriteCommand: commands be overwritten only with functions, command: foo')
+        })
+
+        it('should throw if there is no command to be propertiesObject', function () {
+            const propertiesObject = { __elementOverrides__: { value: {
+                foo: jest.fn()
+            } } }
+            expect(() => overwriteElementCommands.call(null, propertiesObject))
+                .toThrow('overwriteCommand: no command to be overwritten: foo')
+        })
+
+        it('should throw on attempt to overwrite not a function', function () {
+            const propertiesObject = { foo: 'bar', __elementOverrides__: { value: {
+                foo: jest.fn()
+            } } }
+            expect(() => overwriteElementCommands.call(null, propertiesObject))
+                .toThrow('overwriteCommand: only functions can be overwritten, command: foo')
+        })
     })
 })

--- a/packages/webdriverio/src/index.js
+++ b/packages/webdriverio/src/index.js
@@ -36,12 +36,17 @@ export const remote = async function (params = {}, remoteModifier) {
     const instance = await WebDriver.newSession(params, modifier, prototype, wrapCommand)
 
     /**
-     * we need to overwrite the original addCommand in order to wrap the
-     * function within Fibers
+     * we need to overwrite the original addCommand and overwriteCommand
+     * in order to wrap the function within Fibers
      */
     const origAddCommand = ::instance.addCommand
     instance.addCommand = (name, fn, attachToElement) => (
         origAddCommand(name, runFnInFiberContext(fn), attachToElement)
+    )
+
+    const origOverwriteCommand = ::instance.overwriteCommand
+    instance.overwriteCommand = (name, fn, attachToElement) => (
+        origOverwriteCommand(name, runFnInFiberContext(fn), attachToElement)
     )
 
     return instance
@@ -84,12 +89,17 @@ export const multiremote = async function (params = {}) {
     const driver = WebDriver.attachToSession(sessionParams, ::multibrowser.modifier, prototype, wrapCommand)
 
     /**
-     * in order to get custom command added to multiremote instance we need to pass
-     * in the prototype of the multibrowser
+     * in order to get custom command overwritten or added to multiremote instance
+     * we need to pass in the prototype of the multibrowser
      */
     const origAddCommand = ::driver.addCommand
     driver.addCommand = (name, fn, attachToElement) => {
         origAddCommand(name, runFnInFiberContext(fn), attachToElement, Object.getPrototypeOf(multibrowser.baseInstance), multibrowser.instances)
+    }
+
+    const origOverwriteCommand = ::driver.overwriteCommand
+    driver.overwriteCommand = (name, fn, attachToElement) => {
+        origOverwriteCommand(name, runFnInFiberContext(fn), attachToElement, Object.getPrototypeOf(multibrowser.baseInstance), multibrowser.instances)
     }
 
     return driver

--- a/packages/webdriverio/src/multiremote.js
+++ b/packages/webdriverio/src/multiremote.js
@@ -31,7 +31,10 @@ export default class MultiRemote {
         propertiesObject.options = { value: wrapperClient.options }
 
         for (const commandName of wrapperClient.commandList) {
-            propertiesObject[commandName] = { value: this.commandWrapper(commandName) }
+            propertiesObject[commandName] = {
+                value: this.commandWrapper(commandName),
+                configurable: true
+            }
         }
 
         propertiesObject['__propertiesObject__'] = {

--- a/packages/webdriverio/tests/__mocks__/request.js
+++ b/packages/webdriverio/tests/__mocks__/request.js
@@ -190,6 +190,10 @@ const requestMock = jest.fn().mockImplementation((params, cb) => {
         break
     }
 
+    if (params.uri.path && params.uri.path.startsWith(`/wd/hub/session/${sessionId}/element/`) && params.uri.path.includes('/attribute/')) {
+        value = `${params.uri.path.substring(params.uri.path.lastIndexOf('/') + 1)}-value`
+    }
+
     /**
      * Simulate a stale element
      */

--- a/packages/webdriverio/tests/module.test.js
+++ b/packages/webdriverio/tests/module.test.js
@@ -6,7 +6,8 @@ import { remote, multiremote, attach } from '../src'
 jest.mock('webdriver', () => {
     const client = {
         sessionId: 'foobar-123',
-        addCommand: jest.fn()
+        addCommand: jest.fn(),
+        overwriteCommand: jest.fn()
     }
     const newSessionMock = jest.fn()
     newSessionMock.mockReturnValue(new Promise((resolve) => resolve(client)))

--- a/packages/webdriverio/tests/overwriteCommand.test.js
+++ b/packages/webdriverio/tests/overwriteCommand.test.js
@@ -1,0 +1,146 @@
+import { remote, multiremote } from '../src'
+
+const remoteConfig = {
+    baseUrl: 'http://foobar.com',
+    capabilities: {
+        browserName: 'foobar-noW3C'
+    }
+}
+
+const multiremoteConfig = {
+    browserA: {
+        logLevel: 'debug',
+        capabilities: {
+            browserName: 'chrome'
+        }
+    },
+    browserB: {
+        logLevel: 'debug',
+        port: 4445,
+        capabilities: {
+            browserName: 'firefox'
+        }
+    }
+}
+
+const error1 = Error('Thrown 1!')
+const error2 = new Error('Thrown 2!')
+
+const customElementCommand = async (origCmd, origCmdArg, arg) => {
+    const result = await new Promise(
+        (resolve) => setTimeout(async () => resolve(await origCmd(origCmdArg)), 1))
+    return `${result} ${origCmdArg} ${arg}`
+}
+
+const customBrowserCommand = async (origCmd, origCmdArg, arg = 0) => {
+    const start = Date.now()
+    await origCmd(origCmdArg + arg)
+    return Date.now() - start
+}
+
+describe('overwriteCommand', () => {
+    describe('remote', () => {
+        test('should be able to handle async', async () => {
+            const browser = await remote(remoteConfig)
+            browser.overwriteCommand('pause', customBrowserCommand)
+
+            expect(await browser.pause(10, 10)).toBeGreaterThanOrEqual(20)
+        })
+
+        test('should still work on browser calls after fetching an element', async () => {
+            const browser = await remote(remoteConfig)
+            await browser.$('#foo')
+            browser.overwriteCommand('pause', customBrowserCommand)
+
+            expect(await browser.pause(9)).toBeGreaterThanOrEqual(9)
+        })
+
+        test('should be able to overwrite element command', async () => {
+            const browser = await remote(remoteConfig)
+            browser.overwriteCommand('getAttribute', customElementCommand, true)
+            const elem = await browser.$('#foo')
+
+            expect(await elem.getAttribute('foo', 'bar')).toBe('foo-value foo bar')
+        })
+
+        test('should propagate element commands for all prototypes', async () => {
+            const browser = await remote(remoteConfig)
+            browser.overwriteCommand('getAttribute', customElementCommand, true)
+            const elems = await browser.$$('.someRandomElement')
+
+            expect(await elems[0].getAttribute('0', 'q')).toBe('0-value 0 q')
+            expect(await elems[1].getAttribute('1', 'w')).toBe('1-value 1 w')
+            expect(await elems[2].getAttribute('2', 'e')).toBe('2-value 2 e')
+        })
+
+        test('should propagate element commands to sub elements', async () => {
+            const browser = await remote(remoteConfig)
+            browser.overwriteCommand('getAttribute', customElementCommand, true)
+            const elem = await browser.$('#foo')
+            const subElem = await elem.$('.subElem')
+
+            expect(await subElem.getAttribute('bar', 'foo')).toBe('bar-value bar foo')
+        })
+
+        test('should properly throw exceptions on the browser scope', async () => {
+            const browser = await remote(remoteConfig)
+            browser.overwriteCommand('waitUntil', function () {
+                throw error1
+            })
+
+            browser.overwriteCommand('url', async function () {
+                await browser.$('#foo')
+                throw error2
+            })
+
+            await expect(() => browser.waitUntil()).toThrow(error1)
+            await expect(browser.url()).rejects.toThrow(error2)
+        })
+
+        test('should properly throw exceptions on the element scope', async () => {
+            const browser = await remote(remoteConfig)
+            browser.overwriteCommand('click', function () {
+                throw error1
+            }, true)
+            browser.overwriteCommand('waitForDisplayed', async function () {
+                await browser.$('#foo')
+                throw error2
+            }, true)
+            const elem = await browser.$('#foo')
+
+            await expect(() => elem.click()).toThrow(error1)
+            await expect(elem.waitForDisplayed()).rejects.toThrow(error2)
+        })
+    })
+
+    describe('multiremote', () => {
+        test('should allow to overwrite commands', async () => {
+            const browser = await multiremote(multiremoteConfig)
+            browser.overwriteCommand('pause', customBrowserCommand)
+
+            expect(await browser.pause(10, 10)).toBeGreaterThanOrEqual(20)
+        })
+
+        test('should allow to overwrite commands for a single multiremote instance', async () => {
+            const browser = await multiremote(multiremoteConfig)
+            browser.browserA.overwriteCommand('pause', customBrowserCommand)
+
+            expect(await browser.browserA.pause(10, 10)).toBeGreaterThanOrEqual(20)
+            expect(await browser.browserB.pause(10)).toBe(undefined)
+
+            const results = await browser.pause(10)
+            expect(results[0]).toBeGreaterThanOrEqual(10)
+            expect(results[1]).toBe(undefined)
+        })
+
+        test('should be able to overwrite element command in multiremote mode', async () => {
+            const browser = await multiremote(multiremoteConfig)
+            browser.overwriteCommand('getAttribute', customElementCommand, true)
+            const elem = await browser.$('#foo')
+
+            expect(await elem.getAttribute('foo', 'bar')).toEqual([
+                'foo-value foo bar', 'foo-value foo bar'
+            ])
+        })
+    })
+})

--- a/packages/webdriverio/webdriverio.d.ts
+++ b/packages/webdriverio/webdriverio.d.ts
@@ -22,7 +22,7 @@ type ElementAsync = {
 type ElementStatic = Pick<WebdriverIO.Element, 'addCommand'>
 
 // Browser commands that should be wrapper with Promise
-type BrowserPromise = Omit<WebdriverIO.Browser, 'addCommand' | 'options' | '$' | '$$'>;
+type BrowserPromise = Omit<WebdriverIO.Browser, 'addCommand' | 'overwriteCommand' | 'options' | '$' | '$$'>;
 
 // Browser commands wrapper with Promise
 type BrowserAsync = {
@@ -31,7 +31,7 @@ type BrowserAsync = {
 } & AsyncSelectors;
 
 // Browser commands that should not be wrapper with promise
-type BrowserStatic = Pick<WebdriverIO.Browser, 'addCommand' | 'options'>;
+type BrowserStatic = Pick<WebdriverIO.Browser, 'addCommand' | 'overwriteCommand' | 'options'>;
 declare namespace WebdriverIOAsync {
     function remote(
         options?: WebdriverIO.RemoteOptions,

--- a/scripts/templates/webdriverio.tpl.d.ts
+++ b/scripts/templates/webdriverio.tpl.d.ts
@@ -177,6 +177,11 @@ declare namespace WebdriverIO {
             func: Function,
             attachToElement?: boolean
         ): void;
+        overwriteCommand(
+            name: string,
+            func: Function,
+            attachToElement?: boolean
+            ): void;
         options: RemoteOptions;
         // ... browser commands ...
     }

--- a/tests/multiremote/test.js
+++ b/tests/multiremote/test.js
@@ -4,48 +4,122 @@ describe('smoke test multiremote', () => {
     it('should return sync value', () => {
         assert.equal(
             JSON.stringify(browser.getTitle()),
-            JSON.stringify(['Mock Page Title', 'Mock Page Other Title']))
+            JSON.stringify(['Mock Page Title', 'Mock Page Title']))
     })
 
-    it('should respect promises', () => {
-        browser.addCommand('customFn', () => {
-            let start = Date.now()
-            browser.pause(30)
-            return Promise.all([
-                Promise.resolve(Date.now() - start),
-                Promise.resolve(Date.now() - start)
-            ])
+    describe('add customCommands', () => {
+        it('should respect promises', () => {
+            browser.addCommand('customFn', () => {
+                let start = Date.now()
+                browser.pause(30)
+                return Promise.all([
+                    Promise.resolve(Date.now() - start),
+                    Promise.resolve(Date.now() - start)
+                ])
+            })
+
+            const results = browser.customFn()
+
+            assert.strictEqual(results[0] >= 30, true, `First of [${results}] is less than 30`)
         })
 
-        const results = browser.customFn()
+        it('should throw if promise rejects', () => {
+            browser.addCommand('customFn', () => {
+                return Promise.reject('Boom!')
+            })
 
-        assert.strictEqual(results[0] >= 30, true, `First of [${results}] is less than 30`)
-    })
-
-    it('should throw if promise rejects', () => {
-        browser.addCommand('customFn', () => {
-            return Promise.reject('Boom!')
+            let err = null
+            try {
+                browser.customFn()
+            } catch (e) {
+                err = e
+            }
+            assert.equal(err.message, 'Boom!')
         })
 
-        let err = null
-        try {
-            browser.customFn()
-        } catch (e) {
-            err = e
-        }
-        assert.equal(err.message, 'Boom!')
+        it('allows to create custom commands on elements that respects promises', () => {
+            browser.customCommandScenario(Object.keys(browser.instances).length)
+            browser.addCommand('myCustomPromiseCommand', function () {
+                let start = Date.now()
+                browser.pause(30)
+                return Promise.resolve(Date.now() - start)
+            }, true)
+            const elem = $('elem')
+            const results = elem.myCustomPromiseCommand()
+
+            assert.strictEqual(results[0] >= 30, true, `First of [${results}] is less than 30`)
+        })
     })
 
-    it('allows to create custom commands on elements that respects promises', () => {
-        browser.customCommandScenario(Object.keys(browser.instances).length)
-        browser.addCommand('myCustomPromiseCommand', function () {
-            let start = Date.now()
-            browser.pause(30)
-            return Promise.resolve(Date.now() - start)
-        }, true)
-        const elem = $('elem')
-        const results = elem.myCustomPromiseCommand()
+    describe('overwrite native commands', () => {
+        it('should allow to overwrite browser commands', () => {
+            browser.customCommandScenario(Object.keys(browser.instances).length)
+            browser.overwriteCommand('getTitle', function (origCommand, pre = '') {
+                return '' + origCommand().map(result => pre + result)
+            })
 
-        assert.strictEqual(results[0] >= 30, true, `First of [${results}] is less than 30`)
+            assert.equal(browser.getTitle('Foo '), 'Foo Mock Page Title,Foo Mock Page Title')
+        })
+
+        it('should allow to overwrite element commands', () => {
+            browser.customCommandScenario(Object.keys(browser.instances).length)
+            browser.overwriteCommand('getSize', function (origCommand, ratio = 1) {
+                const { width, height } = origCommand()
+                return { width: width * ratio, height: height * ratio }
+            }, true)
+            const elem = $('elem')
+
+            assert.equal(
+                JSON.stringify(elem.getSize(2)),
+                JSON.stringify([{ width: 2, height: 4 }, { width: 2, height: 4 }])
+            )
+        })
+
+        it('should keep the scope', () => {
+            browser.customCommandScenario(Object.keys(browser.instances).length)
+            browser.overwriteCommand('saveRecordingScreen', function (origCommand, filepath, elem) {
+                if (elem) {
+                    return this.execute('1+1') + '-' + elem.instances.map(i => elem[i].selector)
+                }
+                return origCommand(filepath)
+            })
+
+            assert.equal(browser.saveRecordingScreen(null, $('body')), '2,2-body,body')
+        })
+
+        it('should respect promises - browser', () => {
+            browser.customCommandScenario(Object.keys(browser.instances).length)
+            browser.overwriteCommand('getUrl', function (origCommand, append = '') {
+                return Promise.resolve(origCommand().map(result => result + append))
+            })
+
+            assert.equal(browser.getUrl('/foobar'), 'https://mymockpage.com/foobar,https://mymockpage.com/foobar')
+        })
+
+        it('should respect promises - element', () => {
+            browser.customCommandScenario(Object.keys(browser.instances).length)
+            browser.overwriteCommand('getHTML', function (origCommand) {
+                return Promise.resolve('' + origCommand())
+            }, true)
+            const elem = $('elem')
+
+            assert.equal(elem.getHTML(), '2,2')
+        })
+
+        it('should throw if promise rejects', () => {
+            browser.customCommandScenario(Object.keys(browser.instances).length)
+            browser.overwriteCommand('deleteCookies', (origCommand, fail) => {
+                const result = origCommand()
+                return fail ? Promise.reject(result) : result
+            })
+
+            let err = null
+            try {
+                browser.deleteCookies(true)
+            } catch (e) {
+                err = e
+            }
+            assert.equal(err.message, 'deleteAllCookies,deleteAllCookies')
+        })
     })
 })

--- a/tests/typings/sync/sync.ts
+++ b/tests/typings/sync/sync.ts
@@ -25,6 +25,10 @@ callResult.toFixed(2)
 // browser custom command
 browser.browserCustomCommand(5)
 
+browser.overwriteCommand('click', function (origCommand) {
+    origCommand()
+}, true)
+
 // $
 const el1 = $('')
 const el2 = el1.$('')

--- a/tests/typings/webdriverio/async.ts
+++ b/tests/typings/webdriverio/async.ts
@@ -54,6 +54,10 @@ async function bar() {
     // browser custom command
     await browser.browserCustomCommand(14)
 
+    browser.overwriteCommand('click', function (origCommand) {
+        origCommand()
+    })
+
     // $
     const el1 = await $('')
     const el2 = await el1.$('')


### PR DESCRIPTION
## Proposed changes

Ability to overwrite native commands.

**Element**
```
browser.overwriteCommand('addValue', function (origAddValue, value, message) {
  console.log(message)
  return origAddValue(value)
}, true)
```

**Browser**
```
browser.overwriteCommand('pause', function (origPause, ms, msg) {
  console.log(`Sleeping for ${ms}`)
  origPause(ms)
})
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added unit tests
- [x] I have added smoke tests (_in progress_)
- [x] I have added necessary documentation `CustomCommands.md`
- [x] I have added types and tests for types

### Reviewers: @webdriverio/technical-committee
