### PR TITLE
@wdio/sync: throw if command is executed outside of a fiber context

### DIFF
--- a/packages/wdio-runner/src/index.js
+++ b/packages/wdio-runner/src/index.js
@@ -218,6 +218,12 @@ export default class Runner extends EventEmitter {
             return
         }
 
+        /**
+         * suppress @wdio/sync warnings of not running commands inside of
+         * a Fibers contetx
+         */
+        global._HAS_FIBER_CONTEXT = true
+
         let logTypes
         try {
             logTypes = await global.browser.getLogTypes()

--- a/packages/wdio-sync/src/fibers.js
+++ b/packages/wdio-sync/src/fibers.js
@@ -5,6 +5,8 @@ const log = logger('@wdio/sync')
 let Fiber
 let Future
 
+global._HAS_FIBER_CONTEXT = false
+
 /**
  * Helper method to retrieve a version of `fibers` for your Node version.
  */

--- a/packages/wdio-sync/src/index.js
+++ b/packages/wdio-sync/src/index.js
@@ -21,7 +21,9 @@ const log = logger('@wdio/sync')
  */
 const executeSync = async function (fn, repeatTest = 0, args = []) {
     try {
+        global._HAS_FIBER_CONTEXT = true
         let res = fn.apply(this, args)
+        global._HAS_FIBER_CONTEXT = false
 
         /**
          * sometimes function result is Promise,

--- a/packages/wdio-sync/src/runFnInFiberContext.js
+++ b/packages/wdio-sync/src/runFnInFiberContext.js
@@ -9,7 +9,9 @@ export default function runFnInFiberContext (fn) {
     return function (...args) {
         return new Promise((resolve, reject) => Fiber(() => {
             try {
+                global._HAS_FIBER_CONTEXT = true
                 const result = fn.apply(this, args)
+                global._HAS_FIBER_CONTEXT = false
                 return resolve(result)
             } catch (err) {
                 return reject(err)

--- a/packages/wdio-sync/src/runFnInFiberContextWithCallback.js
+++ b/packages/wdio-sync/src/runFnInFiberContextWithCallback.js
@@ -9,7 +9,9 @@ import Fiber from './fibers'
 export default function runFnInFiberContextWithCallback (fn, done) {
     return function (...args) {
         return Fiber(() => {
+            global._HAS_FIBER_CONTEXT = true
             const result = fn.apply(this, args)
+            global._HAS_FIBER_CONTEXT = false
 
             if (typeof done === 'function') {
                 done(result)

--- a/packages/wdio-sync/src/wrapCommand.js
+++ b/packages/wdio-sync/src/wrapCommand.js
@@ -1,7 +1,10 @@
 import { Future } from './fibers'
+import logger from '@wdio/logger'
 
 import executeHooksWithArgs from './executeHooksWithArgs'
 import { sanitizeErrorMessage } from './utils'
+
+const log = logger('@wdio/sync')
 
 /**
  * wraps a function into a Fiber ready context to enable sync execution and hooks
@@ -13,6 +16,13 @@ import { sanitizeErrorMessage } from './utils'
  */
 export default function wrapCommand (commandName, fn) {
     return function wrapCommandFn (...args) {
+        if(!global._HAS_FIBER_CONTEXT) {
+            log.warn(
+                `Can't return command result of ${commandName} synchronously because command ` +
+                'was executed outside of an it block, hook or step definition!'
+            )
+        }
+
         /**
          * Avoid running some functions in Future that are not in Fiber.
          */


### PR DESCRIPTION
People fall into the trap of calling commands outside of `it` blocks or hooks of a test framework. Instead of returning a promise and confuse the user we should immediately throw an error with a helpful message to tell customers to only call commands within expected areas.