### PR TITLE
wdio-crossbrowsertesting-service: Pass along `cbtTunnelOpts` to `cbtTunnels.start()`

### DIFF
--- a/packages/wdio-crossbrowsertesting-service/README.md
+++ b/packages/wdio-crossbrowsertesting-service/README.md
@@ -40,6 +40,9 @@ export.config = {
   user: process.env.CBT_USERNAME,
   key: process.env.CBT_AUTHKEY,
   cbtTunnel: true,
+  cbtTunnelOpts: {
+    // any additional options from cbt_tunnels
+  },
   // ...
 };
 ```
@@ -61,6 +64,12 @@ If true secure CBT local connection is started.
 
 Type: `Boolean`<br>
 Default: `false`
+
+### cbtTunnelOpts
+Any additional options to pass along to the `start()` function of [cbt_tunnels](https://www.npmjs.com/package/cbt_tunnels)
+
+Type: `Object`<br>
+Default: `{}`
 
 
 For more information on WebdriverIO see the [homepage](http://webdriver.io).

--- a/packages/wdio-crossbrowsertesting-service/src/launcher.js
+++ b/packages/wdio-crossbrowsertesting-service/src/launcher.js
@@ -11,7 +11,7 @@ export default class CrossBrowserTestingLauncher {
             authkey: config.key
         }, config.cbtTunnelOpts)
 
-        return new Promise((resolve, reject) => cbt.start({ 'username': config.user, 'authkey': config.key }, (err) => {
+        return new Promise((resolve, reject) => cbt.start(this.cbtTunnelOpts, (err) => {
             if (err) {
                 return reject(err)
             }

--- a/packages/wdio-crossbrowsertesting-service/tests/launcher.test.js
+++ b/packages/wdio-crossbrowsertesting-service/tests/launcher.test.js
@@ -37,8 +37,8 @@ describe('wdio-crossbrowsertesting-service', () => {
             user: 'test',
             key: 'testy'
         }
-        expect(cbtLauncher.onPrepare(config)).resolves.toBe('connected')
-            .then(() => expect(cbtTunnels.start).toHaveBeenCalled())
+        await expect(cbtLauncher.onPrepare(config)).resolves.toBe('connected')
+        expect(cbtTunnels.start).toHaveBeenCalledWith({ username: 'test', authkey: 'testy', options: 'some options' }, expect.any(Function))
         expect(cbtLauncher.cbtTunnelOpts).toEqual({ username: 'test', authkey: 'testy', options: 'some options' })
 
     })
@@ -70,7 +70,7 @@ describe('wdio-crossbrowsertesting-service', () => {
             .then(() => expect(cbtTunnels.stop).toHaveBeenCalled())
     })
 
-    it('onComplete: cbtTunnel.stop succesful', async () => {
+    it('onComplete: cbtTunnel.stop successful', async () => {
         cbtLauncher.tunnel = true
         expect(cbtLauncher.onComplete()).resolves.toBe('stopped')
             .then(() => expect(cbtTunnels.stop).toHaveBeenCalled())


### PR DESCRIPTION
## Proposed changes

Handling of an additional config option named `cbtTunnelOpts` was half-implemented. This change finishes that implementation and adds it to the README.

## Types of changes

- Pass along `this.cbtTunnelOpts` to `cbt.start()`

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

### Reviewers: @webdriverio/technical-committee
