### PR TITLE
Add eslint rule "no-else-return"

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,6 +30,7 @@ module.exports = {
     camelcase: ['error', { properties: 'never' }],
     'comma-spacing': ['error', { before: false, after: true }],
     'no-lonely-if': 'error',
+    'no-else-return': 'error',
     'no-tabs': 'error',
     'no-trailing-spaces': ['error', {
       skipBlankLines: false,

--- a/packages/wdio-allure-reporter/src/compoundError.js
+++ b/packages/wdio-allure-reporter/src/compoundError.js
@@ -11,7 +11,7 @@ export default class CompoundError extends Error {
         const message = ['CompoundError: One or more errors occurred. ---'].
             concat(innerErrors.map(x => {
                 if (x.stack) return `${indentAll(x.stack)}\n--- End of stack trace ---`
-                else return `   ${x.message}\n--- End of error message ---`
+                return `   ${x.message}\n--- End of error message ---`
             })).join('\n')
 
         super(message)


### PR DESCRIPTION
## Proposed changes

In https://github.com/webdriverio/webdriverio/pull/4566#discussion_r331599043 one of the comments was a code style change. I added the corresponding rule of that change to the eslint file, this will make code review easier in the future, as it will be automatic.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
(not really any of them, more like cleanup?)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

### Reviewers: @webdriverio/technical-committee
