### PR TITLE
webdriver: support rebinding of context when invoking origFn in element.overwriteCommand

### DIFF
--- a/packages/wdio-webdriver-mock-service/src/index.js
+++ b/packages/wdio-webdriver-mock-service/src/index.js
@@ -6,6 +6,7 @@ import { newSession, deleteSession } from './mocks/newSession'
 
 const ELEMENT_ID = '401c0039-3306-6a46-a98d-f5939870a249'
 const ELEMENT_REFETCHED = '80d860d0-b829-f540-812e-7078eb983795'
+const ELEMENT_ALT = '8bf4d107-a363-40d1-b823-d94bdbc58afb'
 newSession.value.sessionId = SESSION_ID
 
 export default class WebdriverMockService {
@@ -23,6 +24,7 @@ export default class WebdriverMockService {
         this.command.getTitle().times(2).reply(200, { value: 'Mock Page Title' })
         this.command.getUrl().times(2).reply(200, { value: 'https://mymockpage.com' })
         this.command.getElementRect(ELEMENT_ID).times(2).reply(200, { value: { width: 1, height: 2, x: 3, y: 4 } })
+        this.command.getElementRect(ELEMENT_ALT).times(2).reply(200, { value: { width: 10, height: 20, x: 30, y: 40 } })
         this.command.getLogTypes().reply(200, { value: [] })
     }
 
@@ -109,7 +111,9 @@ export default class WebdriverMockService {
         this.nockReset()
 
         const elemResponse = { 'element-6066-11e4-a52e-4f735466cecf': ELEMENT_ID }
+        const elemAltResponse = { 'element-6066-11e4-a52e-4f735466cecf': ELEMENT_ALT }
         this.command.findElement().times(times).reply(200, { value: elemResponse })
+        this.command.findElement().times(times).reply(200, { value: elemAltResponse })
         this.command.executeScript().times(times).reply(200, { value: '2' })
 
         // overwrite

--- a/packages/webdriver/src/utils.js
+++ b/packages/webdriver/src/utils.js
@@ -382,7 +382,14 @@ export function overwriteElementCommands(propertiesObject) {
         delete propertiesObject[commandName]
 
         const newCommand = function (...args) {
-            return userDefinedCommand.apply(this, [origCommand.bind(this), ...args])
+            const element = this
+            return userDefinedCommand.apply(element, [
+                function origCommandFunction() {
+                    const context = this || element // respect explicite context binding, use element as default
+                    return origCommand.apply(context, arguments)
+                },
+                ...args
+            ])
         }
 
         propertiesObject[commandName] = {

--- a/packages/webdriver/tests/utils.test.js
+++ b/packages/webdriver/tests/utils.test.js
@@ -290,14 +290,33 @@ describe('utils', () => {
     describe('overwriteElementCommands', () => {
         it('should overwrite command', function () {
             const context = {}
+            const origFnMock = jest.fn(() => 1)
             const propertiesObject = {
-                foo: { value() { return 1 } },
+                foo: { value: origFnMock },
                 __elementOverrides__: {
                     value: { foo(origCmd, arg) { return [origCmd(), arg] } }
                 }
             }
             overwriteElementCommands.call(context, propertiesObject)
             expect(propertiesObject.foo.value(5)).toEqual([1, 5])
+            expect(origFnMock.mock.calls.length).toBe(1)
+            expect(origFnMock.mock.instances[0]).toBe(propertiesObject.foo)
+        })
+
+        it('should support rebinding when invoking original fn', function () {
+            const context = {}
+            const origFnMock = jest.fn(() => 1)
+            const origFnContext = {}
+            const propertiesObject = {
+                foo: { value: origFnMock },
+                __elementOverrides__: {
+                    value: { foo(origCmd, arg) { return [origCmd.call(origFnContext), arg] } }
+                }
+            }
+            overwriteElementCommands.call(context, propertiesObject)
+            expect(propertiesObject.foo.value(5)).toEqual([1, 5])
+            expect(origFnMock.mock.calls.length).toBe(1)
+            expect(origFnMock.mock.instances[0]).toBe(origFnContext)
         })
 
         it('should create __elementOverrides__ if not exists', function () {

--- a/tests/mocha/test.js
+++ b/tests/mocha/test.js
@@ -149,6 +149,21 @@ describe('Mocha smoke test', () => {
             )
         })
 
+        it('should allow to invoke native command on different element', () => {
+            browser.customCommandScenario()
+            browser.overwriteCommand('getSize', function (origCommand, ratio = 1) {
+                const elemAlt = $('elemAlt')
+                const { width, height } = origCommand.call(elemAlt)
+                return { width: width * ratio, height: height * ratio }
+            }, true)
+            const elem = $('elem')
+
+            assert.equal(
+                JSON.stringify(elem.getSize(2)),
+                JSON.stringify({ width: 20, height: 40 })
+            )
+        })
+
         it('should keep the scope', () => {
             browser.customCommandScenario()
             browser.overwriteCommand('saveRecordingScreen', function (origCommand, filepath, elem) {


### PR DESCRIPTION
webdriver: support rebinding of context when invoking origFn in `element.overwriteCommand`, fixes https://github.com/webdriverio/webdriverio/issues/4165

## Proposed changes

It is now possible to call the original function in `element.overwriteCommand` with a different context. If no context is set the element is used to keep this backwards compatible.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

### Reviewers: @webdriverio/technical-committee