### PR TITLE
Propagate connection data to detect backend properly

### DIFF
--- a/packages/wdio-cli/src/interface.js
+++ b/packages/wdio-cli/src/interface.js
@@ -186,7 +186,7 @@ export default class WDIOCLInterface extends EventEmitter {
         }
 
         if (event.origin === 'worker' && event.name === 'error') {
-            return this.log(`[${event.cid}]`, 'Error:', event.content.message || event.content.stack || event.content)
+            return this.log(`[${event.cid}]`, chalk.white.bgRed.bold(' Error: '), event.content.message || event.content.stack || event.content)
         }
 
         if (event.origin !== 'reporter') {

--- a/packages/wdio-cli/tests/interface.test.js
+++ b/packages/wdio-cli/tests/interface.test.js
@@ -144,7 +144,7 @@ describe('cli interface', () => {
         })
 
         expect(wdioClInterface.log).toBeCalledTimes(1)
-        expect(wdioClInterface.log).toBeCalledWith('[0-0]', 'Error:', 'foo')
+        expect(wdioClInterface.log).toBeCalledWith('[0-0]', 'bold  Error: ', 'foo')
     })
 
     it('should print message on worker error', () => {
@@ -157,7 +157,7 @@ describe('cli interface', () => {
         })
 
         expect(wdioClInterface.log).toBeCalledTimes(1)
-        expect(wdioClInterface.log).toBeCalledWith('[0-0]', 'Error:', 'bar')
+        expect(wdioClInterface.log).toBeCalledWith('[0-0]', 'bold  Error: ', 'bar')
     })
 
     it('should ignore messages that do not contain a proper origin', () => {

--- a/packages/wdio-config/src/utils.js
+++ b/packages/wdio-config/src/utils.js
@@ -1,7 +1,3 @@
-const DEFAULT_HOSTNAME = '127.0.0.1'
-const DEFAULT_PORT = 4444
-const DEFAULT_PROTOCOL = 'http'
-const DEFAULT_PATH = '/'
 const LEGACY_PATH = '/wd/hub'
 
 const REGION_MAPPING = {
@@ -115,14 +111,10 @@ export function detectBackend (options = {}, isRDC = false) {
     }
 
     /**
-     * no cloud provider detected, fallback to local browser driver
+     * no cloud provider detected, pass on provided params and eventually
+     * fallback to DevTools protocol
      */
-    return {
-        hostname: hostname || DEFAULT_HOSTNAME,
-        port: port || DEFAULT_PORT,
-        protocol: protocol || DEFAULT_PROTOCOL,
-        path: path || DEFAULT_PATH
-    }
+    return { hostname, port, protocol, path }
 }
 
 /**

--- a/packages/wdio-config/src/utils.js
+++ b/packages/wdio-config/src/utils.js
@@ -131,7 +131,7 @@ export function detectBackend (options = {}, isRDC = false) {
  * @param  {Object} options   option to check against
  * @return {Object}           validated config enriched with default values
  */
-export function validateConfig (defaults, options) {
+export function validateConfig (defaults, options, keysToKeep = []) {
     const params = {}
 
     for (const [name, expectedOption] of Object.entries(defaults)) {
@@ -164,6 +164,15 @@ export function validateConfig (defaults, options) {
             }
 
             params[name] = options[name]
+        }
+    }
+
+    for (const [name, option] of Object.entries(options)) {
+        /**
+         * keep keys from source object if desired
+         */
+        if (keysToKeep.includes(name)) {
+            params[name] = option
         }
     }
 

--- a/packages/wdio-config/src/utils.js
+++ b/packages/wdio-config/src/utils.js
@@ -1,3 +1,7 @@
+const DEFAULT_HOSTNAME = '127.0.0.1'
+const DEFAULT_PORT = 4444
+const DEFAULT_PROTOCOL = 'http'
+const DEFAULT_PATH = '/'
 const LEGACY_PATH = '/wd/hub'
 
 const REGION_MAPPING = {
@@ -108,6 +112,18 @@ export function detectBackend (options = {}, isRDC = false) {
             'known cloud service (SauceLabs, Browerstack or Testingbot). ' +
             'Please check if given user and key properties are correct!'
         )
+    }
+
+    /**
+     * default values if on of the WebDriver criticial options is set
+     */
+    if (hostname || port || protocol || path) {
+        return {
+            hostname: hostname || DEFAULT_HOSTNAME,
+            port: port || DEFAULT_PORT,
+            protocol: protocol || DEFAULT_PROTOCOL,
+            path: path || DEFAULT_PATH
+        }
     }
 
     /**

--- a/packages/wdio-config/tests/configparser.test.js
+++ b/packages/wdio-config/tests/configparser.test.js
@@ -186,8 +186,8 @@ describe('ConfigParser', () => {
             configParser.merge({ user: 'barfoo', key: '50fa1411-3121-4gb0-9p07-8q326vvbq7b0' })
 
             const config = configParser.getConfig()
-            expect(config.hostname).toBe('ondemand.saucelabs.com')
-            expect(config.port).toBe(443)
+            expect(config.hostname).toBe('127.0.0.1')
+            expect(config.port).toBe(4444)
         })
 
         it('should allow specifying a exclude file', () => {

--- a/packages/wdio-config/tests/detectBackend.test.js
+++ b/packages/wdio-config/tests/detectBackend.test.js
@@ -13,30 +13,30 @@ describe('detectBackend', () => {
 
     it('should default to local selenium server', () => {
         const caps = detectBackend({})
-        expect(caps.hostname).toBe('127.0.0.1')
-        expect(caps.port).toBe(4444)
-        expect(caps.path).toBe('/')
+        expect(typeof caps.hostname).toBe('undefined')
+        expect(typeof caps.port).toBe('undefined')
+        expect(typeof caps.path).toBe('undefined')
 
         const otherCaps = detectBackend()
-        expect(otherCaps.hostname).toBe('127.0.0.1')
-        expect(otherCaps.port).toBe(4444)
-        expect(otherCaps.path).toBe('/')
+        expect(typeof otherCaps.hostname).toBe('undefined')
+        expect(typeof otherCaps.port).toBe('undefined')
+        expect(typeof otherCaps.path).toBe('undefined')
     })
 
     it('should default if host or port is not given', () => {
         let caps = detectBackend({ port: 1234 })
-        expect(caps.hostname).toBe('127.0.0.1')
+        expect(typeof caps.hostname).toBe('undefined')
         expect(caps.port).toBe(1234)
-        expect(caps.path).toBe('/')
+        expect(typeof caps.path).toBe('undefined')
 
         caps = detectBackend({ hostname: 'foobar' })
         expect(caps.hostname).toBe('foobar')
-        expect(caps.port).toBe(4444)
-        expect(caps.path).toBe('/')
+        expect(typeof caps.port).toBe('undefined')
+        expect(typeof caps.path).toBe('undefined')
 
         caps = detectBackend({ path: '/foo/bar' })
-        expect(caps.hostname).toBe('127.0.0.1')
-        expect(caps.port).toBe(4444)
+        expect(typeof caps.hostname).toBe('undefined')
+        expect(typeof caps.port).toBe('undefined')
         expect(caps.path).toBe('/foo/bar')
     })
 
@@ -173,8 +173,8 @@ describe('detectBackend', () => {
             hostname: 'foobar.com'
         })
         expect(caps.hostname).toBe('foobar.com')
-        expect(caps.port).toBe(4444)
-        expect(caps.path).toBe('/')
+        expect(typeof caps.port).toBe('undefined')
+        expect(typeof caps.path).toBe('undefined')
     })
 
     it('should detect browserstack user but keep custom properties if set', () => {

--- a/packages/wdio-config/tests/detectBackend.test.js
+++ b/packages/wdio-config/tests/detectBackend.test.js
@@ -25,18 +25,18 @@ describe('detectBackend', () => {
 
     it('should default if host or port is not given', () => {
         let caps = detectBackend({ port: 1234 })
-        expect(typeof caps.hostname).toBe('undefined')
+        expect(caps.hostname).toBe('127.0.0.1')
         expect(caps.port).toBe(1234)
-        expect(typeof caps.path).toBe('undefined')
+        expect(caps.path).toBe('/')
 
         caps = detectBackend({ hostname: 'foobar' })
         expect(caps.hostname).toBe('foobar')
-        expect(typeof caps.port).toBe('undefined')
-        expect(typeof caps.path).toBe('undefined')
+        expect(caps.port).toBe(4444)
+        expect(caps.path).toBe('/')
 
         caps = detectBackend({ path: '/foo/bar' })
-        expect(typeof caps.hostname).toBe('undefined')
-        expect(typeof caps.port).toBe('undefined')
+        expect(caps.hostname).toBe('127.0.0.1')
+        expect(caps.port).toBe(4444)
         expect(caps.path).toBe('/foo/bar')
     })
 
@@ -173,8 +173,8 @@ describe('detectBackend', () => {
             hostname: 'foobar.com'
         })
         expect(caps.hostname).toBe('foobar.com')
-        expect(typeof caps.port).toBe('undefined')
-        expect(typeof caps.path).toBe('undefined')
+        expect(caps.port).toBe(4444)
+        expect(caps.path).toBe('/')
     })
 
     it('should detect browserstack user but keep custom properties if set', () => {

--- a/packages/wdio-config/tests/validateConfig.test.js
+++ b/packages/wdio-config/tests/validateConfig.test.js
@@ -72,4 +72,21 @@ describe('validateConfig', () => {
             logLevel: 'info'
         }), 'logLevel')).toBe(true)
     })
+
+    it('should keep certain keys if desired', () => {
+        expect(validateConfig({
+            logLevel: {
+                type: 'string',
+                default: 'trace',
+                match: /(trace|debug|info|warn|error|silent)/
+            }
+        }, {
+            logLevel: 'info',
+            foo: 'bar',
+            bar: 'foo'
+        }, ['foo'])).toEqual({
+            logLevel: 'info',
+            foo: 'bar'
+        })
+    })
 })

--- a/packages/wdio-spec-reporter/src/index.js
+++ b/packages/wdio-spec-reporter/src/index.js
@@ -112,7 +112,7 @@ class SpecReporter extends WDIOReporter {
      */
     getTestLink ({ config, sessionId, isMultiremote, instanceName }) {
         const isSauceJob = (
-            config.hostname.includes('saucelabs') ||
+            (config.hostname && config.hostname.includes('saucelabs')) ||
             // only show if multiremote is not used
             config.capabilities && (
                 // check w3c caps

--- a/packages/webdriverio/src/index.js
+++ b/packages/webdriverio/src/index.js
@@ -20,7 +20,7 @@ const log = logger('webdriverio')
 export const remote = async function (params = {}, remoteModifier) {
     logger.setLogLevelsConfig(params.logLevels, params.logLevel)
 
-    const config = validateConfig(WDIO_DEFAULTS, params)
+    const config = validateConfig(WDIO_DEFAULTS, params, Object.keys(WebDriver.DEFAULTS))
     const modifier = (client, options) => {
         if (typeof remoteModifier === 'function') {
             client = remoteModifier(client, Object.assign(options, config))

--- a/packages/webdriverio/tests/module.test.js
+++ b/packages/webdriverio/tests/module.test.js
@@ -6,6 +6,7 @@ import { runFnInFiberContext } from '@wdio/utils'
 import { remote, multiremote, attach } from '../src'
 
 jest.mock('webdriver', () => {
+    const WebDriver = jest.requireActual('webdriver').default
     const client = {
         sessionId: 'foobar-123',
         addCommand: jest.fn(),
@@ -25,7 +26,8 @@ jest.mock('webdriver', () => {
 
     const module = {
         newSession: newSessionMock,
-        attachToSession: jest.fn().mockReturnValue(client)
+        attachToSession: jest.fn().mockReturnValue(client),
+        DEFAULTS: WebDriver.DEFAULTS
     }
 
     return {
@@ -34,6 +36,7 @@ jest.mock('webdriver', () => {
     }
 })
 jest.mock('devtools', () => {
+    const DevTools = jest.requireActual('devtools').default
     const client = { sessionId: 'foobar-123', isDevtools: true }
     const newSessionMock = jest.fn()
     newSessionMock.mockReturnValue(new Promise((resolve) => resolve(client)))
@@ -48,7 +51,8 @@ jest.mock('devtools', () => {
     const module = {
         newSession: newSessionMock,
         attachToSession: jest.fn().mockReturnValue(client),
-        SUPPORTED_BROWSER: ['chrome']
+        SUPPORTED_BROWSER: ['chrome'],
+        DEFAULTS: DevTools.DEFAULTS
     }
 
     return {

--- a/packages/webdriverio/tests/module.test.js
+++ b/packages/webdriverio/tests/module.test.js
@@ -10,7 +10,8 @@ jest.mock('webdriver', () => {
         sessionId: 'foobar-123',
         addCommand: jest.fn(),
         overwriteCommand: jest.fn(),
-        strategies: new Map()
+        strategies: new Map(),
+        isWebDriver: true
     }
     const newSessionMock = jest.fn()
     newSessionMock.mockReturnValue(new Promise((resolve) => resolve(client)))
@@ -32,10 +33,33 @@ jest.mock('webdriver', () => {
         default: module
     }
 })
+jest.mock('devtools', () => {
+    const client = { sessionId: 'foobar-123', isDevtools: true }
+    const newSessionMock = jest.fn()
+    newSessionMock.mockReturnValue(new Promise((resolve) => resolve(client)))
+    newSessionMock.mockImplementation((params, cb) => {
+        let result = cb(client, params)
+        if (params.test_multiremote) {
+            result.options = { logLevel: 'error' }
+        }
+        return result
+    })
+
+    const module = {
+        newSession: newSessionMock,
+        attachToSession: jest.fn().mockReturnValue(client),
+        SUPPORTED_BROWSER: ['chrome']
+    }
+
+    return {
+        ...module,
+        default: module
+    }
+})
 
 jest.mock('@wdio/config', () => {
     const validateConfigMock = {
-        validateConfig: jest.fn().mockReturnValue({ automationProtocol: 'webdriver' }),
+        validateConfig: jest.fn((_, args) => args),
         detectBackend: jest.fn(),
     }
     return validateConfigMock
@@ -44,6 +68,10 @@ jest.mock('@wdio/config', () => {
 const WebDriver = require('webdriver').default
 
 describe('WebdriverIO module interface', () => {
+    beforeEach(() => {
+        WebDriver.newSession.mockClear()
+    })
+
     it('should provide remote and multiremote access', () => {
         expect(typeof remote).toBe('function')
         expect(typeof attach).toBe('function')
@@ -80,6 +108,16 @@ describe('WebdriverIO module interface', () => {
                 capabilities: {}
             })
             expect(detectBackend).toBeCalled()
+        })
+
+        it('should properly detect automation protocol', async () => {
+            const devtoolsBrowser = await remote({ capabilities: { browserName: 'chrome' } })
+            expect(devtoolsBrowser.isDevtools).toBe(true)
+            const webdriverBrowser = await remote({
+                path: '/',
+                capabilities: { browserName: 'chrome' }
+            })
+            expect(webdriverBrowser.isWebDriver).toBe(true)
         })
 
         it('should set process.env.WDIO_LOG_PATH if outputDir is set in the options', async()=>{
@@ -176,8 +214,16 @@ describe('WebdriverIO module interface', () => {
     describe('multiremote', () => {
         it('register multiple clients', async () => {
             await multiremote({
-                browserA: { test_multiremote: true, capabilities: { browserName: 'chrome' } },
-                browserB: { test_multiremote: true, capabilities: { browserName: 'firefox' } }
+                browserA: {
+                    test_multiremote: true,
+                    automationProtocol: 'webdriver',
+                    capabilities: { browserName: 'chrome' }
+                },
+                browserB: {
+                    test_multiremote: true,
+                    automationProtocol: 'webdriver',
+                    capabilities: { browserName: 'firefox' }
+                }
             })
             expect(WebDriver.attachToSession).toBeCalled()
             expect(WebDriver.newSession.mock.calls).toHaveLength(2)


### PR DESCRIPTION
## Proposed changes

When I tried to reproduce a bug I found an issue with protocol detection where:

```sh
$ npm repl chrome
```
as well as
```
$ npm repl chrome --path /wd/hub
```

would use the DevTools protocol even though it should not do that if path is given and the user showed the intention to use the WebDriver protocol.

It seemed that I got something mixed up when making DevTools the default protocol. This patch fixed the propagation of the right information.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

This patch only fixes a bug that occurs in latest master.

### Reviewers: @webdriverio/technical-committee
