### PR TITLE
Use "devtools" automation protocol as fallback

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,6 +68,9 @@ matrix:
       addons:
         chrome: stable
         firefox: latest
+      before_script:
+        - "export DISPLAY=:99.0"
+        - "sh -e /etc/init.d/xvfb start"
       script: npx run-s test:e2e
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,14 @@ node_js:
   - 10
   - 12
 
+os:
+  - linux
+  - osx
+  - windows
+
 addons:
   chrome: stable
+  firefox: latest
 
 script:
   - npm run ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ matrix:
       addons:
         chrome: stable
         firefox: latest
-      before_script:
+      before_install:
         - "export DISPLAY=:99.0"
         - "sh -e /etc/init.d/xvfb start"
       script: npx run-s test:e2e

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,6 +86,8 @@ matrix:
       name: 'e2e Tests (Windows)'
       os: windows
 
+allow_failures:
+    - name: 'e2e Tests (Windows)'
 
 deploy:
   provider: script

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,49 @@
 dist: xenial
 language: node_js
 
+cache:
+  directories:
+    - node_modules
+    - packages/devtools/node_modules
+    - packages/eslint-plugin-wdio/node_modules
+    - packages/node_modules/node_modules
+    - packages/wdio-allure-reporter/node_modules
+    - packages/wdio-appium-service/node_modules
+    - packages/wdio-applitools-service/node_modules
+    - packages/wdio-browserstack-service/node_modules
+    - packages/wdio-cli/node_modules
+    - packages/wdio-concise-reporter/node_modules
+    - packages/wdio-config/node_modules
+    - packages/wdio-crossbrowsertesting-service/node_modules
+    - packages/wdio-cucumber-framework/node_modules
+    - packages/wdio-devtools-service/node_modules
+    - packages/wdio-dot-reporter/node_modules
+    - packages/wdio-firefox-profile-service/node_modules
+    - packages/wdio-jasmine-framework/node_modules
+    - packages/wdio-junit-reporter/node_modules
+    - packages/wdio-lambda-runner/node_modules
+    - packages/wdio-local-runner/node_modules
+    - packages/wdio-logger/node_modules
+    - packages/wdio-mocha-framework/node_modules
+    - packages/wdio-protocols/node_modules
+    - packages/wdio-repl/node_modules
+    - packages/wdio-reporter/node_modules
+    - packages/wdio-runner/node_modules
+    - packages/wdio-sauce-service/node_modules
+    - packages/wdio-selenium-standalone-service/node_modules
+    - packages/wdio-shared-store-service/node_modules
+    - packages/wdio-smoke-test-reporter/node_modules
+    - packages/wdio-smoke-test-service/node_modules
+    - packages/wdio-spec-reporter/node_modules
+    - packages/wdio-static-server-service/node_modules
+    - packages/wdio-sumologic-reporter/node_modules
+    - packages/wdio-sync/node_modules
+    - packages/wdio-testingbot-service/node_modules
+    - packages/wdio-utils/node_modules
+    - packages/wdio-webdriver-mock-service/node_modules
+    - packages/webdriver/node_modules
+    - packages/webdriverio/node_modules
+
 base_setup: &base_setup
   node_js:
     - 10

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,17 @@
 dist: xenial
 language: node_js
 
+cache:
+  directories:
+    - node_modules
+
 base_setup: &base_setup
   node_js:
     - 10
     - 12
   before_script:
     - npx lerna bootstrap --no-ci
-    - npx run-s build-full
+    - npx run-s build-full link
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,20 +5,30 @@ node_js:
   - 10
   - 12
 
-os:
-  - linux
-  - osx
-  - windows
-
-addons:
-  chrome: stable
-  firefox: latest
-
-script:
-  - npm run ci
-
-after_script:
-  - ./node_modules/.bin/codecov
+matrix:
+  fast_finish: true
+  include:
+    - name: 'Linter'
+      os: linux
+      script: npx run-s test:eslint test:typings
+    - name: 'Unit Tests'
+      os: linux
+      script: echo "Run unit tests" # npx run-s test:coverage
+      after_script:
+        - ./node_modules/.bin/codecov
+    - name: 'Integration Tests'
+      os: linux
+      before_script: npm run link
+      script: echo "Run integration tests" # npx run-s test:smoke
+    - name: 'e2e Tests'
+      os:
+        - linux
+        - osx
+        - windows
+      addons:
+        chrome: stable
+        firefox: latest
+      script: npx run-s test:e2e
 
 deploy:
   provider: script

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,25 +52,40 @@ base_setup: &base_setup
     - npx lerna bootstrap --no-ci
     - npx run-s build-full link
 
+e2e_setup: &e2e_setup
+  addons:
+    chrome: stable
+    firefox: latest
+  services:
+    - xvfb
+  script: npx run-s test:e2e
+
 matrix:
   fast_finish: true
   include:
     - <<: *base_setup
-      name: 'CI Tests'
+      name: 'CI Tests (Node v10)'
       os: linux
+      node_js: 10
       script: npm run ci
     - <<: *base_setup
-      name: 'e2e Tests'
-      os:
-        - linux
-        - osx
-        - windows
-      addons:
-        chrome: stable
-        firefox: latest
-      services:
-        - xvfb
-      script: npx run-s test:e2e
+      name: 'CI Tests (Node v12)'
+      os: linux
+      node_js: 12
+      script: npm run ci
+    - <<: *base_setup
+      <<: *e2e_setup
+      name: 'e2e Tests (Linux)'
+      os: linux
+    - <<: *base_setup
+      <<: *e2e_setup
+      name: 'e2e Tests (OSX)'
+      os: osx
+    - <<: *base_setup
+      <<: *e2e_setup
+      name: 'e2e Tests (Windows)'
+      os: windows
+
 
 deploy:
   provider: script

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,9 +68,8 @@ matrix:
       addons:
         chrome: stable
         firefox: latest
-      before_install:
-        - "export DISPLAY=:99.0"
-        - "sh -e /etc/init.d/xvfb start"
+      services:
+        - xvfb
       script: npx run-s test:e2e
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,13 +38,11 @@ matrix:
       <<: *e2e_setup
       name: 'e2e Tests (OSX)'
       os: osx
-    - <<: *base_setup
-      <<: *e2e_setup
-      name: 'e2e Tests (Windows)'
-      os: windows
-
-allow_failures:
-    - name: 'e2e Tests (Windows)'
+    # Windows on Travis is not stable enough yet
+    # - <<: *base_setup
+    #   <<: *e2e_setup
+    #   name: 'e2e Tests (Windows)'
+    #   os: windows
 
 deploy:
   provider: script

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,49 +1,6 @@
 dist: xenial
 language: node_js
 
-cache:
-  directories:
-    - node_modules
-    - packages/devtools/node_modules
-    - packages/eslint-plugin-wdio/node_modules
-    - packages/node_modules/node_modules
-    - packages/wdio-allure-reporter/node_modules
-    - packages/wdio-appium-service/node_modules
-    - packages/wdio-applitools-service/node_modules
-    - packages/wdio-browserstack-service/node_modules
-    - packages/wdio-cli/node_modules
-    - packages/wdio-concise-reporter/node_modules
-    - packages/wdio-config/node_modules
-    - packages/wdio-crossbrowsertesting-service/node_modules
-    - packages/wdio-cucumber-framework/node_modules
-    - packages/wdio-devtools-service/node_modules
-    - packages/wdio-dot-reporter/node_modules
-    - packages/wdio-firefox-profile-service/node_modules
-    - packages/wdio-jasmine-framework/node_modules
-    - packages/wdio-junit-reporter/node_modules
-    - packages/wdio-lambda-runner/node_modules
-    - packages/wdio-local-runner/node_modules
-    - packages/wdio-logger/node_modules
-    - packages/wdio-mocha-framework/node_modules
-    - packages/wdio-protocols/node_modules
-    - packages/wdio-repl/node_modules
-    - packages/wdio-reporter/node_modules
-    - packages/wdio-runner/node_modules
-    - packages/wdio-sauce-service/node_modules
-    - packages/wdio-selenium-standalone-service/node_modules
-    - packages/wdio-shared-store-service/node_modules
-    - packages/wdio-smoke-test-reporter/node_modules
-    - packages/wdio-smoke-test-service/node_modules
-    - packages/wdio-spec-reporter/node_modules
-    - packages/wdio-static-server-service/node_modules
-    - packages/wdio-sumologic-reporter/node_modules
-    - packages/wdio-sync/node_modules
-    - packages/wdio-testingbot-service/node_modules
-    - packages/wdio-utils/node_modules
-    - packages/wdio-webdriver-mock-service/node_modules
-    - packages/webdriver/node_modules
-    - packages/webdriverio/node_modules
-
 base_setup: &base_setup
   node_js:
     - 10

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,15 @@
 dist: xenial
 language: node_js
 
-node_js:
-  - 10
-  - 12
-
 matrix:
   fast_finish: true
   include:
-    - name: 'Linter'
+    - name: 'CI Tests'
       os: linux
-      script: npx run-s test:eslint test:typings
-    - name: 'Unit Tests'
-      os: linux
-      script: echo "Run unit tests" # npx run-s test:coverage
-      after_script:
-        - ./node_modules/.bin/codecov
-    - name: 'Integration Tests'
-      os: linux
-      before_script: npm run link
-      script: echo "Run integration tests" # npx run-s test:smoke
+      node_js:
+        - 10
+        - 12
+      script: npm run ci
     - name: 'e2e Tests'
       os:
         - linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,9 +55,9 @@ base_setup: &base_setup
 e2e_setup: &e2e_setup
   addons:
     chrome: stable
-    firefox: latest
   services:
     - xvfb
+  before_script: apt install firefox
   script: npx run-s test:e2e
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,9 @@ e2e_setup: &e2e_setup
     chrome: stable
   services:
     - xvfb
-  before_script: apt install firefox
+  before_script:
+    - sudo apt install firefox
+    - firefox --version
   script: npx run-s test:e2e
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,11 +55,9 @@ base_setup: &base_setup
 e2e_setup: &e2e_setup
   addons:
     chrome: stable
+    firefox: latest-nightly
   services:
     - xvfb
-  before_script:
-    - sudo apt install firefox
-    - firefox --version
   script: npx run-s test:e2e
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,45 @@ language: node_js
 cache:
   directories:
     - node_modules
+    - packages/devtools/node_modules
+    - packages/eslint-plugin-wdio/node_modules
+    - packages/node_modules/node_modules
+    - packages/wdio-allure-reporter/node_modules
+    - packages/wdio-appium-service/node_modules
+    - packages/wdio-applitools-service/node_modules
+    - packages/wdio-browserstack-service/node_modules
+    - packages/wdio-cli/node_modules
+    - packages/wdio-concise-reporter/node_modules
+    - packages/wdio-config/node_modules
+    - packages/wdio-crossbrowsertesting-service/node_modules
+    - packages/wdio-cucumber-framework/node_modules
+    - packages/wdio-devtools-service/node_modules
+    - packages/wdio-dot-reporter/node_modules
+    - packages/wdio-firefox-profile-service/node_modules
+    - packages/wdio-jasmine-framework/node_modules
+    - packages/wdio-junit-reporter/node_modules
+    - packages/wdio-lambda-runner/node_modules
+    - packages/wdio-local-runner/node_modules
+    - packages/wdio-logger/node_modules
+    - packages/wdio-mocha-framework/node_modules
+    - packages/wdio-protocols/node_modules
+    - packages/wdio-repl/node_modules
+    - packages/wdio-reporter/node_modules
+    - packages/wdio-runner/node_modules
+    - packages/wdio-sauce-service/node_modules
+    - packages/wdio-selenium-standalone-service/node_modules
+    - packages/wdio-shared-store-service/node_modules
+    - packages/wdio-smoke-test-reporter/node_modules
+    - packages/wdio-smoke-test-service/node_modules
+    - packages/wdio-spec-reporter/node_modules
+    - packages/wdio-static-server-service/node_modules
+    - packages/wdio-sumologic-reporter/node_modules
+    - packages/wdio-sync/node_modules
+    - packages/wdio-testingbot-service/node_modules
+    - packages/wdio-utils/node_modules
+    - packages/wdio-webdriver-mock-service/node_modules
+    - packages/webdriver/node_modules
+    - packages/webdriverio/node_modules
 
 base_setup: &base_setup
   node_js:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,24 @@
 dist: xenial
 language: node_js
 
+base_setup: &base_setup
+  before_script:
+    - npx lerna bootstrap --no-ci
+    - npx run-s build-full
+
+node_js:
+  - 10
+  - 12
+
 matrix:
   fast_finish: true
   include:
-    - name: 'CI Tests'
+    - <<: *base_setup
+      name: 'CI Tests'
       os: linux
