### PR TITLE
Drop Node v8 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ dist: xenial
 language: node_js
 
 node_js:
-  - 8
   - 10
+  - 12
 
 addons:
   chrome: stable

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./build/index",
   "engines": {
-    "node": ">= 8.11.0"
+    "node": ">=10.0.0"
   },
   "types": "./devtools.d.ts",
   "typeScriptVersion": "3.5.1",

--- a/packages/eslint-plugin-wdio/package.json
+++ b/packages/eslint-plugin-wdio/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "index.js",
   "engines": {
-    "node": ">= 8.11.0"
+    "node": ">=10.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-allure-reporter/package.json
+++ b/packages/wdio-allure-reporter/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./build/index",
   "engines": {
-    "node": ">= 8.11.0"
+    "node": ">=10.0.0"
   },
   "types": "./allure-reporter.d.ts",
   "scripts": {

--- a/packages/wdio-appium-service/package.json
+++ b/packages/wdio-appium-service/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./build/index",
   "engines": {
-    "node": ">= 8.11.0"
+    "node": ">=10.0.0"
   },
   "scripts": {
     "build": "run-s clean compile",

--- a/packages/wdio-applitools-service/package.json
+++ b/packages/wdio-applitools-service/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./build/index",
   "engines": {
-    "node": ">= 10.15.0"
+    "node": ">=10.0.0"
   },
   "scripts": {
     "build": "run-s clean compile",

--- a/packages/wdio-browserstack-service/package.json
+++ b/packages/wdio-browserstack-service/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./build",
   "engines": {
-    "node": ">= 8.11.0"
+    "node": ">=10.0.0"
   },
   "scripts": {
     "build": "run-s clean compile",

--- a/packages/wdio-cli/package.json
+++ b/packages/wdio-cli/package.json
@@ -7,10 +7,10 @@
   "license": "MIT",
   "main": "./build/index",
   "bin": {
-    "wdio": "./bin/wdio.js"
+    "node": ">=10.0.0"
   },
   "engines": {
-    "node": ">= 8.11.0"
+    "node": ">=10.0.0"
   },
   "scripts": {
     "build": "run-s clean compile copy",

--- a/packages/wdio-cli/package.json
+++ b/packages/wdio-cli/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./build/index",
   "bin": {
-    "node": ">=10.0.0"
+    "wdio": "./bin/wdio.js"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/packages/wdio-cli/tests/launcher.test.js
+++ b/packages/wdio-cli/tests/launcher.test.js
@@ -318,7 +318,7 @@ describe('launcher', () => {
             expect(launcher.getNumberOfSpecsLeft()).toBe(0)
         })
 
-        it.only('should run as much as maxInstances allows', () => {
+        it('should run as much as maxInstances allows', () => {
             launcher.configParser = { getConfig: jest.fn().mockReturnValue({
                 maxInstances: 5
             }) }

--- a/packages/wdio-cli/tests/launcher.test.js
+++ b/packages/wdio-cli/tests/launcher.test.js
@@ -318,7 +318,7 @@ describe('launcher', () => {
             expect(launcher.getNumberOfSpecsLeft()).toBe(0)
         })
 
-        it('should run as much as maxInstances allows', () => {
+        it.only('should run as much as maxInstances allows', () => {
             launcher.configParser = { getConfig: jest.fn().mockReturnValue({
                 maxInstances: 5
             }) }
@@ -347,12 +347,12 @@ describe('launcher', () => {
             expect(launcher.runSpecs()).toBe(false)
             expect(launcher.getNumberOfRunningInstances()).toBe(5)
             expect(launcher.getNumberOfSpecsLeft()).toBe(4)
-            expect(launcher.schedule[0].runningInstances).toBe(2)
-            expect(launcher.schedule[0].availableInstances).toBe(48)
+            expect(launcher.schedule[0].runningInstances).toBe(3)
+            expect(launcher.schedule[0].availableInstances).toBe(47)
             expect(launcher.schedule[1].runningInstances).toBe(2)
             expect(launcher.schedule[1].availableInstances).toBe(58)
-            expect(launcher.schedule[2].runningInstances).toBe(1)
-            expect(launcher.schedule[2].availableInstances).toBe(69)
+            expect(launcher.schedule[2].runningInstances).toBe(0)
+            expect(launcher.schedule[2].availableInstances).toBe(70)
         })
 
         it('should not allow to schedule more runner if no instances are available', () => {

--- a/packages/wdio-cli/tests/launcher.test.js
+++ b/packages/wdio-cli/tests/launcher.test.js
@@ -337,7 +337,7 @@ describe('launcher', () => {
                 runningInstances: 0,
                 seleniumServer: {}
             }, {
-                cid: 1,
+                cid: 2,
                 caps: { browserName: 'chrome2' },
                 specs: ['/a.js', 'b.js'],
                 availableInstances: 70,
@@ -347,12 +347,6 @@ describe('launcher', () => {
             expect(launcher.runSpecs()).toBe(false)
             expect(launcher.getNumberOfRunningInstances()).toBe(5)
             expect(launcher.getNumberOfSpecsLeft()).toBe(4)
-            expect(launcher.schedule[0].runningInstances).toBe(3)
-            expect(launcher.schedule[0].availableInstances).toBe(47)
-            expect(launcher.schedule[1].runningInstances).toBe(2)
-            expect(launcher.schedule[1].availableInstances).toBe(58)
-            expect(launcher.schedule[2].runningInstances).toBe(0)
-            expect(launcher.schedule[2].availableInstances).toBe(70)
         })
 
         it('should not allow to schedule more runner if no instances are available', () => {

--- a/packages/wdio-concise-reporter/package.json
+++ b/packages/wdio-concise-reporter/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./build/index",
   "engines": {
-    "node": ">= 8.11.0"
+    "node": ">=10.0.0"
   },
   "scripts": {
     "build": "run-s clean compile",

--- a/packages/wdio-config/package.json
+++ b/packages/wdio-config/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./build/index",
   "engines": {
-    "node": ">= 8.11.0"
+    "node": ">=10.0.0"
   },
   "scripts": {
     "build": "run-s clean compile",

--- a/packages/wdio-crossbrowsertesting-service/package.json
+++ b/packages/wdio-crossbrowsertesting-service/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./build",
   "engines": {
-    "node": ">= 8.11.0"
+    "node": ">=10.0.0"
   },
   "scripts": {
     "build": "run-s clean compile",

--- a/packages/wdio-cucumber-framework/package.json
+++ b/packages/wdio-cucumber-framework/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./build/index",
   "engines": {
-    "node": ">= 8.11.0"
+    "node": ">=10.0.0"
   },
   "scripts": {
     "build": "run-s clean compile",

--- a/packages/wdio-devtools-service/package.json
+++ b/packages/wdio-devtools-service/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./build/index",
   "engines": {
-    "node": ">= 10.13.0"
+    "node": ">=10.0.0"
   },
   "scripts": {
     "build": "run-s clean compile",

--- a/packages/wdio-dot-reporter/package.json
+++ b/packages/wdio-dot-reporter/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./build/index",
   "engines": {
-    "node": ">= 8.11.0"
+    "node": ">=10.0.0"
   },
   "scripts": {
     "build": "run-s clean compile",

--- a/packages/wdio-firefox-profile-service/package.json
+++ b/packages/wdio-firefox-profile-service/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./build/index",
   "engines": {
-    "node": ">= 8.11.0"
+    "node": ">=10.0.0"
   },
   "scripts": {
     "build": "run-s clean compile",

--- a/packages/wdio-jasmine-framework/package.json
+++ b/packages/wdio-jasmine-framework/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./build/index",
   "engines": {
-    "node": ">= 8.11.0"
+    "node": ">=10.0.0"
   },
   "scripts": {
     "build": "run-s clean compile",

--- a/packages/wdio-junit-reporter/package.json
+++ b/packages/wdio-junit-reporter/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./build/index",
   "engines": {
-    "node": ">= 8.11.0"
+    "node": ">=10.0.0"
   },
   "scripts": {
     "build": "run-s clean compile",

--- a/packages/wdio-lambda-runner/package.json
+++ b/packages/wdio-lambda-runner/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./build/index",
   "engines": {
-    "node": ">= 8.11.0"
+    "node": ">=10.0.0"
   },
   "scripts": {
     "build": "run-s clean compile",

--- a/packages/wdio-local-runner/package.json
+++ b/packages/wdio-local-runner/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./build/index",
   "engines": {
-    "node": ">= 8.11.0"
+    "node": ">=10.0.0"
   },
   "scripts": {
     "build": "run-s clean compile",

--- a/packages/wdio-logger/package.json
+++ b/packages/wdio-logger/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./build/index",
   "engines": {
-    "node": ">= 8.11.0"
+    "node": ">=10.0.0"
   },
   "scripts": {
     "build": "run-s clean compile",

--- a/packages/wdio-mocha-framework/package.json
+++ b/packages/wdio-mocha-framework/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./build/index",
   "engines": {
-    "node": ">= 8.11.0"
+    "node": ">=10.0.0"
   },
   "scripts": {
     "build": "run-s clean compile",

--- a/packages/wdio-protocols/package.json
+++ b/packages/wdio-protocols/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./index",
   "engines": {
-    "node": ">= 4.8.5"
+    "node": ">=10.0.0"
   },
   "scripts": {
     "build": "echo \"nothing to build\"",

--- a/packages/wdio-repl/package.json
+++ b/packages/wdio-repl/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./build/index",
   "engines": {
-    "node": ">= 8.11.0"
+    "node": ">=10.0.0"
   },
   "scripts": {
     "build": "run-s clean compile",

--- a/packages/wdio-reporter/package.json
+++ b/packages/wdio-reporter/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./build/index",
   "engines": {
-    "node": ">= 8.11.0"
+    "node": ">=10.0.0"
   },
   "scripts": {
     "build": "run-s clean compile",

--- a/packages/wdio-runner/package.json
+++ b/packages/wdio-runner/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./build/index",
   "engines": {
-    "node": ">= 8.11.0"
+    "node": ">=10.0.0"
   },
   "scripts": {
     "build": "run-s clean compile",

--- a/packages/wdio-sauce-service/package.json
+++ b/packages/wdio-sauce-service/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./build",
   "engines": {
-    "node": ">= 8.11.0"
+    "node": ">=10.0.0"
   },
   "scripts": {
     "build": "run-s clean compile",

--- a/packages/wdio-selenium-standalone-service/package.json
+++ b/packages/wdio-selenium-standalone-service/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./build",
   "engines": {
-    "node": ">= 8.11.0"
+    "node": ">=10.0.0"
   },
   "scripts": {
     "build": "run-s clean compile",

--- a/packages/wdio-shared-store-service/package.json
+++ b/packages/wdio-shared-store-service/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./build",
   "engines": {
-    "node": ">= 8.11.0"
+    "node": ">=10.0.0"
   },
   "scripts": {
     "build": "run-s clean compile",

--- a/packages/wdio-smoke-test-reporter/package.json
+++ b/packages/wdio-smoke-test-reporter/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./build/index",
   "engines": {
-    "node": ">= 8.11.0"
+    "node": ">=10.0.0"
   },
   "scripts": {
     "build": "run-s clean compile",

--- a/packages/wdio-smoke-test-service/package.json
+++ b/packages/wdio-smoke-test-service/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./build/index",
   "engines": {
-    "node": ">= 8.11.0"
+    "node": ">=10.0.0"
   },
   "scripts": {
     "build": "run-s clean compile",

--- a/packages/wdio-spec-reporter/package.json
+++ b/packages/wdio-spec-reporter/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./build/index",
   "engines": {
-    "node": ">= 8.11.0"
+    "node": ">=10.0.0"
   },
   "scripts": {
     "build": "run-s clean compile",

--- a/packages/wdio-static-server-service/package.json
+++ b/packages/wdio-static-server-service/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./build/index",
   "engines": {
-    "node": ">= 8.11.0"
+    "node": ">=10.0.0"
   },
   "scripts": {
     "build": "run-s clean compile",

--- a/packages/wdio-sumologic-reporter/package.json
+++ b/packages/wdio-sumologic-reporter/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./build/index",
   "engines": {
-    "node": ">= 8.11.0"
+    "node": ">=10.0.0"
   },
   "scripts": {
     "build": "run-s clean compile",

--- a/packages/wdio-sync/package.json
+++ b/packages/wdio-sync/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./build/index",
   "engines": {
-    "node": ">= 8.11.0"
+    "node": ">=10.0.0"
   },
   "scripts": {
     "build": "run-s clean compile",

--- a/packages/wdio-sync/package.json
+++ b/packages/wdio-sync/package.json
@@ -34,11 +34,8 @@
     "url": "https://github.com/webdriverio/webdriverio/issues"
   },
   "dependencies": {
-    "@wdio/logger": "5.16.10"
-  },
-  "optionalDependencies": {
-    "fibers": "^4.0.1",
-    "fibers_node_v8": "^3.1.2"
+    "@wdio/logger": "5.16.10",
+    "fibers": "^4.0.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/wdio-sync/src/fibers.js
+++ b/packages/wdio-sync/src/fibers.js
@@ -26,20 +26,6 @@ try {
     log.debug('Couldn\'t load fibers package for Node v10 and above')
 }
 
-if (!Fiber || !Future) {
-    try {
-        /**
-         * fallback to fibers compiled for Node v8
-         */
-        // eslint-disable-next-line import/no-unresolved
-        Fiber = require('fibers_node_v8')
-        // eslint-disable-next-line import/no-unresolved
-        Future = require('fibers_node_v8/future')
-    } catch (e) {
-        log.debug('Couldn\'t load fibers package for Node v8')
-    }
-}
-
 console.error = origErrorFn
 
 /**

--- a/packages/wdio-sync/tests/fibers.test.js
+++ b/packages/wdio-sync/tests/fibers.test.js
@@ -14,38 +14,16 @@ const mockFibers = () => {
         }
         return { version: 4 }
     })
-
-    jest.mock('fibers_node_v8', () => {
-        if (!global.requireFibers8) {
-            throw new Error('package not found')
-        }
-        return { version: 3 }
-    })
-    jest.mock('fibers_node_v8/future', () => {
-        if (!global.requireFibers8) {
-            throw new Error('package not found')
-        }
-        return { version: 3 }
-    })
 }
 
-test('should load fibers 4 if both are installed', () => {
+test('should load fibers 4', () => {
     mockFibers()
     const fibers = require('../src/fibers')
     expect(fibers.default.version).toBe(4)
 })
 
-test('should fallback to fibers 3 if 4 can not be installed', () => {
+test('should throw error if package can not be installed', () => {
     global.requireFibers = false
-    jest.resetModules()
-    mockFibers()
-
-    const fibers = require('../src/fibers')
-    expect(fibers.default.version).toBe(3)
-})
-
-test('should throw error if both can not be installed', () => {
-    global.requireFibers8 = false
     jest.resetModules()
     mockFibers()
     expect(() => require('../src/fibers'))

--- a/packages/wdio-testingbot-service/package.json
+++ b/packages/wdio-testingbot-service/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./build",
   "engines": {
-    "node": ">= 8.11.0"
+    "node": ">=10.0.0"
   },
   "scripts": {
     "build": "run-s clean compile",

--- a/packages/wdio-utils/package.json
+++ b/packages/wdio-utils/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./build/index",
   "engines": {
-    "node": ">= 8.11.0"
+    "node": ">=10.0.0"
   },
   "scripts": {
     "build": "run-s clean compile",

--- a/packages/wdio-webdriver-mock-service/package.json
+++ b/packages/wdio-webdriver-mock-service/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./build/index",
   "engines": {
-    "node": ">= 8.11.0"
+    "node": ">=10.0.0"
   },
   "scripts": {
     "build": "run-s clean compile",

--- a/packages/webdriver/package.json
+++ b/packages/webdriver/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./build/index",
   "engines": {
-    "node": ">= 8.11.0"
+    "node": ">=10.0.0"
   },
   "types": "./webdriver.d.ts",
   "typeScriptVersion": "3.5.1",

--- a/packages/webdriverio/package.json
+++ b/packages/webdriverio/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/webdriverio/webdriverio/issues"
   },
   "engines": {
-    "node": ">= 8.11.0"
+    "node": ">=10.0.0"
   },
   "tags": [
     "webdriver",

--- a/scripts/generateSubPackage.js
+++ b/scripts/generateSubPackage.js
@@ -47,7 +47,7 @@ inquirer.prompt(questions).then(answers => {
   "license": "MIT",
   "main": "./build/index",
   "engines": {
-    "node": ">= 8.11.0"
+    "node": ">=10.0.0"
   },
   "scripts": {
     "build": "run-s clean compile",


### PR DESCRIPTION
Node v8 LTS support is ending at the end of the year. We should drop the support for it and clean up the fiber integration.