### PR TITLE
Remove default path in cli

### DIFF
--- a/packages/wdio-cli/src/commands/run.js
+++ b/packages/wdio-cli/src/commands/run.js
@@ -27,7 +27,6 @@ export const cmdArgs = {
     },
     path: {
         type: 'string',
-        default: '/wd/hub',
         desc: 'path to WebDriver endpoints (default /wd/hub)'
     },
     user: {

--- a/packages/wdio-cli/tests/run.test.js
+++ b/packages/wdio-cli/tests/run.test.js
@@ -1,4 +1,4 @@
-import { launch } from '../src/commands/run'
+import { launch, cmdArgs } from '../src/commands/run'
 import Launcher from '../src/launcher'
 
 jest.mock('../src/launcher', () => jest.fn().mockImplementation((conf, result) => ({
@@ -34,5 +34,13 @@ describe('launch', () => {
 
     afterAll(() => {
         console.error.mockRestore()
+    })
+})
+
+describe('cmdArgs', () => {
+    it('should not have default', () => {
+        Object.values(cmdArgs).forEach(cmdArg => {
+            expect(cmdArg.default).toBeUndefined()
+        })
     })
 })


### PR DESCRIPTION
## Proposed changes

It's not possible to set `path` in wdio.conf, the only way to set it is via process args.

This PR fixes it.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

### Reviewers: @webdriverio/technical-committee
