### PR TITLE
Add test coverage feature for devtools service

### DIFF
--- a/packages/wdio-devtools-service/devtools-service.d.ts
+++ b/packages/wdio-devtools-service/devtools-service.d.ts
@@ -64,9 +64,30 @@ type DeviceProfiles = 'Blackberry PlayBook' | 'BlackBerry Z30' | 'Galaxy Note 3'
 
 interface DevtoolsConfig {
   /**
-   * Directory where JS coverage reports are stored
+   * options for the code coverage reporter
    */
-  coverageLogDir?: string;
+  coverageReporter?: CoverageReporterOptions;
+}
+
+export interface CoverageReporterOptions {
+    /**
+     * whether or not to enable code coverage reporting
+     * @default false
+     */
+    enable?: boolean
+    /**
+     * Directory where JS coverage reports are stored
+     */
+    logDir?: string
+    /**
+     * format of report
+     * @default json
+     */
+    type?: 'none' | 'clover' | 'cobertura' | 'html-spa' | 'html' | 'json' | 'json-summary' | 'lcov' | 'lcovonly' | 'teamcity' | 'text' | 'text-lcov' | 'text-summary'
+    /**
+     * Options for coverage report, for details see https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/istanbul-lib-report/index.d.ts
+     */
+    options?: any
 }
 
 interface PerformanceAuditOptions {

--- a/packages/wdio-devtools-service/devtools-service.d.ts
+++ b/packages/wdio-devtools-service/devtools-service.d.ts
@@ -91,7 +91,7 @@ interface DevtoolsConfig {
   coverageReporter?: CoverageReporterOptions;
 }
 
-export interface CoverageReporterOptions {
+interface CoverageReporterOptions {
     /**
      * whether or not to enable code coverage reporting
      * @default false

--- a/packages/wdio-devtools-service/devtools-service.d.ts
+++ b/packages/wdio-devtools-service/devtools-service.d.ts
@@ -64,9 +64,9 @@ type DeviceProfiles = 'Blackberry PlayBook' | 'BlackBerry Z30' | 'Galaxy Note 3'
 
 interface DevtoolsConfig {
   /**
-   * Define endpoint for Chrome DevTools protocol manually (e.g. localhost:24563).
+   * Directory where JS coverage reports are stored
    */
-  debuggerAddress?: string;
+  coverageLogDir?: string;
 }
 
 interface PerformanceAuditOptions {

--- a/packages/wdio-devtools-service/devtools-service.d.ts
+++ b/packages/wdio-devtools-service/devtools-service.d.ts
@@ -30,6 +30,28 @@ interface ErrorAudit {
     error: Error
 }
 
+interface Totals {
+    total: number;
+    covered: number;
+    skipped: number;
+    pct: number;
+}
+
+interface CoverageSummaryData {
+    lines: Totals;
+    statements: Totals;
+    branches: Totals;
+    functions: Totals;
+}
+
+interface Coverage {
+    lines: Totals
+    statements: Totals
+    functions: Totals
+    branches: Totals
+    files: Record<string, CoverageSummaryData>
+}
+
 interface Viewport {
   /**
    * page width in pixels
@@ -144,6 +166,11 @@ interface DevtoolsBrowser {
    * Read more about Lighthouse PWA audits at https://web.dev/lighthouse-pwa/.
    */
   checkPWA(auditsToBeRun?: PWAAudits[]): AuditResult;
+
+  /**
+   * Returns the coverage report for the current opened page.
+   */
+  getCoverageReport(): Coverage;
 
   /**
    * The cdp command is a custom command added to the browser scope that allows you to call directly commands to the protocol.

--- a/packages/wdio-devtools-service/package.json
+++ b/packages/wdio-devtools-service/package.json
@@ -26,17 +26,23 @@
     "url": "https://github.com/webdriverio/webdriverio/issues"
   },
   "dependencies": {
+    "@babel/core": "^7.12.10",
     "@tracerbench/trace-event": "^4.5.2",
     "@types/puppeteer-core": "^2.0.0",
     "@wdio/logger": "6.10.10",
-    "axios": "^0.21.1",
+    "babel-plugin-istanbul": "^6.0.0",
     "core-js": "~3.7.0",
     "devtools-protocol": "^0.0.831461",
+    "istanbul-lib-coverage": "^3.0.0",
+    "istanbul-lib-report": "^3.0.0",
+    "istanbul-reports": "^3.0.2",
     "lighthouse": "^7.0.0",
-    "nyc": "^15.1.0",
     "puppeteer-core": "^5.1.0",
     "speedline": "^1.4.1",
     "stable": "^0.1.8"
+  },
+  "devDependencies": {
+    "@types/atob": "^2.1.2"
   },
   "peerDependencies": {
     "@wdio/cli": "^6.0.1"

--- a/packages/wdio-devtools-service/package.json
+++ b/packages/wdio-devtools-service/package.json
@@ -29,9 +29,11 @@
     "@tracerbench/trace-event": "^4.5.2",
     "@types/puppeteer-core": "^2.0.0",
     "@wdio/logger": "6.10.10",
+    "axios": "^0.21.1",
     "core-js": "~3.7.0",
     "devtools-protocol": "^0.0.831461",
     "lighthouse": "^7.0.0",
+    "nyc": "^15.1.0",
     "puppeteer-core": "^5.1.0",
     "speedline": "^1.4.1",
     "stable": "^0.1.8"

--- a/packages/wdio-devtools-service/package.json
+++ b/packages/wdio-devtools-service/package.json
@@ -30,6 +30,7 @@
     "@tracerbench/trace-event": "^4.5.2",
     "@types/puppeteer-core": "^2.0.0",
     "@wdio/logger": "6.10.10",
+    "atob": "^2.1.2",
     "babel-plugin-istanbul": "^6.0.0",
     "core-js": "~3.7.0",
     "devtools-protocol": "^0.0.831461",

--- a/packages/wdio-devtools-service/src/@types/babel-plugin-istanbul.ts
+++ b/packages/wdio-devtools-service/src/@types/babel-plugin-istanbul.ts
@@ -1,0 +1,1 @@
+declare module 'babel-plugin-istanbul'

--- a/packages/wdio-devtools-service/src/gatherer/coverage.ts
+++ b/packages/wdio-devtools-service/src/gatherer/coverage.ts
@@ -61,7 +61,7 @@ export default class CoverageGatherer extends EventEmitter {
             return this._client.send(
                 'Fetch.continueRequest',
                 { requestId }
-            ).catch((err: Error) => log.debug(err.message))
+            ).catch(/* istanbul ignore next */ (err: Error) => log.debug(err.message))
         }
 
         /**
@@ -69,8 +69,7 @@ export default class CoverageGatherer extends EventEmitter {
          */
         const { body, base64Encoded } = await this._client.send(
             'Fetch.getResponseBody',
-            { requestId }
-        ).catch((err: Error) => log.debug(err.message)) as any
+            { requestId })
         const inputCode = base64Encoded ? atob(body) : body
 
         const url = new URL(request.url)
@@ -113,7 +112,7 @@ export default class CoverageGatherer extends EventEmitter {
             responseCode: responseStatusCode,
             /** do not mock body if it's undefined */
             body: !result ? undefined : Buffer.from(result.code!, 'utf8').toString('base64')
-        }).catch((err: Error) => log.debug(err.message))
+        })
     }
 
     private _clearCaptureInterval () {
@@ -135,7 +134,7 @@ export default class CoverageGatherer extends EventEmitter {
 
             try {
                 const globalCoverageVar = await this._page.evaluate(
-                    // eslint-disable-next-line no-undef
+                    /* istanbul ignore next */
                     () => window['__coverage__' as any]) as any as libCoverage.CoverageMapData
 
                 this._coverageMap = libCoverage.createCoverageMap(globalCoverageVar)
@@ -148,6 +147,7 @@ export default class CoverageGatherer extends EventEmitter {
     }
 
     async _getCoverageMap (retries = 0): Promise<libCoverage.CoverageMap> {
+        /* istanbul ignore if */
         if (retries > MAX_WAIT_RETRIES) {
             return Promise.reject(new Error('Couldn\'t capture coverage data for page'))
         }
@@ -162,10 +162,6 @@ export default class CoverageGatherer extends EventEmitter {
     }
 
     async logCoverage (): Promise<void> {
-        if (!this._coverageLogDir) {
-            return
-        }
-
         this._clearCaptureInterval()
 
         // create a context for report generation

--- a/packages/wdio-devtools-service/src/gatherer/coverage.ts
+++ b/packages/wdio-devtools-service/src/gatherer/coverage.ts
@@ -149,13 +149,13 @@ export default class CoverageGatherer extends EventEmitter {
 
     async _getCoverageMap (retries = 0): Promise<libCoverage.CoverageMap> {
         if (retries > MAX_WAIT_RETRIES) {
-            return Promise.reject(new Error(`Couldn't capture coverage data for page`))
+            return Promise.reject(new Error('Couldn\'t capture coverage data for page'))
         }
 
         if (!this._coverageMap) {
             log.info('No coverage data collected, waiting...')
             await new Promise((resolve) => setTimeout(resolve, CAPTURE_INTERVAL))
-            return this._getCoverageMap(retries)
+            return this._getCoverageMap(++retries)
         }
 
         return this._coverageMap

--- a/packages/wdio-devtools-service/src/gatherer/coverage.ts
+++ b/packages/wdio-devtools-service/src/gatherer/coverage.ts
@@ -93,7 +93,7 @@ export default class CoverageGatherer extends EventEmitter {
         }, CAPTURE_INTERVAL)
     }
 
-    async logCoverage () {
+    async logCoverage (): Promise<void> {
         if (!this._coverageLogDir) {
             return
         }
@@ -121,6 +121,6 @@ export default class CoverageGatherer extends EventEmitter {
                 obj[path] = coverageData
                 return obj
             }, {} as any)
-        return promisify(fs.writeFile)(filename, JSON.stringify(data), 'utf8')
+        await promisify(fs.writeFile)(filename, JSON.stringify(data), 'utf8')
     }
 }

--- a/packages/wdio-devtools-service/src/gatherer/coverage.ts
+++ b/packages/wdio-devtools-service/src/gatherer/coverage.ts
@@ -1,0 +1,126 @@
+import fs from 'fs'
+import path from 'path'
+import cp from 'child_process'
+import { EventEmitter } from 'events'
+import axios from 'axios'
+import { promisify } from 'util'
+
+import logger from '@wdio/logger'
+
+import type { Page } from 'puppeteer-core/lib/cjs/puppeteer/common/Page'
+import type { HTTPRequest } from 'puppeteer-core/lib/cjs/puppeteer/common/HTTPRequest'
+
+const log = logger('@wdio/devtools-service:CoverageGatherer')
+const CAPTURE_INTERVAL = 1000
+const COVERAGE_FILENAME = 'wdio-coverage-all.json'
+
+export default class CoverageGatherer extends EventEmitter {
+    private _coverageLogDir: string
+    private _coverage: any = {}
+    private _capturedData = false
+    private _captureInterval?: NodeJS.Timeout
+
+    constructor (private _page: Page, coverageLogDir: string) {
+        super()
+        this._coverageLogDir = path.resolve(process.cwd(), coverageLogDir)
+        this._capturedData = false
+
+        this._page.on('request', this._handleRequests.bind(this))
+        this._page.on('load', this._captureCoverage.bind(this))
+        this._page.setRequestInterception(true)
+    }
+
+    private async _handleRequests (req: HTTPRequest) {
+        const requestUrl = req.url()
+
+        if (!requestUrl.endsWith('.js')) {
+            return req.continue()
+        }
+
+        const source = await axios.get(requestUrl)
+        const fullPath = this._storeSourceFile(requestUrl, source.data)
+        const nyc = cp.spawn(`nyc instrument ${fullPath}`)
+        return nyc.stdout.pipe(req as any)
+    }
+
+    private _storeSourceFile (requestUrl: string, source: string) {
+        const url = new URL(requestUrl)
+        const fullPath = path.join(this._coverageLogDir, 'files', url.hostname, url.pathname)
+        const dirPath = path.dirname(fullPath)
+
+        /**
+         * create dir if not existing
+         */
+        if (!fs.existsSync(dirPath)) {
+            fs.mkdirSync(dirPath, { recursive: true })
+        }
+
+        fs.writeFileSync(fullPath, source, 'utf8')
+        return fullPath
+    }
+
+    private _clearCaptureInterval () {
+        if (!this._captureInterval) {
+            return
+        }
+
+        clearInterval(this._captureInterval)
+        delete this._captureInterval
+    }
+
+    private _captureCoverage () {
+        this._capturedData = false
+
+        if (this._captureInterval) {
+            this._clearCaptureInterval()
+        }
+
+        this._captureInterval = setInterval(async () => {
+            log.info('capturing coverage data')
+
+            try {
+                const pageCoverage = await this._page.evaluate(
+                    // eslint-disable-next-line no-undef
+                    () => window['__coverage__' as any])
+
+                this._capturedData = true
+                log.info(`Captured coverage data of ${Object.entries(pageCoverage).length} files`)
+                this._coverage = pageCoverage
+            } catch (e) {
+                log.warn(`Couldn't capture data: ${e.message}`)
+                this._clearCaptureInterval()
+            }
+        }, CAPTURE_INTERVAL)
+    }
+
+    async logCoverage () {
+        if (!this._coverageLogDir) {
+            return
+        }
+
+        /**
+         * if no coverage data was captured yet, wait until it was
+         */
+        if (!this._capturedData) {
+            log.info('No coverage data collected, waiting...')
+            await new Promise((resolve) => setTimeout(resolve, CAPTURE_INTERVAL))
+            return this.logCoverage()
+        }
+
+        this._clearCaptureInterval()
+        const filename = path.join(this._coverageLogDir, COVERAGE_FILENAME)
+        log.info(`Store coverage log file at ${filename}`)
+        const data = Object.values(this._coverage)
+            .map((coverageData: any) => {
+                const url = new URL(coverageData.path)
+                const fullPath = path.join(this._coverageLogDir, 'files', url.hostname, url.pathname)
+                coverageData.path = fullPath
+                return [fullPath, coverageData]
+            })
+            .reduce((obj, [path, coverageData]) => {
+                obj[path] = coverageData
+                return obj
+            }, {} as any)
+        return promisify(fs.writeFile)(filename, JSON.stringify(data), 'utf8')
+    }
+}

--- a/packages/wdio-devtools-service/src/index.ts
+++ b/packages/wdio-devtools-service/src/index.ts
@@ -243,8 +243,10 @@ export default class DevToolsService implements WebdriverIO.ServiceInstance {
         /**
          * register coverage gatherer if options is set by user
          */
-        if (typeof this._options.coverageLogDir === 'string') {
-            this._coverageGatherer = new CoverageGatherer(this._page, this._options.coverageLogDir)
+        if (this._options.coverageReporter?.enable) {
+            this._coverageGatherer = new CoverageGatherer(this._page, this._options.coverageReporter)
+            this._browser.addCommand('getCoverageReport', this._coverageGatherer.getCoverageReport.bind(this._coverageGatherer))
+            await this._coverageGatherer.init()
         }
 
         this._devtoolsGatherer = new DevtoolsGatherer()

--- a/packages/wdio-devtools-service/src/index.ts
+++ b/packages/wdio-devtools-service/src/index.ts
@@ -10,10 +10,11 @@ import CommandHandler from './commands'
 import Auditor from './auditor'
 import PWAGatherer from './gatherer/pwa'
 import TraceGatherer from './gatherer/trace'
+import CoverageGatherer from './gatherer/coverage'
 import DevtoolsGatherer, { CDPSessionOnMessageObject } from './gatherer/devtools'
 import { isBrowserSupported, setUnsupportedCommand } from './utils'
 import { NETWORK_STATES, UNSUPPORTED_ERROR_MESSAGE, CLICK_TRANSITION, DEFAULT_THROTTLE_STATE } from './constants'
-import { FormFactor, EnablePerformanceAuditsOptions, DeviceDescription, Device, PWAAudits } from './types'
+import { DevtoolsConfig, FormFactor, EnablePerformanceAuditsOptions, DeviceDescription, Device, PWAAudits } from './types'
 
 const log = logger('@wdio/devtools-service')
 const TRACE_COMMANDS = ['click', 'navigateTo', 'url']
@@ -34,7 +35,10 @@ export default class DevToolsService implements WebdriverIO.ServiceInstance {
 
     private _traceGatherer?: TraceGatherer
     private _devtoolsGatherer?: DevtoolsGatherer
+    private _coverageGatherer?: CoverageGatherer
     private _browser?: WebdriverIO.BrowserObject | WebdriverIO.MultiRemoteBrowserObject
+
+    constructor (private _options: DevtoolsConfig) {}
 
     beforeSession (_: WebdriverIO.Config, caps: WebDriver.DesiredCapabilities) {
         if (!isBrowserSupported(caps)) {
@@ -113,6 +117,12 @@ export default class DevToolsService implements WebdriverIO.ServiceInstance {
                 resolve()
             })
         })
+    }
+
+    async after () {
+        if (this._coverageGatherer) {
+            await this._coverageGatherer.logCoverage()
+        }
     }
 
     /**
@@ -229,6 +239,13 @@ export default class DevToolsService implements WebdriverIO.ServiceInstance {
                 this._session?.send(`${domain}.enable` as any)
             ])
         ))
+
+        /**
+         * register coverage gatherer if options is set by user
+         */
+        if (typeof this._options.coverageLogDir === 'string') {
+            this._coverageGatherer = new CoverageGatherer(this._page, this._options.coverageLogDir)
+        }
 
         this._devtoolsGatherer = new DevtoolsGatherer()
         this._puppeteer['_connection']._transport._ws.addEventListener('message', (event: { data: string }) => {

--- a/packages/wdio-devtools-service/src/types.ts
+++ b/packages/wdio-devtools-service/src/types.ts
@@ -1,6 +1,13 @@
 import type { Viewport } from 'puppeteer-core/lib/cjs/puppeteer/common/PuppeteerViewport'
 import type { NETWORK_STATES, PWA_AUDITS } from './constants'
 
+export interface DevtoolsConfig {
+    /**
+     * Directory where JS coverage reports are stored
+     */
+    coverageLogDir?: string;
+}
+
 export type FormFactor = 'mobile' | 'desktop' | 'none'
 
 export interface EnablePerformanceAuditsOptions {

--- a/packages/wdio-devtools-service/src/types.ts
+++ b/packages/wdio-devtools-service/src/types.ts
@@ -1,11 +1,31 @@
+import type { ReportOptions } from 'istanbul-reports'
+import type { Totals, CoverageSummaryData } from 'istanbul-lib-coverage'
 import type { Viewport } from 'puppeteer-core/lib/cjs/puppeteer/common/PuppeteerViewport'
 import type { NETWORK_STATES, PWA_AUDITS } from './constants'
 
 export interface DevtoolsConfig {
+    coverageReporter?: CoverageReporterOptions
+}
+
+export interface CoverageReporterOptions {
+    /**
+     * whether or not to enable code coverage reporting
+     * @default false
+     */
+    enable?: boolean
     /**
      * Directory where JS coverage reports are stored
      */
-    coverageLogDir?: string;
+    logDir?: string
+    /**
+     * format of report
+     * @default json
+     */
+    type?: keyof ReportOptions
+    /**
+     * Options for coverage report
+     */
+    options?: any
 }
 
 export type FormFactor = 'mobile' | 'desktop' | 'none'
@@ -122,3 +142,11 @@ export interface ErrorAudit {
 }
 
 export type PWAAudits = keyof typeof PWA_AUDITS
+
+export interface Coverage {
+    lines: Totals
+    statements: Totals
+    functions: Totals
+    branches: Totals
+    files: Record<string, CoverageSummaryData>
+}

--- a/packages/wdio-devtools-service/tests/gatherer/__snapshots__/coverage.test.ts.snap
+++ b/packages/wdio-devtools-service/tests/gatherer/__snapshots__/coverage.test.ts.snap
@@ -18,3 +18,17 @@ Array [
   ],
 ]
 `;
+
+exports[`CoverageGatherer getCoverageReport 1`] = `
+Object {
+  "files": Object {
+    "/bar/foo.js": Object {
+      "some": "coverage",
+    },
+    "/foo/bar.js": Object {
+      "some": "coverage",
+    },
+  },
+  "some": "coverageData",
+}
+`;

--- a/packages/wdio-devtools-service/tests/gatherer/__snapshots__/coverage.test.ts.snap
+++ b/packages/wdio-devtools-service/tests/gatherer/__snapshots__/coverage.test.ts.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CoverageGatherer _handleRequests should transform JS files 1`] = `
+Array [
+  Array [
+    "Fetch.getResponseBody",
+    Object {
+      "requestId": "123",
+    },
+  ],
+  Array [
+    "Fetch.fulfillRequest",
+    Object {
+      "body": "dHJhbnNwaWxlZCBjb2Rl",
+      "requestId": "123",
+      "responseCode": 444,
+    },
+  ],
+]
+`;

--- a/packages/wdio-devtools-service/tests/gatherer/coverage.test.ts
+++ b/packages/wdio-devtools-service/tests/gatherer/coverage.test.ts
@@ -1,4 +1,5 @@
 import fs from 'fs'
+import path from 'path'
 import CoverageGatherer from '../../src/gatherer/coverage'
 
 import libReport from 'istanbul-lib-report'
@@ -119,10 +120,12 @@ describe('CoverageGatherer', () => {
 
         expect(sessionMock.send.mock.calls.slice(1))
             .toMatchSnapshot()
-        expect((fs.promises.mkdir as jest.Mock).mock.calls[0][0])
-            .toBe('/foo/bar/files/json.org')
-        expect((fs.promises.writeFile as jest.Mock).mock.calls[0][0])
-            .toBe('/foo/bar/files/json.org/foo.js')
+        expect((fs.promises.mkdir as jest.Mock).mock.calls[0][0].endsWith(
+            path.join('foo', 'bar', 'files', 'json.org')
+        )).toBe(true)
+        expect((fs.promises.writeFile as jest.Mock).mock.calls[0][0].endsWith(
+            path.join('foo', 'bar', 'files', 'json.org', 'foo.js')
+        )).toBe(true)
     })
 
     it('_clearCaptureInterval', () => {
@@ -169,7 +172,9 @@ describe('CoverageGatherer', () => {
         expect(
             (libReport.createContext as jest.Mock).mock.calls[0][0].sourceFinder('/to/a/file.js')
         ).toBe('barfoo')
-        expect(fs.readFileSync).toBeCalledWith('/foo/bar/files/to/a/file.js')
+        expect((fs.readFileSync as jest.Mock).mock.calls[0][0].endsWith(
+            path.join('foo', 'bar', 'files', 'to', 'a', 'file.js')
+        )).toBe(true)
         expect(reports.create).toBeCalledWith('json-summary', { foo: 'bar' })
         // @ts-ignore mock feature
         expect(reports.reportInstance.execute).toBeCalledWith('someContext')

--- a/packages/wdio-devtools-service/tests/gatherer/coverage.test.ts
+++ b/packages/wdio-devtools-service/tests/gatherer/coverage.test.ts
@@ -1,0 +1,137 @@
+import fs from 'fs'
+import CoverageGatherer from '../../src/gatherer/coverage'
+
+import libCoverage from 'istanbul-lib-coverage'
+import { transformAsync as babelTransform } from '@babel/core'
+import type { Page } from 'puppeteer-core/lib/cjs/puppeteer/common/Page'
+
+jest.useFakeTimers()
+
+jest.mock('@babel/core', () => ({
+    transformAsync: jest.fn().mockResolvedValue({ code: 'transpiled code' })
+}))
+
+jest.mock('babel-plugin-istanbul', () => jest.fn())
+jest.mock('istanbul-lib-coverage', () => ({
+    createCoverageMap: jest.fn().mockReturnValue({
+        files: jest.fn().mockReturnValue(['/foo/bar.js'])
+    })
+}))
+jest.mock('istanbul-lib-report', () => jest.fn())
+jest.mock('istanbul-reports', () => jest.fn())
+jest.mock('fs', () => ({
+    existsSync: jest.fn(),
+    promises: {
+        mkdir: jest.fn(),
+        writeFile: jest.fn()
+    }
+}))
+
+const sessionMock = {
+    on: jest.fn(),
+    send: jest.fn().mockResolvedValue({})
+}
+
+const targetMock = {
+    createCDPSession: jest.fn().mockResolvedValue(sessionMock)
+}
+
+let i = 0
+const pageMock = {
+    on: jest.fn(),
+    target: jest.fn().mockReturnValue(targetMock),
+    evaluate: jest.fn()
+        .mockResolvedValueOnce(++i)
+        .mockResolvedValueOnce(++i)
+        .mockRejectedValueOnce(new Error('foo'))
+} as unknown as Page
+
+describe('CoverageGatherer', () => {
+    beforeEach(() => {
+        i = 0
+
+        ;(pageMock.on as jest.Mock).mockClear()
+        ;(sessionMock.on as jest.Mock).mockClear()
+        ;(sessionMock.send as jest.Mock).mockClear()
+        ;(clearInterval as jest.Mock).mockClear()
+    })
+
+    it('initiates properly', async () => {
+        const gatherer = new CoverageGatherer(pageMock, {})
+        expect(pageMock.on).toBeCalledWith('load', expect.any(Function))
+
+        await gatherer.init()
+        expect(sessionMock.send)
+            .toBeCalledWith('Fetch.enable', expect.any(Object))
+        expect(sessionMock.on)
+            .toBeCalledWith('Fetch.requestPaused', expect.any(Function))
+        expect(gatherer['_client']).toBe(sessionMock)
+    })
+
+    it('_handleRequests should return if file is not a JS file', async () => {
+        const gatherer = new CoverageGatherer(pageMock, {})
+        await gatherer.init()
+        await gatherer['_handleRequests']({
+            requestId: '123',
+            request: {
+                url: 'http://json.org/foo.html'
+            },
+            responseStatusCode: 444
+        })
+
+        expect(sessionMock.send).toBeCalledTimes(2)
+        expect(sessionMock.send.mock.calls.pop())
+            .toEqual(['Fetch.continueRequest', { requestId: '123' }])
+        expect(babelTransform).toBeCalledTimes(0)
+    })
+
+    it('_handleRequests should transform JS files', async () => {
+        const gatherer = new CoverageGatherer(pageMock, {
+            logDir: '/foo/bar'
+        })
+        await gatherer.init()
+        await gatherer['_handleRequests']({
+            requestId: '123',
+            request: {
+                url: 'http://json.org/foo.js'
+            },
+            responseStatusCode: 444
+        })
+
+        expect(sessionMock.send.mock.calls.slice(1))
+            .toMatchSnapshot()
+        expect((fs.promises.mkdir as jest.Mock).mock.calls[0][0])
+            .toBe('/foo/bar/files/json.org')
+        expect((fs.promises.writeFile as jest.Mock).mock.calls[0][0])
+            .toBe('/foo/bar/files/json.org/foo.js')
+    })
+
+    it('_clearCaptureInterval', () => {
+        const gatherer = new CoverageGatherer(pageMock, {})
+        gatherer['_clearCaptureInterval']()
+        expect(clearInterval).toBeCalledTimes(0)
+        gatherer['_captureInterval'] = 123 as any
+        gatherer['_clearCaptureInterval']()
+        expect(clearInterval).toBeCalledTimes(1)
+        expect(gatherer['_captureInterval']).toBe(undefined)
+    })
+
+    it('_captureCoverage', async () => {
+        const gatherer = new CoverageGatherer(pageMock, {})
+        gatherer['_clearCaptureInterval'] = jest.fn()
+        gatherer['_captureCoverage']()
+        expect(gatherer['_captureInterval']).not.toBe(undefined)
+        expect(gatherer['_clearCaptureInterval']).toBeCalledTimes(0)
+        gatherer['_captureCoverage']()
+        expect(gatherer['_clearCaptureInterval']).toBeCalledTimes(1)
+    })
+
+    it('_getCoverageMap', async () => {
+        const gatherer = new CoverageGatherer(pageMock, {})
+        let map = gatherer['_getCoverageMap']()
+        jest.advanceTimersByTime(1000)
+        gatherer['_coverageMap'] = 'foobar' as any
+        jest.advanceTimersByTime(1000)
+        expect(await map).toEqual('foobar')
+    })
+})

--- a/tests/typings/sync-devtools-service/devtools-service.ts
+++ b/tests/typings/sync-devtools-service/devtools-service.ts
@@ -1,9 +1,14 @@
 const config: WebdriverIO.Config = {
-  services: [
-    ['devtools', {
-      debuggerAddress: 'localhost:24563'
-    }]
-  ]
+    services: [
+        ['devtools', {
+            coverageReporter: {
+                enable: true,
+                logDir: '/foo/bar',
+                type: 'json',
+                options: {}
+            }
+        }]
+    ]
 }
 
 browser.enablePerformanceAudits()
@@ -34,3 +39,6 @@ browser.endTracing()
 
 const traceLogs: object = browser.getTraceLogs()
 const pageWeight: object = browser.getPageWeight()
+
+const coverage = browser.getCoverageReport()
+coverage.lines.total.toFixed(2)

--- a/tests/typings/webdriverio-devtools-service/devtools-service.ts
+++ b/tests/typings/webdriverio-devtools-service/devtools-service.ts
@@ -1,40 +1,48 @@
 const config: WebdriverIO.Config = {
-  services: [
-    ['devtools', {
-      debuggerAddress: 'localhost:24563'
-    }]
-  ]
+    services: [
+        ['devtools', {
+            coverageReporter: {
+                enable: true,
+                logDir: '/foo/bar',
+                type: 'json',
+                options: {}
+            }
+        }]
+    ]
 }
 
 async function bar() {
-  browser.enablePerformanceAudits()
-  browser.enablePerformanceAudits({
-    networkThrottling: 'online',
-    cpuThrottling: 0,
-    cacheEnabled: false
-  })
-  browser.disablePerformanceAudits()
+    browser.enablePerformanceAudits()
+    browser.enablePerformanceAudits({
+        networkThrottling: 'online',
+        cpuThrottling: 0,
+        cacheEnabled: false
+    })
+    browser.disablePerformanceAudits()
 
-  const metrics: object = browser.getMetrics()
-  const diagnostics: object = browser.getDiagnostics()
-  const mainThreadWorkBreakdown: object[] = browser.getMainThreadWorkBreakdown()
-  const performanceScore: number = browser.getPerformanceScore()
-  const pwaCheck = browser.checkPWA()
-  const pwaFilterdCheck = browser.checkPWA(['maskableIcon', 'isInstallable'])
+    const metrics: object = browser.getMetrics()
+    const diagnostics: object = browser.getDiagnostics()
+    const mainThreadWorkBreakdown: object[] = browser.getMainThreadWorkBreakdown()
+    const performanceScore: number = browser.getPerformanceScore()
+    const pwaCheck = browser.checkPWA()
+    const pwaFilterdCheck = browser.checkPWA(['maskableIcon', 'isInstallable'])
 
-  browser.emulateDevice('iPad')
-  browser.emulateDevice({ viewport: { height: 10, width: 10 }, userAgent: 'test' })
+    browser.emulateDevice('iPad')
+    browser.emulateDevice({ viewport: { height: 10, width: 10 }, userAgent: 'test' })
 
-  const cdpResponse = await browser.cdp('test', 'test')
-  const { host, port } = browser.cdpConnection()
+    const cdpResponse = await browser.cdp('test', 'test')
+    const { host, port } = browser.cdpConnection()
 
-  const nodeId: number = browser.getNodeId('selector')
-  const nodeIds: number[] = browser.getNodeIds('selector')
+    const nodeId: number = browser.getNodeId('selector')
+    const nodeIds: number[] = browser.getNodeIds('selector')
 
-  browser.startTracing()
-  browser.startTracing('test', 1)
-  browser.endTracing()
+    browser.startTracing()
+    browser.startTracing('test', 1)
+    browser.endTracing()
 
-  const traceLogs: object = browser.getTraceLogs()
-  const pageWeight: object = browser.getPageWeight()
+    const traceLogs: object = browser.getTraceLogs()
+    const pageWeight: object = browser.getPageWeight()
+
+    const coverage = await browser.getCoverageReport()
+    coverage.lines.total.toFixed(2)
 }


### PR DESCRIPTION
## Proposed changes

This patch will add a feature to the `@wdio/devtools-service` that allows to measure the test coverage of `.js` files loaded by the browser.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

This is work in progress. Missing:

- evaluate if it is possible to use latest istanbul version instead of the legacy one
- autogenerate HTML report if options is set

### Reviewers: @webdriverio/project-committers 
