### PR TITLE
Docs: Add unbound function note on mocha rerun section.

### DIFF
--- a/docs/Retry.md
+++ b/docs/Retry.md
@@ -7,7 +7,8 @@ You can rerun certain tests with the WebdriverIO testrunner that turn out to be 
 
 ## Rerun suites in Mocha
 
-Since version 3 of Mocha, you can rerun whole test suites (everything inside an `describe` block). If you use Mocha you should favor this retry mechanism instead of the WebdriverIO implementation that only allows you to rerun certain test blocks (everything within an `it` block). 
+Since version 3 of Mocha, you can rerun whole test suites (everything inside an `describe` block). If you use Mocha you should favor this retry mechanism instead of the WebdriverIO implementation that only allows you to rerun certain test blocks (everything within an `it` block).  
+The suite block `describe` must use an unbound function `function(){}` instead of a fat arrow function `()=>{}` as described in [Mocha docs](https://mochajs.org/#arrow-functions).
 
 Here is an example how to rerun a whole suite in Mocha:
 

--- a/docs/Retry.md
+++ b/docs/Retry.md
@@ -8,9 +8,9 @@ You can rerun certain tests with the WebdriverIO testrunner that turn out to be 
 ## Rerun suites in Mocha
 
 Since version 3 of Mocha, you can rerun whole test suites (everything inside an `describe` block). If you use Mocha you should favor this retry mechanism instead of the WebdriverIO implementation that only allows you to rerun certain test blocks (everything within an `it` block).  
-The suite block `describe` must use an unbound function `function(){}` instead of a fat arrow function `()=>{}` as described in [Mocha docs](https://mochajs.org/#arrow-functions).
+In order to use the `this.retries()` method, the suite block `describe` must use an unbound function `function(){}` instead of a fat arrow function `()=>{}`, as described in [Mocha docs](https://mochajs.org/#arrow-functions).
 
-Here is an example how to rerun a whole suite in Mocha:
+Here is an example:
 
 ```js
 describe('retries', function() {


### PR DESCRIPTION
## Proposed changes

[//]: I'm adding a note on mocha unbound functions usage, since it's easy to wrongly use the fat arrow and blame webdriverio for tests failing when using `this.retry(3)`

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
