### PR TITLE
Update reloadSession.js in order to allow for session reload even if remote session has been terminated on server-side

### DIFF
--- a/packages/webdriverio/package.json
+++ b/packages/webdriverio/package.json
@@ -52,7 +52,7 @@
     "clean": "rimraf ./build",
     "compile": "babel src/ -d build/ --config-file ../../babel.config.js",
     "test": "run-s test:*",
-    "test:eslint": "eslint src test",
+    "test:eslint": "eslint src tests",
     "test:unit": "jest"
   },
   "dependencies": {

--- a/packages/webdriverio/src/commands/browser/reloadSession.js
+++ b/packages/webdriverio/src/commands/browser/reloadSession.js
@@ -33,6 +33,7 @@ export default async function reloadSession () {
          * there maybe times where session is ended remotely, browser.deleteSession() will fail in this case)
          * this can be worked around in code but requires a lot of overhead
          */
+         log.warn(`Suppressing error closing the session: ${err.stack}`)
     }
 
     const ProtocolDriver = require(this.options.automationProtocol).default

--- a/packages/webdriverio/src/commands/browser/reloadSession.js
+++ b/packages/webdriverio/src/commands/browser/reloadSession.js
@@ -23,9 +23,17 @@ export default async function reloadSession () {
     const oldSessionId = this.sessionId
 
     /**
-     * end current running session
+     * end current running session, if session already gone suppress exceptions
      */
-    await this.deleteSession()
+    try {
+        await this.deleteSession()
+    } catch (err) {
+        /** 
+         * ignoring all exceptions that could be caused by browser.deleteSession()
+         * there maybe times where session is ended remotely, browser.deleteSession() will fail in this case)
+         * this can be worked around in code but requires a lot of overhead
+         */
+    }
 
     const ProtocolDriver = require(this.options.automationProtocol).default
     await ProtocolDriver.reloadSession(this)

--- a/packages/webdriverio/src/commands/browser/reloadSession.js
+++ b/packages/webdriverio/src/commands/browser/reloadSession.js
@@ -1,3 +1,6 @@
+import logger from '@wdio/logger'
+const log = logger('webdriverio')
+
 /**
  *
  * Creates a new Selenium session with your current capabilities. This is useful if you
@@ -28,12 +31,12 @@ export default async function reloadSession () {
     try {
         await this.deleteSession()
     } catch (err) {
-        /** 
+        /**
          * ignoring all exceptions that could be caused by browser.deleteSession()
          * there maybe times where session is ended remotely, browser.deleteSession() will fail in this case)
          * this can be worked around in code but requires a lot of overhead
          */
-         log.warn(`Suppressing error closing the session: ${err.stack}`)
+        log.warn(`Suppressing error closing the session: ${err.stack}`)
     }
 
     const ProtocolDriver = require(this.options.automationProtocol).default


### PR DESCRIPTION
Adding a try/catch around `deleteSession` in `reloadSession`, a user may want to reload a session and the remote session could have already been terminated, this should not prevent them from acquiring a new session.

## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
