### PR TITLE
webdriver.d.ts colliding type definitions for launchApp between Appium and Chromium

### DIFF
--- a/packages/wdio-protocols/protocols/chromium.json
+++ b/packages/wdio-protocols/protocols/chromium.json
@@ -3,7 +3,7 @@
     "GET": {
       "command": "isAlertOpen",
       "description": "Whether a simple dialog is currently open.",
-      "ref": "https://github.com/bayandin/chromedriver/blob/2.45/alert_commands.cc#L42-L49",
+      "ref": "https://github.com/bayandin/chromedriver/blob/v2.45/alert_commands.cc#L42-L49",
       "examples": [
         [
           "console.log(browser.isAlertOpen()); // outputs: false",
@@ -68,7 +68,7 @@
     "GET": {
       "command": "isLoading",
       "description": "Determines load status for active window handle.",
-      "ref": "https://github.com/bayandin/chromedriver/blob/2.45/session_commands.cc#L783-L802",
+      "ref": "https://github.com/bayandin/chromedriver/blob/v2.45/session_commands.cc#L783-L802",
       "examples": [
         [
           "console.log(browser.isLoading()); // outputs: false",
@@ -88,7 +88,7 @@
     "GET": {
       "command": "takeHeapSnapshot",
       "description": "Takes a heap snapshot of the current execution context.",
-      "ref": "https://github.com/bayandin/chromedriver/blob/2.45/chrome/web_view.h#L198-L202",
+      "ref": "https://github.com/bayandin/chromedriver/blob/v2.45/chrome/web_view.h#L198-L202",
       "parameters": [],
       "returns": {
         "type": "Object",
@@ -122,7 +122,7 @@
       "returns": {
         "type": "Number",
         "name": "connectionType",
-        "description": "A bitmask to represent the network connection type. Airplane Mode (`1`), Wi-Fi only (`2`), Wi-Fi and data (`6`), 4G (`8`), 3G (`10`), 2G (`20`). By default [Wi-Fi and data are enabled](https://github.com/bayandin/chromedriver/blob/2.45/chrome/chrome_desktop_impl.cc#L36-L37)."
+        "description": "A bitmask to represent the network connection type. Airplane Mode (`1`), Wi-Fi only (`2`), Wi-Fi and data (`6`), 4G (`8`), 3G (`10`), 2G (`20`). By default [Wi-Fi and data are enabled](https://github.com/bayandin/chromedriver/blob/v2.45/chrome/chrome_desktop_impl.cc#L36-L37)."
       }
     },
     "POST": {
@@ -162,7 +162,7 @@
     "GET": {
       "command": "getNetworkConditions",
       "description": "Get current network conditions used for emulation.",
-      "ref": "https://github.com/bayandin/chromedriver/blob/2.45/session_commands.cc#L839-L859",
+      "ref": "https://github.com/bayandin/chromedriver/blob/v2.45/session_commands.cc#L839-L859",
       "parameters": [],
       "returns": {
         "type": "Object",
@@ -173,7 +173,7 @@
     "POST": {
       "command": "setNetworkConditions",
       "description": "Set network conditions used for emulation by throttling connection.",
-      "ref": "https://github.com/bayandin/chromedriver/blob/2.45/window_commands.cc#L1663-L1722",
+      "ref": "https://github.com/bayandin/chromedriver/blob/v2.45/window_commands.cc#L1663-L1722",
       "examples": [
         [
           "// Use different download (25kb/s) and upload (50kb/s) throughput values for throttling with a latency of 1000ms",
@@ -200,14 +200,14 @@
       }, {
         "name": "network_name",
         "type": "string",
-        "description": "Name of [network throttling preset](https://github.com/bayandin/chromedriver/blob/2.45/chrome/network_list.cc#L12-L25). `GPRS`, `Regular 2G`, `Good 2G`, `Regular 3G`, `Good 3G`, `Regular 4G`, `DSL`, `WiFi` or `No throttling` to disable. When preset is specified values passed in first argument are not respected.",
+        "description": "Name of [network throttling preset](https://github.com/bayandin/chromedriver/blob/v2.45/chrome/network_list.cc#L12-L25). `GPRS`, `Regular 2G`, `Good 2G`, `Regular 3G`, `Good 3G`, `Regular 4G`, `DSL`, `WiFi` or `No throttling` to disable. When preset is specified values passed in first argument are not respected.",
         "required": false
       }]
     },
     "DELETE": {
       "command": "deleteNetworkConditions",
       "description": "Disable any network throttling which might have been set. Equivalent of setting the `No throttling` preset.",
-      "ref": "https://github.com/bayandin/chromedriver/blob/2.45/window_commands.cc#L1724-L1745",
+      "ref": "https://github.com/bayandin/chromedriver/blob/v2.45/window_commands.cc#L1724-L1745",
       "parameters": []
     }
   },
@@ -215,7 +215,7 @@
     "POST": {
       "command": "sendCommand",
       "description": "Send a command to the DevTools debugger.<br>For a list of available commands and their parameters refer to the [Chrome DevTools Protocol Viewer](https://chromedevtools.github.io/devtools-protocol/).",
-      "ref": "https://github.com/bayandin/chromedriver/blob/2.45/window_commands.cc#L1290-L1304",
+      "ref": "https://github.com/bayandin/chromedriver/blob/v2.45/window_commands.cc#L1290-L1304",
       "parameters": [{
         "name": "cmd",
         "type": "string",
@@ -233,7 +233,7 @@
     "POST": {
       "command": "sendCommandAndGetResult",
       "description": "Send a command to the DevTools debugger and wait for the result.<br>For a list of available commands and their parameters refer to the [Chrome DevTools Protocol Viewer](https://chromedevtools.github.io/devtools-protocol/).",
-      "ref": "https://github.com/bayandin/chromedriver/blob/2.45/window_commands.cc#L1306-L1320",
+      "ref": "https://github.com/bayandin/chromedriver/blob/v2.45/window_commands.cc#L1306-L1320",
       "parameters": [{
         "name": "cmd",
         "type": "string",
@@ -273,7 +273,7 @@
     "POST": {
       "command": "file",
       "description": "Upload a file to remote machine on which the browser is running.",
-      "ref": "https://github.com/bayandin/chromedriver/blob/2.45/session_commands.cc#L1037-L1065",
+      "ref": "https://github.com/bayandin/chromedriver/blob/v2.45/session_commands.cc#L1037-L1065",
       "parameters": [{
         "name": "file",
         "type": "string",
@@ -289,9 +289,9 @@
   },
   "/session/:sessionId/chromium/launch_app": {
     "POST": {
-      "command": "launchApp",
+      "command": "launchChromeApp",
       "description": "Launches a Chrome app by specified id.",
-      "ref": "https://github.com/bayandin/chromedriver/blob/2.45/session_commands.cc#L521-L539",
+      "ref": "https://github.com/bayandin/chromedriver/blob/v2.45/session_commands.cc#L521-L539",
       "examples": [
         [
           "const browser = remote({",
@@ -306,7 +306,7 @@
           "        }",
           "    }",
           "});",
-          "browser.launchApp('aohghmighlieiainnegkcijnfilokake')); // Google Docs (https://chrome.google.com/webstore/detail/docs/aohghmighlieiainnegkcijnfilokake)"
+          "browser.launchChromeApp('aohghmighlieiainnegkcijnfilokake')); // Google Docs (https://chrome.google.com/webstore/detail/docs/aohghmighlieiainnegkcijnfilokake)"
         ]
       ],
       "parameters": [{
@@ -321,7 +321,7 @@
     "GET": {
       "command": "getElementValue",
       "description": "Retrieves the value of a given form control element.",
-      "ref": "https://github.com/bayandin/chromedriver/blob/2.45/element_commands.cc#L431-L443",
+      "ref": "https://github.com/bayandin/chromedriver/blob/v2.45/element_commands.cc#L431-L443",
       "variables": [{
         "name": "elementId",
         "description": "id of element to get value from"
@@ -338,7 +338,7 @@
     "POST": {
       "command": "elementHover",
       "description": "Enable hover state for an element, which is reset upon next interaction.",
-      "ref": "https://github.com/bayandin/chromedriver/blob/2.45/element_commands.cc#L126-L146",
+      "ref": "https://github.com/bayandin/chromedriver/blob/v2.45/element_commands.cc#L126-L146",
       "variables": [{
         "name": "elementId",
         "description": "id of element to hover over to"
@@ -350,7 +350,7 @@
     "POST": {
       "command": "touchPinch",
       "description": "Trigger a pinch zoom effect.",
-      "ref": "https://github.com/bayandin/chromedriver/blob/2.45/window_commands.cc#L813-L827",
+      "ref": "https://github.com/bayandin/chromedriver/blob/v2.45/window_commands.cc#L813-L827",
       "parameters": [{
         "name": "x",
         "type": "number",
@@ -373,7 +373,7 @@
     "POST": {
       "command": "freeze",
       "description": "Freeze the current page. Extension for [Page Lifecycle API](https://developers.google.com/web/updates/2018/07/page-lifecycle-api).",
-      "ref": "https://github.com/bayandin/chromedriver/blob/2.45/window_commands.cc#L625-L633",
+      "ref": "https://github.com/bayandin/chromedriver/blob/v2.45/window_commands.cc#L625-L633",
       "parameters": []
     }
   },
@@ -381,7 +381,7 @@
     "POST": {
       "command": "resume",
       "description": "Resume the current page. Extension for [Page Lifecycle API](https://developers.google.com/web/updates/2018/07/page-lifecycle-api).",
-      "ref": "https://github.com/bayandin/chromedriver/blob/2.45/window_commands.cc#L635-L645",
+      "ref": "https://github.com/bayandin/chromedriver/blob/v2.45/window_commands.cc#L635-L645",
       "parameters": []
     }
   },
@@ -389,7 +389,7 @@
     "POST": {
       "command": "shutdown",
       "description": "Shutdown ChromeDriver process and consequently terminating all active sessions.",
-      "ref": "https://github.com/bayandin/chromedriver/blob/2.45/session_commands.cc#L489-L498",
+      "ref": "https://github.com/bayandin/chromedriver/blob/v2.45/session_commands.cc#L489-L498",
       "parameters": []
     }
   },

--- a/packages/webdriver/webdriver.d.ts
+++ b/packages/webdriver/webdriver.d.ts
@@ -2008,7 +2008,7 @@ declare namespace WebDriver {
         /**
          * [chromium]
          * Whether a simple dialog is currently open.
-         * https://github.com/bayandin/chromedriver/blob/2.45/alert_commands.cc#L42-L49
+         * https://github.com/bayandin/chromedriver/blob/v2.45/alert_commands.cc#L42-L49
          */
         isAlertOpen(): boolean;
 
@@ -2029,14 +2029,14 @@ declare namespace WebDriver {
         /**
          * [chromium]
          * Determines load status for active window handle.
-         * https://github.com/bayandin/chromedriver/blob/2.45/session_commands.cc#L783-L802
+         * https://github.com/bayandin/chromedriver/blob/v2.45/session_commands.cc#L783-L802
          */
         isLoading(): boolean;
 
         /**
          * [chromium]
          * Takes a heap snapshot of the current execution context.
-         * https://github.com/bayandin/chromedriver/blob/2.45/chrome/web_view.h#L198-L202
+         * https://github.com/bayandin/chromedriver/blob/v2.45/chrome/web_view.h#L198-L202
          */
         takeHeapSnapshot(): ProtocolCommandResponse;
 
@@ -2057,35 +2057,35 @@ declare namespace WebDriver {
         /**
          * [chromium]
          * Get current network conditions used for emulation.
-         * https://github.com/bayandin/chromedriver/blob/2.45/session_commands.cc#L839-L859
+         * https://github.com/bayandin/chromedriver/blob/v2.45/session_commands.cc#L839-L859
          */
         getNetworkConditions(): ProtocolCommandResponse;
 
         /**
          * [chromium]
          * Set network conditions used for emulation by throttling connection.
-         * https://github.com/bayandin/chromedriver/blob/2.45/window_commands.cc#L1663-L1722
+         * https://github.com/bayandin/chromedriver/blob/v2.45/window_commands.cc#L1663-L1722
          */
         setNetworkConditions(network_conditions: object, network_name?: string): void;
 
         /**
          * [chromium]
          * Disable any network throttling which might have been set. Equivalent of setting the `No throttling` preset.
-         * https://github.com/bayandin/chromedriver/blob/2.45/window_commands.cc#L1724-L1745
+         * https://github.com/bayandin/chromedriver/blob/v2.45/window_commands.cc#L1724-L1745
          */
         deleteNetworkConditions(): void;
 
         /**
          * [chromium]
          * Send a command to the DevTools debugger.<br>For a list of available commands and their parameters refer to the [Chrome DevTools Protocol Viewer](https://chromedevtools.github.io/devtools-protocol/).
-         * https://github.com/bayandin/chromedriver/blob/2.45/window_commands.cc#L1290-L1304
+         * https://github.com/bayandin/chromedriver/blob/v2.45/window_commands.cc#L1290-L1304
          */
         sendCommand(cmd: string, params: object): void;
 
         /**
          * [chromium]
          * Send a command to the DevTools debugger and wait for the result.<br>For a list of available commands and their parameters refer to the [Chrome DevTools Protocol Viewer](https://chromedevtools.github.io/devtools-protocol/).
-         * https://github.com/bayandin/chromedriver/blob/2.45/window_commands.cc#L1306-L1320
+         * https://github.com/bayandin/chromedriver/blob/v2.45/window_commands.cc#L1306-L1320
          */
         sendCommandAndGetResult(cmd: string, params: object): any;
 
@@ -2099,56 +2099,56 @@ declare namespace WebDriver {
         /**
          * [chromium]
          * Upload a file to remote machine on which the browser is running.
-         * https://github.com/bayandin/chromedriver/blob/2.45/session_commands.cc#L1037-L1065
+         * https://github.com/bayandin/chromedriver/blob/v2.45/session_commands.cc#L1037-L1065
          */
         file(file: string): string;
 
         /**
          * [chromium]
          * Launches a Chrome app by specified id.
-         * https://github.com/bayandin/chromedriver/blob/2.45/session_commands.cc#L521-L539
+         * https://github.com/bayandin/chromedriver/blob/v2.45/session_commands.cc#L521-L539
          */
-        launchApp(id: string): void;
+        launchChromeApp(id: string): void;
 
         /**
          * [chromium]
          * Retrieves the value of a given form control element.
-         * https://github.com/bayandin/chromedriver/blob/2.45/element_commands.cc#L431-L443
+         * https://github.com/bayandin/chromedriver/blob/v2.45/element_commands.cc#L431-L443
          */
         getElementValue(elementId: string): string|null;
 
         /**
          * [chromium]
          * Enable hover state for an element, which is reset upon next interaction.
-         * https://github.com/bayandin/chromedriver/blob/2.45/element_commands.cc#L126-L146
+         * https://github.com/bayandin/chromedriver/blob/v2.45/element_commands.cc#L126-L146
          */
         elementHover(elementId: string): void;
 
         /**
          * [chromium]
          * Trigger a pinch zoom effect.
-         * https://github.com/bayandin/chromedriver/blob/2.45/window_commands.cc#L813-L827
+         * https://github.com/bayandin/chromedriver/blob/v2.45/window_commands.cc#L813-L827
          */
         touchPinch(x: number, y: number, scale: number): void;
 
         /**
          * [chromium]
          * Freeze the current page. Extension for [Page Lifecycle API](https://developers.google.com/web/updates/2018/07/page-lifecycle-api).
-         * https://github.com/bayandin/chromedriver/blob/2.45/window_commands.cc#L625-L633
+         * https://github.com/bayandin/chromedriver/blob/v2.45/window_commands.cc#L625-L633
          */
         freeze(): void;
 
         /**
          * [chromium]
          * Resume the current page. Extension for [Page Lifecycle API](https://developers.google.com/web/updates/2018/07/page-lifecycle-api).
-         * https://github.com/bayandin/chromedriver/blob/2.45/window_commands.cc#L635-L645
+         * https://github.com/bayandin/chromedriver/blob/v2.45/window_commands.cc#L635-L645
          */
         resume(): void;
 
         /**
          * [chromium]
          * Shutdown ChromeDriver process and consequently terminating all active sessions.
-         * https://github.com/bayandin/chromedriver/blob/2.45/session_commands.cc#L489-L498
+         * https://github.com/bayandin/chromedriver/blob/v2.45/session_commands.cc#L489-L498
          */
         shutdown(): void;
 


### PR DESCRIPTION
**Environment (please complete the following information):**
 - **WebdriverIO version:** 5.18.0
 - **Node.js version:** 13.5.0
 - **NPM version:** 6.13.4

**Describe the bug**
node_modules/webdriver/webdriver.d.ts has the following definition for Appium

```
    /**
         * [appium]
         * Launch an app on device. iOS tests with XCUITest can also use the `mobile: launchApp` method. See detailed [documentation](http://appium.io/docs/en/writing-running-appium/ios/ios-xctest-mobile-apps-management/index.html#mobile-launchapp).
         * http://appium.io/docs/en/commands/device/app/launch-app/
         */
        launchApp(): void;
```

And the following definition for Chromium, which comes later

```
        /**
         * [chromium]
         * Launches a Chrome app by specified id.
         * https://github.com/bayandin/chromedriver/blob/2.45/session_commands.cc#L521-L539
         */
        launchApp(id: string): void;
```

That means I am not able to use Appium's method definition (the one without arguments) directly.

The easiest fix I can think of is making `id` optional.