### PR TITLE
wdio-runner: Don't fail test run if some reporters were unsync

### DIFF
--- a/packages/wdio-runner/src/index.js
+++ b/packages/wdio-runner/src/index.js
@@ -270,7 +270,11 @@ export default class Runner extends EventEmitter {
      * kill worker session
      */
     async _shutdown (failures) {
-        await this.reporter.waitForSync()
+        try {
+            await this.reporter.waitForSync()
+        } catch (e) {
+            log.error(e)
+        }
         this.emit('exit', failures === 0 ? 0 : 1)
         return failures
     }


### PR DESCRIPTION
## Proposed changes

Now when some reporter is unsync till timeout causes final launcher exit code not eq 0.
It isn't good because even all test passed we fail CI job.
E.g.:
```
[0-0] 2019-10-19T10:24:16.339Z ERROR @wdio/local-runner: Failed launching test session: Error: Some reporters are still unsynced: ReportPortalReporter
    at Timeout.<anonymous> (C:\Temp\wdio-v5-jasmine\node_modules\@wdio\runner\build\reporter.js:86:25)
    at listOnTimeout (internal/timers.js:531:17)
    at processTimers (internal/timers.js:475:7)
[0-0] FAILED in chrome - C:\Temp\wdio-v5-jasmine\specs\sample.spec.js

 "spec" Reporter:
------------------------------------------------------------------
[chrome  windows nt #0-0] Spec: C:\Temp\wdio-v5-jasmine\specs\sample.spec.js
[chrome  windows nt #0-0] Running: chrome on windows nt
[chrome  windows nt #0-0]
[chrome  windows nt #0-0] test
[chrome  windows nt #0-0]    ✓ Verify test 1
[chrome  windows nt #0-0]
[chrome  windows nt #0-0] 1 passing (2.9s)


Spec Files:      0 passed, 1 failed, 1 total (100% completed) in 00:00:14
```

I think it will be better don't fail tests by reporter issues.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
