### PR TITLE
wdio-cucumber-framework: test-run-started event

### DIFF
--- a/packages/wdio-cucumber-framework/src/cucumberEventListener.js
+++ b/packages/wdio-cucumber-framework/src/cucumberEventListener.js
@@ -14,6 +14,7 @@ export default class CucumberEventListener extends EventEmitter {
         super()
         eventBroadcaster
             .on('gherkin-document', this.onGherkinDocument.bind(this))
+            .on('test-run-started', this.onTestRunStarted.bind(this))
             .on('pickle-accepted', this.onPickleAccepted.bind(this))
             .on('test-case-prepared', this.onTestCasePrepared.bind(this))
             .on('test-case-started', this.onTestCaseStarted.bind(this))
@@ -58,12 +59,12 @@ export default class CucumberEventListener extends EventEmitter {
     // }
     onGherkinDocument (gherkinDocEvent) {
         this.gherkinDocEvents.push(gherkinDocEvent)
+    }
 
-        const uri = gherkinDocEvent.uri
-        const doc = gherkinDocEvent.document
-        const feature = doc.feature
+    onTestRunStarted () {
+        const doc = this.gherkinDocEvents[this.gherkinDocEvents.length - 1]
 
-        this.emit('before-feature', uri, feature)
+        this.emit('before-feature', doc.uri, doc.document.feature)
     }
 
     // pickleEvent = {

--- a/packages/wdio-sync/webdriverio-core.d.ts
+++ b/packages/wdio-sync/webdriverio-core.d.ts
@@ -742,7 +742,7 @@ declare namespace WebdriverIO {
         ): string;
 
         /**
-         * Protocol binding to load or get the URL of the browser. If a baseUrl is
+         * Protocol binding to load the URL of the browser. If a baseUrl is
          * specified in the config, it will be prepended to the url parameter using
          * node's url.resolve() method.
          */

--- a/packages/webdriverio/webdriverio-core-v5.d.ts
+++ b/packages/webdriverio/webdriverio-core-v5.d.ts
@@ -742,7 +742,7 @@ declare namespace WebdriverIO {
         ): string;
 
         /**
-         * Protocol binding to load or get the URL of the browser. If a baseUrl is
+         * Protocol binding to load the URL of the browser. If a baseUrl is
          * specified in the config, it will be prepended to the url parameter using
          * node's url.resolve() method.
          */

--- a/packages/webdriverio/webdriverio-core.d.ts
+++ b/packages/webdriverio/webdriverio-core.d.ts
@@ -742,7 +742,7 @@ declare namespace WebdriverIO {
         ): Promise<string>;
 
         /**
-         * Protocol binding to load or get the URL of the browser. If a baseUrl is
+         * Protocol binding to load the URL of the browser. If a baseUrl is
          * specified in the config, it will be prepended to the url parameter using
          * node's url.resolve() method.
          */

--- a/tests/cucumber/reporter/reporter.config.js
+++ b/tests/cucumber/reporter/reporter.config.js
@@ -1,0 +1,11 @@
+const path = require('path')
+const { config } = require('../../helpers/config')
+
+const reporterConfig = Object.assign({}, config, {
+    framework: 'cucumber',
+    reporters: [['smoke-test', { foo: 'bar' }]],
+})
+
+reporterConfig.cucumberOpts.require = [path.join(__dirname, 'reporter.given.js')]
+
+exports.config = reporterConfig

--- a/tests/cucumber/reporter/reporter.feature
+++ b/tests/cucumber/reporter/reporter.feature
@@ -1,0 +1,5 @@
+Feature: reporter feature
+    A test script of wdio-cucumber-framework reporter
+
+    Scenario: Whatever
+        Given Foo

--- a/tests/cucumber/reporter/reporter.given.js
+++ b/tests/cucumber/reporter/reporter.given.js
@@ -1,0 +1,8 @@
+import { Given, BeforeAll, Before, After, AfterAll } from 'cucumber'
+
+BeforeAll(() => {})
+Before(function () {})
+After(function () {})
+AfterAll(() => {})
+
+Given('Foo', () => {})

--- a/tests/helpers/config.js
+++ b/tests/helpers/config.js
@@ -42,35 +42,4 @@ exports.config = {
         requireModule: ['@babel/register'],
         require: ['./tests/cucumber/step-definitions/*.js']
     },
-
-    async beforeFeature () {
-        await browser.pause(30)
-        browser.Cucumber_Test = 0
-    },
-    beforeScenario: () => {
-        browser.pause(30)
-        browser.Cucumber_Test = 1
-    },
-    beforeStep: async function (uri, feature, stepData, context) {
-        await browser.pause(20)
-        browser.Cucumber_Test += 2
-        browser.Cucumber_CurrentStepText = stepData.step.text
-        browser.Cucumber_CurrentStepContext = context
-    },
-    afterStep: function (uri, feature, result, stepData, context) {
-        browser.pause(25)
-        if (browser.Cucumber_CurrentStepText !== stepData.step.text ||
-            browser.Cucumber_CurrentStepContext !== context) {
-            throw new Error("step data doesn't match")
-        }
-        browser.Cucumber_Test = 1
-    },
-    afterScenario: () => {
-        browser.pause(30)
-        browser.Cucumber_Test = -1
-    },
-    afterFeature: () => {
-        delete browser.Cucumber_Test
-        browser.pause(30)
-    },
 }

--- a/tests/helpers/cucumber-hooks.conf.js
+++ b/tests/helpers/cucumber-hooks.conf.js
@@ -1,0 +1,36 @@
+const { config } = require('./config')
+
+exports.config = Object.assign({}, config, {
+    framework: 'cucumber',
+
+    async beforeFeature () {
+        await browser.pause(30)
+        browser.Cucumber_Test = 0
+    },
+    beforeScenario: () => {
+        browser.pause(30)
+        browser.Cucumber_Test = 1
+    },
+    beforeStep: async function (uri, feature, stepData, context) {
+        await browser.pause(20)
+        browser.Cucumber_Test += 2
+        browser.Cucumber_CurrentStepText = stepData.step.text
+        browser.Cucumber_CurrentStepContext = context
+    },
+    afterStep: function (uri, feature, result, stepData, context) {
+        browser.pause(25)
+        if (browser.Cucumber_CurrentStepText !== stepData.step.text ||
+            browser.Cucumber_CurrentStepContext !== context) {
+            throw new Error("step data doesn't match")
+        }
+        browser.Cucumber_Test = 1
+    },
+    afterScenario: () => {
+        browser.pause(30)
+        browser.Cucumber_Test = -1
+    },
+    afterFeature: () => {
+        delete browser.Cucumber_Test
+        browser.pause(30)
+    },
+})

--- a/tests/helpers/fixtures.js
+++ b/tests/helpers/fixtures.js
@@ -67,3 +67,23 @@ onBeforeCommand
 onAfterCommand
 onRunnerEnd
 `
+
+export const CUCUMBER_REPORTER_LOGS = `onRunnerStart
+onSuiteStart
+onSuiteStart
+onHookStart
+onHookEnd
+onHookStart
+onHookEnd
+onTestStart
+onTestPass
+onHookStart
+onHookEnd
+onHookStart
+onHookEnd
+onSuiteEnd
+onSuiteEnd
+onBeforeCommand
+onAfterCommand
+onRunnerEnd
+`


### PR DESCRIPTION
## Proposed changes

send `'suite:start'` event to wdio reporter on cucumber's `'test-run-started'` instead of `'gherkin-document'`

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

fixes https://github.com/wswebcreation/wdio-cucumberjs-json-reporter/issues/16

### Reviewers: @webdriverio/technical-committee
