### PR TITLE
Types fix for users with noImplicitAny set to true

### DIFF
--- a/packages/wdio-sync/webdriverio.d.ts
+++ b/packages/wdio-sync/webdriverio.d.ts
@@ -12,7 +12,7 @@ declare namespace WebdriverIO {
         // there is no way to wrap generic functions, like `<T>(arg: T) => T`
         // have to declare explicitly for sync and async typings.
         // https://github.com/microsoft/TypeScript/issues/5453
-        call: <T>(callback: (...args) => Promise<T>) => T;
+        call: <T>(callback: (...args: any[]) => Promise<T>) => T;
         execute: <T>(script: string | ((...arguments: any[]) => T), ...arguments: any[]) => T;
 
         // also there is no way to add callback as last parameter after `...args`.

--- a/packages/webdriverio/webdriverio.d.ts
+++ b/packages/webdriverio/webdriverio.d.ts
@@ -57,7 +57,7 @@ declare namespace WebdriverIOAsync {
         // there is no way to wrap generic functions, like `<T>(arg: T) => T`
         // have to declare explicitly for sync and async typings.
         // https://github.com/microsoft/TypeScript/issues/5453
-        call: <T>(callback: (...args) => Promise<T>) => Promise<T>;
+        call: <T>(callback: (...args: any[]) => Promise<T>) => Promise<T>;
         execute: <T>(script: string | ((...arguments: any[]) => T), ...arguments: any[]) => Promise<T>;
 
         // also there is no way to add callback as last parameter after `...args`.

--- a/scripts/templates/webdriverio.tpl.d.ts
+++ b/scripts/templates/webdriverio.tpl.d.ts
@@ -179,7 +179,7 @@ declare namespace WebdriverIO {
         ): void;
         overwriteCommand(
             name: string,
-            func: Function,
+            func: (origCommand: Function, ...args: any[]) => any,
             attachToElement?: boolean
             ): void;
         options: RemoteOptions;

--- a/tests/typings/sync-jasmine/tsconfig.json
+++ b/tests/typings/sync-jasmine/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "noImplicitAny": true,
     "types": [
       "@wdio/sync",
       "@wdio/jasmine-framework",

--- a/tests/typings/sync-mocha/tsconfig.json
+++ b/tests/typings/sync-mocha/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "noImplicitAny": true,
     "types": [
       "@wdio/sync",
       "@wdio/mocha-framework"

--- a/tests/typings/sync/sync.ts
+++ b/tests/typings/sync/sync.ts
@@ -3,7 +3,7 @@ import allure from '@wdio/allure-reporter'
 // An example of adding command withing ts file with @wdio/sync
 declare module "@wdio/sync" {
     interface Element {
-        elementCustomCommand: (arg) => number
+        elementCustomCommand: (arg: unknown) => number
     }
 }
 

--- a/tests/typings/sync/tsconfig.json
+++ b/tests/typings/sync/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "noImplicitAny": true,
     "types": [
       "@wdio/sync",
       "@wdio/allure-reporter",

--- a/tests/typings/sync/types/sync.d.ts
+++ b/tests/typings/sync/types/sync.d.ts
@@ -5,6 +5,6 @@
 // module should be "@wdio/sync" if used within `ts` file instead of `d.ts`
 declare module WebdriverIO {
     interface Browser {
-        browserCustomCommand: (arg) => void
+        browserCustomCommand: (arg: unknown) => void
     }
 }

--- a/tests/typings/webdriverio-jasmine/tsconfig.json
+++ b/tests/typings/webdriverio-jasmine/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "noImplicitAny": true,
     "types": [
       "webdriverio",
       "@wdio/jasmine-framework"

--- a/tests/typings/webdriverio-mocha/tsconfig.json
+++ b/tests/typings/webdriverio-mocha/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "noImplicitAny": true,
     "types": [
       "webdriverio",
       "@wdio/mocha-framework"

--- a/tests/typings/webdriverio/async.ts
+++ b/tests/typings/webdriverio/async.ts
@@ -4,7 +4,7 @@ import { remote, multiremote } from 'webdriverio'
 // An example of adding command withing ts file to WebdriverIOAsync
 declare module "webdriverio" {
     interface Browser {
-        browserCustomCommand: (arg) => Promise<void>
+        browserCustomCommand: (arg: unknown) => Promise<void>
     }
 }
 
@@ -55,7 +55,7 @@ async function bar() {
     await browser.browserCustomCommand(14)
 
     browser.overwriteCommand('click', function (origCommand) {
-        origCommand()
+        return origCommand()
     })
 
     // $

--- a/tests/typings/webdriverio/tsconfig.json
+++ b/tests/typings/webdriverio/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "noImplicitAny": true,
     "lib": ["es2018"],
     "types": [
       "webdriverio",

--- a/tests/typings/webdriverio/types/async.d.ts
+++ b/tests/typings/webdriverio/types/async.d.ts
@@ -11,6 +11,6 @@ declare module WebdriverIOAsync {
     }
 
     interface Element {
-        elementCustomCommand: (arg) => Promise<number>
+        elementCustomCommand: (arg: unknown) => Promise<number>
     }
 }


### PR DESCRIPTION
## Proposed changes

Original fix - changed
`call: <T>(callback: (...args) => Promise<T>) => T;
to
`call: <T>(callback: (...args: any[]) => Promise<T>) => T;`

Updated tests to work with `noImplicitAny` set to true by default to avoid such situation in feature.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

### Reviewers: @webdriverio/technical-committee
