### PR TITLE
Fix cli answer validation

### DIFF
--- a/packages/wdio-cli/src/constants.js
+++ b/packages/wdio-cli/src/constants.js
@@ -220,7 +220,7 @@ export const QUESTIONNAIRE = [{
         /* istanbul ignore next */
         ({ name }) => name === 'chromedriver').value
     ],
-    validate: validateServiceAnswers
+    validate: answers  => validateServiceAnswers(answers)
 }, {
     type: 'input',
     name: 'outputDir',

--- a/packages/wdio-cli/tests/index.test.js
+++ b/packages/wdio-cli/tests/index.test.js
@@ -2,6 +2,7 @@ import yargs from 'yargs'
 
 import { run } from './../src/index'
 import { handler } from './../src/commands/run'
+import { join, resolve } from 'path'
 
 jest.mock('./../src/commands/run', () => ({
     ...jest.requireActual('./../src/commands/run'),
@@ -24,12 +25,12 @@ describe('index', () => {
 
         expect(handler).toHaveBeenCalledWith({
             _: ['wdio.conf.js'],
-            configPath: `${process.cwd()}/wdio.conf.js`
+            configPath: join(`${process.cwd()}`, 'wdio.conf.js')
         })
     })
 
     it('should work properly with absolute paths', async () => {
-        const expectedPath = '/some/absolute/path/here/wdio.conf.js'
+        const expectedPath = resolve('/some/absolute/path/here/wdio.conf.js')
         yargs.argv._[0] = expectedPath
 
         await run({ spec: './foobar.js' }).catch()


### PR DESCRIPTION
## Proposed changes

During a WebdriverIO workshop the people ran into the issue of installing both the `wdio-chromedriver-service` as well as the `wdio-selenium-standalone-service`.
This should have been prevented but was not the case.

Additionally I have fixed the tests to take into account the Windows path system and actually check for a absolute path where required.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

### Reviewers: @webdriverio/technical-committee
