### PR TITLE
reset _NOT_FIBER flag on Timer timeout

### DIFF
--- a/packages/wdio-sync/src/wrapCommand.js
+++ b/packages/wdio-sync/src/wrapCommand.js
@@ -5,8 +5,8 @@ import executeHooksWithArgs from './executeHooksWithArgs'
 import { sanitizeErrorMessage } from './utils'
 
 const log = logger('@wdio/sync')
-let inCommandHook = false
 
+let inCommandHook = false
 const timers = []
 const elements = new Set()
 

--- a/packages/wdio-sync/tests/wrapCommand.test.js
+++ b/packages/wdio-sync/tests/wrapCommand.test.js
@@ -16,10 +16,12 @@ describe('wrapCommand:runCommand', () => {
     })
 
     it('should return result', async () => {
+        process.emit('WDIO_TIMER', { id: 0, start: true })
         const fn = jest.fn(x => (x + x))
         const runCommand = wrapCommand('foo', fn)
         const result = await runCommand.call({ options: {} }, 'bar')
         expect(result).toEqual('barbar')
+        process.emit('WDIO_TIMER', { id: 0 })
     })
 
     it('should set _NOT_FIBER to false if elementId is missing', async () => {
@@ -187,6 +189,21 @@ describe('wrapCommand:runCommand', () => {
             }
             expect(context._NOT_FIBER).toBe(false)
             expect.assertions(2)
+        })
+    })
+
+    /**
+     * actual testing is done with smoke tests
+     * only branch coverage here
+     */
+    describe('WDIO_TIMER', () => {
+        it('WDIO_TIMER listener', () => {
+            process.emit('WDIO_TIMER', { id: 1, start: true })
+            process.emit('WDIO_TIMER', { id: 1 })
+
+            process.emit('WDIO_TIMER', { id: 2, start: true })
+            process.emit('WDIO_TIMER', { id: 3, start: true })
+            process.emit('WDIO_TIMER', { id: 2, timeout: true })
         })
     })
 

--- a/packages/wdio-utils/tests/__mocks__/@wdio/utils.js
+++ b/packages/wdio-utils/tests/__mocks__/@wdio/utils.js
@@ -64,5 +64,6 @@ export const runFnInFiberContext = jest.fn().mockImplementation((fn) => {
         return Promise.resolve(fn.apply(this, args))
     }
 })
+export const setWdioSyncSupport = value => { hasWdioSyncSupport = value }
 export let hasWdioSyncSupport = false
 export const testFnWrapper = jest.fn()

