### PR TITLE
Added possibility to disable automatic strings to unicode translation

### DIFF
--- a/packages/webdriverio/src/commands/element/addValue.js
+++ b/packages/webdriverio/src/commands/element/addValue.js
@@ -21,7 +21,8 @@
  *
  * @alias element.addValue
  * @param {string | number | boolean | object | Array<any>}      value     value to be added
- * @param {boolean} translateToUnicode enable translation string to unicode value automatically
+ * @param {AddValueOptions} options                    command options (optional)
+ * @param {boolean}         options.translateToUnicode enable translation string to unicode value automatically
  * @uses protocol/elements, protocol/elementIdValue
  * @type action
  *

--- a/packages/webdriverio/src/commands/element/addValue.js
+++ b/packages/webdriverio/src/commands/element/addValue.js
@@ -4,7 +4,8 @@
  * characters like Left arrow or Back space. WebdriverIO will take care of
  * translating them into unicode characters. You’ll find all supported characters
  * [here](https://w3c.github.io/webdriver/webdriver-spec.html#keyboard-actions).
- * To do that, the value has to correspond to a key from the table.
+ * To do that, the value has to correspond to a key from the table. It can be disabled
+ * by setting `translateToUnicode` optional parameter to false.
  *
  * <example>
     :addValue.js
@@ -20,6 +21,7 @@
  *
  * @alias element.addValue
  * @param {string | number | boolean | object | Array<any>}      value     value to be added
+ * @param {boolean} translateToUnicode enable translation string to unicode value automatically
  * @uses protocol/elements, protocol/elementIdValue
  * @type action
  *
@@ -27,15 +29,16 @@
 
 import { transformToCharString } from '../../utils'
 
-export default function addValue (value) {
+export default function addValue (value, { translateToUnicode = true } = {}) {
     if (!this.isW3C) {
-        return this.elementSendKeys(this.elementId, transformToCharString(value))
+        return this.elementSendKeys(this.elementId, transformToCharString(value, translateToUnicode))
     }
 
     // Workaround https://github.com/appium/appium/issues/12085
     if (this.isMobile) {
-        return this.elementSendKeys(this.elementId, transformToCharString(value).join(''), transformToCharString(value))
+        return this.elementSendKeys(this.elementId, transformToCharString(value, translateToUnicode).join(''),
+            transformToCharString(value, translateToUnicode))
     }
 
-    return this.elementSendKeys(this.elementId, transformToCharString(value).join(''))
+    return this.elementSendKeys(this.elementId, transformToCharString(value, translateToUnicode).join(''))
 }

--- a/packages/webdriverio/src/commands/element/setValue.js
+++ b/packages/webdriverio/src/commands/element/setValue.js
@@ -20,7 +20,8 @@
  *
  * @alias element.setValue
  * @param {string | number | boolean | object | Array<any>}      value    Value to be added
- * @param {boolean} translateToUnicode enable translation string to unicode value automatically
+ * @param {AddValueOptions} options                    command options (optional)
+ * @param {boolean}         options.translateToUnicode enable translation string to unicode value automatically
  * @uses protocol/elements, protocol/elementIdClear, protocol/elementIdValue
  * @type action
  *

--- a/packages/webdriverio/src/commands/element/setValue.js
+++ b/packages/webdriverio/src/commands/element/setValue.js
@@ -5,7 +5,8 @@
  * unicode characters like Left arrow or Back space. WebdriverIO will take care of
  * translating them into unicode characters. You’ll find all supported characters
  * [here](https://w3c.github.io/webdriver/webdriver-spec.html#keyboard-actions).
- * To do that, the value has to correspond to a key from the table.
+ * To do that, the value has to correspond to a key from the table. It can be disabled
+ * by setting `translateToUnicode` optional parameter to false.
  *
  * <example>
     :setValue.js
@@ -19,12 +20,13 @@
  *
  * @alias element.setValue
  * @param {string | number | boolean | object | Array<any>}      value    Value to be added
+ * @param {boolean} translateToUnicode enable translation string to unicode value automatically
  * @uses protocol/elements, protocol/elementIdClear, protocol/elementIdValue
  * @type action
  *
  */
 
-export default async function setValue (value) {
+export default async function setValue (value, { translateToUnicode = true } = {}) {
     await this.clearValue()
-    return this.addValue(value)
+    return this.addValue(value, { translateToUnicode: translateToUnicode })
 }

--- a/packages/webdriverio/src/utils.js
+++ b/packages/webdriverio/src/utils.js
@@ -82,7 +82,7 @@ export function getBrowserObject (elem) {
 /**
  * transform whatever value is into an array of char strings
  */
-export function transformToCharString (value, translateToUnicode) {
+export function transformToCharString (value, translateToUnicode = true) {
     const ret = []
 
     if (!Array.isArray(value)) {

--- a/packages/webdriverio/src/utils.js
+++ b/packages/webdriverio/src/utils.js
@@ -82,7 +82,7 @@ export function getBrowserObject (elem) {
 /**
  * transform whatever value is into an array of char strings
  */
-export function transformToCharString (value) {
+export function transformToCharString (value, translateToUnicode) {
     const ret = []
 
     if (!Array.isArray(value)) {
@@ -91,7 +91,7 @@ export function transformToCharString (value) {
 
     for (const val of value) {
         if (typeof val === 'string') {
-            ret.push(...checkUnicode(val))
+            (translateToUnicode) ? ret.push(...checkUnicode(val)) : ret.push(...`${val}`.split(''))
         } else if (typeof val === 'number') {
             const entry = `${val}`.split('')
             ret.push(...entry)

--- a/packages/webdriverio/src/utils.js
+++ b/packages/webdriverio/src/utils.js
@@ -91,7 +91,7 @@ export function transformToCharString (value, translateToUnicode = true) {
 
     for (const val of value) {
         if (typeof val === 'string') {
-            (translateToUnicode) ? ret.push(...checkUnicode(val)) : ret.push(...`${val}`.split(''))
+            translateToUnicode ? ret.push(...checkUnicode(val)) : ret.push(...`${val}`.split(''))
         } else if (typeof val === 'number') {
             const entry = `${val}`.split('')
             ret.push(...entry)

--- a/packages/webdriverio/tests/commands/element/addValue.test.js
+++ b/packages/webdriverio/tests/commands/element/addValue.test.js
@@ -184,4 +184,30 @@ describe('addValue test', () => {
             expect(request.mock.calls[2][0].body.value).toEqual(['1', '2', 't', 'r', 'u', 'e', '[', '1', ',', '2', ']'])
         })
     })
+
+    describe('should allow to add value to an input element as workaround for /webdriverio/issues/4936', () => {
+        let browser
+
+        beforeEach(async () => {
+            browser = await remote({
+                baseUrl: 'http://foobar.com',
+                capabilities: {
+                    browserName: 'foobar'
+                }
+            })
+        })
+
+        afterEach(() => {
+            request.mockClear()
+        })
+
+        it('add string', async () => {
+            const elem = await browser.$('#foo')
+
+            await elem.addValue('Delete', { translateToUnicode: false })
+            expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/value')
+            expect(request.mock.calls[2][0].body.text).toEqual('Delete')
+            expect(request.mock.calls[2][0].body.value).toEqual(['D', 'e', 'l', 'e', 't', 'e'])
+        })
+    })
 })

--- a/packages/webdriverio/tests/commands/element/addValue.test.js
+++ b/packages/webdriverio/tests/commands/element/addValue.test.js
@@ -207,7 +207,6 @@ describe('addValue test', () => {
             await elem.addValue('Delete', { translateToUnicode: false })
             expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/value')
             expect(request.mock.calls[2][0].body.text).toEqual('Delete')
-            expect(request.mock.calls[2][0].body.value).toEqual(['D', 'e', 'l', 'e', 't', 'e'])
         })
     })
 })

--- a/packages/webdriverio/tests/commands/element/setValue.test.js
+++ b/packages/webdriverio/tests/commands/element/setValue.test.js
@@ -43,4 +43,13 @@ describe('setValue', () => {
         await elem.setValue([1, '2', true, [1, 2]])
         expect(request.mock.calls[3][0].body.text).toEqual('12true[1,2]')
     })
+
+    test('should set the value clearning the element first', async () => {
+        const elem = await browser.$('#foo')
+
+        await elem.setValue('Delete', { translateToUnicode: false })
+        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/clear')
+        expect(request.mock.calls[3][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/value')
+        expect(request.mock.calls[3][0].body.text).toEqual('Delete')
+    })
 })

--- a/packages/webdriverio/tests/utils.test.js
+++ b/packages/webdriverio/tests/utils.test.js
@@ -90,6 +90,28 @@ describe('utils', () => {
             expect(transformToCharString('Backspace')).toEqual(['\uE003'])
             expect(transformToCharString('Pageup')).toEqual(['\uE00E'])
         })
+
+        it('should transform string without converting to unicode', () => {
+            expect(transformToCharString('Delete', false)).toEqual(
+                ['D', 'e', 'l', 'e', 't', 'e'])
+            expect(transformToCharString('Back space', false)).toEqual(
+                ['B', 'a', 'c', 'k', ' ', 's', 'p', 'a', 'c', 'e'])
+            expect(transformToCharString('Backspace', false)).toEqual(
+                ['B', 'a', 'c', 'k', 's', 'p', 'a', 'c', 'e'])
+            expect(transformToCharString('Pageup', false)).toEqual(
+                ['P', 'a', 'g', 'e', 'u', 'p'])
+        })
+
+        it('should transform string with converting to unicode', () => {
+            expect(transformToCharString('Delete', true)).toEqual(
+                ['D', 'e', 'l', 'e', 't', 'e'])
+            expect(transformToCharString('Back space', true)).toEqual(
+                ['B', 'a', 'c', 'k', ' ', 's', 'p', 'a', 'c', 'e'])
+            expect(transformToCharString('Backspace', true)).toEqual(
+                ['B', 'a', 'c', 'k', 's', 'p', 'a', 'c', 'e'])
+            expect(transformToCharString('Pageup', true)).toEqual(
+                ['P', 'a', 'g', 'e', 'u', 'p'])
+        })
     })
 
     describe('parseCSS', () => {

--- a/packages/webdriverio/tests/utils.test.js
+++ b/packages/webdriverio/tests/utils.test.js
@@ -103,14 +103,10 @@ describe('utils', () => {
         })
 
         it('should transform string with converting to unicode', () => {
-            expect(transformToCharString('Delete', true)).toEqual(
-                ['D', 'e', 'l', 'e', 't', 'e'])
-            expect(transformToCharString('Back space', true)).toEqual(
-                ['B', 'a', 'c', 'k', ' ', 's', 'p', 'a', 'c', 'e'])
-            expect(transformToCharString('Backspace', true)).toEqual(
-                ['B', 'a', 'c', 'k', 's', 'p', 'a', 'c', 'e'])
-            expect(transformToCharString('Pageup', true)).toEqual(
-                ['P', 'a', 'g', 'e', 'u', 'p'])
+            expect(transformToCharString('Delete', true)).toEqual(['\uE017'])
+            expect(transformToCharString('Back space', true)).toEqual(['\uE003'])
+            expect(transformToCharString('Backspace', true)).toEqual(['\uE003'])
+            expect(transformToCharString('Pageup', true)).toEqual(['\uE00E'])
         })
     })
 

--- a/scripts/templates/webdriverio.tpl.d.ts
+++ b/scripts/templates/webdriverio.tpl.d.ts
@@ -252,4 +252,8 @@ declare namespace WebdriverIO {
     }
 
     interface Config extends Options, Omit<WebDriver.Options, "capabilities">, Hooks {}
+
+    interface AddValueOptions {
+        translateToUnicode: boolean
+    }
 }

--- a/scripts/type-generation/generate-typings-utils.js
+++ b/scripts/type-generation/generate-typings-utils.js
@@ -10,6 +10,7 @@ const changeType = (text) => {
     case 'Buffer':
     case 'Function':
     case 'RegExp':
+    case 'AddValueOptions':
     case 'WaitForOptions':
     case 'Element':
     case 'ElementArray': {

--- a/tests/typings/sync/sync.ts
+++ b/tests/typings/sync/sync.ts
@@ -61,6 +61,16 @@ const el5 = el4.$('')
 el4.getAttribute('class')
 el5.scrollIntoView(false)
 
+// An examples of addValue command with enabled/disabled translation to Unicode
+const el = $('')
+el.addValue('Delete', { translateToUnicode: true })
+el.addValue('Delete', { translateToUnicode: false })
+
+// An examples of setValue command with enabled/disabled translation to Unicode
+const elem1 = $('')
+elem1.setValue('Delete', { translateToUnicode: true })
+elem1.setValue('Delete', { translateToUnicode: false })
+
 const selector$$: string | Function = elems.selector
 const parent$$: WebdriverIO.Element | WebdriverIO.BrowserObject = elems.parent
 

--- a/tests/typings/webdriverio/async.ts
+++ b/tests/typings/webdriverio/async.ts
@@ -90,6 +90,16 @@ async function bar() {
     await el4.getAttribute('class')
     await el5.scrollIntoView(false)
 
+    // An examples of addValue command with enabled/disabled translation to Unicode
+    const elem = await $('')
+    await elem.addValue('Delete', { translateToUnicode: true })
+    await elem.addValue('Delete', { translateToUnicode: false })
+
+    // An examples of setValue command with enabled/disabled translation to Unicode
+    const elem1 = await $('')
+    elem1.setValue('Delete', { translateToUnicode: true })
+    elem1.setValue('Delete', { translateToUnicode: false })
+
     const selector$$: string | Function = elems.selector
     const parent$$: WebdriverIOAsync.Element | WebdriverIOAsync.BrowserObject = elems.parent
 


### PR DESCRIPTION
## Proposed changes

This is a fix for wdio automatic translation to [unicode issue](https://github.com/webdriverio/webdriverio/issues/4936). In general, user can't send keys that are predefined in the UNICODE_CHARACTERS [list](https://github.com/webdriverio/webdriverio/blob/master/packages/webdriverio/src/constants.js).

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