-      node_js:
-        - 10
-        - 12
       script: npm run ci
-    - name: 'e2e Tests'
+    - <<: *base_setup
+      name: 'e2e Tests'
       os:
         - linux
         - osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,12 @@ dist: xenial
 language: node_js
 
 base_setup: &base_setup
+  node_js:
+    - 10
+    - 12
   before_script:
     - npx lerna bootstrap --no-ci
     - npx run-s build-full
-
-node_js:
-  - 10
-  - 12
 
 matrix:
   fast_finish: true

--- a/e2e/.eslintrc
+++ b/e2e/.eslintrc
@@ -3,6 +3,7 @@
     "jest": true
   },
   "globals": {
-    "browser": true
+    "browser": true,
+    "$": true
   }
 }

--- a/e2e/jest.config.js
+++ b/e2e/jest.config.js
@@ -1,7 +1,9 @@
 module.exports = {
+    testRunner: 'jest-circus/runner',
     testEnvironment: 'node',
     testMatch: [
         '<rootDir>/*.test.js'
     ],
-    moduleFileExtensions: ['js', 'ts']
+    moduleFileExtensions: ['js', 'ts'],
+    setupFilesAfterEnv: ['./jest.setup.js']
 }

--- a/e2e/jest.setup.js
+++ b/e2e/jest.setup.js
@@ -1,4 +1,2 @@
-beforeAll(async () => {
-    jest.setTimeout(1000 * 60)
-    jest.retryTimes(2)
-})
+jest.setTimeout(1000 * 60)
+jest.retryTimes(2)

--- a/e2e/jest.setup.js
+++ b/e2e/jest.setup.js
@@ -1,0 +1,4 @@
+beforeAll(async () => {
+    jest.setTimeout(1000 * 60)
+    jest.retryTimes(2)
+})

--- a/e2e/testrunner.test.js
+++ b/e2e/testrunner.test.js
@@ -1,8 +1,6 @@
 import assert from 'assert'
 import Launcher from '../packages/wdio-cli/src/launcher.js'
 
