### PR TITLE
update switchToFrame docs

### DIFF
--- a/packages/wdio-protocols/protocols/webdriver.json
+++ b/packages/wdio-protocols/protocols/webdriver.json
@@ -206,8 +206,8 @@
       "ref": "https://w3c.github.io/webdriver/#dfn-switch-to-frame",
       "parameters": [{
         "name": "id",
-        "type": "(number|string|object|null)",
-        "description": "one of three possible types: null: this represents the top-level browsing context (i.e., not an iframe), a Number, representing the index of the window object corresponding to a frame, a string representing an element id that can be received using `findElement`.",
+        "type": "(number|object|null)",
+        "description": "one of three possible types: null: this represents the top-level browsing context (i.e., not an iframe), a Number, representing the index of the window object corresponding to a frame, an Element object received using `findElement`.",
         "required": true
       }]
     }


### PR DESCRIPTION
If you use `element.elementId`, you get the error

```
invalid argument: invalid argument: 'id' can not be string
  (Session info: chrome=80.0.3987.132)
```

but if you just use the element itself, it works.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
