### PR TITLE
Fix process exit code

### DIFF
--- a/packages/wdio-cli/src/interface.js
+++ b/packages/wdio-cli/src/interface.js
@@ -23,12 +23,6 @@ export default class WDIOCLInterface extends EventEmitter {
         this.inDebugMode = false
         this.specFileRetries = config.specFileRetries || 0
 
-        /**
-         * `Launcher.exitHandler` is always called so we need to identify
-         * if `SIGINT` was actually called
-         */
-        this.endedNormally = false
-
         this.on('job:start', ::this.addJob)
         this.on('job:end', ::this.clearJob)
 
@@ -197,7 +191,7 @@ export default class WDIOCLInterface extends EventEmitter {
         /**
          * allow to exit repl mode via Ctrl+C
          */
-        if (this.inDebugMode || this.endedNormally) {
+        if (this.inDebugMode) {
             return false
         }
 
@@ -238,7 +232,6 @@ export default class WDIOCLInterface extends EventEmitter {
             return
         }
 
-        this.endedNormally = true
         this.printReporters()
         this.printSummary()
     }

--- a/packages/wdio-cli/src/run.js
+++ b/packages/wdio-cli/src/run.js
@@ -68,4 +68,9 @@ export default function run (params) {
 export function launch (wdioConf, params) {
     const launcher = new Launcher(wdioConf, params)
     return launcher.run()
+        .then(process.exit)
+        .catch(err => {
+            console.error(err)
+            process.exit(1)
+        })
 }

--- a/packages/wdio-cli/tests/interface.test.js
+++ b/packages/wdio-cli/tests/interface.test.js
@@ -269,13 +269,7 @@ describe('cli interface', () => {
             expect(wdioClInterface.sigintTrigger()[0]).toContain('Ended WebDriver sessions gracefully')
         })
 
-        it('should do nothing if ended normally', () => {
-            wdioClInterface.endedNormally = true
-            expect(wdioClInterface.sigintTrigger()).toBe(false)
-        })
-
         it('should do nothing in debug mode', () => {
-            wdioClInterface.endedNormally = false
             wdioClInterface.inDebugMode = true
             expect(wdioClInterface.sigintTrigger()).toBe(false)
         })

--- a/packages/wdio-cli/tests/launcher.test.js
+++ b/packages/wdio-cli/tests/launcher.test.js
@@ -158,6 +158,18 @@ describe('launcher', () => {
             expect(launcher.runner.shutdown).toBeCalledTimes(0)
         })
 
+        it('should do nothing if shutdown was called before', () => {
+            launcher.hasTriggeredExitRoutine = true
+            launcher.interface = { sigintTrigger: jest.fn() }
+            launcher.runner = { shutdown: jest.fn().mockReturnValue(Promise.resolve()) }
+
+            launcher.exitHandler()
+
+            expect(launcher.hasTriggeredExitRoutine).toBe(true)
+            expect(launcher.interface.sigintTrigger).toBeCalledTimes(0)
+            expect(launcher.runner.shutdown).toBeCalledTimes(0)
+        })
+
         it('should shutdown', () => {
             launcher.hasTriggeredExitRoutine = false
             launcher.interface = { sigintTrigger: jest.fn() }
@@ -413,14 +425,14 @@ describe('launcher', () => {
                 getCapabilities: jest.fn().mockReturnValue(0),
                 getConfig: jest.fn().mockReturnValue(config)
             }
-            launcher.runner = { initialise: jest.fn() }
+            launcher.runner = { initialise: jest.fn(), shutdown: jest.fn() }
             launcher.runMode = jest.fn().mockImplementation((config, caps) => caps)
             launcher.interface = { finalise: jest.fn() }
         })
 
         it('exit code 0', async () => {
             expect(await launcher.run()).toEqual(0)
-            expect(emitSpy).not.toBeCalled()
+            expect(launcher.runner.shutdown).toBeCalled()
 
             expect(launcher.configParser.getCapabilities).toBeCalledTimes(1)
             expect(launcher.configParser.getConfig).toBeCalledTimes(1)
@@ -431,28 +443,21 @@ describe('launcher', () => {
             expect(launcher.interface.finalise).toBeCalledTimes(1)
         })
 
+        it('should not shutdown runner if was called before', async () => {
+            launcher.hasTriggeredExitRoutine = true
+            expect(await launcher.run()).toEqual(0)
+            expect(launcher.runner.shutdown).not.toBeCalled()
+        })
+
         it('onComplete error', async () => {
             // ConfigParser.addFileConfig() will return onComplete as an array of functions
             config.onComplete = [() => { throw new Error() }]
 
             expect(await launcher.run()).toEqual(1)
-            expect(emitSpy).not.toBeCalled()
+            expect(launcher.runner.shutdown).toBeCalled()
         })
 
-        it('should return isComplete=false if failed before onComplete', async () => {
-            delete launcher.configParser
-
-            let error
-            try {
-                await launcher.run()
-            } catch (err) {
-                error = err
-            }
-            expect(emitSpy).toBeCalledWith('shutdown', 1)
-            expect(error).toBeInstanceOf(Error)
-        })
-
-        it('should return isComplete=true if failed after onComplete', async () => {
+        it('should shutdown runner on error', async () => {
             delete logger.waitForBuffer
 
             let error
@@ -461,7 +466,7 @@ describe('launcher', () => {
             } catch (err) {
                 error = err
             }
-            expect(emitSpy).not.toBeCalled()
+            expect(launcher.runner.shutdown).toBeCalled()
             expect(error).toBeInstanceOf(Error)
         })
     })

--- a/packages/wdio-cli/tests/launcher.test.js
+++ b/packages/wdio-cli/tests/launcher.test.js
@@ -163,7 +163,7 @@ describe('launcher', () => {
             launcher.interface = { sigintTrigger: jest.fn() }
             launcher.runner = { shutdown: jest.fn().mockReturnValue(Promise.resolve()) }
 
-            launcher.exitHandler()
+            expect(launcher.exitHandler(() => 'foo')).toBe('foo')
 
             expect(launcher.hasTriggeredExitRoutine).toBe(true)
             expect(launcher.interface.sigintTrigger).toBeCalledTimes(0)

--- a/packages/wdio-cli/tests/run.test.js
+++ b/packages/wdio-cli/tests/run.test.js
@@ -7,6 +7,9 @@ jest.mock('../src/launcher', () => jest.fn().mockImplementation(function(conf, r
     }
 }))
 
+const processExit = process.exit
+const consoleError = global.console.error
+
 describe('launch', () => {
     process.exit = jest.fn()
     global.console.error = jest.fn()
@@ -49,5 +52,10 @@ describe('launch', () => {
         Launcher.mockClear()
         global.console.error.mockClear()
         process.exit.mockClear()
+    })
+
+    afterAll(() => {
+        process.exit = processExit
+        global.console.error = consoleError
     })
 })

--- a/packages/wdio-cli/tests/run.test.js
+++ b/packages/wdio-cli/tests/run.test.js
@@ -1,12 +1,53 @@
 import { launch } from '../src/run'
 import Launcher from '../src/launcher'
 
-jest.mock('../src/launcher')
+jest.mock('../src/launcher', () => jest.fn().mockImplementation(function(conf, result) {
+    return {
+        run: jest.fn().mockImplementation(() => Number.isInteger(result) ? Promise.resolve(result) : Promise.reject(result))
+    }
+}))
 
 describe('launch', () => {
-    it('should pass callback to launcher', () => {
-        launch('configFile', 'argv')
-        expect(Launcher).toBeCalledWith('configFile', 'argv')
-        expect(Launcher.mock.instances[0].run).toBeCalled()
+    process.exit = jest.fn()
+    global.console.error = jest.fn()
+
+    it('should exit with code 0', async () => {
+        launch('configFile', 0)
+        expect(Launcher).toBeCalledWith('configFile', 0)
+        expect(Launcher.mock.instances).toHaveLength(1)
+
+        await Launcher.mock.results[0].value.run.mock.results[0].value
+        expect(process.exit).toBeCalledWith(0)
+    })
+
+    it('should exit with code 1', async () => {
+        launch('configFile', 1)
+        expect(Launcher).toBeCalledWith('configFile', 1)
+        expect(Launcher.mock.instances).toHaveLength(1)
+
+        await Launcher.mock.results[0].value.run.mock.results[0].value
+        expect(process.exit).toBeCalledWith(1)
+    })
+
+    it('should catch errors', async () => {
+        launch('configFile', 'foobar')
+        expect(Launcher).toBeCalledWith('configFile', 'foobar')
+        expect(Launcher.mock.instances).toHaveLength(1)
+
+        let error
+        try {
+            await Launcher.mock.results[0].value.run.mock.results[0].value
+        } catch (err) {
+            error = err
+        }
+        expect(error).toBe('foobar')
+        expect(global.console.error).toBeCalled
+        expect(process.exit).toBeCalledWith(1)
+    })
+
+    afterEach(() => {
+        Launcher.mockClear()
+        global.console.error.mockClear()
+        process.exit.mockClear()
     })
 })

--- a/packages/wdio-local-runner/src/index.js
+++ b/packages/wdio-local-runner/src/index.js
@@ -69,19 +69,19 @@ export default class LocalRunner {
         }
 
         return new Promise((resolve) => {
+            const timeout = setTimeout(resolve, SHUTDOWN_TIMEOUT)
             const interval = setInterval(() => {
                 const busyWorker = Object.entries(this.workerPool)
                     .filter(([, worker]) => worker.isBusy).length
 
                 log.info(`Waiting for ${busyWorker} to shut down gracefully`)
                 if (busyWorker === 0) {
+                    clearTimeout(timeout)
                     clearInterval(interval)
                     log.info('shutting down')
                     return resolve()
                 }
             }, 250)
-
-            setTimeout(resolve, SHUTDOWN_TIMEOUT)
         })
     }
 }


### PR DESCRIPTION
## Proposed changes

After recent changes wdio cli always exits with code 0.
This PR fixes #4368 and doesn't affect recently fixed "process.exit" / "webdriver session hanging" issues.

- exit process with appropriate exit code after runner.shutdown
- fixed shutdown timeout that causes process to hang
- reverted interface changes made in https://github.com/webdriverio/webdriverio/pull/4332

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

### Reviewers: @webdriverio/technical-committee
