### PR TITLE
webdriver: Add interceptors for HTTP requests and responses [v6]

### DIFF
--- a/docs/Options.md
+++ b/docs/Options.md
@@ -102,6 +102,18 @@ Specify custom `headers` to pass into every request.
 Type: `Object`<br>
 Default: `{}`
 
+### `transformRequest`
+Function intercepting [HTTP request options](https://github.com/request/request#requestoptions-callback) before a WebDriver request is made
+
+Type: `(RequestOptions) => RequestOptions`<br>
+Default: *none*
+
+### `transformResponse`
+Function intercepting HTTP response objects after a WebDriver response has arrived. The function is passed the original response object as the first and the corresponding `RequestOptions` as the second argument.
+
+Type: `(Response, RequestOptions) => Response`<br>
+Default: *none*
+
 ---
 
 ## WDIO Options

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -103,7 +103,7 @@ Type: `Object`<br>
 Default: `{}`
 
 ### `transformRequest`
-Function intercepting [HTTP request options](https://github.com/request/request#requestoptions-callback) before a WebDriver request is made
+Function intercepting [HTTP request options](https://github.com/sindresorhus/got#options) before a WebDriver request is made
 
 Type: `(RequestOptions) => RequestOptions`<br>
 Default: *none*

--- a/packages/webdriver/README.md
+++ b/packages/webdriver/README.md
@@ -106,3 +106,15 @@ Count of request retries to the Selenium server.
 
 Type: `Number`<br>
 Default: *2*
+
+### transformRequest
+Function intercepting [HTTP request options](https://github.com/request/request#requestoptions-callback) before a WebDriver request is made
+
+Type: `(RequestOptions) => RequestOptions`<br>
+Default: *none*
+
+### transformResponse
+Function intercepting HTTP response objects after a WebDriver response has arrived
+
+Type: `(Response, RequestOptions) => Response`<br>
+Default: *none*

--- a/packages/webdriver/README.md
+++ b/packages/webdriver/README.md
@@ -108,7 +108,7 @@ Type: `Number`<br>
 Default: *2*
 
 ### transformRequest
-Function intercepting [HTTP request options](https://github.com/request/request#requestoptions-callback) before a WebDriver request is made
+Function intercepting [HTTP request options](https://github.com/sindresorhus/got#options) before a WebDriver request is made
 
 Type: `(RequestOptions) => RequestOptions`<br>
 Default: *none*

--- a/packages/webdriver/package.json
+++ b/packages/webdriver/package.json
@@ -36,5 +36,8 @@
     "@wdio/utils": "6.0.0-beta.0",
     "got": "^10.2.1",
     "lodash.merge": "^4.6.1"
+  },
+  "devDependencies": {
+    "@types/got": "^9.6.9"
   }
 }

--- a/packages/webdriver/src/constants.js
+++ b/packages/webdriver/src/constants.js
@@ -103,5 +103,13 @@ export const DEFAULTS = {
     enableDirectConnect: {
         type: 'boolean',
         default: false
-    }
+    },
+    /**
+     * Function transforming the request options before the request is made
+     */
+    transformRequest: requestOptions => requestOptions,
+    /**
+     * Function transforming the response object after it is received
+     */
+    transformResponse: response => response,
 }

--- a/packages/webdriver/src/request.js
+++ b/packages/webdriver/src/request.js
@@ -40,7 +40,7 @@ export default class WebDriverRequest extends EventEmitter {
 
     makeRequest (options, sessionId) {
         let fullRequestOptions = Object.assign({}, this.defaultOptions, this._createOptions(options, sessionId))
-        if (options.transformRequest) {
+        if (typeof options.transformRequest === 'function') {
             fullRequestOptions = options.transformRequest(fullRequestOptions)
         }
 
@@ -108,7 +108,7 @@ export default class WebDriverRequest extends EventEmitter {
         }
 
         let response = await got(fullRequestOptions.uri, { ...fullRequestOptions })
-        if (transformResponse) {
+        if (typeof transformResponse === 'function') {
             response = transformResponse(response, fullRequestOptions)
         }
 

--- a/packages/webdriver/src/request.js
+++ b/packages/webdriver/src/request.js
@@ -39,9 +39,13 @@ export default class WebDriverRequest extends EventEmitter {
     }
 
     makeRequest (options, sessionId) {
-        const fullRequestOptions = Object.assign({}, this.defaultOptions, this._createOptions(options, sessionId))
+        let fullRequestOptions = Object.assign({}, this.defaultOptions, this._createOptions(options, sessionId))
+        if (options.transformRequest) {
+            fullRequestOptions = options.transformRequest(fullRequestOptions)
+        }
+
         this.emit('request', fullRequestOptions)
-        return this._request(fullRequestOptions, options.connectionRetryCount)
+        return this._request(fullRequestOptions, options.connectionRetryCount, 0, options.transformResponse)
     }
 
     _createOptions (options, sessionId) {
@@ -96,14 +100,18 @@ export default class WebDriverRequest extends EventEmitter {
         return requestOptions
     }
 
-    async _request (fullRequestOptions, totalRetryCount = 0, retryCount = 0) {
+    async _request (fullRequestOptions, totalRetryCount = 0, retryCount = 0, transformResponse) {
         log.info(`[${fullRequestOptions.method}] ${fullRequestOptions.uri.href}`)
 
         if (fullRequestOptions.json && Object.keys(fullRequestOptions.json).length) {
             log.info('DATA', fullRequestOptions.json)
         }
 
-        const response = await got(fullRequestOptions.uri, { ...fullRequestOptions })
+        let response = await got(fullRequestOptions.uri, { ...fullRequestOptions })
+        if (transformResponse) {
+            response = transformResponse(response)
+        }
+
         const error = getErrorFromResponseBody(response.body)
 
         /**
@@ -156,6 +164,6 @@ export default class WebDriverRequest extends EventEmitter {
         this.emit('retry', { error, retryCount })
         log.warn('Request failed due to', error.message)
         log.info(`Retrying ${retryCount}/${totalRetryCount}`)
-        return this._request(fullRequestOptions, totalRetryCount, retryCount)
+        return this._request(fullRequestOptions, totalRetryCount, retryCount, transformResponse)
     }
 }

--- a/packages/webdriver/src/request.js
+++ b/packages/webdriver/src/request.js
@@ -109,7 +109,7 @@ export default class WebDriverRequest extends EventEmitter {
 
         let response = await got(fullRequestOptions.uri, { ...fullRequestOptions })
         if (transformResponse) {
-            response = transformResponse(response)
+            response = transformResponse(response, fullRequestOptions)
         }
 
         const error = getErrorFromResponseBody(response.body)

--- a/packages/webdriver/src/request.js
+++ b/packages/webdriver/src/request.js
@@ -45,7 +45,7 @@ export default class WebDriverRequest extends EventEmitter {
         }
 
         this.emit('request', fullRequestOptions)
-        return this._request(fullRequestOptions, options.connectionRetryCount, 0, options.transformResponse)
+        return this._request(fullRequestOptions, options.transformResponse, options.connectionRetryCount, 0)
     }
 
     _createOptions (options, sessionId) {
@@ -100,7 +100,7 @@ export default class WebDriverRequest extends EventEmitter {
         return requestOptions
     }
 
-    async _request (fullRequestOptions, totalRetryCount = 0, retryCount = 0, transformResponse) {
+    async _request (fullRequestOptions, transformResponse, totalRetryCount = 0, retryCount = 0) {
         log.info(`[${fullRequestOptions.method}] ${fullRequestOptions.uri.href}`)
 
         if (fullRequestOptions.json && Object.keys(fullRequestOptions.json).length) {
@@ -164,6 +164,6 @@ export default class WebDriverRequest extends EventEmitter {
         this.emit('retry', { error, retryCount })
         log.warn('Request failed due to', error.message)
         log.info(`Retrying ${retryCount}/${totalRetryCount}`)
-        return this._request(fullRequestOptions, totalRetryCount, retryCount, transformResponse)
+        return this._request(fullRequestOptions, transformResponse, totalRetryCount, retryCount)
     }
 }

--- a/packages/webdriver/tests/constants.test.js
+++ b/packages/webdriver/tests/constants.test.js
@@ -5,3 +5,19 @@ test('should do correct type check for "path"', () => {
     expect(() => DEFAULTS.path.type('123')).toThrow()
     expect(() => DEFAULTS.path.type('/123')).not.toThrow()
 })
+
+test('should return the passed-in request options', () => {
+    const requestOptions = {
+        uri: { pathname: '/wd/hub/session' }
+    }
+
+    expect(DEFAULTS.transformRequest(requestOptions)).toBe(requestOptions)
+})
+
+test('should return the passed-in response object', () => {
+    const response = {
+        body: { value: { foo: 'bar' } }
+    }
+
+    expect(DEFAULTS.transformResponse(response)).toBe(response)
+})

--- a/packages/webdriver/tests/request.test.js
+++ b/packages/webdriver/tests/request.test.js
@@ -32,7 +32,7 @@ describe('webdriver request', () => {
         req.makeRequest({ connectionRetryCount: 43 }, 'some_id')
         expect(req._request.mock.calls[0][0].foo).toBe('bar')
         expect(req._request.mock.calls[0][0].sessionId).toBe('some_id')
-        expect(req._request.mock.calls[0][1]).toBe(43)
+        expect(req._request.mock.calls[0][2]).toBe(43)
     })
 
     it('should pick up the fullRequestOptions returned by transformRequest', async () => {
@@ -297,7 +297,7 @@ describe('webdriver request', () => {
             req.emit = jest.fn()
 
             const opts = Object.assign(req.defaultOptions, { uri: { pathname: '/failing' } })
-            await expect(req._request(opts, 2)).rejects.toEqual(new Error('unknown error'))
+            await expect(req._request(opts, null, 2)).rejects.toEqual(new Error('unknown error'))
             expect(req.emit.mock.calls).toHaveLength(3)
             expect(warn.mock.calls).toHaveLength(2)
             expect(error.mock.calls).toHaveLength(1)
@@ -308,7 +308,7 @@ describe('webdriver request', () => {
             req.emit = jest.fn()
 
             const opts = Object.assign(req.defaultOptions, { uri: { pathname: '/failing' }, json: { foo: 'bar' } })
-            expect(await req._request(opts, 3)).toEqual({ value: 'caught' })
+            expect(await req._request(opts, null, 3)).toEqual({ value: 'caught' })
             expect(req.emit.mock.calls).toHaveLength(4)
             expect(logger().warn.mock.calls).toHaveLength(3)
             expect(logger().error.mock.calls).toHaveLength(0)

--- a/packages/webdriver/webdriver.d.ts
+++ b/packages/webdriver/webdriver.d.ts
@@ -10,6 +10,9 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 /// <reference types="node"/>
 
+declare type HTTPRequestOptions = import('got').GotOptions<unknown>;
+declare type HTTPResponse = import('got').Response<unknown>;
+
 declare namespace WebDriver {
     type PageLoadingStrategy = 'none' | 'eager' | 'normal';
     type ProxyTypes = 'pac' | 'noproxy' | 'autodetect' | 'system' | 'manual';
@@ -371,6 +374,8 @@ declare namespace WebDriver {
         headers?: {
             [name: string]: string;
         };
+        transformRequest?: (requestOptions: HTTPRequestOptions) => HTTPRequestOptions;
+        transformResponse?: (response: HTTPResponse, requestOptions: HTTPRequestOptions) => HTTPResponse;
     }
 
     interface AttachSessionOptions extends Options {

--- a/packages/webdriver/webdriver.d.ts
+++ b/packages/webdriver/webdriver.d.ts
@@ -10,8 +10,8 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 /// <reference types="node"/>
 
-declare type HTTPRequestOptions = import('got').GotOptions<unknown>;
-declare type HTTPResponse = import('got').Response<unknown>;
+declare type HTTPRequestOptions = import('got').GotOptions<any>;
+declare type HTTPResponse = import('got').Response<any>;
 
 declare namespace WebDriver {
     type PageLoadingStrategy = 'none' | 'eager' | 'normal';

--- a/scripts/templates/webdriver.tpl.d.ts
+++ b/scripts/templates/webdriver.tpl.d.ts
@@ -4,6 +4,9 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 /// <reference types="node"/>
 
+declare type HTTPRequestOptions = import('got').GotOptions<unknown>;
+declare type HTTPResponse = import('got').Response<unknown>;
+
 declare namespace WebDriver {
     type PageLoadingStrategy = 'none' | 'eager' | 'normal';
     type ProxyTypes = 'pac' | 'noproxy' | 'autodetect' | 'system' | 'manual';
@@ -365,6 +368,8 @@ declare namespace WebDriver {
         headers?: {
             [name: string]: string;
         };
+        transformRequest?: (requestOptions: HTTPRequestOptions) => HTTPRequestOptions;
+        transformResponse?: (response: HTTPResponse, requestOptions: HTTPRequestOptions) => HTTPResponse;
     }
 
     interface AttachSessionOptions extends Options {

--- a/scripts/templates/webdriver.tpl.d.ts
+++ b/scripts/templates/webdriver.tpl.d.ts
@@ -4,8 +4,8 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 /// <reference types="node"/>
 
-declare type HTTPRequestOptions = import('got').GotOptions<unknown>;
-declare type HTTPResponse = import('got').Response<unknown>;
+declare type HTTPRequestOptions = import('got').GotOptions<any>;
+declare type HTTPResponse = import('got').Response<any>;
 
 declare namespace WebDriver {
     type PageLoadingStrategy = 'none' | 'eager' | 'normal';

--- a/tests/typings/copy.js
+++ b/tests/typings/copy.js
@@ -23,6 +23,9 @@ const packages = {
     'browserstack-local': 'packages/wdio-browserstack-service/node_modules/browserstack-local',
     '@wdio/browserstack-service': 'packages/wdio-browserstack-service',
 
+    '@types/got': 'packages/webdriver/node_modules/@types/got',
+    '@types/tough-cookie': 'packages/webdriver/node_modules/@types/tough-cookie',
+
     '@types/mocha': 'packages/wdio-mocha-framework/node_modules/@types/mocha',
     '@wdio/mocha-framework': 'packages/wdio-mocha-framework',
 

--- a/tests/typings/sync/config.ts
+++ b/tests/typings/sync/config.ts
@@ -7,4 +7,16 @@ const conf: WebdriverIO.Config = {
 
     // can be function only
     afterSuite: () => {},
+
+    transformRequest: (requestOptions) => {
+        requestOptions.headers['X-Custom-Auth'] = 'custom_header_value'
+        return requestOptions
+    },
+    transformResponse: (response, requestOptions) => {
+        if (requestOptions.method === 'DELETE' && response.statusCode === 200) {
+            response.body.deleted = true
+        }
+
+        return response
+    }
 }


### PR DESCRIPTION
## Proposed changes

This is the v6 equivalent of https://github.com/webdriverio/webdriverio/pull/5062

This PR introduces two new configuration options for webdriver (and webdriverio) with which the HTTP communication between webdriver and the server can be intercepted. In the config, the functions

transformRequest(RequestOptions): RequestOptions and
transformResponse(Response, RequestOptions): Response
can be specified and are then called in webdriver/src/request.js

This can also be seen as a generalization of the options agent and headers, which I have left in to keep compatibility.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
