### PR TITLE
Fix stacktrace formatting

### DIFF
--- a/packages/wdio-sync/src/constants.js
+++ b/packages/wdio-sync/src/constants.js
@@ -4,10 +4,14 @@ const STACKTRACE_FILTER = [
     // exclude @wdio/sync from stack traces
     'node_modules/@wdio/sync/',
 
-    // exclude webdriverio stack traces
+    // exclude webdriverio and webdriver stack traces
     'node_modules/webdriverio/build/',
+    'node_modules/webdriver/build/',
 
-    // exclude Request emit
+    // exclude request
+    'node_modules/request/request',
+
+    // exclude EventEmitter
     ' (events.js:',
     ' (domain.js:',
 

--- a/packages/wdio-sync/src/utils.js
+++ b/packages/wdio-sync/src/utils.js
@@ -11,28 +11,35 @@ export function sanitizeErrorMessage (commandError, savedError) {
     if (commandError instanceof Error) {
         ({ name, message, stack } = commandError)
     } else {
-        ({ name } = savedError)
+        name = 'Error'
         message = commandError
     }
 
     const err = new Error(message)
     err.name = name
-    err.stack = savedError.stack
 
-    // merge stack traces if Error has stack trace
+    let stackArr = savedError.stack.split('\n')
+
+    /**
+     * merge stack traces if `commandError` has stack trace
+     */
     if (stack) {
-        err.stack = stack + '\n' + err.stack
+        // remove duplicated error name from stack trace
+        stack = stack.replace(`${err.name}: ${err.name}`, err.name)
+        // remove first stack trace line from second stack trace
+        stackArr[0] = '\n'
+        // merge
+        stackArr = [...stack.split('\n'), ...stackArr]
     }
 
-    let stackArr = err.stack.split('\n')
-
-    // filter stack trace
-    stackArr = stackArr.filter(STACKTRACE_FILTER_FN)
-
-    // remove duplicates from stack traces
-    err.stack = stackArr.reduce((acc, currentValue) => {
-        return acc.includes(currentValue) ? acc : `${acc}\n${currentValue}`
-    }, '').trim()
+    err.stack = stackArr
+        // filter stack trace
+        .filter(STACKTRACE_FILTER_FN)
+        // remove duplicates from stack traces
+        .reduce((acc, currentValue) => {
+            return acc.includes(currentValue) ? acc : `${acc}\n${currentValue}`
+        }, '')
+        .trim()
 
     return err
 }


### PR DESCRIPTION
## Proposed changes

There is a lot of useless information in stacktrace.

Before:
```
javascript error: javascript error: ofk
  (Session info: headless chrome=76.0.3809.87)
    at getErrorFromResponseBody (/e2e/node_modules/webdriver/build/utils.js:215:10)
    at Request._callback (/e2e/node_modules/webdriver/build/request.js:103:64)
    at Request.self.callback (/e2e/node_modules/request/request.js:185:22)
    at Request.<anonymous> (/e2e/node_modules/request/request.js:1161:10)
    at IncomingMessage.<anonymous> (/e2e/node_modules/request/request.js:1083:12)
Error:
Error: 
    at Context.it (/e2e/test/specs/_debug/debug-wdio.spec.ts:27:21)
    at itBodyWrap (/e2e/src/mocha.ts:170:25)
    at Context.fnWrap (/e2e/src/mocha.ts:67:16)
```

After
```
javascript error: ofk
  (Session info: headless chrome=76.0.3809.87)
    at Context.it (/e2e/test/specs/_debug/debug-wdio.spec.ts:27:21)
    at itBodyWrap (/e2e/src/mocha.ts:170:25)
    at Context.fnWrap (/e2e/src/mocha.ts:67:16)
```

## Types of changes

- [x] Bugfix / polish (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] Tests were added in the past

## Further comments

### Reviewers: @webdriverio/technical-committee
