### PR TITLE
webdriverio: Fix 'oject' typo in click command

### DIFF
--- a/packages/webdriverio/src/commands/element/click.js
+++ b/packages/webdriverio/src/commands/element/click.js
@@ -75,7 +75,7 @@ export default async function click(options) {
     }
 
     if (typeof options !== 'object' || Array.isArray(options)) {
-        throw new TypeError('Options must be an oject')
+        throw new TypeError('Options must be an object')
     }
 
     let {

--- a/packages/webdriverio/tests/commands/element/click.test.js
+++ b/packages/webdriverio/tests/commands/element/click.test.js
@@ -303,7 +303,7 @@ describe('click test', () => {
         })
         const elem = await browser.$('#foo')
 
-        expect(elem.click([])).rejects.toThrow('Options must be an oject')
+        expect(elem.click([])).rejects.toThrow('Options must be an object')
     })
 
     it('should throw an error if no valid coördicates are passed', async () => {


### PR DESCRIPTION
## Proposed changes

Fix for a little typo both in command and tests.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have **fixed** tests that prove my fix is effective or that my feature works

## Further comments

### Reviewers: @webdriverio/technical-committee
