### PR TITLE
webdriverio: fix doubleClick when using w3c

### DIFF
--- a/packages/webdriverio/src/commands/element/doubleClick.js
+++ b/packages/webdriverio/src/commands/element/doubleClick.js
@@ -25,9 +25,9 @@ export default async function doubleClick () {
     /**
      * move to element
      */
-    await this.moveTo()
 
     if (!this.isW3C) {
+        await this.moveTo()
         return this.positionDoubleClick()
     }
 
@@ -39,6 +39,7 @@ export default async function doubleClick () {
         id: 'pointer1',
         parameters: { pointerType: 'mouse' },
         actions: [
+            { type: 'pointerMove', origin: this, x: 0, y: 0 },
             { type: 'pointerDown', button: 0 },
             { type: 'pointerUp', button: 0 },
             { type: 'pause', duration: 10 },

--- a/packages/webdriverio/tests/commands/element/doubleClick.test.js
+++ b/packages/webdriverio/tests/commands/element/doubleClick.test.js
@@ -17,30 +17,21 @@ describe('doubleClick', () => {
         const elem = await browser.$('#elem')
         await elem.doubleClick()
 
-        // move to
-        expect(request.mock.calls[3][0].uri.path).toContain('/foobar-123/actions')
-        expect(request.mock.calls[3][0].body.actions).toHaveLength(1)
-        expect(request.mock.calls[3][0].body.actions[0].type).toBe('pointer')
-        expect(request.mock.calls[3][0].body.actions[0].actions).toHaveLength(1)
-        expect(request.mock.calls[3][0].body.actions[0].actions[0])
-            .toEqual({ type: 'pointerMove', duration: 0, x: 40, y: 35 })
-
-        // release
-        expect(request.mock.calls[4][0].uri.path).toContain('/foobar-123/actions')
-        expect(request.mock.calls[4][0].method).toContain('DELETE')
-
         // double click
-        expect(request.mock.calls[5][0].uri.path).toContain('/foobar-123/actions')
-        expect(request.mock.calls[5][0].body.actions).toHaveLength(1)
-        expect(request.mock.calls[5][0].body.actions[0].type).toBe('pointer')
-        expect(request.mock.calls[5][0].body.actions[0].actions).toHaveLength(5)
-        expect(request.mock.calls[5][0].body.actions[0].actions).toEqual([
-            { button: 0, type: 'pointerDown' },
-            { button: 0, type: 'pointerUp' },
-            { duration: 10, type: 'pause' },
-            { button: 0, type: 'pointerDown' },
-            { button: 0, type: 'pointerUp' }
-        ])
+        expect(request.mock.calls[2][0].uri.path).toContain('/foobar-123/actions')
+        expect(request.mock.calls[2][0].body.actions).toHaveLength(1)
+        expect(request.mock.calls[2][0].body.actions[0].type).toBe('pointer')
+        expect(request.mock.calls[2][0].body.actions[0].actions).toHaveLength(6)
+        expect(request.mock.calls[2][0].body.actions[0].actions[0].type).toBe('pointerMove');
+        expect(request.mock.calls[2][0].body.actions[0].actions[0].origin.elementId).toBe('some-elem-123')
+        expect(request.mock.calls[2][0].body.actions[0].actions[0].origin['element-6066-11e4-a52e-4f735466cecf']).toBe('some-elem-123')
+        expect(request.mock.calls[2][0].body.actions[0].actions[0].x).toBe(0)
+        expect(request.mock.calls[2][0].body.actions[0].actions[0].y).toBe(0)
+        expect(request.mock.calls[2][0].body.actions[0].actions[1]).toEqual({ button: 0, type: 'pointerDown' })
+        expect(request.mock.calls[2][0].body.actions[0].actions[2]).toEqual({ button: 0, type: 'pointerUp' })
+        expect(request.mock.calls[2][0].body.actions[0].actions[3]).toEqual({ duration: 10, type: 'pause' })
+        expect(request.mock.calls[2][0].body.actions[0].actions[4]).toEqual({ button: 0, type: 'pointerDown' })
+        expect(request.mock.calls[2][0].body.actions[0].actions[5]).toEqual({ button: 0, type: 'pointerUp' })
     })
 
     it('should do a doubleClick (no w3c)', async () => {

--- a/packages/webdriverio/tests/commands/element/doubleClick.test.js
+++ b/packages/webdriverio/tests/commands/element/doubleClick.test.js
@@ -22,7 +22,7 @@ describe('doubleClick', () => {
         expect(request.mock.calls[2][0].body.actions).toHaveLength(1)
         expect(request.mock.calls[2][0].body.actions[0].type).toBe('pointer')
         expect(request.mock.calls[2][0].body.actions[0].actions).toHaveLength(6)
-        expect(request.mock.calls[2][0].body.actions[0].actions[0].type).toBe('pointerMove');
+        expect(request.mock.calls[2][0].body.actions[0].actions[0].type).toBe('pointerMove')
         expect(request.mock.calls[2][0].body.actions[0].actions[0].origin.elementId).toBe('some-elem-123')
         expect(request.mock.calls[2][0].body.actions[0].actions[0].origin['element-6066-11e4-a52e-4f735466cecf']).toBe('some-elem-123')
         expect(request.mock.calls[2][0].body.actions[0].actions[0].x).toBe(0)


### PR DESCRIPTION
## Proposed changes

The doubleclick method wasn't working when using w3c, this was because the mouseMove action has to be chained for it to work.
The changed made should fix the issue.

When reviewing, please check if the x and y values need to be set to half of the element's width and height. In my testing scenario's I could not find out if this is needed or not but my cases passed using 0 for both as it's relative from the element's position according to the docs.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
