### PR TITLE
Fix type generation for browser.uploadFile

### DIFF
--- a/packages/webdriverio/src/commands/browser/uploadFile.js
+++ b/packages/webdriverio/src/commands/browser/uploadFile.js
@@ -20,7 +20,7 @@
  * @param {String} localPath local path to file
  * @type utility
  * @uses protocol/file
- * @returns {String} remote URL
+ * @return {String} remote URL
  */
 import fs from 'fs'
 import path from 'path'


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)
PR [#4224 ](https://github.com/webdriverio/webdriverio/pull/4224) seems to not fix the issue with the type generation for `browser.uploadFile`; TS still reports this method returns `void`. 

I've found that this issue is related to the tag used - _@returns_ instead of _@return_. 
[These lines](https://github.com/webdriverio/webdriverio/blob/293840366ec9a62c0672346d811c5e54bd34709e/scripts/type-generation/generate-typings-utils.js#L57-L59) explicitly tell that type information is only retrieved when the tag _@return_ is used; otherwise, the return type will be `void`.

### Reviewers: @webdriverio/technical-committee
