### PR TITLE
set agent.keepAlive based on Connection header

### DIFF
--- a/packages/webdriver/tests/request.test.js
+++ b/packages/webdriver/tests/request.test.js
@@ -66,7 +66,7 @@ describe('webdriver request', () => {
             expect(options.agent).toBe(agent)
         })
 
-        it('ignors path when command is a hub command', () => {
+        it('ignores path when command is a hub command', () => {
             const req = new WebDriverRequest('POST', '/grid/api/hub', {}, true)
             const options = req._createOptions({
                 protocol: 'https',

--- a/packages/webdriver/tests/request.test.js
+++ b/packages/webdriver/tests/request.test.js
@@ -80,6 +80,42 @@ describe('webdriver request', () => {
             expect(options.headers['Connection']).toEqual('close')
         })
 
+        it('preserves agent keep alive if custom', () => {
+            const req = new WebDriverRequest('POST', 'session/:sessionId/element')
+            const agent = new https.Agent({ keepAlive: true })
+            const options = req._createOptions({
+                protocol: 'https',
+                hostname: 'localhost',
+                port: 4445,
+                path: '/wd/hub/',
+                agent,
+                headers: { Connection: 'close' }
+            }, 'foobar12345')
+
+            expect(options.agent.keepAlive).toBe(true)
+            expect(options.headers['Connection']).toEqual('close')
+        })
+
+        it('doesn\'t store mutations to agent', () => {
+            const req = new WebDriverRequest('POST', 'session/:sessionId/element')
+            const options1 = req._createOptions({
+                protocol: 'https',
+                hostname: 'localhost',
+                port: 4445,
+                path: '/wd/hub/',
+                headers: { Connection: 'close' }
+            }, 'foobar12345')
+            const options2 = req._createOptions({
+                protocol: 'https',
+                hostname: 'localhost',
+                port: 4445,
+                path: '/wd/hub/'
+            }, 'foobar12345')
+
+            expect(options1.agent.keepAlive).toBe(false)
+            expect(options2.agent.keepAlive).toBe(true)
+        })
+
         it('ignores path when command is a hub command', () => {
             const req = new WebDriverRequest('POST', '/grid/api/hub', {}, true)
             const options = req._createOptions({

--- a/packages/webdriver/tests/request.test.js
+++ b/packages/webdriver/tests/request.test.js
@@ -66,6 +66,20 @@ describe('webdriver request', () => {
             expect(options.agent).toBe(agent)
         })
 
+        it('turns off agent keep alive if Connection: close header set', () => {
+            const req = new WebDriverRequest('POST', 'session/:sessionId/element')
+            const options = req._createOptions({
+                protocol: 'https',
+                hostname: 'localhost',
+                port: 4445,
+                path: '/wd/hub/',
+                headers: { Connection: 'close' }
+            }, 'foobar12345')
+
+            expect(options.agent.keepAlive).toBe(false)
+            expect(options.headers['Connection']).toEqual('close')
+        })
+
         it('ignores path when command is a hub command', () => {
             const req = new WebDriverRequest('POST', '/grid/api/hub', {}, true)
             const options = req._createOptions({


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

I attempted to turn off the default keep-alive behaviour like this:

```js
      browser = await remote({
        headers: {
          Connection: 'close',
        },
      });
```

but I was still seeing `Connection: 'keep-alive'` in the browser. I tracked down our handoff to the `request` package, and the custom header was correctly `Connection: 'close'`. Turns out, if you send both `Agent.keepAlive` and `Connection: 'close'` to `request`, it will overwrite any custom headers with what is in your agent config. This fixes our agent keep-alive assumption to match the Connection header.

Unfortunately, since we have to now mutate the agents, they can't be globally stored anymore.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
