### PR TITLE
Remove pac-resolver import workaround

### DIFF
--- a/packages/wdio-crossbrowsertesting-service/package.json
+++ b/packages/wdio-crossbrowsertesting-service/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@wdio/logger": "5.13.2",
-    "cbt_tunnels": "^0.9.7"
+    "cbt_tunnels": "^0.9.12"
   },
   "peerDependencies": {
     "@wdio/cli": "^5.0.0"

--- a/packages/wdio-crossbrowsertesting-service/tests/__mocks__/pac-resolver.js
+++ b/packages/wdio-crossbrowsertesting-service/tests/__mocks__/pac-resolver.js
@@ -1,5 +1,0 @@
-let pacResolver = require('@crossbrowsertesting/pac-resolver')
-
-global.PAC_RESOLVER_MOCK = true
-
-module.exports = pacResolver

--- a/packages/wdio-crossbrowsertesting-service/tests/launcher.test.js
+++ b/packages/wdio-crossbrowsertesting-service/tests/launcher.test.js
@@ -1,15 +1,6 @@
 import CrossBrowserTestingLauncher from '../src/launcher'
 import cbtTunnels from 'cbt_tunnels'
 
-/**
- * remove `beforeAll` and `tests/__mocks__/pac-resolver.js` file once issue is fixed
- */
-beforeAll(() => {
-    if (!global.PAC_RESOLVER_MOCK) {
-        throw new Error('https://github.com/crossbrowsertesting/cbt-tunnel-nodejs/issues/25 has been fixed!')
-    }
-})
-
 describe('wdio-crossbrowsertesting-service', () => {
     const cbtLauncher = new CrossBrowserTestingLauncher({})
     const error = new Error('Error!')


### PR DESCRIPTION
## Proposed changes

remove pac-resolver import workaround that was added temporary to unblock tests.

The original issue has been fixed.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments


### Reviewers: @webdriverio/technical-committee
