### PR TITLE
$$ returns an object not an array

### DIFF
--- a/packages/webdriverio/src/commands/browser/$$.js
+++ b/packages/webdriverio/src/commands/browser/$$.js
@@ -1,6 +1,6 @@
 /**
  * The `$$` command is a short way to call the [`findElements`](/docs/api/webdriver.html#findelements) command in order
- * to fetch multiple elements on the page. It returns an array with element results that will have an
+ * to fetch multiple elements on the page. It returns an object with element results that will have an
  * extended prototype to call action commands without passing in a selector. However if you still pass
  * in a selector it will look for that element first and call the action on that element.
  *


### PR DESCRIPTION
## Proposed changes

The docs say that the `$$` command returns and array of elements but it's actually an object that is returned. This changes the docs to reflect what is actually returned.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
  Sorry, read this after. Let me know if I have to change my commit message.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
