### PR TITLE
Enable react$ react$$ typings

### DIFF
--- a/packages/webdriverio/webdriverio.d.ts
+++ b/packages/webdriverio/webdriverio.d.ts
@@ -108,8 +108,6 @@ declare namespace WebdriverIOAsync {
 declare var browser: WebdriverIOAsync.BrowserObject;
 declare var $: $;
 declare var $$: $$;
-declare var react$: react$;
-declare var react$$: react$$;
 
 declare module "webdriverio" {
     export = WebdriverIOAsync

--- a/packages/webdriverio/webdriverio.d.ts
+++ b/packages/webdriverio/webdriverio.d.ts
@@ -2,12 +2,16 @@
 
 type $ = (selector: string | Function) => Promise<WebdriverIOAsync.Element>;
 type $$ = (selector: string | Function) => Promise<WebdriverIOAsync.Element[]>;
+type react$ = (selector: string, props?: object, state?: any[] | number | string | object | boolean) => Promise<WebdriverIOAsync.Element>;
+type react$$ = (selector: string, props?: object, state?: any[] | number | string | object | boolean) => Promise<WebdriverIOAsync.Element[]>;
 
 // Element commands that should be wrapper with Promise
 type ElementPromise = Omit<WebdriverIO.Element,
     'addCommand'
     | '$'
     | '$$'
+    | 'react$'
+    | 'react$$'
     | 'selector'
     | 'elementId'
     | 'element-6066-11e4-a52e-4f735466cecf'
@@ -20,6 +24,8 @@ type ElementPromise = Omit<WebdriverIO.Element,
 interface AsyncSelectors {
     $: $;
     $$: $$;
+    react$: react$;
+    react$$: react$$;
 }
 
 // Element commands wrapper with Promise
@@ -38,7 +44,7 @@ type ElementStatic = Pick<WebdriverIO.Element,
 >;
 
 // Browser commands that should be wrapper with Promise
-type BrowserPromise = Omit<WebdriverIO.Browser, 'addCommand' | 'overwriteCommand' | 'options' | '$' | '$$' | 'touchAction'>;
+type BrowserPromise = Omit<WebdriverIO.Browser, 'addCommand' | 'overwriteCommand' | 'options' | '$' | '$$' | 'react$' | 'react$$' | 'touchAction'>;
 
 // Browser commands wrapper with Promise
 type BrowserAsync = {
@@ -102,6 +108,8 @@ declare namespace WebdriverIOAsync {
 declare var browser: WebdriverIOAsync.BrowserObject;
 declare var $: $;
 declare var $$: $$;
+declare var react$: react$;
+declare var react$$: react$$;
 
 declare module "webdriverio" {
     export = WebdriverIOAsync

--- a/tests/typings/webdriverio/async.ts
+++ b/tests/typings/webdriverio/async.ts
@@ -103,6 +103,10 @@ async function bar() {
     await reactElement.click()
     const reactElements = await reactWrapper.react$$('')
     await reactElements[0].click()
+    const reactElement2 = await react$('')
+    await reactElement2.click()
+    const reactElements2 = await react$$('')
+    await reactElements2[0].click()
 
     // touchAction
     const ele = await $('')
@@ -115,7 +119,7 @@ async function bar() {
     }
     await ele.touchAction(touchAction)
     await browser.touchAction(touchAction)
-    
+
     // dragAndDrop
     await ele.dragAndDrop(ele, 0)
 }


### PR DESCRIPTION
## Proposed changes

Currently, types are missed in `react$` and `react$$`
(Types are enabled in `browser.react$` and `browser.react$$`)

Therefore, I enabled them

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
