### PR TITLE
Add note that FF extensions need to be signed or flag has to be set

### DIFF
--- a/packages/wdio-firefox-profile-service/README.md
+++ b/packages/wdio-firefox-profile-service/README.md
@@ -39,12 +39,15 @@ export.config = {
       '/path/to/extensionA.xpi', // path to .xpi file
       '/path/to/extensionB' // or path to unpacked Firefox extension
     ],
+    'xpinstall.signatures.required': false,
     'browser.startup.homepage': 'https://webdriver.io',
     legacy: true // used for firefox <= 55
   },
   // ...
 };
 ```
+
+If you have build a custom Firefox extension that you want to install in the browser make sure to set `'xpinstall.signatures.required': false` as profile flag since Firefox extensions are required to be [signed by Mozilla](https://wiki.mozilla.org/Add-ons/Extension_Signing).
 
 ## Options
 


### PR DESCRIPTION
## Proposed changes

Adding note to firefox-profile service to inform users how to set extensions.

closes #4602

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

I tested the service and setting flags like `browser.startup.homepage` works as expected.

### Reviewers: @webdriverio/technical-committee
