### PR TITLE
Document back-porting process for maintainers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,7 +131,7 @@ $ git pull
 $ git fetch --all
 ```
 
-Then run the backport script. It fetches all commits connected with PRs that are labeled with `backport-requested` and cherry-picks them into the maintainance branch. Via an interactive console you can get the chance to review the PR again and whether you want to backport it or not. To start the process, just execute:
+Before you can start please export an `GITHUB_AUTH` token into your environment in order to allow the executing script to fetch data about pull requests and set proper labels. Go to your [personal access token](https://github.com/settings/tokens) settings page and generate such token with only having the `public_repo` field enabled. Then export it into your environment and run the backport script. It fetches all commits connected with PRs that are labeled with `backport-requested` and cherry-picks them into the maintainance branch. Via an interactive console you can get the chance to review the PR again and whether you want to backport it or not. To start the process, just execute:
 
 ```sh
 $ npm run backport

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,7 +104,7 @@ Starting from v6 the WebdriverIO team tries to backport all features that would 
 
 ### As Triager
 
-Everyone triaging or reviewing a PR should label it with `backport-requested` if the changes can be applied to the maintained (previous) version.
+Everyone triaging or reviewing a PR should label it with `backport-requested` if the changes can be applied to the maintained (previous) version. Generally every PR that would not be a breaking change for the previous version should be considered to be ported back. If a change relies on features or code pieces that are only available in the current version then a back port can still be considered if you feel comfortable making the necessary adjustments. That said, don't feel forced to back port code if the time investment and complexity is too high. Backporting functionality is a reasonable contribution that can be made by any contributor.
 
 ### As A Merger
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,22 +76,6 @@ It is also a good idea to run jest in watch mode while developing on a single pa
 $ ./node_modules/.bin/jest ./packages/<package-name>/tests --watch
 ```
 
-## Run e2e Experience With Smoke Tests
-
-WebdriverIO maintains a smoke test suites that allows to represent the full e2e experience of a user running the wdio testrunner. It is setup in a way so it doesn't require an actual browser driver since all requests are mocked using the `@wdio/webdriver-mock-service`. This offers you an opportunity to run a wdio test suite without setting up a browser driver and a test page. You can run all smoke tests via:
-
-```sh
-$ npm run test:smoke
-```
-
-There are several [test suites](https://github.com/webdriverio/webdriverio/blob/master/tests/smoke.runner.js#L359-L378) defined that run in different environments, e.g. Mocha, Jasmine and Cucumber. You can run a specific test suite by calling, e.g.:
-
-```sh
-$ npm run test:smoke mochaTestrunner
-```
-
-You can define your own scenario of mock responses in the [`@wdio/webdriver-mock-service`](https://github.com/webdriverio/webdriverio/blob/master/packages/wdio-webdriver-mock-service/src/index.js#L142-L149).
-
 ## Link changes to your current project
 
 When modifying core WebdriverIO packages you can link those changes to your current project to test the changes that you made.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ In order to set up this project and start contributing follow this step by step 
 
     ```sh
     $ npm install
-    $ npm run setup
+    $ npm run setup-full
     ```
 
     * Bootstraps sub-projects via ```npm run bootstrap```
@@ -76,6 +76,22 @@ It is also a good idea to run jest in watch mode while developing on a single pa
 $ ./node_modules/.bin/jest ./packages/<package-name>/tests --watch
 ```
 
