### PR TITLE
wdio-allure-reporter: Add capability to include attachment in afterhook

### DIFF
--- a/packages/wdio-allure-reporter/src/index.js
+++ b/packages/wdio-allure-reporter/src/index.js
@@ -249,9 +249,11 @@ class AllureReporter extends WDIOReporter {
         test.setDescription(description, type)
     }
 
-    addAttachment({ name, content, type = 'text/plain' }) {
-        if (!this.isAnyTestRunning()) {
-            return false
+    addAttachment({ name, content, type = 'text/plain' }, loadExistingAttachmentInAfterHook = false) {
+        if (!loadExistingAttachmentInAfterHook) {
+            if (!this.isAnyTestRunning()) {
+                return false
+            }
         }
 
         if (type === 'application/json') {

--- a/packages/wdio-allure-reporter/tests/allureFeatures.test.js
+++ b/packages/wdio-allure-reporter/tests/allureFeatures.test.js
@@ -138,6 +138,33 @@ describe('reporter runtime implementation', () => {
         expect(addAttachment).toHaveBeenCalledWith('foo', Buffer.from('bar'), 'baz')
     })
 
+    it('should not call add attachment if no test is running', () => {
+        const reporter = new AllureReporter({ stdout: true })
+        const addAttachment = jest.fn()
+        reporter.allure = {
+            getCurrentSuite: jest.fn(() => false),
+            getCurrentTest: jest.fn(() => false),
+            addAttachment
+        }
+
+        reporter.addAttachment({ name: 'foo', content: 'bar', type: 'baz' })
+        expect(addAttachment).toHaveBeenCalledTimes(0)
+    })
+
+    it('should call add attachment if loading an attachment', () => {
+        const reporter = new AllureReporter({ stdout: true })
+        const addAttachment = jest.fn()
+        reporter.allure = {
+            getCurrentSuite: jest.fn(() => false),
+            getCurrentTest: jest.fn(() => false),
+            addAttachment
+        }
+
+        reporter.addAttachment({ name: 'foo', content: 'bar', type: 'baz' }, true)
+        expect(addAttachment).toHaveBeenCalledTimes(1)
+        expect(addAttachment).toHaveBeenCalledWith('foo', Buffer.from('bar'), 'baz')
+    })
+
     it('should correct add "application/json" attachment', () => {
         const reporter = new AllureReporter({ stdout: true })
         const dumpJSON = jest.fn()


### PR DESCRIPTION
## Proposed changes

Adding a simple flag to a reporter to allow us to add an existing attachment in the after hook

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
