### PR TITLE
wdio-mocha-framework: translate test:fail for error in "before each"-hook into hook:end

### DIFF
--- a/packages/wdio-mocha-framework/src/index.js
+++ b/packages/wdio-mocha-framework/src/index.js
@@ -205,7 +205,7 @@ class MochaAdapter {
             /**
              * hook failures are emitted as "test:fail"
              */
-            if (params.payload && params.payload.title && params.payload.title.match(/^"(before|after)( all)*" hook/g)) {
+            if (params.payload && params.payload.title && params.payload.title.match(/^"(before|after)( all| each)?" hook/)) {
                 message.type = 'hook:end'
             }
         }

--- a/packages/wdio-mocha-framework/tests/adapter.test.js
+++ b/packages/wdio-mocha-framework/tests/adapter.test.js
@@ -24,6 +24,12 @@ const adapterFactory = (config) => new MochaAdapter(
     wdioReporter
 )
 
+beforeEach(() => {
+    wdioReporter.write.mockReset()
+    wdioReporter.emit.mockReset()
+    wdioReporter.on.mockReset()
+})
+
 test('comes with a factory', async () => {
     expect(typeof MochaAdapterFactory.init).toBe('function')
     const instance = await MochaAdapterFactory.init(
@@ -226,7 +232,7 @@ test('emit properly reports to reporter', () => {
     expect(wdioReporter.emit.mock.calls[0][1].uid).toBe(123)
 })
 
-test('emits hook errors as hook:end', () => {
+test('emits "before all"-hook errors as hook:end', () => {
     const adapter = adapterFactory()
     adapter.getUID = () => 123
     adapter.emit(
@@ -235,8 +241,21 @@ test('emits hook errors as hook:end', () => {
         new Error('uups')
     )
 
-    expect(wdioReporter.emit.mock.calls[1][0]).toBe('hook:end')
-    expect(wdioReporter.emit.mock.calls[1][1].error.message).toBe('uups')
+    expect(wdioReporter.emit.mock.calls[0][0]).toBe('hook:end')
+    expect(wdioReporter.emit.mock.calls[0][1].error.message).toBe('uups')
+})
+
+test('emits "before each"-hook errors as hook:end', () => {
+    const adapter = adapterFactory()
+    adapter.getUID = () => 123
+    adapter.emit(
+        'test:fail',
+        { title: '"before each" hook' },
+        new Error('uups')
+    )
+
+    expect(wdioReporter.emit.mock.calls[0][0]).toBe('hook:end')
+    expect(wdioReporter.emit.mock.calls[0][1].error.message).toBe('uups')
 })
 
 test('getUID', () => {


### PR DESCRIPTION
This fixes https://github.com/webdriverio/webdriverio/issues/4807.

## Proposed changes

Mocha reports errors in hooks as `fail`-events. The `MochaAdapter` already included a check for titles containing /_"before all" hook_/ in order to translate the occurring `test:fail`-events into `hook:end`-events.
However the check did not cover errors in before-each-hooks where the title starts with /_"before each" hook_/.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

### Reviewers: @webdriverio/technical-committee
