### PR TITLE
Build a script that grants TSC members to release @wdio packages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,7 +111,7 @@ Commits that affect all packages or are not related to any (e.g. changes to NPM 
 
 ## Release New Version
 
-Package releases are made using Lerna's release capabilities and executed by [the technical committee](https://github.com/webdriverio/webdriverio/blob/master/GOVERNANCE.md#the-technical-committee) only. Before you can start please export an `GITHUB_AUTH` token into your environment in order to allow [`lerna-changelog`](https://www.npmjs.com/package/lerna-changelog#github-token) to gather data about the upcoming release and autogenerate the [CHANGELOG.md](/CHANGELOG.md). Go to your [personal access token](https://github.com/settings/tokens) settings page and generate such token with only having the `public_repo` field enabled. Then export it into your environment:
+Package releases are made using Lerna's release capabilities and executed by the [technical steering committee](https://github.com/webdriverio/webdriverio/blob/master/GOVERNANCE.md#the-technical-committee) only. Before you can start please export an `GITHUB_AUTH` token into your environment in order to allow [`lerna-changelog`](https://www.npmjs.com/package/lerna-changelog#github-token) to gather data about the upcoming release and autogenerate the [CHANGELOG.md](/CHANGELOG.md). Go to your [personal access token](https://github.com/settings/tokens) settings page and generate such token with only having the `public_repo` field enabled. Then export it into your environment:
 
 ```sh
 export GITHUB_AUTH=...
@@ -126,4 +126,10 @@ $ git pull origin master --tags
 $ npm run release
 ```
 
-and choose the appropriate version upgrade based on the [Semantic Versioning](https://semver.org/).
+and choose the appropriate version upgrade based on the [Semantic Versioning](https://semver.org/). To help choose the right release type, here are some general guidelines:
+
+- __Breaking Changes__: never do these by yourself! A major release is always a collaborative effort between all TSC members. It requires consensus from all of them.
+- __Minor Release__: minor releases are always required if a new, user focused feature was added to one of the packages. For example if a command was added to WebdriverIO or a service provides a new form of integration a minor version bump would be appropiate. However if an internal package like `@wdio/local-runner` exposes a new interface that is solely used internally we can consider that as a patch release.
+- __Patch Release__: everytime a bug was fixed, documentation (this includes TypeScript definitions) got updated or existing functionality was improved we should do a patch release.
+
+If you are unsure about which release type to pick, reach out in the TSC Gitter channel.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -94,6 +94,7 @@ A Committer is invited to become a TSC member by existing TSC members. A nominat
 1. Set the GitHub user to have the "Owner" role for the WebdriverIO organization
 1. Invite to the Gitter TSC chatroom (`webdriverio/TSC`)
 1. Add the TSC member as an admin to WebdriverIO Twitter Account
+1. Add the TSC member to the NPM organization
 1. Tweet congratulations to the new TSC member from the WebdriverIO Twitter account
 
 ## Consensus Seeking Process


### PR DESCRIPTION
There are a lot of `@wdio` packages that need to be released. As per our governance only TSC members are allowed to release packages. To make on-boarding of new members easier and more automatic, let's build a script that calls NPMs API and registers members (maintained in an extra `json` file in the repository).

Also add a sentence in the `Governance.md` to run the script as part of the on-boarding.