### PR TITLE
Set first failed expectation as error for jasmine

### DIFF
--- a/packages/wdio-utils/src/test-framework/testFnWrapper.js
+++ b/packages/wdio-utils/src/test-framework/testFnWrapper.js
@@ -66,7 +66,7 @@ export const testFrameworkFnWrapper = async function (
      * (in Jasmine failing assertions are not causing the test to throw as
      * oppose to other common assertion libraries like chai)
      */
-    if (afterArgs[0] && afterArgs[0].failedExpectations && afterArgs[0].failedExpectations.length) {
+    if (!error && afterArgs[0] && afterArgs[0].failedExpectations && afterArgs[0].failedExpectations.length) {
         error = afterArgs[0].failedExpectations[0]
     }
 

--- a/packages/wdio-utils/src/test-framework/testFnWrapper.js
+++ b/packages/wdio-utils/src/test-framework/testFnWrapper.js
@@ -59,8 +59,17 @@ export const testFrameworkFnWrapper = async function (
         error = err
     }
     const duration = Date.now() - testStart
-
     let afterArgs = afterFnArgs(this)
+
+    /**
+     * ensure errors are caught in Jasmine tests too
+     * (in Jasmine failing assertions are not causing the test to throw as
+     * oppose to other common assertion libraries like chai)
+     */
+    if (afterArgs[0] && afterArgs[0].failedExpectations && afterArgs[0].failedExpectations.length) {
+        error = afterArgs[0].failedExpectations[0]
+    }
+
     afterArgs.push({
         retries,
         error,

--- a/packages/wdio-utils/tests/test-framework/__snapshots__/testFnWrapper-sync.test.js.snap
+++ b/packages/wdio-utils/tests/test-framework/__snapshots__/testFnWrapper-sync.test.js.snap
@@ -1,0 +1,69 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`testFnWrapper should propagate jasmine failed expecations as errors 1`] = `
+Array [
+  Object {
+    "description": "foo",
+    "duration": 0,
+    "error": Object {
+      "actual": true,
+      "expected": false,
+      "matcherName": "toEqual",
+      "message": "Expected true to equal false.",
+      "passed": false,
+      "stack": "Error: Expected true to equal false.
+    at <Jasmine>
+    at UserContext.it",
+    },
+    "failedExpectations": Array [
+      Object {
+        "actual": true,
+        "expected": false,
+        "matcherName": "toEqual",
+        "message": "Expected true to equal false.",
+        "passed": false,
+        "stack": "Error: Expected true to equal false.
+    at <Jasmine>
+    at UserContext.it",
+      },
+    ],
+    "foo": "bar",
+    "fullTitle": "full title",
+    "passed": false,
+    "title": "foo",
+  },
+  "context",
+  Object {
+    "duration": 0,
+    "error": Object {
+      "actual": true,
+      "expected": false,
+      "matcherName": "toEqual",
+      "message": "Expected true to equal false.",
+      "passed": false,
+      "stack": "Error: Expected true to equal false.
+    at <Jasmine>
+    at UserContext.it",
+    },
+    "passed": false,
+    "result": "@wdio/sync: FooBar 0 0",
+    "retries": Object {
+      "attempts": 0,
+      "limit": 0,
+    },
+  },
+]
+`;
+
+exports[`testFnWrapper should propagate jasmine failed expecations as errors 2`] = `
+Object {
+  "actual": true,
+  "expected": false,
+  "matcherName": "toEqual",
+  "message": "Expected true to equal false.",
+  "passed": false,
+  "stack": "Error: Expected true to equal false.
+    at <Jasmine>
+    at UserContext.it",
+}
+`;

--- a/packages/wdio-utils/tests/test-framework/testFnWrapper-sync.test.js
+++ b/packages/wdio-utils/tests/test-framework/testFnWrapper-sync.test.js
@@ -48,6 +48,21 @@ describe('testFnWrapper', () => {
         ])
     })
 
+    it('should propagate jasmine failed expecations as errors', async () => {
+        const failedExpectation = {
+            matcherName: 'toEqual',
+            message: 'Expected true to equal false.',
+            stack: 'Error: Expected true to equal false.\n    at <Jasmine>\n    at UserContext.it',
+            passed: false,
+            expected: false,
+            actual: true
+        }
+        const args = buildArgs(origFn, undefined, () => ['beforeFnArgs'], () => [{ foo: 'bar', description: 'foo', failedExpectations: [failedExpectation] }, 'context'])
+        const error = await testFnWrapper.call({ test: { fullTitle: () => 'full title' } }, ...args).catch((err) => err)
+        expect(executeHooksWithArgs.mock.calls[1][1]).toMatchSnapshot()
+        expect(error).toMatchSnapshot()
+    })
+
     it('should run fn in sync mode with cucumber', async () => {
         const args = buildArgs(origFn, undefined, () => ['beforeFnArgs'], () => [{ foo: 'bar' }, 2, 3, 4])
         const result = await testFnWrapper(...args)


### PR DESCRIPTION
## Proposed changes

closes #4743

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
