### PR TITLE
Use index when refetching element

### DIFF
--- a/packages/webdriverio/tests/utils/refetchElement.test.js
+++ b/packages/webdriverio/tests/utils/refetchElement.test.js
@@ -43,6 +43,14 @@ describe('refetchElement', () => {
         expect(JSON.stringify(refetchedElement)).toBe(JSON.stringify(subSubElem))
     })
 
+    it('should not lose element index', async () => {
+        const elem = await browser.$('#foo')
+        const subElems = await elem.$$('#subfoo')
+        const subElem = subElems[1]
+        const refetchedElement = await refetchElement(subElem, '$')
+        expect(refetchedElement.elementId).toEqual(subElem.elementId)
+    })
+
     it('should successfully refetch an element that isn\'t immediately present', async () => {
         const elem = await browser.$('#foo')
         request.retryCnt = 0


### PR DESCRIPTION
## Proposed changes

Fix #4270 
refetch `$$('foo')[2].$('bar')` didn't work because we used to look for the first element.
This PR fixes it.

Cases when elements amount or ordering has changed are not handled!

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

### Reviewers: @webdriverio/technical-committee
