### PR TITLE
Convert protocol elements to WebdriverIO elements

### DIFF
--- a/packages/webdriverio/src/commands/browser/$.js
+++ b/packages/webdriverio/src/commands/browser/$.js
@@ -2,7 +2,9 @@
  * The `$` command is a short way to call the [`findElement`](/docs/api/webdriver.html#findelement) command in order
  * to fetch a single element on the page. It returns an object that with an extended prototype to call
  * action commands without passing in a selector. However if you still pass in a selector it will look
- * for that element first and call the action on that element.
+ * for that element first and call the action on that element. You can also pass in an object as selector
+ * where the object contains a property `element-6066-11e4-a52e-4f735466cecf` with the value of a reference
+ * to an element. The command will then transform the reference to an extended WebdriverIO element.
  *
  * Using the wdio testrunner this command is a global variable else it will be located on the browser object instead.
  *
@@ -32,18 +34,32 @@
         });
         console.log(text.$$('li')[2].$('a').getText()); // outputs: "API"
     });
+
+    it('should allow to convert protocol result of an element into a WebdriverIO element', () => {
+        const activeElement = browser.getActiveElement();
+        console.log($(activeElement).getTagName); // outputs active element
+    });
  * </example>
  *
  * @alias $
- * @param {String|Function} selector  selector or JS Function to fetch a certain element
+ * @param {String|Function|Object} selector  selector or JS Function to fetch a certain element
  * @return {Element}
  * @type utility
  *
  */
 import { findElement } from '../../utils'
 import { getElement } from '../../utils/getElementObject'
+import { ELEMENT_KEY } from '../../constants'
 
 export default async function $ (selector) {
+    /**
+     * convert protocol result into WebdriverIO element
+     * e.g. when element was fetched with `getActiveElement`
+     */
+    if (selector && typeof selector[ELEMENT_KEY] === 'string') {
+        return getElement.call(this, selector, res)
+    }
+
     const res = await findElement.call(this, selector)
     return getElement.call(this, selector, res)
 }

