### PR TITLE
Feature/add proxy support for applitools

### DIFF
--- a/packages/wdio-applitools-service/README.md
+++ b/packages/wdio-applitools-service/README.md
@@ -25,7 +25,7 @@ Instructions on how to install `WebdriverIO` can be found [here.](https://webdri
 
 ## Configuration
 
-In order to use the service you need to pass `applitoolsKey`. This can be set in your `wdio.conf.js` config file or pass `APPLITOOLS_KEY` in your environment so that it can access the Applitools API. 
+In order to use the service you need to pass `applitools.key`. This can be set in your `wdio.conf.js` config file or pass `APPLITOOLS_KEY` in your environment so that it can access the Applitools API. 
 
 Also make sure that you added `applitools` to your service list, e.g.
 
@@ -34,11 +34,20 @@ Also make sure that you added `applitools` to your service list, e.g.
 export.config = {
   // ...
   services: ['applitools'],
-  applitoolsKey: 'APPLITOOLS_KEY', // can be passed here or via environment
-  applitoolsServerUrl: 'APPLITOOLS_Server_URL', // optional
   applitools: {
+    key: '<APPLITOOLS_KEY>', // can be passed here or via environment variable `APPLITOOLS_KEY`
+    serverUrl: 'https://<org>eyesapi.applitools.com', // optional, can be passed here or via environment variable `APPLITOOLS_SERVER_URL`
     // options
-    // ...
+    proxy: { // optional
+      url: 'http://corporateproxy.com:8080'
+      username: 'username' // optional
+      password: 'secret' // optional
+      isHttpOnly: true // optional
+    }
+    viewport: { // optional
+      width: 1920,
+      height: 1080
+    }
   }
   // ...
 };
@@ -74,8 +83,38 @@ On the Applitools dashboard you should now find the test with two images:
 
 ## Options
 
+### key
+Applitools API key to be used. Can be passed via wdio config or via environment variable `APPLITOOLS_KEY`
+
+- Optional
+- Type: `string`
+- Type: `string`
+
+### serverUrl
+Applitools server URL to be used
+
+- Optional
+- Type: `string`
+- Default: Public cloud url
+
 ### viewport
 Viewport with which the screenshots should be taken.
 
-Type: `Object`<br>
-Default: `{'width': 1440, 'height': 900}`
+- Optional
+- Type: `object`<br>
+- Default: `{'width': 1440, 'height': 900}`
+
+### proxy
+Use proxy for http/https connections with Applitools.
+
+- Optional
+- Type: `object`<br>
+- Example:
+```js
+{
+  url: 'http://corporateproxy.com:8080'
+  username: 'username' // optional
+  password: 'secret' // optional
+  isHttpOnly: true // optional
+}
+```

--- a/packages/wdio-applitools-service/README.md
+++ b/packages/wdio-applitools-service/README.md
@@ -25,7 +25,7 @@ Instructions on how to install `WebdriverIO` can be found [here.](https://webdri
 
 ## Configuration
 
-In order to use the service you need to pass `applitools.key`. This can be set in your `wdio.conf.js` config file or pass `APPLITOOLS_KEY` in your environment so that it can access the Applitools API. 
+In order to use the service you need to pass the Applitools API key. This can be set in your `wdio.conf.js` config file or pass `APPLITOOLS_KEY` in your environment so that it can access the Applitools API. 
 
 Also make sure that you added `applitools` to your service list, e.g.
 
@@ -87,7 +87,6 @@ On the Applitools dashboard you should now find the test with two images:
 Applitools API key to be used. Can be passed via wdio config or via environment variable `APPLITOOLS_KEY`
 
 - Optional
-- Type: `string`
 - Type: `string`
 
 ### serverUrl

--- a/packages/wdio-applitools-service/README.md
+++ b/packages/wdio-applitools-service/README.md
@@ -81,29 +81,42 @@ On the Applitools dashboard you should now find the test with two images:
 
 ![Applitools Dashboard](/img/applitools.png "Applitools Dashboard")
 
-## Options
+## Config properties
 
-### key
+### applitoolsKey (deprecated)
+Will be replaced by `applitools.key`. Applitools API key to be used. Can be passed via wdio config or via environment variable `APPLITOOLS_KEY`
+
+- Optional
+- Type: `string`
+
+### applitoolsServerUrl (deprecated)
+Will be replaced by `applitools.serverUrl`. Applitools server URL to be used
+- Optional
+- Type: `string`
+
+### applitools
+
+#### key
 Applitools API key to be used. Can be passed via wdio config or via environment variable `APPLITOOLS_KEY`
 
 - Optional
 - Type: `string`
 
-### serverUrl
+#### serverUrl
 Applitools server URL to be used
 
 - Optional
 - Type: `string`
 - Default: Public cloud url
 
-### viewport
+#### viewport
 Viewport with which the screenshots should be taken.
 
 - Optional
 - Type: `object`<br>
 - Default: `{'width': 1440, 'height': 900}`
 
-### proxy
+#### proxy
 Use proxy for http/https connections with Applitools.
 
 - Optional

--- a/packages/wdio-applitools-service/applitools-service.d.ts
+++ b/packages/wdio-applitools-service/applitools-service.d.ts
@@ -14,10 +14,18 @@ interface ApplitoolsConfig {
     applitoolsKey?: string;
     applitoolsServerUrl?: string;
     applitools?: {
+        key?: string;
+        serverUrl?: string;
         viewport?: {
             width: number;
             height: number;
         };
+        proxy?: {
+            url: string;
+            username?: string;
+            password?: string;
+            isHttpOnly?: boolean;
+        }
     };
 }
 

--- a/packages/wdio-applitools-service/applitools-service.d.ts
+++ b/packages/wdio-applitools-service/applitools-service.d.ts
@@ -11,6 +11,8 @@ declare module WebdriverIO {
 }
 
 interface ApplitoolsConfig {
+    applitoolsKey?: string;
+    applitoolsServerUrl?: string;
     applitools?: {
         key?: string;
         serverUrl?: string;

--- a/packages/wdio-applitools-service/applitools-service.d.ts
+++ b/packages/wdio-applitools-service/applitools-service.d.ts
@@ -11,8 +11,6 @@ declare module WebdriverIO {
 }
 
 interface ApplitoolsConfig {
-    applitoolsKey?: string;
-    applitoolsServerUrl?: string;
     applitools?: {
         key?: string;
         serverUrl?: string;

--- a/packages/wdio-applitools-service/package.json
+++ b/packages/wdio-applitools-service/package.json
@@ -34,7 +34,7 @@
     "url": "https://github.com/webdriverio/webdriverio/issues"
   },
   "dependencies": {
-    "@applitools/eyes-webdriverio": "^5.7.0",
+    "@applitools/eyes-webdriverio": "^5.8.4",
     "@wdio/logger": "5.16.10"
   },
   "peerDependencies": {

--- a/packages/wdio-applitools-service/src/index.js
+++ b/packages/wdio-applitools-service/src/index.js
@@ -18,8 +18,8 @@ export default class ApplitoolsService {
      */
     beforeSession (config) {
         const applitoolsConfig = config.applitools || {}
-        const key = applitoolsConfig.key || process.env.APPLITOOLS_KEY
-        const serverUrl = applitoolsConfig.serverUrl || process.env.APPLITOOLS_SERVER_URL
+        const key = applitoolsConfig.key || config.applitoolsKey || process.env.APPLITOOLS_KEY
+        const serverUrl = applitoolsConfig.serverUrl || config.applitoolsServerUrl || process.env.APPLITOOLS_SERVER_URL
 
         if (!key) {
             throw new Error('Couldn\'t find an Applitools "applitools.key" in config nor "APPLITOOLS_KEY" in the environment')

--- a/packages/wdio-applitools-service/src/index.js
+++ b/packages/wdio-applitools-service/src/index.js
@@ -17,12 +17,12 @@ export default class ApplitoolsService {
      * set API key in onPrepare hook and start test
      */
     beforeSession (config) {
-        const key = config.applitoolsKey || process.env.APPLITOOLS_KEY
-        const serverUrl = config.applitoolsServerUrl || process.env.APPLITOOLS_SERVER_URL
         const applitoolsConfig = config.applitools || {}
+        const key = applitoolsConfig.key || process.env.APPLITOOLS_KEY
+        const serverUrl = applitoolsConfig.serverUrl || process.env.APPLITOOLS_SERVER_URL
 
         if (!key) {
-            throw new Error('Couldn\'t find an Applitools "applitoolsKey" in config nor "APPLITOOLS_KEY" in the environment')
+            throw new Error('Couldn\'t find an Applitools "applitools.key" in config nor "APPLITOOLS_KEY" in the environment')
         }
 
         // Optionally set a specific server url
@@ -32,6 +32,11 @@ export default class ApplitoolsService {
 
         this.isConfigured = true
         this.eyes.setApiKey(key)
+
+        if (applitoolsConfig.proxy) {
+            this.eyes.setProxy(applitoolsConfig.proxy)
+        }
+
         this.viewport = Object.assign(DEFAULT_VIEWPORT, applitoolsConfig.viewport)
     }
 

--- a/packages/wdio-applitools-service/tests/__mocks__/@applitools/eyes-webdriverio.js
+++ b/packages/wdio-applitools-service/tests/__mocks__/@applitools/eyes-webdriverio.js
@@ -12,6 +12,7 @@ class Eyes {
     constructor () {
         this.setApiKey = jest.fn()
         this.setServerUrl = jest.fn()
+        this.setProxy = jest.fn()
         this.check = jest.fn()
         this.open = jest.fn()
         this.close = jest.fn()

--- a/packages/wdio-applitools-service/tests/service.test.js
+++ b/packages/wdio-applitools-service/tests/service.test.js
@@ -21,9 +21,12 @@ describe('wdio-applitools-service', () => {
 
         expect(() => service.beforeSession({})).toThrow()
         expect(() => service.beforeSession({ applitools: { serverUrl: 'foobar' } })).toThrow()
+        expect(() => service.beforeSession({ applitoolsServerUrl: 'foobar' })).toThrow()
 
         expect(() => service.beforeSession({ applitools: { key: 'foobar' } })).not.toThrow()
+        expect(() => service.beforeSession({ applitoolsKey: 'foobar' })).not.toThrow()
         expect(() => service.beforeSession({ applitools: { key: 'foobar', serverUrl: 'foobar' } })).not.toThrow()
+        expect(() => service.beforeSession({ applitoolsKey: 'foobar', applitoolsServerUrl: 'foobar' })).not.toThrow()
     })
 
     it('throws if key does not exist in environment', () => {
@@ -45,13 +48,27 @@ describe('wdio-applitools-service', () => {
         process.env.APPLITOOLS_KEY = 'foobarenv'
         process.env.APPLITOOLS_SERVER_URL = 'foobarenvserver'
         service.beforeSession({
-            applitools: {
-                key: 'foobar',
-                serverUrl: 'foobarserver'
-            }
+            applitoolsKey: 'foobar',
+            applitoolsServerUrl: 'foobarserver'
         })
         expect(service.eyes.setApiKey).toBeCalledWith('foobar')
         expect(service.eyes.setServerUrl).toBeCalledWith('foobarserver')
+    })
+
+    it('should prefer applitools object before deprecated applitoolsKey/applitoolsServerUrl', () => {
+        const service = new ApplitoolsService()
+        process.env.APPLITOOLS_KEY = 'foobarenv'
+        process.env.APPLITOOLS_SERVER_URL = 'foobarenvserver'
+        service.beforeSession({
+            applitoolsKey: 'foobar2',
+            applitoolsServerUrl: 'foobarserver2',
+            applitools: {
+                key: 'foobar1',
+                serverUrl: 'foobarserver1'
+            }
+        })
+        expect(service.eyes.setApiKey).toBeCalledWith('foobar1')
+        expect(service.eyes.setServerUrl).toBeCalledWith('foobarserver1')
     })
 
     it('should set proxy config if set in options', () => {

--- a/packages/wdio-applitools-service/tests/service.test.js
+++ b/packages/wdio-applitools-service/tests/service.test.js
@@ -20,10 +20,10 @@ describe('wdio-applitools-service', () => {
         const service = new ApplitoolsService()
 
         expect(() => service.beforeSession({})).toThrow()
-        expect(() => service.beforeSession({ applitoolsServerUrl: 'foobar' })).toThrow()
+        expect(() => service.beforeSession({ applitools: { serverUrl: 'foobar' } })).toThrow()
 
-        expect(() => service.beforeSession({ applitoolsKey: 'foobar' })).not.toThrow()
-        expect(() => service.beforeSession({ applitoolsKey: 'foobar', applitoolsServerUrl: 'foobar' })).not.toThrow()
+        expect(() => service.beforeSession({ applitools: { key: 'foobar' } })).not.toThrow()
+        expect(() => service.beforeSession({ applitools: { key: 'foobar', serverUrl: 'foobar' } })).not.toThrow()
     })
 
     it('throws if key does not exist in environment', () => {
@@ -45,11 +45,39 @@ describe('wdio-applitools-service', () => {
         process.env.APPLITOOLS_KEY = 'foobarenv'
         process.env.APPLITOOLS_SERVER_URL = 'foobarenvserver'
         service.beforeSession({
-            applitoolsKey: 'foobar',
-            applitoolsServerUrl: 'foobarserver'
+            applitools: {
+                key: 'foobar',
+                serverUrl: 'foobarserver'
+            }
         })
         expect(service.eyes.setApiKey).toBeCalledWith('foobar')
         expect(service.eyes.setServerUrl).toBeCalledWith('foobarserver')
+    })
+
+    it('should set proxy config if set in options', () => {
+        const service = new ApplitoolsService()
+        const options = {
+            applitools: {
+                key: 'foobar',
+                proxy: {
+                    url: 'http://foobarproxy.com:8080',
+                    username: 'abc',
+                    password: 'def',
+                    isHttpOnly: true
+                }
+            }
+        }
+
+        service.beforeSession(options)
+        expect(service.eyes.setProxy).toBeCalledWith(options.applitools.proxy)
+    })
+
+    it('should not set proxy config if not set in options', () => {
+        const service = new ApplitoolsService()
+        process.env.APPLITOOLS_KEY = 'foobarenv'
+
+        expect(() => service.beforeSession({})).not.toThrow()
+        expect(service.eyes.setProxy).not.toBeCalled()
     })
 
     describe('before hook', () => {

--- a/tests/typings/sync-applitools/applitools.ts
+++ b/tests/typings/sync-applitools/applitools.ts
@@ -1,7 +1,7 @@
 const config: WebdriverIO.Config = {
-    applitoolsKey: '',
-    applitoolsServerUrl: '',
     applitools: {
+        key: '',
+        serverUrl: '',
         viewport: {
             width: 1,
             height: 1

--- a/tests/typings/webdriverio-applitools/applitools.ts
+++ b/tests/typings/webdriverio-applitools/applitools.ts
@@ -1,7 +1,7 @@
 const config: WebdriverIO.Config = {
-    applitoolsKey: '',
-    applitoolsServerUrl: '',
     applitools: {
+        key: '',
+        serverUrl: '',
         viewport: {
             width: 1,
             height: 1


### PR DESCRIPTION
## Proposed changes

- Add proxy support to wdio-applitools-service
- Extend optional applitools config in wdio config to one object that contains key/serverUrl (and now also the proxy config) etc. **UPDATE:** for backwards compatibility for now, the `applitoolsKey` and `applitoolsServerUrl` will still remain to exist

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
