### PR TITLE
types: fix hook array

### DIFF
--- a/scripts/templates/webdriverio.tpl.d.ts
+++ b/scripts/templates/webdriverio.tpl.d.ts
@@ -86,7 +86,7 @@ declare namespace WebdriverIO {
         failed: number
     }
 
-    interface Hooks {
+    interface HookFunctions {
         onPrepare?(
             config: Config,
             capabilities: WebDriver.DesiredCapabilities
@@ -148,6 +148,11 @@ declare namespace WebdriverIO {
         afterScenario?(scenario: any): void;
         afterStep?(stepResult: any): void;
     }
+    type _HooksArray = {
+        [K in keyof Pick<HookFunctions, "onPrepare" | "onComplete" | "before" | "after" | "beforeSession" | "afterSession">]: HookFunctions[K] | Array<HookFunctions[K]>;
+    };
+    type _Hooks = Omit<HookFunctions, "onPrepare" | "onComplete" | "before" | "after" | "beforeSession" | "afterSession">;
+    interface Hooks extends _HooksArray, _Hooks { }
 
     type ActionTypes = 'press' | 'longPress' | 'tap' | 'moveTo' | 'wait' | 'release';
     interface TouchAction {
@@ -182,7 +187,7 @@ declare namespace WebdriverIO {
             name: string,
             func: (origCommand: Function, ...args: any[]) => any,
             attachToElement?: boolean
-            ): void;
+        ): void;
         options: RemoteOptions;
         // ... browser commands ...
     }

--- a/tests/typings/sync/config.ts
+++ b/tests/typings/sync/config.ts
@@ -1,0 +1,10 @@
+const conf: WebdriverIO.Config = {
+    // can be both array and function
+    onComplete: (config, caps) => { },
+    onPrepare: [
+        () => { }
+    ],
+
+    // can be function only
+    afterSuite: () => {},
+}


### PR DESCRIPTION
## Proposed changes

Hook types should also allow arrays.

I know that some hooks don't support arrays, not sure which exactly. Assuming following hooks to accept functions and array of functions: `"onPrepare" | "onComplete" | "before" | "after" | "beforeSession" | "afterSession"`

Hooks: `onPrepare, onComplete, onReload, before, beforeCommand, beforeHook, beforeSession, beforeSuite, beforeTest, afterHook, after, afterCommand, afterSession, afterSuite, afterTest, beforeFeature, beforeScenario, beforeStep, afterFeature, afterScenario, afterStep`

Let me know what other hooks should be added.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

fix #4104

### Reviewers: @webdriverio/technical-committee
