### PR TITLE
wdio-cli: add glob support for the exclude param

### DIFF
--- a/packages/wdio-config/src/lib/ConfigParser.js
+++ b/packages/wdio-config/src/lib/ConfigParser.js
@@ -218,7 +218,7 @@ export default class ConfigParser {
             if (fs.existsSync(filteredFile) && fs.lstatSync(filteredFile).isFile()) {
                 filesToFilter.add(path.resolve(process.cwd(), filteredFile))
             } else if (globMatchedFiles.length) {
-                globMatchedFiles.forEach(file => filesToFilter.add(file))
+                globMatchedFiles.forEach(filesToFilter.add)
             } else {
                 fileList.forEach(file => {
                     if (file.match(filteredFile)) {

--- a/packages/wdio-config/src/lib/ConfigParser.js
+++ b/packages/wdio-config/src/lib/ConfigParser.js
@@ -218,7 +218,7 @@ export default class ConfigParser {
             if (fs.existsSync(filteredFile) && fs.lstatSync(filteredFile).isFile()) {
                 filesToFilter.add(path.resolve(process.cwd(), filteredFile))
             } else if (globMatchedFiles.length) {
-                globMatchedFiles.forEach(filesToFilter.add)
+                globMatchedFiles.forEach(file => filesToFilter.add(file))
             } else {
                 fileList.forEach(file => {
                     if (file.match(filteredFile)) {

--- a/packages/wdio-config/src/lib/ConfigParser.js
+++ b/packages/wdio-config/src/lib/ConfigParser.js
@@ -214,8 +214,17 @@ export default class ConfigParser {
         const filesToFilter = new Set()
         const fileList = ConfigParser.getFilePaths(config)
         cliArgFileList.forEach(filteredFile => {
+            let matchedFiles = ConfigParser.getFilePaths(glob.sync(filteredFile))
+            let globMatchedFiles = []
+            matchedFiles.forEach(file => {
+                if (matchedFiles.indexOf(file) != -1) {
+                    globMatchedFiles.push(file)
+                }
+            })
             if (fs.existsSync(filteredFile) && fs.lstatSync(filteredFile).isFile()) {
                 filesToFilter.add(path.resolve(process.cwd(), filteredFile))
+            } else if (globMatchedFiles.length) {
+                globMatchedFiles.forEach(file => {filesToFilter.add(file)})
             } else {
                 fileList.forEach(file => {
                     if (file.match(filteredFile)) {

--- a/packages/wdio-config/src/lib/ConfigParser.js
+++ b/packages/wdio-config/src/lib/ConfigParser.js
@@ -214,17 +214,11 @@ export default class ConfigParser {
         const filesToFilter = new Set()
         const fileList = ConfigParser.getFilePaths(config)
         cliArgFileList.forEach(filteredFile => {
-            let matchedFiles = ConfigParser.getFilePaths(glob.sync(filteredFile))
-            let globMatchedFiles = []
-            matchedFiles.forEach(file => {
-                if (matchedFiles.indexOf(file) != -1) {
-                    globMatchedFiles.push(file)
-                }
-            })
+            let globMatchedFiles = ConfigParser.getFilePaths(glob.sync(filteredFile))
             if (fs.existsSync(filteredFile) && fs.lstatSync(filteredFile).isFile()) {
                 filesToFilter.add(path.resolve(process.cwd(), filteredFile))
             } else if (globMatchedFiles.length) {
-                globMatchedFiles.forEach(file => {filesToFilter.add(file)})
+                globMatchedFiles.forEach(file => filesToFilter.add(file))
             } else {
                 fileList.forEach(file => {
                     if (file.match(filteredFile)) {

--- a/packages/wdio-config/tests/configparser.test.js
+++ b/packages/wdio-config/tests/configparser.test.js
@@ -178,6 +178,15 @@ describe('ConfigParser', () => {
             expect(() => configParser.merge({ exclude: [path.resolve(__dirname, 'foobar.js')] })).toThrow()
         })
 
+        it('should allow specifying a glob pattern for exclude', () => {
+            const configParser = new ConfigParser()
+            configParser.addConfigFile(FIXTURES_CONF)
+            configParser.merge({ spec: [INDEX_PATH, FIXTURES_CONF] })
+            configParser.merge({ exclude: [path.resolve(__dirname) + '/*'] })
+            const specs = configParser.getSpecs()
+            expect(specs).toHaveLength(2)
+        })
+
         it('should overwrite exclude if piped into cli command', () => {
             const configParser = new ConfigParser()
             configParser.addConfigFile(FIXTURES_CONF)


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)
On wdio-cli, there's a bug where exclude param is a regex match, not a glob match.  My fix will change it so it attempts a glob match first, if there are no matches, it will attempt a regex match, so as to be backwards compatible.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
