### PR TITLE
Fix cucumber framework initialisation 

### DIFF
--- a/packages/wdio-cucumber-framework/tests/adapter.test.js
+++ b/packages/wdio-cucumber-framework/tests/adapter.test.js
@@ -82,15 +82,15 @@ test('should properly set up cucumber', async () => {
     expect(Cucumber.getTestCasesFromFilesystem).toBeCalled()
 })
 
-test('should throw when initialization fails', () => {
+test('should throw when initialization fails', async () => {
     const adapter = adapterFactory({ requireModule: ['@babel/register'] })
     adapter.registerRequiredModules = jest.fn()
     adapter.loadSpecFiles = jest.fn()
     adapter.wrapSteps = jest.fn()
 
     const runtimeError = new Error('boom')
-    Cucumber.Runtime.mockImplementationOnce(() => { throw runtimeError })
-    expect(adapter.init()).rejects.toEqual(runtimeError)
+    Cucumber.PickleFilter.mockImplementationOnce(() => { throw runtimeError })
+    await expect(adapter.init()).rejects.toEqual(runtimeError)
 })
 
 test('should throw when run fails', async () => {
@@ -102,7 +102,9 @@ test('should throw when run fails', async () => {
     await adapter.init()
 
     const runtimeError = new Error('boom')
-    adapter.runtime.start = () => { throw runtimeError }
+    Cucumber.Runtime = jest.fn().mockImplementationOnce(() => ({
+        start: () => { throw runtimeError }
+    }))
 
     expect(adapter.run()).rejects.toEqual(runtimeError)
 })

--- a/tests/cucumber/step-definitions/given.js
+++ b/tests/cucumber/step-definitions/given.js
@@ -2,12 +2,18 @@
 import assert from 'assert'
 import { Given, BeforeAll, Before, After, AfterAll } from 'cucumber'
 
+browser.addCommand('rootLevel', () => {
+    return true
+})
+
 BeforeAll(() => {
     // defined and modified in hooks
     assert.equal(browser.Cucumber_Test, 0)
 
     // should resolve promises
     assert.strictEqual(browser.pause(1), undefined)
+
+    assert.strictEqual(browser.rootLevel(), true)
 })
 Before(function (scenario) {
     // defined and modified in hooks


### PR DESCRIPTION
## Proposed changes

Fix cucumber framework initialisation 

moved some blocks from `init` to `run` in order to be able to use `browser` in root scope properly.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
