### PR TITLE
WebDriverIO v5 cucumberOpts is not included in WebdriverIO.Config typescript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ See [CHANGELOG - v4](https://github.com/webdriverio-boneyard/v4/blob/master/CHAN
 * `webdriver`
   * [#4194](https://github.com/webdriverio/webdriverio/pull/4194) isSauce should not depend on hostname ([@christian-bromann](https://github.com/christian-bromann))
 
+#### :nail_care: Polish
+* `wdio-webdriver-mock-service`, `webdriver`
+  * [#4186](https://github.com/webdriverio/webdriverio/pull/4186) webdriver: support rebinding of context when invoking origFn in element.overwriteCommand ([@akloeber](https://github.com/akloeber))
+
 #### Committers: 2
 - Andreas Klöber ([@akloeber](https://github.com/akloeber))
 - Christian Bromann ([@christian-bromann](https://github.com/christian-bromann))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@ See [CHANGELOG - v4](https://github.com/webdriverio-boneyard/v4/blob/master/CHAN
 
 ---
 
+## v5.11.5 (2019-07-15)
+
+#### :bug: Bug Fix
+* `webdriver`
+  * [#4194](https://github.com/webdriverio/webdriverio/pull/4194) isSauce should not depend on hostname ([@christian-bromann](https://github.com/christian-bromann))
+
+#### Committers: 2
+- Andreas Klöber ([@akloeber](https://github.com/akloeber))
+- Christian Bromann ([@christian-bromann](https://github.com/christian-bromann))
+
 ## v5.11.4 (2019-07-12)
 
 #### :bug: Bug Fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,30 @@ See [CHANGELOG - v4](https://github.com/webdriverio-boneyard/v4/blob/master/CHAN
 
 ---
 
+## v5.11.6 (2019-07-17)
+
+#### :bug: Bug Fix
+* `wdio-spec-reporter`
+  * [#4204](https://github.com/webdriverio/webdriverio/pull/4204) Print link to Sauce Labs job details page when using Sauce Connect ([@christian-bromann](https://github.com/christian-bromann))
+* `webdriverio`
+  * [#4202](https://github.com/webdriverio/webdriverio/pull/4202) Fix overflow text is displayed ([@mgrybyk](https://github.com/mgrybyk))
+
+#### :nail_care: Polish
+* `webdriverio`
+  * [#4211](https://github.com/webdriverio/webdriverio/pull/4211) clean up setTimeout implementation ([@christian-bromann](https://github.com/christian-bromann))
+* `wdio-cucumber-framework`, `wdio-spec-reporter`
+  * [#4201](https://github.com/webdriverio/webdriverio/pull/4201) Print data tables in spec reporter ([@christian-bromann](https://github.com/christian-bromann))
+
+#### :memo: Documentation
+* [#4189](https://github.com/webdriverio/webdriverio/pull/4189) Fix type for webdriverio onPrepare parameter ([@archonandrewhunt](https://github.com/archonandrewhunt))
+* [#4117](https://github.com/webdriverio/webdriverio/pull/4117) Updated selectors documentation for element ID ([@reds71](https://github.com/reds71))
+
+#### Committers: 4
+- Christian Bromann ([@christian-bromann](https://github.com/christian-bromann))
+- Mykola Grybyk ([@mgrybyk](https://github.com/mgrybyk))
+- Stéphane Rouges ([@reds71](https://github.com/reds71))
+- [@archonandrewhunt](https://github.com/archonandrewhunt)
+
 ## v5.11.5 (2019-07-15)
 
 #### :bug: Bug Fix

--- a/README.md
+++ b/README.md
@@ -83,12 +83,13 @@ If you're looking for issues to help out with, check out [the issues labelled "g
 ### Runner
 
 - [@wdio/local-runner](https://github.com/webdriverio/webdriverio/tree/master/packages/wdio-local-runner) - A WebdriverIO runner to run tests locally
-- [@wdio/lambda-runner](https://github.com/webdriverio/webdriverio/tree/master/packages/wdio-lambda-runner) - A WebdriverIO plugin that allows you to run tests on AWS using Lambda functions
+- [@wdio/lambda-runner](https://github.com/webdriverio/webdriverio/tree/master/packages/wdio-lambda-runner) - A WebdriverIO plugin that allows you to run tests on Lambda functions (experimental)
 
 ### Framework Adapters
 
 - [@wdio/mocha-framework](https://github.com/webdriverio/webdriverio/tree/master/packages/wdio-mocha-framework) - Adapter for [Mocha](https://mochajs.org/) testing framework.
 - [@wdio/jasmine-framework](https://github.com/webdriverio/webdriverio/tree/master/packages/wdio-jasmine-framework) - Adapter for [Jasmine](https://jasmine.github.io/) testing framework
+- [@wdio/cucumber-framework](https://github.com/webdriverio/webdriverio/tree/master/packages/wdio-cucumber-framework) - Adapter for [Cucumber](https://cucumber.io/) testing framework
 
 ### Others
 

--- a/docs/Selectors.md
+++ b/docs/Selectors.md
@@ -105,22 +105,6 @@ const classNameAndText = $('<my-element />');
 console.log(classNameAndText.getText()); // outputs: "WebdriverIO is the best"
 ```
 
-## id
-
-To find an element using an element using their id, query it by using `id=` in front of the query string (e.g. `id=driver`).
-Note: you can use id in css selectors by using `#` before the id name. See [element with certain text](#element-with-certain-text).
-
-```html
-<a id="driver" href="https://webdriver.io">WebdriverIO</a>
-```
-
-You can query this element with id by calling:
-
-```js
-const id = $('id=driver');
-console.log(id.getText()); // outputs: "WebdriverIO"
-```
-
 ## xPath
 
 It is also possible to query elements via a specific [xPath](https://developer.mozilla.org/en-US/docs/Web/XPath). The selector has to have a format like `//BODY/DIV[6]/DIV[1]/SPAN[1]`.
@@ -147,6 +131,9 @@ You can use xPath to also traverse up and down the DOM tree, e.g.
 const parent = paragraph.$('..');
 console.log(parent.getTagName()); // outputs: "body"
 ```
+## id
+
+Finding element by id has no specific syntax in WebDriver and one should use either CSS selectors (`#<my element ID>`) or xPath (`//*[@id="<my element ID>"]`). However some drivers (e.g. [Appium You.i Engine Driver](https://github.com/YOU-i-Labs/appium-youiengine-driver#selector-strategies)) might still [support](https://github.com/YOU-i-Labs/appium-youiengine-driver#selector-strategies) this selector.
 
 ## JS Function
 

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "5.11.5",
+  "version": "5.11.6",
   "changelog": {
     "repo": "webdriverio/webdriverio",
     "cacheDir": ".changelog",

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "5.11.4",
+  "version": "5.11.5",
   "changelog": {
     "repo": "webdriverio/webdriverio",
     "cacheDir": ".changelog",

--- a/packages/wdio-cli/package.json
+++ b/packages/wdio-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wdio/cli",
-  "version": "5.11.2",
+  "version": "5.11.5",
   "description": "WebdriverIO testrunner command line interface",
   "author": "Christian Bromann <christian@saucelabs.com>",
   "homepage": "https://github.com/webdriverio/webdriverio/tree/master/packages/wdio-cli",
@@ -50,7 +50,7 @@
     "lodash.pickby": "^4.6.0",
     "lodash.union": "^4.6.0",
     "log-update": "^3.2.0",
-    "webdriverio": "^5.11.2",
+    "webdriverio": "^5.11.5",
     "yargs": "^13.2.4",
     "yarn-install": "^1.0.0"
   },

--- a/packages/wdio-cli/package.json
+++ b/packages/wdio-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wdio/cli",
-  "version": "5.11.5",
+  "version": "5.11.6",
   "description": "WebdriverIO testrunner command line interface",
   "author": "Christian Bromann <christian@saucelabs.com>",
   "homepage": "https://github.com/webdriverio/webdriverio/tree/master/packages/wdio-cli",
@@ -50,7 +50,7 @@
     "lodash.pickby": "^4.6.0",
     "lodash.union": "^4.6.0",
     "log-update": "^3.2.0",
-    "webdriverio": "^5.11.5",
+    "webdriverio": "^5.11.6",
     "yargs": "^13.2.4",
     "yarn-install": "^1.0.0"
   },

--- a/packages/wdio-cucumber-framework/package.json
+++ b/packages/wdio-cucumber-framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wdio/cucumber-framework",
-  "version": "5.11.3",
+  "version": "5.11.6",
   "description": "A WebdriverIO plugin. Adapter for Cucumber.js testing framework.",
   "author": "Christian Bromann <christian@saucelabs.com>",
   "homepage": "https://github.com/webdriverio/webdriverio/tree/master/packages/wdio-cucumber-framework",

--- a/packages/wdio-cucumber-framework/src/utils.js
+++ b/packages/wdio-cucumber-framework/src/utils.js
@@ -9,14 +9,14 @@ export function createStepArgument ({ argument }) {
     }
 
     if (argument.type === 'DataTable') {
-        return [{
+        return {
             rows: argument.rows.map(row => (
                 {
                     cells: row.cells.map(cell => cell.value),
                     locations: row.cells.map(cell => cell.location)
                 }
             ))
-        }]
+        }
     }
 
     if (argument.type === 'DocString') {

--- a/packages/wdio-cucumber-framework/tests/__snapshots__/utils.test.js.snap
+++ b/packages/wdio-cucumber-framework/tests/__snapshots__/utils.test.js.snap
@@ -1,60 +1,58 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`utils createStepArgument Works with DataTable 1`] = `
-Array [
-  Object {
-    "rows": Array [
-      Object {
-        "cells": Array [
-          1,
-          2,
-        ],
-        "locations": Array [
-          Object {
-            "column": 11,
-            "line": 21,
-          },
-          Object {
-            "column": 11,
-            "line": 21,
-          },
-        ],
-      },
-      Object {
-        "cells": Array [
-          3,
-          4,
-        ],
-        "locations": Array [
-          Object {
-            "column": 11,
-            "line": 21,
-          },
-          Object {
-            "column": 11,
-            "line": 21,
-          },
-        ],
-      },
-      Object {
-        "cells": Array [
-          5,
-          6,
-        ],
-        "locations": Array [
-          Object {
-            "column": 11,
-            "line": 21,
-          },
-          Object {
-            "column": 11,
-            "line": 21,
-          },
-        ],
-      },
-    ],
-  },
-]
+Object {
+  "rows": Array [
+    Object {
+      "cells": Array [
+        1,
+        2,
+      ],
+      "locations": Array [
+        Object {
+          "column": 11,
+          "line": 21,
+        },
+        Object {
+          "column": 11,
+          "line": 21,
+        },
+      ],
+    },
+    Object {
+      "cells": Array [
+        3,
+        4,
+      ],
+      "locations": Array [
+        Object {
+          "column": 11,
+          "line": 21,
+        },
+        Object {
+          "column": 11,
+          "line": 21,
+        },
+      ],
+    },
+    Object {
+      "cells": Array [
+        5,
+        6,
+      ],
+      "locations": Array [
+        Object {
+          "column": 11,
+          "line": 21,
+        },
+        Object {
+          "column": 11,
+          "line": 21,
+        },
+      ],
+    },
+  ],
+}
 `;
 
 exports[`utils formatMessage should not fail if payload was not passed 1`] = `

--- a/packages/wdio-lambda-runner/package.json
+++ b/packages/wdio-lambda-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wdio/lambda-runner",
-  "version": "5.11.2",
+  "version": "5.11.5",
   "description": "A WebdriverIO plugin that allows you to run tests on AWS",
   "author": "Christian Bromann <christian@saucelabs.com>",
   "homepage": "https://github.com/webdriverio/webdriverio/tree/master/packages/wdio-lambda-runner",
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@wdio/logger": "^5.11.0",
-    "@wdio/runner": "^5.11.2",
+    "@wdio/runner": "^5.11.5",
     "find-node-modules": "^2.0.0",
     "serverless": "^1.25.0",
     "shelljs": "^0.8.3",

--- a/packages/wdio-lambda-runner/package.json
+++ b/packages/wdio-lambda-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wdio/lambda-runner",
-  "version": "5.11.5",
+  "version": "5.11.6",
   "description": "A WebdriverIO plugin that allows you to run tests on AWS",
   "author": "Christian Bromann <christian@saucelabs.com>",
   "homepage": "https://github.com/webdriverio/webdriverio/tree/master/packages/wdio-lambda-runner",
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@wdio/logger": "^5.11.0",
-    "@wdio/runner": "^5.11.5",
+    "@wdio/runner": "^5.11.6",
     "find-node-modules": "^2.0.0",
     "serverless": "^1.25.0",
     "shelljs": "^0.8.3",

--- a/packages/wdio-local-runner/package.json
+++ b/packages/wdio-local-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wdio/local-runner",
-  "version": "5.11.5",
+  "version": "5.11.6",
   "description": "A WebdriverIO runner to run tests locally",
   "author": "Christian Bromann <christian@saucelabs.com>",
   "homepage": "https://github.com/webdriverio/webdriverio/tree/master/packages/wdio-local-runner",
@@ -33,7 +33,7 @@
   "dependencies": {
     "@wdio/logger": "^5.11.0",
     "@wdio/repl": "^5.11.0",
-    "@wdio/runner": "^5.11.5",
+    "@wdio/runner": "^5.11.6",
     "async-exit-hook": "^2.0.1",
     "stream-buffers": "^3.0.2"
   },

--- a/packages/wdio-local-runner/package.json
+++ b/packages/wdio-local-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wdio/local-runner",
-  "version": "5.11.2",
+  "version": "5.11.5",
   "description": "A WebdriverIO runner to run tests locally",
   "author": "Christian Bromann <christian@saucelabs.com>",
   "homepage": "https://github.com/webdriverio/webdriverio/tree/master/packages/wdio-local-runner",
@@ -33,7 +33,7 @@
   "dependencies": {
     "@wdio/logger": "^5.11.0",
     "@wdio/repl": "^5.11.0",
-    "@wdio/runner": "^5.11.2",
+    "@wdio/runner": "^5.11.5",
     "async-exit-hook": "^2.0.1",
     "stream-buffers": "^3.0.2"
   },

--- a/packages/wdio-runner/package.json
+++ b/packages/wdio-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wdio/runner",
-  "version": "5.11.5",
+  "version": "5.11.6",
   "description": "A WebdriverIO service that runs tests in arbitrary environments",
   "author": "Christian Bromann <christian@saucelabs.com>",
   "homepage": "https://github.com/webdriverio/webdriverio/tree/master/packages/wdio-runner",
@@ -35,7 +35,7 @@
     "@wdio/utils": "^5.11.1",
     "deepmerge": "^4.0.0",
     "gaze": "^1.1.2",
-    "webdriverio": "^5.11.5"
+    "webdriverio": "^5.11.6"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/wdio-runner/package.json
+++ b/packages/wdio-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wdio/runner",
-  "version": "5.11.2",
+  "version": "5.11.5",
   "description": "A WebdriverIO service that runs tests in arbitrary environments",
   "author": "Christian Bromann <christian@saucelabs.com>",
   "homepage": "https://github.com/webdriverio/webdriverio/tree/master/packages/wdio-runner",
@@ -35,7 +35,7 @@
     "@wdio/utils": "^5.11.1",
     "deepmerge": "^4.0.0",
     "gaze": "^1.1.2",
-    "webdriverio": "^5.11.2"
+    "webdriverio": "^5.11.5"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/wdio-spec-reporter/package.json
+++ b/packages/wdio-spec-reporter/package.json
@@ -32,7 +32,8 @@
   "dependencies": {
     "@wdio/reporter": "^5.11.0",
     "chalk": "^2.3.2",
-    "pretty-ms": "^5.0.0"
+    "pretty-ms": "^5.0.0",
+    "table": "^5.4.2"
   },
   "peerDependencies": {
     "@wdio/cli": "^5.0.0"

--- a/packages/wdio-spec-reporter/package.json
+++ b/packages/wdio-spec-reporter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wdio/spec-reporter",
-  "version": "5.11.0",
+  "version": "5.11.6",
   "description": "A WebdriverIO plugin to report in spec style",
   "author": "Christian Bromann <christian@saucelabs.com>",
   "homepage": "https://github.com/webdriverio/webdriverio/tree/master/packages/wdio-spec-reporter",

--- a/packages/wdio-spec-reporter/src/index.js
+++ b/packages/wdio-spec-reporter/src/index.js
@@ -102,7 +102,18 @@ class SpecReporter extends WDIOReporter {
      * get link to saucelabs job
      */
     getTestLink ({ config, sessionId }) {
-        if (config.hostname.includes('saucelabs')) {
+        const isSauceJob = (
+            config.hostname.includes('saucelabs') ||
+            // only show if multiremote is not used
+            config.capabilities && (
+                // check w3c caps
+                config.capabilities['sauce:options'] ||
+                // check jsonwp caps
+                config.capabilities.tunnelIdentifier
+            )
+        )
+
+        if (isSauceJob) {
             const dc = config.headless
                 ? '.us-east-1'
                 : ['eu', 'eu-central-1'].includes(config.region) ? '.eu-central-1' : ''

--- a/packages/wdio-spec-reporter/src/index.js
+++ b/packages/wdio-spec-reporter/src/index.js
@@ -1,6 +1,13 @@
 import WDIOReporter from '@wdio/reporter'
 import chalk from 'chalk'
 import prettyMs from 'pretty-ms'
+import { table, getBorderCharacters } from 'table'
+
+export const DATA_TABLE_CONFIG = {
+    singleLine: true,
+    drawHorizontalLine: () => false,
+    border: getBorderCharacters('norc')
+}
 
 class SpecReporter extends WDIOReporter {
     constructor (options) {
@@ -171,6 +178,16 @@ class SpecReporter extends WDIOReporter {
 
                 // Output for a single test
                 output.push(`${testIndent}${this.chalk[this.getColor(state)](this.getSymbol(state))} ${testTitle}`)
+
+                // print cucumber data table cells
+                if (test.argument && test.argument.rows && test.argument.rows.length) {
+                    const cells = test.argument.rows.map((row) => row.cells)
+                    output.push(...table(cells, DATA_TABLE_CONFIG)
+                        .split('\n')
+                        .filter(Boolean)
+                        .map((line) => `${testIndent}  ${line}`)
+                    )
+                }
             }
 
             // Put a line break after each suite (only if tests exist in that suite)

--- a/packages/wdio-spec-reporter/tests/__fixtures__/testdata.js
+++ b/packages/wdio-spec-reporter/tests/__fixtures__/testdata.js
@@ -1,11 +1,11 @@
 export const RUNNER = {
-    cid : '0-0',
-    _duration : 5032,
+    cid: '0-0',
+    _duration: 5032,
     config: { hostname: 'localhost' },
-    capabilities : {
-        browserName : 'loremipsum',
+    capabilities: {
+        browserName: 'loremipsum',
     },
-    specs : ['/foo/bar/baz.js'],
+    specs: ['/foo/bar/baz.js'],
 }
 
 export const SUITE_UIDS = [
@@ -14,145 +14,162 @@ export const SUITE_UIDS = [
     'Baz test3',
 ]
 
-export const SUITES = [
-    {
-        uid : SUITE_UIDS[0],
-        title : SUITE_UIDS[0].slice(0, -1),
-        hooks: [],
-        tests : [
-            {
-                uid : 'foo1',
-                title : 'foo',
-                state : 'passed',
-            },
-            {
-                uid : 'bar1',
-                title : 'bar',
-                state : 'passed',
-            }
-        ],
-    },
-    {
-        uid : SUITE_UIDS[1],
-        title : SUITE_UIDS[1].slice(0, -1),
-        hooks: [],
-        tests : [
-            {
-                uid : 'some test1',
-                title : 'some test',
-                state : 'passed',
-            },
-            {
-                uid : 'a failed test2',
-                title : 'a failed test',
-                state : 'failed',
-                error : {
-                    message : 'expected foo to equal bar',
-                    stack : 'Failed test stack trace'
-                }
-            },
-            {
-                uid : 'a failed test3',
-                title : 'a failed test with no stack',
-                state : 'failed',
-                error : {
-                    message : 'expected foo to equal bar'
-                }
-            }
-        ],
-    },
-    {
-        uid : SUITE_UIDS[2],
-        title : SUITE_UIDS[2].slice(0, -1),
-        hooks: [],
-        tests : [
-            {
-                uid : 'foo bar baz1',
-                title : 'foo bar baz',
-                state : 'passed',
-            },
-            {
-                uid : 'a skipped test2',
-                title : 'a skipped test',
-                state : 'skipped',
-            }],
-    }
-]
+export const SUITES = [{
+    uid: SUITE_UIDS[0],
+    title: SUITE_UIDS[0].slice(0, -1),
+    hooks: [],
+    tests: [{
+        uid: 'foo1',
+        title: 'foo',
+        state: 'passed',
+    }, {
+        uid: 'bar1',
+        title: 'bar',
+        state: 'passed',
+    }]
+}, {
+    uid: SUITE_UIDS[1],
+    title: SUITE_UIDS[1].slice(0, -1),
+    hooks: [],
+    tests: [{
+        uid: 'some test1',
+        title: 'some test',
+        state: 'passed',
+    }, {
+        uid: 'a failed test2',
+        title: 'a failed test',
+        state: 'failed',
+        error: {
+            message: 'expected foo to equal bar',
+            stack: 'Failed test stack trace'
+        }
+    }, {
+        uid: 'a failed test3',
+        title: 'a failed test with no stack',
+        state: 'failed',
+        error: {
+            message: 'expected foo to equal bar'
+        }
+    }]
+}, {
+    uid: SUITE_UIDS[2],
+    title: SUITE_UIDS[2].slice(0, -1),
+    hooks: [],
+    tests: [{
+        uid: 'foo bar baz1',
+        title: 'foo bar baz',
+        state: 'passed',
+    }, {
+        uid: 'a skipped test2',
+        title: 'a skipped test',
+        state: 'skipped',
+    }]
+}]
 
-export const SUITES_MULTIPLE_ERRORS = [
-    {
-        uid : SUITE_UIDS[0],
-        title : SUITE_UIDS[0].slice(0, -1),
-        hooks: [],
-        tests : [
-            {
-                uid : 'foo1',
-                title : 'foo',
-                state : 'passed',
-            },
-            {
-                uid : 'bar1',
-                title : 'bar',
-                state : 'passed',
-            }
-        ],
-    },
-    {
-        uid : SUITE_UIDS[1],
-        title : SUITE_UIDS[1].slice(0, -1),
-        hooks: [],
-        tests : [
-            {
-                uid : 'some test1',
-                title : 'some test',
-                state : 'passed',
-            },
-            {
-                uid : 'a failed test',
-                title : 'a test with two failures',
-                state : 'failed',
-                errors : [
-                    {
-                        message : 'expected the party on the first part to be the party on the first part',
-                        stack : 'First failed stack trace'
-                    },
-                    {
-                        message : 'expected the party on the second part to be the party on the second part',
-                        stack : 'Second failed stack trace'
-                    }
-                ]
-            }
-        ],
-    },
-]
+export const SUITES_WITH_DATA_TABLE = [{
+    uid: SUITE_UIDS[0],
+    title: SUITE_UIDS[0].slice(0, -1),
+    hooks: [],
+    tests: [{
+        uid: 'foo1',
+        title: 'foo',
+        state: 'passed',
+        argument: {
+            rows: [{
+                cells: ['Vegetable', 'Rating'],
+                locations: [{
+                    line: 23, column: 15
+                }, {
+                    line: 23, column: 27
+                }]
+            }, {
+                cells: ['Apricot', 5],
+                locations: [{
+                    line: 24, column: 15
+                }, {
+                    line: 24, column: 27
+                }]
+            }, {
+                cells: ['Brocolli', 2],
+                locations: [{
+                    line: 25, column: 15
+                }, {
+                    line: 25, column: 27
+                }]
+            }, {
+                cells: ['Cucumber', 10],
+                locations: [{
+                    line: 26, column: 15
+                }, {
+                    line: 26, column: 27
+                }]
+            }]
+        }
+    }, {
+        uid: 'bar1',
+        title: 'bar',
+        state: 'passed',
+    }]
+}]
 
-export const SUITES_NO_TESTS = [
-    {
-        uid: SUITE_UIDS[0],
-        title: SUITE_UIDS[0].slice(0, -1),
-        tests: [],
-        suites: [],
-        hooks: []
-    },
-]
-
-export const SUITES_NO_TESTS_WITH_HOOK_ERROR = [
-    {
-        uid: SUITE_UIDS[0],
-        title: SUITE_UIDS[0].slice(0, -1),
-        tests: [],
-        suites: [],
-        hooks: [{
-            uid : 'a failed hook2',
-            title : 'a failed hook',
-            state : 'failed',
-            error : {
-                message : 'expected foo to equal bar',
-                stack : 'Failed test stack trace'
-            }
+export const SUITES_MULTIPLE_ERRORS = [{
+    uid: SUITE_UIDS[0],
+    title: SUITE_UIDS[0].slice(0, -1),
+    hooks: [],
+    tests: [{
+        uid: 'foo1',
+        title: 'foo',
+        state: 'passed',
+    }, {
+        uid: 'bar1',
+        title: 'bar',
+        state: 'passed',
+    }]
+}, {
+    uid: SUITE_UIDS[1],
+    title: SUITE_UIDS[1].slice(0, -1),
+    hooks: [],
+    tests: [{
+        uid: 'some test1',
+        title: 'some test',
+        state: 'passed',
+    }, {
+        uid: 'a failed test',
+        title: 'a test with two failures',
+        state: 'failed',
+        errors: [{
+            message: 'expected the party on the first part to be the party on the first part',
+            stack: 'First failed stack trace'
+        }, {
+            message: 'expected the party on the second part to be the party on the second part',
+            stack: 'Second failed stack trace'
         }]
-    },
-]
+    }]
+}]
+
+export const SUITES_NO_TESTS = [{
+    uid: SUITE_UIDS[0],
+    title: SUITE_UIDS[0].slice(0, -1),
+    tests: [],
+    suites: [],
+    hooks: []
+}]
+
+export const SUITES_NO_TESTS_WITH_HOOK_ERROR = [{
+    uid: SUITE_UIDS[0],
+    title: SUITE_UIDS[0].slice(0, -1),
+    tests: [],
+    suites: [],
+    hooks: [{
+        uid: 'a failed hook2',
+        title: 'a failed hook',
+        state: 'failed',
+        error: {
+            message: 'expected foo to equal bar',
+            stack: 'Failed test stack trace'
+        }
+    }]
+}]
 
 export const REPORT = `------------------------------------------------------------------
 [loremipsum #0-0] Spec: /foo/bar/baz.js

--- a/packages/wdio-spec-reporter/tests/__snapshots__/index.test.js.snap
+++ b/packages/wdio-spec-reporter/tests/__snapshots__/index.test.js.snap
@@ -1,0 +1,50 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SpecReporter getResultDisplay should not print if data table format is not given 1`] = `
+Array [
+  "Foo test",
+  "   green ✓ foo",
+  "   green ✓ bar",
+  "",
+]
+`;
+
+exports[`SpecReporter getResultDisplay should not print if data table is empty 1`] = `
+Array [
+  "Foo test",
+  "   green ✓ foo",
+  "   green ✓ bar",
+  "",
+]
+`;
+
+exports[`SpecReporter getResultDisplay should print data tables 1`] = `
+Array [
+  "Foo test",
+  "   green ✓ foo",
+  "     │ Vegetable │ Rating │",
+  "     │ Apricot   │ 5      │",
+  "     │ Brocolli  │ 2      │",
+  "     │ Cucumber  │ 10     │",
+  "   green ✓ bar",
+  "",
+]
+`;
+
+exports[`SpecReporter getResultDisplay should validate the result output with tests 1`] = `
+Array [
+  "Foo test",
+  "   green ✓ foo",
+  "   green ✓ bar",
+  "",
+  "Bar test",
+  "   green ✓ some test",
+  "   red ✖ a failed test",
+  "   red ✖ a failed test with no stack",
+  "",
+  "Baz test",
+  "   green ✓ foo bar baz",
+  "   cyan - a skipped test",
+  "",
+]
+`;

--- a/packages/wdio-spec-reporter/tests/index.test.js
+++ b/packages/wdio-spec-reporter/tests/index.test.js
@@ -5,6 +5,7 @@ import {
     SUITE_UIDS,
     SUITES,
     SUITES_NO_TESTS,
+    SUITES_WITH_DATA_TABLE,
     REPORT,
     SAUCELABS_REPORT,
     SAUCELABS_EU_REPORT,
@@ -260,21 +261,7 @@ describe('SpecReporter', () => {
             tmpReporter.suites = SUITES
 
             const result = tmpReporter.getResultDisplay()
-
-            expect(result.length).toBe(13)
-            expect(result[0]).toBe('Foo test')
-            expect(result[1]).toBe('   green ✓ foo')
-            expect(result[2]).toBe('   green ✓ bar')
-            expect(result[3]).toBe('')
-            expect(result[4]).toBe('Bar test')
-            expect(result[5]).toBe('   green ✓ some test')
-            expect(result[6]).toBe('   red ✖ a failed test')
-            expect(result[7]).toBe('   red ✖ a failed test with no stack')
-            expect(result[8]).toBe('')
-            expect(result[9]).toBe('Baz test')
-            expect(result[10]).toBe('   green ✓ foo bar baz')
-            expect(result[11]).toBe('   cyan - a skipped test')
-            expect(result[12]).toBe('')
+            expect(result).toMatchSnapshot()
         })
 
         it('should validate the result output with no tests', () => {
@@ -282,8 +269,36 @@ describe('SpecReporter', () => {
             tmpReporter.suites = SUITES_NO_TESTS
 
             const result = tmpReporter.getResultDisplay()
-
             expect(result.length).toBe(0)
+        })
+
+        it('should print data tables', () => {
+            tmpReporter.getOrderedSuites = jest.fn(() => SUITES_WITH_DATA_TABLE)
+            tmpReporter.suites = SUITES_WITH_DATA_TABLE
+
+            const result = tmpReporter.getResultDisplay()
+            expect(result).toMatchSnapshot()
+        })
+
+        it('should not print if data table format is not given', () => {
+            tmpReporter.getOrderedSuites = jest.fn(() => {
+                const suites = JSON.parse(JSON.stringify(SUITES_WITH_DATA_TABLE))
+                suites[0].tests[0].argument = 'some different format'
+                return suites
+            })
+            const result = tmpReporter.getResultDisplay()
+            expect(result).toMatchSnapshot()
+        })
+
+        it('should not print if data table is empty', () => {
+            tmpReporter.getOrderedSuites = jest.fn(() => {
+                const suites = JSON.parse(JSON.stringify(SUITES_WITH_DATA_TABLE))
+                suites[0].tests[0].argument.rows = []
+                return suites
+            })
+
+            const result = tmpReporter.getResultDisplay()
+            expect(result).toMatchSnapshot()
         })
     })
 

--- a/packages/wdio-spec-reporter/tests/index.test.js
+++ b/packages/wdio-spec-reporter/tests/index.test.js
@@ -16,6 +16,14 @@ import {
 
 const reporter = new SpecReporter({})
 
+const fakeSessionId = 'ba86cbcb70774ef8a0757c1702c3bdf9'
+const getRunnerConfig = (config) => {
+    return Object.assign({}, RUNNER, {
+        config,
+        sessionId: fakeSessionId
+    })
+}
+
 describe('SpecReporter', () => {
     let tmpReporter = null
 
@@ -144,82 +152,85 @@ describe('SpecReporter', () => {
             printReporter.write = jest.fn()
         })
 
-        it('should print the report to the console', () => {
-            printReporter.suiteUids = SUITE_UIDS
-            printReporter.suites = SUITES
-            printReporter.stateCounts = {
-                passed : 4,
-                failed : 1,
-                skipped : 1,
-            }
-
-            printReporter.printReport(RUNNER)
-
-            expect(printReporter.write).toBeCalledWith(REPORT)
-        })
-
-        it('should print link to SauceLabs job details page', () => {
-            printReporter.suiteUids = SUITE_UIDS
-            printReporter.suites = SUITES
-            printReporter.stateCounts = {
-                passed : 4,
-                failed : 1,
-                skipped : 1,
-            }
-
-            const runner = Object.assign({}, RUNNER, {
-                config: { hostname: 'ondemand.saucelabs.com' },
-                sessionId: 'ba86cbcb70774ef8a0757c1702c3bdf9'
+        describe('with normal setup', () => {
+            beforeEach(() => {
+                printReporter.suiteUids = SUITE_UIDS
+                printReporter.suites = SUITES
+                printReporter.stateCounts = {
+                    passed : 4,
+                    failed : 1,
+                    skipped : 1,
+                }
             })
-            printReporter.printReport(runner)
 
-            expect(printReporter.write).toBeCalledWith(SAUCELABS_REPORT)
-        })
+            it('should print the report to the console', () => {
+                const runner = getRunnerConfig({ hostname: 'localhost' })
+                printReporter.printReport(runner)
+                expect(printReporter.write).toBeCalledWith(REPORT)
+            })
 
-        it('should print link to SauceLabs EU job details page', () => {
-            printReporter.suiteUids = SUITE_UIDS
-            printReporter.suites = SUITES
-            printReporter.stateCounts = {
-                passed : 4,
-                failed : 1,
-                skipped : 1,
-            }
+            it('should print link to SauceLabs job details page', () => {
+                const runner = getRunnerConfig({
+                    hostname: 'ondemand.saucelabs.com',
+                    capabilities: {}
+                })
+                printReporter.printReport(runner)
+                expect(printReporter.write).toBeCalledWith(SAUCELABS_REPORT)
+            })
 
-            printReporter.printReport(Object.assign({}, RUNNER, {
-                config: {
+            it('should print link to SauceLabs job details page if run with Sauce Connect (w3c)', () => {
+                const runner = getRunnerConfig({
+                    capabilities: { 'sauce:options': 'foobar' },
+                    hostname: 'localhost'
+                })
+                printReporter.printReport(runner)
+                expect(printReporter.write).toBeCalledWith(SAUCELABS_REPORT)
+            })
+
+            it('should print link to SauceLabs job details page if run with Sauce Connect (jsonwp)', () => {
+                const runner = getRunnerConfig({
+                    capabilities: { tunnelIdentifier: 'foobar' },
+                    hostname: 'localhost'
+                })
+                printReporter.printReport(runner)
+                expect(printReporter.write).toBeCalledWith(SAUCELABS_REPORT)
+            })
+
+            it('should print link to SauceLabs EU job details page', () => {
+                printReporter.printReport(getRunnerConfig({
+                    capabilities: {},
                     hostname: 'ondemand.saucelabs.com',
                     region: 'eu'
-                },
-                sessionId: 'ba86cbcb70774ef8a0757c1702c3bdf9'
-            }))
-            expect(printReporter.write).toBeCalledWith(SAUCELABS_EU_REPORT)
+                }))
+                expect(printReporter.write).toBeCalledWith(SAUCELABS_EU_REPORT)
 
-            printReporter.write.mockClear()
+                printReporter.write.mockClear()
 
-            printReporter.printReport(Object.assign({}, RUNNER, {
-                config: {
+                printReporter.printReport(getRunnerConfig({
+                    capabilities: {},
                     hostname: 'ondemand.saucelabs.com',
                     region: 'eu-central-1'
-                },
-                sessionId: 'ba86cbcb70774ef8a0757c1702c3bdf9'
-            }))
-            expect(printReporter.write).toBeCalledWith(SAUCELABS_EU_REPORT)
+                }))
+                expect(printReporter.write).toBeCalledWith(SAUCELABS_EU_REPORT)
 
-            printReporter.printReport(Object.assign({}, RUNNER, {
-                config: {
+                printReporter.printReport(getRunnerConfig({
+                    capabilities: {},
                     hostname: 'ondemand.saucelabs.com',
                     headless: true
-                },
-                sessionId: 'ba86cbcb70774ef8a0757c1702c3bdf9'
-            }))
-            expect(printReporter.write).toBeCalledWith(SAUCELABS_HEADLESS_REPORT)
+                }))
+                expect(printReporter.write).toBeCalledWith(SAUCELABS_HEADLESS_REPORT)
+            })
         })
 
         it('should print report for suites with no tests but failed hooks', () => {
             printReporter.suiteUids = SUITE_UIDS
             printReporter.suites = SUITES_NO_TESTS_WITH_HOOK_ERROR
 
-            printReporter.printReport(RUNNER)
+            const runner = getRunnerConfig({
+                capabilities: {},
+                hostname: 'localhost'
+            })
+            printReporter.printReport(runner)
 
             expect(printReporter.write.mock.calls.length).toBe(1)
             expect(printReporter.write.mock.calls[0][0]).toContain('a failed hook')

--- a/packages/wdio-webdriver-mock-service/package.json
+++ b/packages/wdio-webdriver-mock-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wdio/webdriver-mock-service",
-  "version": "5.11.0",
+  "version": "5.11.5",
   "description": "A WebdriverIO service to stub all endpoints for internal testing purposes.",
   "author": "Christian Bromann <christian@saucelabs.com>",
   "homepage": "https://github.com/webdriverio/webdriverio/tree/master/packages/wdio-webdriver-mock-service",
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "nock": "^10.0.4",
-    "webdriver": "^5.11.0"
+    "webdriver": "^5.11.5"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/wdio-webdriver-mock-service/src/index.js
+++ b/packages/wdio-webdriver-mock-service/src/index.js
@@ -6,6 +6,7 @@ import { newSession, deleteSession } from './mocks/newSession'
 
 const ELEMENT_ID = '401c0039-3306-6a46-a98d-f5939870a249'
 const ELEMENT_REFETCHED = '80d860d0-b829-f540-812e-7078eb983795'
+const ELEMENT_ALT = '8bf4d107-a363-40d1-b823-d94bdbc58afb'
 newSession.value.sessionId = SESSION_ID
 
 export default class WebdriverMockService {
@@ -23,6 +24,7 @@ export default class WebdriverMockService {
         this.command.getTitle().times(2).reply(200, { value: 'Mock Page Title' })
         this.command.getUrl().times(2).reply(200, { value: 'https://mymockpage.com' })
         this.command.getElementRect(ELEMENT_ID).times(2).reply(200, { value: { width: 1, height: 2, x: 3, y: 4 } })
+        this.command.getElementRect(ELEMENT_ALT).times(2).reply(200, { value: { width: 10, height: 20, x: 30, y: 40 } })
         this.command.getLogTypes().reply(200, { value: [] })
     }
 
@@ -109,7 +111,9 @@ export default class WebdriverMockService {
         this.nockReset()
 
         const elemResponse = { 'element-6066-11e4-a52e-4f735466cecf': ELEMENT_ID }
+        const elemAltResponse = { 'element-6066-11e4-a52e-4f735466cecf': ELEMENT_ALT }
         this.command.findElement().times(times).reply(200, { value: elemResponse })
+        this.command.findElement().times(times).reply(200, { value: elemAltResponse })
         this.command.executeScript().times(times).reply(200, { value: '2' })
 
         // overwrite

--- a/packages/webdriver/package.json
+++ b/packages/webdriver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webdriver",
-  "version": "5.11.0",
+  "version": "5.11.5",
   "description": "A Node.js bindings implementation for the W3C WebDriver and Mobile JSONWire Protocol",
   "author": "Christian Bromann <christian@saucelabs.com>",
   "homepage": "https://github.com/webdriverio/webdriverio/tree/master/packages/webdriver",

--- a/packages/webdriver/src/utils.js
+++ b/packages/webdriver/src/utils.js
@@ -286,14 +286,10 @@ export function isAndroid (caps) {
  */
 export function isSauce (hostname, caps) {
     return Boolean(
-        hostname &&
-        hostname.includes('saucelabs') &&
+        caps.extendedDebugging ||
         (
-            caps.extendedDebugging ||
-            (
-                caps['sauce:options'] &&
-                caps['sauce:options'].extendedDebugging
-            )
+            caps['sauce:options'] &&
+            caps['sauce:options'].extendedDebugging
         )
     )
 }

--- a/packages/webdriver/src/utils.js
+++ b/packages/webdriver/src/utils.js
@@ -382,7 +382,14 @@ export function overwriteElementCommands(propertiesObject) {
         delete propertiesObject[commandName]
 
         const newCommand = function (...args) {
-            return userDefinedCommand.apply(this, [origCommand.bind(this), ...args])
+            const element = this
+            return userDefinedCommand.apply(element, [
+                function origCommandFunction() {
+                    const context = this || element // respect explicite context binding, use element as default
+                    return origCommand.apply(context, arguments)
+                },
+                ...args
+            ])
         }
 
         propertiesObject[commandName] = {

--- a/packages/webdriver/tests/utils.test.js
+++ b/packages/webdriver/tests/utils.test.js
@@ -290,14 +290,33 @@ describe('utils', () => {
     describe('overwriteElementCommands', () => {
         it('should overwrite command', function () {
             const context = {}
+            const origFnMock = jest.fn(() => 1)
             const propertiesObject = {
-                foo: { value() { return 1 } },
+                foo: { value: origFnMock },
                 __elementOverrides__: {
                     value: { foo(origCmd, arg) { return [origCmd(), arg] } }
                 }
             }
             overwriteElementCommands.call(context, propertiesObject)
             expect(propertiesObject.foo.value(5)).toEqual([1, 5])
+            expect(origFnMock.mock.calls.length).toBe(1)
+            expect(origFnMock.mock.instances[0]).toBe(propertiesObject.foo)
+        })
+
+        it('should support rebinding when invoking original fn', function () {
+            const context = {}
+            const origFnMock = jest.fn(() => 1)
+            const origFnContext = {}
+            const propertiesObject = {
+                foo: { value: origFnMock },
+                __elementOverrides__: {
+                    value: { foo(origCmd, arg) { return [origCmd.call(origFnContext), arg] } }
+                }
+            }
+            overwriteElementCommands.call(context, propertiesObject)
+            expect(propertiesObject.foo.value(5)).toEqual([1, 5])
+            expect(origFnMock.mock.calls.length).toBe(1)
+            expect(origFnMock.mock.instances[0]).toBe(origFnContext)
         })
 
         it('should create __elementOverrides__ if not exists', function () {

--- a/packages/webdriver/tests/utils.test.js
+++ b/packages/webdriver/tests/utils.test.js
@@ -150,7 +150,7 @@ describe('utils', () => {
         it('isSauce', () => {
             const capabilities = { browserName: 'chrome' }
             let requestedCapabilities = { w3cCaps: { alwaysMatch: {} } }
-            let hostname = 'ondemand.saucelabs.com'
+            let hostname = 'localhost' // isSauce should also be true if run through Sauce Connect
 
             expect(environmentDetector({ capabilities, requestedCapabilities }).isSauce).toBe(false)
             expect(environmentDetector({ capabilities, hostname, requestedCapabilities }).isSauce).toBe(false)
@@ -162,7 +162,7 @@ describe('utils', () => {
 
             requestedCapabilities.w3cCaps.alwaysMatch['sauce:options'] = { extendedDebugging: true }
             expect(environmentDetector({ capabilities, hostname, requestedCapabilities }).isSauce).toBe(true)
-            expect(environmentDetector({ capabilities, requestedCapabilities }).isSauce).toBe(false)
+            expect(environmentDetector({ capabilities, requestedCapabilities }).isSauce).toBe(true)
         })
 
         it('isSeleniumStandalone', () => {

--- a/packages/webdriverio/package.json
+++ b/packages/webdriverio/package.json
@@ -67,7 +67,6 @@
     "lodash.zip": "^4.2.0",
     "resq": "^1.5.0",
     "rgb2hex": "^0.1.0",
-    "safe-buffer": "^5.2.0",
     "serialize-error": "^4.1.0",
     "webdriver": "^5.11.5"
   }

--- a/packages/webdriverio/package.json
+++ b/packages/webdriverio/package.json
@@ -1,7 +1,7 @@
 {
   "name": "webdriverio",
   "description": "Next-gen WebDriver test automation framework for Node.js",
-  "version": "5.11.5",
+  "version": "5.11.6",
   "homepage": "https://webdriver.io",
   "author": "Christian Bromann <christian@saucelabs.com>",
   "license": "MIT",

--- a/packages/webdriverio/package.json
+++ b/packages/webdriverio/package.json
@@ -1,7 +1,7 @@
 {
   "name": "webdriverio",
   "description": "Next-gen WebDriver test automation framework for Node.js",
-  "version": "5.11.2",
+  "version": "5.11.5",
   "homepage": "https://webdriver.io",
   "author": "Christian Bromann <christian@saucelabs.com>",
   "license": "MIT",
@@ -69,6 +69,6 @@
     "rgb2hex": "^0.1.0",
     "safe-buffer": "^5.2.0",
     "serialize-error": "^4.1.0",
-    "webdriver": "^5.11.0"
+    "webdriver": "^5.11.5"
   }
 }

--- a/packages/webdriverio/src/commands/browser/saveRecordingScreen.js
+++ b/packages/webdriverio/src/commands/browser/saveRecordingScreen.js
@@ -20,7 +20,6 @@
  */
 
 import fs from 'fs'
-import { Buffer } from 'safe-buffer'
 import { getAbsoluteFilepath, assertDirectoryExists } from '../../utils'
 
 export default async function saveRecordingScreen (filepath) {

--- a/packages/webdriverio/src/commands/browser/saveScreenshot.js
+++ b/packages/webdriverio/src/commands/browser/saveScreenshot.js
@@ -19,7 +19,6 @@
  */
 
 import fs from 'fs'
-import { Buffer } from 'safe-buffer'
 import { getAbsoluteFilepath, assertDirectoryExists } from '../../utils'
 
 export default async function saveScreenshot (filepath) {

--- a/packages/webdriverio/src/commands/element/saveScreenshot.js
+++ b/packages/webdriverio/src/commands/element/saveScreenshot.js
@@ -18,7 +18,6 @@
  */
 
 import fs from 'fs'
-import { Buffer } from 'safe-buffer'
 import { getAbsoluteFilepath, assertDirectoryExists } from '../../utils'
 
 export default async function saveScreenshot (filepath) {

--- a/packages/webdriverio/src/scripts/isElementDisplayed.js
+++ b/packages/webdriverio/src/scripts/isElementDisplayed.js
@@ -30,8 +30,9 @@
  */
 export default function isElementDisplayed(element) {
     function nodeIsElement(node) {
-        if (!node)
+        if (!node) {
             return false
+        }
 
         switch (node.nodeType) {
         case Node.ELEMENT_NODE:
@@ -45,41 +46,47 @@ export default function isElementDisplayed(element) {
     }
 
     function parentElementForElement(element) {
-        if (!element)
+        if (!element) {
             return null
+        }
 
         return enclosingNodeOrSelfMatchingPredicate(element.parentNode, nodeIsElement)
     }
 
     function enclosingNodeOrSelfMatchingPredicate(targetNode, predicate) {
         for (let node = targetNode; node && node !== targetNode.ownerDocument; node = node.parentNode)
-            if (predicate(node))
+            if (predicate(node)) {
                 return node
+            }
 
         return null
     }
 
     function enclosingElementOrSelfMatchingPredicate(targetElement, predicate) {
         for (let element = targetElement; element && element !== targetElement.ownerDocument; element = parentElementForElement(element))
-            if (predicate(element))
+            if (predicate(element)) {
                 return element
+            }
 
         return null
     }
 
     function cascadedStylePropertyForElement(element, property) {
-        if (!element || !property)
+        if (!element || !property) {
             return null
+        }
         // if document-fragment, skip it and use element.host instead. This happens
         // when the element is inside a shadow root.
         // window.getComputedStyle errors on document-fragment.
-        if (element instanceof DocumentFragment)
+        if (element instanceof DocumentFragment) {
             element = element.host
+        }
 
         let computedStyle = window.getComputedStyle(element)
         let computedStyleProperty = computedStyle.getPropertyValue(property)
-        if (computedStyleProperty && computedStyleProperty !== 'inherit')
+        if (computedStyleProperty && computedStyleProperty !== 'inherit') {
             return computedStyleProperty
+        }
 
         // Ideally getPropertyValue would return the 'used' or 'actual' value, but
         // it doesn't for legacy reasons. So we need to do our own poor man's cascade.
@@ -96,8 +103,9 @@ export default function isElementDisplayed(element) {
 
     function elementSubtreeHasNonZeroDimensions(element) {
         let boundingBox = element.getBoundingClientRect()
-        if (boundingBox.width > 0 && boundingBox.height > 0)
+        if (boundingBox.width > 0 && boundingBox.height > 0) {
             return true
+        }
 
         // Paths can have a zero width or height. Treat them as shown if the stroke width is positive.
         if (element.tagName.toUpperCase() === 'PATH' && boundingBox.width + boundingBox.height > 0) {
@@ -106,17 +114,20 @@ export default function isElementDisplayed(element) {
         }
 
         let cascadedOverflow = cascadedStylePropertyForElement(element, 'overflow')
-        if (cascadedOverflow === 'hidden')
+        if (cascadedOverflow === 'hidden') {
             return false
+        }
 
         // If the container's overflow is not hidden and it has zero size, consider the
         // container to have non-zero dimensions if a child node has non-zero dimensions.
         return Array.from(element.childNodes).some((childNode) => {
-            if (childNode.nodeType === Node.TEXT_NODE)
+            if (childNode.nodeType === Node.TEXT_NODE) {
                 return true
+            }
 
-            if (nodeIsElement(childNode))
+            if (nodeIsElement(childNode)) {
                 return elementSubtreeHasNonZeroDimensions(childNode)
+            }
 
             return false
         })
@@ -124,8 +135,9 @@ export default function isElementDisplayed(element) {
 
     function elementOverflowsContainer(element) {
         let cascadedOverflow = cascadedStylePropertyForElement(element, 'overflow')
-        if (cascadedOverflow !== 'hidden')
+        if (cascadedOverflow !== 'hidden') {
             return false
+        }
 
         // FIXME: this needs to take into account the scroll position of the element,
         // the display modes of it and its ancestors, and the container it overflows.
@@ -134,24 +146,33 @@ export default function isElementDisplayed(element) {
     }
 
     function isElementSubtreeHiddenByOverflow(element) {
-        if (!element)
+        if (!element) {
             return false
+        }
 
-        if (!elementOverflowsContainer(element))
+        if (!elementOverflowsContainer(element)) {
             return false
+        }
 
-        if (!element.childNodes.length)
+        if (!element.childNodes.length) {
             return false
+        }
 
         // This element's subtree is hidden by overflow if all child subtrees are as well.
         return Array.from(element.childNodes).every((childNode) => {
             // Returns true if the child node is overflowed or otherwise hidden.
             // Base case: not an element, has zero size, scrolled out, or doesn't overflow container.
-            if (!nodeIsElement(childNode))
+            // Visibility of text nodes is controlled by parent
+            if (childNode.nodeType === Node.TEXT_NODE) {
+                return false
+            }
+            if (!nodeIsElement(childNode)) {
                 return true
+            }
 
-            if (!elementSubtreeHasNonZeroDimensions(childNode))
+            if (!elementSubtreeHasNonZeroDimensions(childNode)) {
                 return true
+            }
 
             // Recurse.
             return isElementSubtreeHiddenByOverflow(childNode)
@@ -171,8 +192,9 @@ export default function isElementDisplayed(element) {
     // This is a partial reimplementation of Selenium's "element is displayed" algorithm.
     // When the W3C specification's algorithm stabilizes, we should implement that.
     // If this command is misdirected to the wrong document (and is NOT inside a shadow root), treat it as not shown.
-    if (!isElementInsideShadowRoot(element) && !document.contains(element))
+    if (!isElementInsideShadowRoot(element) && !document.contains(element)) {
         return false
+    }
 
     // Special cases for specific tag names.
     switch (element.tagName.toUpperCase()) {
@@ -191,8 +213,9 @@ export default function isElementDisplayed(element) {
     }
     case 'INPUT':
         // <input type="hidden"> is considered not shown.
-        if (element.type === 'hidden')
+        if (element.type === 'hidden') {
             return false
+        }
         break
         // case 'MAP':
         // FIXME: Selenium has special handling for <map> elements. We don't do anything now.
@@ -201,8 +224,9 @@ export default function isElementDisplayed(element) {
         break
     }
 
-    if (cascadedStylePropertyForElement(element, 'visibility') !== 'visible')
+    if (cascadedStylePropertyForElement(element, 'visibility') !== 'visible') {
         return false
+    }
 
     let hasAncestorWithZeroOpacity = !!enclosingElementOrSelfMatchingPredicate(element, (e) => {
         return Number(cascadedStylePropertyForElement(e, 'opacity')) === 0
@@ -210,14 +234,17 @@ export default function isElementDisplayed(element) {
     let hasAncestorWithDisplayNone = !!enclosingElementOrSelfMatchingPredicate(element, (e) => {
         return cascadedStylePropertyForElement(e, 'display') === 'none'
     })
-    if (hasAncestorWithZeroOpacity || hasAncestorWithDisplayNone)
+    if (hasAncestorWithZeroOpacity || hasAncestorWithDisplayNone) {
         return false
+    }
 
-    if (!elementSubtreeHasNonZeroDimensions(element))
+    if (!elementSubtreeHasNonZeroDimensions(element)) {
         return false
+    }
 
-    if (isElementSubtreeHiddenByOverflow(element))
+    if (isElementSubtreeHiddenByOverflow(element)) {
         return false
+    }
 
     return true
 }

--- a/scripts/changelog.js
+++ b/scripts/changelog.js
@@ -45,7 +45,7 @@ const BANNER = `
  */
 // eslint-disable-next-line no-console
 console.log('Start generating changelog...')
-changelog.createMarkdown({ tagFrom: 'v5.11.4' }).then((newChangelog) => {
+changelog.createMarkdown({ tagFrom: 'v5.11.5' }).then((newChangelog) => {
     let changelogContent = fs.readFileSync(changelogPath, 'utf8')
     changelogContent = changelogContent.replace('---', '---\n' + newChangelog)
     fs.writeFileSync(changelogPath, changelogContent, 'utf8')

--- a/scripts/changelog.js
+++ b/scripts/changelog.js
@@ -45,7 +45,7 @@ const BANNER = `
  */
 // eslint-disable-next-line no-console
 console.log('Start generating changelog...')
-changelog.createMarkdown({ tagFrom: 'v5.11.3' }).then((newChangelog) => {
+changelog.createMarkdown({ tagFrom: 'v5.11.4' }).then((newChangelog) => {
     let changelogContent = fs.readFileSync(changelogPath, 'utf8')
     changelogContent = changelogContent.replace('---', '---\n' + newChangelog)
     fs.writeFileSync(changelogPath, changelogContent, 'utf8')

--- a/scripts/templates/webdriverio.tpl.d.ts
+++ b/scripts/templates/webdriverio.tpl.d.ts
@@ -89,7 +89,7 @@ declare namespace WebdriverIO {
     interface HookFunctions {
         onPrepare?(
             config: Config,
-            capabilities: WebDriver.DesiredCapabilities
+            capabilities: WebDriver.DesiredCapabilities[]
         ): void;
 
         onComplete?(exitCode: number, config: Config, capabilities: WebDriver.DesiredCapabilities, results: Results): void;

--- a/tests/mocha/test.js
+++ b/tests/mocha/test.js
@@ -149,6 +149,21 @@ describe('Mocha smoke test', () => {
             )
         })
 
+        it('should allow to invoke native command on different element', () => {
+            browser.customCommandScenario()
+            browser.overwriteCommand('getSize', function (origCommand, ratio = 1) {
+                const elemAlt = $('elemAlt')
+                const { width, height } = origCommand.call(elemAlt)
+                return { width: width * ratio, height: height * ratio }
+            }, true)
+            const elem = $('elem')
+
+            assert.equal(
+                JSON.stringify(elem.getSize(2)),
+                JSON.stringify({ width: 20, height: 40 })
+            )
+        })
+
         it('should keep the scope', () => {
             browser.customCommandScenario()
             browser.overwriteCommand('saveRecordingScreen', function (origCommand, filepath, elem) {


### PR DESCRIPTION
## Proposed changes

WebDriverIO v5 cucumberOpts is not included in typescript . I have added wdio.d.ts file but it is nice to have adding in webdriverio package.

WebDriverIO version : 5.11.5

```
    interface Options {
        cucumberOpts?: {
            require: string[],
            backtrace: boolean,
            requireModule: (string | object)[],
            dryRun: boolean,
            failFast: boolean,
            format: string[],
            colors: boolean,
            snippets: boolean,
            source: boolean,
            profile: string[],
            strict: boolean,
            tags: string[],
            timeout: number,
            ignoreUndefinedDefinitions: boolean
        }
    }
```
## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
