### PR TITLE
Fix attach to session caps

### DIFF
--- a/packages/wdio-allure-reporter/src/index.js
+++ b/packages/wdio-allure-reporter/src/index.js
@@ -15,6 +15,7 @@ class AllureReporter extends WDIOReporter {
             useCucumberStepReporter
         })
         this.config = {}
+        this.capabilities = {}
         this.allure = new Allure()
 
         this.allure.setOptions({ targetDir: outputDir })
@@ -38,6 +39,7 @@ class AllureReporter extends WDIOReporter {
 
     onRunnerStart(runner) {
         this.config = runner.config
+        this.capabilities = runner.capabilities
         this.isMultiremote = runner.isMultiremote || false
     }
 
@@ -98,9 +100,9 @@ class AllureReporter extends WDIOReporter {
         const currentTest = this.allure.getCurrentTest()
 
         if (!this.isMultiremote) {
-            const { browserName, deviceName } = this.config.capabilities
+            const { browserName, deviceName } = this.capabilities
             const targetName = browserName || deviceName || cid
-            const version = this.config.capabilities.version || this.config.capabilities.platformVersion || ''
+            const version = this.capabilities.version || this.capabilities.platformVersion || ''
             const paramName = deviceName ? 'device' : 'browser'
             const paramValue = version ? `${targetName}-${version}` : targetName
             currentTest.addParameter('argument', paramName, paramValue)

--- a/packages/wdio-allure-reporter/tests/__fixtures__/runner.js
+++ b/packages/wdio-allure-reporter/tests/__fixtures__/runner.js
@@ -3,9 +3,9 @@ const runner =  () => ({
     start: '2018-05-14T15:17:18.901Z',
     _duration: 0,
     cid: '0-0',
-    capabilities: { foo: 'bar' },
+    capabilities: { browserName: 'chrome', version: '68' }, // session capabilities
     sanitizedCapabilities: 'chrome.66_0_3359_170.linux',
-    config: { capabilities: { browserName: 'chrome', version: '68' } },
+    config: { capabilities: { browserName: 'chrome' } }, // user capabilities
     specs: ['/tmp/user/spec.js']
 })
 

--- a/packages/wdio-allure-reporter/tests/allureFeatures.test.js
+++ b/packages/wdio-allure-reporter/tests/allureFeatures.test.js
@@ -278,14 +278,14 @@ describe('reporter runtime implementation', () => {
         })
 
         it('should correctly add argument for selenium', () => {
-            reporter.onRunnerStart({ config: { capabilities: { browserName: 'firefox', version: '1.2.3' } } })
+            reporter.onRunnerStart({ config: { }, capabilities: { browserName: 'firefox', version: '1.2.3' } })
             reporter.onTestStart({ cid: '0-0', title: 'SomeTest' })
             expect(addParameter).toHaveBeenCalledTimes(1)
             expect(addParameter).toHaveBeenCalledWith('argument', 'browser', 'firefox-1.2.3')
         })
 
         it('should correctly add argument for appium', () => {
-            reporter.onRunnerStart({ config: { capabilities: { deviceName: 'Android Emulator', platformVersion: '8.0' } } })
+            reporter.onRunnerStart({ config: { }, capabilities: { deviceName: 'Android Emulator', platformVersion: '8.0' } })
             reporter.onTestStart({ cid: '0-0', title: 'SomeTest' })
             expect(addParameter).toHaveBeenCalledTimes(1)
             expect(addParameter).toHaveBeenCalledWith('argument', 'device', 'Android Emulator-8.0')

--- a/packages/wdio-allure-reporter/tests/suite.test.js
+++ b/packages/wdio-allure-reporter/tests/suite.test.js
@@ -133,8 +133,8 @@ describe('Failed tests', () => {
         const reporter = new AllureReporter({ stdout: true, outputDir })
 
         const runnerEvent = runnerStart()
-        delete runnerEvent.config.capabilities.browserName
-        delete runnerEvent.config.capabilities.version
+        delete runnerEvent.capabilities.browserName
+        delete runnerEvent.capabilities.version
 
         reporter.onRunnerStart(runnerEvent)
         reporter.onSuiteStart(suiteStart())
@@ -176,8 +176,8 @@ describe('Failed tests', () => {
 
         const runnerEvent = runnerStart()
         runnerEvent.config.framework = 'jasmine'
-        delete runnerEvent.config.capabilities.browserName
-        delete runnerEvent.config.capabilities.version
+        delete runnerEvent.capabilities.browserName
+        delete runnerEvent.capabilities.version
 
         reporter.onRunnerStart(runnerEvent)
         reporter.onSuiteStart(suiteStart())

--- a/packages/wdio-runner/src/utils.js
+++ b/packages/wdio-runner/src/utils.js
@@ -44,6 +44,7 @@ export function sanitizeCaps (caps) {
  * initialise browser instance depending whether remote or multiremote is requested
  * @param  {Object}  config        configuration of sessions
  * @param  {Object}  capabilities  desired session capabilities
+ * @param  {boolean} isMultiremote isMultiremote
  * @return {Promise}               resolves with browser object
  */
 export async function initialiseInstance (config, capabilities, isMultiremote) {
@@ -52,10 +53,8 @@ export async function initialiseInstance (config, capabilities, isMultiremote) {
      */
     if (config.sessionId) {
         log.debug(`attach to session with id ${config.sessionId}`)
-        return attach({
-            ...config,
-            capabilities: capabilities
-        })
+        config.capabilities = sanitizeCaps(capabilities)
+        return attach({ ...config })
     }
 
     if (!isMultiremote) {

--- a/packages/wdio-runner/tests/utils.test.js
+++ b/packages/wdio-runner/tests/utils.test.js
@@ -44,17 +44,17 @@ describe('utils', () => {
 
     describe('initialiseInstance', () => {
         it('should attach to an existing session if sessionId is within config', () => {
-            initialiseInstance({
+            const config = {
                 sessionId: 123,
                 foo: 'bar'
-            }, [
-                { browserName: 'chrome' }
-            ])
+            }
+            initialiseInstance(config, { browserName: 'chrome', maxInstances: 2 })
             expect(attach).toBeCalledWith({
                 sessionId: 123,
                 foo: 'bar',
-                capabilities: [{ browserName: 'chrome' }]
+                capabilities: { browserName: 'chrome', maxInstances: 2 }
             })
+            expect(config.capabilities).toEqual({ browserName: 'chrome' })
             expect(multiremote).toHaveBeenCalledTimes(0)
             expect(remote).toHaveBeenCalledTimes(0)
         })

--- a/packages/wdio-runner/tests/utils.test.js
+++ b/packages/wdio-runner/tests/utils.test.js
@@ -52,7 +52,7 @@ describe('utils', () => {
             expect(attach).toBeCalledWith({
                 sessionId: 123,
                 foo: 'bar',
-                capabilities: { browserName: 'chrome', maxInstances: 2 }
+                capabilities: { browserName: 'chrome' }
             })
             expect(config.capabilities).toEqual({ browserName: 'chrome' })
             expect(multiremote).toHaveBeenCalledTimes(0)


### PR DESCRIPTION
## Proposed changes

fixes allure-reporter in watch mode #4649

also, use sanitized capabilities when attaching to session. We can't use real session capabilities at the moment

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

### Reviewers: @webdriverio/technical-committee
