### PR TITLE
Sync vs Async test execution equality

### DIFF
--- a/docs/Retry.md
+++ b/docs/Retry.md
@@ -7,7 +7,7 @@ You can rerun certain tests with the WebdriverIO testrunner that turn out to be 
 
 ## Rerun suites in Mocha
 
-Since version 3 of Mocha, you can rerun whole test suites (everything inside an `describe` block). If you use Mocha you should favor this retry mechanism instead of the WebdriverIO implementation that only allows you to rerun certain test blocks (everything within an `it` block). In order to use the `this.retries()` method, the suite block `describe` must use an unbound function `function(){}` instead of a fat arrow function `()=>{}`, as described in [Mocha docs](https://mochajs.org/#arrow-functions).
+Since version 3 of Mocha, you can rerun whole test suites (everything inside an `describe` block). If you use Mocha you should favor this retry mechanism instead of the WebdriverIO implementation that only allows you to rerun certain test blocks (everything within an `it` block). In order to use the `this.retries()` method, the suite block `describe` must use an unbound function `function(){}` instead of a fat arrow function `() => {}`, as described in [Mocha docs](https://mochajs.org/#arrow-functions). Using Mocha you can also set a retry count for all specs using `mochaOpts.retries` in your `wdio.conf.js`.
 
 Here is an example:
 
@@ -29,7 +29,7 @@ describe('retries', function() {
 })
 ```
 
-## Rerun single tests in Jasmine or Mocha (`@wdio/sync` only)
+## Rerun single tests in Jasmine or Mocha
 
 To rerun a certain test block you can just apply the number of reruns as last parameter after the test block function:
 

--- a/docs/Retry.md
+++ b/docs/Retry.md
@@ -7,8 +7,7 @@ You can rerun certain tests with the WebdriverIO testrunner that turn out to be 
 
 ## Rerun suites in Mocha
 
-Since version 3 of Mocha, you can rerun whole test suites (everything inside an `describe` block). If you use Mocha you should favor this retry mechanism instead of the WebdriverIO implementation that only allows you to rerun certain test blocks (everything within an `it` block).  
-In order to use the `this.retries()` method, the suite block `describe` must use an unbound function `function(){}` instead of a fat arrow function `()=>{}`, as described in [Mocha docs](https://mochajs.org/#arrow-functions).
+Since version 3 of Mocha, you can rerun whole test suites (everything inside an `describe` block). If you use Mocha you should favor this retry mechanism instead of the WebdriverIO implementation that only allows you to rerun certain test blocks (everything within an `it` block). In order to use the `this.retries()` method, the suite block `describe` must use an unbound function `function(){}` instead of a fat arrow function `()=>{}`, as described in [Mocha docs](https://mochajs.org/#arrow-functions).
 
 Here is an example:
 
@@ -32,14 +31,15 @@ describe('retries', function() {
 
 ## Rerun single tests in Jasmine or Mocha (`@wdio/sync` only)
 
-If you are using `@wdio/sync`, to rerun a certain test block you can just apply the number of reruns as last parameter after the test block function:
+To rerun a certain test block you can just apply the number of reruns as last parameter after the test block function:
 
 ```js
 describe('my flaky app', () => {
     /**
      * spec that runs max 4 times (1 actual run + 3 reruns)
      */
-    it('should rerun a test at least 3 times', () => {
+    it('should rerun a test at least 3 times', function () {
+        console.log(this.retries) // returns number of retries
         // ...
     }, 3)
 })
@@ -84,7 +84,7 @@ Reruns can only be defined in your step definitions file, never in your feature 
 
 ## Add retries on a per-specfile basis
 
-Previously, only test- and suite-level retries were available, which are fine in most cases. 
+Previously, only test- and suite-level retries were available, which are fine in most cases.
 
 But in any tests which involve state (such as on a server or in a database) the state may be left invalid after the first test failure. Any subsequent retries may have no chance of passing, due to the invalid state they would start with.
 

--- a/packages/wdio-sync/src/index.js
+++ b/packages/wdio-sync/src/index.js
@@ -16,6 +16,7 @@ import { STACKTRACE_FILTER_FN } from './constants'
  */
 const executeSync = async function (fn, retries, args = []) {
     delete global.browser._NOT_FIBER
+    this.retries = retries.attempts
 
     try {
         global._HAS_FIBER_CONTEXT = true
@@ -34,7 +35,7 @@ const executeSync = async function (fn, retries, args = []) {
     } catch (e) {
         if (retries.limit > retries.attempts) {
             retries.attempts++
-            return await executeSync(fn, retries, args)
+            return await executeSync.call(this, fn, retries, args)
         }
 
         /**
@@ -46,32 +47,6 @@ const executeSync = async function (fn, retries, args = []) {
 
         e.stack = e.stack.split('\n').filter(STACKTRACE_FILTER_FN).join('\n')
         return Promise.reject(e)
-    }
-}
-
-/**
- * execute test or hook asynchronously
- *
- * @param  {Function} fn         spec or hook method
- * @param  {object}   retries    { limit: number, attempts: number }
- * @param  {Array}    args       arguments passed to hook
- * @return {Promise}             that gets resolved once test/hook is done or was retried enough
- */
-const executeAsync = async function (fn, retries, args = []) {
-    try {
-        return await fn.apply(this, args)
-    } catch (e) {
-        if (retries.limit > retries.attempts) {
-            retries.attempts++
-            return await executeAsync(fn, retries, args)
-        }
-
-        // Only instances of `Error` have a stack trace. Specifcally in mocha, `this.skip()`
-        // does a `throw new Pending('sync skip')` which is not a subsclass of `Error`
-        if (e.stack) {
-            e.stack = e.stack.split('\n').filter(STACKTRACE_FILTER_FN).join('\n')
-        }
-        throw e
     }
 }
 
@@ -88,6 +63,5 @@ export {
     wrapCommand,
     runFnInFiberContext,
     executeSync,
-    executeAsync,
     runSync,
 }

--- a/packages/wdio-utils/src/shim.js
+++ b/packages/wdio-utils/src/shim.js
@@ -2,6 +2,9 @@ import logger from '@wdio/logger'
 
 const log = logger('@wdio/utils:shim')
 
+let hasWdioSyncSupport = false
+let runSync = null
+
 let executeHooksWithArgs = async function executeHooksWithArgsShim (hooks, args) {
     /**
      * make sure hooks are an array of functions
@@ -49,11 +52,82 @@ let runFnInFiberContext = function (fn) {
         return Promise.resolve(fn.apply(this, args))
     }
 }
-let wrapCommand = (_, origFn) => origFn
-let hasWdioSyncSupport = false
-let executeSync = function (fn, _, args = []) { return fn.apply(this, args) }
-let executeAsync = function (fn, _, args = []) { return fn.apply(this, args) }
-let runSync = null
+
+let wrapCommand = async function (commandName, fn, ...args) {
+    await executeHooksWithArgs.call(this, this.options.beforeCommand, [commandName, args])
+
+    let commandResult
+    let commandError
+    try {
+        commandResult = await fn.apply(this, args)
+    } catch (err) {
+        commandError = err
+    }
+
+    await executeHooksWithArgs.call(this, this.options.afterCommand, [commandName, args, commandResult, commandError])
+
+    if (commandError) {
+        throw commandError
+    }
+
+    return commandResult
+}
+
+/**
+ * execute test or hook synchronously
+ *
+ * @param  {Function} fn         spec or hook method
+ * @param  {Number}   retries    { limit: number, attempts: number }
+ * @param  {Array}    args       arguments passed to hook
+ * @return {Promise}             that gets resolved once test/hook is done or was retried enough
+ */
+let executeSync = async function (fn, retries, args = []) {
+    this.retries = retries.attempts
+
+    try {
+        let res = fn.apply(this, args)
+
+        /**
+         * sometimes function result is Promise,
+         * we need to await result before proceeding
+         */
+        if (res instanceof Promise) {
+            return await res
+        }
+
+        return res
+    } catch (e) {
+        if (retries.limit > retries.attempts) {
+            retries.attempts++
+            return await executeSync.call(this, fn, retries, args)
+        }
+
+        return Promise.reject(e)
+    }
+}
+
+/**
+ * execute test or hook asynchronously
+ *
+ * @param  {Function} fn         spec or hook method
+ * @param  {object}   retries    { limit: number, attempts: number }
+ * @param  {Array}    args       arguments passed to hook
+ * @return {Promise}             that gets resolved once test/hook is done or was retried enough
+ */
+const executeAsync = async function (fn, retries, args = []) {
+    this.retries = retries.attempts
+
+    try {
+        return await fn.apply(this, args)
+    } catch (e) {
+        if (retries.limit > retries.attempts) {
+            retries.attempts++
+            return await executeAsync.call(this, fn, retries, args)
+        }
+
+        throw e
+    }
+}
 
 /**
  * shim to make sure that we only wrap commands if wdio-sync is installed as dependency
@@ -66,7 +140,6 @@ try {
     wrapCommand = wdioSync.wrapCommand
     executeHooksWithArgs = wdioSync.executeHooksWithArgs
     executeSync = wdioSync.executeSync
-    executeAsync = wdioSync.executeAsync
     runSync = wdioSync.runSync
 } catch {
     // do nothing

--- a/packages/wdio-utils/tests/shim-sync.test.js
+++ b/packages/wdio-utils/tests/shim-sync.test.js
@@ -1,11 +1,10 @@
-import { executeHooksWithArgs, runFnInFiberContext, wrapCommand, hasWdioSyncSupport, executeSync, executeAsync, runSync } from '../src/shim'
+import { executeHooksWithArgs, runFnInFiberContext, wrapCommand, hasWdioSyncSupport, executeSync, runSync } from '../src/shim'
 
 jest.mock('@wdio/sync', () => ({
     executeHooksWithArgs: 'executeHooksWithArgs',
     runFnInFiberContext: 'runFnInFiberContext',
     wrapCommand: 'wrapCommand',
     executeSync: 'executeSync',
-    executeAsync: 'executeAsync',
     runSync: 'runSync'
 }))
 
@@ -36,12 +35,6 @@ describe('hasWdioSyncSupport', () => {
 describe('executeSync', () => {
     it('should match @wdio/sync', async () => {
         expect(executeSync).toBe('executeSync')
-    })
-})
-
-describe('executeAsync', () => {
-    it('should match @wdio/sync', async () => {
-        expect(executeAsync).toBe('executeAsync')
     })
 })
 

--- a/packages/wdio-utils/tests/shim.test.js
+++ b/packages/wdio-utils/tests/shim.test.js
@@ -1,0 +1,44 @@
+import { wrapCommand } from '../src/shim'
+
+describe('wrapCommand', () => {
+    it('should run command with before and after hook', async () => {
+        const commandFn = jest.fn().mockReturnValue(Promise.resolve('foobar'))
+        const beforeHook = jest.fn()
+        const afterHook = jest.fn()
+        const scope = {
+            options: {
+                beforeCommand: [beforeHook, beforeHook],
+                afterCommand: [afterHook, afterHook, afterHook]
+            }
+        }
+        const res = await wrapCommand.call(scope, 'someCommand', commandFn, 123, 'barfoo')
+        expect(res).toEqual('foobar')
+        expect(commandFn).toBeCalledTimes(1)
+        expect(commandFn).toBeCalledWith(123, 'barfoo')
+
+        expect(beforeHook).toBeCalledTimes(2)
+        expect(beforeHook).toBeCalledWith('someCommand', [123, 'barfoo'])
+
+        expect(afterHook).toBeCalledTimes(3)
+        expect(afterHook).toBeCalledWith('someCommand', [123, 'barfoo'], 'foobar', undefined)
+    })
+
+    it('should throw but still run after command hook', async () => {
+        const error = new Error('uups')
+        const commandFn = jest.fn().mockReturnValue(Promise.reject(error))
+        const afterHook = jest.fn()
+        const scope = {
+            options: {
+                beforeCommand: [],
+                afterCommand: [afterHook, afterHook, afterHook]
+            }
+        }
+        const res = await wrapCommand.call(scope, 'someCommand', commandFn, 123, 'barfoo').catch(err => err)
+        expect(res).toEqual(error)
+        expect(commandFn).toBeCalledTimes(1)
+        expect(commandFn).toBeCalledWith(123, 'barfoo')
+
+        expect(afterHook).toBeCalledTimes(3)
+        expect(afterHook).toBeCalledWith('someCommand', [123, 'barfoo'], undefined, error)
+    })
+})

--- a/tests/cucumber/step-definitions/then.js
+++ b/tests/cucumber/step-definitions/then.js
@@ -13,15 +13,15 @@ Then('the title of the page should be {string} async', async (expectedTitle) => 
     assert.equal(actualTitle, expectedTitle)
 })
 
-let someFlag = false
-Then('I should fail once but pass on the second run', { wrapperOptions: { retry: 1 } }, () => {
-    if (!someFlag) {
-        someFlag = true
+let hasRun = false
+Then('I should fail once but pass on the second run', { wrapperOptions: { retry: 1 } }, function () {
+    if (!hasRun) {
+        hasRun = true
+        assert.equal(this.retries, 0)
         throw new Error('boom!')
     }
 
-    someFlag = false
-    assert.equal(1, 1)
+    assert.equal(this.retries, 1)
 })
 
 Then('this is ambiguous', () => {

--- a/tests/jasmine/test.js
+++ b/tests/jasmine/test.js
@@ -1,13 +1,18 @@
+const assert = require('assert')
+
 describe('Jasmine smoke test', () => {
     it('should return sync value', () => {
         expect(browser.getTitle()).toBe('Mock Page Title')
     })
 
     let hasRun = false
-    it('should retry', () => {
-        if(!hasRun) {
+    it('should retry', function () {
+        if (!hasRun) {
             hasRun = true
+            assert.equal(this.retries, 0)
             throw new Error('booom!')
         }
+
+        assert.equal(this.retries, 1)
     }, 1)
 })

--- a/tests/mocha/retry_and_fail.js
+++ b/tests/mocha/retry_and_fail.js
@@ -1,5 +1,8 @@
+import assert from 'assert'
+
 describe('always fail', function () {
     it('always fail', function () {
+        assert.equal(typeof this.retries, 'number')
         throw Error('Deliberate error.')
     })
 })

--- a/tests/mocha/test.js
+++ b/tests/mocha/test.js
@@ -2,7 +2,6 @@ import assert from 'assert'
 import os from 'os'
 
 describe('Mocha smoke test', () => {
-
     let testJs = 'tests/mocha/test.js:'
 
     before(() => {
@@ -16,11 +15,14 @@ describe('Mocha smoke test', () => {
     })
 
     let hasRun = false
-    it('should retry', () => {
+    it('should retry', function () {
         if (!hasRun) {
             hasRun = true
+            assert.equal(this.retries, 0)
             throw new Error('booom!')
         }
+
+        assert.equal(this.retries, 1)
     }, 1)
 
     it('should work fine after catching an error', () => {


### PR DESCRIPTION
## Proposed changes

Currently there is a difference when running tests synchronously (with `@wdio/sync`) and asynchronously (without `@wdio/sync`):

- tests are not being retried
- no `beforeCommand` and `afterCommand` hooks are run

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

This patch fixes the behavior to make it the same. It also adds `retries` to the function scope so that user have an idea how many times the test was already run.

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

closes #4851
closes #4849

### Reviewers: @webdriverio/project-committers 
