### PR TITLE
Print hooks as they appear in spec reporter

### DIFF
--- a/packages/wdio-reporter/src/index.js
+++ b/packages/wdio-reporter/src/index.js
@@ -70,6 +70,7 @@ export default class WDIOReporter extends EventEmitter {
             const hookStat = new HookStats(hook)
             const currentSuite = this.currentSuites[this.currentSuites.length - 1]
             currentSuite.hooks.push(hookStat)
+            currentSuite.hooksAndTests.push(hookStat)
             this.hooks[hook.uid] = hookStat
             this.onHookStart(hookStat)
         })
@@ -85,6 +86,7 @@ export default class WDIOReporter extends EventEmitter {
             currentTest = new TestStats(test)
             const currentSuite = this.currentSuites[this.currentSuites.length - 1]
             currentSuite.tests.push(currentTest)
+            currentSuite.hooksAndTests.push(currentTest)
             this.tests[test.uid] = currentTest
             this.onTestStart(currentTest)
         })
@@ -131,8 +133,10 @@ export default class WDIOReporter extends EventEmitter {
             const suiteTests = currentSuite.tests
             if (!suiteTests.length || currentTest.uid !== suiteTests[suiteTests.length - 1].uid) {
                 currentSuite.tests.push(currentTest)
+                currentSuite.hooksAndTests.push(currentTest)
             } else {
                 suiteTests[suiteTests.length - 1] = currentTest
+                currentSuite.hooksAndTests[ currentSuite.hooksAndTests.length - 1] = currentTest
             }
 
             this.tests[currentTest.uid] = currentTest

--- a/packages/wdio-reporter/src/index.js
+++ b/packages/wdio-reporter/src/index.js
@@ -136,7 +136,7 @@ export default class WDIOReporter extends EventEmitter {
                 currentSuite.hooksAndTests.push(currentTest)
             } else {
                 suiteTests[suiteTests.length - 1] = currentTest
-                currentSuite.hooksAndTests[ currentSuite.hooksAndTests.length - 1] = currentTest
+                currentSuite.hooksAndTests[currentSuite.hooksAndTests.length - 1] = currentTest
             }
 
             this.tests[currentTest.uid] = currentTest

--- a/packages/wdio-reporter/src/stats/suite.js
+++ b/packages/wdio-reporter/src/stats/suite.js
@@ -14,5 +14,9 @@ export default class SuiteStats extends RunnableStats {
         this.tests = []
         this.hooks = []
         this.suites = []
+        /**
+         * an array of hooks and tests stored in order as they happen
+         */
+        this.hooksAndTests = []
     }
 }

