### PR TITLE
wdio-browserstack-service: fix test session status

### DIFF
--- a/packages/wdio-browserstack-service/src/service.js
+++ b/packages/wdio-browserstack-service/src/service.js
@@ -86,7 +86,7 @@ export default class BrowserstackService {
 
     _getBody() {
         return {
-            status: this.failures === 0 ? 'completed' : 'error',
+            status: this.failures === 0 ? 'passed' : 'failed',
             name: this.fullTitle,
             reason: this.failReason
         }

--- a/packages/wdio-browserstack-service/tests/service.test.js
+++ b/packages/wdio-browserstack-service/tests/service.test.js
@@ -265,7 +265,7 @@ describe('after', () => {
         const json = {
             name: undefined,
             reason: undefined,
-            status: 'completed',
+            status: 'passed',
         }
         expect(got.put).toHaveBeenCalledWith(
             'https://api.browserstack.com/automate/sessions/session123.json',
@@ -276,17 +276,17 @@ describe('after', () => {
 })
 
 describe('_getBody', () => {
-    it('should return "error" if failures', () => {
+    it('should return "failed" if failures', () => {
         service.failures = 1
         service.failReason = 'error message'
         service.fullTitle = 'foo - bar'
-        expect(service._getBody()).toEqual({ status: 'error', reason: 'error message', name: 'foo - bar' })
+        expect(service._getBody()).toEqual({ status: 'failed', reason: 'error message', name: 'foo - bar' })
     })
 
-    it('should return "completed" if no errors', () => {
+    it('should return "passed" if no errors', () => {
         service.failures = 0
         service.fullTitle = 'foo - bar'
 
-        expect(service._getBody()).toEqual({ status: 'completed', name: 'foo - bar', reason: undefined })
+        expect(service._getBody()).toEqual({ status: 'passed', name: 'foo - bar', reason: undefined })
     })
 })


### PR DESCRIPTION
## Proposed changes
BrowserStack sessions are left as "UNMARKED" even if a session passes. A recent change to the BrowserStack UI separates the Status (Running/Complete/Timeout) from the REST-API status (Passed/Failed/Unmarked), making this more apparent.

According to the BrowserStack Rest-API docs ([Link](https://www.browserstack.com/automate/rest-api#rest-api-sessions)), the value for the status key should either be "passed" or "failed", not "completed" or "error"

> **Mark tests as passed or failed**
You can mark tests as passed or failed, using PUT.

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
