### PR TITLE
webdriverio: add config typing to browser object

### DIFF
--- a/scripts/templates/webdriverio.tpl.d.ts
+++ b/scripts/templates/webdriverio.tpl.d.ts
@@ -175,6 +175,7 @@ declare namespace WebdriverIO {
     }
 
     interface Browser {
+        config: Config;
         addCommand(
             name: string,
             func: Function,


### PR DESCRIPTION
## Proposed changes

The config property was missing as a typing on the browser object.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

### Reviewers: @webdriverio/technical-committee
