### PR TITLE
wdio-appium-service: fix args array, print startup failure message

### DIFF
--- a/packages/wdio-appium-service/src/launcher.js
+++ b/packages/wdio-appium-service/src/launcher.js
@@ -56,8 +56,7 @@ export class AppiumLauncher {
             let errorMessage = `Appium exited before timeout (exit code: ${exitCode})`
             if (exitCode == 2) {
                 errorMessage += '\n' + (error || 'Check that you don\'t already have a running Appium service.')
-                // eslint-disable-next-line no-console
-                console.error(errorMessage)
+                log.error(errorMessage)
             }
             callback(new Error(errorMessage), null)
         })

--- a/packages/wdio-appium-service/tests/launcher.test.js
+++ b/packages/wdio-appium-service/tests/launcher.test.js
@@ -10,6 +10,7 @@ jest.mock('fs-extra', () => ({
     createWriteStream: jest.fn(),
     ensureFileSync: jest.fn(),
 }))
+global.console.error = jest.fn()
 
 class eventHandler {
     registered = {};
@@ -32,7 +33,7 @@ class MockProcess {
     removeListener() {}
     kill() {}
     stdout = { pipe: jest.fn(), on: this._eventHandler.delegate.bind(this._eventHandler) }
-    stderr = { pipe: jest.fn() }
+    stderr = { pipe: jest.fn(), once: jest.fn() }
 }
 
 class MockFailingProcess extends MockProcess {
@@ -122,7 +123,8 @@ describe('Appium launcher', () => {
             } catch (e) {
                 error = e
             }
-            const expectedError = new Error("Appium exited before timeout (exit code: 2) - Check that you don't already have a running Appium service.")
+            const expectedError = new Error('Appium exited before timeout (exit code: 2)\n' +
+                "Check that you don't already have a running Appium service.")
             expect(error).toEqual(expectedError)
         })
     })
@@ -192,6 +194,12 @@ describe('Appium launcher', () => {
             expect(args[2]).toBe('--command-timeout')
             expect(args[3]).toBe('7200')
             expect(args[4]).toBe('--session-override')
+        })
+        test('should not format arguments if array passed', () => {
+            const argsArray = ['-p', 4723]
+            const args = launcher._cliArgsFromKeyValue(argsArray)
+
+            expect(args).toBe(argsArray)
         })
     })
 })

--- a/packages/wdio-local-runner/tests/localRunner.test.js
+++ b/packages/wdio-local-runner/tests/localRunner.test.js
@@ -193,3 +193,9 @@ test('should shut down worker processes in watch mode - mutliremote', async () =
     expect(call1.argv.instances).toEqual({ foo: {} })
     expect(call1.argv.caps).toEqual({ foo: { capabilities: { browser: 'chrome' } } })
 })
+
+test('should avoid shutting down if worker is not busy', async () => {
+    const runner = new LocalRunner('/path/to/wdio.conf.js', {})
+
+    expect(runner.initialise()).toBe(undefined)
+})

--- a/packages/webdriver/tests/monad.test.js
+++ b/packages/webdriver/tests/monad.test.js
@@ -121,4 +121,10 @@ describe('monad', () => {
         const client = monad(sessionId)
         expect(client.commandList).toHaveLength(0)
     })
+
+    it('should be ok without modifier', () => {
+        const monad = webdriverMonad({ isW3C: true })
+        const client = monad(sessionId)
+        expect(client.commandList).toHaveLength(0)
+    })
 })

--- a/packages/webdriverio/tests/commands/browser/pause.test.js
+++ b/packages/webdriverio/tests/commands/browser/pause.test.js
@@ -1,18 +1,38 @@
 import request from 'request'
 import { remote } from '../../../src'
 
