### PR TITLE
Temporary set cbt_tunnels version to 0.9.10

### DIFF
--- a/packages/wdio-crossbrowsertesting-service/package.json
+++ b/packages/wdio-crossbrowsertesting-service/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@wdio/logger": "^5.12.1",
-    "cbt_tunnels": "^0.9.7"
+    "cbt_tunnels": "0.9.10"
   },
   "peerDependencies": {
     "@wdio/cli": "^5.0.0"


### PR DESCRIPTION
## Proposed changes

Temporary set `cbt_tunnels` version to `0.9.10` as far as `0.9.11` is broken, see https://github.com/crossbrowsertesting/cbt-tunnel-nodejs/issues/25

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc

## Further comments

### Reviewers: @webdriverio/technical-committee
