### PR TITLE
Update travis ci dist to xenial and set @babel/core version to 7.5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial
 language: node_js
 
 node_js:

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "devDependencies": {
     "@babel/cli": "^7.2.3",
-    "@babel/core": "^7.4.0",
+    "@babel/core": "7.5.5",
     "@babel/node": "^7.2.2",
     "@babel/plugin-proposal-class-properties": "^7.4.0",
     "@babel/plugin-proposal-function-bind": "^7.2.0",


### PR DESCRIPTION
## Proposed changes

- Fix coverage issue by setting fixed @babel/core version 7.5.5
- Fix e2e tests that fails because chrome cannot be installed.

fixes: `Protocol error (Target.getBrowserContexts): \'Target.getBrowserContexts\' wasn\'t found` caused by `dpkg: error processing archive /tmp/google-chrome-stable_current_amd64.deb (--install):
 subprocess dpkg-deb --control returned error exit status 2`

## Types of changes

- [x] CI / build related

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
## Further comments

### Reviewers: @webdriverio/technical-committee