-jest.setTimeout(1000 * 60)
-
 test('should allow to run multiple browser at once', async () => {
     const launcher = new Launcher(`${__dirname}/wdio/wdio.conf.js`)
     const failures = await launcher.run()

--- a/e2e/testrunner.test.js
+++ b/e2e/testrunner.test.js
@@ -11,7 +11,8 @@ test('should allow to run multiple browser at once', async () => {
      * print log files for debugging if test fails
      */
     if (!hasPassed) {
-        const logFiles = fs.readdirSync(path.join(__dirname, 'wdio')).filter((file) => (
+        const rootPath = path.join(__dirname, 'wdio')
+        const logFiles = fs.readdirSync(rootPath).filter((file) => (
             // only log files
             file.endsWith('.log')
         ))
@@ -19,7 +20,7 @@ test('should allow to run multiple browser at once', async () => {
             // eslint-disable-next-line no-console
             console.log(`\n========== LOG OUPUT ${fileName}`)
             // eslint-disable-next-line no-console
-            console.log(fs.readFileSync(path.resolve(__dirname, fileName)).toString())
+            console.log(fs.readFileSync(path.resolve(rootPath, fileName)).toString())
         }
     }
 

--- a/e2e/testrunner.test.js
+++ b/e2e/testrunner.test.js
@@ -1,8 +1,27 @@
-import assert from 'assert'
+import fs from 'fs'
+import path from 'path'
 import Launcher from '../packages/wdio-cli/src/launcher.js'
 
 test('should allow to run multiple browser at once', async () => {
     const launcher = new Launcher(`${__dirname}/wdio/wdio.conf.js`)
     const failures = await launcher.run()
-    assert.equal(failures, 0)
+    const hasPassed = failures === 0
+
+    /**
+     * print log files for debugging if test fails
+     */
+    if (!hasPassed) {
+        const logFiles = fs.readdirSync(path.join(__dirname, 'wdio')).filter((file) => (
+            // only log files
+            file.endsWith('.log')
+        ))
+        for (const fileName of logFiles) {
+            // eslint-disable-next-line no-console
+            console.log(`\n========== LOG OUPUT ${fileName}`)
+            // eslint-disable-next-line no-console
+            console.log(fs.readFileSync(path.resolve(__dirname, fileName)).toString())
+        }
+    }
+
+    expect(hasPassed).toBe(true)
 })

--- a/e2e/testrunner.test.js
+++ b/e2e/testrunner.test.js
@@ -12,10 +12,10 @@ test('should allow to run multiple browser at once', async () => {
      */
     if (!hasPassed) {
         const rootPath = path.join(__dirname, 'wdio')
-        const logFiles = fs.readdirSync(rootPath).filter((file) => (
+        const logFiles = fs.readdirSync(rootPath)
             // only log files
-            file.endsWith('.log')
-        ))
+            .filter((file) => file.endsWith('.log'))
+
         for (const fileName of logFiles) {
             // eslint-disable-next-line no-console
             console.log(`\n========== LOG OUPUT ${fileName}`)

--- a/e2e/wdio/secondTest.e2e.js
+++ b/e2e/wdio/secondTest.e2e.js
@@ -1,8 +1,7 @@
-const assert = require('assert')
-
 describe('main suite 1', () => {
     it('foobar test', () => {
-        browser.url('http://guinea-pig.webdriver.io')
-        assert.equal(browser.getTitle(), 'WebdriverJS Testpage')
+        const browserName = browser.capabilities.browserName.replace('Headless', '').trim()
+        browser.url('http://guinea-pig.webdriver.io/')
+        expect($('#useragent')).toHaveTextContaining(browserName)
     })
 })

--- a/e2e/wdio/test.e2e.js
+++ b/e2e/wdio/test.e2e.js
@@ -1,8 +1,7 @@
-const assert = require('assert')
-
 describe('main suite 1', () => {
     it('foobar test', () => {
-        browser.url('http://guinea-pig.webdriver.io')
-        assert.equal(browser.getTitle(), 'WebdriverJS Testpage')
+        const browserName = browser.capabilities.browserName.replace('Headless', '').trim()
+        browser.url('http://guinea-pig.webdriver.io/')
+        expect($('#useragent')).toHaveTextContaining(browserName)
     })
 })

--- a/e2e/wdio/wdio.conf.js
+++ b/e2e/wdio/wdio.conf.js
@@ -11,10 +11,10 @@ exports.config = {
      */
     capabilities: [{
         browserName: 'chrome',
-        'goog:chromeOptions': { headless: true }
+        'goog:chromeOptions': { headless: true, dumpio: true }
     }, {
         browserName: 'firefox',
-        'moz:firefoxOptions': { headless: true }
+        'moz:firefoxOptions': { headless: true, dumpio: true }
     }],
 
     /**

--- a/e2e/wdio/wdio.conf.js
+++ b/e2e/wdio/wdio.conf.js
@@ -22,8 +22,6 @@ exports.config = {
      */
     logLevel: 'trace',
     framework: 'mocha',
-    outputDir: __dirname,
-
     reporters: ['spec'],
 
     mochaOpts: {

--- a/e2e/wdio/wdio.conf.js
+++ b/e2e/wdio/wdio.conf.js
@@ -13,7 +13,7 @@ exports.config = {
         browserName: 'chrome',
         'goog:chromeOptions': { headless: true }
     }, {
-        browserName: 'firefox',
+        browserName: 'chrome',
         'goog:chromeOptions': { headless: true }
     }],
 
@@ -22,6 +22,8 @@ exports.config = {
      */
     logLevel: 'trace',
     framework: 'mocha',
+    outputDir: __dirname,
+
     reporters: ['spec'],
 
     mochaOpts: {

--- a/e2e/wdio/wdio.conf.js
+++ b/e2e/wdio/wdio.conf.js
@@ -2,11 +2,6 @@ const path = require('path')
 
 exports.config = {
     /**
-     * run tests with devtools
-     */
-    automationProtocol: 'devtools',
-
-    /**
      * specify test files
      */
     specs: [path.resolve(__dirname, '*.e2e.js')],
@@ -18,13 +13,7 @@ exports.config = {
         browserName: 'chrome',
         'goog:chromeOptions': { headless: true }
     }, {
-        browserName: 'chrome',
-        'goog:chromeOptions': { headless: true }
-    }, {
-        browserName: 'chrome',
-        'goog:chromeOptions': { headless: true }
-    }, {
-        browserName: 'chrome',
+        browserName: 'firefox',
         'goog:chromeOptions': { headless: true }
     }],
 

--- a/e2e/wdio/wdio.conf.js
+++ b/e2e/wdio/wdio.conf.js
@@ -13,8 +13,8 @@ exports.config = {
         browserName: 'chrome',
         'goog:chromeOptions': { headless: true }
     }, {
-        browserName: 'chrome',
-        'goog:chromeOptions': { headless: true }
+        browserName: 'firefox',
+        'moz:firefoxOptions': { headless: true }
     }],
 
     /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1140,6 +1140,66 @@
         }
       }
     },
+    "@istanbuljs/load-nyc-config": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.0.0.tgz",
+      "integrity": "sha512-ZR0rq/f/E4f4XcgnDvtMWXCUJpi8eO0rssVhmztsZqLIEFA9UUP9zmpE0VxlM+kv/E1ul2I876Fwil2ayptDVg==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.3.1",
+        "find-up": "^4.1.0",
+        "js-yaml": "^3.13.1",
+        "resolve-from": "^5.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "resolve-from": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+          "dev": true
+        }
+      }
+    },
+    "@istanbuljs/schema": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.2.tgz",
+      "integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==",
+      "dev": true
+    },
     "@jest/console": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/@jest/console/-/console-24.9.0.tgz",
@@ -2874,6 +2934,15 @@
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
       "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
       "dev": true
+    },
+    "@sinonjs/commons": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.0.tgz",
+      "integrity": "sha512-qbk9AP+cZUsKdW1GJsBpxPKFmCJ0T8swwzVje3qFd+AkQb74Q/tiuzrdfFg8AD2g5HH/XbE/I8Uc1KYHVYWfhg==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
     },
     "@szmarczak/http-timer": {
       "version": "1.1.2",
@@ -4669,6 +4738,12 @@
       "version": "1.12.7",
       "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
       "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw==",
+      "dev": true
+    },
+    "collect-v8-coverage": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.0.tgz",
+      "integrity": "sha512-VKIhJgvk8E1W28m5avZ2Gv2Ruv5YiF56ug2oclvaG9md69BuZImMG2sk9g7QNKLUbtYAKQjXjYxbYZVUlMMKmQ==",
       "dev": true
     },
     "collection-visit": {
@@ -9345,6 +9420,529 @@
         "throat": "^4.0.0"
       }
     },
+    "jest-circus": {
+      "version": "25.1.0",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-25.1.0.tgz",
+      "integrity": "sha512-Axlcr2YMxVarMW4SiZhCFCjNKhdF4xF9AIdltyutQOKyyDT795Kl/fzI95O0l8idE51Npj2wDj5GhrV7uEoEJA==",
+      "dev": true,
+      "requires": {
+        "@babel/traverse": "^7.1.0",
+        "@jest/environment": "^25.1.0",
+        "@jest/test-result": "^25.1.0",
+        "@jest/types": "^25.1.0",
+        "chalk": "^3.0.0",
+        "co": "^4.6.0",
+        "expect": "^25.1.0",
+        "is-generator-fn": "^2.0.0",
+        "jest-each": "^25.1.0",
+        "jest-matcher-utils": "^25.1.0",
+        "jest-message-util": "^25.1.0",
+        "jest-snapshot": "^25.1.0",
+        "jest-util": "^25.1.0",
+        "pretty-format": "^25.1.0",
+        "stack-utils": "^1.0.1",
+        "throat": "^5.0.0"
+      },
+      "dependencies": {
+        "@jest/console": {
+          "version": "25.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/console/-/console-25.1.0.tgz",
+          "integrity": "sha512-3P1DpqAMK/L07ag/Y9/Jup5iDEG9P4pRAuZiMQnU0JB3UOvCyYCjCoxr7sIA80SeyUCUKrr24fKAxVpmBgQonA==",
+          "dev": true,
+          "requires": {
+            "@jest/source-map": "^25.1.0",
+            "chalk": "^3.0.0",
+            "jest-util": "^25.1.0",
+            "slash": "^3.0.0"
+          }
+        },
+        "@jest/environment": {
+          "version": "25.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-25.1.0.tgz",
+          "integrity": "sha512-cTpUtsjU4cum53VqBDlcW0E4KbQF03Cn0jckGPW/5rrE9tb+porD3+hhLtHAwhthsqfyF+bizyodTlsRA++sHg==",
+          "dev": true,
+          "requires": {
+            "@jest/fake-timers": "^25.1.0",
+            "@jest/types": "^25.1.0",
+            "jest-mock": "^25.1.0"
+          }
+        },
+        "@jest/fake-timers": {
+          "version": "25.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-25.1.0.tgz",
+          "integrity": "sha512-Eu3dysBzSAO1lD7cylZd/CVKdZZ1/43SF35iYBNV1Lvvn2Undp3Grwsv8PrzvbLhqwRzDd4zxrY4gsiHc+wygQ==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^25.1.0",
+            "jest-message-util": "^25.1.0",
+            "jest-mock": "^25.1.0",
+            "jest-util": "^25.1.0",
+            "lolex": "^5.0.0"
+          }
+        },
+        "@jest/source-map": {
+          "version": "25.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-25.1.0.tgz",
+          "integrity": "sha512-ohf2iKT0xnLWcIUhL6U6QN+CwFWf9XnrM2a6ybL9NXxJjgYijjLSitkYHIdzkd8wFliH73qj/+epIpTiWjRtAA==",
+          "dev": true,
+          "requires": {
+            "callsites": "^3.0.0",
+            "graceful-fs": "^4.2.3",
+            "source-map": "^0.6.0"
+          }
+        },
+        "@jest/test-result": {
+          "version": "25.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-25.1.0.tgz",
+          "integrity": "sha512-FZzSo36h++U93vNWZ0KgvlNuZ9pnDnztvaM7P/UcTx87aPDotG18bXifkf1Ji44B7k/eIatmMzkBapnAzjkJkg==",
+          "dev": true,
+          "requires": {
+            "@jest/console": "^25.1.0",
+            "@jest/transform": "^25.1.0",
+            "@jest/types": "^25.1.0",
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "collect-v8-coverage": "^1.0.0"
+          }
+        },
+        "@jest/transform": {
+          "version": "25.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-25.1.0.tgz",
+          "integrity": "sha512-4ktrQ2TPREVeM+KxB4zskAT84SnmG1vaz4S+51aTefyqn3zocZUnliLLm5Fsl85I3p/kFPN4CRp1RElIfXGegQ==",
+          "dev": true,
+          "requires": {
+            "@babel/core": "^7.1.0",
+            "@jest/types": "^25.1.0",
+            "babel-plugin-istanbul": "^6.0.0",
+            "chalk": "^3.0.0",
+            "convert-source-map": "^1.4.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "graceful-fs": "^4.2.3",
+            "jest-haste-map": "^25.1.0",
+            "jest-regex-util": "^25.1.0",
+            "jest-util": "^25.1.0",
+            "micromatch": "^4.0.2",
+            "pirates": "^4.0.1",
+            "realpath-native": "^1.1.0",
+            "slash": "^3.0.0",
+            "source-map": "^0.6.1",
+            "write-file-atomic": "^3.0.0"
+          }
+        },
+        "@jest/types": {
+          "version": "25.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.1.0.tgz",
+          "integrity": "sha512-VpOtt7tCrgvamWZh1reVsGADujKigBUFTi19mlRjqEGsE8qH4r3s+skY33dNdXOwyZIvuftZ5tqdF1IgsMejMA==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^1.1.1",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^3.0.0"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.3",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.3.tgz",
+          "integrity": "sha512-XCMQRK6kfpNBixHLyHUsGmXrpEmFFxzMrcnSXFMziHd8CoNJo8l16FkHyQq4x+xbM7E2XL83/O78OD8u+iZTdQ==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "anymatch": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+          "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+          "dev": true,
+          "requires": {
+            "normalize-path": "^3.0.0",
+            "picomatch": "^2.0.4"
+          }
+        },
+        "babel-plugin-istanbul": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.0.0.tgz",
+          "integrity": "sha512-AF55rZXpe7trmEylbaE1Gv54wn6rwU03aptvRoVIGP8YykoSxqdVLV1TfwflBCE/QtHmqtP8SWlTENqbK8GCSQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@istanbuljs/load-nyc-config": "^1.0.0",
+            "@istanbuljs/schema": "^0.1.2",
+            "istanbul-lib-instrument": "^4.0.0",
+            "test-exclude": "^6.0.0"
+          }
+        },
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "dev": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "diff-sequences": {
+          "version": "25.1.0",
+          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-25.1.0.tgz",
+          "integrity": "sha512-nFIfVk5B/NStCsJ+zaPO4vYuLjlzQ6uFvPxzYyHlejNZ/UGa7G/n7peOXVrVNvRuyfstt+mZQYGpjxg9Z6N8Kw==",
+          "dev": true
+        },
+        "expect": {
+          "version": "25.1.0",
+          "resolved": "https://registry.npmjs.org/expect/-/expect-25.1.0.tgz",
+          "integrity": "sha512-wqHzuoapQkhc3OKPlrpetsfueuEiMf3iWh0R8+duCu9PIjXoP7HgD5aeypwTnXUAjC8aMsiVDaWwlbJ1RlQ38g==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^25.1.0",
+            "ansi-styles": "^4.0.0",
+            "jest-get-type": "^25.1.0",
+            "jest-matcher-utils": "^25.1.0",
+            "jest-message-util": "^25.1.0",
+            "jest-regex-util": "^25.1.0"
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "dev": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "fsevents": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
+          "integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
+          "dev": true,
+          "optional": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "dev": true
+        },
+        "istanbul-lib-coverage": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
+          "integrity": "sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==",
+          "dev": true
+        },
+        "istanbul-lib-instrument": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.1.tgz",
+          "integrity": "sha512-imIchxnodll7pvQBYOqUu88EufLCU56LMeFPZZM/fJZ1irYcYdqroaV+ACK1Ila8ls09iEYArp+nqyC6lW1Vfg==",
+          "dev": true,
+          "requires": {
+            "@babel/core": "^7.7.5",
+            "@babel/parser": "^7.7.5",
+            "@babel/template": "^7.7.4",
+            "@babel/traverse": "^7.7.4",
+            "@istanbuljs/schema": "^0.1.2",
+            "istanbul-lib-coverage": "^3.0.0",
+            "semver": "^6.3.0"
+          }
+        },
+        "jest-diff": {
+          "version": "25.1.0",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-25.1.0.tgz",
+          "integrity": "sha512-nepXgajT+h017APJTreSieh4zCqnSHEJ1iT8HDlewu630lSJ4Kjjr9KNzm+kzGwwcpsDE6Snx1GJGzzsefaEHw==",
+          "dev": true,
+          "requires": {
+            "chalk": "^3.0.0",
+            "diff-sequences": "^25.1.0",
+            "jest-get-type": "^25.1.0",
+            "pretty-format": "^25.1.0"
+          }
+        },
+        "jest-each": {
+          "version": "25.1.0",
+          "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-25.1.0.tgz",
+          "integrity": "sha512-R9EL8xWzoPySJ5wa0DXFTj7NrzKpRD40Jy+zQDp3Qr/2QmevJgkN9GqioCGtAJ2bW9P/MQRznQHQQhoeAyra7A==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^25.1.0",
+            "chalk": "^3.0.0",
+            "jest-get-type": "^25.1.0",
+            "jest-util": "^25.1.0",
+            "pretty-format": "^25.1.0"
+          }
+        },
+        "jest-get-type": {
+          "version": "25.1.0",
+          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.1.0.tgz",
+          "integrity": "sha512-yWkBnT+5tMr8ANB6V+OjmrIJufHtCAqI5ic2H40v+tRqxDmE0PGnIiTyvRWFOMtmVHYpwRqyazDbTnhpjsGvLw==",
+          "dev": true
+        },
+        "jest-haste-map": {
+          "version": "25.1.0",
+          "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-25.1.0.tgz",
+          "integrity": "sha512-/2oYINIdnQZAqyWSn1GTku571aAfs8NxzSErGek65Iu5o8JYb+113bZysRMcC/pjE5v9w0Yz+ldbj9NxrFyPyw==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^25.1.0",
+            "anymatch": "^3.0.3",
+            "fb-watchman": "^2.0.0",
+            "fsevents": "^2.1.2",
+            "graceful-fs": "^4.2.3",
+            "jest-serializer": "^25.1.0",
+            "jest-util": "^25.1.0",
+            "jest-worker": "^25.1.0",
+            "micromatch": "^4.0.2",
+            "sane": "^4.0.3",
+            "walker": "^1.0.7"
+          }
+        },
+        "jest-matcher-utils": {
+          "version": "25.1.0",
+          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-25.1.0.tgz",
+          "integrity": "sha512-KGOAFcSFbclXIFE7bS4C53iYobKI20ZWleAdAFun4W1Wz1Kkej8Ng6RRbhL8leaEvIOjGXhGf/a1JjO8bkxIWQ==",
+          "dev": true,
+          "requires": {
+            "chalk": "^3.0.0",
+            "jest-diff": "^25.1.0",
+            "jest-get-type": "^25.1.0",
+            "pretty-format": "^25.1.0"
+          }
+        },
+        "jest-message-util": {
+          "version": "25.1.0",
+          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-25.1.0.tgz",
+          "integrity": "sha512-Nr/Iwar2COfN22aCqX0kCVbXgn8IBm9nWf4xwGr5Olv/KZh0CZ32RKgZWMVDXGdOahicM10/fgjdimGNX/ttCQ==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@jest/test-result": "^25.1.0",
+            "@jest/types": "^25.1.0",
+            "@types/stack-utils": "^1.0.1",
+            "chalk": "^3.0.0",
+            "micromatch": "^4.0.2",
+            "slash": "^3.0.0",
+            "stack-utils": "^1.0.1"
+          }
+        },
+        "jest-mock": {
+          "version": "25.1.0",
+          "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-25.1.0.tgz",
+          "integrity": "sha512-28/u0sqS+42vIfcd1mlcg4ZVDmSUYuNvImP4X2lX5hRMLW+CN0BeiKVD4p+ujKKbSPKd3rg/zuhCF+QBLJ4vag==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^25.1.0"
+          }
+        },
+        "jest-regex-util": {
+          "version": "25.1.0",
+          "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-25.1.0.tgz",
+          "integrity": "sha512-9lShaDmDpqwg+xAd73zHydKrBbbrIi08Kk9YryBEBybQFg/lBWR/2BDjjiSE7KIppM9C5+c03XiDaZ+m4Pgs1w==",
+          "dev": true
+        },
+        "jest-resolve": {
+          "version": "25.1.0",
+          "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-25.1.0.tgz",
+          "integrity": "sha512-XkBQaU1SRCHj2Evz2Lu4Czs+uIgJXWypfO57L7JYccmAXv4slXA6hzNblmcRmf7P3cQ1mE7fL3ABV6jAwk4foQ==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^25.1.0",
+            "browser-resolve": "^1.11.3",
+            "chalk": "^3.0.0",
+            "jest-pnp-resolver": "^1.2.1",
+            "realpath-native": "^1.1.0"
+          }
+        },
+        "jest-serializer": {
+          "version": "25.1.0",
+          "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-25.1.0.tgz",
+          "integrity": "sha512-20Wkq5j7o84kssBwvyuJ7Xhn7hdPeTXndnwIblKDR2/sy1SUm6rWWiG9kSCgJPIfkDScJCIsTtOKdlzfIHOfKA==",
+          "dev": true
+        },
+        "jest-snapshot": {
+          "version": "25.1.0",
+          "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-25.1.0.tgz",
+          "integrity": "sha512-xZ73dFYN8b/+X2hKLXz4VpBZGIAn7muD/DAg+pXtDzDGw3iIV10jM7WiHqhCcpDZfGiKEj7/2HXAEPtHTj0P2A==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.0.0",
+            "@jest/types": "^25.1.0",
+            "chalk": "^3.0.0",
+            "expect": "^25.1.0",
+            "jest-diff": "^25.1.0",
+            "jest-get-type": "^25.1.0",
+            "jest-matcher-utils": "^25.1.0",
+            "jest-message-util": "^25.1.0",
+            "jest-resolve": "^25.1.0",
+            "mkdirp": "^0.5.1",
+            "natural-compare": "^1.4.0",
+            "pretty-format": "^25.1.0",
+            "semver": "^7.1.1"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "7.1.3",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-7.1.3.tgz",
+              "integrity": "sha512-ekM0zfiA9SCBlsKa2X1hxyxiI4L3B6EbVJkkdgQXnSEEaHlGdvyodMruTiulSRWMMB4NeIuYNMC9rTKTz97GxA==",
+              "dev": true
+            }
+          }
+        },
+        "jest-util": {
+          "version": "25.1.0",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-25.1.0.tgz",
+          "integrity": "sha512-7did6pLQ++87Qsj26Fs/TIwZMUFBXQ+4XXSodRNy3luch2DnRXsSnmpVtxxQ0Yd6WTipGpbhh2IFP1mq6/fQGw==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^25.1.0",
+            "chalk": "^3.0.0",
+            "is-ci": "^2.0.0",
+            "mkdirp": "^0.5.1"
+          }
+        },
+        "jest-worker": {
+          "version": "25.1.0",
+          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-25.1.0.tgz",
+          "integrity": "sha512-ZHhHtlxOWSxCoNOKHGbiLzXnl42ga9CxDr27H36Qn+15pQZd3R/F24jrmjDelw9j/iHUIWMWs08/u2QN50HHOg==",
+          "dev": true,
+          "requires": {
+            "merge-stream": "^2.0.0",
+            "supports-color": "^7.0.0"
+          }
+        },
+        "micromatch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+          "dev": true,
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.0.5"
+          }
+        },
+        "pretty-format": {
+          "version": "25.1.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.1.0.tgz",
+          "integrity": "sha512-46zLRSGLd02Rp+Lhad9zzuNZ+swunitn8zIpfD2B4OPCRLXbM87RJT2aBLBWYOznNUML/2l/ReMyWNC80PJBUQ==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^25.1.0",
+            "ansi-regex": "^5.0.0",
+            "ansi-styles": "^4.0.0",
+            "react-is": "^16.12.0"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        },
+        "slash": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "test-exclude": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+          "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+          "dev": true,
+          "requires": {
+            "@istanbuljs/schema": "^0.1.2",
+            "glob": "^7.1.4",
+            "minimatch": "^3.0.4"
+          }
+        },
+        "throat": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
+          "integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
+          "dev": true
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "dev": true,
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        },
+        "write-file-atomic": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.1.tgz",
+          "integrity": "sha512-JPStrIyyVJ6oCSz/691fAjFtefZ6q+fP6tm+OS4Qw6o+TGQxNp1ziY2PgS+X/m0V8OWhZiO/m4xSj+Pr4RrZvw==",
+          "dev": true,
+          "requires": {
+            "imurmurhash": "^0.1.4",
+            "is-typedarray": "^1.0.0",
+            "signal-exit": "^3.0.2",
+            "typedarray-to-buffer": "^3.1.5"
+          }
+        }
+      }
+    },
     "jest-config": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-24.9.0.tgz",
