### PR TITLE
Execution fails when running tests in parallel

### DIFF
--- a/e2e/.eslintrc
+++ b/e2e/.eslintrc
@@ -1,5 +1,8 @@
 {
   "env": {
     "jest": true
+  },
+  "globals": {
+    "browser": true
   }
 }

--- a/e2e/testrunner.test.js
+++ b/e2e/testrunner.test.js
@@ -1,0 +1,10 @@
+import assert from 'assert'
+import Launcher from '../packages/wdio-cli/src/launcher.js'
+
+jest.setTimeout(1000 * 60)
+
+test('should allow to run multiple browser at once', async () => {
+    const launcher = new Launcher(`${__dirname}/wdio/wdio.conf.js`)
+    const failures = await launcher.run()
+    assert.equal(failures, 0)
+})

--- a/e2e/wdio/secondTest.e2e.js
+++ b/e2e/wdio/secondTest.e2e.js
@@ -1,0 +1,8 @@
+const assert = require('assert')
+
+describe('main suite 1', () => {
+    it('foobar test', () => {
+        browser.url('http://guinea-pig.webdriver.io')
+        assert.equal(browser.getTitle(), 'WebdriverJS Testpage')
+    })
+})

--- a/e2e/wdio/test.e2e.js
+++ b/e2e/wdio/test.e2e.js
@@ -1,0 +1,8 @@
+const assert = require('assert')
+
+describe('main suite 1', () => {
+    it('foobar test', () => {
+        browser.url('http://guinea-pig.webdriver.io')
+        assert.equal(browser.getTitle(), 'WebdriverJS Testpage')
+    })
+})

--- a/e2e/wdio/wdio.conf.js
+++ b/e2e/wdio/wdio.conf.js
@@ -1,0 +1,45 @@
+const path = require('path')
+
+exports.config = {
+    /**
+     * run tests with devtools
+     */
+    automationProtocol: 'devtools',
+
+    /**
+     * specify test files
+     */
+    specs: [path.resolve(__dirname, '*.e2e.js')],
+
+    /**
+     * capabilities
+     */
+    capabilities: [{
+        browserName: 'chrome',
+        'goog:chromeOptions': { headless: true }
+    }, {
+        browserName: 'chrome',
+        'goog:chromeOptions': { headless: true }
+    }, {
+        browserName: 'chrome',
+        'goog:chromeOptions': { headless: true }
+    }, {
+        browserName: 'chrome',
+        'goog:chromeOptions': { headless: true }
+    }],
+
+    /**
+     * test configurations
+     */
+    logLevel: 'trace',
+    coloredLogs: true,
+    framework: 'mocha',
+    outputDir: __dirname,
+
+    reporters: ['spec'],
+
+    mochaOpts: {
+        ui: 'bdd',
+        timeout: 60000
+    }
+}

--- a/packages/devtools/src/devtoolsdriver.js
+++ b/packages/devtools/src/devtoolsdriver.js
@@ -39,12 +39,6 @@ export default class DevToolsDriver {
         this.setTimeouts(DEFAULT_IMPLICIT_TIMEOUT, DEFAULT_PAGELOAD_TIMEOUT, DEFAULT_SCRIPT_TIMEOUT)
 
         const page = this.getPageHandle()
-
-        if (!page) {
-            console.log(this.windows)
-            return
-        }
-
         page.on('dialog', ::this.dialogHandler)
         page.on('framenavigated', ::this.framenavigatedHandler)
     }
@@ -110,11 +104,6 @@ export default class DevToolsDriver {
         }
 
         const page = this.getPageHandle()
-
-        if (!page) {
-            console.log(this.windows)
-            return
-        }
         page.setDefaultTimeout(this.timeouts.get('pageLoad'))
     }
 

--- a/packages/devtools/src/devtoolsdriver.js
+++ b/packages/devtools/src/devtoolsdriver.js
@@ -38,7 +38,13 @@ export default class DevToolsDriver {
          */
         this.setTimeouts(DEFAULT_IMPLICIT_TIMEOUT, DEFAULT_PAGELOAD_TIMEOUT, DEFAULT_SCRIPT_TIMEOUT)
 
-        const page = this.windows.get(this.currentWindowHandle)
+        const page = this.getPageHandle()
+
+        if (!page) {
+            console.log(this.windows)
+            return
+        }
+
         page.on('dialog', ::this.dialogHandler)
         page.on('framenavigated', ::this.framenavigatedHandler)
     }
@@ -103,7 +109,12 @@ export default class DevToolsDriver {
             this.timeouts.set('script', script)
         }
 
-        const page = this.windows.get(this.currentWindowHandle)
+        const page = this.getPageHandle()
+
+        if (!page) {
+            console.log(this.windows)
+            return
+        }
         page.setDefaultTimeout(this.timeouts.get('pageLoad'))
     }
 

