### PR TITLE
Element refetch is not working with devtools protocol

### DIFF
--- a/packages/devtools/src/commands/elementClear.js
+++ b/packages/devtools/src/commands/elementClear.js
@@ -1,10 +1,11 @@
 import command from '../scripts/elementClear'
+import { getStaleElementError } from '../utils'
 
 export default async function elementClear ({ elementId }) {
     const elementHandle = this.elementStore.get(elementId)
 
     if (!elementHandle) {
-        throw new Error(`Couldn't find element with id ${elementId} in cache`)
+        throw getStaleElementError(elementId)
     }
 
     const page = this.getPageHandle()

--- a/packages/devtools/src/commands/elementClick.js
+++ b/packages/devtools/src/commands/elementClick.js
@@ -1,6 +1,7 @@
 import getElementTagName from './getElementTagName'
 import executeScript from './executeScript'
 import { ELEMENT_KEY } from '../constants'
+import { getStaleElementError } from '../utils'
 
 const SELECT_SCRIPT = 'return (function select (elem) { elem.selected = true }).apply(null, arguments)'
 const PAGELOAD_WAIT_TIMEOUT = 150
@@ -10,7 +11,7 @@ export default async function elementClick ({ elementId }) {
     const elementHandle = this.elementStore.get(elementId)
 
     if (!elementHandle) {
-        throw new Error(`Couldn't find element with id ${elementId} in cache`)
+        throw getStaleElementError(elementId)
     }
 
     /**

--- a/packages/devtools/src/commands/elementSendKeys.js
+++ b/packages/devtools/src/commands/elementSendKeys.js
@@ -1,8 +1,10 @@
+import { getStaleElementError } from '../utils'
+
 export default async function elementSendKeys ({ elementId, text }) {
     const elementHandle = this.elementStore.get(elementId)
 
     if (!elementHandle) {
-        throw new Error(`Couldn't find element with id ${elementId} in cache`)
+        throw getStaleElementError(elementId)
     }
 
     await elementHandle.focus()

--- a/packages/devtools/src/commands/findElementFromElement.js
+++ b/packages/devtools/src/commands/findElementFromElement.js
@@ -1,5 +1,5 @@
 import { SUPPORTED_SELECTOR_STRATEGIES } from '../constants'
-import { findElement } from '../utils'
+import { findElement, getStaleElementError } from '../utils'
 
 export default async function findElementFromElement ({ elementId, using, value }) {
     if (!SUPPORTED_SELECTOR_STRATEGIES.includes(using)) {
@@ -9,7 +9,7 @@ export default async function findElementFromElement ({ elementId, using, value 
     const elementHandle = this.elementStore.get(elementId)
 
     if (!elementHandle) {
-        throw new Error(`Couldn't find element with id ${elementId} in cache`)
+        throw getStaleElementError(elementId)
     }
 
     if (using === 'link text') {

--- a/packages/devtools/src/commands/findElementsFromElement.js
+++ b/packages/devtools/src/commands/findElementsFromElement.js
@@ -1,5 +1,5 @@
 import { SUPPORTED_SELECTOR_STRATEGIES } from '../constants'
-import { findElements } from '../utils'
+import { findElements, getStaleElementError } from '../utils'
 
 export default async function findElementFromElements ({ elementId, using, value }) {
     if (!SUPPORTED_SELECTOR_STRATEGIES.includes(using)) {
@@ -9,7 +9,7 @@ export default async function findElementFromElements ({ elementId, using, value
     const elementHandle = this.elementStore.get(elementId)
 
     if (!elementHandle) {
-        throw new Error(`Couldn't find element with id ${elementId} in cache`)
+        throw getStaleElementError(elementId)
     }
 
     if (using === 'link text') {

--- a/packages/devtools/src/commands/getElementAttribute.js
+++ b/packages/devtools/src/commands/getElementAttribute.js
@@ -1,10 +1,11 @@
 import command from '../scripts/getElementAttribute'
+import { getStaleElementError } from '../utils'
 
 export default async function getElementAttribute ({ elementId, name }) {
     const elementHandle = this.elementStore.get(elementId)
 
     if (!elementHandle) {
-        throw new Error(`Couldn't find element with id ${elementId} in cache`)
+        throw getStaleElementError(elementId)
     }
 
     const page = this.getPageHandle()

--- a/packages/devtools/src/commands/getElementCSSValue.js
+++ b/packages/devtools/src/commands/getElementCSSValue.js
@@ -1,10 +1,11 @@
 import command from '../scripts/getElementCSSValue'
+import { getStaleElementError } from '../utils'
 
 export default async function getElementCSSValue ({ elementId, propertyName }) {
     const elementHandle = this.elementStore.get(elementId)
 
     if (!elementHandle) {
-        throw new Error(`Couldn't find element with id ${elementId} in cache`)
+        throw getStaleElementError(elementId)
     }
 
     const page = this.getPageHandle()

--- a/packages/devtools/src/commands/getElementProperty.js
+++ b/packages/devtools/src/commands/getElementProperty.js
@@ -1,8 +1,10 @@
+import { getStaleElementError } from '../utils'
+
 export default async function getElementProperty ({ elementId, name }) {
     const elementHandle = this.elementStore.get(elementId)
 
     if (!elementHandle) {
-        throw new Error(`Couldn't find element with id ${elementId} in cache`)
+        throw getStaleElementError(elementId)
     }
 
     const jsHandle = await elementHandle.getProperty(name)

--- a/packages/devtools/src/commands/getElementRect.js
+++ b/packages/devtools/src/commands/getElementRect.js
@@ -1,10 +1,11 @@
 import command from '../scripts/getElementRect'
+import { getStaleElementError } from '../utils'
 
 export default function getElementRect ({ elementId }) {
     const elementHandle = this.elementStore.get(elementId)
 
     if (!elementHandle) {
-        throw new Error(`Couldn't find element with id ${elementId} in cache`)
+        throw getStaleElementError(elementId)
     }
 
     const page = this.getPageHandle()

--- a/packages/devtools/src/commands/getElementTagName.js
+++ b/packages/devtools/src/commands/getElementTagName.js
@@ -1,10 +1,11 @@
 import command from '../scripts/getElementTagName'
+import { getStaleElementError } from '../utils'
 
 export default async function getElementTagName ({ elementId }) {
     const elementHandle = this.elementStore.get(elementId)
 
     if (!elementHandle) {
-        throw new Error(`Couldn't find element with id ${elementId} in cache`)
+        throw getStaleElementError(elementId)
     }
 
     const page = this.getPageHandle()

--- a/packages/devtools/src/commands/getElementText.js
+++ b/packages/devtools/src/commands/getElementText.js
@@ -1,10 +1,11 @@
 import command from '../scripts/getElementText'
+import { getStaleElementError } from '../utils'
 
 export default function getElementText ({ elementId }) {
     const elementHandle = this.elementStore.get(elementId)
 
     if (!elementHandle) {
-        throw new Error(`Couldn't find element with id ${elementId} in cache`)
+        throw getStaleElementError(elementId)
     }
 
     const page = this.getPageHandle()

--- a/packages/devtools/src/commands/isElementDisplayed.js
+++ b/packages/devtools/src/commands/isElementDisplayed.js
@@ -1,8 +1,10 @@
+import { getStaleElementError } from '../utils'
+
 export default function isElementDisplayed ({ elementId }) {
     const elementHandle = this.elementStore.get(elementId)
 
     if (!elementHandle) {
-        throw new Error(`Couldn't find element with id ${elementId} in cache`)
+        throw getStaleElementError(elementId)
     }
 
     return elementHandle.isIntersectingViewport()

--- a/packages/devtools/src/commands/switchToFrame.js
+++ b/packages/devtools/src/commands/switchToFrame.js
@@ -1,4 +1,5 @@
 import { ELEMENT_KEY } from '../constants'
+import { getStaleElementError } from '../utils'
 
 export default async function switchToFrame ({ id }) {
     const page = this.getPageHandle()
@@ -10,7 +11,7 @@ export default async function switchToFrame ({ id }) {
         const elementHandle = this.elementStore.get(id[ELEMENT_KEY])
 
         if (!elementHandle) {
-            throw new Error(`Couldn't find element with id ${id[ELEMENT_KEY]} in cache`)
+            throw getStaleElementError(elementHandle)
         }
 
         const contentFrame = await elementHandle.contentFrame()

--- a/packages/devtools/src/commands/takeElementScreenshot.js
+++ b/packages/devtools/src/commands/takeElementScreenshot.js
@@ -1,8 +1,10 @@
+import { getStaleElementError } from '../utils'
+
 export default async function takeElementScreenshot ({ elementId }) {
     const elementHandle = this.elementStore.get(elementId)
 
     if (!elementHandle) {
-        throw new Error(`Couldn't find element with id ${elementId} in cache`)
+        throw getStaleElementError(elementHandle)
     }
 
     return elementHandle.screenshot({

--- a/packages/devtools/src/devtoolsdriver.js
+++ b/packages/devtools/src/devtoolsdriver.js
@@ -72,6 +72,10 @@ export default class DevToolsDriver {
             try {
                 result = await self.commands[command].call(self, params)
             } catch (err) {
+                if (err instanceof Promise) {
+                    throw sanitizeError(await err)
+                }
+
                 throw sanitizeError(err)
             }
 

--- a/packages/devtools/src/devtoolsdriver.js
+++ b/packages/devtools/src/devtoolsdriver.js
@@ -72,10 +72,6 @@ export default class DevToolsDriver {
             try {
                 result = await self.commands[command].call(self, params)
             } catch (err) {
-                if (err instanceof Promise) {
-                    throw sanitizeError(await err)
-                }
-
                 throw sanitizeError(err)
             }
 

--- a/packages/devtools/src/utils.js
+++ b/packages/devtools/src/utils.js
@@ -192,7 +192,7 @@ export async function transformExecuteResult (page, result) {
     return isResultArray ? tmpResult : tmpResult[0]
 }
 
-export async function getStaleElementError (elementId) {
+export function getStaleElementError (elementId) {
     const error = new Error(
         `stale element reference: The element with reference ${elementId} is stale; either the ` +
         'element is no longer attached to the DOM, it is not in the current frame context, or the ' +

--- a/packages/devtools/src/utils.js
+++ b/packages/devtools/src/utils.js
@@ -163,6 +163,11 @@ export function transformExecuteArgs (args) {
     return args.map((arg) => {
         if (arg[ELEMENT_KEY]) {
             const elementHandle = this.elementStore.get(arg[ELEMENT_KEY])
+
+            if (!elementHandle) {
+                throw getStaleElementError(arg[ELEMENT_KEY])
+            }
+
             arg = elementHandle
         }
 

--- a/packages/devtools/src/utils.js
+++ b/packages/devtools/src/utils.js
@@ -191,3 +191,13 @@ export async function transformExecuteResult (page, result) {
 
     return isResultArray ? tmpResult : tmpResult[0]
 }
+
+export async function getStaleElementError (elementId) {
+    const error = new Error(
+        `stale element reference: The element with reference ${elementId} is stale; either the ` +
+        'element is no longer attached to the DOM, it is not in the current frame context, or the ' +
+        'document has been refreshed'
+    )
+    error.name = 'stale element reference'
+    return error
+}

--- a/packages/devtools/tests/utils.test.js
+++ b/packages/devtools/tests/utils.test.js
@@ -246,6 +246,18 @@ test('transformExecuteArgs', () => {
     ])).toEqual(['foo', 'barfoo', true, 42])
 })
 
+test('transformExecuteArgs throws stale element if element is not in store', () => {
+    const scope = { elementStore: new Map() }
+    scope.elementStore.set('foobar', 'barfoo')
+
+    expect(() => transformExecuteArgs.call(scope, [
+        'foo',
+        { 'element-6066-11e4-a52e-4f735466cecf': 'not-existing' },
+        true,
+        42
+    ])).toThrow()
+})
+
 describe('transformExecuteResult', () => {
     test('multiple results', async () => {
         const scope = {

--- a/packages/devtools/tests/utils.test.js
+++ b/packages/devtools/tests/utils.test.js
@@ -1,5 +1,5 @@
 import {
-    validate, getPrototype, findElement, findElements,
+    validate, getPrototype, findElement, findElements, getStaleElementError,
     sanitizeError, transformExecuteArgs, transformExecuteResult
 } from '../src/utils'
 
@@ -276,4 +276,10 @@ describe('transformExecuteResult', () => {
         pageMock.$$.mockClear()
         pageMock.$$eval.mockClear()
     })
+})
+
+test('getStaleElementError', () => {
+    const err = getStaleElementError('foobar')
+    expect(err instanceof Error).toBe(true)
+    expect(err.name).toContain('stale element reference')
 })


### PR DESCRIPTION
**Environment (please complete the following information):**
 - **WebdriverIO version:** 5.12.5 
 - **Mode:** WDIO Testrunner
 - **If WDIO Testrunner, running sync/async:** sync
 - **Node.js version:** 10
 - **Browser name and version:** Chrome 76

**Config of WebdriverIO**
Add `devtools` package from master (pre-release version).
Then enable devtools: `automationProtocol: 'devtools'`

**Describe the bug**
Element refetch throws an exception

**To Reproduce**
```
describe("remote driver", () => {
    it("element", () => {
        browser.url("http://guinea-pig.webdriver.io")
        const mainEl = $("body")
        const el = mainEl.$$("section")[0].$("input.searchinput")

        $('input[type="submit"]').click()
        browser.pause(1000)

        el.getValue() // defect refetch
    })
})
```

**Expected behavior**
refetch should work same as without `automationProtocol: 'devtools'`

**Log**
```
Couldn't find element with id ELEMENT-4 in cache
Error: Couldn't find element with id ELEMENT-4 in cache
    at DevToolsDriver.getElementProperty (e2e/node_modules/devtools/build/commands/getElementProperty.js:15:11)
    at Element.<anonymous> (e2e/node_modules/devtools/build/devtoolsdriver.js:83:47)
    at Context.it (e2e/test/specs/_debug/dt.spec.ts:14:12)
```

## Solution

Throw correct error format so that WebdriverIOs middlware is being triggered.