### PR TITLE
devtools-service: onFrameNavigated - do nothing if tracing is not started

### DIFF
--- a/packages/wdio-devtools-service/src/gatherer/trace.js
+++ b/packages/wdio-devtools-service/src/gatherer/trace.js
@@ -87,6 +87,9 @@ export default class TraceGatherer extends EventEmitter {
      * store frame id of frames that are being traced
      */
     async onFrameNavigated (msgObj) {
+        if (!this.isTracing) {
+            return
+        }
         /**
          * page load failed, cancel tracing
          */


### PR DESCRIPTION
## Proposed changes

Do nothing if tracing is not started in `onFrameNavigated`
fixes #4203

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

### Reviewers: @webdriverio/technical-committee
