### PR TITLE
Replace request lib with got

### DIFF
--- a/packages/wdio-protocols/package.json
+++ b/packages/wdio-protocols/package.json
@@ -10,6 +10,7 @@
     "node": ">= 4.8.5"
   },
   "scripts": {
+    "compile": "echo \"nothing to compile\"",
     "build": "echo \"nothing to build\"",
     "test": "echo \"run json linting tests\""
   },

--- a/packages/webdriver/package.json
+++ b/packages/webdriver/package.json
@@ -34,7 +34,7 @@
     "@wdio/logger": "5.13.2",
     "@wdio/protocols": "5.15.6",
     "@wdio/utils": "5.15.1",
-    "lodash.merge": "^4.6.1",
-    "request": "^2.83.0"
+    "got": "^9.6.0",
+    "lodash.merge": "^4.6.1"
   }
 }

--- a/packages/webdriverio/tests/commands/browser/$$.test.js
+++ b/packages/webdriverio/tests/commands/browser/$$.test.js
@@ -1,4 +1,4 @@
-import request from 'request'
+import got from 'got'
 import { remote } from '../../../src'
 import { ELEMENT_KEY } from '../../../src/constants'
 
@@ -12,9 +12,9 @@ describe('elements', () => {
         })
 
         const elems = await browser.$$('.foo')
-        expect(request.mock.calls[1][0].method).toBe('POST')
-        expect(request.mock.calls[1][0].uri.path).toBe('/wd/hub/session/foobar-123/elements')
-        expect(request.mock.calls[1][0].body).toEqual({ using: 'css selector', value: '.foo' })
+        expect(got.mock.calls[1][1].method).toBe('POST')
+        expect(got.mock.calls[1][1].uri.path).toBe('/wd/hub/session/foobar-123/elements')
+        expect(got.mock.calls[1][1].json).toEqual({ using: 'css selector', value: '.foo' })
         expect(elems).toHaveLength(3)
 
         expect(elems[0].elementId).toBe('some-elem-123')
@@ -69,6 +69,6 @@ describe('elements', () => {
     })
 
     afterEach(() => {
-        request.mockClear()
+        got.mockClear()
     })
 })

--- a/packages/webdriverio/tests/commands/browser/$.test.js
+++ b/packages/webdriverio/tests/commands/browser/$.test.js
@@ -1,4 +1,4 @@
-import request from 'request'
+import got from 'got'
 import { remote } from '../../../src'
 import { ELEMENT_KEY } from '../../../src/constants'
 
@@ -12,9 +12,9 @@ describe('element', () => {
         })
 
         const elem = await browser.$('#foo')
-        expect(request.mock.calls[1][0].method).toBe('POST')
-        expect(request.mock.calls[1][0].uri.path).toBe('/wd/hub/session/foobar-123/element')
-        expect(request.mock.calls[1][0].body).toEqual({ using: 'css selector', value: '#foo' })
+        expect(got.mock.calls[1][1].method).toBe('POST')
+        expect(got.mock.calls[1][1].uri.path).toBe('/wd/hub/session/foobar-123/element')
+        expect(got.mock.calls[1][1].json).toEqual({ using: 'css selector', value: '#foo' })
         expect(elem.elementId).toBe('some-elem-123')
         expect(elem[ELEMENT_KEY]).toBe('some-elem-123')
         expect(elem.ELEMENT).toBe(undefined)
@@ -61,6 +61,6 @@ describe('element', () => {
     })
 
     afterEach(() => {
-        request.mockClear()
+        got.mockClear()
     })
 })

