### PR TITLE
Fix waitUntil first iteration is promise

### DIFF
--- a/packages/wdio-sync/src/wrapCommand.js
+++ b/packages/wdio-sync/src/wrapCommand.js
@@ -25,9 +25,9 @@ export default function wrapCommand (commandName, fn) {
         }
         /**
          * all named nested functions run in parent Fiber context
-         * except of debug
+         * except of debug and waitUntil
          */
-        this._NOT_FIBER = fn.name !== '' && fn.name !== 'debug'
+        this._NOT_FIBER = fn.name !== '' && fn.name !== 'debug' && commandName !== 'waitUntil'
 
         const future = new Future()
 

--- a/packages/wdio-sync/tests/wrapCommand.test.js
+++ b/packages/wdio-sync/tests/wrapCommand.test.js
@@ -102,6 +102,23 @@ describe('wrapCommand:runCommand', () => {
         expect(context._hidden_changes_).toEqual([false, false])
     })
 
+    it('should set _NOT_FIBER to false for waitUntil command', async () => {
+        Future.prototype.wait = () => {}
+        const runCommand = wrapCommand('waitUntil', jest.fn())
+
+        const context = {
+            options: {}, elementId: 'foo', _hidden_: null, _hidden_changes_: [],
+            get _NOT_FIBER () { return this._hidden_ },
+            set _NOT_FIBER (val) {
+                this._hidden_changes_.push(val)
+                this._hidden_ = val
+            }
+        }
+
+        await runCommand.call(context)
+        expect(context._hidden_changes_).toEqual([false, false])
+    })
+
     it('should throw error with proper message', async () => {
         const fn = jest.fn(x => { throw new Error(x) })
         const runCommand = wrapCommand('foo', fn)

--- a/tests/mocha/test.js
+++ b/tests/mocha/test.js
@@ -32,15 +32,13 @@ describe('Mocha smoke test', () => {
         assert.equal(el.$('.selector-2').isExisting(), true)
     })
 
-    it('should waitUntil', () => {
-        let flag = true
+    it('should handle promises in waitUntil callback funciton', () => {
         const results = []
         browser.waitUntil(() => {
-            flag = !flag
-            results.push(browser.pause(1))
-            return flag
+            results.push(browser.getUrl())
+            return results.length > 1
         })
-        assert.deepEqual(results, [undefined, undefined])
+        assert.deepEqual(results, ['https://mymockpage.com', 'https://mymockpage.com'])
     })
 
     describe('middleware', () => {

--- a/tests/mocha/test.js
+++ b/tests/mocha/test.js
@@ -32,6 +32,17 @@ describe('Mocha smoke test', () => {
         assert.equal(el.$('.selector-2').isExisting(), true)
     })
 
+    it('should waitUntil', () => {
+        let flag = true
+        const results = []
+        browser.waitUntil(() => {
+            flag = !flag
+            results.push(browser.pause(1))
+            return flag
+        })
+        assert.deepEqual(results, [undefined, undefined])
+    })
+
     describe('middleware', () => {
         it('should wait for elements if not found immediately', () => {
             browser.waitForElementScenario()

--- a/tests/mocha/test.js
+++ b/tests/mocha/test.js
@@ -34,10 +34,11 @@ describe('Mocha smoke test', () => {
 
     it('should handle promises in waitUntil callback funciton', () => {
         const results = []
-        browser.waitUntil(() => {
+        const result = browser.waitUntil(() => {
             results.push(browser.getUrl())
             return results.length > 1
         })
+        assert.strictEqual(result, true)
         assert.deepEqual(results, ['https://mymockpage.com', 'https://mymockpage.com'])
     })
 


### PR DESCRIPTION
## Proposed changes

First iteration of `browser.waitUntil` doesn't respect promises.
```
const results = []
browser.waitUntil(() => {
    flag = !flag
    results.push(browser.pause(1))
    return flag
})
// results: [ Promise, undefined ]
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

### Reviewers: @webdriverio/technical-committee
