### PR TITLE
wdio-mocha-framework: add mocha error in type DSL

### DIFF
--- a/packages/wdio-mocha-framework/mocha-framework.d.ts
+++ b/packages/wdio-mocha-framework/mocha-framework.d.ts
@@ -14,11 +14,11 @@ declare namespace WebdriverIO {
         passed: boolean;
         duration?: number;
         error?: {
-            actual?: string,
-            expected?: string,
-            message: string
-            stack?: string,
-            type: string
+            actual?: string;
+            expected?: string;
+            message: string;
+            stack?: string;
+            type: string;
         }
     }
 }

--- a/packages/wdio-mocha-framework/mocha-framework.d.ts
+++ b/packages/wdio-mocha-framework/mocha-framework.d.ts
@@ -13,6 +13,13 @@ declare namespace WebdriverIO {
         currentTest: string;
         passed: boolean;
         duration?: number;
+        error?: {
+            actual?: string,
+            expected?: string,
+            message: string
+            stack?: string,
+            type: string
+        }
     }
 }
 

--- a/packages/wdio-mocha-framework/mocha-framework.d.ts
+++ b/packages/wdio-mocha-framework/mocha-framework.d.ts
@@ -14,8 +14,8 @@ declare namespace WebdriverIO {
         passed: boolean;
         duration?: number;
         error?: {
-            actual?: string;
-            expected?: string;
+            actual?: any;
+            expected?: any;
             message: string;
             stack?: string;
             type: string;


### PR DESCRIPTION
## Proposed changes

As the title, I added mocha's error in type DSL.
This type is defined in this pure javascript.
https://github.com/webdriverio/webdriverio/blob/dd63394df0d5b217c495f0a8309f64ecd618b441/packages/wdio-mocha-framework/src/index.js#L150-L156

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

I checked this PR in my local, but I did not add test because I only added type DSL.

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
