### PR TITLE
Fix selector typing

### DIFF
--- a/packages/wdio-sync/webdriverio-core.d.ts
+++ b/packages/wdio-sync/webdriverio-core.d.ts
@@ -194,6 +194,11 @@ declare namespace WebdriverIO {
         reverse?: boolean,
     }
 
+    type DataMatcher = {
+        name: string,
+        args: Array<string>
+    }
+
     type ReactSelectorOptions = {
         props?: object,
         state?: any[] | number | string | object | boolean
@@ -264,7 +269,7 @@ declare namespace WebdriverIO {
          * it from an element scope is that the driver will look within the children of that element.
          */
         $$(
-            selector: string | Function | object
+            selector: string | Function | DataMatcher
         ): ElementArray;
 
         /**
@@ -275,7 +280,7 @@ declare namespace WebdriverIO {
          * to an element. The command will then transform the reference to an extended WebdriverIO element.
          */
         $(
-            selector: string | Function | object
+            selector: string | Function | DataMatcher
         ): Element;
 
         /**

--- a/packages/wdio-sync/webdriverio-core.d.ts
+++ b/packages/wdio-sync/webdriverio-core.d.ts
@@ -264,7 +264,7 @@ declare namespace WebdriverIO {
          * it from an element scope is that the driver will look within the children of that element.
          */
         $$(
-            selector: string | Function
+            selector: string | Function | object
         ): ElementArray;
 
         /**
@@ -275,7 +275,7 @@ declare namespace WebdriverIO {
          * to an element. The command will then transform the reference to an extended WebdriverIO element.
          */
         $(
-            selector: string | Function
+            selector: string | Function | object
         ): Element;
 
         /**

--- a/packages/wdio-sync/webdriverio.d.ts
+++ b/packages/wdio-sync/webdriverio.d.ts
@@ -30,6 +30,7 @@ declare namespace WebdriverIO {
 }
 
 declare var browser: WebdriverIO.BrowserObject;
+declare var driver: WebdriverIO.BrowserObject;
 
 /**
  * find a single element on the page.

--- a/packages/webdriverio/src/commands/element/$$.js
+++ b/packages/webdriverio/src/commands/element/$$.js
@@ -32,7 +32,7 @@
  * </example>
  *
  * @alias $$
- * @param {String|Function|Object} selector  selector or JS Function to fetch multiple elements
+ * @param {String|Function|DataMatcher} selector  selector, JS Function or DataMatcher object to fetch multiple elements
  * @return {ElementArray}
  * @type utility
  *

--- a/packages/webdriverio/src/commands/element/$$.js
+++ b/packages/webdriverio/src/commands/element/$$.js
@@ -32,7 +32,7 @@
  * </example>
  *
  * @alias $$
- * @param {String|Function} selector  selector or JS Function to fetch multiple elements
+ * @param {String|Function|Object} selector  selector or JS Function to fetch multiple elements
  * @return {ElementArray}
  * @type utility
  *

--- a/packages/webdriverio/src/commands/element/$.js
+++ b/packages/webdriverio/src/commands/element/$.js
@@ -43,7 +43,7 @@
  * </example>
  *
  * @alias $
- * @param {String|Function|Object} selector  selector or JS Function to fetch a certain element
+ * @param {String|Function|DataMatcher} selector  selector, JS Function or DataMatcher object to fetch a certain element
  * @return {Element}
  * @type utility
  *

--- a/packages/webdriverio/src/commands/element/$.js
+++ b/packages/webdriverio/src/commands/element/$.js
@@ -43,7 +43,7 @@
  * </example>
  *
  * @alias $
- * @param {String|Function} selector  selector or JS Function to fetch a certain element
+ * @param {String|Function|Object} selector  selector or JS Function to fetch a certain element
  * @return {Element}
  * @type utility
  *

--- a/packages/webdriverio/webdriverio-core.d.ts
+++ b/packages/webdriverio/webdriverio-core.d.ts
@@ -194,6 +194,11 @@ declare namespace WebdriverIO {
         reverse?: boolean,
     }
 
+    type DataMatcher = {
+        name: string,
+        args: Array<string>
+    }
+
     type ReactSelectorOptions = {
         props?: object,
         state?: any[] | number | string | object | boolean
@@ -264,7 +269,7 @@ declare namespace WebdriverIO {
          * it from an element scope is that the driver will look within the children of that element.
          */
         $$(
-            selector: string | Function | object
+            selector: string | Function | DataMatcher
         ): Promise<ElementArray>;
 
         /**
@@ -275,7 +280,7 @@ declare namespace WebdriverIO {
          * to an element. The command will then transform the reference to an extended WebdriverIO element.
          */
         $(
-            selector: string | Function | object
+            selector: string | Function | DataMatcher
         ): Promise<Element>;
 
         /**

--- a/packages/webdriverio/webdriverio-core.d.ts
+++ b/packages/webdriverio/webdriverio-core.d.ts
@@ -264,7 +264,7 @@ declare namespace WebdriverIO {
          * it from an element scope is that the driver will look within the children of that element.
          */
         $$(
-            selector: string | Function
+            selector: string | Function | object
         ): Promise<ElementArray>;
 
         /**
@@ -275,7 +275,7 @@ declare namespace WebdriverIO {
          * to an element. The command will then transform the reference to an extended WebdriverIO element.
          */
         $(
-            selector: string | Function
+            selector: string | Function | object
         ): Promise<Element>;
 
         /**

--- a/packages/webdriverio/webdriverio.d.ts
+++ b/packages/webdriverio/webdriverio.d.ts
@@ -43,6 +43,7 @@ declare namespace WebdriverIO {
 }
 
 declare var browser: WebdriverIO.BrowserObject;
+declare var driver: WebdriverIO.BrowserObject;
 
 /**
  * find a single element on the page.

--- a/scripts/templates/webdriverio.tpl.d.ts
+++ b/scripts/templates/webdriverio.tpl.d.ts
@@ -188,6 +188,11 @@ declare namespace WebdriverIO {
         reverse?: boolean,
     }
 
+    type DataMatcher = {
+        name: string,
+        args: Array<string>
+    }
+
     type ReactSelectorOptions = {
         props?: object,
         state?: any[] | number | string | object | boolean

--- a/scripts/type-generation/constants.js
+++ b/scripts/type-generation/constants.js
@@ -2,7 +2,7 @@ const CUSTOM_INTERFACES = [
     'Buffer', 'Function', 'RegExp', 'WaitForOptions', 'ReactSelectorOptions',
     'MoveToOptions', 'DragAndDropOptions', 'NewWindowOptions', 'Element',
     'ElementArray', 'ClickOptions', 'WaitUntilOptions', 'Cookie', 'Timeouts',
-    'CSSProperty', 'TouchActions'
+    'CSSProperty', 'TouchActions', 'DataMatcher'
 ]
 
 module.exports = {


### PR DESCRIPTION
## Proposed changes

Hello, I noticed there is a glitch in the typings for $ and $$. They both take a string or function as argument, but it actually should be string | function | object since the introduction of android data matcher strategy.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
