### PR TITLE
website: Change API header display style to small-caps

### DIFF
--- a/website/static/styles/_components/_headings.scss
+++ b/website/static/styles/_components/_headings.scss
@@ -1,7 +1,7 @@
 h1 {
     font-size: $h1Size;
     color: $black;
-    text-transform: uppercase;
+    font-variant: small-caps;
     font-weight: 100;
     padding: 0 0 40px;
     line-height: 40px;


### PR DESCRIPTION
## Proposed changes

API commands are case-sensitive and the CSS for the website forces names to ALLUPPERCASE, which makes commands like waitForClickable less obvious. The command example given below the title is helpful, but I still find $(compressed).syntax(hardToRead). This changes the "text-transform: uppercase" to "font-variant: small-caps" to preserve the monospace-like nature of capital letters while allowing one to differentiate between capital and lower-case letters when looking at the header.

A font-weight of 200 may also be warranted but this is untested; 300 appears too bold to me.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation update

## Checklist

- [V] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

### Reviewers: @webdriverio/technical-committee
