### PR TITLE
Report pendingReason from Jasmine tests

### DIFF
--- a/packages/wdio-jasmine-framework/src/reporter.js
+++ b/packages/wdio-jasmine-framework/src/reporter.js
@@ -104,6 +104,7 @@ export default class JasmineReporter {
             title: payload.description,
             fullTitle: payload.fullName,
             pending: payload.status === 'pending',
+            pendingReason: payload.pendingReason,
             parent: this.parent.length ? this.getUniqueIdentifier(this.parent[this.parent.length - 1]) : null,
             type: payload.type,
             // We maintain the single error property for backwards compatibility with reporters

--- a/packages/wdio-jasmine-framework/tests/reporter.test.js
+++ b/packages/wdio-jasmine-framework/tests/reporter.test.js
@@ -60,12 +60,13 @@ test('specDone', () => {
     expect(runnerReporter.emit.mock.calls[5][1].uid).toBe('some failing test spec25')
 
     jasmineReporter.specDone({
-        id: 26, description: 'some pending test spec', failedExpectations: [], status: 'pending'
+        id: 26, description: 'some pending test spec', failedExpectations: [], status: 'pending', pendingReason: 'for no reason'
     })
     expect(runnerReporter.emit.mock.calls[6][0]).toBe('test:pending')
     expect(runnerReporter.emit.mock.calls[6][1].cid).toBe('0-2')
     expect(runnerReporter.emit.mock.calls[6][1].uid).toBe('some pending test spec26')
     expect(runnerReporter.emit.mock.calls[6][1].pending).toBe(true)
+    expect(runnerReporter.emit.mock.calls[6][1].pendingReason).toBe('for no reason')
     expect(runnerReporter.emit.mock.calls[7][0]).toBe('test:end')
     expect(runnerReporter.emit.mock.calls[7][1].uid).toBe('some pending test spec26')
 

--- a/packages/wdio-reporter/src/index.js
+++ b/packages/wdio-reporter/src/index.js
@@ -140,7 +140,7 @@ export default class WDIOReporter extends EventEmitter {
             }
 
             this.tests[currentTest.uid] = currentTest
-            currentTest.skip()
+            currentTest.skip(test.pendingReason)
             this.counts.skipping++
             this.counts.tests++
             this.onTestSkip(currentTest)

--- a/packages/wdio-reporter/src/stats/test.js
+++ b/packages/wdio-reporter/src/stats/test.js
@@ -26,7 +26,8 @@ export default class TestStats extends RunnableStats {
         this.state = 'passed'
     }
 
-    skip () {
+    skip (reason) {
+        this.pendingReason = reason
         this.state = 'skipped'
     }
 

--- a/packages/wdio-reporter/tests/test.stats.test.js
+++ b/packages/wdio-reporter/tests/test.stats.test.js
@@ -28,8 +28,9 @@ describe('TestStats', () => {
     })
 
     it('can get skipped', () => {
-        stat.skip()
+        stat.skip('for no reason')
         expect(stat.state).toBe('skipped')
+        expect(stat.pendingReason).toBe('for no reason')
         expect(stat.complete.mock.calls).toHaveLength(0)
     })
 


### PR DESCRIPTION
## Proposed changes

This solves the problem that the pending reason given using `pending("reason")` in a Jasmine test case is not propagated to the wdio reporter and can thus not be used in custom reporters.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

This affects two packages, both the `wdio-jasmine-framework` as well as the `wdio-reporter`, but since there is a dependency in at least one direction (reporter depends on Jasmine framework), I submit a single PR.

Feel free to adapt/edit/improve/..., all I want is a pending reason in my custom reporter ;-)

### Reviewers: @webdriverio/technical-committee
