### PR TITLE
Add smoke tests for retries

### DIFF
--- a/tests/jasmine/test.js
+++ b/tests/jasmine/test.js
@@ -2,4 +2,12 @@ describe('Jasmine smoke test', () => {
     it('should return sync value', () => {
         expect(browser.getTitle()).toBe('Mock Page Title')
     })
+
+    let hasRun = false
+    it('should retry', () => {
+        if(!hasRun) {
+            hasRun = true
+            throw new Error('booom!')
+        }
+    }, 1)
 })

--- a/tests/mocha/test.js
+++ b/tests/mocha/test.js
@@ -5,6 +5,14 @@ describe('Mocha smoke test', () => {
         assert.equal(browser.getTitle(), 'Mock Page Title')
     })
 
+    let hasRun = false
+    it('should retry', () => {
+        if(!hasRun) {
+            hasRun = true
+            throw new Error('booom!')
+        }
+    }, 1)
+
     it('should be able to wait for an element', () => {
         browser.waitForDisplayedScenario()
         assert($('elem').waitForDisplayed(), true)


### PR DESCRIPTION
Just some smoke tests to ensure that `it` level retries work as expected.

closes #4008