### PR TITLE
introduce profileDirectory option in wdio-firefox-profile-service

### DIFF
--- a/packages/wdio-firefox-profile-service/src/launcher.js
+++ b/packages/wdio-firefox-profile-service/src/launcher.js
@@ -10,7 +10,11 @@ export default class FirefoxProfileLauncher {
             return
         }
 
-        this.profile = new Profile()
+        if(this.config.firefoxProfile.profileDirectory) {
+            this.profile = await promisify(Profile.copy)(this.config.firefoxProfile.profileDirectory)
+        } else {
+            this.profile = new Profile()
+        }
 
         // Set preferences and proxy
         this._setPreferences()

--- a/packages/wdio-firefox-profile-service/tests/__mocks__/firefox-profile.js
+++ b/packages/wdio-firefox-profile-service/tests/__mocks__/firefox-profile.js
@@ -1,4 +1,4 @@
-export default jest.fn(() => ({
+const FirefoxProfile = jest.fn(() => ({
     setPreference : jest.fn(),
     setProxy : jest.fn(),
     updatePreferences : jest.fn(),
@@ -9,3 +9,9 @@ export default jest.fn(() => ({
         cb(null, 'foobar')
     }),
 }))
+
+FirefoxProfile.copy = jest.fn((profileDirectory, cb) => {
+    cb(null, new FirefoxProfile())
+})
+
+export default FirefoxProfile

--- a/packages/wdio-firefox-profile-service/tests/launcher.test.js
+++ b/packages/wdio-firefox-profile-service/tests/launcher.test.js
@@ -1,4 +1,5 @@
 import Launcher from '../src/launcher'
+import FirefoxProfile from 'firefox-profile'
 
 describe('Firefox profile service', () => {
     describe('onPrepare', () => {
@@ -185,6 +186,22 @@ describe('Firefox profile service', () => {
             expect(service.profile.setPreference).toHaveBeenCalledTimes(1)
             expect(service.profile.setPreference).toHaveBeenCalledWith('browser.startup.homepage', 'https://webdriver.io')
             expect(service.profile.updatePreferences).toHaveBeenCalled()
+        })
+
+        test('should load from directory if profileDirectory is set', async () => {
+            const config = {
+                firefoxProfile : {
+                    profileDirectory: '/tmp/firefox-profile',
+                }
+            }
+            const capabilities = [{
+                browserName : 'firefox',
+            }]
+
+            const service = new Launcher()
+            await service.onPrepare(config, capabilities)
+
+            expect(FirefoxProfile.copy).toHaveBeenCalledWith(config.firefoxProfile.profileDirectory, expect.any(Function))
         })
     })
 })


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

Added `profileDirectory ` option to `wdio-firefox-profile-service`. This makes it possible to specify a directory with a pre-made profile. This allows one to configure client certificates. It may also make other things possible which I don't know about.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