--- a/packages/webdriverio/tests/commands/browser/deleteCookies.test.js
+++ b/packages/webdriverio/tests/commands/browser/deleteCookies.test.js
@@ -1,4 +1,4 @@
-import request from 'request'
+import got from 'got'
 import { remote } from '../../../src'
 
 describe('deleteCookies', () => {
@@ -16,22 +16,22 @@ describe('deleteCookies', () => {
     it('should delete all cookies', async () => {
         await browser.deleteCookies()
 
-        expect(request.mock.calls[1][0].method).toBe('DELETE')
-        expect(request.mock.calls[1][0].uri.path).toBe('/wd/hub/session/foobar-123/cookie')
+        expect(got.mock.calls[1][1].method).toBe('DELETE')
+        expect(got.mock.calls[1][1].uri.path).toBe('/wd/hub/session/foobar-123/cookie')
     })
 
     it('should support passing a string', async () => {
         await browser.deleteCookies('cookie1')
 
-        expect(request.mock.calls[0][0].method).toBe('DELETE')
-        expect(request.mock.calls[0][0].uri.path).toBe('/wd/hub/session/foobar-123/cookie/cookie1')
+        expect(got.mock.calls[0][1].method).toBe('DELETE')
+        expect(got.mock.calls[0][1].uri.path).toBe('/wd/hub/session/foobar-123/cookie/cookie1')
     })
 
     it('should support passing a array with a string', async () => {
         await browser.deleteCookies(['cookie1'])
 
-        expect(request.mock.calls[0][0].method).toBe('DELETE')
-        expect(request.mock.calls[0][0].uri.path).toBe('/wd/hub/session/foobar-123/cookie/cookie1')
+        expect(got.mock.calls[0][1].method).toBe('DELETE')
+        expect(got.mock.calls[0][1].uri.path).toBe('/wd/hub/session/foobar-123/cookie/cookie1')
     })
 
     it('should delete cookies that match by name', async () => {
@@ -39,8 +39,8 @@ describe('deleteCookies', () => {
         await browser.deleteCookies(cookieNames)
 
         cookieNames.forEach((name, i) => {
-            expect(request.mock.calls[i][0].method).toBe('DELETE')
-            expect(request.mock.calls[i][0].uri.path).toBe(`/wd/hub/session/foobar-123/cookie/${name}`)
+            expect(got.mock.calls[i][1].method).toBe('DELETE')
+            expect(got.mock.calls[i][1].uri.path).toBe(`/wd/hub/session/foobar-123/cookie/${name}`)
         })
     })
 
@@ -51,6 +51,6 @@ describe('deleteCookies', () => {
     })
 
     afterEach(() => {
-        request.mockClear()
+        got.mockClear()
     })
 })

--- a/packages/webdriverio/tests/commands/browser/execute.test.js
+++ b/packages/webdriverio/tests/commands/browser/execute.test.js
@@ -1,4 +1,4 @@
-import request from 'request'
+import got from 'got'
 import { remote } from '../../../src'
 
 describe('isEnabled test', () => {
@@ -11,9 +11,9 @@ describe('isEnabled test', () => {
         })
 
         await browser.execute(() => 'foobar', 1, 2, 3)
-        expect(request.mock.calls[1][0].uri.path).toBe('/wd/hub/session/foobar-123/execute/sync')
-        expect(request.mock.calls[1][0].body.script).toBe('return (() => \'foobar\').apply(null, arguments)')
-        expect(request.mock.calls[1][0].body.args).toEqual([1, 2, 3])
+        expect(got.mock.calls[1][1].uri.path).toBe('/wd/hub/session/foobar-123/execute/sync')
+        expect(got.mock.calls[1][1].json.script).toBe('return (() => \'foobar\').apply(null, arguments)')
+        expect(got.mock.calls[1][1].json.args).toEqual([1, 2, 3])
     })
 
     it('should throw if script is wrong type', async () => {

--- a/packages/webdriverio/tests/commands/browser/executeAsync.test.js
+++ b/packages/webdriverio/tests/commands/browser/executeAsync.test.js
@@ -1,4 +1,4 @@
-import request from 'request'
+import got from 'got'
 import { remote } from '../../../src'
 
 describe('isEnabled test', () => {
@@ -11,9 +11,9 @@ describe('isEnabled test', () => {
         })
 
         await browser.executeAsync(() => 'foobar', 1, 2, 3)
-        expect(request.mock.calls[1][0].uri.path).toBe('/wd/hub/session/foobar-123/execute/async')
-        expect(request.mock.calls[1][0].body.script).toBe('return (() => \'foobar\').apply(null, arguments)')
-        expect(request.mock.calls[1][0].body.args).toEqual([1, 2, 3])
+        expect(got.mock.calls[1][1].uri.path).toBe('/wd/hub/session/foobar-123/execute/async')
+        expect(got.mock.calls[1][1].json.script).toBe('return (() => \'foobar\').apply(null, arguments)')
+        expect(got.mock.calls[1][1].json.args).toEqual([1, 2, 3])
     })
 
     it('should throw if script is wrong type', async () => {

--- a/packages/webdriverio/tests/commands/browser/getCookies.test.js
+++ b/packages/webdriverio/tests/commands/browser/getCookies.test.js
@@ -1,4 +1,4 @@
-import request from 'request'
+import got from 'got'
 import { remote } from '../../../src'
 
 describe('getCookies', () => {
@@ -16,8 +16,8 @@ describe('getCookies', () => {
     it('should return all cookies', async () => {
         const cookies = await browser.getCookies()
 
-        expect(request.mock.calls[1][0].method).toBe('GET')
-        expect(request.mock.calls[1][0].uri.path).toBe('/wd/hub/session/foobar-123/cookie')
+        expect(got.mock.calls[1][1].method).toBe('GET')
+        expect(got.mock.calls[1][1].uri.path).toBe('/wd/hub/session/foobar-123/cookie')
         expect(cookies).toEqual([
             { name: 'cookie1', value: 'dummy-value-1' },
             { name: 'cookie2', value: 'dummy-value-2' },
@@ -28,16 +28,16 @@ describe('getCookies', () => {
     it('should support passing a string', async () => {
         const cookies = await browser.getCookies('cookie1')
 
-        expect(request.mock.calls[0][0].method).toBe('GET')
-        expect(request.mock.calls[0][0].uri.path).toBe('/wd/hub/session/foobar-123/cookie')
+        expect(got.mock.calls[0][1].method).toBe('GET')
+        expect(got.mock.calls[0][1].uri.path).toBe('/wd/hub/session/foobar-123/cookie')
         expect(cookies).toEqual([{ name: 'cookie1', value: 'dummy-value-1' }])
     })
 
     it('should support passing a array with strings', async () => {
         const cookies = await browser.getCookies(['cookie1'])
 
-        expect(request.mock.calls[0][0].method).toBe('GET')
-        expect(request.mock.calls[0][0].uri.path).toBe('/wd/hub/session/foobar-123/cookie')
+        expect(got.mock.calls[0][1].method).toBe('GET')
+        expect(got.mock.calls[0][1].uri.path).toBe('/wd/hub/session/foobar-123/cookie')
         expect(cookies).toEqual([{ name: 'cookie1', value: 'dummy-value-1' }])
     })
 
@@ -45,8 +45,8 @@ describe('getCookies', () => {
         const cookieNames = ['cookie1', 'doesn-not-exist', 'cookie3']
         const cookies = await browser.getCookies(cookieNames)
 
-        expect(request.mock.calls[0][0].method).toBe('GET')
-        expect(request.mock.calls[0][0].uri.path).toBe('/wd/hub/session/foobar-123/cookie')
+        expect(got.mock.calls[0][1].method).toBe('GET')
+        expect(got.mock.calls[0][1].uri.path).toBe('/wd/hub/session/foobar-123/cookie')
         expect(cookies).toEqual([
             { name: 'cookie1', value: 'dummy-value-1' },
             { name: 'cookie3', value: 'dummy-value-3' },
@@ -60,6 +60,6 @@ describe('getCookies', () => {
     })
 
     afterEach(() => {
-        request.mockClear()
+        got.mockClear()
     })
 })

--- a/packages/webdriverio/tests/commands/browser/getWindowSize.test.js
+++ b/packages/webdriverio/tests/commands/browser/getWindowSize.test.js
@@ -1,4 +1,4 @@
-import request from 'request'
+import got from 'got'
 import { remote } from '../../../src'
 
 describe('getWindowSize', () => {
@@ -15,8 +15,8 @@ describe('getWindowSize', () => {
 
     it('should get size of W3C browser window', async () => {
         await browser.getWindowSize()
-        expect(request.mock.calls[1][0].method).toBe('GET')
-        expect(request.mock.calls[1][0].uri.path).toBe('/wd/hub/session/foobar-123/window/rect')
+        expect(got.mock.calls[1][1].method).toBe('GET')
+        expect(got.mock.calls[1][1].uri.path).toBe('/wd/hub/session/foobar-123/window/rect')
     })
 
     it('should get size of NO-W3C browser window', async () => {
@@ -28,11 +28,11 @@ describe('getWindowSize', () => {
         })
 
         await browser.getWindowSize()
-        expect(request.mock.calls[1][0].method).toBe('GET')
-        expect(request.mock.calls[1][0].uri.path).toBe('/wd/hub/session/foobar-123/window/current/size')
+        expect(got.mock.calls[1][1].method).toBe('GET')
+        expect(got.mock.calls[1][1].uri.path).toBe('/wd/hub/session/foobar-123/window/current/size')
     })
 
     afterEach(() => {
-        request.mockClear()
+        got.mockClear()
     })
 })

--- a/packages/webdriverio/tests/commands/browser/keys.test.js
+++ b/packages/webdriverio/tests/commands/browser/keys.test.js
@@ -1,4 +1,4 @@
-import request from 'request'
+import got from 'got'
 import { remote } from '../../../src'
 
 describe('keys', () => {
@@ -11,12 +11,12 @@ describe('keys', () => {
         })
 
         await browser.keys('foobar')
-        expect(request.mock.calls[1][0].uri.path).toContain('/actions')
-        expect(request.mock.calls[1][0].body.actions).toHaveLength(1)
-        expect(request.mock.calls[1][0].body.actions[0].type).toBe('key')
-        expect(request.mock.calls[1][0].body.actions[0].actions).toHaveLength('foobar'.length * 2)
-        expect(request.mock.calls[1][0].body.actions[0].actions[0]).toEqual({ type: 'keyDown', value: 'f' })
-        expect(request.mock.calls[1][0].body.actions[0].actions[11]).toEqual({ type: 'keyUp', value: 'r' })
+        expect(got.mock.calls[1][1].uri.path).toContain('/actions')
+        expect(got.mock.calls[1][1].json.actions).toHaveLength(1)
+        expect(got.mock.calls[1][1].json.actions[0].type).toBe('key')
+        expect(got.mock.calls[1][1].json.actions[0].actions).toHaveLength('foobar'.length * 2)
+        expect(got.mock.calls[1][1].json.actions[0].actions[0]).toEqual({ type: 'keyDown', value: 'f' })
+        expect(got.mock.calls[1][1].json.actions[0].actions[11]).toEqual({ type: 'keyUp', value: 'r' })
     })
 
     it('should send keys (no w3c)', async () => {
@@ -28,12 +28,12 @@ describe('keys', () => {
         })
 
         await browser.keys('foobar')
-        expect(request.mock.calls[1][0].uri.path).toContain('/keys')
-        expect(request.mock.calls[1][0].body.value).toEqual(['f', 'o', 'o', 'b', 'a', 'r'])
+        expect(got.mock.calls[1][1].uri.path).toContain('/keys')
+        expect(got.mock.calls[1][1].json.value).toEqual(['f', 'o', 'o', 'b', 'a', 'r'])
 
         await browser.keys('Enter')
-        expect(request.mock.calls[2][0].uri.path).toContain('/keys')
-        expect(request.mock.calls[2][0].body.value).toEqual(['\uE007'])
+        expect(got.mock.calls[2][1].uri.path).toContain('/keys')
+        expect(got.mock.calls[2][1].json.value).toEqual(['\uE007'])
     })
 
     it('should allow send keys as array', async () => {
@@ -45,12 +45,12 @@ describe('keys', () => {
         })
 
         await browser.keys(['f', 'o', 'Enter', 'b', 'a', 'r'])
-        expect(request.mock.calls[1][0].uri.path).toContain('/keys')
-        expect(request.mock.calls[1][0].body.value).toEqual(['f', 'o', '\uE007', 'b', 'a', 'r'])
+        expect(got.mock.calls[1][1].uri.path).toContain('/keys')
+        expect(got.mock.calls[1][1].json.value).toEqual(['f', 'o', '\uE007', 'b', 'a', 'r'])
 
         await browser.keys('Enter')
-        expect(request.mock.calls[2][0].uri.path).toContain('/keys')
-        expect(request.mock.calls[2][0].body.value).toEqual(['\uE007'])
+        expect(got.mock.calls[2][1].uri.path).toContain('/keys')
+        expect(got.mock.calls[2][1].json.value).toEqual(['\uE007'])
     })
 
     it('should throw if invalid character was provided', async () => {
@@ -67,6 +67,6 @@ describe('keys', () => {
     })
 
     afterEach(() => {
-        request.mockClear()
+        got.mockClear()
     })
 })

--- a/packages/webdriverio/tests/commands/browser/newWindow.test.js
+++ b/packages/webdriverio/tests/commands/browser/newWindow.test.js
@@ -4,7 +4,7 @@
 
 global.window.open = jest.fn()
 
-import request from 'request'
+import got from 'got'
 import { remote } from '../../../src'
 
 describe('newWindow', () => {
@@ -17,10 +17,10 @@ describe('newWindow', () => {
         })
 
         await browser.newWindow('https://webdriver.io', 'some name', 'some params')
-        expect(request.mock.calls).toHaveLength(4)
-        expect(request.mock.calls[1][0].body.args).toEqual(['https://webdriver.io', 'some name', 'some params'])
-        expect(request.mock.calls[2][0].uri.path).toContain('/window/handles')
-        expect(request.mock.calls[3][0].body.handle).toBe('window-handle-3')
+        expect(got.mock.calls).toHaveLength(4)
+        expect(got.mock.calls[1][1].json.args).toEqual(['https://webdriver.io', 'some name', 'some params'])
+        expect(got.mock.calls[2][1].uri.path).toContain('/window/handles')
+        expect(got.mock.calls[3][1].json.handle).toBe('window-handle-3')
     })
 
     it('should fail if url is invalid', async () => {

--- a/packages/webdriverio/tests/commands/browser/pause.test.js
+++ b/packages/webdriverio/tests/commands/browser/pause.test.js
@@ -1,4 +1,4 @@
-import request from 'request'
+import got from 'got'
 import { remote } from '../../../src'
 
 describe('pause test', () => {
@@ -19,7 +19,7 @@ describe('pause test', () => {
 
         expect((end - start) > 490).toBe(true)
         expect((end - start) < 590).toBe(true)
-        expect(request.mock.calls).toHaveLength(1)
+        expect(got.mock.calls).toHaveLength(1)
     })
 
     it('should pause for default value', async () => {
@@ -29,10 +29,10 @@ describe('pause test', () => {
 
         expect((end - start) > 990).toBe(true)
         expect((end - start) < 1090).toBe(true)
-        expect(request.mock.calls).toHaveLength(1)
+        expect(got.mock.calls).toHaveLength(1)
     })
 
     afterEach(() => {
-        request.mockClear()
+        got.mockClear()
     })
 })

--- a/packages/webdriverio/tests/commands/browser/reactElement.test.js
+++ b/packages/webdriverio/tests/commands/browser/reactElement.test.js
@@ -1,4 +1,4 @@
-import request from 'request'
+import got from 'got'
 import { remote } from '../../../src'
 
 describe('react$', () => {
@@ -17,8 +17,8 @@ describe('react$', () => {
         )
 
         expect(elem.elementId).toBe('some-elem-123')
-        expect(request).toBeCalledTimes(4)
-        expect(request.mock.calls.pop()[0].body.args)
+        expect(got).toBeCalledTimes(4)
+        expect(got.mock.calls.pop()[1].json.args)
             .toEqual(['myComp', { some: 'props' }, { some: 'state' }])
     })
 
@@ -31,7 +31,7 @@ describe('react$', () => {
         })
 
         await browser.react$('myComp')
-        expect(request.mock.calls.pop()[0].body.args).toEqual(['myComp', {}, {}])
+        expect(got.mock.calls.pop()[1].json.args).toEqual(['myComp', {}, {}])
     })
 
     it('should call getElement with React flag true', async () => {
@@ -47,6 +47,6 @@ describe('react$', () => {
     })
 
     afterEach(() => {
-        request.mockClear()
+        got.mockClear()
     })
 })

--- a/packages/webdriverio/tests/commands/browser/reactElements.test.js
+++ b/packages/webdriverio/tests/commands/browser/reactElements.test.js
@@ -1,4 +1,4 @@
-import request from 'request'
+import got from 'got'
 import { ELEMENT_KEY } from '../../../src/constants'
 import { remote } from '../../../src'
 
@@ -33,8 +33,8 @@ describe('react$', () => {
         expect(elems[2].ELEMENT).toBe(undefined)
         expect(elems[2].selector).toBe('myComp')
         expect(elems[2].index).toBe(2)
-        expect(request).toBeCalledTimes(4)
-        expect(request.mock.calls.pop()[0].body.args)
+        expect(got).toBeCalledTimes(4)
+        expect(got.mock.calls.pop()[1].json.args)
             .toEqual(['myComp', { some: 'props' }, { some: 'state' }])
     })
 
@@ -47,7 +47,7 @@ describe('react$', () => {
         })
 
         await browser.react$$('myComp')
-        expect(request.mock.calls.pop()[0].body.args).toEqual(['myComp', {}, {}])
+        expect(got.mock.calls.pop()[1].json.args).toEqual(['myComp', {}, {}])
     })
 
     it('should call getElements with React flag true', async () => {

--- a/packages/webdriverio/tests/commands/browser/reloadSession.test.js
+++ b/packages/webdriverio/tests/commands/browser/reloadSession.test.js
@@ -1,4 +1,4 @@
-import request from 'request'
+import got from 'got'
 import { remote } from '../../../src'
 
 describe('reloadSession test', () => {
@@ -29,7 +29,7 @@ describe('reloadSession test', () => {
 
     scenarios.forEach(scenario => {
         it(scenario.name, async () => {
-            const oldSessionId = request.getSessionId()
+            const oldSessionId = got.getSessionId()
             const hook = jest.fn()
             const browser = await remote({
                 baseUrl: 'http://foobar.com',
@@ -40,14 +40,14 @@ describe('reloadSession test', () => {
                 onReload: [hook]
             })
 
-            request.setSessionId(scenario.sessionIdMock)
-            request.setMockResponse(scenario.requestMock)
+            got.setSessionId(scenario.sessionIdMock)
+            got.setMockResponse(scenario.requestMock)
             await browser.reloadSession()
 
-            expect(request.mock.calls[1][0].method).toBe('DELETE')
-            expect(request.mock.calls[1][0].uri.pathname).toBe(`/wd/hub/session/${oldSessionId}`)
-            expect(request.mock.calls[2][0].method).toBe('POST')
-            expect(request.mock.calls[2][0].uri.pathname).toBe('/wd/hub/session')
+            expect(got.mock.calls[1][1].method).toBe('DELETE')
+            expect(got.mock.calls[1][1].uri.pathname).toBe(`/wd/hub/session/${oldSessionId}`)
+            expect(got.mock.calls[2][1].method).toBe('POST')
+            expect(got.mock.calls[2][1].uri.pathname).toBe('/wd/hub/session')
             expect(hook).toBeCalledWith(oldSessionId, scenario.newSessionId)
         })
     })
@@ -72,14 +72,14 @@ describe('reloadSession test', () => {
 
         browser.sessionId = null // INFO: destroy sessionId in browser object
 
-        request.setSessionId(scenario.sessionIdMock)
-        request.setMockResponse(scenario.requestMock)
+        got.setSessionId(scenario.sessionIdMock)
+        got.setMockResponse(scenario.requestMock)
 
         await browser.reloadSession()
 
-        // INFO: DELETE to /wd/hub/session/${oldSessionId} in not expected to be found in request.mock.calls as it will not complete
-        expect(request.mock.calls[1][0].method).toBe('POST')
-        expect(request.mock.calls[1][0].uri.pathname).toBe('/wd/hub/session')
+        // INFO: DELETE to /wd/hub/session/${oldSessionId} in not expected to be found in got.mock.calls as it will not complete
+        expect(got.mock.calls[1][1].method).toBe('POST')
+        expect(got.mock.calls[1][1].uri.pathname).toBe('/wd/hub/session')
         expect(hook).toBeCalledWith(null, scenario.newSessionId)
     })
 
@@ -103,20 +103,20 @@ describe('reloadSession test', () => {
 
         browser.sessionId = null // INFO: destroy sessionId in browser object
 
-        request.setSessionId(scenario.sessionIdMock)
-        request.setMockResponse(scenario.requestMock)
+        got.setSessionId(scenario.sessionIdMock)
+        got.setMockResponse(scenario.requestMock)
 
         await browser.reloadSession()
 
-        // INFO: DELETE to /wd/hub/session/${oldSessionId} in not expected to be found in request.mock.calls as it will not complete
-        expect(request.mock.calls[1][0].method).toBe('POST')
-        expect(request.mock.calls[1][0].uri.pathname).toBe('/wd/hub/session')
+        // INFO: DELETE to /wd/hub/session/${oldSessionId} in not expected to be found in got.mock.calls as it will not complete
+        expect(got.mock.calls[1][1].method).toBe('POST')
+        expect(got.mock.calls[1][1].uri.pathname).toBe('/wd/hub/session')
         expect(hook).toBeCalledWith(null, scenario.newSessionId)
     })
 
     afterEach(() => {
-        request.mockClear()
-        request.resetSessionId()
-        request.setMockResponse()
+        got.mockClear()
+        got.resetSessionId()
+        got.setMockResponse()
     })
 })

--- a/packages/webdriverio/tests/commands/browser/saveRecordingScreen.test.js
+++ b/packages/webdriverio/tests/commands/browser/saveRecordingScreen.test.js
@@ -1,5 +1,5 @@
 import fs from 'fs'
-import request from 'request'
+import got from 'got'
 import { remote } from '../../../src'
 import * as utils from '../../../src/utils'
 
@@ -41,8 +41,8 @@ describe('saveRecordingScreen', () => {
         expect(assertDirectoryExistsSpy).toHaveBeenCalledWith(getAbsoluteFilepathSpy.mock.results[0].value)
 
         // request
-        expect(request.mock.calls[1][0].method).toBe('POST')
-        expect(request.mock.calls[1][0].uri.pathname).toBe('/wd/hub/session/foobar-123/appium/stop_recording_screen')
+        expect(got.mock.calls[1][1].method).toBe('POST')
+        expect(got.mock.calls[1][1].uri.pathname).toBe('/wd/hub/session/foobar-123/appium/stop_recording_screen')
         expect(video.toString()).toBe('some screenshot')
 
         // write to file

--- a/packages/webdriverio/tests/commands/browser/saveScreenshot.test.js
+++ b/packages/webdriverio/tests/commands/browser/saveScreenshot.test.js
@@ -1,5 +1,5 @@
 import fs from 'fs'
-import request from 'request'
+import got from 'got'
 import { remote } from '../../../src'
 import * as utils from '../../../src/utils'
 
@@ -38,8 +38,8 @@ describe('saveScreenshot', () => {
         expect(assertDirectoryExistsSpy).toHaveBeenCalledWith(getAbsoluteFilepathSpy.mock.results[0].value)
 
         // request
-        expect(request.mock.calls[1][0].method).toBe('GET')
-        expect(request.mock.calls[1][0].uri.pathname).toBe('/wd/hub/session/foobar-123/screenshot')
+        expect(got.mock.calls[1][1].method).toBe('GET')
+        expect(got.mock.calls[1][1].uri.pathname).toBe('/wd/hub/session/foobar-123/screenshot')
         expect(screenshot.toString()).toBe('some screenshot')
 
         // write to file

--- a/packages/webdriverio/tests/commands/browser/setCookies.test.js
+++ b/packages/webdriverio/tests/commands/browser/setCookies.test.js
@@ -1,4 +1,4 @@
-import request from 'request'
+import got from 'got'
 import { remote } from '../../../src'
 
 describe('setCookies', () => {
@@ -15,30 +15,30 @@ describe('setCookies', () => {
 
     it('should output the expected format', async () => {
         await browser.setCookies([{ name: 'cookie1', value: 'dummy-value-1' }])
-        expect(request.mock.calls.length).toBe(2)
-        expect(request.mock.calls[1][0].method).toBe('POST')
-        expect(request.mock.calls[1][0].uri.path).toBe('/wd/hub/session/foobar-123/cookie')
-        expect(request.mock.calls[1][0].body).toEqual({ 'cookie': { name: 'cookie1', value: 'dummy-value-1' } })
+        expect(got.mock.calls).toHaveLength(2)
+        expect(got.mock.calls[1][1].method).toBe('POST')
+        expect(got.mock.calls[1][1].uri.path).toBe('/wd/hub/session/foobar-123/cookie')
+        expect(got.mock.calls[1][1].json).toEqual({ 'cookie': { name: 'cookie1', value: 'dummy-value-1' } })
     })
 
     it('should support passing an object', async () => {
         await browser.setCookies({ name: 'cookie1', value: 'dummy-value-1' })
-        expect(request.mock.calls.length).toBe(1)
-        expect(request.mock.calls[0][0].method).toBe('POST')
-        expect(request.mock.calls[0][0].uri.path).toBe('/wd/hub/session/foobar-123/cookie')
-        expect(request.mock.calls[0][0].body).toEqual({ 'cookie': { name: 'cookie1', value: 'dummy-value-1' } })
+        expect(got.mock.calls).toHaveLength(1)
+        expect(got.mock.calls[0][1].method).toBe('POST')
+        expect(got.mock.calls[0][1].uri.path).toBe('/wd/hub/session/foobar-123/cookie')
+        expect(got.mock.calls[0][1].json).toEqual({ 'cookie': { name: 'cookie1', value: 'dummy-value-1' } })
     })
 
     it('can be called multiple times', async () => {
         await browser.setCookies({ name: 'cookie1', value: 'dummy-value-1' })
         await browser.setCookies({ name: 'cookie2', value: 'dummy-value-1' })
-        expect(request.mock.calls.length).toBe(2)
-        expect(request.mock.calls[0][0].method).toBe('POST')
-        expect(request.mock.calls[0][0].uri.path).toBe('/wd/hub/session/foobar-123/cookie')
-        expect(request.mock.calls[0][0].body).toEqual({ 'cookie': { name: 'cookie1', value: 'dummy-value-1' } })
-        expect(request.mock.calls[1][0].method).toBe('POST')
-        expect(request.mock.calls[1][0].uri.path).toBe('/wd/hub/session/foobar-123/cookie')
-        expect(request.mock.calls[1][0].body).toEqual({ 'cookie': { name: 'cookie2', value: 'dummy-value-1' } })
+        expect(got.mock.calls).toHaveLength(2)
+        expect(got.mock.calls[0][1].method).toBe('POST')
+        expect(got.mock.calls[0][1].uri.path).toBe('/wd/hub/session/foobar-123/cookie')
+        expect(got.mock.calls[0][1].json).toEqual({ 'cookie': { name: 'cookie1', value: 'dummy-value-1' } })
+        expect(got.mock.calls[1][1].method).toBe('POST')
+        expect(got.mock.calls[1][1].uri.path).toBe('/wd/hub/session/foobar-123/cookie')
+        expect(got.mock.calls[1][1].json).toEqual({ 'cookie': { name: 'cookie2', value: 'dummy-value-1' } })
     })
 
     it('should work with multiple objects passed', async () => {
@@ -51,9 +51,9 @@ describe('setCookies', () => {
         await browser.setCookies(cookies)
 
         cookies.forEach((cookie, i) => {
-            expect(request.mock.calls[i][0].method).toBe('POST')
-            expect(request.mock.calls[i][0].uri.path).toBe('/wd/hub/session/foobar-123/cookie')
-            expect(request.mock.calls[i][0].body).toEqual({ 'cookie': cookie })
+            expect(got.mock.calls[i][1].method).toBe('POST')
+            expect(got.mock.calls[i][1].uri.path).toBe('/wd/hub/session/foobar-123/cookie')
+            expect(got.mock.calls[i][1].json).toEqual({ 'cookie': cookie })
         })
     })
 
@@ -64,6 +64,6 @@ describe('setCookies', () => {
     })
 
     afterEach(() => {
-        request.mockClear()
+        got.mockClear()
     })
 })

--- a/packages/webdriverio/tests/commands/browser/setTimeout.test.js
+++ b/packages/webdriverio/tests/commands/browser/setTimeout.test.js
@@ -1,4 +1,4 @@
-import request from 'request'
+import got from 'got'
 import { remote } from '../../../src'
 
 describe('setTimeout', () => {
@@ -12,42 +12,42 @@ describe('setTimeout', () => {
         })
 
         await browser.setTimeout({ implicit: 5000 })
-        expect(request.mock.calls.length).toBe(2)
-        expect(request.mock.calls[1][0].method).toBe('POST')
-        expect(request.mock.calls[1][0].uri.path).toBe('/wd/hub/session/foobar-123/timeouts')
-        expect(request.mock.calls[1][0].body).toEqual({ 'implicit': 5000 })
+        expect(got.mock.calls).toHaveLength(2)
+        expect(got.mock.calls[1][1].method).toBe('POST')
+        expect(got.mock.calls[1][1].uri.path).toBe('/wd/hub/session/foobar-123/timeouts')
+        expect(got.mock.calls[1][1].json).toEqual({ 'implicit': 5000 })
 
         await browser.setTimeout({ pageLoad: 10000 })
-        expect(request.mock.calls.length).toBe(3)
-        expect(request.mock.calls[2][0].method).toBe('POST')
-        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/timeouts')
-        expect(request.mock.calls[2][0].body).toEqual({ 'pageLoad': 10000 })
+        expect(got.mock.calls).toHaveLength(3)
+        expect(got.mock.calls[2][1].method).toBe('POST')
+        expect(got.mock.calls[2][1].uri.path).toBe('/wd/hub/session/foobar-123/timeouts')
+        expect(got.mock.calls[2][1].json).toEqual({ 'pageLoad': 10000 })
 
         await browser.setTimeout({ script: 60000 })
-        expect(request.mock.calls.length).toBe(4)
-        expect(request.mock.calls[3][0].method).toBe('POST')
-        expect(request.mock.calls[3][0].uri.path).toBe('/wd/hub/session/foobar-123/timeouts')
-        expect(request.mock.calls[3][0].body).toEqual({ 'script': 60000 })
+        expect(got.mock.calls).toHaveLength(4)
+        expect(got.mock.calls[3][1].method).toBe('POST')
+        expect(got.mock.calls[3][1].uri.path).toBe('/wd/hub/session/foobar-123/timeouts')
+        expect(got.mock.calls[3][1].json).toEqual({ 'script': 60000 })
 
         await browser.setTimeout({
             implicit: 0,
             pageLoad: 300000,
             script: 30000,
         })
-        expect(request.mock.calls.length).toBe(5)
-        expect(request.mock.calls[4][0].method).toBe('POST')
-        expect(request.mock.calls[4][0].uri.path).toBe('/wd/hub/session/foobar-123/timeouts')
-        expect(request.mock.calls[4][0].body).toEqual({
+        expect(got.mock.calls).toHaveLength(5)
+        expect(got.mock.calls[4][1].method).toBe('POST')
+        expect(got.mock.calls[4][1].uri.path).toBe('/wd/hub/session/foobar-123/timeouts')
+        expect(got.mock.calls[4][1].json).toEqual({
             'implicit': 0,
             'pageLoad': 300000,
             'script': 30000,
         })
 
         await browser.setTimeout({})
-        expect(request.mock.calls.length).toBe(6)
-        expect(request.mock.calls[5][0].method).toBe('POST')
-        expect(request.mock.calls[5][0].uri.path).toBe('/wd/hub/session/foobar-123/timeouts')
-        expect(request.mock.calls[5][0].body).toEqual({})
+        expect(got.mock.calls).toHaveLength(6)
+        expect(got.mock.calls[5][1].method).toBe('POST')
+        expect(got.mock.calls[5][1].uri.path).toBe('/wd/hub/session/foobar-123/timeouts')
+        expect(got.mock.calls[5][1].json).toEqual({})
     })
 
     it('should set timeout (no w3c)', async () => {
@@ -59,41 +59,41 @@ describe('setTimeout', () => {
         })
 
         await browser.setTimeout({ implicit: 5000 })
-        expect(request.mock.calls.length).toBe(2)
-        expect(request.mock.calls[1][0].method).toBe('POST')
-        expect(request.mock.calls[1][0].uri.path).toBe('/wd/hub/session/foobar-123/timeouts')
-        expect(request.mock.calls[1][0].body).toEqual({ 'type': 'implicit', 'ms': 5000 })
+        expect(got.mock.calls).toHaveLength(2)
+        expect(got.mock.calls[1][1].method).toBe('POST')
+        expect(got.mock.calls[1][1].uri.path).toBe('/wd/hub/session/foobar-123/timeouts')
+        expect(got.mock.calls[1][1].json).toEqual({ 'type': 'implicit', 'ms': 5000 })
 
         await browser.setTimeout({ 'page load': 10000 })
-        expect(request.mock.calls.length).toBe(3)
-        expect(request.mock.calls[2][0].method).toBe('POST')
-        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/timeouts')
-        expect(request.mock.calls[2][0].body).toEqual({ 'type': 'page load', 'ms': 10000 })
+        expect(got.mock.calls).toHaveLength(3)
+        expect(got.mock.calls[2][1].method).toBe('POST')
+        expect(got.mock.calls[2][1].uri.path).toBe('/wd/hub/session/foobar-123/timeouts')
+        expect(got.mock.calls[2][1].json).toEqual({ 'type': 'page load', 'ms': 10000 })
 
         await browser.setTimeout({ script: 60000 })
-        expect(request.mock.calls.length).toBe(4)
-        expect(request.mock.calls[3][0].method).toBe('POST')
-        expect(request.mock.calls[3][0].uri.path).toBe('/wd/hub/session/foobar-123/timeouts')
-        expect(request.mock.calls[3][0].body).toEqual({ 'type': 'script', 'ms': 60000 })
+        expect(got.mock.calls).toHaveLength(4)
+        expect(got.mock.calls[3][1].method).toBe('POST')
+        expect(got.mock.calls[3][1].uri.path).toBe('/wd/hub/session/foobar-123/timeouts')
+        expect(got.mock.calls[3][1].json).toEqual({ 'type': 'script', 'ms': 60000 })
 
         await browser.setTimeout({
             implicit: 0,
             pageLoad: 300000,
             script: 30000,
         })
-        expect(request.mock.calls.length).toBe(7)
-        expect(request.mock.calls[4][0].method).toBe('POST')
-        expect(request.mock.calls[4][0].uri.path).toBe('/wd/hub/session/foobar-123/timeouts')
-        expect(request.mock.calls[4][0].body).toEqual({ 'type': 'implicit', 'ms': 0 })
-        expect(request.mock.calls[5][0].method).toBe('POST')
-        expect(request.mock.calls[5][0].uri.path).toBe('/wd/hub/session/foobar-123/timeouts')
-        expect(request.mock.calls[5][0].body).toEqual({ 'type': 'page load', 'ms': 300000 })
-        expect(request.mock.calls[6][0].method).toBe('POST')
-        expect(request.mock.calls[6][0].uri.path).toBe('/wd/hub/session/foobar-123/timeouts')
-        expect(request.mock.calls[6][0].body).toEqual({ 'type': 'script', 'ms': 30000 })
+        expect(got.mock.calls).toHaveLength(7)
+        expect(got.mock.calls[4][1].method).toBe('POST')
+        expect(got.mock.calls[4][1].uri.path).toBe('/wd/hub/session/foobar-123/timeouts')
+        expect(got.mock.calls[4][1].json).toEqual({ 'type': 'implicit', 'ms': 0 })
+        expect(got.mock.calls[5][1].method).toBe('POST')
+        expect(got.mock.calls[5][1].uri.path).toBe('/wd/hub/session/foobar-123/timeouts')
+        expect(got.mock.calls[5][1].json).toEqual({ 'type': 'page load', 'ms': 300000 })
+        expect(got.mock.calls[6][1].method).toBe('POST')
+        expect(got.mock.calls[6][1].uri.path).toBe('/wd/hub/session/foobar-123/timeouts')
+        expect(got.mock.calls[6][1].json).toEqual({ 'type': 'script', 'ms': 30000 })
 
         await browser.setTimeout({})
-        expect(request.mock.calls.length).toBe(7)
+        expect(got.mock.calls).toHaveLength(7)
     })
 
     it('should throw error on setting invalid timeout', async () => {
@@ -131,6 +131,6 @@ describe('setTimeout', () => {
     })
 
     afterEach(() => {
-        request.mockClear()
+        got.mockClear()
     })
 })

--- a/packages/webdriverio/tests/commands/browser/setWindowSize.test.js
+++ b/packages/webdriverio/tests/commands/browser/setWindowSize.test.js
@@ -1,4 +1,4 @@
-import request from 'request'
+import got from 'got'
 import { remote } from '../../../src'
 
 describe('setWindowSize', () => {
@@ -15,9 +15,9 @@ describe('setWindowSize', () => {
 
     it('should resize W3C browser window', async () => {
         await browser.setWindowSize(777, 888)
-        expect(request.mock.calls[1][0].method).toBe('POST')
-        expect(request.mock.calls[1][0].uri.path).toBe('/wd/hub/session/foobar-123/window/rect')
-        expect(request.mock.calls[1][0].body).toEqual({ x: null, y: null, width: 777, height: 888 })
+        expect(got.mock.calls[1][1].method).toBe('POST')
+        expect(got.mock.calls[1][1].uri.path).toBe('/wd/hub/session/foobar-123/window/rect')
+        expect(got.mock.calls[1][1].json).toEqual({ x: null, y: null, width: 777, height: 888 })
     })
 
     it('should resize NO-W3C browser window', async () => {
@@ -29,9 +29,9 @@ describe('setWindowSize', () => {
         })
 
         await browser.setWindowSize(999, 1111)
-        expect(request.mock.calls[1][0].method).toBe('POST')
-        expect(request.mock.calls[1][0].uri.path).toBe('/wd/hub/session/foobar-123/window/current/size')
-        expect(request.mock.calls[1][0].body).toEqual({ width: 999, height: 1111 })
+        expect(got.mock.calls[1][1].method).toBe('POST')
+        expect(got.mock.calls[1][1].uri.path).toBe('/wd/hub/session/foobar-123/window/current/size')
+        expect(got.mock.calls[1][1].json).toEqual({ width: 999, height: 1111 })
     })
 
     describe('input checks', () => {
@@ -59,6 +59,6 @@ describe('setWindowSize', () => {
     })
 
     afterEach(() => {
-        request.mockClear()
+        got.mockClear()
     })
 })

--- a/packages/webdriverio/tests/commands/browser/switchWindow.test.js
+++ b/packages/webdriverio/tests/commands/browser/switchWindow.test.js
@@ -1,11 +1,11 @@
-import request from 'request'
+import got from 'got'
 import { remote } from '../../../src'
 
 describe('switchWindow', () => {
     let browser
 
     beforeEach(async () => {
-        request.setMockResponse()
+        got.setMockResponse()
         browser = await remote({
             baseUrl: 'http://foobar.com',
             capabilities: {
@@ -20,20 +20,20 @@ describe('switchWindow', () => {
     })
 
     it('should iterate over all available handles to find the right window', async () => {
-        request.setMockResponse([null, null, 'foo', 'bar', null, 'hello', 'world', null, 'some', 'url'])
+        got.setMockResponse([null, null, 'foo', 'bar', null, 'hello', 'world', null, 'some', 'url'])
         const tabId = await browser.switchWindow('so')
         expect(tabId).toBe('window-handle-3')
-        request.setMockResponse([null, null, 'foo', 'bar', null, 'hello', 'world', null, 'some', 'url'])
+        got.setMockResponse([null, null, 'foo', 'bar', null, 'hello', 'world', null, 'some', 'url'])
         const otherTabId = await browser.switchWindow(/h(e|a)llo/)
         expect(otherTabId).toBe('window-handle-2')
-        request.setMockResponse([null, null, 'foo', 'bar', null, 'hello', 'world', null, 'some', 'url'])
+        got.setMockResponse([null, null, 'foo', 'bar', null, 'hello', 'world', null, 'some', 'url'])
         const anotherTabId = await browser.switchWindow('world')
         expect(anotherTabId).toBe('window-handle-2')
     })
 
     it('should fail if no window was found', async () => {
         expect.hasAssertions()
-        request.setMockResponse([null, null, 'foo', 'bar', null, 'hello', 'world', null, 'some', 'url'])
+        got.setMockResponse([null, null, 'foo', 'bar', null, 'hello', 'world', null, 'some', 'url'])
 
         try {
             await browser.switchWindow('foobar')

--- a/packages/webdriverio/tests/commands/browser/touchAction.test.js
+++ b/packages/webdriverio/tests/commands/browser/touchAction.test.js
@@ -1,4 +1,4 @@
-import request from 'request'
+import got from 'got'
 import { remote } from '../../../src'
 
 describe('touchAction test', () => {
@@ -29,8 +29,8 @@ describe('touchAction test', () => {
                 y: 2,
                 element: elem
             })
-            expect(request.mock.calls[0][0].uri.path).toContain('/touch/perform')
-            expect(request.mock.calls[0][0].body).toEqual({
+            expect(got.mock.calls[0][1].uri.path).toContain('/touch/perform')
+            expect(got.mock.calls[0][1].json).toEqual({
                 actions: [
                     { action: 'press', options: { x: 1, y: 2, element: 'some-elem-123' } }
                 ]
@@ -43,8 +43,8 @@ describe('touchAction test', () => {
                 x: 1,
                 y: 2
             })
-            expect(request.mock.calls[0][0].uri.path).toContain('/touch/perform')
-            expect(request.mock.calls[0][0].body).toEqual({
+            expect(got.mock.calls[0][1].uri.path).toContain('/touch/perform')
+            expect(got.mock.calls[0][1].json).toEqual({
                 actions: [
                     { action: 'press', options: { x: 1, y: 2 } }
                 ]
@@ -53,8 +53,8 @@ describe('touchAction test', () => {
 
         it('should handle multiple actions as strings properly', async () => {
             await browser.touchAction(['wait', 'release'])
-            expect(request.mock.calls[0][0].uri.path).toContain('/touch/perform')
-            expect(request.mock.calls[0][0].body).toEqual({
+            expect(got.mock.calls[0][1].uri.path).toContain('/touch/perform')
+            expect(got.mock.calls[0][1].json).toEqual({
                 actions: [
                     { action: 'wait' },
                     { action: 'release' }
@@ -66,8 +66,8 @@ describe('touchAction test', () => {
     describe('multi touch', () => {
         it('should transform to array using element as first citizen', async () => {
             await browser.touchAction([['press'], ['release']])
-            expect(request.mock.calls[0][0].uri.path).toContain('/touch/multi/perform')
-            expect(request.mock.calls[0][0].body).toEqual({
+            expect(got.mock.calls[0][1].uri.path).toContain('/touch/multi/perform')
+            expect(got.mock.calls[0][1].json).toEqual({
                 actions: [
                     [{ action: 'press' }],
                     [{ action: 'release' }]
@@ -85,7 +85,7 @@ describe('touchAction test', () => {
                 x: 112,
                 y: 245
             }]])
-            expect(request.mock.calls[0][0].body).toEqual({
+            expect(got.mock.calls[0][1].json).toEqual({
                 actions: [
                     [{ action: 'press', options: { x: 1, y: 2 } }],
                     [{ action: 'tap', options: { x: 112, y: 245 } }]
@@ -105,6 +105,6 @@ describe('touchAction test', () => {
     })
 
     beforeEach(() => {
-        request.mockClear()
+        got.mockClear()
     })
 })

--- a/packages/webdriverio/tests/commands/browser/url.test.js
+++ b/packages/webdriverio/tests/commands/browser/url.test.js
@@ -1,4 +1,4 @@
-import request from 'request'
+import got from 'got'
 import { remote } from '../../../src'
 
 describe('url', () => {
@@ -15,13 +15,13 @@ describe('url', () => {
 
     it('should accept a full url', async () => {
         await browser.url('http://google.com')
-        expect(request.mock.calls[1][0].uri.path).toBe('/wd/hub/session/foobar-123/url')
-        expect(request.mock.calls[1][0].body).toEqual({ url: 'http://google.com/' })
+        expect(got.mock.calls[1][1].uri.path).toBe('/wd/hub/session/foobar-123/url')
+        expect(got.mock.calls[1][1].json).toEqual({ url: 'http://google.com/' })
     })
 
     it('should accept a relative url', async () => {
         await browser.url('/foobar')
-        expect(request.mock.calls[0][0].body).toEqual({ url: 'http://foobar.com/foobar' })
+        expect(got.mock.calls[0][1].json).toEqual({ url: 'http://foobar.com/foobar' })
     })
 
     it('should throw an exception when a non-string value passed in', async () => {
@@ -33,6 +33,6 @@ describe('url', () => {
     })
 
     afterEach(() => {
-        request.mockClear()
+        got.mockClear()
     })
 })

--- a/packages/webdriverio/tests/commands/browser/waitUntil.test.js
+++ b/packages/webdriverio/tests/commands/browser/waitUntil.test.js
@@ -1,4 +1,4 @@
-import request from 'request'
+import got from 'got'
 import { remote } from '../../../src'
 
 jest.setTimeout(10 * 1000)
@@ -124,6 +124,6 @@ describe('waitUntil', () => {
     })
 
     afterEach(() => {
-        request.mockClear()
+        got.mockClear()
     })
 })

--- a/packages/webdriverio/tests/commands/element/$$.test.js
+++ b/packages/webdriverio/tests/commands/element/$$.test.js
@@ -1,4 +1,4 @@
-import request from 'request'
+import got from 'got'
 import { remote } from '../../../src'
 import { ELEMENT_KEY } from '../../../src/constants'
 
@@ -13,13 +13,13 @@ describe('element', () => {
 
         const elem = await browser.$('#foo')
         const elems = await elem.$$('#subfoo')
-        expect(request.mock.calls[1][0].method).toBe('POST')
-        expect(request.mock.calls[1][0].uri.path).toBe('/wd/hub/session/foobar-123/element')
-        expect(request.mock.calls[1][0].body).toEqual({ using: 'css selector', value: '#foo' })
+        expect(got.mock.calls[1][1].method).toBe('POST')
+        expect(got.mock.calls[1][1].uri.path).toBe('/wd/hub/session/foobar-123/element')
+        expect(got.mock.calls[1][1].json).toEqual({ using: 'css selector', value: '#foo' })
         expect(elem.elementId).toBe('some-elem-123')
-        expect(request.mock.calls[2][0].method).toBe('POST')
-        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/elements')
-        expect(request.mock.calls[2][0].body).toEqual({ using: 'css selector', value: '#subfoo' })
+        expect(got.mock.calls[2][1].method).toBe('POST')
+        expect(got.mock.calls[2][1].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/elements')
+        expect(got.mock.calls[2][1].json).toEqual({ using: 'css selector', value: '#subfoo' })
         expect(elems).toHaveLength(3)
 
         expect(elems[0].elementId).toBe('some-sub-elem-321')
@@ -76,6 +76,6 @@ describe('element', () => {
     })
 
     afterEach(() => {
-        request.mockClear()
+        got.mockClear()
     })
 })

--- a/packages/webdriverio/tests/commands/element/$.test.js
+++ b/packages/webdriverio/tests/commands/element/$.test.js
@@ -1,4 +1,4 @@
-import request from 'request'
+import got from 'got'
 import { remote } from '../../../src'
 import { ELEMENT_KEY } from '../../../src/constants'
 
@@ -13,15 +13,15 @@ describe('element', () => {
 
         const elem = await browser.$('#foo')
         const subElem = await elem.$('#subfoo')
-        expect(request.mock.calls[1][0].method).toBe('POST')
-        expect(request.mock.calls[1][0].uri.path).toBe('/wd/hub/session/foobar-123/element')
-        expect(request.mock.calls[1][0].body).toEqual({ using: 'css selector', value: '#foo' })
+        expect(got.mock.calls[1][1].method).toBe('POST')
+        expect(got.mock.calls[1][1].uri.path).toBe('/wd/hub/session/foobar-123/element')
+        expect(got.mock.calls[1][1].json).toEqual({ using: 'css selector', value: '#foo' })
         expect(elem.elementId).toBe('some-elem-123')
         expect(elem[ELEMENT_KEY]).toBe('some-elem-123')
         expect(elem.ELEMENT).toBe(undefined)
-        expect(request.mock.calls[2][0].method).toBe('POST')
-        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/element')
-        expect(request.mock.calls[2][0].body).toEqual({ using: 'css selector', value: '#subfoo' })
+        expect(got.mock.calls[2][1].method).toBe('POST')
+        expect(got.mock.calls[2][1].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/element')
+        expect(got.mock.calls[2][1].json).toEqual({ using: 'css selector', value: '#subfoo' })
         expect(subElem.elementId).toBe('some-sub-elem-321')
         expect(subElem[ELEMENT_KEY]).toBe('some-sub-elem-321')
         expect(subElem.ELEMENT).toBe(undefined)
@@ -72,6 +72,6 @@ describe('element', () => {
     })
 
     afterEach(() => {
-        request.mockClear()
+        got.mockClear()
     })
 })

--- a/packages/webdriverio/tests/commands/element/addValue.test.js
+++ b/packages/webdriverio/tests/commands/element/addValue.test.js
@@ -1,4 +1,4 @@
-import request from 'request'
+import got from 'got'
 import { remote } from '../../../src'
 
 describe('addValue test', () => {
@@ -15,47 +15,47 @@ describe('addValue test', () => {
         })
 
         afterEach(() => {
-            request.mockClear()
+            got.mockClear()
         })
 
         it('add string', async () => {
             const elem = await browser.$('#foo')
             await elem.addValue('foobar')
-            expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/value')
-            expect(request.mock.calls[2][0].body.text).toEqual('foobar')
-            expect(request.mock.calls[2][0].body.value).toEqual(undefined)
+            expect(got.mock.calls[2][1].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/value')
+            expect(got.mock.calls[2][1].json.text).toEqual('foobar')
+            expect(got.mock.calls[2][1].json.value).toEqual(undefined)
         })
 
         it('add number', async () => {
             const elem = await browser.$('#foo')
             await elem.addValue(42)
-            expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/value')
-            expect(request.mock.calls[2][0].body.text).toEqual('42')
-            expect(request.mock.calls[2][0].body.value).toEqual(undefined)
+            expect(got.mock.calls[2][1].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/value')
+            expect(got.mock.calls[2][1].json.text).toEqual('42')
+            expect(got.mock.calls[2][1].json.value).toEqual(undefined)
         })
 
         it('add object', async () => {
             const elem = await browser.$('#foo')
             await elem.addValue({ a: 42 })
-            expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/value')
-            expect(request.mock.calls[2][0].body.text).toEqual('{"a":42}')
-            expect(request.mock.calls[2][0].body.value).toEqual(undefined)
+            expect(got.mock.calls[2][1].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/value')
+            expect(got.mock.calls[2][1].json.text).toEqual('{"a":42}')
+            expect(got.mock.calls[2][1].json.value).toEqual(undefined)
         })
 
         it('add boolean', async () => {
             const elem = await browser.$('#foo')
             await elem.addValue(true)
-            expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/value')
-            expect(request.mock.calls[2][0].body.text).toEqual('true')
-            expect(request.mock.calls[2][0].body.value).toEqual(undefined)
+            expect(got.mock.calls[2][1].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/value')
+            expect(got.mock.calls[2][1].json.text).toEqual('true')
+            expect(got.mock.calls[2][1].json.value).toEqual(undefined)
         })
 
         it('add Array<any>', async () => {
             const elem = await browser.$('#foo')
             await elem.addValue([2, '3', true, [1, 2]])
-            expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/value')
-            expect(request.mock.calls[2][0].body.text).toEqual('23true[1,2]')
-            expect(request.mock.calls[2][0].body.value).toEqual(undefined)
+            expect(got.mock.calls[2][1].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/value')
+            expect(got.mock.calls[2][1].json.text).toEqual('23true[1,2]')
+            expect(got.mock.calls[2][1].json.value).toEqual(undefined)
         })
     })
 
@@ -72,52 +72,52 @@ describe('addValue test', () => {
         })
 
         afterEach(() => {
-            request.mockClear()
+            got.mockClear()
         })
 
         it('add string', async () => {
             const elem = await browser.$('#foo')
 
             await elem.addValue('foobar')
-            expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/value')
-            expect(request.mock.calls[2][0].body.value).toEqual(['f', 'o', 'o', 'b', 'a', 'r'])
-            expect(request.mock.calls[2][0].body.text).toEqual(undefined)
+            expect(got.mock.calls[2][1].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/value')
+            expect(got.mock.calls[2][1].json.value).toEqual(['f', 'o', 'o', 'b', 'a', 'r'])
+            expect(got.mock.calls[2][1].json.text).toEqual(undefined)
         })
 
         it('add number', async () => {
             const elem = await browser.$('#foo')
 
             await elem.addValue(42)
-            expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/value')
-            expect(request.mock.calls[2][0].body.value).toEqual(['4', '2'])
-            expect(request.mock.calls[2][0].body.text).toEqual(undefined)
+            expect(got.mock.calls[2][1].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/value')
+            expect(got.mock.calls[2][1].json.value).toEqual(['4', '2'])
+            expect(got.mock.calls[2][1].json.text).toEqual(undefined)
         })
 
         it('add object', async () => {
             const elem = await browser.$('#foo')
 
             await elem.addValue({ a: 42 })
-            expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/value')
-            expect(request.mock.calls[2][0].body.value).toEqual(['{', '"', 'a', '"', ':', '4', '2', '}'])
-            expect(request.mock.calls[2][0].body.text).toEqual(undefined)
+            expect(got.mock.calls[2][1].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/value')
+            expect(got.mock.calls[2][1].json.value).toEqual(['{', '"', 'a', '"', ':', '4', '2', '}'])
+            expect(got.mock.calls[2][1].json.text).toEqual(undefined)
         })
 
         it('add boolean', async () => {
             const elem = await browser.$('#foo')
 
             await elem.addValue(true)
-            expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/value')
-            expect(request.mock.calls[2][0].body.value).toEqual(['t', 'r', 'u', 'e'])
-            expect(request.mock.calls[2][0].body.text).toEqual(undefined)
+            expect(got.mock.calls[2][1].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/value')
+            expect(got.mock.calls[2][1].json.value).toEqual(['t', 'r', 'u', 'e'])
+            expect(got.mock.calls[2][1].json.text).toEqual(undefined)
         })
 
         it('add Array<any>', async () => {
             const elem = await browser.$('#foo')
 
             await elem.addValue([1, '2', true, [1, 2]])
-            expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/value')
-            expect(request.mock.calls[2][0].body.value).toEqual(['1', '2', 't', 'r', 'u', 'e', '[', '1', ',', '2', ']'])
-            expect(request.mock.calls[2][0].body.text).toEqual(undefined)
+            expect(got.mock.calls[2][1].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/value')
+            expect(got.mock.calls[2][1].json.value).toEqual(['1', '2', 't', 'r', 'u', 'e', '[', '1', ',', '2', ']'])
+            expect(got.mock.calls[2][1].json.text).toEqual(undefined)
         })
     })
 
@@ -136,52 +136,52 @@ describe('addValue test', () => {
         })
 
         afterEach(() => {
-            request.mockClear()
+            got.mockClear()
         })
 
         it('add string', async () => {
             const elem = await browser.$('#foo')
 
             await elem.addValue('foobar')
-            expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/value')
-            expect(request.mock.calls[2][0].body.text).toEqual('foobar')
-            expect(request.mock.calls[2][0].body.value).toEqual(['f', 'o', 'o', 'b', 'a', 'r'])
+            expect(got.mock.calls[2][1].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/value')
+            expect(got.mock.calls[2][1].json.text).toEqual('foobar')
+            expect(got.mock.calls[2][1].json.value).toEqual(['f', 'o', 'o', 'b', 'a', 'r'])
         })
 
         it('add number', async () => {
             const elem = await browser.$('#foo')
 
             await elem.addValue(42)
-            expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/value')
-            expect(request.mock.calls[2][0].body.text).toEqual('42')
-            expect(request.mock.calls[2][0].body.value).toEqual(['4', '2'])
+            expect(got.mock.calls[2][1].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/value')
+            expect(got.mock.calls[2][1].json.text).toEqual('42')
+            expect(got.mock.calls[2][1].json.value).toEqual(['4', '2'])
         })
 
         it('add object', async () => {
             const elem = await browser.$('#foo')
 
             await elem.addValue({ a: 42 })
-            expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/value')
-            expect(request.mock.calls[2][0].body.text).toEqual('{"a":42}')
-            expect(request.mock.calls[2][0].body.value).toEqual(['{', '"', 'a', '"', ':', '4', '2', '}'])
+            expect(got.mock.calls[2][1].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/value')
+            expect(got.mock.calls[2][1].json.text).toEqual('{"a":42}')
+            expect(got.mock.calls[2][1].json.value).toEqual(['{', '"', 'a', '"', ':', '4', '2', '}'])
         })
 
         it('add boolean', async () => {
             const elem = await browser.$('#foo')
 
             await elem.addValue(true)
-            expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/value')
-            expect(request.mock.calls[2][0].body.text).toEqual('true')
-            expect(request.mock.calls[2][0].body.value).toEqual(['t', 'r', 'u', 'e'])
+            expect(got.mock.calls[2][1].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/value')
+            expect(got.mock.calls[2][1].json.text).toEqual('true')
+            expect(got.mock.calls[2][1].json.value).toEqual(['t', 'r', 'u', 'e'])
         })
 
         it('add Array<any>', async () => {
             const elem = await browser.$('#foo')
 
             await elem.addValue([1, '2', true, [1, 2]])
-            expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/value')
-            expect(request.mock.calls[2][0].body.text).toEqual('12true[1,2]')
-            expect(request.mock.calls[2][0].body.value).toEqual(['1', '2', 't', 'r', 'u', 'e', '[', '1', ',', '2', ']'])
+            expect(got.mock.calls[2][1].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/value')
+            expect(got.mock.calls[2][1].json.text).toEqual('12true[1,2]')
+            expect(got.mock.calls[2][1].json.value).toEqual(['1', '2', 't', 'r', 'u', 'e', '[', '1', ',', '2', ']'])
         })
     })
 })

--- a/packages/webdriverio/tests/commands/element/clearValue.test.js
+++ b/packages/webdriverio/tests/commands/element/clearValue.test.js
@@ -1,4 +1,4 @@
-import request from 'request'
+import got from 'got'
 import { remote } from '../../../src'
 
 describe('clearValue test', () => {
@@ -17,10 +17,10 @@ describe('clearValue test', () => {
 
     it('should allow to clear an input element', async () => {
         await elem.clearValue()
-        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/clear')
+        expect(got.mock.calls[2][1].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/clear')
     })
 
     afterEach(() => {
-        request.mockClear()
+        got.mockClear()
     })
 })

--- a/packages/webdriverio/tests/commands/element/click.test.js
+++ b/packages/webdriverio/tests/commands/element/click.test.js
@@ -1,4 +1,4 @@
-import request from 'request'
+import got from 'got'
 import { remote } from '../../../src'
 
 describe('click test', () => {
@@ -13,7 +13,7 @@ describe('click test', () => {
 
         await elem.click()
 
-        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/click')
+        expect(got.mock.calls[2][1].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/click')
     })
 
     it('should allow to left click on an element by passing a button type', async () => {
@@ -27,15 +27,15 @@ describe('click test', () => {
 
         await elem.click({ button: 'left' })
 
-        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/actions')
-        expect(request.mock.calls[2][0].body.actions[0].actions[1]).toStrictEqual({ type: 'pointerDown', button: 0 })
-        expect(request.mock.calls[2][0].body.actions[0].actions[2]).toStrictEqual({ type: 'pointerUp', button: 0 })
+        expect(got.mock.calls[2][1].uri.path).toBe('/wd/hub/session/foobar-123/actions')
+        expect(got.mock.calls[2][1].json.actions[0].actions[1]).toStrictEqual({ type: 'pointerDown', button: 0 })
+        expect(got.mock.calls[2][1].json.actions[0].actions[2]).toStrictEqual({ type: 'pointerUp', button: 0 })
 
         await elem.click({ button: 0 })
 
-        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/actions')
-        expect(request.mock.calls[2][0].body.actions[0].actions[1]).toStrictEqual({ type: 'pointerDown', button: 0 })
-        expect(request.mock.calls[2][0].body.actions[0].actions[2]).toStrictEqual({ type: 'pointerUp', button: 0 })
+        expect(got.mock.calls[2][1].uri.path).toBe('/wd/hub/session/foobar-123/actions')
+        expect(got.mock.calls[2][1].json.actions[0].actions[1]).toStrictEqual({ type: 'pointerDown', button: 0 })
+        expect(got.mock.calls[2][1].json.actions[0].actions[2]).toStrictEqual({ type: 'pointerUp', button: 0 })
     })
 
     it('should allow to right click on an element', async () => {
@@ -49,17 +49,17 @@ describe('click test', () => {
 
         await elem.click({ button: 'right' })
 
-        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/actions')
-        expect(request.mock.calls[2][0].body.actions[0].actions[0].type).toBe('pointerMove')
-        expect(request.mock.calls[2][0].body.actions[0].actions[1]).toStrictEqual({ type: 'pointerDown', button: 2 })
-        expect(request.mock.calls[2][0].body.actions[0].actions[2]).toStrictEqual({ type: 'pointerUp', button: 2 })
+        expect(got.mock.calls[2][1].uri.path).toBe('/wd/hub/session/foobar-123/actions')
+        expect(got.mock.calls[2][1].json.actions[0].actions[0].type).toBe('pointerMove')
+        expect(got.mock.calls[2][1].json.actions[0].actions[1]).toStrictEqual({ type: 'pointerDown', button: 2 })
+        expect(got.mock.calls[2][1].json.actions[0].actions[2]).toStrictEqual({ type: 'pointerUp', button: 2 })
 
         await elem.click({ button: 2 })
 
-        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/actions')
-        expect(request.mock.calls[2][0].body.actions[0].actions[0].type).toBe('pointerMove')
-        expect(request.mock.calls[2][0].body.actions[0].actions[1]).toStrictEqual({ type: 'pointerDown', button: 2 })
-        expect(request.mock.calls[2][0].body.actions[0].actions[2]).toStrictEqual({ type: 'pointerUp', button: 2 })
+        expect(got.mock.calls[2][1].uri.path).toBe('/wd/hub/session/foobar-123/actions')
+        expect(got.mock.calls[2][1].json.actions[0].actions[0].type).toBe('pointerMove')
+        expect(got.mock.calls[2][1].json.actions[0].actions[1]).toStrictEqual({ type: 'pointerDown', button: 2 })
+        expect(got.mock.calls[2][1].json.actions[0].actions[2]).toStrictEqual({ type: 'pointerUp', button: 2 })
     })
 
     it('should allow to middle click on an element', async () => {
@@ -73,17 +73,17 @@ describe('click test', () => {
 
         await elem.click({ button: 'middle' })
 
-        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/actions')
-        expect(request.mock.calls[2][0].body.actions[0].actions[0].type).toBe('pointerMove')
-        expect(request.mock.calls[2][0].body.actions[0].actions[1]).toStrictEqual({ type: 'pointerDown', button: 1 })
-        expect(request.mock.calls[2][0].body.actions[0].actions[2]).toStrictEqual({ type: 'pointerUp', button: 1 })
+        expect(got.mock.calls[2][1].uri.path).toBe('/wd/hub/session/foobar-123/actions')
+        expect(got.mock.calls[2][1].json.actions[0].actions[0].type).toBe('pointerMove')
+        expect(got.mock.calls[2][1].json.actions[0].actions[1]).toStrictEqual({ type: 'pointerDown', button: 1 })
+        expect(got.mock.calls[2][1].json.actions[0].actions[2]).toStrictEqual({ type: 'pointerUp', button: 1 })
 
         await elem.click({ button: 1 })
 
-        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/actions')
-        expect(request.mock.calls[2][0].body.actions[0].actions[0].type).toBe('pointerMove')
-        expect(request.mock.calls[2][0].body.actions[0].actions[1]).toStrictEqual({ type: 'pointerDown', button: 1 })
-        expect(request.mock.calls[2][0].body.actions[0].actions[2]).toStrictEqual({ type: 'pointerUp', button: 1 })
+        expect(got.mock.calls[2][1].uri.path).toBe('/wd/hub/session/foobar-123/actions')
+        expect(got.mock.calls[2][1].json.actions[0].actions[0].type).toBe('pointerMove')
+        expect(got.mock.calls[2][1].json.actions[0].actions[1]).toStrictEqual({ type: 'pointerDown', button: 1 })
+        expect(got.mock.calls[2][1].json.actions[0].actions[2]).toStrictEqual({ type: 'pointerUp', button: 1 })
     })
 
     it('should allow to left click on an element with an offset without passing a button type', async () => {
@@ -97,12 +97,12 @@ describe('click test', () => {
 
         await elem.click({ y: 30 })
 
-        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/actions')
-        expect(request.mock.calls[2][0].body.actions[0].actions[0].type).toBe('pointerMove')
-        expect(request.mock.calls[2][0].body.actions[0].actions[0].x).toBe(0)
-        expect(request.mock.calls[2][0].body.actions[0].actions[0].y).toBe(30)
-        expect(request.mock.calls[2][0].body.actions[0].actions[1]).toStrictEqual({ type: 'pointerDown', button: 0 })
-        expect(request.mock.calls[2][0].body.actions[0].actions[2]).toStrictEqual({ type: 'pointerUp', button: 0 })
+        expect(got.mock.calls[2][1].uri.path).toBe('/wd/hub/session/foobar-123/actions')
+        expect(got.mock.calls[2][1].json.actions[0].actions[0].type).toBe('pointerMove')
+        expect(got.mock.calls[2][1].json.actions[0].actions[0].x).toBe(0)
+        expect(got.mock.calls[2][1].json.actions[0].actions[0].y).toBe(30)
+        expect(got.mock.calls[2][1].json.actions[0].actions[1]).toStrictEqual({ type: 'pointerDown', button: 0 })
+        expect(got.mock.calls[2][1].json.actions[0].actions[2]).toStrictEqual({ type: 'pointerUp', button: 0 })
     })
 
     it('should allow to right click on an element with an offset and passing a button type', async () => {
@@ -116,12 +116,12 @@ describe('click test', () => {
 
         await elem.click({ button: 2, x: 40, y: 30 })
 
-        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/actions')
-        expect(request.mock.calls[2][0].body.actions[0].actions[0].type).toBe('pointerMove')
-        expect(request.mock.calls[2][0].body.actions[0].actions[0].x).toBe(40)
-        expect(request.mock.calls[2][0].body.actions[0].actions[0].y).toBe(30)
-        expect(request.mock.calls[2][0].body.actions[0].actions[1]).toStrictEqual({ type: 'pointerDown', button: 2 })
-        expect(request.mock.calls[2][0].body.actions[0].actions[2]).toStrictEqual({ type: 'pointerUp', button: 2 })
+        expect(got.mock.calls[2][1].uri.path).toBe('/wd/hub/session/foobar-123/actions')
+        expect(got.mock.calls[2][1].json.actions[0].actions[0].type).toBe('pointerMove')
+        expect(got.mock.calls[2][1].json.actions[0].actions[0].x).toBe(40)
+        expect(got.mock.calls[2][1].json.actions[0].actions[0].y).toBe(30)
+        expect(got.mock.calls[2][1].json.actions[0].actions[1]).toStrictEqual({ type: 'pointerDown', button: 2 })
+        expect(got.mock.calls[2][1].json.actions[0].actions[2]).toStrictEqual({ type: 'pointerUp', button: 2 })
     })
 
     it('should allow to left click on an element (no w3c)', async () => {
@@ -135,17 +135,17 @@ describe('click test', () => {
 
         await elem.click({ button: 'left' })
 
-        expect(request.mock.calls[3][0].uri.path).toBe('/wd/hub/session/foobar-123/moveto')
-        expect(request.mock.calls[3][0].body).toStrictEqual({ element: 'some-elem-123', xoffset: 25, yoffset: 15 })
-        expect(request.mock.calls[4][0].uri.path).toBe('/wd/hub/session/foobar-123/click')
-        expect(request.mock.calls[4][0].body).toStrictEqual({ button: 0 })
+        expect(got.mock.calls[3][1].uri.path).toBe('/wd/hub/session/foobar-123/moveto')
+        expect(got.mock.calls[3][1].json).toStrictEqual({ element: 'some-elem-123', xoffset: 25, yoffset: 15 })
+        expect(got.mock.calls[4][1].uri.path).toBe('/wd/hub/session/foobar-123/click')
+        expect(got.mock.calls[4][1].json).toStrictEqual({ button: 0 })
 
         await elem.click({ button: 0 })
 
-        expect(request.mock.calls[3][0].uri.path).toBe('/wd/hub/session/foobar-123/moveto')
-        expect(request.mock.calls[3][0].body).toStrictEqual({ element: 'some-elem-123', xoffset: 25, yoffset: 15 })
-        expect(request.mock.calls[4][0].uri.path).toBe('/wd/hub/session/foobar-123/click')
-        expect(request.mock.calls[4][0].body).toStrictEqual({ button: 0 })
+        expect(got.mock.calls[3][1].uri.path).toBe('/wd/hub/session/foobar-123/moveto')
+        expect(got.mock.calls[3][1].json).toStrictEqual({ element: 'some-elem-123', xoffset: 25, yoffset: 15 })
+        expect(got.mock.calls[4][1].uri.path).toBe('/wd/hub/session/foobar-123/click')
+        expect(got.mock.calls[4][1].json).toStrictEqual({ button: 0 })
     })
 
     it('should allow to right click on an element (no w3c)', async () => {
@@ -159,17 +159,17 @@ describe('click test', () => {
 
         await elem.click({ button: 'right' })
 
-        expect(request.mock.calls[3][0].uri.path).toBe('/wd/hub/session/foobar-123/moveto')
-        expect(request.mock.calls[3][0].body).toStrictEqual({ element: 'some-elem-123', xoffset: 25, yoffset: 15 })
-        expect(request.mock.calls[4][0].uri.path).toBe('/wd/hub/session/foobar-123/click')
-        expect(request.mock.calls[4][0].body).toStrictEqual({ button: 2 })
+        expect(got.mock.calls[3][1].uri.path).toBe('/wd/hub/session/foobar-123/moveto')
+        expect(got.mock.calls[3][1].json).toStrictEqual({ element: 'some-elem-123', xoffset: 25, yoffset: 15 })
+        expect(got.mock.calls[4][1].uri.path).toBe('/wd/hub/session/foobar-123/click')
+        expect(got.mock.calls[4][1].json).toStrictEqual({ button: 2 })
 
         await elem.click({ button: 2 })
 
-        expect(request.mock.calls[3][0].uri.path).toBe('/wd/hub/session/foobar-123/moveto')
-        expect(request.mock.calls[3][0].body).toStrictEqual({ element: 'some-elem-123', xoffset: 25, yoffset: 15 })
-        expect(request.mock.calls[4][0].uri.path).toBe('/wd/hub/session/foobar-123/click')
-        expect(request.mock.calls[4][0].body).toStrictEqual({ button: 2 })
+        expect(got.mock.calls[3][1].uri.path).toBe('/wd/hub/session/foobar-123/moveto')
+        expect(got.mock.calls[3][1].json).toStrictEqual({ element: 'some-elem-123', xoffset: 25, yoffset: 15 })
+        expect(got.mock.calls[4][1].uri.path).toBe('/wd/hub/session/foobar-123/click')
+        expect(got.mock.calls[4][1].json).toStrictEqual({ button: 2 })
     })
 
     it('should allow to middle click on an element (no w3c)', async () => {
@@ -183,17 +183,17 @@ describe('click test', () => {
 
         await elem.click({ button: 'middle' })
 
-        expect(request.mock.calls[3][0].uri.path).toBe('/wd/hub/session/foobar-123/moveto')
-        expect(request.mock.calls[3][0].body).toStrictEqual({ element: 'some-elem-123', xoffset: 25, yoffset: 15 })
-        expect(request.mock.calls[4][0].uri.path).toBe('/wd/hub/session/foobar-123/click')
-        expect(request.mock.calls[4][0].body).toStrictEqual({ button: 1 })
+        expect(got.mock.calls[3][1].uri.path).toBe('/wd/hub/session/foobar-123/moveto')
+        expect(got.mock.calls[3][1].json).toStrictEqual({ element: 'some-elem-123', xoffset: 25, yoffset: 15 })
+        expect(got.mock.calls[4][1].uri.path).toBe('/wd/hub/session/foobar-123/click')
+        expect(got.mock.calls[4][1].json).toStrictEqual({ button: 1 })
 
         await elem.click({ button: 1 })
 
-        expect(request.mock.calls[3][0].uri.path).toBe('/wd/hub/session/foobar-123/moveto')
-        expect(request.mock.calls[3][0].body).toStrictEqual({ element: 'some-elem-123', xoffset: 25, yoffset: 15 })
-        expect(request.mock.calls[4][0].uri.path).toBe('/wd/hub/session/foobar-123/click')
-        expect(request.mock.calls[4][0].body).toStrictEqual({ button: 1 })
+        expect(got.mock.calls[3][1].uri.path).toBe('/wd/hub/session/foobar-123/moveto')
+        expect(got.mock.calls[3][1].json).toStrictEqual({ element: 'some-elem-123', xoffset: 25, yoffset: 15 })
+        expect(got.mock.calls[4][1].uri.path).toBe('/wd/hub/session/foobar-123/click')
+        expect(got.mock.calls[4][1].json).toStrictEqual({ button: 1 })
     })
 
     it('should allow to left click on an element with an offset without passing a button type (no w3c)', async () => {
@@ -207,10 +207,10 @@ describe('click test', () => {
 
         await elem.click({ y: 30 })
 
-        expect(request.mock.calls[3][0].uri.path).toBe('/wd/hub/session/foobar-123/moveto')
-        expect(request.mock.calls[3][0].body).toStrictEqual({ element: 'some-elem-123', xoffset: 25, yoffset: 45 })
-        expect(request.mock.calls[4][0].uri.path).toBe('/wd/hub/session/foobar-123/click')
-        expect(request.mock.calls[4][0].body).toStrictEqual({ button: 0 })
+        expect(got.mock.calls[3][1].uri.path).toBe('/wd/hub/session/foobar-123/moveto')
+        expect(got.mock.calls[3][1].json).toStrictEqual({ element: 'some-elem-123', xoffset: 25, yoffset: 45 })
+        expect(got.mock.calls[4][1].uri.path).toBe('/wd/hub/session/foobar-123/click')
+        expect(got.mock.calls[4][1].json).toStrictEqual({ button: 0 })
     })
 
     it('should allow to right click on an element with an offset and passing a button type (no w3c)', async () => {
@@ -224,10 +224,10 @@ describe('click test', () => {
 
         await elem.click({ button: 2, x: 40, y: 30 })
 
-        expect(request.mock.calls[3][0].uri.path).toBe('/wd/hub/session/foobar-123/moveto')
-        expect(request.mock.calls[3][0].body).toStrictEqual({ element: 'some-elem-123', xoffset: 65, yoffset: 45 })
-        expect(request.mock.calls[4][0].uri.path).toBe('/wd/hub/session/foobar-123/click')
-        expect(request.mock.calls[4][0].body).toStrictEqual({ button: 2 })
+        expect(got.mock.calls[3][1].uri.path).toBe('/wd/hub/session/foobar-123/moveto')
+        expect(got.mock.calls[3][1].json).toStrictEqual({ element: 'some-elem-123', xoffset: 65, yoffset: 45 })
+        expect(got.mock.calls[4][1].uri.path).toBe('/wd/hub/session/foobar-123/click')
+        expect(got.mock.calls[4][1].json).toStrictEqual({ button: 2 })
     })
 
     it('should throw an error if the passed argument is not an options object', async () => {
@@ -267,6 +267,6 @@ describe('click test', () => {
     })
 
     afterEach(() => {
-        request.mockClear()
+        got.mockClear()
     })
 })

--- a/packages/webdriverio/tests/commands/element/doubleClick.test.js
+++ b/packages/webdriverio/tests/commands/element/doubleClick.test.js
@@ -1,9 +1,9 @@
-import request from 'request'
+import got from 'got'
 import { remote } from '../../../src'
 
 describe('doubleClick', () => {
     beforeEach(() => {
-        request.mockClear()
+        got.mockClear()
     })
 
     it('should do a doubleClick', async () => {
@@ -18,20 +18,20 @@ describe('doubleClick', () => {
         await elem.doubleClick()
 
         // double click
-        expect(request.mock.calls[2][0].uri.path).toContain('/foobar-123/actions')
-        expect(request.mock.calls[2][0].body.actions).toHaveLength(1)
-        expect(request.mock.calls[2][0].body.actions[0].type).toBe('pointer')
-        expect(request.mock.calls[2][0].body.actions[0].actions).toHaveLength(6)
-        expect(request.mock.calls[2][0].body.actions[0].actions[0].type).toBe('pointerMove')
-        expect(request.mock.calls[2][0].body.actions[0].actions[0].origin.elementId).toBe('some-elem-123')
-        expect(request.mock.calls[2][0].body.actions[0].actions[0].origin['element-6066-11e4-a52e-4f735466cecf']).toBe('some-elem-123')
-        expect(request.mock.calls[2][0].body.actions[0].actions[0].x).toBe(0)
-        expect(request.mock.calls[2][0].body.actions[0].actions[0].y).toBe(0)
-        expect(request.mock.calls[2][0].body.actions[0].actions[1]).toEqual({ button: 0, type: 'pointerDown' })
-        expect(request.mock.calls[2][0].body.actions[0].actions[2]).toEqual({ button: 0, type: 'pointerUp' })
-        expect(request.mock.calls[2][0].body.actions[0].actions[3]).toEqual({ duration: 10, type: 'pause' })
-        expect(request.mock.calls[2][0].body.actions[0].actions[4]).toEqual({ button: 0, type: 'pointerDown' })
-        expect(request.mock.calls[2][0].body.actions[0].actions[5]).toEqual({ button: 0, type: 'pointerUp' })
+        expect(got.mock.calls[2][1].uri.path).toContain('/foobar-123/actions')
+        expect(got.mock.calls[2][1].json.actions).toHaveLength(1)
+        expect(got.mock.calls[2][1].json.actions[0].type).toBe('pointer')
+        expect(got.mock.calls[2][1].json.actions[0].actions).toHaveLength(6)
+        expect(got.mock.calls[2][1].json.actions[0].actions[0].type).toBe('pointerMove')
+        expect(got.mock.calls[2][1].json.actions[0].actions[0].origin.elementId).toBe('some-elem-123')
+        expect(got.mock.calls[2][1].json.actions[0].actions[0].origin['element-6066-11e4-a52e-4f735466cecf']).toBe('some-elem-123')
+        expect(got.mock.calls[2][1].json.actions[0].actions[0].x).toBe(0)
+        expect(got.mock.calls[2][1].json.actions[0].actions[0].y).toBe(0)
+        expect(got.mock.calls[2][1].json.actions[0].actions[1]).toEqual({ button: 0, type: 'pointerDown' })
+        expect(got.mock.calls[2][1].json.actions[0].actions[2]).toEqual({ button: 0, type: 'pointerUp' })
+        expect(got.mock.calls[2][1].json.actions[0].actions[3]).toEqual({ duration: 10, type: 'pause' })
+        expect(got.mock.calls[2][1].json.actions[0].actions[4]).toEqual({ button: 0, type: 'pointerDown' })
+        expect(got.mock.calls[2][1].json.actions[0].actions[5]).toEqual({ button: 0, type: 'pointerUp' })
     })
 
     it('should do a doubleClick (no w3c)', async () => {
@@ -46,10 +46,10 @@ describe('doubleClick', () => {
         await elem.doubleClick()
 
         // move to
-        expect(request.mock.calls[2][0].uri.path).toContain('/foobar-123/moveto')
-        expect(request.mock.calls[2][0].body).toEqual({ element: 'some-elem-123' })
+        expect(got.mock.calls[2][1].uri.path).toContain('/foobar-123/moveto')
+        expect(got.mock.calls[2][1].json).toEqual({ element: 'some-elem-123' })
 
         // double click
-        expect(request.mock.calls[3][0].uri.path).toContain('/foobar-123/doubleclick')
+        expect(got.mock.calls[3][1].uri.path).toContain('/foobar-123/doubleclick')
     })
 })

--- a/packages/webdriverio/tests/commands/element/dragAndDrop.test.js
+++ b/packages/webdriverio/tests/commands/element/dragAndDrop.test.js
@@ -1,9 +1,9 @@
-import request from 'request'
+import got from 'got'
 import { remote } from '../../../src'
 
 describe('dragAndDrop', () => {
     beforeEach(() => {
-        request.mockClear()
+        got.mockClear()
     })
 
     it('should throw when parameter are invalid', async () => {
@@ -40,25 +40,25 @@ describe('dragAndDrop', () => {
 
         const elem = await browser.$('#foo')
         const subElem = await elem.$('#subfoo')
-        request.setMockResponse([{ scrollX: 0, scrollY: 20 }])
+        got.setMockResponse([{ scrollX: 0, scrollY: 20 }])
         await elem.dragAndDrop(subElem)
 
         // move to
-        expect(request.mock.calls[4][0].uri.path).toContain('/element/some-elem-123/rect')
-        expect(request.mock.calls[5][0].uri.path).toContain('/element/some-sub-elem-321/rect')
-        expect(request.mock.calls[6][0].uri.path).toContain('/foobar-123/actions')
-        expect(request.mock.calls[6][0].body.actions).toHaveLength(1)
-        expect(request.mock.calls[6][0].body.actions[0].type).toBe('pointer')
-        expect(request.mock.calls[6][0].body.actions[0].actions).toHaveLength(5)
-        expect(request.mock.calls[6][0].body.actions[0].actions).toEqual([
+        expect(got.mock.calls[4][1].uri.path).toContain('/element/some-elem-123/rect')
+        expect(got.mock.calls[5][1].uri.path).toContain('/element/some-sub-elem-321/rect')
+        expect(got.mock.calls[6][1].uri.path).toContain('/foobar-123/actions')
+        expect(got.mock.calls[6][1].json.actions).toHaveLength(1)
+        expect(got.mock.calls[6][1].json.actions[0].type).toBe('pointer')
+        expect(got.mock.calls[6][1].json.actions[0].actions).toHaveLength(5)
+        expect(got.mock.calls[6][1].json.actions[0].actions).toEqual([
             { type: 'pointerMove', duration: 0, x: 40, y: 15 },
             { type: 'pointerDown', button: 0 },
             { type: 'pause', duration: 10 },
             { type: 'pointerMove', duration: 100, origin: 'pointer', x: 135, y: 225 },
             { type: 'pointerUp', button: 0 }
         ])
-        expect(request.mock.calls[7][0].uri.path).toContain('/foobar-123/actions')
-        expect(request.mock.calls[7][0].method).toContain('DELETE')
+        expect(got.mock.calls[7][1].uri.path).toContain('/foobar-123/actions')
+        expect(got.mock.calls[7][1].method).toContain('DELETE')
     })
 
     it('should do a dragAndDrop (no w3c)', async () => {
@@ -73,11 +73,11 @@ describe('dragAndDrop', () => {
         const subElem = await elem.$('#subfoo')
         await elem.dragAndDrop(subElem)
 
-        expect(request.mock.calls[3][0].uri.path).toContain('/foobar-123/moveto')
-        expect(request.mock.calls[3][0].body).toEqual({ element: 'some-elem-123' })
-        expect(request.mock.calls[4][0].uri.path).toContain('/foobar-123/buttondown')
-        expect(request.mock.calls[5][0].uri.path).toContain('/foobar-123/moveto')
-        expect(request.mock.calls[5][0].body).toEqual({ element: 'some-sub-elem-321' })
-        expect(request.mock.calls[6][0].uri.path).toContain('/foobar-123/buttonup')
+        expect(got.mock.calls[3][1].uri.path).toContain('/foobar-123/moveto')
+        expect(got.mock.calls[3][1].json).toEqual({ element: 'some-elem-123' })
+        expect(got.mock.calls[4][1].uri.path).toContain('/foobar-123/buttondown')
+        expect(got.mock.calls[5][1].uri.path).toContain('/foobar-123/moveto')
+        expect(got.mock.calls[5][1].json).toEqual({ element: 'some-sub-elem-321' })
+        expect(got.mock.calls[6][1].uri.path).toContain('/foobar-123/buttonup')
     })
 })

--- a/packages/webdriverio/tests/commands/element/getAttribute.test.js
+++ b/packages/webdriverio/tests/commands/element/getAttribute.test.js
@@ -1,4 +1,4 @@
-import request from 'request'
+import got from 'got'
 import { remote } from '../../../src'
 
 describe('getAttribute test', () => {
@@ -17,10 +17,10 @@ describe('getAttribute test', () => {
 
     it('should allow to get attribute from element', async () => {
         await elem.getAttribute('foo')
-        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/attribute/foo')
+        expect(got.mock.calls[2][1].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/attribute/foo')
     })
 
     afterEach(() => {
-        request.mockClear()
+        got.mockClear()
     })
 })

--- a/packages/webdriverio/tests/commands/element/getCSSProperty.test.js
+++ b/packages/webdriverio/tests/commands/element/getCSSProperty.test.js
@@ -1,4 +1,4 @@
-import request from 'request'
+import got from 'got'
 import { remote } from '../../../src'
 
 describe('getCSSProperty test', () => {
@@ -12,12 +12,12 @@ describe('getCSSProperty test', () => {
         const elem = await browser.$('#foo')
         const property = await elem.getCSSProperty('width')
 
-        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/css/width')
+        expect(got.mock.calls[2][1].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/css/width')
         expect(property.value).toBe('1250px')
         expect(property.parsed.value).toBe(1250)
     })
 
     afterEach(() => {
-        request.mockClear()
+        got.mockClear()
     })
 })

--- a/packages/webdriverio/tests/commands/element/getHTML.test.js
+++ b/packages/webdriverio/tests/commands/element/getHTML.test.js
@@ -1,4 +1,4 @@
-import request from 'request'
+import got from 'got'
 import { remote } from '../../../src'
 
 describe('getHTML test', () => {
@@ -16,7 +16,7 @@ describe('getHTML test', () => {
         }
 
         let result = await elem.getHTML()
-        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/execute/sync')
+        expect(got.mock.calls[2][1].uri.path).toBe('/wd/hub/session/foobar-123/execute/sync')
         expect(result).toBe('<some>outer html</some>')
 
         result = await elem.getHTML(false)
@@ -24,6 +24,6 @@ describe('getHTML test', () => {
     })
 
     afterEach(() => {
-        request.mockClear()
+        got.mockClear()
     })
 })

--- a/packages/webdriverio/tests/commands/element/getLocation.test.js
+++ b/packages/webdriverio/tests/commands/element/getLocation.test.js
@@ -1,4 +1,4 @@
-import request from 'request'
+import got from 'got'
 import { remote } from '../../../src'
 
 describe('getLocation test', () => {
@@ -12,7 +12,7 @@ describe('getLocation test', () => {
         const elem = await browser.$('#foo')
         const size = await elem.getLocation()
 
-        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/rect')
+        expect(got.mock.calls[2][1].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/rect')
         expect(size.x).toBe(15)
         expect(size.y).toBe(20)
     })
@@ -28,7 +28,7 @@ describe('getLocation test', () => {
         const elem = await browser.$('#foo')
         const size = await elem.getLocation()
 
-        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/location')
+        expect(got.mock.calls[2][1].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/location')
         expect(size.x).toBe(15)
         expect(size.y).toBe(20)
     })
@@ -48,6 +48,6 @@ describe('getLocation test', () => {
     })
 
     afterEach(() => {
-        request.mockClear()
+        got.mockClear()
     })
 })

--- a/packages/webdriverio/tests/commands/element/getProperty.test.js
+++ b/packages/webdriverio/tests/commands/element/getProperty.test.js
@@ -1,4 +1,4 @@
-import request from 'request'
+import got from 'got'
 import { remote } from '../../../src'
 
 describe('getProperty test', () => {
@@ -12,7 +12,7 @@ describe('getProperty test', () => {
         const elem = await browser.$('#foo')
         const property = await elem.getProperty('tagName')
 
-        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/property/tagName')
+        expect(got.mock.calls[2][1].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/property/tagName')
         expect(property).toBe('BODY')
     })
 
@@ -27,11 +27,11 @@ describe('getProperty test', () => {
         elem.elementId = { tagName: 'BODY' }
         const property = await elem.getProperty('tagName')
 
-        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/execute')
+        expect(got.mock.calls[2][1].uri.path).toBe('/wd/hub/session/foobar-123/execute')
         expect(property).toBe('BODY')
     })
 
     afterEach(() => {
-        request.mockClear()
+        got.mockClear()
     })
 })

--- a/packages/webdriverio/tests/commands/element/getSize.test.js
+++ b/packages/webdriverio/tests/commands/element/getSize.test.js
@@ -1,4 +1,4 @@
-import request from 'request'
+import got from 'got'
 import { remote } from '../../../src'
 
 jest.setTimeout(3000)
@@ -14,7 +14,7 @@ describe('getSize test', () => {
         const elem = await browser.$('#foo')
         const size = await elem.getSize()
 
-        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/rect')
+        expect(got.mock.calls[2][1].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/rect')
         expect(size.width).toBe(50)
         expect(size.height).toBe(30)
     })
@@ -30,7 +30,7 @@ describe('getSize test', () => {
         const elem = await browser.$('#foo')
         const size = await elem.getSize()
 
-        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/size')
+        expect(got.mock.calls[2][1].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/size')
         expect(size.width).toBe(50)
         expect(size.height).toBe(30)
     })
@@ -51,6 +51,6 @@ describe('getSize test', () => {
     })
 
     afterEach(() => {
-        request.mockClear()
+        got.mockClear()
     })
 })

--- a/packages/webdriverio/tests/commands/element/getTagName.test.js
+++ b/packages/webdriverio/tests/commands/element/getTagName.test.js
@@ -1,4 +1,4 @@
-import request from 'request'
+import got from 'got'
 import { remote } from '../../../src'
 
 describe('getTagName test', () => {
@@ -17,10 +17,10 @@ describe('getTagName test', () => {
 
     it('should allow to get the tag name of an element', async () => {
         await elem.getTagName()
-        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/name')
+        expect(got.mock.calls[2][1].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/name')
     })
 
     afterEach(() => {
-        request.mockClear()
+        got.mockClear()
     })
 })

--- a/packages/webdriverio/tests/commands/element/getText.test.js
+++ b/packages/webdriverio/tests/commands/element/getText.test.js
@@ -1,4 +1,4 @@
-import request from 'request'
+import got from 'got'
 import { remote } from '../../../src'
 
 describe('getText test', () => {
@@ -17,10 +17,10 @@ describe('getText test', () => {
 
     it('should allow to get the text of an element', async () => {
         await elem.getText()
-        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/text')
+        expect(got.mock.calls[2][1].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/text')
     })
 
     afterEach(() => {
-        request.mockClear()
+        got.mockClear()
     })
 })

--- a/packages/webdriverio/tests/commands/element/getValue.test.js
+++ b/packages/webdriverio/tests/commands/element/getValue.test.js
@@ -1,9 +1,9 @@
-import request from 'request'
+import got from 'got'
 import { remote } from '../../../src'
 
 describe('getValue', () => {
     beforeEach(() => {
-        request.mockClear()
+        got.mockClear()
     })
 
     test('should get the value using getElementProperty', async () => {
@@ -17,7 +17,7 @@ describe('getValue', () => {
         const elem = await browser.$('#foo')
 
         await elem.getValue()
-        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/property/value')
+        expect(got.mock.calls[2][1].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/property/value')
     })
 
     test('should get the value using getElementAttribute', async () => {
@@ -31,7 +31,7 @@ describe('getValue', () => {
         const elem = await browser.$('#foo')
 
         await elem.getValue()
-        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/attribute/value')
+        expect(got.mock.calls[2][1].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/attribute/value')
     })
 
     it('should get value in mobile mode', async () => {
@@ -45,6 +45,6 @@ describe('getValue', () => {
         const elem = await browser.$('#foo')
 
         await elem.getValue()
-        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/attribute/value')
+        expect(got.mock.calls[2][1].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/attribute/value')
     })
 })

--- a/packages/webdriverio/tests/commands/element/isClickable.test.js
+++ b/packages/webdriverio/tests/commands/element/isClickable.test.js
@@ -1,4 +1,4 @@
-import request from 'request'
+import got from 'got'
 import { remote } from '../../../src'
 
 describe('isClickable test', () => {
@@ -13,14 +13,14 @@ describe('isClickable test', () => {
             }
         })
         elem = await browser.$('#foo')
-        request.mockClear()
+        got.mockClear()
     })
 
     it('should allow to check if element is displayed', async () => {
         await elem.isClickable()
-        expect(request.mock.calls[0][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/displayed')
-        expect(request.mock.calls[1][0].uri.path).toBe('/wd/hub/session/foobar-123/execute/sync')
-        expect(request.mock.calls[1][0].body.args[0]).toEqual({
+        expect(got.mock.calls[0][1].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/displayed')
+        expect(got.mock.calls[1][1].uri.path).toBe('/wd/hub/session/foobar-123/execute/sync')
+        expect(got.mock.calls[1][1].json.args[0]).toEqual({
             'element-6066-11e4-a52e-4f735466cecf': 'some-elem-123',
             ELEMENT: 'some-elem-123'
         })
@@ -29,10 +29,10 @@ describe('isClickable test', () => {
     it('should return false if element can\'t be found after refetching it', async () => {
         const elem = await browser.$('#nonexisting')
         expect(await elem.isClickable()).toBe(false)
-        expect(request).toBeCalledTimes(2)
+        expect(got).toBeCalledTimes(2)
     })
 
     afterEach(() => {
-        request.mockClear()
+        got.mockClear()
     })
 })

--- a/packages/webdriverio/tests/commands/element/isDisplayed.test.js
+++ b/packages/webdriverio/tests/commands/element/isDisplayed.test.js
@@ -1,4 +1,4 @@
-import request from 'request'
+import got from 'got'
 import { remote } from '../../../src'
 jest.mock('../../../src/scripts/isElementDisplayed', () => ({
     __esModule: true,
@@ -17,13 +17,13 @@ describe('isDisplayed test', () => {
             }
         })
         elem = await browser.$('#foo')
-        request.mockClear()
+        got.mockClear()
     })
 
     it('should allow to check if element is displayed', async () => {
         expect(await elem.isDisplayed()).toBe(true)
-        expect(request).toBeCalledTimes(1)
-        expect(request.mock.calls[0][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/displayed')
+        expect(got).toBeCalledTimes(1)
+        expect(got.mock.calls[0][1].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/displayed')
     })
 
     it('should allow to check if element is displayed in mobile mode without browserName', async () => {
@@ -35,18 +35,18 @@ describe('isDisplayed test', () => {
             }
         })
         elem = await browser.$('#foo')
-        request.mockClear()
+        got.mockClear()
         expect(await elem.isDisplayed()).toBe(true)
-        expect(request).toBeCalledTimes(1)
-        expect(request.mock.calls[0][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/displayed')
+        expect(got).toBeCalledTimes(1)
+        expect(got.mock.calls[0][1].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/displayed')
     })
 
     it('should refetch element if non existing', async () => {
         delete elem.elementId
         expect(await elem.isDisplayed()).toBe(true)
-        expect(request).toBeCalledTimes(2)
-        expect(request.mock.calls[0][0].uri.path).toBe('/wd/hub/session/foobar-123/element')
-        expect(request.mock.calls[1][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/displayed')
+        expect(got).toBeCalledTimes(2)
+        expect(got.mock.calls[0][1].uri.path).toBe('/wd/hub/session/foobar-123/element')
+        expect(got.mock.calls[1][1].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/displayed')
     })
 
     it('should refect React element if non existing', async () => {
@@ -70,7 +70,7 @@ describe('isDisplayed test', () => {
         expect(await elem.isDisplayed()).toBe(true)
 
         elem.selector = '#nonexisting'
-        request.setMockResponse([{ error: 'no such element', statusCode: 404 }])
+        got.setMockResponse([{ error: 'no such element', statusCode: 404 }])
 
         expect(await elem.isDisplayed()).toBe(false)
     })
@@ -78,7 +78,7 @@ describe('isDisplayed test', () => {
     it('should return false if element can\'t be found after refetching it', async () => {
         const elem = await browser.$('#nonexisting')
         expect(await elem.isDisplayed()).toBe(false)
-        expect(request).toBeCalledTimes(2)
+        expect(got).toBeCalledTimes(2)
     })
 
     describe('isElementDisplayed script', () => {
@@ -91,12 +91,12 @@ describe('isDisplayed test', () => {
                 }
             })
             elem = await browser.$('#foo')
-            request.mockClear()
+            got.mockClear()
 
             expect(await elem.isDisplayed()).toBe(true)
-            expect(request).toBeCalledTimes(1)
-            expect(request.mock.calls[0][0].uri.path).toBe('/wd/hub/session/foobar-123/execute/sync')
-            expect(request.mock.calls[0][0].body.args[0]).toEqual({
+            expect(got).toBeCalledTimes(1)
+            expect(got.mock.calls[0][1].uri.path).toBe('/wd/hub/session/foobar-123/execute/sync')
+            expect(got.mock.calls[0][1].json.args[0]).toEqual({
                 'element-6066-11e4-a52e-4f735466cecf': 'some-elem-123',
                 ELEMENT: 'some-elem-123'
             })
@@ -110,12 +110,12 @@ describe('isDisplayed test', () => {
                 }
             })
             elem = await browser.$('#foo')
-            request.mockClear()
+            got.mockClear()
 
             expect(await elem.isDisplayed()).toBe(true)
-            expect(request).toBeCalledTimes(1)
-            expect(request.mock.calls[0][0].uri.path).toBe('/wd/hub/session/foobar-123/execute/sync')
-            expect(request.mock.calls[0][0].body.args[0]).toEqual({
+            expect(got).toBeCalledTimes(1)
+            expect(got.mock.calls[0][1].uri.path).toBe('/wd/hub/session/foobar-123/execute/sync')
+            expect(got.mock.calls[0][1].json.args[0]).toEqual({
                 'element-6066-11e4-a52e-4f735466cecf': 'some-elem-123',
                 ELEMENT: 'some-elem-123'
             })
@@ -129,12 +129,12 @@ describe('isDisplayed test', () => {
                 }
             })
             elem = await browser.$('#foo')
-            request.mockClear()
+            got.mockClear()
 
             expect(await elem.isDisplayed()).toBe(true)
-            expect(request).toBeCalledTimes(1)
-            expect(request.mock.calls[0][0].uri.path).toBe('/wd/hub/session/foobar-123/execute/sync')
-            expect(request.mock.calls[0][0].body.args[0]).toEqual({
+            expect(got).toBeCalledTimes(1)
+            expect(got.mock.calls[0][1].uri.path).toBe('/wd/hub/session/foobar-123/execute/sync')
+            expect(got.mock.calls[0][1].json.args[0]).toEqual({
                 'element-6066-11e4-a52e-4f735466cecf': 'some-elem-123',
                 ELEMENT: 'some-elem-123'
             })
@@ -149,13 +149,13 @@ describe('isDisplayed test', () => {
                 }
             })
             elem = await browser.$('#foo')
-            request.mockClear()
+            got.mockClear()
             browser.isDevTools = true
 
             expect(await elem.isDisplayed()).toBe(true)
-            expect(request).toBeCalledTimes(1)
-            expect(request.mock.calls[0][0].uri.path).toBe('/wd/hub/session/foobar-123/execute/sync')
-            expect(request.mock.calls[0][0].body.args[0]).toEqual({
+            expect(got).toBeCalledTimes(1)
+            expect(got.mock.calls[0][1].uri.path).toBe('/wd/hub/session/foobar-123/execute/sync')
+            expect(got.mock.calls[0][1].json.args[0]).toEqual({
                 'element-6066-11e4-a52e-4f735466cecf': 'some-elem-123',
                 ELEMENT: 'some-elem-123'
             })

--- a/packages/webdriverio/tests/commands/element/isDisplayedInViewport.test.js
+++ b/packages/webdriverio/tests/commands/element/isDisplayedInViewport.test.js
@@ -1,4 +1,4 @@
-import request from 'request'
+import got from 'got'
 import { remote } from '../../../src'
 
 describe('isDisplayedInViewport test', () => {
@@ -13,14 +13,14 @@ describe('isDisplayedInViewport test', () => {
             }
         })
         elem = await browser.$('#foo')
-        request.mockClear()
+        got.mockClear()
     })
 
     it('should allow to check if element is displayed', async () => {
         await elem.isDisplayedInViewport()
-        expect(request.mock.calls[0][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/displayed')
-        expect(request.mock.calls[1][0].uri.path).toBe('/wd/hub/session/foobar-123/execute/sync')
-        expect(request.mock.calls[1][0].body.args[0]).toEqual({
+        expect(got.mock.calls[0][1].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/displayed')
+        expect(got.mock.calls[1][1].uri.path).toBe('/wd/hub/session/foobar-123/execute/sync')
+        expect(got.mock.calls[1][1].json.args[0]).toEqual({
             'element-6066-11e4-a52e-4f735466cecf': 'some-elem-123',
             ELEMENT: 'some-elem-123'
         })
@@ -29,10 +29,10 @@ describe('isDisplayedInViewport test', () => {
     it('should return false if element can\'t be found after refetching it', async () => {
         const elem = await browser.$('#nonexisting')
         expect(await elem.isDisplayedInViewport()).toBe(false)
-        expect(request).toBeCalledTimes(2)
+        expect(got).toBeCalledTimes(2)
     })
 
     afterEach(() => {
-        request.mockClear()
+        got.mockClear()
     })
 })

--- a/packages/webdriverio/tests/commands/element/isEnabled.test.js
+++ b/packages/webdriverio/tests/commands/element/isEnabled.test.js
@@ -1,4 +1,4 @@
-import request from 'request'
+import got from 'got'
 import { remote } from '../../../src'
 
 describe('isEnabled test', () => {
@@ -17,10 +17,10 @@ describe('isEnabled test', () => {
 
     it('should allow to check if an element is enabled', async () => {
         await elem.isEnabled()
-        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/enabled')
+        expect(got.mock.calls[2][1].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/enabled')
     })
 
     afterEach(() => {
-        request.mockClear()
+        got.mockClear()
     })
 })

--- a/packages/webdriverio/tests/commands/element/isExisting.test.js
+++ b/packages/webdriverio/tests/commands/element/isExisting.test.js
@@ -1,4 +1,4 @@
-import request from 'request'
+import got from 'got'
 import { remote } from '../../../src'
 
 describe('isExisting test', () => {
@@ -17,10 +17,10 @@ describe('isExisting test', () => {
 
     it('should allow to check if an element is enabled', async () => {
         await elem.isExisting()
-        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/elements')
+        expect(got.mock.calls[2][1].uri.path).toBe('/wd/hub/session/foobar-123/elements')
     })
 
     afterEach(() => {
-        request.mockClear()
+        got.mockClear()
     })
 })

--- a/packages/webdriverio/tests/commands/element/isFocused.test.js
+++ b/packages/webdriverio/tests/commands/element/isFocused.test.js
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-import request from 'request'
+import got from 'got'
 import { remote } from '../../../src'
 
 describe('isFocused test', () => {
@@ -21,14 +21,14 @@ describe('isFocused test', () => {
 
     it('should allow to check if element is displayed', async () => {
         await elem.isFocused()
-        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/execute/sync')
-        expect(request.mock.calls[2][0].body.args[0]).toEqual({
+        expect(got.mock.calls[2][1].uri.path).toBe('/wd/hub/session/foobar-123/execute/sync')
+        expect(got.mock.calls[2][1].json.args[0]).toEqual({
             'element-6066-11e4-a52e-4f735466cecf': 'some-elem-123',
             ELEMENT: 'some-elem-123'
         })
     })
 
     afterEach(() => {
-        request.mockClear()
+        got.mockClear()
     })
 })

--- a/packages/webdriverio/tests/commands/element/isSelected.test.js
+++ b/packages/webdriverio/tests/commands/element/isSelected.test.js
@@ -1,4 +1,4 @@
-import request from 'request'
+import got from 'got'
 import { remote } from '../../../src'
 
 describe('isSelected test', () => {
@@ -17,10 +17,10 @@ describe('isSelected test', () => {
 
     it('should allow to check if element is selected', async () => {
         await elem.isSelected()
-        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/selected')
+        expect(got.mock.calls[2][1].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/selected')
     })
 
     afterEach(() => {
-        request.mockClear()
+        got.mockClear()
     })
 })

--- a/packages/webdriverio/tests/commands/element/moveTo.test.js
+++ b/packages/webdriverio/tests/commands/element/moveTo.test.js
@@ -1,4 +1,4 @@
-import request from 'request'
+import got from 'got'
 import { remote } from '../../../src'
 
 describe('moveTo', () => {
@@ -11,14 +11,14 @@ describe('moveTo', () => {
         })
 
         const elem = await browser.$('#elem')
-        request.setMockResponse([undefined, { scrollX: 0, scrollY: 20 }])
+        got.setMockResponse([undefined, { scrollX: 0, scrollY: 20 }])
         await elem.moveTo()
 
-        expect(request.mock.calls[4][0].uri.path).toContain('/foobar-123/actions')
-        expect(request.mock.calls[4][0].body.actions).toHaveLength(1)
-        expect(request.mock.calls[4][0].body.actions[0].type).toBe('pointer')
-        expect(request.mock.calls[4][0].body.actions[0].actions).toHaveLength(1)
-        expect(request.mock.calls[4][0].body.actions[0].actions[0])
+        expect(got.mock.calls[4][1].uri.path).toContain('/foobar-123/actions')
+        expect(got.mock.calls[4][1].json.actions).toHaveLength(1)
+        expect(got.mock.calls[4][1].json.actions[0].type).toBe('pointer')
+        expect(got.mock.calls[4][1].json.actions[0].actions).toHaveLength(1)
+        expect(got.mock.calls[4][1].json.actions[0].actions[0])
             .toEqual({ type: 'pointerMove', duration: 0, x: 40, y: 15 })
     })
 
@@ -31,9 +31,9 @@ describe('moveTo', () => {
         })
 
         const elem = await browser.$('#elem')
-        request.setMockResponse([undefined, { scrollX: 19, scrollY: 0 }])
+        got.setMockResponse([undefined, { scrollX: 19, scrollY: 0 }])
         await elem.moveTo(5, 10)
-        expect(request.mock.calls[4][0].body.actions[0].actions[0])
+        expect(got.mock.calls[4][1].json.actions[0].actions[0])
             .toEqual({ type: 'pointerMove', duration: 0, x: 1, y: 30 })
     })
 
@@ -46,9 +46,9 @@ describe('moveTo', () => {
         })
 
         const elem = await browser.$('#elem')
-        request.setMockResponse([{}, { x: 5, y: 10, height: 33, width: 44 }, { scrollX: 0, scrollY: 0 }])
+        got.setMockResponse([{}, { x: 5, y: 10, height: 33, width: 44 }, { scrollX: 0, scrollY: 0 }])
         await elem.moveTo(5, 10)
-        expect(request.mock.calls[5][0].body.actions[0].actions[0])
+        expect(got.mock.calls[5][1].json.actions[0].actions[0])
             .toEqual({ type: 'pointerMove', duration: 0, x: 10, y: 20 })
     })
 
@@ -61,7 +61,7 @@ describe('moveTo', () => {
         })
 
         const elem = await browser.$('#elem')
-        request.setMockResponse([{}, {}])
+        got.setMockResponse([{}, {}])
         await expect(elem.moveTo(5, 10)).rejects.toThrow('Failed to receive element rects via execute command')
     })
 
@@ -75,15 +75,15 @@ describe('moveTo', () => {
 
         const elem = await browser.$('#elem')
         await elem.moveTo()
-        expect(request.mock.calls[2][0].uri.path).toContain('/foobar-123/moveto')
-        expect(request.mock.calls[2][0].body).toEqual({ element: 'some-elem-123' })
+        expect(got.mock.calls[2][1].uri.path).toContain('/foobar-123/moveto')
+        expect(got.mock.calls[2][1].json).toEqual({ element: 'some-elem-123' })
 
         await elem.moveTo(5, 10)
-        expect(request.mock.calls[3][0].uri.path).toContain('/foobar-123/moveto')
-        expect(request.mock.calls[3][0].body).toEqual({ element: 'some-elem-123', xoffset: 5, yoffset: 10 })
+        expect(got.mock.calls[3][1].uri.path).toContain('/foobar-123/moveto')
+        expect(got.mock.calls[3][1].json).toEqual({ element: 'some-elem-123', xoffset: 5, yoffset: 10 })
     })
 
     afterEach(() => {
-        request.mockClear()
+        got.mockClear()
     })
 })

--- a/packages/webdriverio/tests/commands/element/reactElement.test.js
+++ b/packages/webdriverio/tests/commands/element/reactElement.test.js
@@ -1,4 +1,4 @@
-import request from 'request'
+import got from 'got'
 import { remote } from '../../../src'
 import { ELEMENT_KEY } from '../../../src/constants'
 
@@ -19,7 +19,7 @@ describe('elem.react$', () => {
             true,
         )
         expect(elem.elementId).toBe('some-elem-123')
-        expect(request.mock.calls.pop()[0].body.args)
+        expect(got.mock.calls.pop()[1].json.args)
             .toEqual([
                 'MyComp',
                 { some: 'props' },
@@ -43,7 +43,7 @@ describe('elem.react$', () => {
         await elem.react$('MyComp')
 
         expect(elem.elementId).toBe('some-elem-123')
-        expect(request.mock.calls.pop()[0].body.args).toEqual([
+        expect(got.mock.calls.pop()[1].json.args).toEqual([
             'MyComp',
             {},
             {},

--- a/packages/webdriverio/tests/commands/element/reactElements.test.js
+++ b/packages/webdriverio/tests/commands/element/reactElements.test.js
@@ -1,4 +1,4 @@
-import request from 'request'
+import got from 'got'
 import { remote } from '../../../src'
 import { ELEMENT_KEY } from '../../../src/constants'
 
@@ -19,7 +19,7 @@ describe('elem.react$', () => {
             true
         )
         expect(elem.elementId).toBe('some-elem-123')
-        expect(request.mock.calls.pop()[0].body.args)
+        expect(got.mock.calls.pop()[1].json.args)
             .toEqual([
                 'MyComp',
                 { some: 'props' },
@@ -43,7 +43,7 @@ describe('elem.react$', () => {
 
         await elem.react$$('MyComp')
         expect(elem.elementId).toBe('some-elem-123')
-        expect(request.mock.calls.pop()[0].body.args).toEqual([
+        expect(got.mock.calls.pop()[1].json.args).toEqual([
             'MyComp',
             {},
             {},

--- a/packages/webdriverio/tests/commands/element/saveScreenshot.test.js
+++ b/packages/webdriverio/tests/commands/element/saveScreenshot.test.js
@@ -1,5 +1,5 @@
 import fs from 'fs'
-import request from 'request'
+import got from 'got'
 import { remote } from '../../../src'
 import * as utils from '../../../src/utils'
 
@@ -40,8 +40,8 @@ describe('saveScreenshot', () => {
         expect(assertDirectoryExistsSpy).toHaveBeenCalledWith(getAbsoluteFilepathSpy.mock.results[0].value)
 
         // request
-        expect(request.mock.calls[2][0].method).toBe('GET')
-        expect(request.mock.calls[2][0].uri.pathname).toBe('/wd/hub/session/foobar-123/element/some-elem-123/screenshot')
+        expect(got.mock.calls[2][1].method).toBe('GET')
+        expect(got.mock.calls[2][1].uri.pathname).toBe('/wd/hub/session/foobar-123/element/some-elem-123/screenshot')
         expect(screenshot.toString()).toBe('some element screenshot')
 
         // write to file

--- a/packages/webdriverio/tests/commands/element/scrollIntoView.test.js
+++ b/packages/webdriverio/tests/commands/element/scrollIntoView.test.js
@@ -1,4 +1,4 @@
-import request from 'request'
+import got from 'got'
 import { remote } from '../../../src'
 
 describe('scrollIntoView test', () => {
@@ -18,13 +18,13 @@ describe('scrollIntoView test', () => {
     it('should allow to check if an element is enabled', async () => {
         elem.elementId = { scrollIntoView: jest.fn() }
         await elem.scrollIntoView()
-        const executeCall = request.mock.calls[2][0]
+        const executeCall = got.mock.calls[2][1]
         expect(executeCall.uri.path).toBe('/wd/hub/session/foobar-123/execute/sync')
-        expect(Object.keys(executeCall.body.args[0])).toHaveLength(2)
+        expect(Object.keys(executeCall.json.args[0])).toHaveLength(2)
         expect(elem.elementId.scrollIntoView.mock.calls).toHaveLength(1)
     })
 
     afterEach(() => {
-        request.mockClear()
+        got.mockClear()
     })
 })

--- a/packages/webdriverio/tests/commands/element/selectByAttribute.test.js
+++ b/packages/webdriverio/tests/commands/element/selectByAttribute.test.js
@@ -1,4 +1,4 @@
-import request from 'request'
+import got from 'got'
 import { remote } from '../../../src'
 import { ELEMENT_KEY } from '../../../src/constants'
 import * as utils from '../../../src/utils'
@@ -19,17 +19,17 @@ describe('selectByAttribute test', () => {
     })
 
     afterEach(() => {
-        request.mockClear()
+        got.mockClear()
         getElementFromResponseSpy.mockClear()
     })
 
     it('should select value by attribute when value is string', async () => {
         await elem.selectByAttribute('value', ' someValue1 ')
 
-        expect(request.mock.calls[1][0].uri.path).toBe('/wd/hub/session/foobar-123/element')
-        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/element')
-        expect(request.mock.calls[2][0].body.value).toBe('./option[normalize-space(@value) = "someValue1"]|./optgroup/option[normalize-space(@value) = "someValue1"]')
-        expect(request.mock.calls[3][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-sub-elem-321/click')
+        expect(got.mock.calls[1][1].uri.path).toBe('/wd/hub/session/foobar-123/element')
+        expect(got.mock.calls[2][1].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/element')
+        expect(got.mock.calls[2][1].json.value).toBe('./option[normalize-space(@value) = "someValue1"]|./optgroup/option[normalize-space(@value) = "someValue1"]')
+        expect(got.mock.calls[3][1].uri.path).toBe('/wd/hub/session/foobar-123/element/some-sub-elem-321/click')
         expect(getElementFromResponseSpy).toBeCalledWith({
             [ELEMENT_KEY]: 'some-sub-elem-321'
         })
@@ -38,10 +38,10 @@ describe('selectByAttribute test', () => {
     it('should select value by attribute when value is number', async () => {
         await elem.selectByAttribute('value', 123)
 
-        expect(request.mock.calls[1][0].uri.path).toBe('/wd/hub/session/foobar-123/element')
-        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/element')
-        expect(request.mock.calls[2][0].body.value).toBe('./option[normalize-space(@value) = "123"]|./optgroup/option[normalize-space(@value) = "123"]')
-        expect(request.mock.calls[3][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-sub-elem-321/click')
+        expect(got.mock.calls[1][1].uri.path).toBe('/wd/hub/session/foobar-123/element')
+        expect(got.mock.calls[2][1].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/element')
+        expect(got.mock.calls[2][1].json.value).toBe('./option[normalize-space(@value) = "123"]|./optgroup/option[normalize-space(@value) = "123"]')
+        expect(got.mock.calls[3][1].uri.path).toBe('/wd/hub/session/foobar-123/element/some-sub-elem-321/click')
         expect(getElementFromResponseSpy).toBeCalledWith({
             [ELEMENT_KEY]: 'some-sub-elem-321'
         })

--- a/packages/webdriverio/tests/commands/element/selectByIndex.test.js
+++ b/packages/webdriverio/tests/commands/element/selectByIndex.test.js
@@ -1,4 +1,4 @@
-import request from 'request'
+import got from 'got'
 import { remote } from '../../../src'
 import { ELEMENT_KEY } from '../../../src/constants'
 import * as utils from '../../../src/utils'
@@ -19,15 +19,15 @@ describe('selectByIndex test', () => {
     })
 
     afterEach(() => {
-        request.mockClear()
+        got.mockClear()
     })
 
     it('should select by index', async () => {
         await elem.selectByIndex(1)
 
-        expect(request.mock.calls[1][0].uri.path).toBe('/wd/hub/session/foobar-123/element')
-        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/elements')
-        expect(request.mock.calls[3][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-456/click')
+        expect(got.mock.calls[1][1].uri.path).toBe('/wd/hub/session/foobar-123/element')
+        expect(got.mock.calls[2][1].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/elements')
+        expect(got.mock.calls[3][1].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-456/click')
         expect(getElementFromResponseSpy).toBeCalledWith({
             [ELEMENT_KEY]: 'some-elem-456'
         })

--- a/packages/webdriverio/tests/commands/element/selectByVisibleText.test.js
+++ b/packages/webdriverio/tests/commands/element/selectByVisibleText.test.js
@@ -1,4 +1,4 @@
-import request from 'request'
+import got from 'got'
 import { remote } from '../../../src'
 import { ELEMENT_KEY } from '../../../src/constants'
 import * as utils from '../../../src/utils'
@@ -19,7 +19,7 @@ describe('selectByVisibleText test', () => {
     })
 
     afterEach(() => {
-        request.mockClear()
+        got.mockClear()
         getElementFromResponseSpy.mockClear()
     })
 
@@ -28,10 +28,10 @@ describe('selectByVisibleText test', () => {
         const optionSelection = './option[. = "someValue1"]|./option[normalize-space(text()) = "someValue1"]'
         const optgroupSelection = './optgroup/option[. = "someValue1"]|./optgroup/option[normalize-space(text()) = "someValue1"]'
 
-        expect(request.mock.calls[1][0].uri.path).toBe('/wd/hub/session/foobar-123/element')
-        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/element')
-        expect(request.mock.calls[2][0].body.value).toBe(`${optionSelection}|${optgroupSelection}`)
-        expect(request.mock.calls[3][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-sub-elem-321/click')
+        expect(got.mock.calls[1][1].uri.path).toBe('/wd/hub/session/foobar-123/element')
+        expect(got.mock.calls[2][1].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/element')
+        expect(got.mock.calls[2][1].json.value).toBe(`${optionSelection}|${optgroupSelection}`)
+        expect(got.mock.calls[3][1].uri.path).toBe('/wd/hub/session/foobar-123/element/some-sub-elem-321/click')
         expect(getElementFromResponseSpy).toBeCalledWith({
             [ELEMENT_KEY]: 'some-sub-elem-321'
         })
@@ -42,10 +42,10 @@ describe('selectByVisibleText test', () => {
         const optionSelection = './option[. = "some Value1"]|./option[normalize-space(text()) = "some Value1"]'
         const optgroupSelection = './optgroup/option[. = "some Value1"]|./optgroup/option[normalize-space(text()) = "some Value1"]'
 
-        expect(request.mock.calls[1][0].uri.path).toBe('/wd/hub/session/foobar-123/element')
-        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/element')
-        expect(request.mock.calls[2][0].body.value).toBe(`${optionSelection}|${optgroupSelection}`)
-        expect(request.mock.calls[3][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-sub-elem-321/click')
+        expect(got.mock.calls[1][1].uri.path).toBe('/wd/hub/session/foobar-123/element')
+        expect(got.mock.calls[2][1].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/element')
+        expect(got.mock.calls[2][1].json.value).toBe(`${optionSelection}|${optgroupSelection}`)
+        expect(got.mock.calls[3][1].uri.path).toBe('/wd/hub/session/foobar-123/element/some-sub-elem-321/click')
         expect(getElementFromResponseSpy).toBeCalledWith({
             [ELEMENT_KEY]: 'some-sub-elem-321'
         })
@@ -56,10 +56,10 @@ describe('selectByVisibleText test', () => {
         const optionSelection = './option[. = "someValue1"]|./option[normalize-space(text()) = "someValue1"]'
         const optgroupSelection = './optgroup/option[. = "someValue1"]|./optgroup/option[normalize-space(text()) = "someValue1"]'
 
-        expect(request.mock.calls[1][0].uri.path).toBe('/wd/hub/session/foobar-123/element')
-        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/element')
-        expect(request.mock.calls[2][0].body.value).toBe(`${optionSelection}|${optgroupSelection}`)
-        expect(request.mock.calls[3][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-sub-elem-321/click')
+        expect(got.mock.calls[1][1].uri.path).toBe('/wd/hub/session/foobar-123/element')
+        expect(got.mock.calls[2][1].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/element')
+        expect(got.mock.calls[2][1].json.value).toBe(`${optionSelection}|${optgroupSelection}`)
+        expect(got.mock.calls[3][1].uri.path).toBe('/wd/hub/session/foobar-123/element/some-sub-elem-321/click')
         expect(getElementFromResponseSpy).toBeCalledWith({
             [ELEMENT_KEY]: 'some-sub-elem-321'
         })
@@ -70,10 +70,10 @@ describe('selectByVisibleText test', () => {
         const optionSelection = './option[. = "some Value1"]|./option[normalize-space(text()) = "some Value1"]'
         const optgroupSelection = './optgroup/option[. = "some Value1"]|./optgroup/option[normalize-space(text()) = "some Value1"]'
 
-        expect(request.mock.calls[1][0].uri.path).toBe('/wd/hub/session/foobar-123/element')
-        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/element')
-        expect(request.mock.calls[2][0].body.value).toBe(`${optionSelection}|${optgroupSelection}`)
-        expect(request.mock.calls[3][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-sub-elem-321/click')
+        expect(got.mock.calls[1][1].uri.path).toBe('/wd/hub/session/foobar-123/element')
+        expect(got.mock.calls[2][1].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/element')
+        expect(got.mock.calls[2][1].json.value).toBe(`${optionSelection}|${optgroupSelection}`)
+        expect(got.mock.calls[3][1].uri.path).toBe('/wd/hub/session/foobar-123/element/some-sub-elem-321/click')
         expect(getElementFromResponseSpy).toBeCalledWith({
             [ELEMENT_KEY]: 'some-sub-elem-321'
         })
@@ -84,10 +84,10 @@ describe('selectByVisibleText test', () => {
         const optionSelection = './option[. = concat("", \'"\', "someValue1", \'"\', "", \'"\', "")]|./option[normalize-space(text()) = concat("", \'"\', "someValue1", \'"\', "", \'"\', "")]'
         const optgroupSelection = './optgroup/option[. = concat("", \'"\', "someValue1", \'"\', "", \'"\', "")]|./optgroup/option[normalize-space(text()) = concat("", \'"\', "someValue1", \'"\', "", \'"\', "")]'
 
-        expect(request.mock.calls[1][0].uri.path).toBe('/wd/hub/session/foobar-123/element')
-        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/element')
-        expect(request.mock.calls[2][0].body.value).toBe(`${optionSelection}|${optgroupSelection}`)
-        expect(request.mock.calls[3][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-sub-elem-321/click')
+        expect(got.mock.calls[1][1].uri.path).toBe('/wd/hub/session/foobar-123/element')
+        expect(got.mock.calls[2][1].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/element')
+        expect(got.mock.calls[2][1].json.value).toBe(`${optionSelection}|${optgroupSelection}`)
+        expect(got.mock.calls[3][1].uri.path).toBe('/wd/hub/session/foobar-123/element/some-sub-elem-321/click')
         expect(getElementFromResponseSpy).toBeCalledWith({
             [ELEMENT_KEY]: 'some-sub-elem-321'
         })
@@ -98,10 +98,10 @@ describe('selectByVisibleText test', () => {
         const optionSelection = './option[. = "123"]|./option[normalize-space(text()) = "123"]'
         const optgroupSelection = './optgroup/option[. = "123"]|./optgroup/option[normalize-space(text()) = "123"]'
 
-        expect(request.mock.calls[1][0].uri.path).toBe('/wd/hub/session/foobar-123/element')
-        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/element')
-        expect(request.mock.calls[2][0].body.value).toBe(`${optionSelection}|${optgroupSelection}`)
-        expect(request.mock.calls[3][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-sub-elem-321/click')
+        expect(got.mock.calls[1][1].uri.path).toBe('/wd/hub/session/foobar-123/element')
+        expect(got.mock.calls[2][1].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/element')
+        expect(got.mock.calls[2][1].json.value).toBe(`${optionSelection}|${optgroupSelection}`)
+        expect(got.mock.calls[3][1].uri.path).toBe('/wd/hub/session/foobar-123/element/some-sub-elem-321/click')
         expect(getElementFromResponseSpy).toBeCalledWith({
             [ELEMENT_KEY]: 'some-sub-elem-321'
         })

--- a/packages/webdriverio/tests/commands/element/setValue.test.js
+++ b/packages/webdriverio/tests/commands/element/setValue.test.js
@@ -1,4 +1,4 @@
-import request from 'request'
+import got from 'got'
 import { remote } from '../../../src'
 
 describe('setValue', () => {
@@ -14,33 +14,33 @@ describe('setValue', () => {
     })
 
     afterEach(() => {
-        request.mockClear()
+        got.mockClear()
     })
 
     test('should set the value clearning the element first', async () => {
         const elem = await browser.$('#foo')
 
         await elem.setValue('foobar')
-        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/clear')
-        expect(request.mock.calls[3][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/value')
-        expect(request.mock.calls[3][0].body.text).toEqual('foobar')
+        expect(got.mock.calls[2][1].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/clear')
+        expect(got.mock.calls[3][1].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/value')
+        expect(got.mock.calls[3][1].json.text).toEqual('foobar')
     })
 
     test('should stringify number', async () => {
         const elem = await browser.$('#boo')
         await elem.setValue(42)
-        expect(request.mock.calls[3][0].body.text).toEqual('42')
+        expect(got.mock.calls[3][1].json.text).toEqual('42')
     })
 
     test('should stringify object', async () => {
         const elem = await browser.$('#foo')
         await elem.setValue({ a: 22 })
-        expect(request.mock.calls[3][0].body.text).toEqual('{"a":22}')
+        expect(got.mock.calls[3][1].json.text).toEqual('{"a":22}')
     })
 
     test('should stringify Array<any>', async () => {
         const elem = await browser.$('#foo')
         await elem.setValue([1, '2', true, [1, 2]])
-        expect(request.mock.calls[3][0].body.text).toEqual('12true[1,2]')
+        expect(got.mock.calls[3][1].json.text).toEqual('12true[1,2]')
     })
 })

--- a/packages/webdriverio/tests/commands/element/touchAction.test.js
+++ b/packages/webdriverio/tests/commands/element/touchAction.test.js
@@ -1,4 +1,4 @@
-import request from 'request'
+import got from 'got'
 import { remote } from '../../../src'
 
 describe('touchAction element test', () => {
@@ -21,8 +21,8 @@ describe('touchAction element test', () => {
     describe('single touch', () => {
         it('should transform to array', async () => {
             await elem.touchAction('press')
-            expect(request.mock.calls[0][0].uri.path).toContain('/touch/perform')
-            expect(request.mock.calls[0][0].body).toEqual({
+            expect(got.mock.calls[0][1].uri.path).toContain('/touch/perform')
+            expect(got.mock.calls[0][1].json).toEqual({
                 actions: [
                     { action: 'press', options: { element: 'some-elem-123' } }
                 ]
@@ -35,8 +35,8 @@ describe('touchAction element test', () => {
                 x: 1,
                 y: 2
             })
-            expect(request.mock.calls[0][0].uri.path).toContain('/touch/perform')
-            expect(request.mock.calls[0][0].body).toEqual({
+            expect(got.mock.calls[0][1].uri.path).toContain('/touch/perform')
+            expect(got.mock.calls[0][1].json).toEqual({
                 actions: [
                     { action: 'press', options: { x: 1, y: 2, element: 'some-elem-123' } }
                 ]
@@ -45,8 +45,8 @@ describe('touchAction element test', () => {
 
         it('should transform object into array if no x and y options are given', async () => {
             await elem.touchAction({ action: 'press' })
-            expect(request.mock.calls[0][0].uri.path).toContain('/touch/perform')
-            expect(request.mock.calls[0][0].body).toEqual({
+            expect(got.mock.calls[0][1].uri.path).toContain('/touch/perform')
+            expect(got.mock.calls[0][1].json).toEqual({
                 actions: [
                     { action: 'press', options: { element: 'some-elem-123' } }
                 ]
@@ -59,8 +59,8 @@ describe('touchAction element test', () => {
                 x: 1,
                 y: 2
             }])
-            expect(request.mock.calls[0][0].uri.path).toContain('/touch/perform')
-            expect(request.mock.calls[0][0].body).toEqual({
+            expect(got.mock.calls[0][1].uri.path).toContain('/touch/perform')
+            expect(got.mock.calls[0][1].json).toEqual({
                 actions: [
                     { action: 'press', options: { x: 1, y: 2, element: 'some-elem-123' } }
                 ]
@@ -69,8 +69,8 @@ describe('touchAction element test', () => {
 
         it('should handle multiple actions as strings properly', async () => {
             await elem.touchAction(['wait', 'release'])
-            expect(request.mock.calls[0][0].uri.path).toContain('/touch/perform')
-            expect(request.mock.calls[0][0].body).toEqual({
+            expect(got.mock.calls[0][1].uri.path).toContain('/touch/perform')
+            expect(got.mock.calls[0][1].json).toEqual({
                 actions: [
                     { action: 'wait' },
                     { action: 'release' }
@@ -90,8 +90,8 @@ describe('touchAction element test', () => {
                 x: 3,
                 y: 4
             }])
-            expect(request.mock.calls[0][0].uri.path).toContain('/touch/perform')
-            expect(request.mock.calls[0][0].body).toEqual({
+            expect(got.mock.calls[0][1].uri.path).toContain('/touch/perform')
+            expect(got.mock.calls[0][1].json).toEqual({
                 actions: [{
                     action: 'press',
                     options: {
@@ -120,8 +120,8 @@ describe('touchAction element test', () => {
                 action: 'press',
                 element: subElem
             })
-            expect(request.mock.calls[0][0].uri.path).toContain('/touch/perform')
-            expect(request.mock.calls[0][0].body).toEqual({
+            expect(got.mock.calls[0][1].uri.path).toContain('/touch/perform')
+            expect(got.mock.calls[0][1].json).toEqual({
                 actions: [
                     { action: 'press', options: { element: 'some-sub-elem-321' } }
                 ]
@@ -139,8 +139,8 @@ describe('touchAction element test', () => {
                 element: subSubElem
             }])
 
-            expect(request.mock.calls[0][0].uri.path).toContain('/touch/perform')
-            expect(request.mock.calls[0][0].body).toEqual({
+            expect(got.mock.calls[0][1].uri.path).toContain('/touch/perform')
+            expect(got.mock.calls[0][1].json).toEqual({
                 actions: [
                     { action: 'press', options: { element: 'some-sub-elem-321', x: 1, y: 2 } },
                     { action: 'moveTo', options: { element: 'some-sub-sub-elem-231' } }
@@ -171,8 +171,8 @@ describe('touchAction element test', () => {
                 y: 2
             })
 
-            expect(request.mock.calls[0][0].uri.path).toContain('/touch/perform')
-            expect(request.mock.calls[0][0].body).toEqual({
+            expect(got.mock.calls[0][1].uri.path).toContain('/touch/perform')
+            expect(got.mock.calls[0][1].json).toEqual({
                 actions: [
                     { action: 'press', options: { x: 1, y: 2, element: 'some-elem-123' } }
                 ]
@@ -186,8 +186,8 @@ describe('touchAction element test', () => {
                 y: 0
             })
 
-            expect(request.mock.calls[0][0].uri.path).toContain('/touch/perform')
-            expect(request.mock.calls[0][0].body).toEqual({
+            expect(got.mock.calls[0][1].uri.path).toContain('/touch/perform')
+            expect(got.mock.calls[0][1].json).toEqual({
                 actions: [
                     { action: 'moveTo', options: { x: 0, y: 0, element: 'some-elem-123' } }
                 ]
@@ -198,8 +198,8 @@ describe('touchAction element test', () => {
     describe('multi touch', () => {
         it('should transform to array using element as first citizen', async () => {
             await elem.touchAction([['press'], ['release']])
-            expect(request.mock.calls[0][0].uri.path).toContain('/touch/multi/perform')
-            expect(request.mock.calls[0][0].body).toEqual({
+            expect(got.mock.calls[0][1].uri.path).toContain('/touch/multi/perform')
+            expect(got.mock.calls[0][1].json).toEqual({
                 actions: [
                     [{ action: 'press', options: { element: 'some-elem-123' } }],
                     [{ action: 'release' }]
@@ -217,7 +217,7 @@ describe('touchAction element test', () => {
                 x: 112,
                 y: 245
             }]])
-            expect(request.mock.calls[0][0].body).toEqual({
+            expect(got.mock.calls[0][1].json).toEqual({
                 actions: [
                     [{ action: 'press', options: { element: 'some-elem-123', x: 1, y: 2 } }],
                     [{ action: 'tap', options: { element: 'some-elem-123', x: 112, y: 245 } }]
@@ -234,7 +234,7 @@ describe('touchAction element test', () => {
                     y: 4
                 }]
             ])
-            expect(request.mock.calls[0][0].body).toEqual({
+            expect(got.mock.calls[0][1].json).toEqual({
                 actions: [
                     [{ action: 'press', options: { element: 'some-elem-123' } }],
                     [{ action: 'tap', options: { element: 'some-elem-123', x: 3, y: 4 } }]
@@ -259,7 +259,7 @@ describe('touchAction element test', () => {
                     y: 6
                 }]
             ])
-            expect(request.mock.calls[0][0].body).toEqual({
+            expect(got.mock.calls[0][1].json).toEqual({
                 actions: [
                     [{ action: 'press', options: { element: 'some-elem-123', x: 1, y: 2 } }],
                     [{ action: 'longPress', options: { element: 'some-elem-123', x: 3, y: 4 } }, { action: 'tap', options: { element: 'some-elem-123', x: 5, y: 6 } }]
@@ -269,6 +269,6 @@ describe('touchAction element test', () => {
     })
 
     beforeEach(() => {
-        request.mockClear()
+        got.mockClear()
     })
 })

--- a/packages/webdriverio/tests/commands/element/waitForDisplayed.test.js
+++ b/packages/webdriverio/tests/commands/element/waitForDisplayed.test.js
@@ -1,4 +1,4 @@
-import request from 'request'
+import got from 'got'
 import { remote } from '../../../src'
 
 describe('waitForDisplayed', () => {
@@ -6,7 +6,7 @@ describe('waitForDisplayed', () => {
     let browser
 
     beforeEach(async () => {
-        request.mockClear()
+        got.mockClear()
 
         browser = await remote({
             baseUrl: 'http://foobar.com',
@@ -38,7 +38,7 @@ describe('waitForDisplayed', () => {
         const result = await elem.waitForDisplayed(duration)
 
         expect(result).toBe(true)
-        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/displayed')
+        expect(got.mock.calls[2][1].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/displayed')
     })
 
     test('should call isDisplayed and return true if eventually true', async () => {

--- a/packages/webdriverio/tests/commands/element/waitForEnabled.test.js
+++ b/packages/webdriverio/tests/commands/element/waitForEnabled.test.js
@@ -1,4 +1,4 @@
-import request from 'request'
+import got from 'got'
 import { remote } from '../../../src'
 
 describe('waitForEnabled', () => {
@@ -6,7 +6,7 @@ describe('waitForEnabled', () => {
     let browser
 
     beforeAll(async () => {
-        request.mockClear()
+        got.mockClear()
 
         browser = await remote({
             baseUrl: 'http://foobar.com',

--- a/packages/webdriverio/tests/commands/element/waitForExist.test.js
+++ b/packages/webdriverio/tests/commands/element/waitForExist.test.js
@@ -1,4 +1,4 @@
-import request from 'request'
+import got from 'got'
 import { remote } from '../../../src'
 
 describe('waitForExists', () => {
@@ -6,7 +6,7 @@ describe('waitForExists', () => {
     let browser
 
     beforeEach(async () => {
-        request.mockClear()
+        got.mockClear()
 
         browser = await remote({
             baseUrl: 'http://foobar.com',

--- a/packages/webdriverio/tests/commands/element/waitUntil.test.js
+++ b/packages/webdriverio/tests/commands/element/waitUntil.test.js
@@ -1,4 +1,4 @@
-import request from 'request'
+import got from 'got'
 import { remote } from '../../../src'
 
 jest.setTimeout(10 * 1000)
@@ -22,6 +22,6 @@ describe('waitUntil', () => {
     })
 
     afterEach(() => {
-        request.mockClear()
+        got.mockClear()
     })
 })

--- a/packages/webdriverio/tests/middleware.test.js
+++ b/packages/webdriverio/tests/middleware.test.js
@@ -1,6 +1,6 @@
 import logger from '@wdio/logger'
 import { remote } from '../src'
-import request from 'request'
+import got from 'got'
 
 jest.mock('../src/commands/element/waitUntil', () => ({
     __esModule: true,
@@ -64,16 +64,16 @@ describe('middleware', () => {
         expect(await subSubElem.click()).toEqual(null)
         expect(warn.mock.calls).toHaveLength(1)
         expect(warn.mock.calls).toEqual([['Request encountered a stale element - terminating request']])
-        request.retryCnt = 0
+        got.retryCnt = 0
     })
 
     it('should successfully getAttribute of an element that falls stale after being re-found in Safari', async () => {
         const elem = await browser.$('#foo')
         elem.selector = '#nonexisting'
-        request.setMockResponse([{ error: 'no such element', statusCode: 404 }, undefined, undefined, 'bar'])
+        got.setMockResponse([{ error: 'no such element', statusCode: 404 }, undefined, undefined, 'bar'])
         expect(await elem.getAttribute('foo')).toEqual('bar')
         expect(waitForExist.default.mock.calls).toHaveLength(1)
-        request.mockClear()
+        got.mockClear()
     })
 
     it('should successfully click on a stale element', async () => {

--- a/packages/webdriverio/tests/multiremote.test.js
+++ b/packages/webdriverio/tests/multiremote.test.js
@@ -1,4 +1,4 @@
-import request from 'request'
+import got from 'got'
 
 import { multiremote } from '../src'
 
@@ -27,14 +27,14 @@ test('should run command on all instances', async () => {
     const result = await browser.execute(() => 'foobar')
     expect(result).toEqual(['foobar', 'foobar'])
 
-    expect(request.mock.calls[0][0].uri.path).toBe('/wd/hub/session')
-    expect(request.mock.calls[0][0].method).toBe('POST')
-    expect(request.mock.calls[1][0].uri.path).toBe('/wd/hub/session')
-    expect(request.mock.calls[1][0].method).toBe('POST')
-    expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/execute/sync')
-    expect(request.mock.calls[2][0].method).toBe('POST')
-    expect(request.mock.calls[3][0].uri.path).toBe('/wd/hub/session/foobar-123/execute/sync')
-    expect(request.mock.calls[3][0].method).toBe('POST')
+    expect(got.mock.calls[0][1].uri.path).toBe('/wd/hub/session')
+    expect(got.mock.calls[0][1].method).toBe('POST')
+    expect(got.mock.calls[1][1].uri.path).toBe('/wd/hub/session')
+    expect(got.mock.calls[1][1].method).toBe('POST')
+    expect(got.mock.calls[2][1].uri.path).toBe('/wd/hub/session/foobar-123/execute/sync')
+    expect(got.mock.calls[2][1].method).toBe('POST')
+    expect(got.mock.calls[3][1].uri.path).toBe('/wd/hub/session/foobar-123/execute/sync')
+    expect(got.mock.calls[3][1].method).toBe('POST')
 })
 
 test('should allow to call on elements', async () => {
@@ -49,10 +49,10 @@ test('should allow to call on elements', async () => {
     const result = await elem.getSize()
     expect(result).toEqual([{ width: 50, height: 30 }, { width: 50, height: 30 }])
 
-    expect(request.mock.calls[2][0].uri.path).toEqual('/wd/hub/session/foobar-123/element')
-    expect(request.mock.calls[3][0].uri.path).toEqual('/wd/hub/session/foobar-123/element')
-    expect(request.mock.calls[4][0].uri.path).toEqual('/wd/hub/session/foobar-123/element/some-elem-123/rect')
-    expect(request.mock.calls[5][0].uri.path).toEqual('/wd/hub/session/foobar-123/element/some-elem-123/rect')
+    expect(got.mock.calls[2][1].uri.path).toEqual('/wd/hub/session/foobar-123/element')
+    expect(got.mock.calls[3][1].uri.path).toEqual('/wd/hub/session/foobar-123/element')
+    expect(got.mock.calls[4][1].uri.path).toEqual('/wd/hub/session/foobar-123/element/some-elem-123/rect')
+    expect(got.mock.calls[5][1].uri.path).toEqual('/wd/hub/session/foobar-123/element/some-elem-123/rect')
 })
 
 test('should be able to fetch multiple elements', async () => {
@@ -101,5 +101,5 @@ test('should be able to overwrite command to and element in multiremote', async 
 })
 
 afterEach(() => {
-    request.mockClear()
+    got.mockClear()
 })

--- a/packages/webdriverio/tests/utils/refetchElement.test.js
+++ b/packages/webdriverio/tests/utils/refetchElement.test.js
@@ -1,5 +1,5 @@
 import { remote } from '../../src'
-import request from 'request'
+import got from 'got'
 import refetchElement from '../../src/utils/refetchElement'
 
 jest.mock('../../src/commands/element/waitForExist', () => ({
@@ -53,7 +53,7 @@ describe('refetchElement', () => {
 
     it('should successfully refetch an element that isn\'t immediately present', async () => {
         const elem = await browser.$('#foo')
-        request.retryCnt = 0
+        got.retryCnt = 0
         const notFound = await browser.$('#slowRerender')
         const refetchedElement = await refetchElement(notFound, 'click')
         expect(waitForExist.default.mock.calls).toHaveLength(1)


### PR DESCRIPTION
## Proposed changes

In order to reduce memory usage and being able to run WebdriverIO in the browser we want to replace the heavy request lib with something more lightweight like Got.

I ultimately decided to use Got because of this comparison table:
https://github.com/sindresorhus/got#comparison

Given that various parts of WebdriverIO (e.g. repl) relies on Node.JS APIs we won't get around having to bundle it anyway.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
