### PR TITLE
Add onWorkerStart hook to launch service

### DIFF
--- a/docs/ConfigurationFile.md
+++ b/docs/ConfigurationFile.md
@@ -249,11 +249,10 @@ exports.config = {
      * @param  {String} cid      capability id (e.g 0-0)
      * @param  {[type]} caps     object containing capabilities for session that will be spawn in the worker
      * @param  {[type]} specs    specs to be run in the worker process
-     * @param  {[type]} argv     object that allows you to overwrite configurations like framework
-     *                           options or connection details
+     * @param  {[type]} args     object that will be merged with the main configuration once worker is initialised
      * @param  {[type]} execArgv list of string arguments passed to the worker process
      */
-    onWorkerStart: function (cid, caps, specs, argv, execArgv) {
+    onWorkerStart: function (cid, caps, specs, args, execArgv) {
     },
     /**
      * Gets executed just before initialising the webdriver session and test framework. It allows you

--- a/docs/ConfigurationFile.md
+++ b/docs/ConfigurationFile.md
@@ -236,13 +236,24 @@ exports.config = {
     // methods. If one of them returns with a promise, WebdriverIO will wait until that promise is
     // resolved to continue.
     //
-
     /**
      * Gets executed once before all workers get launched.
      * @param {Object} config wdio configuration object
      * @param {Array.<Object>} capabilities list of capabilities details
      */
     onPrepare: function (config, capabilities) {
+    },
+    /**
+     * Gets executed before a worker process is spawned and can be used to initialise specific service
+     * for that worker as well as modify runtime environments in an async fashion.
+     * @param  {String} cid      capability id (e.g 0-0)
+     * @param  {[type]} caps     object containing capabilities for session that will be spawn in the worker
+     * @param  {[type]} specs    specs to be run in the worker process
+     * @param  {[type]} argv     object that allows you to overwrite configurations like framework
+     *                           options or connection details
+     * @param  {[type]} execArgv list of string arguments passed to the worker process
+     */
+    onWorkerStart: function (cid, caps, specs, argv, execArgv) {
     },
     /**
      * Gets executed just before initialising the webdriver session and test framework. It allows you

--- a/docs/CustomServices.md
+++ b/docs/CustomServices.md
@@ -11,15 +11,19 @@ The basic construction of a custom service should look like this:
 
 ```js
 export default class CustomService {
-  onPrepare(config, capabilities) {
-    // TODO: something before the workers launch
-  }
+    onPrepare(config, capabilities) {
+        // TODO: something before all workers launch
+    }
 
-  onComplete(exitCode, config, capabilities) {
-    // TODO: something after the workers shutdown
-  },
+    onWorkerStart(cid, caps, specs, argv, execArgv) {
+        // TODO: something before specific worker launch
+    }
 
-  // ...
+    onComplete(exitCode, config, capabilities) {
+        // TODO: something after the workers shutdown
+    },
+
+    // custom service methods ...
 }
 ```
 
@@ -70,7 +74,7 @@ exports.config = {
 }
 ```
 
-> **Note:** Services that are added by name behave slightly differently compared to your own imported services. Instead of the service handling all the hooks, as in the example above, the service needs to export a launcher that handles `onPrepare` and `onComplete`. The rest of the hooks will be handled by the service (the default export), as normal.
+> **Note:** Services that are added by name behave slightly differently compared to your own imported services. Instead of the service handling all the hooks, as in the example above, the service needs to export a launcher that handles `onPrepare`, `onWorkerStart` and `onComplete`. The rest of the hooks will be handled by the service (the default export), as normal.
 >
 > Example:
 >

--- a/docs/CustomServices.md
+++ b/docs/CustomServices.md
@@ -15,7 +15,7 @@ export default class CustomService {
         // TODO: something before all workers launch
     }
 
-    onWorkerStart(cid, caps, specs, argv, execArgv) {
+    onWorkerStart(cid, caps, specs, args, execArgv) {
         // TODO: something before specific worker launch
     }
 

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -264,7 +264,7 @@ This allows custom actions (e.g., take screenshot if a test fails).
 
 Every hook has as parameter specific information about the lifecycle (i.e. information about the test suite or test).
 
-The following hooks are available: `onPrepare`, `beforeSession`, `before`, `beforeSuite`, `beforeHook`, `afterHook`, `beforeTest`, `beforeCommand`, `afterCommand`, `afterTest`, `afterSuite`, `after`, `afterSession`, `onComplete`, `onReload`, `beforeFeature`, `beforeScenario`, `beforeStep`, `afterStep`, `afterScenario`, `afterFeature`.
+The following hooks are available: `onPrepare`, `onWorkerStart`, `beforeSession`, `before`, `beforeSuite`, `beforeHook`, `afterHook`, `beforeTest`, `beforeCommand`, `afterCommand`, `afterTest`, `afterSuite`, `after`, `afterSession`, `onComplete`, `onReload`, `beforeFeature`, `beforeScenario`, `beforeStep`, `afterStep`, `afterScenario`, `afterFeature`.
 
 Type: `Function`<br>
 Default: `null`

--- a/examples/pageobject/wdio.conf.js
+++ b/examples/pageobject/wdio.conf.js
@@ -92,7 +92,7 @@ exports.config = {
     //
     // Gets executed before a worker process is spawned and can be used to initialise specific service
     // for that worker as well as modify runtime environments in an async fashion.
-    // onWorkerStart: function (cid, caps, specs, argv, execArgv) {
+    // onWorkerStart: function (cid, caps, specs, args, execArgv) {
     // },
     //
     // Gets executed before test execution begins. At this point you can access to all global

--- a/examples/pageobject/wdio.conf.js
+++ b/examples/pageobject/wdio.conf.js
@@ -90,6 +90,11 @@ exports.config = {
     // onPrepare: function (config, capabilities) {
     // },
     //
+    // Gets executed before a worker process is spawned and can be used to initialise specific service
+    // for that worker as well as modify runtime environments in an async fashion.
+    // onWorkerStart: function (cid, caps, specs, argv, execArgv) {
+    // },
+    //
     // Gets executed before test execution begins. At this point you can access to all global
     // variables like `browser`. It is the perfect place to define custom commands.
     // before: function (capabilities, specs) {

--- a/examples/wdio.conf.js
+++ b/examples/wdio.conf.js
@@ -195,6 +195,18 @@ exports.config = {
     onPrepare: function (config, capabilities) {
     },
     /**
+     * Gets executed before a worker process is spawned and can be used to initialise specific service
+     * for that worker as well as modify runtime environments in an async fashion.
+     * @param  {String} cid      capability id (e.g 0-0)
+     * @param  {[type]} caps     object containing capabilities for session that will be spawn in the worker
+     * @param  {[type]} specs    specs to be run in the worker process
+     * @param  {[type]} argv     object that allows you to overwrite configurations like framework
+     *                           options or connection details
+     * @param  {[type]} execArgv list of string arguments passed to the worker process
+     */
+    onWorkerStart: function (cid, caps, specs, argv, execArgv) {
+    },
+    /**
      * Gets executed just before initialising the webdriver session and test framework. It allows you
      * to manipulate configurations depending on the capability or spec.
      * @param {Object} config wdio configuration object

--- a/examples/wdio.conf.js
+++ b/examples/wdio.conf.js
@@ -200,11 +200,10 @@ exports.config = {
      * @param  {String} cid      capability id (e.g 0-0)
      * @param  {[type]} caps     object containing capabilities for session that will be spawn in the worker
      * @param  {[type]} specs    specs to be run in the worker process
-     * @param  {[type]} argv     object that allows you to overwrite configurations like framework
-     *                           options or connection details
+     * @param  {[type]} args     object that will be merged with the main configuration once worker is initialised
      * @param  {[type]} execArgv list of string arguments passed to the worker process
      */
-    onWorkerStart: function (cid, caps, specs, argv, execArgv) {
+    onWorkerStart: function (cid, caps, specs, args, execArgv) {
     },
     /**
      * Gets executed just before initialising the webdriver session and test framework. It allows you

--- a/examples/wdio/custom-service/my.custom.service.js
+++ b/examples/wdio/custom-service/my.custom.service.js
@@ -10,6 +10,9 @@ module.exports = class CustomService {
     onPrepare () {
         console.log('execute onPrepare(config, capabilities)')
     }
+    onWorkerStart () {
+        console.log('execute onWorkerStart(cid, caps, specs, argv, execArgv)')
+    }
     beforeSession () {
         console.log('execute beforeSession(config, capabilities, specs)')
     }

--- a/examples/wdio/custom-service/my.custom.service.js
+++ b/examples/wdio/custom-service/my.custom.service.js
@@ -11,7 +11,7 @@ module.exports = class CustomService {
         console.log('execute onPrepare(config, capabilities)')
     }
     onWorkerStart () {
-        console.log('execute onWorkerStart(cid, caps, specs, argv, execArgv)')
+        console.log('execute onWorkerStart(cid, caps, specs, args, execArgv)')
     }
     beforeSession () {
         console.log('execute beforeSession(config, capabilities, specs)')

--- a/packages/wdio-cli/src/launcher.js
+++ b/packages/wdio-cli/src/launcher.js
@@ -7,18 +7,18 @@ import { ConfigParser } from '@wdio/config'
 import { initialisePlugin, initialiseServices } from '@wdio/utils'
 
 import CLInterface from './interface'
-import { runOnPrepareHook, runOnCompleteHook, runServiceHook } from './utils'
+import { runLauncherHook, runOnCompleteHook, runServiceHook } from './utils'
 
 const log = logger('@wdio/cli:launcher')
 
 class Launcher {
-    constructor (configFilePath, argv = {}, isWatchMode = false) {
-        this.argv = argv
+    constructor (configFilePath, args = {}, isWatchMode = false) {
+        this.args = args
         this.configFilePath = configFilePath
 
         this.configParser = new ConfigParser()
         this.configParser.addConfigFile(configFilePath)
-        this.configParser.merge(argv)
+        this.configParser.merge(args)
 
         const config = this.configParser.getConfig()
         const capabilities = this.configParser.getCapabilities()
@@ -69,7 +69,7 @@ class Launcher {
         try {
             const config = this.configParser.getConfig()
             const caps = this.configParser.getCapabilities()
-            const launcher = initialiseServices(config, caps, 'launcher')
+            this.launcher = initialiseServices(config, caps, 'launcher')
 
             /**
              * run pre test tasks for runner plugins
@@ -81,8 +81,8 @@ class Launcher {
              * run onPrepare hook
              */
             log.info('Run onPrepare hook')
-            await runOnPrepareHook(config.onPrepare, config, caps)
-            await runServiceHook(launcher, 'onPrepare', config, caps)
+            await runLauncherHook(config.onPrepare, config, caps)
+            await runServiceHook(this.launcher, 'onPrepare', config, caps)
 
             exitCode = await this.runMode(config, caps)
 
@@ -91,8 +91,7 @@ class Launcher {
              * even if it fails we still want to see result and end logger stream
              */
             log.info('Run onComplete hook')
-            await runServiceHook(launcher, 'onComplete', exitCode, config, caps)
-
+            await runServiceHook(this.launcher, 'onComplete', exitCode, config, caps)
             const onCompleteResults = await runOnCompleteHook(config.onComplete, config, caps, exitCode, this.interface.result)
 
             // if any of the onComplete hooks failed, update the exit code
@@ -160,8 +159,7 @@ class Launcher {
                     caps: capabilities,
                     specs: this.configParser.getSpecs(capabilities.specs, capabilities.exclude).map(s => ({ files: [s], retries: specFileRetries })),
                     availableInstances: capabilities.maxInstances || config.maxInstancesPerCapability,
-                    runningInstances: 0,
-                    seleniumServer: { hostname: config.hostname, port: config.port, protocol: config.protocol }
+                    runningInstances: 0
                 })
             }
         }
@@ -247,7 +245,6 @@ class Launcher {
                 specs.files,
                 schedulableCaps[0].caps,
                 schedulableCaps[0].cid,
-                schedulableCaps[0].seleniumServer,
                 specs.rid,
                 specs.retries
             )
@@ -281,7 +278,7 @@ class Launcher {
      * @param  {String} rid  Runner ID override
      * @param  {Number} retries  Number of retries remaining
      */
-    startInstance (specs, caps, cid, server, rid, retries) {
+    async startInstance (specs, caps, cid, rid, retries) {
         let config = this.configParser.getConfig()
         // Retried tests receive the cid of the failing test as rid
         // so they can run with the same cid of the failing test.
@@ -324,23 +321,28 @@ class Launcher {
         // If an arg appears multiple times the last occurrence is used
         let execArgv = [...defaultArgs, ...debugArgs, ...capExecArgs]
 
+        // bump up worker count
+        this.runnerStarted++
+
+        // run worker hook to allow modify runtime and capabilities of a specific worker
+        log.info('Run onWorkerStart hook')
+        await runLauncherHook(config.onWorkerStart, cid, caps, specs, this.args, execArgv)
+        await runServiceHook(this.launcher, 'onWorkerStart', cid, caps, specs, this.args, execArgv)
+
         // prefer launcher settings in capabilities over general launcher
         const worker = this.runner.run({
             cid,
             command: 'run',
             configFile: this.configFilePath,
-            argv: this.argv,
+            args: this.args,
             caps,
             specs,
-            server,
             execArgv,
             retries
         })
         worker.on('message', ::this.interface.onMessage)
         worker.on('error', ::this.interface.onMessage)
         worker.on('exit', ::this.endHandler)
-
-        this.runnerStarted++
     }
 
     /**

--- a/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
+++ b/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
@@ -224,6 +224,17 @@ exports.config = {
      * @param {Array.<Object>} capabilities list of capabilities details
      */
     // onPrepare: function (config, capabilities) {
+    // },/**
+     * Gets executed before a worker process is spawned and can be used to initialise specific service
+     * for that worker as well as modify runtime environments in an async fashion.
+     * @param  {String} cid      capability id (e.g 0-0)
+     * @param  {[type]} caps     object containing capabilities for session that will be spawn in the worker
+     * @param  {[type]} specs    specs to be run in the worker process
+     * @param  {[type]} argv     object that allows you to overwrite configurations like framework
+     *                           options or connection details
+     * @param  {[type]} execArgv list of string arguments passed to the worker process
+     */
+    // onWorkerStart: function (cid, caps, specs, argv, execArgv) {
     // },
     /**
      * Gets executed just before initialising the webdriver session and test framework. It allows you

--- a/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
+++ b/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
@@ -230,11 +230,10 @@ exports.config = {
      * @param  {String} cid      capability id (e.g 0-0)
      * @param  {[type]} caps     object containing capabilities for session that will be spawn in the worker
      * @param  {[type]} specs    specs to be run in the worker process
-     * @param  {[type]} argv     object that allows you to overwrite configurations like framework
-     *                           options or connection details
+     * @param  {[type]} args     object that will be merged with the main configuration once worker is initialised
      * @param  {[type]} execArgv list of string arguments passed to the worker process
      */
-    // onWorkerStart: function (cid, caps, specs, argv, execArgv) {
+    // onWorkerStart: function (cid, caps, specs, args, execArgv) {
     // },
     /**
      * Gets executed just before initialising the webdriver session and test framework. It allows you

--- a/packages/wdio-cli/src/utils.js
+++ b/packages/wdio-cli/src/utils.js
@@ -27,21 +27,21 @@ export async function runServiceHook (launcher, hookName, ...args) {
 }
 
 /**
- * Run onPrepareHook in Launcher
- * @param {Array|Function} onPrepareHook - can be array of functions or single function
+ * Run hook in service launcher
+ * @param {Array|Function} hook - can be array of functions or single function
  * @param {Object} config
  * @param {Object} capabilities
  */
-export async function runOnPrepareHook(onPrepareHook, config, capabilities) {
-    const catchFn = (e) => log.error(`Error in onPrepareHook: ${e.stack}`)
+export async function runLauncherHook(hook, ...args) {
+    const catchFn = (e) => log.error(`Error in hook: ${e.stack}`)
 
-    if (typeof onPrepareHook === 'function') {
-        onPrepareHook = [onPrepareHook]
+    if (typeof hook === 'function') {
+        hook = [hook]
     }
 
-    return Promise.all(onPrepareHook.map((hook) => {
+    return Promise.all(hook.map((hook) => {
         try {
-            return hook(config, capabilities)
+            return hook(...args)
         } catch (e) {
             return catchFn(e)
         }

--- a/packages/wdio-cli/src/watcher.js
+++ b/packages/wdio-cli/src/watcher.js
@@ -126,8 +126,8 @@ export default class Watcher {
          */
         for (const [, worker] of Object.entries(workers)) {
             const { cid, caps, specs, sessionId } = worker
-            const argv = Object.assign({ sessionId }, params)
-            worker.postMessage('run', argv)
+            const args = Object.assign({ sessionId }, params)
+            worker.postMessage('run', args)
             this.launcher.interface.emit('job:start', { cid, caps, specs })
         }
     }

--- a/packages/wdio-cli/src/watcher.js
+++ b/packages/wdio-cli/src/watcher.js
@@ -9,10 +9,10 @@ import Launcher from './launcher.js'
 const log = logger('@wdio/cli:watch')
 
 export default class Watcher {
-    constructor (configFile, argv) {
+    constructor (configFile, args) {
         log.info('Starting launcher in watch mode')
-        this.launcher = new Launcher(configFile, argv, true)
-        this.argv = argv
+        this.launcher = new Launcher(configFile, args, true)
+        this.args = args
 
         const specs = this.launcher.configParser.getSpecs()
         const capSpecs = this.launcher.isMultiremote ? [] : union(flattenDeep(
@@ -68,7 +68,7 @@ export default class Watcher {
      */
     getFileListener (passOnFile = true) {
         return (spec) => this.run(
-            Object.assign({}, this.argv, passOnFile ? { spec } : {})
+            Object.assign({}, this.args, passOnFile ? { spec } : {})
         )
     }
 

--- a/packages/wdio-cli/tests/launcher.test.js
+++ b/packages/wdio-cli/tests/launcher.test.js
@@ -5,20 +5,20 @@ import fs from 'fs-extra'
 const caps = { maxInstances: 1, browserName: 'chrome' }
 
 jest.mock('fs-extra')
-global.console.log = jest.fn()
 
 describe('launcher', () => {
     const emitSpy = jest.spyOn(process, 'emit')
     let launcher
 
     beforeEach(() => {
+        global.console.log = jest.fn()
         emitSpy.mockClear()
         launcher = new Launcher('./')
     })
 
     describe('defaults', () => {
         it('should have default for the argv parameter', () => {
-            expect(launcher.argv).toEqual({})
+            expect(launcher.args).toEqual({})
         })
     })
 
@@ -410,10 +410,34 @@ describe('launcher', () => {
             launcher.interface.emit = jest.fn()
         })
 
-        it('should allow override of runner id', () => {
-            launcher.startInstance([], { browserName: 'chrome' }, 0, undefined, '0-5')
+        it('should start an instance', async () => {
+            const onWorkerStartMock = jest.fn()
+            const caps = {
+                browserName: 'chrome',
+                execArgv: ['--foo', 'bar']
+            }
+            launcher.configParser.getConfig = () => ({ onWorkerStart: onWorkerStartMock })
+            launcher.args.hostname = '127.0.0.2'
+
+            expect(launcher.runnerStarted).toBe(0)
+            await launcher.startInstance(
+                ['/foo.test.js'],
+                caps,
+                0,
+                '0-5',
+                0
+            )
+
+            expect(launcher.runnerStarted).toBe(1)
             expect(launcher.runner.run.mock.calls[0][0]).toHaveProperty('cid', '0-5')
             expect(launcher.getRunnerId(0)).toBe('0-0')
+            expect(onWorkerStartMock).toHaveBeenCalledWith(
+                '0-5',
+                caps,
+                ['/foo.test.js'],
+                { hostname: '127.0.0.2' },
+                ['--foo', 'bar']
+            )
         })
     })
 
@@ -489,5 +513,9 @@ describe('launcher', () => {
             expect(launcher.runner.shutdown).toBeCalled()
             expect(error).toBeInstanceOf(Error)
         })
+    })
+
+    afterEach(() => {
+        global.console.log.mockReset()
     })
 })

--- a/packages/wdio-cli/tests/utils.test.js
+++ b/packages/wdio-cli/tests/utils.test.js
@@ -3,7 +3,7 @@ import ejs from 'ejs'
 import childProcess from 'child_process'
 
 import {
-    runOnPrepareHook,
+    runLauncherHook,
     runOnCompleteHook,
     runServiceHook,
     getRunnerName,
@@ -52,28 +52,31 @@ test('runServiceHook', () => {
     expect(hookFailing).toBeCalledTimes(1)
 })
 
-test('runOnPrepareHook handles array of functions', () => {
+test('runLauncherHook handles array of functions', () => {
     const hookSuccess = jest.fn()
     const hookFailing = jest.fn().mockImplementation(() => { throw new Error('buhh') })
 
-    runOnPrepareHook([hookSuccess, hookFailing], {}, {})
+    runLauncherHook([hookSuccess, hookFailing], 1, 2, 3, 4, 5, 6)
     expect(hookSuccess).toBeCalledTimes(1)
+    expect(hookSuccess).toHaveBeenCalledWith(1, 2, 3, 4, 5, 6)
     expect(hookFailing).toBeCalledTimes(1)
+    expect(hookFailing).toHaveBeenCalledWith(1, 2, 3, 4, 5, 6)
 })
 
-test('runOnPrepareHook handles async functions', async () => {
+test('runLauncherHook handles async functions', async () => {
     const hookSuccess = () => new Promise(resolve => setTimeout(resolve, 31))
 
     const start = Date.now()
-    await runOnPrepareHook([hookSuccess], {}, {})
+    await runLauncherHook([hookSuccess], {}, {})
     expect(Date.now() - start).toBeGreaterThanOrEqual(30)
 })
 
-test('runOnPrepareHook handles a single function', () => {
+test('runLauncherHook handles a single function', () => {
     const hookSuccess = jest.fn()
 
-    runOnPrepareHook(hookSuccess, {}, {})
+    runLauncherHook(hookSuccess, 1, 2, 3, 4, 5, 6)
     expect(hookSuccess).toBeCalledTimes(1)
+    expect(hookSuccess).toHaveBeenCalledWith(1, 2, 3, 4, 5, 6)
 })
 
 test('runOnCompleteHook handles array of functions', () => {

--- a/packages/wdio-cli/tests/watcher.test.js
+++ b/packages/wdio-cli/tests/watcher.test.js
@@ -7,11 +7,11 @@ jest.mock('../src/launcher', () => {
     const { ConfigParser } = require('@wdio/config')
 
     class LauncherMock {
-        constructor (configFile, argv) {
+        constructor (configFile, args) {
             this.configParser = new ConfigParser()
             this.configParser.addConfigFile(configFile)
-            this.configParser.merge(argv)
-            this.isMultiremote = argv.isMultiremote
+            this.configParser.merge(args)
+            this.isMultiremote = args.isMultiremote
             this.runner = {}
             this.interface = {
                 emit: jest.fn(),

--- a/packages/wdio-config/src/constants.js
+++ b/packages/wdio-config/src/constants.js
@@ -45,6 +45,7 @@ export const DEFAULT_CONFIGS = () => ({
      * hooks
      */
     onPrepare: [],
+    onWorkerStart: [],
     before: [],
     beforeSession: [],
     beforeSuite: [],
@@ -75,7 +76,7 @@ export const SUPPORTED_HOOKS = [
     'before', 'beforeSession', 'beforeSuite', 'beforeHook', 'beforeTest', 'beforeCommand',
     'afterCommand', 'afterTest', 'afterHook', 'afterSuite', 'afterSession', 'after',
     'beforeFeature', 'beforeScenario', 'beforeStep', 'afterStep', 'afterScenario', 'afterFeature',
-    'onReload', 'onPrepare', 'onComplete'
+    'onReload', 'onPrepare', 'onWorkerStart', 'onComplete'
 ]
 
 /**

--- a/packages/wdio-local-runner/src/index.js
+++ b/packages/wdio-local-runner/src/index.js
@@ -24,7 +24,7 @@ export default class LocalRunner {
         return Object.keys(this.workerPool).length
     }
 
-    run ({ command, argv, ...options }) {
+    run ({ command, args, ...options }) {
         /**
          * adjust max listeners on stdout/stderr when creating listeners
          */
@@ -36,7 +36,7 @@ export default class LocalRunner {
 
         const worker = new WorkerInstance(this.config, options, this.stdout, this.stderr)
         this.workerPool[options.cid] = worker
-        worker.postMessage(command, argv)
+        worker.postMessage(command, args)
 
         return worker
     }

--- a/packages/wdio-local-runner/src/index.js
+++ b/packages/wdio-local-runner/src/index.js
@@ -24,7 +24,7 @@ export default class LocalRunner {
         return Object.keys(this.workerPool).length
     }
 
-    run ({ command, args, ...options }) {
+    run ({ command, args, ...workerOptions }) {
         /**
          * adjust max listeners on stdout/stderr when creating listeners
          */
@@ -34,8 +34,8 @@ export default class LocalRunner {
             process.stderr.setMaxListeners(workerCnt + 2)
         }
 
-        const worker = new WorkerInstance(this.config, options, this.stdout, this.stderr)
-        this.workerPool[options.cid] = worker
+        const worker = new WorkerInstance(this.config, workerOptions, this.stdout, this.stderr)
+        this.workerPool[workerOptions.cid] = worker
         worker.postMessage(command, args)
 
         return worker

--- a/packages/wdio-local-runner/src/worker.js
+++ b/packages/wdio-local-runner/src/worker.js
@@ -153,7 +153,7 @@ export default class WorkerInstance extends EventEmitter {
      * @param  {object} argv     arguments for functions to call
      * @return null
      */
-    postMessage (command, argv) {
+    postMessage (command, args) {
         const { cid, configFile, caps, specs, retries, isBusy } = this
 
         if (isBusy && command !== 'endSession') {
@@ -168,7 +168,7 @@ export default class WorkerInstance extends EventEmitter {
             this.childProcess = this.startProcess()
         }
 
-        this.childProcess.send({ cid, command, configFile, argv, caps, specs, retries })
+        this.childProcess.send({ cid, command, configFile, args, caps, specs, retries })
         this.isBusy = true
     }
 }

--- a/packages/wdio-local-runner/src/worker.js
+++ b/packages/wdio-local-runner/src/worker.js
@@ -29,18 +29,16 @@ export default class WorkerInstance extends EventEmitter {
      * @param  {string}   configFile  path to config file (for sub process to parse)
      * @param  {object}   caps        capability object
      * @param  {string[]} specs       list of paths to test files to run in this worker
-     * @param  {object}   server      configuration details about automation backend this session is using
      * @param  {number}   retries     number of retries remaining
      * @param  {object}   execArgv    execution arguments for the test run
      */
-    constructor (config, { cid, configFile, caps, specs, server, execArgv, retries }, stdout, stderr) {
+    constructor (config, { cid, configFile, caps, specs, execArgv, retries }, stdout, stderr) {
         super()
         this.cid = cid
         this.config = config
         this.configFile = configFile
         this.caps = caps
         this.specs = specs
-        this.server = server || {}
         this.execArgv = execArgv
         this.retries = retries
         this.isBusy = false
@@ -103,7 +101,6 @@ export default class WorkerInstance extends EventEmitter {
             } else {
                 this.sessionId = payload.content.sessionId
                 delete payload.content.sessionId
-                Object.assign(this.server, payload.content)
             }
             return
         }
@@ -157,7 +154,7 @@ export default class WorkerInstance extends EventEmitter {
      * @return null
      */
     postMessage (command, argv) {
-        const { cid, configFile, caps, specs, server, retries, isBusy } = this
+        const { cid, configFile, caps, specs, retries, isBusy } = this
 
         if (isBusy && command !== 'endSession') {
             return log.info(`worker with cid ${cid} already busy and can't take new commands`)
@@ -171,7 +168,7 @@ export default class WorkerInstance extends EventEmitter {
             this.childProcess = this.startProcess()
         }
 
-        this.childProcess.send({ cid, command, configFile, argv, caps, specs, server, retries })
+        this.childProcess.send({ cid, command, configFile, argv, caps, specs, retries })
         this.isBusy = true
     }
 }

--- a/packages/wdio-local-runner/tests/__mocks__/@wdio/local-runner.js
+++ b/packages/wdio-local-runner/tests/__mocks__/@wdio/local-runner.js
@@ -7,9 +7,9 @@ export default class LocalRunnerMock {
         this.run = jest.fn()
     }
 
-    run ({ command, argv, ...options }) {
+    run ({ command, args, ...options }) {
         this.workerPool[options.cid] = { postMessage: jest.fn() }
-        this.workerPool[options.cid].postMessage(command, argv)
+        this.workerPool[options.cid].postMessage(command, args)
         return this.workerPool[options.cid]
     }
 }

--- a/packages/wdio-local-runner/tests/localRunner.test.js
+++ b/packages/wdio-local-runner/tests/localRunner.test.js
@@ -21,7 +21,7 @@ test('should fork a new process', () => {
         cid: '0-5',
         command: 'run',
         configFile: '/path/to/wdio.conf.js',
-        argv: {},
+        args: {},
         caps: {},
         processNumber: 123,
         specs: ['/foo/bar.test.js']
@@ -38,12 +38,11 @@ test('should fork a new process', () => {
     expect(childProcess.on).toBeCalled()
 
     expect(childProcess.send).toBeCalledWith({
-        argv: {},
+        args: {},
         caps: {},
         cid: '0-5',
         command: 'run',
         configFile: '/path/to/wdio.conf.js',
-        server: {},
         specs: ['/foo/bar.test.js']
     })
 
@@ -59,7 +58,7 @@ test('should shut down worker processes', async () => {
         cid: '0-4',
         command: 'run',
         configFile: '/path/to/wdio.conf.js',
-        argv: {},
+        args: {},
         caps: {},
         processNumber: 124,
         specs: ['/foo/bar2.test.js']
@@ -68,7 +67,7 @@ test('should shut down worker processes', async () => {
         cid: '0-5',
         command: 'run',
         configFile: '/path/to/wdio.conf.js',
-        argv: {},
+        args: {},
         caps: {},
         processNumber: 123,
         specs: ['/foo/bar.test.js']
@@ -103,7 +102,7 @@ test('should avoid shutting down if worker is not busy', async () => {
         cid: '0-8',
         command: 'run',
         configFile: '/path/to/wdio.conf.js',
-        argv: { sessionId: 'abc' },
+        args: { sessionId: 'abc' },
         caps: {},
         processNumber: 231,
         specs: ['/foo/bar2.test.js'],
@@ -126,7 +125,7 @@ test('should shut down worker processes in watch mode - regular', async () => {
         cid: '0-6',
         command: 'run',
         configFile: '/path/to/wdio.conf.js',
-        argv: { sessionId: 'abc' },
+        args: { sessionId: 'abc' },
         caps: {},
         processNumber: 231,
         specs: ['/foo/bar2.test.js'],
@@ -148,11 +147,11 @@ test('should shut down worker processes in watch mode - regular', async () => {
     const call2 = worker.childProcess.send.mock.calls.pop()[0]
     expect(call2.cid).toBe('0-6')
     expect(call2.command).toBe('endSession')
-    expect(call2.argv.watch).toBe(true)
-    expect(call2.argv.isMultiremote).toBeFalsy()
-    expect(call2.argv.config.sessionId).toBe('abc')
-    expect(call2.argv.config.host).toEqual('foo')
-    expect(call2.argv.caps).toEqual({ browser: 'chrome' })
+    expect(call2.args.watch).toBe(true)
+    expect(call2.args.isMultiremote).toBeFalsy()
+    expect(call2.args.config.sessionId).toBe('abc')
+    expect(call2.args.config.host).toEqual('foo')
+    expect(call2.args.caps).toEqual({ browser: 'chrome' })
 })
 
 test('should shut down worker processes in watch mode - mutliremote', async () => {
@@ -166,7 +165,7 @@ test('should shut down worker processes in watch mode - mutliremote', async () =
         cid: '0-7',
         command: 'run',
         configFile: '/path/to/wdio.conf.js',
-        argv: {},
+        args: {},
         caps: {},
         processNumber: 232,
         specs: ['/foo/bar.test.js'],
@@ -188,10 +187,10 @@ test('should shut down worker processes in watch mode - mutliremote', async () =
     const call1 = worker.childProcess.send.mock.calls.pop()[0]
     expect(call1.cid).toBe('0-7')
     expect(call1.command).toBe('endSession')
-    expect(call1.argv.watch).toBe(true)
-    expect(call1.argv.isMultiremote).toBe(true)
-    expect(call1.argv.instances).toEqual({ foo: {} })
-    expect(call1.argv.caps).toEqual({ foo: { capabilities: { browser: 'chrome' } } })
+    expect(call1.args.watch).toBe(true)
+    expect(call1.args.isMultiremote).toBe(true)
+    expect(call1.args.instances).toEqual({ foo: {} })
+    expect(call1.args.caps).toEqual({ foo: { capabilities: { browser: 'chrome' } } })
 })
 
 test('should avoid shutting down if worker is not busy', async () => {

--- a/packages/wdio-local-runner/tests/worker.test.js
+++ b/packages/wdio-local-runner/tests/worker.test.js
@@ -24,8 +24,7 @@ describe('handleMessage', () => {
         const worker = new Worker(
             {},
             {
-                cid: '0-3',
-                server: { foo: 'bar' }
+                cid: '0-3'
             }
         )
         worker.emit = jest.fn()
@@ -39,10 +38,6 @@ describe('handleMessage', () => {
         worker._handleMessage(payload)
         expect(worker.sessionId).toEqual('abc123')
         expect(payload.sessionId).toBe(undefined)
-        expect(worker.server).toEqual({
-            foo: 'bar',
-            bar: 'foo'
-        })
         expect(worker.emit).not.toBeCalled()
     })
 

--- a/packages/wdio-runner/src/utils.js
+++ b/packages/wdio-runner/src/utils.js
@@ -139,30 +139,3 @@ export function getInstancesData(browser, isMultiremote) {
 
     return instances
 }
-
-/**
- * Attach to Multiremote
- * @param {object} instances mutliremote instances object
- * @param {object} caps multiremote capabilities
- * @return {object}
- */
-export async function attachToMultiremote(instances, caps) {
-    // emulate multiremote browser object
-    const browser = {
-        instances: Object.keys(instances),
-        deleteSession () {
-            return Promise.all(Object.keys(instances).map(name => browser[name].deleteSession()))
-        }
-    }
-
-    /**
-     * attach to every multiremote instance
-     */
-    await Promise.all(
-        Object.keys(instances).map(async name => {
-            browser[name] = await initialiseInstance(instances[name], caps[name].capabilities, false)
-        })
-    )
-
-    return browser
-}

--- a/packages/wdio-runner/tests/utils.test.js
+++ b/packages/wdio-runner/tests/utils.test.js
@@ -1,7 +1,7 @@
 import { logMock } from '@wdio/logger'
 import { attach, remote, multiremote } from 'webdriverio'
 
-import { runHook, initialiseInstance, sanitizeCaps, sendFailureMessage, getInstancesData, attachToMultiremote } from '../src/utils'
+import { runHook, initialiseInstance, sanitizeCaps, sendFailureMessage, getInstancesData } from '../src/utils'
 
 process.send = jest.fn()
 
@@ -184,35 +184,6 @@ describe('utils', () => {
 
         it('isMultiremote = false', () => {
             expect(getInstancesData(null, false)).toEqual(undefined)
-        })
-    })
-
-    describe('attachToMultiremote', () => {
-        it('should build browser object', async () => {
-            const browser = await attachToMultiremote({
-                foo: { sessionId: 'foo' },
-                bar: { sessionId: 'bar' }
-            }, {
-                foo: { capabilities: { browserName: 'chrome' } },
-                bar: { capabilities: { browserName: 'firefox' } }
-            })
-
-            expect(attach.mock.calls[0][0]).toEqual({
-                sessionId: 'foo',
-                capabilities: { browserName: 'chrome' }
-            })
-            expect(attach.mock.calls[1][0]).toEqual({
-                sessionId: 'bar',
-                capabilities: { browserName: 'firefox' }
-            })
-
-            expect(typeof browser.deleteSession).toEqual('function')
-            expect(typeof browser.foo.deleteSession).toEqual('function')
-            expect(typeof browser.bar.deleteSession).toEqual('function')
-            expect(browser.foo.sessionId).toBeTruthy()
-            expect(browser.bar.sessionId).toBeTruthy()
-
-            expect(await browser.deleteSession()).toHaveLength(2)
         })
     })
 })

--- a/packages/wdio-smoke-test-service/src/index.js
+++ b/packages/wdio-smoke-test-service/src/index.js
@@ -24,6 +24,7 @@ class SmokeServiceLauncher {
         this.logFile = fs.createWriteStream(path.join(process.cwd(), 'tests', 'helpers', 'launcher.log'))
     }
     onPrepare () { this.logFile.write('onPrepare called\n') } // eslint-disable-line no-console
+    onWorkerStart () { this.logFile.write('onWorkerStart called\n')} // eslint-disable-line no-console
     onComplete () { this.logFile.write('onComplete called\n') } // eslint-disable-line no-console
 }
 

--- a/packages/wdio-sync/webdriverio-core.d.ts
+++ b/packages/wdio-sync/webdriverio-core.d.ts
@@ -102,6 +102,14 @@ declare namespace WebdriverIO {
             capabilities: WebDriver.DesiredCapabilities[]
         ): void;
 
+        onWorkerStart?(
+            cid: string,
+            caps: WebDriver.DesiredCapabilities,
+            specs: string[],
+            args: Config,
+            execArgv: string[]
+        ): void;
+
         onComplete?(exitCode: number, config: Config, capabilities: WebDriver.DesiredCapabilities, results: Results): void;
 
         onReload?(oldSessionId: string, newSessionId: string): void;
@@ -163,9 +171,9 @@ declare namespace WebdriverIO {
         }): void;
     }
     type _HooksArray = {
-        [K in keyof Pick<HookFunctions, "onPrepare" | "onComplete" | "before" | "after" | "beforeSession" | "afterSession">]: HookFunctions[K] | Array<HookFunctions[K]>;
+        [K in keyof Pick<HookFunctions, "onPrepare" | "onWorkerStart" | "onComplete" | "before" | "after" | "beforeSession" | "afterSession">]: HookFunctions[K] | Array<HookFunctions[K]>;
     };
-    type _Hooks = Omit<HookFunctions, "onPrepare" | "onComplete" | "before" | "after" | "beforeSession" | "afterSession">;
+    type _Hooks = Omit<HookFunctions, "onPrepare" | "onWorkerStart" | "onComplete" | "before" | "after" | "beforeSession" | "afterSession">;
     interface Hooks extends _HooksArray, _Hooks { }
 
     type ActionTypes = 'press' | 'longPress' | 'tap' | 'moveTo' | 'wait' | 'release';
@@ -217,7 +225,7 @@ declare namespace WebdriverIO {
             name: string,
             func: Function
         ): void;
-        
+
         /**
          * The `$$` command is a short way to call the [`findElements`](/docs/api/webdriver.html#findelements) command in order
          * to fetch multiple elements on the page similar to the `$$` command from the browser scope. The difference when calling
@@ -600,7 +608,7 @@ declare namespace WebdriverIO {
             name: string,
             func: (elementFetchingMethod: (selector: string) => any) => void
         ): void
-        
+
         /**
          * The `$$` command is a short way to call the [`findElements`](/docs/api/webdriver.html#findelements) command in order
          * to fetch multiple elements on the page. It returns an array with element results that will have an

--- a/packages/webdriver/src/utils.js
+++ b/packages/webdriver/src/utils.js
@@ -51,7 +51,7 @@ export async function startWebDriverSession (params) {
         response = await sessionRequest.makeRequest(params)
     } catch (err) {
         log.error(err)
-        const message = getSessionError(err)
+        const message = getSessionError(err, params)
         throw new Error('Failed to create session.\n' + message)
     }
     const sessionId = response.value.sessionId || response.sessionId
@@ -255,10 +255,10 @@ export function setupDirectConnect(params) {
  * get human readable message from response error
  * @param {Error} err response error
  */
-export const getSessionError = (err) => {
+export const getSessionError = (err, params) => {
     // browser driver / service is not started
     if (err.code === 'ECONNREFUSED') {
-        return `Unable to connect to "${err.address}:${err.port}", make sure browser driver is running on that address.` +
+        return `Unable to connect to "${params.protocol}://${params.hostname}:${params.port}${params.path}", make sure browser driver is running on that address.` +
             '\nIf you use services like chromedriver see initialiseServices logs above or in wdio.log file.'
     }
 

--- a/packages/webdriver/tests/utils.test.js
+++ b/packages/webdriver/tests/utils.test.js
@@ -184,7 +184,12 @@ describe('utils', () => {
                 address: '127.0.0.1',
                 port: 4444,
                 message: 'ECONNREFUSED 127.0.0.1:4444'
-            })).toContain('Unable to connect to "127.0.0.1:4444"')
+            }, {
+                protocol: 'http',
+                hostname: 'localhost',
+                port: 1234,
+                path: '/'
+            })).toContain('Unable to connect to "http://localhost:1234/"')
         })
 
         it('path: selenium-standalone path', () => {

--- a/packages/webdriverio/src/constants.js
+++ b/packages/webdriverio/src/constants.js
@@ -275,6 +275,7 @@ export const WDIO_DEFAULTS = {
      * hooks
      */
     onPrepare: HOOK_DEFINITION,
+    onWorkerStart: HOOK_DEFINITION,
     before: HOOK_DEFINITION,
     beforeSession: HOOK_DEFINITION,
     beforeSuite: HOOK_DEFINITION,

--- a/packages/webdriverio/webdriverio-core.d.ts
+++ b/packages/webdriverio/webdriverio-core.d.ts
@@ -102,6 +102,14 @@ declare namespace WebdriverIO {
             capabilities: WebDriver.DesiredCapabilities[]
         ): void;
 
+        onWorkerStart?(
+            cid: string,
+            caps: WebDriver.DesiredCapabilities,
+            specs: string[],
+            args: Config,
+            execArgv: string[]
+        ): void;
+
         onComplete?(exitCode: number, config: Config, capabilities: WebDriver.DesiredCapabilities, results: Results): void;
 
         onReload?(oldSessionId: string, newSessionId: string): void;
@@ -163,9 +171,9 @@ declare namespace WebdriverIO {
         }): void;
     }
     type _HooksArray = {
-        [K in keyof Pick<HookFunctions, "onPrepare" | "onComplete" | "before" | "after" | "beforeSession" | "afterSession">]: HookFunctions[K] | Array<HookFunctions[K]>;
+        [K in keyof Pick<HookFunctions, "onPrepare" | "onWorkerStart" | "onComplete" | "before" | "after" | "beforeSession" | "afterSession">]: HookFunctions[K] | Array<HookFunctions[K]>;
     };
-    type _Hooks = Omit<HookFunctions, "onPrepare" | "onComplete" | "before" | "after" | "beforeSession" | "afterSession">;
+    type _Hooks = Omit<HookFunctions, "onPrepare" | "onWorkerStart" | "onComplete" | "before" | "after" | "beforeSession" | "afterSession">;
     interface Hooks extends _HooksArray, _Hooks { }
 
     type ActionTypes = 'press' | 'longPress' | 'tap' | 'moveTo' | 'wait' | 'release';
@@ -217,7 +225,7 @@ declare namespace WebdriverIO {
             name: string,
             func: Function
         ): void;
-        
+
         /**
          * The `$$` command is a short way to call the [`findElements`](/docs/api/webdriver.html#findelements) command in order
          * to fetch multiple elements on the page similar to the `$$` command from the browser scope. The difference when calling
@@ -600,7 +608,7 @@ declare namespace WebdriverIO {
             name: string,
             func: (elementFetchingMethod: (selector: string) => any) => void
         ): void
-        
+
         /**
          * The `$$` command is a short way to call the [`findElements`](/docs/api/webdriver.html#findelements) command in order
          * to fetch multiple elements on the page. It returns an array with element results that will have an

--- a/scripts/templates/webdriverio.tpl.d.ts
+++ b/scripts/templates/webdriverio.tpl.d.ts
@@ -96,6 +96,14 @@ declare namespace WebdriverIO {
             capabilities: WebDriver.DesiredCapabilities[]
         ): void;
 
+        onWorkerStart?(
+            cid: string,
+            caps: WebDriver.DesiredCapabilities,
+            specs: string[],
+            args: Config,
+            execArgv: string[]
+        ): void;
+
         onComplete?(exitCode: number, config: Config, capabilities: WebDriver.DesiredCapabilities, results: Results): void;
 
         onReload?(oldSessionId: string, newSessionId: string): void;
@@ -157,9 +165,9 @@ declare namespace WebdriverIO {
         }): void;
     }
     type _HooksArray = {
-        [K in keyof Pick<HookFunctions, "onPrepare" | "onComplete" | "before" | "after" | "beforeSession" | "afterSession">]: HookFunctions[K] | Array<HookFunctions[K]>;
+        [K in keyof Pick<HookFunctions, "onPrepare" | "onWorkerStart" | "onComplete" | "before" | "after" | "beforeSession" | "afterSession">]: HookFunctions[K] | Array<HookFunctions[K]>;
     };
-    type _Hooks = Omit<HookFunctions, "onPrepare" | "onComplete" | "before" | "after" | "beforeSession" | "afterSession">;
+    type _Hooks = Omit<HookFunctions, "onPrepare" | "onWorkerStart" | "onComplete" | "before" | "after" | "beforeSession" | "afterSession">;
     interface Hooks extends _HooksArray, _Hooks { }
 
     type ActionTypes = 'press' | 'longPress' | 'tap' | 'moveTo' | 'wait' | 'release';

--- a/tests/helpers/fixtures.js
+++ b/tests/helpers/fixtures.js
@@ -13,6 +13,7 @@ afterSession called
 `
 
 export const LAUNCHER_LOGS = `onPrepare called
+onWorkerStart called
 onComplete called
 `
 


### PR DESCRIPTION
## Proposed changes

In order to allow users to modify the runtime of specific workers, e.g.

- connection details to WebDriver server (like `hostname`, `port` etc.)
- modify framework configurations
- allow to transpile a spec file and modify the spec argument for that worker
- probably a lot of other use cases

this PR adds a new hook called `onWorkerStart` that is being run before a new process if being forked. As oppose to `onPrepare` this hook allows to run async operations only for a specific worker.

See also #4721.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)


### Reviewers: @webdriverio/project-committers 
