### PR TITLE
TypeScript: add elementId as parameter to protocol commands with variable

### DIFF
--- a/packages/webdriverio/webdriverio.d.ts
+++ b/packages/webdriverio/webdriverio.d.ts
@@ -4,7 +4,15 @@ type $ = (selector: string | Function) => Promise<WebdriverIOAsync.Element>;
 type $$ = (selector: string | Function) => Promise<WebdriverIOAsync.Element[]>;
 
 // Element commands that should be wrapper with Promise
-type ElementPromise = Omit<WebdriverIO.Element, 'addCommand' | '$' | '$$' | 'selector' | 'elementId'>;
+type ElementPromise = Omit<WebdriverIO.Element,
+    'addCommand'
+    | '$'
+    | '$$'
+    | 'selector'
+    | 'elementId'
+    | 'element-6066-11e4-a52e-4f735466cecf'
+    | 'ELEMENT'
+>;
 
 // Methods which return async element(s) so non-async equivalents cannot just be promise-wrapped
 interface AsyncSelectors {
@@ -19,7 +27,13 @@ type ElementAsync = {
 } & AsyncSelectors;
 
 // Element commands that should not be wrapper with promise
-type ElementStatic = Pick<WebdriverIO.Element, 'addCommand' | 'selector' | 'elementId'>
+type ElementStatic = Pick<WebdriverIO.Element,
+    'addCommand'
+    | 'selector'
+    | 'elementId'
+    | 'element-6066-11e4-a52e-4f735466cecf'
+    | 'ELEMENT'
+>;
 
 // Browser commands that should be wrapper with Promise
 type BrowserPromise = Omit<WebdriverIO.Browser, 'addCommand' | 'overwriteCommand' | 'options' | '$' | '$$'>;

--- a/scripts/templates/webdriverio.tpl.d.ts
+++ b/scripts/templates/webdriverio.tpl.d.ts
@@ -157,6 +157,8 @@ declare namespace WebdriverIO {
     type TouchActions = string | TouchAction | TouchAction[];
 
     interface Element {
+        "element-6066-11e4-a52e-4f735466cecf"?: string;
+        ELEMENT?: string;
         selector: string;
         elementId: string;
         addCommand(

--- a/scripts/type-generation/webdriver-generate-typings.js
+++ b/scripts/type-generation/webdriver-generate-typings.js
@@ -15,7 +15,9 @@ for (const [protocolName, definition] of Object.entries(PROTOCOLS)) {
         for (const [, description] of Object.entries(methods)) {
             const { command, parameters = [], variables = [], returns } = description
             const vars = variables
-                .filter((v) => v.name != 'sessionId' && v.name != 'elementId')
+                // sessionId is handled by WebdriverIO for all protocol requests
+                .filter((v) => v.name != 'sessionId')
+                // url params are always type of string
                 .map((v) => `${v.name}: string`)
             const params = parameters.map((p) => `${p.name}${p.required === false ? '?' : ''}: ${p.type.toLowerCase()}`)
             const varsAndParams = vars.concat(params)

--- a/tests/typings/sync/sync.ts
+++ b/tests/typings/sync/sync.ts
@@ -22,6 +22,9 @@ const callResult = <number>browser.call(() =>
 )
 callResult.toFixed(2)
 
+// browser element command
+browser.getElementRect('elementId')
+
 // browser custom command
 browser.browserCustomCommand(5)
 

--- a/tests/typings/webdriverio/async.ts
+++ b/tests/typings/webdriverio/async.ts
@@ -51,6 +51,9 @@ async function bar() {
     )
     callResult.toFixed(2)
 
+    // browser element command
+    browser.getElementRect('elementId')
+
     // browser custom command
     await browser.browserCustomCommand(14)
 


### PR DESCRIPTION
## Proposed changes

Add elementId as parameter to protocol commands with variable

fixes: #4298

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

### Reviewers: @webdriverio/technical-committee
