### PR TITLE
Fix scrollIntoView in isClickable for old browsers 

### DIFF
--- a/packages/webdriverio/src/scripts/isElementClickable.js
+++ b/packages/webdriverio/src/scripts/isElementClickable.js
@@ -62,10 +62,13 @@ export default function isElementClickable (elem) {
         return isElementInViewport(elem) && elem.disabled !== true && isOverlappingElementMatch(getOverlappingElements(elem), elem)
     }
 
+    // returns true for Chrome and Firefox and false for Safari, Edge and IE
+    let scrollIntoViewFullSupport = !window.safari || !window.StyleMedia
+
     // scroll to the element if it's not clickable
     if (!isClickable(elem)) {
-        // works well in dialogs, but the element may be still overlapped by some sticky header/footerx
-        elem.scrollIntoView({ block: 'nearest', inline: 'nearest' })
+        // works well in dialogs, but the element may be still overlapped by some sticky header/footer
+        elem.scrollIntoView(scrollIntoViewFullSupport ? { block: 'nearest', inline: 'nearest' } : false)
 
         // if element is still not clickable take another scroll attempt
         if (!isClickable(elem)) {


### PR DESCRIPTION
## Proposed changes

Fix scrollIntoView in browsers that don't fully support it: Safari, Edge, IE.

Chrome, Firefox and Edge 79 fully support scrollIntoView

fixes #4790 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

### Reviewers: @webdriverio/technical-committee
