### PR TITLE
Add scRelay flag to not use SC as a Selenium Relay by default

### DIFF
--- a/packages/wdio-sauce-service/README.md
+++ b/packages/wdio-sauce-service/README.md
@@ -77,3 +77,9 @@ Type: `Object`<br>
 Default: `{}`
 
 *(only for vm and or em/simulators)*
+
+### scRelay
+Use Sauce Connect as a Selenium Relay. See more [here](https://wiki.saucelabs.com/display/DOCS/Using+the+Selenium+Relay+with+Sauce+Connect+Proxy).
+
+Type: `Boolean`<br>
+Default: `false`

--- a/packages/wdio-sauce-service/src/launcher.js
+++ b/packages/wdio-sauce-service/src/launcher.js
@@ -17,9 +17,11 @@ export default class SauceLauncher {
             logger: log.debug
         }, config.sauceConnectOpts)
 
-        config.protocol = 'http'
-        config.hostname = 'localhost'
-        config.port = this.sauceConnectOpts.port || 4445
+        if (config.scRelay) {
+            config.protocol = 'http'
+            config.hostname = 'localhost'
+            config.port = this.sauceConnectOpts.port || 4445
+        }
 
         const sauceConnectTunnelIdentifier = this.sauceConnectOpts.tunnelIdentifier
 

--- a/packages/wdio-sauce-service/tests/launcher.test.js
+++ b/packages/wdio-sauce-service/tests/launcher.test.js
@@ -38,6 +38,23 @@ test('onPrepare w/o identifier', () => {
     expect(SauceConnectLauncher).toBeCalled()
 })
 
+test('onPrepare w/ SauceConnect w/o scRelay', () => {
+    const caps = [{}]
+    const config = {
+        user: 'foobaruser',
+        key: '12345',
+        sauceConnect: true
+    }
+    const service = new SauceServiceLauncher()
+    expect(service.sauceConnectProcess).toBeUndefined()
+    service.onPrepare(config, caps)
+
+    expect(service.sauceConnectProcess).not.toBeUndefined()
+    expect(config.port).toBe(undefined)
+    expect(config.protocol).toBe(undefined)
+    expect(config.hostname).toBe(undefined)
+})
+
 test('onPrepare multiremote', () => {
     const caps = {
         browserA: {
@@ -51,6 +68,7 @@ test('onPrepare multiremote', () => {
         user: 'foobaruser',
         key: '12345',
         sauceConnect: true,
+        scRelay: true,
         sauceConnectOpts: {
             port: 4446,
             tunnelIdentifier: 'my-tunnel'
@@ -117,6 +135,7 @@ test('onPrepare multiremote with tunnel identifier and with w3c caps ', () => {
         user: 'foobaruser',
         key: '12345',
         sauceConnect: true,
+        scRelay: true,
         sauceConnectOpts: {
             port: 4446,
             tunnelIdentifier: 'my-tunnel'
@@ -163,6 +182,7 @@ test('onPrepare with tunnel identifier and without w3c caps ', () => {
         user: 'foobaruser',
         key: '12345',
         sauceConnect: true,
+        scRelay: true,
         sauceConnectOpts: {
             port: 4446,
             tunnelIdentifier: 'my-tunnel'
@@ -264,6 +284,7 @@ test('onPrepare with tunnel identifier and with w3c caps ', () => {
         user: 'foobaruser',
         key: '12345',
         sauceConnect: true,
+        scRelay: true,
         sauceConnectOpts: {
             port: 4446,
             tunnelIdentifier: 'my-tunnel'


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

Prior to this change, Sauce Connect as a Selenium Relay was always used if sauceConnect was set to true.
This change makes it possible to use the OnDemand endpoint and starting SC with webdriverio

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)

## Further comments

This is a somewhat breaking change since by default all WebDriver traffic will now go to https://ondemand.saucelabs.com instead than http://localhost:[port]

In general most Sauce Labs customers have ondemand.saucelabs.com whitelisted but there might be a few that might get surprised by this change.

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
