### PR TITLE
Remove args filter in executeHooksWithArgs

### DIFF
--- a/packages/wdio-sync/src/executeHooksWithArgs.js
+++ b/packages/wdio-sync/src/executeHooksWithArgs.js
@@ -24,7 +24,7 @@ export default function executeHooksWithArgs (hooks = [], args) {
      * make sure args is an array since we are calling apply
      */
     if (!Array.isArray(args)) {
-        args = [args].filter((hook) => typeof hook === 'function')
+        args = [args]
     }
 
     hooks = hooks.map((hook) => new Promise((resolve) => {

--- a/packages/wdio-utils/src/shim.js
+++ b/packages/wdio-utils/src/shim.js
@@ -14,7 +14,7 @@ let executeHooksWithArgs = async function executeHooksWithArgsShim (hooks, args)
      * make sure args is an array since we are calling apply
      */
     if (!Array.isArray(args)) {
-        args = [args].filter((hook) => typeof hook === 'function')
+        args = [args]
     }
 
     hooks = hooks.map((hook) => new Promise((resolve) => {

--- a/tests/helpers/hooks.conf.js
+++ b/tests/helpers/hooks.conf.js
@@ -49,4 +49,7 @@ exports.config = Object.assign({}, config, {
             throw new Error('wdio afterTest error: ' + test.title)
         }
     },
+    beforeSuite(suite) {
+        global.WDIO_SERVICE_BEFORE_SUITE = suite
+    }
 })

--- a/tests/mocha/wdio_hooks.js
+++ b/tests/mocha/wdio_hooks.js
@@ -7,6 +7,7 @@ before(async () => {
 describe('my feature 1', () => {
     it('should do stuff 1', () => {
         assert.equal(browser.getTitle(), 'Mock Page Title')
+        assert.equal(global.WDIO_SERVICE_BEFORE_SUITE.title, 'my feature 1')
     })
 })
 


### PR DESCRIPTION
## Proposed changes

Remove args filter in executeHooksWithArgs

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

Have no idea why have I added that filter, maybe by mistake or while debugging something.
We didn't have the filter before and I can't see any reason to have it.

If we need to filter out args typeof functions at the point (why?) I can change the filter to `.filter((hook) => typeof hook !== 'function')` and add a comment why we need it.

### Reviewers: @webdriverio/technical-committee
