### PR TITLE
Filter services that should not run in worker process

### DIFF
--- a/packages/wdio-config/src/constants.js
+++ b/packages/wdio-config/src/constants.js
@@ -74,3 +74,10 @@ export const SUPPORTED_HOOKS = [
     'beforeFeature', 'beforeScenario', 'beforeStep', 'afterStep', 'afterScenario', 'afterFeature',
     'onReload', 'onPrepare', 'onComplete'
 ]
+
+/**
+ * these services should not be started in worker process
+ */
+export const NON_WORKER_SERVICES = [
+    'chromedriver', 'selenium-standalone', 'appium', 'reportportal', 'firefox-profile'
+]

--- a/packages/wdio-config/src/lib/ConfigParser.js
+++ b/packages/wdio-config/src/lib/ConfigParser.js
@@ -7,7 +7,7 @@ import logger from '@wdio/logger'
 
 import { detectBackend } from '../utils'
 
-import { DEFAULT_CONFIGS, SUPPORTED_HOOKS } from '../constants'
+import { DEFAULT_CONFIGS, SUPPORTED_HOOKS, NON_WORKER_SERVICES } from '../constants'
 
 const log = logger('@wdio/config:ConfigParser')
 const MERGE_OPTIONS = { clone: false }
@@ -289,5 +289,17 @@ export default class ConfigParser {
         }
 
         return files
+    }
+
+    /**
+     * remove services that has nothing to do in worker
+     */
+    filterWorkerServices () {
+        if (!Array.isArray(this._config.services)) {
+            return
+        }
+        this._config.services = this._config.services.filter((service) => {
+            return !NON_WORKER_SERVICES.includes(service)
+        })
     }
 }

--- a/packages/wdio-config/tests/configparser.test.js
+++ b/packages/wdio-config/tests/configparser.test.js
@@ -335,4 +335,22 @@ describe('ConfigParser', () => {
             expect(config.key).toBe('50fa142c-3121-4gb0-9p07-8q326vvbq7b0')
         })
     })
+
+    describe('filterWorkerServices', () => {
+        const configParser = new ConfigParser()
+        configParser.addConfigFile(FIXTURES_CONF)
+        const config = configParser.getConfig()
+
+        it('should do nothing if services is not an array', () => {
+            config.services = null
+            configParser.filterWorkerServices()
+            expect(config.services).toBeNull()
+        })
+
+        it('should remove non worker services', () => {
+            config.services = ['sauce', 'selenium-standalone']
+            configParser.filterWorkerServices()
+            expect(config.services).toEqual(['sauce'])
+        })
+    })
 })

--- a/packages/wdio-runner/src/index.js
+++ b/packages/wdio-runner/src/index.js
@@ -54,6 +54,11 @@ export default class Runner extends EventEmitter {
          */
         this.configParser.merge(server)
 
+        /**
+         * remove services that has nothing to do in worker
+         */
+        this.configParser.filterWorkerServices()
+
         this.config = this.configParser.getConfig()
         logger.setLogLevelsConfig(this.config.logLevels, this.config.logLevel)
         this.isMultiremote = !Array.isArray(this.configParser.getCapabilities())

--- a/packages/wdio-runner/tests/index.test.js
+++ b/packages/wdio-runner/tests/index.test.js
@@ -285,6 +285,7 @@ describe('wdio-runner', () => {
                 framework: 'testWithFailures'
             }
             runner.configParser.getConfig = jest.fn().mockReturnValue(config)
+            runner.configParser.filterWorkerServices = jest.fn()
             runner._shutdown = jest.fn()
             runner._initSession = jest.fn().mockReturnValue({
                 capabilities: { browserName: 'chrome' },
@@ -309,6 +310,7 @@ describe('wdio-runner', () => {
                 beforeSession: []
             }
             runner.configParser.getConfig = jest.fn().mockReturnValue(config)
+            runner.configParser.filterWorkerServices = jest.fn()
             runner._initSession = jest.fn().mockReturnValue({ options: { capabilities: {} } })
             const failures = await runner.run({ argv: {}, caps: {} })
 
@@ -323,6 +325,7 @@ describe('wdio-runner', () => {
                 beforeSession: []
             }
             runner.configParser.getConfig = jest.fn().mockReturnValue(config)
+            runner.configParser.filterWorkerServices = jest.fn()
             global.browser = { url: jest.fn(url => url) }
             runner._initSession = jest.fn().mockReturnValue({ options: { capabilities: {} } })
             const failures = await runner.run({ argv: { watch: true }, caps: {} })
@@ -339,6 +342,7 @@ describe('wdio-runner', () => {
                 beforeSession: []
             }
             runner.configParser.getConfig = jest.fn().mockReturnValue(config)
+            runner.configParser.filterWorkerServices = jest.fn()
             runner._initSession = jest.fn().mockReturnValue({ options: { capabilities: {} } })
             runner.emit = jest.fn()
             const failures = await runner.run({ argv: {}, caps: {} })
@@ -357,6 +361,7 @@ describe('wdio-runner', () => {
                 beforeSession: []
             }
             runner.configParser.getConfig = jest.fn().mockReturnValue(config)
+            runner.configParser.filterWorkerServices = jest.fn()
             runner._shutdown = jest.fn()
             runner.endSession = jest.fn()
             runner._initSession = jest.fn().mockReturnValue({})
@@ -370,6 +375,7 @@ describe('wdio-runner', () => {
 
             expect(runner.endSession).toBeCalledTimes(1)
             expect(runner._shutdown).toBeCalledWith(0)
+            expect(runner.configParser.filterWorkerServices).toBeCalled()
         })
     })
 


### PR DESCRIPTION
## Proposed changes

avoid starting `'chromedriver', 'selenium-standalone', 'appium', 'reportportal', 'firefox-profile'` services in worker process

#4615 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

### Reviewers: @webdriverio/technical-committee
