### PR TITLE
Fix typo in shared-store service doc

### DIFF
--- a/packages/wdio-shared-store-service/README.md
+++ b/packages/wdio-shared-store-service/README.md
@@ -7,8 +7,9 @@ WebdriverIO Shared Store Service
 
 Get/set a value (plain object) to/from the store by key (string).
 
-`browser.sharedStore().set('key', 'value')` set value to store
-`browser.sharedStore().get('key')` get value from store (returns `'value'`)
+`browser.sharedStore.set('key', 'value')` set value to store
+
+`browser.sharedStore.get('key')` get value from store (returns `'value'`)
 
 IMPORTANT! Every spec file should be atomic and isolated from others specs.
 The idea of the service is to deal with very specific environment setup issues.


### PR DESCRIPTION
## Proposed changes

`browser.sharedStore()` -> `browser.sharedStore`

## Types of changes

- [x] Documentation update

### Reviewers: @webdriverio/technical-committee
