### PR TITLE
Pass empty capabilities if session failed to start

### DIFF
--- a/packages/wdio-runner/src/index.js
+++ b/packages/wdio-runner/src/index.js
@@ -70,7 +70,7 @@ export default class Runner extends EventEmitter {
         await runHook('beforeSession', this.config, this.caps, this.specs)
         const browser = await this._initSession(this.config, this.caps)
 
-        this.reporter = new BaseReporter(this.config, this.cid, browser.capabilities)
+        this.reporter = new BaseReporter(this.config, this.cid, browser ? browser.capabilities : {})
         this.inWatchMode = Boolean(this.config.watch)
 
         /**

--- a/packages/webdriver/src/utils.js
+++ b/packages/webdriver/src/utils.js
@@ -404,7 +404,8 @@ export function setupDirectConnect(params) {
 export const getSessionError = (err) => {
     // browser driver / service is not started
     if (err.code === 'ECONNREFUSED') {
-        return `Unable to connect to "${err.address}:${err.port}", make sure browser driver is running on that address.`
+        return `Unable to connect to "${err.address}:${err.port}", make sure browser driver is running on that address.` +
+            '\nIf you use services like chromedriver see initialiseServices logs above or in wdio.log file.'
     }
 
     if (!err.message) {


### PR DESCRIPTION
## Proposed changes

minor polish

- fix `TypeError: Cannot read property 'capabilities' of null`
- add better message to logs

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

ref #4728

### Reviewers: @webdriverio/technical-committee
