### PR TITLE
Fix call, execute, executeAsync, remote, multiremote

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,12 +63,9 @@ typings/
 
 **/build
 /*.js
-*.d.ts
-!/scripts/templates/*.d.ts
-!/packages/wdio-mocha-framework/mocha-framework.d.ts
-!/packages/wdio-jasmine-framework/jasmine-framework.d.ts
-!/packages/wdio-selenium-standalone-service/selenium-standalone-service.d.ts
-!/packages/**/webdriverio.d.ts
+allure-reporter.d.ts
+webdriver.d.ts
+webdriverio-core.d.ts
 !babel.config.js
 !.eslintrc.js
 package-lock.json

--- a/docs/TypeScript.md
+++ b/docs/TypeScript.md
@@ -4,7 +4,7 @@ title: TypeScript Setup
 ---
 
 Similar to Babel setup, you can register [TypeScript](http://www.typescriptlang.org/) to compile your .ts files in your before hook of your config file. You will need [ts-node](https://github.com/TypeStrong/ts-node) and [tsconfig-paths](https://github.com/dividab/tsconfig-paths) as the installed devDependencies.
-Minimal TypeScript version is 3.2.1
+Minimal TypeScript version is 3.5.1
 
 ```js
 // wdio.conf.js
@@ -53,7 +53,9 @@ For sync mode (@wdio/sync) `webdriverio` types have to be replaced with `@wdio/s
 }
 ```
 
-Please avoid importing webdriverio or @wdio/sync explicitly. `WebdriverIO` and `WebDriver` typings are accessible from anywhere once added to types in `tsconfig.json`.
+Please avoid importing webdriverio or @wdio/sync explicitly. `WebdriverIO` and `WebDriver` types are accessible from anywhere once added to types in `tsconfig.json`.
+
+### Typed Configuration
 
 You can even use a typed configuration if you desire.
 All you have to do is create a plain js config file that registers typescript and requires the typed config:
@@ -73,8 +75,10 @@ const config: WebdriverIO.Config = {
 export { config }
 ```
 
-Depending on the framework you use, you will need to add the typings for that framework to your `tsconfig.json` types property.
-For instance, if we decide to use the mocha framework, we need to add it like this to have all typings globally available:
+### Framework types
+
+Depending on the framework you use, you will need to add the types for that framework to your `tsconfig.json` types property.
+For instance, if we decide to use the mocha framework, we need to add it like this to have all types globally available:
 
 ```json
 {
@@ -92,7 +96,7 @@ For instance, if we decide to use the mocha framework, we need to add it like th
 }
 ```
 
-Instead of having all type definitions globally available, you can also import only the typings that you need like this:
+Instead of having all type definitions globally available, you can also import only the types that you need like this:
 
 ```typescript
 /*
@@ -100,4 +104,42 @@ Instead of having all type definitions globally available, you can also import o
 * the beforeTest, afterTest, beforeSuite and afterSuite hooks.
 */
 import { Suite, Test } from "@wdio/mocha-framework"
+```
+
+### Adding custom command
+
+With TypeScript it's easy to extend WebdriverIO interfaces. Adding types for your [custom commands](CustomCommands.md) looks like this:
+
+1. Create types definition file, ex: `./types/wdio.d.ts`
+2. Specify path to types in `tsconfig.json`
+```json
+{
+    "compilerOptions": {
+        "typeRoots": ["./types"]
+    }
+}
+```
+3. Add defintions for your commands depending on mode.
+
+**Sync mode**
+
+```
+declare module WebdriverIO {
+    // adding command to `browser`
+    interface Browser {
+        browserCustomCommand: (arg) => void
+    }
+}
+```
+
+**Async mode**
+
+```
+declare module WebdriverIOAsync {
+    adding command to `$()`
+    interface Element {
+        // don't forget to wrap return values with Promise
+        elementCustomCommand: (arg) => Promise<number>
+    }
+}
 ```