-describe('isEnabled test', () => {
-    it('should allow to check if an element is enabled', async () => {
-        const browser = await remote({
+describe('pause test', () => {
+    let browser
+    beforeEach(async () => {
+        browser = await remote({
             baseUrl: 'http://foobar.com',
             capabilities: {
                 browserName: 'foobar'
             }
         })
+    })
 
+    it('should pause for value provided as arg', async () => {
         const start = Date.now()
-        await browser.pause(1000)
-        expect((Date.now() - start) > 990).toBe(true)
+        await browser.pause(500)
+        const end = Date.now()
+
+        expect((end - start) > 490).toBe(true)
+        expect((end - start) < 590).toBe(true)
         expect(request.mock.calls).toHaveLength(1)
+    })
+
+    it('should pause for default value', async () => {
+        const start = Date.now()
+        await browser.pause()
+        const end = Date.now()
+
+        expect((end - start) > 990).toBe(true)
+        expect((end - start) < 1090).toBe(true)
+        expect(request.mock.calls).toHaveLength(1)
+    })
+
+    afterEach(() => {
+        request.mockClear()
     })
 })

--- a/packages/webdriverio/tests/commands/element/reactElement.test.js
+++ b/packages/webdriverio/tests/commands/element/reactElement.test.js
@@ -30,4 +30,27 @@ describe('elem.react$', () => {
                 },
             ])
     })
+
+    it('does request to get React component with default params', async () => {
+        const browser = await remote({
+            baseUrl: 'http://foobar.com',
+            capabilities: {
+                browserName: 'foobar'
+            }
+        })
+
+        const elem = await browser.$('#foo')
+        await elem.react$('MyComp')
+
+        expect(elem.elementId).toBe('some-elem-123')
+        expect(request.mock.calls.pop()[0].body.args).toEqual([
+            'MyComp',
+            {},
+            {},
+            {
+                ELEMENT: elem.elementId,
+                [ELEMENT_KEY]: elem.elementId
+            },
+        ])
+    })
 })

--- a/packages/webdriverio/tests/commands/element/reactElements.test.js
+++ b/packages/webdriverio/tests/commands/element/reactElements.test.js
@@ -30,4 +30,27 @@ describe('elem.react$', () => {
                 },
             ])
     })
+
+    it('does request to get React component with default params', async () => {
+        const browser = await remote({
+            baseUrl: 'http://foobar.com',
+            capabilities: {
+                browserName: 'foobar'
+            }
+        })
+
+        const elem = await browser.$('#foo')
+
+        await elem.react$$('MyComp')
+        expect(elem.elementId).toBe('some-elem-123')
+        expect(request.mock.calls.pop()[0].body.args).toEqual([
+            'MyComp',
+            {},
+            {},
+            {
+                ELEMENT: elem.elementId,
+                [ELEMENT_KEY]: elem.elementId
+            },
+        ])
+    })
 })

--- a/packages/webdriverio/tests/commands/element/waitUntil.test.js
+++ b/packages/webdriverio/tests/commands/element/waitUntil.test.js
@@ -1,0 +1,27 @@
+import request from 'request'
+import { remote } from '../../../src'
+
+jest.setTimeout(10 * 1000)
+
+describe('waitUntil', () => {
+    let browser
+
+    beforeAll(async () => {
+        browser = await remote({
+            baseUrl: 'http://foobar.com',
+            capabilities: {
+                browserName: 'foobar'
+            }
+        })
+    })
+
+    it('Should throw an error if an invalid condition is used', async () => {
+        const el = await browser.$('foo')
+        const result = await el.waitUntil(async () => true)
+        expect(result).toBe(true)
+    })
+
+    afterEach(() => {
+        request.mockClear()
+    })
+})


### PR DESCRIPTION
## Proposed changes

- fix args array support
- print startup failure message (previously it was only static message)
![image](https://user-images.githubusercontent.com/25589559/59807426-231a9480-92f8-11e9-9d21-f07b3b1c9bf0.png)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

### Reviewers: @webdriverio/technical-committee
