### PR TITLE
@wdio/allure-reporter: Fix undefined/unknown step status

### DIFF
--- a/packages/wdio-allure-reporter/src/constants.js
+++ b/packages/wdio-allure-reporter/src/constants.js
@@ -2,7 +2,6 @@ const PASSED = 'passed'
 const FAILED = 'failed'
 const BROKEN = 'broken'
 const PENDING = 'pending'
-const CANCELED = 'canceled'
 
 const testStatuses = {
     PASSED,
@@ -15,7 +14,7 @@ const stepStatuses = {
     PASSED,
     FAILED,
     BROKEN,
-    CANCELED
+    PENDING
 }
 
 const events = {

--- a/packages/wdio-allure-reporter/src/index.js
+++ b/packages/wdio-allure-reporter/src/index.js
@@ -136,7 +136,7 @@ class AllureReporter extends WDIOReporter {
 
     onTestSkip(test) {
         if (this.options.useCucumberStepReporter) {
-            this.allure.endStep(stepStatuses.CANCELED)
+            this.allure.endStep(stepStatuses.PENDING)
         } else if (!this.allure.getCurrentTest() || this.allure.getCurrentTest().name !== test.title) {
             this.allure.pendingCase(test.title)
         } else {

--- a/packages/wdio-allure-reporter/tests/constants.test.js
+++ b/packages/wdio-allure-reporter/tests/constants.test.js
@@ -7,7 +7,7 @@ describe('Important constants', () => {
         expect(stepStatuses.BROKEN).toEqual('broken')
         expect(stepStatuses.PASSED).toEqual('passed')
         expect(stepStatuses.FAILED).toEqual('failed')
-        expect(stepStatuses.CANCELED).toEqual('canceled')
+        expect(stepStatuses.PENDING).toEqual('pending')
     })
 
     it('should have correct step statuses', () => {

--- a/packages/wdio-allure-reporter/tests/cucumber.suite.test.js
+++ b/packages/wdio-allure-reporter/tests/cucumber.suite.test.js
@@ -153,7 +153,7 @@ describe('reporter option "useCucumberStepReporter" set to true', () => {
             expect(allureXml('test-case').attr('status')).toEqual('failed')
             expect(allureXml('step > name').eq(0).text()).toEqual('Hook')
             expect(allureXml('step').eq(0).attr('status')).toEqual('failed')
-            expect(allureXml('step').eq(1).attr('status')).toEqual('canceled')
+            expect(allureXml('step').eq(1).attr('status')).toEqual('pending')
             expect(allureXml('test-case parameter[kind="argument"]')).toHaveLength(1)
             expect(allureXml('test-case parameter[name="browser"]').eq(0).attr('value')).toEqual('chrome-68')
         })

--- a/packages/wdio-allure-reporter/tests/runtime.test.js
+++ b/packages/wdio-allure-reporter/tests/runtime.test.js
@@ -113,12 +113,12 @@ describe('reporter reporter api', () => {
 
     it('should throw exception for incorrect status for addStep', () => {
         const cb = () => { reporter.addStep('foo', { content: 'baz' }, 'invalid-status')}
-        expect(cb).toThrowError('Step status must be passed or failed or broken or canceled. You tried to set "invalid-status"')
+        expect(cb).toThrowError('Step status must be passed or failed or broken or pending. You tried to set "invalid-status"')
     })
 
     it('should throw exception for incorrect status for endStep', () => {
         const cb = () => { reporter.endStep('invalid-status') }
-        expect(cb).toThrowError('Step status must be passed or failed or broken or canceled. You tried to set "invalid-status"')
+        expect(cb).toThrowError('Step status must be passed or failed or broken or pending. You tried to set "invalid-status"')
     })
 
     it('should pass correct data from addArgument', () => {


### PR DESCRIPTION
## Proposed changes
In #4220 we followed allure1 guidelines and used the "canceled" step status. This caused a regression compared to V4 behavior, which is detailed in #4409
This commit replaces the "canceled" status with "pending" as it was implemented in v4.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
I didn't test the change yet, working on it.
@espekkaya it would be great if you can confirm that it does fix your issue (I've cloned your repo but could not run it because of some typescript compilation issues).

### Reviewers: @webdriverio/technical-committee