### PR TITLE
Inconsistency between webdriver and devtools getElementText command

### DIFF
--- a/e2e/protocol.test.js
+++ b/e2e/protocol.test.js
@@ -23,9 +23,8 @@ it('should navigate to a page and get page info', async () => {
     expect(await browser.getUrl()).toContain('http://guinea-pig.webdriver.io')
     expect(await browser.getPageSource()).toContain('WebdriverJS Testpage')
 
-    const elem = await browser.$('#t')
-    const text = await elem.getText()
-    expect(text).toBe('lions, tigers')
+    const elem = await browser.findElement('css selector', '#t')
+    expect(await browser.getElementText(elem[ELEMENT_KEY])).toBe('lions, tigers')
 })
 
 it('should include the hash', async () => {

--- a/e2e/protocol.test.js
+++ b/e2e/protocol.test.js
@@ -22,6 +22,10 @@ it('should navigate to a page and get page info', async () => {
     expect(await browser.getTitle()).toBe('WebdriverJS Testpage')
     expect(await browser.getUrl()).toContain('http://guinea-pig.webdriver.io')
     expect(await browser.getPageSource()).toContain('WebdriverJS Testpage')
+
+    const elem = await browser.$('#t')
+    const text = await elem.getText()
+    expect(text).toBe('lions, tigers')
 })
 
 it('should include the hash', async () => {

--- a/packages/devtools/src/scripts/getElementText.js
+++ b/packages/devtools/src/scripts/getElementText.js
@@ -1,3 +1,3 @@
 export default function getElementText (html, elem) {
-    return elem.textContent
+    return elem.innerText
 }

--- a/packages/webdriverio/src/utils/Timer.js
+++ b/packages/webdriverio/src/utils/Timer.js
@@ -23,8 +23,9 @@ class Timer {
          * only wrap waitUntil condition if:
          *  - wdio-sync is installed
          *  - function name is not async
+         *  - we run with the wdio testrunner
          */
-        if (hasWdioSyncSupport && !fn.name.includes('async')) {
+        if (hasWdioSyncSupport && !fn.name.includes('async') && Boolean(global.browser)) {
             this._fn = () => runFnInFiberContext(fn)()
         }
 


### PR DESCRIPTION
**Environment (please complete the following information):**
 - **WebdriverIO version:** 5.16.5

**Config of WebdriverIO**
`automationProtocom: 'devtools'`

**Describe the bug**
`getText` returns content content that is not visible to user in devtools protocol

**To Reproduce**
```
it('foo', () => {
    browser.url("https://fiddle.jshell.net/xlenz/1rkLjctp/show/")
    $("#result iframe").waitForDisplayed()
    browser.switchToFrame($("#result iframe"))

    const text = $('#t').getText()
    console.log(text)
});
```

ACTUAL result:
``` 

lions,
tigers
and bears

```

**Expected behavior**
`lions, tigers`

**Additional context**
Shall we use `innerText` instead of `textContent` here https://github.com/webdriverio/webdriverio/blob/e30649c9151aebc034a935db1e8399149ddf6078/packages/devtools/src/scripts/getElementText.js#L2 ?