### PR TITLE
docs(template): Fix API parameters

### DIFF
--- a/scripts/templates/api.tpl.ejs
+++ b/scripts/templates/api.tpl.ejs
@@ -27,8 +27,9 @@ title: <?= method.command ?>
 | Name | Type | Details |
 | ---- | ---- | ------- |
 <? method.paramTags.forEach((paramTag) => {
+    var paramKey = (paramTag.types && paramTag.typesDescription) ? paramTag.typesDescription : paramTag.type
     ?>| <code><var><?= paramTag.name ?></var></code><? if ((!paramTag.required && typeof paramTag.optional === 'undefined') || paramTag.optional) { ?><br><span class="label labelWarning">optional</span><? }
-    ?> | <?= paramTag.type.split('|').join(', ').replace('(', '').replace(')', '')
+    ?> | <?= paramKey.split('|').join(', ').replace('(', '').replace(')', '')
     ?> | <?= paramTag.description ?> |
 <? }) ?>
 <? } ?>

--- a/scripts/templates/api.tpl.ejs
+++ b/scripts/templates/api.tpl.ejs
@@ -27,7 +27,7 @@ title: <?= method.command ?>
 | Name | Type | Details |
 | ---- | ---- | ------- |
 <? method.paramTags.forEach((paramTag) => {
-    ?>| <?= paramTag.name ?><? if ((!paramTag.required && typeof paramTag.optional === 'undefined') || paramTag.optional) { ?><br><span class="label labelWarning">optional</span><? }
+    ?>| <code><var><?= paramTag.name ?></var></code><? if ((!paramTag.required && typeof paramTag.optional === 'undefined') || paramTag.optional) { ?><br><span class="label labelWarning">optional</span><? }
     ?> | <?= paramTag.type.split('|').join(', ').replace('(', '').replace(')', '')
     ?> | <?= paramTag.description ?> |
 <? }) ?>
@@ -45,7 +45,7 @@ title: <?= method.command ?>
 <? if (method.returns) { ?>
 ##### Returns
 
-- **&lt;<?= method.returns.type ?>&gt; <?= method.returns.name ?>:** <?= method.returns.description ?>
+- **&lt;<?= method.returns.type ?>&gt; <code><var><?= method.returns.name ?></var></code>:** <?= method.returns.description ?>
 <? } ?>
 
 <? if (method.throwsTags.length) { ?>


### PR DESCRIPTION
## Proposed changes

Different sections of the API docs have slightly different lookups when generating the parameters table for the API docs.

This covers both types (and adds a tiny bit of markup as a bonus).


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

This Pull Request is a reboot of #4597.  

Major differences:

* This only modifies the template, but leaves all existing JSDoc comments alone.  
* This doesn’t involve `eslint-plugin-jsdoc`.  

I’ll revisit both of these with separate Pull Requests.

### Reviewers: @webdriverio/technical-committee
