### PR TITLE
Cucumber: add result argument to afterScenario hook

### DIFF
--- a/docs/ConfigurationFile.md
+++ b/docs/ConfigurationFile.md
@@ -350,7 +350,7 @@ exports.config = {
     },
     afterStep: function (uri, feature, scenario, step, result) {
     },
-    afterScenario: function (uri, feature, scenario) {
+    afterScenario: function (uri, feature, scenario, result) {
     },
     afterFeature: function (uri, feature) {
     }

--- a/examples/pageobject/wdio.conf.js
+++ b/examples/pageobject/wdio.conf.js
@@ -142,7 +142,7 @@ exports.config = {
     // },
     //
     // Runs after a Cucumber Scenario
-    // afterScenario: function (uri, feature, scenario) {
+    // afterScenario: function (uri, feature, scenario, result) {
     // },
     //
     // Runs before a Cucumber Step

--- a/examples/wdio.conf.js
+++ b/examples/wdio.conf.js
@@ -319,7 +319,7 @@ exports.config = {
     },
     afterStep: function (uri, feature, scenario, step, result) {
     },
-    afterScenario: function (uri, feature, scenario) {
+    afterScenario: function (uri, feature, scenario, result) {
     },
     afterFeature: function (uri, feature) {
     }

--- a/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
+++ b/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
@@ -330,7 +330,7 @@ exports.config = {
      * Runs after a Cucumber scenario
      * @param {Object} scenario scenario details
      */
-    // afterScenario: function (uri, feature, scenario) {
+    // afterScenario: function (uri, feature, scenario, result) {
     // },
     /**
      * Runs after a Cucumber feature

--- a/packages/wdio-cucumber-framework/src/cucumberEventListener.js
+++ b/packages/wdio-cucumber-framework/src/cucumberEventListener.js
@@ -174,14 +174,14 @@ export default class CucumberEventListener extends EventEmitter {
     //     sourceLocation: { uri: string, line: 0 }
     // }
     onTestCaseFinished (testCaseFinishedEvent) {
-        const sourceLocation = testCaseFinishedEvent.sourceLocation
+        const { sourceLocation, result } = testCaseFinishedEvent
         const uri = sourceLocation.uri
 
         const doc = this.gherkinDocEvents.find(gde => gde.uri === uri).document
         const feature = doc.feature
         const scenario = feature.children.find((child) => compareScenarioLineWithSourceLine(child, sourceLocation))
 
-        this.emit('after-scenario', uri, feature, scenario, sourceLocation)
+        this.emit('after-scenario', uri, feature, scenario, result, sourceLocation)
 
         this.currentPickle = null
     }

--- a/packages/wdio-cucumber-framework/src/reporter.js
+++ b/packages/wdio-cucumber-framework/src/reporter.js
@@ -144,7 +144,7 @@ class CucumberReporter {
         this.emit('test:' + state, payload)
     }
 
-    handleAfterScenario (uri, feature, scenario, sourceLocation) {
+    handleAfterScenario (uri, feature, scenario, result, sourceLocation) {
         this.emit('suite:end', {
             uid: getUniqueIdentifier(scenario, sourceLocation),
             title: this.getTitle(scenario),

--- a/packages/wdio-cucumber-framework/tests/eventListener.test.js
+++ b/packages/wdio-cucumber-framework/tests/eventListener.test.js
@@ -73,3 +73,38 @@ test('onTestCasePrepared', () => {
     listener.onTestCasePrepared(testCasePreparedEvent)
     expect(listener.gherkinDocEvents[0].document.feature.children[0].steps).toHaveLength(1)
 })
+
+test('onTestCaseFinished', () => {
+    const uri = '/myFeature.feature'
+    const scenario = {
+        type: 'Scenario',
+        location: { line: 321 }
+    }
+    const feature = {
+        children: [scenario]
+    }
+    const eventBroadcaster = new EventEmitter()
+    const listener = new CucumberEventListener(eventBroadcaster)
+    listener.gherkinDocEvents = [{
+        uri,
+        document: {
+            feature
+        }
+    }]
+
+    const result = { duration: 2, status: 'passed' }
+    const sourceLocation = {
+        line: 321,
+        uri
+    }
+    const testCaseFinishedEvent = {
+        sourceLocation,
+        result
+    }
+    const spy = jest.fn()
+    listener.on('after-scenario', spy)
+    listener.onTestCaseFinished(testCaseFinishedEvent)
+
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy).toHaveBeenCalledWith(uri, feature, scenario, result, sourceLocation)
+})

--- a/scripts/templates/webdriverio.tpl.d.ts
+++ b/scripts/templates/webdriverio.tpl.d.ts
@@ -145,7 +145,7 @@ declare namespace WebdriverIO {
         beforeScenario?(uri: any, feature: any, scenario: any): void;
         beforeStep?(uri: any, feature: any, scenario: any, step: any): void;
         afterFeature?(uri: any, feature: any, scenario: any, step: any, result: any): void;
-        afterScenario?(uri: any, feature: any, scenario: any): void;
+        afterScenario?(uri: any, feature: any, scenario: any, result: {status: string, duration: number}): void;
         afterStep?(uri: any, feature: any): void;
     }
     type _HooksArray = {


### PR DESCRIPTION
## Proposed changes
afterScenario hook gets called with one additional "result" argument which contains duration and status.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
