### PR TITLE
Fix Chrome getLogTypes and getLogs Protocol

### DIFF
--- a/packages/wdio-protocols/protocols/chromium.json
+++ b/packages/wdio-protocols/protocols/chromium.json
@@ -415,7 +415,7 @@
       }
     }
   },
-  "/session/:sessionId/se/log/types": {
+  "/session/:sessionId/log/types": {
     "GET": {
       "command": "getLogTypes",
       "description": "Get available log types.",
@@ -428,7 +428,7 @@
       }
     }
   },
-  "/session/:sessionId/se/log": {
+  "/session/:sessionId/log": {
     "POST": {
       "command": "getLogs",
       "description": "Get the log for a given log type. Log buffer is reset after each request.",


### PR DESCRIPTION
## Proposed changes

Fix for chrome getLogs and getLogTypes to chromium protocol.

## Types of changes

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

Updated chromium protocol as per https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidlogtypes

### Reviewers: @webdriverio/technical-committee
