### PR TITLE
Fix slow before/after command hook in sync mode

### DIFF
--- a/packages/wdio-sync/src/wrapCommand.js
+++ b/packages/wdio-sync/src/wrapCommand.js
@@ -59,7 +59,10 @@ export default function wrapCommand (commandName, fn) {
  * helper method that runs the command with before/afterCommand hook
  */
 async function runCommandWithHooks (commandName, fn, ...args) {
-    await runBeforeCommand.apply(this, [commandName, ...args])
+    await executeHooksWithArgs(
+        this.options.beforeCommand,
+        [commandName, args]
+    )
 
     let commandResult
     let commandError
@@ -69,7 +72,10 @@ async function runCommandWithHooks (commandName, fn, ...args) {
         commandError = err
     }
 
-    await runAfterCommand.apply(this, [commandName, commandResult, commandError, ...args])
+    await executeHooksWithArgs(
+        this.options.afterCommand,
+        [commandName, args, commandResult, commandError]
+    )
 
     if (commandError) {
         throw commandError
@@ -87,14 +93,6 @@ async function runCommand (fn, ...args) {
     } catch (err) {
         throw sanitizeErrorMessage(err, stackError)
     }
-}
-
-function runBeforeCommand (commandName, ...args) {
-    return executeHooksWithArgs(this.options.beforeCommand, [commandName, args])
-}
-
-function runAfterCommand (commandName, commandResult, commandError, ...args) {
-    return executeHooksWithArgs(this.options.afterCommand, [commandName, args, commandResult, commandError])
 }
 
 /**

--- a/packages/wdio-sync/src/wrapCommand.js
+++ b/packages/wdio-sync/src/wrapCommand.js
@@ -15,6 +15,13 @@ const IGNORED_FUNCTIONS = ['elementErrorHandlerFn', 'wrapCommandFn', 'elementErr
  */
 export default function wrapCommand (commandName, fn) {
     return function wrapCommandFn (...args) {
+        /**
+         * Avoid running some functions in Future that are not in Fiber.
+         */
+        if (fn.SKIP_COMMAND_HOOK === true || fn.name === 'wrapCommandFn') {
+            return runCommand.apply(this, [fn, ...args])
+        }
+
         const future = new Future()
 
         const result = runCommandWithHooks.apply(this, [commandName, fn, ...args])

--- a/packages/wdio-sync/src/wrapCommand.js
+++ b/packages/wdio-sync/src/wrapCommand.js
@@ -3,6 +3,8 @@ import Future from 'fibers/future'
 import executeHooksWithArgs from './executeHooksWithArgs'
 import { sanitizeErrorMessage } from './utils'
 
+const IGNORED_FUNCTIONS = ['elementErrorHandlerFn', 'wrapCommandFn', 'elementErrorHandlerCallbackFn']
+
 /**
  * wraps a function into a Fiber ready context to enable sync execution and hooks
  * @param  {Function}   fn             function to be executed
@@ -90,6 +92,5 @@ function runAfterCommand (commandName, commandResult, commandError, ...args) {
 }
 
 function shouldSkipHook(fn) {
-    const ignoredFunctions = ['elementErrorHandlerFn', 'wrapCommandFn', 'elementErrorHandlerCallbackFn']
-    return fn.SKIP_COMMAND_HOOK === true || ignoredFunctions.some(fnName => fnName === fn.name)
+    return fn.SKIP_COMMAND_HOOK === true || IGNORED_FUNCTIONS.some(fnName => fnName === fn.name)
 }

--- a/packages/wdio-sync/tests/wrapCommand.test.js
+++ b/packages/wdio-sync/tests/wrapCommand.test.js
@@ -23,6 +23,27 @@ describe('wrapCommand:runCommand', () => {
         expect(result).toEqual('barbar')
     })
 
+    it('should ignore hooks by SKIP_COMMAND_HOOK', async () => {
+        const fn = jest.fn(x => (x + x))
+        function elementErrorHandlerCallbackFn (...args) {
+            return fn(args)
+        }
+        elementErrorHandlerCallbackFn.SKIP_COMMAND_HOOK = true
+        const runCommand = wrapCommand('foo', elementErrorHandlerCallbackFn)
+        const result = await runCommand.call({ options: {} }, 'bar')
+        expect(result).toEqual('barbar')
+    })
+
+    it('should ignore hooks by fn.name', async () => {
+        const fn = jest.fn(x => (x + x))
+        function elementErrorHandlerCallbackFn (...args) {
+            return fn(args)
+        }
+        const runCommand = wrapCommand('foo', elementErrorHandlerCallbackFn)
+        const result = await runCommand.call({ options: {} }, 'bar')
+        expect(result).toEqual('barbar')
+    })
+
     it('should throw error with proper message', async () => {
         const fn = jest.fn(x => { throw new Error(x) })
         const runCommand = wrapCommand('foo', fn)
@@ -39,7 +60,7 @@ describe('wrapCommand:runCommand', () => {
         } catch (err) {
             expect(err).toEqual(new Error('AnotherError'))
             expect(err.name).toBe('Error')
-            expect(err.stack.split('wrapCommand.test.js')).toHaveLength(3)
+            expect(err.stack.split('wrapCommand.test.js')).toHaveLength(2)
             expect(err.stack).toContain('__mocks__')
         }
         expect.assertions(4)
@@ -54,7 +75,7 @@ describe('wrapCommand:runCommand', () => {
         } catch (err) {
             expect(err).toEqual(new Error('bar'))
             expect(err.name).toBe('Error')
-            expect(err.stack.split('wrapCommand.test.js')).toHaveLength(2)
+            expect(err.stack.split('wrapCommand.test.js')).toHaveLength(1)
         }
         expect.assertions(3)
     })
@@ -68,7 +89,7 @@ describe('wrapCommand:runCommand', () => {
         } catch (err) {
             expect(err).toEqual(new Error())
             expect(err.name).toBe('Error')
-            expect(err.stack.split('wrapCommand.test.js')).toHaveLength(2)
+            expect(err.stack.split('wrapCommand.test.js')).toHaveLength(1)
         }
         expect.assertions(3)
     })

--- a/packages/webdriver/src/command.js
+++ b/packages/webdriver/src/command.js
@@ -7,7 +7,7 @@ const log = logger('webdriver')
 export default function (method, endpointUri, commandInfo) {
     const { command, ref, parameters, variables = [], isHubCommand = false } = commandInfo
 
-    return function (...args) {
+    function protocolCommand (...args) {
         let endpoint = endpointUri // clone endpointUri in case we change it
         const commandParams = [...variables.map((v) => Object.assign(v, {
             /**
@@ -88,4 +88,12 @@ export default function (method, endpointUri, commandInfo) {
             return result.value
         })
     }
+
+    /**
+     * skip certain protocol commands as far as these commands are wrapped by WebdriverIO
+     */
+    if (endpointUri.includes('element')) {
+        protocolCommand.SKIP_COMMAND_HOOK = true
+    }
+    return protocolCommand
 }

--- a/packages/webdriver/src/command.js
+++ b/packages/webdriver/src/command.js
@@ -7,7 +7,7 @@ const log = logger('webdriver')
 export default function (method, endpointUri, commandInfo) {
     const { command, ref, parameters, variables = [], isHubCommand = false } = commandInfo
 
-    function protocolCommand (...args) {
+    return function protocolCommand (...args) {
         let endpoint = endpointUri // clone endpointUri in case we change it
         const commandParams = [...variables.map((v) => Object.assign(v, {
             /**
@@ -88,13 +88,4 @@ export default function (method, endpointUri, commandInfo) {
             return result.value
         })
     }
-
-    /**
-     * skip certain protocol commands as far as these commands are wrapped by WebdriverIO
-     */
-    if ((endpointUri.includes('/:elementId/') && command.toLowerCase().includes('element'))
-        || command.startsWith('findElement')) {
-        protocolCommand.SKIP_COMMAND_HOOK = true
-    }
-    return protocolCommand
 }

--- a/packages/webdriver/src/command.js
+++ b/packages/webdriver/src/command.js
@@ -92,7 +92,8 @@ export default function (method, endpointUri, commandInfo) {
     /**
      * skip certain protocol commands as far as these commands are wrapped by WebdriverIO
      */
-    if (endpointUri.includes('element')) {
+    if ((endpointUri.includes('/:elementId/') && command.toLowerCase().includes('element'))
+        || command.startsWith('findElement')) {
         protocolCommand.SKIP_COMMAND_HOOK = true
     }
     return protocolCommand

--- a/packages/webdriverio/src/middlewares.js
+++ b/packages/webdriverio/src/middlewares.js
@@ -9,8 +9,11 @@ import implicitWait from './utils/implicitWait'
  * @param  {Function} fn  commandWrap from wdio-sync package (or shim if not running in sync)
  */
 export const elementErrorHandler = (fn) => (commandName, commandFn) => {
-    return function (...args) {
-        return fn(commandName, async () => {
+    function elementErrorHandlerFn (...args) {
+        elementErrorHandlerFn.CALLS_COUNTER++
+
+        const elementErrorHandlerCallbackFn = async () => {
+            commandFn.IS_ERROR_HANDLER = true
             const element = await implicitWait(this, commandName)
             this.elementId = element.elementId
 
@@ -38,9 +41,23 @@ export const elementErrorHandler = (fn) => (commandName, commandFn) => {
                 }
                 throw error
             }
-        }).apply(this)
+        }
+
+        /**
+         * Avoid calling before/after command hook if function marked accordingly
+         * or function call counter reached (wrapped function calling another wrapped function that causes same hook to be called multiple times)
+         */
+        if (commandFn.SKIP_COMMAND_HOOK || commandFn.IS_ERROR_HANDLER || elementErrorHandlerFn.CALLS_COUNTER > 2) {
+            elementErrorHandlerCallbackFn.SKIP_COMMAND_HOOK = true
+            elementErrorHandlerFn.SKIP_COMMAND_HOOK = true
+        }
+
+        return fn(commandName, elementErrorHandlerCallbackFn).apply(this)
 
     }
+
+    elementErrorHandlerFn.CALLS_COUNTER = 0
+    return elementErrorHandlerFn
 }
 
 /**

--- a/packages/webdriverio/src/middlewares.js
+++ b/packages/webdriverio/src/middlewares.js
@@ -13,7 +13,6 @@ export const elementErrorHandler = (fn) => (commandName, commandFn) => {
         elementErrorHandlerFn.CALLS_COUNTER++
 
         const elementErrorHandlerCallbackFn = async () => {
-            commandFn.IS_ERROR_HANDLER = true
             const element = await implicitWait(this, commandName)
             this.elementId = element.elementId
 
@@ -47,7 +46,7 @@ export const elementErrorHandler = (fn) => (commandName, commandFn) => {
          * Avoid calling before/after command hook if function marked accordingly
          * or function call counter reached (wrapped function calling another wrapped function that causes same hook to be called multiple times)
          */
-        if (commandFn.SKIP_COMMAND_HOOK || commandFn.IS_ERROR_HANDLER || elementErrorHandlerFn.CALLS_COUNTER > 2) {
+        if (commandFn.SKIP_COMMAND_HOOK || elementErrorHandlerFn.CALLS_COUNTER > 2) {
             elementErrorHandlerCallbackFn.SKIP_COMMAND_HOOK = true
             elementErrorHandlerFn.SKIP_COMMAND_HOOK = true
         }

--- a/packages/webdriverio/src/middlewares.js
+++ b/packages/webdriverio/src/middlewares.js
@@ -9,10 +9,8 @@ import implicitWait from './utils/implicitWait'
  * @param  {Function} fn  commandWrap from wdio-sync package (or shim if not running in sync)
  */
 export const elementErrorHandler = (fn) => (commandName, commandFn) => {
-    function elementErrorHandlerFn (...args) {
-        elementErrorHandlerFn.CALLS_COUNTER++
-
-        const elementErrorHandlerCallbackFn = async () => {
+    return function elementErrorHandlerCallback (...args) {
+        return fn(commandName, async function elementErrorHandlerCallbackFn () {
             const element = await implicitWait(this, commandName)
             this.elementId = element.elementId
 
@@ -40,23 +38,9 @@ export const elementErrorHandler = (fn) => (commandName, commandFn) => {
                 }
                 throw error
             }
-        }
-
-        /**
-         * Avoid calling before/after command hook if function marked accordingly
-         * or function call counter reached (wrapped function calling another wrapped function that causes same hook to be called multiple times)
-         */
-        if (commandFn.SKIP_COMMAND_HOOK || elementErrorHandlerFn.CALLS_COUNTER > 2) {
-            elementErrorHandlerCallbackFn.SKIP_COMMAND_HOOK = true
-            elementErrorHandlerFn.SKIP_COMMAND_HOOK = true
-        }
-
-        return fn(commandName, elementErrorHandlerCallbackFn).apply(this)
+        }).apply(this)
 
     }
-
-    elementErrorHandlerFn.CALLS_COUNTER = 0
-    return elementErrorHandlerFn
 }
 
 /**

--- a/packages/webdriverio/src/utils/getElementObject.js
+++ b/packages/webdriverio/src/utils/getElementObject.js
@@ -61,7 +61,6 @@ export const getElement = function findElement (selector, res) {
  */
 export const getElements = function getElements (selector, res) {
     const browser = getBrowserObject(this)
-    const partialPrototype = { ...getWDIOPrototype('element'), scope: 'element' }
 
     const elements = res.map((res, i) => {
         const element = webdriverMonad(this.options, (client) => {
@@ -90,7 +89,7 @@ export const getElements = function getElements (selector, res) {
             client.index = i
             client.emit = ::this.emit
             return client
-        }, { ...clone(browser.__propertiesObject__), ...partialPrototype })
+        }, { ...clone(browser.__propertiesObject__), ...getWDIOPrototype('element'), scope: 'element' })
 
         const elementInstance = element(this.sessionId, elementErrorHandler(wrapCommand))
 


### PR DESCRIPTION
## Proposed changes

Fix slow before/after command hook in sync mode. #4133 
Avoid calling before/after hook for all nested commands.

**93% faster now!**

See test used https://github.com/webdriverio/webdriverio/pull/4221#issuecomment-513987108

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

To make this fix working properly we need to merge https://github.com/webdriverio/webdriverio/pull/4229 first and rebase

### Reviewers: @webdriverio/technical-committee
