### PR TITLE
Fix getting scroll position in IE11

### DIFF
--- a/packages/webdriverio/src/utils.js
+++ b/packages/webdriverio/src/utils.js
@@ -358,5 +358,5 @@ export function validateUrl (url, origError) {
  * @param {object} scope
  */
 export function getScrollPosition (scope) {
-    return getBrowserObject(scope).execute('return { scrollX: this.scrollX, scrollY: this.scrollY };')
+    return getBrowserObject(scope).execute('return { scrollX: this.pageXOffset, scrollY: this.pageYOffset };')
 }


### PR DESCRIPTION
## Proposed changes

Change `scrollX` / `scrollY` that doesn't work in IE11 to `pageXOffset` / `pageYOffset` that works in IE11, chrome, firefox, safari, edge.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

### Reviewers: @webdriverio/technical-committee
