### PR TITLE
devtools-service: fix tracing

### DIFF
--- a/packages/wdio-devtools-service/src/index.js
+++ b/packages/wdio-devtools-service/src/index.js
@@ -10,7 +10,7 @@ import { NETWORK_STATES, DEFAULT_NETWORK_THROTTLING_STATE } from './constants'
 
 const log = logger('@wdio/devtools-service')
 const UNSUPPORTED_ERROR_MESSAGE = 'The @wdio/devtools-service currently only supports Chrome version 63 and up'
-const TRACE_COMMANDS = ['click', 'navigateTo']
+const TRACE_COMMANDS = ['click', 'navigateTo', 'url']
 
 export default class DevToolsService {
     constructor (options = {}) {
@@ -95,7 +95,7 @@ export default class DevToolsService {
          */
         this._setThrottlingProfile(this.networkThrottling, this.cpuThrottling, this.cacheEnabled)
 
-        const url = commandName === 'navigateTo' ? params[0] : 'click transition'
+        const url = ['url', 'navigateTo'].some(cmdName => cmdName === commandName) ? params[0] : 'click transition'
         return this.traceGatherer.startTracing(url)
     }
 

--- a/packages/wdio-devtools-service/tests/service.test.js
+++ b/packages/wdio-devtools-service/tests/service.test.js
@@ -136,8 +136,13 @@ test('beforeCommand', () => {
     expect(service.traceGatherer.startTracing).toBeCalledWith('some page')
     expect(service._setThrottlingProfile).toBeCalledWith(1, 2, 3)
 
-    service.beforeCommand('click', ['some other page'])
+    service.beforeCommand('url', ['next page'])
     expect(service.traceGatherer.startTracing).toBeCalledTimes(2)
+    expect(service.traceGatherer.startTracing).toBeCalledWith('next page')
+    expect(service._setThrottlingProfile).toBeCalledWith(1, 2, 3)
+
+    service.beforeCommand('click', ['some other page'])
+    expect(service.traceGatherer.startTracing).toBeCalledTimes(3)
     expect(service.traceGatherer.startTracing).toBeCalledWith('click transition')
 })
 
@@ -158,8 +163,11 @@ test('afterCommand', () => {
     service.afterCommand('navigateTo')
     expect(service.traceGatherer.once).toBeCalledTimes(2)
 
-    service.afterCommand('click')
+    service.afterCommand('url')
     expect(service.traceGatherer.once).toBeCalledTimes(4)
+
+    service.afterCommand('click')
+    expect(service.traceGatherer.once).toBeCalledTimes(6)
 })
 
 test('afterCommand: should create a new auditor instance and should update the browser commands', () => {
@@ -168,7 +176,7 @@ test('afterCommand: should create a new auditor instance and should update the b
     service.traceGatherer.isTracing = true
     service.devtoolsGatherer = { getLogs: jest.fn() }
     global.browser = 'some browser'
-    service.afterCommand('navigateTo')
+    service.afterCommand('url')
     service.traceGatherer.emit('tracingComplete', { some: 'events' })
 
     const auditor = new Auditor()


### PR DESCRIPTION
## Proposed changes

due to recent changes before/after command hooks are not called for `navigateTo` command if it was called using `url` command.
Added `url` command to `TRACE_COMMANDS`

fix #4278 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

### Reviewers: @webdriverio/technical-committee
