### PR TITLE
open travis site instead of picture when clicking on build-badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-    <a href="https://travis-ci.org/webdriverio/webdriverio.svg?branch=master">
+    <a href="https://travis-ci.org/webdriverio/webdriverio">
         <img alt="Build Status" src="https://travis-ci.org/webdriverio/webdriverio.svg?branch=master">
     </a>
     <a href="https://codecov.io/gh/webdriverio/webdriverio">


### PR DESCRIPTION
## Proposed changes

When clicking on the badge labeled "build" it currently opens a picture of the badge. With my change the user gets directed to the correct page of the travis build.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
