### PR TITLE
Chore: increase blog posts shown in the side meny

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -59,7 +59,9 @@ module.exports = {
     scrollToTop: true,
 
     /* Show last update time */
-    enableUpdateTime: true
+    enableUpdateTime: true,
+    
+    blogSidebarCount: 25
 
     // You may provide arbitrary config keys to be used as needed by your
     // template. For example, if you need your repo's URL...


### PR DESCRIPTION
Currently we only see the default 5 blog posts in the side menu. We have space for more, so I've set it to 25.

I do think we need to have something like a *all posts* option, but I couldn't find it in the config

