### PR TITLE
webdriverIO - Experitest Cli - Simplify the flow

### DIFF
--- a/packages/wdio-cli/src/constants.js
+++ b/packages/wdio-cli/src/constants.js
@@ -128,22 +128,11 @@ export const QUESTIONNAIRE = [{
     default: 'example.experitest.com',
     when: /* istanbul ignore next */ (answers) => answers.backend === 'In the cloud using Experitest'
 }, {
-    type: 'list',
-    name: 'expEnvPort',
-    message: 'Choose a port for environment variable',
-    default: 443,
-    choices: [
-        '443',
-        '80',
-        'Other'
-    ],
-    when: /* istanbul ignore next */ (answers) => answers.backend === 'In the cloud using Experitest'
-}, {
     type: 'input',
     name: 'expEnvPort',
-    message: 'Environment variable for other port',
-    default: 'OTHER_PORT',
-    when: /* istanbul ignore next */ (answers) => answers.expEnvPort === 'Other'
+    message: 'Environment variable for port',
+    default: '443',
+    when: /* istanbul ignore next */ (answers) => answers.backend === 'In the cloud using Experitest'
 }, {
     type: 'list',
     name: 'expEnvProtocol',
@@ -153,7 +142,9 @@ export const QUESTIONNAIRE = [{
         'https',
         'http'
     ],
-    when: /* istanbul ignore next */ (answers) => answers.expEnvPort && answers.expEnvPort !== '80' && answers.expEnvPort !== '443'
+    when: /* istanbul ignore next */ (answers) => {
+        return answers.backend === 'In the cloud using Experitest' && answers.expEnvPort !== '80' && answers.expEnvPort !== '443'
+    }
 }, {
     type: 'input',
     name: 'env_user',


### PR DESCRIPTION
## Proposed changes

- Fixed issue in the user flow when he chooses 'Other' port. The step to enter a port is skipped and the user is unable to write the desired port.
- Simplify the user flow.

## Types of changes
- Support users who have Cloud with a custom port.
- Make the CLI flow simpler for Experitest users.

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

### Reviewers: @webdriverio/technical-committee
