### PR TITLE
Fix commands error handling in sync mode

### DIFF
--- a/packages/wdio-sync/src/wrapCommand.js
+++ b/packages/wdio-sync/src/wrapCommand.js
@@ -12,13 +12,10 @@ import { sanitizeErrorMessage } from './utils'
  * @return {Function}   actual wrapped function
  */
 export default function wrapCommand (commandName, fn) {
-    let stackError
     return function wrapCommandFn (...args) {
         // save error for getting full stack in case of failure
         // should be before any async calls
-        if (!stackError) {
-            stackError = new Error()
-        }
+        const stackError = new Error()
         /**
          * Avoid running some functions in Future that are not in Fiber.
          */

--- a/packages/wdio-sync/src/wrapCommand.js
+++ b/packages/wdio-sync/src/wrapCommand.js
@@ -92,7 +92,6 @@ async function runCommand (fn, stackError, ...args) {
     try {
         return await fn.apply(this, args)
     } catch (err) {
-        this._NOT_FIBER = false
         throw sanitizeErrorMessage(err, stackError)
     }
 }

--- a/packages/wdio-sync/tests/wrapCommand.test.js
+++ b/packages/wdio-sync/tests/wrapCommand.test.js
@@ -79,7 +79,7 @@ describe('wrapCommand:runCommand', () => {
         } catch (err) {
             expect(err).toEqual(new Error('AnotherError'))
             expect(err.name).toBe('Error')
-            expect(err.stack.split('wrapCommand.test.js')).toHaveLength(2)
+            expect(err.stack.split('wrapCommand.test.js')).toHaveLength(3)
             expect(err.stack).toContain('__mocks__')
         }
         expect.assertions(4)
@@ -94,7 +94,7 @@ describe('wrapCommand:runCommand', () => {
         } catch (err) {
             expect(err).toEqual(new Error('bar'))
             expect(err.name).toBe('Error')
-            expect(err.stack.split('wrapCommand.test.js')).toHaveLength(1)
+            expect(err.stack.split('wrapCommand.test.js')).toHaveLength(2)
         }
         expect.assertions(3)
     })
@@ -108,7 +108,7 @@ describe('wrapCommand:runCommand', () => {
         } catch (err) {
             expect(err).toEqual(new Error())
             expect(err.name).toBe('Error')
-            expect(err.stack.split('wrapCommand.test.js')).toHaveLength(1)
+            expect(err.stack.split('wrapCommand.test.js')).toHaveLength(2)
         }
         expect.assertions(3)
     })

--- a/packages/wdio-sync/tests/wrapCommand.test.js
+++ b/packages/wdio-sync/tests/wrapCommand.test.js
@@ -121,12 +121,14 @@ describe('wrapCommand:runCommand', () => {
         it('should throw regular error', () => {
             const fn = jest.fn(() => {})
             const runCommand = wrapCommand('foo', fn)
+            const context = { options: {} }
             try {
-                runCommand.call({ options: {} }, 'bar')
+                runCommand.call(context, 'bar')
             } catch (err) {
                 expect(Future.wait).toThrow()
             }
-            expect.assertions(1)
+            expect(context._NOT_FIBER).toBe(false)
+            expect.assertions(2)
         })
     })
 

--- a/packages/wdio-webdriver-mock-service/src/index.js
+++ b/packages/wdio-webdriver-mock-service/src/index.js
@@ -44,6 +44,15 @@ export default class WebdriverMockService {
         global.browser.addCommand('customCommandScenario', ::this.customCommandScenario)
         global.browser.addCommand('waitForDisplayedScenario', ::this.waitForDisplayedScenario)
         global.browser.addCommand('cucumberScenario', ::this.cucumberScenario)
+        global.browser.addCommand('clickScenario', ::this.clickScenario)
+    }
+
+    clickScenario() {
+        this.nockReset()
+        const elemResponse = { 'element-6066-11e4-a52e-4f735466cecf': ELEMENT_ID }
+
+        this.command.findElement().times(2).reply(200, { value: elemResponse })
+        this.command.elementClick(ELEMENT_ID).once().reply(200, { value: null })
     }
 
     waitForElementScenario () {

--- a/tests/mocha/test.js
+++ b/tests/mocha/test.js
@@ -10,6 +10,17 @@ describe('Mocha smoke test', () => {
         assert($('elem').waitForDisplayed(), true)
     })
 
+    it('should work fine after catching an error', () => {
+        browser.clickScenario()
+        try {
+            browser.getAlertText()
+        } catch (err) {
+            // ignored
+        }
+
+        $('elem').click()
+    })
+
     describe('middleware', () => {
         it('should wait for elements if not found immediately', () => {
             browser.waitForElementScenario()


### PR DESCRIPTION
## Proposed changes

After https://github.com/webdriverio/webdriverio/pull/4221 error handling of commands was broken.

Should fix:
- promise was not resolved after error in previous command;  #4244 
- stacktrace is not full;

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments


### Reviewers: @webdriverio/technical-committee
