### PR TITLE
support direct connect functionality for load balanced session redirection

### DIFF
--- a/packages/webdriver/src/constants.js
+++ b/packages/webdriver/src/constants.js
@@ -86,5 +86,12 @@ export const DEFAULTS = {
      */
     headers: {
         type: 'object'
+    },
+    /**
+     * Whether to allow direct connect caps to adjust endpoint details
+     */
+    enableDirectConnect: {
+        type: 'boolean',
+        default: false
     }
 }

--- a/packages/webdriver/src/index.js
+++ b/packages/webdriver/src/index.js
@@ -4,7 +4,7 @@ import { validateConfig } from '@wdio/config'
 import webdriverMonad from './monad'
 import WebDriverRequest from './request'
 import { DEFAULTS } from './constants'
-import { getPrototype, environmentDetector, getEnvironmentVars } from './utils'
+import { getPrototype, environmentDetector, getEnvironmentVars, setupDirectConnect } from './utils'
 
 import WebDriverProtocol from '../protocol/webdriver.json'
 import JsonWProtocol from '../protocol/jsonwp.json'
@@ -57,6 +57,17 @@ export default class WebDriver {
          * save actual receveived session details
          */
         params.capabilities = response.value.capabilities || response.value
+
+        /**
+         * if the server responded with direct connect information, update the
+         * params to speak directly to the appium host instead of a load
+         * balancer (see https://github.com/appium/python-client#direct-connect-urls
+         * for example). But only do this if the user has enabled this
+         * behavior in the first place.
+         */
+        if (params.enableDirectConnect) {
+            setupDirectConnect(params)
+        }
 
         const environment = environmentDetector(params)
         const environmentPrototype = getEnvironmentVars(environment)

--- a/packages/webdriver/src/utils.js
+++ b/packages/webdriver/src/utils.js
@@ -415,3 +415,25 @@ export function getEnvironmentVars({ isW3C, isMobile, isIOS, isAndroid, isChrome
         isSeleniumStandalone: { value: isSeleniumStandalone }
     }
 }
+
+/**
+ * Decorate the params object with host updates based on the presence of
+ * directConnect capabilities in the new session response. Note that this
+ * mutates the object.
+ * @param  {Object} params    post-new-session params used to build driver
+ */
+export function setupDirectConnect(params) {
+    log.info(JSON.stringify(params))
+    const { directConnectProtocol, directConnectHost, directConnectPort,
+        directConnectPath } = params.capabilities
+    if (directConnectProtocol && directConnectHost && directConnectPort &&
+        directConnectPath) {
+        log.info('Found direct connect information in new session response. ' +
+                 `Will connect to server at ${directConnectProtocol}://` +
+                 `${directConnectHost}:${directConnectPort}/${directConnectPath}`)
+        params.protocol = directConnectProtocol
+        params.hostname = directConnectHost
+        params.port = directConnectPort
+        params.path = directConnectPath
+    }
+}

--- a/packages/webdriver/src/utils.js
+++ b/packages/webdriver/src/utils.js
@@ -426,7 +426,7 @@ export function setupDirectConnect(params) {
     const { directConnectProtocol, directConnectHost, directConnectPort,
         directConnectPath } = params.capabilities
     if (directConnectProtocol && directConnectHost && directConnectPort &&
-        directConnectPath) {
+        (directConnectPath || directConnectPath === '')) {
         log.info('Found direct connect information in new session response. ' +
                  `Will connect to server at ${directConnectProtocol}://` +
                  `${directConnectHost}:${directConnectPort}/${directConnectPath}`)

--- a/packages/webdriver/src/utils.js
+++ b/packages/webdriver/src/utils.js
@@ -423,7 +423,6 @@ export function getEnvironmentVars({ isW3C, isMobile, isIOS, isAndroid, isChrome
  * @param  {Object} params    post-new-session params used to build driver
  */
 export function setupDirectConnect(params) {
-    log.info(JSON.stringify(params))
     const { directConnectProtocol, directConnectHost, directConnectPort,
         directConnectPath } = params.capabilities
     if (directConnectProtocol && directConnectHost && directConnectPort &&

--- a/packages/webdriver/tests/utils.test.js
+++ b/packages/webdriver/tests/utils.test.js
@@ -1,6 +1,7 @@
 import {
     isSuccessfulResponse, isValidParameter, getArgumentType, getPrototype, commandCallStructure,
-    environmentDetector, getErrorFromResponseBody, isW3C, CustomRequestError, overwriteElementCommands
+    environmentDetector, getErrorFromResponseBody, isW3C, CustomRequestError, overwriteElementCommands,
+    setupDirectConnect
 } from '../src/utils'
 
 import appiumResponse from './__fixtures__/appium.response.json'
@@ -347,6 +348,42 @@ describe('utils', () => {
             } } }
             expect(() => overwriteElementCommands.call(null, propertiesObject))
                 .toThrow('overwriteCommand: only functions can be overwritten, command: foo')
+        })
+    })
+
+    describe('setupDirectConnect', () => {
+        it('should do nothing if params contain no direct connect caps', function () {
+            const params = { hostname: 'bar', capabilities: { platformName: 'baz' } }
+            const paramsCopy = JSON.parse(JSON.stringify(params))
+            setupDirectConnect(params)
+            expect(params).toEqual(paramsCopy)
+        })
+
+        it('should do nothing if params contain incomplete direct connect caps', function () {
+            const params = { hostname: 'bar', capabilities: { directConnectHost: 'baz' } }
+            const paramsCopy = JSON.parse(JSON.stringify(params))
+            setupDirectConnect(params)
+            expect(params).toEqual(paramsCopy)
+        })
+
+        it('should update connection params if caps contain all direct connect fields', function () {
+            const params = {
+                protocol: 'http',
+                hostname: 'foo',
+                port: 1234,
+                path: '',
+                capabilities: {
+                    directConnectProtocol: 'https',
+                    directConnectHost: 'bar',
+                    directConnectPort: 4321,
+                    directConnectPath: '/wd/hub'
+                }
+            }
+            setupDirectConnect(params)
+            expect(params.protocol).toBe('https')
+            expect(params.hostname).toBe('bar')
+            expect(params.port).toBe(4321)
+            expect(params.path).toBe('/wd/hub')
         })
     })
 })

--- a/packages/webdriver/tests/utils.test.js
+++ b/packages/webdriver/tests/utils.test.js
@@ -385,5 +385,25 @@ describe('utils', () => {
             expect(params.port).toBe(4321)
             expect(params.path).toBe('/wd/hub')
         })
+
+        it('should update connection params even if path is empty string', function () {
+            const params = {
+                protocol: 'http',
+                hostname: 'foo',
+                port: 1234,
+                path: '/wd/hub',
+                capabilities: {
+                    directConnectProtocol: 'https',
+                    directConnectHost: 'bar',
+                    directConnectPort: 4321,
+                    directConnectPath: ''
+                }
+            }
+            setupDirectConnect(params)
+            expect(params.protocol).toBe('https')
+            expect(params.hostname).toBe('bar')
+            expect(params.port).toBe(4321)
+            expect(params.path).toBe('')
+        })
     })
 })


### PR DESCRIPTION
## Proposed changes

Bringing the functionality of https://github.com/appium/python-client#direct-connect-urls to wdio.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works - adding an e2e test would be difficult since we'd have to rely on a cloud provider. I did test this with HeadSpin, which supports this cap, and it worked as expected.
- [ ] I have added necessary documentation (if appropriate)

### Reviewers: @webdriverio/technical-committee
