### PR TITLE
Retried specfiles are inserted at the start of the specs queue

### DIFF
--- a/docs/ConfigurationFile.md
+++ b/docs/ConfigurationFile.md
@@ -170,6 +170,8 @@ exports.config = {
     //
     // The number of times to retry the entire specfile when it fails as a whole
     specFileRetries: 1,
+    // Whether or not retried specfiles should be retried immediately or deferred to the end of the queue
+    specFileRetriesDeferred: false,
     //
     // Test reporter for stdout.
     // The only one supported by default is 'dot'

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -148,10 +148,16 @@ Type: `Number`<br>
 Default: `0` (don't bail; run all tests)
 
 ### `specFileRetries`
-The number of retry attempts for an entire specfile when it fails as a whole.
+The number of times to retry an entire specfile when it fails as a whole.
 
 Type: `Number`<br>
 Default: `0`
+
+### `specFileRetriesDeferred`
+Whether or not retried specfiles should be retried immediately or deferred to the end of the queue.
+
+Type: `Boolean`<br>
+Default: `true`
 
 ### `waitforTimeout`
 Default timeout for all `waitFor*` commands. (Note the lowercase `f` in the option name.) This timeout __only__ affects commands starting with `waitFor*` and their default wait time.

--- a/docs/Retry.md
+++ b/docs/Retry.md
@@ -95,6 +95,10 @@ module.exports = function () {
     /**
      * The number of times to retry the entire specfile when it fails as a whole
      */
-    specFileRetries: 1
+    specFileRetries: 1,
+    /**
+     * Retried specfiles are inserted at the beginning of the queue and retried immediately
+     */
+    specFileRetriesDeferred: false
 }
 ```

--- a/examples/wdio.conf.js
+++ b/examples/wdio.conf.js
@@ -122,6 +122,9 @@ exports.config = {
     // The number of times to retry the entire specfile when it fails as a whole
     specFileRetries: 1,
     //
+    // Retried specfiles are inserted at the beginning of the queue and retried immediately
+    specFileRetriesDeferred: false,
+    //
     // Test reporter for stdout.
     // The only one supported by default is 'dot'
     // see also: https://webdriver.io/docs/dot-reporter.html

--- a/packages/wdio-cli/src/launcher.js
+++ b/packages/wdio-cli/src/launcher.js
@@ -366,7 +366,9 @@ class Launcher {
         const passed = this.isWatchModeHalted() || exitCode === 0
 
         if (!passed && retries > 0) {
-            this.schedule[parseInt(cid)].specs.push({ files: specs, retries: retries - 1, rid: cid })
+            // Default is true, so test for false explicitly
+            const requeue = this.configParser.getConfig().specFileRetriesDeferred !== false ? 'push' : 'unshift'
+            this.schedule[parseInt(cid)].specs[requeue]({ files: specs, retries: retries - 1, rid: cid })
         } else {
             this.exitCode = this.isWatchModeHalted() ? 0 : this.exitCode || exitCode
             this.runnerFailed += !passed ? 1 : 0

--- a/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
+++ b/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
@@ -166,6 +166,9 @@ exports.config = {
     // The number of times to retry the entire specfile when it fails as a whole
     // specFileRetries: 1,
     //
+    // Whether or not retried specfiles should be retried immediately or deferred to the end of the queue
+    // specFileRetriesDeferred: false,
+    //
     <%- include('reporters', { reporters: answers.reporters }) %> <%
     if(answers.framework === 'mocha') { %>
     //

--- a/packages/wdio-cli/tests/launcher.test.js
+++ b/packages/wdio-cli/tests/launcher.test.js
@@ -169,6 +169,19 @@ describe('launcher', () => {
             launcher.endHandler({ cid: '0-5', exitCode: 1, retries: 1, specs: ['a.js'] })
             expect(launcher.schedule).toMatchObject([{ cid: 0, specs: [{ rid: '0-5', files: ['a.js'], retries: 0 }] }])
         })
+
+        it('should requeue retried specfiles at beginning of queue', () => {
+            launcher.configParser.getConfig = jest.fn().mockReturnValue({ specFileRetriesDeferred: false })
+            launcher.schedule = [{ cid: 0, specs: [{ files: ['b.js'] }] }]
+            launcher.endHandler({ cid: '0-5', exitCode: 1, retries: 1, specs: ['a.js'] })
+            expect(launcher.schedule).toMatchObject([{ cid: 0, specs: [{ rid: '0-5', files: ['a.js'], retries: 0 }, { files: ['b.js'] }] }])
+        })
+
+        it('should requeue retried specfiles at end of queue', () => {
+            launcher.schedule = [{ cid: 0, specs: [{ files: ['b.js'] }] }]
+            launcher.endHandler({ cid: '0-5', exitCode: 1, retries: 1, specs: ['a.js'] })
+            expect(launcher.schedule).toMatchObject([{ cid: 0, specs: [{ files: ['b.js'] }, { rid: '0-5', files: ['a.js'], retries: 0 }] }])
+        })
     })
 
     describe('exitHandler', () => {


### PR DESCRIPTION
## Proposed changes

In our case we take care to list specfiles in decreasing order of expected runtime, to avoid the overall runtime being unnecessarily extended by a single long-running specfile at the end.
In such cases, whenever a specfile fails, it is beneficial to retry it as soon as possible by inserting it into the start of the queue instead of the end.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] New feature (non-breaking change which adds functionality)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