--- a/packages/webdriverio/src/commands/browser/$.js
+++ b/packages/webdriverio/src/commands/browser/$.js
@@ -57,7 +57,7 @@ export default async function $ (selector) {
      * e.g. when element was fetched with `getActiveElement`
      */
     if (selector && typeof selector[ELEMENT_KEY] === 'string') {
-        return getElement.call(this, selector, res)
+        return getElement.call(this, null, selector)
     }
 
     const res = await findElement.call(this, selector)

--- a/packages/webdriverio/src/commands/browser/$.js
+++ b/packages/webdriverio/src/commands/browser/$.js
@@ -37,7 +37,7 @@
 
     it('should allow to convert protocol result of an element into a WebdriverIO element', () => {
         const activeElement = browser.getActiveElement();
-        console.log($(activeElement).getTagName); // outputs active element
+        console.log($(activeElement).getTagName()); // outputs active element
     });
  * </example>
  *

--- a/packages/webdriverio/src/commands/element/$.js
+++ b/packages/webdriverio/src/commands/element/$.js
@@ -1,7 +1,9 @@
 /**
  * The `$` command is a short way to call the [`findElement`](/docs/api/webdriver.html#findelement) command in order
  * to fetch a single element on the page similar to the `$` command from the browser scope. The difference when calling
- * it from an element scope is that the driver will look within the children of that element.
+ * it from an element scope is that the driver will look within the children of that element. You can also pass in an object as selector
+ * where the object contains a property `element-6066-11e4-a52e-4f735466cecf` with the value of a reference
+ * to an element. The command will then transform the reference to an extended WebdriverIO element.
  *
  * Note: chaining `$` and `$$` commands only make sense when you use multiple selector strategies. You will otherwise
  * make unnecessary requests that slow down the test (e.g. `$('body').$('div')` will trigger two request whereas
@@ -33,6 +35,11 @@
             return this.querySelector('a'); // Element
         }).getText()); // outputs: "API"
     });
+
+    it('should allow to convert protocol result of an element into a WebdriverIO element', () => {
+        const activeElement = browser.getActiveElement();
+        console.log($(activeElement).getTagName); // outputs active element
+    });
  * </example>
  *
  * @alias $
@@ -43,8 +50,17 @@
  */
 import { findElement } from '../../utils'
 import { getElement } from '../../utils/getElementObject'
+import { ELEMENT_KEY } from '../../constants'
 
 export default async function $ (selector) {
+    /**
+     * convert protocol result into WebdriverIO element
+     * e.g. when element was fetched with `getActiveElement`
+     */
+    if (selector && typeof selector[ELEMENT_KEY] === 'string') {
+        return getElement.call(this, selector, res)
+    }
+
     const res = await findElement.call(this, selector)
     return getElement.call(this, selector, res)
 }

--- a/packages/webdriverio/src/commands/element/$.js
+++ b/packages/webdriverio/src/commands/element/$.js
@@ -58,7 +58,7 @@ export default async function $ (selector) {
      * e.g. when element was fetched with `getActiveElement`
      */
     if (selector && typeof selector[ELEMENT_KEY] === 'string') {
-        return getElement.call(this, selector, res)
+        return getElement.call(this, null, selector)
     }
 
     const res = await findElement.call(this, selector)

--- a/packages/webdriverio/src/commands/element/$.js
+++ b/packages/webdriverio/src/commands/element/$.js
@@ -38,7 +38,7 @@
 
     it('should allow to convert protocol result of an element into a WebdriverIO element', () => {
         const activeElement = browser.getActiveElement();
-        console.log($(activeElement).getTagName); // outputs active element
+        console.log($(activeElement).getTagName()); // outputs active element
     });
  * </example>
  *

--- a/packages/webdriverio/tests/commands/browser/$.test.js
+++ b/packages/webdriverio/tests/commands/browser/$.test.js
@@ -33,6 +33,18 @@ describe('element', () => {
         expect(elem.ELEMENT).toBe('some-elem-123')
     })
 
+    it('should allow to transform protocol reference into a WebdriverIO element', async () => {
+        const browser = await remote({
+            baseUrl: 'http://foobar.com',
+            capabilities: {
+                browserName: 'foobar-noW3C'
+            }
+        })
+
+        const elem = await browser.$({ [ELEMENT_KEY]: 'foobar' })
+        expect(elem.elementId).toBe('foobar')
+    })
+
     it('keeps prototype from browser object', async () => {
         const browser = await remote({
             baseUrl: 'http://foobar.com',

--- a/packages/webdriverio/tests/commands/element/$.test.js
+++ b/packages/webdriverio/tests/commands/element/$.test.js
@@ -43,6 +43,19 @@ describe('element', () => {
         expect(subElem.ELEMENT).toBe('some-sub-elem-321')
     })
 
+    it('should allow to transform protocol reference into a WebdriverIO element', async () => {
+        const browser = await remote({
+            baseUrl: 'http://foobar.com',
+            capabilities: {
+                browserName: 'foobar-noW3C'
+            }
+        })
+
+        const elem = await browser.$('#foo')
+        const subElem = await elem.$({ [ELEMENT_KEY]: 'foobar' })
+        expect(subElem.elementId).toBe('foobar')
+    })
+
     it('keeps prototype from browser object', async () => {
         const browser = await remote({
             baseUrl: 'http://foobar.com',


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
There are some commands like `getActiveElement` that returns something like `element-6066-11e4-a52e-4f735466cecf:"ELEMENT-57"`

There is no way to interact with such object like with WebdriverIO element

**Goal**
I'd like to be able to wrap such responses, ideally automatically somehow

**Suggested solutions**
- add command WebdriverIO for every protocol command, like `getActiveElement` to wrap response with WebdriverIO element;
- add some command, like `browser.wrap(browser.getActiveElement())` to be able to convert protocol element objects to WebdriverIO elements
- automatically convert responses that have only `element-6066-11e4-a52e-4f735466cecf` in body to WebdriverIO elements.
