### PR TITLE
add execute driver support

### DIFF
--- a/packages/webdriver/protocol/appium.json
+++ b/packages/webdriver/protocol/appium.json
@@ -1401,5 +1401,33 @@
         }
       }
     }
+  },
+  "/session/:sessionId/appium/execute_driver": {
+    "POST": {
+      "command": "driverScript",
+      "description": "This command allows you to define a webdriverio script in a string and send it to the Appium server to be executed locally to the server itself, thus reducing latency that might otherwise occur along with each command.",
+      "ref": "https://github.com/appium/appium/blob/master/docs/en/commands/session/execute-driver.md",
+      "parameters": [{
+        "name": "script",
+        "type": "string",
+        "description": "The script to execute. It has access to a 'driver' object which represents a webdriverio session attached to the current server.",
+        "required": true
+      }, {
+        "name": "type",
+        "type": "string",
+        "description": "The language/framework used in the script. Currently, only 'webdriverio' is supported and is the default.",
+        "required": false
+      }, {
+        "name": "timeout",
+        "type": "number",
+        "description": "The number of milliseconds the script should be allowed to run before being killed by the Appium server. Defaults to the equivalent of 1 hour.",
+        "required": false
+      }],
+      "returns": {
+        "type": "object",
+        "name": "result",
+        "description": "An object containing two fields: 'result', which is the return value of the script itself, and 'logs', which contains 3 inner fields, 'log', 'warn', and 'error', which hold an array of strings logged by console.log, console.warn, and console.error in the script's execution."
+      }
+    }
   }
 }


### PR DESCRIPTION
## Proposed changes

Appium has added a new feature which allows batching of commands as a single webdriverio string, and executing that script via the new execute_driver endpoint. This PR adds support to the webdriver package for this new endpoint, in the Appium protocol definition.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)

## Further comments

Hey @christian-bromann I did not see a great place to add tests for this, can you please let me know where I should?

### Reviewers: @webdriverio/technical-committee
