### PR TITLE
Add sauce-connect-launcher to logger of wdio-sauce-service

### DIFF
--- a/packages/wdio-sauce-service/src/launcher.js
+++ b/packages/wdio-sauce-service/src/launcher.js
@@ -1,5 +1,7 @@
+import logger from '@wdio/logger'
 import SauceConnectLauncher from 'sauce-connect-launcher'
 
+const log = logger('@wdio/sauce-service')
 export default class SauceLauncher {
     /**
      * modify config and launch sauce connect
@@ -11,7 +13,8 @@ export default class SauceLauncher {
 
         this.sauceConnectOpts = Object.assign({
             username: config.user,
-            accessKey: config.key
+            accessKey: config.key,
+            logger: log.debug
         }, config.sauceConnectOpts)
 
         config.protocol = 'http'


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

Prior to this change, the output of Sauce Connect was being lost.
Even adding "verbose" to sauceConnectOpts would not surface to stdout

This change sets the "logger" option of sauce-connect-launcher to wdio-sauce-service's logger on debug logLevel.
This way if a user sets the logLevel to debug they can see what the sauce-service is doing with SC.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
