### PR TITLE
checkUnicode should always return an array regardless of isDevTools

### DIFF
--- a/packages/webdriverio/src/utils.js
+++ b/packages/webdriverio/src/utils.js
@@ -185,7 +185,7 @@ export function parseCSS (cssPropertyValue, cssProperty) {
  */
 export function checkUnicode (value, isDevTools) {
     return Object.prototype.hasOwnProperty.call(UNICODE_CHARACTERS, value)
-        ? isDevTools ? value : [UNICODE_CHARACTERS[value]]
+        ? isDevTools ? [value] : [UNICODE_CHARACTERS[value]]
         : new GraphemeSplitter().splitGraphemes(value)
 }
 

--- a/packages/webdriverio/tests/utils.test.js
+++ b/packages/webdriverio/tests/utils.test.js
@@ -184,20 +184,23 @@ describe('utils', () => {
             const result = checkUnicode('Home')
 
             expect(Array.isArray(result)).toBe(true)
+            expect(result).toHaveLength(1)
             expect(result[0]).toEqual('\uE011')
         })
 
         it('should not convert unicode if devtools is used', () => {
             const result = checkUnicode('Home', true)
 
-            expect(Array.isArray(result)).toBe(false)
-            expect(result).toEqual('Home')
+            expect(Array.isArray(result)).toBe(true)
+            expect(result).toHaveLength(1)
+            expect(result[0]).toEqual('Home')
         })
 
         it('should return an array without unicode', () => {
             const result = checkUnicode('foo')
 
             expect(Array.isArray(result)).toBe(true)
+            expect(result).toHaveLength(3)
             expect(result[0]).toBe('f')
             expect(result[1]).toBe('o')
             expect(result[2]).toBe('o')


### PR DESCRIPTION
## Proposed changes
There's code relying on the fact that `checkUnicode` returns an array.
For example, `commands/browser/keys.js` assumes this.

The addition of the `isDevTools` flag, introduced in 49eda5119d6b7504d25de1ac17e9b60e6f24f419
messes this up and results in an inconsistent return value.

This was caught because examples for multiple remote browsers failed.

Fixes #5087

Relevant stack trace;

```
[MultiremoteBrowser #0-0] keySequence.map is not a function
[MultiremoteBrowser #0-0] TypeError: keySequence.map is not a function
[MultiremoteBrowser #0-0]     at Browser.apply (/Users/dm/test/webdriverio/packages/webdriverio/src/commands/browser/keys.js:55:40)
[MultiremoteBrowser #0-0]     at Browser.runCommandWithHooks (/Users/dm/test/webdriverio/packages/wdio-sync/src/wrapCommand.js:114:34)
[MultiremoteBrowser #0-0]     at processTicksAndRejections (internal/process/task_queues.js:97:5)
[MultiremoteBrowser #0-0]     at Browser.apply (/Users/dm/test/webdriverio/packages/wdio-sync/src/wrapCommand.js:107:24)
[MultiremoteBrowser #0-0]     at Browser.wrapCommandFn (/Users/dm/test/webdriverio/packages/wdio-sync/src/wrapCommand.js:72:44)
[MultiremoteBrowser #0-0]     at map (/Users/dm/test/webdriverio/packages/webdriverio/src/multiremote.js:97:65)
[MultiremoteBrowser #0-0]     at Array.map (<anonymous>)
[MultiremoteBrowser #0-0]     at MultiRemoteDriver.apply (/Users/dm/test/webdriverio/packages/webdriverio/src/multiremote.js:97:43)
[MultiremoteBrowser #0-0]     at MultiRemoteDriver.runCommandWithHooks (/Users/dm/test/webdriverio/packages/wdio-sync/src/wrapCommand.js:114:34)
[MultiremoteBrowser #0-0]     at MultiRemoteDriver.apply (/Users/dm/test/webdriverio/packages/wdio-sync/src/wrapCommand.js:107:24)
[MultiremoteBrowser #0-0]     at MultiRemoteDriver.wrapCommandFn (/Users/dm/test/webdriverio/packages/wdio-sync/src/wrapCommand.js:72:44)
[MultiremoteBrowser #0-0]     at Context.apply (/Users/dm/test/webdriverio/examples/wdio/multiremote/mocha.test.js:9:17)
[MultiremoteBrowser #0-0]     at Context.call (/Users/dm/test/webdriverio/packages/wdio-sync/src/index.js:33:22)
[MultiremoteBrowser #0-0]     at /Users/dm/test/webdriverio/packages/wdio-sync/src/index.js:68:33
```

I might be utterly wrong, but it seems that the `keys` command is almost completly broken when using the devtools protocol.

I also found this PR: https://github.com/webdriverio/webdriverio/pull/5093 which might be about to hide the problem by switching the protocol for the `multiremote` example back to `webdriver`.

#5073 might be plagued by the same problem

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

An alternative solution is to update the code here: https://github.com/webdriverio/webdriverio/blob/cfa898f0445f3c468d34f9092f44d2a24553e893/packages/webdriverio/src/commands/browser/keys.js#L55 to make sure that it doesn't assume that `checkUnicode` always returns an array.

I did not go with this approach because returning a consistent value makes the calling code easier to read and maintain. It woudl require additional handling in the `keys` command for no good reason IMHO.

### Reviewers: @webdriverio/technical-committee
