### PR TITLE
Fix sanitization of capabilities object (due to DEFAULT_CONFIGS now being a function)

### DIFF
--- a/packages/wdio-config/tests/__mocks__/@wdio/config.js
+++ b/packages/wdio-config/tests/__mocks__/@wdio/config.js
@@ -21,7 +21,7 @@ class ConfigParserMock {
     }
 }
 
-export const DEFAULT_CONFIGS = DEFAULT_CONFIGS_IMPORT()
+export const DEFAULT_CONFIGS = DEFAULT_CONFIGS_IMPORT
 export const getSauceEndpoint = getSauceEndpointMock
 export const validateConfig = jest.fn().mockImplementation(
     (_, config) => Object.assign(

--- a/packages/wdio-runner/src/utils.js
+++ b/packages/wdio-runner/src/utils.js
@@ -29,11 +29,12 @@ export function runHook (hookName, config, caps, specs) {
  * @return {Object}       sanitized caps
  */
 export function sanitizeCaps (caps) {
+    const defaultConfigs = DEFAULT_CONFIGS()
     return Object.keys(caps).filter(key => (
         /**
          * filter out all wdio config keys
          */
-        !Object.keys(DEFAULT_CONFIGS).includes(key)
+        !Object.keys(defaultConfigs).includes(key)
     )).reduce((obj, key) => {
         obj[key] = caps[key]
         return obj


### PR DESCRIPTION
## Proposed changes

https://github.com/webdriverio/webdriverio/pull/4923 causes another bug where non-WD capability options are not filtered, resulting in errors on starting, e.g. -
ERROR webdriver: invalid argument: invalid argument: unrecognized capability: maxInstances

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

### Reviewers: @webdriverio/technical-committee