--- a/packages/wdio-spec-reporter/src/index.js
+++ b/packages/wdio-spec-reporter/src/index.js
@@ -149,14 +149,12 @@ class SpecReporter extends WDIOReporter {
     getEventsToReport (suite) {
         return [
             /**
-             * report all tests
+             * report all tests and only hooks that failed
              */
-            ...suite.tests,
-            /**
-             * and only hooks that failed
-             */
-            ...suite.hooks
-                .filter((hook) => Boolean(hook.error))
+            ...suite.hooksAndTests
+                .filter((item) => {
+                    return item.type === 'test' || Boolean(item.error)
+                })
         ]
     }
 

--- a/packages/wdio-spec-reporter/tests/__fixtures__/testdata.js
+++ b/packages/wdio-spec-reporter/tests/__fixtures__/testdata.js
@@ -22,10 +22,12 @@ export const SUITES = [{
         uid: 'foo1',
         title: 'foo',
         state: 'passed',
+        type: 'test'
     }, {
         uid: 'bar1',
         title: 'bar',
         state: 'passed',
+        type: 'test'
     }]
 }, {
     uid: SUITE_UIDS[1],
@@ -35,10 +37,12 @@ export const SUITES = [{
         uid: 'some test1',
         title: 'some test',
         state: 'passed',
+        type: 'test'
     }, {
         uid: 'a failed test2',
         title: 'a failed test',
         state: 'failed',
+        type: 'test',
         error: {
             message: 'expected foo to equal bar',
             stack: 'Failed test stack trace'
@@ -59,12 +63,17 @@ export const SUITES = [{
         uid: 'foo bar baz1',
         title: 'foo bar baz',
         state: 'passed',
+        type: 'test'
     }, {
         uid: 'a skipped test2',
         title: 'a skipped test',
         state: 'skipped',
+        type: 'test'
     }]
 }]
+SUITES.forEach(suite => {
+    suite.hooksAndTests = [...suite.tests]
+})
 
 export const SUITES_WITH_DATA_TABLE = [{
     uid: SUITE_UIDS[0],
@@ -74,6 +83,7 @@ export const SUITES_WITH_DATA_TABLE = [{
         uid: 'foo1',
         title: 'foo',
         state: 'passed',
+        type: 'test',
         argument: {
             rows: [{
                 cells: ['Vegetable', 'Rating'],
@@ -109,8 +119,12 @@ export const SUITES_WITH_DATA_TABLE = [{
         uid: 'bar1',
         title: 'bar',
         state: 'passed',
+        type: 'test'
     }]
 }]
+SUITES_WITH_DATA_TABLE.forEach(suite => {
+    suite.hooksAndTests = [...suite.tests]
+})
 
 export const SUITES_MULTIPLE_ERRORS = [{
     uid: SUITE_UIDS[0],
@@ -120,10 +134,12 @@ export const SUITES_MULTIPLE_ERRORS = [{
         uid: 'foo1',
         title: 'foo',
         state: 'passed',
+        type: 'test'
     }, {
         uid: 'bar1',
         title: 'bar',
         state: 'passed',
+        type: 'test'
     }]
 }, {
     uid: SUITE_UIDS[1],
@@ -133,10 +149,12 @@ export const SUITES_MULTIPLE_ERRORS = [{
         uid: 'some test1',
         title: 'some test',
         state: 'passed',
+        type: 'test'
     }, {
         uid: 'a failed test',
         title: 'a test with two failures',
         state: 'failed',
+        type: 'test',
         errors: [{
             message: 'expected the party on the first part to be the party on the first part',
             stack: 'First failed stack trace'
@@ -146,13 +164,17 @@ export const SUITES_MULTIPLE_ERRORS = [{
         }]
     }]
 }]
+SUITES_MULTIPLE_ERRORS.forEach(suite => {
+    suite.hooksAndTests = [...suite.tests]
+})
 
 export const SUITES_NO_TESTS = [{
     uid: SUITE_UIDS[0],
     title: SUITE_UIDS[0].slice(0, -1),
     tests: [],
     suites: [],
-    hooks: []
+    hooks: [],
+    hooksAndTests: []
 }]
 
 export const SUITES_NO_TESTS_WITH_HOOK_ERROR = [{
@@ -170,6 +192,9 @@ export const SUITES_NO_TESTS_WITH_HOOK_ERROR = [{
         }
     }]
 }]
+SUITES_NO_TESTS_WITH_HOOK_ERROR.forEach(suite => {
+    suite.hooksAndTests = [...suite.hooks]
+})
 
 export const REPORT = `------------------------------------------------------------------
 [loremipsum #0-0] Spec: /foo/bar/baz.js

--- a/packages/wdio-spec-reporter/tests/index.test.js
+++ b/packages/wdio-spec-reporter/tests/index.test.js
@@ -78,13 +78,15 @@ describe('SpecReporter', () => {
     describe('getEventsToReport', () => {
         it('should return all tests and hook errors to report', () => {
             expect(tmpReporter.getEventsToReport({
-                tests: [1, 2, 3],
-                hooks: [4, 5, 6]
-            })).toEqual([1, 2, 3])
+                tests: [{ type: 'test',  title: '1' }, { type: 'test',  title: '2' }],
+                hooks: [{}],
+                hooksAndTests: [{}, { type: 'test',  title: '11' }, {}, { type: 'test',  title: '22' }, {}]
+            })).toEqual([{ type: 'test',  title: '11' }, { type: 'test',  title: '22' }])
             expect(tmpReporter.getEventsToReport({
-                tests: [1, 2, 3],
-                hooks: [{ error: 1 }, 5, { error: 2 }]
-            })).toEqual([1, 2, 3, { error: 1 }, { error: 2 }])
+                tests: [{ type: 'test',  title: '1' }, { type: 'test',  title: '2' }],
+                hooks: [{ error: 1 }, {}, { error: 2 }],
+                hooksAndTests: [{}, { error: 11 }, {}, { type: 'test',  title: '33' }, {}, { error: 22 }, {}]
+            })).toEqual([{ error: 11 }, { type: 'test',  title: '33' }, { error: 22 }])
         })
     })
 
@@ -294,7 +296,7 @@ describe('SpecReporter', () => {
         it('should not print if data table format is not given', () => {
             tmpReporter.getOrderedSuites = jest.fn(() => {
                 const suites = JSON.parse(JSON.stringify(SUITES_WITH_DATA_TABLE))
-                suites[0].tests[0].argument = 'some different format'
+                suites[0].hooksAndTests[0].argument = 'some different format'
                 return suites
             })
             const result = tmpReporter.getResultDisplay()
@@ -304,7 +306,7 @@ describe('SpecReporter', () => {
         it('should not print if data table is empty', () => {
             tmpReporter.getOrderedSuites = jest.fn(() => {
                 const suites = JSON.parse(JSON.stringify(SUITES_WITH_DATA_TABLE))
-                suites[0].tests[0].argument.rows = []
+                suites[0].hooksAndTests[0].argument.rows = []
                 return suites
             })
 


### PR DESCRIPTION
## Proposed changes

Print hooks as they appear in spec reporter for Jasmine and Cucumber. Mocha is not affected.

Added combined list of hooks/tests to store them in order as they appear.

![image](https://user-images.githubusercontent.com/25589559/66261264-6119c680-e7ca-11e9-8e21-cf6ae7ce7865.png)
![image](https://user-images.githubusercontent.com/25589559/66261267-67a83e00-e7ca-11e9-8b63-ebb1c970686b.png)

fixes #4571 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works

## Further comments

ref https://github.com/webdriverio/webdriverio/pull/4572 https://github.com/webdriverio/webdriverio/pull/4566

@martinfrancois 

### Reviewers: @webdriverio/technical-committee
