### PR TITLE
wdio-spec-reporter: fix header in multiremote mode

### DIFF
--- a/packages/wdio-spec-reporter/src/index.js
+++ b/packages/wdio-spec-reporter/src/index.js
@@ -111,7 +111,7 @@ class SpecReporter extends WDIOReporter {
      * @return {Array}         Header data
      */
     getHeaderDisplay(runner) {
-        const combo = this.getEnviromentCombo(runner.capabilities).trim()
+        const combo = this.getEnviromentCombo(runner.capabilities, undefined, runner.isMultiremote).trim()
 
         // Spec file name and enviroment information
         const output = [

--- a/packages/wdio-spec-reporter/tests/index.test.js
+++ b/packages/wdio-spec-reporter/tests/index.test.js
@@ -243,6 +243,15 @@ describe('SpecReporter', () => {
             expect(result[1]).toBe('Running: loremipsum')
             expect(result[2]).toBe('')
         })
+
+        it('should validate header output in multiremote', () => {
+            const result = tmpReporter.getHeaderDisplay({ ...RUNNER, isMultiremote: true })
+
+            expect(result.length).toBe(3)
+            expect(result[0]).toBe('Spec: /foo/bar/baz.js')
+            expect(result[1]).toBe('Running: MultiremoteBrowser')
+            expect(result[2]).toBe('')
+        })
     })
 
     describe('getResultDisplay', () => {


### PR DESCRIPTION
## Proposed changes

fix `Running: undefined` issue in Multiremote mode.

Before: `[MultiremoteBrowser #0-0] Running: undefined`
After: `[MultiremoteBrowser #0-0] Running: MultiremoteBrowser`

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

### Reviewers: @webdriverio/technical-committee
