### PR TITLE
docs: changed deprecated assert method to current one in example test

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -95,7 +95,7 @@ describe('webdriver.io page', () => {
     it('should have the right title', () => {
         browser.url('https://webdriver.io');
         const title = browser.getTitle();
-        assert.equal(title, 'WebdriverIO · Next-gen WebDriver test framework for Node.js');
+        assert.strictEqual(title, 'WebdriverIO · Next-gen WebDriver test framework for Node.js');
     });
 });
 ```
@@ -109,7 +109,7 @@ describe('webdriver.io page', () => {
     it('should have the right title', async () => {
         await browser.url('https://webdriver.io');
         const title = await browser.getTitle();
-        assert.equal(title, 'WebdriverIO · Next-gen WebDriver test framework for Node.js');
+        assert.strictEqual(title, 'WebdriverIO · Next-gen WebDriver test framework for Node.js');
     });
 });
 ```


### PR DESCRIPTION
## Proposed changes

[//]: # deprecated assert method was used in the getting started example, I changed it to the currently supported method

## Types of changes

[//]: # text change
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