--- a/docs/TypeScript.md
+++ b/docs/TypeScript.md
@@ -136,7 +136,7 @@ declare module WebdriverIO {
 
 ```
 declare module WebdriverIOAsync {
-    adding command to `$()`
+    // adding command to `$()`
     interface Element {
         // don't forget to wrap return values with Promise
         elementCustomCommand: (arg) => Promise<number>

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "shelljs": "^0.8.3",
     "source-map-support": "^0.5.11",
     "tempy": "^0.3.0",
-    "typescript": "^3.4.1"
+    "typescript": "^3.5.1"
   },
   "husky": {
     "hooks": {

--- a/packages/wdio-sync/webdriverio.d.ts
+++ b/packages/wdio-sync/webdriverio.d.ts
@@ -1,17 +1,6 @@
 /// <reference types="@wdio/sync/webdriverio-core"/>
 
-type BrowserObject = WebDriver.ClientOptions & WebDriver.Client & WebdriverIO.Browser;
-
 declare namespace WebdriverIO {
-    function remote(
-        options?: WebDriver.Options,
-        modifier?: (...args: any[]) => any
-    ): BrowserObject;
-
-    function multiremote(
-        options: WebdriverIO.MultiRemoteOptions
-    ): WebDriver.Client;
-
     interface Browser {
         waitUntil(
             condition: () => boolean,
@@ -19,10 +8,23 @@ declare namespace WebdriverIO {
             timeoutMsg?: string,
             interval?: number
         ): boolean
+
+        // there is no way to wrap generic functions, like `<T>(arg: T) => T`
+        // have to declare explicitly for sync and async typings.
+        // https://github.com/microsoft/TypeScript/issues/5453
+        call: <T>(callback: (...args) => Promise<T>) => T;
+        execute: <T>(script: string | ((...arguments: any[]) => T), ...arguments: any[]) => T;
+
+        // also there is no way to add callback as last parameter after `...args`.
+        // https://github.com/Microsoft/TypeScript/issues/1360
+        // executeAsync: <T>(script: string | ((...arguments: any[], callback: (result: T) => void) => void), ...arguments: any[]) => T;
+        executeAsync: (script: string | ((...arguments: any[]) => void), ...arguments: any[]) => any;
     }
+
+    interface BrowserObject extends WebDriver.ClientOptions, WebDriver.Client, WebdriverIO.Browser { }
 }
 
-declare var browser: BrowserObject;
+declare var browser: WebdriverIO.BrowserObject;
 declare function $(selector: string | Function): WebdriverIO.Element;
 declare function $$(selector: string | Function): WebdriverIO.Element[];
 

--- a/packages/webdriver/protocol/jsonwp.json
+++ b/packages/webdriver/protocol/jsonwp.json
@@ -710,7 +710,7 @@
         "name": "args",
         "type": "(string|object|number|boolean|undefined)[]",
         "description": "the script arguments",
-        "required": true
+        "required": false
       }],
       "returns": {
         "type": "*",

--- a/packages/webdriver/protocol/webdriver.json
+++ b/packages/webdriver/protocol/webdriver.json
@@ -651,7 +651,7 @@
         "name": "args",
         "type": "(string|object|number|boolean|undefined)[]",
         "description": "an array of JSON values which will be deserialized and passed as arguments to your function",
-        "required": true
+        "required": false
       }],
       "returns": {
         "type": "*",

--- a/packages/webdriverio/webdriverio.d.ts
+++ b/packages/webdriverio/webdriverio.d.ts
@@ -1,11 +1,10 @@
 /// <reference types="webdriverio/webdriverio-core"/>
 
-type BrowserObject = WebDriver.ClientOptions & WebDriver.ClientAsync & WebdriverIOAsync.Browser;
 type $ = (selector: string | Function) => Promise<WebdriverIOAsync.Element>;
 type $$ = (selector: string | Function) => Promise<WebdriverIOAsync.Element[]>;
 
 // Element commands that should be wrapper with Promise
-type ElementPromise = WdioOmit<WebdriverIO.Element, 'addCommand' | '$' | '$$'>;
+type ElementPromise = Omit<WebdriverIO.Element, 'addCommand' | '$' | '$$'>;
 
 // Methods which return async element(s) so non-async equivalents cannot just be promise-wrapped
 interface AsyncSelectors {
@@ -15,35 +14,37 @@ interface AsyncSelectors {
 
 // Element commands wrapper with Promise
 type ElementAsync = {
-    [K in keyof ElementPromise]: WrapWithPromise<ElementPromise[K], ReturnType<ElementPromise[K]>>
+    [K in keyof ElementPromise]:
+    (...args: Parameters<ElementPromise[K]>) => Promise<ReturnType<ElementPromise[K]>>;
 } & AsyncSelectors;
 
 // Element commands that should not be wrapper with promise
 type ElementStatic = Pick<WebdriverIO.Element, 'addCommand'>
 
 // Browser commands that should be wrapper with Promise
-type BrowserPromise = WdioOmit<WebdriverIO.Browser, 'addCommand' | 'options' | '$' | '$$'>;
+type BrowserPromise = Omit<WebdriverIO.Browser, 'addCommand' | 'options' | '$' | '$$'>;
 
 // Browser commands wrapper with Promise
 type BrowserAsync = {
-    [K in keyof BrowserPromise]: WrapWithPromise<BrowserPromise[K], ReturnType<BrowserPromise[K]>>
+    [K in keyof BrowserPromise]:
+    (...args: Parameters<BrowserPromise[K]>) => Promise<ReturnType<BrowserPromise[K]>>;
 } & AsyncSelectors;
 
 // Browser commands that should not be wrapper with promise
 type BrowserStatic = Pick<WebdriverIO.Browser, 'addCommand' | 'options'>;
 declare namespace WebdriverIOAsync {
     function remote(
-        options?: WebDriver.Options & WebdriverIO.Options,
+        options?: WebdriverIO.RemoteOptions,
         modifier?: (...args: any[]) => any
     ): BrowserObject;
 
     function attach(
-        options?: WebDriver.AttachSessionOptions,
+        options: WebDriver.AttachSessionOptions,
     ): BrowserObject;
 
     function multiremote(
         options: WebdriverIO.MultiRemoteOptions
-    ): WebDriver.ClientAsync;
+    ): BrowserObject;
 
     interface Browser extends BrowserAsync, BrowserStatic {
         waitUntil(
@@ -51,14 +52,27 @@ declare namespace WebdriverIOAsync {
             timeout?: number,
             timeoutMsg?: string,
             interval?: number
-        ): Promise<boolean>
+        ): Promise<boolean>;
+
+        // there is no way to wrap generic functions, like `<T>(arg: T) => T`
+        // have to declare explicitly for sync and async typings.
+        // https://github.com/microsoft/TypeScript/issues/5453
+        call: <T>(callback: (...args) => Promise<T>) => Promise<T>;
+        execute: <T>(script: string | ((...arguments: any[]) => T), ...arguments: any[]) => Promise<T>;
+
+        // also there is no way to add callback as last parameter after `...args`.
+        // https://github.com/Microsoft/TypeScript/issues/1360
+        // executeAsync: <T>(script: string | ((...arguments: any[], callback: (result: T) => void) => void), ...arguments: any[]) => Promise<T>;
+        executeAsync: (script: string | ((...arguments: any[]) => void), ...arguments: any[]) => Promise<any>;
     }
 
     interface Element extends ElementAsync, ElementStatic { }
-    interface Config {}
+    interface Config { }
+
+    interface BrowserObject extends WebDriver.ClientOptions, WebDriver.ClientAsync, WebdriverIOAsync.Browser {}
 }
 
-declare var browser: BrowserObject;
+declare var browser: WebdriverIOAsync.BrowserObject;
 declare var $: $;
 declare var $$: $$;
 

--- a/scripts/templates/webdriver.tpl.d.ts
+++ b/scripts/templates/webdriver.tpl.d.ts
@@ -4,11 +4,6 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 /// <reference types="node"/>
 
-type WdioOmit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
-
-type ArgumentTypes<T> = T extends (...args: infer U) => infer R ? U : never;
-type WrapWithPromise<T, R> = (...args: ArgumentTypes<T>) => Promise<R>;
-
 declare namespace WebDriver {
     type PageLoadingStrategy = 'none' | 'eager' | 'normal';
     type ProxyTypes = 'pac' | 'noproxy' | 'autodetect' | 'system' | 'manual';
@@ -373,11 +368,12 @@ declare namespace WebDriver {
     // generated typings
     // ... insert here ...
 
-    interface ClientAsync extends AsyncClient {}
+    interface ClientAsync extends AsyncClient { }
 }
 
 type AsyncClient = {
-    [K in keyof WebDriver.Client]: WrapWithPromise<WebDriver.Client[K], ReturnType<WebDriver.Client[K]>>
+    [K in keyof WebDriver.Client]:
+    (...args: Parameters<WebDriver.Client[K]>) => Promise<ReturnType<WebDriver.Client[K]>>;
 }
 
 declare module "webdriver" {

--- a/scripts/templates/webdriverio.tpl.d.ts
+++ b/scripts/templates/webdriverio.tpl.d.ts
@@ -43,6 +43,12 @@ declare namespace WebdriverIO {
         }
     }
 
+    interface MultiRemoteCapabilities {
+        [instanceName: string]: {
+            capabilities: WebDriver.DesiredCapabilities;
+        };
+    }
+
     interface Options {
         runner?: string,
         specs?: string[],
@@ -50,7 +56,7 @@ declare namespace WebdriverIO {
         suites?: object,
         maxInstances?: number,
         maxInstancesPerCapability?: number,
-        capabilities?: WebDriver.DesiredCapabilities | WebDriver.DesiredCapabilities[],
+        capabilities?: WebDriver.DesiredCapabilities[] | MultiRemoteCapabilities,
         outputDir?: string,
         baseUrl?: string,
         bail?: number,
@@ -64,8 +70,10 @@ declare namespace WebdriverIO {
         execArgv?: string[]
     }
 
+    interface RemoteOptions extends WebDriver.Options, Omit<Options, 'capabilities'> { }
+
     interface MultiRemoteOptions {
-        [capabilityName: string]: Options;
+        [instanceName: string]: WebDriver.DesiredCapabilities;
     }
 
     interface Suite {}
@@ -157,9 +165,6 @@ declare namespace WebdriverIO {
         // ... element commands ...
     }
 
-    type Execute = <T>(script: string | ((...arguments: any[]) => T), ...arguments: any[]) => T;
-    type ExecuteAsync = (script: string | ((...arguments: any[]) => any), ...arguments: any[]) => any;
-    type Call = <T>(callback: Function) => T;
     interface Timeouts {
         implicit?: number,
         pageLoad?: number,
@@ -172,12 +177,9 @@ declare namespace WebdriverIO {
             func: Function,
             attachToElement?: boolean
         ): void;
-        execute: Execute;
-        executeAsync: ExecuteAsync;
-        call: Call;
-        options: Options;
+        options: RemoteOptions;
         // ... browser commands ...
     }
 
-    interface Config extends Options, WdioOmit<WebDriver.Options, "capabilities">, Hooks {}
+    interface Config extends Options, Omit<WebDriver.Options, "capabilities">, Hooks {}
 }

--- a/tests/typings/sync/sync.ts
+++ b/tests/typings/sync/sync.ts
@@ -1,13 +1,29 @@
 import allure from '@wdio/allure-reporter'
 
+// An example of adding command withing ts file with @wdio/sync
+declare module "@wdio/sync" {
+    interface Element {
+        elementCustomCommand: (arg) => number
+    }
+}
+
 // browser
 browser.pause(1)
 const waitUntil: boolean = browser.waitUntil(() => true, 1, '', 1)
 browser.getCookies()
-let res = browser.execute(function (x: number) {
+
+const executeResult = browser.execute(function (x: number) {
     return x
 }, 4)
-res.toFixed(2)
+executeResult.toFixed(2)
+
+const callResult = <number>browser.call(() =>
+    new Promise(resolve => setTimeout(() => resolve(4), 1))
+)
+callResult.toFixed(2)
+
+// browser custom command
+browser.browserCustomCommand(5)
 
 // $
 const el1 = $('')
@@ -15,7 +31,9 @@ const el2 = el1.$('')
 const el3 = el2.$('')
 el1.getCSSProperty('style')
 el2.click()
-el3.waitForDisplayed()
+// element custom command
+const el2result = el3.elementCustomCommand(4)
+el2result.toFixed(2)
 
 // $$
 const elems = $$('')

--- a/tests/typings/sync/tsconfig.json
+++ b/tests/typings/sync/tsconfig.json
@@ -4,6 +4,7 @@
       "@wdio/sync",
       "@wdio/allure-reporter",
       "@wdio/selenium-standalone-service"
-    ]
+    ],
+    "typeRoots" : ["./types"]
   }
 }

--- a/tests/typings/sync/types/sync.d.ts
+++ b/tests/typings/sync/types/sync.d.ts
@@ -1,0 +1,10 @@
+/**
+ * An example of adding command withing d.ts file with @wdio/sync
+ */
+
+// module should be "@wdio/sync" if used within `ts` file instead of `d.ts`
+declare module WebdriverIO {
+    interface Browser {
+        browserCustomCommand: (arg) => void
+    }
+}

--- a/tests/typings/webdriverio/async.ts
+++ b/tests/typings/webdriverio/async.ts
@@ -1,16 +1,58 @@
 import allure from '@wdio/allure-reporter'
+import { remote, multiremote } from 'webdriverio'
+
+// An example of adding command withing ts file to WebdriverIOAsync
+declare module "webdriverio" {
+    interface Browser {
+        browserCustomCommand: (arg) => Promise<void>
+    }
+}
 
 async function bar() {
+    // multiremote
+    const mr = await multiremote({
+        myBrowserInstance: {
+            browserName: 'chrome'
+        }
+    })
+
+    // interact with specific instance
+    const mrSingleElem = await mr.myBrowserInstance.$('')
+    await mrSingleElem.click()
+
+    // interact with all instances
+    const mrElem = await mr.$('')
+    await mrElem.click()
+
+    // instances array
+    mr.instances[0].substr(0, 1)
+
+    ////////////////////////////////////////////////////////////////////////////////
+
+    // remote
+    const r = await remote({ capabilities: { browserName: 'chrome' } })
+    const rElem = await r.$('')
+    await rElem.click()
+
+    ////////////////////////////////////////////////////////////////////////////////
+
     // browser
     await browser.pause(1)
     const waitUntil: boolean = await browser.waitUntil(() => Promise.resolve(true), 1, '', 1)
     await browser.getCookies()
 
-    // ToDo fix typing for `execute` and `call`
-    // let res = browser.execute(function (x: number) {
-    //     return x
-    // }, 4)
-    // res.toFixed(2)
+    const executeResult = await browser.execute(function (x: number) {
+        return x
+    }, 4)
+    executeResult.toFixed(2)
+
+    const callResult = <number>await browser.call(() =>
+        new Promise(resolve => setTimeout(() => resolve(4), 1))
+    )
+    callResult.toFixed(2)
+
+    // browser custom command
+    await browser.browserCustomCommand(14)
 
     // $
     const el1 = await $('')
@@ -18,7 +60,9 @@ async function bar() {
     const el3 = await el2.$('')
     await el1.getCSSProperty('style')
     await el2.click()
-    await el3.waitForDisplayed()
+    // element custom command
+    const el2result = await el3.elementCustomCommand(4)
+    el2result.toFixed(2)
 
     // $$
     const elems = await $$('')

--- a/tests/typings/webdriverio/tsconfig.json
+++ b/tests/typings/webdriverio/tsconfig.json
@@ -5,6 +5,7 @@
       "webdriverio",
       "@wdio/allure-reporter",
       "@wdio/selenium-standalone-service"
-    ]
+    ],
+    "typeRoots": ["./types"]
   }
 }

--- a/tests/typings/webdriverio/types/async.d.ts
+++ b/tests/typings/webdriverio/types/async.d.ts
@@ -1,0 +1,16 @@
+/**
+ * An example of adding command withing d.ts file to WebdriverIOAsync
+ */
+
+// module should be "webdriverio" if used within `ts` file instead of `d.ts`
+declare module WebdriverIOAsync {
+    interface BrowserObject {
+        // multiremote
+        instances: ['myBrowserInstance']
+        myBrowserInstance: BrowserObject
+    }
+
+    interface Element {
+        elementCustomCommand: (arg) => Promise<number>
+    }
+}


### PR DESCRIPTION
## Proposed changes

With this PR I'd like to
- update minimum TypeScript version to 3.5.1 (this might be **breaking** change for TS users with lower versions!)
- fixed `call`, `execute`, `executeAsync` in async mode (wrapped with Promises)
- changed `BrowserObject` to interface so that it can be extended
- fixed `remote` to use proper capabilities object
- changed `multiremote` return type to `BrowserObject` from `WebDriver.ClientAsync`, hope it make sense
- changed `attach` Options to be required as far as sessionId is required
- **removed** `remote`, `multiremote`, `attach` from _sync_ mode (please correct me if it is possible to use these commands in _sync_ mode)
- added tests and examples for using custom commands

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

Fix #3796

### Reviewers: @webdriverio/technical-committee
