### PR TITLE
Fix documentation formatter

### DIFF
--- a/scripts/utils/formatter.js
+++ b/scripts/utils/formatter.js
@@ -22,10 +22,17 @@ module.exports = function (docfile) {
     let tagVersion = ''
     let tagAuthor = ''
     let tagType = ''
+    let isTypeObject = false
 
     for (const tag of javadoc.tags) {
         if (tag.type == 'param') {
             tag.joinedTypes = tag.types.join('|').replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;')
+
+            if (tag.typesDescription.includes('|<code>undefined</code>')) {
+                tag.typesDescription = `<code>${tag.joinedTypes}</code>`
+                isTypeObject = true
+            }
+
             paramTags.push(tag)
             paramStr.push(tag.name)
         } else if (tag.type == 'property') {
@@ -136,6 +143,20 @@ module.exports = function (docfile) {
          * remove example section from description
          */
         description = description.substr(0, description.indexOf('<example>'))
+    }
+
+    /**
+     * format param strings, from
+     * ```
+     * $(selector).waitForDisplayed(options, options.timeout, options.reverse, options.timeoutMsg, options.interval)
+     * ```
+     * to
+     * ```
+     * $(selector).waitForDisplayed({ timeout, reverse, timeoutMsg, interval })
+     * ```
+     */
+    if (isTypeObject) {
+        paramStr = [`{ ${paramStr.slice(1).map((p) => p.slice(p.indexOf('.') + 1)).join(', ')} }`]
     }
 
     const commandDescription = {


### PR DESCRIPTION
## Proposed changes

For commands that have typed parameters the docs page was kind of borked:

![Screenshot 2020-02-20 at 11 01 05](https://user-images.githubusercontent.com/731337/74922988-55711a00-53d0-11ea-89a4-0dd2a5633aa6.png)

This patch fixes the formatting:

![Screenshot 2020-02-20 at 11 01 15](https://user-images.githubusercontent.com/731337/74923002-5bff9180-53d0-11ea-8fcf-a00c19258c98.png)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
