### PR TITLE
Run travis CI with Node.js 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: node_js
 
 node_js:
   - 8
+  - 10
+  - 12
 
 script:
   - npm run ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ language: node_js
 node_js:
   - 8
   - 10
-  - 12
 
 script:
   - npm run ci


### PR DESCRIPTION
## Proposed changes
Since many developers use Node.js 10 for WebdriverIO, and Appium minimum Node.js version has bumped to v10, it`s better to run travisCI with Node.js 10
https://github.com/appium/appium/releases/tag/v1.14.0

## Types of changes
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

### Reviewers: @webdriverio/technical-committee
