### PR TITLE
Fix FirefoxOptions prefs type to optional

### DIFF
--- a/scripts/templates/webdriver.tpl.d.ts
+++ b/scripts/templates/webdriver.tpl.d.ts
@@ -79,7 +79,7 @@ declare namespace WebDriver {
         args?: string[],
         profile?: string,
         log?: FirefoxLogObject,
-        prefs: {
+        prefs?: {
             [name: string]: string | number | boolean;
         }
     }


### PR DESCRIPTION
## Proposed changes

I fixed FirefoxOptions prefs type to optional, because it should be optional.
https://developer.mozilla.org/en-US/docs/Web/WebDriver/Capabilities/firefoxOptions

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

### Reviewers: @webdriverio/technical-committee
