### PR TITLE
wdio-utils: Make safeRequire use require.resolve

### DIFF
--- a/packages/wdio-utils/src/initialisePlugin.js
+++ b/packages/wdio-utils/src/initialisePlugin.js
@@ -6,13 +6,15 @@
  */
 function safeRequire (name) {
     try {
+        require.resolve(name)
+    } catch (e) {
+        return null
+    }
+
+    try {
         return require(name)
     } catch (e) {
-        if (!e.message.match(`Cannot find module '${name}'`)) {
-            throw new Error(`Couldn't initialise "${name}".\n${e.stack}`)
-        }
-
-        return null
+        throw new Error(`Couldn't initialise "${name}".\n${e.stack}`)
     }
 }
 


### PR DESCRIPTION
By using require.resolve we split resolution errors into separate logic, which eliminates need for 'not-safe' string matching.

## Proposed changes

[//]: # Because current implementation of safeRequire is using string based matching, it's not possible to use WebDriver.io with [yarn pnp](https://yarnpkg.com/en/docs/pnp). Yarn throws different message than `npm` is doing when package not found.

Instead of doing string based match it's better to use standard Node api `require.resolve` to find out whether the module is available or not.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee