### PR TITLE
Replace args with options object in some methods

### DIFF
--- a/docs/Selectors.md
+++ b/docs/Selectors.md
@@ -378,13 +378,17 @@ ReactDOM.render(<App />, document.querySelector('#root'))
 If you want to select the instance of `MyComponent` that has a prop `name` as `WebdriverIO`, you can execute the command like so:
 
 ```js
-const myCmp = browser.react$('MyComponent', { name: 'WebdriverIO' })
+const myCmp = browser.react$('MyComponent', {
+    props: { name: 'WebdriverIO' }
+})
 ```
 
 If you wanted to filter our selection by state, the `browser` command would looks something like so:
 
 ```js
-const myCmp = browser.react$('MyComponent', undefined, { myState: 'some value' })
+const myCmp = browser.react$('MyComponent', {
+    state: { myState: 'some value' }
+})
 ```
 
 #### Dealing with `React.Fragment`

--- a/packages/wdio-sync/webdriverio-core.d.ts
+++ b/packages/wdio-sync/webdriverio-core.d.ts
@@ -185,6 +185,11 @@ declare namespace WebdriverIO {
         reverse?: boolean,
     }
 
+    type ReactSelectorOptions = {
+        props?: object,
+        state?: any[] | number | string | object | boolean
+    }
+
     interface Element {
         selector: string;
         elementId: string;
@@ -431,8 +436,7 @@ declare namespace WebdriverIO {
          */
         react$$(
             selector: string,
-            props?: object,
-            state?: any[] | number | string | object | boolean
+            options?: ReactSelectorOptions
         ): ElementArray;
 
         /**
@@ -441,8 +445,7 @@ declare namespace WebdriverIO {
          */
         react$(
             selector: string,
-            props?: object,
-            state?: any[] | number | string | object | boolean
+            options?: ReactSelectorOptions
         ): Element;
 
         /**
@@ -702,8 +705,7 @@ declare namespace WebdriverIO {
          */
         react$$(
             selector: string,
-            props?: object,
-            state?: any[] | number | string | object | boolean
+            options?: ReactSelectorOptions
         ): ElementArray;
 
         /**
@@ -712,8 +714,7 @@ declare namespace WebdriverIO {
          */
         react$(
             selector: string,
-            props?: object,
-            state?: any[] | number | string | object | boolean
+            options?: ReactSelectorOptions
         ): Element;
 
         /**

--- a/packages/wdio-sync/webdriverio-core.d.ts
+++ b/packages/wdio-sync/webdriverio-core.d.ts
@@ -190,6 +190,20 @@ declare namespace WebdriverIO {
         state?: any[] | number | string | object | boolean
     }
 
+    type MoveToOptions = {
+        xOffset?: number,
+        yOffset?: number
+    }
+
+    type DragAndDropOptions = {
+        duration?: number
+    }
+
+    type NewWindowOptions = {
+        windowName?: string,
+        windowFeatures?: string
+    }
+
     interface Element {
         selector: string;
         elementId: string;
@@ -294,7 +308,7 @@ declare namespace WebdriverIO {
          */
         dragAndDrop(
             target: Element,
-            duration?: number
+            options?: DragAndDropOptions
         ): void;
 
         /**
@@ -426,8 +440,7 @@ declare namespace WebdriverIO {
          * is not visible, it will be scrolled into view.
          */
         moveTo(
-            xoffset?: number,
-            yoffset?: number
+            options?: MoveToOptions
         ): void;
 
         /**
@@ -456,8 +469,7 @@ declare namespace WebdriverIO {
         ): Buffer;
 
         /**
-         * Scroll element into viewport.
-         * https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView
+         * Scroll element into viewport ([MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView)).
          */
         scrollIntoView(
             scrollIntoViewOptions?: object | boolean
@@ -531,9 +543,7 @@ declare namespace WebdriverIO {
          * milliseconds to be displayed or not displayed.
          */
         waitForDisplayed(
-            ms?: number,
-            reverse?: boolean,
-            error?: string
+            options?: WaitForOptions
         ): boolean;
 
         /**
@@ -542,9 +552,7 @@ declare namespace WebdriverIO {
          * selector, it returns true if at least one element is (dis/en)abled.
          */
         waitForEnabled(
-            ms?: number,
-            reverse?: boolean,
-            error?: string
+            options?: WaitForOptions
         ): boolean;
 
         /**
@@ -555,9 +563,7 @@ declare namespace WebdriverIO {
          * if the selector does not match any elements.
          */
         waitForExist(
-            ms?: number,
-            reverse?: boolean,
-            error?: string
+            options?: WaitForOptions
         ): boolean;
     }
 
@@ -686,8 +692,7 @@ declare namespace WebdriverIO {
          */
         newWindow(
             url: string,
-            windowName?: string,
-            windowFeatures?: string
+            options?: NewWindowOptions
         ): string;
 
         /**

--- a/packages/wdio-sync/webdriverio.d.ts
+++ b/packages/wdio-sync/webdriverio.d.ts
@@ -1,15 +1,19 @@
 /// <reference types="@wdio/sync/webdriverio-core"/>
 
 declare namespace WebdriverIO {
+    type WaitUntilOptions = {
+        timeout?: number,
+        timeoutMsg?: string,
+        interval?: number
+    }
+
     interface Browser {
         /**
          * waits until the condition is fulfilled with a truthy value
          */
         waitUntil(
             condition: () => boolean,
-            timeout?: number,
-            timeoutMsg?: string,
-            interval?: number
+            options?: WaitUntilOptions
         ): boolean
 
         /**

--- a/packages/webdriverio/src/commands/browser/newWindow.js
+++ b/packages/webdriverio/src/commands/browser/newWindow.js
@@ -21,9 +21,10 @@
  * </example>
  *
  * @param {String}  url      website URL to open
- * @param {Object=} options  newWindow command options
- * @param {String=} options.windowName     name of the new window
- * @param {String=} options.windowFeatures features of opened window (e.g. size, position, scrollbars, etc.)
+ * @param {NewWindowOptions=} options                newWindow command options
+ * @param {String=}           options.windowName     name of the new window
+ * @param {String=}           options.windowFeatures features of opened window (e.g. size, position, scrollbars, etc.)
+ *
  * @return {String}          id of window handle of new tab
  *
  * @uses browser/execute, protocol/getWindowHandles, protocol/switchToWindow

--- a/packages/webdriverio/src/commands/browser/newWindow.js
+++ b/packages/webdriverio/src/commands/browser/newWindow.js
@@ -20,10 +20,11 @@
     });
  * </example>
  *
- * @param {String} url            website URL to open
- * @param {String=} windowName     name of the new window
- * @param {String=} windowFeatures features of opened window (e.g. size, position, scrollbars, etc.)
- * @return {String}                id of window handle of new tab
+ * @param {String}  url      website URL to open
+ * @param {Object=} options  newWindow command options
+ * @param {String=} options.windowName     name of the new window
+ * @param {String=} options.windowFeatures features of opened window (e.g. size, position, scrollbars, etc.)
+ * @return {String}          id of window handle of new tab
  *
  * @uses browser/execute, protocol/getWindowHandles, protocol/switchToWindow
  * @alias browser.newWindow
@@ -32,7 +33,7 @@
 
 import newWindowHelper from '../../scripts/newWindow'
 
-export default async function newWindow (url, windowName = 'New Window', windowFeatures = '') {
+export default async function newWindow (url, { windowName = 'New Window', windowFeatures = '' } = {}) {
     /*!
      * parameter check
      */

--- a/packages/webdriverio/src/commands/browser/react$$.js
+++ b/packages/webdriverio/src/commands/browser/react$$.js
@@ -19,8 +19,8 @@
  *
  * @alias browser.react$$
  * @param {String}  selector        of React component
- * @param {Object=} options         React selector options
- * @param {Object=} options.props   React props the element should contain
+ * @param {ReactSelectorOptions=}                    options         React selector options
+ * @param {Object=}                                  options.props   React props the element should contain
  * @param {Array<any>|number|string|object|boolean=} options.state  React state the element should be in
  * @return {ElementArray}
  *

--- a/packages/webdriverio/src/commands/browser/react$$.js
+++ b/packages/webdriverio/src/commands/browser/react$$.js
@@ -10,15 +10,18 @@
     it('should calculate 7 * 6', () => {
         browser.url('https://ahfarmer.github.io/calculator/');
 
-        const orangeButtons = browser.react$$('t', { orange: true })
+        const orangeButtons = browser.react$$('t', {
+            props: { orange: true }
+        })
         console.log(orangeButtons.map((btn) => btn.getText())); // prints "[ '÷', 'x', '-', '+', '=' ]"
     });
  * </example>
  *
  * @alias browser.react$$
- * @param {String} selector of React component
- * @param {Object=} props  React props the element should contain
- * @param {Array<any>|number|string|object|boolean=} state  React state the element should be in
+ * @param {String}  selector        of React component
+ * @param {Object=} options         React selector options
+ * @param {Object=} options.props   React props the element should contain
+ * @param {Array<any>|number|string|object|boolean=} options.state  React state the element should be in
  * @return {ElementArray}
  *
  */
@@ -29,7 +32,7 @@ import { waitToLoadReact, react$$ as react$$Script } from '../../scripts/resq'
 
 const resqScript = fs.readFileSync(require.resolve('resq'))
 
-export default async function react$$ (selector, props = {}, state = {}) {
+export default async function react$$ (selector, { props = {}, state = {} } = {}) {
     await this.executeScript(resqScript.toString(), [])
     await this.execute(waitToLoadReact)
     const res = await this.execute(react$$Script, selector, props, state)

--- a/packages/webdriverio/src/commands/browser/react$.js
+++ b/packages/webdriverio/src/commands/browser/react$.js
@@ -29,8 +29,8 @@
  *
  * @alias browser.react$
  * @param {String}  selector        of React component
- * @param {Object=} options         React selector options
- * @param {Object=} options.props   React props the element should contain
+ * @param {ReactSelectorOptions=}                    options         React selector options
+ * @param {Object=}                                  options.props   React props the element should contain
  * @param {Array<any>|number|string|object|boolean=} options.state  React state the element should be in
  * @return {Element}
  *

--- a/packages/webdriverio/src/commands/browser/react$.js
+++ b/packages/webdriverio/src/commands/browser/react$.js
@@ -10,19 +10,28 @@
     it('should calculate 7 * 6', () => {
         browser.url('https://ahfarmer.github.io/calculator/');
 
-        browser.react$('t', { name: '7' }).click()
-        browser.react$('t', { name: 'x' }).click()
-        browser.react$('t', { name: '6' }).click()
-        browser.react$('t', { name: '=' }).click()
+        browser.react$('t', {
+            props: { name: '7' }
+        }).click()
+        browser.react$('t', {
+            props: { name: 'x' }
+        }).click()
+        browser.react$('t', {
+            props: { name: '6' }
+        }).click()
+        browser.react$('t', {
+            props: { name: '=' }
+        }).click()
 
         console.log($('.component-display').getText()); // prints "42"
     });
  * </example>
  *
  * @alias browser.react$
- * @param {String} selector of React component
- * @param {Object=} props  React props the element should contain
- * @param {Array<any>|number|string|object|boolean=} state  React state the element should be in
+ * @param {String}  selector        of React component
+ * @param {Object=} options         React selector options
+ * @param {Object=} options.props   React props the element should contain
+ * @param {Array<any>|number|string|object|boolean=} options.state  React state the element should be in
  * @return {Element}
  *
  */
@@ -32,7 +41,7 @@ import { waitToLoadReact, react$ as react$Script } from '../../scripts/resq'
 
 const resqScript = fs.readFileSync(require.resolve('resq'))
 
-export default async function react$ (selector, props = {}, state = {}) {
+export default async function react$ (selector, { props = {}, state = {} } = {}) {
     await this.executeScript(resqScript.toString(), [])
     await this.execute(waitToLoadReact)
     const res = await this.execute(react$Script, selector, props, state)

--- a/packages/webdriverio/src/commands/browser/waitUntil.js
+++ b/packages/webdriverio/src/commands/browser/waitUntil.js
@@ -42,7 +42,14 @@
 
 import Timer from '../../utils/Timer'
 
-export default function (condition, { timeout, timeoutMsg, interval } = {}) {
+export default function (
+    condition,
+    {
+        timeout = this.options.waitforTimeout,
+        interval = this.options.waitforInterval,
+        timeoutMsg
+    } = {}
+) {
     if (typeof condition !== 'function') {
         throw new Error('Condition is not a function')
     }

--- a/packages/webdriverio/src/commands/browser/waitUntil.js
+++ b/packages/webdriverio/src/commands/browser/waitUntil.js
@@ -17,18 +17,23 @@
 
     :waitUntil.js
     it('should wait until text has changed', () => {
-        browser.waitUntil(() => {
-          return $('#someText').getText() === 'I am now different'
-        }, 5000, 'expected text to be different after 5s');
+        browser.waitUntil(
+            () => $('#someText').getText() === 'I am now different',
+            {
+                timeout: 5000,
+                timeoutMsg: 'expected text to be different after 5s'
+            }
+        );
     });
  * </example>
  *
  *
  * @alias browser.waitUntil
  * @param {Function} condition  condition to wait on
- * @param {Number=}  timeout    timeout in ms (default: 5000)
- * @param {String=}  timeoutMsg error message to throw when waitUntil times out
- * @param {Number=}  interval   interval between condition checks (default: 500)
+ * @param {Object}   options    command options
+ * @param {Number=}  options.timeout     timeout in ms (default: 5000)
+ * @param {String=}  options.timeoutMsg  error message to throw when waitUntil times out
+ * @param {Number=}  options.interval    interval between condition checks (default: 500)
  * @return {Boolean} true if condition is fulfilled
  * @uses utility/pause
  * @type utility
@@ -37,7 +42,7 @@
 
 import Timer from '../../utils/Timer'
 
-export default function (condition, timeout, timeoutMsg, interval) {
+export default function (condition, { timeout, timeoutMsg, interval } = {}) {
     if (typeof condition !== 'function') {
         throw new Error('Condition is not a function')
     }

--- a/packages/webdriverio/src/commands/element/dragAndDrop.js
+++ b/packages/webdriverio/src/commands/element/dragAndDrop.js
@@ -13,8 +13,8 @@
  *
  * @alias element.dragAndDrop
  * @param {Element} target    destination selector
- * @param {Object=} options   dragAndDrop command options
- * @param {Number=} options.duration  how long the drag should take place
+ * @param {DragAndDropOptions=} options           dragAndDrop command options
+ * @param {Number=}             options.duration  how long the drag should take place
  * @uses action/moveToObject, protocol/buttonDown, protocol/buttonUp, property/getLocation, protocol/touchDown, protocol/touchMove, protocol/touchUp
  * @type action
  *

--- a/packages/webdriverio/src/commands/element/dragAndDrop.js
+++ b/packages/webdriverio/src/commands/element/dragAndDrop.js
@@ -2,9 +2,19 @@
  *
  * Drag an item to a destination element.
  *
+ * <example>
+    :example.test.js
+    it('should demonstrate the doubleClick command', () => {
+        const elem = $('#someElem')
+        const target = $('#someTarget')
+        elem.dragAndDrop(target)
+    })
+ * </example>
+ *
  * @alias element.dragAndDrop
  * @param {Element} target    destination selector
- * @param {Number=}  duration  how long the drag should take place
+ * @param {Object=} options   dragAndDrop command options
+ * @param {Number=} options.duration  how long the drag should take place
  * @uses action/moveToObject, protocol/buttonDown, protocol/buttonUp, property/getLocation, protocol/touchDown, protocol/touchMove, protocol/touchUp
  * @type action
  *
@@ -14,7 +24,7 @@ import { getElementRect, getScrollPosition } from '../../utils'
 
 const ACTION_BUTTON = 0
 
-export default async function dragAndDrop (target, duration = 100) {
+export default async function dragAndDrop (target, { duration = 100 } = {}) {
     if (!target || target.constructor.name !== 'Element') {
         throw new Error('command dragAndDrop requires an WebdriverIO Element as first parameter')
     }

--- a/packages/webdriverio/src/commands/element/moveTo.js
+++ b/packages/webdriverio/src/commands/element/moveTo.js
@@ -5,8 +5,9 @@
  * no offset, the mouse will be moved to the center of the element. If the element
  * is not visible, it will be scrolled into view.
  *
- * @param {Number=} xoffset  X offset to move to, relative to the top-left corner of the element. If not specified, the mouse will move to the middle of the element.
- * @param {Number=} yoffset  Y offset to move to, relative to the top-left corner of the element. If not specified, the mouse will move to the middle of the element.
+ * @param (Object=) options          moveTo command options
+ * @param {Number=} options.xOffset  X offset to move to, relative to the top-left corner of the element. If not specified, the mouse will move to the middle of the element.
+ * @param {Number=} options.yOffset  Y offset to move to, relative to the top-left corner of the element. If not specified, the mouse will move to the middle of the element.
  *
  * @see  https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidmoveto
  * @type protocol
@@ -14,9 +15,9 @@
 
 import { getElementRect, getScrollPosition } from '../../utils'
 
-export default async function moveTo (xoffset, yoffset) {
+export default async function moveTo ({ xOffset, yOffset } = {}) {
     if (!this.isW3C) {
-        return this.moveToElement(this.elementId, xoffset, yoffset)
+        return this.moveToElement(this.elementId, xOffset, yOffset)
     }
 
     /**
@@ -24,8 +25,8 @@ export default async function moveTo (xoffset, yoffset) {
      */
     const { x, y, width, height } = await getElementRect(this)
     const { scrollX, scrollY } = await getScrollPosition(this)
-    const newXoffset = parseInt(x + (typeof xoffset === 'number' ? xoffset : (width / 2)), 10) - scrollX
-    const newYoffset = parseInt(y + (typeof yoffset === 'number' ? yoffset : (height / 2)), 10) - scrollY
+    const newXOffset = parseInt(x + (typeof xOffset === 'number' ? xOffset : (width / 2)), 10) - scrollX
+    const newYOffset = parseInt(y + (typeof yOffset === 'number' ? yOffset : (height / 2)), 10) - scrollY
 
     /**
      * W3C way of handle the mouse move actions
@@ -34,6 +35,6 @@ export default async function moveTo (xoffset, yoffset) {
         type: 'pointer',
         id: 'finger1',
         parameters: { pointerType: 'mouse' },
-        actions: [{ type: 'pointerMove', duration: 0, x: newXoffset, y: newYoffset }]
+        actions: [{ type: 'pointerMove', duration: 0, x: newXOffset, y: newYOffset }]
     }]).then(() => this.releaseActions())
 }

--- a/packages/webdriverio/src/commands/element/moveTo.js
+++ b/packages/webdriverio/src/commands/element/moveTo.js
@@ -5,9 +5,9 @@
  * no offset, the mouse will be moved to the center of the element. If the element
  * is not visible, it will be scrolled into view.
  *
- * @param (Object=) options          moveTo command options
- * @param {Number=} options.xOffset  X offset to move to, relative to the top-left corner of the element. If not specified, the mouse will move to the middle of the element.
- * @param {Number=} options.yOffset  Y offset to move to, relative to the top-left corner of the element. If not specified, the mouse will move to the middle of the element.
+ * @param {MoveToOptions=} options          moveTo command options
+ * @param {Number=}        options.xOffset  X offset to move to, relative to the top-left corner of the element. If not specified, the mouse will move to the middle of the element.
+ * @param {Number=}        options.yOffset  Y offset to move to, relative to the top-left corner of the element. If not specified, the mouse will move to the middle of the element.
  *
  * @see  https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidmoveto
  * @type protocol

--- a/packages/webdriverio/src/commands/element/react$$.js
+++ b/packages/webdriverio/src/commands/element/react$$.js
@@ -20,8 +20,8 @@
  *
  * @alias react$$
  * @param {String}  selector        of React component
- * @param {Object=} options         React selector options
- * @param {Object=} options.props   React props the element should contain
+ * @param {ReactSelectorOptions=}                    options         React selector options
+ * @param {Object=}                                  options.props   React props the element should contain
  * @param {Array<any>|number|string|object|boolean=} options.state  React state the element should be in
  * @return {ElementArray}
  *

--- a/packages/webdriverio/src/commands/element/react$$.js
+++ b/packages/webdriverio/src/commands/element/react$$.js
@@ -11,15 +11,18 @@
         browser.url('https://ahfarmer.github.io/calculator/');
         const appWrapper = browser.$('div#root')
 
-        const orangeButtons = appWrapper.react$$('t', { orange: true })
+        const orangeButtons = browser.react$$('t', {
+            props: { orange: true }
+        })
         console.log(orangeButtons.map((btn) => btn.getText())); // prints "[ '÷', 'x', '-', '+', '=' ]"
     });
  * </example>
  *
  * @alias react$$
- * @param {String} selector of React component
- * @param {Object=} props  React props the element should contain
- * @param {Array<any>|number|string|object|boolean=} state  React state the element should be in
+ * @param {String}  selector        of React component
+ * @param {Object=} options         React selector options
+ * @param {Object=} options.props   React props the element should contain
+ * @param {Array<any>|number|string|object|boolean=} options.state  React state the element should be in
  * @return {ElementArray}
  *
  */
@@ -30,7 +33,7 @@ import { waitToLoadReact, react$$ as react$$Script } from '../../scripts/resq'
 
 const resqScript = fs.readFileSync(require.resolve('resq'))
 
-export default async function react$$(selector, props = {}, state = {}) {
+export default async function react$$(selector, { props = {}, state = {} } = {}) {
     await this.executeScript(resqScript.toString(), [])
     await this.execute(waitToLoadReact)
     const res = await this.execute(react$$Script, selector, props, state, this)

--- a/packages/webdriverio/src/commands/element/react$.js
+++ b/packages/webdriverio/src/commands/element/react$.js
@@ -30,8 +30,8 @@
  *
  * @alias react$
  * @param {String}  selector        of React component
- * @param {Object=} options         React selector options
- * @param {Object=} options.props   React props the element should contain
+ * @param {ReactSelectorOptions=}                    options         React selector options
+ * @param {Object=}                                  options.props   React props the element should contain
  * @param {Array<any>|number|string|object|boolean=} options.state  React state the element should be in
  * @return {Element}
  *

--- a/packages/webdriverio/src/commands/element/react$.js
+++ b/packages/webdriverio/src/commands/element/react$.js
@@ -11,19 +11,28 @@
         browser.url('https://ahfarmer.github.io/calculator/');
         const appWrapper = browser.$('div#root')
 
-        appWrapper.react$('t', { name: '7' }).click()
-        appWrapper.react$('t', { name: 'x' }).click()
-        appWrapper.react$('t', { name: '6' }).click()
-        appWrapper.react$('t', { name: '=' }).click()
+        browser.react$('t', {
+            props: { name: '7' }
+        }).click()
+        browser.react$('t', {
+            props: { name: 'x' }
+        }).click()
+        browser.react$('t', {
+            props: { name: '6' }
+        }).click()
+        browser.react$('t', {
+            props: { name: '=' }
+        }).click()
 
         console.log($('.component-display').getText()); // prints "42"
     });
  * </example>
  *
  * @alias react$
- * @param {String} selector of React component
- * @param {Object=} props  React props the element should contain
- * @param {Array<any>|number|string|object|boolean=} state  React state the element should be in
+ * @param {String}  selector        of React component
+ * @param {Object=} options         React selector options
+ * @param {Object=} options.props   React props the element should contain
+ * @param {Array<any>|number|string|object|boolean=} options.state  React state the element should be in
  * @return {Element}
  *
  */
@@ -33,7 +42,7 @@ import { waitToLoadReact, react$ as react$Script } from '../../scripts/resq'
 
 const resqScript = fs.readFileSync(require.resolve('resq'))
 
-export default async function react$(selector, props = {}, state = {}) {
+export default async function react$(selector, { props = {}, state = {} } = {}) {
     await this.executeScript(resqScript.toString(), [])
     await this.execute(waitToLoadReact)
     const res = await this.execute(react$Script, selector, props, state, this)

--- a/packages/webdriverio/src/commands/element/scrollIntoView.js
+++ b/packages/webdriverio/src/commands/element/scrollIntoView.js
@@ -1,7 +1,6 @@
 /**
  *
- * Scroll element into viewport.
- * https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView
+ * Scroll element into viewport ([MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView)).
  *
  * <example>
     :scrollIntoView.js
@@ -13,7 +12,7 @@
  * </example>
  *
  * @alias element.scrollIntoView
- * @param {object|boolean=} scrollIntoViewOptions  boolean alignToTop or scrollIntoViewOptions object
+ * @param {object|boolean=} scrollIntoViewOptions  options for `Element.scrollIntoView()` (default: `true`)
  * @uses protocol/execute
  * @type utility
  *

--- a/packages/webdriverio/src/commands/element/waitForClickable.js
+++ b/packages/webdriverio/src/commands/element/waitForClickable.js
@@ -16,11 +16,11 @@
  * </example>
  *
  * @alias element.waitForClickable
- * @param {Object=}   options             waitForClickable options (optional)
- * @param {Number=}   options.timeout     time in ms (default: `waitforTimeout`)
- * @param {Boolean=}  options.reverse     if true it waits for the opposite (default: false)
- * @param {String=}   options.timeoutMsg  error message to throw when waitUntil times out
- * @param {Number=}   options.interval    interval between checks (default: `waitforInterval`)
+ * @param {WaitForOptions=}  options             waitForEnabled options (optional)
+ * @param {Number=}          options.timeout     time in ms (default: 500)
+ * @param {Boolean=}         options.reverse     if true it waits for the opposite (default: false)
+ * @param {String=}          options.timeoutMsg  if exists it overrides the default error message
+ * @param {Number=}          options.interval    interval between checks (default: `waitforInterval`)
  * @return {Boolean} `true` if element is clickable (or doesn't if flag is set)
  *
  */

--- a/packages/webdriverio/src/commands/element/waitForClickable.js
+++ b/packages/webdriverio/src/commands/element/waitForClickable.js
@@ -26,8 +26,8 @@
  */
 
 export default async function waitForClickable ({
-    timeout, // defaults defined in waitUntil command
-    interval, // defaults defined in waitUntil command
+    timeout = this.options.waitforTimeout,
+    interval = this.options.waitforInterval,
     reverse = false,
     timeoutMsg = `element ("${this.selector}") still ${reverse ? '' : 'not '}clickable after ${timeout}ms`
 } = {}) {

--- a/packages/webdriverio/src/commands/element/waitForClickable.js
+++ b/packages/webdriverio/src/commands/element/waitForClickable.js
@@ -26,8 +26,8 @@
  */
 
 export default async function waitForClickable ({
-    timeout = this.options.waitforTimeout,
-    interval = this.options.waitforInterval,
+    timeout, // defaults defined in waitUntil command
+    interval, // defaults defined in waitUntil command
     reverse = false,
     timeoutMsg = `element ("${this.selector}") still ${reverse ? '' : 'not '}clickable after ${timeout}ms`
 } = {}) {

--- a/packages/webdriverio/src/commands/element/waitForClickable.js
+++ b/packages/webdriverio/src/commands/element/waitForClickable.js
@@ -16,11 +16,11 @@
  * </example>
  *
  * @alias element.waitForClickable
- * @param {WaitForOptions=}  options            Object (optional)
- * @param {Number=}  options.timeout    time in ms (default: `waitforTimeout`)
- * @param {Boolean=} options.reverse    if true it waits for the opposite (default: false)
- * @param {String=}  options.timeoutMsg error message to throw when waitUntil times out
- * @param {Number=}  options.interval   interval between checks (default: `waitforInterval`)
+ * @param {Object=}   options             waitForClickable options (optional)
+ * @param {Number=}   options.timeout     time in ms (default: `waitforTimeout`)
+ * @param {Boolean=}  options.reverse     if true it waits for the opposite (default: false)
+ * @param {String=}   options.timeoutMsg  error message to throw when waitUntil times out
+ * @param {Number=}   options.interval    interval between checks (default: `waitforInterval`)
  * @return {Boolean} `true` if element is clickable (or doesn't if flag is set)
  *
  */
@@ -31,5 +31,8 @@ export default async function waitForClickable ({
     reverse = false,
     timeoutMsg = `element ("${this.selector}") still ${reverse ? '' : 'not '}clickable after ${timeout}ms`
 } = {}) {
-    return this.waitUntil(async () => reverse !== await this.isClickable(), timeout, timeoutMsg, interval)
+    return this.waitUntil(
+        async () => reverse !== await this.isClickable(),
+        { timeout, timeoutMsg, interval }
+    )
 }

--- a/packages/webdriverio/src/commands/element/waitForDisplayed.js
+++ b/packages/webdriverio/src/commands/element/waitForDisplayed.js
@@ -15,35 +15,35 @@
     :waitForVisibleExample.js
     it('should detect when element is visible', () => {
         const elem = $('#elem')
-        elem.waitForDisplayed(3000);
+        elem.waitForDisplayed({ timeout: 3000 });
     });
     it('should detect when element is no longer visible', () => {
         const elem = $('#elem')
         // passing 'undefined' allows us to keep the default timeout value without overwriting it
-        elem.waitForDisplayed(undefined, true);
+        elem.waitForDisplayed({ reverse: true });
     });
  * </example>
  *
  * @alias element.waitForDisplayed
- * @param {Number=}  ms       time in ms (default: 500)
- * @param {Boolean=} reverse  if true it waits for the opposite (default: false)
- * @param {String=}  error    if exists it overrides the default error message
+ * @param {Object=}  options             waitForDisplayed options (optional)
+ * @param {Number=}  options.timeout     time in ms (default: 500)
+ * @param {Boolean=} options.reverse     if true it waits for the opposite (default: false)
+ * @param {String=}  options.timeoutMsg  if exists it overrides the default error message
+ * @param {Number=}  options.interval    interval between checks (default: `waitforInterval`)
  * @return {Boolean} true     if element is displayed (or doesn't if flag is set)
  * @uses utility/waitUntil, state/isDisplayed
  * @type utility
  *
  */
 
-export default async function waitForDisplayed (ms, reverse = false, error) {
-    /*
-     * ensure that ms is set properly
-     */
-    if (typeof ms !== 'number') {
-        ms = this.options.waitforTimeout
-    }
-
-    const isReversed = reverse ? '' : 'not '
-    const errorMsg = typeof error === 'string' ? error : `element ("${this.selector}") still ${isReversed}displayed after ${ms}ms`
-
-    return this.waitUntil(async () => reverse !== await this.isDisplayed(), ms, errorMsg)
+export default async function waitForDisplayed ({
+    timeout = this.options.waitforTimeout,
+    interval = this.options.waitforInterval,
+    reverse = false,
+    timeoutMsg = `element ("${this.selector}") still ${reverse ? '' : 'not '}displayed after ${timeout}ms`
+} = {}) {
+    return this.waitUntil(
+        async () => reverse !== await this.isDisplayed(),
+        { timeout, interval, timeoutMsg }
+    )
 }

--- a/packages/webdriverio/src/commands/element/waitForDisplayed.js
+++ b/packages/webdriverio/src/commands/element/waitForDisplayed.js
@@ -25,11 +25,11 @@
  * </example>
  *
  * @alias element.waitForDisplayed
- * @param {Object=}  options             waitForDisplayed options (optional)
- * @param {Number=}  options.timeout     time in ms (default: 500)
- * @param {Boolean=} options.reverse     if true it waits for the opposite (default: false)
- * @param {String=}  options.timeoutMsg  if exists it overrides the default error message
- * @param {Number=}  options.interval    interval between checks (default: `waitforInterval`)
+ * @param {WaitForOptions=}  options             waitForEnabled options (optional)
+ * @param {Number=}          options.timeout     time in ms (default: 500)
+ * @param {Boolean=}         options.reverse     if true it waits for the opposite (default: false)
+ * @param {String=}          options.timeoutMsg  if exists it overrides the default error message
+ * @param {Number=}          options.interval    interval between checks (default: `waitforInterval`)
  * @return {Boolean} true     if element is displayed (or doesn't if flag is set)
  * @uses utility/waitUntil, state/isDisplayed
  * @type utility

--- a/packages/webdriverio/src/commands/element/waitForDisplayed.js
+++ b/packages/webdriverio/src/commands/element/waitForDisplayed.js
@@ -37,8 +37,8 @@
  */
 
 export default async function waitForDisplayed ({
-    timeout, // defaults defined in waitUntil command
-    interval, // defaults defined in waitUntil command
+    timeout = this.options.waitforTimeout,
+    interval = this.options.waitforInterval,
     reverse = false,
     timeoutMsg = `element ("${this.selector}") still ${reverse ? '' : 'not '}displayed after ${timeout}ms`
 } = {}) {

--- a/packages/webdriverio/src/commands/element/waitForDisplayed.js
+++ b/packages/webdriverio/src/commands/element/waitForDisplayed.js
@@ -37,8 +37,8 @@
  */
 
 export default async function waitForDisplayed ({
-    timeout = this.options.waitforTimeout,
-    interval = this.options.waitforInterval,
+    timeout, // defaults defined in waitUntil command
+    interval, // defaults defined in waitUntil command
     reverse = false,
     timeoutMsg = `element ("${this.selector}") still ${reverse ? '' : 'not '}displayed after ${timeout}ms`
 } = {}) {

--- a/packages/webdriverio/src/commands/element/waitForEnabled.js
+++ b/packages/webdriverio/src/commands/element/waitForEnabled.js
@@ -24,11 +24,11 @@
  * </example>
  *
  * @alias element.waitForEnabled
- * @param {Object=}  options             waitForEnabled options (optional)
- * @param {Number=}  options.timeout     time in ms (default: 500)
- * @param {Boolean=} options.reverse     if true it waits for the opposite (default: false)
- * @param {String=}  options.timeoutMsg  if exists it overrides the default error message
- * @param {Number=}  options.interval    interval between checks (default: `waitforInterval`)
+ * @param {WaitForOptions=}  options             waitForEnabled options (optional)
+ * @param {Number=}          options.timeout     time in ms (default: 500)
+ * @param {Boolean=}         options.reverse     if true it waits for the opposite (default: false)
+ * @param {String=}          options.timeoutMsg  if exists it overrides the default error message
+ * @param {Number=}          options.interval    interval between checks (default: `waitforInterval`)
  * @return {Boolean} true     if element is (dis/en)abled
  * @uses utility/waitUntil, state/isEnabled
  * @type utility

--- a/packages/webdriverio/src/commands/element/waitForEnabled.js
+++ b/packages/webdriverio/src/commands/element/waitForEnabled.js
@@ -14,41 +14,42 @@
     </script>
     :waitForEnabledExample.js
     it('should detect when element is enabled', () => {
-        $('#username').waitForEnabled(3000);
+        $('#username').waitForEnabled({ timeout: 3000 });
     });
 
     it('should detect when element is disabled', () => {
         elem = $('#username');
-        elem.waitForEnabled(3000, true)
+        elem.waitForEnabled({ reverse: true })
     });
  * </example>
  *
  * @alias element.waitForEnabled
- * @param {Number=}  ms       time in ms (default: 500)
- * @param {Boolean=} reverse  if true it waits for the opposite (default: false)
- * @param {String=}  error    if exists it overrides the default error message
+ * @param {Object=}  options             waitForEnabled options (optional)
+ * @param {Number=}  options.timeout     time in ms (default: 500)
+ * @param {Boolean=} options.reverse     if true it waits for the opposite (default: false)
+ * @param {String=}  options.timeoutMsg  if exists it overrides the default error message
+ * @param {Number=}  options.interval    interval between checks (default: `waitforInterval`)
  * @return {Boolean} true     if element is (dis/en)abled
  * @uses utility/waitUntil, state/isEnabled
  * @type utility
  *
  */
 
-export default async function waitForEnabled(ms, reverse = false, error) {
-    // If the element doesn't already exist, wait for it to exist
+export default async function waitForEnabled({
+    timeout = this.options.waitforTimeout,
+    interval = this.options.waitforInterval,
+    reverse = false,
+    timeoutMsg = `element ("${this.selector}") still ${reverse ? '' : 'not '}enabled after ${timeout}ms`
+} = {}) {
+    /**
+     * if the element doesn't already exist, wait for it to exist
+     */
     if (!this.elementId && !reverse) {
-        await this.waitForExist(ms, false, error)
+        await this.waitForExist({ timeout, interval, timeoutMsg })
     }
 
-    if (typeof ms !== 'number') {
-        ms = this.options.waitforTimeout
-    }
-
-    const isReversed = reverse ? '' : 'not '
-    const errorMessage = typeof error === 'string' ? error : `element ("${this.selector}") still ${isReversed}enabled after ${ms}ms`
-
-    return this.waitUntil(async () => {
-        const isEnabled = await this.isEnabled()
-
-        return isEnabled !== reverse
-    }, ms, errorMessage)
+    return this.waitUntil(
+        async () => reverse !== await this.isEnabled(),
+        { timeout, interval, timeoutMsg }
+    )
 }

--- a/packages/webdriverio/src/commands/element/waitForEnabled.js
+++ b/packages/webdriverio/src/commands/element/waitForEnabled.js
@@ -36,8 +36,8 @@
  */
 
 export default async function waitForEnabled({
-    timeout, // defaults defined in waitUntil command
-    interval, // defaults defined in waitUntil command
+    timeout = this.options.waitforTimeout,
+    interval = this.options.waitforInterval,
     reverse = false,
     timeoutMsg = `element ("${this.selector}") still ${reverse ? '' : 'not '}enabled after ${timeout}ms`
 } = {}) {

--- a/packages/webdriverio/src/commands/element/waitForEnabled.js
+++ b/packages/webdriverio/src/commands/element/waitForEnabled.js
@@ -36,8 +36,8 @@
  */
 
 export default async function waitForEnabled({
-    timeout = this.options.waitforTimeout,
-    interval = this.options.waitforInterval,
+    timeout, // defaults defined in waitUntil command
+    interval, // defaults defined in waitUntil command
     reverse = false,
     timeoutMsg = `element ("${this.selector}") still ${reverse ? '' : 'not '}enabled after ${timeout}ms`
 } = {}) {

--- a/packages/webdriverio/src/commands/element/waitForExist.js
+++ b/packages/webdriverio/src/commands/element/waitForExist.js
@@ -38,8 +38,8 @@
  */
 
 export default function waitForExist ({
-    timeout = this.options.waitforTimeout,
-    interval = this.options.waitforInterval,
+    timeout, // defaults defined in waitUntil command
+    interval, // defaults defined in waitUntil command
     reverse = false,
     timeoutMsg = `element ("${this.selector}") still ${reverse ? '' : 'not '}existing after ${timeout}ms`
 } = {}) {

--- a/packages/webdriverio/src/commands/element/waitForExist.js
+++ b/packages/webdriverio/src/commands/element/waitForExist.js
@@ -26,9 +26,11 @@
  * </example>
  *
  * @alias element.waitForExist
- * @param {Number=}  ms       time in ms (default: 500)
- * @param {Boolean=} reverse  if true it instead waits for the selector to not match any elements (default: false)
- * @param {String=}  error    if exists it overrides the default error message
+ * @param {WaitForOptions=}  options             waitForEnabled options (optional)
+ * @param {Number=}          options.timeout     time in ms (default: 500)
+ * @param {Boolean=}         options.reverse     if true it waits for the opposite (default: false)
+ * @param {String=}          options.timeoutMsg  if exists it overrides the default error message
+ * @param {Number=}          options.interval    interval between checks (default: `waitforInterval`)
  * @return {Boolean} true     if element exists (or doesn't if flag is set)
  * @uses utility/waitUntil, state/isExisting
  * @type utility

--- a/packages/webdriverio/src/commands/element/waitForExist.js
+++ b/packages/webdriverio/src/commands/element/waitForExist.js
@@ -38,8 +38,8 @@
  */
 
 export default function waitForExist ({
-    timeout, // defaults defined in waitUntil command
-    interval, // defaults defined in waitUntil command
+    timeout = this.options.waitforTimeout,
+    interval = this.options.waitforInterval,
     reverse = false,
     timeoutMsg = `element ("${this.selector}") still ${reverse ? '' : 'not '}existing after ${timeout}ms`
 } = {}) {

--- a/packages/webdriverio/src/commands/element/waitForExist.js
+++ b/packages/webdriverio/src/commands/element/waitForExist.js
@@ -13,7 +13,7 @@
         const form = $('form');
         const notification = $('.notification');
         form.$(".send").click();
-        notification.waitForExist(5000);
+        notification.waitForExist({ timeout: 5000 });
         expect(notification.getText()).to.be.equal('Data transmitted successfully!')
     });
     it('should remove a message after successful form submit', function () {
@@ -21,7 +21,7 @@
         const message = $('.message');
         form.$(".send").click();
         // passing 'undefined' allows us to keep the default timeout value without overwriting it
-        message.waitForExist(undefined, true);
+        message.waitForExist({ reverse: true });
     });
  * </example>
  *
@@ -35,18 +35,14 @@
  *
  */
 
-export default function waitForExist (ms, reverse = false, error) {
-    /*!
-     * ensure that ms is set properly
-     */
-    if (typeof ms !== 'number') {
-        ms = this.options.waitforTimeout
-    }
-
-    const isReversed = reverse ? '' : 'not '
-    const errorMsg = typeof error === 'string' ? error : `element ("${this.selector}") still ${isReversed}existing after ${ms}ms`
-
-    return this.waitUntil(function async () {
-        return this.isExisting().then((isExisting) => isExisting !== reverse)
-    }, ms, errorMsg)
+export default function waitForExist ({
+    timeout = this.options.waitforTimeout,
+    interval = this.options.waitforInterval,
+    reverse = false,
+    timeoutMsg = `element ("${this.selector}") still ${reverse ? '' : 'not '}existing after ${timeout}ms`
+} = {}) {
+    return this.waitUntil(
+        async () => reverse !== await this.isExisting(),
+        { timeout, interval, timeoutMsg }
+    )
 }

--- a/packages/webdriverio/src/commands/element/waitUntil.js
+++ b/packages/webdriverio/src/commands/element/waitUntil.js
@@ -1,8 +1,42 @@
 /**
- * Nothing to see here!
- * The original implementation is in [the browser scope](https://webdriver.io/docs/api/browser/waitUntil.html). Since the element
- * scope should be able to query sub elements of itself this command is
- * just a placeholder so it gets picked up as regular command.
+ *
+ * This wait command is your universal weapon if you want to wait on something. It expects a condition
+ * and waits until that condition is fulfilled with a truthy value. If you use the WDIO testrunner the
+ * commands within the condition are getting executed synchronously like in your test.
+ *
+ * A common example is to wait until a certain element contains a certain text (see example).
+ *
+ * <example>
+    :example.html
+    <div id="someText">I am some text</div>
+    <script>
+      setTimeout(() => {
+        $('#someText').html('I am now different');
+      }, 1000);
+    </script>
+
+    :waitUntil.js
+    it('should wait until text has changed', () => {
+        const elem = $('#someText')
+        elem.waitUntil(function () {
+            return this.getText() === 'I am now different',
+        }, {
+            timeout: 5000,
+            timeoutMsg: 'expected text to be different after 5s'
+        });
+    });
+ * </example>
+ *
+ *
+ * @alias element.waitUntil
+ * @param {Function} condition  condition to wait on
+ * @param {Object}   options    command options
+ * @param {Number=}  options.timeout     timeout in ms (default: 5000)
+ * @param {String=}  options.timeoutMsg  error message to throw when waitUntil times out
+ * @param {Number=}  options.interval    interval between condition checks (default: 500)
+ * @return {Boolean} true if condition is fulfilled
+ * @type utility
+ *
  */
 import waitUntil from '../browser/waitUntil'
 export default waitUntil

--- a/packages/webdriverio/tests/commands/browser/newWindow.test.js
+++ b/packages/webdriverio/tests/commands/browser/newWindow.test.js
@@ -8,6 +8,10 @@ import got from 'got'
 import { remote } from '../../../src'
 
 describe('newWindow', () => {
+    beforeEach(() => {
+        got.mockClear()
+    })
+
     it('should allow to create a new window handle', async () => {
         const browser = await remote({
             baseUrl: 'http://foobar.com',
@@ -16,7 +20,10 @@ describe('newWindow', () => {
             }
         })
 
-        await browser.newWindow('https://webdriver.io', 'some name', 'some params')
+        await browser.newWindow('https://webdriver.io', {
+            windowName: 'some name',
+            windowFeatures: 'some params'
+        })
         expect(got.mock.calls).toHaveLength(4)
         expect(got.mock.calls[1][1].json.args)
             .toEqual(['https://webdriver.io', 'some name', 'some params'])
@@ -24,6 +31,20 @@ describe('newWindow', () => {
             .toContain('/window/handles')
         expect(got.mock.calls[3][1].json.handle)
             .toBe('window-handle-3')
+    })
+
+    it('should apply default args', async () => {
+        const browser = await remote({
+            baseUrl: 'http://foobar.com',
+            capabilities: {
+                browserName: 'foobar'
+            }
+        })
+
+        await browser.newWindow('https://webdriver.io')
+        expect(got.mock.calls).toHaveLength(4)
+        expect(got.mock.calls[1][1].json.args)
+            .toEqual(['https://webdriver.io', 'New Window', ''])
     })
 
     it('should fail if url is invalid', async () => {

--- a/packages/webdriverio/tests/commands/browser/reactElement.test.js
+++ b/packages/webdriverio/tests/commands/browser/reactElement.test.js
@@ -10,11 +10,11 @@ describe('react$', () => {
             }
         })
 
-        const elem = await browser.react$(
-            'myComp',
-            { some: 'props' },
-            { some: 'state' }
-        )
+        const options = {
+            props: { some: 'props' },
+            state: { some: 'state' }
+        }
+        const elem = await browser.react$('myComp', options)
 
         expect(elem.elementId).toBe('some-elem-123')
         expect(got).toBeCalledTimes(4)

--- a/packages/webdriverio/tests/commands/browser/reactElements.test.js
+++ b/packages/webdriverio/tests/commands/browser/reactElements.test.js
@@ -11,11 +11,11 @@ describe('react$', () => {
             }
         })
 
-        const elems = await browser.react$$(
-            'myComp',
-            { some: 'props' },
-            { some: 'state' }
-        )
+        const options = {
+            props: { some: 'props' },
+            state: { some: 'state' }
+        }
+        const elems = await browser.react$$('myComp', options)
 
         expect(elems.length).toBe(3)
         expect(elems[0].elementId).toBe('some-elem-123')

--- a/packages/webdriverio/tests/commands/browser/waitUntil.test.js
+++ b/packages/webdriverio/tests/commands/browser/waitUntil.test.js
@@ -19,7 +19,11 @@ describe('waitUntil', () => {
         let error
         expect.assertions(1)
         try {
-            await browser.waitUntil('foo', 500, 'Timed Out', 200)
+            await browser.waitUntil('foo', {
+                timeout: 500,
+                timeoutMsg: 'Timed Out',
+                interval: 200
+            })
         } catch(e) {
             error = e
         } finally{
@@ -31,12 +35,18 @@ describe('waitUntil', () => {
         let error
         expect.assertions(1)
         try {
-            await browser.waitUntil(() =>
-                new Promise((resolve) =>
-                    setTimeout(
+            await browser.waitUntil(
+                () => new Promise(
+                    (resolve) => setTimeout(
                         () => resolve(false),
-                        200)),
-            500, 'Timed Out', 200)
+                        200
+                    )
+                ), {
+                    timeout: 500,
+                    timeoutMsg: 'Timed Out',
+                    interval: 200
+                }
+            )
         } catch(e) {
             error = e
         } finally{
@@ -48,12 +58,18 @@ describe('waitUntil', () => {
         let error
         expect.assertions(1)
         try {
-            await browser.waitUntil(() =>
-                new Promise((resolve, reject) =>
-                    setTimeout(
+            await browser.waitUntil(
+                () => new Promise(
+                    (resolve, reject) => setTimeout(
                         () => reject(new Error('foobar')),
-                        200, 400)),
-            500, 'Timed Out', 200)
+                        200
+                    )
+                ), {
+                    timeout: 500,
+                    timeoutMsg: 'Timed Out',
+                    interval: 200
+                }
+            )
         } catch(e) {
             error = e
         } finally{
@@ -64,9 +80,16 @@ describe('waitUntil', () => {
     it('Should throw an error when the promise is rejected without error message', async () => {
         expect.assertions(1)
         try {
-            await browser.waitUntil(() => new Promise((resolve, reject) =>
-                setTimeout(() => reject(new Error()), 200)),
-            500)
+            await browser.waitUntil(
+                () => new Promise(
+                    (resolve, reject) => setTimeout(
+                        () => reject(new Error()),
+                        200
+                    )
+                ), {
+                    timeout: 500
+                }
+            )
         } catch(e) {
             expect(e.message).toContain('waitUntil condition failed with the following reason: Error')
         }
@@ -76,12 +99,17 @@ describe('waitUntil', () => {
         let error
         expect.assertions(1)
         try {
-            await browser.waitUntil(() =>
-                new Promise((resolve) =>
-                    setTimeout(
+            await browser.waitUntil(
+                () => new Promise(
+                    (resolve) => setTimeout(
                         () => resolve(false),
-                        500)),
-            'blah', undefined, 200)
+                        500
+                    )
+                ), {
+                    timeout: 'blah',
+                    interval: 200
+                }
+            )
         } catch(e) {
             error = e
         } finally{
@@ -93,12 +121,18 @@ describe('waitUntil', () => {
         let error
         expect.assertions(1)
         try {
-            await browser.waitUntil(() =>
-                new Promise((resolve) =>
-                    setTimeout(
+            await browser.waitUntil(
+                () => new Promise(
+                    (resolve) => setTimeout(
                         () => resolve(false),
-                        500)),
-            1000, 'Timed Out', 'blah')
+                        500
+                    )
+                ), {
+                    timeout: 1000,
+                    timeoutMsg: 'Timed Out',
+                    interval: 'blah'
+                }
+            )
         } catch(e) {
             error = e
         } finally{
@@ -110,12 +144,18 @@ describe('waitUntil', () => {
         let error
         expect.assertions(1)
         try {
-            await browser.waitUntil(() =>
-                new Promise((resolve) =>
-                    setTimeout(
+            await browser.waitUntil(
+                () => new Promise(
+                    (resolve) => setTimeout(
                         () => resolve(true),
-                        200)),
-            500, 'Timed Out', 200)
+                        200
+                    )
+                ), {
+                    timeout: 500,
+                    timeoutMsg: 'Timed Out',
+                    interval: 200
+                }
+            )
         } catch(e) {
             error = e
         } finally{

--- a/packages/webdriverio/tests/commands/element/__snapshots__/waitForClickable.test.js.snap
+++ b/packages/webdriverio/tests/commands/element/__snapshots__/waitForClickable.test.js.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`waitForClickable should call waitUntil 1`] = `
+Array [
+  Array [
+    [Function],
+    Object {
+      "interval": 5,
+      "timeout": 1000,
+      "timeoutMsg": "element (\\"#foo\\") still not clickable after 1000ms",
+    },
+  ],
+]
+`;
+
+exports[`waitForClickable should do reverse 1`] = `
+Array [
+  Array [
+    [Function],
+    Object {
+      "interval": 50,
+      "timeout": 500,
+      "timeoutMsg": "element (\\"#foo\\") still clickable after 500ms",
+    },
+  ],
+]
+`;

--- a/packages/webdriverio/tests/commands/element/__snapshots__/waitForDisplayed.test.js.snap
+++ b/packages/webdriverio/tests/commands/element/__snapshots__/waitForDisplayed.test.js.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`waitForDisplayed should call waitUntil 1`] = `
+Array [
+  Array [
+    [Function],
+    Object {
+      "interval": 5,
+      "timeout": 1000,
+      "timeoutMsg": "element (\\"#foo\\") still not displayed after 1000ms",
+    },
+  ],
+]
+`;
+
+exports[`waitForDisplayed should do reverse 1`] = `
+Array [
+  Array [
+    [Function],
+    Object {
+      "interval": 50,
+      "timeout": 500,
+      "timeoutMsg": "element (\\"#foo\\") still displayed after 500ms",
+    },
+  ],
+]
+`;

--- a/packages/webdriverio/tests/commands/element/__snapshots__/waitForEnabled.test.js.snap
+++ b/packages/webdriverio/tests/commands/element/__snapshots__/waitForEnabled.test.js.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`waitForEnabled should call waitUntil 1`] = `
+Array [
+  Array [
+    [Function],
+    Object {
+      "interval": 5,
+      "timeout": 1000,
+      "timeoutMsg": "element (\\"#foo\\") still not enabled after 1000ms",
+    },
+  ],
+]
+`;
+
+exports[`waitForEnabled should do reverse 1`] = `
+Array [
+  Array [
+    [Function],
+    Object {
+      "interval": 50,
+      "timeout": 500,
+      "timeoutMsg": "element (\\"#foo\\") still enabled after 500ms",
+    },
+  ],
+]
+`;

--- a/packages/webdriverio/tests/commands/element/__snapshots__/waitForExist.test.js.snap
+++ b/packages/webdriverio/tests/commands/element/__snapshots__/waitForExist.test.js.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`waitForExists should allow to set custom error 1`] = `
+Array [
+  Array [
+    [Function],
+    Object {
+      "interval": 5,
+      "timeout": 1000,
+      "timeoutMsg": "my custom error",
+    },
+  ],
+]
+`;
+
+exports[`waitForExists should use default waitFor options 1`] = `
+Array [
+  Array [
+    [Function],
+    Object {
+      "interval": 5,
+      "timeout": 1000,
+      "timeoutMsg": "element (\\"undefined\\") still not existing after 1000ms",
+    },
+  ],
+]
+`;

--- a/packages/webdriverio/tests/commands/element/moveTo.test.js
+++ b/packages/webdriverio/tests/commands/element/moveTo.test.js
@@ -32,7 +32,7 @@ describe('moveTo', () => {
 
         const elem = await browser.$('#elem')
         got.setMockResponse([undefined, { scrollX: 19, scrollY: 0 }])
-        await elem.moveTo(5, 10)
+        await elem.moveTo({ xOffset: 5, yOffset: 10 })
         expect(got.mock.calls[4][1].json.actions[0].actions[0])
             .toEqual({ type: 'pointerMove', duration: 0, x: 1, y: 30 })
     })
@@ -47,7 +47,7 @@ describe('moveTo', () => {
 
         const elem = await browser.$('#elem')
         got.setMockResponse([{}, { x: 5, y: 10, height: 33, width: 44 }, { scrollX: 0, scrollY: 0 }])
-        await elem.moveTo(5, 10)
+        await elem.moveTo({ xOffset: 5, yOffset: 10 })
         expect(got.mock.calls[5][1].json.actions[0].actions[0])
             .toEqual({ type: 'pointerMove', duration: 0, x: 10, y: 20 })
     })
@@ -62,7 +62,8 @@ describe('moveTo', () => {
 
         const elem = await browser.$('#elem')
         got.setMockResponse([{}, {}])
-        await expect(elem.moveTo(5, 10)).rejects.toThrow('Failed to receive element rects via execute command')
+        await expect(elem.moveTo({ xOffset: 5, yOffset: 10 }))
+            .rejects.toThrow('Failed to receive element rects via execute command')
     })
 
     it('should do a moveTo without params (no-w3c)', async () => {
@@ -75,12 +76,16 @@ describe('moveTo', () => {
 
         const elem = await browser.$('#elem')
         await elem.moveTo()
-        expect(got.mock.calls[2][1].uri.pathname).toContain('/foobar-123/moveto')
-        expect(got.mock.calls[2][1].json).toEqual({ element: 'some-elem-123' })
+        expect(got.mock.calls[2][1].uri.pathname)
+            .toContain('/foobar-123/moveto')
+        expect(got.mock.calls[2][1].json)
+            .toEqual({ element: 'some-elem-123' })
 
-        await elem.moveTo(5, 10)
-        expect(got.mock.calls[3][1].uri.pathname).toContain('/foobar-123/moveto')
-        expect(got.mock.calls[3][1].json).toEqual({ element: 'some-elem-123', xoffset: 5, yoffset: 10 })
+        await elem.moveTo({ xOffset: 5, yOffset: 10 })
+        expect(got.mock.calls[3][1].uri.pathname)
+            .toContain('/foobar-123/moveto')
+        expect(got.mock.calls[3][1].json)
+            .toEqual({ element: 'some-elem-123', xoffset: 5, yoffset: 10 })
     })
 
     afterEach(() => {

--- a/packages/webdriverio/tests/commands/element/reactElement.test.js
+++ b/packages/webdriverio/tests/commands/element/reactElement.test.js
@@ -13,11 +13,11 @@ describe('elem.react$', () => {
 
         const elem = await browser.$('#foo')
 
-        await elem.react$(
-            'MyComp',
-            { some: 'props' },
-            true,
-        )
+        const options = {
+            props: { some: 'props' },
+            state: true
+        }
+        await elem.react$('MyComp', options)
         expect(elem.elementId).toBe('some-elem-123')
         expect(got.mock.calls.pop()[1].json.args)
             .toEqual([

--- a/packages/webdriverio/tests/commands/element/reactElements.test.js
+++ b/packages/webdriverio/tests/commands/element/reactElements.test.js
@@ -13,11 +13,11 @@ describe('elem.react$', () => {
 
         const elem = await browser.$('#foo')
 
-        await elem.react$$(
-            'MyComp',
-            { some: 'props' },
-            true
-        )
+        const options = {
+            props: { some: 'props' },
+            state: true
+        }
+        await elem.react$$('MyComp', options)
         expect(elem.elementId).toBe('some-elem-123')
         expect(got.mock.calls.pop()[1].json.args)
             .toEqual([

--- a/packages/webdriverio/tests/commands/element/waitForClickable.test.js
+++ b/packages/webdriverio/tests/commands/element/waitForClickable.test.js
@@ -24,14 +24,13 @@ describe('waitForClickable', () => {
             waitForClickable : tmpElem.waitForClickable,
             elementId : 123,
             waitUntil : jest.fn(((cb))),
-            options : { waitforInterval: 5, waitforTimeout: duration },
+            options : { waitforInterval: 5, waitforTimeout: duration }
         }
 
         await elem.waitForClickable()
 
         expect(cb).toBeCalled()
-        expect(elem.waitUntil.mock.calls[0][1]).toBe(duration)
-        expect(elem.waitUntil.mock.calls[0][2]).toBe(`element ("#foo") still not clickable after ${duration}ms`)
+        expect(elem.waitUntil.mock.calls).toMatchSnapshot()
     })
 
     test('should call isClickable and return true immediately if true', async () => {
@@ -70,7 +69,7 @@ describe('waitForClickable', () => {
             elementId : 123,
             waitUntil : tmpElem.waitUntil,
             isClickable : jest.fn(() => false),
-            options : { waitforTimeout : 500 },
+            options : { waitforTimeout : 500, waitforInterval: 50 },
         }
 
         try {
@@ -89,7 +88,7 @@ describe('waitForClickable', () => {
             waitUntil : tmpElem.waitUntil,
             isDisplayed : tmpElem.isDisplayed,
             isClickable : tmpElem.isClickable,
-            options : { waitforTimeout : 500 },
+            options : { waitforTimeout : 500, waitforInterval: 50 },
         }
 
         try {
@@ -108,13 +107,12 @@ describe('waitForClickable', () => {
             elementId : 123,
             waitUntil : jest.fn(((cb))),
             isClickable : jest.fn(() => true),
-            options : { waitforTimeout : 500 },
+            options : { waitforTimeout : 500, waitforInterval: 50 },
         }
 
         await elem.waitForClickable({ reverse: true })
 
-        expect(elem.waitUntil.mock.calls[0][1]).toBe(elem.options.waitforTimeout)
-        expect(elem.waitUntil.mock.calls[0][2]).toBe(`element ("#foo") still clickable after ${elem.options.waitforTimeout}ms`)
+        expect(elem.waitUntil.mock.calls).toMatchSnapshot()
     })
 
     test('should call isClickable and return false with custom error', async () => {
@@ -126,7 +124,7 @@ describe('waitForClickable', () => {
             elementId : 123,
             waitUntil : tmpElem.waitUntil,
             isClickable : jest.fn(() => false),
-            options : { waitforTimeout : 500 },
+            options : { waitforTimeout : 500, waitforInterval: 50 },
         }
 
         try {

--- a/packages/webdriverio/tests/commands/element/waitForDisplayed.test.js
+++ b/packages/webdriverio/tests/commands/element/waitForDisplayed.test.js
@@ -2,7 +2,7 @@ import got from 'got'
 import { remote } from '../../../src'
 
 describe('waitForDisplayed', () => {
-    const duration = 1000
+    const timeout = 1000
     let browser
 
     beforeEach(async () => {
@@ -20,22 +20,21 @@ describe('waitForDisplayed', () => {
         const cb = jest.fn()
         const tmpElem = await browser.$('#foo')
         const elem = {
-            selector : '#foo',
-            waitForDisplayed : tmpElem.waitForDisplayed,
-            elementId : 123,
-            waitUntil : jest.fn(((cb))),
+            selector: '#foo',
+            waitForDisplayed: tmpElem.waitForDisplayed,
+            elementId: 123,
+            waitUntil: jest.fn().mockImplementation(cb),
+            options : { waitforInterval: 5, waitforTimeout: timeout }
         }
 
-        await elem.waitForDisplayed(duration)
-
+        await elem.waitForDisplayed({ timeout })
         expect(cb).toBeCalled()
-        expect(elem.waitUntil.mock.calls[0][1]).toBe(duration)
-        expect(elem.waitUntil.mock.calls[0][2]).toBe(`element ("#foo") still not displayed after ${duration}ms`)
+        expect(elem.waitUntil.mock.calls).toMatchSnapshot()
     })
 
     test('should call isDisplayed and return true immediately if true', async () => {
         const elem = await browser.$('#foo')
-        const result = await elem.waitForDisplayed(duration)
+        const result = await elem.waitForDisplayed({ timeout })
 
         expect(result).toBe(true)
         expect(got.mock.calls[2][1].uri.pathname)
@@ -45,18 +44,18 @@ describe('waitForDisplayed', () => {
     test('should call isDisplayed and return true if eventually true', async () => {
         const tmpElem = await browser.$('#foo')
         const elem = {
-            selector : '#foo',
-            waitForDisplayed : tmpElem.waitForDisplayed,
-            elementId : 123,
-            waitUntil : tmpElem.waitUntil,
-            isDisplayed : jest.fn()
+            selector: '#foo',
+            waitForDisplayed: tmpElem.waitForDisplayed,
+            elementId: 123,
+            waitUntil: tmpElem.waitUntil,
+            isDisplayed: jest.fn()
                 .mockImplementationOnce(() => false)
                 .mockImplementationOnce(() => false)
                 .mockImplementationOnce(() => true),
-            options : { waitforTimeout : 50, waitforInterval: 5 },
+            options: { waitforTimeout: 50, waitforInterval: 5 },
         }
 
-        const result = await elem.waitForDisplayed(duration)
+        const result = await elem.waitForDisplayed({ timeout })
         expect(result).toBe(true)
     })
 
@@ -64,36 +63,36 @@ describe('waitForDisplayed', () => {
         expect.assertions(1)
         const tmpElem = await browser.$('#foo')
         const elem = {
-            selector : '#foo',
-            waitForDisplayed : tmpElem.waitForDisplayed,
-            elementId : 123,
-            waitUntil : tmpElem.waitUntil,
-            isDisplayed : jest.fn(() => false),
-            options : { waitforTimeout : 500 },
+            selector: '#foo',
+            waitForDisplayed: tmpElem.waitForDisplayed,
+            elementId: 123,
+            waitUntil: tmpElem.waitUntil,
+            isDisplayed: jest.fn(() => false),
+            options: { waitforTimeout: 500, waitforInterval: 50 },
         }
 
         try {
-            await elem.waitForDisplayed(duration)
+            await elem.waitForDisplayed({ timeout })
         } catch (e) {
-            expect(e.message).toBe(`element ("#foo") still not displayed after ${duration}ms`)
+            expect(e.message).toBe(`element ("#foo") still not displayed after ${timeout}ms`)
         }
     })
 
     test('should not call isDisplayed and return false if never found', async () => {
         const tmpElem = await browser.$('#foo')
         const elem = {
-            selector : '#foo',
+            selector: '#foo',
             parent: { $: jest.fn(() => { return elem}) },
-            waitForDisplayed : tmpElem.waitForDisplayed,
-            waitUntil : tmpElem.waitUntil,
-            isDisplayed : tmpElem.isDisplayed,
-            options : { waitforTimeout : 500 },
+            waitForDisplayed: tmpElem.waitForDisplayed,
+            waitUntil: tmpElem.waitUntil,
+            isDisplayed: tmpElem.isDisplayed,
+            options: { waitforTimeout: 500, waitforInterval: 50 },
         }
 
         try {
-            await elem.waitForDisplayed(duration)
+            await elem.waitForDisplayed({ timeout })
         } catch (e) {
-            expect(e.message).toBe(`element ("#foo") still not displayed after ${duration}ms`)
+            expect(e.message).toBe(`element ("#foo") still not displayed after ${timeout}ms`)
         }
     })
 
@@ -101,34 +100,32 @@ describe('waitForDisplayed', () => {
         const cb = jest.fn()
         const tmpElem = await browser.$('#foo')
         const elem = {
-            selector : '#foo',
-            waitForDisplayed : tmpElem.waitForDisplayed,
-            elementId : 123,
-            waitUntil : jest.fn(((cb))),
-            isDisplayed : jest.fn(() => true),
-            options : { waitforTimeout : 500 },
+            selector: '#foo',
+            waitForDisplayed: tmpElem.waitForDisplayed,
+            elementId: 123,
+            waitUntil: jest.fn().mockImplementation(cb),
+            isDisplayed: jest.fn(() => true),
+            options: { waitforTimeout: 500, waitforInterval: 50 },
         }
 
-        await elem.waitForDisplayed(null, true)
-
-        expect(elem.waitUntil.mock.calls[0][1]).toBe(elem.options.waitforTimeout)
-        expect(elem.waitUntil.mock.calls[0][2]).toBe(`element ("#foo") still displayed after ${elem.options.waitforTimeout}ms`)
+        await elem.waitForDisplayed({ reverse: true })
+        expect(elem.waitUntil.mock.calls).toMatchSnapshot()
     })
 
     test('should call isDisplayed and return false with custom error', async () => {
         expect.assertions(1)
         const tmpElem = await browser.$('#foo')
         const elem = {
-            selector : '#foo',
-            waitForDisplayed : tmpElem.waitForDisplayed,
-            elementId : 123,
-            waitUntil : tmpElem.waitUntil,
-            isDisplayed : jest.fn(() => false),
-            options : { waitforTimeout : 500 },
+            selector: '#foo',
+            waitForDisplayed: tmpElem.waitForDisplayed,
+            elementId: 123,
+            waitUntil: tmpElem.waitUntil,
+            isDisplayed: jest.fn(() => false),
+            options: { waitforTimeout: 500 },
         }
 
         try {
-            await elem.waitForDisplayed(duration, false, 'Element foo never displayed')
+            await elem.waitForDisplayed({ timeout, timeoutMsg: 'Element foo never displayed' })
         } catch (e) {
             expect(e.message).toBe('Element foo never displayed')
         }

--- a/packages/webdriverio/tests/commands/element/waitForEnabled.test.js
+++ b/packages/webdriverio/tests/commands/element/waitForEnabled.test.js
@@ -2,7 +2,7 @@ import got from 'got'
 import { remote } from '../../../src'
 
 describe('waitForEnabled', () => {
-    const duration = 1000
+    const timeout = 1000
     let browser
 
     beforeAll(async () => {
@@ -23,10 +23,10 @@ describe('waitForEnabled', () => {
             waitForExist : jest.fn(),
             elementId : null,
             waitUntil : jest.fn(),
-            isEnabled : jest.fn(() => Promise.resolve())
+            options : { waitforInterval: 5, waitforTimeout: timeout }
         }
 
-        await elem.waitForEnabled(duration)
+        await elem.waitForEnabled({ timeout })
         expect(elem.waitForExist).toBeCalled()
     })
 
@@ -37,10 +37,11 @@ describe('waitForEnabled', () => {
             waitForExist : jest.fn(),
             elementId : 123,
             waitUntil : jest.fn(),
-            isEnabled : jest.fn(() => Promise.resolve())
+            isEnabled : jest.fn(() => Promise.resolve()),
+            options : { waitforInterval: 5, waitforTimeout: timeout }
         }
 
-        await elem.waitForEnabled(duration)
+        await elem.waitForEnabled({ timeout })
         expect(elem.waitForExist).not.toBeCalled()
     })
 
@@ -53,14 +54,14 @@ describe('waitForEnabled', () => {
             waitForExist : jest.fn(),
             elementId : 123,
             waitUntil : jest.fn(((cb))),
-            isEnabled : jest.fn(() => Promise.resolve())
+            isEnabled : jest.fn(() => Promise.resolve()),
+            options : { waitforInterval: 5, waitforTimeout: timeout }
         }
 
-        await elem.waitForEnabled(duration)
+        await elem.waitForEnabled({ timeout })
 
         expect(cb).toBeCalled()
-        expect(elem.waitUntil.mock.calls[0][1]).toBe(duration)
-        expect(elem.waitUntil.mock.calls[0][2]).toBe(`element ("#foo") still not enabled after ${duration}ms`)
+        expect(elem.waitUntil.mock.calls).toMatchSnapshot()
     })
 
     test('should call isEnabled and return true', async () => {
@@ -72,10 +73,10 @@ describe('waitForEnabled', () => {
             elementId : 123,
             waitUntil : tmpElem.waitUntil,
             isEnabled : jest.fn(() => true),
-            options : { waitforTimeout : 500 },
+            options : { waitforInterval: 5, waitforTimeout: timeout }
         }
 
-        const result = await elem.waitForEnabled(duration)
+        const result = await elem.waitForEnabled({ timeout })
         expect(result).toBe(true)
     })
 
@@ -88,13 +89,13 @@ describe('waitForEnabled', () => {
             elementId : 123,
             waitUntil : tmpElem.waitUntil,
             isEnabled : jest.fn(() => false),
-            options : { waitforTimeout : 500 },
+            options : { waitforInterval: 5, waitforTimeout: timeout }
         }
 
         try {
-            await elem.waitForEnabled(duration)
+            await elem.waitForEnabled({ timeout })
         } catch (e) {
-            expect(e.message).toBe(`element ("#foo") still not enabled after ${duration}ms`)
+            expect(e.message).toBe(`element ("#foo") still not enabled after ${timeout}ms`)
         }
     })
 
@@ -108,13 +109,11 @@ describe('waitForEnabled', () => {
             elementId : 123,
             waitUntil : jest.fn(((cb))),
             isEnabled : jest.fn(() => Promise.resolve()),
-            options : { waitforTimeout : 500 },
+            options : { waitforInterval: 50, waitforTimeout: 500 }
         }
 
-        await elem.waitForEnabled(null, true)
-
-        expect(elem.waitUntil.mock.calls[0][1]).toBe(elem.options.waitforTimeout)
-        expect(elem.waitUntil.mock.calls[0][2]).toBe(`element ("#foo") still enabled after ${elem.options.waitforTimeout}ms`)
+        await elem.waitForEnabled({ reverse: true })
+        expect(elem.waitUntil.mock.calls).toMatchSnapshot()
     })
 
     test('should call isEnabled and return false with custom error', async () => {
@@ -130,7 +129,11 @@ describe('waitForEnabled', () => {
         }
 
         try {
-            await elem.waitForEnabled(duration, false, 'Element foo never enabled')
+            await elem.waitForEnabled({
+                timeout,
+                reverse: false,
+                timeoutMsg: 'Element foo never enabled'
+            })
         } catch (e) {
             expect(e.message).toBe('Element foo never enabled')
         }

--- a/packages/webdriverio/tests/commands/element/waitForExist.test.js
+++ b/packages/webdriverio/tests/commands/element/waitForExist.test.js
@@ -2,7 +2,7 @@ import got from 'got'
 import { remote } from '../../../src'
 
 describe('waitForExists', () => {
-    const duration = 1000
+    const timeout = 1000
     let browser
 
     beforeEach(async () => {
@@ -16,56 +16,31 @@ describe('waitForExists', () => {
         })
     })
 
-    test('should wait for the element to exist', async () => {
+    test('should use default waitFor options', async () => {
         const tmpElem = await browser.$('#foo')
         const elem = {
-            selector: 'foobar',
-            waitForExist : tmpElem.waitForExist,
-            isExisting: jest.fn().mockReturnValueOnce(Promise.resolve(true)),
-            elementId : null,
-            waitUntil : jest.fn().mockImplementation(
-                (condition) => condition.call(elem)),
-            isElementDisplayed : jest.fn(() => Promise.resolve())
-        }
-
-        await elem.waitForExist(duration)
-        expect(elem.isExisting).toBeCalled()
-        expect(elem.waitUntil.mock.calls[0][1]).toBe(1000)
-        expect(elem.waitUntil.mock.calls[0][2]).toBe('element ("foobar") still not existing after 1000ms')
-    })
-
-    test('should use default waitFor duration', async () => {
-        const tmpElem = await browser.$('#foo')
-        const elem = {
-            options: { waitforTimeout: 1234 },
-            waitForExist : tmpElem.waitForExist,
-            isExisting: jest.fn().mockReturnValueOnce(Promise.resolve(true)),
-            elementId : null,
-            waitUntil : jest.fn().mockImplementation(
-                (condition) => condition.call(elem)),
-            isElementDisplayed : jest.fn(() => Promise.resolve())
+            waitForExist: tmpElem.waitForExist,
+            waitUntil: jest.fn(),
+            options: { waitforInterval: 5, waitforTimeout: timeout }
         }
 
         await elem.waitForExist()
-        expect(elem.isExisting).toBeCalled()
-        expect(elem.waitUntil.mock.calls[0][1]).toBe(1234)
+        expect(elem.waitUntil.mock.calls).toMatchSnapshot()
     })
 
     test('should allow to set custom error', async () => {
         const tmpElem = await browser.$('#foo')
         const elem = {
-            selector: 'barfoo',
-            options: { waitforTimeout: 1234 },
-            waitForExist : tmpElem.waitForExist,
-            isExisting: jest.fn().mockReturnValueOnce(Promise.resolve(true)),
-            elementId : null,
-            waitUntil : jest.fn().mockImplementation(
-                (condition) => condition.call(elem)),
-            isElementDisplayed : jest.fn(() => Promise.resolve())
+            waitForExist: tmpElem.waitForExist,
+            waitUntil: jest.fn(),
+            options: { waitforInterval: 5, waitforTimeout: timeout }
         }
 
-        await elem.waitForExist(duration, true, 'my custom error')
-        expect(elem.isExisting).toBeCalled()
-        expect(elem.waitUntil.mock.calls[0][2]).toBe('my custom error')
+        await elem.waitForExist({
+            timeout,
+            reverse: true,
+            timeoutMsg: 'my custom error'
+        })
+        expect(elem.waitUntil.mock.calls).toMatchSnapshot()
     })
 })

--- a/packages/webdriverio/webdriverio-core-v5.d.ts
+++ b/packages/webdriverio/webdriverio-core-v5.d.ts
@@ -190,6 +190,20 @@ declare namespace WebdriverIO {
         state?: any[] | number | string | object | boolean
     }
 
+    type MoveToOptions = {
+        xOffset?: number,
+        yOffset?: number
+    }
+
+    type DragAndDropOptions = {
+        duration?: number
+    }
+
+    type NewWindowOptions = {
+        windowName?: string,
+        windowFeatures?: string
+    }
+
     interface Element {
         selector: string;
         elementId: string;
@@ -222,7 +236,7 @@ declare namespace WebdriverIO {
             name: string,
             func: Function
         ): void;
-
+        
         /**
          * The `$$` command is a short way to call the [`findElements`](/docs/api/webdriver.html#findelements) command in order
          * to fetch multiple elements on the page similar to the `$$` command from the browser scope. The difference when calling
@@ -294,7 +308,7 @@ declare namespace WebdriverIO {
          */
         dragAndDrop(
             target: Element,
-            duration?: number
+            options?: DragAndDropOptions
         ): void;
 
         /**
@@ -426,8 +440,7 @@ declare namespace WebdriverIO {
          * is not visible, it will be scrolled into view.
          */
         moveTo(
-            xoffset?: number,
-            yoffset?: number
+            options?: MoveToOptions
         ): void;
 
         /**
@@ -456,8 +469,7 @@ declare namespace WebdriverIO {
         ): Buffer;
 
         /**
-         * Scroll element into viewport.
-         * https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView
+         * Scroll element into viewport ([MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView)).
          */
         scrollIntoView(
             scrollIntoViewOptions?: object | boolean
@@ -531,9 +543,7 @@ declare namespace WebdriverIO {
          * milliseconds to be displayed or not displayed.
          */
         waitForDisplayed(
-            ms?: number,
-            reverse?: boolean,
-            error?: string
+            options?: WaitForOptions
         ): boolean;
 
         /**
@@ -542,9 +552,7 @@ declare namespace WebdriverIO {
          * selector, it returns true if at least one element is (dis/en)abled.
          */
         waitForEnabled(
-            ms?: number,
-            reverse?: boolean,
-            error?: string
+            options?: WaitForOptions
         ): boolean;
 
         /**
@@ -555,9 +563,7 @@ declare namespace WebdriverIO {
          * if the selector does not match any elements.
          */
         waitForExist(
-            ms?: number,
-            reverse?: boolean,
-            error?: string
+            options?: WaitForOptions
         ): boolean;
     }
 
@@ -595,7 +601,7 @@ declare namespace WebdriverIO {
             func: (origCommand: Function, ...args: any[]) => any,
             attachToElement?: boolean
         ): void;
-
+        
         /**
          * create custom selector
          */
@@ -686,8 +692,7 @@ declare namespace WebdriverIO {
          */
         newWindow(
             url: string,
-            windowName?: string,
-            windowFeatures?: string
+            options?: NewWindowOptions
         ): string;
 
         /**

--- a/packages/webdriverio/webdriverio-core-v5.d.ts
+++ b/packages/webdriverio/webdriverio-core-v5.d.ts
@@ -185,6 +185,11 @@ declare namespace WebdriverIO {
         reverse?: boolean,
     }
 
+    type ReactSelectorOptions = {
+        props?: object,
+        state?: any[] | number | string | object | boolean
+    }
+
     interface Element {
         selector: string;
         elementId: string;
@@ -217,7 +222,7 @@ declare namespace WebdriverIO {
             name: string,
             func: Function
         ): void;
-        
+
         /**
          * The `$$` command is a short way to call the [`findElements`](/docs/api/webdriver.html#findelements) command in order
          * to fetch multiple elements on the page similar to the `$$` command from the browser scope. The difference when calling
@@ -431,8 +436,7 @@ declare namespace WebdriverIO {
          */
         react$$(
             selector: string,
-            props?: object,
-            state?: any[] | number | string | object | boolean
+            options?: ReactSelectorOptions
         ): ElementArray;
 
         /**
@@ -441,8 +445,7 @@ declare namespace WebdriverIO {
          */
         react$(
             selector: string,
-            props?: object,
-            state?: any[] | number | string | object | boolean
+            options?: ReactSelectorOptions
         ): Element;
 
         /**
@@ -600,7 +603,7 @@ declare namespace WebdriverIO {
             name: string,
             func: (elementFetchingMethod: (selector: string) => any) => void
         ): void
-        
+
         /**
          * The `$$` command is a short way to call the [`findElements`](/docs/api/webdriver.html#findelements) command in order
          * to fetch multiple elements on the page. It returns an array with element results that will have an
@@ -702,8 +705,7 @@ declare namespace WebdriverIO {
          */
         react$$(
             selector: string,
-            props?: object,
-            state?: any[] | number | string | object | boolean
+            options?: ReactSelectorOptions
         ): ElementArray;
 
         /**
@@ -712,8 +714,7 @@ declare namespace WebdriverIO {
          */
         react$(
             selector: string,
-            props?: object,
-            state?: any[] | number | string | object | boolean
+            options?: ReactSelectorOptions
         ): Element;
 
         /**

--- a/packages/webdriverio/webdriverio-core.d.ts
+++ b/packages/webdriverio/webdriverio-core.d.ts
@@ -185,6 +185,11 @@ declare namespace WebdriverIO {
         reverse?: boolean,
     }
 
+    type ReactSelectorOptions = {
+        props?: object,
+        state?: any[] | number | string | object | boolean
+    }
+
     interface Element {
         selector: string;
         elementId: string;
@@ -431,8 +436,7 @@ declare namespace WebdriverIO {
          */
         react$$(
             selector: string,
-            props?: object,
-            state?: any[] | number | string | object | boolean
+            options?: ReactSelectorOptions
         ): Promise<ElementArray>;
 
         /**
@@ -441,8 +445,7 @@ declare namespace WebdriverIO {
          */
         react$(
             selector: string,
-            props?: object,
-            state?: any[] | number | string | object | boolean
+            options?: ReactSelectorOptions
         ): Promise<Element>;
 
         /**
@@ -702,8 +705,7 @@ declare namespace WebdriverIO {
          */
         react$$(
             selector: string,
-            props?: object,
-            state?: any[] | number | string | object | boolean
+            options?: ReactSelectorOptions
         ): Promise<ElementArray>;
 
         /**
@@ -712,8 +714,7 @@ declare namespace WebdriverIO {
          */
         react$(
             selector: string,
-            props?: object,
-            state?: any[] | number | string | object | boolean
+            options?: ReactSelectorOptions
         ): Promise<Element>;
 
         /**

--- a/packages/webdriverio/webdriverio-core.d.ts
+++ b/packages/webdriverio/webdriverio-core.d.ts
@@ -190,6 +190,20 @@ declare namespace WebdriverIO {
         state?: any[] | number | string | object | boolean
     }
 
+    type MoveToOptions = {
+        xOffset?: number,
+        yOffset?: number
+    }
+
+    type DragAndDropOptions = {
+        duration?: number
+    }
+
+    type NewWindowOptions = {
+        windowName?: string,
+        windowFeatures?: string
+    }
+
     interface Element {
         selector: string;
         elementId: string;
@@ -294,7 +308,7 @@ declare namespace WebdriverIO {
          */
         dragAndDrop(
             target: Element,
-            duration?: number
+            options?: DragAndDropOptions
         ): Promise<void>;
 
         /**
@@ -426,8 +440,7 @@ declare namespace WebdriverIO {
          * is not visible, it will be scrolled into view.
          */
         moveTo(
-            xoffset?: number,
-            yoffset?: number
+            options?: MoveToOptions
         ): Promise<void>;
 
         /**
@@ -456,8 +469,7 @@ declare namespace WebdriverIO {
         ): Promise<Buffer>;
 
         /**
-         * Scroll element into viewport.
-         * https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView
+         * Scroll element into viewport ([MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView)).
          */
         scrollIntoView(
             scrollIntoViewOptions?: object | boolean
@@ -531,9 +543,7 @@ declare namespace WebdriverIO {
          * milliseconds to be displayed or not displayed.
          */
         waitForDisplayed(
-            ms?: number,
-            reverse?: boolean,
-            error?: string
+            options?: WaitForOptions
         ): Promise<boolean>;
 
         /**
@@ -542,9 +552,7 @@ declare namespace WebdriverIO {
          * selector, it returns true if at least one element is (dis/en)abled.
          */
         waitForEnabled(
-            ms?: number,
-            reverse?: boolean,
-            error?: string
+            options?: WaitForOptions
         ): Promise<boolean>;
 
         /**
@@ -555,9 +563,7 @@ declare namespace WebdriverIO {
          * if the selector does not match any elements.
          */
         waitForExist(
-            ms?: number,
-            reverse?: boolean,
-            error?: string
+            options?: WaitForOptions
         ): Promise<boolean>;
     }
 
@@ -686,8 +692,7 @@ declare namespace WebdriverIO {
          */
         newWindow(
             url: string,
-            windowName?: string,
-            windowFeatures?: string
+            options?: NewWindowOptions
         ): Promise<string>;
 
         /**

--- a/scripts/templates/webdriverio.tpl.d.ts
+++ b/scripts/templates/webdriverio.tpl.d.ts
@@ -179,6 +179,25 @@ declare namespace WebdriverIO {
         reverse?: boolean,
     }
 
+    type ReactSelectorOptions = {
+        props?: object,
+        state?: any[] | number | string | object | boolean
+    }
+
+    type MoveToOptions = {
+        xOffset?: number,
+        yOffset?: number
+    }
+
+    type DragAndDropOptions = {
+        duration?: number
+    }
+
+    type NewWindowOptions = {
+        windowName?: string,
+        windowFeatures?: string
+    }
+
     interface Element {
         selector: string;
         elementId: string;

--- a/scripts/type-generation/constants.js
+++ b/scripts/type-generation/constants.js
@@ -1,5 +1,7 @@
 const CUSTOM_INTERFACES = [
-    'Buffer', 'Function', 'RegExp', 'WaitForOptions', 'Element', 'ElementArray'
+    'Buffer', 'Function', 'RegExp', 'WaitForOptions', 'ReactSelectorOptions',
+    'MoveToOptions', 'DragAndDropOptions', 'NewWindowOptions', 'Element',
+    'ElementArray'
 ]
 
 module.exports = {

--- a/tests/mocha/test.js
+++ b/tests/mocha/test.js
@@ -67,7 +67,7 @@ describe('Mocha smoke test', () => {
             browser.waitUntil(() => {
                 elem.click()
                 return false
-            }, 1000)
+            }, { timeout: 1000 })
         } catch (err) {
             // ignored
         }

--- a/tests/typings/sync/sync.ts
+++ b/tests/typings/sync/sync.ts
@@ -9,7 +9,18 @@ declare module "@wdio/sync" {
 
 // browser
 browser.pause(1)
-const waitUntil: boolean = browser.waitUntil(() => true, 1, '', 1)
+browser.newWindow('https://webdriver.io', {
+    windowName: 'some name',
+    windowFeatures: 'some features'
+})
+const waitUntil: boolean = browser.waitUntil(
+    () => true,
+    {
+        timeout: 1,
+        timeoutMsg: '',
+        interval: 1
+    }
+)
 browser.getCookies()
 
 const executeResult = browser.execute(function (x: number) {
@@ -50,6 +61,31 @@ const el2 = el1.$('')
 const el3 = el2.$('')
 el1.getCSSProperty('style')
 el2.click()
+el1.moveTo({ xOffset: 0, yOffset: 0 })
+const elementExists: boolean = el2.waitForExist({
+    timeout: 1,
+    timeoutMsg: '',
+    interval: 1,
+    reverse: true
+})
+const elementDisplayed: boolean = el2.waitForDisplayed({
+    timeout: 1,
+    timeoutMsg: '',
+    interval: 1,
+    reverse: true
+})
+const elementEnabled: boolean = el2.waitForEnabled({
+    timeout: 1,
+    timeoutMsg: '',
+    interval: 1,
+    reverse: true
+})
+const elementClickable: boolean = el2.waitForClickable({
+    timeout: 1,
+    timeoutMsg: '',
+    interval: 1,
+    reverse: true
+})
 // element custom command
 const el2result = el3.elementCustomCommand(4)
 el2result.toFixed(2)
@@ -72,18 +108,18 @@ const shadowElems = el6.shadow$$('')
 shadowElems[0].click()
 // react$ react$$
 const reactWrapper = browser.react$('')
-const reactWrapper = browser.react$('', {
+const reactWrapperWithOptions = browser.react$('', {
     props: {},
     state: true
 })
 const reactElement = reactWrapper.react$('')
-const reactElement = reactWrapper.react$('', {
+const reactElementWithOptions = reactWrapper.react$('', {
     props: {},
     state: true
 })
 reactElement.click()
 const reactElements = reactWrapper.react$$('')
-const reactElements = reactWrapper.react$$('', {
+const reactElementsWithOptions = reactWrapper.react$$('', {
     props: {},
     state: true
 })
@@ -102,7 +138,7 @@ ele.touchAction(touchAction)
 browser.touchAction(touchAction)
 
 // dragAndDrop
-ele.dragAndDrop(ele, 0)
+ele.dragAndDrop(ele, { duration: 0 })
 
 // addLocatorStrategy
 browser.addLocatorStrategy('myStrat', () => {})

--- a/tests/typings/sync/sync.ts
+++ b/tests/typings/sync/sync.ts
@@ -72,9 +72,21 @@ const shadowElems = el6.shadow$$('')
 shadowElems[0].click()
 // react$ react$$
 const reactWrapper = browser.react$('')
+const reactWrapper = browser.react$('', {
+    props: {},
+    state: true
+})
 const reactElement = reactWrapper.react$('')
+const reactElement = reactWrapper.react$('', {
+    props: {},
+    state: true
+})
 reactElement.click()
 const reactElements = reactWrapper.react$$('')
+const reactElements = reactWrapper.react$$('', {
+    props: {},
+    state: true
+})
 reactElements[0].click()
 
 // touchAction

--- a/tests/typings/webdriverio/async.ts
+++ b/tests/typings/webdriverio/async.ts
@@ -38,6 +38,10 @@ async function bar() {
 
     // browser
     await browser.pause(1)
+    await browser.newWindow('https://webdriver.io', {
+        windowName: 'some name',
+        windowFeatures: 'some features'
+    })
     const waitUntil: boolean = await browser.waitUntil(() => Promise.resolve(true), 1, '', 1)
     await browser.getCookies()
 
@@ -79,6 +83,31 @@ async function bar() {
     const el3 = await el2.$('')
     await el1.getCSSProperty('style')
     await el2.click()
+    await el1.moveTo({ xOffset: 0, yOffset: 0 })
+    const elementExists: boolean = await el2.waitForExist({
+        timeout: 1,
+        timeoutMsg: '',
+        interval: 1,
+        reverse: true
+    })
+    const elementDisplayed: boolean = await el2.waitForDisplayed({
+        timeout: 1,
+        timeoutMsg: '',
+        interval: 1,
+        reverse: true
+    })
+    const elementEnabled: boolean = await el2.waitForEnabled({
+        timeout: 1,
+        timeoutMsg: '',
+        interval: 1,
+        reverse: true
+    })
+    const elementClickable: boolean = await el2.waitForClickable({
+        timeout: 1,
+        timeoutMsg: '',
+        interval: 1,
+        reverse: true
+    })
     // element custom command
     const el2result = await el3.elementCustomCommand(4)
     el2result.toFixed(2)
@@ -102,18 +131,18 @@ async function bar() {
 
     // react$ react$$
     const reactWrapper = await browser.react$('')
-    const reactWrapper = await browser.react$('', {
+    const reactWrapperWithOptions = await browser.react$('', {
         props: {},
         state: true
     })
     const reactElement = await reactWrapper.react$('')
-    const reactElement = await reactWrapper.react$('', {
+    const reactElementWithOptions = await reactWrapper.react$('', {
         props: {},
         state: true
     })
     await reactElement.click()
     const reactElements = await reactWrapper.react$$('')
-    const reactElements = await reactWrapper.react$$('', {
+    const reactElementsWithOptions = await reactWrapper.react$$('', {
         props: {},
         state: true
     })
@@ -132,7 +161,7 @@ async function bar() {
     await browser.touchAction(touchAction)
 
     // dragAndDrop
-    await ele.dragAndDrop(ele, 0)
+    await ele.dragAndDrop(ele, { duration: 0 })
 
     // addLocatorStrategy
     browser.addLocatorStrategy('myStrat', () => {})

--- a/tests/typings/webdriverio/async.ts
+++ b/tests/typings/webdriverio/async.ts
@@ -102,9 +102,21 @@ async function bar() {
 
     // react$ react$$
     const reactWrapper = await browser.react$('')
+    const reactWrapper = await browser.react$('', {
+        props: {},
+        state: true
+    })
     const reactElement = await reactWrapper.react$('')
+    const reactElement = await reactWrapper.react$('', {
+        props: {},
+        state: true
+    })
     await reactElement.click()
     const reactElements = await reactWrapper.react$$('')
+    const reactElements = await reactWrapper.react$$('', {
+        props: {},
+        state: true
+    })
     await reactElements[0].click()
 
     // touchAction

--- a/website/blog/2019-04-03-react-selectors.md
+++ b/website/blog/2019-04-03-react-selectors.md
@@ -20,7 +20,10 @@ const selector = 'MyComponent'
 const propFilter = { someProp: true }
 const stateFilter = 'this is my state'
 
-browser.react$(selector, propFilter, stateFilter)
+browser.react$(selector, {
+    props: propFilter,
+    state: stateFilter
+})
 ```
 
 In the examples we will cover basic usages for all three parameters.
@@ -77,7 +80,9 @@ Simple, no? But what if we want to select the component that says `Hello Webdriv
 // spec/mycomponent.test.js
 
 test('it should correctly display "Hello WebdriverIO"', () => {
-    const myComponent = browser.react$('MyComponent', { name: 'WebdriverIO' })
+    const myComponent = browser.react$('MyComponent', {
+        props: { name: 'WebdriverIO' }
+    })
 
     expect(myComponent.getText()).toBe('Hello WebdriverIO') // pass
 })
@@ -90,7 +95,9 @@ You might've noticed that in our component we have a state that adds extra text 
 // spec/mycomponent.test.js
 
 test('it should correctly display "Hello WebdriverIO"', () => {
-    const myComponent = browser.react$('MyComponent', {}, ', how are you?')
+    const myComponent = browser.react$('MyComponent', {
+        state: ', how are you?'
+    })
 
     expect(myComponent.getText()).toBe('Hello there, how are you?') // pass
 })
@@ -104,3 +111,5 @@ By now you might be wondering why we are using `browser.react$` in all the examp
 ## Final Words
 
 We are very pleased with this addition and we hope you can take full advantage of it. We suggest you use [React Dev Tools](https://github.com/facebook/react-devtools), using this tool will help you see how the components in the application are called, which props they have, and which state they are currently in. Once you know this information, using WebdriverIO's React API will be a lot easier.
+
+> __Note:__ This blog post was updated after the v6 release to reflect changes to the command interface.


### PR DESCRIPTION
## Proposed changes

It's not convenient to have `browser.waitUntil(() => $(''foo).isExisting(), null, null, 1000)`

Let's use options instead, ex:
`browser.waitUntil(() => $(''foo).isExisting(), { interval: 1000 })`

affected `browser` methods:
- newWindow
- react$
- react$$
- waitUntil

affected `element` methods:
- dragAndDrop
- moveTo
- react$
- react$$
- scrollIntoView
- waitForClickable
- waitForDisplayed
- waitForEnabled
- waitForExist
- waitUntil

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

See original issue: #4715

### Reviewers: @webdriverio/project-committers 
