### PR TITLE
feature(cucumber-framework): add skip tags support

### DIFF
--- a/docs/Frameworks.md
+++ b/docs/Frameworks.md
@@ -104,3 +104,19 @@ If you want to use Cucumber, set the `framework` property to `cucumber` by addin
 Options for Cucumber can be given in the config file with `cucumberOpts`. Check out the whole list of options [here](https://github.com/webdriverio/webdriverio/tree/master/packages/wdio-cucumber-framework#cucumberopts-options).
 
 To get up and running quickly with Cucumber, have a look on our [`cucumber-boilerplate`](https://github.com/webdriverio/cucumber-boilerplate) project that comes with all the step definitions you need to get stared, and you'll be writing feature files right away.
+
+### Skipping tests in cucumber
+
+Note that if you want to skip a test using regular cucumber test filtering capabilities available in `cucumberOpts`, you will do it for all the browsers and devices configured in the capabilities. In order to be able to skip scenarios only for specific capabilities combinations without having a session started if not necessary, webdriverio provides the following specific tag syntax for cucumber:
+
+`@skip([condition])`
+
+were condition is an optional combination of capabilities properties with their values that when **all** matched with cause the tagged scenario or feature to be skipped. Of course you can add several tags to scenarios and features to skip a tests under several different conditions.
+
+Here you have some examples of this syntax:
+- `@skip()`: will always skip the tagged item
+- `@skip(browserName="chrome")`: the test will not be executed against chrome browsers.
+- `@skip(browserName="firefox";platformName="linux")`: will skip the test in firefox over linux executions.
+- `@skip(browserName=["chrome","firefox"])`: tagged items will be skipped for both chrome and firefox browsers.
+- `@skip(browserName=/i.*explorer/`: capabilities with browsers matching the regexp will be skipped (like `iexplorer`, `internet explorer`, `internet-explorer`, ...).
+

--- a/tests/cucumber/step-definitions/then.js
+++ b/tests/cucumber/step-definitions/then.js
@@ -26,3 +26,7 @@ Then('I should fail once but pass on the second run', { wrapperOptions: { retry:
 
 Then('this is ambiguous', () => {
 })
+
+Then('this test should fail', () => {
+    assert.equal(true, false, 'This step should have never been executed :-(')
+})

--- a/tests/cucumber/test.feature
+++ b/tests/cucumber/test.feature
@@ -18,6 +18,10 @@ Feature: Example feature
     Scenario: Retry Check
         Then  I should fail once but pass on the second run
 
+    @skip(browserName="chrome")
+    Scenario: Skipped... should never be executed
+        Then  this test should fail
+
     Scenario Outline: Multiple Examples
         Given Foo <foo> and Bar <bar> are passed
 


### PR DESCRIPTION
## Proposed changes

With the changes in #4531, it is now possible to mocha and Jasmine not to start browsers when skipping depending on browser capabilities. For cucumber users, this is no possible as, even though cucumber providers filtering tag options, you cannot rely on them when performing tests against multiple browsers to filter tests depending on the browser.

With this changes a cucumber tag exclusion system is enabled in webdriverio so that you can use: `@skip(browserName="firefox")` to skip tests, while still avoiding to bootstrap the browser (no cucumber hook involved).

Matchings are case insensitive and syntax supports:
* several capability properties separated by colon: `@skip(browserName="firefox",platformName="linux")`
* lists: `@skip(browserName=["chrome","firefox"])`
* regexp: `@skip(browserName=/i.*explorer/`

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

### Reviewers: @webdriverio/technical-committee
