### PR TITLE
fix(webdriverio): broader return types for Element.getProperty

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,7 +1,7 @@
 {
-  "version": "5.15.4",
-  "lockfileVersion": 1,
+  "name": "webdriverio-monorepo",
   "requires": true,
+  "lockfileVersion": 1,
   "dependencies": {
     "@babel/cli": {
       "version": "7.6.4",

--- a/packages/wdio-sync/webdriverio-core.d.ts
+++ b/packages/wdio-sync/webdriverio-core.d.ts
@@ -305,7 +305,7 @@ declare namespace WebdriverIO {
          */
         getProperty(
             property: string
-        ): object | string;
+        ): object | string | boolean | number;
 
         /**
          * Get the width and height for an DOM-element.

--- a/packages/webdriverio/src/commands/element/getProperty.js
+++ b/packages/webdriverio/src/commands/element/getProperty.js
@@ -3,16 +3,16 @@
  *
  * <example>
     :getProperty.js
-    it('should demonstrate the getCSSProperty command', () => {
+    it('should demonstrate the getProperty command', () => {
         var elem = $('body')
-        var color = elem.getProperty('tagName')
-        console.log(color) // outputs: "BODY"
+        var tag = elem.getProperty('tagName')
+        console.log(tag) // outputs: "BODY"
     })
  * </example>
  *
  * @alias element.getProperty
  * @param {String} property  name of the element property
- * @return {Object|String} the value of the property of the selected element
+ * @return {Object|String|Boolean|Number|null} the value of the property of the selected element
  */
 
 import { getBrowserObject } from '../../utils'

--- a/packages/webdriverio/webdriverio-core-v5.d.ts
+++ b/packages/webdriverio/webdriverio-core-v5.d.ts
@@ -305,7 +305,7 @@ declare namespace WebdriverIO {
          */
         getProperty(
             property: string
-        ): object | string;
+        ): object | string | boolean | number;
 
         /**
          * Get the width and height for an DOM-element.

--- a/packages/webdriverio/webdriverio-core.d.ts
+++ b/packages/webdriverio/webdriverio-core.d.ts
@@ -305,7 +305,7 @@ declare namespace WebdriverIO {
          */
         getProperty(
             property: string
-        ): Promise<object | string>;
+        ): Promise<object | string | boolean | number>;
 
         /**
          * Get the width and height for an DOM-element.


### PR DESCRIPTION
## Proposed changes
Fixes the return types for Element.getProperty
https://github.com/webdriverio/webdriverio/issues/4786
## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
