### PR TITLE
wdio-allure-reporter: add flag to ignore/allow mocha hooks to have stacktrace and screenshots when they fail

### DIFF
--- a/packages/wdio-allure-reporter/README.md
+++ b/packages/wdio-allure-reporter/README.md
@@ -42,6 +42,7 @@ exports.config = {
 - `disableWebdriverStepsReporting` - optional parameter(`false` by default), in order to log only custom steps to the reporter.
 - `disableWebdriverScreenshotsReporting` - optional parameter(`false` by default), in order to not attach screenshots to the reporter.
 - `useCucumberStepReporter` - optional parameter (`false` by default), set it to true in order to change the report hierarchy when using cucumber. Try it for yourself and see how it looks.
+- `disableMochaHooks` - optional parameter (`false` by default), set it to true in order to not fetch the `before/after` stacktrace/screenshot/result hooks into the Allure Reporter.
 
 ## Supported Allure API
 * `addLabel(name, value)` - assign a custom label to test


### PR DESCRIPTION
## Proposed changes

Right now the allure reporter is not saving the stacktrace/screenshot when a mocha hook (`before/after`) fails. So, if we have some setup on our `before` that breaks the test, we're not able to debug it properly. (reference https://github.com/webdriverio/webdriverio/issues/4767 )
This MR adds an option (disableMochaHooks) that needs to be turned on in order to not count the hooks as meaningful for the report, and the default behaviour is, once again, registering all the actions in all the hooks. (basically this PR https://github.com/webdriverio/webdriverio/pull/4406 will have a flag for it to display once again as it was supposed to)

Not sure about marking this as **breaking** though, might be interpreted as a bug fix as well 😅 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
