### PR TITLE
[@wdio/devtools-service] Add command for mobile emulation

### DIFF
--- a/packages/wdio-devtools-service/README.md
+++ b/packages/wdio-devtools-service/README.md
@@ -176,6 +176,34 @@ browser.enablePerformanceAudits({
 
 The following network throttling profiles are available: `offline`, `GPRS`, `Regular 2G`, `Good 2G`, `Regular 3G`, `Good 3G`, `Regular 4G`, `DSL`, `Wifi` and `online` (no throttling).
 
+### Device Emulation
+
+The service allows you to emulate a specific device type. If set, the browser viewport will be modified to fit the device capabilities as well as the user agent will set according to the device user agent. To set a predefined device profile you can run:
+
+```js
+browser.emulateDevice('iPhone 10')
+// or `browser.emulateDevice('iPhone 10', true)` if you want to be in landscape mode
+```
+
+Available predefined device profiles are: `Blackberry PlayBook`, `BlackBerry Z30`, `Galaxy Note 3`, `Galaxy Note II`, `Galaxy S III`, `Galaxy S5`, `iPad`, `iPad Mini`, `iPad Pro`, `iPhone 4`, `iPhone 5`, `iPhone 6`, `iPhone 6 Plus`, `iPhone 7`, `iPhone 7 Plus`, `iPhone 8`, `iPhone 8 Plus`, `iPhone SE`, `iPhone X`, `JioPhone 2`,
+`Kindle Fire HDX`, `LG Optimus L70`, `Microsoft Lumia 550`, `Microsoft Lumia 950`, `Nexus 10`, `Nexus 4`, `Nexus 5`, `Nexus 5X`, `Nexus 6`, `Nexus 6P`, `Nexus 7`, `Nokia Lumia 520`, `Nokia N9`, `Pixel 2`, `Pixel 2 XL`
+
+You can also define your own device profile by providing an object as parameter like in the following example:
+
+```js
+browser.emulateDevice({
+    viewport: {
+        width: 550, // <number> page width in pixels.
+        height: 300, // <number> page height in pixels.
+        deviceScaleFactor: 1, //  <number> Specify device scale factor (can be thought of as dpr). Defaults to 1
+        isMobile: true, // <boolean> Whether the meta viewport tag is taken into account. Defaults to false
+        hasTouch: true, // <boolean> Specifies if viewport supports touch events. Defaults to false
+        isLandscape: true // <boolean> Specifies if viewport is in landscape mode. Defaults to false
+    },
+    userAgent: 'my custom user agent'
+})
+```
+
 ### Chrome DevTools Access
 
 For now the service allows two different ways to access the Chrome DevTools Protocol:

--- a/packages/wdio-devtools-service/src/driver.js
+++ b/packages/wdio-devtools-service/src/driver.js
@@ -18,6 +18,10 @@ export default class DevToolsDriver {
          */
     }
 
+    get devices () {
+        return puppeteer.devices
+    }
+
     static async attach (url) {
         log.info(`Connect to ${url}`)
         const browser = await puppeteer.connect({

--- a/packages/wdio-devtools-service/src/index.js
+++ b/packages/wdio-devtools-service/src/index.js
@@ -77,6 +77,7 @@ export default class DevToolsService {
 
         global.browser.addCommand('enablePerformanceAudits', ::this._enablePerformanceAudits)
         global.browser.addCommand('disablePerformanceAudits', ::this._disablePerformanceAudits)
+        global.browser.addCommand('emulateDevice', ::this._emulateDevice)
 
         /**
          * allow user to work with Puppeteer directly
@@ -151,6 +152,28 @@ export default class DevToolsService {
      */
     _disablePerformanceAudits () {
         this.shouldRunPerformanceAudits = false
+    }
+
+    /**
+     * set device emulation
+     */
+    async _emulateDevice (device, inLandscape) {
+        const page = await this.devtoolsDriver.getActivePage()
+
+        if (typeof device === 'string') {
+            const deviceName = device + (inLandscape ? ' landscape' : '')
+            const deviceCapabilities = this.devtoolsDriver.devices[deviceName]
+            if (!deviceCapabilities) {
+                const deviceNames = this.devtoolsDriver.devices
+                    .map((device) => device.name)
+                    .filter((device) => !device.endsWith('landscape'))
+                throw new Error(`Unknown device, available options: ${deviceNames.join(', ')}`)
+            }
+
+            return page.emulate(deviceCapabilities)
+        }
+
+        return page.emulate(device)
     }
 
     /**

--- a/packages/wdio-devtools-service/tests/__mocks__/puppeteer-core.js
+++ b/packages/wdio-devtools-service/tests/__mocks__/puppeteer-core.js
@@ -1,30 +1,60 @@
 const sendMock = jest.fn()
 const listenerMock = jest.fn()
 
+const devices = [{
+    name: 'Nexus 6P',
+    userAgent: 'Mozilla/5.0 (Linux; Android 8.0.0; Nexus 6P Build/OPP3.170518.006) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Mobile Safari/537.36',
+    viewport: {
+        width: 412,
+        height: 732,
+        deviceScaleFactor: 3.5,
+        isMobile: true,
+        hasTouch: true,
+        isLandscape: false
+    }
+}, {
+    name: 'Nexus 6P landscape',
+    userAgent: 'Mozilla/5.0 (Linux; Android 8.0.0; Nexus 6P Build/OPP3.170518.006) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Mobile Safari/537.36',
+    viewport: {
+        width: 732,
+        height: 412,
+        deviceScaleFactor: 3.5,
+        isMobile: true,
+        hasTouch: true,
+        isLandscape: true
+    }
+}]
+devices['Nexus 6P'] = devices[0]
+devices['Nexus 6P landscape'] = devices[0]
+
 class CDPSessionMock {
     constructor () {
         this.send = sendMock
         this.on = listenerMock
     }
 }
+const cdpSession = new CDPSessionMock()
 
 class PageMock {
     constructor () {
         this.on = jest.fn()
+        this.emulate = jest.fn()
     }
 }
+const page = new PageMock()
 
 class TargetMock {
     constructor () {
-        this.page = jest.fn().mockImplementation(() => new PageMock())
-        this.createCDPSession = jest.fn().mockImplementation(() => new CDPSessionMock())
+        this.page = jest.fn().mockImplementation(() => page)
+        this.createCDPSession = jest.fn().mockImplementation(() => cdpSession)
     }
 }
+const target = new TargetMock()
 
 class PuppeteerMock {
     constructor () {
-        this.waitForTarget = jest.fn().mockImplementation(() => new TargetMock())
-        this.getActivePage = jest.fn().mockImplementation(() => new PageMock())
+        this.waitForTarget = jest.fn().mockImplementation(() => target)
+        this.getActivePage = jest.fn().mockImplementation(() => page)
     }
 }
 
@@ -35,6 +65,7 @@ export default {
     PuppeteerMock,
     sendMock,
     listenerMock,
+    devices,
     connect: jest.fn().mockImplementation(
         () => Promise.resolve(new PuppeteerMock()))
 }

--- a/packages/wdio-devtools-service/tests/__snapshots__/service.test.js.snap
+++ b/packages/wdio-devtools-service/tests/__snapshots__/service.test.js.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`_emulateDevice 1`] = `
+Array [
+  Array [
+    Object {
+      "name": "Nexus 6P",
+      "userAgent": "Mozilla/5.0 (Linux; Android 8.0.0; Nexus 6P Build/OPP3.170518.006) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Mobile Safari/537.36",
+      "viewport": Object {
+        "deviceScaleFactor": 3.5,
+        "hasTouch": true,
+        "height": 732,
+        "isLandscape": false,
+        "isMobile": true,
+        "width": 412,
+      },
+    },
+  ],
+]
+`;


### PR DESCRIPTION
## Proposed changes

As per Twitter request: https://twitter.com/Pythonic_/status/1166833679265456129

I added a custom command to allow mobile emulation in Chrome using our `@wdio/devtools-service`.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)


### Reviewers: @webdriverio/project-committers 