### PR TITLE
Avoid wrapping it.only fn

### DIFF
--- a/packages/wdio-utils/tests/test-framework/testInterfaceWrapper.test.js
+++ b/packages/wdio-utils/tests/test-framework/testInterfaceWrapper.test.js
@@ -80,13 +80,17 @@ describe('wrapTestFunction', () => {
 describe('runTestInFiberContext', () => {
     it('should wrap skip and only functions', () => {
         const skipFn = () => { }
+        const onlyFn = function (...args) { return global.foobar(...args) }
         global.foobar = testFunction
-        global.foobar.only = testFnWrapper
+        global.foobar.only = onlyFn
         global.foobar.skip = skipFn
         runTestInFiberContext(true, 'beforeFn', () => [], 'afterFn', () => [], 'foobar', 'cid')
 
+        expect(global.foobar.skip).toBe(skipFn)
+        expect(global.foobar.only).toBe(onlyFn)
+
         const specFn = jest.fn()
-        global.foobar('test title', specFn, 3)
+        global.foobar.only('test title', specFn, 3)
         expect(testFnWrapper).toBeCalledWith(
             'Test',
             { specFn, specFnArgs: ['foo', 'bar'] },


### PR DESCRIPTION
## Proposed changes

run hooks only once for `it.only`

fixes #4631

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

### Reviewers: @webdriverio/technical-committee
