### PR TITLE
Implement `performActions` for devtools automation protocol

### DIFF
--- a/e2e/element.test.js
+++ b/e2e/element.test.js
@@ -122,6 +122,7 @@ describe('elements', () => {
     })
 
     it('should be able to do a drag&drop', async () => {
+        await browser.executeScript('window.scrollTo(0, 0)', [])
         await browser.performActions([{
             type: 'pointer',
             id: 'finger1',

--- a/e2e/element.test.js
+++ b/e2e/element.test.js
@@ -120,6 +120,64 @@ describe('elements', () => {
         const link = await browser.findElement('partial link text', 'new tab')
         expect(await browser.getElementText(link[ELEMENT_KEY])).toBe('open new tab')
     })
+
+    it('should be able to do a drag&drop', async () => {
+        await browser.performActions([{
+            type: 'pointer',
+            id: 'finger1',
+            parameters: {
+                pointerType: 'mouse'
+            },
+            actions: [{
+                type: 'pointerMove',
+                duration: 0,
+                x: 65,
+                y: 544
+            }, {
+                type: 'pointerDown',
+                button: 0
+            }, {
+                type: 'pause',
+                duration: 10
+            }, {
+                type: 'pointerMove',
+                duration: 100,
+                origin: 'pointer',
+                x: 1,
+                y: -251
+            }, {
+                type: 'pointerUp',
+                button: 0
+            }]
+        }])
+
+        const elem = await browser.$('.searchinput')
+        expect(await browser.getElementProperty(elem[ELEMENT_KEY])).toBe('Dropped!')
+    })
+
+    it('should be able to use keys command', async () => {
+        const textarea = await browser.findElement('css selector', 'textarea')
+        await browser.elementClick(textarea[ELEMENT_KEY])
+        await browser.performActions([{
+            type: 'key',
+            id: 'keyboard',
+            actions: [
+                { type: 'keyDown', value: 'f' },
+                { type: 'keyDown', value: 'o' },
+                { type: 'keyDown', value: 'o' },
+                { type: 'keyDown', value: 'b' },
+                { type: 'keyDown', value: 'a' },
+                { type: 'keyDown', value: 'r' },
+                { type: 'keyUp', value: 'f' },
+                { type: 'keyUp', value: 'o' },
+                { type: 'keyUp', value: 'o' },
+                { type: 'keyUp', value: 'b' },
+                { type: 'keyUp', value: 'a' },
+                { type: 'keyUp', value: 'r' }
+            ]
+        }])
+        expect(await browser.getElementProperty(textarea[ELEMENT_KEY])).toBe('Dropped!')
+    })
 })
 
 afterAll(async () => {

--- a/e2e/element.test.js
+++ b/e2e/element.test.js
@@ -170,16 +170,18 @@ describe('elements', () => {
                 { type: 'keyDown', value: 'b' },
                 { type: 'keyDown', value: 'a' },
                 { type: 'keyDown', value: 'r' },
+                { type: 'keyDown', value: '😉' },
                 { type: 'keyUp', value: 'f' },
                 { type: 'keyUp', value: 'o' },
                 { type: 'keyUp', value: 'o' },
                 { type: 'keyUp', value: 'b' },
                 { type: 'keyUp', value: 'a' },
-                { type: 'keyUp', value: 'r' }
+                { type: 'keyUp', value: 'r' },
+                { type: 'keyUp', value: '😉' }
             ]
         }])
         expect(await browser.getElementProperty(textarea[ELEMENT_KEY], 'value'))
-            .toBe('foobar')
+            .toBe('foobar😉')
     })
 })
 

--- a/e2e/element.test.js
+++ b/e2e/element.test.js
@@ -151,8 +151,9 @@ describe('elements', () => {
             }]
         }])
 
-        const elem = await browser.$('.searchinput')
-        expect(await browser.getElementProperty(elem[ELEMENT_KEY])).toBe('Dropped!')
+        const elem = await browser.findElement('css selector', '.searchinput')
+        expect(await browser.getElementProperty(elem[ELEMENT_KEY], 'value'))
+            .toBe('Dropped!')
     })
 
     it('should be able to use keys command', async () => {
@@ -176,7 +177,8 @@ describe('elements', () => {
                 { type: 'keyUp', value: 'r' }
             ]
         }])
-        expect(await browser.getElementProperty(textarea[ELEMENT_KEY])).toBe('foobar')
+        expect(await browser.getElementProperty(textarea[ELEMENT_KEY], 'value'))
+            .toBe('foobar')
     })
 })
 

