### PR TITLE
Fix user hooks in sync mode

### DIFF
--- a/packages/wdio-cucumber-framework/src/utils.js
+++ b/packages/wdio-cucumber-framework/src/utils.js
@@ -185,8 +185,8 @@ export function setUserHookNames (options) {
         options[hookName].forEach(testRunHookDefinition => {
             const hookFn = testRunHookDefinition.code
             if (!hookFn.name.startsWith('wdioHook')) {
-                const userHookAsyncFn = async (...args) => hookFn(args)
-                const userHookFn = (...args) => hookFn(args)
+                const userHookAsyncFn = async function (...args) { return hookFn.apply(this, args) }
+                const userHookFn = function (...args) { return hookFn.apply(this, args) }
                 testRunHookDefinition.code = (isFunctionAsync(hookFn)) ? userHookAsyncFn : userHookFn
             }
         })

--- a/packages/wdio-cucumber-framework/src/utils.js
+++ b/packages/wdio-cucumber-framework/src/utils.js
@@ -194,19 +194,19 @@ export function setUserHookNames (options) {
 }
 
 /**
- * returns a function that calls `beforeStep` before step and then calls `afterStep` (even if step has failed)
- * We need this workaround because `BeforeStep` and `AfterStep` hooks are not implemented in CucumberJS
- * https://github.com/cucumber/cucumber-js/issues/997
+ * returns a function that calls first before hook, then user step/hook and finally after hook (even if step has failed)
+ * @param {string}      type    Step or Hook
  * @param {Function}    code    step function
- * @param {object}      config  wdio config
+ * @param {Function}    before  before hook function
+ * @param {Function}    after   after hook function
  * @param {string}      cid     cid
  */
-export function wrapStepWithHooks (code, config, cid) {
-    const userStepFn = async (...args) => {
+export function wrapWithHooks (type, code, before, after, cid) {
+    const userFn = async function (...args) {
         const { uri, feature } = getDataFromResult(global.result)
 
-        // beforeStep hook
-        notifyStepHookError('BeforeStep', await executeHooksWithArgs(config.beforeStep, [uri, feature]), cid)
+        // before hook
+        notifyStepHookError(`Before${type}`, await executeHooksWithArgs(before, [uri, feature]), cid)
 
         // step
         let result
@@ -217,15 +217,15 @@ export function wrapStepWithHooks (code, config, cid) {
             error = err
         }
 
-        // afterStep
-        notifyStepHookError('AfterStep', await executeHooksWithArgs(config.afterStep, [uri, feature, { error, result }]), cid)
+        // after
+        notifyStepHookError(`Before${type}`, await executeHooksWithArgs(after, [uri, feature, { error, result }]), cid)
 
         if (error) {
             throw error
         }
         return result
     }
-    return userStepFn
+    return userFn
 }
 
 /**

--- a/packages/wdio-cucumber-framework/src/utils.js
+++ b/packages/wdio-cucumber-framework/src/utils.js
@@ -218,7 +218,7 @@ export function wrapWithHooks (type, code, before, after, cid) {
         }
 
         // after
-        notifyStepHookError(`Before${type}`, await executeHooksWithArgs(after, [uri, feature, { error, result }]), cid)
+        notifyStepHookError(`After${type}`, await executeHooksWithArgs(after, [uri, feature, { error, result }]), cid)
 
         if (error) {
             throw error

--- a/packages/wdio-cucumber-framework/tests/adapter.test.js
+++ b/packages/wdio-cucumber-framework/tests/adapter.test.js
@@ -182,11 +182,11 @@ describe('wrapStep', () => {
         config.hasWdioSyncSupport = true
         const adapter = adapterFactory()
 
-        const fn = adapter.wrapStep('fn')
+        const fn = adapter.wrapStep('fn', undefined, undefined, {})
         expect(typeof fn).toBe('function')
 
         fn(1, 2, 3)
-        expect(executeSync).toBeCalledWith('fn', 0, [1, 2, 3])
+        expect(executeSync).toBeCalledWith(expect.any(Function), 0, [1, 2, 3])
     })
 
     test('should use async if function name is sync', () => {
@@ -194,22 +194,22 @@ describe('wrapStep', () => {
         const adapter = adapterFactory()
 
         const code = function async () { }
-        const fn = adapter.wrapStep(code, 123)
+        const fn = adapter.wrapStep(code, 123, undefined, {})
         expect(typeof fn).toBe('function')
 
         fn(1, 2, 3)
-        expect(executeAsync).toBeCalledWith(code, 123, [1, 2, 3])
+        expect(executeAsync).toBeCalledWith(expect.any(Function), 123, [1, 2, 3])
     })
 
     test('should use async hasWdioSyncSupport is false and set proper default arguments', () => {
         config.hasWdioSyncSupport = false
         const adapter = adapterFactory()
 
-        const fn = adapter.wrapStep('fn')
+        const fn = adapter.wrapStep('fn', undefined, undefined, {})
         expect(typeof fn).toBe('function')
 
         fn(1, 2, 3)
-        expect(executeAsync).toBeCalledWith('fn', 0, [1, 2, 3])
+        expect(executeAsync).toBeCalledWith(expect.any(Function), 0, [1, 2, 3])
     })
 })
 

--- a/tests/cucumber/step-definitions/given.js
+++ b/tests/cucumber/step-definitions/given.js
@@ -5,18 +5,40 @@ import { Given, BeforeAll, Before, After, AfterAll } from 'cucumber'
 BeforeAll(() => {
     // defined and modified in hooks
     assert.equal(browser.Cucumber_Test, 0)
+
+    // should resolve promises
+    assert.strictEqual(browser.pause(1), undefined)
 })
-Before(() => {
+Before(function (scenario) {
     // defined and modified in hooks
     assert.equal(browser.Cucumber_Test, 1)
+
+    assert.strictEqual(Array.isArray(scenario.pickle.tags), true)
+
+    // World
+    assert.strictEqual(typeof this.attach, 'function')
+
+    // should resolve promises
+    assert.strictEqual(browser.pause(1), undefined)
 })
-After(() => {
+After(function (scenario) {
     // defined and modified in hooks
     assert.equal(browser.Cucumber_Test, 1)
+
+    assert.strictEqual(typeof this.attach, 'function')
+
+    // World
+    assert.strictEqual(Array.isArray(scenario.pickle.tags), true)
+
+    // should resolve promises
+    assert.strictEqual(browser.pause(1), undefined)
 })
 AfterAll(() => {
     // defined and modified in hooks
     assert.equal(browser.Cucumber_Test, -1)
+
+    // should resolve promises
+    assert.strictEqual(browser.pause(1), undefined)
 })
 
 Given('I choose the {string} scenario', { retry: { wrapperOptions: { retry: 1 } } }, (scenario) => {
@@ -27,7 +49,10 @@ Given('I choose the {string} scenario', { retry: { wrapperOptions: { retry: 1 } 
     browser[scenario]()
 })
 
-Given('I go on the website {string}', (url) => {
+Given('I go on the website {string}', function (url) {
+    // World
+    assert.strictEqual(typeof this.attach, 'function')
+
     browser.url(url)
 })
 


### PR DESCRIPTION
## Proposed changes

- fix World for Given/Then, Before/After
- fix running Before/BeforeAll/After/AfterAll in sync mode
- fix args passed to Before/After hooks #4370

Additionally
- added beforeHook/afterHook wdio hooks

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] unit tests
- [x] smoke tests

## Further comments

fixes (at least partially) #4364

### Reviewers: @webdriverio/technical-committee
