### PR TITLE
Handle multiline text in isClickable

### DIFF
--- a/packages/webdriverio/tests/scripts/isElementClickable.test.js
+++ b/packages/webdriverio/tests/scripts/isElementClickable.test.js
@@ -16,7 +16,10 @@ describe('isElementClickable script', () => {
                 top: 33,
                 left: 455
             }),
-            scrollIntoView: () => {},
+            clientHeight: 55,
+            clientWidth: 22,
+            getClientRects: () => [{}],
+            scrollIntoView: () => { },
             contains: () => false
         }
         global.document = { elementFromPoint: () => elemMock }
@@ -32,10 +35,42 @@ describe('isElementClickable script', () => {
                 top: 33,
                 left: 455
             }),
-            scrollIntoView: () => {},
+            clientHeight: 55,
+            clientWidth: 22,
+            getClientRects: () => [{}],
+            scrollIntoView: () => { },
             contains: () => true
         }
         global.document = { elementFromPoint: () => 'some element' }
+
+        expect(isElementClickable(elemMock)).toBe(true)
+    })
+
+    it('should be clickable if in viewport and elementFromPoint of the rect matches', () => {
+        const elemMock = {
+            getBoundingClientRect: () => ({
+                height: 55,
+                width: 22,
+                top: 33,
+                left: 455
+            }),
+            clientHeight: 55,
+            clientWidth: 22,
+            getClientRects: () => [{
+                height: 55,
+                width: 2200,
+                top: 33,
+                left: 45500
+            }],
+            scrollIntoView: () => { },
+            contains: () => false
+        }
+        global.document = {
+            // only return elemMock in getOverlappingRects
+            elementFromPoint: (x) => {
+                return x > 45500 ? elemMock : null
+            }
+        }
 
         expect(isElementClickable(elemMock)).toBe(true)
     })
@@ -48,7 +83,10 @@ describe('isElementClickable script', () => {
                 top: 33,
                 left: 455
             }),
-            scrollIntoView: () => {},
+            clientHeight: 55,
+            clientWidth: 22,
+            getClientRects: () => [{}],
+            scrollIntoView: () => { },
             disabled: true
         }
         global.document = { elementFromPoint: () => elemMock }
@@ -64,7 +102,10 @@ describe('isElementClickable script', () => {
                 top: 33,
                 left: 455
             }),
-            scrollIntoView: () => {},
+            clientHeight: 55,
+            clientWidth: 22,
+            getClientRects: () => [{}],
+            scrollIntoView: () => { },
         }
         global.document = { elementFromPoint: () => null }
 
@@ -79,7 +120,10 @@ describe('isElementClickable script', () => {
                 top: 33,
                 left: 999
             }),
-            scrollIntoView: () => {},
+            clientHeight: 55,
+            clientWidth: 22,
+            getClientRects: () => [{}],
+            scrollIntoView: () => { },
         }
         global.document = { elementFromPoint: () => elemMock }
 

--- a/packages/webdriverio/tests/scripts/isElementClickable.test.js
+++ b/packages/webdriverio/tests/scripts/isElementClickable.test.js
@@ -87,6 +87,7 @@ describe('isElementClickable script', () => {
             clientWidth: 22,
             getClientRects: () => [{}],
             scrollIntoView: () => { },
+            contains: () => false,
             disabled: true
         }
         global.document = { elementFromPoint: () => elemMock }
@@ -106,6 +107,7 @@ describe('isElementClickable script', () => {
             clientWidth: 22,
             getClientRects: () => [{}],
             scrollIntoView: () => { },
+            contains: () => false
         }
         global.document = { elementFromPoint: () => null }
 
@@ -120,10 +122,9 @@ describe('isElementClickable script', () => {
                 top: 33,
                 left: 999
             }),
-            clientHeight: 55,
-            clientWidth: 22,
             getClientRects: () => [{}],
             scrollIntoView: () => { },
+            contains: () => false
         }
         global.document = { elementFromPoint: () => elemMock }
 


### PR DESCRIPTION
## Proposed changes

Handle multiline text in `isClickable`, fixes #4770

Getting element center with `getBoundingClientRect` doesn't work properly if element is a multiline text, example:
![image](https://user-images.githubusercontent.com/25589559/68676314-11ad7f80-055a-11ea-9125-92da64080369.png)

in the case above center of the selected `<A>` element is `<SPAN>`.

Webdriver clicks on center of the first element's rect (line of text) which is `Slow` on the screenshot and we have to do the same.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments


### Reviewers: @webdriverio/technical-committee
