### PR TITLE
webdriverio: Fix isClickable in Edge if the element is documentFragment

### DIFF
--- a/packages/webdriverio/src/scripts/isElementClickable.js
+++ b/packages/webdriverio/src/scripts/isElementClickable.js
@@ -51,11 +51,12 @@ export default function isElementClickable (elem) {
                     return true
                 }
 
+                tmpElement = tmpElement.parentNode
+
                 // DocumentFragment / ShadowRoot polyfill like ShadyRoot
-                if (tmpElement.nodeType === 11 && tmpElement.host) {
+                if (tmpElement && tmpElement.nodeType === 11 && tmpElement.host) {
                     tmpElement = tmpElement.host
                 }
-                tmpElement = tmpElement.parentNode
             }
             return false
         }

--- a/packages/webdriverio/src/scripts/isElementClickable.js
+++ b/packages/webdriverio/src/scripts/isElementClickable.js
@@ -52,7 +52,6 @@ export default function isElementClickable (elem) {
                 }
 
                 tmpElement = tmpElement.parentNode
-
                 // DocumentFragment / ShadowRoot polyfill like ShadyRoot
                 if (tmpElement && tmpElement.nodeType === 11 && tmpElement.host) {
                     tmpElement = tmpElement.host

--- a/packages/webdriverio/tests/scripts/isElementClickable.test.js
+++ b/packages/webdriverio/tests/scripts/isElementClickable.test.js
@@ -74,6 +74,35 @@ describe('isElementClickable script', () => {
         expect(elemMock.scrollIntoView).toBeCalledWith(true)
     })
 
+    it('should be clickable if in viewport and elementFromPoint if element is Document Fragment [Edge]', () => {
+        const elemMock = {
+            getBoundingClientRect: () => ({
+                height: 55,
+                width: 22,
+                top: 33,
+                left: 455
+            }),
+            clientHeight: 55,
+            clientWidth: 22,
+            nodeType: 11,
+            getClientRects: () => [{}],
+            scrollIntoView: jest.fn(),
+            contains: () => { throw new Error('should not be called in old Edge!') }
+        }
+        // emulate old Edge
+        global.window.StyleMedia = () => { }
+
+        let attempts = 0
+        global.document = { elementFromPoint: () => {
+            attempts += 1
+            return { parentNode: attempts > 4 ? elemMock : {} }
+        } }
+
+        expect(isElementClickable(elemMock)).toBe(true)
+        expect(elemMock.scrollIntoView).toBeCalledWith(false)
+        expect(elemMock.scrollIntoView).toBeCalledWith(true)
+    })
+
     it('should be clickable if in viewport and elementFromPoint of the rect matches', () => {
         const elemMock = {
             getBoundingClientRect: () => ({


### PR DESCRIPTION
## Proposed changes

Fix defect in #4808 , for Edge if the element is documentFragment and is in ShadowRoot polyfill
## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
- [X] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee @mgrybyk 
