### PR TITLE
Add waitForClickable command

### DIFF
--- a/packages/wdio-sync/webdriverio-core.d.ts
+++ b/packages/wdio-sync/webdriverio-core.d.ts
@@ -169,6 +169,13 @@ declare namespace WebdriverIO {
     }
     type TouchActions = string | TouchAction | TouchAction[];
 
+    type WaitForOptions = {
+        timeout?: number,
+        interval?: number,
+        timeoutMsg?: string,
+        reverse?: boolean,
+    }
+
     interface Element {
         "element-6066-11e4-a52e-4f735466cecf"?: string;
         ELEMENT?: string;
@@ -332,6 +339,11 @@ declare namespace WebdriverIO {
 
         /**
          * Return true if the selected DOM-element:
+         * - exists;
+         * - is visible;
+         * - is within viewport (if not try scroll to it);
+         * - its center is not overlapped with another element;
+         * - is not disabled.
          */
         isClickable(): boolean;
 
@@ -467,6 +479,14 @@ declare namespace WebdriverIO {
         touchAction(
             action: TouchActions
         ): void;
+
+        /**
+         * Wait for an element for the provided amount of
+         * milliseconds to be clickable or not clickable.
+         */
+        waitForClickable(
+            options?: WaitForOptions
+        ): boolean;
 
         /**
          * Wait for an element for the provided amount of
@@ -620,7 +640,7 @@ declare namespace WebdriverIO {
         /**
          * Pauses execution for a specific amount of time. It is recommended to not use this command to wait for an
          * element to show up. In order to avoid flaky test results it is better to use commands like
-         * [`waitforExist`](/docs/api/element/waitForExist.html) or other waitFor* commands.
+         * [`waitForExist`](/docs/api/element/waitForExist.html) or other waitFor* commands.
          */
         pause(
             milliseconds: number

--- a/packages/webdriverio/src/commands/browser/pause.js
+++ b/packages/webdriverio/src/commands/browser/pause.js
@@ -2,7 +2,7 @@
  *
  * Pauses execution for a specific amount of time. It is recommended to not use this command to wait for an
  * element to show up. In order to avoid flaky test results it is better to use commands like
- * [`waitforExist`](/docs/api/element/waitForExist.html) or other waitFor* commands.
+ * [`waitForExist`](/docs/api/element/waitForExist.html) or other waitFor* commands.
  *
  * <example>
     :pause.js

--- a/packages/webdriverio/src/commands/element.js
+++ b/packages/webdriverio/src/commands/element.js
@@ -35,6 +35,7 @@ export const setValue = require('./element/setValue').default
 export const shadow$$ = require('./element/shadow$$').default
 export const shadow$ = require('./element/shadow$').default
 export const touchAction = require('./element/touchAction').default
+export const waitForClickable = require('./element/waitForClickable').default
 export const waitForDisplayed = require('./element/waitForDisplayed').default
 export const waitForEnabled = require('./element/waitForEnabled').default
 export const waitForExist = require('./element/waitForExist').default

--- a/packages/webdriverio/src/commands/element/isClickable.js
+++ b/packages/webdriverio/src/commands/element/isClickable.js
@@ -2,7 +2,6 @@
 /**
  *
  * Return true if the selected DOM-element:
- *
  * - exists;
  * - is visible;
  * - is within viewport (if not try scroll to it);

--- a/packages/webdriverio/src/commands/element/waitForClickable.js
+++ b/packages/webdriverio/src/commands/element/waitForClickable.js
@@ -1,0 +1,35 @@
+
+/**
+ * Wait for an element for the provided amount of
+ * milliseconds to be clickable or not clickable.
+ *
+ * <example>
+    :waitForClickable.js
+    it('should detect when element is clickable', () => {
+        const elem = $('#elem')
+        elem.waitForClickable({ timeout: 3000 });
+    });
+    it('should detect when element is no longer clickable', () => {
+        const elem = $('#elem')
+        elem.waitForClickable({ reverse: true });
+    });
+ * </example>
+ *
+ * @alias element.waitForClickable
+ * @param {WaitForOptions=}  options            Object (optional)
+ * @param {Number=}  options.timeout    time in ms (default: `waitforTimeout`)
+ * @param {Boolean=} options.reverse    if true it waits for the opposite (default: false)
+ * @param {String=}  options.timeoutMsg error message to throw when waitUntil times out
+ * @param {Number=}  options.interval   interval between checks (default: `waitforInterval`)
+ * @return {Boolean} `true` if element is clickable (or doesn't if flag is set)
+ *
+ */
+
+export default async function waitForClickable ({
+    timeout = this.options.waitforTimeout,
+    interval = this.options.waitforInterval,
+    reverse = false,
+    timeoutMsg = `element ("${this.selector}") still ${reverse ? '' : 'not '}clickable after ${timeout}ms`
+} = {}) {
+    return this.waitUntil(async () => reverse !== await this.isClickable(), timeout, timeoutMsg, interval)
+}

--- a/packages/webdriverio/tests/commands/element/waitForClickable.test.js
+++ b/packages/webdriverio/tests/commands/element/waitForClickable.test.js
@@ -1,0 +1,138 @@
+import request from 'request'
+import { remote } from '../../../src'
+
+describe('waitForClickable', () => {
+    const duration = 1000
+    let browser
+
+    beforeEach(async () => {
+        request.mockClear()
+
+        browser = await remote({
+            baseUrl: 'http://foobar.com',
+            capabilities: {
+                browserName: 'foobar'
+            }
+        })
+    })
+
+    test('should call waitUntil', async () => {
+        const cb = jest.fn()
+        const tmpElem = await browser.$('#foo')
+        const elem = {
+            selector : '#foo',
+            waitForClickable : tmpElem.waitForClickable,
+            elementId : 123,
+            waitUntil : jest.fn(((cb))),
+            options : { waitforInterval: 5, waitforTimeout: duration },
+        }
+
+        await elem.waitForClickable()
+
+        expect(cb).toBeCalled()
+        expect(elem.waitUntil.mock.calls[0][1]).toBe(duration)
+        expect(elem.waitUntil.mock.calls[0][2]).toBe(`element ("#foo") still not clickable after ${duration}ms`)
+    })
+
+    test('should call isClickable and return true immediately if true', async () => {
+        const elem = await browser.$('#foo')
+        delete elem.isClickable
+        elem.isClickable = jest.fn().mockImplementationOnce(() => true)
+        const result = await elem.waitForClickable({ timeout: duration })
+
+        expect(result).toBe(true)
+    })
+
+    test('should call isClickable and return true if eventually true', async () => {
+        const tmpElem = await browser.$('#foo')
+        const elem = {
+            selector : '#foo',
+            waitForClickable : tmpElem.waitForClickable,
+            elementId : 123,
+            waitUntil : tmpElem.waitUntil,
+            isClickable : jest.fn()
+                .mockImplementationOnce(() => false)
+                .mockImplementationOnce(() => false)
+                .mockImplementationOnce(() => true),
+            options : { waitforTimeout : 50, waitforInterval: 5 },
+        }
+
+        const result = await elem.waitForClickable({ timeout: duration })
+        expect(result).toBe(true)
+    })
+
+    test('should call isClickable and return false', async () => {
+        expect.assertions(1)
+        const tmpElem = await browser.$('#foo')
+        const elem = {
+            selector : '#foo',
+            waitForClickable : tmpElem.waitForClickable,
+            elementId : 123,
+            waitUntil : tmpElem.waitUntil,
+            isClickable : jest.fn(() => false),
+            options : { waitforTimeout : 500 },
+        }
+
+        try {
+            await elem.waitForClickable({ timeout: duration })
+        } catch (e) {
+            expect(e.message).toBe(`element ("#foo") still not clickable after ${duration}ms`)
+        }
+    })
+
+    test('should not call isClickable and return false if never found', async () => {
+        const tmpElem = await browser.$('#foo')
+        const elem = {
+            selector : '#foo',
+            parent: { $: jest.fn(() => { return elem}) },
+            waitForClickable : tmpElem.waitForClickable,
+            waitUntil : tmpElem.waitUntil,
+            isDisplayed : tmpElem.isDisplayed,
+            isClickable : tmpElem.isClickable,
+            options : { waitforTimeout : 500 },
+        }
+
+        try {
+            await elem.waitForClickable({ timeout: duration })
+        } catch (e) {
+            expect(e.message).toBe(`element ("#foo") still not clickable after ${duration}ms`)
+        }
+    })
+
+    test('should do reverse', async () => {
+        const cb = jest.fn()
+        const tmpElem = await browser.$('#foo')
+        const elem = {
+            selector : '#foo',
+            waitForClickable : tmpElem.waitForClickable,
+            elementId : 123,
+            waitUntil : jest.fn(((cb))),
+            isClickable : jest.fn(() => true),
+            options : { waitforTimeout : 500 },
+        }
+
+        await elem.waitForClickable({ reverse: true })
+
+        expect(elem.waitUntil.mock.calls[0][1]).toBe(elem.options.waitforTimeout)
+        expect(elem.waitUntil.mock.calls[0][2]).toBe(`element ("#foo") still clickable after ${elem.options.waitforTimeout}ms`)
+    })
+
+    test('should call isClickable and return false with custom error', async () => {
+        expect.assertions(1)
+        const tmpElem = await browser.$('#foo')
+        const elem = {
+            selector : '#foo',
+            waitForClickable : tmpElem.waitForClickable,
+            elementId : 123,
+            waitUntil : tmpElem.waitUntil,
+            isClickable : jest.fn(() => false),
+            options : { waitforTimeout : 500 },
+        }
+
+        try {
+            await elem.waitForClickable({ timeout: duration, timeoutMsg: 'Element foo never clickable' })
+        } catch (e) {
+            expect(e.message).toBe('Element foo never clickable')
+        }
+    })
+})

--- a/packages/webdriverio/webdriverio-core-v5.d.ts
+++ b/packages/webdriverio/webdriverio-core-v5.d.ts
@@ -169,6 +169,13 @@ declare namespace WebdriverIO {
     }
     type TouchActions = string | TouchAction | TouchAction[];
 
+    type WaitForOptions = {
+        timeout?: number,
+        interval?: number,
+        timeoutMsg?: string,
+        reverse?: boolean,
+    }
+
     interface Element {
         "element-6066-11e4-a52e-4f735466cecf"?: string;
         ELEMENT?: string;
@@ -332,6 +339,11 @@ declare namespace WebdriverIO {
 
         /**
          * Return true if the selected DOM-element:
+         * - exists;
+         * - is visible;
+         * - is within viewport (if not try scroll to it);
+         * - its center is not overlapped with another element;
+         * - is not disabled.
          */
         isClickable(): boolean;
 
@@ -467,6 +479,14 @@ declare namespace WebdriverIO {
         touchAction(
             action: TouchActions
         ): void;
+
+        /**
+         * Wait for an element for the provided amount of
+         * milliseconds to be clickable or not clickable.
+         */
+        waitForClickable(
+            options?: WaitForOptions
+        ): boolean;
 
         /**
          * Wait for an element for the provided amount of
@@ -620,7 +640,7 @@ declare namespace WebdriverIO {
         /**
          * Pauses execution for a specific amount of time. It is recommended to not use this command to wait for an
          * element to show up. In order to avoid flaky test results it is better to use commands like
-         * [`waitforExist`](/docs/api/element/waitForExist.html) or other waitFor* commands.
+         * [`waitForExist`](/docs/api/element/waitForExist.html) or other waitFor* commands.
          */
         pause(
             milliseconds: number

--- a/packages/webdriverio/webdriverio-core.d.ts
+++ b/packages/webdriverio/webdriverio-core.d.ts
@@ -169,6 +169,13 @@ declare namespace WebdriverIO {
     }
     type TouchActions = string | TouchAction | TouchAction[];
 
+    type WaitForOptions = {
+        timeout?: number,
+        interval?: number,
+        timeoutMsg?: string,
+        reverse?: boolean,
+    }
+
     interface Element {
         "element-6066-11e4-a52e-4f735466cecf"?: string;
         ELEMENT?: string;
@@ -332,6 +339,11 @@ declare namespace WebdriverIO {
 
         /**
          * Return true if the selected DOM-element:
+         * - exists;
+         * - is visible;
+         * - is within viewport (if not try scroll to it);
+         * - its center is not overlapped with another element;
+         * - is not disabled.
          */
         isClickable(): Promise<boolean>;
 
@@ -467,6 +479,14 @@ declare namespace WebdriverIO {
         touchAction(
             action: TouchActions
         ): Promise<void>;
+
+        /**
+         * Wait for an element for the provided amount of
+         * milliseconds to be clickable or not clickable.
+         */
+        waitForClickable(
+            options?: WaitForOptions
+        ): Promise<boolean>;
 
         /**
          * Wait for an element for the provided amount of
@@ -620,7 +640,7 @@ declare namespace WebdriverIO {
         /**
          * Pauses execution for a specific amount of time. It is recommended to not use this command to wait for an
          * element to show up. In order to avoid flaky test results it is better to use commands like
-         * [`waitforExist`](/docs/api/element/waitForExist.html) or other waitFor* commands.
+         * [`waitForExist`](/docs/api/element/waitForExist.html) or other waitFor* commands.
          */
         pause(
             milliseconds: number

--- a/scripts/templates/webdriverio.tpl.d.ts
+++ b/scripts/templates/webdriverio.tpl.d.ts
@@ -169,6 +169,13 @@ declare namespace WebdriverIO {
     }
     type TouchActions = string | TouchAction | TouchAction[];
 
+    type WaitForOptions = {
+        timeout?: number,
+        interval?: number,
+        timeoutMsg?: string,
+        reverse?: boolean,
+    }
+
     interface Element {
         "element-6066-11e4-a52e-4f735466cecf"?: string;
         ELEMENT?: string;

--- a/scripts/type-generation/generate-typings-utils.js
+++ b/scripts/type-generation/generate-typings-utils.js
@@ -10,6 +10,7 @@ const changeType = (text) => {
     case 'Buffer':
     case 'Function':
     case 'RegExp':
+    case 'WaitForOptions':
     case 'Element':
     case 'Element[]': {
         break


### PR DESCRIPTION
## Proposed changes

Add `waitForClickable` command

We need to agree on option names like:
- timeout
- interval
- timeoutMsg
- reverse

example: `$('el').waitForClickable({ timeoutMsg: 'foobar' })`

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

- fixed typo in `pause` command
- removed newline in `isClickable` to see better docs
![image](https://user-images.githubusercontent.com/25589559/68197148-0a1a3380-ffba-11e9-94a3-11d049b1990a.png)

### Reviewers: @webdriverio/technical-committee
