### PR TITLE
Looks for Browserstack style versions in capabilities

### DIFF
--- a/packages/wdio-allure-reporter/src/index.js
+++ b/packages/wdio-allure-reporter/src/index.js
@@ -103,7 +103,8 @@ class AllureReporter extends WDIOReporter {
         if (!this.isMultiremote) {
             const { browserName, deviceName } = this.capabilities
             const targetName = browserName || deviceName || cid
-            const version = this.capabilities.version || this.capabilities.platformVersion || ''
+            const browserstackVersion = this.capabilities.os_version || this.capabilities.osVersion
+            const version = browserstackVersion || this.capabilities.version || this.capabilities.platformVersion || ''
             const paramName = deviceName ? 'device' : 'browser'
             const paramValue = version ? `${targetName}-${version}` : targetName
             currentTest.addParameter('argument', paramName, paramValue)


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

This work to look for Browserstack style capabilities for version in Allure report when building the device/browser parameter value using `os_version` and `osVersion`. `platformVersion` can vary as Browserstack does not gauruntee minor OS versions for iOS. So when re-running Allure would not consider them the same test as `device:` would be `iphone-12.1` or `iphone-12.0` (or even `iphone-12.2`). This will use the user-provided value, which does not change, not the matched value `platformVersion` for Allure reports.



![Screen Shot 2019-11-01 at 9 40 22 PM](https://user-images.githubusercontent.com/6209204/68064306-40bd2900-fcf0-11e9-8196-353c575e4625.png)
![Screen Shot 2019-11-01 at 9 40 25 PM](https://user-images.githubusercontent.com/6209204/68064307-4450b000-fcf0-11e9-9893-12df2682ab1e.png)
![Screen Shot 2019-11-01 at 9 38 56 PM](https://user-images.githubusercontent.com/6209204/68064357-db1d6c80-fcf0-11e9-9030-c69d95a5af55.png)


## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
