### PR TITLE
isSauce should not depend on hostname

### DIFF
--- a/packages/webdriver/src/utils.js
+++ b/packages/webdriver/src/utils.js
@@ -286,14 +286,10 @@ export function isAndroid (caps) {
  */
 export function isSauce (hostname, caps) {
     return Boolean(
-        hostname &&
-        hostname.includes('saucelabs') &&
+        caps.extendedDebugging ||
         (
-            caps.extendedDebugging ||
-            (
-                caps['sauce:options'] &&
-                caps['sauce:options'].extendedDebugging
-            )
+            caps['sauce:options'] &&
+            caps['sauce:options'].extendedDebugging
         )
     )
 }

--- a/packages/webdriver/tests/utils.test.js
+++ b/packages/webdriver/tests/utils.test.js
@@ -162,7 +162,7 @@ describe('utils', () => {
 
             requestedCapabilities.w3cCaps.alwaysMatch['sauce:options'] = { extendedDebugging: true }
             expect(environmentDetector({ capabilities, hostname, requestedCapabilities }).isSauce).toBe(true)
-            expect(environmentDetector({ capabilities, requestedCapabilities }).isSauce).toBe(false)
+            expect(environmentDetector({ capabilities, requestedCapabilities }).isSauce).toBe(true)
         })
 
         it('isSeleniumStandalone', () => {

--- a/packages/webdriver/tests/utils.test.js
+++ b/packages/webdriver/tests/utils.test.js
@@ -150,7 +150,7 @@ describe('utils', () => {
         it('isSauce', () => {
             const capabilities = { browserName: 'chrome' }
             let requestedCapabilities = { w3cCaps: { alwaysMatch: {} } }
-            let hostname = 'ondemand.saucelabs.com'
+            let hostname = 'localhost' // isSauce should also be true if run through Sauce Connect
 
             expect(environmentDetector({ capabilities, requestedCapabilities }).isSauce).toBe(false)
             expect(environmentDetector({ capabilities, hostname, requestedCapabilities }).isSauce).toBe(false)


### PR DESCRIPTION
## Proposed changes

Removing the hostname check in the `isSauce` utility as the package should also mark this flag to `true` if the user runs tests through Sauce Connect.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
