### PR TITLE
wdio-cli: add wdio-wiremock-service to cli wizard

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -156,6 +156,7 @@ intercept
 zafira-listener
 reportportal
 docker
+wiremock
 ```
 
 #### List of supported reporters

--- a/packages/wdio-cli/src/constants.js
+++ b/packages/wdio-cli/src/constants.js
@@ -81,6 +81,7 @@ export const SUPPORTED_PACKAGES = {
         { name: 'zafira-listener', value: 'wdio-zafira-listener-service$--$zafira-listener' },
         { name: 'reportportal', value: 'wdio-reportportal-service$--$reportportal' },
         { name: 'docker', value: 'wdio-docker-service$--$docker' },
+        { name: 'wiremock', value: 'wdio-wiremock-service$--$wiremock' },
     ],
 }
 

--- a/scripts/docs-generation/3rd-party/services.json
+++ b/scripts/docs-generation/3rd-party/services.json
@@ -28,5 +28,11 @@
     "title": "Docker",
     "githubUrl": "https://github.com/stsvilik/wdio-docker-service",
     "npmUrl": "https://www.npmjs.com/package/wdio-docker-service"
+  },
+  {
+    "packageName": "wdio-wiremock-service",
+    "title": "WireMock",
+    "githubUrl": "https://github.com/erwinheitzman/wdio-wiremock-service",
+    "npmUrl": "https://www.npmjs.com/package/wdio-wiremock-service"
   }
 ]


### PR DESCRIPTION
## Proposed changes

I have created a new service that runs WireMock alongside your WDIO testsuite.
This service is now added to the cli wizard.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

### Reviewers: @webdriverio/technical-committee
