### PR TITLE
@wdio/allure-reporter: Skip reporting of passing hooks with option useCucumberStepReporter

### DIFF
--- a/packages/wdio-allure-reporter/src/index.js
+++ b/packages/wdio-allure-reporter/src/index.js
@@ -228,6 +228,16 @@ class AllureReporter extends WDIOReporter {
             // remove hook from suite if it has no steps
             if (this.allure.getCurrentTest().steps.length === 0 && !this.options.useCucumberStepReporter) {
                 this.allure.getCurrentSuite().testcases.pop()
+            } else if (this.options.useCucumberStepReporter) {
+                // remove hook when it's registered as a step and if it's passed
+                const step = this.allure.getCurrentTest().steps.pop()
+
+                // if it had any attachments, reattach them to current test
+                if (step.attachments.length >= 1) {
+                    step.attachments.forEach(attachment => {
+                        this.allure.getCurrentTest().addAttachment(attachment)
+                    })
+                }
             }
         }
     }

--- a/packages/wdio-allure-reporter/src/index.js
+++ b/packages/wdio-allure-reporter/src/index.js
@@ -233,7 +233,7 @@ class AllureReporter extends WDIOReporter {
                 const step = this.allure.getCurrentTest().steps.pop()
 
                 // if it had any attachments, reattach them to current test
-                if (step.attachments.length >= 1) {
+                if (step && step.attachments.length >= 1) {
                     step.attachments.forEach(attachment => {
                         this.allure.getCurrentTest().addAttachment(attachment)
                     })

--- a/packages/wdio-allure-reporter/tests/__fixtures__/attachment.js
+++ b/packages/wdio-allure-reporter/tests/__fixtures__/attachment.js
@@ -1,0 +1,7 @@
+export function xmlAttachment() {
+    return {
+        name: 'Page source',
+        type: 'application/xml',
+        content: '<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>'
+    }
+}

--- a/packages/wdio-allure-reporter/tests/cucumber.suite.test.js
+++ b/packages/wdio-allure-reporter/tests/cucumber.suite.test.js
@@ -10,6 +10,7 @@ import { clean, getResults } from 'wdio-allure-helper'
 import AllureReporter from '../src/'
 import { runnerEnd, runnerStart } from './__fixtures__/runner'
 import * as cucumberHelper from './__fixtures__/cucumber'
+import * as attachmentHelper from './__fixtures__/attachment'
 import { commandStart, commandEnd } from './__fixtures__/command'
 
 let processOn
@@ -40,12 +41,16 @@ describe('reporter option "useCucumberStepReporter" set to true', () => {
             reporter.onBeforeCommand(commandStart())
             reporter.onAfterCommand(commandEnd())
             reporter.onTestPass(cucumberHelper.testPass())
+            reporter.onHookStart(cucumberHelper.hookStart())
+            reporter.addAttachment(attachmentHelper.xmlAttachment())
+            reporter.onHookEnd(cucumberHelper.hookEnd())
             reporter.onSuiteEnd(cucumberHelper.scenarioEnd())
             reporter.onSuiteEnd(cucumberHelper.featureEnd())
             reporter.onRunnerEnd(runnerEnd())
+
             const results = getResults(outputDir)
-            expect(results).toHaveLength(1)
-            allureXml = results[0]
+            expect(results).toHaveLength(2) // one for report, one for attachment
+            allureXml = results.find(xml => xml('ns2\\:test-suite').length >= 1)
         })
 
         afterAll(() => {
@@ -62,18 +67,16 @@ describe('reporter option "useCucumberStepReporter" set to true', () => {
             expect(allureXml('test-case').attr('status')).toEqual('passed')
         })
 
-        it('should report one hook', () => {
-            expect(allureXml('step > name').eq(0).text()).toEqual('Hook')
-            expect(allureXml('step > title').eq(0).text()).toEqual('Hook')
+        it('should not report passing hook', () => {
+            expect(allureXml('step > name').eq(0).text()).not.toContain('Hook')
+            expect(allureXml('step > title').eq(0).text()).not.toContain('Hook')
         })
 
-        it('should report one step', () => {
-            expect(allureXml('step > name').eq(1).text()).toEqual('I do something')
-            expect(allureXml('step > title').eq(1).text()).toEqual('I do something')
-        })
-
-        it('should report hook and step as passing', () => {
-            expect(allureXml('step[status="passed"]').length).toEqual(2)
+        it('should report one passing step', () => {
+            expect(allureXml('step > name').eq(0).text()).toEqual('I do something')
+            expect(allureXml('step > title').eq(0).text()).toEqual('I do something')
+            expect(allureXml('step').eq(0).attr('status')).toEqual('passed')
+            expect(allureXml('step').length).toEqual(1)
         })
 
         it('should detect analytics labels in test case', () => {
@@ -84,6 +87,10 @@ describe('reporter option "useCucumberStepReporter" set to true', () => {
         it('should add browser name as test argument', () => {
             expect(allureXml('test-case parameter[kind="argument"]')).toHaveLength(1)
             expect(allureXml('test-case parameter[name="browser"]').eq(0).attr('value')).toEqual('chrome-68')
+        })
+
+        it('should move attachments from successfull hook to test-case', () => {
+            expect(allureXml('test-case > attachments > attachment').length).toEqual(1)
         })
     })
 
@@ -144,7 +151,7 @@ describe('reporter option "useCucumberStepReporter" set to true', () => {
             expect(allureXml('ns2\\:test-suite > name').text()).toEqual('MyFeature')
             expect(allureXml('test-case > name').text()).toEqual('MyScenario')
             expect(allureXml('test-case').attr('status')).toEqual('failed')
-            expect(allureXml('step').attr('status')).toEqual('failed')
+            expect(allureXml('step > name').eq(0).text()).toEqual('Hook')
             expect(allureXml('step').eq(0).attr('status')).toEqual('failed')
             expect(allureXml('step').eq(1).attr('status')).toEqual('canceled')
             expect(allureXml('test-case parameter[kind="argument"]')).toHaveLength(1)


### PR DESCRIPTION
## Proposed changes
When using the allure reporter option "useCucumberstepReporter", this change will stop reporting passing hooks, and reattach any attachment from those hooks to the test-case.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
I have checked "Breaking change" because this does change the way allure reporter behaves when using "useCucumberReporter" option, though I believe it's for the better ;)

### Reviewers: @webdriverio/technical-committee
