### PR TITLE
wdio-cucumber-framework:  Filter cucumber features before process spawned

### DIFF
--- a/packages/wdio-cli/src/launcher.js
+++ b/packages/wdio-cli/src/launcher.js
@@ -60,6 +60,13 @@ class Launcher {
     async run () {
         let config = this.configParser.getConfig()
         let caps = this.configParser.getCapabilities()
+        // /**
+        //  * run filter on specs
+        //  */
+        if (Array.isArray(config.specs) && config.specs.length && typeof config.specsFilter === 'function') {
+            config.specs = await config.specsFilter(config)
+        }
+
         const launcher = initialiseServices(config, caps, 'launcher')
 
         /**

--- a/packages/wdio-cli/src/utils.js
+++ b/packages/wdio-cli/src/utils.js
@@ -158,6 +158,7 @@ export function replaceConfig(
 
         return config.replace(text, buildNewConfigArray(text, type, name))
     }
+    return config
 }
 
 export function addServiceDeps(names, packages, update) {

--- a/packages/wdio-cli/tests/launcher.test.js
+++ b/packages/wdio-cli/tests/launcher.test.js
@@ -305,12 +305,12 @@ describe('launcher', () => {
             expect(launcher.runSpecs()).toBe(false)
             expect(launcher.getNumberOfRunningInstances()).toBe(5)
             expect(launcher.getNumberOfSpecsLeft()).toBe(4)
-            expect(launcher.schedule[0].runningInstances).toBe(3)
-            expect(launcher.schedule[0].availableInstances).toBe(47)
+            expect(launcher.schedule[0].runningInstances).toBe(2)
+            expect(launcher.schedule[0].availableInstances).toBe(48)
             expect(launcher.schedule[1].runningInstances).toBe(2)
             expect(launcher.schedule[1].availableInstances).toBe(58)
-            expect(launcher.schedule[2].runningInstances).toBe(0)
-            expect(launcher.schedule[2].availableInstances).toBe(70)
+            expect(launcher.schedule[2].runningInstances).toBe(1)
+            expect(launcher.schedule[2].availableInstances).toBe(69)
         })
 
         it('should not allow to schedule more runner if no instances are available', () => {

--- a/packages/wdio-cli/tests/launcher.test.js
+++ b/packages/wdio-cli/tests/launcher.test.js
@@ -434,8 +434,5 @@ describe('launcher', () => {
 
             expect(await launcher.run()).toBe(1)
         })
-        it('filter specs', async () => {
-
-        })
     })
 })

--- a/packages/wdio-cli/tests/launcher.test.js
+++ b/packages/wdio-cli/tests/launcher.test.js
@@ -305,12 +305,12 @@ describe('launcher', () => {
             expect(launcher.runSpecs()).toBe(false)
             expect(launcher.getNumberOfRunningInstances()).toBe(5)
             expect(launcher.getNumberOfSpecsLeft()).toBe(4)
-            expect(launcher.schedule[0].runningInstances).toBe(2)
-            expect(launcher.schedule[0].availableInstances).toBe(48)
+            expect(launcher.schedule[0].runningInstances).toBe(3)
+            expect(launcher.schedule[0].availableInstances).toBe(47)
             expect(launcher.schedule[1].runningInstances).toBe(2)
             expect(launcher.schedule[1].availableInstances).toBe(58)
-            expect(launcher.schedule[2].runningInstances).toBe(1)
-            expect(launcher.schedule[2].availableInstances).toBe(69)
+            expect(launcher.schedule[2].runningInstances).toBe(0)
+            expect(launcher.schedule[2].availableInstances).toBe(70)
         })
 
         it('should not allow to schedule more runner if no instances are available', () => {
@@ -403,6 +403,8 @@ describe('launcher', () => {
                 // ConfigParser.addFileConfig() will return onPrepare and onComplete as arrays of functions
                 onPrepare: [jest.fn()],
                 onComplete: [jest.fn()],
+                specs: ['foo/bar'],
+                specsFilter: jest.fn()
             }
             launcher.configParser = {
                 getCapabilities: jest.fn().mockReturnValue(0),
@@ -418,6 +420,7 @@ describe('launcher', () => {
 
             expect(launcher.configParser.getCapabilities).toBeCalledTimes(1)
             expect(launcher.configParser.getConfig).toBeCalledTimes(1)
+            expect(config.specsFilter).toBeCalledTimes(1)
             expect(launcher.runner.initialise).toBeCalledTimes(1)
             expect(config.onPrepare[0]).toBeCalledTimes(1)
             expect(launcher.runMode).toBeCalledTimes(1)
@@ -430,6 +433,9 @@ describe('launcher', () => {
             config.onComplete = [() => { throw new Error() }]
 
             expect(await launcher.run()).toBe(1)
+        })
+        it('filter specs', async () => {
+
         })
     })
 })

--- a/packages/wdio-cli/tests/utils.test.js
+++ b/packages/wdio-cli/tests/utils.test.js
@@ -205,6 +205,17 @@ describe('replaceConfig', () => {
 }`
         )
     })
+    it('return the original config', () => {
+        const fakeConfig = `exports.config = {
+    runner: 'local',
+}`
+        expect(replaceConfig(fakeConfig, 'noexist', 'foo')).toBe(
+            `exports.config = {
+    runner: 'local',
+}`
+        )
+    })
+
 })
 
 describe('addServiceDeps', () => {

--- a/packages/wdio-cucumber-framework/README.md
+++ b/packages/wdio-cucumber-framework/README.md
@@ -119,7 +119,17 @@ Default: `false`
 
 ### tagExpression
 Only execute the features or scenarios with tags matching the expression. Note that untagged
-features will still spawn a Selenium session (see issue [webdriverio/webdriverio#1247](https://github.com/webdriverio/webdriverio/issues/1247)).
+features will still spawn a Selenium session (see issue [webdriverio/webdriverio#1247](https://github.com/webdriverio/webdriverio/issues/1247)). To workaround this issue, you can add a filter in `onPrepare` hook:
+```js
+// wdio.conf.js
+exports.config = {
+  // ...
+  onPrepare: async function (config, capabilities) {
+    config.specs = await require('@wdio/cucumber-framework').filterSpecsByTag(config)
+  }
+}
+  // ...
+```
 Please see the [Cucumber documentation](https://docs.cucumber.io/cucumber/api/#tag-expressions) for more details.
 
 Type: `String`<br>

--- a/packages/wdio-cucumber-framework/README.md
+++ b/packages/wdio-cucumber-framework/README.md
@@ -119,16 +119,20 @@ Default: `false`
 
 ### tagExpression
 Only execute the features or scenarios with tags matching the expression. Note that untagged
-features will still spawn a Selenium session (see issue [webdriverio/webdriverio#1247](https://github.com/webdriverio/webdriverio/issues/1247)). To workaround this issue, you can add a filter in `onPrepare` hook:
+features will still spawn a Selenium session (see issue [webdriverio/webdriverio#1247](https://github.com/webdriverio/webdriverio/issues/1247)). To workaround this issue, you can add a filter in to `specFilter` options.
 ```js
 // wdio.conf.js
 exports.config = {
   // ...
-  onPrepare: async function (config, capabilities) {
-    config.specs = await require('@wdio/cucumber-framework').filterSpecsByTag(config)
-  }
-}
+  specsFilter: require('@wdio/cucumber-framework').filterSpecsByTag
   // ...
+  cucumberOpts: {
+      // ...
+    tagExpression: '@smoke and @stable'
+      // ...
+  }
+  // ...
+}
 ```
 Please see the [Cucumber documentation](https://docs.cucumber.io/cucumber/api/#tag-expressions) for more details.
 

--- a/packages/wdio-cucumber-framework/src/filters.js
+++ b/packages/wdio-cucumber-framework/src/filters.js
@@ -1,0 +1,20 @@
+import { EventEmitter } from 'events'
+import { ConfigParser } from '@wdio/config'
+import { DEFAULT_OPTS } from './constants'
+import { getTestCases } from './utils'
+
+/**
+ * Filter Specs By TagExpression
+ * @param {Object} config wdio configuration object
+ * @return {string[]} Array of filtered specs
+ */
+export async function filterSpecsByTag (config) {
+    const cucumberOpts = { ...DEFAULT_OPTS, ...config.cucumberOpts }
+    if (!cucumberOpts.tagExpression) {
+        return config.specs
+    }
+    const specs = ConfigParser.getFilePaths(config.specs, false)
+    const testCases = await getTestCases(config, cucumberOpts, specs, new EventEmitter(), process.cwd())
+    const filteredSpecs = [...new Set(testCases.map(testCase => testCase.uri))]
+    return filteredSpecs
+}

--- a/packages/wdio-cucumber-framework/src/filters.js
+++ b/packages/wdio-cucumber-framework/src/filters.js
@@ -6,7 +6,7 @@ import { getTestCases } from './utils'
 /**
  * Filter Specs By TagExpression
  * @param {Object} config wdio configuration object
- * @return {string[]} Array of filtered specs
+ * @return {Promise<string[]>} Array of filtered specs
  */
 export async function filterSpecsByTag (config) {
     const cucumberOpts = { ...DEFAULT_OPTS, ...config.cucumberOpts }

--- a/packages/wdio-cucumber-framework/src/index.js
+++ b/packages/wdio-cucumber-framework/src/index.js
@@ -207,4 +207,4 @@ adapterFactory.run = async function (...args) {
 
 export default adapterFactory
 export { CucumberAdapter, adapterFactory }
-export { filterSpecsByTag } from 'util'
+export { filterSpecsByTag } from './utils'

--- a/packages/wdio-cucumber-framework/src/index.js
+++ b/packages/wdio-cucumber-framework/src/index.js
@@ -207,3 +207,4 @@ adapterFactory.run = async function (...args) {
 
 export default adapterFactory
 export { CucumberAdapter, adapterFactory }
+export { filterSpecsByTag } from 'util'

--- a/packages/wdio-cucumber-framework/src/index.js
+++ b/packages/wdio-cucumber-framework/src/index.js
@@ -50,7 +50,7 @@ class CucumberAdapter {
             }
 
             this.cucumberReporter = new CucumberReporter(eventBroadcaster, reporterOptions, this.cid, this.specs, this.reporter)
-            const testCases = getTestCases(this.config, this.specs, eventBroadcaster, this.cwd)
+            const testCases = getTestCases(this.config, this.cucumberOpts, this.specs, eventBroadcaster, this.cwd)
             const runtime = new Cucumber.Runtime({
                 eventBroadcaster,
                 options: this.cucumberOpts,

--- a/packages/wdio-cucumber-framework/src/index.js
+++ b/packages/wdio-cucumber-framework/src/index.js
@@ -14,9 +14,10 @@ import {
     runFnInFiberContext, hasWdioSyncSupport
 } from '@wdio/config'
 import { DEFAULT_OPTS } from './constants'
+import { getTestCases } from './utils'
 
 class CucumberAdapter {
-    constructor (cid, config, specs, capabilities, reporter) {
+    constructor(cid, config, specs, capabilities, reporter) {
         this.cwd = process.cwd()
         this.cid = cid
         this.specs = specs
@@ -49,19 +50,7 @@ class CucumberAdapter {
             }
 
             this.cucumberReporter = new CucumberReporter(eventBroadcaster, reporterOptions, this.cid, this.specs, this.reporter)
-
-            const pickleFilter = new Cucumber.PickleFilter({
-                featurePaths: this.specs,
-                names: this.cucumberOpts.name,
-                tagExpression: this.cucumberOpts.tagExpression
-            })
-            const testCases = await Cucumber.getTestCasesFromFilesystem({
-                cwd: this.cwd,
-                eventBroadcaster,
-                featurePaths: this.specs,
-                order: this.cucumberOpts.order,
-                pickleFilter
-            })
+            const testCases = getTestCases(this.config, this.specs, eventBroadcaster, this.cwd)
             const runtime = new Cucumber.Runtime({
                 eventBroadcaster,
                 options: this.cucumberOpts,
@@ -207,4 +196,4 @@ adapterFactory.run = async function (...args) {
 
 export default adapterFactory
 export { CucumberAdapter, adapterFactory }
-export { filterSpecsByTag } from './utils'
+export { filterSpecsByTag } from './filters'

--- a/packages/wdio-cucumber-framework/src/utils.js
+++ b/packages/wdio-cucumber-framework/src/utils.js
@@ -1,4 +1,7 @@
 import * as path from 'path'
+import * as Cucumber from 'cucumber'
+import { EventEmitter } from 'events'
+import { DEFAULT_OPTS } from './constants'
 
 /**
  * NOTE: this function is exported for testing only
@@ -159,4 +162,31 @@ export function getStepFromFeature(feature, pickle, stepIndex, sourceLocation) {
     }
 
     return targetStep
+}
+
+/**
+ * Filter Specs By TagExpression
+ * @param  {Object}    config   wdio configuration object
+ * @return {Array}            Array of filtered specs
+ */
+export async function filterSpecsByTag (config) {
+    const cucumberOpts = Object.assign(DEFAULT_OPTS, config.cucumberOpts)
+    if (!cucumberOpts.tagExpression) {
+        return config.specs
+    }
+    const pickleFilter = new Cucumber.PickleFilter({
+        featurePaths: config.specs,
+        names: cucumberOpts.name,
+        tagExpression: cucumberOpts.tagExpression
+    })
+    const testCases = await Cucumber.getTestCasesFromFilesystem({
+        cwd: process.cwd(),
+        eventBroadcaster: new EventEmitter(),
+        featurePaths: config.specs,
+        order: cucumberOpts.order,
+        pickleFilter
+    })
+
+    const filteredSpecs = new Set(testCases.map(testCase => testCase.uri))
+    return filteredSpecs
 }

--- a/packages/wdio-cucumber-framework/src/utils.js
+++ b/packages/wdio-cucumber-framework/src/utils.js
@@ -1,8 +1,5 @@
 import * as path from 'path'
 import * as Cucumber from 'cucumber'
-import { EventEmitter } from 'events'
-import { DEFAULT_OPTS } from './constants'
-import { ConfigParser } from '@wdio/config'
 /**
  * NOTE: this function is exported for testing only
  */
@@ -165,29 +162,27 @@ export function getStepFromFeature(feature, pickle, stepIndex, sourceLocation) {
 }
 
 /**
- * Filter Specs By TagExpression
- * @param  {Object}    config   wdio configuration object
- * @return {Array}            Array of filtered specs
+ * Get an array of Cucumber test cases
+ * @param {Object} config wdio config object
+ * @param {Object} cucumberOpts cucumber option object
+ * @param {string[]} specs Array of paths of specs
+ * @param {Object} eventBroadcaster event emitter
+ * @param {string} cwd current working directoty
+ * @return {Object[]} Array of test cases
  */
-export async function filterSpecsByTag (config) {
-    const cucumberOpts = { ...DEFAULT_OPTS, ...config.cucumberOpts }
-    if (!cucumberOpts.tagExpression) {
-        return config.specs
-    }
-    const featurePaths = ConfigParser.getFilePaths(config.specs, false)
+export async function getTestCases (config, cucumberOpts, specs, eventBroadcaster, cwd) {
     const pickleFilter = new Cucumber.PickleFilter({
+        featurePaths: specs,
         names: cucumberOpts.name,
         tagExpression: cucumberOpts.tagExpression,
-        featurePaths
     })
     const testCases = await Cucumber.getTestCasesFromFilesystem({
-        cwd: process.cwd(),
-        eventBroadcaster: new EventEmitter(),
+        featurePaths: specs,
         order: cucumberOpts.order,
-        featurePaths,
+        cwd,
+        eventBroadcaster,
         pickleFilter
     })
-
-    const filteredSpecs = [...new Set(testCases.map(testCase => testCase.uri))]
-    return filteredSpecs
+    return testCases
 }
+

--- a/packages/wdio-cucumber-framework/src/utils.js
+++ b/packages/wdio-cucumber-framework/src/utils.js
@@ -168,7 +168,7 @@ export function getStepFromFeature(feature, pickle, stepIndex, sourceLocation) {
  * @param {string[]} specs Array of paths of specs
  * @param {Object} eventBroadcaster event emitter
  * @param {string} cwd current working directoty
- * @return {Object[]} Array of test cases
+ * @return {Promise<Object[]>} Array of test cases
  */
 export async function getTestCases (config, cucumberOpts, specs, eventBroadcaster, cwd) {
     const pickleFilter = new Cucumber.PickleFilter({

--- a/packages/wdio-cucumber-framework/src/utils.js
+++ b/packages/wdio-cucumber-framework/src/utils.js
@@ -2,7 +2,7 @@ import * as path from 'path'
 import * as Cucumber from 'cucumber'
 import { EventEmitter } from 'events'
 import { DEFAULT_OPTS } from './constants'
-
+import { ConfigParser } from '@wdio/config'
 /**
  * NOTE: this function is exported for testing only
  */
@@ -174,16 +174,17 @@ export async function filterSpecsByTag (config) {
     if (!cucumberOpts.tagExpression) {
         return config.specs
     }
+    const featurePaths = ConfigParser.getFilePaths(config.specs, false)
     const pickleFilter = new Cucumber.PickleFilter({
-        featurePaths: config.specs,
         names: cucumberOpts.name,
-        tagExpression: cucumberOpts.tagExpression
+        tagExpression: cucumberOpts.tagExpression,
+        featurePaths
     })
     const testCases = await Cucumber.getTestCasesFromFilesystem({
         cwd: process.cwd(),
         eventBroadcaster: new EventEmitter(),
-        featurePaths: config.specs,
         order: cucumberOpts.order,
+        featurePaths,
         pickleFilter
     })
 

--- a/packages/wdio-cucumber-framework/src/utils.js
+++ b/packages/wdio-cucumber-framework/src/utils.js
@@ -30,7 +30,7 @@ export function createStepArgument ({ argument }) {
 }
 
 /**
- * builds test parent string from feature and scneario names
+ * builds test parent string from feature and scenario names
  * NOTE: this function is exported for testing only
  * @param {object} feature cucumber feature object
  * @param {object} scenario cucumber scenario object
@@ -170,7 +170,7 @@ export function getStepFromFeature(feature, pickle, stepIndex, sourceLocation) {
  * @return {Array}            Array of filtered specs
  */
 export async function filterSpecsByTag (config) {
-    const cucumberOpts = Object.assign(DEFAULT_OPTS, config.cucumberOpts)
+    const cucumberOpts = { ...DEFAULT_OPTS, ...config.cucumberOpts }
     if (!cucumberOpts.tagExpression) {
         return config.specs
     }
@@ -187,6 +187,6 @@ export async function filterSpecsByTag (config) {
         pickleFilter
     })
 
-    const filteredSpecs = new Set(testCases.map(testCase => testCase.uri))
+    const filteredSpecs = [...new Set(testCases.map(testCase => testCase.uri))]
     return filteredSpecs
 }

--- a/packages/wdio-cucumber-framework/tests/adapter.test.js
+++ b/packages/wdio-cucumber-framework/tests/adapter.test.js
@@ -4,6 +4,9 @@ import * as Cucumber from 'cucumber'
 import { executeHooksWithArgs, runFnInFiberContext, executeAsync } from '@wdio/config'
 
 import CucumberAdapterFactory, { CucumberAdapter } from '../src'
+import { getTestCases } from '../src/utils'
+
+jest.mock('../src/utils')
 
 global.browser = {
     config: {},
@@ -49,8 +52,7 @@ test('should properly set up cucumber', async () => {
     expect(Cucumber.supportCodeLibraryBuilder.reset).toBeCalled()
 
     expect(executeHooksWithArgs).toBeCalledTimes(2)
-    expect(Cucumber.PickleFilter).toBeCalled()
-    expect(Cucumber.getTestCasesFromFilesystem).toBeCalled()
+    expect(getTestCases).toBeCalled()
 })
 
 test('should properly set up cucumber', async () => {
@@ -68,8 +70,7 @@ test('should properly set up cucumber', async () => {
     expect(Cucumber.supportCodeLibraryBuilder.reset).toBeCalled()
 
     expect(executeHooksWithArgs).toBeCalledTimes(2)
-    expect(Cucumber.PickleFilter).toBeCalled()
-    expect(Cucumber.getTestCasesFromFilesystem).toBeCalled()
+    expect(getTestCases).toBeCalled()
 })
 
 test('should throw when initialization fails', () => {

--- a/packages/wdio-cucumber-framework/tests/filters.test.js
+++ b/packages/wdio-cucumber-framework/tests/filters.test.js
@@ -1,0 +1,32 @@
+import { ConfigParser } from '@wdio/config'
+import { filterSpecsByTag } from '../src/filters'
+import { getTestCases } from '../src/utils'
+
+jest.mock('../src/utils')
+
+describe('filter', () => {
+    describe('filterSpecsByTag', () => {
+        it('should return filter specs if tagExpression is passed', async () => {
+            const config = {
+                specs: ['foo/**/*.feature'],
+                cucumberOpts: { tagExpression: '@test' }
+            }
+            ConfigParser.getFilePaths = jest.fn().mockReturnValue([
+                'foo/tag.feature',
+                'foo/no_tag.feature'
+            ])
+            getTestCases.mockReturnValue([
+                { uri: 'foo/tag.feature' },
+                { uri: 'foo/tag.feature' },
+            ])
+            expect(await filterSpecsByTag(config)).toEqual(['foo/tag.feature'])
+        })
+        it('should return original specs if tagExpression is not passed', async () => {
+            const config = {
+                specs: ['foo/**/*.feature'],
+                cucumberOpts: { tagExpression: '' }
+            }
+            expect(await filterSpecsByTag(config)).toBe(config.specs)
+        })
+    })
+})

--- a/packages/wdio-cucumber-framework/tests/utils.test.js
+++ b/packages/wdio-cucumber-framework/tests/utils.test.js
@@ -8,9 +8,8 @@ import {
     getUniqueIdentifier,
     getTestStepTitle,
     buildStepPayload,
-    filterSpecsByTag
+    getTestCases
 } from '../src/utils'
-import { ConfigParser } from '@wdio/config'
 
 describe('utils', () => {
     describe('createStepArgument', () => {
@@ -185,28 +184,11 @@ describe('utils', () => {
         })
     })
 
-    describe('filterSpecsByTag', () => {
-        it('should return filter specs if tagExpression is passed', async () => {
-            const config = {
-                specs: ['foo/**/*.feature'],
-                cucumberOpts: { tagExpression: '@test' }
-            }
-            ConfigParser.getFilePaths = jest.fn().mockReturnValue([
-                'foo/tag.feature',
-                'foo/no_tag.feature'
-            ])
-            Cucumber.getTestCasesFromFilesystem.mockReturnValue([
-                { uri: 'foo/tag.feature' },
-                { uri: 'foo/tag.feature' },
-            ])
-            expect(await filterSpecsByTag(config)).toEqual(['foo/tag.feature'])
-        })
-        it('should return original specs if tagExpression is not passed', async () => {
-            const config = {
-                specs: ['foo/**/*.feature'],
-                cucumberOpts: {}
-            }
-            expect(await filterSpecsByTag(config)).toBe(config.specs)
+    describe('getTestCases', () => {
+        it('should return test cases', async () => {
+            await getTestCases({}, {}, ['foo/bar'], {}, '')
+            expect(Cucumber.PickleFilter).toBeCalled()
+            expect(Cucumber.getTestCasesFromFilesystem).toBeCalled()
         })
     })
 })

--- a/packages/wdio-cucumber-framework/tests/utils.test.js
+++ b/packages/wdio-cucumber-framework/tests/utils.test.js
@@ -1,3 +1,4 @@
+import * as Cucumber from 'cucumber'
 import {
     createStepArgument,
     compareScenarioLineWithSourceLine,
@@ -6,7 +7,8 @@ import {
     formatMessage,
     getUniqueIdentifier,
     getTestStepTitle,
-    buildStepPayload
+    buildStepPayload,
+    filterSpecsByTag
 } from '../src/utils'
 
 describe('utils', () => {
@@ -162,7 +164,7 @@ describe('utils', () => {
     })
 
     describe('getTestStepTitle', () => {
-        it('keword and title are not passed', () => {
+        it('keyword and title are not passed', () => {
             expect(getTestStepTitle()).toEqual('Undefined Step')
         })
         it('should not add undefined step for hooks', () => {
@@ -179,6 +181,30 @@ describe('utils', () => {
                 title: 'Foo Undefined Step',
                 uid: 'undefined',
             })
+        })
+    })
+
+    describe('filterSpecsByTag', () => {
+        it('should return filter specs if tagExpression is passed', async () => {
+            const config = {
+                specs: ['features/**/*.feature'],
+                cucumberOpts: { tagExpression: '@test' }
+            }
+            Cucumber.getTestCasesFromFilesystem.mockImplementationOnce(() => [
+                { uri: 'foo/bar' },
+                { uri: 'foo/bar' },
+                { uri: 'bar/baz' }
+            ])
+            console.log(config)
+            expect(await filterSpecsByTag(config)).toEqual(['foo/bar', 'bar/baz'])
+        })
+        it('should return original specs if tagExpression is not passed', async () => {
+            const config = {
+                specs: ['features/**/*.feature'],
+                cucumberOpts: {}
+            }
+            console.log(config)
+            expect(await filterSpecsByTag(config)).toBe(config.specs)
         })
     })
 })

--- a/packages/wdio-cucumber-framework/tests/utils.test.js
+++ b/packages/wdio-cucumber-framework/tests/utils.test.js
@@ -10,6 +10,7 @@ import {
     buildStepPayload,
     filterSpecsByTag
 } from '../src/utils'
+import { ConfigParser } from '@wdio/config'
 
 describe('utils', () => {
     describe('createStepArgument', () => {
@@ -187,23 +188,24 @@ describe('utils', () => {
     describe('filterSpecsByTag', () => {
         it('should return filter specs if tagExpression is passed', async () => {
             const config = {
-                specs: ['features/**/*.feature'],
+                specs: ['foo/**/*.feature'],
                 cucumberOpts: { tagExpression: '@test' }
             }
-            Cucumber.getTestCasesFromFilesystem.mockImplementationOnce(() => [
-                { uri: 'foo/bar' },
-                { uri: 'foo/bar' },
-                { uri: 'bar/baz' }
+            ConfigParser.getFilePaths = jest.fn().mockReturnValue([
+                'foo/tag.feature',
+                'foo/no_tag.feature'
             ])
-            console.log(config)
-            expect(await filterSpecsByTag(config)).toEqual(['foo/bar', 'bar/baz'])
+            Cucumber.getTestCasesFromFilesystem.mockReturnValue([
+                { uri: 'foo/tag.feature' },
+                { uri: 'foo/tag.feature' },
+            ])
+            expect(await filterSpecsByTag(config)).toEqual(['foo/tag.feature'])
         })
         it('should return original specs if tagExpression is not passed', async () => {
             const config = {
-                specs: ['features/**/*.feature'],
+                specs: ['foo/**/*.feature'],
                 cucumberOpts: {}
             }
-            console.log(config)
             expect(await filterSpecsByTag(config)).toBe(config.specs)
         })
     })


### PR DESCRIPTION
## Proposed changes

Fix #1247
Do an additional filtering  in `wdio-cli/src/launcher.js` before process spawned

Export a utility function to filter features by tag expression
Use with `specsFilter` option in config `specFilter: (config) => string[]`

```js
// wdio.conf.js
exports.config = {
  // ...
  specsFilter: require('@wdio/cucumber-framework').filterSpecsByTag
  // ...
  cucumberOpts: {
      // ...
    tagExpression: '@smoke and @stable'
      // ...
  }
  // ...
}
```
A simple example of filter by file name using `specsFilter`:
```js
const { ConfigParser } = require('@wdio/config')
exports.config = {
  // ...
  namePattern: 'moduleA',
  specsFilter: (config) => {
      const specs = ConfigParser.getFilePaths(config.specs, false)
      return specs.filter(spec => spec.includes(config.namePattern))
  }
  // ...
}
```
Other frameworks should exported their own filters, as each framework has its own implementation.

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
