### PR TITLE
devtools automationProtocol: getUrl does not include #hash

### DIFF
--- a/e2e/protocol.test.js
+++ b/e2e/protocol.test.js
@@ -24,6 +24,11 @@ it('should navigate to a page and get page info', async () => {
     expect(await browser.getPageSource()).toContain('WebdriverJS Testpage')
 })
 
+it('should include the hash', async () => {
+    await browser.navigateTo('http://guinea-pig.webdriver.ioe#hash=hello')
+    expect(await browser.getUrl()).toBe('http://guinea-pig.webdriver.io/#hash=hello')
+})
+
 describe('timeouts', () => {
     beforeAll(async () => {
         await browser.navigateTo('http://guinea-pig.webdriver.io')

--- a/e2e/protocol.test.js
+++ b/e2e/protocol.test.js
@@ -25,7 +25,7 @@ it('should navigate to a page and get page info', async () => {
 })
 
 it('should include the hash', async () => {
-    await browser.navigateTo('http://guinea-pig.webdriver.ioe#hash=hello')
+    await browser.navigateTo('http://guinea-pig.webdriver.io#hash=hello')
     expect(await browser.getUrl()).toBe('http://guinea-pig.webdriver.io/#hash=hello')
 })
 

--- a/packages/devtools/src/commands/getUrl.js
+++ b/packages/devtools/src/commands/getUrl.js
@@ -1,4 +1,6 @@
+import command from '../scripts/getUrl'
+
 export default async function getUrl () {
     const page = this.getPageHandle(true)
-    return page.url()
+    return page.$eval('html', command)
 }

--- a/packages/devtools/src/scripts/getUrl.js
+++ b/packages/devtools/src/scripts/getUrl.js
@@ -1,0 +1,3 @@
+export default function getUrl () {
+    return document.location.href
+}


### PR DESCRIPTION
**Environment (please complete the following information):**
 - **WebdriverIO version:** 5.15.1
 - **Mode:** standalone
 - **If WDIO Testrunner, running sync/async:** [e.g. sync/async]
 - **Node.js version:** 10
 - **NPM version:** yarn 1.19.1
 - **Browser name and version:** Chrome 76
 - **Platform name and version:** MacOS
 - **Additional wdio packages used (if applicable):**  devtools

**Config of WebdriverIO**

```
automationProtocol: 'devtools',
```

**Describe the bug**

```ts
// Page url: http://localhost/test/page#hash=hello
const url = await browser.getUrl();
console.log(url); // Returns http://localhost/test/page
```

## Error

url hash is not included in the url.

## Code being executed:

https://github.com/webdriverio/webdriverio/blob/master/packages/devtools/src/commands/getUrl.js

**To Reproduce**

See above.

**Additional context**

Workaround:
```ts
const url = await browser.execute<string>('return document.location.href');
```