### PR TITLE
webdriver: Add interceptors for HTTP requests and responses [v5]

### DIFF
--- a/docs/Options.md
+++ b/docs/Options.md
@@ -102,6 +102,18 @@ Specify custom `headers` to pass into every request.
 Type: `Object`<br>
 Default: `{}`
 
+### `transformRequest`
+Function intercepting [HTTP request options](https://github.com/request/request#requestoptions-callback) before a WebDriver request is made
+
+Type: `(RequestOptions) => RequestOptions`<br>
+Default: *none*
+
+### `transformResponse`
+Function intercepting HTTP response objects after a WebDriver response has arrived. The function is passed the original response object as the first and the corresponding `RequestOptions` as the second argument.
+
+Type: `(Response, RequestOptions) => Response`<br>
+Default: *none*
+
 ---
 
 ## WDIO Options

--- a/packages/webdriver/README.md
+++ b/packages/webdriver/README.md
@@ -106,3 +106,15 @@ Count of request retries to the Selenium server.
 
 Type: `Number`<br>
 Default: *2*
+
+### transformRequest
+Function intercepting [HTTP request options](https://github.com/request/request#requestoptions-callback) before a WebDriver request is made
+
+Type: `(RequestOptions) => RequestOptions`<br>
+Default: *none*
+
+### transformResponse
+Function intercepting HTTP response objects after a WebDriver response has arrived
+
+Type: `(Response, RequestOptions) => Response`<br>
+Default: *none*

--- a/packages/webdriver/package.json
+++ b/packages/webdriver/package.json
@@ -36,5 +36,8 @@
     "@wdio/utils": "5.18.6",
     "lodash.merge": "^4.6.1",
     "request": "^2.83.0"
+  },
+  "devDependencies": {
+    "@types/request": "^2.48.4"
   }
 }

--- a/packages/webdriver/src/constants.js
+++ b/packages/webdriver/src/constants.js
@@ -103,5 +103,13 @@ export const DEFAULTS = {
     enableDirectConnect: {
         type: 'boolean',
         default: false
-    }
+    },
+    /**
+     * Function transforming the request options before the request is made
+     */
+    transformRequest: requestOptions => requestOptions,
+    /**
+     * Function transforming the response object after it is received
+     */
+    transformResponse: response => response,
 }

--- a/packages/webdriver/src/request.js
+++ b/packages/webdriver/src/request.js
@@ -117,7 +117,7 @@ export default class WebDriverRequest extends EventEmitter {
                 response = transformResponse(response, fullRequestOptions)
             }
 