--- a/packages/devtools/src/launcher.js
+++ b/packages/devtools/src/launcher.js
@@ -3,6 +3,7 @@ import puppeteer from 'puppeteer-core'
 import puppeteerFirefox from 'puppeteer-firefox'
 import logger from '@wdio/logger'
 
+import { getPages } from './utils'
 import {
     CHROME_NAMES, FIREFOX_NAMES, EDGE_NAMES, DEFAULT_FLAGS, DEFAULT_WIDTH,
     DEFAULT_HEIGHT, DEFAULT_X_POSITION, DEFAULT_Y_POSITION
@@ -46,7 +47,7 @@ async function launchChrome (capabilities) {
      * when using Chrome Launcher we have to close a tab as Puppeteer
      * creates automatically a new one
      */
-    const pages = await browser.pages()
+    const pages = await getPages(browser)
     for (const page of pages.slice(0, -1)) {
         if (page.url() === 'about:blank') {
             await page.close()

--- a/packages/devtools/src/utils.js
+++ b/packages/devtools/src/utils.js
@@ -223,7 +223,7 @@ export async function getPages (browser, retryInterval = 100) {
         log.info('no browser pages found, retrying...')
 
         /**
-         * wait for 200ms to try again
+         * wait for some milliseconds to try again
          */
         await new Promise((resolve) => setTimeout(resolve, retryInterval))
         return getPages(browser)

--- a/packages/devtools/src/utils.js
+++ b/packages/devtools/src/utils.js
@@ -206,3 +206,28 @@ export function getStaleElementError (elementId) {
     error.name = 'stale element reference'
     return error
 }
+
+/**
+ * Helper function to get a list of Puppeteer pages from a Chrome browser.
+ * In case many headless browser are run in parallel there are situations
+ * where there are no pages because the machine is busy booting the headless
+ * browser.
+ *
+ * @param  {Puppeteer.Browser} browser  browser instance
+ * @return {Puppeteer.Page[]}           list of browser pages
+ */
+export async function getPages (browser, retryInterval = 100) {
+    const pages = await browser.pages()
+
+    if (pages.length === 0) {
+        log.info('no browser pages found, retrying...')
+
+        /**
+         * wait for 200ms to try again
+         */
+        await new Promise((resolve) => setTimeout(resolve, retryInterval))
+        return getPages(browser)
+    }
+
+    return pages
+}

--- a/packages/devtools/tests/utils.test.js
+++ b/packages/devtools/tests/utils.test.js
@@ -1,6 +1,6 @@
 import {
     validate, getPrototype, findElement, findElements, getStaleElementError,
-    sanitizeError, transformExecuteArgs, transformExecuteResult
+    sanitizeError, transformExecuteArgs, transformExecuteResult, getPages
 } from '../src/utils'
 
 const command = {
@@ -288,6 +288,17 @@ describe('transformExecuteResult', () => {
         pageMock.$$.mockClear()
         pageMock.$$eval.mockClear()
     })
+})
+
+test('getPages', async () => {
+    const browser = {
+        pages: jest.fn()
+            .mockReturnValueOnce([])
+            .mockReturnValueOnce([])
+            .mockReturnValueOnce([{}])
+    }
+    await getPages(browser, 10)
+    expect(browser.pages).toBeCalledTimes(3)
 })
 
 test('getStaleElementError', () => {


### PR DESCRIPTION
**Environment (please complete the following information):**
 - **WebdriverIO version:** 5.12.5 
 - **Mode:** WDIO Testrunner
 - **If WDIO Testrunner, running sync/async:** sync
 - **Node.js version:** 10
 - **Browser name and version:** Chrome 76

**Config of WebdriverIO**
Add `devtools` package from master (pre-release version).
Then enable devtools: `automationProtocol: 'devtools'`

**Describe the bug**
Some test(s) are failing when running multiple tests in parallel

**To Reproduce**
1. Create 4-8 files like this:
```
describe("main suite 1", () => {
    it("foobar test", () => {
        browser.url("http://guinea-pig.webdriver.io")
    })
})
```
2. run tests in parallel, ex `maxInstances: 4`

NOTE: sometimes it fails even with `maxInstances: 2`, there more tests and instances we have the more tests are failing.

**Expected behavior**
should work same as without `automationProtocol: 'devtools'`

**Log**
```
TypeError: Cannot read property 'setDefaultTimeout' of undefined
    at DevToolsDriver.setTimeouts (/e2e/node_modules/devtools/build/devtoolsdriver.js:116:10)
    at new DevToolsDriver (/e2e/node_modules/devtools/build/devtoolsdriver.js:53:10)
    at Function.newSession (/e2e/node_modules/devtools/build/index.js:47:20)
```

## Solution

Wait for pages to be available and resolve `createSession` call after that. I am not sure if it is just technically not possible to run more than 4 headless Chrome instances at a time but with this simple patch it resolves the issue. I don't think that user will run a significant number of parallel Chrome sessions on a single machine due to CPU limitations.