### PR TITLE
Wdio sync executeAsync tests

### DIFF
--- a/packages/wdio-sync/tests/index.test.js
+++ b/packages/wdio-sync/tests/index.test.js
@@ -1,4 +1,4 @@
-import { executeSync, runSync } from '../src'
+import { executeSync, runSync, executeAsync } from '../src'
 
 beforeAll(() => {
     if (!global.browser) {
@@ -55,7 +55,7 @@ describe('executeSync', () => {
         expect(counter).toEqual(0)
     })
 
-    it('should throw if repeatTest attemps exceeded', async () => {
+    it('should throw if repeatTest attempts exceeded', async () => {
         let counter = 3
         let error
         try {
@@ -70,6 +70,65 @@ describe('executeSync', () => {
             error = err
         }
         expect(error.message).toEqual('foobar')
+    })
+})
+
+describe('executeAsync', () => {
+    it('should pass with default values and fn returning synchronous value', async () => {
+        const result = await executeAsync(() => 'foo')
+        expect(result).toEqual('foo')
+    })
+
+    it('should pass when optional arguments are passed', async () => {
+        const result = await executeAsync(async arg => arg, 1, ['foo'])
+        expect(result).toEqual('foo')
+    })
+
+    it('should reject if fn throws error directly', async () => {
+        let error
+        const hook = () => {throw new Error('foo')}
+        try {
+            await executeAsync(hook)
+        } catch (e) {
+            error = e
+        }
+        expect(error.message).toEqual('foo')
+    })
+
+    it('should repeat if fn throws error directly and repeatTest provided', async () => {
+        let counter = 3
+        const result = await executeAsync(() => {
+            if (counter > 0) {
+                counter--
+                throw new Error('foo')
+            }
+            return true
+        }, counter)
+        expect(result).toEqual(true)
+        expect(counter).toEqual(0)
+    })
+
+    it('should return rejected promise if fn rejects', async () => {
+        let error
+        try {
+            await executeAsync(() => Promise.reject('foo'), 1)
+        } catch (e) {
+            error = e
+        }
+        expect(error).toEqual('foo')
+    })
+
+    it('should repeat if fn rejects and repeatTest provided', async () => {
+        let counter = 3
+        const result = await executeAsync(() => {
+            if (counter > 0) {
+                counter--
+                return Promise.reject('foo')
+            }
+            return true
+        }, counter)
+        expect(result).toEqual(true)
+        expect(counter).toEqual(0)
     })
 })
 

--- a/packages/wdio-sync/tests/index.test.js
+++ b/packages/wdio-sync/tests/index.test.js
@@ -111,11 +111,13 @@ describe('executeAsync', () => {
     it('should return rejected promise if fn rejects', async () => {
         let error
         try {
-            await executeAsync(() => Promise.reject('foo'), 1)
+            await executeAsync(() => Promise.reject({
+                stack: ' at node_modules/@wdio/sync/foo.js\n at src/localDir/localFile.js'
+            }))
         } catch (e) {
             error = e
         }
-        expect(error).toEqual('foo')
+        expect(error.stack).toEqual(' at src/localDir/localFile.js')
     })
 
     it('should repeat if fn rejects and repeatTest provided', async () => {


### PR DESCRIPTION
## Proposed changes

Add tests for executeAsync in @wdio/sync as per [this issue](https://github.com/webdriverio/webdriverio/issues/4292)

Additional slight refactor of executeAsynx to fix a bug.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments
Added tests for the executeAsync function. In doing so, I realised that if the hook returns a  promise which rejects, the stack filtering functionality was unreachable. I had a go at refactoring this, and I _think_ it should be fine, but there might well be implications to this that I have missed/don't know about. Let me know what you think.

Also fixed one or two typos in comments etc.

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
