### PR TITLE
Fix docs for TS setup with Mocha

### DIFF
--- a/docs/TypeScript.md
+++ b/docs/TypeScript.md
@@ -7,27 +7,34 @@ Similar to Babel setup, you can register [TypeScript](http://www.typescriptlang.
 
 The minimum TypeScript version is 3.7.3.
 
-```js
-// wdio.conf.js
-before: function() {
-    // not needed for Cucumber
-    require('ts-node').register({ files: true })
-},
-```
+## Framework Setup
 
-Similarly for Mocha:
+The following framework configurations need to be applied to set up TypeScript properly with WebdriverIO.
+
+### Mocha
 
 ```js
 // wdio.conf.js
 mochaOpts: {
     ui: 'bdd',
-    require: [
+    require: 'ts-node/register',
+    compilers: [
+        // optional
         'tsconfig-paths/register'
     ]
 },
 ```
 
-And Cucumber:
+### Jasmine
+
+```js
+// wdio.conf.js
+jasmineNodeOpts: {
+    requires: ['ts-node/register']
+},
+```
+
+### Cucumber
 
 ```js
 // wdio.conf.js
@@ -71,7 +78,7 @@ For sync mode (`@wdio/sync`), `webdriverio` types must be replaced with `@wdio/s
 Please avoid importing `webdriverio` or `@wdio/sync` explicitly.
 `WebdriverIO` and `WebDriver` types are accessible from anywhere once added to `types` in `tsconfig.json`.
 
-### Typed Configuration
+## Typed Configuration
 
 You can even use a typed configuration if you desire.
 All you have to do is create a plain JS config file that registers TypeScript and requires the typed config:
@@ -91,7 +98,7 @@ const config: WebdriverIO.Config = {
 export { config }
 ```
 
-### Framework types
+## Framework types
 
 Depending on the framework you use, you will need to add the types for that framework to your `tsconfig.json` types property.
 
@@ -123,42 +130,42 @@ Instead of having all type definitions globally available, you can also `import`
 import { Suite, Test } from '@wdio/mocha-framework'
 ```
 
-### Adding custom commands
+## Adding custom commands
 
 With TypeScript, it's easy to extend WebdriverIO interfaces. Add types to your [custom commands](CustomCommands.md) like this:
 
 1. Create types definition file (e.g., `./types/wdio.d.ts`)
 2. Specify path to types in `tsconfig.json`
 
-```json
-{
-    "compilerOptions": {
-        "typeRoots": ["./types"]
+    ```json
+    {
+        "compilerOptions": {
+            "typeRoots": ["./types"]
+        }
     }
-}
-```
+    ```
 
 3. Add defintions for your commands according to your execution mode.
 
-**Sync mode**
+    **Sync mode**
 
-```typescript
-declare module WebdriverIO {
-    // adding command to `browser`
-    interface Browser {
-        browserCustomCommand: (arg) => void
+    ```typescript
+    declare module WebdriverIO {
+        // adding command to `browser`
+        interface Browser {
+            browserCustomCommand: (arg) => void
+        }
     }
-}
-```
+    ```
 
-**Async mode**
+    **Async mode**
 
-```typescript
-declare module WebdriverIO {
-    // adding command to `$()`
-    interface Element {
-        // don't forget to wrap return values with Promise
-        elementCustomCommand: (arg) => Promise<number>
+    ```typescript
+    declare module WebdriverIO {
+        // adding command to `$()`
+        interface Element {
+            // don't forget to wrap return values with Promise
+            elementCustomCommand: (arg) => Promise<number>
+        }
     }
-}
-```
+    ```


### PR DESCRIPTION
## Proposed changes

See issue #5079. In order to make spec filtering work we can't inject TypeScript in the before hook. This patch updates the docs to it.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/technical-committee
