### PR TITLE
Show link to job details page for each multiremote instance - …

### DIFF
--- a/packages/wdio-runner/src/index.js
+++ b/packages/wdio-runner/src/index.js
@@ -129,6 +129,7 @@ export default class Runner extends EventEmitter {
             capabilities: isMultiremote
                 ? browser.instances.reduce((caps, browserName) => {
                     caps[browserName] = browser[browserName].capabilities
+                    caps[browserName].sessionId = browser[browserName].sessionId
                     return caps
                 }, {})
                 : browser.capabilities,

--- a/packages/wdio-spec-reporter/src/index.js
+++ b/packages/wdio-spec-reporter/src/index.js
@@ -85,10 +85,17 @@ class SpecReporter extends WDIOReporter {
             : this.getTestLink(runner)
         const output = [
             ...this.getHeaderDisplay(runner),
+            '',
             ...results,
             ...this.getCountDisplay(duration),
             ...this.getFailureDisplay(),
-            ...(testLinks.length ? ['', ...testLinks] : testLinks)
+            ...(testLinks.length
+                /**
+                 * if we have test links add an empty line
+                 */
+                ? ['', ...testLinks]
+                : []
+            )
         ]
 
         // Prefix all values with the browser information
@@ -137,9 +144,15 @@ class SpecReporter extends WDIOReporter {
         // Spec file name and enviroment information
         const output = [
             `Spec: ${runner.specs[0]}`,
-            `Running: ${combo}`,
-            '',
+            `Running: ${combo}`
         ]
+
+        /**
+         * print session ID if not multiremote
+         */
+        if (runner.capabilities.sessionId) {
+            output.push(`Session ID: ${runner.capabilities.sessionId}`)
+        }
 
         return output
     }

--- a/packages/wdio-spec-reporter/src/index.js
+++ b/packages/wdio-spec-reporter/src/index.js
@@ -75,12 +75,20 @@ class SpecReporter extends WDIOReporter {
             return
         }
 
+        const testLinks = runner.isMultiremote
+            ? Object.entries(runner.capabilities).map(([instanceName, capabilities]) => this.getTestLink({
+                config: { ...runner.config, ...{ capabilities } },
+                sessionId: capabilities.sessionId,
+                isMultiremote: runner.isMultiremote,
+                instanceName
+            }))
+            : this.getTestLink(runner)
         const output = [
             ...this.getHeaderDisplay(runner),
             ...results,
             ...this.getCountDisplay(duration),
             ...this.getFailureDisplay(),
-            ...this.getTestLink(runner)
+            ...(testLinks.length ? ['', ...testLinks] : testLinks)
         ]
 
         // Prefix all values with the browser information
@@ -95,7 +103,7 @@ class SpecReporter extends WDIOReporter {
     /**
      * get link to saucelabs job
      */
-    getTestLink ({ config, sessionId }) {
+    getTestLink ({ config, sessionId, isMultiremote, instanceName }) {
         const isSauceJob = (
             config.hostname.includes('saucelabs') ||
             // only show if multiremote is not used
@@ -111,7 +119,8 @@ class SpecReporter extends WDIOReporter {
             const dc = config.headless
                 ? '.us-east-1'
                 : ['eu', 'eu-central-1'].includes(config.region) ? '.eu-central-1' : ''
-            return ['', `Check out job at https://app${dc}.saucelabs.com/tests/${sessionId}`]
+            const multiremoteNote = isMultiremote ? ` ${instanceName}` : ''
+            return [`Check out${multiremoteNote} job at https://app${dc}.saucelabs.com/tests/${sessionId}`]
         }
 
         return []

--- a/packages/wdio-spec-reporter/tests/__fixtures__/testdata.js
+++ b/packages/wdio-spec-reporter/tests/__fixtures__/testdata.js
@@ -2,9 +2,6 @@ export const RUNNER = {
     cid: '0-0',
     _duration: 5032,
     config: { hostname: 'localhost' },
-    capabilities: {
-        browserName: 'loremipsum',
-    },
     specs: ['/foo/bar/baz.js'],
 }
 
@@ -195,44 +192,3 @@ export const SUITES_NO_TESTS_WITH_HOOK_ERROR = [{
 SUITES_NO_TESTS_WITH_HOOK_ERROR.forEach(suite => {
     suite.hooksAndTests = [...suite.hooks]
 })
-
-export const REPORT = `------------------------------------------------------------------
-[loremipsum #0-0] Spec: /foo/bar/baz.js
-[loremipsum #0-0] Running: loremipsum
-[loremipsum #0-0]
-[loremipsum #0-0] Foo test
-[loremipsum #0-0]    green ✓ foo
-[loremipsum #0-0]    green ✓ bar
-[loremipsum #0-0]
-[loremipsum #0-0] Bar test
-[loremipsum #0-0]    green ✓ some test
-[loremipsum #0-0]    red ✖ a failed test
-[loremipsum #0-0]    red ✖ a failed test with no stack
-[loremipsum #0-0]
-[loremipsum #0-0] Baz test
-[loremipsum #0-0]    green ✓ foo bar baz
-[loremipsum #0-0]    cyan - a skipped test
-[loremipsum #0-0]
-[loremipsum #0-0] green 4 passing (5s)
-[loremipsum #0-0] red 1 failing
-[loremipsum #0-0] cyan 1 skipped
-[loremipsum #0-0]
-[loremipsum #0-0] 1) Bar test a failed test
-[loremipsum #0-0] red expected foo to equal bar
-[loremipsum #0-0] gray Failed test stack trace
-[loremipsum #0-0]
-[loremipsum #0-0] 2) Bar test a failed test with no stack
-[loremipsum #0-0] red expected foo to equal bar
-`
-
-export const SAUCELABS_REPORT = REPORT + `[loremipsum #0-0]
-[loremipsum #0-0] Check out job at https://app.saucelabs.com/tests/ba86cbcb70774ef8a0757c1702c3bdf9
-`
-
-export const SAUCELABS_EU_REPORT = REPORT + `[loremipsum #0-0]
-[loremipsum #0-0] Check out job at https://app.eu-central-1.saucelabs.com/tests/ba86cbcb70774ef8a0757c1702c3bdf9
-`
-
-export const SAUCELABS_HEADLESS_REPORT = REPORT + `[loremipsum #0-0]
-[loremipsum #0-0] Check out job at https://app.us-east-1.saucelabs.com/tests/ba86cbcb70774ef8a0757c1702c3bdf9
-`

--- a/packages/wdio-spec-reporter/tests/__snapshots__/index.test.js.snap
+++ b/packages/wdio-spec-reporter/tests/__snapshots__/index.test.js.snap
@@ -48,3 +48,330 @@ Array [
   "",
 ]
 `;
+
+exports[`SpecReporter printReport with normal setup should print jobs of all instance when run with multiremote 1`] = `
+Array [
+  Array [
+    "------------------------------------------------------------------
+[MultiremoteBrowser #0-0] Spec: /foo/bar/baz.js
+[MultiremoteBrowser #0-0] Running: MultiremoteBrowser
+[MultiremoteBrowser #0-0]
+[MultiremoteBrowser #0-0] Foo test
+[MultiremoteBrowser #0-0]    green ✓ foo
+[MultiremoteBrowser #0-0]    green ✓ bar
+[MultiremoteBrowser #0-0]
+[MultiremoteBrowser #0-0] Bar test
+[MultiremoteBrowser #0-0]    green ✓ some test
+[MultiremoteBrowser #0-0]    red ✖ a failed test
+[MultiremoteBrowser #0-0]    red ✖ a failed test with no stack
+[MultiremoteBrowser #0-0]
+[MultiremoteBrowser #0-0] Baz test
+[MultiremoteBrowser #0-0]    green ✓ foo bar baz
+[MultiremoteBrowser #0-0]    cyan - a skipped test
+[MultiremoteBrowser #0-0]
+[MultiremoteBrowser #0-0] green 4 passing (5s)
+[MultiremoteBrowser #0-0] red 1 failing
+[MultiremoteBrowser #0-0] cyan 1 skipped
+[MultiremoteBrowser #0-0]
+[MultiremoteBrowser #0-0] 1) Bar test a failed test
+[MultiremoteBrowser #0-0] red expected foo to equal bar
+[MultiremoteBrowser #0-0] gray Failed test stack trace
+[MultiremoteBrowser #0-0]
+[MultiremoteBrowser #0-0] 2) Bar test a failed test with no stack
+[MultiremoteBrowser #0-0] red expected foo to equal bar
+[MultiremoteBrowser #0-0]
+[MultiremoteBrowser #0-0] Check out browserA job at https://app.saucelabs.com/tests/foobar
+[MultiremoteBrowser #0-0] Check out browserB job at https://app.saucelabs.com/tests/barfoo
+",
+  ],
+]
+`;
+
+exports[`SpecReporter printReport with normal setup should print link to SauceLabs EU job details page 1`] = `
+Array [
+  Array [
+    "------------------------------------------------------------------
+[loremipsum #0-0] Spec: /foo/bar/baz.js
+[loremipsum #0-0] Running: loremipsum
+[loremipsum #0-0]
+[loremipsum #0-0] Foo test
+[loremipsum #0-0]    green ✓ foo
+[loremipsum #0-0]    green ✓ bar
+[loremipsum #0-0]
+[loremipsum #0-0] Bar test
+[loremipsum #0-0]    green ✓ some test
+[loremipsum #0-0]    red ✖ a failed test
+[loremipsum #0-0]    red ✖ a failed test with no stack
+[loremipsum #0-0]
+[loremipsum #0-0] Baz test
+[loremipsum #0-0]    green ✓ foo bar baz
+[loremipsum #0-0]    cyan - a skipped test
+[loremipsum #0-0]
+[loremipsum #0-0] green 4 passing (5s)
+[loremipsum #0-0] red 1 failing
+[loremipsum #0-0] cyan 1 skipped
+[loremipsum #0-0]
+[loremipsum #0-0] 1) Bar test a failed test
+[loremipsum #0-0] red expected foo to equal bar
+[loremipsum #0-0] gray Failed test stack trace
+[loremipsum #0-0]
+[loremipsum #0-0] 2) Bar test a failed test with no stack
+[loremipsum #0-0] red expected foo to equal bar
+[loremipsum #0-0]
+[loremipsum #0-0] Check out job at https://app.eu-central-1.saucelabs.com/tests/ba86cbcb70774ef8a0757c1702c3bdf9
+",
+  ],
+]
+`;
+
+exports[`SpecReporter printReport with normal setup should print link to SauceLabs EU job details page 2`] = `
+Array [
+  Array [
+    "------------------------------------------------------------------
+[loremipsum #0-0] Spec: /foo/bar/baz.js
+[loremipsum #0-0] Running: loremipsum
+[loremipsum #0-0]
+[loremipsum #0-0] Foo test
+[loremipsum #0-0]    green ✓ foo
+[loremipsum #0-0]    green ✓ bar
+[loremipsum #0-0]
+[loremipsum #0-0] Bar test
+[loremipsum #0-0]    green ✓ some test
+[loremipsum #0-0]    red ✖ a failed test
+[loremipsum #0-0]    red ✖ a failed test with no stack
+[loremipsum #0-0]
+[loremipsum #0-0] Baz test
+[loremipsum #0-0]    green ✓ foo bar baz
+[loremipsum #0-0]    cyan - a skipped test
+[loremipsum #0-0]
+[loremipsum #0-0] green 4 passing (5s)
+[loremipsum #0-0] red 1 failing
+[loremipsum #0-0] cyan 1 skipped
+[loremipsum #0-0]
+[loremipsum #0-0] 1) Bar test a failed test
+[loremipsum #0-0] red expected foo to equal bar
+[loremipsum #0-0] gray Failed test stack trace
+[loremipsum #0-0]
+[loremipsum #0-0] 2) Bar test a failed test with no stack
+[loremipsum #0-0] red expected foo to equal bar
+[loremipsum #0-0]
+[loremipsum #0-0] Check out job at https://app.eu-central-1.saucelabs.com/tests/ba86cbcb70774ef8a0757c1702c3bdf9
+",
+  ],
+]
+`;
+
+exports[`SpecReporter printReport with normal setup should print link to SauceLabs EU job details page 3`] = `
+Array [
+  Array [
+    "------------------------------------------------------------------
+[loremipsum #0-0] Spec: /foo/bar/baz.js
+[loremipsum #0-0] Running: loremipsum
+[loremipsum #0-0]
+[loremipsum #0-0] Foo test
+[loremipsum #0-0]    green ✓ foo
+[loremipsum #0-0]    green ✓ bar
+[loremipsum #0-0]
+[loremipsum #0-0] Bar test
+[loremipsum #0-0]    green ✓ some test
+[loremipsum #0-0]    red ✖ a failed test
+[loremipsum #0-0]    red ✖ a failed test with no stack
+[loremipsum #0-0]
+[loremipsum #0-0] Baz test
+[loremipsum #0-0]    green ✓ foo bar baz
+[loremipsum #0-0]    cyan - a skipped test
+[loremipsum #0-0]
+[loremipsum #0-0] green 4 passing (5s)
+[loremipsum #0-0] red 1 failing
+[loremipsum #0-0] cyan 1 skipped
+[loremipsum #0-0]
+[loremipsum #0-0] 1) Bar test a failed test
+[loremipsum #0-0] red expected foo to equal bar
+[loremipsum #0-0] gray Failed test stack trace
+[loremipsum #0-0]
+[loremipsum #0-0] 2) Bar test a failed test with no stack
+[loremipsum #0-0] red expected foo to equal bar
+[loremipsum #0-0]
+[loremipsum #0-0] Check out job at https://app.eu-central-1.saucelabs.com/tests/ba86cbcb70774ef8a0757c1702c3bdf9
+",
+  ],
+  Array [
+    "------------------------------------------------------------------
+[loremipsum #0-0] Spec: /foo/bar/baz.js
+[loremipsum #0-0] Running: loremipsum
+[loremipsum #0-0]
+[loremipsum #0-0] Foo test
+[loremipsum #0-0]    green ✓ foo
+[loremipsum #0-0]    green ✓ bar
+[loremipsum #0-0]
+[loremipsum #0-0] Bar test
+[loremipsum #0-0]    green ✓ some test
+[loremipsum #0-0]    red ✖ a failed test
+[loremipsum #0-0]    red ✖ a failed test with no stack
+[loremipsum #0-0]
+[loremipsum #0-0] Baz test
+[loremipsum #0-0]    green ✓ foo bar baz
+[loremipsum #0-0]    cyan - a skipped test
+[loremipsum #0-0]
+[loremipsum #0-0] green 4 passing (5s)
+[loremipsum #0-0] red 1 failing
+[loremipsum #0-0] cyan 1 skipped
+[loremipsum #0-0]
+[loremipsum #0-0] 1) Bar test a failed test
+[loremipsum #0-0] red expected foo to equal bar
+[loremipsum #0-0] gray Failed test stack trace
+[loremipsum #0-0]
+[loremipsum #0-0] 2) Bar test a failed test with no stack
+[loremipsum #0-0] red expected foo to equal bar
+[loremipsum #0-0]
+[loremipsum #0-0] Check out job at https://app.us-east-1.saucelabs.com/tests/ba86cbcb70774ef8a0757c1702c3bdf9
+",
+  ],
+]
+`;
+
+exports[`SpecReporter printReport with normal setup should print link to SauceLabs job details page 1`] = `
+Array [
+  Array [
+    "------------------------------------------------------------------
+[loremipsum #0-0] Spec: /foo/bar/baz.js
+[loremipsum #0-0] Running: loremipsum
+[loremipsum #0-0]
+[loremipsum #0-0] Foo test
+[loremipsum #0-0]    green ✓ foo
+[loremipsum #0-0]    green ✓ bar
+[loremipsum #0-0]
+[loremipsum #0-0] Bar test
+[loremipsum #0-0]    green ✓ some test
+[loremipsum #0-0]    red ✖ a failed test
+[loremipsum #0-0]    red ✖ a failed test with no stack
+[loremipsum #0-0]
+[loremipsum #0-0] Baz test
+[loremipsum #0-0]    green ✓ foo bar baz
+[loremipsum #0-0]    cyan - a skipped test
+[loremipsum #0-0]
+[loremipsum #0-0] green 4 passing (5s)
+[loremipsum #0-0] red 1 failing
+[loremipsum #0-0] cyan 1 skipped
+[loremipsum #0-0]
+[loremipsum #0-0] 1) Bar test a failed test
+[loremipsum #0-0] red expected foo to equal bar
+[loremipsum #0-0] gray Failed test stack trace
+[loremipsum #0-0]
+[loremipsum #0-0] 2) Bar test a failed test with no stack
+[loremipsum #0-0] red expected foo to equal bar
+[loremipsum #0-0]
+[loremipsum #0-0] Check out job at https://app.saucelabs.com/tests/ba86cbcb70774ef8a0757c1702c3bdf9
+",
+  ],
+]
+`;
+
+exports[`SpecReporter printReport with normal setup should print link to SauceLabs job details page if run with Sauce Connect (jsonwp) 1`] = `
+Array [
+  Array [
+    "------------------------------------------------------------------
+[loremipsum #0-0] Spec: /foo/bar/baz.js
+[loremipsum #0-0] Running: loremipsum
+[loremipsum #0-0]
+[loremipsum #0-0] Foo test
+[loremipsum #0-0]    green ✓ foo
+[loremipsum #0-0]    green ✓ bar
+[loremipsum #0-0]
+[loremipsum #0-0] Bar test
+[loremipsum #0-0]    green ✓ some test
+[loremipsum #0-0]    red ✖ a failed test
+[loremipsum #0-0]    red ✖ a failed test with no stack
+[loremipsum #0-0]
+[loremipsum #0-0] Baz test
+[loremipsum #0-0]    green ✓ foo bar baz
+[loremipsum #0-0]    cyan - a skipped test
+[loremipsum #0-0]
+[loremipsum #0-0] green 4 passing (5s)
+[loremipsum #0-0] red 1 failing
+[loremipsum #0-0] cyan 1 skipped
+[loremipsum #0-0]
+[loremipsum #0-0] 1) Bar test a failed test
+[loremipsum #0-0] red expected foo to equal bar
+[loremipsum #0-0] gray Failed test stack trace
+[loremipsum #0-0]
+[loremipsum #0-0] 2) Bar test a failed test with no stack
+[loremipsum #0-0] red expected foo to equal bar
+[loremipsum #0-0]
+[loremipsum #0-0] Check out job at https://app.saucelabs.com/tests/ba86cbcb70774ef8a0757c1702c3bdf9
+",
+  ],
+]
+`;
+
+exports[`SpecReporter printReport with normal setup should print link to SauceLabs job details page if run with Sauce Connect (w3c) 1`] = `
+Array [
+  Array [
+    "------------------------------------------------------------------
+[loremipsum #0-0] Spec: /foo/bar/baz.js
+[loremipsum #0-0] Running: loremipsum
+[loremipsum #0-0]
+[loremipsum #0-0] Foo test
+[loremipsum #0-0]    green ✓ foo
+[loremipsum #0-0]    green ✓ bar
+[loremipsum #0-0]
+[loremipsum #0-0] Bar test
+[loremipsum #0-0]    green ✓ some test
+[loremipsum #0-0]    red ✖ a failed test
+[loremipsum #0-0]    red ✖ a failed test with no stack
+[loremipsum #0-0]
+[loremipsum #0-0] Baz test
+[loremipsum #0-0]    green ✓ foo bar baz
+[loremipsum #0-0]    cyan - a skipped test
+[loremipsum #0-0]
+[loremipsum #0-0] green 4 passing (5s)
+[loremipsum #0-0] red 1 failing
+[loremipsum #0-0] cyan 1 skipped
+[loremipsum #0-0]
+[loremipsum #0-0] 1) Bar test a failed test
+[loremipsum #0-0] red expected foo to equal bar
+[loremipsum #0-0] gray Failed test stack trace
+[loremipsum #0-0]
+[loremipsum #0-0] 2) Bar test a failed test with no stack
+[loremipsum #0-0] red expected foo to equal bar
+[loremipsum #0-0]
+[loremipsum #0-0] Check out job at https://app.saucelabs.com/tests/ba86cbcb70774ef8a0757c1702c3bdf9
+",
+  ],
+]
+`;
+
+exports[`SpecReporter printReport with normal setup should print the report to the console 1`] = `
+Array [
+  Array [
+    "------------------------------------------------------------------
+[loremipsum #0-0] Spec: /foo/bar/baz.js
+[loremipsum #0-0] Running: loremipsum
+[loremipsum #0-0]
+[loremipsum #0-0] Foo test
+[loremipsum #0-0]    green ✓ foo
+[loremipsum #0-0]    green ✓ bar
+[loremipsum #0-0]
+[loremipsum #0-0] Bar test
+[loremipsum #0-0]    green ✓ some test
+[loremipsum #0-0]    red ✖ a failed test
+[loremipsum #0-0]    red ✖ a failed test with no stack
+[loremipsum #0-0]
+[loremipsum #0-0] Baz test
+[loremipsum #0-0]    green ✓ foo bar baz
+[loremipsum #0-0]    cyan - a skipped test
+[loremipsum #0-0]
+[loremipsum #0-0] green 4 passing (5s)
+[loremipsum #0-0] red 1 failing
+[loremipsum #0-0] cyan 1 skipped
+[loremipsum #0-0]
+[loremipsum #0-0] 1) Bar test a failed test
+[loremipsum #0-0] red expected foo to equal bar
+[loremipsum #0-0] gray Failed test stack trace
+[loremipsum #0-0]
+[loremipsum #0-0] 2) Bar test a failed test with no stack
+[loremipsum #0-0] red expected foo to equal bar
+",
+  ],
+]
+`;

--- a/packages/wdio-spec-reporter/tests/__snapshots__/index.test.js.snap
+++ b/packages/wdio-spec-reporter/tests/__snapshots__/index.test.js.snap
@@ -93,6 +93,7 @@ Array [
     "------------------------------------------------------------------
 [loremipsum #0-0] Spec: /foo/bar/baz.js
 [loremipsum #0-0] Running: loremipsum
+[loremipsum #0-0] Session ID: foobar
 [loremipsum #0-0]
 [loremipsum #0-0] Foo test
 [loremipsum #0-0]    green ✓ foo
@@ -130,6 +131,7 @@ Array [
     "------------------------------------------------------------------
 [loremipsum #0-0] Spec: /foo/bar/baz.js
 [loremipsum #0-0] Running: loremipsum
+[loremipsum #0-0] Session ID: foobar
 [loremipsum #0-0]
 [loremipsum #0-0] Foo test
 [loremipsum #0-0]    green ✓ foo
@@ -167,6 +169,7 @@ Array [
     "------------------------------------------------------------------
 [loremipsum #0-0] Spec: /foo/bar/baz.js
 [loremipsum #0-0] Running: loremipsum
+[loremipsum #0-0] Session ID: foobar
 [loremipsum #0-0]
 [loremipsum #0-0] Foo test
 [loremipsum #0-0]    green ✓ foo
@@ -199,6 +202,7 @@ Array [
     "------------------------------------------------------------------
 [loremipsum #0-0] Spec: /foo/bar/baz.js
 [loremipsum #0-0] Running: loremipsum
+[loremipsum #0-0] Session ID: foobar
 [loremipsum #0-0]
 [loremipsum #0-0] Foo test
 [loremipsum #0-0]    green ✓ foo
@@ -236,6 +240,7 @@ Array [
     "------------------------------------------------------------------
 [loremipsum #0-0] Spec: /foo/bar/baz.js
 [loremipsum #0-0] Running: loremipsum
+[loremipsum #0-0] Session ID: foobar
 [loremipsum #0-0]
 [loremipsum #0-0] Foo test
 [loremipsum #0-0]    green ✓ foo
@@ -273,6 +278,7 @@ Array [
     "------------------------------------------------------------------
 [loremipsum #0-0] Spec: /foo/bar/baz.js
 [loremipsum #0-0] Running: loremipsum
+[loremipsum #0-0] Session ID: foobar
 [loremipsum #0-0]
 [loremipsum #0-0] Foo test
 [loremipsum #0-0]    green ✓ foo
@@ -310,6 +316,7 @@ Array [
     "------------------------------------------------------------------
 [loremipsum #0-0] Spec: /foo/bar/baz.js
 [loremipsum #0-0] Running: loremipsum
+[loremipsum #0-0] Session ID: foobar
 [loremipsum #0-0]
 [loremipsum #0-0] Foo test
 [loremipsum #0-0]    green ✓ foo
@@ -347,6 +354,7 @@ Array [
     "------------------------------------------------------------------
 [loremipsum #0-0] Spec: /foo/bar/baz.js
 [loremipsum #0-0] Running: loremipsum
+[loremipsum #0-0] Session ID: foobar
 [loremipsum #0-0]
 [loremipsum #0-0] Foo test
 [loremipsum #0-0]    green ✓ foo

--- a/packages/wdio-spec-reporter/tests/index.test.js
+++ b/packages/wdio-spec-reporter/tests/index.test.js
@@ -6,21 +6,20 @@ import {
     SUITES,
     SUITES_NO_TESTS,
     SUITES_WITH_DATA_TABLE,
-    REPORT,
-    SAUCELABS_REPORT,
-    SAUCELABS_EU_REPORT,
-    SAUCELABS_HEADLESS_REPORT,
     SUITES_NO_TESTS_WITH_HOOK_ERROR,
     SUITES_MULTIPLE_ERRORS
 } from './__fixtures__/testdata'
 
 const reporter = new SpecReporter({})
 
+const defaultCaps = { browserName: 'loremipsum' }
 const fakeSessionId = 'ba86cbcb70774ef8a0757c1702c3bdf9'
-const getRunnerConfig = (config) => {
+const getRunnerConfig = (config = {}) => {
     return Object.assign({}, RUNNER, {
+        capabilities: config.capabilities || defaultCaps,
         config,
-        sessionId: fakeSessionId
+        sessionId: fakeSessionId,
+        isMultiremote: Boolean(config.isMultiremote)
     })
 }
 
@@ -168,59 +167,74 @@ describe('SpecReporter', () => {
             it('should print the report to the console', () => {
                 const runner = getRunnerConfig({ hostname: 'localhost' })
                 printReporter.printReport(runner)
-                expect(printReporter.write).toBeCalledWith(REPORT)
+                expect(printReporter.write.mock.calls).toMatchSnapshot()
             })
 
             it('should print link to SauceLabs job details page', () => {
                 const runner = getRunnerConfig({
-                    hostname: 'ondemand.saucelabs.com',
-                    capabilities: {}
+                    hostname: 'ondemand.saucelabs.com'
                 })
                 printReporter.printReport(runner)
-                expect(printReporter.write).toBeCalledWith(SAUCELABS_REPORT)
+                expect(printReporter.write.mock.calls).toMatchSnapshot()
+            })
+
+            it('should print jobs of all instance when run with multiremote', () => {
+                const runner = getRunnerConfig({
+                    hostname: 'ondemand.saucelabs.com',
+                    capabilities: {
+                        browserA: { sessionId: 'foobar' },
+                        browserB: { sessionId: 'barfoo' }
+                    },
+                    isMultiremote: true
+                })
+                printReporter.printReport(runner)
+                expect(printReporter.write.mock.calls).toMatchSnapshot()
             })
 
             it('should print link to SauceLabs job details page if run with Sauce Connect (w3c)', () => {
                 const runner = getRunnerConfig({
-                    capabilities: { 'sauce:options': 'foobar' },
+                    capabilities: {
+                        ...defaultCaps,
+                        'sauce:options': 'foobar'
+                    },
                     hostname: 'localhost'
                 })
                 printReporter.printReport(runner)
-                expect(printReporter.write).toBeCalledWith(SAUCELABS_REPORT)
+                expect(printReporter.write.mock.calls).toMatchSnapshot()
             })
 
             it('should print link to SauceLabs job details page if run with Sauce Connect (jsonwp)', () => {
                 const runner = getRunnerConfig({
-                    capabilities: { tunnelIdentifier: 'foobar' },
+                    capabilities: {
+                        tunnelIdentifier: 'foobar',
+                        ...defaultCaps
+                    },
                     hostname: 'localhost'
                 })
                 printReporter.printReport(runner)
-                expect(printReporter.write).toBeCalledWith(SAUCELABS_REPORT)
+                expect(printReporter.write.mock.calls).toMatchSnapshot()
             })
 
             it('should print link to SauceLabs EU job details page', () => {
                 printReporter.printReport(getRunnerConfig({
-                    capabilities: {},
                     hostname: 'ondemand.saucelabs.com',
                     region: 'eu'
                 }))
-                expect(printReporter.write).toBeCalledWith(SAUCELABS_EU_REPORT)
+                expect(printReporter.write.mock.calls).toMatchSnapshot()
 
                 printReporter.write.mockClear()
 
                 printReporter.printReport(getRunnerConfig({
-                    capabilities: {},
                     hostname: 'ondemand.saucelabs.com',
                     region: 'eu-central-1'
                 }))
-                expect(printReporter.write).toBeCalledWith(SAUCELABS_EU_REPORT)
+                expect(printReporter.write.mock.calls).toMatchSnapshot()
 
                 printReporter.printReport(getRunnerConfig({
-                    capabilities: {},
                     hostname: 'ondemand.saucelabs.com',
                     headless: true
                 }))
-                expect(printReporter.write).toBeCalledWith(SAUCELABS_HEADLESS_REPORT)
+                expect(printReporter.write.mock.calls).toMatchSnapshot()
             })
         })
 
@@ -242,7 +256,7 @@ describe('SpecReporter', () => {
             printReporter.suiteUids = SUITE_UIDS
             printReporter.suites = SUITES_NO_TESTS
 
-            printReporter.printReport(RUNNER)
+            printReporter.printReport(getRunnerConfig())
 
             expect(printReporter.write.mock.calls.length).toBe(0)
         })
@@ -250,7 +264,7 @@ describe('SpecReporter', () => {
 
     describe('getHeaderDisplay', () => {
         it('should validate header output', () => {
-            const result = reporter.getHeaderDisplay(RUNNER)
+            const result = reporter.getHeaderDisplay(getRunnerConfig())
 
             expect(result.length).toBe(3)
             expect(result[0]).toBe('Spec: /foo/bar/baz.js')
@@ -259,7 +273,8 @@ describe('SpecReporter', () => {
         })
 
         it('should validate header output in multiremote', () => {
-            const result = tmpReporter.getHeaderDisplay({ ...RUNNER, isMultiremote: true })
+            const result = tmpReporter.getHeaderDisplay(
+                getRunnerConfig({ isMultiremote: true }))
 
             expect(result.length).toBe(3)
             expect(result[0]).toBe('Spec: /foo/bar/baz.js')

--- a/packages/wdio-spec-reporter/tests/index.test.js
+++ b/packages/wdio-spec-reporter/tests/index.test.js
@@ -12,7 +12,7 @@ import {
 
 const reporter = new SpecReporter({})
 
-const defaultCaps = { browserName: 'loremipsum' }
+const defaultCaps = { browserName: 'loremipsum', sessionId: 'foobar' }
 const fakeSessionId = 'ba86cbcb70774ef8a0757c1702c3bdf9'
 const getRunnerConfig = (config = {}) => {
     return Object.assign({}, RUNNER, {
@@ -269,7 +269,6 @@ describe('SpecReporter', () => {
             expect(result.length).toBe(3)
             expect(result[0]).toBe('Spec: /foo/bar/baz.js')
             expect(result[1]).toBe('Running: loremipsum')
-            expect(result[2]).toBe('')
         })
 
         it('should validate header output in multiremote', () => {
@@ -279,7 +278,6 @@ describe('SpecReporter', () => {
             expect(result.length).toBe(3)
             expect(result[0]).toBe('Spec: /foo/bar/baz.js')
             expect(result[1]).toBe('Running: MultiremoteBrowser')
-            expect(result[2]).toBe('')
         })
     })
 


### PR DESCRIPTION
## Proposed changes

When run multiremote tests on Sauce Labs with the spec reporter, it would not show the links to the job details page correctly:

```
[MultiremoteBrowser #0-0] Spec: /Users/joshuagrant/Documents/saucelabs-sample-test-frameworks/JS-Mocha-WebdriverIO-Selenium/tests/multi_login.j
s
[MultiremoteBrowser #0-0] Running: undefined
[MultiremoteBrowser #0-0]
[MultiremoteBrowser #0-0] Multiuser Login
[MultiremoteBrowser #0-0]    ✓ correct messages appear
[MultiremoteBrowser #0-0]
[MultiremoteBrowser #0-0] 1 passing (5.9s)
[MultiremoteBrowser #0-0]
[MultiremoteBrowser #0-0] Check out job at https://app.saucelabs.com/tests/undefined
```

This patch fixes that and shows the link including the instance name:

```
[MultiremoteBrowser #0-0] Spec: /foo/bar/baz.js
[MultiremoteBrowser #0-0] Running: MultiremoteBrowser
[MultiremoteBrowser #0-0]
[MultiremoteBrowser #0-0] Foo test
[MultiremoteBrowser #0-0]    green ✓ foo
[MultiremoteBrowser #0-0]    green ✓ bar
[MultiremoteBrowser #0-0]
[MultiremoteBrowser #0-0] Bar test
[MultiremoteBrowser #0-0]    green ✓ some test
[MultiremoteBrowser #0-0]    red ✖ a failed test
[MultiremoteBrowser #0-0]    red ✖ a failed test with no stack
[MultiremoteBrowser #0-0]
[MultiremoteBrowser #0-0] Baz test
[MultiremoteBrowser #0-0]    green ✓ foo bar baz
[MultiremoteBrowser #0-0]    cyan - a skipped test
[MultiremoteBrowser #0-0]
[MultiremoteBrowser #0-0] green 4 passing (5s)
[MultiremoteBrowser #0-0] red 1 failing
[MultiremoteBrowser #0-0] cyan 1 skipped
[MultiremoteBrowser #0-0]
[MultiremoteBrowser #0-0] 1) Bar test a failed test
[MultiremoteBrowser #0-0] red expected foo to equal bar
[MultiremoteBrowser #0-0] gray Failed test stack trace
[MultiremoteBrowser #0-0]
[MultiremoteBrowser #0-0] 2) Bar test a failed test with no stack
[MultiremoteBrowser #0-0] red expected foo to equal bar
[MultiremoteBrowser #0-0]
[MultiremoteBrowser #0-0] Check out browserA job at https://app.saucelabs.com/tests/foobar
[MultiremoteBrowser #0-0] Check out browserB job at https://app.saucelabs.com/tests/barfoo
```

closes #4645

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
