### PR TITLE
wdio-cli: Add Experitest Cloud to configuration utility

### DIFF
--- a/packages/wdio-cli/src/constants.js
+++ b/packages/wdio-cli/src/constants.js
@@ -99,7 +99,7 @@ export const QUESTIONNAIRE = [{
     message: 'Where is your automation backend located?',
     choices: [
         'On my local machine',
-        'In the Experitest cloud',
+        'In the cloud using Experitest',
         'In the cloud using Sauce Labs',
         'In the cloud using Browserstack or Testingbot or a different service',
         'I have my own Selenium cloud'
@@ -117,43 +117,43 @@ export const QUESTIONNAIRE = [{
     when: /* istanbul ignore next */ (answers) => answers.backend.indexOf('different service') > -1
 }, {
     type: 'input',
-    name: 'exp_env_access_key',
+    name: 'expEnvAccessKey',
     message: 'Access key from Experitest Cloud',
     default: 'EXPERITEST_ACCESS_KEY',
-    when: /* istanbul ignore next */ (answers) => answers.backend === 'In the Experitest cloud'
+    when: /* istanbul ignore next */ (answers) => answers.backend === 'In the cloud using Experitest'
 }, {
     type: 'input',
-    name: 'exp_env_hostname',
+    name: 'expEnvHostname',
     message: 'Environment variable for cloud url',
     default: 'example.experitest.com',
-    when: /* istanbul ignore next */ (answers) => answers.backend === 'In the Experitest cloud'
+    when: /* istanbul ignore next */ (answers) => answers.backend === 'In the cloud using Experitest'
 }, {
     type: 'list',
-    name: 'exp_env_port',
+    name: 'expEnvPort',
     message: 'Choose a port for environment variable',
     default: 443,
     choices: [
-        443,
-        80,
+        '443',
+        '80',
         'Other'
     ],
-    when: /* istanbul ignore next */ (answers) => answers.backend === 'In the Experitest cloud'
+    when: /* istanbul ignore next */ (answers) => answers.backend === 'In the cloud using Experitest'
 }, {
     type: 'input',
-    name: 'exp_env_port',
+    name: 'expEnvPort',
     message: 'Environment variable for other port',
-    default: 'EXPERITEST PORT',
-    when: /* istanbul ignore next */ (answers) => answers.exp_env_port === 'Other'
+    default: 'OTHER_PORT',
+    when: /* istanbul ignore next */ (answers) => answers.expEnvPort === 'Other'
 }, {
     type: 'list',
-    name: 'exp_env_protocol',
+    name: 'expEnvProtocol',
     message: 'Choose a protocol for environment variable',
     default: 'https',
     choices: [
         'https',
         'http'
     ],
-    when: /* istanbul ignore next */ (answers) => answers.backend === 'In the Experitest cloud'
+    when: /* istanbul ignore next */ (answers) => answers.expEnvPort && answers.expEnvPort !== '80' && answers.expEnvPort !== '443'
 }, {
     type: 'input',
     name: 'env_user',

--- a/packages/wdio-cli/src/constants.js
+++ b/packages/wdio-cli/src/constants.js
@@ -99,6 +99,7 @@ export const QUESTIONNAIRE = [{
     message: 'Where is your automation backend located?',
     choices: [
         'On my local machine',
+        'In the Experitest cloud',
         'In the cloud using Sauce Labs',
         'In the cloud using Browserstack or Testingbot or a different service',
         'I have my own Selenium cloud'
@@ -114,6 +115,45 @@ export const QUESTIONNAIRE = [{
     message: 'What is the port on which that service is running?',
     default: '80',
     when: /* istanbul ignore next */ (answers) => answers.backend.indexOf('different service') > -1
+}, {
+    type: 'input',
+    name: 'exp_env_access_key',
+    message: 'Access key from Experitest Cloud',
+    default: 'EXPERITEST_ACCESS_KEY',
+    when: /* istanbul ignore next */ (answers) => answers.backend === 'In the Experitest cloud'
+}, {
+    type: 'input',
+    name: 'exp_env_hostname',
+    message: 'Environment variable for cloud url',
+    default: 'example.experitest.com',
+    when: /* istanbul ignore next */ (answers) => answers.backend === 'In the Experitest cloud'
+}, {
+    type: 'list',
+    name: 'exp_env_port',
+    message: 'Choose a port for environment variable',
+    default: 443,
+    choices: [
+        443,
+        80,
+        'Other'
+    ],
+    when: /* istanbul ignore next */ (answers) => answers.backend === 'In the Experitest cloud'
+}, {
+    type: 'input',
+    name: 'exp_env_port',
+    message: 'Environment variable for other port',
+    default: 'EXPERITEST PORT',
+    when: /* istanbul ignore next */ (answers) => answers.exp_env_port === 'Other'
+}, {
+    type: 'list',
+    name: 'exp_env_protocol',
+    message: 'Choose a protocol for environment variable',
+    default: 'https',
+    choices: [
+        'https',
+        'http'
+    ],
+    when: /* istanbul ignore next */ (answers) => answers.backend === 'In the Experitest cloud'
 }, {
     type: 'input',
     name: 'env_user',

--- a/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
+++ b/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
@@ -10,7 +10,7 @@ exports.config = {
 
     if(answers.expEnvAccessKey){ %>
     hostname: '<%= answers.expEnvHostname %>',
-    <% if (answers.expEnvPort === '443'){%>protocol: https,
+    <% if (answers.expEnvPort === '443'){%>protocol: 'https',
     <%} else if (answers.expEnvPort === '80'){%>protocol: http,
     <%} else { %>protocol: '<%= answers.expEnvProtocol %>',<%}%>
     port: <%= answers.expEnvPort %>,

--- a/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
+++ b/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
@@ -7,7 +7,13 @@ exports.config = {
     // WebdriverIO allows it to run your tests in arbitrary locations (e.g. locally or
     // on a remote machine).
     runner: '<%= answers.runner %>',<%
-    if(answers.hostname && answers.port) { %>
+
+    if(answers.exp_env_access_key){ %>
+    hostname: '<%= answers.exp_env_hostname %>',
+    protocol: '<%= answers.exp_env_protocol %>',
+    port: <%= answers.exp_env_port %>,
+    path: '/wd/hub',
+    <% } else if(answers.hostname && answers.port) { %>
     //
     // =====================
     // Server Configurations
@@ -84,6 +90,7 @@ exports.config = {
     // https://docs.saucelabs.com/reference/platforms-configurator
     //
     capabilities: [{
+    <%if(answers.exp_env_access_key){%> accessKey: '<%= answers.exp_env_access_key %>',<%}%>
         // maxInstances can get overwritten per capability. So if you have an in-house Selenium
         // grid with only 5 firefox instances available you can make sure that not more than
         // 5 instances get started at a time.
@@ -227,7 +234,8 @@ exports.config = {
      * @param {Array.<Object>} capabilities list of capabilities details
      */
     // onPrepare: function (config, capabilities) {
-    // },/**
+    // },
+    /**
      * Gets executed before a worker process is spawned and can be used to initialise specific service
      * for that worker as well as modify runtime environments in an async fashion.
      * @param  {String} cid      capability id (e.g 0-0)

--- a/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
+++ b/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
@@ -8,10 +8,12 @@ exports.config = {
     // on a remote machine).
     runner: '<%= answers.runner %>',<%
 
-    if(answers.exp_env_access_key){ %>
-    hostname: '<%= answers.exp_env_hostname %>',
-    protocol: '<%= answers.exp_env_protocol %>',
-    port: <%= answers.exp_env_port %>,
+    if(answers.expEnvAccessKey){ %>
+    hostname: '<%= answers.expEnvHostname %>',
+    <% if (answers.expEnvPort === '443'){%>protocol: https,
+    <%} else if (answers.expEnvPort === '80'){%>protocol: http,
+    <%} else { %>protocol: '<%= answers.expEnvProtocol %>',<%}%>
+    port: <%= answers.expEnvPort %>,
     path: '/wd/hub',
     <% } else if(answers.hostname && answers.port) { %>
     //
@@ -90,7 +92,7 @@ exports.config = {
     // https://docs.saucelabs.com/reference/platforms-configurator
     //
     capabilities: [{
-    <%if(answers.exp_env_access_key){%> accessKey: '<%= answers.exp_env_access_key %>',<%}%>
+    <%if(answers.expEnvAccessKey){%> 'experitest:accessKey': '<%= answers.expEnvAccessKey %>',<%}%>
         // maxInstances can get overwritten per capability. So if you have an in-house Selenium
         // grid with only 5 firefox instances available you can make sure that not more than
         // 5 instances get started at a time.

--- a/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
+++ b/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
@@ -11,7 +11,7 @@ exports.config = {
     if(answers.expEnvAccessKey){ %>
     hostname: '<%= answers.expEnvHostname %>',
     <% if (answers.expEnvPort === '443'){%>protocol: 'https',
-    <%} else if (answers.expEnvPort === '80'){%>protocol: http,
+    <%} else if (answers.expEnvPort === '80'){%>protocol: 'http',
     <%} else { %>protocol: '<%= answers.expEnvProtocol %>',<%}%>
     port: <%= answers.expEnvPort %>,
     path: '/wd/hub',


### PR DESCRIPTION
## Proposed changes

WebdriverIO users will be able to setup a config file that integrates with the Experitest Cloud with the help of wdio-cli.
Experitest users will need only access key from their Cloud.
		
If Experitest integration is chosen we will add to the config file:
- 'hostname' - The hostname of the Cloud (example.ex.com) - User configurable
- 'protocol' - HTTP or HTTPS - User configurable
- 'port' - 80, 443 or other - User configurable
- 'path' - /wd/hub
- capabilities.accessKey - User configurable


## Types of changes

WebdriverIO users can have integration with Experitest Cloud

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works - **Not applicable because the change is only in the configuration utility**
- [x] I have added necessary documentation (if appropriate) - **Documentation is not applicable because the change is only in the configuration utility**
- [x] I have added proper type definitions for new commands (if appropriate) - **Not applicable because the change is only in the configuration utility**

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
