### PR TITLE
Fix/issue/4796

### DIFF
--- a/packages/webdriverio/src/scripts/isElementClickable.js
+++ b/packages/webdriverio/src/scripts/isElementClickable.js
@@ -4,7 +4,19 @@
  * @return {Boolean}           false if element is not overlapped
  */
 export default function isElementClickable (elem) {
-    if (!elem.getBoundingClientRect || !elem.scrollIntoView || !elem.contains || !elem.getClientRects || !document.elementFromPoint) {
+    if (!elem.getBoundingClientRect || !elem.scrollIntoView || !elem.getClientRects || !document.elementFromPoint) {
+        return false
+    }
+
+    // check if the childElement is contained in containerElement with ShadowDom support
+    function nodeContains(containerElement, childElement){
+        // see https://github.com/jsdom/jsdom/blob/75a921eab52c239b2468e08be9f547f46c7f86bd/lib/jsdom/living/nodes/Node-impl.js#L358
+        while (childElement) {
+            if (childElement === containerElement) return true
+            // DocumentFragment / ShadowRoot
+            if (childElement.nodeType === 11) childElement = childElement.host
+            childElement = childElement.parentNode
+        }
         return false
     }
 
@@ -38,7 +50,7 @@ export default function isElementClickable (elem) {
 
     // is one of overlapping elements the `elem` or one of its child
     function isOverlappingElementMatch (elementsFromPoint, elem) {
-        return elementsFromPoint.some(elementFromPoint => elementFromPoint === elem || elem.contains(elementFromPoint))
+        return elementsFromPoint.some(elementFromPoint => elementFromPoint === elem || nodeContains(elementFromPoint, elem))
     }
 
     // copied from `isElementInViewport.js`

--- a/packages/webdriverio/tests/scripts/isElementClickable.test.js
+++ b/packages/webdriverio/tests/scripts/isElementClickable.test.js
@@ -19,8 +19,7 @@ describe('isElementClickable script', () => {
             clientHeight: 55,
             clientWidth: 22,
             getClientRects: () => [{}],
-            scrollIntoView: () => { },
-            contains: () => false
+            scrollIntoView: () => { }
         }
         global.document = { elementFromPoint: () => elemMock }
 
@@ -38,12 +37,11 @@ describe('isElementClickable script', () => {
             clientHeight: 55,
             clientWidth: 22,
             getClientRects: () => [{}],
-            scrollIntoView: () => { },
-            contains: () => true
+            scrollIntoView: () => { }
         }
         global.document = { elementFromPoint: () => 'some element' }
 
-        expect(isElementClickable(elemMock)).toBe(true)
+        expect(isElementClickable(elemMock)).toBe(false)
     })
 
     it('should be clickable if in viewport and elementFromPoint of the rect matches', () => {
@@ -62,8 +60,7 @@ describe('isElementClickable script', () => {
                 top: 33,
                 left: 45500
             }],
-            scrollIntoView: () => { },
-            contains: () => false
+            scrollIntoView: () => { }
         }
         global.document = {
             // only return elemMock in getOverlappingRects
@@ -87,7 +84,6 @@ describe('isElementClickable script', () => {
             clientWidth: 22,
             getClientRects: () => [{}],
             scrollIntoView: () => { },
-            contains: () => false,
             disabled: true
         }
         global.document = { elementFromPoint: () => elemMock }
@@ -106,8 +102,7 @@ describe('isElementClickable script', () => {
             clientHeight: 55,
             clientWidth: 22,
             getClientRects: () => [{}],
-            scrollIntoView: () => { },
-            contains: () => false
+            scrollIntoView: () => { }
         }
         global.document = { elementFromPoint: () => null }
 
@@ -123,11 +118,41 @@ describe('isElementClickable script', () => {
                 left: 999
             }),
             getClientRects: () => [{}],
-            scrollIntoView: () => { },
-            contains: () => false
+            scrollIntoView: () => { }
         }
         global.document = { elementFromPoint: () => elemMock }
 
         expect(isElementClickable(elemMock)).toBe(false)
+    })
+
+    it('should be clickable if not in viewport', () => {
+        const getBoundingClientRect = () => ({
+            height: 55,
+            width: 22,
+            top: 33,
+            left: 100
+        })
+        const wrapElementMock = {
+            getBoundingClientRect,
+            parentNode: null,
+            getClientRects: () => [{}],
+            scrollIntoView: () => { }
+        }
+        const shadowNodeMock = {
+            getBoundingClientRect,
+            nodeType: 11,
+            host: {
+                parentNode: wrapElementMock
+            }
+        }
+        const elemMock = {
+            getBoundingClientRect,
+            getClientRects: () => [{}],
+            scrollIntoView: () => { },
+            parentNode: shadowNodeMock
+        }
+        global.document = { elementFromPoint: () => wrapElementMock }
+
+        expect(isElementClickable(elemMock)).toBe(true)
     })
 })

--- a/packages/webdriverio/tests/scripts/isElementClickable.test.js
+++ b/packages/webdriverio/tests/scripts/isElementClickable.test.js
@@ -125,7 +125,7 @@ describe('isElementClickable script', () => {
         expect(isElementClickable(elemMock)).toBe(false)
     })
 
-    it('should be clickable if not in viewport', () => {
+    it('should be clickable when element is inside in the ShadowDom', () => {
         const getBoundingClientRect = () => ({
             height: 55,
             width: 22,


### PR DESCRIPTION
## Proposed changes
### package webdriverio
Fix problem with `isElementClickable()` method.

This function use [element.contains()](https://developer.mozilla.org/en/docs/Web/API/Node/contains) to check if element is inside of parent elemente; but this function not found when element (child) is in ShadowRoot (DocumentFragment) node.

[fixes#4796](https://github.com/webdriverio/webdriverio/issues/4796)

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
