### PR TITLE
Docs: Normalize terminal commands

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -8,8 +8,8 @@ WebdriverIO comes with its own test runner to help you get started with integrat
 Starting with v5 of WebdriverIO the testrunner will be bundled as a separate NPM package `@wdio/cli`. To see the command line interface help just type the following command in your terminal:
 
 ```sh
-$ npm install @wdio/cli
-$ ./node_modules/.bin/wdio --help
+npm install @wdio/cli
+./node_modules/.bin/wdio --help
 
 WebdriverIO CLI runner
 
@@ -60,7 +60,7 @@ Options:
 Sweet! Now you need to define a configuration file where all information about your tests, capabilities and settings are set. Switch over to the [Configuration File](ConfigurationFile.md) section to find out how that file should look like. With the `wdio` configuration helper it is super easy to generate your config file. Just run:
 
 ```sh
-$ ./node_modules/.bin/wdio config
+./node_modules/.bin/wdio config
 ```
 
 and it launches the helper utility. It will ask you questions depending on the answers you give. This way
@@ -72,28 +72,28 @@ Once you have your configuration file set up you can start your
 integration tests by calling:
 
 ```sh
-$ ./node_modules/.bin/wdio wdio.conf.js
+./node_modules/.bin/wdio wdio.conf.js
 ```
 
 That's it! Now, you can access to the selenium instance via the global variable `browser`.
 
 ## Commands
 
-### $ wdio install
+### wdio install
 The `install` command allows you to add reporters and services to your WebdriverIO projects via the CLI.
 
 Example:
 
 ```bash
-$ wdio install service sauce # installs @wdio/sauce-service
-$ wdio install reporter dot # installs @wdio/dot-reporter
-$ wdio install framework mocha # installs @wdio/mocha-framework
+wdio install service sauce # installs @wdio/sauce-service
+wdio install reporter dot # installs @wdio/dot-reporter
+wdio install framework mocha # installs @wdio/mocha-framework
 ```
 
 If your project is using `package-lock.json` instead of `yarn.lock`, you can pass a `--npm` flag to make sure the packages are installed via NPM.
 
 ```bash
-$ wdio install service sauce --npm
+wdio install service sauce --npm
 ```
 
 #### List of supported services

--- a/docs/Debugging.md
+++ b/docs/Debugging.md
@@ -46,7 +46,7 @@ See [timeouts](Timeouts.md) for more information on how to do that using other f
 To get it working, you need to pass the `--inspect` flag down to the wdio command running tests like this:
 
 ```sh
-$ wdio wdio.conf.js --inspect
+wdio wdio.conf.js --inspect
 ```
 
 This will start the runner process with this inspect flag enabled. With that you can open the DevTools and can connect to the runner process. Make sure you set a `debugger` statement somewhere in order to start fiddling around with commands in the console.

--- a/docs/DriverBinaries.md
+++ b/docs/DriverBinaries.md
@@ -14,19 +14,19 @@ Download the latest version of geckodriver for your environment and unpack it in
 **Linux 64 bit**
 
 ```sh
-$ curl -L https://github.com/mozilla/geckodriver/releases/download/v0.24.0/geckodriver-v0.24.0-linux64.tar.gz | tar xz
+curl -L https://github.com/mozilla/geckodriver/releases/download/v0.24.0/geckodriver-v0.24.0-linux64.tar.gz | tar xz
 ```
 
 **OSX**
 
 ```sh
-$ curl -L https://github.com/mozilla/geckodriver/releases/download/v0.24.0/geckodriver-v0.24.0-macos.tar.gz | tar xz
+curl -L https://github.com/mozilla/geckodriver/releases/download/v0.24.0/geckodriver-v0.24.0-macos.tar.gz | tar xz
 ```
 
 or with [brew](https://brew.sh/)
 
 ```sh
