### PR TITLE
Fix devtools types

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "ts:sync-jasmine": "cd tests/typings/sync-jasmine && tsc --incremental",
     "ts:sync-cucumber": "cd tests/typings/sync-cucumber && tsc --incremental",
     "ts:webdriverio": "cd tests/typings/webdriverio && tsc --incremental",
+    "ts:webdriverio-devtools": "cd tests/typings/sync-devtools && tsc --incremental",
     "ts:webdriverio-mocha": "cd tests/typings/webdriverio-mocha && tsc --incremental",
     "ts:webdriverio-jasmine": "cd tests/typings/webdriverio-jasmine && tsc --incremental",
     "watch": "node ./scripts/watch",

--- a/scripts/templates/devtools.tpl.d.ts
+++ b/scripts/templates/devtools.tpl.d.ts
@@ -1,12 +1,14 @@
 /// <reference types="node"/>
 /// <reference types="webdriver"/>
 
-declare namespace DevTools {
-    interface ClientOptions extends WebDriver.ClientOptions {
+declare namespace WebDriver {
+    interface ClientOptions {
         isDevTools: boolean;
         getPuppeteer: (...args: any[]) => any;
     }
+}
 
+declare namespace DevTools {
     function newSession(
         options?: WebDriver.Options,
         modifier?: (...args: any[]) => any,

--- a/tests/typings/copy.js
+++ b/tests/typings/copy.js
@@ -5,7 +5,7 @@ const path = require('path')
 // TypeScript project root for testing particular typings
 const outDirs = [
     'sync', 'sync-mocha', 'sync-jasmine', 'webdriverio', 'webdriverio-mocha',
-    'webdriverio-jasmine', 'sync-cucumber', 'devtools'
+    'webdriverio-jasmine', 'sync-cucumber', 'devtools', 'sync-devtools'
 ]
 
 const packages = {

--- a/tests/typings/sync-devtools/devtools.ts
+++ b/tests/typings/sync-devtools/devtools.ts
@@ -1,0 +1,2 @@
+const isDevTools: boolean = browser.isDevTools
+const isMobile: boolean = browser.isMobile

--- a/tests/typings/sync-devtools/tsconfig.json
+++ b/tests/typings/sync-devtools/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "outDir": "dist",
+    "noImplicitAny": true,
+    "lib": ["es2018"],
+    "types": [
+      "webdriverio",
+      "devtools"
+    ],
+    "typeRoots": ["./types"]
+  }
+}


### PR DESCRIPTION
## Proposed changes

devtools types doesn't work in combination with webdriverio, ex: `browser.isDevTools` won't work

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

### Reviewers: @webdriverio/technical-committee
