### PR TITLE
Fix bug where environment flags aren't attached to session

### DIFF
--- a/packages/webdriver/src/index.js
+++ b/packages/webdriver/src/index.js
@@ -5,7 +5,7 @@ import { validateConfig } from '@wdio/config'
 import webdriverMonad from './monad'
 import WebDriverRequest from './request'
 import { DEFAULTS } from './constants'
-import { getPrototype, environmentDetector } from './utils'
+import { getPrototype, environmentDetector, getEnvironmentVars } from './utils'
 
 import WebDriverProtocol from '../protocol/webdriver.json'
 import JsonWProtocol from '../protocol/jsonwp.json'
@@ -59,21 +59,10 @@ export default class WebDriver {
          */
         params.capabilities = response.value.capabilities || response.value
 
-        /**
-         * apply mobile flags to driver scope
-         */
-        const { isW3C, isMobile, isIOS, isAndroid, isChrome, isSauce } = environmentDetector(params)
-        const environmentFlags = {
-            isW3C: { value: isW3C },
-            isMobile: { value: isMobile },
-            isIOS: { value: isIOS },
-            isAndroid: { value: isAndroid },
-            isChrome: { value: isChrome },
-            isSauce: { value: isSauce }
-        }
-
-        const protocolCommands = getPrototype({ isW3C, isChrome, isMobile, isSauce })
-        const prototype = merge(protocolCommands, environmentFlags, userPrototype)
+        const environment = environmentDetector(params)
+        const environmentPrototype = getEnvironmentVars(environment)
+        const protocolCommands = getPrototype(environment)
+        const prototype = merge(protocolCommands, environmentPrototype, userPrototype)
         const monad = webdriverMonad(params, modifier, prototype)
         return monad(response.value.sessionId || response.sessionId, commandWrapper)
     }
@@ -94,21 +83,9 @@ export default class WebDriver {
         options.capabilities = options.capabilities || {}
         options.isW3C = options.isW3C === false ? false : true
 
-        /**
-         * apply mobile flags to driver scope
-         */
-        const { isW3C, isMobile, isIOS, isAndroid, isChrome, isSauce } = options
-        const environmentFlags = {
-            isW3C: { value: isW3C },
-            isMobile: { value: isMobile },
-            isIOS: { value: isIOS },
-            isAndroid: { value: isAndroid },
-            isChrome: { value: isChrome },
-            isSauce: { value: isSauce }
-        }
-
-        const protocolCommands = getPrototype({ isW3C, isChrome, isMobile, isSauce })
-        const prototype = merge(protocolCommands, environmentFlags, userPrototype)
+        const environmentPrototype = getEnvironmentVars(options)
+        const protocolCommands = getPrototype(options)
+        const prototype = merge(protocolCommands, environmentPrototype, userPrototype)
         const monad = webdriverMonad(options, modifier, prototype)
         return monad(options.sessionId, commandWrapper)
     }

--- a/packages/webdriver/src/index.js
+++ b/packages/webdriver/src/index.js
@@ -68,7 +68,8 @@ export default class WebDriver {
             isMobile: { value: isMobile },
             isIOS: { value: isIOS },
             isAndroid: { value: isAndroid },
-            isChrome: { value: isChrome }
+            isChrome: { value: isChrome },
+            isSauce: { value: isSauce }
         }
 
         const protocolCommands = getPrototype({ isW3C, isChrome, isMobile, isSauce })
@@ -92,7 +93,22 @@ export default class WebDriver {
 
         options.capabilities = options.capabilities || {}
         options.isW3C = options.isW3C === false ? false : true
-        const prototype = Object.assign(getPrototype({ ...options }), userPrototype)
+
+        /**
+         * apply mobile flags to driver scope
+         */
+        const { isW3C, isMobile, isIOS, isAndroid, isChrome, isSauce } = options
+        const environmentFlags = {
+            isW3C: { value: isW3C },
+            isMobile: { value: isMobile },
+            isIOS: { value: isIOS },
+            isAndroid: { value: isAndroid },
+            isChrome: { value: isChrome },
+            isSauce: { value: isSauce }
+        }
+
+        const protocolCommands = getPrototype({ isW3C, isChrome, isMobile, isSauce })
+        const prototype = merge(protocolCommands, environmentFlags, userPrototype)
         const monad = webdriverMonad(options, modifier, prototype)
         return monad(options.sessionId, commandWrapper)
     }

--- a/packages/webdriver/src/utils.js
+++ b/packages/webdriver/src/utils.js
@@ -378,3 +378,20 @@ export function overwriteElementCommands(propertiesObject) {
     delete propertiesObject['__elementOverrides__']
     propertiesObject['__elementOverrides__'] = { value: {} }
 }
+
+/**
+ * return all supported flags and return them in a format so we can attach them
+ * to the instance protocol
+ * @param  {Object} options   driver instance or option object containing these flags
+ * @return {Object}           prototype object
+ */
+export function getEnvironmentVars({ isW3C, isMobile, isIOS, isAndroid, isChrome, isSauce }) {
+    return {
+        isW3C: { value: isW3C },
+        isMobile: { value: isMobile },
+        isIOS: { value: isIOS },
+        isAndroid: { value: isAndroid },
+        isChrome: { value: isChrome },
+        isSauce: { value: isSauce }
+    }
+}

--- a/packages/webdriver/tests/index.test.js
+++ b/packages/webdriver/tests/index.test.js
@@ -129,6 +129,38 @@ describe('WebDriver', () => {
             expect(client.getDeviceTime).toBeTruthy()
         })
 
+        test('it should propagate all environment flags', () => {
+            const client = WebDriver.attachToSession({ ...sessionOptions,
+                isW3C: false,
+                isMobile: false,
+                isIOS: false,
+                isAndroid: false,
+                isChrome: false,
+                isSauce: false
+            })
+            expect(client.isW3C).toBe(false)
+            expect(client.isMobile).toBe(false)
+            expect(client.isIOS).toBe(false)
+            expect(client.isAndroid).toBe(false)
+            expect(client.isChrome).toBe(false)
+            expect(client.isSauce).toBe(false)
+
+            const anotherClient = WebDriver.attachToSession({ ...sessionOptions,
+                isW3C: true,
+                isMobile: true,
+                isIOS: true,
+                isAndroid: true,
+                isChrome: true,
+                isSauce: true
+            })
+            expect(anotherClient.isW3C).toBe(true)
+            expect(anotherClient.isMobile).toBe(true)
+            expect(anotherClient.isIOS).toBe(true)
+            expect(anotherClient.isAndroid).toBe(true)
+            expect(anotherClient.isChrome).toBe(true)
+            expect(anotherClient.isSauce).toBe(true)
+        })
+
         test('should fail attaching to session if sessionId is not given', () => {
             expect(() => WebDriver.attachToSession({})).toThrow(/sessionId is required/)
         })


### PR DESCRIPTION
## Proposed changes

Currently if you use `attachSession` or `attach` our environment flags aren't properly set on the attached session. This patches fixes this.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

This bug was detected during Appiums development on badge processes: https://github.com/appium/appium-base-driver/pull/328/files

### Reviewers: @webdriverio/project-committers 
