### PR TITLE
Separate launcher from worker services

### DIFF
--- a/packages/wdio-cli/src/launcher.js
+++ b/packages/wdio-cli/src/launcher.js
@@ -38,7 +38,7 @@ class Launcher {
                 .reduce((a, b) => a + b, 0)
             : 1
 
-        const Runner = initialisePlugin(config.runner, 'runner')
+        const Runner = initialisePlugin(config.runner, 'runner').default
         this.runner = new Runner(configFilePath, config)
 
         this.interface = new CLInterface(config, totalWorkerCnt, this.isWatchMode)

--- a/packages/wdio-cli/src/launcher.js
+++ b/packages/wdio-cli/src/launcher.js
@@ -4,7 +4,7 @@ import exitHook from 'async-exit-hook'
 
 import logger from '@wdio/logger'
 import { ConfigParser } from '@wdio/config'
-import { initialisePlugin, initialiseServices } from '@wdio/utils'
+import { initialisePlugin, initialiseLauncherService } from '@wdio/utils'
 
 import CLInterface from './interface'
 import { runLauncherHook, runOnCompleteHook, runServiceHook } from './utils'
@@ -69,7 +69,9 @@ class Launcher {
         try {
             const config = this.configParser.getConfig()
             const caps = this.configParser.getCapabilities()
-            this.launcher = initialiseServices(config, caps, 'launcher')
+            const { ignoredWorkerServices, launcherServices } = initialiseLauncherService(config, caps)
+            this.launcher = launcherServices
+            this.args.ignoredWorkerServices = ignoredWorkerServices
 
             /**
              * run pre test tasks for runner plugins

--- a/packages/wdio-config/src/constants.js
+++ b/packages/wdio-config/src/constants.js
@@ -16,6 +16,7 @@ export const DEFAULT_CONFIGS = () => ({
     waitforTimeout: 5000,
     framework: 'mocha',
     reporters: [],
+    services: [],
     maxInstances: 100,
     maxInstancesPerCapability: 100,
     filesToWatch: [],

--- a/packages/wdio-config/src/constants.js
+++ b/packages/wdio-config/src/constants.js
@@ -78,10 +78,3 @@ export const SUPPORTED_HOOKS = [
     'beforeFeature', 'beforeScenario', 'beforeStep', 'afterStep', 'afterScenario', 'afterFeature',
     'onReload', 'onPrepare', 'onWorkerStart', 'onComplete'
 ]
-
-/**
- * these services should not be started in worker process
- */
-export const NON_WORKER_SERVICES = [
-    'chromedriver', 'selenium-standalone', 'appium', 'reportportal', 'firefox-profile'
-]

--- a/packages/wdio-config/src/lib/ConfigParser.js
+++ b/packages/wdio-config/src/lib/ConfigParser.js
@@ -7,7 +7,7 @@ import logger from '@wdio/logger'
 
 import { detectBackend, removeLineNumbers, isCucumberFeatureWithLineNumber } from '../utils'
 
-import { DEFAULT_CONFIGS, SUPPORTED_HOOKS, NON_WORKER_SERVICES } from '../constants'
+import { DEFAULT_CONFIGS, SUPPORTED_HOOKS } from '../constants'
 
 const log = logger('@wdio/config:ConfigParser')
 const MERGE_OPTIONS = { clone: false }
@@ -310,17 +310,5 @@ export default class ConfigParser {
         }
 
         return files
-    }
-
-    /**
-     * remove services that has nothing to do in worker
-     */
-    filterWorkerServices () {
-        if (!Array.isArray(this._config.services)) {
-            return
-        }
-        this._config.services = this._config.services.filter((service) => {
-            return !NON_WORKER_SERVICES.includes(service)
-        })
     }
 }

--- a/packages/wdio-config/tests/configparser.test.js
+++ b/packages/wdio-config/tests/configparser.test.js
@@ -403,22 +403,4 @@ describe('ConfigParser', () => {
             expect(config.key).toBe('50fa142c-3121-4gb0-9p07-8q326vvbq7b0')
         })
     })