--- a/e2e/element.test.js
+++ b/e2e/element.test.js
@@ -176,7 +176,7 @@ describe('elements', () => {
                 { type: 'keyUp', value: 'r' }
             ]
         }])
-        expect(await browser.getElementProperty(textarea[ELEMENT_KEY])).toBe('Dropped!')
+        expect(await browser.getElementProperty(textarea[ELEMENT_KEY])).toBe('foobar')
     })
 })
 

--- a/packages/devtools/src/commands/performActions.js
+++ b/packages/devtools/src/commands/performActions.js
@@ -1,0 +1,83 @@
+const sleep = (time = 0) => new Promise(
+    (resolve) => setTimeout(resolve, time))
+
+export default async function performActions ({ actions }) {
+    const page = this.getPageHandle()
+    const lastPointer = {}
+
+    for (const action of actions) {
+        /**
+         * Used with an integer argument to specify the duration of a tick,
+         * or as a placeholder to indicate that an input source does nothing
+         * during a particular tick.
+         */
+        if (action.type === null || action.type === 'null') {
+            for (const singleAction of action.actions) {
+                await sleep(singleAction.duration)
+            }
+            continue
+        }
+
+        if (action.type === 'key') {
+            for (const singleAction of action.actions) {
+                if (singleAction.type === 'pause') {
+                    await sleep(singleAction.duration)
+                    continue
+                }
+
+                const cmd = singleAction.type.slice(3).toLowerCase()
+                const keyboardFn = ::page.keyboard[cmd]
+                await keyboardFn(singleAction.value, { text: singleAction.value })
+                continue
+            }
+            continue
+        }
+
+        if (action.type === 'pointer') {
+            if (action.parameters && action.parameters.pointerType && action.parameters.pointerType !== 'mouse') {
+                throw new Error('Currently only "mouse" is supported as pointer type')
+            }
+
+            for (const singleAction of action.actions) {
+                if (singleAction.type === 'pause') {
+                    await sleep(singleAction.duration)
+                    continue
+                }
+
+                const cmd = singleAction.type.slice(7).toLowerCase()
+                const keyboardFn = ::page.mouse[cmd]
+                let { x, y, duration, button, origin } = singleAction
+
+                if (cmd === 'move') {
+                    /**
+                     * set location relative from last position if origin is set to pointer
+                     */
+                    if (origin === 'pointer' && lastPointer.x && lastPointer.y) {
+                        x += lastPointer.x
+                        y += lastPointer.y
+                    }
+
+                    lastPointer.x = x
+                    lastPointer.y = y
+                    await keyboardFn(x, y, { steps: 10 })
+                    continue
+                } else {
+                    const pptrButton = (
+                        button === 0 ? 'left' : (
+                            button === 1 ? 'middle' : 'right'
+                        )
+                    )
+                    await keyboardFn({ button: pptrButton })
+                }
+
+                if (duration) {
+                    await sleep(duration)
+                }
+                continue
+            }
+            continue
+        }
+
+        throw new Error(`Unknown action type ("${action.type}"), allowed are only: null, key and pointer`)
+    }
+}

--- a/packages/devtools/src/commands/performActions.js
+++ b/packages/devtools/src/commands/performActions.js
@@ -1,5 +1,8 @@
 import USKeyboardLayout from 'puppeteer-core/lib/USKeyboardLayout'
 
+const KEY = 'key'
+const POINTER = 'pointer'
+
 const sleep = (time = 0) => new Promise(
     (resolve) => setTimeout(resolve, time))
 
@@ -27,7 +30,7 @@ export default async function performActions ({ actions }) {
                     continue
                 }
 
