### PR TITLE
Add support for run *.mjs files

### DIFF
--- a/packages/wdio-config/src/lib/ConfigParser.js
+++ b/packages/wdio-config/src/lib/ConfigParser.js
@@ -278,6 +278,7 @@ export default class ConfigParser {
 
             filenames = filenames.filter(filename =>
                 filename.slice(-3) === '.js' ||
+                filename.slice(-4) === '.mjs' ||
                 filename.slice(-4) === '.es6' ||
                 filename.slice(-3) === '.ts' ||
                 filename.slice(-8) === '.feature' ||

--- a/packages/wdio-config/tests/configparser.test.js
+++ b/packages/wdio-config/tests/configparser.test.js
@@ -302,6 +302,15 @@ describe('ConfigParser', () => {
             expect(specs).toContain(path.resolve(FIXTURES_PATH, 'test.es6'))
         })
 
+        it('should include mjs files', () => {
+            const configParser = new ConfigParser()
+            configParser.addConfigFile(FIXTURES_CONF)
+
+            const mjsFile = path.resolve(FIXTURES_PATH, '*.mjs')
+            const specs = configParser.getSpecs([mjsFile])
+            expect(specs).toContain(path.resolve(FIXTURES_PATH, 'test.mjs'))
+        })
+
         it('should not include other file types', () => {
             const configParser = new ConfigParser()
             configParser.addConfigFile(FIXTURES_CONF)


### PR DESCRIPTION
## Proposed changes

[//]: In the new version of Node was supported *.mjs files. I want to add the opportunity to write the tests in *.mjs files

## Types of changes

[//]:

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

### Reviewers: @webdriverio/technical-committee
