### PR TITLE
wdio-config: fix capabilities spec not overwriting

### DIFF
--- a/packages/wdio-config/src/lib/ConfigParser.js
+++ b/packages/wdio-config/src/lib/ConfigParser.js
@@ -196,11 +196,11 @@ export default class ConfigParser {
         }
 
         if (Array.isArray(capSpecs)) {
-            specs = specs.concat(ConfigParser.getFilePaths(capSpecs))
+            specs = ConfigParser.getFilePaths(capSpecs)
         }
 
         if (Array.isArray(capExclude)) {
-            exclude = exclude.concat(ConfigParser.getFilePaths(capExclude))
+            exclude = ConfigParser.getFilePaths(capExclude)
         }
 
         return specs.filter(spec => !exclude.includes(spec))


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

Taking a stab at fixing issue #4703. Previously, `ConfigParser.getSpecs()` would concatenate config `specs` and capability `specs` instead of allowing the capability `specs` to overwrite the config `specs`. I made a similar change to exclusions. I debated whether or not to check for `Array.length` as well but decided against it.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
