### PR TITLE
Fix chrome getLogs and getLogTypes

### DIFF
--- a/packages/webdriver/protocol/chromium.json
+++ b/packages/webdriver/protocol/chromium.json
@@ -424,7 +424,7 @@
       "returns": {
         "type": "String[]",
         "name": "logTypes",
-        "description": "The list of available log types."
+        "description": "The list of available log types, example: browser, driver."
       }
     }
   },

--- a/packages/webdriver/protocol/chromium.json
+++ b/packages/webdriver/protocol/chromium.json
@@ -414,5 +414,36 @@
         "description": "The base64-encoded PNG image data comprising the screenshot of the visible region of an element’s bounding rectangle after it has been scrolled into view."
       }
     }
+  },
+  "/session/:sessionId/se/log/types": {
+    "GET": {
+      "command": "getLogTypes",
+      "description": "Get available log types.",
+      "ref": "https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidlogtypes",
+      "parameters": [],
+      "returns": {
+        "type": "String[]",
+        "name": "logTypes",
+        "description": "The list of available log types."
+      }
+    }
+  },
+  "/session/:sessionId/se/log": {
+    "POST": {
+      "command": "getLogs",
+      "description": "Get the log for a given log type. Log buffer is reset after each request.",
+      "ref": "https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidlog",
+      "parameters": [{
+        "name": "type",
+        "type": "string",
+        "description": "the log type",
+        "required": true
+      }],
+      "returns": {
+        "type": "Object[]",
+        "name": "logs",
+        "description": "The list of log entries."
+      }
+    }
   }
 }


### PR DESCRIPTION
## Proposed changes

Since chromedriver 75 get log commands were deprecated in w3c mode.
Since chromedriver 76 get log commands were added again, see https://bugs.chromium.org/p/chromedriver/issues/detail?id=2947

Fix chrome `getLogs` and `getLogTypes` by adding these commands to chromium protocol.

fixes #4297

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

### Reviewers: @webdriverio/technical-committee
