### PR TITLE
webdriverio: waituntil -- generate err msg until timeout

### DIFF
--- a/packages/webdriverio/src/commands/browser/waitUntil.js
+++ b/packages/webdriverio/src/commands/browser/waitUntil.js
@@ -60,6 +60,8 @@ export default function (condition, timeout, timeoutMsg, interval) {
         if (e.message === 'timeout') {
             if (typeof timeoutMsg === 'string') {
                 throw new Error(timeoutMsg)
+            } else if (typeof timeoutMsg === 'function') {
+                throw new Error(timeoutMsg())
             }
             throw new Error(`waitUntil condition timed out after ${timeout}ms`)
         }

--- a/packages/webdriverio/tests/commands/browser/waitUntil.test.js
+++ b/packages/webdriverio/tests/commands/browser/waitUntil.test.js
@@ -61,6 +61,26 @@ describe('waitUntil', () => {
         }
     })
 
+    it('Should throw an error message created when the waitUntil times out', async () => {
+        let error
+        let errMsgObj = { msg: 'original msg' }
+        expect.assertions(1)
+        try {
+            await browser.waitUntil(() =>
+                new Promise((resolve) =>
+                    setTimeout(() => {
+                        errMsgObj.msg = 'changed error msg'
+                        resolve(false)
+                    },
+                    100)),
+            500, () => errMsgObj.msg, 200) // create error message
+        } catch(e) {
+            error = e
+        } finally {
+            expect(error.message).toContain('changed error msg')
+        }
+    })
+
     it('Should throw an error when the promise is rejected without error message', async () => {
         expect.assertions(1)
         try {

--- a/packages/webdriverio/webdriverio.d.ts
+++ b/packages/webdriverio/webdriverio.d.ts
@@ -64,7 +64,7 @@ declare namespace WebdriverIOAsync {
         waitUntil(
             condition: () => Promise<boolean>,
             timeout?: number,
-            timeoutMsg?: string,
+            timeoutMsg?: (() => string) | string,
             interval?: number
         ): Promise<boolean>;
 


### PR DESCRIPTION
## Proposed changes

`browser.waitUntil` uses error message generated at the time of timeout. Please see #4351 

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