-$ brew install geckodriver
+brew install geckodriver
 ```
 
 **Windows 64 bit**
@@ -65,14 +65,14 @@ Note: Other geckodriver releases are available [here](https://github.com/mozilla
 Start Geckodriver by running:
 
 ```sh
-$ /path/to/binary/geckodriver --port 4444
+/path/to/binary/geckodriver --port 4444
 ```
 
 For example, if you ran the curl command from above, you should have a `geckodriver` binary available in the current folder. You can run the following to start it:
 
 
 ```sh
-$ ./geckodriver --port 4444
+./geckodriver --port 4444
 ```
 
 This will start Geckodriver on `localhost:4444` with the WebDriver endpoint set to `/`.

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -20,8 +20,8 @@ Before installing dependencies, we need to initialize an empty NPM project (this
 To do this, run:
 
 ```sh
-$ mkdir webdriverio-test && cd webdriverio-test
-$ npm init -y
+mkdir webdriverio-test && cd webdriverio-test
+npm init -y
 ```
 
 The `-y` will answer 'yes' to all the prompts, giving us a standard NPM project. Feel free to omit the `-y` if you'd like to specify your own project details.
@@ -33,7 +33,7 @@ If you want to use WebdriverIO in your project for integration testing we recomm
 Now we need to install the cli. Do that by running:
 
 ```sh
-$ npm i --save-dev @wdio/cli
+npm i --save-dev @wdio/cli
 ```
 
 ### Generate Configuration File
@@ -41,7 +41,7 @@ $ npm i --save-dev @wdio/cli
 We'll next want to generate a configuration file that stores all of our WebdriverIO settings. To do that just run the configuration utility:
 
 ```sh
-$ ./node_modules/.bin/wdio config
+./node_modules/.bin/wdio config
 ```
 
 A question interface pops up. It will help to create the config easy and fast. If you are not sure what to answer follow this answers:
@@ -77,13 +77,13 @@ That's it! The configurator now installs all required packages for you and creat
 Now it's time to create our test file. We're going to store all of our files in a new folder. Create the test folder like this:
 
 ```sh
-$ mkdir -p ./test/specs
+mkdir -p ./test/specs
 ```
 
 Create a new file in that folder (we'll call it `basic.js`):
 
 ```sh
-$ touch ./test/specs/basic.js
+touch ./test/specs/basic.js
 ```
 
 Open that file up and add the following code to it:
@@ -122,7 +122,7 @@ Once added, save, then return to your terminal.
 The last step is to execute the test runner. To do so just run:
 
 ```sh
-$ ./node_modules/.bin/wdio wdio.conf.js
+./node_modules/.bin/wdio wdio.conf.js
 ```
 
 Hurray! The test should pass and you can start writing integration tests with WebdriverIO.

--- a/docs/OrganizingTestSuites.md
+++ b/docs/OrganizingTestSuites.md
@@ -83,13 +83,13 @@ exports.config = {
 Now, if you want to only run a single suite, you can pass the suite name as cli argument like:
 
 ```sh
-$ wdio wdio.conf.js --suite login
+wdio wdio.conf.js --suite login
 ```
 
 or run multiple suites at once:
 
 ```sh
-$ wdio wdio.conf.js --suite login --suite otherFeature
+wdio wdio.conf.js --suite login --suite otherFeature
 ```
 
 ## Run Selected Tests
@@ -97,19 +97,19 @@ $ wdio wdio.conf.js --suite login --suite otherFeature
 In some cases, you may wish to only execute a single test or a subset of your suites. With the `--spec` parameter you can specify which suite (Mocha, Jasmine) or feature (Cucumber) should be run. For example if you only want to run your login test, do:
 
 ```sh
-$ wdio wdio.conf.js --spec ./test/specs/e2e/login.js
+wdio wdio.conf.js --spec ./test/specs/e2e/login.js
 ```
 
 or run multiple specs at once:
 
 ```sh
