### PR TITLE
wdio-cucumber-framework: fix hook handling

### DIFF
--- a/packages/wdio-cucumber-framework/src/reporter.js
+++ b/packages/wdio-cucumber-framework/src/reporter.js
@@ -1,7 +1,7 @@
 import { Status } from 'cucumber'
 
 import CucumberEventListener from './cucumberEventListener'
-import { createStepArgument, getTestParent, getTestStepTitle, getUniqueIdentifier, formatMessage } from './utils'
+import { getTestStepTitle, getUniqueIdentifier, formatMessage, getStepType, buildStepPayload } from './utils'
 
 class CucumberReporter {
     gherkinDocEvents = []
@@ -54,52 +54,51 @@ class CucumberReporter {
 
     handleBeforeStep (uri, feature, scenario, step, /*sourceLocation*/) {
         this.testStart = new Date()
+        const type = getStepType(step.type)
+        const payload = buildStepPayload(uri, feature, scenario, step, type, getTestStepTitle(step.keyword, step.text))
 
-        this.emit('test:start', {
-            uid: getUniqueIdentifier(step),
-            title: getTestStepTitle(step),
-            type: 'test',
-            file: uri,
-            parent: getTestParent(feature, scenario),
-            tags: scenario.tags,
-            featureName: feature.name,
-            scenarioName: scenario.name,
-            argument: createStepArgument(step)
-        })
+        this.emit(`${type}:start`, payload)
     }
 
     handleAfterStep (uri, feature, scenario, step, result, /*sourceLocation*/) {
-        let e = 'undefined'
+        const type = getStepType(step.type)
+
+        if (type === 'hook') {
+            return this.afterHook(uri, feature, scenario, step, result)
+        }
+        return this.afterTest(uri, feature, scenario, step, result)
+    }
+
+    afterHook (uri, feature, scenario, step, result) {
+        const payload = buildStepPayload(uri, feature, scenario, step, 'hook', getTestStepTitle(step.keyword, step.text, 'hook'), result.status, result.exception, new Date() - this.testStart)
+
+        this.emit('hook:end', payload)
+    }
+
+    afterTest (uri, feature, scenario, step, result) {
+        let state = 'undefined'
         switch (result.status) {
         case Status.FAILED:
         case Status.UNDEFINED:
-            e = 'fail'
+            state = 'fail'
             break
         case Status.PASSED:
-            e = 'pass'
+            state = 'pass'
             break
         case Status.PENDING:
         case Status.SKIPPED:
         case Status.AMBIGUOUS:
-            e = 'pending'
+            state = 'pending'
         }
-        let error = {}
-        let stepTitle = getTestStepTitle(step)
-
-        /**
-         * if step name is undefined we are dealing with a hook
-         * don't report hooks if no error happened
-         */
-        if (!step.text && result.status !== Status.FAILED) {
-            return
-        }
+        let error = result.exception
+        let stepTitle = getTestStepTitle(step.keyword, step.text)
 
         if (result.status === Status.UNDEFINED) {
             if (this.options.ignoreUndefinedDefinitions) {
                 /**
                  * mark test as pending
                  */
-                e = 'pending'
+                state = 'pending'
                 stepTitle += ' (undefined step)'
             } else {
                 /**
@@ -108,31 +107,20 @@ class CucumberReporter {
                 this.failedCount++
 
                 error = {
-                    message: `Step "${stepTitle}" is not defined. You can ignore this error by setting
-                              cucumberOpts.ignoreUndefinedDefinitions as true.`,
+                    message: `Step "${stepTitle}" is not defined. You can ignore this error by setting cucumberOpts.ignoreUndefinedDefinitions as true.`,
                     stack: `${step.uri}:${step.line}`
                 }
             }
         } else if (result.status === Status.FAILED) {
-            /**
-             * cucumber failure exception can't get send to parent process
-             * for some reasons
-             */
-            let err = result.exception
-            if (err instanceof Error) {
+            this.failedCount++
+            if (false === result.exception instanceof Error) {
                 error = {
-                    message: err.message,
-                    stack: err.stack
-                }
-            } else {
-                error = {
-                    message: err,
+                    message: result.exception,
                     stack: ''
                 }
             }
-            this.failedCount++
         } else if (result.status === Status.AMBIGUOUS && this.options.failAmbiguousDefinitions) {
-            e = 'fail'
+            state = 'fail'
             this.failedCount++
             error = {
                 message: result.exception,
@@ -140,21 +128,8 @@ class CucumberReporter {
             }
         }
 
-        const parent = getTestParent(feature, scenario)
-        const payload = {
-            uid: getUniqueIdentifier(step),
-            title: stepTitle,
-            type: 'test',
-            file: uri,
-            parent: parent,
-            error: error,
-            duration: new Date() - this.testStart,
-            tags: scenario.tags,
-            keyword: step.keyword,
-            argument: createStepArgument(step)
-        }
-
-        this.emit('test:' + e, payload)
+        const payload = buildStepPayload(uri, feature, scenario, step, 'test', stepTitle, state, error, new Date() - this.testStart, state === 'pass')
+        this.emit('test:' + state, payload)
     }
 
     handleAfterScenario (uri, feature, scenario, sourceLocation) {

--- a/packages/wdio-cucumber-framework/src/reporter.js
+++ b/packages/wdio-cucumber-framework/src/reporter.js
@@ -55,7 +55,7 @@ class CucumberReporter {
     handleBeforeStep (uri, feature, scenario, step, /*sourceLocation*/) {
         this.testStart = new Date()
         const type = getStepType(step.type)
-        const payload = buildStepPayload(uri, feature, scenario, step, type, getTestStepTitle(step.keyword, step.text))
+        const payload = buildStepPayload(uri, feature, scenario, step, { type })
 
         this.emit(`${type}:start`, payload)
     }
@@ -70,7 +70,12 @@ class CucumberReporter {
     }
 
     afterHook (uri, feature, scenario, step, result) {
-        const payload = buildStepPayload(uri, feature, scenario, step, 'hook', getTestStepTitle(step.keyword, step.text, 'hook'), result.status, result.exception, new Date() - this.testStart)
+        const payload = buildStepPayload(uri, feature, scenario, step, {
+            type: 'hook',
+            state: result.status,
+            error: result.exception,
+            duration: new Date() - this.testStart
+        })
 
         this.emit('hook:end', payload)
     }
@@ -128,7 +133,14 @@ class CucumberReporter {
             }
         }
 
-        const payload = buildStepPayload(uri, feature, scenario, step, 'test', stepTitle, state, error, new Date() - this.testStart, state === 'pass')
+        const payload = buildStepPayload(uri, feature, scenario, step, {
+            type: 'test',
+            title: stepTitle,
+            state,
+            error,
+            duration: new Date() - this.testStart,
+            passed: state === 'pass'
+        })
         this.emit('test:' + state, payload)
     }
 

--- a/packages/wdio-cucumber-framework/src/utils.js
+++ b/packages/wdio-cucumber-framework/src/utils.js
@@ -115,9 +115,10 @@ export function getStepType(type) {
 /**
  * build payload for test/hook event
  */
-export function buildStepPayload(uri, feature, scenario, step, type, title, state, error, duration, passed) {
+export function buildStepPayload(uri, feature, scenario, step, params = {}) {
     return {
         uid: getUniqueIdentifier(step),
+        title: getTestStepTitle(step.keyword, step.text, params.type),
         parent: getTestParent(feature, scenario),
         argument: createStepArgument(step),
         file: uri,
@@ -125,12 +126,7 @@ export function buildStepPayload(uri, feature, scenario, step, type, title, stat
         keyword: step.keyword,
         featureName: feature.name,
         scenarioName: scenario.name,
-        type,
-        title,
-        state,
-        error,
-        passed,
-        duration
+        ...params
     }
 }
 

--- a/packages/wdio-cucumber-framework/src/utils.js
+++ b/packages/wdio-cucumber-framework/src/utils.js
@@ -42,7 +42,7 @@ export function getTestParent(feature, scenario) {
  */
 export function getTestStepTitle (keyword = '', text = '', type) {
     const title = (!text && type !== 'hook') ? 'Undefined Step' : text
-    return `${keyword.trim()} ${title.trim()}`
+    return `${keyword.trim()} ${title.trim()}`.trim()
 }
 
 /**

--- a/packages/wdio-cucumber-framework/tests/__snapshots__/utils.test.js.snap
+++ b/packages/wdio-cucumber-framework/tests/__snapshots__/utils.test.js.snap
@@ -65,20 +65,7 @@ Object {
 
 exports[`utils formatMessage should set passed state for test hooks 1`] = `
 Object {
-  "passed": true,
   "state": "passed",
   "type": "afterTest",
-}
-`;
-
-exports[`utils formatMessage should set title for custom type 1`] = `
-Object {
-  "ctx": Object {
-    "currentTest": Object {
-      "title": "barfoo",
-    },
-  },
-  "currentTest": "barfoo",
-  "type": "foobar",
 }
 `;

--- a/packages/wdio-cucumber-framework/tests/reporter.test.js
+++ b/packages/wdio-cucumber-framework/tests/reporter.test.js
@@ -102,8 +102,14 @@ const buildGherkinDocEvent = () => ({
                 name: 'scenario',
                 steps: [
                     {
+                        type: 'Hook',
+                        location: { line: 132, column: 1, uri: './any.feature' },
+                        keyword: 'Hook',
+                        text: '',
+                    },
+                    {
                         type: 'Step',
-                        location: { line: 132, column: 1 },
+                        location: { line: 133, column: 2 },
                         keyword: '',
                         text: '',
                     },
@@ -173,7 +179,7 @@ describe('cucumber reporter', () => {
                 specs,
                 tags: [...gherkinDocEvent.document.feature.tags],
                 title: gherkinDocEvent.document.feature.name,
-                // type: 'suite',
+                type: 'suite:start',
                 uid: 'feature123',
             }))
         })
@@ -202,7 +208,7 @@ describe('cucumber reporter', () => {
             startSuite(eventBroadcaster)
 
             expect(wdioReporter.emit).toHaveBeenCalledWith('suite:start', expect.objectContaining({
-                // type: 'suite',
+                type: 'suite:start',
                 cid: '0-1',
                 parent: 'feature123',
                 uid: 'scenario126',
@@ -229,7 +235,7 @@ describe('cucumber reporter', () => {
                 })
 
                 expect(wdioReporter.emit).toHaveBeenCalledWith('test:start', expect.objectContaining({
-                    // type: 'test',
+                    type: 'test:start',
                     title: 'Given step-title-passing',
                     cid: '0-1',
                     parent: 'feature: scenario',
@@ -244,7 +250,7 @@ describe('cucumber reporter', () => {
                 }))
             })
 
-            it('pretend `test-step-finished` to look like a hook', () => {
+            it('passed hook', () => {
                 eventBroadcaster.emit('test-step-finished', {
                     index: 1,
                     result: { duration: 10, status: 'passed' },
@@ -253,7 +259,25 @@ describe('cucumber reporter', () => {
                     }
                 })
 
-                expect(wdioReporter.emit).not.toBeCalled()
+                expect(wdioReporter.emit).toHaveBeenCalledWith('hook:end', expect.objectContaining({
+                    type: 'hook:end',
+                    error: undefined,
+                }))
+            })
+
+            it('failed hook', () => {
+                eventBroadcaster.emit('test-step-finished', {
+                    index: 1,
+                    result: { duration: 10, status: 'failed', exception: 'err' },
+                    testCase: {
+                        sourceLocation: { uri: gherkinDocEvent.uri, line: 131 }
+                    }
+                })
+
+                expect(wdioReporter.emit).toHaveBeenCalledWith('hook:end', expect.objectContaining({
+                    type: 'hook:end',
+                    error: 'err',
+                }))
             })
 
             it('should send proper data on successful `test-step-finished` event', () => {
@@ -266,7 +290,7 @@ describe('cucumber reporter', () => {
                 })
 
                 expect(wdioReporter.emit).toHaveBeenCalledWith('test:pass', expect.objectContaining({
-                    // type: 'test',
+                    type: 'test:pass',
                     title: 'Given step-title-passing',
                     cid: '0-1',
                     parent: 'feature: scenario',
@@ -289,7 +313,7 @@ describe('cucumber reporter', () => {
                 })
 
                 expect(wdioReporter.emit).toHaveBeenCalledWith('test:pending', expect.objectContaining({
-                    // type: 'test',
+                    type: 'test:pending',
                     title: 'Given step-title-passing',
                     cid: '0-1',
                     parent: 'feature: scenario',
@@ -312,7 +336,7 @@ describe('cucumber reporter', () => {
                 })
 
                 expect(wdioReporter.emit).toHaveBeenCalledWith('test:pending', expect.objectContaining({
-                    // type: 'test',
+                    type: 'test:pending',
                     title: 'Given step-title-passing',
                     cid: '0-1',
                     parent: 'feature: scenario',
@@ -340,7 +364,7 @@ describe('cucumber reporter', () => {
                 })
 
                 expect(wdioReporter.emit).toHaveBeenCalledWith('test:fail', expect.objectContaining({
-                    // type: 'test',
+                    type: 'test:fail',
                     title: 'When step-title-failing',
                     cid: '0-1',
                     parent: 'feature: scenario',
@@ -371,7 +395,7 @@ describe('cucumber reporter', () => {
                 })
 
                 expect(wdioReporter.emit).toHaveBeenCalledWith('test:fail', expect.objectContaining({
-                    // type: 'test',
+                    type: 'test:fail',
                     title: 'When step-title-failing',
                     cid: '0-1',
                     parent: 'feature: scenario',
@@ -402,7 +426,7 @@ describe('cucumber reporter', () => {
                 })
 
                 expect(wdioReporter.emit).toHaveBeenCalledWith('test:fail', expect.objectContaining({
-                    // type: 'test',
+                    type: 'test:fail',
                     title: 'When step-title-failing',
                     cid: '0-1',
                     parent: 'feature: scenario',
@@ -426,7 +450,7 @@ describe('cucumber reporter', () => {
                 })
 
                 expect(wdioReporter.emit).toHaveBeenCalledWith('suite:end', expect.objectContaining({
-                    // type: 'suite',
+                    type: 'suite:end',
                     cid: '0-1',
                     parent: 'feature123',
                     uid: 'scenario126',
@@ -444,7 +468,7 @@ describe('cucumber reporter', () => {
                 })
 
                 expect(wdioReporter.emit).toHaveBeenCalledWith('suite:end', expect.objectContaining({
-                    // type: 'suite',
+                    type: 'suite:end',
                     title: 'feature',
                     file: './any.feature',
                     uid: 'feature123',
@@ -552,7 +576,7 @@ describe('cucumber reporter', () => {
             eventBroadcaster.emit('gherkin-document', gherkinDocEvent)
 
             expect(wdioReporter.emit).toHaveBeenCalledWith('suite:start', expect.objectContaining({
-                // type: 'suite',
+                type: 'suite:start',
                 title: '@feature-tag1, @feature-tag2: feature',
                 uid: 'feature123',
                 file: './any.feature',
@@ -583,7 +607,7 @@ describe('cucumber reporter', () => {
             eventBroadcaster.emit('test-case-started', {})
 
             expect(wdioReporter.emit).toHaveBeenCalledWith('suite:start', expect.objectContaining({
-                // type: 'suite',
+                type: 'suite:start',
                 title: '@scenario-tag1, @scenario-tag2: scenario',
                 uid: 'scenario126',
                 file: './any.feature',

--- a/packages/wdio-cucumber-framework/tests/utils.test.js
+++ b/packages/wdio-cucumber-framework/tests/utils.test.js
@@ -1,4 +1,13 @@
-import { createStepArgument, compareScenarioLineWithSourceLine, getStepFromFeature, getTestParent, formatMessage, getUniqueIdentifier, getTestStepTitle } from '../src/utils'
+import {
+    createStepArgument,
+    compareScenarioLineWithSourceLine,
+    getStepFromFeature,
+    getTestParent,
+    formatMessage,
+    getUniqueIdentifier,
+    getTestStepTitle,
+    buildStepPayload
+} from '../src/utils'
 
 describe('utils', () => {
     describe('createStepArgument', () => {
@@ -139,6 +148,18 @@ describe('utils', () => {
         })
         it('should not add undefined step for hooks', () => {
             expect(getTestStepTitle('Some Hook ', '', 'hook')).toEqual('Some Hook')
+        })
+    })
+
+    describe('buildStepPayload', () => {
+        it('params not passed', () => {
+            expect(buildStepPayload('uri', {}, {}, { keyword: 'Foo', location: 'bar' })).toEqual({
+                file: 'uri',
+                keyword: 'Foo',
+                parent: 'Undefined Feature: Undefined Scenario',
+                title: 'Foo Undefined Step',
+                uid: 'undefined',
+            })
         })
     })
 })

--- a/packages/wdio-cucumber-framework/tests/utils.test.js
+++ b/packages/wdio-cucumber-framework/tests/utils.test.js
@@ -69,24 +69,6 @@ describe('utils', () => {
     })
 
     describe('formatMessage', () => {
-        it('should set title for custom type', () => {
-            expect(formatMessage({
-                type: 'foobar',
-                payload: { ctx: { currentTest: { title: 'barfoo' } } }
-            })).toMatchSnapshot()
-        })
-
-        it('should set type to hook:end', () => {
-            expect(formatMessage({
-                type: 'foobar',
-                payload: {
-                    title: '"before all" hook',
-                    error: new Error('boom'),
-                    state: 'passed'
-                }
-            }).type).toBe('hook:end')
-        })
-
         it('should set passed state for test hooks', () => {
             expect(formatMessage({
                 type: 'afterTest',

--- a/packages/wdio-cucumber-framework/tests/utils.test.js
+++ b/packages/wdio-cucumber-framework/tests/utils.test.js
@@ -1,4 +1,4 @@
-import { createStepArgument, compareScenarioLineWithSourceLine, getStepFromFeature, getTestParent, formatMessage, getUniqueIdentifier } from '../src/utils'
+import { createStepArgument, compareScenarioLineWithSourceLine, getStepFromFeature, getTestParent, formatMessage, getUniqueIdentifier, getTestStepTitle } from '../src/utils'
 
 describe('utils', () => {
     describe('createStepArgument', () => {
@@ -130,6 +130,15 @@ describe('utils', () => {
                     }]
                 }]
             }, { line: 123 })).toBe('realval here123')
+        })
+    })
+
+    describe('getTestStepTitle', () => {
+        it('keword and title are not passed', () => {
+            expect(getTestStepTitle()).toEqual('Undefined Step')
+        })
+        it('should not add undefined step for hooks', () => {
+            expect(getTestStepTitle('Some Hook ', '', 'hook')).toEqual('Some Hook')
         })
     })
 })


### PR DESCRIPTION
## Proposed changes

Hook events were emitted like test events that were causing `? HookUndefined Step` to appear.

Now before/after each hooks work like this:
Before hook failure is treated as a test failure.
![image](https://user-images.githubusercontent.com/25589559/61060076-541f4e00-a3fa-11e9-909b-c05e822f5189.png)

After hook failure is added to report as Hook. Sorry to say there is no information on hook type in event payload, maybe there is someway to improve it.
![image](https://user-images.githubusercontent.com/25589559/61060226-82049280-a3fa-11e9-9c42-fb3b8173a558.png)

Passed before/after each hooks are not showing up in report.

fix #4175

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

We don't have listeners for BeforeAll and AfterAll at all, so, in case of success results are not shown, failure are treated as worker errors. These hooks are not a part of this PR and should be handled separately later on.
```
[0-0] BeforeAll
0-0 worker error { name: 'VError',
  message:
   'a BeforeAll hook errored, process exiting: test/step-definitions/given.ts:6: beforeAll error',
  stack:
   'VError: a BeforeAll hook errored, process exiting: test/step-definitions/given.ts:6: beforeAll error\n    at /e2e/node_modules/cucumber/lib/runtime/index.js:68:19\n    at Generator.next (<anonymous>)\n    at asyncGeneratorStep (/e2e/node_modules/cucumber/lib/runtime/index.js:26:103)\n    at _next (/e2e/node_modules/cucumber/lib/runtime/index.js:28:194)' }
[0-0] FAILED in chrome - /test/specs/login-success.feature
```

### Reviewers: @webdriverio/technical-committee
