### PR TITLE
Emit before and after command events in devtools

### DIFF
--- a/packages/devtools/tests/__snapshots__/devtoolsdriver.test.js.snap
+++ b/packages/devtools/tests/__snapshots__/devtoolsdriver.test.js.snap
@@ -23,3 +23,91 @@ Map {
   "script" => 30000,
 }
 `;
+
+exports[`should rerun command if it was executed within navigation 1`] = `
+Array [
+  Array [
+    "command",
+    Object {
+      "command": "elementClick",
+      "params": Object {
+        "elementId": "123",
+        "text": "some text",
+        "value": Array [
+          "some value",
+        ],
+      },
+      "retries": 0,
+    },
+  ],
+  Array [
+    "command",
+    Object {
+      "command": "elementClick",
+      "params": Object {
+        "elementId": "123",
+        "text": "some text",
+        "value": Array [
+          "some value",
+        ],
+      },
+      "retries": 1,
+    },
+  ],
+  Array [
+    "result",
+    Object {
+      "command": "elementClick",
+      "params": Object {
+        "elementId": "123",
+        "text": "some text",
+        "value": Array [
+          "some value",
+        ],
+      },
+      "result": null,
+      "retries": 1,
+    },
+  ],
+]
+`;
+
+exports[`should return proper result 1`] = `
+Array [
+  Array [
+    "command",
+    Object {
+      "command": "elementClick",
+      "params": Object {
+        "elementId": "123",
+        "text": "some text",
+        "value": Array [
+          "some value",
+        ],
+      },
+      "retries": 0,
+    },
+  ],
+  Array [
+    "result",
+    Object {
+      "command": "elementClick",
+      "params": Object {
+        "elementId": "123",
+        "text": "some text",
+        "value": Array [
+          "some value",
+        ],
+      },
+      "result": Object {
+        "elementId": "123",
+        "text": "some text",
+        "value": Array [
+          "some value",
+        ],
+      },
+      "retries": 0,
+    },
+  ],
+]
+`;


### PR DESCRIPTION
closes #4583

## Proposed changes

The `onBeforeCommand` and `onAfterCommand` were never emitted in reporter when running on the devtools protocol.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
