### PR TITLE
touchAction should be used with Appium

### DIFF
--- a/packages/webdriverio/src/commands/constant.js
+++ b/packages/webdriverio/src/commands/constant.js
@@ -82,6 +82,9 @@ export const validateParameters = (params) => {
 }
 
 export const touchAction = function (actions) {
+    if (!this.multiTouchPerform || !this.touchPerform) {
+        throw new Error('touchAction can be used with Appium only.')
+    }
     if (!Array.isArray(actions)) {
         actions = [actions]
     }

--- a/packages/webdriverio/tests/commands/browser/touchAction.test.js
+++ b/packages/webdriverio/tests/commands/browser/touchAction.test.js
@@ -94,6 +94,16 @@ describe('touchAction test', () => {
         })
     })
 
+    describe('wrong protocol', () => {
+        it('should transform object into array', async () => {
+            const desktopBrowser = await remote({
+                capabilities: { browserName: 'foobar' }
+            })
+
+            expect(() => desktopBrowser.touchAction(['release'])).toThrow('touchAction can be used with Appium only.')
+        })
+    })
+
     beforeEach(() => {
         request.mockClear()
     })


### PR DESCRIPTION
## Proposed changes

Show better error if `touchAction` is used not with Appium.
```
[chrome  mac os x #0-0] Error: touchAction can be used with Appium only.
```

## Types of changes

- [x] polish

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

#4595

### Reviewers: @webdriverio/technical-committee
