### PR TITLE
webdriver: Fixed url params being encoded twice, breaking id/name based lookups

### DIFF
--- a/packages/webdriver/src/command.js
+++ b/packages/webdriver/src/command.js
@@ -5,7 +5,7 @@ import WebDriverRequest from './request'
 
 const log = logger('webdriver')
 
-export default function (method, endpointUri, commandInfo) {
+export default function (method, endpointUri, commandInfo, doubleEncodeVariables = false) {
     const { command, ref, parameters, variables = [], isHubCommand = false } = commandInfo
 
     return function protocolCommand (...args) {
@@ -65,7 +65,8 @@ export default function (method, endpointUri, commandInfo) {
              * inject url variables
              */
             if (i < variables.length) {
-                endpoint = endpoint.replace(`:${commandParams[i].name}`, encodeURIComponent(encodeURIComponent(arg)))
+                const encodedArg = doubleEncodeVariables ? encodeURIComponent(encodeURIComponent(arg)) : encodeURIComponent(arg)
+                endpoint = endpoint.replace(`:${commandParams[i].name}`, encodedArg)
                 continue
             }
 

--- a/packages/webdriver/src/utils.js
+++ b/packages/webdriver/src/utils.js
@@ -158,7 +158,7 @@ export function getPrototype ({ isW3C, isChrome, isMobile, isSauce, isSeleniumSt
 
     for (const [endpoint, methods] of Object.entries(ProtocolCommands)) {
         for (const [method, commandData] of Object.entries(methods)) {
-            prototype[commandData.command] = { value: command(method, endpoint, commandData) }
+            prototype[commandData.command] = { value: command(method, endpoint, commandData, isSeleniumStandalone) }
         }
     }
 

--- a/packages/webdriver/tests/__fixtures__/ghostdriver.response.json
+++ b/packages/webdriver/tests/__fixtures__/ghostdriver.response.json
@@ -1,0 +1,26 @@
+{
+  "status": 0,
+  "sessionId": "XXXXXXXX00000000XXXXXXXXXXXXXXXX",
+  "value": {
+    "browserName":"phantomjs",
+    "version":"2.1.1",
+    "driverName":"ghostdriver",
+    "driverVersion":"1.2.0",
+    "platform":"mac-unknown-64bit",
+    "javascriptEnabled": true,
+    "takesScreenshot": true,
+    "handlesAlerts": false,
+    "databaseEnabled": false,
+    "locationContextEnabled": false,
+    "applicationCacheEnabled": false,
+    "browserConnectionEnabled": false,
+    "cssSelectorsEnabled": true,
+    "webStorageEnabled": false,
+    "rotatable": false,
+    "acceptSslCerts": false,
+    "nativeEvents": true,
+    "proxy": {
+      "proxyType":"direct"
+    }
+  }
+}

--- a/packages/webdriver/tests/command.test.js
+++ b/packages/webdriver/tests/command.test.js
@@ -92,6 +92,16 @@ describe('command wrapper', () => {
         commandFn.call(scope, '/path', 'css selector', '#body', 123)
 
         const [, endpoint] = requestMock.mock.calls[0]
+        expect(endpoint).toBe('/session/:sessionId/element/%2Fpath/element')
+        requestMock.mockClear()
+    })
+
+    it('should double encode uri parameters if using selenium', () => {
+        const commandFn = commandWrapper(command.method, command.endpoint, command, true)
+        const requestMock = require('../src/request')
+        commandFn.call(scope, '/path', 'css selector', '#body', 123)
+
+        const [, endpoint] = requestMock.mock.calls[0]
         expect(endpoint).toBe('/session/:sessionId/element/%252Fpath/element')
         requestMock.mockClear()
     })

--- a/packages/webdriver/tests/utils.test.js
+++ b/packages/webdriver/tests/utils.test.js
@@ -6,6 +6,7 @@ import {
 import appiumResponse from './__fixtures__/appium.response.json'
 import chromedriverResponse from './__fixtures__/chromedriver.response.json'
 import geckodriverResponse from './__fixtures__/geckodriver.response.json'
+import ghostdriverResponse from './__fixtures__/ghostdriver.response.json'
 import safaridriverResponse from './__fixtures__/safaridriver.response.json'
 import safaridriverLegacyResponse from './__fixtures__/safaridriver.legacy.response.json'
 import edgedriverResponse from './__fixtures__/edgedriver.response.json'
@@ -80,6 +81,7 @@ describe('utils', () => {
         const appiumCaps = appiumResponse.value.capabilities
         const geckoCaps = geckodriverResponse.value.capabilities
         const edgeCaps = edgedriverResponse.value.capabilities
+        const phantomCaps = ghostdriverResponse.value
         const safariCaps = safaridriverResponse.value.capabilities
         const safariLegacyCaps = safaridriverLegacyResponse.value
         const standaloneCaps = seleniumstandaloneResponse.value
@@ -92,6 +94,7 @@ describe('utils', () => {
             expect(environmentDetector({ capabilities: safariCaps, requestedCapabilities }).isW3C).toBe(true)
             expect(environmentDetector({ capabilities: edgeCaps, requestedCapabilities }).isW3C).toBe(true)
             expect(environmentDetector({ capabilities: safariLegacyCaps, requestedCapabilities }).isW3C).toBe(false)
+            expect(environmentDetector({ capabilities: phantomCaps, requestedCapabilities }).isW3C).toBe(false)
             expect(isW3C()).toBe(false)
         })
 
@@ -100,6 +103,7 @@ describe('utils', () => {
             expect(environmentDetector({ capabilities: appiumCaps, requestedCapabilities }).isChrome).toBe(false)
             expect(environmentDetector({ capabilities: chromeCaps, requestedCapabilities }).isChrome).toBe(true)
             expect(environmentDetector({ capabilities: geckoCaps, requestedCapabilities }).isChrome).toBe(false)
+            expect(environmentDetector({ capabilities: phantomCaps, requestedCapabilities }).isChrome).toBe(false)
         })
 
         it('isSauce', () => {


### PR DESCRIPTION
Fixes #4466 

## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

This just makes it so items (eg. element id, cookie names, etc...) used in a command path are only encoded once instead of twice, as doing it twice was causing it to have a different value when interpreted by the browser and therefore would fail to find the specified item.

Note: I also had a look at creating a more end to end test but since everything is mocked, that didn't seem to be feasible with the current tests (since it'd likely require interaction with a real browser).

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