-$ wdio wdio.conf.js --spec ./test/specs/signup.js --spec ./test/specs/forgot-password.js
+wdio wdio.conf.js --spec ./test/specs/signup.js --spec ./test/specs/forgot-password.js
 ```
 
 If the spec passed in is not a path to a spec file, it is used as a filter for the spec file names defined in your configuration file. To run all specs with the word 'dialog' in the spec file names, you could use:
 
 ```sh
-$ wdio wdio.conf.js --spec dialog
+wdio wdio.conf.js --spec dialog
 ```
 
 Note that each test file is running in a single test runner process. Since we don't scan files in advance (see the next section for information on piping filenames to `wdio`) you _can't_ use for example `describe.only` at the top of your spec file to say Mocha to only run that suite. This feature will help you though to do that in the same way.
@@ -119,15 +119,15 @@ Note that each test file is running in a single test runner process. Since we do
  When needed, if you need to exclude particular spec file(s) from a run, you can use the `--exclude` parameter (Mocha, Jasmine) or feature (Cucumber). For example if you want to exclude your login
 test from the test run, do:
  ```sh
-$ wdio wdio.conf.js --exclude ./test/specs/e2e/login.js
+wdio wdio.conf.js --exclude ./test/specs/e2e/login.js
 ```
  or exclude multiple spec files:
  ```sh
-$ wdio wdio.conf.js --exclude ./test/specs/signup.js --exclude ./test/specs/forgot-password.js
+wdio wdio.conf.js --exclude ./test/specs/signup.js --exclude ./test/specs/forgot-password.js
 ```
  or exclude a spec file when filtering using a suite:
  ```sh
-$ wdio wdio.conf.js --suite login --exclude ./test/specs/e2e/login.js
+wdio wdio.conf.js --suite login --exclude ./test/specs/e2e/login.js
 ```
 
 ## Run Suites and Test Specs
@@ -135,7 +135,7 @@ $ wdio wdio.conf.js --suite login --exclude ./test/specs/e2e/login.js
 This will allow you to run an entire suite along with individual spec's.
 
 ```sh
-$ wdio wdio.conf.js --suite login --spec ./test/specs/signup.js
+wdio wdio.conf.js --suite login --spec ./test/specs/signup.js
 ```
 
 ## Run Multiple, Specific Test Specs
@@ -143,7 +143,7 @@ $ wdio wdio.conf.js --suite login --spec ./test/specs/signup.js
 It is sometimes necessary&mdash;in the context of continuous integration and otherwise&mdash;to specify multiple sets of specs to be run at runtime. WebdriverIO's `wdio` command line utility will accept piped input in the form of filenames (from `find`, `grep`, or others). These filenames will override the list of glob patterns or filenames specified in the configuration file's `spec` list.
 
 ```sh
