### PR TITLE
isDisplayedInViewport returns false if element is missing

### DIFF
--- a/packages/webdriverio/src/commands/element/isDisplayed.js
+++ b/packages/webdriverio/src/commands/element/isDisplayed.js
@@ -41,7 +41,7 @@
  */
 
 import { ELEMENT_KEY } from '../../constants'
-import { getBrowserObject } from '../../utils'
+import { getBrowserObject, hasElementId } from '../../utils'
 import isElementDisplayedScript from '../../scripts/isElementDisplayed'
 
 const noW3CEndpoint = ['microsoftedge', 'safari', 'chrome']
@@ -50,19 +50,7 @@ export default async function isDisplayed() {
 
     let browser = getBrowserObject(this)
 
-    /*
-     * This is only necessary as isDisplayed is on the exclusion list for the middleware
-     */
-    if (!this.elementId) {
-        const method = this.isReactElement ? 'react$' : '$'
-
-        this.elementId = (await this.parent[method](this.selector)).elementId
-    }
-
-    /*
-     * if element was still not found it also is not displayed
-     */
-    if (!this.elementId) {
+    if (!await hasElementId(this)) {
         return false
     }
 

--- a/packages/webdriverio/src/commands/element/isDisplayedInViewport.js
+++ b/packages/webdriverio/src/commands/element/isDisplayedInViewport.js
@@ -37,10 +37,14 @@
  */
 
 import { ELEMENT_KEY } from '../../constants'
-import { getBrowserObject } from '../../utils'
+import { getBrowserObject, hasElementId } from '../../utils'
 import isDisplayedInViewportScript from '../../scripts/isDisplayedInViewport'
 
-export default function isDisplayedInViewport () {
+export default async function isDisplayedInViewport () {
+    if (!await hasElementId(this)) {
+        return false
+    }
+
     return getBrowserObject(this).execute(isDisplayedInViewportScript, {
         [ELEMENT_KEY]: this.elementId, // w3c compatible
         ELEMENT: this.elementId // jsonwp compatible

--- a/packages/webdriverio/src/utils.js
+++ b/packages/webdriverio/src/utils.js
@@ -360,3 +360,22 @@ export function validateUrl (url, origError) {
 export function getScrollPosition (scope) {
     return getBrowserObject(scope).execute('return { scrollX: this.pageXOffset, scrollY: this.pageYOffset };')
 }
+
+export async function hasElementId (element) {
+    /*
+     * This is only necessary as isDisplayed is on the exclusion list for the middleware
+     */
+    if (!element.elementId) {
+        const method = element.isReactElement ? 'react$' : '$'
+
+        element.elementId = (await element.parent[method](element.selector)).elementId
+    }
+
+    /*
+     * if element was still not found it also is not displayed
+     */
+    if (!element.elementId) {
+        return false
+    }
+    return true
+}

--- a/packages/webdriverio/tests/commands/element/isDisplayedInViewport.test.js
+++ b/packages/webdriverio/tests/commands/element/isDisplayedInViewport.test.js
@@ -28,6 +28,12 @@ describe('isDisplayedInViewport test', () => {
         })
     })
 
+    it('should return false if element can\'t be found after refetching it', async () => {
+        const elem = await browser.$('#nonexisting')
+        expect(await elem.isDisplayedInViewport()).toBe(false)
+        expect(request).toBeCalledTimes(2)
+    })
+
     afterEach(() => {
         request.mockClear()
     })


### PR DESCRIPTION
## Proposed changes

`isDisplayedInViewport` returns `false` if element is missing.

fixes 1 of 2 issues in #4646

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

### Reviewers: @webdriverio/technical-committee
