### PR TITLE
webdriver: Add the `headers` option to the Options type

### DIFF
--- a/packages/webdriver/webdriver.d.ts
+++ b/packages/webdriver/webdriver.d.ts
@@ -360,6 +360,9 @@ declare namespace WebDriver {
         connectionRetryCount?: number;
         user?: string;
         key?: string;
+        headers?: {
+            [name: string]: string;
+        };
     }
 
     interface AttachSessionOptions extends Options {


### PR DESCRIPTION
## Proposed changes

This PR adds the `headers` option to custom typings. The `headers` option was added in https://github.com/webdriverio/webdriverio/pull/3651, but typings weren’t updated accordingly.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)


### Reviewers: @webdriverio/technical-committee
