### PR TITLE
Cucumber: TypeScript Setup doc, pass function to requireModule

### DIFF
--- a/docs/TypeScript.md
+++ b/docs/TypeScript.md
@@ -9,6 +9,7 @@ Minimal TypeScript version is 3.5.1
 ```js
 // wdio.conf.js
 before: function() {
+    // not needed for Cucumber
     require('ts-node').register({ files: true });
 },
 ```
@@ -22,6 +23,19 @@ mochaOpts: {
     require: [
         'tsconfig-paths/register'
     ]
+},
+```
+
+And Cucumber:
+
+```js
+// wdio.conf.js
+cucumberOpts: {
+    requireModule: [
+        'tsconfig-paths/register',
+        () => { require('ts-node').register({ files: true }) },
+    ],
+    require: [/* support and step definitions files here */],
 },
 ```
 

--- a/packages/wdio-cucumber-framework/README.md
+++ b/packages/wdio-cucumber-framework/README.md
@@ -52,7 +52,7 @@ Require modules prior to requiring any support files.
 
 Type: `String[]`<br>
 Default: `[]`<br>
-Example: `['@babel/register']` or `[['@babel/register', { rootMode: 'upward', ignore: ['node_modules'] }]]`
+Example: `['@babel/register']` or `[['@babel/register', { rootMode: 'upward', ignore: ['node_modules'] }]] or [() => { require('ts-node').register({ files: true }) }]`
 
 ### failAmbiguousDefinitions
 **Please note that this is a @wdio/cucumber-framework specific option and not recognized by cucumber-js itself**

--- a/packages/wdio-cucumber-framework/src/constants.js
+++ b/packages/wdio-cucumber-framework/src/constants.js
@@ -2,7 +2,7 @@ export const DEFAULT_TIMEOUT = 60000
 
 export const DEFAULT_OPTS = {
     backtrace: false, // <boolean> show full backtrace for errors
-    requireModule: [], // <string[]> ("extension:module") require files with the given EXTENSION after requiring MODULE (repeatable)
+    requireModule: [], // <string[]> ("module") require MODULE files (repeatable)
     failAmbiguousDefinitions: false, // <boolean> treat ambiguous definitions as errors
     failFast: false, // <boolean> abort the run on first failure
     ignoreUndefinedDefinitions: false, // <boolean> treat undefined definitions as warnings

--- a/packages/wdio-cucumber-framework/src/index.js
+++ b/packages/wdio-cucumber-framework/src/index.js
@@ -102,11 +102,15 @@ class CucumberAdapter {
      * we extend it a bit with ability to init and pass configuration to modules.
      * Pass an array with path to module and its configuration instead:
      * Usage: `[['module', {}]]`
+     * Or pass your own function
+     * Usage: `[() => { require('ts-node').register({ files: true }) }]`
      */
     registerRequiredModules () {
         this.cucumberOpts.requireModule.map(requiredModule => {
             if (Array.isArray(requiredModule)) {
                 require(requiredModule[0])(requiredModule[1])
+            } else if (typeof requiredModule === 'function') {
+                requiredModule()
             } else {
                 require(requiredModule)
             }


### PR DESCRIPTION
## Proposed changes

- ability to pass function to `requireModule` (alternative solutions are welcomed)
- Add Typescript setup for cucumber doc

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments


### Reviewers: @webdriverio/technical-committee
