### PR TITLE
Update Type for config to allow cucumber options

### DIFF
--- a/scripts/templates/webdriverio.tpl.d.ts
+++ b/scripts/templates/webdriverio.tpl.d.ts
@@ -66,6 +66,22 @@ declare namespace WebdriverIO {
         framework?: string,
         mochaOpts?: object,
         jasmineNodeOpts?: object,
+        cucumberOpts?: {
+            require?: string[],
+            backtrace?: boolean,
+            compiler?: string[],
+            dryRun?: boolean,
+            failFast?: boolean,
+            format?: string[],
+            colors?: boolean,
+            snippets?: boolean,
+            source?: boolean,
+            profile?: string[],
+            strict?: boolean,
+            tagExpression?: string[],
+            timeout?: number,
+            ignoreUndefinedDefinitions?: boolean
+        },
         reporters?: (string | object)[],
         services?: (string | object)[],
         execArgv?: string[]


### PR DESCRIPTION
The documentation shows a way to declare a typed configuration (wdio.conf.ts)
The types for cucumberOpts are not in the type definition for config so typescript says it's invalid.

## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
