### PR TITLE
Look for device capability before deviceName, deviceName is not consistent in BrowserStack

### DIFF
--- a/packages/wdio-allure-reporter/src/index.js
+++ b/packages/wdio-allure-reporter/src/index.js
@@ -101,12 +101,14 @@ class AllureReporter extends WDIOReporter {
         const currentTest = this.allure.getCurrentTest()
 
         if (!this.isMultiremote) {
-            const { browserName, deviceName } = this.capabilities
-            const targetName = browserName || this.capabilities.device || deviceName || cid
-            const browserstackVersion = this.capabilities.os_version || this.capabilities.osVersion
-            const version = browserstackVersion || this.capabilities.version || this.capabilities.platformVersion || ''
-            const paramName = this.capabilities.device || deviceName ? 'device' : 'browser'
-            const paramValue = version ? `${targetName}-${version}` : targetName
+            // eslint-disable-next-line camelcase
+            const { browserName, device, deviceName, version, platformVersion, os_version, osVersion } = this.capabilities
+            const targetName = browserName || device || deviceName || cid
+            // eslint-disable-next-line camelcase
+            const browserstackVersion = os_version || osVersion
+            const paramVersion = browserstackVersion || version || platformVersion || ''
+            const paramName = device || deviceName ? 'device' : 'browser'
+            const paramValue = paramVersion ? `${targetName}-${paramVersion}` : targetName
             currentTest.addParameter('argument', paramName, paramValue)
         } else {
             currentTest.addParameter('argument', 'isMultiremote', 'true')

--- a/packages/wdio-allure-reporter/src/index.js
+++ b/packages/wdio-allure-reporter/src/index.js
@@ -101,13 +101,22 @@ class AllureReporter extends WDIOReporter {
         const currentTest = this.allure.getCurrentTest()
 
         if (!this.isMultiremote) {
-            // eslint-disable-next-line camelcase
-            const { browserName, device, deviceName, version, platformVersion, os_version, osVersion } = this.capabilities
-            const targetName = browserName || device || deviceName || cid
-            // eslint-disable-next-line camelcase
-            const browserstackVersion = os_version || osVersion
-            const paramVersion = browserstackVersion || version || platformVersion || ''
-            const paramName = device || deviceName ? 'device' : 'browser'
+            const { browserName, device, deviceName, version, platformVersion } = this.capabilities
+
+            let targetName = browserName || device || deviceName || cid
+            let paramVersion = version || platformVersion || ''
+            let paramName = device || deviceName ? 'device' : 'browser'
+
+            if (this.config.hostname.includes('browserstack')) {
+                // eslint-disable-next-line camelcase
+                const { browser_name: browserNameLegacy, os_version: osVersionLegacy, osVersion: osVersionW3C } = this.capabilities
+                const { version: mobileVersion } = this.capabilities.mobile
+
+                targetName = browserNameLegacy || mobileVersion || device || deviceName || cid
+                paramVersion = osVersionW3C || osVersionLegacy || version || platformVersion || ''
+                paramName = mobileVersion || device || deviceName ? 'device' : 'browser'
+            }
+
             const paramValue = paramVersion ? `${targetName}-${paramVersion}` : targetName
             currentTest.addParameter('argument', paramName, paramValue)
         } else {

--- a/packages/wdio-allure-reporter/src/index.js
+++ b/packages/wdio-allure-reporter/src/index.js
@@ -102,10 +102,10 @@ class AllureReporter extends WDIOReporter {
 
         if (!this.isMultiremote) {
             const { browserName, deviceName } = this.capabilities
-            const targetName = browserName || deviceName || cid
+            const targetName = browserName || this.capabilities.device || deviceName || cid
             const browserstackVersion = this.capabilities.os_version || this.capabilities.osVersion
             const version = browserstackVersion || this.capabilities.version || this.capabilities.platformVersion || ''
-            const paramName = deviceName ? 'device' : 'browser'
+            const paramName = this.capabilities.device || deviceName ? 'device' : 'browser'
             const paramValue = version ? `${targetName}-${version}` : targetName
             currentTest.addParameter('argument', paramName, paramValue)
         } else {


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

This work builds on #4719 and looks for `device` from `capabilities` in Allure Reporter. The `deviceName` is `iphone` or `ipad` for iOS devices but is non-consistent for Android, `device` has a sane model name, we could use other bits of data.  I have added the output of both to explore if this is the best capability to use.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee

##### Android device capabilities in Allure Reporter:
```
{ platform: 'ANDROID',
 webStorageEnabled: false,
 takesScreenshot: true,
 javascriptEnabled: true,
 databaseEnabled: false,
 networkConnectionEnabled: true,
 locationContextEnabled: false,
 warnings: {},
 systemPort: 8201,
 orientation: 'PORTRAIT',
 udid: '8APY0P28Y',
 os: 'Android',
 os_version: '9.0',
 device: 'google pixel 3 xl', // would like to see this in Allure Report
 deviceName: '8APY0P28Y', // this is not consistent
 automationName: 'UIAutomator2',
 platformName: 'android',
 'browserstack.appium_version': '1.14.0',
 'browserstack.debug': 'true',
 'browserstack.video': 'true',
 appWaitDuration: 60000,
 acceptSslCert: false,
 detected_language: 'webdriver/5.15.1',
 osVersion: '9.0',
 browser_name: 'Google Pixel 3 XL',
 'browserstack.appiumVersion': '1.14.0',
 sessionName: 'subsequent-aquamarine',
 buildName: 'local michael switch-to-bs Google Pixel 3 XL  Android 9.0',
 projectName: 'Player Team Cucumber Test (sdk-wdio)',
 'browserstack.tunnelIdentifier': '',
 'browserstack.appiumLogs': 'true',
 'browserstack.minOSVersion': '4.1',
 appPackage: 'com.longtailvideo.jwplayer.testapp',
 appActivity: 'com.longtailvideo.jwplayer.testapp.activities.MainActivity',
 bundleID: 'com.longtailvideo.jwplayer.testapp',
 'browserstack.deviceLogs': 'true',
 nativeWebScreenshot: true,
 version: '',
 mobile: { browser: 'mobile', version: 'Google Pixel 3 XL-9.0' }, // this could be used or this but in iPhone it has the version with minor
 orig_os: 'android',
 '64bit': false,
 'browserstack.video.disableWaterMark': 'true',
 proxy_type: 'node',
 realMobile: 'true',
 appium_port: 38081,
 newCommandTimeout: 100,
 'browserstack.ie.noFlash': 'false',
 acceptSslCerts: false,
 deviceUDID: '8APY0P28Y',
 deviceApiLevel: 28,
 platformVersion: '9',
 deviceScreenSize: '1440x2960',
 deviceScreenDensity: 560,
 deviceModel: 'Pixel 3 XL', // we could also use this but this isn't available for iOS
 deviceManufacturer: 'Google', // we could also use this but this isn't available for iOS
 pixelRatio: 3.5,
 statBarHeight: 171,
 viewportRect: { left: 0, top: 171, width: 1440, height: 2450 } }
```
##### iOS device capabilities in Allure Reporter:
```
{ webStorageEnabled: false,
  locationContextEnabled: false,
  browserName: '',
  platform: 'MAC',
  javascriptEnabled: true,
  databaseEnabled: false,
  takesScreenshot: true,
  networkConnectionEnabled: false,
  platformVersion: '12.0',
  useXctestrunFile: true,
  bootstrapPath:
   '/usr/local/.browserstack/config/wda_derived_data_00008020-001D150234D8002E_348acf752a85988280f798fcf24e340b/Build/Products',
  orientation: 'PORTRAIT',
  'browserstack.isTargetBased': 'false',
  udid: '00008020-001D150234D8002E',
  os: 'iOS',
  os_version: '12',
  device: 'iphone',
  deviceName: 'iphone',
  automationName: 'XCUITest',
  platformName: 'ios',
  'browserstack.appium_version': '1.13.0',
  'browserstack.debug': 'true',
  'browserstack.video': 'true',
  launchTimeout: 45000,
  acceptSslCert: false,
  detected_language: 'webdriver/5.15.1',
  osVersion: '12',
  browser_name: 'iPhone XS',
  'browserstack.appiumVersion': '1.13.0',
  sessionName: 'renewed-brown',
  buildName: 'local michael switch-to-bs iPhone XS  iOS 12',
  projectName: 'Player Team Cucumber Test (sdk-wdio)',
  'browserstack.tunnelIdentifier': '',
  'browserstack.appiumLogs': 'true',
  'browserstack.minOSVersion': '9.0',
  bundleID: 'com.jwplayer.JWTestApp',
  'browserstack.deviceLogs': 'true',
  waitForQuiescence: false,
  version: '',
  mobile: { browser: 'mobile', version: 'iPhone XS-12.1' },
  orig_os: 'ios',
  '64bit': false,
  'browserstack.video.disableWaterMark': 'true',
  proxy_type: 'node',
  realMobile: 'true',
  appium_port: 8082,
  safariInitialUrl: 'http://mobile-internet-check.browserstack.com',
  webkitResponseTimeout: 20000,
  newCommandTimeout: 100,
  deviceOrientation: 'portrait',
  'browserstack.ie.noFlash': 'false',
  acceptSslCerts: false,
  wda_port: 8402,
  bundleId: 'com.jwplayer.JWTestApp' }
```