### PR TITLE
Replace table with easy-table in @wdio/spec-repoter

### DIFF
--- a/packages/wdio-spec-reporter/package.json
+++ b/packages/wdio-spec-reporter/package.json
@@ -32,8 +32,8 @@
   "dependencies": {
     "@wdio/reporter": "5.14.5",
     "chalk": "^2.3.2",
-    "pretty-ms": "^5.0.0",
-    "table": "^5.4.2"
+    "easy-table": "^1.1.1",
+    "pretty-ms": "^5.0.0"
   },
   "peerDependencies": {
     "@wdio/cli": "^5.0.0"

--- a/packages/wdio-spec-reporter/src/index.js
+++ b/packages/wdio-spec-reporter/src/index.js
@@ -1,13 +1,7 @@
 import WDIOReporter from '@wdio/reporter'
 import chalk from 'chalk'
 import prettyMs from 'pretty-ms'
-import { table, getBorderCharacters } from 'table'
-
-export const DATA_TABLE_CONFIG = {
-    singleLine: true,
-    drawHorizontalLine: () => false,
-    border: getBorderCharacters('norc')
-}
+import { buildTableData, printTable, getFormattedRows } from './utils'
 
 class SpecReporter extends WDIOReporter {
     constructor (options) {
@@ -190,12 +184,10 @@ class SpecReporter extends WDIOReporter {
 
                 // print cucumber data table cells
                 if (test.argument && test.argument.rows && test.argument.rows.length) {
-                    const cells = test.argument.rows.map((row) => row.cells)
-                    output.push(...table(cells, DATA_TABLE_CONFIG)
-                        .split('\n')
-                        .filter(Boolean)
-                        .map((line) => `${testIndent}  ${line}`)
-                    )
+                    const data = buildTableData(test.argument.rows)
+                    const rawTable = printTable(data)
+                    const table = getFormattedRows(rawTable, testIndent)
+                    output.push(...table)
                 }
             }
 

--- a/packages/wdio-spec-reporter/src/utils.js
+++ b/packages/wdio-spec-reporter/src/utils.js
@@ -1,0 +1,34 @@
+import Table from 'easy-table'
+
+const SEPARATOR = '│'
+
+/**
+ * transform cucumber table to format suitable for `easy-table`
+ * @param   {object[]} rows cucumber table rows
+ * @returns {object[]}
+ */
+export const buildTableData = (rows) => rows.map(row => {
+    const tableRow = {};
+    [...row.cells, ''].forEach((cell, idx) => {
+        tableRow[idx] = (idx === 0 ? `${SEPARATOR} ` : '') + cell
+    })
+    return tableRow
+})
+
+/**
+ * returns table in string format
+ * @param   {object[]} data table data
+ * @returns {string}
+ */
+export const printTable = (data) => Table.print(data, null, (table) => {
+    table.separator = ` ${SEPARATOR} `
+    return table.print()
+})
+
+/**
+ * add indentation
+ * @param {string} table printed table
+ * @param {string} testIndent whitespaces
+ */
+export const getFormattedRows = (table, testIndent) =>
+    table.split('\n').filter(Boolean).map((line) => `${testIndent}  ${line}`.trimRight())


### PR DESCRIPTION
## Proposed changes

Replace `table` with `easy-table` in @wdio/spec-repoter to reduce memory usage per worker.
#4614

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

### Reviewers: @webdriverio/technical-committee
