### PR TITLE
[#4949] WIP: fix: transpile once only

### DIFF
--- a/packages/wdio-cucumber-framework/src/index.js
+++ b/packages/wdio-cucumber-framework/src/index.js
@@ -73,9 +73,14 @@ class CucumberAdapter {
         let result
 
         try {
+            // we need tp ensure that we don't run the registration code
+            // multiple times, otherwise we will get duplicated transpilations
+            // we also need to make sure that we only require spec files once
+            // otherwise they will be transpiled each time they are required
+            if(!global.supportCodeLibrary) {
+                // indentation is deliberately off so the diff is minimal
             this.registerRequiredModules()
             Cucumber.supportCodeLibraryBuilder.reset(this.cwd)
-
             /**
              * wdio hooks should be added before spec files are loaded
              */
@@ -89,7 +94,8 @@ class CucumberAdapter {
              */
             setUserHookNames(Cucumber.supportCodeLibraryBuilder.options)
             Cucumber.setDefaultTimeout(this.cucumberOpts.timeout)
-            const supportCodeLibrary = Cucumber.supportCodeLibraryBuilder.finalize()
+            global.supportCodeLibrary = Cucumber.supportCodeLibraryBuilder.finalize()
+            }
 
             /**
              * gets current step data: `{ uri, feature, scenario, step, sourceLocation }`
@@ -102,7 +108,7 @@ class CucumberAdapter {
             const runtime = new Cucumber.Runtime({
                 eventBroadcaster: this.eventBroadcaster,
                 options: this.cucumberOpts,
-                supportCodeLibrary,
+                supportCodeLibrary: global.supportCodeLibrary,
                 testCases: this.testCases
             })
 

--- a/packages/wdio-runner/src/reporter.js
+++ b/packages/wdio-runner/src/reporter.js
@@ -15,10 +15,11 @@ const DEFAULT_SYNC_INTERVAL = 100 // 100ms
  * to all these reporters
  */
 export default class BaseReporter {
-    constructor (config, cid, caps) {
+    constructor (config, cid, caps, target) {
         this.config = config
         this.cid = cid
         this.caps = caps
+        this.target = target
 
         /**
          * these configurations are not publicly documented as there should be no desire for it
@@ -43,7 +44,7 @@ export default class BaseReporter {
         /**
          * Send failure message (only once) in case of test or hook failure
          */
-        sendFailureMessage(e, payload)
+        sendFailureMessage(e, payload, this.target)
 
         this.reporters.forEach((reporter) => reporter.emit(e, payload))
     }
@@ -88,7 +89,7 @@ export default class BaseReporter {
      */
     getWriteStreamObject (reporter) {
         return {
-            write: /* istanbul ignore next */ (content) => process.send({
+            write: /* istanbul ignore next */ (content) => this.target.send({
                 origin: 'reporter',
                 name: reporter,
                 content

--- a/packages/wdio-runner/src/utils.js
+++ b/packages/wdio-runner/src/utils.js
@@ -108,9 +108,9 @@ export function filterLogTypes(excludeDriverLogs, driverLogTypes) {
  * @param {string} e        event
  * @param {object} payload  payload
  */
-export function sendFailureMessage(e, payload) {
+export function sendFailureMessage(e, payload, target) {
     if (e === 'test:fail' || (e === 'hook:end' && payload.error && mochaAllHooks.some(hook => payload.title.startsWith(hook)))) {
-        process.send({
+        target.send({
             origin: 'reporter',
             name: 'printFailureMessage',
             content: payload


### PR DESCRIPTION
This PR exemplifies potential changes to fix the issue described in #4949.

It is a WIP and is there to discuss how this can be made to work in a better way.
The general gist is:

* it removes the child process used for the test execution
* it injects a dependency into all packages that assume to be executed in a child process which use `process.send` to communicate with the parent process that is used instead for communication.
* Reporting works as expected in contrary to #4974