### PR TITLE
wdio-crossbrowsertesting-service: fix process killed prematurely

### DIFF
--- a/packages/wdio-crossbrowsertesting-service/src/launcher.js
+++ b/packages/wdio-crossbrowsertesting-service/src/launcher.js
@@ -8,7 +8,8 @@ export default class CrossBrowserTestingLauncher {
 
         this.cbtTunnelOpts = Object.assign({
             username: config.user,
-            authkey: config.key
+            authkey: config.key,
+            nokill: true
         }, config.cbtTunnelOpts)
 
         return new Promise((resolve, reject) => cbt.start(this.cbtTunnelOpts, (err) => {

--- a/packages/wdio-crossbrowsertesting-service/tests/launcher.test.js
+++ b/packages/wdio-crossbrowsertesting-service/tests/launcher.test.js
@@ -38,8 +38,8 @@ describe('wdio-crossbrowsertesting-service', () => {
             key: 'testy'
         }
         await expect(cbtLauncher.onPrepare(config)).resolves.toBe('connected')
-        expect(cbtTunnels.start).toHaveBeenCalledWith({ username: 'test', authkey: 'testy', options: 'some options' }, expect.any(Function))
-        expect(cbtLauncher.cbtTunnelOpts).toEqual({ username: 'test', authkey: 'testy', options: 'some options' })
+        expect(cbtTunnels.start).toHaveBeenCalledWith({ username: 'test', authkey: 'testy', nokill: true, options: 'some options' }, expect.any(Function))
+        expect(cbtLauncher.cbtTunnelOpts).toEqual({ username: 'test', authkey: 'testy', nokill: true, options: 'some options' })
 
     })
 


### PR DESCRIPTION
## Proposed changes

When stopping the cbtTunnel, wdio process is killed before reporting test results.
`nokill` option seems to address this need:
- [cbt-tunnel-nodejs](https://github.com/crossbrowsertesting/cbt-tunnel-nodejs/blob/master/cbt_tunnels.js#L716)
- [karma-cbt-launcher](https://github.com/crossbrowsertesting/karma-cbt-launcher/blob/master/src/tunnel.js#L37)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
