### PR TITLE
Fix spawn declaration on Windows

### DIFF
--- a/packages/wdio-appium-service/src/launcher.js
+++ b/packages/wdio-appium-service/src/launcher.js
@@ -39,7 +39,7 @@ export class AppiumLauncher {
 
     _startAppium(command, args, waitStartTime, callback) {
         log.debug(`Will spawn Appium process: ${command} ${args.join(' ')}`)
-        let process = spawn(command, args, { stdio: ['ignore', 'pipe', 'pipe'] })
+        let process = spawn('node', [command, ...args], { stdio: ['ignore', 'pipe', 'pipe'] })
         let error
 
         process.stdout.on('data', (data) => {

--- a/packages/wdio-appium-service/src/launcher.js
+++ b/packages/wdio-appium-service/src/launcher.js
@@ -22,7 +22,7 @@ export class AppiumLauncher {
 
         // Set command
         if (appiumConfig.command) {
-            this.commmand = appiumConfig.command
+            this.command = appiumConfig.command
         } else {
             this.command = 'node'
             this.appiumArgs.push(this._getAppiumCommand())

--- a/packages/wdio-appium-service/src/launcher.js
+++ b/packages/wdio-appium-service/src/launcher.js
@@ -19,8 +19,17 @@ export class AppiumLauncher {
         const appiumConfig = config.appium || {}
 
         this.logPath = appiumConfig.logPath || config.outputDir
-        this.command = appiumConfig.command || this._getAppiumCommand()
-        this.appiumArgs = this._cliArgsFromKeyValue(appiumConfig.args || {})
+
+        // Set command
+        if (appiumConfig.command) {
+            this.commmand = appiumConfig.command
+        } else {
+            this.command = 'node'
+            this.appiumArgs = this._getAppiumCommand()
+        }
+
+        // Append args
+        this.appiumArgs.push(...this._cliArgsFromKeyValue(appiumConfig.args || {}))
 
         const asyncStartAppium = promisify(this._startAppium)
         this.process = await asyncStartAppium(this.command, this.appiumArgs, this.waitStartTime)

--- a/packages/wdio-appium-service/src/launcher.js
+++ b/packages/wdio-appium-service/src/launcher.js
@@ -39,7 +39,7 @@ export class AppiumLauncher {
 
     _startAppium(command, args, waitStartTime, callback) {
         log.debug(`Will spawn Appium process: ${command} ${args.join(' ')}`)
-        let process = spawn('node', [command, ...args], { stdio: ['ignore', 'pipe', 'pipe'] })
+        let process = spawn(command, args, { stdio: ['ignore', 'pipe', 'pipe'] })
         let error
 
         process.stdout.on('data', (data) => {

--- a/packages/wdio-appium-service/src/launcher.js
+++ b/packages/wdio-appium-service/src/launcher.js
@@ -20,15 +20,16 @@ export class AppiumLauncher {
 
         this.logPath = appiumConfig.logPath || config.outputDir
 
-        // Set command
+        // Set config command
         if (appiumConfig.command) {
             this.command = appiumConfig.command
         } else {
+            // Windows expects node to be explicitely set as command and appium module path as it's first argument
             this.command = 'node'
             this.appiumArgs.push(this._getAppiumCommand())
         }
 
-        // Append args
+        // Append remaining arguments
         this.appiumArgs.push(...this._cliArgsFromKeyValue(appiumConfig.args || {}))
 
         const asyncStartAppium = promisify(this._startAppium)

--- a/packages/wdio-appium-service/src/launcher.js
+++ b/packages/wdio-appium-service/src/launcher.js
@@ -25,7 +25,7 @@ export class AppiumLauncher {
             this.commmand = appiumConfig.command
         } else {
             this.command = 'node'
-            this.appiumArgs = this._getAppiumCommand()
+            this.appiumArgs.push(this._getAppiumCommand())
         }
 
         // Append args

--- a/packages/wdio-appium-service/tests/launcher.test.js
+++ b/packages/wdio-appium-service/tests/launcher.test.js
@@ -85,8 +85,8 @@ describe('Appium launcher', () => {
             await launcher.onPrepare({})
 
             expect(launcher.logPath).toBe(undefined)
-            expect(launcher.command).toBe(path.join(process.cwd(), 'packages/wdio-appium-service/node_modules/param-case/param-case.js'))
-            expect(launcher.appiumArgs).toEqual([])
+            expect(launcher.command).toBe('node')
+            expect(launcher.appiumArgs).toEqual([path.join(process.cwd(), 'packages/wdio-appium-service/node_modules/param-case/param-case.js')])
         })
 
         test('should start Appium', async () => {
@@ -96,8 +96,8 @@ describe('Appium launcher', () => {
                 }
             })
 
-            expect(childProcess.spawn.mock.calls[0][0]).toBe(path.join(process.cwd(), 'packages/wdio-appium-service/node_modules/param-case/param-case.js'))
-            expect(childProcess.spawn.mock.calls[0][1]).toEqual(['--superspeed'])
+            expect(childProcess.spawn.mock.calls[0][0]).toBe('node')
+            expect(childProcess.spawn.mock.calls[0][1]).toEqual([path.join(process.cwd(), 'packages/wdio-appium-service/node_modules/param-case/param-case.js'), '--superspeed'])
             expect(childProcess.spawn.mock.calls[0][2]).toEqual({ stdio: ['ignore', 'pipe', 'pipe'] })
         })
 


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

When configured a service like 'appium' in configuration, @wdio/appium-service launcher tries to spawn `PROJECT_DIR\appium\build\lib\main.js` file.

On Windows OS this results in error:
```
ERROR @wdio/cli:utils: A service failed in the 'onPrepare' hook
Error: spawn UNKNOWN
    at ChildProcess.spawn (internal/child_process.js:371:11)
    at spawn (child_process.js:561:9)
    at _startAppium (PROJECT_DIR\node_modules\@wdio\appium-service\build\launcher.js:54:44)
```

This happens due to fact that shebangs (`#!/usr/bin/env node`) don't work on Windows and command should be executed explicitly via node:
```js
spawn('node', ['PROJECT_DIR\node_modules\@wdio\appium-service\build\launcher.js', arg1, arg2])
```

instead of
```js
spawn('PROJECT_DIR\node_modules\@wdio\appium-service\build\launcher.js', [arg1, arg2])
```

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee

~~~
Workaround:

in wdio.config.js use [Options](https://www.npmjs.com/package/@wdio/appium-service#options)
```js
appium: {
  command: 'node',
  args: [require.resolve('appium')]
}
```