@@ -10526,6 +11124,15 @@
         }
       }
     },
+    "lolex": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-5.1.2.tgz",
+      "integrity": "sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
     "loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -11427,8 +12034,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "normalize-url": {
       "version": "3.3.0",
@@ -14385,6 +14991,12 @@
         "prelude-ls": "~1.1.2"
       }
     },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
+    },
     "type-fest": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
@@ -14396,6 +15008,15 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
+    },
+    "typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "dev": true,
+      "requires": {
+        "is-typedarray": "^1.0.0"
+      }
     },
     "typescript": {
       "version": "3.7.4",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "husky": "^3.0.7",
     "inquirer": "^7.0.0",
     "jest": "^24.9.0",
+    "jest-circus": "^25.1.0",
     "lerna": "^3.16.4",
     "lerna-changelog": "^1.0.0",
     "markdox": "^0.1.10",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build-full": "lerna run --parallel build",
     "build": "npm run clean:build && lerna run --parallel compile && lerna run --parallel copy",
     "changelog": "node ./scripts/changelog.js",
-    "ci": "test:eslint test:typings test:coverage link test:smoke",
+    "ci": "run-s test:eslint test:typings test:coverage test:smoke",
     "clean": "run-p clean-full:* clean:*",
     "clean:build": "rimraf ./packages/*/build",
     "clean:pkglock": "rimraf ./packages/*/package-lock.json",

--- a/package.json
+++ b/package.json
@@ -113,10 +113,10 @@
     "collectCoverage": true,
     "coverageThreshold": {
       "global": {
-        "branches": 96,
-        "functions": 99,
-        "lines": 99,
-        "statements": 99
+        "branches": 95,
+        "functions": 98,
+        "lines": 98,
+        "statements": 98
       }
     },
     "testEnvironment": "node",
@@ -128,7 +128,11 @@
       "packages/webdriverio/build",
       "packages/webdriver/build",
       "packages/wdio-cucumber-framework/tests/fixtures",
-      "packages/wdio-logger/build"
+      "packages/wdio-logger/build",
+      "packages/wdio-webdriver-mock-service",
+      "packages/wdio-lambda-runner",
+      "packages/wdio-smoke-test-reporter",
+      "packages/wdio-smoke-test-service"
     ]
   },
   "greenkeeper": {

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
       "<rootDir>/tests/",
       "<rootDir>/node_modules/"
     ],
+    "collectCoverageFrom": [ "packages/**/src/*.js"],
     "coverageDirectory": "./coverage/",
     "collectCoverage": true,
     "coverageThreshold": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build-full": "lerna run --parallel build",
     "build": "npm run clean:build && lerna run --parallel compile && lerna run --parallel copy",
     "changelog": "node ./scripts/changelog.js",
-    "ci": "run-s test:eslint test:typings test:coverage test:smoke",
+    "ci": "lerna bootstrap --no-ci && run-s build-full test:eslint test:typings test:coverage test:smoke",
     "clean": "run-p clean-full:* clean:*",
     "clean:build": "rimraf ./packages/*/build",
     "clean:pkglock": "rimraf ./packages/*/package-lock.json",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build-full": "lerna run --parallel build",
     "build": "npm run clean:build && lerna run --parallel compile && lerna run --parallel copy",
     "changelog": "node ./scripts/changelog.js",
-    "ci": "lerna bootstrap --no-ci && run-s build-full test:eslint test:typings test:coverage link test:smoke",
+    "ci": "test:eslint test:typings test:coverage link test:smoke",
     "clean": "run-p clean-full:* clean:*",
     "clean:build": "rimraf ./packages/*/build",
     "clean:pkglock": "rimraf ./packages/*/package-lock.json",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,9 @@
       "<rootDir>/tests/",
       "<rootDir>/node_modules/"
     ],
-    "collectCoverageFrom": [ "packages/**/src/*.js"],
+    "collectCoverageFrom": [
+      "packages/**/src/*.js"
+    ],
     "coverageDirectory": "./coverage/",
     "collectCoverage": true,
     "coverageThreshold": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build-full": "lerna run --parallel build",
     "build": "npm run clean:build && lerna run --parallel compile && lerna run --parallel copy",
     "changelog": "node ./scripts/changelog.js",
-    "ci": "lerna bootstrap --no-ci && run-s build-full test:eslint test:typings test:coverage link test:smoke test:e2e",
+    "ci": "lerna bootstrap --no-ci && run-s build-full test:eslint test:typings test:coverage link test:smoke",
     "clean": "run-p clean-full:* clean:*",
     "clean:build": "rimraf ./packages/*/build",
     "clean:pkglock": "rimraf ./packages/*/package-lock.json",

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -35,12 +35,9 @@
     "@wdio/protocols": "6.0.0-alpha.1",
     "@wdio/utils": "6.0.0-alpha.1",
     "chrome-launcher": "^0.11.1",
-    "puppeteer-core": "^1.18.1"
+    "puppeteer-core": "^2.1.1"
   },
   "devDependencies": {
     "@types/puppeteer": "^1.19.0"
-  },
-  "optionalDependencies": {
-    "puppeteer-firefox": "^0.5.0"
   }
 }

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -38,6 +38,6 @@
     "puppeteer-core": "^2.1.1"
   },
   "devDependencies": {
-    "@types/puppeteer": "^1.19.0"
+    "@types/puppeteer": "^2.0.0"
   }
 }

