### PR TITLE
wdio-allure-reporter: add suite separator

### DIFF
--- a/packages/wdio-allure-reporter/src/index.js
+++ b/packages/wdio-allure-reporter/src/index.js
@@ -41,7 +41,7 @@ class AllureReporter extends WDIOReporter {
 
     onSuiteStart(suite) {
         const currentSuite = this.allure.getCurrentSuite()
-        const prefix = currentSuite ? currentSuite.name + ' ' : ''
+        const prefix = currentSuite ? currentSuite.name + ': ' : ''
         this.allure.startSuite(prefix + suite.title)
     }
 

--- a/packages/wdio-allure-reporter/tests/allureFeatures.test.js
+++ b/packages/wdio-allure-reporter/tests/allureFeatures.test.js
@@ -475,6 +475,6 @@ describe('nested suite naming', () => {
         reporter.onSuiteStart({ title: 'bar' })
 
         expect(startSuite).toHaveBeenCalledTimes(1)
-        expect(startSuite).toHaveBeenCalledWith('foo bar')
+        expect(startSuite).toHaveBeenCalledWith('foo: bar')
     })
 })


### PR DESCRIPTION
## Proposed changes

Added suite separator.
`suite1 suite2 suite3` -> `suite1: suite2: suite3`

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

### Reviewers: @webdriverio/technical-committee
