### PR TITLE
pretty e.stack only if it exists

### DIFF
--- a/packages/wdio-sync/src/index.js
+++ b/packages/wdio-sync/src/index.js
@@ -71,7 +71,9 @@ const executeAsync = async function (fn, repeatTest = 0, args = []) {
             return await executeAsync(fn, --repeatTest, args)
         }
 
-        if (e.stack) e.stack = e.stack.split('\n').filter(STACKTRACE_FILTER_FN).join('\n')
+        if (e.stack) {
+           e.stack = e.stack.split('\n').filter(STACKTRACE_FILTER_FN).join('\n')
+        }
         throw e
     }
 }

--- a/packages/wdio-sync/src/index.js
+++ b/packages/wdio-sync/src/index.js
@@ -72,7 +72,7 @@ const executeAsync = async function (fn, repeatTest = 0, args = []) {
         }
 
         if (e.stack) {
-           e.stack = e.stack.split('\n').filter(STACKTRACE_FILTER_FN).join('\n')
+            e.stack = e.stack.split('\n').filter(STACKTRACE_FILTER_FN).join('\n')
         }
         throw e
     }

--- a/packages/wdio-sync/src/index.js
+++ b/packages/wdio-sync/src/index.js
@@ -70,7 +70,9 @@ const executeAsync = async function (fn, repeatTest = 0, args = []) {
         if(repeatTest > 0) {
             return await executeAsync(fn, --repeatTest, args)
         }
-
+        
+        // Only instances of `Error` have a stack trace. Specifcally in mocha, `this.skip()` 
+        // does a `throw new Pending('sync skip')` which is not a subsclass of `Error`
         if (e.stack) {
             e.stack = e.stack.split('\n').filter(STACKTRACE_FILTER_FN).join('\n')
         }

--- a/packages/wdio-sync/src/index.js
+++ b/packages/wdio-sync/src/index.js
@@ -70,8 +70,8 @@ const executeAsync = async function (fn, repeatTest = 0, args = []) {
         if(repeatTest > 0) {
             return await executeAsync(fn, --repeatTest, args)
         }
-        
-        // Only instances of `Error` have a stack trace. Specifcally in mocha, `this.skip()` 
+
+        // Only instances of `Error` have a stack trace. Specifcally in mocha, `this.skip()`
         // does a `throw new Pending('sync skip')` which is not a subsclass of `Error`
         if (e.stack) {
             e.stack = e.stack.split('\n').filter(STACKTRACE_FILTER_FN).join('\n')

--- a/packages/wdio-sync/src/index.js
+++ b/packages/wdio-sync/src/index.js
@@ -71,7 +71,7 @@ const executeAsync = async function (fn, repeatTest = 0, args = []) {
             return await executeAsync(fn, --repeatTest, args)
         }
 
-        e.stack = e.stack.split('\n').filter(STACKTRACE_FILTER_FN).join('\n')
+        if (e.stack) e.stack = e.stack.split('\n').filter(STACKTRACE_FILTER_FN).join('\n')
         throw e
     }
 }


### PR DESCRIPTION
Addresses #4697.  skipped tests in mocha result in `throw new Pending('sync skip')` that do not have stack traces.

## Proposed changes

Mocha throws a `new Pending('sync skip)` when an async test is `this.skip()`ed. This used to pass through wdio, but now gets evaluated and the stack prettied. However, the stack doesn't always exist - particularly from this non exception use case - and will result in a new exception `Cannot read property 'split' of undefined` from wdio. 

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist
- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

### Reviewers: @webdriverio/technical-committee
