### PR TITLE
wdio-reporter: add suite tags

### DIFF
--- a/packages/wdio-reporter/src/stats/suite.js
+++ b/packages/wdio-reporter/src/stats/suite.js
@@ -10,6 +10,7 @@ export default class SuiteStats extends RunnableStats {
         this.cid = suite.cid
         this.title = suite.title
         this.fullTitle = suite.fullTitle
+        this.tags = suite.tags
         this.tests = []
         this.hooks = []
         this.suites = []


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)
In wdio v4 we used to have access to the suite tags, when using cucumber, from the reporters. In wdio v5, this seems to be no longer possible. As we have a custom reporter that generates a JSON to integrate with a Jira plugin, we really need the tags, because they're the key that will link the test result from the automated execution to a test case in the Jira plugin. 

This PR aims to make the tags available from the reporters again.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