-                const cmd = singleAction.type.slice(3).toLowerCase()
+                const cmd = singleAction.type.slice(KEY.length).toLowerCase()
                 const keyboardFn = ::page.keyboard[cmd]
 
                 /**
@@ -66,7 +69,7 @@ export default async function performActions ({ actions }) {
                     continue
                 }
 
-                const cmd = singleAction.type.slice(7).toLowerCase()
+                const cmd = singleAction.type.slice(POINTER.length).toLowerCase()
                 const keyboardFn = ::page.mouse[cmd]
                 let { x, y, duration, button, origin } = singleAction
 

--- a/packages/devtools/src/commands/performActions.js
+++ b/packages/devtools/src/commands/performActions.js
@@ -5,12 +5,11 @@ export default async function performActions ({ actions }) {
     const page = this.getPageHandle()
     const lastPointer = {}
 
+    /**
+     * see https://github.com/jlipps/simple-wd-spec#input-sources-and-corresponding-actions
+     * for details on the `actions` format
+     */
     for (const action of actions) {
-        /**
-         * Used with an integer argument to specify the duration of a tick,
-         * or as a placeholder to indicate that an input source does nothing
-         * during a particular tick.
-         */
         if (action.type === null || action.type === 'null') {
             for (const singleAction of action.actions) {
                 await sleep(singleAction.duration)

--- a/packages/devtools/src/commands/releaseActions.js
+++ b/packages/devtools/src/commands/releaseActions.js
@@ -1,0 +1,6 @@
+/**
+ * there is no reference implementation for it in Puppeteer
+ */
+export default async function performActions () {
+    // NYI
+}

--- a/packages/devtools/src/devtoolsdriver.js
+++ b/packages/devtools/src/devtoolsdriver.js
@@ -103,9 +103,11 @@ export default class DevToolsDriver {
             }
 
             this.emit('result', { command, params, retries, result })
-            log.info('RESULT', command.toLowerCase().includes('screenshot')
-                && typeof result === 'string' && result.length > 64
-                ? `${result.substr(0, 61)}...` : result)
+            if (typeof result !== 'undefined') {
+                log.info('RESULT', command.toLowerCase().includes('screenshot')
+                    && typeof result === 'string' && result.length > 64
+                    ? `${result.substr(0, 61)}...` : result)
+            }
 
             return result
         }

--- a/packages/devtools/src/devtoolsdriver.js
+++ b/packages/devtools/src/devtoolsdriver.js
@@ -104,9 +104,12 @@ export default class DevToolsDriver {
 
             this.emit('result', { command, params, retries, result })
             if (typeof result !== 'undefined') {
-                log.info('RESULT', command.toLowerCase().includes('screenshot')
-                    && typeof result === 'string' && result.length > 64
-                    ? `${result.substr(0, 61)}...` : result)
+                const isScreenshot = (
+                    command.toLowerCase().includes('screenshot') &&
+                    typeof result === 'string' &&
+                    result.length > 64
+                )
+                log.info('RESULT', isScreenshot ? `${result.substr(0, 61)}...` : result)
             }
 
             return result

--- a/packages/webdriverio/src/commands/browser/keys.js
+++ b/packages/webdriverio/src/commands/browser/keys.js
@@ -33,10 +33,10 @@ export default function keys (value) {
      * replace key with corresponding unicode character
      */
     if (typeof value === 'string') {
-        keySequence = checkUnicode(value)
+        keySequence = checkUnicode(value, this.isDevTools)
     } else if (value instanceof Array) {
         for (const charSet of value) {
-            keySequence = keySequence.concat(checkUnicode(charSet))
+            keySequence = keySequence.concat(checkUnicode(charSet, this.isDevTools))
         }
     } else {
         throw new Error('"keys" command requires a string or array of strings as parameter')

--- a/packages/webdriverio/src/utils.js
+++ b/packages/webdriverio/src/utils.js
@@ -181,9 +181,9 @@ export function parseCSS (cssPropertyValue, cssProperty) {
  * @param  {String} value  text
  * @return {Array}         set of characters or unicode symbols
  */
-export function checkUnicode (value) {
+export function checkUnicode (value, isDevTools) {
     return Object.prototype.hasOwnProperty.call(UNICODE_CHARACTERS, value)
-        ? [UNICODE_CHARACTERS[value]]
+        ? isDevTools ? value : [UNICODE_CHARACTERS[value]]
         : new GraphemeSplitter().splitGraphemes(value)
 }
 

--- a/packages/webdriverio/tests/utils.test.js
+++ b/packages/webdriverio/tests/utils.test.js
@@ -171,6 +171,13 @@ describe('utils', () => {
             expect(result[0]).toEqual('\uE011')
         })
 
+        it('should not convert unicode if devtools is used', () => {
+            const result = checkUnicode('Home', true)
+
+            expect(Array.isArray(result)).toBe(false)
+            expect(result).toEqual('Home')
+        })
+
         it('should return an array without unicode', () => {
             const result = checkUnicode('foo')
 


### PR DESCRIPTION
## Proposed changes

These are the last two important protocol commands we have to implement for the devtools automation protocol. Given that there are a few commands (e.g. `keys` or `dragAndDrop`) that use `performActions` this was necessary to do before the v6 release.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

### Reviewers: @webdriverio/project-committers 
