### PR TITLE
webdriverio: remove actions.release from moveTo command

### DIFF
--- a/packages/webdriverio/src/commands/element/moveTo.js
+++ b/packages/webdriverio/src/commands/element/moveTo.js
@@ -35,5 +35,5 @@ export default async function moveTo (xoffset, yoffset) {
         id: 'finger1',
         parameters: { pointerType: 'mouse' },
         actions: [{ type: 'pointerMove', duration: 0, x: newXoffset, y: newYoffset }]
-    }]).then(() => this.releaseActions())
+    }])
 }


### PR DESCRIPTION
## Proposed changes

Removes the explicit `browser.releaseActions()` from `element.moveTo()`

In SafariDriver, the act of releasing the actions was causing the mouse pointer to hop back to `0,0` on the page, invalidating the mouse hover state the user would have wanted.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

This fixes https://github.com/webdriverio/webdriverio/issues/4322

### Reviewers: @webdriverio/technical-committee
