### PR TITLE
Add step data and context to hooks

### DIFF
--- a/docs/ConfigurationFile.md
+++ b/docs/ConfigurationFile.md
@@ -263,15 +263,17 @@ exports.config = {
     },
     /**
      * Hook that gets executed _before_ a hook within the suite starts (e.g. runs before calling
-     * beforeEach in Mocha)
+     * beforeEach in Mocha).
+     * stepData and world are Cucumber framework specific
      */
-    beforeHook: function (test, context) {
+    beforeHook: function (test, context/*, stepData, world*/) {
     },
     /**
      * Hook that gets executed _after_ a hook within the suite ends (e.g. runs after calling
      * afterEach in Mocha)
+     * stepData and world are Cucumber framework specific
      */
-    afterHook: function (test, context, { error, result, duration, passed }) {
+    afterHook: function (test, context, { error, result, duration, passed }/*, stepData, world*/) {
     },
     /**
      * Function to be executed before a test (in Mocha/Jasmine) starts.
@@ -346,9 +348,9 @@ exports.config = {
     },
     beforeScenario: function (uri, feature, scenario, sourceLocation) {
     },
-    beforeStep: function (uri, feature) {
+    beforeStep: function (uri, feature, stepData, context) {
     },
-    afterStep: function (uri, feature, { error, result, duration, passed }) {
+    afterStep: function (uri, feature, { error, result, duration, passed }, stepData, context) {
     },
     afterScenario: function (uri, feature, scenario, result, sourceLocation) {
     },

--- a/examples/pageobject/wdio.conf.js
+++ b/examples/pageobject/wdio.conf.js
@@ -101,12 +101,14 @@ exports.config = {
     //
     // Hook that gets executed _before_ a hook within the suite starts (e.g. runs before calling
     // beforeEach in Mocha)
-    // beforeHook: function (test, context) {
+    // stepData and world are Cucumber framework specific
+    // beforeHook: function (test, context, stepData, world) {
     // },
     //
     // Hook that gets executed _after_ a hook within the suite ends (e.g. runs after calling
     // afterEach in Mocha)
-    // afterHook: function (test, context, { error, result, duration, passed }) {
+    // stepData and world are Cucumber framework specific
+    // afterHook: function (test, context, { error, result, duration, passed }, stepData, world) {
     // },
     //
     // Function to be executed before a test (in Mocha/Jasmine) starts.
@@ -146,11 +148,11 @@ exports.config = {
     // },
     //
     // Runs before a Cucumber Step
-    // beforeStep: function (uri, feature) {
+    // beforeStep: function (uri, feature, stepData, context) {
     // },
     //
     // Runs after a Cucumber Step
-    // afterStep: function (uri, feature, { error, result, duration, passed }) {
+    // afterStep: function (uri, feature, { error, result, duration, passed }, stepData, context) {
     // },
     //
     // Gets executed after all tests are done. You still have access to all global variables from

--- a/examples/wdio.conf.js
+++ b/examples/wdio.conf.js
@@ -233,14 +233,16 @@ exports.config = {
     /**
      * Hook that gets executed _before_ a hook within the suite starts (e.g. runs before calling
      * beforeEach in Mocha)
+     * stepData and world are Cucumber framework specific
      */
-    beforeHook: function (test, context) {
+    beforeHook: function (test, context/*, stepData, world*/) {
     },
     /**
      * Hook that gets executed _after_ a hook within the suite ends (e.g. runs after calling
      * afterEach in Mocha)
+     * stepData and world are Cucumber framework specific
      */
-    afterHook: function (test, context, { error, result, duration, passed }) {
+    afterHook: function (test, context, { error, result, duration, passed }/*, stepData, world*/) {
     },
     /**
      * Function to be executed before a test (in Mocha/Jasmine) starts.
@@ -315,9 +317,9 @@ exports.config = {
     },
     beforeScenario: function (uri, feature, scenario, sourceLocation) {
     },
-    beforeStep: function (uri, feature) {
+    beforeStep: function (uri, feature, stepData, context) {
     },
-    afterStep: function (uri, feature, { error, result, duration, passed }) {
+    afterStep: function (uri, feature, { error, result, duration, passed }, stepData, context) {
     },
     afterScenario: function (uri, feature, scenario, result, sourceLocation) {
     },

--- a/examples/wdio/custom-service/my.custom.service.js
+++ b/examples/wdio/custom-service/my.custom.service.js
@@ -59,10 +59,10 @@ module.exports = class CustomService {
         console.log('execute beforeScenario(uri, feature, scenario, sourceLocation)')
     }
     beforeStep () {
-        console.log('execute beforeStep(uri, feature)')
+        console.log('execute beforeStep(uri, feature, stepData, context)')
     }
     afterStep () {
-        console.log('execute afterStep(uri, feature, { error, result, duration, passed })')
+        console.log('execute afterStep(uri, feature, { error, result, duration, passed }, stepData, context)')
     }
     afterScenario () {
         console.log('execute afterScenario(uri, feature, scenario, result, sourceLocation)')

--- a/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
+++ b/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
@@ -304,12 +304,12 @@ exports.config = {
     /**
      * Runs before a Cucumber step
      */
-    // beforeStep: function (uri, feature) {
+    // beforeStep: function (uri, feature, stepData, context) {
     // },
     /**
      * Runs after a Cucumber step
      */
-    // afterStep: function (uri, feature, { error, result, duration, passed }) {
+    // afterStep: function (uri, feature, { error, result, duration, passed }, stepData, context) {
     // },
     /**
      * Runs after a Cucumber scenario

--- a/packages/wdio-cucumber-framework/cucumber-framework.d.ts
+++ b/packages/wdio-cucumber-framework/cucumber-framework.d.ts
@@ -24,8 +24,8 @@ interface CucumberHookObject {
 interface CucumberHookFunctions {
     beforeFeature?(uri: string, feature: CucumberHookObject, scenarios: CucumberHookObject[]): void;
     beforeScenario?(uri: string, feature: CucumberHookObject, scenario: CucumberHookObject, sourceLocation: SourceLocation): void;
-    beforeStep?(uri: string, feature: CucumberHookObject): void;
-    afterStep?(uri: string, feature: CucumberHookObject, result: { error?: any, result?: any, passed: boolean, duration: number }): void;
+    beforeStep?(uri: string, feature: CucumberHookObject, stepData?: any, context?: any): void;
+    afterStep?(uri: string, feature: CucumberHookObject, result: { error?: any, result?: any, passed: boolean, duration: number }, stepData?: any, context?: any): void;
     afterScenario?(uri: string, feature: CucumberHookObject, scenario: CucumberHookObject, result: CucumberHookResult, sourceLocation: SourceLocation): void;
     afterFeature?(uri: string, feature: CucumberHookObject, scenarios: CucumberHookObject[]): void;
 }

--- a/packages/wdio-cucumber-framework/src/cucumberEventListener.js
+++ b/packages/wdio-cucumber-framework/src/cucumberEventListener.js
@@ -7,6 +7,7 @@ export default class CucumberEventListener extends EventEmitter {
     acceptedPickles = []
     currentPickle = null
     currentStep = null
+    isStepRunning = false
     testCasePreparedEvents = []
 
     constructor (eventBroadcaster) {
@@ -109,6 +110,7 @@ export default class CucumberEventListener extends EventEmitter {
 
         if (step.type === 'Step') {
             this.currentStep = { uri, feature, scenario, step, sourceLocation }
+            this.isStepRunning = true
         }
 
         this.emit('before-step', uri, feature, scenario, step, sourceLocation)
@@ -172,6 +174,10 @@ export default class CucumberEventListener extends EventEmitter {
         const result = testStepFinishedEvent.result
 
         this.emit('after-step', uri, feature, scenario, step, result, sourceLocation)
+
+        if (this.isStepRunning === true && result.status !== 'passed') {
+            this.isStepRunning = false
+        }
     }
 
     // testCaseFinishedEvent = {
@@ -190,6 +196,7 @@ export default class CucumberEventListener extends EventEmitter {
 
         this.currentPickle = null
         this.currentStep = null
+        this.isStepRunning = false
     }
 
     // testRunFinishedEvent = {

--- a/packages/wdio-cucumber-framework/src/cucumberEventListener.js
+++ b/packages/wdio-cucumber-framework/src/cucumberEventListener.js
@@ -6,6 +6,7 @@ export default class CucumberEventListener extends EventEmitter {
     gherkinDocEvents = []
     acceptedPickles = []
     currentPickle = null
+    currentStep = null
     testCasePreparedEvents = []
 
     constructor (eventBroadcaster) {
@@ -106,6 +107,10 @@ export default class CucumberEventListener extends EventEmitter {
         const scenario = feature.children.find((child) => compareScenarioLineWithSourceLine(child, sourceLocation))
         const step = getStepFromFeature(feature, this.currentPickle, testStepStartedEvent.index, sourceLocation)
 
+        if (step.type === 'Step') {
+            this.currentStep = { uri, feature, scenario, step, sourceLocation }
+        }
+
         this.emit('before-step', uri, feature, scenario, step, sourceLocation)
     }
 
@@ -184,6 +189,7 @@ export default class CucumberEventListener extends EventEmitter {
         this.emit('after-scenario', uri, feature, scenario, result, sourceLocation)
 
         this.currentPickle = null
+        this.currentStep = null
     }
 
     // testRunFinishedEvent = {
@@ -196,5 +202,9 @@ export default class CucumberEventListener extends EventEmitter {
         const feature = doc.feature
 
         this.emit('after-feature', uri, feature)
+    }
+
+    getCurrentStep () {
+        return this.currentStep
     }
 }

--- a/packages/wdio-cucumber-framework/src/cucumberEventListener.js
+++ b/packages/wdio-cucumber-framework/src/cucumberEventListener.js
@@ -7,7 +7,6 @@ export default class CucumberEventListener extends EventEmitter {
     acceptedPickles = []
     currentPickle = null
     currentStep = null
-    isStepRunning = false
     testCasePreparedEvents = []
 
     constructor (eventBroadcaster) {
@@ -110,7 +109,6 @@ export default class CucumberEventListener extends EventEmitter {
 
         if (step.type === 'Step') {
             this.currentStep = { uri, feature, scenario, step, sourceLocation }
-            this.isStepRunning = true
         }
 
         this.emit('before-step', uri, feature, scenario, step, sourceLocation)
@@ -174,10 +172,6 @@ export default class CucumberEventListener extends EventEmitter {
         const result = testStepFinishedEvent.result
 
         this.emit('after-step', uri, feature, scenario, step, result, sourceLocation)
-
-        if (this.isStepRunning === true && result.status !== 'passed') {
-            this.isStepRunning = false
-        }
     }
 
     // testCaseFinishedEvent = {
@@ -196,7 +190,6 @@ export default class CucumberEventListener extends EventEmitter {
 
         this.currentPickle = null
         this.currentStep = null
-        this.isStepRunning = false
     }
 
     // testRunFinishedEvent = {

--- a/packages/wdio-cucumber-framework/src/index.js
+++ b/packages/wdio-cucumber-framework/src/index.js
@@ -62,7 +62,7 @@ class CucumberAdapter {
              *
              * @return  {object|null}
              */
-            this.getCurrentStep = this.cucumberReporter.eventListener.getCurrentStep.bind(this.cucumberReporter.eventListener)
+            this.getCurrentStep = ::this.cucumberReporter.eventListener.getCurrentStep
 
             const pickleFilter = new Cucumber.PickleFilter({
                 featurePaths: this.specs,

--- a/packages/wdio-cucumber-framework/src/index.js
+++ b/packages/wdio-cucumber-framework/src/index.js
@@ -21,14 +21,6 @@ class CucumberAdapter {
         this.capabilities = capabilities
         this.config = config
         this.cucumberOpts = Object.assign(DEFAULT_OPTS, config.cucumberOpts)
-
-        /**
-         * gets current step data: `{ uri, feature, scenario, step, sourceLocation }`
-         * or `null` for some hooks.
-         *
-         * @return  {object|null}
-         */
-        this.getCurrentStep = () => this._getCurrentStep()
     }
 
     async run () {
@@ -63,7 +55,14 @@ class CucumberAdapter {
             }
 
             this.cucumberReporter = new CucumberReporter(eventBroadcaster, reporterOptions, this.cid, this.specs, this.reporter)
-            this._getCurrentStep = this.cucumberReporter.eventListener.getCurrentStep.bind(this.cucumberReporter.eventListener)
+
+            /**
+             * gets current step data: `{ uri, feature, scenario, step, sourceLocation }`
+             * or `null` for some hooks.
+             *
+             * @return  {object|null}
+             */
+            this.getCurrentStep = this.cucumberReporter.eventListener.getCurrentStep.bind(this.cucumberReporter.eventListener)
 
             const pickleFilter = new Cucumber.PickleFilter({
                 featurePaths: this.specs,
@@ -194,7 +193,7 @@ class CucumberAdapter {
     wrapSteps (config) {
         const wrapStep = this.wrapStep
         const cid = this.cid
-        const getCurrentStep = this.getCurrentStep
+        const getCurrentStep = () => this.getCurrentStep()
 
         Cucumber.setDefinitionFunctionWrapper((fn, options = {}) => {
             /**

--- a/packages/wdio-cucumber-framework/src/index.js
+++ b/packages/wdio-cucumber-framework/src/index.js
@@ -21,6 +21,14 @@ class CucumberAdapter {
         this.capabilities = capabilities
         this.config = config
         this.cucumberOpts = Object.assign(DEFAULT_OPTS, config.cucumberOpts)
+
+        /**
+         * gets current step data: `{ uri, feature, scenario, step, sourceLocation }`
+         * or `null` for some hooks.
+         *
+         * @return  {object|null}
+         */
+        this.getCurrentStep = () => this._getCurrentStep()
     }
 
     async run () {
@@ -55,6 +63,7 @@ class CucumberAdapter {
             }
 
             this.cucumberReporter = new CucumberReporter(eventBroadcaster, reporterOptions, this.cid, this.specs, this.reporter)
+            this._getCurrentStep = this.cucumberReporter.eventListener.getCurrentStep.bind(this.cucumberReporter.eventListener)
 
             const pickleFilter = new Cucumber.PickleFilter({
                 featurePaths: this.specs,
@@ -185,6 +194,7 @@ class CucumberAdapter {
     wrapSteps (config) {
         const wrapStep = this.wrapStep
         const cid = this.cid
+        const getCurrentStep = this.getCurrentStep
 
         Cucumber.setDefinitionFunctionWrapper((fn, options = {}) => {
             /**
@@ -202,20 +212,21 @@ class CucumberAdapter {
             const isStep = !fn.name.startsWith('userHook')
 
             const retryTest = isStep && isFinite(options.retry) ? parseInt(options.retry, 10) : 0
-            return wrapStep(fn, retryTest, isStep, config, cid)
+            return wrapStep(fn, retryTest, isStep, config, cid, getCurrentStep)
         })
     }
 
     /**
      * wrap step definition to enable retry ability
-     * @param   {Function}  code        step definitoon
-     * @param   {Number}    retryTest   amount of allowed repeats is case of a failure
+     * @param   {Function}  code            step definitoon
+     * @param   {Number}    retryTest       amount of allowed repeats is case of a failure
      * @param   {boolean}   isStep
      * @param   {object}    config
-     * @param   {string}    cid         cid
-     * @return  {Function}              wrapped step definiton for sync WebdriverIO code
+     * @param   {string}    cid             cid
+     * @param   {Function}  getCurrentStep  step definitoon
+     * @return  {Function}                  wrapped step definiton for sync WebdriverIO code
      */
-    wrapStep (code, retryTest = 0, isStep, config, cid) {
+    wrapStep (code, retryTest = 0, isStep, config, cid, getCurrentStep) {
         return function (...args) {
             /**
              * wrap user step/hook with wdio before/after hooks
@@ -226,8 +237,8 @@ class CucumberAdapter {
             return testFnWrapper.call(this,
                 isStep ? 'Step' : 'Hook',
                 { specFn: code, specFnArgs: args },
-                { beforeFn, beforeFnArgs: () => [uri, feature] },
-                { afterFn, afterFnArgs: () => [uri, feature] },
+                { beforeFn, beforeFnArgs: (context) => [uri, feature, getCurrentStep(), context] },
+                { afterFn, afterFnArgs: (context) => [uri, feature, getCurrentStep(), context] },
                 cid,
                 retryTest)
         }

--- a/packages/wdio-cucumber-framework/src/reporter.js
+++ b/packages/wdio-cucumber-framework/src/reporter.js
@@ -63,15 +63,11 @@ class CucumberReporter {
     handleAfterStep (uri, feature, scenario, step, result, /*sourceLocation*/) {
         const type = getStepType(step.type)
 
-        let stepData = { uri, feature, scenario, step }
         if (type === 'hook') {
-            if (!this.eventListener.isStepRunning) {
-                return this.afterHook(uri, feature, scenario, step, result)
-            }
-            stepData = this.eventListener.getCurrentStep()
+            return this.afterHook(uri, feature, scenario, step, result)
         }
 
-        return this.afterTest(stepData.uri, stepData.feature, stepData.scenario, stepData.step, result)
+        return this.afterTest(uri, feature, scenario, step, result)
     }
 
     afterHook (uri, feature, scenario, step, result) {

--- a/packages/wdio-cucumber-framework/src/reporter.js
+++ b/packages/wdio-cucumber-framework/src/reporter.js
@@ -63,10 +63,15 @@ class CucumberReporter {
     handleAfterStep (uri, feature, scenario, step, result, /*sourceLocation*/) {
         const type = getStepType(step.type)
 
+        let stepData = { uri, feature, scenario, step }
         if (type === 'hook') {
-            return this.afterHook(uri, feature, scenario, step, result)
+            if (!this.eventListener.isStepRunning) {
+                return this.afterHook(uri, feature, scenario, step, result)
+            }
+            stepData = this.eventListener.getCurrentStep()
         }
-        return this.afterTest(uri, feature, scenario, step, result)
+
+        return this.afterTest(stepData.uri, stepData.feature, stepData.scenario, stepData.step, result)
     }
 
     afterHook (uri, feature, scenario, step, result) {

--- a/packages/wdio-cucumber-framework/src/reporter.js
+++ b/packages/wdio-cucumber-framework/src/reporter.js
@@ -66,7 +66,6 @@ class CucumberReporter {
         if (type === 'hook') {
             return this.afterHook(uri, feature, scenario, step, result)
         }
-
         return this.afterTest(uri, feature, scenario, step, result)
     }
 

--- a/packages/wdio-cucumber-framework/src/utils.js
+++ b/packages/wdio-cucumber-framework/src/utils.js
@@ -155,6 +155,20 @@ export function getStepFromFeature(feature, pickle, stepIndex, sourceLocation) {
         }
         combinedSteps = combinedSteps.concat(child.steps)
     })
+
+    /**
+     * `wdioHookBeforeScenario` should be the first item
+     * otherwise it is swapped with `Background` step(s).
+     * Example:
+     * from: [background step, wdioHookBeforeScenario, userHook, step, userHook, wdioHookAfterScenario]
+     * to:   [wdioHookBeforeScenario, background step, userHook, step, userHook, wdioHookAfterScenario]
+     */
+    const wdioHooks = combinedSteps.filter(step => step.type === 'Hook' && step.location.uri && step.location.uri.includes('@wdio/cucumber-framework'))
+    const idx = combinedSteps.indexOf(wdioHooks[0])
+    if (wdioHooks.length === 2 && idx > 0) {
+        combinedSteps = [wdioHooks[0], ...combinedSteps.slice(0, idx), ...combinedSteps.slice(idx + 1)]
+    }
+
     const targetStep = combinedSteps[stepIndex]
 
     if (targetStep.type === 'Step') {

--- a/packages/wdio-cucumber-framework/src/utils.js
+++ b/packages/wdio-cucumber-framework/src/utils.js
@@ -147,17 +147,12 @@ export function compareScenarioLineWithSourceLine(scenario, sourceLocation) {
     return scenario.location.line === sourceLocation.line
 }
 
-export function getStepFromFeature (feature, pickle, stepIndex, sourceLocation) {
+export function getStepFromFeature(feature, pickle, stepIndex, sourceLocation) {
     let combinedSteps = []
     const background = feature.children.find((child) => child.type === 'Background')
     feature.children
-        .filter((child) => child.type !== 'Background')
-        .forEach((child) => {
-            if (child.type.indexOf('Scenario') > -1 && !compareScenarioLineWithSourceLine(child, sourceLocation)) {
-                return
-            }
-            combinedSteps = combinedSteps.concat(child.steps)
-        })
+        .filter((child) => child.type !== 'Background' && !(child.type.indexOf('Scenario') > -1 && !compareScenarioLineWithSourceLine(child, sourceLocation)))
+        .forEach((child) => { combinedSteps = combinedSteps.concat(child.steps) })
 
     /**
      * all the hooks are executed before `Background` step(s).

--- a/packages/wdio-cucumber-framework/src/utils.js
+++ b/packages/wdio-cucumber-framework/src/utils.js
@@ -160,8 +160,8 @@ export function getStepFromFeature(feature, pickle, stepIndex, sourceLocation) {
      * `wdioHookBeforeScenario` should be the first item
      * otherwise it is swapped with `Background` step(s).
      * Example:
-     * from: [background step, wdioHookBeforeScenario, userHook, step, userHook, wdioHookAfterScenario]
-     * to:   [wdioHookBeforeScenario, background step, userHook, step, userHook, wdioHookAfterScenario]
+     * from: [Background steps, wdioHookBeforeScenario, userHooks, steps, userHooks, wdioHookAfterScenario]
+     * to:   [wdioHookBeforeScenario, Background steps, userHooks, steps, userHooks, wdioHookAfterScenario]
      */
     const wdioHooks = combinedSteps.filter(step => step.type === 'Hook' && step.location.uri && step.location.uri.includes('@wdio/cucumber-framework'))
     const idx = combinedSteps.indexOf(wdioHooks[0])

--- a/packages/wdio-cucumber-framework/tests/adapter.test.js
+++ b/packages/wdio-cucumber-framework/tests/adapter.test.js
@@ -143,14 +143,14 @@ describe('wrapSteps', () => {
         const wrappedFunction = jest.fn()
 
         functionWrapper(wrappedFunction)
-        expect(adapter.wrapStep).toBeCalledWith(expect.any(Function), 0, true, adapter.config, '0-2')
+        expect(adapter.wrapStep).toBeCalledWith(expect.any(Function), 0, true, adapter.config, '0-2', expect.any(Function))
     })
 
     test('should use passed arguments', () => {
         const wrappedFunction = jest.fn()
 
         functionWrapper(wrappedFunction, { retry: 123 })
-        expect(adapter.wrapStep).toBeCalledWith(expect.any(Function), 123, true, adapter.config, '0-2')
+        expect(adapter.wrapStep).toBeCalledWith(expect.any(Function), 123, true, adapter.config, '0-2', expect.any(Function))
     })
 
     test('should not wrap wdio hooks', () => {
@@ -164,7 +164,7 @@ describe('wrapSteps', () => {
         const userHookFn = () => { }
 
         functionWrapper(userHookFn)
-        expect(adapter.wrapStep).toBeCalledWith(expect.any(Function), 0, false, adapter.config, '0-2')
+        expect(adapter.wrapStep).toBeCalledWith(expect.any(Function), 0, false, adapter.config, '0-2', expect.any(Function))
     })
 
     afterEach(() => {
@@ -191,29 +191,29 @@ describe('wrapStep', () => {
     test('should be proper type for Step', () => {
         const adapter = adapterFactory()
 
-        const fn = adapter.wrapStep('specFn', 3, true, adapter.config, 'cid')
+        const fn = adapter.wrapStep('specFn', 3, true, adapter.config, 'cid', jest.fn().mockImplementation(() => 'getCurrentStep'))
         fn(1, 2)
 
         expect(testFnWrapper).toBeCalledWith(...fnWrapperArgs('Step', 3))
 
         const beforeFnArgs = testFnWrapper.mock.calls[0][2].beforeFnArgs
-        expect(beforeFnArgs()).toEqual(['uri', 'feature'])
+        expect(beforeFnArgs('context')).toEqual(['uri', 'feature', 'getCurrentStep', 'context'])
         const afterFnArgs = testFnWrapper.mock.calls[0][3].afterFnArgs
-        expect(afterFnArgs()).toEqual(['uri', 'feature'])
+        expect(afterFnArgs('context')).toEqual(['uri', 'feature', 'getCurrentStep', 'context'])
     })
 
     test('should be proper type for Hook', () => {
         const adapter = adapterFactory()
 
-        const fn = adapter.wrapStep('specFn', undefined, false, adapter.config, 'cid')
+        const fn = adapter.wrapStep('specFn', undefined, false, adapter.config, 'cid', jest.fn().mockImplementation(() => 'getCurrentStep'))
         fn(1, 2)
 
         expect(testFnWrapper).toBeCalledWith(...fnWrapperArgs('Hook', 0))
 
         const beforeFnArgs = testFnWrapper.mock.calls[0][2].beforeFnArgs
-        expect(beforeFnArgs()).toEqual(['uri', 'feature'])
+        expect(beforeFnArgs('context')).toEqual(['uri', 'feature', 'getCurrentStep', 'context'])
         const afterFnArgs = testFnWrapper.mock.calls[0][3].afterFnArgs
-        expect(afterFnArgs()).toEqual(['uri', 'feature'])
+        expect(afterFnArgs('context')).toEqual(['uri', 'feature', 'getCurrentStep', 'context'])
     })
 })
 

--- a/packages/wdio-cucumber-framework/tests/eventListener.test.js
+++ b/packages/wdio-cucumber-framework/tests/eventListener.test.js
@@ -108,3 +108,13 @@ test('onTestCaseFinished', () => {
     expect(spy).toHaveBeenCalledTimes(1)
     expect(spy).toHaveBeenCalledWith(uri, feature, scenario, result, sourceLocation)
 })
+
+test('getCurrentStep', () => {
+    const eventBroadcaster = new EventEmitter()
+    const listener = new CucumberEventListener(eventBroadcaster)
+
+    expect(listener.getCurrentStep()).toBeNull()
+
+    listener.currentStep = 'foobar'
+    expect(listener.getCurrentStep()).toBe('foobar')
+})

--- a/packages/wdio-cucumber-framework/tests/utils.test.js
+++ b/packages/wdio-cucumber-framework/tests/utils.test.js
@@ -197,9 +197,9 @@ describe('utils', () => {
             const steps = pickle.steps.map(step => ({ type: step.type, text: step.text, location: step.locations[0] }))
             const expectedResult = [
                 wdioHookBeforeScenario,
+                userBeforeHook,
                 steps[0],
                 steps[1],
-                userBeforeHook,
                 steps[2],
                 steps[3],
                 userAfterHook,

--- a/packages/wdio-utils/tests/test-framework/testFnWrapper-sync.test.js
+++ b/packages/wdio-utils/tests/test-framework/testFnWrapper-sync.test.js
@@ -26,8 +26,8 @@ describe('testFnWrapper', () => {
         retries
     ]
 
-    it('should run fn in sync mode', async () => {
-        const args = buildArgs(origFn, undefined, () => ['beforeFnArgs'], () => [{ foo: 'bar' }])
+    it('should run fn in sync mode with mocha or jasmine', async () => {
+        const args = buildArgs(origFn, undefined, () => ['beforeFnArgs'], () => [{ foo: 'bar' }, 'context'])
         const result = await testFnWrapper(...args)
 
         expect(result).toBe('@wdio/sync: FooBar 0')
@@ -35,7 +35,24 @@ describe('testFnWrapper', () => {
         expect(executeHooksWithArgs).toBeCalledWith('beforeFn', ['beforeFnArgs'])
         expect(executeHooksWithArgs).toBeCalledWith('afterFn', [
             { duration: expect.any(Number), error: undefined, passed: true, foo: 'bar' },
+            'context',
             { duration: expect.any(Number), error: undefined, passed: true, result: '@wdio/sync: FooBar 0' }
+        ])
+    })
+
+    it('should run fn in sync mode with cucumber', async () => {
+        const args = buildArgs(origFn, undefined, () => ['beforeFnArgs'], () => [{ foo: 'bar' }, 2, 3, 4])
+        const result = await testFnWrapper(...args)
+
+        expect(result).toBe('@wdio/sync: FooBar 0')
+        expect(executeHooksWithArgs).toBeCalledTimes(2)
+        expect(executeHooksWithArgs).toBeCalledWith('beforeFn', ['beforeFnArgs'])
+        expect(executeHooksWithArgs).toBeCalledWith('afterFn', [
+            { foo: 'bar' },
+            2,
+            { duration: expect.any(Number), error: undefined, passed: true, result: '@wdio/sync: FooBar 0' },
+            3,
+            4
         ])
     })
 

--- a/scripts/templates/webdriverio.tpl.d.ts
+++ b/scripts/templates/webdriverio.tpl.d.ts
@@ -106,7 +106,7 @@ declare namespace WebdriverIO {
             args: any[]
         ): void;
 
-        beforeHook?(test: any, context: any): void;
+        beforeHook?(test: any, context: any, stepData?: any, world?: any): void;
 
         beforeSession?(
             config: Config,
@@ -116,7 +116,7 @@ declare namespace WebdriverIO {
 
         beforeSuite?(suite: Suite): void;
         beforeTest?(test: Test, context: any): void;
-        afterHook?(test: any, context: any, result: { error?: any, result?: any, passed: boolean, duration: number }): void;
+        afterHook?(test: any, context: any, result: { error?: any, result?: any, passed: boolean, duration: number }, stepData?: any, world?: any): void;
 
         after?(
             result: number,

--- a/tests/cucumber/step-definitions/given.js
+++ b/tests/cucumber/step-definitions/given.js
@@ -49,9 +49,12 @@ Given('I choose the {string} scenario', { retry: { wrapperOptions: { retry: 1 } 
     browser[scenario]()
 })
 
-Given('I go on the website {string}', function (url) {
+const stepText = 'I go on the website'
+Given(`${stepText} {string}`, function (url) {
     // World
     assert.strictEqual(typeof this.attach, 'function')
+    assert.strictEqual(browser.Cucumber_CurrentStepText.startsWith(stepText), true)
+    assert.strictEqual(browser.Cucumber_CurrentStepContext, this)
 
     browser.url(url)
 })

--- a/tests/helpers/config.js
+++ b/tests/helpers/config.js
@@ -50,12 +50,18 @@ exports.config = {
         browser.pause(30)
         browser.Cucumber_Test = 1
     },
-    beforeStep: async function () {
+    beforeStep: async function (uri, feature, stepData, context) {
         await browser.pause(20)
         browser.Cucumber_Test += 2
+        browser.Cucumber_CurrentStepText = stepData.step.text
+        browser.Cucumber_CurrentStepContext = context
     },
-    afterStep: function () {
+    afterStep: function (uri, feature, result, stepData, context) {
         browser.pause(25)
+        if (browser.Cucumber_CurrentStepText !== stepData.step.text ||
+            browser.Cucumber_CurrentStepContext !== context) {
+            throw new Error("step data doesn't match")
+        }
         browser.Cucumber_Test = 1
     },
     afterScenario: () => {

--- a/tests/typings/sync-cucumber/cucumber.ts
+++ b/tests/typings/sync-cucumber/cucumber.ts
@@ -4,9 +4,9 @@ const hook: WebdriverIO.HookFunctions = {
     },
     beforeScenario: function (uri, feature, scenario, sourceLocation) {
     },
-    beforeStep: function (uri, feature) {
+    beforeStep: function (uri, feature, stepData, context) {
     },
-    afterStep(uri: string, feature, { error, result, duration, passed }) {
+    afterStep(uri: string, feature, { error, result, duration, passed }, stepData, context) {
     },
     afterScenario: function (uri, feature, scenario, result, sourceLocation) {
     },


### PR DESCRIPTION
## Proposed changes

add stepData and context to before/after Step/Hook.

stepsData is `{ uri, feature, scenario, step, sourceLocation }`
context is Cucumber World

Fixes: #4248 #4396 #4500

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments
![image](https://user-images.githubusercontent.com/25589559/65810217-eb996f00-e1a7-11e9-9609-9cca12952f15.png)

Ref https://github.com/BorisOsipov/wdio-reportportal-reporter/issues/80

### Reviewers: @webdriverio/technical-committee
