### PR TITLE
wdio-allure-reporter: Bug fix where tests get unknown status and has no execution information

### DIFF
--- a/packages/wdio-allure-reporter/src/index.js
+++ b/packages/wdio-allure-reporter/src/index.js
@@ -227,7 +227,7 @@ class AllureReporter extends WDIOReporter {
         }
 
         // add beforeEach / afterEach hook as step to test
-        if (this.options.disableMochaHooks && isMochaEachHooks(hook.title)) {
+        if (isMochaEachHooks(hook.title)) {
             if (this.allure.getCurrentTest()) {
                 this.allure.startStep(hook.title)
             }
@@ -245,12 +245,12 @@ class AllureReporter extends WDIOReporter {
 
     onHookEnd(hook) {
         // ignore global hooks
-        if (!hook.parent || !this.allure.getCurrentSuite() || (this.options.disableMochaHooks && !isMochaAllHooks(hook.title) && !this.allure.getCurrentTest())) {
+        if (!hook.parent || !this.allure.getCurrentSuite() || (!isMochaAllHooks(hook.title) && !this.allure.getCurrentTest())) {
             return false
         }
 
         // set beforeEach / afterEach hook (step) status
-        if (this.options.disableMochaHooks && isMochaEachHooks(hook.title)) {
+        if (isMochaEachHooks(hook.title)) {
             if (hook.error) {
                 this.allure.endStep(stepStatuses.FAILED)
             } else {

--- a/packages/wdio-allure-reporter/tests/allureFeatures.test.js
+++ b/packages/wdio-allure-reporter/tests/allureFeatures.test.js
@@ -525,20 +525,20 @@ describe('hooks handling default', () => {
         endStep = jest.fn(result => result)
     })
 
-    it('should capture mocha each hooks', () => {
+    it('should not capture mocha each hooks', () => {
         reporter.allure = allureInstance()
         reporter.onHookStart({ title: '"before each" hook', parent: 'foo' })
 
-        expect(startStep).toHaveBeenCalledTimes(0)
-        expect(startCase).toHaveBeenCalledTimes(1)
+        expect(startStep).toHaveBeenCalledTimes(1)
+        expect(startCase).toHaveBeenCalledTimes(0)
     })
 
-    it('should not ignore mocha each hooks if no test', () => {
+    it('should ignore mocha each hooks if no test', () => {
         reporter.allure = allureInstance({ test: null })
         reporter.onHookStart({ title: '"after each" hook', parent: 'foo' })
 
         expect(startStep).toHaveBeenCalledTimes(0)
-        expect(startCase).toHaveBeenCalledTimes(1)
+        expect(startCase).toHaveBeenCalledTimes(0)
     })
 
     it('should keep passed hooks if there are no steps (before/after)', () => {


### PR DESCRIPTION
## Proposed changes

This PR is for fixing #4953. It seems like the unknown status happened due to #4773, the added logic messed with the listener lifecycle (specially for "before each" and "after each"). I fixed it by only allowing "before all" and "after all" to be treated as their own test and be affected by the flag "disableMochaHooks". I made "before each" and "after each" unaffected by the flag along with preventing them from displaying in Allure as their own test. Since "before all" and "after all" run only once, it makes sense for them to appear in Allure as their own test. However "before each" and "after each" run with every test, so it makes sense to only include them as part of a test. Let me know if this is ok.

<img width="1052" alt="disableMochaHooks_false" src="https://user-images.githubusercontent.com/13144677/74779857-2e410e00-5253-11ea-89bc-68286c3f3389.png">
<img width="1112" alt="disableMochaHooks_true" src="https://user-images.githubusercontent.com/13144677/74779861-30a36800-5253-11ea-9544-b468c5c26915.png">


## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
