### PR TITLE
update appium service

### DIFF
--- a/packages/wdio-appium-service/README.md
+++ b/packages/wdio-appium-service/README.md
@@ -31,6 +31,7 @@ In order to use the service you need to add `appium` to your service array:
 // wdio.conf.js
 export.config = {
   // ...
+  port: 4723, // default appium port
   services: ['appium'],
   // ...
 };
@@ -57,7 +58,7 @@ export.config = {
 ```
 
 ### command
-The name of the command which should be started.
+To use your own installation of Appium, ex globally installed, specify the command which should be started.
 
 Type: `String`
 
@@ -67,7 +68,8 @@ Example:
 ```js
 export.config = {
     appium: {
-        command: "myAppium",
+        // for globally installed Appium just pass appium
+        command: "appium",
     }
 }
 ```
@@ -76,9 +78,9 @@ export.config = {
 Map of arguments for the Appium server, passed directly to `appium`.
 
 See [the documentation](http://appium.io/docs/en/writing-running-appium/server-args/index.html) for possible arguments.
-The arguments should be supplied in lower camel case, so `--pre-launch true` becomes `preLaunch: true`.
+The arguments should be supplied in lower camel case, so `--pre-launch true` becomes `preLaunch: true` or passed as an array.
 
-Type: `Object`
+Type: `Object` or `Array`
 
 Default: `{}`
 
@@ -92,6 +94,8 @@ export.config = {
       platformName: 'iOS',
       // ...
     }
+    // or
+    // args: ['-p', '4722', '--relaxed-security', '--log-level', 'info:info']
   }
 },
 ```

--- a/packages/wdio-appium-service/package.json
+++ b/packages/wdio-appium-service/package.json
@@ -33,8 +33,10 @@
   "bugs": {
     "url": "https://github.com/webdriverio/webdriverio/issues"
   },
+  "devDependencies": {
+    "appium": "^1.13.0"
+  },
   "dependencies": {
-    "appium": "^1.12.0",
     "fs-extra": "^8.0.1",
     "param-case": "^2.1.1"
   },

--- a/packages/wdio-appium-service/package.json
+++ b/packages/wdio-appium-service/package.json
@@ -33,9 +33,6 @@
   "bugs": {
     "url": "https://github.com/webdriverio/webdriverio/issues"
   },
-  "devDependencies": {
-    "appium": "^1.13.0"
-  },
   "dependencies": {
     "fs-extra": "^8.0.1",
     "param-case": "^2.1.1"

--- a/packages/wdio-appium-service/src/launcher.js
+++ b/packages/wdio-appium-service/src/launcher.js
@@ -18,7 +18,7 @@ export class AppiumLauncher {
     async onPrepare(config) {
         const appiumConfig = config.appium || {}
 
-        this.logPath = appiumConfig.logPath
+        this.logPath = appiumConfig.logPath || config.outputDir
         this.command = appiumConfig.command || this._getAppiumCommand()
         this.appiumArgs = this._cliArgsFromKeyValue(appiumConfig.args || {})
 

--- a/packages/wdio-appium-service/src/launcher.js
+++ b/packages/wdio-appium-service/src/launcher.js
@@ -70,7 +70,15 @@ export class AppiumLauncher {
     }
 
     _getAppiumCommand(moduleName = 'appium') {
-        return require.resolve(moduleName)
+        try {
+            return require.resolve(moduleName)
+        } catch (err) {
+            log.error('appium is not installed locally.\n' +
+            'If you use globally installed appium please add\n' +
+            "appium: { command: 'appium' }\n" +
+            'to your wdio.conf.js!')
+            throw err
+        }
     }
 
     _cliArgsFromKeyValue(keyValueArgs) {

--- a/packages/wdio-appium-service/src/launcher.js
+++ b/packages/wdio-appium-service/src/launcher.js
@@ -69,8 +69,8 @@ export class AppiumLauncher {
         this.process.stderr.pipe(logStream)
     }
 
-    _getAppiumCommand() {
-        return require.resolve('appium')
+    _getAppiumCommand(moduleName = 'appium') {
+        return require.resolve(moduleName)
     }
 
     _cliArgsFromKeyValue(keyValueArgs) {

--- a/packages/wdio-appium-service/tests/launcher.test.js
+++ b/packages/wdio-appium-service/tests/launcher.test.js
@@ -7,8 +7,8 @@ jest.mock('child_process', () => ({
     spawn: jest.fn(),
 }))
 jest.mock('fs-extra', () => ({
-    createWriteStream : jest.fn(),
-    ensureFileSync : jest.fn(),
+    createWriteStream: jest.fn(),
+    ensureFileSync: jest.fn(),
 }))
 
 class eventHandler {
@@ -50,11 +50,14 @@ class MockFailingProcess extends MockProcess {
 
 describe('Appium launcher', () => {
     let launcher = undefined
+    let getAppiumCommand
 
     beforeEach(() => {
         childProcess.spawn.mockClear()
         childProcess.spawn.mockReturnValue(new MockProcess())
         launcher = new AppiumLauncher()
+        getAppiumCommand = launcher._getAppiumCommand
+        launcher._getAppiumCommand = jest.fn().mockImplementation(() => require.resolve('param-case'))
     })
 
     afterEach(() => {
@@ -81,7 +84,7 @@ describe('Appium launcher', () => {
             await launcher.onPrepare({})
 
             expect(launcher.logPath).toBe(undefined)
-            expect(launcher.command).toBe(path.join(process.cwd(), 'packages/wdio-appium-service/node_modules/appium/build/lib/main.js'))
+            expect(launcher.command).toBe(path.join(process.cwd(), 'packages/wdio-appium-service/node_modules/param-case/param-case.js'))
             expect(launcher.appiumArgs).toEqual([])
         })
 
@@ -92,7 +95,7 @@ describe('Appium launcher', () => {
                 }
             })
 
-            expect(childProcess.spawn.mock.calls[0][0]).toBe(path.join(process.cwd(), 'packages/wdio-appium-service/node_modules/appium/build/lib/main.js'))
+            expect(childProcess.spawn.mock.calls[0][0]).toBe(path.join(process.cwd(), 'packages/wdio-appium-service/node_modules/param-case/param-case.js'))
             expect(childProcess.spawn.mock.calls[0][1]).toEqual(['--superspeed'])
             expect(childProcess.spawn.mock.calls[0][2]).toEqual({ stdio: ['ignore', 'pipe', 'pipe'] })
         })
@@ -167,7 +170,10 @@ describe('Appium launcher', () => {
 
     describe('_getAppiumCommand', () => {
         test('should return path to dependency', () => {
-            expect(launcher._getAppiumCommand()).toBe(path.join(process.cwd(), 'packages/wdio-appium-service/node_modules/appium/build/lib/main.js'))
+            expect(getAppiumCommand('fs-extra')).toBe(path.join(process.cwd(), 'packages/wdio-appium-service/node_modules/fs-extra/lib/index.js'))
+        })
+        test('should be appium by default', () => {
+            expect(() => getAppiumCommand()).toThrow("Cannot find module 'appium' from 'launcher.js'")
         })
     })
 

--- a/packages/wdio-cli/src/commands/install.js
+++ b/packages/wdio-cli/src/commands/install.js
@@ -11,7 +11,8 @@ import { SUPPORTED_SERVICES, SUPPORTED_REPORTER, SUPPORTED_FRAMEWORKS } from '..
 import {
     parseInstallNameAndPackage,
     replaceConfig,
-    findInConfig
+    findInConfig,
+    addServiceDeps
 } from '../utils'
 
 const supportedInstallations = {
@@ -89,16 +90,17 @@ You can create one by running 'wdio config'`)
         return
     }
 
-    const pkgName = supportedInstallations[type][name]
-    console.log(`Installing ${pkgName}${npm ? ' using npm.' : '.'}`)
-    const install = yarnInstall({ deps: [pkgName], dev: true, respectNpm5: npm })
+    const pkgNames = [supportedInstallations[type][name]]
+    addServiceDeps(pkgNames, pkgNames, true)
+    console.log(`Installing ${pkgNames}${npm ? ' using npm.' : '.'}`)
+    const install = yarnInstall({ deps: pkgNames, dev: true, respectNpm5: npm })
 
     if (install.status !== 0) {
         console.error('Error installing packages', install.stderr)
         process.exit(1)
     }
 
-    console.log(`Package ${pkgName} installed successfully.`)
+    console.log(`Package ${pkgNames} installed successfully.`)
     console.log('Updating wdio.conf.js file.')
 
     const newConfig = replaceConfig(configFile, type, name)

--- a/packages/wdio-cli/src/setup.js
+++ b/packages/wdio-cli/src/setup.js
@@ -1,15 +1,17 @@
+/* eslint-disable no-console */
 import fs from 'fs'
 import ejs from 'ejs'
 import path from 'path'
 import inquirer from 'inquirer'
 import yarnInstall from 'yarn-install'
+import { execSync } from 'child_process'
 
 import { CONFIG_HELPER_INTRO, CONFIG_HELPER_SUCCESS_MESSAGE, QUESTIONNAIRE } from './config'
 import { getNpmPackageName, getPackageName } from './utils'
 
 export default async function setup (exit = true) {
     try {
-        console.log(CONFIG_HELPER_INTRO) // eslint-disable-line no-console
+        console.log(CONFIG_HELPER_INTRO)
         const answers = await inquirer.prompt(QUESTIONNAIRE)
         const packagesToInstall = [
             getNpmPackageName(answers.runner),
@@ -30,19 +32,33 @@ export default async function setup (exit = true) {
             packagesToInstall.push('chromedriver')
         }
 
-        console.log('\nInstalling wdio packages:\n-', packagesToInstall.join('\n- ')) // eslint-disable-line no-console
+        /**
+         * install Appium if it is not installed globally if `@wdio/appium-service`
+         * was selected for install
+         */
+        if (answers.services.some((answer) => answer.includes('@wdio/appium-service'))) {
+            const result = execSync('appium --version || echo APPIUM_MISSING').toString().trim()
+            if (result === 'APPIUM_MISSING') {
+                packagesToInstall.push('appium')
+            } else {
+                console.log('Using globally installed appium', result)
+            }
+        }
+
+        console.log('\nInstalling wdio packages:\n-', packagesToInstall.join('\n- '))
         const result = yarnInstall({ deps: packagesToInstall, dev: true })
         if (result.status !== 0) {
             throw new Error(result.stderr)
         }
-        console.log('\nPackages installed successfully, creating configuration file...') // eslint-disable-line no-console
+        console.log('\nPackages installed successfully, creating configuration file...')
 
         const parsedAnswers = {
             ...answers,
             runner: getPackageName(answers.runner),
             framework: getPackageName(answers.framework),
             reporters: answers.reporters.map(getPackageName),
-            services: answers.services.map(getPackageName)
+            services: answers.services.map(getPackageName),
+            packagesToInstall
         }
 
         renderConfigurationFile(parsedAnswers)
@@ -59,5 +75,5 @@ function renderConfigurationFile (answers) {
     const tpl = fs.readFileSync(path.join(__dirname, '/templates/wdio.conf.tpl.ejs'), 'utf8')
     const renderedTpl = ejs.render(tpl, { answers })
     fs.writeFileSync(path.join(process.cwd(), 'wdio.conf.js'), renderedTpl)
-    console.log(CONFIG_HELPER_SUCCESS_MESSAGE) // eslint-disable-line no-console
+    console.log(CONFIG_HELPER_SUCCESS_MESSAGE)
 }

--- a/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
+++ b/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
@@ -21,9 +21,10 @@ exports.config = {
     //
     hostname: '<%= answers.hostname %>',
     port: <%= answers.port %>,
-    path: '<%= answers.path %>',<% }
+    path: '<%= answers.path %>',<% } else if (answers.services.includes('appium')) { %>
+    port: 4723,<% }
 
-    if(answers.services.includes('wdio-chromedriver-service')) { %>
+    if(answers.services.includes('chromedriver')) { %>
     //
     // Override default path ('/wd/hub') for chromedriver service.
     path: '/',<% }
@@ -96,7 +97,7 @@ exports.config = {
         // 5 instances get started at a time.
         maxInstances: 5,
         //
-        browserName: '<%= answers.services.includes('wdio-chromedriver-service') ? 'chrome' : 'firefox' %>',
+        browserName: '<%= answers.services.includes('chromedriver') ? 'chrome' : 'firefox' %>',
         // If outputDir is provided WebdriverIO can capture driver session logs
         // it is possible to configure which logTypes to include/exclude.
         // excludeDriverLogs: ['*'], // pass '*' to exclude all driver session logs
@@ -152,7 +153,14 @@ exports.config = {
     <% if(answers.services.length) {
     %>services: [<%- answers.services.map(service => `'${service}'`) %>],
     <% } else {
-    %>// services: [],<% } %>//
+    %>// services: [],<% }
+
+    if (answers.services.includes('appium')) {%>//
+    // Appium Service config
+    // see details: https://webdriver.io/docs/appium-service.html
+    appium: {
+        <%- answers.packagesToInstall.includes('appium') ? '// ' : '' %>command: 'appium',
+    }, <% } %>//
     // Framework you want to run your specs with.
     // The following are supported: Mocha, Jasmine, and Cucumber
     // see also: https://webdriver.io/docs/frameworks.html

--- a/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
+++ b/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
@@ -122,8 +122,8 @@ exports.config = {
     // - @wdio/cli, @wdio/config, @wdio/sync, @wdio/utils
     // Level of logging verbosity: trace | debug | info | warn | error | silent
     // logLevels: {
-        // webdriver: 'info',
-        // '@wdio/applitools-service': 'info'
+    //     webdriver: 'info',
+    //     '@wdio/applitools-service': 'info'
     // },
     //
     // If you only want to run your tests until a specific amount of tests have failed use
@@ -153,14 +153,16 @@ exports.config = {
     <% if(answers.services.length) {
     %>services: [<%- answers.services.map(service => `'${service}'`) %>],
     <% } else {
-    %>// services: [],<% }
+    %>// services: [],
+    //<% }
 
-    if (answers.services.includes('appium')) {%>//
+    if (answers.services.includes('appium')) {%>
     // Appium Service config
     // see details: https://webdriver.io/docs/appium-service.html
     appium: {
         <%- answers.packagesToInstall.includes('appium') ? '// ' : '' %>command: 'appium',
-    }, <% } %>//
+    },
+    //<% } %>
     // Framework you want to run your specs with.
     // The following are supported: Mocha, Jasmine, and Cucumber
     // see also: https://webdriver.io/docs/frameworks.html
@@ -261,8 +263,8 @@ exports.config = {
      * @param {Array} args arguments that command would receive
      */
     // beforeCommand: function (commandName, args) {
-    // },
-    <% if(answers.framework === 'mocha' || answers.framework === 'jasmine') { %>
+    // },<%
+    if(answers.framework === 'mocha' || answers.framework === 'jasmine') { %>
     /**
      * Hook that gets executed before the suite starts
      * @param {Object} suite suite details
@@ -298,8 +300,7 @@ exports.config = {
      * @param {Object} suite suite details
      */
     // afterSuite: function (suite) {
-    // },
-    <% }
+    // },<% }
     if(answers.framework === 'cucumber') { %>
     /**
      * Runs before a Cucumber feature

--- a/packages/wdio-cli/src/utils.js
+++ b/packages/wdio-cli/src/utils.js
@@ -1,4 +1,5 @@
 import logger from '@wdio/logger'
+import { execSync } from 'child_process'
 
 const log = logger('@wdio/cli:utils')
 
@@ -156,5 +157,34 @@ export function replaceConfig(
         const text = match.pop()
 
         return config.replace(text, buildNewConfigArray(text, type, name))
+    }
+}
+
+export function addServiceDeps(names, packages, update) {
+    /**
+     * automatically install latest Chromedriver if `wdio-chromedriver-service`
+     * was selected for install
+     */
+    if (names.some((answer) => answer.includes('wdio-chromedriver-service'))) {
+        packages.push('chromedriver')
+    }
+
+    /**
+     * install Appium if it is not installed globally if `@wdio/appium-service`
+     * was selected for install
+     */
+    if (names.some((answer) => answer.includes('@wdio/appium-service'))) {
+        const result = execSync('appium --version || echo APPIUM_MISSING').toString().trim()
+        if (result === 'APPIUM_MISSING') {
+            packages.push('appium')
+        } else if (update) {
+            // eslint-disable-next-line no-console
+            console.log(
+                '\n=======',
+                '\nUsing globally installed appium', result,
+                '\nPlease add the following to your wdio.conf.js:',
+                "\nappium: { command: 'appium' }",
+                '\n=======\n')
+        }
     }
 }

--- a/packages/wdio-cli/src/utils.js
+++ b/packages/wdio-cli/src/utils.js
@@ -167,6 +167,14 @@ export function addServiceDeps(names, packages, update) {
      */
     if (names.some((answer) => answer.includes('wdio-chromedriver-service'))) {
         packages.push('chromedriver')
+        if (update) {
+            // eslint-disable-next-line no-console
+            console.log(
+                '\n=======',
+                '\nPlease change path to / in your wdio.conf.js:',
+                "\npath: '/'",
+                '\n=======\n')
+        }
     }
 
     /**

--- a/packages/webdriverio/tests/overwriteCommand.test.js
+++ b/packages/webdriverio/tests/overwriteCommand.test.js
@@ -33,7 +33,7 @@ const customElementCommand = async (origCmd, origCmdArg, arg) => {
 }
 
 const customBrowserCommand = async (origCmd, origCmdArg, arg = 0) => {
-    const start = Date.now()
+    const start = Date.now() - 1
     await origCmd(origCmdArg + arg)
     return Date.now() - start
 }


### PR DESCRIPTION
## Proposed changes

Remove `appium` from `@wdio/appium-service` dependencies and install `appium` same as `chromedriver` if it is not installed globally.

fixed #4081 

also
- use outputDir as folder for appium logs if it is not specified in appium
- fixed `chromedriver` condition in `wdio.conf.tpl.ejs`
- `chromedriver` and `appium` packages are added when using `wdio install service ...`
- fixed some failing tests because of Date.now()

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

tested changes in my project.

### Reviewers: @webdriverio/technical-committee
