### PR TITLE
chore(comments): Use 1-star for non-JSdoc comments

### DIFF
--- a/e2e/transitions.test.js
+++ b/e2e/transitions.test.js
@@ -48,7 +48,7 @@ test('can handle random page transitions', async () => {
         const title = await browser.getTitle()
         expect(typeof title).toBe('string')
 
-        /**
+        /*
          * stop loop if new page was reached
          */
         if (title.includes('GitHub')) {

--- a/e2e/wdio/wdio.conf.js
+++ b/e2e/wdio/wdio.conf.js
@@ -1,17 +1,17 @@
 const path = require('path')
 
 exports.config = {
-    /**
+    /*
      * run tests with devtools
      */
     automationProtocol: 'devtools',
 
-    /**
+    /*
      * specify test files
      */
     specs: [path.resolve(__dirname, '*.e2e.js')],
 
-    /**
+    /*
      * capabilities
      */
     capabilities: [{
@@ -28,7 +28,7 @@ exports.config = {
         'goog:chromeOptions': { headless: true }
     }],
 
-    /**
+    /*
      * test configurations
      */
     logLevel: 'trace',

--- a/examples/appium/appium-draws-its-logo.js
+++ b/examples/appium/appium-draws-its-logo.js
@@ -1,7 +1,7 @@
 import { circleAction, arcAction, innerArcAction } from './helpers/drawHelper'
 import { remote } from '../../packages/webdriverio/build'
 
-/**
+/*
  * in order to test this you need to compile the app from the old v4 repository
  * (https://github.com/webdriverio-boneyard/v4/blob/master/package.json#L34)
  */

--- a/examples/devtools/intercept.js
+++ b/examples/devtools/intercept.js
@@ -1,4 +1,4 @@
-/**
+/*
  * in order to run this file make sure you have `webdriverio` and `devtools`
  * installed using NPM before running it:
  *

--- a/examples/multiremote/chat.js
+++ b/examples/multiremote/chat.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Multiremote example
  * To run this script you need to have Mocha installed on your system.
  * If not try to run: $ npm install mocha @babel/register

--- a/examples/multiremote/webrtc.js
+++ b/examples/multiremote/webrtc.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Multiremote example
  * To run this script you need to have Babel installed on your system.
  * If not try to run: `$ npm install @babel/node`

--- a/examples/pageobject/pageobjects/checkbox.page.js
+++ b/examples/pageobject/pageobjects/checkbox.page.js
@@ -1,13 +1,13 @@
 import Page from './page'
 
 class CheckboxPage extends Page {
-    /**
+    /*
      * define elements
      */
     get lastCheckbox () { return $('#checkboxes input:last-Child') }
     get firstCheckbox () { return $('#checkboxes input:first-Child') }
 
-    /**
+    /*
      * define or overwrite page methods
      */
     open () {

--- a/examples/pageobject/pageobjects/dynamic.page.js
+++ b/examples/pageobject/pageobjects/dynamic.page.js
@@ -1,13 +1,13 @@
 import Page from './page'
 
 class DynamicPage extends Page {
-    /**
+    /*
      * define elements
      */
     get btnStart () { return $('button=Start') }
     get loadedPage () { return $('#finish') }
 
-    /**
+    /*
      * define or overwrite page methods
      */
     open () {

--- a/examples/pageobject/pageobjects/form.page.js
+++ b/examples/pageobject/pageobjects/form.page.js
@@ -1,7 +1,7 @@
 import Page from './page'
 
 class FormPage extends Page {
-    /**
+    /*
      * define elements
      */
     get username () { return $('#username') }
@@ -9,7 +9,7 @@ class FormPage extends Page {
     get submitButton () { return $('#login button[type=submit]') }
     get flash () { return $('#flash') }
 
-    /**
+    /*
      * define or overwrite page methods
      */
     open () {

--- a/examples/wdio/cucumber/step-definitions.js
+++ b/examples/wdio/cucumber/step-definitions.js
@@ -1,4 +1,4 @@
-/**
+/*
  * to run these tests you need install Cucumber.js on your machine
  * take a look at https://github.com/cucumber/cucumber-js for more informations
  *

--- a/examples/wdio/cucumber/wdio.conf.js
+++ b/examples/wdio/cucumber/wdio.conf.js
@@ -1,25 +1,25 @@
 exports.config = {
-    /**
+    /*
      * server configurations
      */
     hostname: 'localhost',
     port: 4444,
 
-    /**
+    /*
      * specify test files
      */
     specs: [
         __dirname + '/features/*.feature'
     ],
 
-    /**
+    /*
      * capabilities
      */
     capabilities: [{
         browserName: 'chrome'
     }],
 
-    /**
+    /*
      * test configurations
      */
     logLevel: 'error',

--- a/examples/wdio/custom-reporter/wdio.conf.js
+++ b/examples/wdio/custom-reporter/wdio.conf.js
@@ -2,25 +2,25 @@ const path = require('path')
 const CustomReporter = require('./reporter/my.custom.reporter')
 
 exports.config = {
-    /**
+    /*
      * server configurations
      */
     hostname: 'localhost',
     port: 4444,
 
-    /**
+    /*
      * specify test files
      */
     specs: [path.resolve(__dirname, 'mocha.test.js')],
 
-    /**
+    /*
      * capabilities
      */
     capabilities: [{
         browserName: 'chrome'
     }],
 
-    /**
+    /*
      * test configurations
      */
     logLevel: 'trace',

--- a/examples/wdio/custom-service/my.custom.service.js
+++ b/examples/wdio/custom-service/my.custom.service.js
@@ -1,4 +1,4 @@
-/**
+/*
  * you can also use
  * `export default class CustomService`
  * here

--- a/examples/wdio/custom-service/wdio.conf.js
+++ b/examples/wdio/custom-service/wdio.conf.js
@@ -2,25 +2,25 @@ const path = require('path')
 const CustomService = require('./my.custom.service')
 
 exports.config = {
-    /**
+    /*
      * server configurations
      */
     hostname: 'localhost',
     port: 4444,
 
-    /**
+    /*
      * specify test files
      */
     specs: [path.resolve(__dirname, 'mocha.test.js')],
 
-    /**
+    /*
      * capabilities
      */
     capabilities: [{
         browserName: 'chrome'
     }],
 
-    /**
+    /*
      * test configurations
      */
     logLevel: 'trace',

--- a/examples/wdio/jasmine/wdio.conf.js
+++ b/examples/wdio/jasmine/wdio.conf.js
@@ -2,25 +2,25 @@ const path = require('path')
 
 exports.config = {
 
-    /**
+    /*
      * server configurations
      */
     hostname: 'localhost',
     port: 4444,
 
-    /**
+    /*
      * specify test files
      */
     specs: [path.resolve(__dirname, 'jasmine.spec.js')],
 
-    /**
+    /*
      * capabilities
      */
     capabilities: [{
         browserName: 'chrome'
     }],
 
-    /**
+    /*
      * test configurations
      */
     logLevel: 'trace',
@@ -33,7 +33,7 @@ exports.config = {
         defaultTimeoutInterval: 1000 * 60 * 3
     },
 
-    /**
+    /*
      * hooks
      */
     onPrepare: function() {

--- a/examples/wdio/mocha/wdio.conf.js
+++ b/examples/wdio/mocha/wdio.conf.js
@@ -1,25 +1,25 @@
 const path = require('path')
 
 exports.config = {
-    /**
+    /*
      * server configurations
      */
     hostname: 'localhost',
     port: 4444,
 
-    /**
+    /*
      * specify test files
      */
     specs: [path.resolve(__dirname, 'mocha.test.js')],
 
-    /**
+    /*
      * capabilities
      */
     capabilities: [{
         browserName: 'chrome'
     }],
 
-    /**
+    /*
      * test configurations
      */
     logLevel: 'trace',
@@ -33,7 +33,7 @@ exports.config = {
         timeout: 60000
     },
 
-    /**
+    /*
      * hooks
      */
     onPrepare: function() {

--- a/examples/wdio/multiremote/wdio.conf.js
+++ b/examples/wdio/multiremote/wdio.conf.js
@@ -1,18 +1,18 @@
 const path = require('path')
 
 exports.config = {
-    /**
+    /*
      * server configurations
      */
     hostname: 'localhost',
     port: 4444,
 
-    /**
+    /*
      * specify test files
      */
     specs: [path.resolve(__dirname, 'mocha.test.js')],
 
-    /**
+    /*
      * capabilities
      */
     capabilities: {
@@ -28,7 +28,7 @@ exports.config = {
         }
     },
 
-    /**
+    /*
      * test configurations
      */
     logLevel: 'trace',

--- a/packages/devtools/src/commands/elementClick.js
+++ b/packages/devtools/src/commands/elementClick.js
@@ -13,7 +13,7 @@ export default async function elementClick ({ elementId }) {
         throw getStaleElementError(elementId)
     }
 
-    /**
+    /*
      * in order to allow clicking on option elements (as WebDriver does)
      * we need to check if the element is such a an element and select
      * it instead of actually executing the click
@@ -26,18 +26,18 @@ export default async function elementClick ({ elementId }) {
         })
     }
 
-    /**
+    /*
      * ensure to fulfill the click promise if the click has triggered an alert
      */
     return new Promise((resolve, reject) => {
-        /**
+        /*
          * listen on possible modal dialogs that might pop up due to the
          * click action, just continue in this case
          */
         const dialogHandler = () => resolve(null)
         page.once('dialog', dialogHandler)
         return elementHandle.click().then(() => {
-            /**
+            /*
              * no modals popped up, so clean up the listener
              */
             page.removeListener('dialog', dialogHandler)

--- a/packages/devtools/src/commands/getActiveElement.js
+++ b/packages/devtools/src/commands/getActiveElement.js
@@ -7,7 +7,7 @@ export default async function getActiveElement () {
     const page = this.getPageHandle(true)
     const selector = `[${SERIALIZE_PROPERTY}]`
 
-    /**
+    /*
      * set data property to active element to allow to query for it
      */
     const hasElem = await page.$eval('html', command, SERIALIZE_PROPERTY)
@@ -16,7 +16,7 @@ export default async function getActiveElement () {
         throw new Error('no element active')
     }
 
-    /**
+    /*
      * query for element
      */
     const activeElement = await findElement.call(this, {
@@ -24,7 +24,7 @@ export default async function getActiveElement () {
         value: selector
     })
 
-    /**
+    /*
      * clean up data property
      */
     await page.$eval(selector, cleanUp, SERIALIZE_PROPERTY)

--- a/packages/devtools/src/commands/navigateTo.js
+++ b/packages/devtools/src/commands/navigateTo.js
@@ -1,5 +1,5 @@
 export default async function navigateTo ({ url }) {
-    /**
+    /*
      * when navigating to a new url get out of frame scope
      */
     delete this.currentFrame

--- a/packages/devtools/src/commands/switchToFrame.js
+++ b/packages/devtools/src/commands/switchToFrame.js
@@ -4,7 +4,7 @@ import { getStaleElementError } from '../utils'
 export default async function switchToFrame ({ id }) {
     const page = this.getPageHandle(true)
 
-    /**
+    /*
      * switch frame by element ID
      */
     if (typeof id[ELEMENT_KEY] === 'string') {
@@ -24,11 +24,11 @@ export default async function switchToFrame ({ id }) {
         return null
     }
 
-    /**
+    /*
      * switch frame by number
      */
     if (typeof id === 'number') {
-        /**
+        /*
          * `page` has `frames` method while `frame` has `childFrames` method
          */
         let getFrames = page.frames || page.childFrames
@@ -43,7 +43,7 @@ export default async function switchToFrame ({ id }) {
         return null
     }
 
-    /**
+    /*
      * switch to parent frame
      */
     if (id === null && typeof page.parentFrame === 'function') {

--- a/packages/devtools/src/commands/switchToParentFrame.js
+++ b/packages/devtools/src/commands/switchToParentFrame.js
@@ -1,7 +1,7 @@
 export default async function switchToParentFrame () {
     const page = this.getPageHandle(true)
 
-    /**
+    /*
      * check if we can access child frames, if now we are already in the
      * parent browsing context
      */

--- a/packages/devtools/src/constants.js
+++ b/packages/devtools/src/constants.js
@@ -35,7 +35,7 @@ export const DEFAULT_FLAGS = [
     '--disable-ipc-flooding-protection',
     '--disable-renderer-backgrounding',
     '--enable-features=NetworkService,NetworkServiceInProcess',
-    /**
+    /*
      * `site-per-process` affects `page.frames()`, see #4471
      * `TranslateUI` disables built-in Google Translate service
      */

--- a/packages/devtools/src/devtoolsdriver.js
+++ b/packages/devtools/src/devtoolsdriver.js
@@ -33,7 +33,7 @@ export default class DevToolsDriver {
             this.currentWindowHandle = pageId
         }
 
-        /**
+        /*
          * set default timeouts
          */
         this.setTimeouts(DEFAULT_IMPLICIT_TIMEOUT, DEFAULT_PAGELOAD_TIMEOUT, DEFAULT_SCRIPT_TIMEOUT)
@@ -55,14 +55,14 @@ export default class DevToolsDriver {
         const self = this
         const { command, ref, parameters, variables = [] } = commandInfo
 
-        /**
+        /*
          * check if command is implemented
          */
         if (typeof this.commands[command] !== 'function') {
             return () => { throw new Error(`Command "${command}" is not yet implemented`) }
         }
 
-        /**
+        /*
          * within here you find the webdriver scope
          */
         const wrappedCommand = async function (...args) {
@@ -73,7 +73,7 @@ export default class DevToolsDriver {
             try {
                 result = await self.commands[command].call(self, params)
             } catch (err) {
-                /**
+                /*
                  * if though we check for an execution context before executing a command we
                  * can technically still run into the situation (especially if the command
                  * contains multiple interaction with the page and is long) where the execution
@@ -142,13 +142,13 @@ export default class DevToolsDriver {
     }
 
     async checkPendingNavigations (pendingNavigationStart) {
-        /**
+        /*
          * ensure there is no page transition happening and an execution context
          * is available
          */
         let page = this.getPageHandle()
 
-        /**
+        /*
          * ignore pending navigation check if dialog is open
          * or there are no pages
          */
@@ -159,7 +159,7 @@ export default class DevToolsDriver {
         pendingNavigationStart = pendingNavigationStart || Date.now()
         const pageloadTimeout = this.timeouts.get('pageLoad')
 
-        /**
+        /*
          * if current page is a frame we have to get the page from the browser
          * that has this frame listed
          */
@@ -175,7 +175,7 @@ export default class DevToolsDriver {
         try {
             await executionContext.evaluate('1')
 
-            /**
+            /*
              * if we have an execution context, also check for the ready state
              */
             const readyState = await executionContext.evaluate('document.readyState')
@@ -183,7 +183,7 @@ export default class DevToolsDriver {
                 return this.checkPendingNavigations(pendingNavigationStart)
             }
         } catch (err) {
-            /**
+            /*
              * throw original error if a context could not be established
              */
             if (pageloadTimeoutReached) {

--- a/packages/devtools/src/index.js
+++ b/packages/devtools/src/index.js
@@ -36,7 +36,7 @@ export default class DevTools {
             )
         }
 
-        /**
+        /*
          * save original set of capabilities to allow to request the same session again
          * (e.g. for reloadSession command in WebdriverIO)
          */

--- a/packages/devtools/src/launcher.js
+++ b/packages/devtools/src/launcher.js
@@ -43,7 +43,7 @@ async function launchChrome (capabilities) {
         defaultViewport: null
     })
 
-    /**
+    /*
      * when using Chrome Launcher we have to close a tab as Puppeteer
      * creates automatically a new one
      */

--- a/packages/devtools/src/utils.js
+++ b/packages/devtools/src/utils.js
@@ -9,7 +9,7 @@ const log = logger('devtools')
 
 export const validate = function (command, parameters, variables, ref, args) {
     const commandParams = [...variables.map((v) => Object.assign(v, {
-        /**
+        /*
          * url variables are:
          */
         required: true, // always required as they are part of the endpoint
@@ -20,7 +20,7 @@ export const validate = function (command, parameters, variables, ref, args) {
     const moreInfo = `\n\nFor more info see ${ref}\n`
     const body = {}
 
-    /**
+    /*
      * parameter check
      */
     const minAllowedParams = commandParams.filter((param) => param.required).length
@@ -37,14 +37,14 @@ export const validate = function (command, parameters, variables, ref, args) {
         )
     }
 
-    /**
+    /*
      * parameter type check
      */
     for (const [i, arg] of Object.entries(args)) {
         const commandParam = commandParams[i]
 
         if (!isValidParameter(arg, commandParam.type)) {
-            /**
+            /*
              * ignore if argument is not required
              */
             if (typeof arg === 'undefined' && !commandParam.required) {
@@ -59,7 +59,7 @@ export const validate = function (command, parameters, variables, ref, args) {
             )
         }
 
-        /**
+        /*
          * rest of args are part of body payload
          */
         body[commandParams[i].name] = arg
@@ -82,7 +82,7 @@ export function getPrototype (commandWrapper) {
 }
 
 export async function findElement (context, using, value) {
-    /**
+    /*
      * implicitly wait for the element if timeout is set
      */
     const implicitTimeout = this.timeouts.get('implicit')
@@ -97,7 +97,7 @@ export async function findElement (context, using, value) {
             ? (await context.$x(value))[0]
             : await context.$(value)
     } catch (err) {
-        /**
+        /*
          * throw if method failed for other reasons
          */
         if (!err.message.includes('failed to find element')) {
@@ -114,7 +114,7 @@ export async function findElement (context, using, value) {
 }
 
 export async function findElements (context, using, value) {
-    /**
+    /*
      * implicitly wait for the element if timeout is set
      */
     const implicitTimeout = this.timeouts.get('implicit')
@@ -222,7 +222,7 @@ export async function getPages (browser, retryInterval = 100) {
     if (pages.length === 0) {
         log.info('no browser pages found, retrying...')
 
-        /**
+        /*
          * wait for some milliseconds to try again
          */
         await new Promise((resolve) => setTimeout(resolve, retryInterval))

--- a/packages/wdio-allure-reporter/src/compoundError.js
+++ b/packages/wdio-allure-reporter/src/compoundError.js
@@ -5,6 +5,8 @@ function indentAll(lines) {
 /**
  * An error that encapsulates more than one error, to support soft-assertions from Jasmine
  * even though Allure's API assumes one error-per test
+ *
+ * @extends Error
  */
 export default class CompoundError extends Error {
     constructor(...innerErrors) {

--- a/packages/wdio-browserstack-service/src/service.js
+++ b/packages/wdio-browserstack-service/src/service.js
@@ -60,7 +60,7 @@ export default class BrowserstackService {
         return this._update(this.sessionId, this._getBody())
     }
 
-    /**
+    /*
      * For CucumberJS
      */
 

--- a/packages/wdio-cli/bin/wdio.js
+++ b/packages/wdio-cli/bin/wdio.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-/**
+/*
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */

--- a/packages/wdio-cli/src/commands/config.js
+++ b/packages/wdio-cli/src/commands/config.js
@@ -54,7 +54,7 @@ export const runConfig = async function (useYarn, yes, exit) {
         packagesToInstall.push('@wdio/sync')
     }
 
-    /**
+    /*
      * add packages that are required by services
      */
     addServiceDeps(answers.services, packagesToInstall)
@@ -83,7 +83,7 @@ export const runConfig = async function (useYarn, yes, exit) {
         return !process.env.JEST_WORKER_ID && process.exit(1)
     }
 
-    /**
+    /*
      * don't exit if running unit tests
      */
     if (exit && !process.env.JEST_WORKER_ID) {
@@ -97,17 +97,17 @@ export async function getAnswers(yes) {
         ? QUESTIONNAIRE.reduce((answers, question) => Object.assign(
             answers,
             question.when && !question.when(answers)
-                /**
+                /*
                  * set nothing if question doesn't apply
                  */
                 ? {}
                 : answers[question.name] = question.default
-                    /**
+                    /*
                      * set default value if existing
                      */
                     ? question.default
                     : question.choices && question.choices.length
-                    /**
+                    /*
                      * pick first choice, select value if it exists
                      */
                         ? question.choices[0].value

--- a/packages/wdio-cli/src/commands/install.js
+++ b/packages/wdio-cli/src/commands/install.js
@@ -50,14 +50,14 @@ export const builder = (yargs) => {
 }
 
 export async function handler(argv) {
-    /**
+    /*
      * type = service | reporter | framework
      * name = names for the supported service or reporter
      * yarn = optional flag to install package using yarn instead of default yarn
      */
     const { type, name, yarn } = argv
 
-    /**
+    /*
      * verify for supported types via `supportedInstallations` keys
      */
     if (!Object.keys(supportedInstallations).includes(type)) {
@@ -66,7 +66,7 @@ export async function handler(argv) {
         return
     }
 
-    /**
+    /*
      * verify if the name of the `type` is valid
      */
     if (!supportedInstallations[type].find(pkg => pkg.short === name)) {

--- a/packages/wdio-cli/src/commands/repl.js
+++ b/packages/wdio-cli/src/commands/repl.js
@@ -45,7 +45,7 @@ export const builder = (yargs) => {
 export const handler = async (argv) => {
     const caps = getCapabilities(argv)
 
-    /**
+    /*
      * runner option required to wrap commands within Fibers context
      */
     const execMode = hasWdioSyncSupport ? { runner: 'repl' } : {}

--- a/packages/wdio-cli/src/commands/run.js
+++ b/packages/wdio-cli/src/commands/run.js
@@ -144,7 +144,7 @@ export async function handler(argv) {
     const localConf = path.join(process.cwd(), 'wdio.conf.js')
     const wdioConf = configPath || (fs.existsSync(localConf) ? localConf : null)
 
-    /**
+    /*
      * if `--watch` param is set, run launcher in watch mode
      */
     if (params.watch) {
@@ -152,7 +152,7 @@ export async function handler(argv) {
         return watcher.watch()
     }
 
-    /**
+    /*
      * if stdin.isTTY, then no piped input is present and launcher should be
      * called immediately, otherwise piped input is processed, expecting
      * a list of files to process.

--- a/packages/wdio-cli/src/index.js
+++ b/packages/wdio-cli/src/index.js
@@ -33,7 +33,7 @@ export const run = async () => {
         .updateStrings({ 'Commands:': `${DESCRIPTION.join('\n')}\n\nCommands:` })
         .epilogue(CLI_EPILOGUE)
 
-    /**
+    /*
      * parse CLI arguments according to what run expects, without this adding
      * `--spec ./test.js` results in propagating the spec parameter as a
      * string while in reality is should be parsed into a array of strings
@@ -42,7 +42,7 @@ export const run = async () => {
         argv.options(cmdArgs)
     }
 
-    /**
+    /*
      * The only way we reach this point is if the user runs the binary without a command (i.e. wdio wdio.conf.js)
      * We can safely assume that if this is the case, the user is trying to execute the `run` command as it
      * was previous to https://github.com/webdriverio/webdriverio/pull/4402

--- a/packages/wdio-cli/src/interface.js
+++ b/packages/wdio-cli/src/interface.js
@@ -10,7 +10,7 @@ export default class WDIOCLInterface extends EventEmitter {
     constructor (config, specs, totalWorkerCnt, isWatchMode = false) {
         super()
 
-        /**
+        /*
          * Colors can be forcibly enabled/disabled with env variable `FORCE_COLOR`
          * `FORCE_COLOR=1` - forcibly enable colors
          * `FORCE_COLOR=0` - forcibly disable colors
@@ -35,7 +35,7 @@ export default class WDIOCLInterface extends EventEmitter {
         this.jobs = new Map()
         this.start = new Date()
 
-        /**
+        /*
          * The relationship between totalWorkerCnt and these counters are as follows:
          * totalWorkerCnt - retries = finished = passed + failed
          */
@@ -46,7 +46,7 @@ export default class WDIOCLInterface extends EventEmitter {
             failed: 0
         }
         this.messages = {
-            /**
+            /*
              * messages from worker reporters
              */
             reporter: {}
@@ -209,7 +209,7 @@ export default class WDIOCLInterface extends EventEmitter {
     }
 
     sigintTrigger () {
-        /**
+        /*
          * allow to exit repl mode via Ctrl+C
          */
         if (this.inDebugMode) {
@@ -225,7 +225,7 @@ export default class WDIOCLInterface extends EventEmitter {
     }
 
     printReporters () {
-        /**
+        /*
          * print reporter output
          */
         const reporter = this.messages.reporter

--- a/packages/wdio-cli/src/launcher.js
+++ b/packages/wdio-cli/src/launcher.js
@@ -60,7 +60,7 @@ class Launcher {
      * @return  {Promise}               that only gets resolves with either an exitCode or an error
      */
     async run () {
-        /**
+        /*
          * catches ctrl+c event
          */
         exitHook(::this.exitHandler)
@@ -72,13 +72,13 @@ class Launcher {
             const caps = this.configParser.getCapabilities()
             const launcher = initialiseServices(config, caps, 'launcher')
 
-            /**
+            /*
              * run pre test tasks for runner plugins
              * (e.g. deploy Lambda function to AWS)
              */
             await this.runner.initialise()
 
-            /**
+            /*
              * run onPrepare hook
              */
             log.info('Run onPrepare hook')
@@ -87,7 +87,7 @@ class Launcher {
 
             exitCode = await this.runMode(config, caps)
 
-            /**
+            /*
              * run onComplete hook
              * even if it fails we still want to see result and end logger stream
              */
@@ -121,7 +121,7 @@ class Launcher {
      * run without triggering onPrepare/onComplete hooks
      */
     runMode (config, caps) {
-        /**
+        /*
          * fail if no caps were found
          */
         if (!caps || (!this.isMultiremote && !caps.length)) {
@@ -131,17 +131,17 @@ class Launcher {
             })
         }
 
-        /**
+        /*
          * avoid retries in watch mode
          */
         const specFileRetries = this.isWatchMode ? 0 : config.specFileRetries
 
-        /**
+        /*
          * schedule test runs
          */
         let cid = 0
         if (this.isMultiremote) {
-            /**
+            /*
              * Multiremote mode
              */
             this.schedule.push({
@@ -152,7 +152,7 @@ class Launcher {
                 runningInstances: 0
             })
         } else {
-            /**
+            /*
              * Regular mode
              */
             for (let capabilities of caps) {
@@ -170,7 +170,7 @@ class Launcher {
         return new Promise((resolve) => {
             this.resolve = resolve
 
-            /**
+            /*
              * fail if no specs were found or specified
              */
             if (Object.values(this.schedule).reduce((specCnt, schedule) => specCnt + schedule.specs.length, 0) === 0) {
@@ -178,7 +178,7 @@ class Launcher {
                 return resolve(1)
             }
 
-            /**
+            /*
              * return immediately if no spec was run
              */
             if (this.runSpecs()) {
@@ -194,7 +194,7 @@ class Launcher {
     runSpecs () {
         let config = this.configParser.getConfig()
 
-        /**
+        /*
          * stop spawning new processes when CTRL+C was triggered
          */
         if (this.hasTriggeredExitRoutine) {
@@ -203,14 +203,14 @@ class Launcher {
 
         while (this.getNumberOfRunningInstances() < config.maxInstances) {
             let schedulableCaps = this.schedule
-                /**
+                /*
                  * bail if number of errors exceeds allowed
                  */
                 .filter(() => {
                     const filter = typeof config.bail !== 'number' || config.bail < 1 ||
                                    config.bail > this.runnerFailed
 
-                    /**
+                    /*
                      * clear number of specs when filter is false
                      */
                     if (!filter) {
@@ -219,24 +219,24 @@ class Launcher {
 
                     return filter
                 })
-                /**
+                /*
                  * make sure complete number of running instances is not higher than general maxInstances number
                  */
                 .filter(() => this.getNumberOfRunningInstances() < config.maxInstances)
-                /**
+                /*
                  * make sure the capability has available capacities
                  */
                 .filter((a) => a.availableInstances > 0)
-                /**
+                /*
                  * make sure capability has still caps to run
                  */
                 .filter((a) => a.specs.length > 0)
-                /**
+                /*
                  * make sure we are running caps with less running instances first
                  */
                 .sort((a, b) => a.runningInstances > b.runningInstances)
 
-            /**
+            /*
              * continue if no capability were schedulable
              */
             if (schedulableCaps.length === 0) {
@@ -373,14 +373,14 @@ class Launcher {
             this.runnerFailed += !passed ? 1 : 0
         }
 
-        /**
+        /*
          * avoid emitting job:end if watch mode has been stopped by user
          */
         if (!this.isWatchModeHalted()) {
             this.interface.emit('job:end', { cid, passed, retries })
         }
 
-        /**
+        /*
          * Update schedule now this process has ended
          */
         // get cid (capability id) from rid (runner id)
@@ -389,7 +389,7 @@ class Launcher {
         this.schedule[cid].availableInstances++
         this.schedule[cid].runningInstances--
 
-        /**
+        /*
          * do nothing if
          * - there are specs to be executed
          * - we are running watch mode

--- a/packages/wdio-cli/src/utils.js
+++ b/packages/wdio-cli/src/utils.js
@@ -135,7 +135,7 @@ export function replaceConfig(config, type, name) {
 }
 
 export function addServiceDeps(names, packages, update) {
-    /**
+    /*
      * automatically install latest Chromedriver if `wdio-chromedriver-service`
      * was selected for install
      */
@@ -151,7 +151,7 @@ export function addServiceDeps(names, packages, update) {
         }
     }
 
-    /**
+    /*
      * install Appium if it is not installed globally if `@wdio/appium-service`
      * was selected for install
      */
@@ -201,7 +201,7 @@ export async function missingConfigurationPrompt(command, message, useYarn = fal
         }
     ])
 
-    /**
+    /*
      * don't exit if running unit tests
      */
     if (!config && !process.env.JEST_WORKER_ID) {
@@ -238,7 +238,7 @@ export function getCapabilities(arg) {
         udid: arg.udid || null,
         ...(arg.deviceName && { deviceName: arg.deviceName })
     }
-    /**
+    /*
      * Parsing of option property and constructing desiredCapabilities
      * for Appium session. Could be application(1) or browser(2-3) session.
      */

--- a/packages/wdio-cli/src/watcher.js
+++ b/packages/wdio-cli/src/watcher.js
@@ -23,14 +23,14 @@ export default class Watcher {
     }
 
     async watch () {
-        /**
+        /*
          * listen on spec changes and rerun specific spec file
          */
         chokidar.watch(this.specs, { ignoreInitial: true })
             .on('add', this.getFileListener())
             .on('change', this.getFileListener())
 
-        /**
+        /*
          * listen on filesToWatch changes an rerun complete suite
          */
         const { filesToWatch } = this.launcher.configParser.getConfig()
@@ -40,17 +40,17 @@ export default class Watcher {
                 .on('change', this.getFileListener(false))
         }
 
-        /**
+        /*
          * run initial test suite
          */
         await this.launcher.run()
 
-        /**
+        /*
          * clean interface once all worker finish
          */
         const workers = this.getWorkers()
         Object.values(workers).forEach((worker) => worker.on('exit', () => {
-            /**
+            /*
              * check if all workers have finished
              */
             if (Object.values(workers).find((w) => w.isBusy)) {
@@ -85,7 +85,7 @@ export default class Watcher {
             workers = pickBy(workers, pickByFn)
         }
 
-        /**
+        /*
          * filter out busy workers, only skip if explicitely desired
          */
         if (!includeBusyWorker) {
@@ -103,25 +103,25 @@ export default class Watcher {
         const workers = this.getWorkers(
             params.spec ? (worker) => worker.specs.includes(params.spec) : null)
 
-        /**
+        /*
          * don't do anything if no worker was found
          */
         if (Object.keys(workers).length === 0) {
             return
         }
 
-        /**
+        /*
          * update total worker count interface
          * ToDo: this should have a cleaner solution
          */
         this.launcher.interface.totalWorkerCnt = Object.entries(workers).length
 
-        /**
+        /*
          * clean up interface
          */
         this.cleanUp()
 
-        /**
+        /*
          * trigger new run for non busy worker
          */
         for (const [, worker] of Object.entries(workers)) {

--- a/packages/wdio-concise-reporter/src/index.js
+++ b/packages/wdio-concise-reporter/src/index.js
@@ -3,7 +3,7 @@ import chalk from 'chalk'
 
 export default class ConciseReporter extends WDIOReporter {
     constructor (options) {
-        /**
+        /*
          * make Concise reporter to write to output stream by default
          */
         options = Object.assign(options, { stdout: true })

--- a/packages/wdio-config/src/constants.js
+++ b/packages/wdio-config/src/constants.js
@@ -28,7 +28,7 @@ export const DEFAULT_CONFIGS = {
         specFiltering: undefined
     },
 
-    /**
+    /*
      * framework defaults
      */
     mochaOpts: {
@@ -41,7 +41,7 @@ export const DEFAULT_CONFIGS = {
         timeout: DEFAULT_TIMEOUT
     },
 
-    /**
+    /*
      * hooks
      */
     onPrepare: [],
@@ -60,7 +60,7 @@ export const DEFAULT_CONFIGS = {
     onComplete: [],
     onReload: [],
 
-    /**
+    /*
      * cucumber specific hooks
      */
     beforeFeature: [],
@@ -78,7 +78,7 @@ export const SUPPORTED_HOOKS = [
     'onReload', 'onPrepare', 'onComplete'
 ]
 
-/**
+/*
  * these services should not be started in worker process
  */
 export const NON_WORKER_SERVICES = [

--- a/packages/wdio-config/src/index.js
+++ b/packages/wdio-config/src/index.js
@@ -8,7 +8,7 @@ export {
     detectBackend,
     ConfigParser,
 
-    /**
+    /*
      * constants
      */
     DEFAULT_CONFIGS

--- a/packages/wdio-config/src/lib/ConfigParser.js
+++ b/packages/wdio-config/src/lib/ConfigParser.js
@@ -30,19 +30,19 @@ export default class ConfigParser {
         var filePath = path.resolve(process.cwd(), filename)
 
         try {
-            /**
+            /*
              * clone the original config
              */
             var fileConfig = merge(require(filePath).config, {}, MERGE_OPTIONS)
 
-            /**
+            /*
              * merge capabilities
              */
             const defaultTo = Array.isArray(this._capabilities) ? [] : {}
             this._capabilities = merge(this._capabilities, fileConfig.capabilities || defaultTo, MERGE_OPTIONS)
             delete fileConfig.capabilities
 
-            /**
+            /*
              * Add hooks from the file config and remove them from file config object to avoid
              * complications when using merge function
              */
@@ -53,7 +53,7 @@ export default class ConfigParser {
 
             this._config = merge(this._config, fileConfig, MERGE_OPTIONS)
 
-            /**
+            /*
              * For Sauce Labs RDC we need to determine if the config file has a `testobject_api_key`
              * If so, we need to provide a boolean to the `detectBackend` to set the correct hostname
              *
@@ -61,12 +61,12 @@ export default class ConfigParser {
              */
             const isRDC = Array.isArray(this._capabilities) && this._capabilities.some(capability => 'testobject_api_key' in capability)
 
-            /**
+            /*
              * detect Selenium backend
              */
             this._config = merge(detectBackend(this._config, isRDC), this._config, MERGE_OPTIONS)
 
-            /**
+            /*
              * remove `watch` from config as far as it can be only passed as command line argument
              */
             delete this._config.watch
@@ -85,7 +85,7 @@ export default class ConfigParser {
         let spec = Array.isArray(object.spec) ? object.spec : []
         let exclude = Array.isArray(object.exclude) ? object.exclude : []
 
-        /**
+        /*
          * overwrite config specs that got piped into the wdio command
          */
         if (object.specs && object.specs.length > 0) {
@@ -94,23 +94,23 @@ export default class ConfigParser {
             this._config.exclude = object.exclude
         }
 
-        /**
+        /*
          * merge capabilities
          */
         const defaultTo = Array.isArray(this._capabilities) ? [] : {}
         this._capabilities = merge(this._capabilities, this._config.capabilities || defaultTo, MERGE_OPTIONS)
 
-        /**
+        /*
          * save original specs if Cucumber's feature line number is provided
          */
         if (this._config.spec && isCucumberFeatureWithLineNumber(this._config.spec)) {
-            /**
+            /*
              * `this._config.spec` is string instead of Array in watch mode
              */
             this._config.cucumberFeaturesWithLineNumbers = Array.isArray(this._config.spec) ? [...this._config.spec] : [this._config.spec]
         }
 
-        /**
+        /*
          * run single spec file only, regardless of multiple-spec specification
          */
         if (spec.length > 0) {
@@ -120,7 +120,7 @@ export default class ConfigParser {
             this._config.exclude = [...this.setFilePathToFilterOptions(exclude, this._config.exclude)]
         }
 
-        /**
+        /*
          * user and key could get added via cli arguments so we need to detect again
          * Note: cli arguments are on the right and overwrite config
          * if host and port are default, remove them to get new values
@@ -170,7 +170,7 @@ export default class ConfigParser {
         let exclude = ConfigParser.getFilePaths(this._config.exclude)
         let suites = Array.isArray(this._config.suite) ? this._config.suite : []
 
-        /**
+        /*
          * check if user has specified a specific suites to run
          */
         if (suites.length > 0) {

--- a/packages/wdio-config/src/utils.js
+++ b/packages/wdio-config/src/utils.js
@@ -48,7 +48,7 @@ export function isCucumberFeatureWithLineNumber(spec) {
 export function detectBackend (options = {}, isRDC = false) {
     let { port, hostname, user, key, protocol, region, headless } = options
 
-    /**
+    /*
      * browserstack
      * e.g. zHcv9sZ39ip8ZPsxBVJ2
      */
@@ -60,7 +60,7 @@ export function detectBackend (options = {}, isRDC = false) {
         }
     }
 
-    /**
+    /*
      * testingbot
      * e.g. ec337d7b677720a4dde7bd72be0bfc67
      */
@@ -71,7 +71,7 @@ export function detectBackend (options = {}, isRDC = false) {
         }
     }
 
-    /**
+    /*
      * Sauce Labs
      * e.g. 50aa152c-1932-B2f0-9707-18z46q2n1mb0
      */
@@ -92,11 +92,11 @@ export function detectBackend (options = {}, isRDC = false) {
     }
 
     if (
-        /**
+        /*
          * user and key are set in config
          */
         (typeof user === 'string' || typeof key === 'string') &&
-        /**
+        /*
          * but no custom WebDriver endpoint was configured
          */
         !hostname
@@ -108,7 +108,7 @@ export function detectBackend (options = {}, isRDC = false) {
         )
     }
 
-    /**
+    /*
      * no cloud provider detected, fallback to local browser driver
      */
     return {
@@ -128,7 +128,7 @@ export function validateConfig (defaults, options) {
     const params = {}
 
     for (const [name, expectedOption] of Object.entries(defaults)) {
-        /**
+        /*
          * check if options is given
          */
         if (typeof options[name] === 'undefined' && !expectedOption.default && expectedOption.required) {

--- a/packages/wdio-crossbrowsertesting-service/src/service.js
+++ b/packages/wdio-crossbrowsertesting-service/src/service.js
@@ -41,7 +41,7 @@ export default class CrossBrowserTestingService {
             return
         }
 
-        /**
+        /*
          * in jasmine we get Jasmine__TopLevel__Suite as title since service using test
          * framework hooks in order to execute async functions.
          * This tweak allows us to set the real suite name for jasmine jobs.
@@ -68,7 +68,7 @@ export default class CrossBrowserTestingService {
         }
     }
 
-    /**
+    /*
      * For CucumberJS
      */
 
@@ -108,7 +108,7 @@ export default class CrossBrowserTestingService {
 
         let failures = this.failures
 
-        /**
+        /*
          * set failures if user has bail option set in which case afterTest and
          * afterSuite aren't executed before after hook
          */
@@ -177,12 +177,12 @@ export default class CrossBrowserTestingService {
     getBody (failures, calledOnReload = false, browserName) {
         let body = { test: {} }
 
-        /**
+        /*
          * set default values
          */
         body.test['name'] = this.suiteTitle
 
-        /**
+        /*
          * add reload count to title if reload is used
          */
         if (calledOnReload || this.testCnt) {

--- a/packages/wdio-cucumber-framework/src/index.js
+++ b/packages/wdio-cucumber-framework/src/index.js
@@ -61,7 +61,7 @@ class CucumberAdapter {
     }
 
     hasTests () {
-        /**
+        /*
          * Avoid spec filtering only if the feature is disabled explicitly
          * The feature has no impact on how framework/browser session is initialised.
          */
@@ -76,14 +76,14 @@ class CucumberAdapter {
             this.registerRequiredModules()
             Cucumber.supportCodeLibraryBuilder.reset(this.cwd)
 
-            /**
+            /*
              * wdio hooks should be added before spec files are loaded
              */
             this.addWdioHooks(this.config)
             this.loadSpecFiles()
             this.wrapSteps(this.config)
 
-            /**
+            /*
              * we need to somehow identify is function is step or hook
              * so we wrap every user hook function
              */
@@ -108,7 +108,7 @@ class CucumberAdapter {
 
             result = await runtime.start() ? 0 : 1
 
-            /**
+            /*
              * if we ignore undefined definitions we trust the reporter
              * with the fail count
              */
@@ -122,7 +122,7 @@ class CucumberAdapter {
 
         await executeHooksWithArgs(this.config.after, [runtimeError || result, this.capabilities, this.specs])
 
-        /**
+        /*
          * in case the spec has a runtime error throw after the wdio hook
          */
         if (runtimeError) {
@@ -218,14 +218,14 @@ class CucumberAdapter {
         const getCurrentStep = () => this.getCurrentStep()
 
         Cucumber.setDefinitionFunctionWrapper((fn, options = {}) => {
-            /**
+            /*
              * hooks defined in wdio.conf are already wrapped
              */
             if (fn.name.startsWith('wdioHook')) {
                 return fn
             }
 
-            /**
+            /*
              * this flag is used to:
              * - avoid hook retry
              * - avoid wrap hooks with beforeStep and afterStep
@@ -249,7 +249,7 @@ class CucumberAdapter {
      */
     wrapStep (code, retryTest = 0, isStep, config, cid, getCurrentStep) {
         return function (...args) {
-            /**
+            /*
              * wrap user step/hook with wdio before/after hooks
              */
             const { uri, feature } = getDataFromResult(global.result)

--- a/packages/wdio-cucumber-framework/src/reporter.js
+++ b/packages/wdio-cucumber-framework/src/reporter.js
@@ -100,13 +100,13 @@ class CucumberReporter {
 
         if (result.status === Status.UNDEFINED) {
             if (this.options.ignoreUndefinedDefinitions) {
-                /**
+                /*
                  * mark test as pending
                  */
                 state = 'pending'
                 stepTitle += ' (undefined step)'
             } else {
-                /**
+                /*
                  * mark test as failed
                  */
                 this.failedCount++

--- a/packages/wdio-cucumber-framework/src/utils.js
+++ b/packages/wdio-cucumber-framework/src/utils.js
@@ -2,7 +2,7 @@ import * as path from 'path'
 import { isFunctionAsync } from '@wdio/utils'
 import { CUCUMBER_HOOK_DEFINITION_TYPES } from './constants'
 
-/**
+/*
  * NOTE: this function is exported for testing only
  */
 export function createStepArgument ({ argument }) {
@@ -98,7 +98,7 @@ export function getUniqueIdentifier (target, sourceLocation) {
 export function formatMessage ({ payload = {} }) {
     let content = { ...payload }
 
-    /**
+    /*
      * need to convert Error to plain object, otherwise it is lost on process.send
      */
     if (payload.error && (payload.error.message || payload.error.stack)) {
@@ -184,7 +184,7 @@ export function getTestCaseSteps (feature, scenario, pickle, testCasePreparedEve
     const allSteps = getAllSteps(feature, scenario)
 
     const steps = testCasePreparedEvent.steps.map(eventStep => {
-        /**
+        /*
          * find scenario step matching eventStep
          */
         let step = allSteps.find(scenarioStep => {

--- a/packages/wdio-devtools-service/src/auditor.js
+++ b/packages/wdio-devtools-service/src/auditor.js
@@ -83,7 +83,7 @@ export default class Auditor {
     async getDiagnostics () {
         const result = await this._audit(Diagnostics)
 
-        /**
+        /*
          * return null if Audit fails
          */
         if (!Object.prototype.hasOwnProperty.call(result, 'details')) {
@@ -118,7 +118,7 @@ export default class Auditor {
             firstMeaningfulPaint, firstCPUIdle, firstInteractive, speedIndex, estimatedInputLatency
         } = await this.getMetrics()
 
-        /**
+        /*
          * return null if any of the metrics could not bet calculated and
          * therefor are undefined
          */

--- a/packages/wdio-devtools-service/src/commands.js
+++ b/packages/wdio-devtools-service/src/commands.js
@@ -15,14 +15,14 @@ export default class CommandHandler {
         this.isTracing = false
         this.networkHandler = new NetworkHandler(client)
 
-        /**
+        /*
          * register browser commands
          */
         const commands = Object.getOwnPropertyNames(Object.getPrototypeOf(this)).filter(
             fnName => fnName !== 'constructor' && !fnName.startsWith('_'))
         commands.forEach(fnName => this.browser.addCommand(fnName, ::this[fnName]))
 
-        /**
+        /*
          * propagate CDP events to the browser event listener
          */
         this.client.on('event', (event) => {

--- a/packages/wdio-devtools-service/src/driver.js
+++ b/packages/wdio-devtools-service/src/driver.js
@@ -11,7 +11,7 @@ export default class DevToolsDriver {
     constructor (browser) {
         this.browser = browser
 
-        /**
+        /*
          * ToDo (Christian): handle target changes
          * this should usually never happens as we only connect within one
          * target within the VM so maybe we can discard this

--- a/packages/wdio-devtools-service/src/gatherer/trace.js
+++ b/packages/wdio-devtools-service/src/gatherer/trace.js
@@ -39,12 +39,12 @@ export default class TraceGatherer extends EventEmitter {
     }
 
     async startTracing (url) {
-        /**
+        /*
          * delete old trace
          */
         delete this.trace
 
-        /**
+        /*
          * register listener for network status monitoring
          */
         const session = await this.driver.getCDPSession()
@@ -61,7 +61,7 @@ export default class TraceGatherer extends EventEmitter {
             screenshots: true
         })
 
-        /**
+        /*
          * if this tracing was started from a click event
          * then we want to discard page trace if no load detected
          */
@@ -74,7 +74,7 @@ export default class TraceGatherer extends EventEmitter {
             }, FRAME_LOAD_START_TIMEOUT)
         }
 
-        /**
+        /*
          * register performance observer
          */
         await page.evaluateOnNewDocument(registerPerformanceObserverInPage)
@@ -90,7 +90,7 @@ export default class TraceGatherer extends EventEmitter {
         if (!this.isTracing) {
             return
         }
-        /**
+        /*
          * page load failed, cancel tracing
          */
         if (this.failingFrameLoadIds.includes(msgObj.frame.id)) {
@@ -103,7 +103,7 @@ export default class TraceGatherer extends EventEmitter {
             return clearTimeout(this.clickTraceTimeout)
         }
 
-        /**
+        /*
          * ignore event if
          */
         if (
@@ -123,7 +123,7 @@ export default class TraceGatherer extends EventEmitter {
         this.pageUrl = msgObj.frame.url
         log.info(`Page load detected: ${this.pageUrl}, set frameId ${this.frameId}, set loaderId ${this.loaderId}`)
 
-        /**
+        /*
          * clear click tracing timeout if it's still waiting
          *
          * the reason we have to tie this to Page.frameNavigated instead of Page.frameStartedLoading
@@ -148,7 +148,7 @@ export default class TraceGatherer extends EventEmitter {
             return
         }
 
-        /**
+        /*
          * Ensure that page is fully loaded and all metrics can be calculated.
          *
          * This can only be ensured if the following conditions are met:
@@ -163,7 +163,7 @@ export default class TraceGatherer extends EventEmitter {
             this.waitForNetworkIdleEvent.promise,
             this.waitForCPUIdleEvent.promise
         ]).then(() => () => {
-            /**
+            /*
              * ensure that we trace at least for 5s to ensure that we can
              * calculate firstInteractive
              */
@@ -208,7 +208,7 @@ export default class TraceGatherer extends EventEmitter {
         log.info(`Tracing completed after ${traceDuration}ms, capturing performance data for frame ${this.frameId}`)
         const page = await this.driver.getActivePage()
 
-        /**
+        /*
          * download all tracing data
          * in case it fails, continue without capturing any data
          */
@@ -216,7 +216,7 @@ export default class TraceGatherer extends EventEmitter {
             const traceBuffer = await page.tracing.stop()
             const traceEvents = JSON.parse(traceBuffer.toString('utf8'))
 
-            /**
+            /*
              * modify pid of renderer frame to be the same as where tracing was started
              * possibly related to https://github.com/GoogleChrome/lighthouse/issues/6968
              */
@@ -262,7 +262,7 @@ export default class TraceGatherer extends EventEmitter {
         log.info(`Tracing for ${this.frameId} completed`)
         this.pageLoadDetected = false
 
-        /**
+        /*
          * clean up the listeners
          */
         this.driver.getCDPSession().then((session) => {

--- a/packages/wdio-devtools-service/src/handler/network.js
+++ b/packages/wdio-devtools-service/src/handler/network.js
@@ -15,7 +15,7 @@ export default class NetworkHandler {
     findRequest (params) {
         let request = this.requestLog.requests.find((req) => req.id === params.requestId)
 
-        /**
+        /*
          * If no match is found, check if the corresponding request is the cached first request
          */
         if (!request && this.cachedFirstRequest && this.cachedFirstRequest.id === params.requestId) {
@@ -27,7 +27,7 @@ export default class NetworkHandler {
     onDataReceived (params) {
         let request = this.findRequest(params)
 
-        /**
+        /*
          * ensure that
          *  - a requestWillBeSent event was triggered before
          *  - the request type is accurate and known (sometimes this is not the case when `Network.requestWillBeSent` is triggered)
@@ -42,7 +42,7 @@ export default class NetworkHandler {
 
     onNetworkResponseReceived (params) {
         let request = this.findRequest(params)
-        /**
+        /*
          * ensure that a requestWillBeSent event was triggered before
          */
         if (!request) {
@@ -60,25 +60,25 @@ export default class NetworkHandler {
         let isFirstRequestOfFrame = false
 
         if (
-            /**
+            /*
              * A new page was opened when request type is a document.
              * The first request is sent before the Page.frameNavigated event is triggered,
              * so this request must be cached to be able to add it to the requestLog later.
              */
             params.type === 'Document' &&
-            /**
+            /*
              * ensure that only page loads triggered by non scripts (devtools only) are considered
              * new page loads
              */
             params.initiator.type === 'other' &&
-            /**
+            /*
              * ignore pages not initated by the user
              */
             IGNORED_URLS.filter((url) => params.request.url.startsWith(url)).length === 0
         ) {
             isFirstRequestOfFrame = true
 
-            /**
+            /*
              * reset the request type sizes
              */
             this.requestTypes = {}
@@ -119,7 +119,7 @@ export default class NetworkHandler {
     }
 
     onPageFrameNavigated (params) {
-        /**
+        /*
          * Only create a requestLog for pages that don't have a parent frame.
          * I.e. iframes are ignored
          */
@@ -129,11 +129,11 @@ export default class NetworkHandler {
                 url: params.frame.url,
                 requests: []
             }
-            /**
+            /*
              * Add the first request that was cached before the actual requestLog could be created
              */
             if (this.cachedFirstRequest && this.cachedFirstRequest.loaderId === params.frame.loaderId) {
-                /**
+                /*
                  * Delete the loaderId of the first request so that all request data has the same structure
                  */
                 delete this.cachedFirstRequest.loaderId

--- a/packages/wdio-devtools-service/src/index.js
+++ b/packages/wdio-devtools-service/src/index.js
@@ -56,7 +56,7 @@ export default class DevToolsService {
             const page = await this.devtoolsDriver.getActivePage()
             page.on('requestfailed', ::this.traceGatherer.onFrameLoadFail)
 
-            /**
+            /*
              * enable domains for client
              */
             await Promise.all(['Page', 'Network', 'Console'].map(
@@ -79,7 +79,7 @@ export default class DevToolsService {
         global.browser.addCommand('disablePerformanceAudits', ::this._disablePerformanceAudits)
         global.browser.addCommand('emulateDevice', ::this._emulateDevice)
 
-        /**
+        /*
          * allow user to work with Puppeteer directly
          */
         global.browser.addCommand('getPuppeteer',
@@ -91,7 +91,7 @@ export default class DevToolsService {
             return
         }
 
-        /**
+        /*
          * set browser profile
          */
         this._setThrottlingProfile(this.networkThrottling, this.cpuThrottling, this.cacheEnabled)
@@ -105,7 +105,7 @@ export default class DevToolsService {
             return
         }
 
-        /**
+        /*
          * update custom commands once tracing finishes
          */
         this.traceGatherer.once('tracingComplete', (traceEvents) => {
@@ -123,7 +123,7 @@ export default class DevToolsService {
         return new Promise((resolve) => {
             log.info(`Wait until tracing for command ${commandName} finishes`)
 
-            /**
+            /*
              * wait until tracing stops
              */
             this.traceGatherer.once('tracingFinished', async () => {

--- a/packages/wdio-devtools-service/src/utils.js
+++ b/packages/wdio-devtools-service/src/utils.js
@@ -16,7 +16,7 @@ const VERSION_PROPS = ['browserVersion', 'browser_version', 'version']
  * page. In case a newer version is used (+v65) we check the DevToolsActivePort file
  */
 export async function findCDPInterface () {
-    /**
+    /*
      * check if interface is part of goog:chromeOptions value
      */
     const chromeOptions = global.browser.capabilities['goog:chromeOptions']
@@ -25,7 +25,7 @@ export async function findCDPInterface () {
         return { host, port: parseInt(port, 10) }
     }
 
-    /**
+    /*
      * otherwise look into chrome flags
      */
     await global.browser.url('chrome://version')
@@ -33,7 +33,7 @@ export async function findCDPInterface () {
     const cmdLineText = await cmdLineTextElem.getText()
     let port = parseInt(cmdLineText.match(RE_DEVTOOLS_DEBUGGING_PORT_SWITCH)[1], 10)
 
-    /**
+    /*
      * newer Chrome versions store port in DevToolsActivePort file
      */
     if (port === 0) {

--- a/packages/wdio-dot-reporter/src/index.js
+++ b/packages/wdio-dot-reporter/src/index.js
@@ -6,7 +6,7 @@ import WDIOReporter from '@wdio/reporter'
  */
 export default class DotReporter extends WDIOReporter {
     constructor (options) {
-        /**
+        /*
          * make dot reporter to write to output stream by default
          */
         options = Object.assign({ stdout: true }, options)

--- a/packages/wdio-jasmine-framework/src/index.js
+++ b/packages/wdio-jasmine-framework/src/index.js
@@ -52,17 +52,17 @@ class JasmineAdapter {
         jasmine.DEFAULT_TIMEOUT_INTERVAL = this.jasmineNodeOpts.defaultTimeoutInterval || DEFAULT_TIMEOUT_INTERVAL
         jasmineEnv.addReporter(this.reporter)
 
-        /**
+        /*
          * Set whether to stop suite execution when a spec fails
          */
         const stopOnSpecFailure = !!this.jasmineNodeOpts.stopOnSpecFailure
 
-        /**
+        /*
          * Set whether to stop spec execution when an expectation fails
         */
         const stopSpecOnExpectationFailure = !!this.jasmineNodeOpts.stopSpecOnExpectationFailure
 
-        /**
+        /*
          * Filter specs to run based on jasmineNodeOpts.grep and jasmineNodeOpts.invert
          */
         jasmineEnv.configure({
@@ -73,7 +73,7 @@ class JasmineAdapter {
             failFast: this.jasmineNodeOpts.failFast
         })
 
-        /**
+        /*
          * enable expectHandler
          */
         jasmine.Spec.prototype.addExpectationResult = this.getExpectationResultHandler(jasmine)
@@ -93,7 +93,7 @@ class JasmineAdapter {
             this.reporter.emit('hook:' + eventType, hook)
         }
 
-        /**
+        /*
          * wrap commands with wdio-sync
          */
         INTERFACES['bdd'].forEach((fnName) => {
@@ -101,7 +101,7 @@ class JasmineAdapter {
             const beforeHook = [...this.config.beforeHook]
             const afterHook = [...this.config.afterHook]
 
-            /**
+            /*
              * add beforeAll and afterAll hooks to reporter
              */
             if (fnName.includes('All')) {
@@ -120,13 +120,13 @@ class JasmineAdapter {
             )
         })
 
-        /**
+        /*
          * for a clean stdout we need to avoid that Jasmine initialises the
          * default reporter
          */
         Jasmine.prototype.configureDefaultReporter = NOOP
 
-        /**
+        /*
          * wrap Suite and Spec prototypes to get access to their data
          */
         let beforeAllMock = jasmine.Suite.prototype.beforeAll
@@ -185,7 +185,7 @@ class JasmineAdapter {
     }
 
     hasTests () {
-        /**
+        /*
          * filter specs only if feature enabled explicitly to avoid breaking changes.
          * If the feature is enabled user should avoid interacting with `browser` object before session is started
          */
@@ -297,7 +297,7 @@ class JasmineAdapter {
             try {
                 expectationResultHandler.call(this, passed, data)
             } catch (e) {
-                /**
+                /*
                  * propagate expectationResultHandler error if actual assertion passed
                  * but the custom handler decides to throw
                  */

--- a/packages/wdio-jasmine-framework/src/reporter.js
+++ b/packages/wdio-jasmine-framework/src/reporter.js
@@ -37,7 +37,7 @@ export default class JasmineReporter {
     }
 
     specDone (test) {
-        /**
+        /*
          * excluded tests are treated as pending tests
          */
         if (test.status === 'excluded') {
@@ -67,7 +67,7 @@ export default class JasmineReporter {
     suiteDone (suite) {
         const parentSuite = this.parent[this.parent.length - 1]
 
-        /**
+        /*
          * in case there is a runtime error within one of the specs
          * create an empty test to attach the error to it
          */

--- a/packages/wdio-junit-reporter/src/index.js
+++ b/packages/wdio-junit-reporter/src/index.js
@@ -3,10 +3,14 @@ import WDIOReporter from '@wdio/reporter'
 import { limit } from './utils'
 
 /**
- * Reporter that converts test results from a single instance/runner into an XML JUnit report. This class
- * uses junit-report-builder (https://github.com/davidparsson/junit-report-builder) to build report.The report
- * generated from this reporter should conform to the standard JUnit report schema
+ * Reporter that converts test results from a single instance/runner into an XML JUnit report.
+ * This class uses junit-report-builder (https://github.com/davidparsson/junit-report-builder)
+ * to build report.
+ *
+ * The report generated from this reporter should conform to the standard JUnit report schema
  * (https://github.com/junit-team/junit5/blob/master/platform-tests/src/test/resources/jenkins-junit.xsd).
+ *
+ * @extends WDIOReporter
  */
 class JunitReporter extends WDIOReporter {
     constructor (options) {

--- a/packages/wdio-junit-reporter/src/index.js
+++ b/packages/wdio-junit-reporter/src/index.js
@@ -34,7 +34,7 @@ class JunitReporter extends WDIOReporter {
             : runner.sanitizedCapabilities
 
         for (let suiteKey of Object.keys(this.suites)) {
-            /**
+            /*
              * ignore root before all
              */
             /* istanbul ignore if  */
@@ -55,7 +55,7 @@ class JunitReporter extends WDIOReporter {
                 .property('capabilities', runner.sanitizedCapabilities)
                 .property('file', specFileName.replace(process.cwd(), '.'))
 
-            /**
+            /*
              * Add failed before and after all hooks to suite as tests.
              */
             const failedHooks = suite.hooks.filter(hook => hook.error && (hook.title === '"before all" hook' || hook.title === '"after all" hook'))

--- a/packages/wdio-lambda-runner/src/handler.js
+++ b/packages/wdio-lambda-runner/src/handler.js
@@ -7,7 +7,7 @@ module.exports.run = (event, context, callback) => {
     log.info('Start Lambda function...')
     const runner = new Runner()
 
-    /**
+    /*
      * run test
      */
     runner.run(event).catch((e) => {

--- a/packages/wdio-lambda-runner/src/index.js
+++ b/packages/wdio-lambda-runner/src/index.js
@@ -31,7 +31,7 @@ export default class AWSLambdaRunner extends EventEmitter {
     }
 
     async initialise () {
-        /**
+        /*
          * generate temp dir for AWS service
          */
         this.serviceDir = tmp.dirSync({
@@ -42,12 +42,12 @@ export default class AWSLambdaRunner extends EventEmitter {
 
         log.info('Generating temporary AWS Lamdba service directory at %s', this.serviceDir.name)
 
-        /**
+        /*
          * link node_modules
          */
         this.link(this.nodeModulesDir, path.resolve(this.serviceDir.name, 'node_modules'))
 
-        /**
+        /*
          * link wdio config
          */
         this.link(
@@ -55,14 +55,14 @@ export default class AWSLambdaRunner extends EventEmitter {
             path.resolve(this.serviceDir.name, this.configFile)
         )
 
-        /**
+        /*
          * link specs
          */
         this.specs.forEach((spec) => {
             this.link(spec, path.join(this.serviceDir.name, spec.replace(process.cwd(), '')))
         })
 
-        /**
+        /*
          * create config
          */
         const runnerConfig = Object.assign(DEFAULT_CONFIG, {
@@ -73,7 +73,7 @@ export default class AWSLambdaRunner extends EventEmitter {
             }
         })
 
-        /**
+        /*
          * copy over files
          */
         shell.cp(path.resolve(__dirname, '..', 'config', 'serverless.yml'), path.resolve(this.serviceDir.name, 'serverless.yml'))
@@ -116,7 +116,7 @@ export default class AWSLambdaRunner extends EventEmitter {
             const child = shell.exec(script, { async: true, silent: true })
             child.stdout.on('data', (stdout) => {
                 const trimmedStdout = stdout.trim().replace(/^Serverless: /, '')
-                /**
+                /*
                  * in case stdout is starting with `{` we assume it
                  * is the resulrt of serverless.run therefor return
                  * json
@@ -128,7 +128,7 @@ export default class AWSLambdaRunner extends EventEmitter {
             })
             child.stderr.on('data', ::log.error)
             child.on('close', (code) => {
-                /**
+                /*
                  * ...otherwise resolve with status code
                  */
                 if (code === 0) {

--- a/packages/wdio-local-runner/src/index.js
+++ b/packages/wdio-local-runner/src/index.js
@@ -15,7 +15,7 @@ export default class LocalRunner {
         this.stderr = new WritableStreamBuffer(BUFFER_OPTIONS)
     }
 
-    /**
+    /*
      * nothing to initialise when running locally
      */
     initialise () {}
@@ -25,7 +25,7 @@ export default class LocalRunner {
     }
 
     run ({ command, argv, ...options }) {
-        /**
+        /*
          * adjust max listeners on stdout/stderr when creating listeners
          */
         const workerCnt = this.getWorkerCount()
@@ -54,7 +54,7 @@ export default class LocalRunner {
             const { caps, server, sessionId, config, isMultiremote, instances } = worker
             let payload = {}
 
-            /**
+            /*
              * put connection information to payload if in watch mode
              * in order to attach to browser session and kill it
              */

--- a/packages/wdio-local-runner/src/replQueue.js
+++ b/packages/wdio-local-runner/src/replQueue.js
@@ -3,6 +3,8 @@ import WDIORepl from './repl'
 /**
  * repl queue class
  * allows to run debug commands in mutliple workers one after another
+ *
+ * @extends ReplQueue
  */
 export default class ReplQueue {
     constructor () {

--- a/packages/wdio-local-runner/src/run.js
+++ b/packages/wdio-local-runner/src/run.js
@@ -37,7 +37,7 @@ process.on('message', (m) => {
     )
 })
 
-/**
+/*
  * catch sigint messages as they are handled by main process
  */
 exitHook((callback) => {

--- a/packages/wdio-local-runner/src/stdStream.js
+++ b/packages/wdio-local-runner/src/stdStream.js
@@ -5,7 +5,7 @@ export default class RunnerStream extends Transform {
     constructor () {
         super()
 
-        /**
+        /*
          * Remove events that are automatically created by Writable stream
          */
         this.on('pipe', () => {

--- a/packages/wdio-local-runner/src/worker.js
+++ b/packages/wdio-local-runner/src/worker.js
@@ -87,14 +87,14 @@ export default class WorkerInstance extends EventEmitter {
     _handleMessage (payload) {
         const { cid, childProcess } = this
 
-        /**
+        /*
          * resolve pending commands
          */
         if (payload.name === 'finisedCommand') {
             this.isBusy = false
         }
 
-        /**
+        /*
          * store sessionId and connection data to worker instance
          */
         if (payload.name === 'sessionStarted') {
@@ -108,7 +108,7 @@ export default class WorkerInstance extends EventEmitter {
             return
         }
 
-        /**
+        /*
          * handle debug command called within worker process
          */
         if (payload.origin === 'debugger' && payload.name === 'start') {
@@ -121,7 +121,7 @@ export default class WorkerInstance extends EventEmitter {
             return replQueue.next()
         }
 
-        /**
+        /*
          * handle debugger results
          */
         if (replQueue.isRunning && payload.origin === 'debugger' && payload.name === 'result') {
@@ -139,7 +139,7 @@ export default class WorkerInstance extends EventEmitter {
     _handleExit (exitCode) {
         const { cid, childProcess, specs, retries } = this
 
-        /**
+        /*
          * delete process of worker
          */
         delete this.childProcess
@@ -163,7 +163,7 @@ export default class WorkerInstance extends EventEmitter {
             return log.info(`worker with cid ${cid} already busy and can't take new commands`)
         }
 
-        /**
+        /*
          * start up process if worker hasn't done yet or if child process
          * closes after running its job
          */

--- a/packages/wdio-logger/src/index.js
+++ b/packages/wdio-logger/src/index.js
@@ -1,4 +1,4 @@
-/**
+/*
  * environment check to allow to use this package in a web context
  */
 

--- a/packages/wdio-logger/src/node.js
+++ b/packages/wdio-logger/src/node.js
@@ -23,25 +23,25 @@ const matches = {
 }
 
 const SERIALIZERS = [{
-    /**
+    /*
      * display error stack
      */
     matches: (err) => err instanceof Error,
     serialize: (err) => err.stack
 }, {
-    /**
+    /*
      * color commands blue
      */
     matches: (log) => log === matches.COMMAND,
     serialize: (log) => chalk.magenta(log)
 }, {
-    /**
+    /*
      * color data yellow
      */
     matches: (log) => log === matches.DATA,
     serialize: (log) => chalk.yellow(log)
 }, {
-    /**
+    /*
      * color result cyan
      */
     matches: (log) => log === matches.RESULT,
@@ -57,14 +57,14 @@ const originalFactory = log.methodFactory
 log.methodFactory = function (methodName, logLevel, loggerName) {
     const rawMethod = originalFactory(methodName, logLevel, loggerName)
     return (...args) => {
-        /**
+        /*
          * create logFile lazily
          */
         if (!logFile && process.env.WDIO_LOG_PATH) {
             logFile = fs.createWriteStream(process.env.WDIO_LOG_PATH)
         }
 
-        /**
+        /*
          * split `prefixer: value` sting to `prefixer: ` and `value`
          * so that SERIALIZERS can match certain string
          */
@@ -85,7 +85,7 @@ log.methodFactory = function (methodName, logLevel, loggerName) {
 
         const logText = ansiStrip(`${util.format.apply(this, args)}\n`)
         if (logFile && logFile.writable) {
-            /**
+            /*
              * empty logging cache if stuff got logged before
              */
             if (logCache.size) {
@@ -109,7 +109,7 @@ prefix.apply(log, {
 })
 
 export default function getLogger (name) {
-    /**
+    /*
      * check if logger was already initiated
      */
     if (loggers[name]) {
@@ -126,7 +126,7 @@ export default function getLogger (name) {
     loggers[name].setLevel(logLevel)
     return loggers[name]
 }
-/**
+/*
  * Wait for writable stream to be flushed.
  * Calling this prevents part of the logs in the very env to be lost.
  */
@@ -141,7 +141,7 @@ getLogger.waitForBuffer = async () => new Promise(resolve => {
 })
 getLogger.setLevel = (name, level) => loggers[name].setLevel(level)
 getLogger.setLogLevelsConfig = (logLevels = {}, wdioLogLevel = DEFAULT_LEVEL) => {
-    /**
+    /*
      * set log level
      */
     if (process.env.WDIO_LOG_LEVEL === undefined) {
@@ -150,7 +150,7 @@ getLogger.setLogLevelsConfig = (logLevels = {}, wdioLogLevel = DEFAULT_LEVEL) =>
 
     logLevelsConfig = {}
 
-    /**
+    /*
      * build logLevelsConfig object
      */
     Object.entries(logLevels).forEach(([logName, logLevel]) => {
@@ -158,13 +158,13 @@ getLogger.setLogLevelsConfig = (logLevels = {}, wdioLogLevel = DEFAULT_LEVEL) =>
         logLevelsConfig[logLevelName] = logLevel
     })
 
-    /**
+    /*
      * set log level for each logger
      */
     Object.keys(loggers).forEach(logName => {
         const logLevelName = getLogLevelName(logName)
 
-        /**
+        /*
          * either apply log level from logLevels object or use global logLevel
          */
         const logLevel = typeof logLevelsConfig[logLevelName] !== 'undefined' ? logLevelsConfig[logLevelName] : process.env.WDIO_LOG_LEVEL

--- a/packages/wdio-mocha-framework/src/index.js
+++ b/packages/wdio-mocha-framework/src/index.js
@@ -9,7 +9,7 @@ import { INTERFACES, EVENTS, NOOP } from './constants'
 
 const log = logger('@wdio/mocha-framework')
 
-/**
+/*
 * Extracts the mocha UI type following this convention:
 *  - If the mochaOpts.ui provided doesn't contain a '-' then the full name
 *      is taken as ui type (i.e. 'bdd','tdd','qunit')
@@ -63,7 +63,7 @@ class MochaAdapter {
         try {
             this.mocha.loadFiles()
 
-            /**
+            /*
              * grep
              */
             const mochaRunner = new Mocha.Runner(this.mocha.suite)
@@ -84,7 +84,7 @@ class MochaAdapter {
     }
 
     hasTests () {
-        /**
+        /*
          * filter specs only if feature enabled explicitly to avoid breaking changes.
          * If the feature is enabled user should avoid interacting with `browser` object before session is started
          */
@@ -110,7 +110,7 @@ class MochaAdapter {
         })
         await executeHooksWithArgs(this.config.after, [runtimeError || result, this.capabilities, this.specs])
 
-        /**
+        /*
          * in case the spec has a runtime error throw after the wdio hook
          */
         if (runtimeError) {
@@ -202,7 +202,7 @@ class MochaAdapter {
                 actual: params.err.actual
             }
 
-            /**
+            /*
              * hook failures are emitted as "test:fail"
              */
             if (params.payload && params.payload.title && params.payload.title.match(/^"(before|after)( all)*" hook/g)) {
@@ -219,7 +219,7 @@ class MochaAdapter {
             message.file = params.payload.file
             message.duration = params.payload.duration
 
-            /**
+            /*
              * Add the current test title to the payload for cases where it helps to
              * identify the test, e.g. when running inside a beforeEach hook
              */
@@ -254,7 +254,7 @@ class MochaAdapter {
     }
 
     emit (event, payload, err) {
-        /**
+        /*
          * For some reason, Mocha fires a second 'suite:end' event for the root suite,
          * with no matching 'suite:start', so this can be ignored.
          */

--- a/packages/wdio-repl/src/index.js
+++ b/packages/wdio-repl/src/index.js
@@ -99,7 +99,7 @@ export default class WDIORepl {
         )
 
         result.then((res) => {
-            /**
+            /*
              * don't do anything if timeout was called
              */
             if (timeout._called) {
@@ -109,7 +109,7 @@ export default class WDIORepl {
             clearTimeout(timeout)
             return callback(null, res)
         }, (e) => {
-            /**
+            /*
              * don't do anything if timeout was called
              */
             if (timeout._called) {

--- a/packages/wdio-reporter/src/index.js
+++ b/packages/wdio-reporter/src/index.js
@@ -102,7 +102,7 @@ export default class WDIOReporter extends EventEmitter {
         this.on('test:fail',  /* istanbul ignore next */ (test) => {
             const testStat = this.tests[test.uid]
 
-            /**
+            /*
              * replace "Ensure the done() callback is being called in this test." with more meaningful
              * message (Mocha only)
              */
@@ -122,7 +122,7 @@ export default class WDIOReporter extends EventEmitter {
             const currentSuite = this.currentSuites[this.currentSuites.length - 1]
             currentTest = new TestStats(test)
 
-            /**
+            /*
              * In Mocha: tests that are skipped don't have a start event but a test end.
              * In Jasmine: tests have a start event, therefor we need to replace the
              * test instance with the pending test here
@@ -166,7 +166,7 @@ export default class WDIOReporter extends EventEmitter {
             this.onRunnerEnd(this.runnerStat)
         })
 
-        /**
+        /*
          * browser client event handlers
          */
         this.on('client:command',  /* istanbul ignore next */ (payload) => {

--- a/packages/wdio-reporter/src/stats/runnable.js
+++ b/packages/wdio-reporter/src/stats/runnable.js
@@ -21,7 +21,7 @@ export default class RunnableStats {
         return new Date() - this.start
     }
 
-    /**
+    /*
      * ToDo: we should always rely on uid
      */
     static getIdentifier (runner) {

--- a/packages/wdio-reporter/src/stats/suite.js
+++ b/packages/wdio-reporter/src/stats/suite.js
@@ -14,7 +14,7 @@ export default class SuiteStats extends RunnableStats {
         this.tests = []
         this.hooks = []
         this.suites = []
-        /**
+        /*
          * an array of hooks and tests stored in order as they happen
          */
         this.hooksAndTests = []

--- a/packages/wdio-reporter/src/stats/test.js
+++ b/packages/wdio-reporter/src/stats/test.js
@@ -14,7 +14,7 @@ export default class TestStats extends RunnableStats {
         this.output = []
         this.argument = test.argument
 
-        /**
+        /*
          * initial test state is pending
          * the state can change to the following: passed, skipped, failed
          */

--- a/packages/wdio-reporter/src/utils.js
+++ b/packages/wdio-reporter/src/utils.js
@@ -26,7 +26,7 @@ export function sanitizeCaps (caps) {
 
     let result
 
-    /**
+    /*
      * mobile caps
      */
     if (caps.deviceName) {

--- a/packages/wdio-runner/src/index.js
+++ b/packages/wdio-runner/src/index.js
@@ -35,7 +35,7 @@ export default class Runner extends EventEmitter {
         this.specs = specs
         this.caps = caps
 
-        /**
+        /*
          * add config file
          */
         try {
@@ -44,17 +44,17 @@ export default class Runner extends EventEmitter {
             return this._shutdown(1)
         }
 
-        /**
+        /*
          * merge cli arguments into config
          */
         this.configParser.merge(argv)
 
-        /**
+        /*
          * merge host/port changes by service launcher into config
          */
         this.configParser.merge(server)
 
-        /**
+        /*
          * remove services that has nothing to do in worker
          */
         this.configParser.filterWorkerServices()
@@ -67,7 +67,7 @@ export default class Runner extends EventEmitter {
 
         const isMultiremote = this.isMultiremote = !Array.isArray(this.configParser.getCapabilities())
 
-        /**
+        /*
          * create `browser` stub only if `specFiltering` feature is enabled
          */
         let browser = this.config.featureFlags.specFiltering === true ? await this._startSession({
@@ -77,7 +77,7 @@ export default class Runner extends EventEmitter {
         }, caps) : undefined
 
         this.reporter = new BaseReporter(this.config, this.cid, { ...caps })
-        /**
+        /*
          * initialise framework
          */
         this.framework = initialisePlugin(this.config.framework, 'framework')
@@ -94,7 +94,7 @@ export default class Runner extends EventEmitter {
 
         this.inWatchMode = Boolean(this.config.watch)
 
-        /**
+        /*
          * return if session initialisation failed
          */
         if (!browser) {
@@ -105,7 +105,7 @@ export default class Runner extends EventEmitter {
 
         await executeHooksWithArgs(this.config.before, [this.caps, this.specs])
 
-        /**
+        /*
          * kill session of SIGINT signal showed up while trying to
          * get a session ID
          */
@@ -117,7 +117,7 @@ export default class Runner extends EventEmitter {
 
         const instances = getInstancesData(browser, isMultiremote)
 
-        /**
+        /*
          * initialisation successful, send start message
          */
         this.reporter.emit('runner:start', {
@@ -135,7 +135,7 @@ export default class Runner extends EventEmitter {
             retry: this.config.specFileRetryAttempts
         })
 
-        /**
+        /*
          * report sessionId and target connection information to worker
          */
         const { protocol, hostname, port, path, queryParams } = browser.options
@@ -146,7 +146,7 @@ export default class Runner extends EventEmitter {
             content: { sessionId, isW3C, protocol, hostname, port, path, queryParams, isMultiremote, instances }
         })
 
-        /**
+        /*
          * kick off tests in framework
          */
         let failures = 0
@@ -159,7 +159,7 @@ export default class Runner extends EventEmitter {
             failures = 1
         }
 
-        /**
+        /*
          * in watch mode we don't close the session and leave current page opened
          */
         if (!argv.watch) {
@@ -197,13 +197,13 @@ export default class Runner extends EventEmitter {
             })
         }
 
-        /**
+        /*
          * register global helper method to fetch elements
          */
         global.$ = (selector) => browser.$(selector)
         global.$$ = (selector) => browser.$$(selector)
 
-        /**
+        /*
          * register command event
          */
         browser.on('command', (command) => this.reporter.emit(
@@ -211,7 +211,7 @@ export default class Runner extends EventEmitter {
             Object.assign(command, { sessionId: browser.sessionId })
         ))
 
-        /**
+        /*
          * register result event
          */
         browser.on('result', (result) => this.reporter.emit(
@@ -248,19 +248,19 @@ export default class Runner extends EventEmitter {
      * fetch logs provided by browser driver
      */
     async _fetchDriverLogs (config, excludeDriverLogs) {
-        /**
+        /*
          * only fetch logs if
          */
         if (
-            /**
+            /*
              * a log directory is given in config
              */
             !config.outputDir ||
-            /**
+            /*
              * the session wasn't killed during start up phase
              */
             !global.browser.sessionId ||
-            /**
+            /*
              * driver supports it
              */
             typeof global.browser.getLogs === 'undefined'
@@ -268,7 +268,7 @@ export default class Runner extends EventEmitter {
             return
         }
 
-        /**
+        /*
          * suppress @wdio/sync warnings of not running commands inside of
          * a Fibers context
          */
@@ -278,7 +278,7 @@ export default class Runner extends EventEmitter {
         try {
             logTypes = await global.browser.getLogTypes()
         } catch (errIgnored) {
-            /**
+            /*
              * getLogTypes is not supported by browser
              */
             return
@@ -296,7 +296,7 @@ export default class Runner extends EventEmitter {
                 return log.warn(`Couldn't fetch logs for ${logType}: ${e.message}`)
             }
 
-            /**
+            /*
              * don't write to file if no logs were captured
              */
             if (logs.length === 0) {
@@ -330,7 +330,7 @@ export default class Runner extends EventEmitter {
      * within a hook by the user
      */
     async endSession (payload) {
-        /**
+        /*
          * Attach to browser session before killing it in Multiremote
          */
         if (!global.browser && payload && payload.argv && payload.argv.watch) {
@@ -342,20 +342,20 @@ export default class Runner extends EventEmitter {
             }
         }
 
-        /**
+        /*
          * make sure instance(s) exist and have `sessionId`
          */
         const hasSessionId = global.browser && (this.isMultiremote
-            /**
+            /*
              * every multiremote instance should exist and should have `sessionId`
              */
             ? !global.browser.instances.some(i => global.browser[i] && !global.browser[i].sessionId)
-            /**
+            /*
              * browser object should have `sessionId` in regular mode
              */
             : global.browser.sessionId)
 
-        /**
+        /*
          * don't do anything if test framework returns after SIGINT
          * if endSession is called without payload we expect a session id
          */
@@ -363,7 +363,7 @@ export default class Runner extends EventEmitter {
             return
         }
 
-        /**
+        /*
          * if payload was called but no session was created, wait until it was
          * and try to end it
          */
@@ -372,7 +372,7 @@ export default class Runner extends EventEmitter {
             return this.endSession(payload)
         }
 
-        /**
+        /*
          * store capabilities for afterSession hook
          */
         let capabilities = global.browser.capabilities || {}
@@ -382,7 +382,7 @@ export default class Runner extends EventEmitter {
 
         await global.browser.deleteSession()
 
-        /**
+        /*
          * delete session(s)
          */
         if (this.isMultiremote) {

--- a/packages/wdio-runner/src/reporter.js
+++ b/packages/wdio-runner/src/reporter.js
@@ -20,7 +20,7 @@ export default class BaseReporter {
         this.cid = cid
         this.caps = caps
 
-        /**
+        /*
          * these configurations are not publicly documented as there should be no desire for it
          */
         this.reporterSyncInterval = this.config.reporterSyncInterval || DEFAULT_SYNC_INTERVAL
@@ -40,7 +40,7 @@ export default class BaseReporter {
     emit (e, payload) {
         payload.cid = this.cid
 
-        /**
+        /*
          * Send failure message (only once) in case of test or hook failure
          */
         sendFailureMessage(e, payload)
@@ -113,7 +113,7 @@ export default class BaseReporter {
                     return reject(new Error(`Some reporters are still unsynced: ${unsyncedReporter.join(', ')}`))
                 }
 
-                /**
+                /*
                  * no reporter are in need to sync anymore, continue
                  */
                 if (!unsyncedReporter.length) {
@@ -137,7 +137,7 @@ export default class BaseReporter {
             setLogFile: NOOP
         }
 
-        /**
+        /*
          * check if reporter has custom options
          */
         if (Array.isArray(reporter)) {
@@ -145,7 +145,7 @@ export default class BaseReporter {
             reporter = reporter[0]
         }
 
-        /**
+        /*
          * check if reporter was passed in from a file, e.g.
          *
          * ```js
@@ -168,7 +168,7 @@ export default class BaseReporter {
             return new ReporterClass(options)
         }
 
-        /**
+        /*
          * check if reporter is a node package, e.g. wdio-dot reporter
          *
          * ```js
@@ -190,7 +190,7 @@ export default class BaseReporter {
             return new ReporterClass(options)
         }
 
-        /**
+        /*
          * throw error if reporter property was invalid
          */
         throw new Error('Invalid reporters config')

--- a/packages/wdio-runner/src/utils.js
+++ b/packages/wdio-runner/src/utils.js
@@ -30,7 +30,7 @@ export function runHook (hookName, config, caps, specs) {
  */
 export function sanitizeCaps (caps) {
     return Object.keys(caps).filter(key => (
-        /**
+        /*
          * filter out all wdio config keys
          */
         !Object.keys(DEFAULT_CONFIGS).includes(key)
@@ -48,7 +48,7 @@ export function sanitizeCaps (caps) {
  * @return {Promise}               resolves with browser object
  */
 export async function initialiseInstance (config, capabilities, isMultiremote) {
-    /**
+    /*
      * check if config has sessionId and attach it to a running session if so
      */
     if (config.sessionId) {
@@ -154,7 +154,7 @@ export async function attachToMultiremote(instances, caps) {
         }
     }
 
-    /**
+    /*
      * attach to every multiremote instance
      */
     await Promise.all(

--- a/packages/wdio-sauce-service/src/service.js
+++ b/packages/wdio-sauce-service/src/service.js
@@ -23,7 +23,7 @@ export default class SauceService {
         this.isRDC = 'testobject_api_key' in this.capabilities
         this.isServiceEnabled = true
 
-        /**
+        /*
          * if no user and key is specified even though a sauce service was
          * provided set user and key with values so that the session request
          * will fail (not for RDC tho due to other auth mechansim)
@@ -52,7 +52,7 @@ export default class SauceService {
             return
         }
 
-        /**
+        /*
          * in jasmine we get Jasmine__TopLevel__Suite as title since service using test
          * framework hooks in order to execute async functions.
          * This tweak allows us to set the real suite name for jasmine jobs.
@@ -79,9 +79,10 @@ export default class SauceService {
         }
     }
 
-    /**
+    /*
      * For CucumberJS
      */
+
     beforeFeature (uri, feature) {
         if (!this.isServiceEnabled || this.isRDC) {
             return
@@ -116,7 +117,7 @@ export default class SauceService {
 
         let failures = this.failures
 
-        /**
+        /*
          * set failures if user has bail option set in which case afterTest and
          * afterSuite aren't executed before after hook
          */
@@ -173,7 +174,7 @@ export default class SauceService {
     getBody (failures, calledOnReload = false, browserName) {
         let body = {}
 
-        /**
+        /*
          * set default values
          */
         body.name = this.suiteTitle
@@ -182,7 +183,7 @@ export default class SauceService {
             body.name = `${browserName}: ${body.name}`
         }
 
-        /**
+        /*
          * add reload count to title if reload is used
          */
         if (calledOnReload || this.testCnt) {

--- a/packages/wdio-shared-store-service/src/server.js
+++ b/packages/wdio-shared-store-service/src/server.js
@@ -4,7 +4,7 @@ const { json } = require('@polka/parse')
 const store = {}
 
 const app = polka()
-    /**
+    /*
      * middleware
      * `json` middleware transforms body to json for every request or returns empty object
      */
@@ -20,7 +20,7 @@ const app = polka()
     })
 
 const startServer = () => new Promise((resolve, reject) => {
-    /**
+    /*
      * run server on a random port, `0` stands for random port
      * > If port is omitted or is 0, the operating system will assign
      * > an arbitrary unused port, which can be retrieved by using `server.address().port`

--- a/packages/wdio-shared-store-service/src/service.js
+++ b/packages/wdio-shared-store-service/src/service.js
@@ -3,7 +3,7 @@ import { getValue, setValue, setPort } from './client'
 
 export default class SharedStoreService {
     async beforeSession () {
-        /**
+        /*
          * get port from parent's pid file saved in `onPrepare` hook
          */
         const port = await readFile(getPidPath(process.ppid))

--- a/packages/wdio-spec-reporter/src/index.js
+++ b/packages/wdio-spec-reporter/src/index.js
@@ -5,7 +5,7 @@ import { buildTableData, printTable, getFormattedRows } from './utils'
 
 class SpecReporter extends WDIOReporter {
     constructor (options) {
-        /**
+        /*
          * make spec reporter to write to output stream by default
          */
         options = Object.assign({ stdout: true }, options)
@@ -142,7 +142,7 @@ class SpecReporter extends WDIOReporter {
      */
     getEventsToReport (suite) {
         return [
-            /**
+            /*
              * report all tests and only hooks that failed
              */
             ...suite.hooksAndTests

--- a/packages/wdio-sumologic-reporter/src/index.js
+++ b/packages/wdio-sumologic-reporter/src/index.js
@@ -117,7 +117,7 @@ export default class SumoLogicReporter extends WDIOReporter {
     }
 
     sync () {
-        /**
+        /*
          * don't synchronise logs if
          *  - we've already send out a request and are waiting for the successful response
          *  - we have nothing to synchronise
@@ -129,7 +129,7 @@ export default class SumoLogicReporter extends WDIOReporter {
 
         const logLines = this.unsynced.slice(0, MAX_LINES).join('\n')
 
-        /**
+        /*
          * set `isSynchronising` to true so we don't sync when a request is being made
          */
         this.isSynchronising = true
@@ -147,12 +147,12 @@ export default class SumoLogicReporter extends WDIOReporter {
                 return log.error('failed send data to Sumo Logic:\n', err.stack ? err.stack : err)
             }
 
-            /**
+            /*
              * remove transfered logs from log bucket
              */
             this.unsynced.splice(0, MAX_LINES)
 
-            /**
+            /*
              * reset sync flag so we can sync again
              */
             log.debug(`synchronised collector data, server status: ${resp.statusCode}`)

--- a/packages/wdio-sync/src/executeHooksWithArgs.js
+++ b/packages/wdio-sync/src/executeHooksWithArgs.js
@@ -13,14 +13,14 @@ const log = logger('@wdio/sync')
  * @return {Promise}  promise that gets resolved once all hooks finished running
  */
 export default function executeHooksWithArgs (hooks = [], args) {
-    /**
+    /*
      * make sure hooks are an array of functions
      */
     if (typeof hooks === 'function') {
         hooks = [hooks]
     }
 
-    /**
+    /*
      * make sure args is an array since we are calling apply
      */
     if (!Array.isArray(args)) {
@@ -49,7 +49,7 @@ export default function executeHooksWithArgs (hooks = [], args) {
             resolve(result)
         }
 
-        /**
+        /*
          * after command hooks require additional Fiber environment
          */
         return hook.constructor.name === 'AsyncFunction' ? execHook() : Fiber(execHook).run()

--- a/packages/wdio-sync/src/fibers.js
+++ b/packages/wdio-sync/src/fibers.js
@@ -11,11 +11,11 @@ const origErrorFn = ::console.error
 const errors = []
 console.error = /* istanbul ignore next */ (...args) => errors.push(args)
 
-/**
+/*
  * Helper method to retrieve a version of `fibers` for your Node version.
  */
 try {
-    /**
+    /*
      * try original fibers package first
      */
     // eslint-disable-next-line import/no-unresolved
@@ -28,7 +28,7 @@ try {
 
 if (!Fiber || !Future) {
     try {
-        /**
+        /*
          * fallback to fibers compiled for Node v8
          */
         // eslint-disable-next-line import/no-unresolved
@@ -42,7 +42,7 @@ if (!Fiber || !Future) {
 
 console.error = origErrorFn
 
-/**
+/*
  * throw if no fibers could be loaded
  */
 if (!Fiber || !Future) {

--- a/packages/wdio-sync/src/index.js
+++ b/packages/wdio-sync/src/index.js
@@ -22,7 +22,7 @@ const executeSync = async function (fn, retries, args = []) {
         let res = fn.apply(this, args)
         global._HAS_FIBER_CONTEXT = false
 
-        /**
+        /*
          * sometimes function result is Promise,
          * we need to await result before proceeding
          */
@@ -37,7 +37,7 @@ const executeSync = async function (fn, retries, args = []) {
             return await executeSync(fn, retries, args)
         }
 
-        /**
+        /*
          * no need to modify stack if no stack available
          */
         if (!e.stack) {

--- a/packages/wdio-sync/src/utils.js
+++ b/packages/wdio-sync/src/utils.js
@@ -20,7 +20,7 @@ export function sanitizeErrorMessage (commandError, savedError) {
 
     let stackArr = savedError.stack.split('\n')
 
-    /**
+    /*
      * merge stack traces if `commandError` has stack trace
      */
     if (stack) {

--- a/packages/wdio-sync/src/wrapCommand.js
+++ b/packages/wdio-sync/src/wrapCommand.js
@@ -38,7 +38,7 @@ process.on('WDIO_TIMER', (payload) => {
  */
 export default function wrapCommand (commandName, fn) {
     return function wrapCommandFn (...args) {
-        /**
+        /*
          * print error if a user is using a fiberized command outside of the Fibers context
          */
         if(!global._HAS_FIBER_CONTEXT && global.WDIO_WORKER) {
@@ -48,21 +48,21 @@ export default function wrapCommand (commandName, fn) {
             )
         }
 
-        /**
+        /*
          * store element if Timer is running to reset `_NOT_FIBER` if timeout has occurred
          */
         if (timers.length > 0) {
             elements.add(this)
         }
 
-        /**
+        /*
          * Avoid running some functions in Future that are not in Fiber.
          */
         if (this._NOT_FIBER === true) {
             this._NOT_FIBER = isNotInFiber(this, fn.name)
             return fn.apply(this, args)
         }
-        /**
+        /*
          * all named nested functions run in parent Fiber context
          */
         this._NOT_FIBER = fn.name !== ''
@@ -77,14 +77,14 @@ export default function wrapCommand (commandName, fn) {
             inFiber(this)
             return futureResult
         } catch (e) {
-            /**
+            /*
              * in case some 3rd party lib rejects without bundling into an error
              */
             if (typeof e === 'string') {
                 throw new Error(e)
             }
 
-            /**
+            /*
              * in case we run commands where no fiber function was used
              * e.g. when we call deleteSession
              */

--- a/packages/wdio-testingbot-service/src/service.js
+++ b/packages/wdio-testingbot-service/src/service.js
@@ -41,7 +41,7 @@ export default class TestingBotService {
             return
         }
 
-        /**
+        /*
          * in jasmine we get Jasmine__TopLevel__Suite as title since service using test
          * framework hooks in order to execute async functions.
          * This tweak allows us to set the real suite name for jasmine jobs.
@@ -72,7 +72,7 @@ export default class TestingBotService {
         }
     }
 
-    /**
+    /*
      * For CucumberJS
      */
 
@@ -128,7 +128,7 @@ export default class TestingBotService {
 
         let failures = this.failures
 
-        /**
+        /*
          * set failures if user has bail option set in which case afterTest and
          * afterSuite aren't executed before after hook
          */
@@ -197,12 +197,12 @@ export default class TestingBotService {
     getBody (failures, calledOnReload = false, browserName) {
         let body = { test: {} }
 
-        /**
+        /*
          * set default values
          */
         body.test['name'] = this.suiteTitle
 
-        /**
+        /*
          * add reload count to title if reload is used
          */
         if (calledOnReload || this.testCnt) {

--- a/packages/wdio-utils/src/envDetector.js
+++ b/packages/wdio-utils/src/envDetector.js
@@ -10,7 +10,7 @@ const MOBILE_CAPABILITIES = [
  * @return {Boolean}               true if W3C (browser)
  */
 function isW3C (capabilities) {
-    /**
+    /*
      * JSONWire protocol doesn't return a property `capabilities`.
      * Also check for Appium response as it is using JSONWire protocol for most of the part.
      */
@@ -18,7 +18,7 @@ function isW3C (capabilities) {
         return false
     }
 
-    /**
+    /*
      * assume session to be a WebDriver session when
      * - capabilities are returned
      *   (https://w3c.github.io/webdriver/#dfn-new-sessions)
@@ -28,7 +28,7 @@ function isW3C (capabilities) {
     const hasW3CCaps = (
         capabilities.platformName &&
         capabilities.browserVersion &&
-        /**
+        /*
          * local safari and BrowserStack don't provide platformVersion therefor
          * check also if setWindowRect is provided
          */
@@ -64,19 +64,19 @@ function isMobile (caps) {
     }
     const browserName = (caps.browserName || '').toLowerCase()
 
-    /**
+    /*
      * we have mobile caps if
      */
     return Boolean(
-        /**
+        /*
          * capabilities contain mobile only specific capabilities
          */
         Object.keys(caps).find((cap) => MOBILE_CAPABILITIES.includes(cap)) ||
-        /**
+        /*
          * browserName is empty (and eventually app is defined)
          */
         caps.browserName === '' ||
-        /**
+        /*
          * browserName is a mobile browser
          */
         MOBILE_BROWSER_NAMES.includes(browserName)

--- a/packages/wdio-utils/src/index.js
+++ b/packages/wdio-utils/src/index.js
@@ -22,7 +22,7 @@ export {
     getArgumentType,
     safeRequire,
 
-    /**
+    /*
      * wdio-sync shim
      */
     wrapCommand,
@@ -34,7 +34,7 @@ export {
     executeHooksWithArgs,
     hasWdioSyncSupport,
 
-    /**
+    /*
      * environmentDetector
      */
     sessionEnvironmentDetector,

--- a/packages/wdio-utils/src/initialisePlugin.js
+++ b/packages/wdio-utils/src/initialisePlugin.js
@@ -7,7 +7,7 @@ import { safeRequire } from './utils'
  * 3. otherwise try to require "wdio-<name>-<type>"
  */
 export default function initialisePlugin (name, type, target = 'default') {
-    /**
+    /*
      * directly import packages that are scoped
      */
     if (name[0] === '@') {
@@ -15,7 +15,7 @@ export default function initialisePlugin (name, type, target = 'default') {
         return service[target]
     }
 
-    /**
+    /*
      * check for scoped version of plugin first (e.g. @wdio/sauce-service)
      */
     const scopedPlugin = safeRequire(`@wdio/${name.toLowerCase()}-${type}`)
@@ -23,7 +23,7 @@ export default function initialisePlugin (name, type, target = 'default') {
         return scopedPlugin[target]
     }
 
-    /**
+    /*
      * check for old type of
      */
     const plugin = safeRequire(`wdio-${name.toLowerCase()}-${type}`)

--- a/packages/wdio-utils/src/initialiseServices.js
+++ b/packages/wdio-utils/src/initialiseServices.js
@@ -22,7 +22,7 @@ export default function initialiseServices (config, caps, type) {
     for (let serviceName of config.services) {
         let serviceConfig = config
 
-        /**
+        /*
          * allow custom services with custom options
          */
         if (Array.isArray(serviceName)) {
@@ -30,7 +30,7 @@ export default function initialiseServices (config, caps, type) {
             serviceName = serviceName[0]
         }
 
-        /**
+        /*
          * allow custom services that are already initialised
          */
         if (serviceName && typeof serviceName === 'object' && !Array.isArray(serviceName)) {
@@ -40,7 +40,7 @@ export default function initialiseServices (config, caps, type) {
         }
 
         try {
-            /**
+            /*
              * allow custom service classes
              */
             if (typeof serviceName === 'function') {
@@ -52,7 +52,7 @@ export default function initialiseServices (config, caps, type) {
             log.debug(`initialise wdio service "${serviceName}"`)
             const Service = initialisePlugin(serviceName, 'service', type)
 
-            /**
+            /*
              * service only contains a launcher
              */
             if (!Service) {

--- a/packages/wdio-utils/src/monad.js
+++ b/packages/wdio-utils/src/monad.js
@@ -9,7 +9,7 @@ const SCOPE_TYPES = {
 }
 
 export default function WebDriver (options, modifier, propertiesObject = {}) {
-    /**
+    /*
      * In order to allow named scopes for elements we have to propagate that
      * info within the `propertiesObject` object. This doesn't have any functional
      * advantages just provides better description of objects when debugging them
@@ -30,7 +30,7 @@ export default function WebDriver (options, modifier, propertiesObject = {}) {
         propertiesObject.commandList = { value: Object.keys(propertiesObject) }
         propertiesObject.options = { value: options }
 
-        /**
+        /*
          * allow to wrap commands if necessary
          * e.g. in wdio-cli to make them synchronous
          */
@@ -45,12 +45,12 @@ export default function WebDriver (options, modifier, propertiesObject = {}) {
             }
         }
 
-        /**
+        /*
          * overwrite native element commands with user defined
          */
         overwriteElementCommands.call(this, propertiesObject)
 
-        /**
+        /*
          * assign propertiesObject to itself so the client can be recreated
          */
         propertiesObject['__propertiesObject__'] = { value: propertiesObject }
@@ -58,7 +58,7 @@ export default function WebDriver (options, modifier, propertiesObject = {}) {
         let client = Object.create(prototype, propertiesObject)
         client.sessionId = sessionId
 
-        /**
+        /*
          * register capabilities only to browser scope
          */
         if (scopeType.name === 'Browser') {
@@ -74,7 +74,7 @@ export default function WebDriver (options, modifier, propertiesObject = {}) {
                 ? commandWrapper(name, func)
                 : func
             if (attachToElement) {
-                /**
+                /*
                  * add command to every multiremote instance
                  */
                 if (instances) {
@@ -106,14 +106,14 @@ export default function WebDriver (options, modifier, propertiesObject = {}) {
                 : func
             if (attachToElement) {
                 if (instances) {
-                    /**
+                    /*
                      * add command to every multiremote instance
                      */
                     Object.values(instances).forEach(instance => {
                         instance.__propertiesObject__.__elementOverrides__.value[name] = customCommand
                     })
                 } else {
-                    /**
+                    /*
                      * regular mode
                      */
                     this.__propertiesObject__.__elementOverrides__.value[name] = customCommand
@@ -141,7 +141,7 @@ export default function WebDriver (options, modifier, propertiesObject = {}) {
         (proto || prototype)[name] = function next (...args) {
             log.info('COMMAND', commandCallStructure(name, args))
 
-            /**
+            /*
              * set name of function for better error stack
              */
             Object.defineProperty(func, 'name', {
@@ -151,7 +151,7 @@ export default function WebDriver (options, modifier, propertiesObject = {}) {
 
             const result = func.apply(this, origCommand ? [origCommand, ...args] : args)
 
-            /**
+            /*
              * always transform result into promise as we don't know whether or not
              * the user is running tests with wdio-sync or not
              */
@@ -164,7 +164,7 @@ export default function WebDriver (options, modifier, propertiesObject = {}) {
         }
     }
 
-    /**
+    /*
      * register event emitter
      */
     for (let eventCommand in EVENTHANDLER_FUNCTIONS) {

--- a/packages/wdio-utils/src/shim.js
+++ b/packages/wdio-utils/src/shim.js
@@ -3,14 +3,14 @@ import logger from '@wdio/logger'
 const log = logger('@wdio/utils:shim')
 
 let executeHooksWithArgs = async function executeHooksWithArgsShim (hooks, args) {
-    /**
+    /*
      * make sure hooks are an array of functions
      */
     if (!Array.isArray(hooks)) {
         hooks = [hooks]
     }
 
-    /**
+    /*
      * make sure args is an array since we are calling apply
      */
     if (!Array.isArray(args)) {
@@ -27,7 +27,7 @@ let executeHooksWithArgs = async function executeHooksWithArgsShim (hooks, args)
             return resolve(e)
         }
 
-        /**
+        /*
          * if a promise is returned make sure we don't have a catch handler
          * so in case of a rejection it won't cause the hook to fail
          */
@@ -55,7 +55,7 @@ let executeSync = function (fn, _, args = []) { return fn.apply(this, args) }
 let executeAsync = function (fn, _, args = []) { return fn.apply(this, args) }
 let runSync = null
 
-/**
+/*
  * shim to make sure that we only wrap commands if wdio-sync is installed as dependency
  */
 try {

--- a/packages/wdio-utils/src/test-framework/errorHandler.js
+++ b/packages/wdio-utils/src/test-framework/errorHandler.js
@@ -13,7 +13,7 @@ export const logHookError = (hookName, hookResults = [], cid) => {
         return
     }
 
-    /**
+    /*
      * need to convert Error to plain object, otherwise it is lost on process.send
      */
     const error = { message: result.message }

--- a/packages/wdio-utils/src/test-framework/testFnWrapper.js
+++ b/packages/wdio-utils/src/test-framework/testFnWrapper.js
@@ -43,7 +43,7 @@ export const testFrameworkFnWrapper = async function (
     let promise
     let result
     let error
-    /**
+    /*
      * user wants handle async command using promises, no need to wrap in fiber context
      */
     if (isFunctionAsync(specFn) || !runSync) {
@@ -69,7 +69,7 @@ export const testFrameworkFnWrapper = async function (
         passed: !error
     })
 
-    /**
+    /*
      * avoid breaking changes in hook function signatures
      */
     afterArgs = mochaJasmineCompatibility(afterArgs, this)

--- a/packages/wdio-utils/src/test-framework/testInterfaceWrapper.js
+++ b/packages/wdio-utils/src/test-framework/testInterfaceWrapper.js
@@ -65,7 +65,7 @@ export const runSpec = function (specTitle, specFn, origFn, beforeFn, beforeFnAr
  */
 export const wrapTestFunction = function (origFn, isSpec, beforeFn, beforeArgsFn, afterFn, afterArgsFn, cid) {
     return function (...specArguments) {
-        /**
+        /*
          * Variadic arguments:
          * [title, fn], [title], [fn]
          * [title, fn, retryCnt], [title, retryCnt], [fn, retryCnt]
@@ -78,7 +78,7 @@ export const wrapTestFunction = function (origFn, isSpec, beforeFn, beforeArgsFn
         if (isSpec) {
             if (specFn) return runSpec(specTitle, specFn, origFn, beforeFn, beforeArgsFn, afterFn, afterArgsFn, cid, retryCnt)
 
-            /**
+            /*
              * if specFn is undefined we are dealing with a pending function
              */
             return origFn(specTitle)

--- a/packages/wdio-utils/src/test-framework/testInterfaceWrapper.js
+++ b/packages/wdio-utils/src/test-framework/testInterfaceWrapper.js
@@ -1,4 +1,5 @@
 /**
+ * @fileoverview
  * used to wrap mocha, jasmine test frameworks functions (`it`, `beforeEach` and other)
  * with WebdriverIO before/after Test/Hook hooks.
  * Entrypoint is `runTestInFiberContext`, other functions are exported for testing purposes.

--- a/packages/wdio-utils/src/utils.js
+++ b/packages/wdio-utils/src/utils.js
@@ -83,7 +83,7 @@ export function isValidParameter (arg, expectedType) {
         shouldBeArray = true
     }
 
-    /**
+    /*
      * check type of each individual array element
      */
     if (shouldBeArray) {
@@ -91,7 +91,7 @@ export function isValidParameter (arg, expectedType) {
             return false
         }
     } else {
-        /**
+        /*
          * transform to array to have a unified check
          */
         arg = [arg]
@@ -123,7 +123,7 @@ export function getArgumentType (arg) {
 export function safeRequire (name) {
     let requirePath
     try {
-        /**
+        /*
          * Check if cli command was called from local directory, if not require
          * the plugin from the place where the command is called. This avoids
          * issues where user have the @wdio/cli package installed globally
@@ -136,7 +136,7 @@ export function safeRequire (name) {
         if (!require.main.paths.includes(localNodeModules)) {
             require.main.paths.push(localNodeModules)
 
-            /**
+            /*
              * don't set requireOpts when running unit tests as it
              * confuses Jest require magic
              */

--- a/packages/wdio-webdriver-mock-service/src/WebDriverMock.js
+++ b/packages/wdio-webdriver-mock-service/src/WebDriverMock.js
@@ -40,14 +40,14 @@ export default class WebDriverMock {
             if (method === 'POST') {
                 return this.scope[method.toLowerCase()](urlPath, (body) => {
                     for (const param of commandData.parameters) {
-                        /**
+                        /*
                          * check if parameter was set
                          */
                         if (!body[param.name]) {
                             return false
                         }
 
-                        /**
+                        /*
                          * check if parameter has correct type
                          */
                         if (param.required && typeof body[param.name] === 'undefined') {
@@ -55,7 +55,7 @@ export default class WebDriverMock {
                         }
                     }
 
-                    /**
+                    /*
                      * all parameters are valid
                      */
                     return true

--- a/packages/wdio-webdriver-mock-service/src/index.js
+++ b/packages/wdio-webdriver-mock-service/src/index.js
@@ -29,12 +29,12 @@ export default class WebdriverMockService {
     }
 
     before () {
-        /**
+        /*
          * assign mocks to browser object to tweak responses
          */
         global.browser.mocks = this.mocks
 
-        /**
+        /*
          * register request interceptors for specific scenarios
          */
         global.browser.addCommand('waitForElementScenario', ::this.waitForElementScenario)
@@ -163,7 +163,7 @@ export default class WebdriverMockService {
     }
 }
 
-/**
+/*
  * export for 3rd party usage
  */
 export { WebDriverMock }

--- a/packages/webdriver/src/command.js
+++ b/packages/webdriver/src/command.js
@@ -11,7 +11,7 @@ export default function (method, endpointUri, commandInfo, doubleEncodeVariables
     return function protocolCommand (...args) {
         let endpoint = endpointUri // clone endpointUri in case we change it
         const commandParams = [...variables.map((v) => Object.assign(v, {
-            /**
+            /*
              * url variables are:
              */
             required: true, // always required as they are part of the endpoint
@@ -22,7 +22,7 @@ export default function (method, endpointUri, commandInfo, doubleEncodeVariables
         const moreInfo = `\n\nFor more info see ${ref}\n`
         const body = {}
 
-        /**
+        /*
          * parameter check
          */
         const minAllowedParams = commandParams.filter((param) => param.required).length
@@ -39,14 +39,14 @@ export default function (method, endpointUri, commandInfo, doubleEncodeVariables
             )
         }
 
-        /**
+        /*
          * parameter type check
          */
         for (const [i, arg] of Object.entries(args)) {
             const commandParam = commandParams[i]
 
             if (!isValidParameter(arg, commandParam.type)) {
-                /**
+                /*
                  * ignore if argument is not required
                  */
                 if (typeof arg === 'undefined' && !commandParam.required) {
@@ -64,7 +64,7 @@ export default function (method, endpointUri, commandInfo, doubleEncodeVariables
                 )
             }
 
-            /**
+            /*
              * inject url variables
              */
             if (i < variables.length) {
@@ -73,7 +73,7 @@ export default function (method, endpointUri, commandInfo, doubleEncodeVariables
                 continue
             }
 
-            /**
+            /*
              * rest of args are part of body payload
              */
             body[commandParams[i].name] = arg

--- a/packages/webdriver/src/index.js
+++ b/packages/webdriver/src/index.js
@@ -15,7 +15,7 @@ export default class WebDriver {
             logger.setLevel('webdriver', params.logLevel)
         }
 
-        /**
+        /*
          * if the server responded with direct connect information, update the
          * params to speak directly to the appium host instead of a load
          * balancer (see https://github.com/appium/python-client#direct-connect-urls
@@ -85,7 +85,7 @@ export default class WebDriver {
     }
 }
 
-/**
+/*
  * Helper methods consumed by webdriverio package
  */
 export { getPrototype }

--- a/packages/webdriver/src/request.js
+++ b/packages/webdriver/src/request.js
@@ -53,7 +53,7 @@ export default class WebDriverRequest extends EventEmitter {
             qs: typeof options.queryParams === 'object' ? options.queryParams : {}
         }
 
-        /**
+        /*
          * only apply body property if existing
          */
         if (this.body && (Object.keys(this.body).length || this.method === 'POST')) {
@@ -65,7 +65,7 @@ export default class WebDriverRequest extends EventEmitter {
             }
         }
 
-        /**
+        /*
          * if we don't have a session id we set it here, unless we call commands that don't require session ids, for
          * example /sessions. The call to /sessions is not connected to a session itself and it therefore doesn't
          * require it
@@ -82,7 +82,7 @@ export default class WebDriverRequest extends EventEmitter {
                 : path.join(options.path, this.endpoint.replace(':sessionId', sessionId)))
         )
 
-        /**
+        /*
          * send authentication credentials only when creating new session
          */
         if (this.endpoint === '/session' && options.user && options.key) {
@@ -92,7 +92,7 @@ export default class WebDriverRequest extends EventEmitter {
             }
         }
 
-        /**
+        /*
          * if the environment variable "STRICT_SSL" is defined as "false", it doesn't require SSL certificates to be valid.
          */
         requestOptions.strictSSL = !(process.env.STRICT_SSL === 'false' || process.env.strict_ssl === 'false')
@@ -110,12 +110,12 @@ export default class WebDriverRequest extends EventEmitter {
         return new Promise((resolve, reject) => request(fullRequestOptions, (err, response, body) => {
             const error = err || getErrorFromResponseBody(body)
 
-            /**
+            /*
              * hub commands don't follow standard response formats
              * and can have empty bodies
              */
             if (this.isHubCommand) {
-                /**
+                /*
                  * if body contains HTML the command was called on a node
                  * directly without using a hub, therefor throw
                  */
@@ -126,7 +126,7 @@ export default class WebDriverRequest extends EventEmitter {
                 body = { value: body || null }
             }
 
-            /**
+            /*
              * Resolve only if successful response
              */
             if (!err && isSuccessfulResponse(response.statusCode, body)) {
@@ -134,7 +134,7 @@ export default class WebDriverRequest extends EventEmitter {
                 return resolve(body)
             }
 
-            /**
+            /*
              *  stop retrying as this will never be successful.
              *  we will handle this at the elementErrorHandler
              */
@@ -144,7 +144,7 @@ export default class WebDriverRequest extends EventEmitter {
                 return reject(error)
             }
 
-            /**
+            /*
              * stop retrying if totalRetryCount was exceeded or there is no reason to
              * retry, e.g. if sessionId is invalid
              */

--- a/packages/webdriver/src/utils.js
+++ b/packages/webdriver/src/utils.js
@@ -21,18 +21,18 @@ const BROWSER_DRIVER_ERRORS = [
  * start browser session with WebDriver protocol
  */
 export async function startWebDriverSession (params) {
-    /**
+    /*
      * the user could have passed in either w3c style or jsonwp style caps
      * and we want to pass both styles to the server, which means we need
      * to check what style the user sent in so we know how to construct the
      * object for the other style
      */
     const [w3cCaps, jsonwpCaps] = params.capabilities && params.capabilities.alwaysMatch
-        /**
+        /*
          * in case W3C compliant capabilities are provided
          */
         ? [params.capabilities, params.capabilities.alwaysMatch]
-        /**
+        /*
          * otherwise assume they passed in jsonwp-style caps (flat object)
          */
         : [{ alwaysMatch: params.capabilities, firstMatch: [{}] }, params.capabilities]
@@ -56,13 +56,13 @@ export async function startWebDriverSession (params) {
     }
     const sessionId = response.value.sessionId || response.sessionId
 
-    /**
+    /*
      * save original set of capabilities to allow to request the same session again
      * (e.g. for reloadSession command in WebdriverIO)
      */
     params.requestedCapabilities = { w3cCaps, jsonwpCaps }
 
-    /**
+    /*
      * save actual receveived session details
      */
     params.capabilities = response.value.capabilities || response.value
@@ -76,7 +76,7 @@ export async function startWebDriverSession (params) {
  * @return {Boolean}       true if request was successful
  */
 export function isSuccessfulResponse (statusCode, body) {
-    /**
+    /*
      * response contains a body
      */
     if (!body || typeof body.value === 'undefined') {
@@ -84,7 +84,7 @@ export function isSuccessfulResponse (statusCode, body) {
         return false
     }
 
-    /**
+    /*
      * ignore failing element request to enable lazy loading capability
      */
     if (
@@ -100,7 +100,7 @@ export function isSuccessfulResponse (statusCode, body) {
         return true
     }
 
-    /**
+    /*
      * if it has a status property, it should be 0
      * (just here to stay backwards compatible to the jsonwire protocol)
      */
@@ -111,14 +111,14 @@ export function isSuccessfulResponse (statusCode, body) {
 
     const hasErrorResponse = body.value && (body.value.error || body.value.stackTrace || body.value.stacktrace)
 
-    /**
+    /*
      * check status code
      */
     if (statusCode === 200 && !hasErrorResponse) {
         return true
     }
 
-    /**
+    /*
      * if an element was not found we don't flag it as failed request because
      * we lazy load it
      */
@@ -126,7 +126,7 @@ export function isSuccessfulResponse (statusCode, body) {
         return true
     }
 
-    /**
+    /*
      * that has no error property (Appium only)
      */
     if (hasErrorResponse) {
@@ -143,7 +143,7 @@ export function isSuccessfulResponse (statusCode, body) {
 export function getPrototype ({ isW3C, isChrome, isMobile, isSauce, isSeleniumStandalone }) {
     const prototype = {}
     const ProtocolCommands = merge(
-        /**
+        /*
          * if mobile apply JSONWire and WebDriver protocol because
          * some legacy JSONWire commands are still used in Appium
          * (e.g. set/get geolocation)
@@ -151,19 +151,19 @@ export function getPrototype ({ isW3C, isChrome, isMobile, isSauce, isSeleniumSt
         isMobile
             ? merge({}, JsonWProtocol, WebDriverProtocol)
             : isW3C ? WebDriverProtocol : JsonWProtocol,
-        /**
+        /*
          * only apply mobile protocol if session is actually for mobile
          */
         isMobile ? merge({}, MJsonWProtocol, AppiumProtocol) : {},
-        /**
+        /*
          * only apply special Chrome commands if session is using Chrome
          */
         isChrome ? ChromiumProtocol : {},
-        /**
+        /*
          * only Sauce Labs specific vendor commands
          */
         isSauce ? SauceLabsProtocol : {},
-        /**
+        /*
          * only apply special commands when running tests using
          * Selenium Grid or Selenium Standalone server
          */

--- a/packages/webdriverio/src/commands/browser/$.js
+++ b/packages/webdriverio/src/commands/browser/$.js
@@ -1,3 +1,7 @@
+import { findElement } from '../../utils'
+import { getElement } from '../../utils/getElementObject'
+import { ELEMENT_KEY } from '../../constants'
+
 /**
  * The `$` command is a short way to call the [`findElement`](/docs/api/webdriver.html#findelement) command in order
  * to fetch a single element on the page. It returns an object that with an extended prototype to call
@@ -47,12 +51,8 @@
  * @type utility
  *
  */
-import { findElement } from '../../utils'
-import { getElement } from '../../utils/getElementObject'
-import { ELEMENT_KEY } from '../../constants'
-
 export default async function $ (selector) {
-    /**
+    /*
      * convert protocol result into WebdriverIO element
      * e.g. when element was fetched with `getActiveElement`
      */

--- a/packages/webdriverio/src/commands/browser/custom$.js
+++ b/packages/webdriverio/src/commands/browser/custom$.js
@@ -1,3 +1,6 @@
+import { getElement } from '../../utils/getElementObject'
+import { ELEMENT_KEY } from '../../constants'
+
 /**
  *
  * The `custom$` allows you to use a custom strategy declared by using `browser.addLocatorStrategy`
@@ -21,9 +24,6 @@
  * @param {Any} strategyArguments
  * @return {Element}
  */
-import { getElement } from '../../utils/getElementObject'
-import { ELEMENT_KEY } from '../../constants'
-
 async function custom$ (strategyName, strategyArguments) {
     const strategy = this.strategies.get(strategyName)
 
@@ -33,7 +33,7 @@ async function custom$ (strategyName, strategyArguments) {
 
     let res = await this.execute(strategy, strategyArguments)
 
-    /**
+    /*
      * if the user's script returns multiple elements
      * then we just return the first one as this method
      * is intended to return just one element

--- a/packages/webdriverio/src/commands/browser/debug.js
+++ b/packages/webdriverio/src/commands/browser/debug.js
@@ -37,7 +37,7 @@ export default function debug(commandTimeout = 5000) {
     const repl = new WDIORepl()
     const { introMessage } = WDIORepl
 
-    /**
+    /*
      * run repl in standalone mode
      */
     if (!process.env.WDIO_WORKER) {
@@ -52,12 +52,12 @@ export default function debug(commandTimeout = 5000) {
         return repl.start(context)
     }
 
-    /**
+    /*
      * register worker process as debugger target
      */
     process._debugProcess(process.pid)
 
-    /**
+    /*
      * initialise repl in testrunner
      */
     process.send({
@@ -91,7 +91,7 @@ export default function debug(commandTimeout = 5000) {
                     })
                 }
 
-                /**
+                /*
                  * try to do some smart serializations
                  */
                 if (typeof result === 'function') {

--- a/packages/webdriverio/src/commands/browser/getWindowSize.js
+++ b/packages/webdriverio/src/commands/browser/getWindowSize.js
@@ -1,3 +1,5 @@
+import { getBrowserObject } from '../../utils'
+
 /**
  *
  * Returns browser window size (and position for drivers with W3C support).
@@ -18,9 +20,6 @@
  * @type window
  *
  */
-
-import { getBrowserObject } from '../../utils'
-
 export default function getWindowSize() {
     const browser = getBrowserObject(this)
 

--- a/packages/webdriverio/src/commands/browser/keys.js
+++ b/packages/webdriverio/src/commands/browser/keys.js
@@ -1,3 +1,5 @@
+import { checkUnicode } from '../../utils'
+
 /**
  *
  * Send a sequence of key strokes to the active element. You can also use characters like
@@ -23,13 +25,10 @@
  * @see https://w3c.github.io/webdriver/#dispatching-actions
  *
  */
-
-import { checkUnicode } from '../../utils'
-
 export default function keys (value) {
     let keySequence = []
 
-    /**
+    /*
      * replace key with corresponding unicode character
      */
     if (typeof value === 'string') {
@@ -42,14 +41,14 @@ export default function keys (value) {
         throw new Error('"keys" command requires a string or array of strings as parameter')
     }
 
-    /**
+    /*
      * JsonWireProtocol action
      */
     if (!this.isW3C) {
         return this.sendKeys(keySequence)
     }
 
-    /**
+    /*
      * W3C way of handle it key actions
      */
     const keyDownActions = keySequence.map((value) => ({ type: 'keyDown', value }))

--- a/packages/webdriverio/src/commands/browser/newWindow.js
+++ b/packages/webdriverio/src/commands/browser/newWindow.js
@@ -1,3 +1,4 @@
+import newWindowHelper from '../../scripts/newWindow'
 
 /**
  *
@@ -29,9 +30,6 @@
  * @alias browser.newWindow
  * @type window
  */
-
-import newWindowHelper from '../../scripts/newWindow'
-
 export default async function newWindow (url, windowName = 'New Window', windowFeatures = '') {
     /*!
      * parameter check

--- a/packages/webdriverio/src/commands/browser/react$.js
+++ b/packages/webdriverio/src/commands/browser/react$.js
@@ -1,3 +1,9 @@
+import fs from 'fs'
+import { getElement } from '../../utils/getElementObject'
+import { waitToLoadReact, react$ as react$Script } from '../../scripts/resq'
+
+const resqScript = fs.readFileSync(require.resolve('resq'))
+
 /**
  *
  * The `react$` command is a useful command to query React Components by their
@@ -26,12 +32,6 @@
  * @return {Element}
  *
  */
-import fs from 'fs'
-import { getElement } from '../../utils/getElementObject'
-import { waitToLoadReact, react$ as react$Script } from '../../scripts/resq'
-
-const resqScript = fs.readFileSync(require.resolve('resq'))
-
 export default async function react$ (selector, props = {}, state = {}) {
     await this.executeScript(resqScript.toString(), [])
     await this.execute(waitToLoadReact)

--- a/packages/webdriverio/src/commands/browser/reloadSession.js
+++ b/packages/webdriverio/src/commands/browser/reloadSession.js
@@ -25,13 +25,13 @@ const log = logger('webdriverio')
 export default async function reloadSession () {
     const oldSessionId = this.sessionId
 
-    /**
+    /*
      * end current running session, if session already gone suppress exceptions
      */
     try {
         await this.deleteSession()
     } catch (err) {
-        /**
+        /*
          * ignoring all exceptions that could be caused by browser.deleteSession()
          * there maybe times where session is ended remotely, browser.deleteSession() will fail in this case)
          * this can be worked around in code but requires a lot of overhead

--- a/packages/webdriverio/src/commands/browser/saveRecordingScreen.js
+++ b/packages/webdriverio/src/commands/browser/saveRecordingScreen.js
@@ -1,3 +1,6 @@
+import fs from 'fs'
+import { getAbsoluteFilepath, assertDirectoryExists } from '../../utils'
+
 /**
  *
  * Appium only. Save a video started by startRecordingScreen command to file.
@@ -18,12 +21,8 @@
  * @type utility
  *
  */
-
-import fs from 'fs'
-import { getAbsoluteFilepath, assertDirectoryExists } from '../../utils'
-
 export default async function saveRecordingScreen (filepath) {
-    /**
+    /*
      * type check
      */
     if (typeof filepath !== 'string') {

--- a/packages/webdriverio/src/commands/browser/saveScreenshot.js
+++ b/packages/webdriverio/src/commands/browser/saveScreenshot.js
@@ -1,3 +1,6 @@
+import fs from 'fs'
+import { getAbsoluteFilepath, assertDirectoryExists } from '../../utils'
+
 /**
  *
  * Save a screenshot of the current browsing context to a PNG file on your OS. Be aware that
@@ -17,12 +20,8 @@
  * @type utility
  *
  */
-
-import fs from 'fs'
-import { getAbsoluteFilepath, assertDirectoryExists } from '../../utils'
-
 export default async function saveScreenshot (filepath) {
-    /**
+    /*
      * type check
      */
     if (typeof filepath !== 'string' || !filepath.endsWith('.png')) {

--- a/packages/webdriverio/src/commands/browser/setTimeout.js
+++ b/packages/webdriverio/src/commands/browser/setTimeout.js
@@ -32,7 +32,7 @@ export default async function setTimeout(timeouts) {
         throw new Error('Parameter for "setTimeout" command needs to be an object')
     }
 
-    /**
+    /*
      * If value is not an integer, or it is less than 0 or greater than the maximum safe
      * integer, return error with error code invalid argument.
      */
@@ -46,7 +46,7 @@ export default async function setTimeout(timeouts) {
     const pageLoad = timeouts['page load'] || timeouts.pageLoad
     const script = timeouts.script
 
-    /**
+    /*
      * JsonWireProtocol action
      */
     if (!this.isW3C) {

--- a/packages/webdriverio/src/commands/browser/setWindowSize.js
+++ b/packages/webdriverio/src/commands/browser/setWindowSize.js
@@ -1,3 +1,5 @@
+import { getBrowserObject } from '../../utils'
+
 /**
  *
  * Resizes browser window outer size according to provided width and height.
@@ -16,21 +18,18 @@
  * @type window
  *
  */
-
-import { getBrowserObject } from '../../utils'
-
 export default function setWindowSize(width, height) {
     const minWindowSize = 0
     const maxWindowSize = 2147483647
 
-    /**
+    /*
      * type check
      */
     if (typeof width !== 'number' || typeof height !== 'number') {
         throw new Error('setWindowSize expects width and height of type number')
     }
 
-    /**
+    /*
      * value check
      */
     if ((width < minWindowSize || width > maxWindowSize) || (height < minWindowSize || height > maxWindowSize)) {

--- a/packages/webdriverio/src/commands/browser/switchWindow.js
+++ b/packages/webdriverio/src/commands/browser/switchWindow.js
@@ -40,7 +40,7 @@ export default async function switchWindow (urlOrTitleToMatch) {
     for (const tab of tabs) {
         await this.switchToWindow(tab)
 
-        /**
+        /*
          * check if url matches
          */
         const url = await this.getUrl()
@@ -48,7 +48,7 @@ export default async function switchWindow (urlOrTitleToMatch) {
             return tab
         }
 
-        /**
+        /*
          * check title
          */
         const title = await this.getTitle()

--- a/packages/webdriverio/src/commands/browser/touchAction.js
+++ b/packages/webdriverio/src/commands/browser/touchAction.js
@@ -1,3 +1,5 @@
+import { touchAction as touchActionCommand } from '../constant'
+
 /**
  *
  * The Touch Action API provides the basis of all gestures that can be automated in Appium.
@@ -58,9 +60,6 @@
  * @uses mobile/performTouchAction, mobile/performMultiAction
  *
  */
-
-import { touchAction as touchActionCommand } from '../constant'
-
 export default function touchAction (...args) {
     return touchActionCommand.apply(this, args)
 }

--- a/packages/webdriverio/src/commands/browser/uploadFile.js
+++ b/packages/webdriverio/src/commands/browser/uploadFile.js
@@ -1,3 +1,7 @@
+import fs from 'fs'
+import path from 'path'
+import archiver from 'archiver'
+
 /**
  * Uploads a file to the Selenium Standalone server or other browser driver
  * (e.g. Chromedriver) by using the [`file`](/api/protocol/file.html) command.
@@ -22,19 +26,15 @@
  * @uses protocol/file
  * @return {String} remote URL
  */
-import fs from 'fs'
-import path from 'path'
-import archiver from 'archiver'
-
 export default async function uploadFile (localPath) {
-    /**
+    /*
      * parameter check
      */
     if (typeof localPath !== 'string') {
         throw new Error('number or type of arguments don\'t agree with uploadFile command')
     }
 
-    /**
+    /*
      * check if command is available
      */
     if (typeof this.file !== 'function') {

--- a/packages/webdriverio/src/commands/browser/url.js
+++ b/packages/webdriverio/src/commands/browser/url.js
@@ -1,3 +1,6 @@
+import nodeUrl from 'url'
+import { validateUrl } from '../../utils'
+
 /**
  *
  * Protocol binding to load the URL of the browser. If a baseUrl is
@@ -31,10 +34,6 @@
  * @type protocol
  *
  */
-
-import nodeUrl from 'url'
-import { validateUrl } from '../../utils'
-
 export default function url (path) {
     if (typeof path !== 'string') {
         throw new Error('Parameter for "url" command needs to be type of string')

--- a/packages/webdriverio/src/commands/browser/waitUntil.js
+++ b/packages/webdriverio/src/commands/browser/waitUntil.js
@@ -1,3 +1,5 @@
+import Timer from '../../utils/Timer'
+
 /**
  *
  * This wait command is your universal weapon if you want to wait on something. It expects a condition
@@ -34,9 +36,6 @@
  * @type utility
  *
  */
-
-import Timer from '../../utils/Timer'
-
 export default function (condition, timeout, timeoutMsg, interval) {
     if (typeof condition !== 'function') {
         throw new Error('Condition is not a function')

--- a/packages/webdriverio/src/commands/constant.js
+++ b/packages/webdriverio/src/commands/constant.js
@@ -1,5 +1,5 @@
 /**
- * Constants around commands
+ * @fileoverview Constants around commands
  */
 
 const TOUCH_ACTIONS = ['press', 'longPress', 'tap', 'moveTo', 'wait', 'release']

--- a/packages/webdriverio/src/commands/constant.js
+++ b/packages/webdriverio/src/commands/constant.js
@@ -18,7 +18,7 @@ export const formatArgs = function (scope, actions) {
 
         const formattedAction = { action: action.action, options: {} }
 
-        /**
+        /*
          * don't propagate for actions that don't require element options
          */
         const actionElement = action.element && typeof action.element.elementId === 'string'
@@ -32,7 +32,7 @@ export const formatArgs = function (scope, actions) {
         if (isFinite(action.y)) formattedAction.options.y = action.y
         if (action.ms) formattedAction.options.ms = action.ms
 
-        /**
+        /*
          * remove options property if empty
          */
         if (Object.keys(formattedAction.options).length === 0) {

--- a/packages/webdriverio/src/commands/element/$.js
+++ b/packages/webdriverio/src/commands/element/$.js
@@ -1,3 +1,7 @@
+import { findElement } from '../../utils'
+import { getElement } from '../../utils/getElementObject'
+import { ELEMENT_KEY } from '../../constants'
+
 /**
  * The `$` command is a short way to call the [`findElement`](/docs/api/webdriver.html#findelement) command in order
  * to fetch a single element on the page similar to the `$` command from the browser scope. The difference when calling
@@ -48,12 +52,8 @@
  * @type utility
  *
  */
-import { findElement } from '../../utils'
-import { getElement } from '../../utils/getElementObject'
-import { ELEMENT_KEY } from '../../constants'
-
 export default async function $ (selector) {
-    /**
+    /*
      * convert protocol result into WebdriverIO element
      * e.g. when element was fetched with `getActiveElement`
      */

--- a/packages/webdriverio/src/commands/element/addValue.js
+++ b/packages/webdriverio/src/commands/element/addValue.js
@@ -1,3 +1,5 @@
+import { transformToCharString } from '../../utils'
+
 /**
  *
  * Add a value to an object found by given selector. You can also use unicode
@@ -24,9 +26,6 @@
  * @type action
  *
  */
-
-import { transformToCharString } from '../../utils'
-
 export default function addValue (value) {
     if (!this.isW3C) {
         return this.elementSendKeys(this.elementId, transformToCharString(value))

--- a/packages/webdriverio/src/commands/element/custom$.js
+++ b/packages/webdriverio/src/commands/element/custom$.js
@@ -1,3 +1,7 @@
+import { getElement } from '../../utils/getElementObject'
+import { getBrowserObject } from '../../utils'
+import { ELEMENT_KEY } from '../../constants'
+
 /**
  *
  * The `custom$` allows you to use a custom strategy declared by using `browser.addLocatorStrategy`
@@ -22,10 +26,6 @@
  * @param {Any} strategyArguments
  * @return {Element}
  */
-import { getElement } from '../../utils/getElementObject'
-import { getBrowserObject } from '../../utils'
-import { ELEMENT_KEY } from '../../constants'
-
 async function custom$ (strategyName, strategyArguments) {
     const browserObject = getBrowserObject(this)
     const strategy = browserObject.strategies.get(strategyName)
@@ -34,7 +34,7 @@ async function custom$ (strategyName, strategyArguments) {
         throw Error('No strategy found for ' + strategyName)
     }
 
-    /**
+    /*
      * fail if root element is not found, similar to:
      * $('.notExisting').$('.someElem')
      */
@@ -44,7 +44,7 @@ async function custom$ (strategyName, strategyArguments) {
 
     let res = await this.execute(strategy, strategyArguments, this)
 
-    /**
+    /*
      * if the user's script returns multiple elements
      * then we just return the first one as this method
      * is intended to return just one element

--- a/packages/webdriverio/src/commands/element/doubleClick.js
+++ b/packages/webdriverio/src/commands/element/doubleClick.js
@@ -22,7 +22,7 @@
  *
  */
 export default async function doubleClick () {
-    /**
+    /*
      * move to element
      */
 
@@ -31,7 +31,7 @@ export default async function doubleClick () {
         return this.positionDoubleClick()
     }
 
-    /**
+    /*
      * W3C way of handle the double click actions
      */
     await this.performActions([{

--- a/packages/webdriverio/src/commands/element/dragAndDrop.js
+++ b/packages/webdriverio/src/commands/element/dragAndDrop.js
@@ -1,3 +1,7 @@
+import { getElementRect, getScrollPosition } from '../../utils'
+
+const ACTION_BUTTON = 0
+
 /**
  *
  * Drag an item to a destination element.
@@ -9,11 +13,6 @@
  * @type action
  *
  */
-
-import { getElementRect, getScrollPosition } from '../../utils'
-
-const ACTION_BUTTON = 0
-
 export default async function dragAndDrop (target, duration = 100) {
     if (!target || target.constructor.name !== 'Element') {
         throw new Error('command dragAndDrop requires an WebdriverIO Element as first parameter')
@@ -26,7 +25,7 @@ export default async function dragAndDrop (target, duration = 100) {
         return this.buttonUp(ACTION_BUTTON)
     }
 
-    /**
+    /*
      * get coordinates to drag and drop
      */
     const { scrollX, scrollY } = await getScrollPosition(this)
@@ -37,7 +36,7 @@ export default async function dragAndDrop (target, duration = 100) {
     const targetX = parseInt(targetRect.x - scrollX + (targetRect.width / 2), 10) - sourceX
     const targetY = parseInt(targetRect.y - scrollY + (targetRect.height / 2), 10) - sourceY
 
-    /**
+    /*
      * W3C way of handle the drag and drop action
      */
     return this.performActions([{

--- a/packages/webdriverio/src/commands/element/getCSSProperty.js
+++ b/packages/webdriverio/src/commands/element/getCSSProperty.js
@@ -1,3 +1,5 @@
+import { parseCSS } from '../../utils'
+
 /**
  *
  * Get a css property from a DOM-element selected by given selector. The return value
@@ -64,9 +66,6 @@
  * @type property
  *
  */
-
-import { parseCSS } from '../../utils'
-
 export default async function getCSSProperty (cssProperty) {
     const cssValue = await this.getElementCSSValue(this.elementId, cssProperty)
     return parseCSS(cssValue, cssProperty)

--- a/packages/webdriverio/src/commands/element/getHTML.js
+++ b/packages/webdriverio/src/commands/element/getHTML.js
@@ -1,3 +1,7 @@
+import { ELEMENT_KEY } from '../../constants'
+import { getBrowserObject } from '../../utils'
+import getHTMLScript from '../../scripts/getHTML'
+
 /**
  *
  * Get source code of specified DOM element by selector.
@@ -28,11 +32,6 @@
  * @type property
  *
  */
-
-import { ELEMENT_KEY } from '../../constants'
-import { getBrowserObject } from '../../utils'
-import getHTMLScript from '../../scripts/getHTML'
-
 export default function getHTML (includeSelectorTag = true) {
     return getBrowserObject(this).execute(getHTMLScript, {
         [ELEMENT_KEY]: this.elementId, // w3c compatible

--- a/packages/webdriverio/src/commands/element/getLocation.js
+++ b/packages/webdriverio/src/commands/element/getLocation.js
@@ -1,3 +1,5 @@
+import { getElementRect } from '../../utils'
+
 /**
  *
  * Determine an element’s location on the page. The point (0, 0) refers to
@@ -25,9 +27,6 @@
  * @uses protocol/elementIdLocation
  * @type property
  */
-
-import { getElementRect } from '../../utils'
-
 export default async function getLocation (prop) {
     let location = {}
 

--- a/packages/webdriverio/src/commands/element/getSize.js
+++ b/packages/webdriverio/src/commands/element/getSize.js
@@ -1,3 +1,5 @@
+import { getElementRect } from '../../utils'
+
 /**
  *
  * Get the width and height for an DOM-element.
@@ -25,9 +27,6 @@
  * @type property
  *
  */
-
-import { getElementRect } from '../../utils'
-
 export default async function getSize(prop = null) {
     let rect = {}
 

--- a/packages/webdriverio/src/commands/element/isClickable.js
+++ b/packages/webdriverio/src/commands/element/isClickable.js
@@ -1,3 +1,6 @@
+import { ELEMENT_KEY } from '../../constants'
+import { getBrowserObject } from '../../utils'
+import isElementClickableScript from '../../scripts/isElementClickable'
 
 /**
  *
@@ -30,11 +33,6 @@
  * @type state
  *
  */
-
-import { ELEMENT_KEY } from '../../constants'
-import { getBrowserObject } from '../../utils'
-import isElementClickableScript from '../../scripts/isElementClickable'
-
 export default async function isClickable () {
     if (!await this.isDisplayed()) {
         return false

--- a/packages/webdriverio/src/commands/element/isDisplayedInViewport.js
+++ b/packages/webdriverio/src/commands/element/isDisplayedInViewport.js
@@ -1,3 +1,6 @@
+import { ELEMENT_KEY } from '../../constants'
+import { getBrowserObject } from '../../utils'
+import isElementInViewportScript from '../../scripts/isElementInViewport'
 
 /**
  *
@@ -35,11 +38,6 @@
  * @type state
  *
  */
-
-import { ELEMENT_KEY } from '../../constants'
-import { getBrowserObject } from '../../utils'
-import isElementInViewportScript from '../../scripts/isElementInViewport'
-
 export default async function isDisplayedInViewport () {
     if (!await this.isDisplayed()) {
         return false

--- a/packages/webdriverio/src/commands/element/isFocused.js
+++ b/packages/webdriverio/src/commands/element/isFocused.js
@@ -1,3 +1,7 @@
+import { ELEMENT_KEY } from '../../constants'
+import { getBrowserObject } from '../../utils'
+import isFocusedScript from '../../scripts/isFocused'
+
 /**
  *
  * Return true or false if the selected DOM-element currently has focus. If the selector matches
@@ -24,11 +28,6 @@
  * @type state
  *
  */
-
-import { ELEMENT_KEY } from '../../constants'
-import { getBrowserObject } from '../../utils'
-import isFocusedScript from '../../scripts/isFocused'
-
 export default async function isFocused () {
     const isFocused = await getBrowserObject(this).execute(isFocusedScript, {
         [ELEMENT_KEY]: this.elementId, // w3c compatible

--- a/packages/webdriverio/src/commands/element/moveTo.js
+++ b/packages/webdriverio/src/commands/element/moveTo.js
@@ -1,5 +1,6 @@
+import { getElementRect, getScrollPosition } from '../../utils'
+
 /**
- *
  * Move the mouse by an offset of the specified element. If no element is specified,
  * the move is relative to the current mouse cursor. If an element is provided but
  * no offset, the mouse will be moved to the center of the element. If the element
@@ -11,15 +12,12 @@
  * @see  https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidmoveto
  * @type protocol
  */
-
-import { getElementRect, getScrollPosition } from '../../utils'
-
 export default async function moveTo (xoffset, yoffset) {
     if (!this.isW3C) {
         return this.moveToElement(this.elementId, xoffset, yoffset)
     }
 
-    /**
+    /*
      * get rect of element
      */
     const { x, y, width, height } = await getElementRect(this)
@@ -27,7 +25,7 @@ export default async function moveTo (xoffset, yoffset) {
     const newXoffset = parseInt(x + (typeof xoffset === 'number' ? xoffset : (width / 2)), 10) - scrollX
     const newYoffset = parseInt(y + (typeof yoffset === 'number' ? yoffset : (height / 2)), 10) - scrollY
 
-    /**
+    /*
      * W3C way of handle the mouse move actions
      */
     return this.performActions([{

--- a/packages/webdriverio/src/commands/element/react$.js
+++ b/packages/webdriverio/src/commands/element/react$.js
@@ -1,3 +1,9 @@
+import fs from 'fs'
+import { getElement } from '../../utils/getElementObject'
+import { waitToLoadReact, react$ as react$Script } from '../../scripts/resq'
+
+const resqScript = fs.readFileSync(require.resolve('resq'))
+
 /**
  *
  * The `react$` command is a useful command to query React Components by their
@@ -27,12 +33,6 @@
  * @return {Element}
  *
  */
-import fs from 'fs'
-import { getElement } from '../../utils/getElementObject'
-import { waitToLoadReact, react$ as react$Script } from '../../scripts/resq'
-
-const resqScript = fs.readFileSync(require.resolve('resq'))
-
 export default async function react$(selector, props = {}, state = {}) {
     await this.executeScript(resqScript.toString(), [])
     await this.execute(waitToLoadReact)

--- a/packages/webdriverio/src/commands/element/saveScreenshot.js
+++ b/packages/webdriverio/src/commands/element/saveScreenshot.js
@@ -1,3 +1,6 @@
+import fs from 'fs'
+import { getAbsoluteFilepath, assertDirectoryExists } from '../../utils'
+
 /**
  *
  * Save a screenshot of an element to a PNG file on your OS.
@@ -16,12 +19,8 @@
  * @type utility
  *
  */
-
-import fs from 'fs'
-import { getAbsoluteFilepath, assertDirectoryExists } from '../../utils'
-
 export default async function saveScreenshot (filepath) {
-    /**
+    /*
      * type check
      */
     if (typeof filepath !== 'string' || !filepath.endsWith('.png')) {

--- a/packages/webdriverio/src/commands/element/scrollIntoView.js
+++ b/packages/webdriverio/src/commands/element/scrollIntoView.js
@@ -1,3 +1,5 @@
+import { ELEMENT_KEY } from '../../constants'
+
 /**
  *
  * Scroll element into viewport.
@@ -18,9 +20,6 @@
  * @type utility
  *
  */
-
-import { ELEMENT_KEY } from '../../constants'
-
 export default function scrollIntoView (scrollIntoViewOptions = true) {
     return this.parent.execute(/* istanbul ignore next */function (elem, options) {
         elem.scrollIntoView(options)

--- a/packages/webdriverio/src/commands/element/selectByAttribute.js
+++ b/packages/webdriverio/src/commands/element/selectByAttribute.js
@@ -1,3 +1,5 @@
+import { getElementFromResponse } from '../../utils'
+
 /**
  *
  * Select option with a specific value.
@@ -33,18 +35,15 @@
  * @type action
  *
  */
-
-import { getElementFromResponse } from '../../utils'
-
 export default async function selectByAttribute (attribute, value) {
-    /**
+    /*
      * convert value into string
      */
     value = typeof value === 'number'
         ? value.toString()
         : value
 
-    /**
+    /*
     * find option elememnt using xpath
     */
     const normalized = `[normalize-space(@${attribute.trim()}) = "${value.trim()}"]`
@@ -54,7 +53,7 @@ export default async function selectByAttribute (attribute, value) {
         throw new Error(`Option with attribute "${attribute}=${value}" not found.`)
     }
 
-    /**
+    /*
     * select option
     */
     return this.elementClick(getElementFromResponse(optionElement))

--- a/packages/webdriverio/src/commands/element/selectByIndex.js
+++ b/packages/webdriverio/src/commands/element/selectByIndex.js
@@ -1,3 +1,5 @@
+import { getElementFromResponse } from '../../utils'
+
 /**
  *
  * Select option with a specific index.
@@ -27,18 +29,15 @@
  * @type action
  *
  */
-
-import { getElementFromResponse } from '../../utils'
-
 export default async function selectByIndex (index) {
-    /**
+    /*
      * negative index check
      */
     if (index < 0) {
         throw new Error('Index needs to be 0 or any other positive number')
     }
 
-    /**
+    /*
     * get option elememnts using css
     */
     const optionElements = await this.findElementsFromElement(this.elementId, 'css selector',  'option')
@@ -51,7 +50,7 @@ export default async function selectByIndex (index) {
         throw new Error(`Option with index "${index}" not found. Select element only contains ${optionElements.length} option elements`)
     }
 
-    /**
+    /*
     * select option
     */
     return this.elementClick(getElementFromResponse(optionElements[index]))

--- a/packages/webdriverio/src/commands/element/selectByVisibleText.js
+++ b/packages/webdriverio/src/commands/element/selectByVisibleText.js
@@ -1,3 +1,5 @@
+import { getElementFromResponse } from '../../utils'
+
 /**
  *
  * Select option with displayed text matching the argument.
@@ -27,11 +29,8 @@
  * @type action
  *
  */
-
-import { getElementFromResponse } from '../../utils'
-
 export default async function selectByVisibleText (text) {
-    /**
+    /*
      * convert value into string
      */
     text = typeof text === 'number'
@@ -42,7 +41,7 @@ export default async function selectByVisibleText (text) {
         .trim() // strip leading and trailing white-space characters
         .replace(/\s+/, ' ') // replace sequences of whitespace characters by a single space
 
-    /**
+    /*
     * find option element using xpath
     */
     const formatted = /"/.test(normalized)
@@ -64,7 +63,7 @@ export default async function selectByVisibleText (text) {
         throw new Error(`Option with text "${text}" not found.`)
     }
 
-    /**
+    /*
     * select option
     */
     return this.elementClick(getElementFromResponse(optionElement))

--- a/packages/webdriverio/src/commands/element/shadow$.js
+++ b/packages/webdriverio/src/commands/element/shadow$.js
@@ -1,3 +1,5 @@
+import { shadowFnFactory } from '../../scripts/shadowFnFactory'
+
 /**
  *
  * Access an element inside a given element's shadowRoot
@@ -16,9 +18,6 @@
  * @type utility
  *
  */
-
-import { shadowFnFactory } from '../../scripts/shadowFnFactory'
-
 export default async function shadowRoot (selector) {
     return await this.$(shadowFnFactory(selector))
 }

--- a/packages/webdriverio/src/commands/element/touchAction.js
+++ b/packages/webdriverio/src/commands/element/touchAction.js
@@ -1,5 +1,6 @@
+import { touchAction as touchActionCommand } from '../constant'
+
 /**
- *
  * The Touch Action API provides the basis of all gestures that can be automated in Appium.
  * It is currently only available to native apps and can not be used to interact with webapps.
  * At its core is the ability to chain together _ad hoc_ individual actions, which will then be
@@ -51,9 +52,6 @@
  * @uses mobile/performTouchAction, mobile/performMultiAction
  *
  */
-
-import { touchAction as touchActionCommand } from '../constant'
-
 export default function touchAction (...args) {
     return touchActionCommand.apply(this, args)
 }

--- a/packages/webdriverio/src/commands/element/waitUntil.js
+++ b/packages/webdriverio/src/commands/element/waitUntil.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Nothing to see here!
  * The original implementation is in [the browser scope](https://webdriver.io/docs/api/browser/waitUntil.html). Since the element
  * scope should be able to query sub elements of itself this command is

--- a/packages/webdriverio/src/constants.js
+++ b/packages/webdriverio/src/constants.js
@@ -2,18 +2,18 @@
 
 const HOOK_DEFINITION = {
     type: (param) => {
-        /**
+        /*
          * option must be an array
          */
         if (!Array.isArray(param)) {
             throw new Error('a hook option needs to be a list of functions')
         }
 
-        /**
+        /*
          * array elements must be functions
          */
         for (const option of param) {
-            /**
+            /*
              * either a string
              */
             if (typeof option === 'function') {
@@ -29,7 +29,7 @@ const HOOK_DEFINITION = {
 export const ELEMENT_KEY = 'element-6066-11e4-a52e-4f735466cecf'
 
 export const WDIO_DEFAULTS = {
-    /**
+    /*
      * allows to specify automation protocol
      */
     automationProtocol: {
@@ -52,7 +52,7 @@ export const WDIO_DEFAULTS = {
             }
         }
     },
-    /**
+    /*
      * define specs for test execution
      */
     specs: {
@@ -62,7 +62,7 @@ export const WDIO_DEFAULTS = {
             }
         }
     },
-    /**
+    /*
      * exclude specs from test execution
      */
     exclude: {
@@ -72,19 +72,19 @@ export const WDIO_DEFAULTS = {
             }
         }
     },
-    /**
+    /*
      * key/value definition of suites (named by key) and a list of specs as value
      * to specify a specific set of tests to execute
      */
     suites: {
         type: 'object'
     },
-    /**
+    /*
      * capabilities of WebDriver sessions
      */
     capabilities: {
         type: (param) => {
-            /**
+            /*
              * should be an object
              */
             if (!Array.isArray(param)) {
@@ -95,7 +95,7 @@ export const WDIO_DEFAULTS = {
                 throw new Error('the "capabilities" options needs to be an object or a list of objects')
             }
 
-            /**
+            /*
              * or an array of objects
              */
             for (const option of param) {
@@ -110,13 +110,13 @@ export const WDIO_DEFAULTS = {
         },
         required: true
     },
-    /**
+    /*
      * Shorten navigateTo command calls by setting a base url
      */
     baseUrl: {
         type: 'string'
     },
-    /**
+    /*
      * If you only want to run your tests until a specific amount of tests have failed use
      * bail (default is 0 - don't bail, run all tests).
      */
@@ -124,27 +124,27 @@ export const WDIO_DEFAULTS = {
         type: 'number',
         default: 0
     },
-    /**
+    /*
      * Default interval for all waitFor* commands
      */
     waitforInterval: {
         type: 'number',
         default: 500
     },
-    /**
+    /*
      * Default timeout for all waitFor* commands
      */
     waitforTimeout: {
         type: 'number',
         default: 3000
     },
-    /**
+    /*
      * supported test framework by wdio testrunner
      */
     framework: {
         type: 'string'
     },
-    /**
+    /*
      * list of reporters to use, a reporter can be either a string or an object with
      * reporter options, e.g.:
      * [
@@ -157,7 +157,7 @@ export const WDIO_DEFAULTS = {
      */
     reporters: {
         type: (param) => {
-            /**
+            /*
              * option must be an array
              */
             if (!Array.isArray(param)) {
@@ -169,18 +169,18 @@ export const WDIO_DEFAULTS = {
                 (typeof option === 'function')
             )
 
-            /**
+            /*
              * array elements must be:
              */
             for (const option of param) {
-                /**
+                /*
                  * either a string or a function (custom reporter)
                  */
                 if (isValidReporter(option)) {
                     continue
                 }
 
-                /**
+                /*
                  * or an array with the name of the reporter as first element and the options
                  * as second element
                  */
@@ -202,19 +202,19 @@ export const WDIO_DEFAULTS = {
             return true
         }
     },
-    /**
+    /*
      * set of WDIO services to use
      */
     services: {
         type: (param) => {
-            /**
+            /*
              * should be an array
              */
             if (!Array.isArray(param)) {
                 throw new Error('the "services" options needs to be a list of strings and/or arrays')
             }
 
-            /**
+            /*
              * with arrays and/or strings
              */
             for (const option of param) {
@@ -230,7 +230,7 @@ export const WDIO_DEFAULTS = {
         },
         default: []
     },
-    /**
+    /*
      * Node arguments to specify when launching child processes
      */
     execArgv: {
@@ -241,26 +241,26 @@ export const WDIO_DEFAULTS = {
         },
         default: []
     },
-    /**
+    /*
      * amount of instances to be allowed to run in total
      */
     maxInstances: {
         type: 'number'
     },
-    /**
+    /*
      * amount of instances to be allowed to run per capability
      */
     maxInstancesPerCapability: {
         type: 'number'
     },
-    /**
+    /*
      * directory for log files
      */
     outputDir: {
         type: 'string',
         default: process.cwd()
     },
-    /**
+    /*
      * list of strings to watch of `wdio` command is called with `--watch` flag
      */
     filesToWatch: {
@@ -271,7 +271,7 @@ export const WDIO_DEFAULTS = {
         }
     },
 
-    /**
+    /*
      * hooks
      */
     onPrepare: HOOK_DEFINITION,
@@ -290,7 +290,7 @@ export const WDIO_DEFAULTS = {
     onComplete: HOOK_DEFINITION,
     onReload: HOOK_DEFINITION,
 
-    /**
+    /*
      * cucumber specific hooks
      */
     beforeFeature: HOOK_DEFINITION,

--- a/packages/webdriverio/src/index.js
+++ b/packages/webdriverio/src/index.js
@@ -44,7 +44,7 @@ export const remote = async function (params = {}, remoteModifier) {
     const commandWrapper = params.runner ? wrapCommand : (_, origFn) => origFn
     const instance = await ProtocolDriver.newSession(params, modifier, prototype, commandWrapper)
 
-    /**
+    /*
      * we need to overwrite the original addCommand and overwriteCommand
      * in order to wrap the function within Fibers (only if webdriverio
      * is used with @wdio/cli)
@@ -75,7 +75,7 @@ export const multiremote = async function (params = {}, config = {}) {
     const multibrowser = new MultiRemote()
     const browserNames = Object.keys(params)
 
-    /**
+    /*
      * create all instance sessions
      */
     await Promise.all(
@@ -85,7 +85,7 @@ export const multiremote = async function (params = {}, config = {}) {
         })
     )
 
-    /**
+    /*
      * use attachToSession capability to wrap instances around blank pod
      */
     const prototype = getPrototype('browser')
@@ -98,7 +98,7 @@ export const multiremote = async function (params = {}, config = {}) {
     const ProtocolDriver = isStub(config.automationProtocol) ? require(config.automationProtocol).default : WebDriver
     const driver = ProtocolDriver.attachToSession(sessionParams, ::multibrowser.modifier, prototype, wrapCommand)
 
-    /**
+    /*
      * in order to get custom command overwritten or added to multiremote instance
      * we need to pass in the prototype of the multibrowser
      */

--- a/packages/webdriverio/src/middlewares.js
+++ b/packages/webdriverio/src/middlewares.js
@@ -17,7 +17,7 @@ export const elementErrorHandler = (fn) => (commandName, commandFn) => {
             try {
                 const result = await fn(commandName, commandFn).apply(this, args)
 
-                /**
+                /*
                  * assume Safari responses like { error: 'no such element', message: '', stacktrace: '' }
                  * as `stale element reference`
                  */

--- a/packages/webdriverio/src/multiremote.js
+++ b/packages/webdriverio/src/multiremote.js
@@ -43,7 +43,7 @@ export default class MultiRemote {
         this.baseInstance = new MultiRemoteDriver(this.instances, propertiesObject)
         const client = Object.create(this.baseInstance, propertiesObject)
 
-        /**
+        /*
          * attach instances to wrapper client
          */
         for (const [identifier, instance] of Object.entries(this.instances)) {
@@ -72,7 +72,7 @@ export default class MultiRemote {
         const prototype = { ...propertiesObject, ...clone(getPrototype('element')), scope: 'element' }
 
         const element = webdriverMonad({}, (client) => {
-            /**
+            /*
              * attach instances to wrapper client
              */
             for (const [i, identifier] of Object.entries(Object.keys(instances))) {
@@ -97,7 +97,7 @@ export default class MultiRemote {
                 Object.entries(instances).map(([, instance]) => instance[commandName](...args))
             )
 
-            /**
+            /*
              * return element object to call commands directly
              */
             if (commandName === '$') {

--- a/packages/webdriverio/src/protocol-stub.js
+++ b/packages/webdriverio/src/protocol-stub.js
@@ -34,7 +34,7 @@ export default class ProtocolStub {
             return ProtocolStub.newSession(options)
         }
 
-        /**
+        /*
          * MultiRemote
          */
         return addCommands(modifier({

--- a/packages/webdriverio/src/utils.js
+++ b/packages/webdriverio/src/utils.js
@@ -33,7 +33,7 @@ const applyScopePrototype = (prototype, scope) => {
 export const getPrototype = (scope) => {
     const prototype = {}
 
-    /**
+    /*
      * register action commands
      */
     applyScopePrototype(prototype, scope)
@@ -48,21 +48,21 @@ export const getPrototype = (scope) => {
  * @return {?string}   element id or null if element couldn't be found
  */
 export const getElementFromResponse = (res) => {
-    /**
+    /*
     * a function selector can return null
     */
     if (!res) {
         return null
     }
 
-    /**
+    /*
      * deprecated JSONWireProtocol response
      */
     if (res.ELEMENT) {
         return res.ELEMENT
     }
 
-    /**
+    /*
      * W3C WebDriver response
      */
     if (res[ELEMENT_KEY]) {
@@ -134,12 +134,12 @@ export function parseCSS (cssPropertyValue, cssProperty) {
     }
 
     if (parsedValue.value.indexOf('rgb') === 0) {
-        /**
+        /*
          * remove whitespaces in rgb values
          */
         parsedValue.value = parsedValue.value.replace(/\s/g, '')
 
-        /**
+        /*
          * parse color values
          */
         let color = parsedValue.value
@@ -154,7 +154,7 @@ export function parseCSS (cssPropertyValue, cssProperty) {
         parsedValue.value = sanitizeCSS(font[0].value || font[0].string)
         parsedValue.parsed = { value, type: 'font', string }
     } else {
-        /**
+        /*
          * parse other css properties
          */
         try {
@@ -191,7 +191,7 @@ function fetchElementByJSFunction (selector, scope) {
     if (!scope.elementId) {
         return scope.execute(selector)
     }
-    /**
+    /*
      * use a regular function because IE does not understand arrow functions
      */
     const script = (function (elem) { return (selector).call(elem) }).toString().replace('selector', `(${selector.toString()})`)
@@ -202,7 +202,7 @@ function fetchElementByJSFunction (selector, scope) {
  * logic to find an element
  */
 export async function findElement(selector) {
-    /**
+    /*
      * fetch element using regular protocol command
      */
     if (typeof selector === 'string') {
@@ -212,7 +212,7 @@ export async function findElement(selector) {
             : this.findElement(using, value)
     }
 
-    /**
+    /*
      * fetch element with JS function
      */
     if (typeof selector === 'function') {
@@ -229,7 +229,7 @@ export async function findElement(selector) {
  * logic to find a elements
  */
 export async function findElements(selector) {
-    /**
+    /*
      * fetch element using regular protocol command
      */
     if (typeof selector === 'string') {
@@ -239,7 +239,7 @@ export async function findElements(selector) {
             : this.findElements(using, value)
     }
 
-    /**
+    /*
      * fetch element with JS function
      */
     if (typeof selector === 'function') {
@@ -282,7 +282,7 @@ export async function getElementRect(scope) {
 
     let defaults = { x: 0, y: 0, width: 0, height: 0 }
 
-    /**
+    /*
      * getElementRect workaround for Safari 12.0.3
      * if one of [x, y, height, width] is undefined get rect with javascript
      */
@@ -344,7 +344,7 @@ export function validateUrl (url, origError) {
         const urlObject = new URL(url)
         return urlObject.href
     } catch (e) {
-        /**
+        /*
          * if even adding http:// doesn't help, fail with original error
          */
         if (origError) {

--- a/packages/webdriverio/src/utils/Timer.js
+++ b/packages/webdriverio/src/utils/Timer.js
@@ -19,7 +19,7 @@ class Timer {
         this._leading = leading
         this._conditionExecutedCnt = 0
 
-        /**
+        /*
          * only wrap waitUntil condition if:
          *  - wdio-sync is installed
          *  - function name is not async
@@ -49,7 +49,7 @@ class Timer {
         }
 
         this._mainTimeoutId = setTimeout(() => {
-            /**
+            /*
              * make sure that condition was executed at least once
              */
             if (!this.wasConditionExecuted()) {

--- a/packages/webdriverio/src/utils/findStrategy.js
+++ b/packages/webdriverio/src/utils/findStrategy.js
@@ -187,7 +187,7 @@ export const findStrategy = function (selector, isW3C, isMobile) {
     }
     }
 
-    /**
+    /*
      * ensure selector strategy is supported
      */
     if (!isMobile && isW3C && !W3C_SELECTOR_STRATEGIES.includes(using)) {

--- a/packages/webdriverio/src/utils/getElementObject.js
+++ b/packages/webdriverio/src/utils/getElementObject.js
@@ -19,12 +19,12 @@ export const getElement = function findElement (selector, res, isReactElement = 
         const elementId = getElementFromResponse(res)
 
         if (elementId) {
-            /**
+            /*
              * set elementId for easy access
              */
             client.elementId = elementId
 
-            /**
+            /*
              * set element id with proper key so element can be passed into execute commands
              */
             if (this.isW3C) {
@@ -69,12 +69,12 @@ export const getElements = function getElements (selector, res, isReactElement =
             const elementId = getElementFromResponse(res)
 
             if (elementId) {
-                /**
+                /*
                  * set elementId for easy access
                  */
                 client.elementId = elementId
 
-                /**
+                /*
                  * set element id with proper key so element can be passed into execute commands
                  */
                 if (this.isW3C) {

--- a/packages/webdriverio/src/utils/implicitWait.js
+++ b/packages/webdriverio/src/utils/implicitWait.js
@@ -19,7 +19,7 @@ export default async function implicitWait (currentElement, commandName) {
 
         try {
             await currentElement.waitForExist()
-            /**
+            /*
              * if waitForExist was successful requery element and assign elementId to the scope
              */
             return await currentElement.parent.$(currentElement.selector)

--- a/packages/webdriverio/src/utils/refetchElement.js
+++ b/packages/webdriverio/src/utils/refetchElement.js
@@ -24,7 +24,7 @@ export default async function refetchElement (currentElement, commandName) {
         const resolvedElement = await elementPromise
         let nextElement = index > 0 ? (await resolvedElement.$$(selector))[index] : null
         nextElement = nextElement || await resolvedElement.$(selector)
-        /**
+        /*
          *  For error purposes, changing command name to '$' if we aren't
          *  on the last element of the array
          */

--- a/scripts/changelog.js
+++ b/scripts/changelog.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-/**
+/*
  * script to auto update CHANGELOG.md file
  */
 const fs = require('fs')
@@ -27,7 +27,7 @@ const config = load({ nextVersionFromMetadata: false })
 config.nextVersion = version
 const changelog = new Changelog(config)
 
-/**
+/*
  * update local tags
  */
 shell.exec('git fetch --tags --force')
@@ -39,7 +39,7 @@ const BANNER = `
 ###                 ###
 #######################`
 
-/**
+/*
  * in case the error check above doesn't has any effect and a release
  * was made without updating changelogs, just put
  *
@@ -56,7 +56,7 @@ changelog.createMarkdown({ tagFrom: `${latestRelease}` }).then((newChangelog) =>
     changelogContent = changelogContent.replace('---', '---' + newChangelog)
     fs.writeFileSync(changelogPath, changelogContent, 'utf8')
 
-    /**
+    /*
      * print changelog
      */
     const highlighted = highlight(newChangelog, {

--- a/scripts/docs-generation/3rdPartyDocs.js
+++ b/scripts/docs-generation/3rdPartyDocs.js
@@ -76,12 +76,12 @@ function downloadReadme(githubUrl) {
  * @return {string}             readme content without header
  */
 function normalizeDoc(readme, githubUrl, preface, repoInfo) {
-    /**
+    /*
      * remove badges
      */
     let readmeArr = readme.split('\n').filter(row => !readmeBadges.some(b => row.includes(b)))
 
-    /**
+    /*
      * get index of header to remove further
      */
     let sliceIdx = 0
@@ -92,19 +92,19 @@ function normalizeDoc(readme, githubUrl, preface, repoInfo) {
     }
     readmeArr = readmeArr.slice(sliceIdx)
 
-    /**
+    /*
      * prepend additional # to header rows
      * and add path to links
      */
     readmeArr.forEach((row, idx) => {
-        /**
+        /*
          * prepend # to header rows
          */
         if (row.match(/^(#)\1* /)) {
             readmeArr[idx] = `#${row}`
         }
 
-        /**
+        /*
          * transform partial to full links
          * match links like [foo](bar). `stringInParentheses` would be `bar`
          * do not match [foo](http://bar), [foo](#bar)

--- a/scripts/docs-generation/generateDocs.js
+++ b/scripts/docs-generation/generateDocs.js
@@ -9,7 +9,7 @@ const { generateReportersAndServicesDocs } = require('./packagesDocs')
 const { generate3rdPartyDocs } = require('./3rdPartyDocs')
 
 async function generateDocs() {
-    /**
+    /*
      * NOTE: all generate docs functions mutate `sidebars` object!
      */
 

--- a/scripts/docs-generation/wdioDocs.js
+++ b/scripts/docs-generation/wdioDocs.js
@@ -45,7 +45,7 @@ exports.generateWdioDocs = (sidebars) => {
                 }
             )
 
-            /**
+            /*
              * add command to sidebar
              */
             if (!sidebars.api[scope]) {

--- a/scripts/generateSubPackage.js
+++ b/scripts/generateSubPackage.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-/**
+/*
  * This script generates new sub package with initial structure and files
  */
 

--- a/scripts/link.js
+++ b/scripts/link.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-/**
+/*
  * This script initialises the playground by linking all package into the /test directory
  */
 

--- a/scripts/utils/formatter.js
+++ b/scripts/utils/formatter.js
@@ -97,13 +97,13 @@ module.exports = function (docfile) {
 
                 if(exampleCodeLine.length) {
 
-                    /**
+                    /*
                      * remove filename expression in first line
                      */
                     exampleFilename = exampleCodeLine.shift().trim().substr(1)
                     var code = exampleCodeLine.join('\n')
 
-                    /**
+                    /*
                      * add example
                      */
                     if(exampleFilename !== '' && code !== '') {
@@ -114,13 +114,13 @@ module.exports = function (docfile) {
                         })
                     }
 
-                    /**
+                    /*
                      * reset loop conditions
                      */
                     exampleCodeLine = []
                 }
 
-                /**
+                /*
                  * if this is the last line of code dont proceed
                  */
                 if(currentLine === example.length) {
@@ -132,7 +132,7 @@ module.exports = function (docfile) {
             exampleCodeLine.push(line.substr(4))
         })
 
-        /**
+        /*
          * remove example section from description
          */
         description = description.substr(0, description.indexOf('<example>'))

--- a/scripts/utils/helpers.js
+++ b/scripts/utils/helpers.js
@@ -4,12 +4,12 @@ const path = require('path')
 const { IGNORED_SUBPACKAGES_FOR_DOCS } = require('../constants')
 
 const getSubPackages = () => shell.ls(path.join(__dirname, '..', '..', 'packages')).filter((pkg) => (
-    /**
+    /*
      * ignore node_modules directory that is created by the link script to test the
      * wdio test runner
      */
     pkg !== 'node_modules' &&
-    /**
+    /*
      * ignore packages that don't need to be compiled
      */
     !IGNORED_SUBPACKAGES_FOR_DOCS.includes(pkg)

--- a/scripts/watch.js
+++ b/scripts/watch.js
@@ -7,7 +7,7 @@ const { getSubPackages } = require('./utils/helpers')
 
 const packages = getSubPackages()
 
-/**
+/*
  * set proper size of max listener
  */
 require('events').EventEmitter.defaultMaxListeners = packages.length + 3

--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2017-present, Facebook, Inc.
  *
  * This source code is licensed under the MIT license found in the

--- a/website/pages/en/help.js
+++ b/website/pages/en/help.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2017-present, Facebook, Inc.
  *
  * This source code is licensed under the MIT license found in the

--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2017-present, Facebook, Inc.
  *
  * This source code is licensed under the MIT license found in the


### PR DESCRIPTION
## Proposed changes

Use of 2-stars at the beginning of comment blocks (i.e. `/**…`) is supposed to mark these comments as different from normal 1-star block comments.

Several comments that were clearly not intended to be used for documentation had 2 stars.  This Pull Request fixes that.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

This is part of a redo of Issue #4597.  If this is accepted, I plan to continue the work in a series of more Pull Requests.  (Next, I hope to add `eslint-plugin-jsdoc` and do some cleanup to the existing JSDoc comments.  After that, I can add JSDocs to undocumented public functions, classes, and methods.)  

### Reviewers: @webdriverio/technical-committee
