### PR TITLE
Add EsLint check for dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test:eslint": "rm -fr packages/node_modules && eslint packages examples scripts tests",
     "test:typings": "npm run generate:typings && node tests/typings/copy && npm run ts && npm run clean:tests",
     "test:coverage": "jest --coverage --detectOpenHandles",
-    "test:smoke": "babel-node ./tests/smoke.runner.js",
+    "test:smoke": "npm run link && babel-node ./tests/smoke.runner.js",
     "ts": "run-p ts:*",
     "ts:sync": "cd tests/typings/sync && tsc",
     "ts:sync-mocha": "cd tests/typings/sync-mocha && tsc",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "docs:build": "cd ./website && npm run build && cd ..",
     "docs:deploy": "./scripts/updateDocs.js",
     "test": "run-s test:*",
-    "test:eslint": "rm -r packages/node_modules && eslint packages examples scripts tests",
+    "test:eslint": "rm -fr packages/node_modules && eslint packages examples scripts tests",
     "test:typings": "npm run generate:typings && node tests/typings/copy && npm run ts && npm run clean:tests",
     "test:coverage": "jest --coverage --detectOpenHandles",
     "test:smoke": "babel-node ./tests/smoke.runner.js",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "docs:build": "cd ./website && npm run build && cd ..",
     "docs:deploy": "./scripts/updateDocs.js",
     "test": "run-s test:*",
-    "test:eslint": "eslint packages examples scripts tests",
+    "test:eslint": "rm -r packages/node_modules && eslint packages examples scripts tests",
     "test:typings": "npm run generate:typings && node tests/typings/copy && npm run ts && npm run clean:tests",
     "test:coverage": "jest --coverage --detectOpenHandles",
     "test:smoke": "babel-node ./tests/smoke.runner.js",

--- a/packages/wdio-appium-service/package.json
+++ b/packages/wdio-appium-service/package.json
@@ -34,6 +34,7 @@
     "url": "https://github.com/webdriverio/webdriverio/issues"
   },
   "dependencies": {
+    "@wdio/logger": "^5.11.0",
     "fs-extra": "^8.0.1",
     "param-case": "^2.1.1"
   },

--- a/packages/wdio-crossbrowsertesting-service/package.json
+++ b/packages/wdio-crossbrowsertesting-service/package.json
@@ -30,6 +30,7 @@
     "url": "https://github.com/webdriverio/webdriverio/issues"
   },
   "dependencies": {
+    "@wdio/logger": "^5.11.0",
     "cbt_tunnels": "^0.9.7"
   },
   "peerDependencies": {

--- a/packages/wdio-testingbot-service/package.json
+++ b/packages/wdio-testingbot-service/package.json
@@ -31,6 +31,7 @@
     "url": "https://github.com/webdriverio/webdriverio/issues"
   },
   "dependencies": {
+    "@wdio/logger": "^5.11.0",
     "request": "^2.85.0",
     "testingbot-tunnel-launcher": "^1.1.7"
   },


### PR DESCRIPTION
Yesterday we released a new version where a dependency was added to a sub package but not added as a dependency in the package.json. For some reason an Eslint check for this is not in place. This should be fixed so we don't introduce such bugs again.