-
-    describe('filterWorkerServices', () => {
-        const configParser = new ConfigParser()
-        configParser.addConfigFile(FIXTURES_CONF)
-        const config = configParser.getConfig()
-
-        it('should do nothing if services is not an array', () => {
-            config.services = null
-            configParser.filterWorkerServices()
-            expect(config.services).toBeNull()
-        })
-
-        it('should remove non worker services', () => {
-            config.services = ['sauce', 'selenium-standalone']
-            configParser.filterWorkerServices()
-            expect(config.services).toEqual(['sauce'])
-        })
-    })
 })

--- a/packages/wdio-runner/src/index.js
+++ b/packages/wdio-runner/src/index.js
@@ -6,7 +6,7 @@ import EventEmitter from 'events'
 import { setOptions } from 'expect-webdriverio'
 
 import logger from '@wdio/logger'
-import { initialiseServices, initialisePlugin, executeHooksWithArgs } from '@wdio/utils'
+import { initialiseWorkerService, initialisePlugin, executeHooksWithArgs } from '@wdio/utils'
 import { ConfigParser } from '@wdio/config'
 
 import BaseReporter from './reporter'
@@ -75,7 +75,8 @@ export default class Runner extends EventEmitter {
             return this._shutdown(0)
         }
 
-        initialiseServices(this.config, caps).map(::this.configParser.addService)
+        initialiseWorkerService(this.config, caps, args.ignoredWorkerServices)
+            .map(::this.configParser.addService)
 
         /**
          * set options for `expect-webdriverio` assertion lib

--- a/packages/wdio-runner/src/index.js
+++ b/packages/wdio-runner/src/index.js
@@ -68,7 +68,7 @@ export default class Runner extends EventEmitter {
         /**
          * initialise framework
          */
