### PR TITLE
allure-reporter: fixed bug with mocha all hooks being treated as tests

### DIFF
--- a/packages/wdio-allure-reporter/src/constants.js
+++ b/packages/wdio-allure-reporter/src/constants.js
@@ -34,5 +34,6 @@ const events = {
 }
 
 const mochaEachHooks = ['"before each" hook', '"after each" hook']
+const mochaAllHooks = ['"before all" hook', '"after all" hook']
 
-export { testStatuses, stepStatuses, events, mochaEachHooks }
+export { testStatuses, stepStatuses, events, mochaEachHooks, mochaAllHooks }

--- a/packages/wdio-allure-reporter/src/utils.js
+++ b/packages/wdio-allure-reporter/src/utils.js
@@ -1,6 +1,6 @@
 import process from 'process'
 import CompoundError from './compoundError'
-import { testStatuses, mochaEachHooks } from './constants'
+import { testStatuses, mochaEachHooks, mochaAllHooks } from './constants'
 
 /**
  * Get allure test status by TestStat object
@@ -36,6 +36,14 @@ export const isEmpty = (object) => !object || Object.keys(object).length === 0
  * @private
  */
 export const isMochaEachHooks = title => mochaEachHooks.some(hook => title.includes(hook))
+
+/**
+ * Is mocha beforeAll / afterAll hook
+ * @param title {String} - hook title
+ * @returns {boolean}
+ * @private
+ */
+export const isMochaAllHooks = title => mochaAllHooks.some(hook => title.includes(hook))
 
 /**
  * Call reporter

--- a/packages/wdio-allure-reporter/tests/allureFeatures.test.js
+++ b/packages/wdio-allure-reporter/tests/allureFeatures.test.js
@@ -410,9 +410,8 @@ describe('hooks handling', () => {
         reporter.allure = allureInstance({ suite: { testcases }, test: { steps: [] } })
         reporter.onHookEnd({ title: '"before all" hook', parent: 'foo' })
 
-        expect(endCase).toHaveBeenCalledTimes(1)
-        expect(endCase.mock.results[0].value).toBe('passed')
-        expect(testcases).toHaveLength(0)
+        expect(endCase).toHaveBeenCalledTimes(0)
+        expect(testcases).toHaveLength(1)
     })
 
     it('should keep passed hooks if there are some steps', () => {
@@ -461,6 +460,23 @@ describe('hooks handling', () => {
         expect(endCase).toHaveBeenCalledTimes(0)
         expect(endStep).toHaveBeenCalledTimes(1)
         expect(endStep.mock.results[0].value).toBe('failed')
+    })
+
+    it('should ignore mocha all hooks if hook passes', () => {
+        reporter.allure = allureInstance()
+        reporter.onHookStart({ title: '"after all" hook', parent: 'foo' })
+
+        expect(startCase).toHaveBeenCalledTimes(0)
+        expect(endCase).toHaveBeenCalledTimes(0)
+    })
+
+    it('should treat mocha all hooks as tests if hook throws', () => {
+        reporter.allure = allureInstance()
+        reporter.onHookEnd({ title: '"before all" hook', parent: 'foo', error: { message: '', stack: '' } })
+
+        expect(startCase).toHaveBeenCalledTimes(1)
+        expect(endCase).toHaveBeenCalledTimes(1)
+        expect(endCase.mock.results[0].value).toBe('broken')
     })
 })
 

--- a/packages/wdio-allure-reporter/tests/utils.test.js
+++ b/packages/wdio-allure-reporter/tests/utils.test.js
@@ -1,6 +1,6 @@
 import process from 'process'
 import CompoundError from '../src/compoundError'
-import { getTestStatus, isEmpty, tellReporter, isMochaEachHooks, getErrorFromFailedTest } from '../src/utils'
+import { getTestStatus, isEmpty, tellReporter, isMochaEachHooks, getErrorFromFailedTest, isMochaAllHooks } from '../src/utils'
 import { testStatuses } from '../src/constants'
 
 describe('utils', () => {
@@ -67,6 +67,11 @@ describe('utils', () => {
             expect(isMochaEachHooks('"after all" hook')).toEqual(false)
             expect(isMochaEachHooks('"before each" hook')).toEqual(true)
             expect(isMochaEachHooks('"after each" hook')).toEqual(true)
+
+            expect(isMochaAllHooks('"before all" hook')).toEqual(true)
+            expect(isMochaAllHooks('"after all" hook')).toEqual(true)
+            expect(isMochaAllHooks('"before each" hook')).toEqual(false)
+            expect(isMochaAllHooks('"after each" hook')).toEqual(false)
         })
     })
 


### PR DESCRIPTION
## Proposed changes

[//]: # Before and After hooks appear in report like tests which breaks statistics of tests. I might have 1 failing test out of 1 and it's 100% fails but with successful hooks it's only 33%.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ x] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
