### PR TITLE
Add allure-reporter option useCucumberStepReporter

### DIFF
--- a/packages/wdio-allure-reporter/README.md
+++ b/packages/wdio-allure-reporter/README.md
@@ -41,6 +41,7 @@ exports.config = {
 - `outputDir` defaults to `./allure-results`. After a test run is complete, you will find that this directory has been populated with an `.xml` file for each spec, plus a number of `.txt` and `.png` files and other attachments.
 - `disableWebdriverStepsReporting` - optional parameter(`false` by default), in order to log only custom steps to the reporter.
 - `disableWebdriverScreenshotsReporting` - optional parameter(`false` by default), in order to not attach screenshots to the reporter.
+- `useCucumberStepReporter` - optional parameter(`false`by default), set it to true in order to change the report hierarchy when using cucumber. Try it for yourself and see how it looks.
 
 ## Supported Allure API
 * `addFeature(featureName)` – assign feature to test

--- a/packages/wdio-allure-reporter/README.md
+++ b/packages/wdio-allure-reporter/README.md
@@ -41,7 +41,7 @@ exports.config = {
 - `outputDir` defaults to `./allure-results`. After a test run is complete, you will find that this directory has been populated with an `.xml` file for each spec, plus a number of `.txt` and `.png` files and other attachments.
 - `disableWebdriverStepsReporting` - optional parameter(`false` by default), in order to log only custom steps to the reporter.
 - `disableWebdriverScreenshotsReporting` - optional parameter(`false` by default), in order to not attach screenshots to the reporter.
-- `useCucumberStepReporter` - optional parameter(`false`by default), set it to true in order to change the report hierarchy when using cucumber. Try it for yourself and see how it looks.
+- `useCucumberStepReporter` - optional parameter (`false` by default), set it to true in order to change the report hierarchy when using cucumber. Try it for yourself and see how it looks.
 
 ## Supported Allure API
 * `addFeature(featureName)` – assign feature to test

--- a/packages/wdio-allure-reporter/src/constants.js
+++ b/packages/wdio-allure-reporter/src/constants.js
@@ -2,7 +2,7 @@ const PASSED = 'passed'
 const FAILED = 'failed'
 const BROKEN = 'broken'
 const PENDING = 'pending'
-const SKIPPED = 'skipped'
+const CANCELED = 'canceled'
 
 const testStatuses = {
     PASSED,
@@ -15,7 +15,7 @@ const stepStatuses = {
     PASSED,
     FAILED,
     BROKEN,
-    SKIPPED
+    CANCELED
 }
 
 const events = {

--- a/packages/wdio-allure-reporter/src/constants.js
+++ b/packages/wdio-allure-reporter/src/constants.js
@@ -2,6 +2,7 @@ const PASSED = 'passed'
 const FAILED = 'failed'
 const BROKEN = 'broken'
 const PENDING = 'pending'
+const SKIPPED = 'skipped'
 
 const testStatuses = {
     PASSED,
@@ -13,7 +14,8 @@ const testStatuses = {
 const stepStatuses = {
     PASSED,
     FAILED,
-    BROKEN
+    BROKEN,
+    SKIPPED
 }
 
 const events = {

--- a/packages/wdio-allure-reporter/src/index.js
+++ b/packages/wdio-allure-reporter/src/index.js
@@ -135,7 +135,7 @@ class AllureReporter extends WDIOReporter {
 
     onTestSkip(test) {
         if (this.options.useCucumberStepReporter) {
-            this.allure.endStep(stepStatuses.SKIPPED)
+            this.allure.endStep(stepStatuses.CANCELED)
         } else if (!this.allure.getCurrentTest() || this.allure.getCurrentTest().name !== test.title) {
             this.allure.pendingCase(test.title)
         } else {

--- a/packages/wdio-allure-reporter/src/index.js
+++ b/packages/wdio-allure-reporter/src/index.js
@@ -45,17 +45,17 @@ class AllureReporter extends WDIOReporter {
         if (this.options.useCucumberStepReporter) {
             if (suite.type === 'feature') {
                 // handle cucumber features as allure "suite"
-                this.allure.startSuite(suite.title)
-            } else {
-                // handle cucumber scenarii as allure "case" instead of "suite"
-                this.allure.startCase(suite.title)
-                this.setCaseParameters(suite.cid)
+                return this.allure.startSuite(suite.title)
             }
-        } else {
-            const currentSuite = this.allure.getCurrentSuite()
-            const prefix = currentSuite ? currentSuite.name + ': ' : ''
-            this.allure.startSuite(prefix + suite.title)
+
+            // handle cucumber scenarii as allure "case" instead of "suite"
+            this.allure.startCase(suite.title)
+            return this.setCaseParameters(suite.cid)
         }
+
+        const currentSuite = this.allure.getCurrentSuite()
+        const prefix = currentSuite ? currentSuite.name + ': ' : ''
+        this.allure.startSuite(prefix + suite.title)
     }
 
     onSuiteEnd(suite) {
@@ -64,20 +64,21 @@ class AllureReporter extends WDIOReporter {
             if (isPassed) {
                 // Only close passing tests because
                 // non passing tests are closed in onTestFailed event
-                this.allure.endCase(testStatuses.PASSED)
+                return this.allure.endCase(testStatuses.PASSED)
             }
-        } else {
-            this.allure.endSuite()
+            return
         }
+
+        this.allure.endSuite()
     }
 
     onTestStart(test) {
         if (this.options.useCucumberStepReporter) {
-            this.allure.startStep(test.title)
-        } else {
-            this.allure.startCase(test.title)
-            this.setCaseParameters(test.cid)
+            return this.allure.startStep(test.title)
         }
+
+        this.allure.startCase(test.title)
+        this.setCaseParameters(test.cid)
     }
 
     setCaseParameters(cid) {
@@ -102,10 +103,10 @@ class AllureReporter extends WDIOReporter {
 
     onTestPass() {
         if (this.options.useCucumberStepReporter) {
-            this.allure.endStep(stepStatuses.PASSED)
-        } else {
-            this.allure.endCase(testStatuses.PASSED)
+            return this.allure.endStep(stepStatuses.PASSED)
         }
+
+        this.allure.endCase(testStatuses.PASSED)
     }
 
     onTestFail(test) {

--- a/packages/wdio-allure-reporter/src/index.js
+++ b/packages/wdio-allure-reporter/src/index.js
@@ -60,7 +60,8 @@ class AllureReporter extends WDIOReporter {
 
     onSuiteEnd(suite) {
         if (this.options.useCucumberStepReporter && suite.type === 'scenario') {
-            const isPassed = !suite.tests.some(test => test.state !== testStatuses.PASSED)
+            const isPassed = !suite.tests.some(test => test.state !== testStatuses.PASSED) &&
+                !suite.hooks.some(hook => hook.state && hook.state !== testStatuses.PASSED)
             if (isPassed) {
                 // Only close passing tests because
                 // non passing tests are closed in onTestFailed event

--- a/packages/wdio-allure-reporter/src/index.js
+++ b/packages/wdio-allure-reporter/src/index.js
@@ -7,10 +7,12 @@ import { events, stepStatuses, testStatuses } from './constants'
 class AllureReporter extends WDIOReporter {
     constructor(options) {
         const outputDir = options.outputDir || 'allure-results'
+        const useCucumberStepReporter = Boolean(options.useCucumberStepReporter)
 
         super({
             ...options,
-            outputDir
+            outputDir,
+            useCucumberStepReporter
         })
         this.config = {}
         this.allure = new Allure()
@@ -40,23 +42,50 @@ class AllureReporter extends WDIOReporter {
     }
 
     onSuiteStart(suite) {
-        const currentSuite = this.allure.getCurrentSuite()
-        const prefix = currentSuite ? currentSuite.name + ': ' : ''
-        this.allure.startSuite(prefix + suite.title)
+        if (this.options.useCucumberStepReporter) {
+            if (suite.type === 'feature') {
+                // handle cucumber features as allure "suite"
+                this.allure.startSuite(suite.title)
+            } else {
+                // handle cucumber scenarii as allure "case" instead of "suite"
+                this.allure.startCase(suite.title)
+                this.setCaseParameters(suite.cid)
+            }
+        } else {
+            const currentSuite = this.allure.getCurrentSuite()
+            const prefix = currentSuite ? currentSuite.name + ': ' : ''
+            this.allure.startSuite(prefix + suite.title)
+        }
     }
 
-    onSuiteEnd() {
-        this.allure.endSuite()
+    onSuiteEnd(suite) {
+        if (this.options.useCucumberStepReporter && suite.type === 'scenario') {
+            const isPassed = !suite.tests.some(test => test.state !== testStatuses.PASSED)
+            if (isPassed) {
+                // Only close passing tests because
+                // non passing tests are closed in onTestFailed event
+                this.allure.endCase(testStatuses.PASSED)
+            }
+        } else {
+            this.allure.endSuite()
+        }
     }
 
     onTestStart(test) {
-        this.allure.startCase(test.title)
+        if (this.options.useCucumberStepReporter) {
+            this.allure.startStep(test.title)
+        } else {
+            this.allure.startCase(test.title)
+            this.setCaseParameters(test.cid)
+        }
+    }
 
+    setCaseParameters(cid) {
         const currentTest = this.allure.getCurrentTest()
 
         if (!this.isMultiremote) {
             const { browserName, deviceName } = this.config.capabilities
-            const targetName = browserName || deviceName || test.cid
+            const targetName = browserName || deviceName || cid
             const version = this.config.capabilities.version || this.config.capabilities.platformVersion || ''
             const paramName = deviceName ? 'device' : 'browser'
             const paramValue = version ? `${targetName}-${version}` : targetName
@@ -68,15 +97,28 @@ class AllureReporter extends WDIOReporter {
         // Allure analytics labels. See https://github.com/allure-framework/allure2/blob/master/Analytics.md
         currentTest.addLabel('language', 'javascript')
         currentTest.addLabel('framework', 'wdio')
-        currentTest.addLabel('thread', test.cid)
+        currentTest.addLabel('thread', cid)
     }
 
     onTestPass() {
-        this.allure.endCase(testStatuses.PASSED)
+        if (this.options.useCucumberStepReporter) {
+            this.allure.endStep(stepStatuses.PASSED)
+        } else {
+            this.allure.endCase(testStatuses.PASSED)
+        }
     }
 
     onTestFail(test) {
-        if (!this.isAnyTestRunning()) {
+        if (this.options.useCucumberStepReporter) {
+            const testStatus = getTestStatus(test, this.config)
+            const stepStatus = Object.values(stepStatuses).indexOf(testStatus >= 0) ?
+                testStatus : stepStatuses.FAILED
+            this.allure.endStep(stepStatus)
+            this.allure.endCase(testStatus, getErrorFromFailedTest(test))
+            return
+        }
+
+        if (!this.isAnyTestRunning()) { // is any CASE running
             this.allure.startCase(test.title)
         } else {
             this.allure.getCurrentTest().name = test.title
@@ -91,7 +133,9 @@ class AllureReporter extends WDIOReporter {
     }
 
     onTestSkip(test) {
-        if (!this.allure.getCurrentTest() || this.allure.getCurrentTest().name !== test.title) {
+        if (this.options.useCucumberStepReporter) {
+            this.allure.endStep(stepStatuses.SKIPPED)
+        } else if (!this.allure.getCurrentTest() || this.allure.getCurrentTest().name !== test.title) {
             this.allure.pendingCase(test.title)
         } else {
             this.allure.endCase(testStatuses.PENDING)
@@ -103,7 +147,7 @@ class AllureReporter extends WDIOReporter {
             return
         }
 
-        if (this.options.disableWebdriverStepsReporting || this.isMultiremote) {
+        if (this.options.disableWebdriverStepsReporting || this.options.useCucumberStepReporter || this.isMultiremote) {
             return
         }
 
@@ -119,13 +163,13 @@ class AllureReporter extends WDIOReporter {
             return
         }
 
-        const { disableWebdriverStepsReporting, disableWebdriverScreenshotsReporting } = this.options
+        const { disableWebdriverStepsReporting, disableWebdriverScreenshotsReporting, useCucumberStepReporter } = this.options
         if (this.isScreenshotCommand(command) && command.result.value) {
             if (!disableWebdriverScreenshotsReporting) {
                 this.allure.addAttachment('Screenshot', Buffer.from(command.result.value, 'base64'))
             }
         }
-        if (!disableWebdriverStepsReporting) {
+        if (!disableWebdriverStepsReporting && !useCucumberStepReporter) {
             if (command.result && command.result.value && !this.isScreenshotCommand(command)) {
                 this.dumpJSON('Response', command.result.value)
             }
@@ -180,7 +224,7 @@ class AllureReporter extends WDIOReporter {
             this.onTestPass()
 
             // remove hook from suite if it has no steps
-            if (this.allure.getCurrentTest().steps.length === 0) {
+            if (this.allure.getCurrentTest().steps.length === 0 && !this.options.useCucumberStepReporter) {
                 this.allure.getCurrentSuite().testcases.pop()
             }
         }

--- a/packages/wdio-allure-reporter/tests/__fixtures__/cucumber.js
+++ b/packages/wdio-allure-reporter/tests/__fixtures__/cucumber.js
@@ -11,14 +11,23 @@ const suite = (type = 'feature') => ({
     suites: []
 })
 
+const error = {
+    message: 'foo == bar',
+    stack: 'AssertionError [ERR_ASSERTION]: foo == bar',
+    type: 'AssertionError [ERR_ASSERTION]',
+    name: 'AssertionError',
+    expected: 'foo',
+    actual: 'bar'
+}
+
 export function featureStart() {
     return Object.assign(suite('feature'))
 }
 
-export function featureEnd() {
+export function featureEnd(failCause = null) {
     return Object.assign(suite('feature'), {
         _duration: 1516,
-        suites: [scenarioEnd()],
+        suites: [scenarioEnd(failCause)],
         end: '2019-07-22T12:21:37.696Z'
     })
 }
@@ -27,11 +36,11 @@ export function scenarioStart() {
     return Object.assign(suite('scenario'))
 }
 
-export function scenarioEnd() {
+export function scenarioEnd(failCause = null) {
     return Object.assign(suite('scenario'), {
         _duration: 1451,
-        tests: [testPass()],
-        hooks: [hookEnd()],
+        tests: [failCause === 'test' ? testFail() : testPass()],
+        hooks: [failCause === 'hook' ? hookFail() : hookEnd()],
         end: '2019-07-22T12:21:37.695Z'
     })
 }
@@ -49,6 +58,17 @@ const hook = () => ({
 export function hookStart() {
     return Object.assign(hook())
 }
+
+export function hookFail() {
+    return Object.assign(hook(), {
+        _duration: 1,
+        errors: [error],
+        error: error,
+        state: 'failed',
+        end: '2019-07-22T12:21:36.250Z'
+    })
+}
+
 export function hookEnd() {
     return Object.assign(hook(), {
         _duration: 4,
@@ -74,11 +94,23 @@ const test = () => ({
 export function testStart() {
     return Object.assign(test())
 }
+
 export function testFail() {
     return Object.assign(test(), {
-        // todo
+        _duration: 10,
+        errors: [error],
+        error: error,
+        state: 'failed',
+        end: '2019-07-22T12:21:37.684Z'
     })
 }
+
+export function testSkipped() {
+    return Object.assign(test(), {
+        state: 'skipped'
+    })
+}
+
 export function testPass() {
     return Object.assign(test(), {
         _duration: 1433,

--- a/packages/wdio-allure-reporter/tests/__fixtures__/cucumber.js
+++ b/packages/wdio-allure-reporter/tests/__fixtures__/cucumber.js
@@ -1,0 +1,88 @@
+const suite = (type = 'feature') => ({
+    type,
+    start: '2019-07-22T12:21:36.244Z',
+    _duration: 0,
+    uid: type === 'feature' ? 'MyFeature1' : 'MyScenario2',
+    cid: '0-0',
+    title: type === 'feature' ? 'MyFeature': 'MyScenario',
+    fullTitle: type === 'feature' ? undefined: 'MyFeature1: My Scenario',
+    tests: [],
+    hooks: [],
+    suites: []
+})
+
+export function featureStart() {
+    return Object.assign(suite('feature'))
+}
+
+export function featureEnd() {
+    return Object.assign(suite('feature'), {
+        _duration: 1516,
+        suites: [scenarioEnd()],
+        end: '2019-07-22T12:21:37.696Z'
+    })
+}
+
+export function scenarioStart() {
+    return Object.assign(suite('scenario'))
+}
+
+export function scenarioEnd() {
+    return Object.assign(suite('scenario'), {
+        _duration: 1451,
+        tests: [testPass()],
+        hooks: [hookEnd()],
+        end: '2019-07-22T12:21:37.695Z'
+    })
+}
+
+const hook = () => ({
+    type: 'hook',
+    start: '2019-07-22T12:21:36.246Z',
+    _duration: 0,
+    uid: 'hooks.js8',
+    cid: '0-0',
+    title: 'Hook',
+    parent: 'MyFeature: MyScenario'
+})
+
+export function hookStart() {
+    return Object.assign(hook())
+}
+export function hookEnd() {
+    return Object.assign(hook(), {
+        _duration: 4,
+        errors: [],
+        end: '2019-07-22T12:21:36.250Z'
+    })
+}
+
+// a cucumber *step* triggers a wdio event *test*
+const test = () => ({
+    type: 'test',
+    start: '2019-07-22T12:21:36.251Z',
+    _duration: 0,
+    uid: 'I do something4',
+    cid: '0-0',
+    title: 'I do something',
+    fullTitle: 'MyFeature: MyScenario: I do something',
+    output: [],
+    argument: undefined,
+    state: 'pending'
+})
+
+export function testStart() {
+    return Object.assign(test())
+}
+export function testFail() {
+    return Object.assign(test(), {
+        // todo
+    })
+}
+export function testPass() {
+    return Object.assign(test(), {
+        _duration: 1433,
+        state: 'passed',
+        end: '2019-07-22T12:21:37.684Z'
+    })
+}

--- a/packages/wdio-allure-reporter/tests/constants.test.js
+++ b/packages/wdio-allure-reporter/tests/constants.test.js
@@ -7,7 +7,7 @@ describe('Important constants', () => {
         expect(stepStatuses.BROKEN).toEqual('broken')
         expect(stepStatuses.PASSED).toEqual('passed')
         expect(stepStatuses.FAILED).toEqual('failed')
-        expect(stepStatuses.SKIPPED).toEqual('skipped')
+        expect(stepStatuses.CANCELED).toEqual('canceled')
     })
 
     it('should have correct step statuses', () => {

--- a/packages/wdio-allure-reporter/tests/constants.test.js
+++ b/packages/wdio-allure-reporter/tests/constants.test.js
@@ -3,10 +3,11 @@ import { testStatuses, stepStatuses, events } from '../src/constants'
 describe('Important constants', () => {
 
     it('should have correct step statuses', () => {
-        expect(Object.values(stepStatuses)).toHaveLength(3)
+        expect(Object.values(stepStatuses)).toHaveLength(4)
         expect(stepStatuses.BROKEN).toEqual('broken')
         expect(stepStatuses.PASSED).toEqual('passed')
         expect(stepStatuses.FAILED).toEqual('failed')
+        expect(stepStatuses.SKIPPED).toEqual('skipped')
     })
 
     it('should have correct step statuses', () => {

--- a/packages/wdio-allure-reporter/tests/cucumber.suite.test.js
+++ b/packages/wdio-allure-reporter/tests/cucumber.suite.test.js
@@ -1,0 +1,250 @@
+import { directory } from 'tempy'
+
+/**
+ * this is not a real package and only used to utilize helper
+ * methods without having to ignore them for test coverage
+ */
+// eslint-disable-next-line
+import { clean, getResults } from 'wdio-allure-helper'
+
+import AllureReporter from '../src/'
+import { runnerEnd, runnerStart } from './__fixtures__/runner'
+import * as cucumberHelper from './__fixtures__/cucumber'
+import { commandStart, commandEnd } from './__fixtures__/command'
+
+let processOn
+beforeAll(() => {
+    processOn = ::process.on
+    process.on = jest.fn()
+})
+
+afterAll(() => {
+    process.on = processOn
+})
+
+describe('reporter option "useCucumberStepReporter" set to true', () => {
+
+    describe('Passing tests with option', () => {
+        const outputDir = directory()
+        // const outputDir = process.cwd() + '/allure-results'
+        let allureXml
+
+        beforeAll(() => {
+            const reporter = new AllureReporter({ stdout: true, outputDir, useCucumberStepReporter: true })
+
+            reporter.onRunnerStart(runnerStart())
+            reporter.onSuiteStart(cucumberHelper.featureStart())
+            reporter.onSuiteStart(cucumberHelper.scenarioStart())
+            reporter.onHookStart(cucumberHelper.hookStart())
+            reporter.onHookEnd(cucumberHelper.hookEnd())
+            reporter.onTestStart(cucumberHelper.testStart())
+            reporter.onBeforeCommand(commandStart())
+            reporter.onAfterCommand(commandEnd())
+            reporter.onTestPass(cucumberHelper.testPass())
+            reporter.onSuiteEnd(cucumberHelper.scenarioEnd())
+            reporter.onSuiteEnd(cucumberHelper.featureEnd())
+            reporter.onRunnerEnd(runnerEnd())
+            const results = getResults(outputDir)
+            expect(results).toHaveLength(1)
+            allureXml = results[0]
+        })
+
+        afterAll(() => {
+            clean(outputDir)
+        })
+
+        it('should report one suite', () => {
+            expect(allureXml('ns2\\:test-suite > name').text()).toEqual('MyFeature')
+            expect(allureXml('ns2\\:test-suite > title').text()).toEqual('MyFeature')
+        })
+
+        it('should detect passed test case', () => {
+            expect(allureXml('test-case > name').text()).toEqual('MyScenario')
+            expect(allureXml('test-case').attr('status')).toEqual('passed')
+        })
+
+        it('should report one hook', () => {
+            expect(allureXml('step > name').eq(0).text()).toEqual('Hook')
+            expect(allureXml('step > title').eq(0).text()).toEqual('Hook')
+        })
+
+        it('should report one step', () => {
+            expect(allureXml('step > name').eq(1).text()).toEqual('I do something')
+            expect(allureXml('step > title').eq(1).text()).toEqual('I do something')
+        })
+
+        it('should report hook and step as passing', () => {
+            expect(allureXml('step[status="passed"]').length).toEqual(2)
+        })
+
+        it('should detect analytics labels in test case', () => {
+            expect(allureXml('test-case label[name="language"]').eq(0).attr('value')).toEqual('javascript')
+            expect(allureXml('test-case label[name="framework"]').eq(0).attr('value')).toEqual('wdio')
+        })
+
+        it('should add browser name as test argument', () => {
+            expect(allureXml('test-case parameter[kind="argument"]')).toHaveLength(1)
+            expect(allureXml('test-case parameter[name="browser"]').eq(0).attr('value')).toEqual('chrome-68')
+        })
+    })
+
+    // describe('Failed tests', () => {
+    //     let outputDir
+    //     let allureXml
+
+    //     beforeEach(() => {
+    //         outputDir = directory()
+    //     })
+
+    //     afterEach(() => {
+    //         clean(outputDir)
+    //     })
+
+    //     it('should detect failed test case', () => {
+    //         const reporter = new AllureReporter({ stdout: true, outputDir })
+
+    //         const runnerEvent = runnerStart()
+    //         delete runnerEvent.config.capabilities.browserName
+    //         delete runnerEvent.config.capabilities.version
+
+    //         reporter.onRunnerStart(runnerEvent)
+    //         reporter.onSuiteStart(suiteStart())
+    //         reporter.onTestStart(testStart())
+    //         reporter.onTestFail(testFailed())
+    //         reporter.onSuiteEnd(suiteEnd())
+    //         reporter.onRunnerEnd(runnerEnd())
+
+    //         const results = getResults(outputDir)
+    //         expect(results).toHaveLength(1)
+    //         allureXml = results[0]
+
+    //         expect(allureXml('test-case > name').text()).toEqual('should can do something')
+    //         expect(allureXml('test-case').attr('status')).toEqual('failed')
+
+    //         expect(allureXml('test-case parameter[kind="argument"]')).toHaveLength(1)
+    //         expect(allureXml('test-case parameter[name="browser"]').eq(0).attr('value')).toEqual(testStart().cid)
+    //     })
+
+    //     it('should detect failed test case without start event', () => {
+    //         const reporter = new AllureReporter({ stdout: true, outputDir })
+
+    //         reporter.onRunnerStart(runnerStart())
+    //         reporter.onSuiteStart(suiteStart())
+    //         reporter.onTestFail(testFailed())
+    //         reporter.onSuiteEnd(suiteEnd())
+    //         reporter.onRunnerEnd(runnerEnd())
+
+    //         const results = getResults(outputDir)
+    //         expect(results).toHaveLength(1)
+    //         allureXml = results[0]
+
+    //         expect(allureXml('test-case > name').text()).toEqual('should can do something')
+    //         expect(allureXml('test-case').attr('status')).toEqual('failed')
+    //     })
+
+    //     it('should detect failed test case with multiple errors', () => {
+    //         const reporter = new AllureReporter({ stdout: true, outputDir } )
+
+    //         const runnerEvent = runnerStart()
+    //         runnerEvent.config.framework = 'jasmine'
+    //         delete runnerEvent.config.capabilities.browserName
+    //         delete runnerEvent.config.capabilities.version
+
+    //         reporter.onRunnerStart(runnerEvent)
+    //         reporter.onSuiteStart(suiteStart())
+    //         reporter.onTestStart(testStart())
+    //         reporter.onTestFail(testFailedWithMultipleErrors())
+    //         reporter.onSuiteEnd(suiteEnd())
+    //         reporter.onRunnerEnd(runnerEnd())
+
+    //         const results = getResults(outputDir)
+    //         expect(results).toHaveLength(1)
+
+    //         allureXml = results[0]
+    //         expect(allureXml('test-case > name').text()).toEqual('should can do something')
+    //         expect(allureXml('test-case').attr('status')).toEqual('failed')
+    //         const message = allureXml('message').text()
+    //         const lines = message.split('\n')
+    //         expect(lines[0]).toBe('CompoundError: One or more errors occurred. ---')
+    //         expect(lines[1].trim()).toBe('ReferenceError: All is Dust')
+    //         expect(lines[3].trim()).toBe('InternalError: Abandon Hope')
+    //     })
+    // })
+
+    // describe('Pending tests', () => {
+    //     let outputDir
+
+    //     afterEach(() => {
+    //         clean(outputDir)
+    //     })
+
+    //     it('should detect started pending test case', () => {
+    //         outputDir = directory()
+    //         const reporter = new AllureReporter({ stdout: true, outputDir })
+
+    //         reporter.onRunnerStart(runnerStart())
+    //         reporter.onSuiteStart(suiteStart())
+    //         reporter.onTestStart(testStart())
+    //         reporter.onTestSkip(testPending())
+    //         reporter.onSuiteEnd(suiteEnd())
+    //         reporter.onRunnerEnd(runnerEnd())
+
+    //         const results = getResults(outputDir)
+    //         expect(results).toHaveLength(1)
+    //         const allureXml = results[0]
+
+    //         expect(allureXml('test-case > name').text()).toEqual('should can do something')
+    //         expect(allureXml('test-case').attr('status')).toEqual('pending')
+    //     })
+
+    //     it('should detect not started pending test case', () => {
+    //         outputDir = directory()
+    //         const reporter = new AllureReporter({ stdout: true, outputDir })
+
+    //         reporter.onRunnerStart(runnerStart())
+    //         reporter.onSuiteStart(suiteStart())
+    //         reporter.onTestSkip(testPending())
+    //         reporter.onSuiteEnd(suiteEnd())
+    //         reporter.onRunnerEnd(runnerEnd())
+
+    //         const results = getResults(outputDir)
+    //         expect(results).toHaveLength(1)
+    //         const allureXml = results[0]
+
+    //         expect(allureXml('test-case > name').text()).toEqual('should can do something')
+    //         expect(allureXml('test-case').attr('status')).toEqual('pending')
+    //     })
+
+    //     it('should detect not started pending test case after completed test', () => {
+    //         outputDir = directory()
+    //         const reporter = new AllureReporter({ stdout: true, outputDir })
+    //         let passed = testStart()
+    //         passed = {
+    //             ...passed,
+    //             title: passed.title + '2',
+    //             uid: passed.uid + '2',
+    //             fullTitle: passed.fullTitle + '2'
+    //         }
+
+    //         reporter.onRunnerStart(runnerStart())
+    //         reporter.onSuiteStart(suiteStart())
+    //         reporter.onTestStart(passed)
+    //         reporter.onTestPass({ ...passed, state: 'passed' })
+    //         reporter.onTestSkip(testPending())
+    //         reporter.onSuiteEnd(suiteEnd())
+    //         reporter.onRunnerEnd(runnerEnd())
+
+    //         const results = getResults(outputDir)
+    //         expect(results).toHaveLength(1)
+    //         const allureXml = results[0]
+
+    //         expect(allureXml('test-case > name').length).toEqual(2)
+
+    //         expect(allureXml('test-case > name').last().text()).toEqual('should can do something')
+    //         expect(allureXml('test-case').last().attr('status')).toEqual('pending')
+
+    //         expect(allureXml('test-case > name').first().text()).toEqual(passed.title)
+    //         expect(allureXml('test-case').first().attr('status')).toEqual('passed')
+    //     })
+    // })
+})

--- a/packages/wdio-allure-reporter/tests/runtime.test.js
+++ b/packages/wdio-allure-reporter/tests/runtime.test.js
@@ -113,12 +113,12 @@ describe('reporter reporter api', () => {
 
     it('should throw exception for incorrect status for addStep', () => {
         const cb = () => { reporter.addStep('foo', { content: 'baz' }, 'canceled')}
-        expect(cb).toThrowError('Step status must be passed or failed or broken. You tried to set "canceled"')
+        expect(cb).toThrowError('Step status must be passed or failed or broken or skipped. You tried to set "canceled"')
     })
 
     it('should throw exception for incorrect status for endStep', () => {
         const cb = () => { reporter.endStep('canceled') }
-        expect(cb).toThrowError('Step status must be passed or failed or broken. You tried to set "canceled"')
+        expect(cb).toThrowError('Step status must be passed or failed or broken or skipped. You tried to set "canceled"')
     })
 
     it('should pass correct data from addArgument', () => {

--- a/packages/wdio-allure-reporter/tests/runtime.test.js
+++ b/packages/wdio-allure-reporter/tests/runtime.test.js
@@ -112,13 +112,13 @@ describe('reporter reporter api', () => {
     })
 
     it('should throw exception for incorrect status for addStep', () => {
-        const cb = () => { reporter.addStep('foo', { content: 'baz' }, 'canceled')}
-        expect(cb).toThrowError('Step status must be passed or failed or broken or skipped. You tried to set "canceled"')
+        const cb = () => { reporter.addStep('foo', { content: 'baz' }, 'invalid-status')}
+        expect(cb).toThrowError('Step status must be passed or failed or broken or canceled. You tried to set "invalid-status"')
     })
 
     it('should throw exception for incorrect status for endStep', () => {
-        const cb = () => { reporter.endStep('canceled') }
-        expect(cb).toThrowError('Step status must be passed or failed or broken or skipped. You tried to set "canceled"')
+        const cb = () => { reporter.endStep('invalid-status') }
+        expect(cb).toThrowError('Step status must be passed or failed or broken or canceled. You tried to set "invalid-status"')
     })
 
     it('should pass correct data from addArgument', () => {

--- a/packages/wdio-cucumber-framework/src/reporter.js
+++ b/packages/wdio-cucumber-framework/src/reporter.js
@@ -134,7 +134,7 @@ class CucumberReporter {
         }
 
         const payload = buildStepPayload(uri, feature, scenario, step, {
-            type: 'test',
+            type: 'step',
             title: stepTitle,
             state,
             error,
@@ -149,7 +149,7 @@ class CucumberReporter {
             uid: getUniqueIdentifier(scenario, sourceLocation),
             title: this.getTitle(scenario),
             parent: getUniqueIdentifier(feature),
-            type: 'suite',
+            type: 'scenario',
             file: uri,
             duration: new Date() - this.scenarioStart,
             tags: scenario.tags
@@ -160,7 +160,7 @@ class CucumberReporter {
         this.emit('suite:end', {
             uid: getUniqueIdentifier(feature),
             title: this.getTitle(feature),
-            type: 'suite',
+            type: 'feature',
             file: uri,
             duration: new Date() - this.featureStart,
             tags: feature.tags

--- a/packages/wdio-cucumber-framework/src/reporter.js
+++ b/packages/wdio-cucumber-framework/src/reporter.js
@@ -30,7 +30,7 @@ class CucumberReporter {
         this.emit('suite:start', {
             uid: getUniqueIdentifier(feature),
             title: this.getTitle(feature),
-            type: 'suite',
+            type: 'feature',
             file: uri,
             tags: feature.tags,
             description: feature.description,
@@ -46,7 +46,7 @@ class CucumberReporter {
             uid: getUniqueIdentifier(scenario),
             title: this.getTitle(scenario),
             parent: getUniqueIdentifier(feature),
-            type: 'suite',
+            type: 'scenario',
             file: uri,
             tags: scenario.tags
         })
@@ -168,13 +168,13 @@ class CucumberReporter {
     }
 
     emit (event, payload) {
-        let message = formatMessage({ type: event, payload })
+        let message = formatMessage({ payload })
 
         message.cid = this.cid
         message.specs = this.specs
         message.uid = payload.uid
 
-        this.reporter.emit(message.type, message)
+        this.reporter.emit(event, message)
     }
 
     getTitle (featureOrScenario) {

--- a/packages/wdio-cucumber-framework/src/utils.js
+++ b/packages/wdio-cucumber-framework/src/utils.js
@@ -91,10 +91,9 @@ export function getUniqueIdentifier (target, sourceLocation) {
  * format message
  * @param {object} message { type: string, payload: object }
  */
-export function formatMessage ({ type, payload = {} }) {
+export function formatMessage ({ payload = {} }) {
     let message = {
         ...payload,
-        type: type
     }
 
     if (payload.title && payload.parent) {

--- a/packages/wdio-cucumber-framework/tests/__snapshots__/utils.test.js.snap
+++ b/packages/wdio-cucumber-framework/tests/__snapshots__/utils.test.js.snap
@@ -55,15 +55,8 @@ Object {
 }
 `;
 
-exports[`utils formatMessage should not fail if payload was not passed 1`] = `
-Object {
-  "type": "test",
-}
-`;
-
 exports[`utils formatMessage should set passed state for test hooks 1`] = `
 Object {
   "state": "passed",
-  "type": "afterTest",
 }
 `;

--- a/packages/wdio-cucumber-framework/tests/reporter.test.js
+++ b/packages/wdio-cucumber-framework/tests/reporter.test.js
@@ -179,7 +179,7 @@ describe('cucumber reporter', () => {
                 specs,
                 tags: [...gherkinDocEvent.document.feature.tags],
                 title: gherkinDocEvent.document.feature.name,
-                type: 'suite:start',
+                type: 'feature',
                 uid: 'feature123',
             }))
         })
@@ -208,7 +208,7 @@ describe('cucumber reporter', () => {
             startSuite(eventBroadcaster)
 
             expect(wdioReporter.emit).toHaveBeenCalledWith('suite:start', expect.objectContaining({
-                type: 'suite:start',
+                type: 'scenario',
                 cid: '0-1',
                 parent: 'feature123',
                 uid: 'scenario126',
@@ -235,7 +235,7 @@ describe('cucumber reporter', () => {
                 })
 
                 expect(wdioReporter.emit).toHaveBeenCalledWith('test:start', expect.objectContaining({
-                    type: 'test:start',
+                    type: 'test',
                     title: 'Given step-title-passing',
                     cid: '0-1',
                     parent: 'feature: scenario',
@@ -260,7 +260,7 @@ describe('cucumber reporter', () => {
                 })
 
                 expect(wdioReporter.emit).toHaveBeenCalledWith('hook:end', expect.objectContaining({
-                    type: 'hook:end',
+                    type: 'hook',
                     error: undefined,
                 }))
             })
@@ -275,7 +275,7 @@ describe('cucumber reporter', () => {
                 })
 
                 expect(wdioReporter.emit).toHaveBeenCalledWith('hook:end', expect.objectContaining({
-                    type: 'hook:end',
+                    type: 'hook',
                     error: 'err',
                 }))
             })
@@ -290,7 +290,7 @@ describe('cucumber reporter', () => {
                 })
 
                 expect(wdioReporter.emit).toHaveBeenCalledWith('test:pass', expect.objectContaining({
-                    type: 'test:pass',
+                    type: 'step',
                     title: 'Given step-title-passing',
                     cid: '0-1',
                     parent: 'feature: scenario',
@@ -313,7 +313,7 @@ describe('cucumber reporter', () => {
                 })
 
                 expect(wdioReporter.emit).toHaveBeenCalledWith('test:pending', expect.objectContaining({
-                    type: 'test:pending',
+                    type: 'step',
                     title: 'Given step-title-passing',
                     cid: '0-1',
                     parent: 'feature: scenario',
@@ -336,7 +336,7 @@ describe('cucumber reporter', () => {
                 })
 
                 expect(wdioReporter.emit).toHaveBeenCalledWith('test:pending', expect.objectContaining({
-                    type: 'test:pending',
+                    type: 'step',
                     title: 'Given step-title-passing',
                     cid: '0-1',
                     parent: 'feature: scenario',
@@ -364,7 +364,7 @@ describe('cucumber reporter', () => {
                 })
 
                 expect(wdioReporter.emit).toHaveBeenCalledWith('test:fail', expect.objectContaining({
-                    type: 'test:fail',
+                    type: 'step',
                     title: 'When step-title-failing',
                     cid: '0-1',
                     parent: 'feature: scenario',
@@ -395,7 +395,7 @@ describe('cucumber reporter', () => {
                 })
 
                 expect(wdioReporter.emit).toHaveBeenCalledWith('test:fail', expect.objectContaining({
-                    type: 'test:fail',
+                    type: 'step',
                     title: 'When step-title-failing',
                     cid: '0-1',
                     parent: 'feature: scenario',
@@ -426,7 +426,7 @@ describe('cucumber reporter', () => {
                 })
 
                 expect(wdioReporter.emit).toHaveBeenCalledWith('test:fail', expect.objectContaining({
-                    type: 'test:fail',
+                    type: 'step',
                     title: 'When step-title-failing',
                     cid: '0-1',
                     parent: 'feature: scenario',
@@ -450,7 +450,7 @@ describe('cucumber reporter', () => {
                 })
 
                 expect(wdioReporter.emit).toHaveBeenCalledWith('suite:end', expect.objectContaining({
-                    type: 'suite:end',
+                    type: 'scenario',
                     cid: '0-1',
                     parent: 'feature123',
                     uid: 'scenario126',
@@ -468,7 +468,7 @@ describe('cucumber reporter', () => {
                 })
 
                 expect(wdioReporter.emit).toHaveBeenCalledWith('suite:end', expect.objectContaining({
-                    type: 'suite:end',
+                    type: 'feature',
                     title: 'feature',
                     file: './any.feature',
                     uid: 'feature123',
@@ -576,7 +576,7 @@ describe('cucumber reporter', () => {
             eventBroadcaster.emit('gherkin-document', gherkinDocEvent)
 
             expect(wdioReporter.emit).toHaveBeenCalledWith('suite:start', expect.objectContaining({
-                type: 'suite:start',
+                type: 'feature',
                 title: '@feature-tag1, @feature-tag2: feature',
                 uid: 'feature123',
                 file: './any.feature',
@@ -607,7 +607,7 @@ describe('cucumber reporter', () => {
             eventBroadcaster.emit('test-case-started', {})
 
             expect(wdioReporter.emit).toHaveBeenCalledWith('suite:start', expect.objectContaining({
-                type: 'suite:start',
+                type: 'scenario',
                 title: '@scenario-tag1, @scenario-tag2: scenario',
                 uid: 'scenario126',
                 file: './any.feature',

--- a/packages/wdio-cucumber-framework/tests/utils.test.js
+++ b/packages/wdio-cucumber-framework/tests/utils.test.js
@@ -80,23 +80,20 @@ describe('utils', () => {
     describe('formatMessage', () => {
         it('should set passed state for test hooks', () => {
             expect(formatMessage({
-                type: 'afterTest',
                 payload: { state: 'passed' }
             })).toMatchSnapshot()
         })
 
         it('should not fail if payload was not passed', () => {
-            expect(formatMessage({ type: 'test' })).toMatchSnapshot()
+            expect(formatMessage({})).toEqual({})
         })
 
         it('should set fullTitle', () => {
             expect(formatMessage({
-                type: 'foobar',
                 payload: { parent: 'foo', title: 'bar' }
             })).toEqual({
                 parent: 'foo',
                 title: 'bar',
-                type: 'foobar',
                 fullTitle: 'foo: bar',
             })
         })

--- a/packages/wdio-reporter/src/stats/suite.js
+++ b/packages/wdio-reporter/src/stats/suite.js
@@ -5,7 +5,7 @@ import RunnableStats from './runnable'
  */
 export default class SuiteStats extends RunnableStats {
     constructor (suite) {
-        super('suite')
+        super(suite.type || 'suite')
         this.uid = RunnableStats.getIdentifier(suite)
         this.cid = suite.cid
         this.title = suite.title


### PR DESCRIPTION
## Proposed changes
This new option to allure-reporter changes the way cucumber Feature / Scenario / Steps are reported within allure.
Basically it reports cucumber scenario as allure tests, and cucumber steps as allure steps.
Current behavior is cucumber scenario -> allure suite, cucumber step -> allure test, wdio command -> allure step
This is the reimplementation of an options that existed on v4 but was not ported to v5.

I haven't fixed / added unit tests or documentation yet, I first would like to have some feedback, to see if the changes I've made are correct.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