-        this.framework = initialisePlugin(this.config.framework, 'framework')
+        this.framework = initialisePlugin(this.config.framework, 'framework').default
         this.framework = await this.framework.init(cid, this.config, specs, caps, this.reporter)
         process.send({ name: 'testFrameworkInit', content: { cid, caps, specs, hasTests: this.framework.hasTests() } })
         if (!this.framework.hasTests()) {

--- a/packages/wdio-runner/src/index.js
+++ b/packages/wdio-runner/src/index.js
@@ -50,17 +50,9 @@ export default class Runner extends EventEmitter {
          */
         this.configParser.merge(args)
 
-        /**
-         * remove services that has nothing to do in worker
-         */
-        this.configParser.filterWorkerServices()
-
         this.config = this.configParser.getConfig()
-
         this.config.specFileRetryAttempts = (this.config.specFileRetries || 0) - (retries || 0)
-
         logger.setLogLevelsConfig(this.config.logLevels, this.config.logLevel)
-
         const isMultiremote = this.isMultiremote = !Array.isArray(this.configParser.getCapabilities())
 
         /**

--- a/packages/wdio-runner/src/reporter.js
+++ b/packages/wdio-runner/src/reporter.js
@@ -183,7 +183,7 @@ export default class BaseReporter {
          * ```
          */
         if (typeof reporter === 'string') {
-            ReporterClass = initialisePlugin(reporter, 'reporter')
+            ReporterClass = initialisePlugin(reporter, 'reporter').default
             const customLogFile = options.setLogFile(this.cid, reporter)
             options.logFile = customLogFile || this.getLogFile(reporter)
             options.writeStream = this.getWriteStreamObject(reporter)

--- a/packages/wdio-runner/tests/index.test.js
+++ b/packages/wdio-runner/tests/index.test.js
@@ -195,7 +195,6 @@ describe('wdio-runner', () => {
                 featureFlags: {}
             }
             runner.configParser.getConfig = jest.fn().mockReturnValue(config)
-            runner.configParser.filterWorkerServices = jest.fn()
             runner._shutdown = jest.fn()
             runner._initSession = jest.fn().mockReturnValue({
                 capabilities: { browserName: 'chrome' },
@@ -226,7 +225,6 @@ describe('wdio-runner', () => {
                 featureFlags: {}
             }
             runner.configParser.getConfig = jest.fn().mockReturnValue(config)
-            runner.configParser.filterWorkerServices = jest.fn()
             runner._initSession = jest.fn().mockReturnValue({ options: { capabilities: {} } })
             const failures = await runner.run({ args: {}, caps: {} })
 
@@ -242,7 +240,6 @@ describe('wdio-runner', () => {
                 featureFlags: {}
             }
             runner.configParser.getConfig = jest.fn().mockReturnValue(config)
-            runner.configParser.filterWorkerServices = jest.fn()
             global.browser = { url: jest.fn(url => url) }
             runner._startSession = jest.fn().mockReturnValue({ })
             runner._initSession = jest.fn().mockReturnValue({ options: { capabilities: {} } })
@@ -261,7 +258,6 @@ describe('wdio-runner', () => {
                 featureFlags: {}
             }
             runner.configParser.getConfig = jest.fn().mockReturnValue(config)
-            runner.configParser.filterWorkerServices = jest.fn()
             runner._initSession = jest.fn().mockReturnValue({ options: { capabilities: {} } })
             runner.emit = jest.fn()
             const failures = await runner.run({ args: {}, caps: {} })
@@ -281,7 +277,6 @@ describe('wdio-runner', () => {
                 featureFlags: {}
             }
             runner.configParser.getConfig = jest.fn().mockReturnValue(config)
-            runner.configParser.filterWorkerServices = jest.fn()
             runner._shutdown = jest.fn()
             runner.endSession = jest.fn()
             runner._initSession = jest.fn().mockReturnValue({})
@@ -295,7 +290,6 @@ describe('wdio-runner', () => {
 
             expect(runner.endSession).toBeCalledTimes(1)
             expect(runner._shutdown).toBeCalledWith(0)
-            expect(runner.configParser.filterWorkerServices).toBeCalled()
         })
 
         it('should not initSession if there are no tests to run', async () => {
@@ -307,7 +301,6 @@ describe('wdio-runner', () => {
                 featureFlags: {}
             }
             runner.configParser.getConfig = jest.fn().mockReturnValue(config)
-            runner.configParser.filterWorkerServices = jest.fn()
             runner._shutdown = jest.fn().mockImplementation((arg) => arg)
             runner._initSession = jest.fn()
 
@@ -327,7 +320,6 @@ describe('wdio-runner', () => {
                 featureFlags: {}
             }
             runner.configParser.getConfig = jest.fn().mockReturnValue(config)
-            runner.configParser.filterWorkerServices = jest.fn()
             runner._shutdown = jest.fn().mockReturnValue('_shutdown')
             runner.endSession = jest.fn()
             runner._initSession = jest.fn().mockReturnValue(null)

--- a/packages/wdio-utils/src/index.js
+++ b/packages/wdio-utils/src/index.js
@@ -1,5 +1,5 @@
 import initialisePlugin from './initialisePlugin'
-import initialiseServices from './initialiseServices'
+import { initialiseWorkerService, initialiseLauncherService } from './initialiseServices'
 import webdriverMonad from './monad'
 import {
     commandCallStructure, isValidParameter, getArgumentType, safeRequire,
@@ -14,7 +14,8 @@ import { capabilitiesEnvironmentDetector, sessionEnvironmentDetector, devtoolsEn
 
 export {
     initialisePlugin,
-    initialiseServices,
+    initialiseLauncherService,
+    initialiseWorkerService,
     isFunctionAsync,
     webdriverMonad,
     commandCallStructure,

--- a/packages/wdio-utils/src/initialisePlugin.js
+++ b/packages/wdio-utils/src/initialisePlugin.js
@@ -9,17 +9,22 @@ import { safeRequire } from './utils'
  */
 export default function initialisePlugin (name, type, target = 'default') {
     /**
+     * check plugin for launcher export
+     */
+    const targetCheck = target === 'launcher' && target
+
+    /**
      * directly import packages that are scoped or start with an absolute path
      */
     if (name[0] === '@' || path.isAbsolute(name)) {
-        const service = safeRequire(name)
+        const service = safeRequire(name, targetCheck)
         return service[target]
     }
 
     /**
      * check for scoped version of plugin first (e.g. @wdio/sauce-service)
      */
-    const scopedPlugin = safeRequire(`@wdio/${name.toLowerCase()}-${type}`)
+    const scopedPlugin = safeRequire(`@wdio/${name.toLowerCase()}-${type}`, targetCheck)
     if (scopedPlugin) {
         return scopedPlugin[target]
     }
@@ -27,7 +32,7 @@ export default function initialisePlugin (name, type, target = 'default') {
     /**
      * check for old type of
      */
-    const plugin = safeRequire(`wdio-${name.toLowerCase()}-${type}`)
+    const plugin = safeRequire(`wdio-${name.toLowerCase()}-${type}`, targetCheck)
     if (plugin) {
         return plugin[target]
     }

--- a/packages/wdio-utils/src/initialisePlugin.js
+++ b/packages/wdio-utils/src/initialisePlugin.js
@@ -7,13 +7,13 @@ import { safeRequire } from './utils'
  * 2. otherwise try to require "@wdio/<name>-<type>"
  * 3. otherwise try to require "wdio-<name>-<type>"
  */
-export default function initialisePlugin (name, type, target = 'default') {
+export default function initialisePlugin (name, type) {
     /**
      * directly import packages that are scoped or start with an absolute path
      */
     if (name[0] === '@' || path.isAbsolute(name)) {
         const service = safeRequire(name)
-        return service[target]
+        return service
     }
 
     /**
@@ -21,7 +21,7 @@ export default function initialisePlugin (name, type, target = 'default') {
      */
     const scopedPlugin = safeRequire(`@wdio/${name.toLowerCase()}-${type}`)
     if (scopedPlugin) {
-        return scopedPlugin[target]
+        return scopedPlugin
     }
 
     /**
@@ -29,7 +29,7 @@ export default function initialisePlugin (name, type, target = 'default') {
      */
     const plugin = safeRequire(`wdio-${name.toLowerCase()}-${type}`)
     if (plugin) {
-        return plugin[target]
+        return plugin
     }
 
     throw new Error(

--- a/packages/wdio-utils/src/initialisePlugin.js
+++ b/packages/wdio-utils/src/initialisePlugin.js
@@ -9,22 +9,17 @@ import { safeRequire } from './utils'
  */
 export default function initialisePlugin (name, type, target = 'default') {
     /**
-     * check plugin for launcher export
-     */
-    const targetCheck = target === 'launcher' && target
-
-    /**
      * directly import packages that are scoped or start with an absolute path
      */
     if (name[0] === '@' || path.isAbsolute(name)) {
-        const service = safeRequire(name, targetCheck)
+        const service = safeRequire(name)
         return service[target]
     }
 
     /**
      * check for scoped version of plugin first (e.g. @wdio/sauce-service)
      */
-    const scopedPlugin = safeRequire(`@wdio/${name.toLowerCase()}-${type}`, targetCheck)
+    const scopedPlugin = safeRequire(`@wdio/${name.toLowerCase()}-${type}`)
     if (scopedPlugin) {
         return scopedPlugin[target]
     }
@@ -32,7 +27,7 @@ export default function initialisePlugin (name, type, target = 'default') {
     /**
      * check for old type of
      */
-    const plugin = safeRequire(`wdio-${name.toLowerCase()}-${type}`, targetCheck)
+    const plugin = safeRequire(`wdio-${name.toLowerCase()}-${type}`)
     if (plugin) {
         return plugin[target]
     }

--- a/packages/wdio-utils/src/initialiseServices.js
+++ b/packages/wdio-utils/src/initialiseServices.js
@@ -17,9 +17,10 @@ function initialiseServices (services) {
          * allow custom services that are already initialised, e.g.
          *
          * ```
-         * services: [{
-         *     beforeTest: () => { ... }
-         * }]
+         * services: [
+         *     [{ beforeTest: () => { ... } }]
+         * ]
+         * ```
          */
         if (typeof serviceName === 'object') {
             log.debug('initialise custom initiated service')

--- a/packages/wdio-utils/src/initialiseServices.js
+++ b/packages/wdio-utils/src/initialiseServices.js
@@ -5,73 +5,153 @@ import initialisePlugin from './initialisePlugin'
 const log = logger('@wdio/utils:initialiseServices')
 
 /**
- * initialise services based on configuration
- * @param  {Object}    config  config of running session
- * @param  {Object}    caps    capabilities of running session
- * @param  {String}    type    define sub type of plugins (for services it could be "launcher")
- * @return {Object[]}          list of service classes that got initialised
+ * Maps list of services of a config file into a list of actionable objects
+ * @param  {Object}    config            config of running session
+ * @param  {Object}    caps              capabilities of running session
+ * @return {[(Object|Class), Object][]}  list of services with their config objects
  */
-export default function initialiseServices (config, caps, type) {
-    config.workerServices = []
+function initialiseServices (services) {
     const initialisedServices = []
-
-    if (!Array.isArray(config.services)) {
-        return initialisedServices
-    }
-
-    for (let serviceName of config.services) {
-        let serviceConfig = {}
-
+    for (let [serviceName, serviceConfig] of services) {
         /**
-         * allow custom services with custom options
+         * allow custom services that are already initialised, e.g.
+         *
+         * ```
+         * services: [{
+         *     beforeTest: () => { ... }
+         * }]
          */
-        if (Array.isArray(serviceName)) {
-            serviceConfig = Object.assign({}, serviceName[1] || {})
-            serviceName = serviceName[0]
+        if (typeof serviceName === 'object') {
+            log.debug('initialise custom initiated service')
+            initialisedServices.push([serviceName, {}])
+            continue
         }
 
         /**
-         * allow custom services that are already initialised
+         * allow custom service classes, e.g.
+         *
+         * ```
+         * class MyService { ... }
+         * ```
+         *
+         * in wdio.conf.js:
+         *
+         * ```
+         * services: [MyService]
+         * ```
          */
-        if (serviceName && typeof serviceName === 'object' && !Array.isArray(serviceName)) {
-            log.debug('initialise custom initiated service')
-            initialisedServices.push(serviceName)
+        if (typeof serviceName === 'function') {
+            log.debug(`initialise custom service "${serviceName.name}"`)
+            initialisedServices.push([serviceName, serviceConfig])
             continue
+        }
+
+        /**
+         * services as NPM packages
+         *
+         * ```
+         * services: ['@wdio/devtools-service']
+         * ```
+         */
+        log.debug(`initialise service "${serviceName}" as NPM package`)
+        const service = initialisePlugin(serviceName, 'service')
+        initialisedServices.push([service, serviceConfig, serviceName])
+    }
+
+    return initialisedServices
+}
+
+/**
+ * formats service array into proper structure which is an array with
+ * the service object as first parameter and the service option as
+ * second parameter
+ * @param  {[Any]} service               list of services from config file
+ * @return {[service, serviceConfig][]}  formatted list of services
+ */
+function sanitizeServiceArray (service) {
+    return Array.isArray(service) ? service : [service, {}]
+}
+
+/**
+ * initialise service for launcher process
+ * @param  {Object}   config  wdio config
+ * @param  {Object[]} caps    list of capabilities
+ * @return {Object}           containing a list of launcher services as well
+ *                            as a list of services that don't need to be
+ *                            required in the worker
+ */
+export function initialiseLauncherService (config, caps) {
+    const ignoredWorkerServices = []
+    const launcherServices = []
+
+    const services = initialiseServices(config.services.map(sanitizeServiceArray))
+    for (const [service, serviceConfig, serviceName] of services) {
+        /**
+         * add object service
+         */
+        if (typeof service === 'object') {
+            return launcherServices.push(service)
         }
 
         try {
             /**
-             * allow custom service classes
+             * add class service
              */
-            if (typeof serviceName === 'function') {
-                log.debug(`initialise custom service "${serviceName.name}"`)
-                initialisedServices.push(new serviceName(serviceConfig, caps, config))
-                continue
-            }
-
-            log.debug(`initialise wdio service "${serviceName}"`)
-            const Service = initialisePlugin(serviceName, 'service', type)
-
-            /**
-             * check if service also exports a default class which would be initiated in the
-             * worker. If not, we can skip importing the service there.
-             */
-            if (initialisePlugin(serviceName, 'service')) {
-                config.workerServices.push(serviceName)
+            if (service.launcher === 'function') {
+                launcherServices.push(new service.launcher(serviceConfig, caps, config))
             }
 
             /**
-             * service only contains a launcher
+             * check if service has a default export
              */
-            if (!Service) {
-                continue
+            if (
+                serviceName &&
+                typeof service.default !== 'function' &&
+                typeof service !== 'function'
+            ) {
+                ignoredWorkerServices.push(serviceName)
             }
-
-            initialisedServices.push(new Service(serviceConfig, caps, config))
-        } catch(e) {
-            log.error(e)
+        } catch (err) {
+            /**
+             * don't break if service can't be initiated
+             */
+            log.error(err)
         }
     }
 
-    return initialisedServices
+    return { ignoredWorkerServices, launcherServices }
+}
+
+/**
+ * initialise services for worker instance
+ * @param  {Object} config                 wdio config
+ * @param  {Object} caps                   worker capabilities
+ * @param  {[type]} ignoredWorkerServices  list of services that don't need to be required in a worker
+ *                                         as they don't export a service for it
+ * @return {Object[]}                      list if worker initiated worker services
+ */
+export function initialiseWorkerService (config, caps, ignoredWorkerServices = []) {
+    const workerServices = config.services
+        .map(sanitizeServiceArray)
+        .filter(([serviceName]) => !ignoredWorkerServices.includes(serviceName))
+
+    const services = initialiseServices(workerServices)
+    return services.map(([service, serviceConfig]) => {
+        /**
+         * add object service
+         */
+        if (typeof service === 'object') {
+            return service
+        }
+
+        try {
+            const Service = service.default || service
+            return new Service(serviceConfig, caps, config)
+        } catch (err) {
+            /**
+             * don't break if service can't be initiated
+             */
+            log.error(err)
+        }
+    })
 }

--- a/packages/wdio-utils/src/initialiseServices.js
+++ b/packages/wdio-utils/src/initialiseServices.js
@@ -12,6 +12,7 @@ const log = logger('@wdio/utils:initialiseServices')
  * @return {Object[]}          list of service classes that got initialised
  */
 export default function initialiseServices (config, caps, type) {
+    config.workerServices = []
     const initialisedServices = []
 
     if (!Array.isArray(config.services)) {
@@ -50,6 +51,14 @@ export default function initialiseServices (config, caps, type) {
 
             log.debug(`initialise wdio service "${serviceName}"`)
             const Service = initialisePlugin(serviceName, 'service', type)
+
+            /**
+             * check if service also exports a default class which would be initiated in the
+             * worker. If not, we can skip importing the service there.
+             */
+            if (initialisePlugin(serviceName, 'service')) {
+                config.workerServices.push(serviceName)
+            }
 
             /**
              * service only contains a launcher

--- a/packages/wdio-utils/src/utils.js
+++ b/packages/wdio-utils/src/utils.js
@@ -1,7 +1,3 @@
-import fs from 'fs'
-
-const EXPORT_REGEX = /(exports\.launcher|export\s(const|let|var)\slauncher)\s*=/g
-
 /**
  * overwrite native element commands with user defined
  * @param {object} propertiesObject propertiesObject
@@ -124,7 +120,7 @@ export function getArgumentType (arg) {
  * @param  {string} name  of package
  * @return {object}       package content
  */
-export function safeRequire (name, targetCheck) {
+export function safeRequire (name) {
     let requirePath
     try {
         /**
@@ -153,22 +149,6 @@ export function safeRequire (name, targetCheck) {
         }
     } catch (e) {
         return null
-    }
-
-    /**
-     * allow to check if a specific target is being exported without importing
-     * the whole service. It checks if the following exports are being made:
-     *
-     * exports.launcher = launcher;
-     * export const launcher = AppiumLauncher
-     * export let launcher = AppiumLauncher
-     * export var launcher = AppiumLauncher
-     */
-    if (targetCheck) {
-        const fileContent = fs.readFileSync(requirePath)
-        if (!fileContent.match(EXPORT_REGEX)) {
-            return {}
-        }
     }
 
     try {

--- a/packages/wdio-utils/src/utils.js
+++ b/packages/wdio-utils/src/utils.js
@@ -1,3 +1,7 @@
+import fs from 'fs'
+
+const EXPORT_REGEX = /(exports\.launcher|export\s(const|let|var)\slauncher)\s*=/g
+
 /**
  * overwrite native element commands with user defined
  * @param {object} propertiesObject propertiesObject
@@ -120,7 +124,7 @@ export function getArgumentType (arg) {
  * @param  {string} name  of package
  * @return {object}       package content
  */
-export function safeRequire (name) {
+export function safeRequire (name, targetCheck) {
     let requirePath
     try {
         /**
@@ -149,6 +153,22 @@ export function safeRequire (name) {
         }
     } catch (e) {
         return null
+    }
+
+    /**
+     * allow to check if a specific target is being exported without importing
+     * the whole service. It checks if the following exports are being made:
+     *
+     * exports.launcher = launcher;
+     * export const launcher = AppiumLauncher
+     * export let launcher = AppiumLauncher
+     * export var launcher = AppiumLauncher
+     */
+    if (targetCheck) {
+        const fileContent = fs.readFileSync(requirePath)
+        if (!fileContent.match(EXPORT_REGEX)) {
+            return {}
+        }
     }
 
     try {

--- a/packages/wdio-utils/tests/__mocks__/@wdio/utils.js
+++ b/packages/wdio-utils/tests/__mocks__/@wdio/utils.js
@@ -58,7 +58,7 @@ const pluginMocks = {
 }
 
 export const initialisePlugin = jest.fn().mockImplementation(
-    (name, type) => pluginMocks[type][name])
+    (name, type) => ({ default: pluginMocks[type][name] }))
 export const initialiseWorkerService = jest.fn().mockReturnValue([])
 export const initialiseLauncherService = jest.fn().mockReturnValue({
     launcherServices: [],

--- a/packages/wdio-utils/tests/__mocks__/@wdio/utils.js
+++ b/packages/wdio-utils/tests/__mocks__/@wdio/utils.js
@@ -59,7 +59,11 @@ const pluginMocks = {
 
 export const initialisePlugin = jest.fn().mockImplementation(
     (name, type) => pluginMocks[type][name])
-export const initialiseServices = jest.fn().mockReturnValue([])
+export const initialiseWorkerService = jest.fn().mockReturnValue([])
+export const initialiseLauncherService = jest.fn().mockReturnValue({
+    launcherServices: [],
+    ignoredWorkerServices: []
+})
 export const isValidParameter = isValidParameterOrig
 export const commandCallStructure = commandCallStructureOrig
 export const isFunctionAsync = isFnAsync

--- a/packages/wdio-utils/tests/initialisePlugin.test.js
+++ b/packages/wdio-utils/tests/initialisePlugin.test.js
@@ -2,43 +2,46 @@ import initialisePlugin from '../src/initialisePlugin'
 
 describe('initialisePlugin', () => {
     it('should allow to load a scoped service plugin', () => {
-        const Service = initialisePlugin('foobar', 'service')
+        const Service = initialisePlugin('foobar', 'service').default
         const service = new Service()
         expect(service.foo).toBe('foobar')
     })
 
     it('should allow to load unscoped service plugin from wdio', () => {
-        const Service = initialisePlugin('@wdio/foobar-service', 'service')
+        const Service = initialisePlugin('@wdio/foobar-service', 'service').default
         const service = new Service()
         expect(service.foo).toBe('foobar')
     })
 
     it('should allow to load unscoped service plugin', () => {
-        const Service = initialisePlugin('test', 'service')
+        const Service = initialisePlugin('test', 'service').default
         const service = new Service()
         expect(service.foo).toBe('bar')
     })
 
     it('should allow to load scoped services', () => {
-        const Service = initialisePlugin('@saucelabs/wdio-foobar-reporter', 'reporter')
+        const Service = initialisePlugin('@saucelabs/wdio-foobar-reporter', 'reporter').default
         const service = new Service()
         expect(service.foo).toBe('barfoo')
     })
 
     it('should allow to load service referenced with an absolute path', () => {
-        const Service = initialisePlugin(require.resolve(__dirname + '/__mocks__/@saucelabs/wdio-foobar-reporter'))
+        const path = require.resolve(__dirname + '/__mocks__/@saucelabs/wdio-foobar-reporter')
+        const Service = initialisePlugin(path).default
         const service = new Service()
         expect(service.foo).toBe('barfoo')
     })
 
     it('should prefer scoped over unscoped packages', () => {
-        const Service = initialisePlugin('scoped', 'service')
+        const Service = initialisePlugin('scoped', 'service').default
         const service = new Service()
         expect(service.isScoped).toBe(true)
     })
 
     it('should throw meaningful error message', () => {
-        expect(() => initialisePlugin('lala', 'service')).toThrow(/Please make sure you have it installed!/)
-        expect(() => initialisePlugin('borked', 'framework')).toThrow(/Error: foobar/)
+        expect(() => initialisePlugin('lala', 'service'))
+            .toThrow(/Please make sure you have it installed!/)
+        expect(() => initialisePlugin('borked', 'framework'))
+            .toThrow(/Error: foobar/)
     })
 })

--- a/packages/wdio-utils/tests/initialiseServices.test.js
+++ b/packages/wdio-utils/tests/initialiseServices.test.js
@@ -83,6 +83,15 @@ describe('initialiseLauncherService', () => {
         expect(ignoredWorkerServices).toEqual(['launcher-only'])
     })
 
+    it('should ignore worker services', () => {
+        const {
+            launcherServices,
+            ignoredWorkerServices
+        } = initialiseLauncherService({ services: ['scoped'] })
+        expect(launcherServices).toHaveLength(0)
+        expect(ignoredWorkerServices).toHaveLength(0)
+    })
+
     it('should not fail if service is borked', () => {
         const {
             launcherServices,


### PR DESCRIPTION
## Problem

Currently we require a service module within the worker process even we don't need it there (e.g. Chromedriver service). This causes quit some memory hog. See also #4623.

Let's allow services to define where they are suppose to be used (in the main launcher process or in the worker process or maybe in both). We need to expose this information so that we don't need to require the whole module in the worker.