--- a/packages/webdriverio/src/utils/Timer.js
+++ b/packages/webdriverio/src/utils/Timer.js
@@ -41,6 +41,7 @@ class Timer {
     start () {
         this._start = Date.now()
         this._ticks = 0
+        emitTimerEvent({ id: this._start, start: true })
         if (this._leading) {
             this.tick()
         } else {
@@ -55,6 +56,7 @@ class Timer {
                 return
             }
 
+            emitTimerEvent({ id: this._start, timeout: true })
             const reason = this.lastError || new Error(TIMEOUT_ERROR)
             this._reject(reason)
             this.stop()
@@ -69,6 +71,7 @@ class Timer {
     }
 
     stopMain () {
+        emitTimerEvent({ id: this._start })
         clearTimeout(this._mainTimeoutId)
     }
 
@@ -124,6 +127,16 @@ class Timer {
 
     wasConditionExecuted () {
         return this._conditionExecutedCnt > 0
+    }
+}
+
+/**
+ * emit `WDIO_TIMER` event
+ * @param   {object}  payload
+ */
+function emitTimerEvent(payload) {
+    if (hasWdioSyncSupport) {
+        process.emit('WDIO_TIMER', payload)
     }
 }
 

--- a/packages/webdriverio/tests/utils/Timer.test.js
+++ b/packages/webdriverio/tests/utils/Timer.test.js
@@ -1,20 +1,26 @@
+import { setWdioSyncSupport, runFnInFiberContext } from '@wdio/utils'
 import Timer from '../../src/utils/Timer'
 
 describe('timer', () => {
+    const processEmitSpy = jest.spyOn(process, 'emit')
+
     describe('promise', () => {
         it('should be rejected by timeout', async () => {
             let timer = new Timer(20, 30, () => Promise.resolve(false))
             await expect(timer).rejects.toMatchObject(new Error('timeout'))
+            expect(processEmitSpy).not.toBeCalled()
         })
 
         it('should be fulfilled when resolved with true value', async () => {
             let timer = new Timer(20, 30, () => Promise.resolve(true))
             await expect(timer).resolves
+            expect(processEmitSpy).not.toBeCalled()
         })
 
         it('should not be fulfilled when resolved with false value', async () => {
             let timer = new Timer(20, 30, () => Promise.resolve(false))
             await expect(timer).rejects.toMatchObject(new Error('timeout'))
+            expect(processEmitSpy).not.toBeCalled()
         })
 
         it('should be rejected', async () => {
@@ -49,5 +55,42 @@ describe('timer', () => {
     it('should execute synchronously', async () => {
         let timer = new Timer(20, 30, () => Promise.resolve(true), () => {return true}, true)
         await expect(timer).resolves
+    })
+
+    describe('emitTimerEvent', () => {
+        it('should trigger events', async () => {
+            setWdioSyncSupport(true)
+            await new Timer(20, 30, () => Promise.resolve(true))
+            expect(processEmitSpy).toBeCalledWith('WDIO_TIMER', { id: expect.any(Number), start: true })
+            expect(processEmitSpy).toBeCalledWith('WDIO_TIMER', { id: expect.any(Number) })
+        })
+
+        it('should trigger timeout event', async () => {
+            runFnInFiberContext.mockImplementation((fn) => {
+                return function (...args) {
+                    return fn(...args)
+                }
+            })
+            try {
+                await new Timer(100, 200, () => new Promise((resolve, reject) =>
+                    setTimeout(() => {
+                        return reject()
+                    }, 50)
+                ))
+            } catch (err) {
+                // ignored
+            }
+            expect(processEmitSpy).toBeCalledWith('WDIO_TIMER', { id: expect.any(Number), start: true })
+            expect(processEmitSpy).toBeCalledWith('WDIO_TIMER', { id: expect.any(Number), timeout: true })
+        })
+
+        afterAll(() => {
+            setWdioSyncSupport(false)
+        })
+    })
+
+    afterEach(() => {
+        runFnInFiberContext.mockClear()
+        processEmitSpy.mockClear()
     })
 })

--- a/tests/mocha/test-middleware.js
+++ b/tests/mocha/test-middleware.js
@@ -1,0 +1,21 @@
+import assert from 'assert'
+
+describe('Mocha smoke test', () => {
+    describe('middleware', () => {
+        it('should wait for elements if not found immediately', () => {
+            browser.waitForElementScenario()
+            const elem = $('elem')
+            //Element will be found
+            assert.doesNotThrow(() => elem.click())
+        })
+
+        it('should refetch stale elements', () => {
+            browser.staleElementRefetchScenario()
+
+            const elem = $('elem')
+            elem.click()
+            // element becomes stale
+            elem.click()
+        })
+    })
+})

--- a/tests/mocha/test-waitForElement.js
+++ b/tests/mocha/test-waitForElement.js
@@ -1,0 +1,8 @@
+import assert from 'assert'
+
+describe('Mocha smoke test', () => {
+    it('should be able to wait for an element', () => {
+        browser.waitForDisplayedScenario()
+        assert($('elem').waitForDisplayed(), true)
+    })
+})

--- a/tests/mocha/test.js
+++ b/tests/mocha/test.js
@@ -17,7 +17,7 @@ describe('Mocha smoke test', () => {
 
     let hasRun = false
     it('should retry', () => {
-        if(!hasRun) {
+        if (!hasRun) {
             hasRun = true
             throw new Error('booom!')
         }
@@ -77,6 +77,20 @@ describe('Mocha smoke test', () => {
             // element becomes stale
             elem.click()
         })
+    })
+
+    it('should handle waitUntil timeout', () => {
+        browser.staleElementRefetchScenario()
+        const elem = $('elem')
+        try {
+            browser.waitUntil(() => {
+                elem.click()
+                return false
+            }, 1000)
+        } catch (err) {
+            // ignored
+        }
+        assert.equal(JSON.stringify(elem.getSize()), JSON.stringify({ width: 1, height: 2 }))
     })
 
     describe('isDisplayed', () => {

--- a/tests/mocha/test.js
+++ b/tests/mocha/test.js
@@ -23,11 +23,6 @@ describe('Mocha smoke test', () => {
         }
     }, 1)
 
-    it('should be able to wait for an element', () => {
-        browser.waitForDisplayedScenario()
-        assert($('elem').waitForDisplayed(), true)
-    })
-
     it('should work fine after catching an error', () => {
         browser.clickScenario()
 
@@ -59,24 +54,6 @@ describe('Mocha smoke test', () => {
         })
         assert.strictEqual(result, true)
         assert.deepEqual(results, ['https://mymockpage.com', 'https://mymockpage.com'])
-    })
-
-    describe('middleware', () => {
-        it('should wait for elements if not found immediately', () => {
-            browser.waitForElementScenario()
-            const elem = $('elem')
-            //Element will be found
-            assert.doesNotThrow(() => elem.click())
-        })
-
-        it('should refetch stale elements', () => {
-            browser.staleElementRefetchScenario()
-
-            const elem = $('elem')
-            elem.click()
-            // element becomes stale
-            elem.click()
-        })
     })
 
     it('should handle waitUntil timeout', () => {

--- a/tests/smoke.runner.js
+++ b/tests/smoke.runner.js
@@ -20,7 +20,13 @@ const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms))
 const mochaTestrunner = async () => {
     await launch(
         path.resolve(__dirname, 'helpers', 'config.js'),
-        { specs: [path.resolve(__dirname, 'mocha', 'test.js')] })
+        {
+            specs: [
+                path.resolve(__dirname, 'mocha', 'test.js'),
+                path.resolve(__dirname, 'mocha', 'test-middleware.js'),
+                path.resolve(__dirname, 'mocha', 'test-waitForElement.js')
+            ]
+        })
 }
 /**
  * Jasmine wdio testrunner tests


### PR DESCRIPTION
## Proposed changes

fixes #4599

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

`_NOT_FIBER` should be somehow reseted on timeout in Timer. Have no idea how to deal with it better

### Reviewers: @webdriverio/technical-committee
