### PR TITLE
Fix MaxListenersExceededWarning

### DIFF
--- a/packages/wdio-local-runner/src/stdStream.js
+++ b/packages/wdio-local-runner/src/stdStream.js
@@ -1,0 +1,28 @@
+import { Transform } from 'stream'
+import { removeLastListener } from './utils'
+
+export default class RunnerStream extends Transform {
+    constructor () {
+        super()
+
+        /**
+         * Remove events that are automatically created by Writable stream
+         */
+        this.on('pipe', () => {
+            removeLastListener(this, 'close')
+            removeLastListener(this, 'drain')
+            removeLastListener(this, 'error')
+            removeLastListener(this, 'finish')
+            removeLastListener(this, 'unpipe')
+        })
+    }
+
+    _transform (chunk, encoding, callback) {
+        callback(null, chunk)
+    }
+
+    _final (callback) {
+        this.unpipe()
+        callback()
+    }
+}

--- a/packages/wdio-local-runner/src/utils.js
+++ b/packages/wdio-local-runner/src/utils.js
@@ -1,0 +1,6 @@
+export function removeLastListener (target, eventName) {
+    const listener = target.listeners(eventName).reverse()[0]
+    if (listener) {
+        target.removeListener(eventName, listener)
+    }
+}

--- a/packages/wdio-local-runner/tests/stdStream.test.js
+++ b/packages/wdio-local-runner/tests/stdStream.test.js
@@ -1,0 +1,36 @@
+import RunnerStream from '../src/stdStream'
+
+describe('RunnerStream', () => {
+    let stream
+    let pushSpy
+    const cb = jest.fn()
+    beforeEach(() => {
+        stream = new RunnerStream()
+        pushSpy = jest.spyOn(stream, 'push')
+    })
+
+    test('should have pipe listener', () => {
+        stream._transform('foobar', null, cb)
+        expect(cb).toBeCalledWith(null, 'foobar')
+    })
+
+    test('should remove certain last listener on pipe', () => {
+        const stream2 = new RunnerStream()
+        stream.on('foobar', () => {})
+        stream.on('error', () => {})
+        stream2.pipe(stream)
+
+        expect(stream.listeners('foobar')).toHaveLength(1)
+        expect(stream.listeners('error')).toHaveLength(1)
+        expect(stream.listeners('close')).toHaveLength(0)
+        expect(stream.listeners('drain')).toHaveLength(0)
+        expect(stream.listeners('finish')).toHaveLength(0)
+        expect(stream.listeners('unpipe')).toHaveLength(0)
+    })
+
+    afterEach((done) => {
+        cb.mockClear()
+        pushSpy.mockClear()
+        stream.end(() => done())
+    })
+})

--- a/packages/wdio-local-runner/tests/transformStream.test.js
+++ b/packages/wdio-local-runner/tests/transformStream.test.js
@@ -20,7 +20,7 @@ test('should ignore debugger messages', () => {
     expect(pushSpy).toBeCalledTimes(0)
 })
 
-test('should ignore debugger messages', (done) => {
+test('should unpipe in the end', (done) => {
     const stream = new RunnerTransformStream('0-5')
     const stream2 = new RunnerTransformStream('0-6')
 

--- a/packages/wdio-local-runner/tests/utils.test.js
+++ b/packages/wdio-local-runner/tests/utils.test.js
@@ -1,0 +1,19 @@
+import RunnerStream from '../src/stdStream'
+import { removeLastListener } from '../src/utils'
+
+describe('removeLastListener', () => {
+    it('should remove only last listener', () => {
+        const stream = new RunnerStream()
+        stream.on('foobar', () => {})
+        stream.on('foobar', () => {})
+        expect(stream.listeners('foobar')).toHaveLength(2)
+        removeLastListener(stream, 'foobar')
+        expect(stream.listeners('foobar')).toHaveLength(1)
+    })
+
+    it('should not fail if listener is missing', () => {
+        const stream = new RunnerStream()
+        removeLastListener(stream, 'foobar')
+        expect(stream.listeners('foobar')).toHaveLength(0)
+    })
+})


### PR DESCRIPTION
## Proposed changes

Fix `MaxListenersExceededWarning: Possible EventEmitter memory leak detected.` 
#3877 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

Certain event listeners are added automatically when Readable / Writable stream is piped.
As far as we pipe all worker streams with process stdout, stderr and stdin, lots of event listeners are created. 

### Reviewers: @webdriverio/technical-committee
