### PR TITLE
Don't close all tabs when deleting session

### DIFF
--- a/packages/devtools/src/commands/deleteSession.js
+++ b/packages/devtools/src/commands/deleteSession.js
@@ -1,13 +1,4 @@
 export default async function deleteSession () {
-    const pages = await this.browser.pages()
-
-    /**
-     * close all tabs
-     */
-    for (const page of pages) {
-        await page.close()
-    }
-
     await this.browser.close()
     return null
 }


### PR DESCRIPTION
## Proposed changes

This is a small tweak to the deleteSession command in the devtools package in order to close the browser properly also in FF. It seems that there is a bug in puppeteer-firefox that doesn't allow to close pages. The promise is never resolved and therefor the browser doesn't close. This patch makes it so that the browser is just closed right away.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers 
