### PR TITLE
Update minimal TypeScript version to 3.7.2 or higher

### DIFF
--- a/docs/TypeScript.md
+++ b/docs/TypeScript.md
@@ -5,7 +5,7 @@ title: TypeScript Setup
 
 Similar to Babel setup, you can register [TypeScript](http://www.typescriptlang.org) to compile your `*.ts` files in the `before` hook of your config file. You will need [`ts-node`](https://github.com/TypeStrong/ts-node) and [`tsconfig-paths`](https://github.com/dividab/tsconfig-paths) installed as `devDependencies`.
 
-The minimum TypeScript version is 3.5.1.
+The minimum TypeScript version is 3.7.3.
 
 ```js
 // wdio.conf.js

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -10,7 +10,7 @@
     "node": ">= 8.11.0"
   },
   "types": "./devtools.d.ts",
-  "typeScriptVersion": "3.5.1",
+  "typeScriptVersion": "3.7.3",
   "scripts": {
     "build": "run-s clean compile",
     "clean": "rimraf ./build",

--- a/packages/wdio-shared-store-service/shared-store-service.d.ts
+++ b/packages/wdio-shared-store-service/shared-store-service.d.ts
@@ -3,14 +3,6 @@ type jsonObject = { [x: string]: jsonPrimitive | jsonObject | jsonArray };
 type jsonArray = Array<jsonPrimitive | jsonObject | jsonArrayWorkaround>;
 type jsonCompatible = jsonPrimitive | jsonObject | jsonArray;
 
-/**
- * circular reference workaround until TypeScript 3.7
- * https://github.com/microsoft/TypeScript/pull/33050
- * `jsonArray` should repplace `jsonArrayWorkaround` in `jsonArray` array types
- * and interface below can be removed
- */
-interface jsonArrayWorkaround extends Array<jsonPrimitive | jsonObject | jsonArray> { }
-
 declare namespace WebdriverIO {
     interface BrowserObject {
         sharedStore: {

--- a/packages/wdio-shared-store-service/shared-store-service.d.ts
+++ b/packages/wdio-shared-store-service/shared-store-service.d.ts
@@ -1,6 +1,6 @@
 type jsonPrimitive = string | number | boolean | null;
 type jsonObject = { [x: string]: jsonPrimitive | jsonObject | jsonArray };
-type jsonArray = Array<jsonPrimitive | jsonObject | jsonArrayWorkaround>;
+type jsonArray = Array<jsonPrimitive | jsonObject>;
 type jsonCompatible = jsonPrimitive | jsonObject | jsonArray;
 
 declare namespace WebdriverIO {

--- a/packages/wdio-shared-store-service/shared-store-service.d.ts
+++ b/packages/wdio-shared-store-service/shared-store-service.d.ts
@@ -1,6 +1,6 @@
 type jsonPrimitive = string | number | boolean | null;
 type jsonObject = { [x: string]: jsonPrimitive | jsonObject | jsonArray };
-type jsonArray = Array<jsonPrimitive | jsonObject>;
+type jsonArray = Array<jsonPrimitive | jsonObject | jsonArray>;
 type jsonCompatible = jsonPrimitive | jsonObject | jsonArray;
 
 declare namespace WebdriverIO {

--- a/packages/wdio-sync/package.json
+++ b/packages/wdio-sync/package.json
@@ -18,7 +18,7 @@
     "test:unit": "jest"
   },
   "types": "./webdriverio.d.ts",
-  "typeScriptVersion": "3.5.1",
+  "typeScriptVersion": "3.7.3",
   "repository": {
     "type": "git",
     "url": "git://github.com/webdriverio/webdriverio.git"

--- a/packages/webdriver/package.json
+++ b/packages/webdriver/package.json
@@ -10,7 +10,7 @@
     "node": ">= 8.11.0"
   },
   "types": "./webdriver.d.ts",
-  "typeScriptVersion": "3.5.1",
+  "typeScriptVersion": "3.7.3",
   "scripts": {
     "build": "run-s clean compile",
     "clean": "rimraf ./build",

--- a/packages/webdriverio/package.json
+++ b/packages/webdriverio/package.json
@@ -46,7 +46,7 @@
     "testingbot"
   ],
   "types": "./webdriverio.d.ts",
-  "typeScriptVersion": "3.5.1",
+  "typeScriptVersion": "3.7.3",
   "scripts": {
     "build": "run-s clean compile",
     "clean": "rimraf ./build",


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
Update TypeScript minimal version to 3.7.2 or higher to be able to use latest features of TypeScript language in types files

**Describe the solution you'd like**
update minimal version of typescript from 3.5.1 to 3.7.2 or latest available at that moment:
- in docs: `TypeScript.md`
- `typeScriptVersion` in package.json files: devtools, webdriver, webdriverio, @wdio/sync
- remove workaround https://github.com/webdriverio/webdriverio/blob/master/packages/wdio-shared-store-service/shared-store-service.d.ts#L7

**Describe alternatives you've considered**


**Additional context**

