### PR TITLE
Set log levels when run in standalone mode

### DIFF
--- a/packages/webdriverio/src/index.js
+++ b/packages/webdriverio/src/index.js
@@ -17,6 +17,8 @@ const log = logger('webdriverio')
  * @return {object}                   browser object with sessionId
  */
 export const remote = async function (params = {}, remoteModifier) {
+    logger.setLogLevelsConfig(params.logLevels, params.logLevel)
+
     const config = validateConfig(WDIO_DEFAULTS, params)
     const modifier = (client, options) => {
         if (typeof remoteModifier === 'function') {

--- a/packages/webdriverio/tests/module.test.js
+++ b/packages/webdriverio/tests/module.test.js
@@ -1,4 +1,5 @@
 import path from 'path'
+import logger from '@wdio/logger'
 import { detectBackend, runFnInFiberContext } from '@wdio/config'
 
 import { remote, multiremote, attach } from '../src'
@@ -44,13 +45,15 @@ const WebDriver = require('webdriver').default
 describe('WebdriverIO module interface', () => {
     it('should provide remote and multiremote access', () => {
         expect(typeof remote).toBe('function')
+        expect(typeof attach).toBe('function')
         expect(typeof multiremote).toBe('function')
     })
 
     describe('remote function', () => {
         it('creates a webdriver session', async () => {
-            const browser = await remote({ capabilities: {} })
+            const browser = await remote({ capabilities: {}, logLevel: 'trace' })
             expect(browser.sessionId).toBe('foobar-123')
+            expect(logger.setLogLevelsConfig).toBeCalledWith(undefined, 'trace')
         })
 
         it('allows to propagate a modifier', async () => {


### PR DESCRIPTION
## Proposed changes

Set log level for `@wdio/logger` when WebdriverIO is being run in standalone mode.

closes #4433

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)


### Reviewers: @webdriverio/project-committers 