-            let { body } = response
+            let body = response && response.body
             const error = err || getErrorFromResponseBody(body)
 
             /**

--- a/packages/webdriver/src/request.js
+++ b/packages/webdriver/src/request.js
@@ -168,7 +168,7 @@ export default class WebDriverRequest extends EventEmitter {
             this.emit('retry', { error, retryCount })
             log.warn('Request failed due to', error.message)
             log.info(`Retrying ${retryCount}/${totalRetryCount}`)
-            this._request(fullRequestOptions, totalRetryCount, retryCount, transformResponse).then(resolve, reject)
+            this._request(fullRequestOptions, transformResponse, totalRetryCount, retryCount).then(resolve, reject)
         }))
     }
 }

--- a/packages/webdriver/src/request.js
+++ b/packages/webdriver/src/request.js
@@ -39,7 +39,7 @@ export default class WebDriverRequest extends EventEmitter {
 
     makeRequest (options, sessionId) {
         let fullRequestOptions = Object.assign({}, this.defaultOptions, this._createOptions(options, sessionId))
-        if (options.transformRequest) {
+        if (typeof options.transformRequest === 'function') {
             fullRequestOptions = options.transformRequest(fullRequestOptions)
         }
 
@@ -113,7 +113,7 @@ export default class WebDriverRequest extends EventEmitter {
         }
 
         return new Promise((resolve, reject) => request(fullRequestOptions, (err, response) => {
-            if (transformResponse) {
+            if (typeof transformResponse === 'function') {
                 response = transformResponse(response, fullRequestOptions)
             }
 
@@ -168,7 +168,7 @@ export default class WebDriverRequest extends EventEmitter {
             this.emit('retry', { error, retryCount })
             log.warn('Request failed due to', error.message)
             log.info(`Retrying ${retryCount}/${totalRetryCount}`)
-            this._request(fullRequestOptions, totalRetryCount, retryCount).then(resolve, reject)
+            this._request(fullRequestOptions, totalRetryCount, retryCount, transformResponse).then(resolve, reject)
         }))
     }
 }

--- a/packages/webdriver/src/request.js
+++ b/packages/webdriver/src/request.js
@@ -105,7 +105,7 @@ export default class WebDriverRequest extends EventEmitter {
         return requestOptions
     }
 
-    _request (fullRequestOptions, totalRetryCount = 0, retryCount = 0, transformResponse) {
+    _request (fullRequestOptions, transformResponse, totalRetryCount = 0, retryCount = 0) {
         log.info(`[${fullRequestOptions.method}] ${fullRequestOptions.uri.href}`)
 
         if (fullRequestOptions.body && Object.keys(fullRequestOptions.body).length) {

--- a/packages/webdriver/src/request.js
+++ b/packages/webdriver/src/request.js
@@ -38,9 +38,13 @@ export default class WebDriverRequest extends EventEmitter {
     }
 
     makeRequest (options, sessionId) {
-        const fullRequestOptions = Object.assign({}, this.defaultOptions, this._createOptions(options, sessionId))
+        let fullRequestOptions = Object.assign({}, this.defaultOptions, this._createOptions(options, sessionId))
+        if (options.transformRequest) {
+            fullRequestOptions = options.transformRequest(fullRequestOptions)
+        }
+
         this.emit('request', fullRequestOptions)
-        return this._request(fullRequestOptions, options.connectionRetryCount)
+        return this._request(fullRequestOptions, options.connectionRetryCount, 0, options.transformResponse)
     }
 
     _createOptions (options, sessionId) {
@@ -101,14 +105,19 @@ export default class WebDriverRequest extends EventEmitter {
         return requestOptions
     }
 
-    _request (fullRequestOptions, totalRetryCount = 0, retryCount = 0) {
+    _request (fullRequestOptions, totalRetryCount = 0, retryCount = 0, transformResponse) {
         log.info(`[${fullRequestOptions.method}] ${fullRequestOptions.uri.href}`)
 
         if (fullRequestOptions.body && Object.keys(fullRequestOptions.body).length) {
             log.info('DATA', fullRequestOptions.body)
         }
 
-        return new Promise((resolve, reject) => request(fullRequestOptions, (err, response, body) => {
+        return new Promise((resolve, reject) => request(fullRequestOptions, (err, response) => {
+            if (transformResponse) {
+                response = transformResponse(response, fullRequestOptions)
+            }
+
+            let { body } = response
             const error = err || getErrorFromResponseBody(body)
 
             /**

--- a/packages/webdriver/src/request.js
+++ b/packages/webdriver/src/request.js
@@ -44,7 +44,7 @@ export default class WebDriverRequest extends EventEmitter {
         }
 
         this.emit('request', fullRequestOptions)
-        return this._request(fullRequestOptions, options.connectionRetryCount, 0, options.transformResponse)
+        return this._request(fullRequestOptions, options.transformResponse, options.connectionRetryCount)
     }
 
     _createOptions (options, sessionId) {

--- a/packages/webdriver/tests/constants.test.js
+++ b/packages/webdriver/tests/constants.test.js
@@ -5,3 +5,19 @@ test('should do correct type check for "path"', () => {
     expect(() => DEFAULTS.path.type('123')).toThrow()
     expect(() => DEFAULTS.path.type('/123')).not.toThrow()
 })
+
+test('should return the passed-in request options', () => {
+    const requestOptions = {
+        uri: { pathname: '/wd/hub/session' }
+    }
+
+    expect(DEFAULTS.transformRequest(requestOptions)).toBe(requestOptions)
+})
+
+test('should return the passed-in response object', () => {
+    const response = {
+        body: { value: { foo: 'bar' } }
+    }
+
+    expect(DEFAULTS.transformResponse(response)).toBe(response)
+})

--- a/packages/webdriver/tests/request.test.js
+++ b/packages/webdriver/tests/request.test.js
@@ -25,7 +25,7 @@ describe('webdriver request', () => {
         req.makeRequest({ connectionRetryCount: 43 }, 'some_id')
         expect(req._request.mock.calls[0][0].foo).toBe('bar')
         expect(req._request.mock.calls[0][0].sessionId).toBe('some_id')
-        expect(req._request.mock.calls[0][1]).toBe(43)
+        expect(req._request.mock.calls[0][2]).toBe(43)
     })
 
     it('should pick up the fullRequestOptions returned by transformRequest', () => {
@@ -283,7 +283,7 @@ describe('webdriver request', () => {
             req.emit = jest.fn()
 
             const opts = Object.assign(req.defaultOptions, { uri: { path: '/wd/hub/failing' } })
-            await expect(req._request(opts, 2)).rejects.toEqual(new Error('Could not send request'))
+            await expect(req._request(opts, null, 2)).rejects.toEqual(new Error('Could not send request'))
             expect(req.emit.mock.calls).toHaveLength(3)
             expect(warn.mock.calls).toHaveLength(2)
             expect(error.mock.calls).toHaveLength(1)
@@ -299,7 +299,7 @@ describe('webdriver request', () => {
 
             request.mockClear()
             const opts = Object.assign(req.defaultOptions, { uri: { path: '/wd/hub/failing' }, body: { foo: 'bar' } })
-            expect(await req._request(opts, 3)).toEqual({ value: 'caught' })
+            expect(await req._request(opts, null, 3)).toEqual({ value: 'caught' })
             expect(req.emit.mock.calls).toHaveLength(4)
             expect(logger().warn.mock.calls).toHaveLength(3)
             expect(logger().error.mock.calls).toHaveLength(0)

--- a/packages/webdriver/webdriver.d.ts
+++ b/packages/webdriver/webdriver.d.ts
@@ -9,6 +9,9 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 /// <reference types="node"/>
 
+declare type HTTPRequestOptions = import('request').CoreOptions;
+declare type HTTPResponse = import('request').Response;
+
 declare namespace WebDriver {
     type PageLoadingStrategy = 'none' | 'eager' | 'normal';
     type ProxyTypes = 'pac' | 'noproxy' | 'autodetect' | 'system' | 'manual';
@@ -370,8 +373,8 @@ declare namespace WebDriver {
         headers?: {
             [name: string]: string;
         };
-        transformRequest?: (requestOptions: any) => any;
-        transformResponse?: (requestOptions: any, response: any) => any;
+        transformRequest?: (requestOptions: HTTPRequestOptions) => HTTPRequestOptions;
+        transformResponse?: (requestOptions: HTTPRequestOptions, response: HTTPResponse) => HTTPResponse;
     }
 
     interface AttachSessionOptions extends Options {

--- a/packages/webdriver/webdriver.d.ts
+++ b/packages/webdriver/webdriver.d.ts
@@ -374,7 +374,7 @@ declare namespace WebDriver {
             [name: string]: string;
         };
         transformRequest?: (requestOptions: HTTPRequestOptions) => HTTPRequestOptions;
-        transformResponse?: (requestOptions: HTTPRequestOptions, response: HTTPResponse) => HTTPResponse;
+        transformResponse?: (response: HTTPResponse, requestOptions: HTTPRequestOptions) => HTTPResponse;
     }
 
     interface AttachSessionOptions extends Options {

--- a/packages/webdriver/webdriver.d.ts
+++ b/packages/webdriver/webdriver.d.ts
@@ -370,6 +370,8 @@ declare namespace WebDriver {
         headers?: {
             [name: string]: string;
         };
+        transformRequest?: (requestOptions: any) => any;
+        transformResponse?: (requestOptions: any, response: any) => any;
     }
 
     interface AttachSessionOptions extends Options {

--- a/scripts/templates/webdriver.tpl.d.ts
+++ b/scripts/templates/webdriver.tpl.d.ts
@@ -369,7 +369,7 @@ declare namespace WebDriver {
             [name: string]: string;
         };
         transformRequest?: (requestOptions: HTTPRequestOptions) => HTTPRequestOptions;
-        transformResponse?: (requestOptions: HTTPRequestOptions, response: HTTPResponse) => HTTPResponse;
+        transformResponse?: (response: HTTPResponse, requestOptions: HTTPRequestOptions) => HTTPResponse;
     }
 
     interface AttachSessionOptions extends Options {

--- a/scripts/templates/webdriver.tpl.d.ts
+++ b/scripts/templates/webdriver.tpl.d.ts
@@ -365,6 +365,8 @@ declare namespace WebDriver {
         headers?: {
             [name: string]: string;
         };
+        transformRequest?: (requestOptions: any) => any;
+        transformResponse?: (requestOptions: any, response: any) => any;
     }
 
     interface AttachSessionOptions extends Options {

--- a/scripts/templates/webdriver.tpl.d.ts
+++ b/scripts/templates/webdriver.tpl.d.ts
@@ -4,6 +4,9 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 /// <reference types="node"/>
 
+declare type HTTPRequestOptions = import('request').CoreOptions;
+declare type HTTPResponse = import('request').Response;
+
 declare namespace WebDriver {
     type PageLoadingStrategy = 'none' | 'eager' | 'normal';
     type ProxyTypes = 'pac' | 'noproxy' | 'autodetect' | 'system' | 'manual';
@@ -365,8 +368,8 @@ declare namespace WebDriver {
         headers?: {
             [name: string]: string;
         };
-        transformRequest?: (requestOptions: any) => any;
-        transformResponse?: (requestOptions: any, response: any) => any;
+        transformRequest?: (requestOptions: HTTPRequestOptions) => HTTPRequestOptions;
+        transformResponse?: (requestOptions: HTTPRequestOptions, response: HTTPResponse) => HTTPResponse;
     }
 
     interface AttachSessionOptions extends Options {

--- a/tests/typings/copy.js
+++ b/tests/typings/copy.js
@@ -33,6 +33,11 @@ const packages = {
     '@types/jasmine/ts3.1': 'packages/wdio-jasmine-framework/node_modules/@types/jasmine/ts3.1',
     '@wdio/jasmine-framework': 'packages/wdio-jasmine-framework',
 
+    '@types/request': 'packages/webdriver/node_modules/@types/request',
+    '@types/caseless': 'packages/webdriver/node_modules/@types/caseless',
+    '@types/tough-cookie': 'packages/webdriver/node_modules/@types/tough-cookie',
+    'form-data': 'packages/webdriver/node_modules/@types/request/node_modules/form-data',
+
     '@types/selenium-standalone': 'packages/wdio-selenium-standalone-service/node_modules/@types/selenium-standalone',
     '@wdio/selenium-standalone-service': 'packages/wdio-selenium-standalone-service',
 

--- a/tests/typings/sync/config.ts
+++ b/tests/typings/sync/config.ts
@@ -7,4 +7,16 @@ const conf: WebdriverIO.Config = {
 
     // can be function only
     afterSuite: () => {},
+
+    transformRequest: (requestOptions) => {
+        requestOptions.headers['X-Custom-Auth'] = 'custom_header_value'
+        return requestOptions
+    },
+    transformResponse: (response, requestOptions) => {
+        if (requestOptions.method === 'DELETE' && response.statusCode === 200) {
+            response.body.deleted = true
+        }
+
+        return response
+    }
 }


### PR DESCRIPTION
## Proposed changes

This PR introduces two new configuration options for `webdriver` (and `webdriverio`) with which the HTTP communication between `webdriver` and the server can be intercepted. In the config, the functions

* `transformRequest(RequestOptions): RequestOptions` and
* `transformResponse(Response, RequestOptions): Response`

can be specified and are then called in `webdriver/src/request.js`

This can also be seen as a generalization of the options `agent` and `headers`, which I have left in to keep compatibility.

The PR is the result of [a conversation on Gitter](https://gitter.im/webdriverio/webdriverio?at=5e43fb51cd2d737bb072b4fa) where the specific needs for my use case are stated.

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

* I based this PR on `v5`, but I'm happy to provide a similar solution (with `got` instead of `request`) for v6 once we agreed on how to proceed with this (there's already a branch, see https://github.com/webdriverio/webdriverio/compare/master...janizde:http-request-interceptors-v6?expand=0)
* Alternatively to passing the `request.Response` to `transformResponse` I thought about only passing the response body, but ended up giving full control over the response object. Happy to discuss this!
* ~~As for the typings I have added `transformRequest: (requestOptions: any): any` and `transformResponse(response: any, requestOptions: any): any` but couldn't get more specific since as soon as `import request from 'request'` the definition file becomes a module instead of a script. Also I couldn't get it to work with `/// <reference types="request"/>`. Any idea how to make this more specific?~~

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
