### PR TITLE
Print link to Sauce Labs job details page when using Sauce Connect

### DIFF
--- a/packages/wdio-spec-reporter/src/index.js
+++ b/packages/wdio-spec-reporter/src/index.js
@@ -95,7 +95,15 @@ class SpecReporter extends WDIOReporter {
      * get link to saucelabs job
      */
     getTestLink ({ config, sessionId }) {
-        if (config.hostname.includes('saucelabs')) {
+        const isSauceJob = (
+            config.hostname.includes('saucelabs') ||
+            // check w3c caps
+            config.capabilities['sauce:options'] ||
+            // check jsonwp caps
+            config.capabilities.tunnelIdentifier
+        )
+
+        if (isSauceJob) {
             const dc = config.headless
                 ? '.us-east-1'
                 : ['eu', 'eu-central-1'].includes(config.region) ? '.eu-central-1' : ''

--- a/packages/wdio-spec-reporter/src/index.js
+++ b/packages/wdio-spec-reporter/src/index.js
@@ -97,10 +97,13 @@ class SpecReporter extends WDIOReporter {
     getTestLink ({ config, sessionId }) {
         const isSauceJob = (
             config.hostname.includes('saucelabs') ||
-            // check w3c caps
-            config.capabilities['sauce:options'] ||
-            // check jsonwp caps
-            config.capabilities.tunnelIdentifier
+            // only show if multiremote is not used
+            config.capabilities && (
+                // check w3c caps
+                config.capabilities['sauce:options'] ||
+                // check jsonwp caps
+                config.capabilities.tunnelIdentifier
+            )
         )
 
         if (isSauceJob) {

--- a/packages/wdio-spec-reporter/tests/index.test.js
+++ b/packages/wdio-spec-reporter/tests/index.test.js
@@ -15,6 +15,14 @@ import {
 
 const reporter = new SpecReporter({})
 
+const fakeSessionId = 'ba86cbcb70774ef8a0757c1702c3bdf9'
+const getRunnerConfig = (config) => {
+    return Object.assign({}, RUNNER, {
+        config,
+        sessionId: fakeSessionId
+    })
+}
+
 describe('SpecReporter', () => {
     let tmpReporter = null
 
@@ -143,141 +151,83 @@ describe('SpecReporter', () => {
             printReporter.write = jest.fn()
         })
 
-        it('should print the report to the console', () => {
-            printReporter.suiteUids = SUITE_UIDS
-            printReporter.suites = SUITES
-            printReporter.stateCounts = {
-                passed : 4,
-                failed : 1,
-                skipped : 1,
-            }
-
-            const runner = Object.assign({}, RUNNER, {
-                config: {
-                    hostname: 'localhost'
-                },
-                sessionId: 'ba86cbcb70774ef8a0757c1702c3bdf9'
+        describe('with normal setup', () => {
+            beforeEach(() => {
+                printReporter.suiteUids = SUITE_UIDS
+                printReporter.suites = SUITES
+                printReporter.stateCounts = {
+                    passed : 4,
+                    failed : 1,
+                    skipped : 1,
+                }
             })
-            printReporter.printReport(runner)
 
-            expect(printReporter.write).toBeCalledWith(REPORT)
-        })
+            it('should print the report to the console', () => {
+                const runner = getRunnerConfig({ hostname: 'localhost' })
+                printReporter.printReport(runner)
+                expect(printReporter.write).toBeCalledWith(REPORT)
+            })
 
-        it('should print link to SauceLabs job details page', () => {
-            printReporter.suiteUids = SUITE_UIDS
-            printReporter.suites = SUITES
-            printReporter.stateCounts = {
-                passed : 4,
-                failed : 1,
-                skipped : 1,
-            }
-
-            const runner = Object.assign({}, RUNNER, {
-                config: {
+            it('should print link to SauceLabs job details page', () => {
+                const runner = getRunnerConfig({
                     hostname: 'ondemand.saucelabs.com',
                     capabilities: {}
-                },
-                sessionId: 'ba86cbcb70774ef8a0757c1702c3bdf9'
+                })
+                printReporter.printReport(runner)
+                expect(printReporter.write).toBeCalledWith(SAUCELABS_REPORT)
             })
-            printReporter.printReport(runner)
 
-            expect(printReporter.write).toBeCalledWith(SAUCELABS_REPORT)
-        })
-
-        it('should print link to SauceLabs job details page if run with Sauce Connect (w3c)', () => {
-            printReporter.suiteUids = SUITE_UIDS
-            printReporter.suites = SUITES
-            printReporter.stateCounts = {
-                passed : 4,
-                failed : 1,
-                skipped : 1,
-            }
-
-            const runner = Object.assign({}, RUNNER, {
-                config: {
+            it('should print link to SauceLabs job details page if run with Sauce Connect (w3c)', () => {
+                const runner = getRunnerConfig({
                     capabilities: { 'sauce:options': 'foobar' },
                     hostname: 'localhost'
-                },
-                sessionId: 'ba86cbcb70774ef8a0757c1702c3bdf9'
+                })
+                printReporter.printReport(runner)
+                expect(printReporter.write).toBeCalledWith(SAUCELABS_REPORT)
             })
-            printReporter.printReport(runner)
 
-            expect(printReporter.write).toBeCalledWith(SAUCELABS_REPORT)
-        })
-
-        it('should print link to SauceLabs job details page if run with Sauce Connect (jsonwp)', () => {
-            printReporter.suiteUids = SUITE_UIDS
-            printReporter.suites = SUITES
-            printReporter.stateCounts = {
-                passed : 4,
-                failed : 1,
-                skipped : 1,
-            }
-
-            const runner = Object.assign({}, RUNNER, {
-                config: {
+            it('should print link to SauceLabs job details page if run with Sauce Connect (jsonwp)', () => {
+                const runner = getRunnerConfig({
                     capabilities: { tunnelIdentifier: 'foobar' },
                     hostname: 'localhost'
-                },
-                sessionId: 'ba86cbcb70774ef8a0757c1702c3bdf9'
+                })
+                printReporter.printReport(runner)
+                expect(printReporter.write).toBeCalledWith(SAUCELABS_REPORT)
             })
-            printReporter.printReport(runner)
 
-            expect(printReporter.write).toBeCalledWith(SAUCELABS_REPORT)
-        })
-
-        it('should print link to SauceLabs EU job details page', () => {
-            printReporter.suiteUids = SUITE_UIDS
-            printReporter.suites = SUITES
-            printReporter.stateCounts = {
-                passed : 4,
-                failed : 1,
-                skipped : 1,
-            }
-
-            printReporter.printReport(Object.assign({}, RUNNER, {
-                config: {
+            it('should print link to SauceLabs EU job details page', () => {
+                printReporter.printReport(getRunnerConfig({
                     capabilities: {},
                     hostname: 'ondemand.saucelabs.com',
                     region: 'eu'
-                },
-                sessionId: 'ba86cbcb70774ef8a0757c1702c3bdf9'
-            }))
-            expect(printReporter.write).toBeCalledWith(SAUCELABS_EU_REPORT)
+                }))
+                expect(printReporter.write).toBeCalledWith(SAUCELABS_EU_REPORT)
 
-            printReporter.write.mockClear()
+                printReporter.write.mockClear()
 
-            printReporter.printReport(Object.assign({}, RUNNER, {
-                config: {
+                printReporter.printReport(getRunnerConfig({
                     capabilities: {},
                     hostname: 'ondemand.saucelabs.com',
                     region: 'eu-central-1'
-                },
-                sessionId: 'ba86cbcb70774ef8a0757c1702c3bdf9'
-            }))
-            expect(printReporter.write).toBeCalledWith(SAUCELABS_EU_REPORT)
+                }))
+                expect(printReporter.write).toBeCalledWith(SAUCELABS_EU_REPORT)
 
-            printReporter.printReport(Object.assign({}, RUNNER, {
-                config: {
+                printReporter.printReport(getRunnerConfig({
                     capabilities: {},
                     hostname: 'ondemand.saucelabs.com',
                     headless: true
-                },
-                sessionId: 'ba86cbcb70774ef8a0757c1702c3bdf9'
-            }))
-            expect(printReporter.write).toBeCalledWith(SAUCELABS_HEADLESS_REPORT)
+                }))
+                expect(printReporter.write).toBeCalledWith(SAUCELABS_HEADLESS_REPORT)
+            })
         })
 
         it('should print report for suites with no tests but failed hooks', () => {
             printReporter.suiteUids = SUITE_UIDS
             printReporter.suites = SUITES_NO_TESTS_WITH_HOOK_ERROR
 
-            const runner = Object.assign({}, RUNNER, {
-                config: {
-                    capabilities: {},
-                    hostname: 'localhost'
-                },
-                sessionId: 'ba86cbcb70774ef8a0757c1702c3bdf9'
+            const runner = getRunnerConfig({
+                capabilities: {},
+                hostname: 'localhost'
             })
             printReporter.printReport(runner)
 

--- a/packages/wdio-spec-reporter/tests/index.test.js
+++ b/packages/wdio-spec-reporter/tests/index.test.js
@@ -154,8 +154,7 @@ describe('SpecReporter', () => {
 
             const runner = Object.assign({}, RUNNER, {
                 config: {
-                    hostname: 'localhost',
-                    capabilities: {}
+                    hostname: 'localhost'
                 },
                 sessionId: 'ba86cbcb70774ef8a0757c1702c3bdf9'
             })

--- a/packages/wdio-spec-reporter/tests/index.test.js
+++ b/packages/wdio-spec-reporter/tests/index.test.js
@@ -152,7 +152,14 @@ describe('SpecReporter', () => {
                 skipped : 1,
             }
 
-            printReporter.printReport(RUNNER)
+            const runner = Object.assign({}, RUNNER, {
+                config: {
+                    hostname: 'localhost',
+                    capabilities: {}
+                },
+                sessionId: 'ba86cbcb70774ef8a0757c1702c3bdf9'
+            })
+            printReporter.printReport(runner)
 
             expect(printReporter.write).toBeCalledWith(REPORT)
         })
@@ -167,7 +174,52 @@ describe('SpecReporter', () => {
             }
 
             const runner = Object.assign({}, RUNNER, {
-                config: { hostname: 'ondemand.saucelabs.com' },
+                config: {
+                    hostname: 'ondemand.saucelabs.com',
+                    capabilities: {}
+                },
+                sessionId: 'ba86cbcb70774ef8a0757c1702c3bdf9'
+            })
+            printReporter.printReport(runner)
+
+            expect(printReporter.write).toBeCalledWith(SAUCELABS_REPORT)
+        })
+
+        it('should print link to SauceLabs job details page if run with Sauce Connect (w3c)', () => {
+            printReporter.suiteUids = SUITE_UIDS
+            printReporter.suites = SUITES
+            printReporter.stateCounts = {
+                passed : 4,
+                failed : 1,
+                skipped : 1,
+            }
+
+            const runner = Object.assign({}, RUNNER, {
+                config: {
+                    capabilities: { 'sauce:options': 'foobar' },
+                    hostname: 'localhost'
+                },
+                sessionId: 'ba86cbcb70774ef8a0757c1702c3bdf9'
+            })
+            printReporter.printReport(runner)
+
+            expect(printReporter.write).toBeCalledWith(SAUCELABS_REPORT)
+        })
+
+        it('should print link to SauceLabs job details page if run with Sauce Connect (jsonwp)', () => {
+            printReporter.suiteUids = SUITE_UIDS
+            printReporter.suites = SUITES
+            printReporter.stateCounts = {
+                passed : 4,
+                failed : 1,
+                skipped : 1,
+            }
+
+            const runner = Object.assign({}, RUNNER, {
+                config: {
+                    capabilities: { tunnelIdentifier: 'foobar' },
+                    hostname: 'localhost'
+                },
                 sessionId: 'ba86cbcb70774ef8a0757c1702c3bdf9'
             })
             printReporter.printReport(runner)
@@ -186,6 +238,7 @@ describe('SpecReporter', () => {
 
             printReporter.printReport(Object.assign({}, RUNNER, {
                 config: {
+                    capabilities: {},
                     hostname: 'ondemand.saucelabs.com',
                     region: 'eu'
                 },
@@ -197,6 +250,7 @@ describe('SpecReporter', () => {
 
             printReporter.printReport(Object.assign({}, RUNNER, {
                 config: {
+                    capabilities: {},
                     hostname: 'ondemand.saucelabs.com',
                     region: 'eu-central-1'
                 },
@@ -206,6 +260,7 @@ describe('SpecReporter', () => {
 
             printReporter.printReport(Object.assign({}, RUNNER, {
                 config: {
+                    capabilities: {},
                     hostname: 'ondemand.saucelabs.com',
                     headless: true
                 },
@@ -218,7 +273,14 @@ describe('SpecReporter', () => {
             printReporter.suiteUids = SUITE_UIDS
             printReporter.suites = SUITES_NO_TESTS_WITH_HOOK_ERROR
 
-            printReporter.printReport(RUNNER)
+            const runner = Object.assign({}, RUNNER, {
+                config: {
+                    capabilities: {},
+                    hostname: 'localhost'
+                },
+                sessionId: 'ba86cbcb70774ef8a0757c1702c3bdf9'
+            })
+            printReporter.printReport(runner)
 
             expect(printReporter.write.mock.calls.length).toBe(1)
             expect(printReporter.write.mock.calls[0][0]).toContain('a failed hook')


### PR DESCRIPTION
## Proposed changes

When using Sauce Connect the spec reporter wouldn't provide the link to the job details page. This link fixes it.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

closes #4197

### Reviewers: @webdriverio/technical-committee
