### PR TITLE
Print data tables in spec reporter

### DIFF
--- a/packages/wdio-cucumber-framework/src/utils.js
+++ b/packages/wdio-cucumber-framework/src/utils.js
@@ -9,14 +9,14 @@ export function createStepArgument ({ argument }) {
     }
 
     if (argument.type === 'DataTable') {
-        return [{
+        return {
             rows: argument.rows.map(row => (
                 {
                     cells: row.cells.map(cell => cell.value),
                     locations: row.cells.map(cell => cell.location)
                 }
             ))
-        }]
+        }
     }
 
     if (argument.type === 'DocString') {

--- a/packages/wdio-cucumber-framework/tests/__snapshots__/utils.test.js.snap
+++ b/packages/wdio-cucumber-framework/tests/__snapshots__/utils.test.js.snap
@@ -1,60 +1,58 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`utils createStepArgument Works with DataTable 1`] = `
-Array [
-  Object {
-    "rows": Array [
-      Object {
-        "cells": Array [
-          1,
-          2,
-        ],
-        "locations": Array [
-          Object {
-            "column": 11,
-            "line": 21,
-          },
-          Object {
-            "column": 11,
-            "line": 21,
-          },
-        ],
-      },
-      Object {
-        "cells": Array [
-          3,
-          4,
-        ],
-        "locations": Array [
-          Object {
-            "column": 11,
-            "line": 21,
-          },
-          Object {
-            "column": 11,
-            "line": 21,
-          },
-        ],
-      },
-      Object {
-        "cells": Array [
-          5,
-          6,
-        ],
-        "locations": Array [
-          Object {
-            "column": 11,
-            "line": 21,
-          },
-          Object {
-            "column": 11,
-            "line": 21,
-          },
-        ],
-      },
-    ],
-  },
-]
+Object {
+  "rows": Array [
+    Object {
+      "cells": Array [
+        1,
+        2,
+      ],
+      "locations": Array [
+        Object {
+          "column": 11,
+          "line": 21,
+        },
+        Object {
+          "column": 11,
+          "line": 21,
+        },
+      ],
+    },
+    Object {
+      "cells": Array [
+        3,
+        4,
+      ],
+      "locations": Array [
+        Object {
+          "column": 11,
+          "line": 21,
+        },
+        Object {
+          "column": 11,
+          "line": 21,
+        },
+      ],
+    },
+    Object {
+      "cells": Array [
+        5,
+        6,
+      ],
+      "locations": Array [
+        Object {
+          "column": 11,
+          "line": 21,
+        },
+        Object {
+          "column": 11,
+          "line": 21,
+        },
+      ],
+    },
+  ],
+}
 `;
 
 exports[`utils formatMessage should not fail if payload was not passed 1`] = `

--- a/packages/wdio-spec-reporter/package.json
+++ b/packages/wdio-spec-reporter/package.json
@@ -32,7 +32,8 @@
   "dependencies": {
     "@wdio/reporter": "^5.11.0",
     "chalk": "^2.3.2",
-    "pretty-ms": "^5.0.0"
+    "pretty-ms": "^5.0.0",
+    "table": "^5.4.2"
   },
   "peerDependencies": {
     "@wdio/cli": "^5.0.0"

--- a/packages/wdio-spec-reporter/src/index.js
+++ b/packages/wdio-spec-reporter/src/index.js
@@ -1,6 +1,13 @@
 import WDIOReporter from '@wdio/reporter'
 import chalk from 'chalk'
 import prettyMs from 'pretty-ms'
+import { table, getBorderCharacters } from 'table'
+
+export const DATA_TABLE_CONFIG = {
+    singleLine: true,
+    drawHorizontalLine: () => false,
+    border: getBorderCharacters('norc')
+}
 
 class SpecReporter extends WDIOReporter {
     constructor (options) {
@@ -171,6 +178,16 @@ class SpecReporter extends WDIOReporter {
 
                 // Output for a single test
                 output.push(`${testIndent}${this.chalk[this.getColor(state)](this.getSymbol(state))} ${testTitle}`)
+
+                // print cucumber data table cells
+                if (test.argument) {
+                    const cells = test.argument.rows.map((row) => row.cells)
+                    output.push(...table(cells, DATA_TABLE_CONFIG)
+                        .split('\n')
+                        .filter(Boolean)
+                        .map((line) => `${testIndent}  ${line}`)
+                    )
+                }
             }
 
             // Put a line break after each suite (only if tests exist in that suite)

--- a/packages/wdio-spec-reporter/src/index.js
+++ b/packages/wdio-spec-reporter/src/index.js
@@ -180,7 +180,7 @@ class SpecReporter extends WDIOReporter {
                 output.push(`${testIndent}${this.chalk[this.getColor(state)](this.getSymbol(state))} ${testTitle}`)
 
                 // print cucumber data table cells
-                if (test.argument) {
+                if (test.argument && test.argument.rows && test.argument.rows.length) {
                     const cells = test.argument.rows.map((row) => row.cells)
                     output.push(...table(cells, DATA_TABLE_CONFIG)
                         .split('\n')

--- a/packages/wdio-spec-reporter/tests/__fixtures__/testdata.js
+++ b/packages/wdio-spec-reporter/tests/__fixtures__/testdata.js
@@ -1,11 +1,11 @@
 export const RUNNER = {
-    cid : '0-0',
-    _duration : 5032,
+    cid: '0-0',
+    _duration: 5032,
     config: { hostname: 'localhost' },
-    capabilities : {
-        browserName : 'loremipsum',
+    capabilities: {
+        browserName: 'loremipsum',
     },
-    specs : ['/foo/bar/baz.js'],
+    specs: ['/foo/bar/baz.js'],
 }
 
 export const SUITE_UIDS = [
@@ -14,145 +14,162 @@ export const SUITE_UIDS = [
     'Baz test3',
 ]
 
-export const SUITES = [
-    {
-        uid : SUITE_UIDS[0],
-        title : SUITE_UIDS[0].slice(0, -1),
-        hooks: [],
-        tests : [
-            {
-                uid : 'foo1',
-                title : 'foo',
-                state : 'passed',
-            },
-            {
-                uid : 'bar1',
-                title : 'bar',
-                state : 'passed',
-            }
-        ],
-    },
-    {
-        uid : SUITE_UIDS[1],
-        title : SUITE_UIDS[1].slice(0, -1),
-        hooks: [],
-        tests : [
-            {
-                uid : 'some test1',
-                title : 'some test',
-                state : 'passed',
-            },
-            {
-                uid : 'a failed test2',
-                title : 'a failed test',
-                state : 'failed',
-                error : {
-                    message : 'expected foo to equal bar',
-                    stack : 'Failed test stack trace'
-                }
-            },
-            {
-                uid : 'a failed test3',
-                title : 'a failed test with no stack',
-                state : 'failed',
-                error : {
-                    message : 'expected foo to equal bar'
-                }
-            }
-        ],
-    },
-    {
-        uid : SUITE_UIDS[2],
-        title : SUITE_UIDS[2].slice(0, -1),
-        hooks: [],
-        tests : [
-            {
-                uid : 'foo bar baz1',
-                title : 'foo bar baz',
-                state : 'passed',
-            },
-            {
-                uid : 'a skipped test2',
-                title : 'a skipped test',
-                state : 'skipped',
-            }],
-    }
-]
+export const SUITES = [{
+    uid: SUITE_UIDS[0],
+    title: SUITE_UIDS[0].slice(0, -1),
+    hooks: [],
+    tests: [{
+        uid: 'foo1',
+        title: 'foo',
+        state: 'passed',
+    }, {
+        uid: 'bar1',
+        title: 'bar',
+        state: 'passed',
+    }]
+}, {
+    uid: SUITE_UIDS[1],
+    title: SUITE_UIDS[1].slice(0, -1),
+    hooks: [],
+    tests: [{
+        uid: 'some test1',
+        title: 'some test',
+        state: 'passed',
+    }, {
+        uid: 'a failed test2',
+        title: 'a failed test',
+        state: 'failed',
+        error: {
+            message: 'expected foo to equal bar',
+            stack: 'Failed test stack trace'
+        }
+    }, {
+        uid: 'a failed test3',
+        title: 'a failed test with no stack',
+        state: 'failed',
+        error: {
+            message: 'expected foo to equal bar'
+        }
+    }]
+}, {
+    uid: SUITE_UIDS[2],
+    title: SUITE_UIDS[2].slice(0, -1),
+    hooks: [],
+    tests: [{
+        uid: 'foo bar baz1',
+        title: 'foo bar baz',
+        state: 'passed',
+    }, {
+        uid: 'a skipped test2',
+        title: 'a skipped test',
+        state: 'skipped',
+    }]
+}]
 
-export const SUITES_MULTIPLE_ERRORS = [
-    {
-        uid : SUITE_UIDS[0],
-        title : SUITE_UIDS[0].slice(0, -1),
-        hooks: [],
-        tests : [
-            {
-                uid : 'foo1',
-                title : 'foo',
-                state : 'passed',
-            },
-            {
-                uid : 'bar1',
-                title : 'bar',
-                state : 'passed',
-            }
-        ],
-    },
-    {
-        uid : SUITE_UIDS[1],
-        title : SUITE_UIDS[1].slice(0, -1),
-        hooks: [],
-        tests : [
-            {
-                uid : 'some test1',
-                title : 'some test',
-                state : 'passed',
-            },
-            {
-                uid : 'a failed test',
-                title : 'a test with two failures',
-                state : 'failed',
-                errors : [
-                    {
-                        message : 'expected the party on the first part to be the party on the first part',
-                        stack : 'First failed stack trace'
-                    },
-                    {
-                        message : 'expected the party on the second part to be the party on the second part',
-                        stack : 'Second failed stack trace'
-                    }
-                ]
-            }
-        ],
-    },
-]
+export const SUITES_WITH_DATA_TABLE = [{
+    uid: SUITE_UIDS[0],
+    title: SUITE_UIDS[0].slice(0, -1),
+    hooks: [],
+    tests: [{
+        uid: 'foo1',
+        title: 'foo',
+        state: 'passed',
+        argument: {
+            rows: [{
+                cells: ['Vegetable', 'Rating'],
+                locations: [{
+                    line: 23, column: 15
+                }, {
+                    line: 23, column: 27
+                }]
+            }, {
+                cells: ['Apricot', 5],
+                locations: [{
+                    line: 24, column: 15
+                }, {
+                    line: 24, column: 27
+                }]
+            }, {
+                cells: ['Brocolli', 2],
+                locations: [{
+                    line: 25, column: 15
+                }, {
+                    line: 25, column: 27
+                }]
+            }, {
+                cells: ['Cucumber', 10],
+                locations: [{
+                    line: 26, column: 15
+                }, {
+                    line: 26, column: 27
+                }]
+            }]
+        }
+    }, {
+        uid: 'bar1',
+        title: 'bar',
+        state: 'passed',
+    }]
+}]
 
-export const SUITES_NO_TESTS = [
-    {
-        uid: SUITE_UIDS[0],
-        title: SUITE_UIDS[0].slice(0, -1),
-        tests: [],
-        suites: [],
-        hooks: []
-    },
-]
-
-export const SUITES_NO_TESTS_WITH_HOOK_ERROR = [
-    {
-        uid: SUITE_UIDS[0],
-        title: SUITE_UIDS[0].slice(0, -1),
-        tests: [],
-        suites: [],
-        hooks: [{
-            uid : 'a failed hook2',
-            title : 'a failed hook',
-            state : 'failed',
-            error : {
-                message : 'expected foo to equal bar',
-                stack : 'Failed test stack trace'
-            }
+export const SUITES_MULTIPLE_ERRORS = [{
+    uid: SUITE_UIDS[0],
+    title: SUITE_UIDS[0].slice(0, -1),
+    hooks: [],
+    tests: [{
+        uid: 'foo1',
+        title: 'foo',
+        state: 'passed',
+    }, {
+        uid: 'bar1',
+        title: 'bar',
+        state: 'passed',
+    }]
+}, {
+    uid: SUITE_UIDS[1],
+    title: SUITE_UIDS[1].slice(0, -1),
+    hooks: [],
+    tests: [{
+        uid: 'some test1',
+        title: 'some test',
+        state: 'passed',
+    }, {
+        uid: 'a failed test',
+        title: 'a test with two failures',
+        state: 'failed',
+        errors: [{
+            message: 'expected the party on the first part to be the party on the first part',
+            stack: 'First failed stack trace'
+        }, {
+            message: 'expected the party on the second part to be the party on the second part',
+            stack: 'Second failed stack trace'
         }]
-    },
-]
+    }]
+}]
+
+export const SUITES_NO_TESTS = [{
+    uid: SUITE_UIDS[0],
+    title: SUITE_UIDS[0].slice(0, -1),
+    tests: [],
+    suites: [],
+    hooks: []
+}]
+
+export const SUITES_NO_TESTS_WITH_HOOK_ERROR = [{
+    uid: SUITE_UIDS[0],
+    title: SUITE_UIDS[0].slice(0, -1),
+    tests: [],
+    suites: [],
+    hooks: [{
+        uid: 'a failed hook2',
+        title: 'a failed hook',
+        state: 'failed',
+        error: {
+            message: 'expected foo to equal bar',
+            stack: 'Failed test stack trace'
+        }
+    }]
+}]
 
 export const REPORT = `------------------------------------------------------------------
 [loremipsum #0-0] Spec: /foo/bar/baz.js

--- a/packages/wdio-spec-reporter/tests/__snapshots__/index.test.js.snap
+++ b/packages/wdio-spec-reporter/tests/__snapshots__/index.test.js.snap
@@ -1,0 +1,32 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SpecReporter getResultDisplay should print data tables 1`] = `
+Array [
+  "Foo test",
+  "   green ✓ foo",
+  "     │ Vegetable │ Rating │",
+  "     │ Apricot   │ 5      │",
+  "     │ Brocolli  │ 2      │",
+  "     │ Cucumber  │ 10     │",
+  "   green ✓ bar",
+  "",
+]
+`;
+
+exports[`SpecReporter getResultDisplay should validate the result output with tests 1`] = `
+Array [
+  "Foo test",
+  "   green ✓ foo",
+  "   green ✓ bar",
+  "",
+  "Bar test",
+  "   green ✓ some test",
+  "   red ✖ a failed test",
+  "   red ✖ a failed test with no stack",
+  "",
+  "Baz test",
+  "   green ✓ foo bar baz",
+  "   cyan - a skipped test",
+  "",
+]
+`;

--- a/packages/wdio-spec-reporter/tests/__snapshots__/index.test.js.snap
+++ b/packages/wdio-spec-reporter/tests/__snapshots__/index.test.js.snap
@@ -1,5 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`SpecReporter getResultDisplay should not print if data table format is not given 1`] = `
+Array [
+  "Foo test",
+  "   green ✓ foo",
+  "   green ✓ bar",
+  "",
+]
+`;
+
+exports[`SpecReporter getResultDisplay should not print if data table is empty 1`] = `
+Array [
+  "Foo test",
+  "   green ✓ foo",
+  "   green ✓ bar",
+  "",
+]
+`;
+
 exports[`SpecReporter getResultDisplay should print data tables 1`] = `
 Array [
   "Foo test",

--- a/packages/wdio-spec-reporter/tests/index.test.js
+++ b/packages/wdio-spec-reporter/tests/index.test.js
@@ -5,6 +5,7 @@ import {
     SUITE_UIDS,
     SUITES,
     SUITES_NO_TESTS,
+    SUITES_WITH_DATA_TABLE,
     REPORT,
     SAUCELABS_REPORT,
     SAUCELABS_EU_REPORT,
@@ -260,21 +261,7 @@ describe('SpecReporter', () => {
             tmpReporter.suites = SUITES
 
             const result = tmpReporter.getResultDisplay()
-
-            expect(result.length).toBe(13)
-            expect(result[0]).toBe('Foo test')
-            expect(result[1]).toBe('   green ✓ foo')
-            expect(result[2]).toBe('   green ✓ bar')
-            expect(result[3]).toBe('')
-            expect(result[4]).toBe('Bar test')
-            expect(result[5]).toBe('   green ✓ some test')
-            expect(result[6]).toBe('   red ✖ a failed test')
-            expect(result[7]).toBe('   red ✖ a failed test with no stack')
-            expect(result[8]).toBe('')
-            expect(result[9]).toBe('Baz test')
-            expect(result[10]).toBe('   green ✓ foo bar baz')
-            expect(result[11]).toBe('   cyan - a skipped test')
-            expect(result[12]).toBe('')
+            expect(result).toMatchSnapshot()
         })
 
         it('should validate the result output with no tests', () => {
@@ -282,8 +269,15 @@ describe('SpecReporter', () => {
             tmpReporter.suites = SUITES_NO_TESTS
 
             const result = tmpReporter.getResultDisplay()
-
             expect(result.length).toBe(0)
+        })
+
+        it('should print data tables', () => {
+            tmpReporter.getOrderedSuites = jest.fn(() => SUITES_WITH_DATA_TABLE)
+            tmpReporter.suites = SUITES_WITH_DATA_TABLE
+
+            const result = tmpReporter.getResultDisplay()
+            expect(result).toMatchSnapshot()
         })
     })
 

--- a/packages/wdio-spec-reporter/tests/index.test.js
+++ b/packages/wdio-spec-reporter/tests/index.test.js
@@ -279,6 +279,27 @@ describe('SpecReporter', () => {
             const result = tmpReporter.getResultDisplay()
             expect(result).toMatchSnapshot()
         })
+
+        it('should not print if data table format is not given', () => {
+            tmpReporter.getOrderedSuites = jest.fn(() => {
+                const suites = JSON.parse(JSON.stringify(SUITES_WITH_DATA_TABLE))
+                suites[0].tests[0].argument = 'some different format'
+                return suites
+            })
+            const result = tmpReporter.getResultDisplay()
+            expect(result).toMatchSnapshot()
+        })
+
+        it('should not print if data table is empty', () => {
+            tmpReporter.getOrderedSuites = jest.fn(() => {
+                const suites = JSON.parse(JSON.stringify(SUITES_WITH_DATA_TABLE))
+                suites[0].tests[0].argument.rows = []
+                return suites
+            })
+
+            const result = tmpReporter.getResultDisplay()
+            expect(result).toMatchSnapshot()
+        })
     })
 
     describe('getCountDisplay', () => {


### PR DESCRIPTION
## Proposed changes

This patch allows our spec reporter to print the data table into the report:

<img width="701" alt="Screen Shot 2019-07-16 at 11 31 37 AM" src="https://user-images.githubusercontent.com/731337/61284377-1f771200-a7bf-11e9-9074-fb343c101b51.png">

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

closes #4199

### Reviewers: @webdriverio/technical-committee