--- a/packages/devtools/src/constants.js
+++ b/packages/devtools/src/constants.js
@@ -45,6 +45,7 @@ export const DEFAULT_FLAGS = [
 export const CHROME_NAMES = ['chrome', 'googlechrome', 'headlesschrome', 'google-chrome', 'chromium']
 export const FIREFOX_NAMES = ['firefox', 'ff', 'mozilla', 'mozillafirefox', 'headless firefox', 'headlessfirefox']
 export const EDGE_NAMES = ['edge', 'msedge', 'microsoft-edge', 'microsoftedge']
+export const SUPPORTED_BROWSER = [...CHROME_NAMES, ...FIREFOX_NAMES, ...EDGE_NAMES]
 
 export const DEFAULTS = {
     capabilities: {

--- a/packages/devtools/src/devtoolsdriver.js
+++ b/packages/devtools/src/devtoolsdriver.js
@@ -30,6 +30,7 @@ export default class DevToolsDriver {
         for (const page of pages) {
             const pageId = uuidv4()
             this.windows.set(pageId, page)
+            this.currentFrame = page
             this.currentWindowHandle = pageId
         }
 

--- a/packages/devtools/src/finder/edge.js
+++ b/packages/devtools/src/finder/edge.js
@@ -1,0 +1,146 @@
+/**
+ * @license Copyright 2016 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+import path from 'path'
+import { execSync, execFileSync } from 'child_process'
+
+import { sort, canAccess, uniq } from '../utils'
+
+const newLineRegex = /\r?\n/
+
+function darwin() {
+    const suffixes = [
+        '/Contents/MacOS/Microsoft Edge'
+    ]
+
+    const LSREGISTER = '/System/Library/Frameworks/CoreServices.framework' +
+        '/Versions/A/Frameworks/LaunchServices.framework' +
+        '/Versions/A/Support/lsregister'
+
+    const installations = []
+
+    execSync(
+        `${LSREGISTER} -dump` +
+        ' | grep -i \'microsoft edge\\?.app.*$\'' +
+        ' | awk \'{$1=""; print $0}\''
+    )
+        .toString()
+        .split(newLineRegex)
+        .forEach((inst) => {
+            suffixes.forEach(suffix => {
+                const execPath = path.join(inst.substring(0, inst.indexOf('.app') + 4).trim(), suffix)
+                if (canAccess(execPath) && installations.indexOf(execPath) === -1) {
+                    installations.push(execPath)
+                }
+            })
+        })
+
+    // Retains one per line to maintain readability.
+    // clang-format off
+    const priorities = [
+        { regex: new RegExp(`^${process.env.HOME}/Applications/.*Microsoft Edge.app`), weight: 50 },
+        { regex: /^\/Applications\/.*Microsoft Edge.app/, weight: 100 },
+        { regex: /^\/Volumes\/.*Microsoft Edge.app/, weight: -2 }
+    ]
+
+    // clang-format on
+    return sort(installations, priorities)
+}
+
+/**
+ * Look for linux executables in 3 ways
+ * 1. Look into the directories where .desktop are saved on gnome based distro's
+ * 2. Look for edge by using the which command
+ */
+function linux() {
+    let installations = []
+
+    // 1. Look into the directories where .desktop are saved on gnome based distro's
+    const desktopInstallationFolders = [
+        path.join(require('os').homedir(), '.local/share/applications/'),
+        '/usr/share/applications/',
+    ]
+    desktopInstallationFolders.forEach(folder => {
+        installations = installations.concat(findEdgeExecutables(folder))
+    })
+
+    // 2. Look for edge executables by
+    // using the which command
+    const executables = [
+        'edge',
+    ]
+
+    executables.forEach((executable) => {
+        try {
+            const edgePath =
+                execFileSync('which', [executable], { stdio: 'pipe' }).toString().split(newLineRegex)[0]
+
+            if (canAccess(edgePath)) {
+                installations.push(edgePath)
+            }
+        } catch (e) {
+            // Not installed.
+        }
+    })
+
+    const priorities = [
+        { regex: /edge/, weight: 51 }
+    ]
+
+    return sort(uniq(installations.filter(Boolean)), priorities)
+}
+
+function win32() {
+    const installations = []
+    const suffixes = [
+        `${path.sep}Microsoft${path.sep}Edge${path.sep}Application${path.sep}edge.exe`
+    ]
+
+    const prefixes = [
+        process.env.LOCALAPPDATA, process.env.PROGRAMFILES, process.env['PROGRAMFILES(X86)']
+    ].filter(Boolean)
+
+    prefixes.forEach(prefix => suffixes.forEach(suffix => {
+        const edgePath = path.join(prefix, suffix)
+        if (canAccess(edgePath)) {
+            installations.push(edgePath)
+        }
+    }))
+
+    return installations
+}
+
+function findEdgeExecutables(folder) {
+    const argumentsRegex = /(^[^ ]+).*/ // Take everything up to the first space
+    const edgeExecRegex = '^Exec=/.*/(edge)-.*'
+
+    let installations = []
+    if (canAccess(folder)) {
+        let execPaths
+
+        // Some systems do not support grep -R so fallback to -r.
+        // See https://github.com/GoogleChrome/chrome-launcher/issues/46 for more context.
+        try {
+            execPaths = execSync(
+                `grep -ER "${edgeExecRegex}" ${folder} | awk -F '=' '{print $2}'`, { stdio: 'pipe' })
+        } catch (e) {
+            execPaths = execSync(
+                `grep -Er "${edgeExecRegex}" ${folder} | awk -F '=' '{print $2}'`, { stdio: 'pipe' })
+        }
+
+        execPaths = execPaths.toString().split(newLineRegex).map(
+            (execPath) => execPath.replace(argumentsRegex, '$1'))
+
+        execPaths.forEach((execPath) => canAccess(execPath) && installations.push(execPath))
+    }
+
+    return installations
+}
+
+export default {
+    darwin,
+    linux,
+    win32
+}

--- a/packages/devtools/src/finder/edge.js
+++ b/packages/devtools/src/finder/edge.js
@@ -1,3 +1,5 @@
+/* istanbul ignore file */
+
 /**
  * @license Copyright 2016 Google Inc. All Rights Reserved.
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/packages/devtools/src/finder/edge.js
+++ b/packages/devtools/src/finder/edge.js
@@ -6,11 +6,13 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 import path from 'path'
-import { execSync, execFileSync } from 'child_process'
+import { execSync } from 'child_process'
 
-import { sort, canAccess, uniq } from '../utils'
+import { sort, canAccess, findByWhich } from '../utils'
 
 const newLineRegex = /\r?\n/
+const EDGE_BINARY_NAMES = ['edge', 'msedge', 'microsoftedge']
+const EDGE_REGEX = /((ms|microsoft))?edge/g
 
 function darwin() {
     const suffixes = [
@@ -47,8 +49,12 @@ function darwin() {
         { regex: /^\/Volumes\/.*Microsoft Edge.app/, weight: -2 }
     ]
 
-    // clang-format on
-    return sort(installations, priorities)
+    const whichFinds = findByWhich(
+        EDGE_BINARY_NAMES,
+        [{ regex: EDGE_REGEX, weight: 51 }]
+    )
+    const installFinds = sort(installations, priorities)
+    return [...installFinds, ...whichFinds]
 }
 
 /**
@@ -68,30 +74,10 @@ function linux() {
         installations = installations.concat(findEdgeExecutables(folder))
     })
 
-    // 2. Look for edge executables by
-    // using the which command
-    const executables = [
-        'edge',
-    ]
-
-    executables.forEach((executable) => {
-        try {
-            const edgePath =
-                execFileSync('which', [executable], { stdio: 'pipe' }).toString().split(newLineRegex)[0]
-
-            if (canAccess(edgePath)) {
-                installations.push(edgePath)
-            }
-        } catch (e) {
-            // Not installed.
-        }
-    })
-
-    const priorities = [
-        { regex: /edge/, weight: 51 }
-    ]
-
-    return sort(uniq(installations.filter(Boolean)), priorities)
+    return findByWhich(
+        EDGE_BINARY_NAMES,
+        [{ regex: EDGE_REGEX, weight: 51 }]
+    )
 }
 
 function win32() {

--- a/packages/devtools/src/finder/firefox.js
+++ b/packages/devtools/src/finder/firefox.js
@@ -74,11 +74,11 @@ function linux() {
 
     executables.forEach((executable) => {
         try {
-            const edgePath =
+            const firefoxPath =
                 execFileSync('which', [executable], { stdio: 'pipe' }).toString().split(newLineRegex)[0]
 
-            if (canAccess(edgePath)) {
-                installations.push(edgePath)
+            if (canAccess(firefoxPath)) {
+                installations.push(firefoxPath)
             }
         } catch (e) {
             // Not installed.
@@ -103,9 +103,9 @@ function win32() {
     ].filter(Boolean)
 
     prefixes.forEach(prefix => suffixes.forEach(suffix => {
-        const edgePath = path.join(prefix, suffix)
-        if (canAccess(edgePath)) {
-            installations.push(edgePath)
+        const firefoxPath = path.join(prefix, suffix)
+        if (canAccess(firefoxPath)) {
+            installations.push(firefoxPath)
         }
     }))
 

--- a/packages/devtools/src/finder/firefox.js
+++ b/packages/devtools/src/finder/firefox.js
@@ -1,0 +1,146 @@
+/**
+ * @license Copyright 2016 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+import path from 'path'
+import { execSync, execFileSync } from 'child_process'
+
+import { sort, canAccess, uniq } from '../utils'
+
+const newLineRegex = /\r?\n/
+
+function darwin() {
+    const suffixes = [
+        '/Contents/MacOS/firefox-bin'
+    ]
+
+    const LSREGISTER = '/System/Library/Frameworks/CoreServices.framework' +
+        '/Versions/A/Frameworks/LaunchServices.framework' +
+        '/Versions/A/Support/lsregister'
+
+    const installations = []
+
+    execSync(
+        `${LSREGISTER} -dump` +
+        ' | grep -i \'firefox\\?.app.*$\'' +
+        ' | awk \'{$1=""; print $0}\''
+    )
+        .toString()
+        .split(newLineRegex)
+        .forEach((inst) => {
+            suffixes.forEach(suffix => {
+                const execPath = path.join(inst.substring(0, inst.indexOf('.app') + 4).trim(), suffix)
+                if (canAccess(execPath) && installations.indexOf(execPath) === -1) {
+                    installations.push(execPath)
+                }
+            })
+        })
+
+    // Retains one per line to maintain readability.
+    // clang-format off
+    const priorities = [
+        { regex: new RegExp(`^${process.env.HOME}/Applications/.*Firefox.app`), weight: 50 },
+        { regex: /^\/Applications\/.*Firefox.app/, weight: 100 },
+        { regex: /^\/Volumes\/.*Firefox.app/, weight: -2 }
+    ]
+
+    // clang-format on
+    return sort(installations, priorities)
+}
+
+/**
+ * Look for linux executables in 3 ways
+ * 1. Look into the directories where .desktop are saved on gnome based distro's
+ * 2. Look for edge by using the which command
+ */
+function linux() {
+    let installations = []
+
+    // 1. Look into the directories where .desktop are saved on gnome based distro's
+    const desktopInstallationFolders = [
+        path.join(require('os').homedir(), '.local/share/applications/'),
+        '/usr/share/applications/',
+    ]
+    desktopInstallationFolders.forEach(folder => {
+        installations = installations.concat(findEdgeExecutables(folder))
+    })
+
+    // 2. Look for edge executables by
+    // using the which command
+    const executables = [
+        'firefox',
+    ]
+
+    executables.forEach((executable) => {
+        try {
+            const edgePath =
+                execFileSync('which', [executable], { stdio: 'pipe' }).toString().split(newLineRegex)[0]
+
+            if (canAccess(edgePath)) {
+                installations.push(edgePath)
+            }
+        } catch (e) {
+            // Not installed.
+        }
+    })
+
+    const priorities = [
+        { regex: /firefox/, weight: 51 }
+    ]
+
+    return sort(uniq(installations.filter(Boolean)), priorities)
+}
+
+function win32() {
+    const installations = []
+    const suffixes = [
+        `${path.sep}Firefox${path.sep}Application${path.sep}firefox.exe`
+    ]
+
+    const prefixes = [
+        process.env.LOCALAPPDATA, process.env.PROGRAMFILES, process.env['PROGRAMFILES(X86)']
+    ].filter(Boolean)
+
+    prefixes.forEach(prefix => suffixes.forEach(suffix => {
+        const edgePath = path.join(prefix, suffix)
+        if (canAccess(edgePath)) {
+            installations.push(edgePath)
+        }
+    }))
+
+    return installations
+}
+
+function findEdgeExecutables(folder) {
+    const argumentsRegex = /(^[^ ]+).*/ // Take everything up to the first space
+    const edgeExecRegex = '^Exec=/.*/(firefox)-.*'
+
+    let installations = []
+    if (canAccess(folder)) {
+        let execPaths
+
+        // Some systems do not support grep -R so fallback to -r.
+        // See https://github.com/GoogleChrome/chrome-launcher/issues/46 for more context.
+        try {
+            execPaths = execSync(
+                `grep -ER "${edgeExecRegex}" ${folder} | awk -F '=' '{print $2}'`, { stdio: 'pipe' })
+        } catch (e) {
+            execPaths = execSync(
+                `grep -Er "${edgeExecRegex}" ${folder} | awk -F '=' '{print $2}'`, { stdio: 'pipe' })
+        }
+
+        execPaths = execPaths.toString().split(newLineRegex).map(
+            (execPath) => execPath.replace(argumentsRegex, '$1'))
+
+        execPaths.forEach((execPath) => canAccess(execPath) && installations.push(execPath))
+    }
+
+    return installations
+}
+
+export default {
+    darwin,
+    linux,
+    win32
+}

--- a/packages/devtools/src/finder/firefox.js
+++ b/packages/devtools/src/finder/firefox.js
@@ -1,3 +1,5 @@
+/* istanbul ignore file */
+
 /**
  * @license Copyright 2016 Google Inc. All Rights Reserved.
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/packages/devtools/src/index.js
+++ b/packages/devtools/src/index.js
@@ -7,7 +7,7 @@ import { validateConfig } from '@wdio/config'
 
 import DevToolsDriver from './devtoolsdriver'
 import launch from './launcher'
-import { DEFAULTS } from './constants'
+import { DEFAULTS, SUPPORTED_BROWSER } from './constants'
 import { getPrototype } from './utils'
 
 const log = logger('devtools:puppeteer')
@@ -105,3 +105,5 @@ export default class DevTools {
         throw new Error('not yet implemented')
     }
 }
+
+export { SUPPORTED_BROWSER }

--- a/packages/devtools/src/index.js
+++ b/packages/devtools/src/index.js
@@ -1,4 +1,5 @@
 import os from 'os'
+import path from 'path'
 import uuidv4 from 'uuid/v4'
 import logger from '@wdio/logger'
 import { webdriverMonad, devtoolsEnvironmentDetector } from '@wdio/utils'
@@ -8,6 +9,23 @@ import DevToolsDriver from './devtoolsdriver'
 import launch from './launcher'
 import { DEFAULTS } from './constants'
 import { getPrototype } from './utils'
+
+const log = logger('devtools:puppeteer')
+
+/**
+ * log puppeteer messages
+ */
+const PREFIX = 'puppeteer:protocol'
+const puppeteerDebugPkg = path.resolve(
+    path.dirname(require.resolve('puppeteer-core')),
+    'node_modules',
+    'debug')
+require(puppeteerDebugPkg).log = (msg) => {
+    if (msg.includes('puppeteer:protocol')) {
+        msg = msg.slice(msg.indexOf(PREFIX) + PREFIX.length).trim()
+    }
+    log.debug(msg)
+}
 
 export const sessionMap = new Map()
 

--- a/packages/devtools/src/index.js
+++ b/packages/devtools/src/index.js
@@ -20,6 +20,7 @@ const puppeteerDebugPkg = path.resolve(
     path.dirname(require.resolve('puppeteer-core')),
     'node_modules',
     'debug')
+/* istanbul ignore next */
 require(puppeteerDebugPkg).log = (msg) => {
     if (msg.includes('puppeteer:protocol')) {
         msg = msg.slice(msg.indexOf(PREFIX) + PREFIX.length).trim()

--- a/packages/devtools/src/launcher.js
+++ b/packages/devtools/src/launcher.js
@@ -32,7 +32,7 @@ async function launchChrome (capabilities) {
         ...(chromeOptions.args || [])
     ]
 
-    log.info(`Launch Chrome with flags: ${chromeFlags.join(' ')}`)
+    log.info(`Launch Google Chrome with flags: ${chromeFlags.join(' ')}`)
     const chrome = await launchChromeBrowser({
         chromePath: chromeOptions.binary,
         chromeFlags
@@ -74,11 +74,13 @@ function launchBrowser (capabilities, executablePath, vendorCapKey, config = {})
 
 function launchFirefox (capabilities) {
     const executablePath = firefoxFinder[process.platform]()[0]
+    log.info(`Launch Firefox from path: ${executablePath}`)
     return launchBrowser(capabilities, executablePath, 'moz:firefoxOptions', { product: 'firefox' })
 }
 
 function launchEdge (capabilities) {
     const executablePath = edgeFinder[process.platform]()[0]
+    log.info(`Launch MS Edge (Chromium) from path: ${executablePath}`)
     return launchBrowser(capabilities, executablePath, 'ms:edgeOptions')
 }
 

--- a/packages/devtools/src/launcher.js
+++ b/packages/devtools/src/launcher.js
@@ -67,6 +67,11 @@ function launchBrowser (capabilities, executablePath, vendorCapKey) {
             height: DEFAULT_HEIGHT
         }
     }, capabilities[vendorCapKey] || {})
+
+    if (!executablePath) {
+        throw new Error('Couldn\'t find executeable for browser')
+    }
+
     log.info(`Launch ${executablePath} with config: ${JSON.stringify(puppeteerOptions)}`)
     return puppeteer.launch(puppeteerOptions)
 }

--- a/packages/devtools/src/launcher.js
+++ b/packages/devtools/src/launcher.js
@@ -67,13 +67,12 @@ function launchBrowser (capabilities, executablePath, vendorCapKey) {
             height: DEFAULT_HEIGHT
         }
     }, capabilities[vendorCapKey] || {})
+    log.info(`Launch ${executablePath} with config: ${JSON.stringify(puppeteerOptions)}`)
     return puppeteer.launch(puppeteerOptions)
 }
 
 function launchFirefox (capabilities) {
     const executablePath = firefoxFinder[process.platform]()[0]
-    log.info(`Launch Firefox from path: ${executablePath}`)
-
     const vendorPrefix = 'moz:firefoxOptions'
     if (!capabilities[vendorPrefix]) {
         capabilities[vendorPrefix] = {}
@@ -85,7 +84,6 @@ function launchFirefox (capabilities) {
 
 function launchEdge (capabilities) {
     const executablePath = edgeFinder[process.platform]()[0]
-    log.info(`Launch MS Edge (Chromium) from path: ${executablePath}`)
     return launchBrowser(capabilities, executablePath, 'ms:edgeOptions')
 }
 

--- a/packages/devtools/src/launcher.js
+++ b/packages/devtools/src/launcher.js
@@ -2,6 +2,8 @@ import { launch as launchChromeBrowser } from 'chrome-launcher'
 import puppeteer from 'puppeteer-core'
 import logger from '@wdio/logger'
 
+import edgeFinder from './finder/edge'
+import firefoxFinder from './finder/firefox'
 import { getPages } from './utils'
 import {
     CHROME_NAMES, FIREFOX_NAMES, EDGE_NAMES, DEFAULT_FLAGS, DEFAULT_WIDTH,
@@ -56,22 +58,28 @@ async function launchChrome (capabilities) {
     return browser
 }
 
-function launchFirefox (capabilities) {
-    const puppeteerFirefox = require('puppeteer-firefox')
-    const firefoxOptions = capabilities['moz:firefoxOptions'] || {}
-    return puppeteerFirefox.launch({
-        args: firefoxOptions.args || [],
-        headless: Boolean(firefoxOptions.headless),
+function launchBrowser (capabilities, executablePath, vendorCapKey, config = {}) {
+    const edgeOptions = capabilities[vendorCapKey] || {}
+    return puppeteer.launch({
+        ...config,
+        executablePath,
+        args: edgeOptions.args || [],
+        headless: Boolean(edgeOptions.headless),
         defaultViewport: {
-            width: firefoxOptions.width || DEFAULT_WIDTH,
-            height: firefoxOptions.height || DEFAULT_HEIGHT
+            width: edgeOptions.width || DEFAULT_WIDTH,
+            height: edgeOptions.height || DEFAULT_HEIGHT
         }
     })
 }
 
-/* istanbul ignore next */
-function launchEdge () {
-    throw new Error('not yet implemented')
+function launchFirefox (capabilities) {
+    const executablePath = firefoxFinder[process.platform]()[0]
+    return launchBrowser(capabilities, executablePath, 'moz:firefoxOptions', { product: 'firefox' })
+}
+
+function launchEdge (capabilities) {
+    const executablePath = edgeFinder[process.platform]()[0]
+    return launchBrowser(capabilities, executablePath, 'ms:edgeOptions')
 }
 
 export default function launch (capabilities) {

--- a/packages/devtools/src/utils.js
+++ b/packages/devtools/src/utils.js
@@ -234,11 +234,6 @@ export async function getPages (browser, retryInterval = 100) {
     return pages
 }
 
-/**
- * all the next utils are copied form `chrome-launcher` and don't need
- * to be tested
- */
-/* istanbul ignore next */
 export function sort(installations, priorities) {
     const defaultPriority = 10
     return installations
@@ -258,7 +253,11 @@ export function sort(installations, priorities) {
         .map(pair => pair.path)
 }
 
-/* istanbul ignore next */
+/**
+ * helper utility to check if binary is accessible
+ * @param  {String}  file  path to browser binary
+ * @return {Boolean}       true if browser is accessible
+ */
 export function canAccess(file) {
     if (!file) {
         return false
@@ -272,7 +271,11 @@ export function canAccess(file) {
     }
 }
 
-/* istanbul ignore next */
+/**
+ * helper utitlity to clone a list
+ * @param  {Any[]} arr  list of things
+ * @return {Any[]}      new list of same things
+ */
 export function uniq(arr) {
     return Array.from(new Set(arr))
 }

--- a/packages/devtools/src/utils.js
+++ b/packages/devtools/src/utils.js
@@ -259,10 +259,6 @@ export function sort(installations, priorities) {
  * @return {Boolean}       true if browser is accessible
  */
 export function canAccess(file) {
-    if (!file) {
-        return false
-    }
-
     try {
         fs.accessSync(file)
         return true

--- a/packages/devtools/src/utils.js
+++ b/packages/devtools/src/utils.js
@@ -1,4 +1,5 @@
 import fs from 'fs'
+import { execFileSync } from 'child_process'
 import logger from '@wdio/logger'
 import { commandCallStructure, isValidParameter, getArgumentType } from '@wdio/utils'
 import { WebDriverProtocol } from '@wdio/protocols'
@@ -274,4 +275,28 @@ export function canAccess(file) {
 /* istanbul ignore next */
 export function uniq(arr) {
     return Array.from(new Set(arr))
+}
+
+/**
+ * Look for edge executables by using the which command
+ */
+export function findByWhich (executables, priorities) {
+    const installations = []
+    executables.forEach((executable) => {
+        try {
+            const browserPath = execFileSync(
+                'which',
+                [executable],
+                { stdio: 'pipe' }
+            ).toString().split(/\r?\n/)[0]
+
+            if (canAccess(browserPath)) {
+                installations.push(browserPath)
+            }
+        } catch (e) {
+            // Not installed.
+        }
+    })
+
+    return sort(uniq(installations.filter(Boolean)), priorities)
 }

--- a/packages/devtools/src/utils.js
+++ b/packages/devtools/src/utils.js
@@ -1,3 +1,4 @@
+import fs from 'fs'
 import logger from '@wdio/logger'
 import { commandCallStructure, isValidParameter, getArgumentType } from '@wdio/utils'
 import { WebDriverProtocol } from '@wdio/protocols'
@@ -230,4 +231,40 @@ export async function getPages (browser, retryInterval = 100) {
     }
 
     return pages
+}
+
+export function sort(installations, priorities) {
+    const defaultPriority = 10
+    return installations
+        // assign priorities
+        .map((inst) => {
+            for (const pair of priorities) {
+                if (pair.regex.test(inst)) {
+                    return { path: inst, weight: pair.weight }
+                }
+            }
+
+            return { path: inst, weight: defaultPriority }
+        })
+        // sort based on priorities
+        .sort((a, b) => (b.weight - a.weight))
+        // remove priority flag
+        .map(pair => pair.path)
+}
+
+export function canAccess(file) {
+    if (!file) {
+        return false
+    }
+
+    try {
+        fs.accessSync(file)
+        return true
+    } catch (e) {
+        return false
+    }
+}
+
+export function uniq(arr) {
+    return Array.from(new Set(arr))
 }

--- a/packages/devtools/src/utils.js
+++ b/packages/devtools/src/utils.js
@@ -233,6 +233,11 @@ export async function getPages (browser, retryInterval = 100) {
     return pages
 }
 
+/**
+ * all the next utils are copied form `chrome-launcher` and don't need
+ * to be tested
+ */
+/* istanbul ignore next */
 export function sort(installations, priorities) {
     const defaultPriority = 10
     return installations
@@ -252,6 +257,7 @@ export function sort(installations, priorities) {
         .map(pair => pair.path)
 }
 
+/* istanbul ignore next */
 export function canAccess(file) {
     if (!file) {
         return false
@@ -265,6 +271,7 @@ export function canAccess(file) {
     }
 }
 
+/* istanbul ignore next */
 export function uniq(arr) {
     return Array.from(new Set(arr))
 }

--- a/packages/devtools/tests/__mocks__/puppeteer-core.js
+++ b/packages/devtools/tests/__mocks__/puppeteer-core.js
@@ -77,6 +77,8 @@ export default {
     sendMock,
     listenerMock,
     devices,
+    launch: jest.fn().mockImplementation(
+        () => Promise.resolve(new PuppeteerMock())),
     connect: jest.fn().mockImplementation(
         () => Promise.resolve(new PuppeteerMock()))
 }

--- a/packages/devtools/tests/__mocks__/puppeteer-firefox.js
+++ b/packages/devtools/tests/__mocks__/puppeteer-firefox.js
@@ -1,3 +1,0 @@
-module.exports = {
-    launch: jest.fn()
-}

--- a/packages/devtools/tests/__snapshots__/launcher.test.js.snap
+++ b/packages/devtools/tests/__snapshots__/launcher.test.js.snap
@@ -1,5 +1,39 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`launch Edge with custom arguments 1`] = `
+Array [
+  Array [
+    Object {
+      "args": Array [
+        "foobar",
+      ],
+      "defaultViewport": Object {
+        "height": 456,
+        "width": 123,
+      },
+      "executablePath": "/path/to/edge",
+      "headless": true,
+    },
+  ],
+]
+`;
+
+exports[`launch Edge with default values 1`] = `
+Array [
+  Array [
+    Object {
+      "args": Array [],
+      "defaultViewport": Object {
+        "height": 900,
+        "width": 1200,
+      },
+      "executablePath": "/path/to/edge",
+      "headless": false,
+    },
+  ],
+]
+`;
+
 exports[`launch Firefox with custom arguments 1`] = `
 Array [
   Array [
@@ -11,7 +45,9 @@ Array [
         "height": 456,
         "width": 123,
       },
+      "executablePath": "/path/to/firefox",
       "headless": true,
+      "product": "firefox",
     },
   ],
 ]
@@ -26,7 +62,9 @@ Array [
         "height": 900,
         "width": 1200,
       },
+      "executablePath": "/path/to/firefox",
       "headless": false,
+      "product": "firefox",
     },
   ],
 ]

--- a/packages/devtools/tests/__snapshots__/launcher.test.js.snap
+++ b/packages/devtools/tests/__snapshots__/launcher.test.js.snap
@@ -22,13 +22,11 @@ exports[`launch Edge with default values 1`] = `
 Array [
   Array [
     Object {
-      "args": Array [],
       "defaultViewport": Object {
         "height": 900,
         "width": 1200,
       },
       "executablePath": "/path/to/edge",
-      "headless": false,
     },
   ],
 ]
@@ -57,13 +55,11 @@ exports[`launch Firefox with default values 1`] = `
 Array [
   Array [
     Object {
-      "args": Array [],
       "defaultViewport": Object {
         "height": 900,
         "width": 1200,
       },
       "executablePath": "/path/to/firefox",
-      "headless": false,
       "product": "firefox",
     },
   ],

--- a/packages/devtools/tests/launcher.test.js
+++ b/packages/devtools/tests/launcher.test.js
@@ -59,8 +59,10 @@ test('launch Firefox with custom arguments', async () => {
         'moz:firefoxOptions': {
             args: ['foobar'],
             headless: true,
-            width: 123,
-            height: 456
+            defaultViewport: {
+                width: 123,
+                height: 456
+            }
         }
     })
     expect(puppeteer.launch.mock.calls).toMatchSnapshot()
@@ -79,8 +81,10 @@ test('launch Edge with custom arguments', async () => {
         'ms:edgeOptions': {
             args: ['foobar'],
             headless: true,
-            width: 123,
-            height: 456
+            defaultViewport: {
+                width: 123,
+                height: 456
+            }
         }
     })
     expect(puppeteer.launch.mock.calls).toMatchSnapshot()

--- a/packages/devtools/tests/launcher.test.js
+++ b/packages/devtools/tests/launcher.test.js
@@ -3,9 +3,22 @@ import { launch as launchChromeBrowser } from 'chrome-launcher'
 
 import launch from '../src/launcher'
 
+jest.mock('../src/finder/firefox', () => ({
+    darwin: jest.fn().mockReturnValue(['/path/to/firefox']),
+    linux: jest.fn().mockReturnValue(['/path/to/firefox']),
+    win32: jest.fn().mockReturnValue(['/path/to/firefox'])
+}))
+
+jest.mock('../src/finder/edge', () => ({
+    darwin: jest.fn().mockReturnValue(['/path/to/edge']),
+    linux: jest.fn().mockReturnValue(['/path/to/edge']),
+    win32: jest.fn().mockReturnValue(['/path/to/edge'])
+}))
+
 beforeEach(() => {
     puppeteer.connect.mockClear()
     launchChromeBrowser.mockClear()
+    puppeteer.launch.mockClear()
 })
 
 test('launch chrome with default values', async () => {
@@ -44,6 +57,26 @@ test('launch Firefox with custom arguments', async () => {
     await launch({
         browserName: 'firefox',
         'moz:firefoxOptions': {
+            args: ['foobar'],
+            headless: true,
+            width: 123,
+            height: 456
+        }
+    })
+    expect(puppeteer.launch.mock.calls).toMatchSnapshot()
+})
+
+test('launch Edge with default values', async () => {
+    await launch({
+        browserName: 'edge'
+    })
+    expect(puppeteer.launch.mock.calls).toMatchSnapshot()
+})
+
+test('launch Edge with custom arguments', async () => {
+    await launch({
+        browserName: 'edge',
+        'ms:edgeOptions': {
             args: ['foobar'],
             headless: true,
             width: 123,

--- a/packages/devtools/tests/launcher.test.js
+++ b/packages/devtools/tests/launcher.test.js
@@ -1,12 +1,10 @@
 import puppeteer from 'puppeteer-core'
-import puppeteerFirefox from 'puppeteer-firefox'
 import { launch as launchChromeBrowser } from 'chrome-launcher'
 
 import launch from '../src/launcher'
 
 beforeEach(() => {
     puppeteer.connect.mockClear()
-    puppeteerFirefox.launch.mockClear()
     launchChromeBrowser.mockClear()
 })
 
@@ -16,7 +14,6 @@ test('launch chrome with default values', async () => {
     })
     expect(launchChromeBrowser.mock.calls).toMatchSnapshot()
     expect(puppeteer.connect.mock.calls).toMatchSnapshot()
-    expect(puppeteerFirefox.launch).toBeCalledTimes(0)
 
     const pages = await browser.pages()
     expect(pages[0].close).toBeCalledTimes(1)
@@ -33,14 +30,14 @@ test('launch chrome with chrome arguments', async () => {
         }
     })
     expect(launchChromeBrowser.mock.calls).toMatchSnapshot()
-    expect(puppeteerFirefox.launch).toBeCalledTimes(0)
+    expect(puppeteer.launch).toBeCalledTimes(0)
 })
 
 test('launch Firefox with default values', async () => {
     await launch({
         browserName: 'firefox'
     })
-    expect(puppeteerFirefox.launch.mock.calls).toMatchSnapshot()
+    expect(puppeteer.launch.mock.calls).toMatchSnapshot()
 })
 
 test('launch Firefox with custom arguments', async () => {
@@ -53,7 +50,7 @@ test('launch Firefox with custom arguments', async () => {
             height: 456
         }
     })
-    expect(puppeteerFirefox.launch.mock.calls).toMatchSnapshot()
+    expect(puppeteer.launch.mock.calls).toMatchSnapshot()
 })
 
 test('throws if browser is unknown', async () => {

--- a/packages/devtools/tests/utils.test.js
+++ b/packages/devtools/tests/utils.test.js
@@ -336,7 +336,10 @@ test('getStaleElementError', () => {
 })
 
 test('canAccess', () => {
+    fs.shouldThrow(true)
     expect(canAccess()).toBe(false)
+
+    fs.shouldThrow(false)
     expect(canAccess('/some/file')).toBe(true)
 
     fs.shouldThrow(true)

--- a/packages/wdio-appium-service/src/index.js
+++ b/packages/wdio-appium-service/src/index.js
@@ -1,3 +1,5 @@
+/* istanbul ignore file */
+
 import AppiumLauncher from './launcher'
 
 export default class AppiumService {}

--- a/packages/wdio-browserstack-service/src/index.js
+++ b/packages/wdio-browserstack-service/src/index.js
@@ -1,3 +1,5 @@
+/* istanbul ignore file */
+
 import BrowserstackLauncher from './launcher'
 import BrowserstackService from './service'
 

--- a/packages/wdio-config/src/constants.js
+++ b/packages/wdio-config/src/constants.js
@@ -24,6 +24,7 @@ export const DEFAULT_CONFIGS = () => ({
     execArgv: [],
     runnerEnv: {},
     runner: 'local',
+    automationProtocol: 'devtools',
     featureFlags: {
         specFiltering: undefined
     },

--- a/packages/wdio-config/src/constants.js
+++ b/packages/wdio-config/src/constants.js
@@ -10,7 +10,6 @@ export const DEFAULT_CONFIGS = () => ({
     logLevel: 'info',
     logLevels: {},
     excludeDriverLogs: [],
-    baseUrl: undefined,
     bail: 0,
     waitforInterval: 500,
     waitforTimeout: 5000,
@@ -24,7 +23,6 @@ export const DEFAULT_CONFIGS = () => ({
     execArgv: [],
     runnerEnv: {},
     runner: 'local',
-    automationProtocol: 'devtools',
     featureFlags: {
         specFiltering: undefined
     },

--- a/packages/wdio-crossbrowsertesting-service/src/index.js
+++ b/packages/wdio-crossbrowsertesting-service/src/index.js
@@ -1,3 +1,5 @@
+/* istanbul ignore file */
+
 import CrossBrowserTestingLauncher from './launcher'
 import CrossBrowserTestingService from './service'
 

--- a/packages/wdio-firefox-profile-service/src/index.js
+++ b/packages/wdio-firefox-profile-service/src/index.js
@@ -1,3 +1,5 @@
+/* istanbul ignore file */
+
 import FirefoxProfileLauncher from './launcher'
 
 export const launcher = FirefoxProfileLauncher

--- a/packages/wdio-logger/src/index.js
+++ b/packages/wdio-logger/src/index.js
@@ -1,3 +1,5 @@
+/* istanbul ignore file */
+
 /**
  * environment check to allow to use this package in a web context
  */

--- a/packages/wdio-logger/src/web.js
+++ b/packages/wdio-logger/src/web.js
@@ -1,3 +1,5 @@
+/* istanbul ignore file */
+
 export default function getLogger (component) {
     return ['error', 'warn', 'info', 'debug', 'trace', 'silent'].reduce((acc, cur) => {
         // check if the method is available on console (web doesn't have

--- a/packages/wdio-selenium-standalone-service/src/index.js
+++ b/packages/wdio-selenium-standalone-service/src/index.js
@@ -1,3 +1,5 @@
+/* istanbul ignore file */
+
 import SeleniumStandaloneLauncher from './launcher'
 
 export default class SeleniumStandaloneService {}

--- a/packages/wdio-static-server-service/src/index.js
+++ b/packages/wdio-static-server-service/src/index.js
@@ -1,3 +1,5 @@
+/* istanbul ignore file */
+
 import StaticServerLauncher from './launcher'
 
 export default class StaticServerService {}

--- a/packages/wdio-testingbot-service/src/index.js
+++ b/packages/wdio-testingbot-service/src/index.js
@@ -1,3 +1,5 @@
+/* istanbul ignore file */
+
 import TestingBotLauncher from './launcher'
 import TestingBotService from './service'
 

--- a/packages/wdio-utils/src/index.js
+++ b/packages/wdio-utils/src/index.js
@@ -1,3 +1,5 @@
+/* istanbul ignore file */
+
 import initialisePlugin from './initialisePlugin'
 import initialiseServices from './initialiseServices'
 import webdriverMonad from './monad'

--- a/packages/wdio-webdriver-mock-service/src/index.js
+++ b/packages/wdio-webdriver-mock-service/src/index.js
@@ -19,6 +19,7 @@ export default class WebdriverMockService {
         this.command = this.mock.command
 
         // define required responses
+        this.command.status().reply(200, { value: {} })
         this.command.newSession().times(2).reply(200, newSession)
         this.command.deleteSession().times(2).reply(200, deleteSession)
         this.command.getTitle().times(10).reply(200, { value: 'Mock Page Title' })

--- a/packages/wdio-webdriver-mock-service/src/index.js
+++ b/packages/wdio-webdriver-mock-service/src/index.js
@@ -19,7 +19,7 @@ export default class WebdriverMockService {
         this.command = this.mock.command
 
         // define required responses
-        this.command.status().reply(200, { value: {} })
+        this.command.status().times(Infinity).reply(200, { value: {} })
         this.command.newSession().times(2).reply(200, newSession)
         this.command.deleteSession().times(2).reply(200, deleteSession)
         this.command.getTitle().times(10).reply(200, { value: 'Mock Page Title' })

--- a/packages/webdriverio/package.json
+++ b/packages/webdriverio/package.json
@@ -62,6 +62,7 @@
     "@wdio/utils": "6.0.0-alpha.1",
     "archiver": "^3.0.0",
     "css-value": "^0.0.1",
+    "devtools": "^6.0.0-alpha.1",
     "grapheme-splitter": "^1.0.2",
     "lodash.clonedeep": "^4.5.0",
     "lodash.isobject": "^3.0.2",

--- a/packages/webdriverio/src/constants.js
+++ b/packages/webdriverio/src/constants.js
@@ -33,7 +33,7 @@ export const WDIO_DEFAULTS = {
      * allows to specify automation protocol
      */
     automationProtocol: {
-        default: 'webdriver',
+        default: 'devtools',
         type: (param) => {
             if (typeof param !== 'string') {
                 throw new Error('the "automationProtocol" option needs to from type strings')

--- a/packages/webdriverio/src/constants.js
+++ b/packages/webdriverio/src/constants.js
@@ -422,3 +422,9 @@ export const APPIUM_CAPABILITES = [
     ...APPIUM_ANDROID_CAPABILITIES,
     ...APPIUM_IOS_CAPABILITIES
 ]
+export const DRIVER_DEFAULT_ENDPOINT = {
+    method: 'GET',
+    host: 'localhost',
+    port: 4444,
+    path: '/status'
+}

--- a/packages/webdriverio/src/constants.js
+++ b/packages/webdriverio/src/constants.js
@@ -33,7 +33,6 @@ export const WDIO_DEFAULTS = {
      * allows to specify automation protocol
      */
     automationProtocol: {
-        default: 'devtools',
         type: (param) => {
             if (typeof param !== 'string') {
                 throw new Error('the "automationProtocol" option needs to from type strings')

--- a/packages/webdriverio/src/index.js
+++ b/packages/webdriverio/src/index.js
@@ -6,7 +6,7 @@ import { wrapCommand, runFnInFiberContext } from '@wdio/utils'
 
 import MultiRemote from './multiremote'
 import { WDIO_DEFAULTS } from './constants'
-import { getPrototype, addLocatorStrategyHandler, isStub } from './utils'
+import { getPrototype, addLocatorStrategyHandler, isStub, getAutomationProtocol } from './utils'
 
 const log = logger('webdriverio')
 
@@ -38,9 +38,10 @@ export const remote = async function (params = {}, remoteModifier) {
         process.env.WDIO_LOG_PATH = path.join(params.outputDir, 'wdio.log')
     }
 
+    const automationProtocol = await getAutomationProtocol(config)
     const prototype = getPrototype('browser')
-    log.info(`Initiate new session using the ${config.automationProtocol} protocol`)
-    const ProtocolDriver = require(config.automationProtocol).default
+    log.info(`Initiate new session using the ${automationProtocol} protocol`)
+    const ProtocolDriver = require(automationProtocol).default
     const instance = await ProtocolDriver.newSession(params, modifier, prototype, wrapCommand)
 
     /**

--- a/packages/webdriverio/src/utils.js
+++ b/packages/webdriverio/src/utils.js
@@ -434,7 +434,7 @@ export const getAutomationProtocol = async (config) => {
         req.end()
     })
 
-    if (driverEndpointHeaders && driverEndpointHeaders.statusCode === '200') {
+    if (driverEndpointHeaders && parseInt(driverEndpointHeaders.statusCode, 10) === 200) {
         return config.automationProtocol // option defaults to 'webdriver'
     }
 

--- a/packages/webdriverio/src/utils.js
+++ b/packages/webdriverio/src/utils.js
@@ -7,6 +7,7 @@ import GraphemeSplitter from 'grapheme-splitter'
 import logger from '@wdio/logger'
 import isObject from 'lodash.isobject'
 import { URL } from 'url'
+import { SUPPORTED_BROWSER } from 'devtools'
 
 import { ELEMENT_KEY, UNICODE_CHARACTERS, DRIVER_DEFAULT_ENDPOINT } from './constants'
 import { findStrategy } from './utils/findStrategy'
@@ -425,10 +426,20 @@ export const getAutomationProtocol = async (config) => {
     }
 
     /**
-     * don't modify automation protocol if hostname or port is set as
-     * it is very likely that "webdriver" will be used
+     * run WebDriver if hostname or port is set
      */
     if (config.hostname || config.port || (config.user && config.key)) {
+        return 'webdriver'
+    }
+
+    /**
+     * only run DevTools protocol if capabilities match supported platforms
+     */
+    if (
+        config.capabilities &&
+        typeof config.capabilities.browserName === 'string' &&
+        !SUPPORTED_BROWSER.includes(config.capabilities.browserName.toLowerCase())
+    ) {
         return 'webdriver'
     }
 

--- a/packages/webdriverio/src/utils.js
+++ b/packages/webdriverio/src/utils.js
@@ -8,7 +8,7 @@ import logger from '@wdio/logger'
 import isObject from 'lodash.isobject'
 import { URL } from 'url'
 
-import { ELEMENT_KEY, UNICODE_CHARACTERS } from './constants'
+import { ELEMENT_KEY, UNICODE_CHARACTERS, DRIVER_DEFAULT_ENDPOINT } from './constants'
 import { findStrategy } from './utils/findStrategy'
 
 const browserCommands = require('./commands/browser')
@@ -418,10 +418,10 @@ export const isStub = (automationProtocol) => automationProtocol === './protocol
 
 export const getAutomationProtocol = async (config) => {
     /**
-     * don't modify automation protocol if hostname is set as it is very likely
-     * that "webdriver" will be used
+     * don't modify automation protocol if hostname or port is set as
+     * it is very likely that "webdriver" will be used
      */
-    if (config.hostname || (config.user && config.key)) {
+    if (config.hostname || config.port || (config.user && config.key)) {
         return config.automationProtocol
     }
 
@@ -429,18 +429,13 @@ export const getAutomationProtocol = async (config) => {
      * make a head request to check if a driver is available
      */
     const driverEndpointHeaders = await new Promise((resolve) => {
-        const req = http.request({
-            method: 'GET',
-            host: 'localhost',
-            port: config.port || 4444,
-            path: '/status'
-        }, resolve)
+        const req = http.request(DRIVER_DEFAULT_ENDPOINT, resolve)
         req.on('error', resolve)
         req.end()
     })
 
     if (driverEndpointHeaders && driverEndpointHeaders.statusCode === '200') {
-        return config.automationProtocol
+        return config.automationProtocol // option defaults to 'webdriver'
     }
 
     return 'devtools'

--- a/packages/webdriverio/src/utils.js
+++ b/packages/webdriverio/src/utils.js
@@ -418,11 +418,18 @@ export const isStub = (automationProtocol) => automationProtocol === './protocol
 
 export const getAutomationProtocol = async (config) => {
     /**
+     * if automation protocol is set by user prefer this
+     */
+    if (config.automationProtocol) {
+        return config.automationProtocol
+    }
+
+    /**
      * don't modify automation protocol if hostname or port is set as
      * it is very likely that "webdriver" will be used
      */
-    if (config.automationProtocol || config.hostname || config.port || (config.user && config.key)) {
-        return config.automationProtocol
+    if (config.hostname || config.port || (config.user && config.key)) {
+        return 'webdriver'
     }
 
     /**
@@ -435,7 +442,7 @@ export const getAutomationProtocol = async (config) => {
     })
 
     if (driverEndpointHeaders && parseInt(driverEndpointHeaders.statusCode, 10) === 200) {
-        return config.automationProtocol // option defaults to 'webdriver'
+        return 'webdriver'
     }
 
     return 'devtools'

--- a/packages/webdriverio/src/utils.js
+++ b/packages/webdriverio/src/utils.js
@@ -430,7 +430,7 @@ export const getAutomationProtocol = async (config) => {
      */
     const driverEndpointHeaders = await new Promise((resolve) => {
         const req = http.request(DRIVER_DEFAULT_ENDPOINT, resolve)
-        req.on('error', resolve)
+        req.on('error', (error) => resolve({ error }))
         req.end()
     })
 

--- a/packages/webdriverio/src/utils.js
+++ b/packages/webdriverio/src/utils.js
@@ -421,7 +421,7 @@ export const getAutomationProtocol = async (config) => {
      * don't modify automation protocol if hostname or port is set as
      * it is very likely that "webdriver" will be used
      */
-    if (config.hostname || config.port || (config.user && config.key)) {
+    if (config.automationProtocol || config.hostname || config.port || (config.user && config.key)) {
         return config.automationProtocol
     }
 

--- a/packages/webdriverio/src/utils.js
+++ b/packages/webdriverio/src/utils.js
@@ -428,7 +428,7 @@ export const getAutomationProtocol = async (config) => {
     /**
      * run WebDriver if hostname or port is set
      */
-    if (config.hostname || config.port || (config.user && config.key)) {
+    if (config.hostname || config.port || config.path || (config.user && config.key)) {
         return 'webdriver'
     }
 

--- a/packages/webdriverio/tests/commands/element/waitForClickable.test.js
+++ b/packages/webdriverio/tests/commands/element/waitForClickable.test.js
@@ -1,4 +1,3 @@
-import request from 'request'
 import { remote } from '../../../src'
 
 describe('waitForClickable', () => {
@@ -6,8 +5,6 @@ describe('waitForClickable', () => {
     let browser
 
     beforeEach(async () => {
-        request.mockClear()
-
         browser = await remote({
             baseUrl: 'http://foobar.com',
             capabilities: {

--- a/packages/webdriverio/tests/module.test.js
+++ b/packages/webdriverio/tests/module.test.js
@@ -52,13 +52,20 @@ describe('WebdriverIO module interface', () => {
 
     describe('remote function', () => {
         it('creates a webdriver session', async () => {
-            const browser = await remote({ capabilities: {}, logLevel: 'trace' })
+            const browser = await remote({
+                automationProtocol: 'webdriver',
+                capabilities: {},
+                logLevel: 'trace'
+            })
             expect(browser.sessionId).toBe('foobar-123')
             expect(logger.setLogLevelsConfig).toBeCalledWith(undefined, 'trace')
         })
 
         it('allows to propagate a modifier', async () => {
-            const browser = await remote({ capabilities: {} }, (client) => {
+            const browser = await remote({
+                automationProtocol: 'webdriver',
+                capabilities: {}
+            }, (client) => {
                 client.foobar = 'barfoo'
                 return client
             })
@@ -67,18 +74,29 @@ describe('WebdriverIO module interface', () => {
         })
 
         it('should try to detect the backend', async () => {
-            await remote({ user: 'foo', key: 'bar', capabilities: {} })
+            await remote({
+                user: 'foo',
+                key: 'bar',
+                capabilities: {}
+            })
             expect(detectBackend).toBeCalled()
         })
 
         it('should set process.env.WDIO_LOG_PATH if outputDir is set in the options', async()=>{
             let testDirPath = './logs'
-            await remote({ outputDir: testDirPath, capabilities: { browserName: 'firefox' } })
+            await remote({
+                automationProtocol: 'webdriver',
+                outputDir: testDirPath,
+                capabilities: { browserName: 'firefox' }
+            })
             expect(process.env.WDIO_LOG_PATH).toEqual(path.join(testDirPath, 'wdio.log'))
         })
 
         it('should not wrap custom commands into fiber context if used as standalone', async () => {
-            const browser = await remote({ capabilities: {} })
+            const browser = await remote({
+                automationProtocol: 'webdriver',
+                capabilities: {}
+            })
             const customCommand = jest.fn()
             browser.addCommand('someCommand', customCommand)
             expect(runFnInFiberContext).toBeCalledTimes(0)
@@ -88,7 +106,11 @@ describe('WebdriverIO module interface', () => {
         })
 
         it('should wrap custom commands into fiber context', async () => {
-            const browser = await remote({ capabilities: {}, runner: 'local' })
+            const browser = await remote({
+                automationProtocol: 'webdriver',
+                capabilities: {},
+                runner: 'local'
+            })
             const customCommand = jest.fn()
             browser.addCommand('someCommand', customCommand)
             expect(runFnInFiberContext).toBeCalledTimes(1)
@@ -98,17 +120,22 @@ describe('WebdriverIO module interface', () => {
         })
 
         it('should attach custom locators to the strategies', async () => {
-            const browser = await remote({ capabilities: {} })
+            const browser = await remote({
+                automationProtocol: 'webdriver',
+                capabilities: {}
+            })
             const fakeFn = () => { return 'test'}
 
             browser.addLocatorStrategy('test-strat', fakeFn)
-
             expect(browser.strategies.get('test-strat').toString()).toBe(fakeFn.toString())
         })
 
         it('throws error if trying to overwrite locator strategy', async () => {
             expect.assertions(1)
-            const browser = await remote({ capabilities: {} })
+            const browser = await remote({
+                automationProtocol: 'webdriver',
+                capabilities: {}
+            })
 
             try {
                 const fakeFn = () => { return 'test'}
@@ -120,7 +147,9 @@ describe('WebdriverIO module interface', () => {
         })
 
         it('should properly create stub instance', async () => {
-            validateConfig.mockReturnValueOnce({ automationProtocol: './protocol-stub' })
+            validateConfig.mockReturnValueOnce({
+                automationProtocol: './protocol-stub'
+            })
             const browser = await remote({ capabilities: { browserName: 'chrome' } })
 
             expect(browser.sessionId).toBeUndefined()

--- a/packages/webdriverio/tests/utils.test.js
+++ b/packages/webdriverio/tests/utils.test.js
@@ -489,8 +489,10 @@ describe('utils', () => {
 
         it('should default to devtools if /status request fails', async () => {
             http.setResponse({ statusCode: 404 })
-            expect(await getAutomationProtocol({ automationProtocol: 'webdriver' }))
+            expect(await getAutomationProtocol({}))
                 .toBe('devtools')
+            expect(await getAutomationProtocol({ automationProtocol: 'webdriver' }))
+                .toBe('webdriver')
         })
     })
 })

--- a/packages/webdriverio/tests/utils.test.js
+++ b/packages/webdriverio/tests/utils.test.js
@@ -494,5 +494,11 @@ describe('utils', () => {
             expect(await getAutomationProtocol({ automationProtocol: 'webdriver' }))
                 .toBe('webdriver')
         })
+
+        it('should default to webdriver if browserName is not supported with DevTools automation protocol', async () => {
+            http.setResponse({ statusCode: 404 })
+            expect(await getAutomationProtocol({ capabilities: { browserName: 'foobar' } }))
+                .toBe('webdriver')
+        })
     })
 })

--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -21,8 +21,7 @@ const VENDOR_PROTOCOLS = ['chromium']
 const IGNORED_SUBPACKAGES_FOR_DOCS = [
     'eslint-plugin-wdio',
     'wdio-smoke-test-service',
-    'wdio-smoke-test-reporter',
-    'wdio-webdriver-mock-service'
+    'wdio-smoke-test-reporter'
 ]
 
 const EDIT_WARNING = `// -------------------- ATTENTION --------------------

--- a/tests/mocha/standalone.js
+++ b/tests/mocha/standalone.js
@@ -1,20 +1,18 @@
 import assert from 'assert'
 import { remote } from '../../packages/webdriverio'
-import { hasWdioSyncSupport } from '../../packages/wdio-utils'
-
-console.log(hasWdioSyncSupport)
 
 function sleep (ms) {
     return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
 describe('scripts run in standalone mode', () => {
-    it('should allow to be run asynchronous', async () => {
-        browser.clickScenario()
-        let beforeCmdCounter = 0
-        let afterCmdCounter = 0
+    let remoteBrowser
+    let beforeCmdCounter = 0
+    let afterCmdCounter = 0
 
-        const remoteBrowser = await remote({
+    before(async () => {
+        browser.clickScenario()
+        remoteBrowser = await remote({
             hostname: 'localhost',
             port: 4444,
             path: '/',
@@ -30,11 +28,15 @@ describe('scripts run in standalone mode', () => {
                 ++afterCmdCounter
             }]
         })
+    })
 
+    it('should allow to be run asynchronous', async () => {
         const start = Date.now()
         assert.equal(await remoteBrowser.getTitle(), 'Mock Page Title')
         assert.equal(beforeCmdCounter, 1)
         assert.equal(afterCmdCounter, 1)
         assert.ok((Date.now() - start) > 200)
     })
+
+    after(() => remoteBrowser.deleteSession())
 })


### PR DESCRIPTION
## Proposed changes

Given that Puppeteer now supports Chrome, Firefox and Edge (Chromium) without having to install a browser it makes sense to use it as fallback in case a driver doesn't exist. This patch adds:

- support for Edge (Chromium) using the devtools automation protocol
- removal of `puppeteer-firefox` dependency (now lives directly within `puppeteer`)
- driver endpoint check and fallback to `devtools` if endpoint couldn't be reached

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

This is work in progress. It needs to be tested on Linux and Windows.

### Reviewers: @webdriverio/technical-committee