-$ grep -r -l --include "*.js" "myText" | wdio wdio.conf.js
+grep -r -l --include "*.js" "myText" | wdio wdio.conf.js
 ```
 
 _**Note:** This will_ not _override the `--spec` flag for running a single spec._

--- a/docs/Proxy.md
+++ b/docs/Proxy.md
@@ -13,24 +13,24 @@ You can tunnel two different types of request through a proxy:
 If your company has a corporate proxy (e.g. on `http://my.corp.proxy.com:9090`) for all outgoing requests you can set it using the `PROXY` environment variable as explained in the [request module](https://github.com/request/request#controlling-proxy-behaviour-using-environment-variables). Before you start the test make sure you exported the variable in the terminal as follows:
 
 ```sh
-$ export HTTP_PROXY=http://my.corp.proxy.com:9090
-$ export HTTPS_PROXY=https://my.corp.proxy.com:9090
-$ wdio wdio.conf.js
+export HTTP_PROXY=http://my.corp.proxy.com:9090
+export HTTPS_PROXY=https://my.corp.proxy.com:9090
+wdio wdio.conf.js
 ```
 
 Additionally, if you run into errors concerning SSL certificates during test execution, you can set the `STRICT_SSL` environment variable to `false`, which will turn off SSL key validation when making requests with https:
 
 ```sh
-$ export HTTP_PROXY=http://my.corp.proxy.com:9090
-$ export HTTPS_PROXY=https://my.corp.proxy.com:9090
-$ export STRICT_SSL=false
-$ wdio wdio.conf.js
+export HTTP_PROXY=http://my.corp.proxy.com:9090
+export HTTPS_PROXY=https://my.corp.proxy.com:9090
+export STRICT_SSL=false
+wdio wdio.conf.js
 ```
 
 If you use [Sauce Connect Proxy](https://wiki.saucelabs.com/display/DOCS/Sauce+Connect+Proxy) start it via:
 
 ```sh
-$ sc -u $SAUCE_USERNAME -k $SAUCE_ACCESS_KEY --no-autodetect -p http://my.corp.proxy.com:9090
+sc -u $SAUCE_USERNAME -k $SAUCE_ACCESS_KEY --no-autodetect -p http://my.corp.proxy.com:9090
 ```
 
 ## Proxy Between Browser And Internet

--- a/docs/RunProgrammatically.md
+++ b/docs/RunProgrammatically.md
@@ -10,7 +10,7 @@ Before start you have to setup either [driver binaries](DriverBinaries.md) or se
 Let's start with installing `webdriverio` by calling:
 
 ```sh
-$ npm install webdriverio
+npm install webdriverio
 ```
 
 Create a test file (e.g. `test.js`) with the following content:
@@ -40,7 +40,7 @@ const { remote } = require('webdriverio');
 
 
 ```sh
-$ node test.js
+node test.js
 ```
 
 this should output the following:

--- a/docs/WatchFiles.md
+++ b/docs/WatchFiles.md
@@ -6,7 +6,7 @@ title: Watch Test Files
 With the WDIO testrunner you can watch files while you are working on them. They automatically rerun if you change either something in your app or in your test files. By adding a `--watch` flag when calling the `wdio` command the testrunner will wait for file changes after it ran all tests, e.g.
 
 ```sh
-$ wdio wdio.conf.js --watch
+wdio wdio.conf.js --watch
 ```
 
 By default it only watches for changes in your `specs` files. However by setting a `filesToWatch` property in your `wdio.conf.js` that contains a list of file paths (globbing supported) it will also watch for these files to be changed in order to rerun the whole suite. This is useful if you want to automatically rerun all your tests if you have changed your application code, e.g.

--- a/docs/repl.md
+++ b/docs/repl.md
@@ -6,13 +6,13 @@ title: REPL interface
 With `v4.5.0` WebdriverIO introduces a [REPL](https://en.wikipedia.org/wiki/Read%E2%80%93eval%E2%80%93print_loop) interface that helps you to not only discover the framework API but also debug and inspect your tests. It can be used in multiple ways. First you can use it as CLI command and spawn a WebDriver session from the command line, e.g.
 
 ```sh
-$ wdio repl chrome
+wdio repl chrome
 ```
 
 This would open a Chrome browser that you can control with the REPL interface. Make sure you have a browser driver running on port `4444` in order to initiate the session. If you have a [SauceLabs](https://saucelabs.com) (or other cloud vendor) account you can also directly run the browser on your command line in the cloud via:
 
 ```sh
-$ wdio repl chrome -u $SAUCE_USERNAME -k $SAUCE_ACCESS_KEY
+wdio repl chrome -u $SAUCE_USERNAME -k $SAUCE_ACCESS_KEY
 ```
 
 You can apply any options (see `wdio --help`) available for your REPL session.


### PR DESCRIPTION
## Proposed changes

Currently there are two different ways terminal commands are defined in the docs, with and without a `$`. Theses should be normalized.

`$ npm i --save-dev @wdio/cli`

`npm i --save-dev @wdio/cli`

Removing the `$` prefix as that could be confusing for new users who copy and paste the commands although I don't really have a preference if the `$` is there or not.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

### Reviewers: @webdriverio/technical-committee
