### PR TITLE
webdriver: truncate screen recording log #4251

### DIFF
--- a/packages/webdriver/src/command.js
+++ b/packages/webdriver/src/command.js
@@ -79,7 +79,7 @@ export default function (method, endpointUri, commandInfo) {
         log.info('COMMAND', commandCallStructure(command, args))
         return request.makeRequest(this.options, this.sessionId).then((result) => {
             if (result.value != null) {
-                log.info('RESULT', command.toLowerCase().includes('screenshot')
+                log.info('RESULT', /screenshot|recording/i.test(command)
                     && typeof result.value === 'string' && result.value.length > 64
                     ? `${result.value.substr(0, 61)}...` : result.value)
             }

--- a/packages/webdriver/tests/command.test.js
+++ b/packages/webdriver/tests/command.test.js
@@ -125,6 +125,22 @@ describe('command wrapper result log', () => {
         value: 'f'.repeat(123),
         log: 'f'.repeat(61) + '...'
     }, {
+        title: 'truncate long string value',
+        command: {
+            ...takeScreenshotCmd,
+            command: 'startRecordingScreen'
+        },
+        value: 'f'.repeat(123),
+        log: 'f'.repeat(61) + '...'
+    }, {
+        title: 'truncate long string value',
+        command: {
+            ...takeScreenshotCmd,
+            command: 'stopRecordingScreen'
+        },
+        value: 'f'.repeat(123),
+        log: 'f'.repeat(61) + '...'
+    }, {
         title: 'do nothing to values with length less then 65',
         command: { ...takeScreenshotCmd },
         value: 'f'.repeat(64),


### PR DESCRIPTION
## Proposed changes

Truncate result before logging if given command is screen recording related

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

Fixes #4251 

### Reviewers: @webdriverio/technical-committee
