### PR TITLE
Cucumber fix error message

### DIFF
--- a/packages/wdio-cucumber-framework/src/reporter.js
+++ b/packages/wdio-cucumber-framework/src/reporter.js
@@ -126,7 +126,8 @@ class CucumberReporter {
                 }
             } else {
                 error = {
-                    message: err
+                    message: err,
+                    stack: ''
                 }
             }
             this.failedCount++
@@ -134,7 +135,8 @@ class CucumberReporter {
             e = 'fail'
             this.failedCount++
             error = {
-                message: result.exception
+                message: result.exception,
+                stack: ''
             }
         }
 

--- a/packages/wdio-cucumber-framework/src/utils.js
+++ b/packages/wdio-cucumber-framework/src/utils.js
@@ -116,7 +116,7 @@ export function formatMessage ({ type, payload = {} }) {
     }
 
     if (payload.title && payload.parent) {
-        payload.fullTitle = getTestFullTitle(payload.parent, payload.title)
+        message.fullTitle = getTestFullTitle(payload.parent, payload.title)
     }
 
     return message

--- a/packages/wdio-cucumber-framework/tests/reporter.test.js
+++ b/packages/wdio-cucumber-framework/tests/reporter.test.js
@@ -326,12 +326,13 @@ describe('cucumber reporter', () => {
             })
 
             it('should send proper data on failing `test-step-finished` event with exception', () => {
+                const err = new Error('exception-error')
                 eventBroadcaster.emit('test-step-finished', {
                     index: 2,
                     result: {
                         duration: 10,
                         status: 'failed',
-                        exception: new Error('exception-error')
+                        exception: err
                     },
                     testCase: {
                         sourceLocation: { uri: gherkinDocEvent.uri, line: 126 }
@@ -350,7 +351,8 @@ describe('cucumber reporter', () => {
                         { name: '@scenario-tag2' }
                     ],
                     error: expect.objectContaining({
-                        message: 'exception-error'
+                        message: err.message,
+                        stack: err.stack
                     })
                 }))
             })
@@ -380,7 +382,8 @@ describe('cucumber reporter', () => {
                         { name: '@scenario-tag2' }
                     ],
                     error: expect.objectContaining({
-                        message: 'string-error'
+                        message: 'string-error',
+                        stack: ''
                     })
                 }))
             })
@@ -410,7 +413,8 @@ describe('cucumber reporter', () => {
                         { name: '@scenario-tag2' }
                     ],
                     error: expect.objectContaining({
-                        message: 'cucumber-ambiguous-error-message'
+                        message: 'cucumber-ambiguous-error-message',
+                        stack: ''
                     })
                 }))
             })
@@ -490,7 +494,8 @@ describe('cucumber reporter', () => {
                 result: {
                     duration: 10,
                     status: 'ambiguous',
-                    exception: 'cucumber-ambiguous-error-message'
+                    exception: 'cucumber-ambiguous-error-message',
+                    stack: ''
                 },
                 testCase: {
                     sourceLocation: { uri: gherkinDocEvent.uri, line: 126 }

--- a/packages/wdio-cucumber-framework/tests/utils.test.js
+++ b/packages/wdio-cucumber-framework/tests/utils.test.js
@@ -97,6 +97,18 @@ describe('utils', () => {
         it('should not fail if payload was not passed', () => {
             expect(formatMessage({ type: 'test' })).toMatchSnapshot()
         })
+
+        it('should set fullTitle', () => {
+            expect(formatMessage({
+                type: 'foobar',
+                payload: { parent: 'foo', title: 'bar' }
+            })).toEqual({
+                parent: 'foo',
+                title: 'bar',
+                type: 'foobar',
+                fullTitle: 'foo: bar',
+            })
+        })
     })
 
     describe('getUniqueIdentifier', () => {


### PR DESCRIPTION
## Proposed changes

- Fix `Error in "undefined"`. I think I have fixed it but then broken or something. Added test this time (there should be fullTitle in message)
- added `stack` to `error` because if stack is missing some reporters crashes. I have fixed it for spec reporter, but allure reporter has the same issue, and maybe some other reporters, so I think it is better to fix root cause.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

### Reviewers: @webdriverio/technical-committee
