### PR TITLE
webdriverio: expanded click command with offset

### DIFF
--- a/packages/webdriverio/src/commands/element/click.js
+++ b/packages/webdriverio/src/commands/element/click.js
@@ -63,10 +63,10 @@
  * @alias element.click
  * @uses protocol/element, protocol/elementIdClick, protocol/performActions, protocol/positionClick
  * @type action
- * @param options Object (optional)
- * @param options.button can be one of [0, "left", 1, "middle", 2, "right"] (optional)
- * @param options.x Number (optional)
- * @param options.y Number (optional)
+ * @param {object} options Object (optional)
+ * @param {string | number} options.button can be one of [0, "left", 1, "middle", 2, "right"] (optional)
+ * @param {number} options.x Number (optional)
+ * @param {number} options.y Number (optional)
  */
 
 export default async function click(options) {

--- a/packages/webdriverio/src/commands/element/click.js
+++ b/packages/webdriverio/src/commands/element/click.js
@@ -63,10 +63,10 @@
  * @alias element.click
  * @uses protocol/element, protocol/elementIdClick, protocol/performActions, protocol/positionClick
  * @type action
- * @param {object} options Object (optional)
- * @param {string | number} options.button can be one of [0, "left", 1, "middle", 2, "right"] (optional)
- * @param {number} options.x Number (optional)
- * @param {number} options.y Number (optional)
+ * @param {object=} options Object (optional)
+ * @param {string= | number=} options.button can be one of [0, "left", 1, "middle", 2, "right"] (optional)
+ * @param {number=} options.x Number (optional)
+ * @param {number=} options.y Number (optional)
  */
 
 export default async function click(options) {

--- a/packages/webdriverio/src/commands/element/click.js
+++ b/packages/webdriverio/src/commands/element/click.js
@@ -64,7 +64,7 @@
  * @uses protocol/element, protocol/elementIdClick, protocol/performActions, protocol/positionClick
  * @type action
  * @param options Object (optional)
- * @param options.button String | Number (optional)
+ * @param options.button can be one of [0, "left", 1, "middle", 2, "right"] (optional)
  * @param options.x Number (optional)
  * @param options.y Number (optional)
  */

--- a/packages/webdriverio/tests/commands/element/click.test.js
+++ b/packages/webdriverio/tests/commands/element/click.test.js
@@ -28,14 +28,14 @@ describe('click test', () => {
         await elem.click({ button: 'left' })
 
         expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/actions')
-        expect(request.mock.calls[2][0].body.actions[0].actions[1]).toEqual({ type: 'pointerDown', button: 0 })
-        expect(request.mock.calls[2][0].body.actions[0].actions[2]).toEqual({ type: 'pointerUp', button: 0 })
+        expect(request.mock.calls[2][0].body.actions[0].actions[1]).toStrictEqual({ type: 'pointerDown', button: 0 })
+        expect(request.mock.calls[2][0].body.actions[0].actions[2]).toStrictEqual({ type: 'pointerUp', button: 0 })
 
         await elem.click({ button: 0 })
 
         expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/actions')
-        expect(request.mock.calls[2][0].body.actions[0].actions[1]).toEqual({ type: 'pointerDown', button: 0 })
-        expect(request.mock.calls[2][0].body.actions[0].actions[2]).toEqual({ type: 'pointerUp', button: 0 })
+        expect(request.mock.calls[2][0].body.actions[0].actions[1]).toStrictEqual({ type: 'pointerDown', button: 0 })
+        expect(request.mock.calls[2][0].body.actions[0].actions[2]).toStrictEqual({ type: 'pointerUp', button: 0 })
     })
 
     it('should allow to right click on an element', async () => {
@@ -51,15 +51,15 @@ describe('click test', () => {
 
         expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/actions')
         expect(request.mock.calls[2][0].body.actions[0].actions[0].type).toBe('pointerMove')
-        expect(request.mock.calls[2][0].body.actions[0].actions[1]).toEqual({ type: 'pointerDown', button: 2 })
-        expect(request.mock.calls[2][0].body.actions[0].actions[2]).toEqual({ type: 'pointerUp', button: 2 })
+        expect(request.mock.calls[2][0].body.actions[0].actions[1]).toStrictEqual({ type: 'pointerDown', button: 2 })
+        expect(request.mock.calls[2][0].body.actions[0].actions[2]).toStrictEqual({ type: 'pointerUp', button: 2 })
 
         await elem.click({ button: 2 })
 
         expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/actions')
         expect(request.mock.calls[2][0].body.actions[0].actions[0].type).toBe('pointerMove')
-        expect(request.mock.calls[2][0].body.actions[0].actions[1]).toEqual({ type: 'pointerDown', button: 2 })
-        expect(request.mock.calls[2][0].body.actions[0].actions[2]).toEqual({ type: 'pointerUp', button: 2 })
+        expect(request.mock.calls[2][0].body.actions[0].actions[1]).toStrictEqual({ type: 'pointerDown', button: 2 })
+        expect(request.mock.calls[2][0].body.actions[0].actions[2]).toStrictEqual({ type: 'pointerUp', button: 2 })
     })
 
     it('should allow to middle click on an element', async () => {
@@ -75,15 +75,53 @@ describe('click test', () => {
 
         expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/actions')
         expect(request.mock.calls[2][0].body.actions[0].actions[0].type).toBe('pointerMove')
-        expect(request.mock.calls[2][0].body.actions[0].actions[1]).toEqual({ type: 'pointerDown', button: 1 })
-        expect(request.mock.calls[2][0].body.actions[0].actions[2]).toEqual({ type: 'pointerUp', button: 1 })
+        expect(request.mock.calls[2][0].body.actions[0].actions[1]).toStrictEqual({ type: 'pointerDown', button: 1 })
+        expect(request.mock.calls[2][0].body.actions[0].actions[2]).toStrictEqual({ type: 'pointerUp', button: 1 })
 
         await elem.click({ button: 1 })
 
         expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/actions')
         expect(request.mock.calls[2][0].body.actions[0].actions[0].type).toBe('pointerMove')
-        expect(request.mock.calls[2][0].body.actions[0].actions[1]).toEqual({ type: 'pointerDown', button: 1 })
-        expect(request.mock.calls[2][0].body.actions[0].actions[2]).toEqual({ type: 'pointerUp', button: 1 })
+        expect(request.mock.calls[2][0].body.actions[0].actions[1]).toStrictEqual({ type: 'pointerDown', button: 1 })
+        expect(request.mock.calls[2][0].body.actions[0].actions[2]).toStrictEqual({ type: 'pointerUp', button: 1 })
+    })
+
+    it('should allow to left click on an element with an offset without passing a button type', async () => {
+        const browser = await remote({
+            baseUrl: 'http://foobar.com',
+            capabilities: {
+                browserName: 'foobar'
+            }
+        })
+        const elem = await browser.$('#foo')
+
+        await elem.click({ y: 30 })
+
+        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/actions')
+        expect(request.mock.calls[2][0].body.actions[0].actions[0].type).toBe('pointerMove')
+        expect(request.mock.calls[2][0].body.actions[0].actions[0].x).toBe(0)
+        expect(request.mock.calls[2][0].body.actions[0].actions[0].y).toBe(30)
+        expect(request.mock.calls[2][0].body.actions[0].actions[1]).toStrictEqual({ type: 'pointerDown', button: 0 })
+        expect(request.mock.calls[2][0].body.actions[0].actions[2]).toStrictEqual({ type: 'pointerUp', button: 0 })
+    })
+
+    it('should allow to right click on an element with an offset and passing a button type', async () => {
+        const browser = await remote({
+            baseUrl: 'http://foobar.com',
+            capabilities: {
+                browserName: 'foobar'
+            }
+        })
+        const elem = await browser.$('#foo')
+
+        await elem.click({ button: 2, x: 40, y: 30 })
+
+        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/actions')
+        expect(request.mock.calls[2][0].body.actions[0].actions[0].type).toBe('pointerMove')
+        expect(request.mock.calls[2][0].body.actions[0].actions[0].x).toBe(40)
+        expect(request.mock.calls[2][0].body.actions[0].actions[0].y).toBe(30)
+        expect(request.mock.calls[2][0].body.actions[0].actions[1]).toStrictEqual({ type: 'pointerDown', button: 2 })
+        expect(request.mock.calls[2][0].body.actions[0].actions[2]).toStrictEqual({ type: 'pointerUp', button: 2 })
     })
 
     it('should allow to left click on an element (no w3c)', async () => {
@@ -97,15 +135,17 @@ describe('click test', () => {
 
         await elem.click({ button: 'left' })
 
-        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/moveto')
-        expect(request.mock.calls[3][0].uri.path).toBe('/wd/hub/session/foobar-123/click')
-        expect(request.mock.calls[3][0].body).toEqual({ 'button': 0 })
+        expect(request.mock.calls[3][0].uri.path).toBe('/wd/hub/session/foobar-123/moveto')
+        expect(request.mock.calls[3][0].body).toStrictEqual({ element: 'some-elem-123', xoffset: 25, yoffset: 15 })
+        expect(request.mock.calls[4][0].uri.path).toBe('/wd/hub/session/foobar-123/click')
+        expect(request.mock.calls[4][0].body).toStrictEqual({ button: 0 })
 
         await elem.click({ button: 0 })
 
-        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/moveto')
-        expect(request.mock.calls[3][0].uri.path).toBe('/wd/hub/session/foobar-123/click')
-        expect(request.mock.calls[3][0].body).toEqual({ 'button': 0 })
+        expect(request.mock.calls[3][0].uri.path).toBe('/wd/hub/session/foobar-123/moveto')
+        expect(request.mock.calls[3][0].body).toStrictEqual({ element: 'some-elem-123', xoffset: 25, yoffset: 15 })
+        expect(request.mock.calls[4][0].uri.path).toBe('/wd/hub/session/foobar-123/click')
+        expect(request.mock.calls[4][0].body).toStrictEqual({ button: 0 })
     })
 
     it('should allow to right click on an element (no w3c)', async () => {
@@ -119,15 +159,17 @@ describe('click test', () => {
 
         await elem.click({ button: 'right' })
 
-        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/moveto')
-        expect(request.mock.calls[3][0].uri.path).toBe('/wd/hub/session/foobar-123/click')
-        expect(request.mock.calls[3][0].body).toEqual({ 'button': 2 })
+        expect(request.mock.calls[3][0].uri.path).toBe('/wd/hub/session/foobar-123/moveto')
+        expect(request.mock.calls[3][0].body).toStrictEqual({ element: 'some-elem-123', xoffset: 25, yoffset: 15 })
+        expect(request.mock.calls[4][0].uri.path).toBe('/wd/hub/session/foobar-123/click')
+        expect(request.mock.calls[4][0].body).toStrictEqual({ button: 2 })
 
         await elem.click({ button: 2 })
 
-        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/moveto')
-        expect(request.mock.calls[3][0].uri.path).toBe('/wd/hub/session/foobar-123/click')
-        expect(request.mock.calls[3][0].body).toEqual({ 'button': 2 })
+        expect(request.mock.calls[3][0].uri.path).toBe('/wd/hub/session/foobar-123/moveto')
+        expect(request.mock.calls[3][0].body).toStrictEqual({ element: 'some-elem-123', xoffset: 25, yoffset: 15 })
+        expect(request.mock.calls[4][0].uri.path).toBe('/wd/hub/session/foobar-123/click')
+        expect(request.mock.calls[4][0].body).toStrictEqual({ button: 2 })
     })
 
     it('should allow to middle click on an element (no w3c)', async () => {
@@ -141,22 +183,82 @@ describe('click test', () => {
 
         await elem.click({ button: 'middle' })
 
-        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/moveto')
-        expect(request.mock.calls[3][0].uri.path).toBe('/wd/hub/session/foobar-123/click')
-        expect(request.mock.calls[3][0].body).toEqual({ 'button': 1 })
+        expect(request.mock.calls[3][0].uri.path).toBe('/wd/hub/session/foobar-123/moveto')
+        expect(request.mock.calls[3][0].body).toStrictEqual({ element: 'some-elem-123', xoffset: 25, yoffset: 15 })
+        expect(request.mock.calls[4][0].uri.path).toBe('/wd/hub/session/foobar-123/click')
+        expect(request.mock.calls[4][0].body).toStrictEqual({ button: 1 })
 
         await elem.click({ button: 1 })
 
-        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/moveto')
-        expect(request.mock.calls[3][0].uri.path).toBe('/wd/hub/session/foobar-123/click')
-        expect(request.mock.calls[3][0].body).toEqual({ 'button': 1 })
+        expect(request.mock.calls[3][0].uri.path).toBe('/wd/hub/session/foobar-123/moveto')
+        expect(request.mock.calls[3][0].body).toStrictEqual({ element: 'some-elem-123', xoffset: 25, yoffset: 15 })
+        expect(request.mock.calls[4][0].uri.path).toBe('/wd/hub/session/foobar-123/click')
+        expect(request.mock.calls[4][0].body).toStrictEqual({ button: 1 })
+    })
+
+    it('should allow to left click on an element with an offset without passing a button type (no w3c)', async () => {
+        const browser = await remote({
+            baseUrl: 'http://foobar.com',
+            capabilities: {
+                browserName: 'foobar-noW3C'
+            }
+        })
+        const elem = await browser.$('#foo')
+
+        await elem.click({ y: 30 })
+
+        expect(request.mock.calls[3][0].uri.path).toBe('/wd/hub/session/foobar-123/moveto')
+        expect(request.mock.calls[3][0].body).toStrictEqual({ element: 'some-elem-123', xoffset: 25, yoffset: 45 })
+        expect(request.mock.calls[4][0].uri.path).toBe('/wd/hub/session/foobar-123/click')
+        expect(request.mock.calls[4][0].body).toStrictEqual({ button: 0 })
+    })
+
+    it('should allow to right click on an element with an offset and passing a button type (no w3c)', async () => {
+        const browser = await remote({
+            baseUrl: 'http://foobar.com',
+            capabilities: {
+                browserName: 'foobar-noW3C'
+            }
+        })
+        const elem = await browser.$('#foo')
+
+        await elem.click({ button: 2, x: 40, y: 30 })
+
+        expect(request.mock.calls[3][0].uri.path).toBe('/wd/hub/session/foobar-123/moveto')
+        expect(request.mock.calls[3][0].body).toStrictEqual({ element: 'some-elem-123', xoffset: 65, yoffset: 45 })
+        expect(request.mock.calls[4][0].uri.path).toBe('/wd/hub/session/foobar-123/click')
+        expect(request.mock.calls[4][0].body).toStrictEqual({ button: 2 })
+    })
+
+    it('should throw an error if the passed argument is not an options object', async () => {
+        const browser = await remote({
+            baseUrl: 'http://foobar.com',
+            capabilities: {
+                browserName: 'foobar'
+            }
+        })
+        const elem = await browser.$('#foo')
+
+        expect(elem.click([])).rejects.toThrow('Options must be an oject')
+    })
+
+    it('should throw an error if no valid coördicates are passed', async () => {
+        const browser = await remote({
+            baseUrl: 'http://foobar.com',
+            capabilities: {
+                browserName: 'foobar'
+            }
+        })
+        const elem = await browser.$('#foo')
+
+        expect(elem.click({ x: 'not-suppported' })).rejects.toThrow('Coördinates must be integers')
     })
 
     it('should throw an error if no valid button type is passed', async () => {
         const browser = await remote({
             baseUrl: 'http://foobar.com',
             capabilities: {
-                browserName: 'foobar-noW3C'
+                browserName: 'foobar'
             }
         })
         const elem = await browser.$('#foo')


### PR DESCRIPTION
## Proposed changes

Expand click command with an `x` and `y` offset (can be combined with the `button` property)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

### Reviewers: @webdriverio/technical-committee
