### PR TITLE
wdio-crossbrowsertesting-service: temporary mock pac-resolver

### DIFF
--- a/packages/wdio-crossbrowsertesting-service/tests/__mocks__/pac-resolver.js
+++ b/packages/wdio-crossbrowsertesting-service/tests/__mocks__/pac-resolver.js
@@ -1,0 +1,5 @@
+let pacResolver = require('@crossbrowsertesting/pac-resolver')
+
+global.PAC_RESOLVER_MOCK = true
+
+module.exports = pacResolver

--- a/packages/wdio-crossbrowsertesting-service/tests/launcher.test.js
+++ b/packages/wdio-crossbrowsertesting-service/tests/launcher.test.js
@@ -1,6 +1,15 @@
 import CrossBrowserTestingLauncher from '../src/launcher'
 import cbtTunnels from 'cbt_tunnels'
 
+/**
+ * remove `beforeAll` and `tests/__mocks__/pac-resolver.js` file once issue is fixed
+ */
+beforeAll(() => {
+    if (!global.PAC_RESOLVER_MOCK) {
+        throw new Error('https://github.com/crossbrowsertesting/cbt-tunnel-nodejs/issues/25 has been fixed!')
+    }
+})
+
 describe('wdio-crossbrowsertesting-service', () => {
     const cbtLauncher = new CrossBrowserTestingLauncher({})
     const error = new Error('Error!')


### PR DESCRIPTION
## Proposed changes

Temporary mock `pac-resolver` to make tests pass.

Tests will start failing again once https://github.com/crossbrowsertesting/cbt-tunnel-nodejs/issues/25 is fixed

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc

## Further comments

### Reviewers: @webdriverio/technical-committee
