### PR TITLE
webdriverio: uploadFile return type void => string

### DIFF
--- a/packages/webdriverio/src/commands/browser/uploadFile.js
+++ b/packages/webdriverio/src/commands/browser/uploadFile.js
@@ -20,7 +20,7 @@
  * @param {String} localPath local path to file
  * @type utility
  * @uses protocol/file
- *
+ * @returns {String} remote URL
  */
 import fs from 'fs'
 import path from 'path'


### PR DESCRIPTION
## Proposed changes

Resolves issue #4217  "uploadFile has return type void"

## Types of changes

Merely annotating the return type of `uploadFile`

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

I wasn't sure whether to report the return type as String or Promise. Technically, it _is_ a promise, but the issue asked for a fix in sync mode. Please let me know. Happy to update the PR.

### Reviewers: @webdriverio/technical-committee
