### PR TITLE
Devtools: Make puppeteer-firefox optional in status.js

### DIFF
--- a/packages/devtools/src/commands/status.js
+++ b/packages/devtools/src/commands/status.js
@@ -2,8 +2,23 @@ import path from 'path'
 
 const puppeteerPath = require.resolve('puppeteer-core')
 const puppeteerPkg = require(`${path.dirname(puppeteerPath)}/package.json`)
-const puppeteerFirefoxPath = require.resolve('puppeteer-firefox')
-const puppeteerFirefoxPkg = require(`${path.dirname(puppeteerFirefoxPath)}/package.json`)
+
+let puppeteerFirefoxPath
+let puppeteerFirefoxPkg
+
+try {
+    puppeteerFirefoxPath = require.resolve('puppeteer-firefox')
+} catch (error) {
+    /*
+     * puppeteer-firefox is an optional dependency and we expect to ignore
+     * an error from require.resolve if it's not installed
+     */
+}
+
+// Only require puppeteer-firefox package.json if it's installed
+puppeteerFirefoxPkg = (puppeteerFirefoxPath) ?
+    require(`${path.dirname(puppeteerFirefoxPath)}/package.json`) :
+    {}
 
 export default async function status () {
     return {


### PR DESCRIPTION
## Proposed changes

Fix #4992 by updating status.js so that no error is thrown if puppeteer-firefox is not installed (as it's supposed to be optional now that #4481 is closed)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments
I didn't see any existing tests around status.js, so I assumed they are out of scope for this change.

### Reviewers: @webdriverio/technical-committee
