### PR TITLE
Add test retry attempts to after hooks

### DIFF
--- a/docs/ConfigurationFile.md
+++ b/docs/ConfigurationFile.md
@@ -3,7 +3,7 @@ id: configurationfile
 title: Testrunner Configuration
 ---
 
-The configuration file contains all necessary information to run your test suite. It’s just a NodeJS module that exports a JSON. 
+The configuration file contains all necessary information to run your test suite. It’s just a NodeJS module that exports a JSON.
 
 Here is an example configuration with all supported properties and additional information:
 
@@ -52,10 +52,10 @@ exports.config = {
     // Specify Test Files
     // ==================
     // Define which test specs should run. The pattern is relative to the directory
-    // from which `wdio` was called. 
+    // from which `wdio` was called.
     //
     // If you are calling `wdio` from an NPM script (see https://docs.npmjs.com/cli/run-script),
-    // then the current working directory is where your `package.json` resides, so `wdio` 
+    // then the current working directory is where your `package.json` resides, so `wdio`
     // will be called from there.
     //
     specs: [
@@ -72,15 +72,15 @@ exports.config = {
     // ============
     // Define your capabilities here. WebdriverIO can run multiple capabilities at the same
     // time. Depending on the number of capabilities, WebdriverIO launches several test
-    // sessions. Within your `capabilities`, you can overwrite the `spec` and `exclude` 
+    // sessions. Within your `capabilities`, you can overwrite the `spec` and `exclude`
     // options in order to group specific specs to a specific capability.
     //
     // First, you can define how many instances should be started at the same time. Let's
     // say you have 3 different capabilities (Chrome, Firefox, and Safari) and you have
-    // set `maxInstances` to 1. wdio will spawn 3 processes. 
+    // set `maxInstances` to 1. wdio will spawn 3 processes.
     //
-    // Therefore, if you have 10 spec files and you set `maxInstances` to 10, all spec files 
-    // will be tested at the same time and 30 processes will be spawned. 
+    // Therefore, if you have 10 spec files and you set `maxInstances` to 10, all spec files
+    // will be tested at the same time and 30 processes will be spawned.
     //
     // The property basically handles how many capabilities from the same test should run tests.
     //
@@ -282,7 +282,7 @@ exports.config = {
      *
      * (`stepData` and `world` are Cucumber-specific.)
      */
-    afterHook: function (test, context, { error, result, duration, passed }/*, stepData, world*/) {
+    afterHook: function (test, context, { error, result, duration, passed, retries }/*, stepData, world*/) {
     },
     /**
      * Function to be executed before a test (in Mocha/Jasmine) starts.
@@ -308,7 +308,7 @@ exports.config = {
     /**
      * Function to be executed after a test (in Mocha/Jasmine)
      */
-    afterTest: function (test, context, { error, result, duration, passed }) {
+    afterTest: function (test, context, { error, result, duration, passed, retries }) {
     },
     /**
      * Hook that gets executed after the suite has ended.
@@ -334,7 +334,7 @@ exports.config = {
     afterSession: function (config, capabilities, specs) {
     },
     /**
-     * Gets executed after all workers have shut down and the process is about to exit. 
+     * Gets executed after all workers have shut down and the process is about to exit.
      * An error thrown in the `onComplete` hook will result in the test run failing.
      * @param {Object} exitCode 0 - success, 1 - fail
      * @param {Object} config wdio configuration object

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -3,7 +3,7 @@ id: options
 title: Options
 ---
 
-WebdriverIO is not just a binding for the WebDriver protocol (like Selenium). It is a full test framework with numerous additional features and utilities. It is based on the [`webdriver`](https://www.npmjs.com/package/webdriver) package, which is a lightweight, non-opinionated implementation of the WebDriver specification including mobile commands supported by Appium. 
+WebdriverIO is not just a binding for the WebDriver protocol (like Selenium). It is a full test framework with numerous additional features and utilities. It is based on the [`webdriver`](https://www.npmjs.com/package/webdriver) package, which is a lightweight, non-opinionated implementation of the WebDriver specification including mobile commands supported by Appium.
 
 WebdriverIO takes the protocol commands and creates smart user commands that makes using the protocol for test automation much easier.
 
@@ -44,7 +44,7 @@ Type: `Object`<br>
 Default: `null`
 
 ### `capabilities`
-Defines the capabilities you want to run in your WebDriver session. Check out the [WebDriver Protocol](https://w3c.github.io/webdriver/#capabilities) for more details. If you run an older driver that doesn't support the WebDriver protocol, you’ll need to use the [JSONWireProtocol capabilities](https://github.com/SeleniumHQ/selenium/wiki/DesiredCapabilities) to successfuly run a session. 
+Defines the capabilities you want to run in your WebDriver session. Check out the [WebDriver Protocol](https://w3c.github.io/webdriver/#capabilities) for more details. If you run an older driver that doesn't support the WebDriver protocol, you’ll need to use the [JSONWireProtocol capabilities](https://github.com/SeleniumHQ/selenium/wiki/DesiredCapabilities) to successfuly run a session.
 
 Additionaly, a useful utility is the Sauce Labs [Automated Test Configurator](https://wiki.saucelabs.com/display/DOCS/Platform+Configurator#/), which helps you create this object by clicking together your desired capabilities.
 
@@ -133,15 +133,15 @@ Type: `Object`|`Object[]`<br>
 Default: `[{ maxInstances: 5, browserName: 'firefox' }]`
 
 ### `baseUrl`
-Shorten `url` command calls by setting a base URL. 
-- If your `url` parameter starts with `/`, then `baseUrl` is prepended (except the `baseUrl` path, if it has one). 
+Shorten `url` command calls by setting a base URL.
+- If your `url` parameter starts with `/`, then `baseUrl` is prepended (except the `baseUrl` path, if it has one).
 - If your `url` parameter starts without a scheme or `/` (like `some/path`), then the full `baseUrl` is prepended directly.
 
 Type: `String`<br>
 Default: `null`
 
 ### `bail`
-If you want your test run to stop after a specific number of test failures, use `bail`. 
+If you want your test run to stop after a specific number of test failures, use `bail`.
 (It defaults to `0`, which runs all tests no matter what.) **Note:** Please be aware that when using a third party test runner (such as Mocha), additional configuration might be required.
 
 Type: `Number`<br>
@@ -154,7 +154,7 @@ Type: `Number`<br>
 Default: `0`
 
 ### `waitforTimeout`
-Default timeout for all `waitFor*` commands. (Note the lowercase `f` in the option name.) This timeout __only__ affects commands starting with `waitFor*` and their default wait time. 
+Default timeout for all `waitFor*` commands. (Note the lowercase `f` in the option name.) This timeout __only__ affects commands starting with `waitFor*` and their default wait time.
 
 To increase the timeout for a _test_, please see the framework docs.
 
@@ -168,7 +168,7 @@ Type: `Number`<br>
 Default: `500`
 
 ### `services`
-Services take over a specific job you don't want to take care of. They enhance your test setup with almost no effort. 
+Services take over a specific job you don't want to take care of. They enhance your test setup with almost no effort.
 
 Unlike plugins, they don't add new commands. Instead, they hook into the test process.
 
@@ -211,7 +211,7 @@ reporters: [
 
 ### `automationProtocol`
 
-Define the protocol you want to use for your browser automation. Currently only [`webdriver`](https://www.npmjs.com/package/webdriver) and [`devtools`](https://www.npmjs.com/package/devtools) are supported, as these are the main browser automation technologies available. 
+Define the protocol you want to use for your browser automation. Currently only [`webdriver`](https://www.npmjs.com/package/webdriver) and [`devtools`](https://www.npmjs.com/package/devtools) are supported, as these are the main browser automation technologies available.
 
 If you want to automate the browser using `devtools`, make sure you have the NPM package installed (`$ npm install --save-dev devtools`).
 
@@ -237,7 +237,7 @@ Type: `String`
 Default: `null`
 
 ### `region`
-If running on Sauce Labs, you can choose to run tests between different datacenters: US or EU. 
+If running on Sauce Labs, you can choose to run tests between different datacenters: US or EU.
 To change your region to EU, add `region: 'eu'` to your config.
 
 __Note:__ This only has an effect if you provide `user` and `key` options that are connected to your Sauce Labs account.
@@ -260,9 +260,9 @@ Default: `false`
 ## `Hooks`
 
 WebdriverIO allows you to set hooks to trigger at specific times of the test lifecycle.
-This allows custom actions (e.g., take screenshot if a test fails). 
+This allows custom actions (e.g., take screenshot if a test fails).
 
-Every hook has as parameter specific information about the lifecycle (i.e. information about the test suite or test). 
+Every hook has as parameter specific information about the lifecycle (i.e. information about the test suite or test).
 
 The following hooks are available: `onPrepare`, `beforeSession`, `before`, `beforeSuite`, `beforeHook`, `afterHook`, `beforeTest`, `beforeCommand`, `afterCommand`, `afterTest`, `afterSuite`, `after`, `afterSession`, `onComplete`, `onReload`, `beforeFeature`, `beforeScenario`, `beforeStep`, `afterStep`, `afterScenario`, `afterFeature`.
 
@@ -275,7 +275,7 @@ Example:
 // wdio.conf.js
 exports.config = {
     // ...
-    afterTest: (test, context, { error, result, duration, passed }) => {
+    afterTest: (test, context, { error, result, duration, passed, retries }) => {
         console.log(`Finished test "${test.parent} - ${test.title}"`)
     }
     // ...

--- a/examples/pageobject/wdio.conf.js
+++ b/examples/pageobject/wdio.conf.js
@@ -108,7 +108,7 @@ exports.config = {
     // Hook that gets executed _after_ a hook within the suite ends (e.g. runs after calling
     // afterEach in Mocha)
     // stepData and world are Cucumber framework specific
-    // afterHook: function (test, context, { error, result, duration, passed }, stepData, world) {
+    // afterHook: function (test, context, { error, result, duration, passed, retries }, stepData, world) {
     // },
     //
     // Function to be executed before a test (in Mocha/Jasmine) starts.
@@ -124,7 +124,7 @@ exports.config = {
     // },
     //
     // Function to be executed after a test (in Mocha/Jasmine) ends.
-    // afterTest: function (test, context, { error, result, duration, passed }) {
+    // afterTest: function (test, context, { error, result, duration, passed, retries }) {
     // },
     //
     // Hook that gets executed after the suite has ended

--- a/examples/wdio.conf.js
+++ b/examples/wdio.conf.js
@@ -229,7 +229,7 @@ exports.config = {
      * afterEach in Mocha)
      * stepData and world are Cucumber framework specific
      */
-    afterHook: function (test, context, { error, result, duration, passed }/*, stepData, world*/) {
+    afterHook: function (test, context, { error, result, duration, passed, retries }/*, stepData, world*/) {
     },
     /**
      * Function to be executed before a test (in Mocha/Jasmine) starts.
@@ -256,7 +256,7 @@ exports.config = {
     /**
      * Function to be executed after a test (in Mocha/Jasmine) ends.
      */
-    afterTest: function (test, context, { error, result, duration, passed }) {
+    afterTest: function (test, context, { error, result, duration, passed, retries }) {
     },
     /**
      * Hook that gets executed after the suite has ended

--- a/examples/wdio/custom-service/my.custom.service.js
+++ b/examples/wdio/custom-service/my.custom.service.js
@@ -23,7 +23,7 @@ module.exports = class CustomService {
         console.log('execute beforeHook(test, context)')
     }
     afterHook () {
-        console.log('execute afterHook(test, context, { error, result, duration, passed })')
+        console.log('execute afterHook(test, context, { error, result, duration, passed, retries })')
     }
     beforeTest () {
         console.log('execute beforeTest(test, context)')
@@ -35,7 +35,7 @@ module.exports = class CustomService {
         console.log('execute afterCommand(commandName, args, result, error)')
     }
     afterTest () {
-        console.log('execute afterTest(test, context, { error, result, duration, passed })')
+        console.log('execute afterTest(test, context, { error, result, duration, passed, retries })')
     }
     afterSuite () {
         console.log('execute afterSuite(suite)')

--- a/packages/wdio-cli/src/templates/afterTest.ejs
+++ b/packages/wdio-cli/src/templates/afterTest.ejs
@@ -2,12 +2,12 @@
      * Function to be executed after a test (in Mocha/Jasmine).
      */<%
 if (reporters.length && reporters.includes('allure')) {%>
-    afterTest: function(test, context, { error, result, duration, passed }) {
+    afterTest: function(test, context, { error, result, duration, passed, retries }) {
         if (!passed) {
             browser.takeScreenshot();
         }
     },
 <% } else { %>
-    // afterTest: function(test, context, { error, result, duration, passed }) {
+    // afterTest: function(test, context, { error, result, duration, passed, retries }) {
     // },
 <% } %>

--- a/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
+++ b/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
@@ -281,7 +281,7 @@ exports.config = {
      * Hook that gets executed _after_ a hook within the suite starts (e.g. runs after calling
      * afterEach in Mocha)
      */
-    // afterHook: function (test, context, { error, result, duration, passed }) {
+    // afterHook: function (test, context, { error, result, duration, passed, retries }) {
     // },
     <%- include('afterTest', { reporters: answers.reporters }) %>
     /**

--- a/packages/wdio-runner/src/index.js
+++ b/packages/wdio-runner/src/index.js
@@ -60,6 +60,9 @@ export default class Runner extends EventEmitter {
         this.configParser.filterWorkerServices()
 
         this.config = this.configParser.getConfig()
+
+        this.config.specFileRetryAttempts = (this.config.specFileRetries || 0) - (retries || 0)
+
         logger.setLogLevelsConfig(this.config.logLevels, this.config.logLevel)
         this.isMultiremote = !Array.isArray(this.configParser.getCapabilities())
         initialiseServices(this.config, caps).map(::this.configParser.addService)
@@ -111,7 +114,7 @@ export default class Runner extends EventEmitter {
                     return caps
                 }, {})
                 : browser.capabilities,
-            retry: (this.config.specFileRetries || 0) - (retries || 0)
+            retry: this.config.specFileRetryAttempts
         })
 
         /**

--- a/packages/wdio-sync/webdriverio-core.d.ts
+++ b/packages/wdio-sync/webdriverio-core.d.ts
@@ -116,7 +116,13 @@ declare namespace WebdriverIO {
 
         beforeSuite?(suite: Suite): void;
         beforeTest?(test: Test, context: any): void;
-        afterHook?(test: any, context: any, result: { error?: any, result?: any, passed: boolean, duration: number }, stepData?: any, world?: any): void;
+        afterHook?(test: any, context: any, result: {
+            error?: any,
+            result?: any,
+            passed: boolean,
+            duration: number,
+            retries: { limit: number, attempts: number }
+        }, stepData?: any, world?: any): void;
 
         after?(
             result: number,
@@ -138,7 +144,13 @@ declare namespace WebdriverIO {
         ): void;
 
         afterSuite?(suite: Suite): void;
-        afterTest?(test: Test, context: any, result: { error?: any, result?: any, passed: boolean, duration: number }): void;
+        afterTest?(test: Test, context: any, result: {
+            error?: any,
+            result?: any,
+            passed: boolean,
+            duration: number,
+            retries: { limit: number, attempts: number }
+        }): void;
     }
     type _HooksArray = {
         [K in keyof Pick<HookFunctions, "onPrepare" | "onComplete" | "before" | "after" | "beforeSession" | "afterSession">]: HookFunctions[K] | Array<HookFunctions[K]>;
@@ -214,6 +226,22 @@ declare namespace WebdriverIO {
         click(
             options?: object
         ): void;
+
+        /**
+         * The `customs$` allows you to use a custom strategy declared by using `browser.addLocatorStrategy`
+         */
+        custom$$(
+            strategyName: string,
+            strategyArguments: any
+        ): Element;
+
+        /**
+         * The `custom$` allows you to use a custom strategy declared by using `browser.addLocatorStrategy`
+         */
+        custom$(
+            strategyName: string,
+            strategyArguments: any
+        ): Element;
 
         /**
          * Double-click on an element.
@@ -522,6 +550,22 @@ declare namespace WebdriverIO {
          */
         $(
             selector: string | Function | object
+        ): Element;
+
+        /**
+         * The `customs$` allows you to use a custom strategy declared by using `browser.addLocatorStrategy`
+         */
+        custom$$(
+            strategyName: string,
+            strategyArguments: any
+        ): Element;
+
+        /**
+         * The `custom$` allows you to use a custom strategy declared by using `browser.addLocatorStrategy`
+         */
+        custom$(
+            strategyName: string,
+            strategyArguments: any
         ): Element;
 
         /**

--- a/packages/wdio-sync/webdriverio-core.d.ts
+++ b/packages/wdio-sync/webdriverio-core.d.ts
@@ -61,6 +61,7 @@ declare namespace WebdriverIO {
         baseUrl?: string,
         bail?: number,
         specFileRetries?: number,
+        readonly specFileRetryAttempts?: number,
         waitforTimeout?: number,
         waitforInterval?: number,
         framework?: string,

--- a/packages/wdio-utils/src/test-framework/testFnWrapper.js
+++ b/packages/wdio-utils/src/test-framework/testFnWrapper.js
@@ -36,6 +36,7 @@ export const testFrameworkFnWrapper = async function (
     { beforeFn, beforeFnArgs },
     { afterFn, afterFnArgs },
     cid, repeatTest = 0) {
+    const retries = { attempts: 0, limit: repeatTest }
     const beforeArgs = mochaJasmineCompatibility(beforeFnArgs(this), this)
     await logHookError(`Before${type}`, await executeHooksWithArgs(beforeFn, beforeArgs), cid)
 
@@ -46,9 +47,9 @@ export const testFrameworkFnWrapper = async function (
      * user wants handle async command using promises, no need to wrap in fiber context
      */
     if (isFunctionAsync(specFn) || !runSync) {
-        promise = executeAsync.call(this, specFn, repeatTest, specFnArgs)
+        promise = executeAsync.call(this, specFn, retries, specFnArgs)
     } else {
-        promise = new Promise(runSync.call(this, specFn, repeatTest, specFnArgs))
+        promise = new Promise(runSync.call(this, specFn, retries, specFnArgs))
     }
 
     const testStart = Date.now()
@@ -61,6 +62,7 @@ export const testFrameworkFnWrapper = async function (
 
     let afterArgs = afterFnArgs(this)
     afterArgs.push({
+        retries,
         error,
         result,
         duration,

--- a/packages/wdio-utils/src/test-framework/testInterfaceWrapper.js
+++ b/packages/wdio-utils/src/test-framework/testInterfaceWrapper.js
@@ -25,7 +25,7 @@ const MOCHA_COMMANDS = ['skip', 'only']
  * @param  {Number}   repeatTest    number of retries if hook fails
  * @return {Function}               wrapped framework hook function
  */
-export const runHook = function (hookFn, origFn, beforeFn, beforeFnArgs, afterFn, afterFnArgs, cid, repeatTest = 0) {
+export const runHook = function (hookFn, origFn, beforeFn, beforeFnArgs, afterFn, afterFnArgs, cid, repeatTest) {
     return origFn(function (...hookFnArgs) {
         return testFnWrapper.call(this, 'Hook', { specFn: hookFn, specFnArgs: filterSpecArgs(hookFnArgs) }, { beforeFn, beforeFnArgs }, { afterFn, afterFnArgs }, cid, repeatTest)
     })
@@ -45,7 +45,7 @@ export const runHook = function (hookFn, origFn, beforeFn, beforeFnArgs, afterFn
  * @param  {Number}   repeatTest    number of retries if test fails
  * @return {Function}               wrapped test function
  */
-export const runSpec = function (specTitle, specFn, origFn, beforeFn, beforeFnArgs, afterFn, afterFnArgs, cid, repeatTest = 0) {
+export const runSpec = function (specTitle, specFn, origFn, beforeFn, beforeFnArgs, afterFn, afterFnArgs, cid, repeatTest) {
     return origFn(specTitle, function (...specFnArgs) {
         return testFnWrapper.call(this, 'Test', { specFn, specFnArgs: filterSpecArgs(specFnArgs) }, { beforeFn, beforeFnArgs }, { afterFn, afterFnArgs }, cid, repeatTest)
     })

--- a/packages/wdio-utils/tests/test-framework/testFnWrapper-sync.test.js
+++ b/packages/wdio-utils/tests/test-framework/testFnWrapper-sync.test.js
@@ -3,9 +3,9 @@ import { testFnWrapper } from '../../src/test-framework/testFnWrapper'
 
 jest.mock('../../src/shim', () => ({
     executeHooksWithArgs: jest.fn(),
-    runSync: (fn, repeatTest, args = []) => async (resolve, reject) => {
+    runSync: (fn, { attempts, limit }, args = []) => async (resolve, reject) => {
         try {
-            return resolve(await fn('@wdio/sync', repeatTest, ...args))
+            return resolve(await fn('@wdio/sync', attempts, limit, ...args))
         } catch (err) {
             reject(err)
         }
@@ -16,7 +16,7 @@ jest.mock('../../src/shim', () => ({
 const executeHooksWithArgs = shim.executeHooksWithArgs
 
 describe('testFnWrapper', () => {
-    const origFn = (mode, repeatTest, arg) => `${mode}: Foo${arg} ${repeatTest}`
+    const origFn = (mode, attempts, limit, arg) => `${mode}: Foo${arg} ${attempts} ${limit}`
     const buildArgs = (specFn, retries, beforeFnArgs, afterFnArgs) => [
         'Foo',
         { specFn, specFnArgs: ['Bar'] },
@@ -31,13 +31,20 @@ describe('testFnWrapper', () => {
         const result = await testFnWrapper.call({ test: { fullTitle: () => 'full title' } }, ...args)
 
         const expectedResults = { duration: expect.any(Number), error: undefined, passed: true }
-        expect(result).toBe('@wdio/sync: FooBar 0')
+        expect(result).toBe('@wdio/sync: FooBar 0 0')
         expect(executeHooksWithArgs).toBeCalledTimes(2)
         expect(executeHooksWithArgs).toBeCalledWith('beforeFn', ['beforeFnArgs'])
         expect(executeHooksWithArgs).toBeCalledWith('afterFn', [
             { ...expectedResults, foo: 'bar', fullTitle: 'full title', title: 'foo', description: 'foo' },
             'context',
-            { ...expectedResults, result: '@wdio/sync: FooBar 0' }
+            {
+                ...expectedResults,
+                result: '@wdio/sync: FooBar 0 0',
+                retries: {
+                    attempts: 0,
+                    limit: 0
+                }
+            }
         ])
     })
 
@@ -45,13 +52,22 @@ describe('testFnWrapper', () => {
         const args = buildArgs(origFn, undefined, () => ['beforeFnArgs'], () => [{ foo: 'bar' }, 2, 3, 4])
         const result = await testFnWrapper(...args)
 
-        expect(result).toBe('@wdio/sync: FooBar 0')
+        expect(result).toBe('@wdio/sync: FooBar 0 0')
         expect(executeHooksWithArgs).toBeCalledTimes(2)
         expect(executeHooksWithArgs).toBeCalledWith('beforeFn', ['beforeFnArgs'])
         expect(executeHooksWithArgs).toBeCalledWith('afterFn', [
             { foo: 'bar' },
             2,
-            { duration: expect.any(Number), error: undefined, passed: true, result: '@wdio/sync: FooBar 0' },
+            {
+                duration: expect.any(Number),
+                error: undefined,
+                passed: true,
+                result: '@wdio/sync: FooBar 0 0',
+                retries: {
+                    attempts: 0,
+                    limit: 0
+                }
+            },
             3,
             4
         ])

--- a/packages/wdio-utils/tests/test-framework/testInterfaceWrapper.test.js
+++ b/packages/wdio-utils/tests/test-framework/testInterfaceWrapper.test.js
@@ -19,7 +19,7 @@ describe('runHook', () => {
             { beforeFn: 'beforeFn', beforeFnArgs },
             { afterFn: 'afterFn', afterFnArgs },
             'cid',
-            0
+            undefined
         )
     })
 })
@@ -35,7 +35,7 @@ describe('runSpec', () => {
             { beforeFn: 'beforeFn', beforeFnArgs },
             { afterFn: 'afterFn', afterFnArgs },
             'cid',
-            0
+            undefined
         )
     })
 })

--- a/packages/webdriver/webdriver.d.ts
+++ b/packages/webdriver/webdriver.d.ts
@@ -1263,7 +1263,7 @@ declare namespace WebDriver {
 
         /**
          * [jsonwp]
-         * Query the server's current status. The server should respond with a general "HTTP 200 OK" response if it is alive and accepting commands. The response body should be a JSON object describing the state of the server. All server implementations should return two basic objects describing the server's current platform and when the server was built. All fields are optional; if omitted, the client should assume the value is uknown. Furthermore, server implementations may include additional fields not listed here.
+         * Query the server's current status. The server should respond with a general "HTTP 200 OK" response if it is alive and accepting commands. The response body should be a JSON object describing the state of the server. All server implementations should return two basic objects describing the server's current platform and when the server was built. All fields are optional; if omitted, the client should assume the value is unknown. Furthermore, server implementations may include additional fields not listed here.
          * https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#status
          */
         status(): StatusReturn;

--- a/packages/webdriverio/src/commands/element/isClickable.js
+++ b/packages/webdriverio/src/commands/element/isClickable.js
@@ -18,7 +18,7 @@
     it('should detect if an element is clickable', () => {
         const el = $('#el')
         let clickable = el.isClickable();
-        console.log(clickable); // outputs: true or flase
+        console.log(clickable); // outputs: true or false
 
         // wait for element to be clickable
         browser.waitUntil(() => el.isClickable())

--- a/packages/webdriverio/webdriverio-core-v5.d.ts
+++ b/packages/webdriverio/webdriverio-core-v5.d.ts
@@ -116,7 +116,13 @@ declare namespace WebdriverIO {
 
         beforeSuite?(suite: Suite): void;
         beforeTest?(test: Test, context: any): void;
-        afterHook?(test: any, context: any, result: { error?: any, result?: any, passed: boolean, duration: number }, stepData?: any, world?: any): void;
+        afterHook?(test: any, context: any, result: {
+            error?: any,
+            result?: any,
+            passed: boolean,
+            duration: number,
+            retries: { limit: number, attempts: number }
+        }, stepData?: any, world?: any): void;
 
         after?(
             result: number,
@@ -138,7 +144,13 @@ declare namespace WebdriverIO {
         ): void;
 
         afterSuite?(suite: Suite): void;
-        afterTest?(test: Test, context: any, result: { error?: any, result?: any, passed: boolean, duration: number }): void;
+        afterTest?(test: Test, context: any, result: {
+            error?: any,
+            result?: any,
+            passed: boolean,
+            duration: number,
+            retries: { limit: number, attempts: number }
+        }): void;
     }
     type _HooksArray = {
         [K in keyof Pick<HookFunctions, "onPrepare" | "onComplete" | "before" | "after" | "beforeSession" | "afterSession">]: HookFunctions[K] | Array<HookFunctions[K]>;
@@ -214,6 +226,22 @@ declare namespace WebdriverIO {
         click(
             options?: object
         ): void;
+
+        /**
+         * The `customs$` allows you to use a custom strategy declared by using `browser.addLocatorStrategy`
+         */
+        custom$$(
+            strategyName: string,
+            strategyArguments: any
+        ): Element;
+
+        /**
+         * The `custom$` allows you to use a custom strategy declared by using `browser.addLocatorStrategy`
+         */
+        custom$(
+            strategyName: string,
+            strategyArguments: any
+        ): Element;
 
         /**
          * Double-click on an element.
@@ -522,6 +550,22 @@ declare namespace WebdriverIO {
          */
         $(
             selector: string | Function | object
+        ): Element;
+
+        /**
+         * The `customs$` allows you to use a custom strategy declared by using `browser.addLocatorStrategy`
+         */
+        custom$$(
+            strategyName: string,
+            strategyArguments: any
+        ): Element;
+
+        /**
+         * The `custom$` allows you to use a custom strategy declared by using `browser.addLocatorStrategy`
+         */
+        custom$(
+            strategyName: string,
+            strategyArguments: any
         ): Element;
 
         /**

--- a/packages/webdriverio/webdriverio-core-v5.d.ts
+++ b/packages/webdriverio/webdriverio-core-v5.d.ts
@@ -61,6 +61,7 @@ declare namespace WebdriverIO {
         baseUrl?: string,
         bail?: number,
         specFileRetries?: number,
+        readonly specFileRetryAttempts?: number,
         waitforTimeout?: number,
         waitforInterval?: number,
         framework?: string,

--- a/packages/webdriverio/webdriverio-core.d.ts
+++ b/packages/webdriverio/webdriverio-core.d.ts
@@ -116,7 +116,13 @@ declare namespace WebdriverIO {
 
         beforeSuite?(suite: Suite): void;
         beforeTest?(test: Test, context: any): void;
-        afterHook?(test: any, context: any, result: { error?: any, result?: any, passed: boolean, duration: number }, stepData?: any, world?: any): void;
+        afterHook?(test: any, context: any, result: {
+            error?: any,
+            result?: any,
+            passed: boolean,
+            duration: number,
+            retries: { limit: number, attempts: number }
+        }, stepData?: any, world?: any): void;
 
         after?(
             result: number,
@@ -138,7 +144,13 @@ declare namespace WebdriverIO {
         ): void;
 
         afterSuite?(suite: Suite): void;
-        afterTest?(test: Test, context: any, result: { error?: any, result?: any, passed: boolean, duration: number }): void;
+        afterTest?(test: Test, context: any, result: {
+            error?: any,
+            result?: any,
+            passed: boolean,
+            duration: number,
+            retries: { limit: number, attempts: number }
+        }): void;
     }
     type _HooksArray = {
         [K in keyof Pick<HookFunctions, "onPrepare" | "onComplete" | "before" | "after" | "beforeSession" | "afterSession">]: HookFunctions[K] | Array<HookFunctions[K]>;
@@ -214,6 +226,22 @@ declare namespace WebdriverIO {
         click(
             options?: object
         ): Promise<void>;
+
+        /**
+         * The `customs$` allows you to use a custom strategy declared by using `browser.addLocatorStrategy`
+         */
+        custom$$(
+            strategyName: string,
+            strategyArguments: any
+        ): Promise<Element>;
+
+        /**
+         * The `custom$` allows you to use a custom strategy declared by using `browser.addLocatorStrategy`
+         */
+        custom$(
+            strategyName: string,
+            strategyArguments: any
+        ): Promise<Element>;
 
         /**
          * Double-click on an element.
@@ -522,6 +550,22 @@ declare namespace WebdriverIO {
          */
         $(
             selector: string | Function | object
+        ): Promise<Element>;
+
+        /**
+         * The `customs$` allows you to use a custom strategy declared by using `browser.addLocatorStrategy`
+         */
+        custom$$(
+            strategyName: string,
+            strategyArguments: any
+        ): Promise<Element>;
+
+        /**
+         * The `custom$` allows you to use a custom strategy declared by using `browser.addLocatorStrategy`
+         */
+        custom$(
+            strategyName: string,
+            strategyArguments: any
         ): Promise<Element>;
 
         /**

--- a/packages/webdriverio/webdriverio-core.d.ts
+++ b/packages/webdriverio/webdriverio-core.d.ts
@@ -61,6 +61,7 @@ declare namespace WebdriverIO {
         baseUrl?: string,
         bail?: number,
         specFileRetries?: number,
+        readonly specFileRetryAttempts?: number,
         waitforTimeout?: number,
         waitforInterval?: number,
         framework?: string,

--- a/scripts/templates/webdriverio.tpl.d.ts
+++ b/scripts/templates/webdriverio.tpl.d.ts
@@ -116,7 +116,13 @@ declare namespace WebdriverIO {
 
         beforeSuite?(suite: Suite): void;
         beforeTest?(test: Test, context: any): void;
-        afterHook?(test: any, context: any, result: { error?: any, result?: any, passed: boolean, duration: number }, stepData?: any, world?: any): void;
+        afterHook?(test: any, context: any, result: {
+            error?: any,
+            result?: any,
+            passed: boolean,
+            duration: number,
+            retries: { limit: number, attempts: number }
+        }, stepData?: any, world?: any): void;
 
         after?(
             result: number,
@@ -138,7 +144,13 @@ declare namespace WebdriverIO {
         ): void;
 
         afterSuite?(suite: Suite): void;
-        afterTest?(test: Test, context: any, result: { error?: any, result?: any, passed: boolean, duration: number }): void;
+        afterTest?(test: Test, context: any, result: {
+            error?: any,
+            result?: any,
+            passed: boolean,
+            duration: number,
+            retries: { limit: number, attempts: number }
+        }): void;
     }
     type _HooksArray = {
         [K in keyof Pick<HookFunctions, "onPrepare" | "onComplete" | "before" | "after" | "beforeSession" | "afterSession">]: HookFunctions[K] | Array<HookFunctions[K]>;

--- a/scripts/templates/webdriverio.tpl.d.ts
+++ b/scripts/templates/webdriverio.tpl.d.ts
@@ -61,6 +61,7 @@ declare namespace WebdriverIO {
         baseUrl?: string,
         bail?: number,
         specFileRetries?: number,
+        readonly specFileRetryAttempts?: number,
         waitforTimeout?: number,
         waitforInterval?: number,
         framework?: string,


### PR DESCRIPTION
## Proposed changes

- add TEST retries limit and attempts to after test / hook.

![image](https://user-images.githubusercontent.com/25589559/68078950-dd5ef400-fde0-11e9-8e33-f438f8a041be.png)

- add SPEC FILE retries attempts to config `browser.config.specFileRetryAttempts`. We already have `specFileRetries` in config defined by user.
![image](https://user-images.githubusercontent.com/25589559/68078968-362e8c80-fde1-11e9-8607-69ad1f109b1b.png)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

works same in mocha, cucumber, etc

fixes #4662

### Reviewers: @webdriverio/technical-committee