+## Run e2e Experience With Smoke Tests
+
+WebdriverIO maintains a smoke test suites that allows to represent the full e2e experience of a user running the wdio testrunner. It is setup in a way so it doesn't require an actual browser driver since all requests are mocked using the `@wdio/webdriver-mock-service`. This offers you an opportunity to run a wdio test suite without setting up a browser driver and a test page. You can run all smoke tests via:
+
+```sh
+$ npm run test:smoke
+```
+
+There are several [test suites](https://github.com/webdriverio/webdriverio/blob/master/tests/smoke.runner.js#L359-L378) defined that run in different environments, e.g. Mocha, Jasmine and Cucumber. You can run a specific test suite by calling, e.g.:
+
+```sh
+$ npm run test:smoke mochaTestrunner
+```
+
+You can define your own scenario of mock responses in the [`@wdio/webdriver-mock-service`](https://github.com/webdriverio/webdriverio/blob/master/packages/wdio-webdriver-mock-service/src/index.js#L142-L149).
+
 ## Link changes to your current project
 
 When modifying core WebdriverIO packages you can link those changes to your current project to test the changes that you made.
@@ -97,6 +113,28 @@ npm link @wdio/cli
 ## Test Your Changes
 
 In order to test certain scenarios this project has a test directory that allows you to run predefined test. It allows you to check your code changes while you are working on it. You find all these files in `/examples`. You find all necessary information [in there](https://github.com/webdriverio/webdriverio/tree/master/examples/README.md).
+
+## Back-Porting Bug Fixes
+
+Starting from v6 the WebdriverIO team tries to backport all features that would be still backwards compatible with older versions. The team tries to release a new major version every year (usually around December/Januar). With a new major version update (e.g. v6) we continue to maintain the last version (e.g. v5) and depcrecate the previous maintained version (e.g. v4). With that the team commits to always support 2 major versions.
+
+### As Triager
+
+Everyone triaging or reviewing a PR should label it with `backport-requested` if the changes can be applied to the maintained (previous) version.
+
+### As A Merger
+
+Once a PR with a `backport-requested` label got merged, you are responsible for the backporting the patch to the older version. To do so, pull the latest code from GitHub:
+
+```sh
+$ git pull
+```
+
+Then run the backport script. It fetches all commits connected with PRs that are labeled with `backport-requested` and cherry-picks them into the maintainance branch:
+
+```sh
+$ npm run backport
+```
 
 ## Commit Messages Convention
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,7 +121,7 @@ Before you can start please export an `GITHUB_AUTH` token into your environment 
 $ npm run backport
 ```
 
-If during the process a cherry-pick fails you can always abort and manually troubleshoot. A successful backport of two PRs will look like this:
+If during the process a cherry-pick fails you can always abort and manually troubleshoot. If you are not able to resolve the problem, create an issue in the repo and include the author of that PR. A successful backport of two PRs will look like this:
 
 ```
 $ npm run backport

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,6 +128,7 @@ Once a PR with a `backport-requested` label got merged, you are responsible for 
 
 ```sh
 $ git pull
+$ git fetch --all
 ```
 
 Then run the backport script. It fetches all commits connected with PRs that are labeled with `backport-requested` and cherry-picks them into the maintainance branch:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,7 +100,7 @@ In order to test certain scenarios this project has a test directory that allows
 
 ## Back-Porting Bug Fixes
 
-Starting from v6 the WebdriverIO team tries to backport all features that would be still backwards compatible with older versions. The team tries to release a new major version every year (usually around December/Januar). With a new major version update (e.g. v6) we continue to maintain the last version (e.g. v5) and depcrecate the previous maintained version (e.g. v4). With that the team commits to always support 2 major versions.
+Starting from v6 the WebdriverIO team tries to backport all features that would be still backwards compatible with older versions. The team tries to release a new major version every year (usually around December/January). With a new major version update (e.g. v6) we continue to maintain the last version (e.g. v5) and depcrecate the previous maintained version (e.g. v4). With that the team commits to always support 2 major versions.
 
 ### As Triager
 
@@ -108,7 +108,7 @@ Everyone triaging or reviewing a PR should label it with `backport-requested` if
 
 ### As A Merger
 
-Once a PR with a `backport-requested` label got merged, you are responsible for the backporting the patch to the older version. To do so, pull the latest code from GitHub:
+Once a PR with a `backport-requested` label got merged, you are responsible for backporting the patch to the older version. To do so, pull the latest code from GitHub:
 
 ```sh
 $ git pull

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,11 +131,40 @@ $ git pull
 $ git fetch --all
 ```
 
-Then run the backport script. It fetches all commits connected with PRs that are labeled with `backport-requested` and cherry-picks them into the maintainance branch:
+Then run the backport script. It fetches all commits connected with PRs that are labeled with `backport-requested` and cherry-picks them into the maintainance branch. Via an interactive console you can get the chance to review the PR again and whether you want to backport it or not. To start the process, just execute:
 
 ```sh
 $ npm run backport
 ```
+
+If during the process a cherry-pick fails you can always abort and manually troubleshoot. A successful backport of two PRs will look like this:
+
+```
+$ npm run backport
+
+> webdriverio-monorepo@ backport /path/to/webdriverio/webdriverio
+> node ./scripts/backport.js
+
+? You want to backport "Backporting Test PR" by christian-bromann?
+(See PR https://github.com/webdriverio/webdriverio/pull/4890) Yes
+Backporting sha 264b7bc49dfc3fe8f1ed8b58d681ce562aaf1544 from v6 to v5
+[cb-backport-process e47c5527] Backporting Test PR (#4890)
+ Author: Christian Bromann <mail@christian-bromann.com>
+ Date: Mon Dec 16 14:54:02 2019 +0100
+ 1 file changed, 2 insertions(+)
+? You want to backport "Second backport test" by christian-bromann?
+(See PR https://github.com/webdriverio/webdriverio/pull/4891) Yes
+Backporting sha 77dc52fdb86c51242b92f299998d2904004cb347 from v6 to v5
+[cb-backport-process 35a3ad41] Second backport test (#4891)
+ Author: Christian Bromann <mail@christian-bromann.com>
+ Date: Mon Dec 16 16:01:46 2019 +0100
+ 1 file changed, 2 deletions(-)
+
+Successfully backported 2 PRs 👏!
+Please now push them to master and make a new v5.x release!
+```
+
+You can always reach out to the `webdriverio/ProjectCommitters` channel on Gitter for questions.
 
 ## Commit Messages Convention
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2736,9 +2736,9 @@
       }
     },
     "@octokit/rest": {
-      "version": "16.35.0",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.35.0.tgz",
-      "integrity": "sha512-9ShFqYWo0CLoGYhA1FdtdykJuMzS/9H6vSbbQWDX4pWr4p9v+15MsH/wpd/3fIU+tSxylaNO48+PIHqOkBRx3w==",
+      "version": "16.35.2",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.35.2.tgz",
+      "integrity": "sha512-iijaNZpn9hBpUdh8YdXqNiWazmq4R1vCUsmxpBB0kCQ0asHZpCx+HNs22eiHuwYKRhO31ZSAGBJLi0c+3XHaKQ==",
       "dev": true,
       "requires": {
         "@octokit/request": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@babel/plugin-syntax-export-default-from": "^7.2.0",
     "@babel/preset-env": "^7.6.2",
     "@babel/register": "^7.6.2",
+    "@octokit/rest": "^16.35.2",
     "@types/jest": "^24.0.18",
     "aws-sdk": "^2.539.0",
     "babel-core": "^6.26.3",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "scripts": {
     "create": "node ./scripts/generateSubPackage",
+    "backport": "node ./scripts/backport.js",
     "bootstrap-full": "npm run clean && lerna bootstrap --no-ci && npm run link",
     "bootstrap": "run-p clean:* && lerna bootstrap --force-local && npm run link",
     "build-full": "lerna run --parallel build",

--- a/scripts/backport.js
+++ b/scripts/backport.js
@@ -1,0 +1,1 @@
+#!/usr/bin/env node

--- a/scripts/backport.js
+++ b/scripts/backport.js
@@ -109,7 +109,7 @@ const api = new Octokit({ auth: process.env.GITHUB_AUTH })
             owner: 'webdriverio',
             repo: 'webdriverio',
             issue_number: prToBackport.number,
-            name: 'backported'
+            labels: 'backported'
         })
 
         ++backportedPRs

--- a/scripts/backport.js
+++ b/scripts/backport.js
@@ -20,13 +20,13 @@ if (!process.env.GITHUB_AUTH) {
 /**
  * check if user is in right branch
  */
-// const { stdout: branch } = shell.exec('git rev-parse --abbrev-ref HEAD', { silent: true })
-// if (branch !== maintenanceLTSVersion) {
-//     throw new Error(
-//         'In order to start backport process witch to the maintenance LTS branch via:\n' +
-//         `$ git checkout ${maintenanceLTSVersion}`
-//     )
-// }
+const { stdout: branch } = shell.exec('git rev-parse --abbrev-ref HEAD', { silent: true })
+if (branch !== maintenanceLTSVersion) {
+    throw new Error(
+        'In order to start backport process witch to the maintenance LTS branch via:\n' +
+        `$ git checkout ${maintenanceLTSVersion}`
+    )
+}
 
 function getPrompt (pr) {
     return [{
@@ -99,7 +99,7 @@ const api = new Octokit({ auth: process.env.GITHUB_AUTH })
         }
 
         /**
-         * switch labels}
+         * switch labels
          */
         await api.issues.removeLabel({
             owner: 'webdriverio',
@@ -121,8 +121,8 @@ const api = new Octokit({ auth: process.env.GITHUB_AUTH })
 })().then(
     (amount) => console.log(amount
         ? (
-            `\nSuccessfully backported ${amount} PRs!\n` +
-            'Please now push them and make a release!'
+            `\nSuccessfully backported ${amount} PRs 👏!\n` +
+            `Please now push them to master and make a new ${maintenanceLTSVersion}.x release!`
         )
         : 'Bye!'
     ),

--- a/scripts/backport.js
+++ b/scripts/backport.js
@@ -1,1 +1,106 @@
 #!/usr/bin/env node
+
+const Octokit = require('@octokit/rest')
+const inquirer = require('inquirer')
+const shell = require('shelljs')
+
+const activeLTSVersion = 'v6'
+const maintenanceLTSVersion = 'v5'
+
+/**
+ * check if `GITHUB_AUTH` environment variable is set to interact with GitHub API
+ */
+if (!process.env.GITHUB_AUTH) {
+    throw new Error(
+        'Please export a "GITHUB_AUTH" access token to generate the changelog.\n' +
+        'See also https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md#release-new-version'
+    )
+}
+
+/**
+ * check if user is in right branch
+ */
+// const { stdout: branch } = shell.exec('git rev-parse --abbrev-ref HEAD', { silent: true })
+// if (branch !== maintenanceLTSVersion) {
+//     throw new Error(
+//         'In order to start backport process witch to the maintenance LTS branch via:\n' +
+//         `$ git checkout ${maintenanceLTSVersion}`
+//     )
+// }
+
+function getPrompt (pr) {
+    return [{
+        name: 'toBackport',
+        type: 'confirm',
+        default: true,
+        message: `You want to backport "${pr.title}" by ${pr.user.login}?\n(See PR ${pr.html_url})`
+    }, {
+        name: 'exit',
+        type: 'confirm',
+        default: false,
+        message: 'Exit process?',
+        when: ({ toBackport }) => !toBackport
+    }]
+}
+
+const api = new Octokit({ auth: process.env.GITHUB_AUTH })
+
+/* eslint-disable no-console */
+;(async () => {
+    const prs = await api.pulls.list({
+        owner: 'webdriverio',
+        repo: 'webdriverio',
+        state: 'closed'
+    })
+    const prsToBackport = prs.data.filter(
+        (pr) => pr.labels.find(
+            (label) => label.name === 'backport-requested'))
+
+    let backportedPRs = 0
+    for (const prToBackport of prsToBackport) {
+        const { toBackport, exit } = await inquirer.prompt(getPrompt(prToBackport))
+
+        if (exit) {
+            return backportedPRs
+        }
+
+        if (!toBackport) {
+            continue
+        }
+
+        console.log(`Backporting sha ${prToBackport.merge_commit_sha} from ${activeLTSVersion} to ${maintenanceLTSVersion}`)
+        const cherryPickResult = shell.exec(`git cherry-pick ${prToBackport.merge_commit_sha}`)
+
+        /**
+         * handle failing cherry-pick
+         */
+        if (cherryPickResult.stderr) {
+            const { exit } = await inquirer.prompt([{
+                name: 'exit',
+                type: 'confirm',
+                default: true,
+                message: 'Oh oh! Something failed with backporting, do you want to exit to check that?'
+            }])
+
+            if (exit) {
+                return backportedPRs
+            }
+
+            console.log('Ignoring error, continuing backporting...')
+            continue
+        }
+
+        ++backportedPRs
+    }
+
+    return backportedPRs
+})().then(
+    (amount) => console.log(amount
+        ? (
+            `\nSuccessfully backported ${amount} PRs!\n` +
+            'Please now push them and make a release!'
+        )
+        : 'Bye!'
+    ),
+    (err) => console.error(`Error uploading docs: ${err.stack}`)
+)

--- a/scripts/backport.js
+++ b/scripts/backport.js
@@ -52,11 +52,13 @@ const api = new Octokit({ auth: process.env.GITHUB_AUTH })
     const prs = await api.pulls.list({
         owner: 'webdriverio',
         repo: 'webdriverio',
-        state: 'closed'
+        state: 'closed',
+        sort: 'created',
+        direction: 'desc'
     })
     const prsToBackport = prs.data.filter(
         (pr) => pr.labels.find(
-            (label) => label.name === 'backport-requested'))
+            (label) => label.name === 'backport-requested')).reverse()
 
     if (prsToBackport.length === 0) {
         console.log('Nothing to backport!')
@@ -109,7 +111,7 @@ const api = new Octokit({ auth: process.env.GITHUB_AUTH })
             owner: 'webdriverio',
             repo: 'webdriverio',
             issue_number: prToBackport.number,
-            labels: 'backported'
+            labels: ['backported']
         })
 
         ++backportedPRs


### PR DESCRIPTION
**Pre-check**
- [x] I'm aware that I can [edit the docs](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) and submit a pull request

**Describe the improvement**

I'd like to report
- [ ] Unclear documentation
- [ ] A typo
- [x] Missing documentation
- [ ] Other

**Description of the improvement / report**
With v6 we want to ensure that people that have not yet updated their WebdriverIO versions still benefit from the bug fixes that have been proposed upstream to v6.
