### PR TITLE
Add support for .cjs files

### DIFF
--- a/packages/wdio-config/src/constants.js
+++ b/packages/wdio-config/src/constants.js
@@ -78,3 +78,7 @@ export const SUPPORTED_HOOKS = [
     'beforeFeature', 'beforeScenario', 'beforeStep', 'afterStep', 'afterScenario', 'afterFeature',
     'onReload', 'onPrepare', 'onWorkerStart', 'onComplete'
 ]
+
+export const SUPPORTED_FILE_EXTENSIONS = [
+    '.js', '.mjs', '.es6', '.ts', '.feature', '.coffee', '.cjs'
+]

--- a/packages/wdio-config/src/lib/ConfigParser.js
+++ b/packages/wdio-config/src/lib/ConfigParser.js
@@ -7,7 +7,7 @@ import logger from '@wdio/logger'
 
 import { detectBackend, removeLineNumbers, isCucumberFeatureWithLineNumber } from '../utils'
 
-import { DEFAULT_CONFIGS, SUPPORTED_HOOKS } from '../constants'
+import { DEFAULT_CONFIGS, SUPPORTED_HOOKS, SUPPORTED_FILE_EXTENSIONS } from '../constants'
 
 const log = logger('@wdio/config:ConfigParser')
 const MERGE_OPTIONS = { clone: false }
@@ -291,13 +291,9 @@ export default class ConfigParser {
         for (let pattern of patterns) {
             let filenames = glob.sync(pattern)
 
-            filenames = filenames.filter(filename =>
-                filename.slice(-3) === '.js' ||
-                filename.slice(-4) === '.mjs' ||
-                filename.slice(-4) === '.es6' ||
-                filename.slice(-3) === '.ts' ||
-                filename.slice(-8) === '.feature' ||
-                filename.slice(-7) === '.coffee')
+            filenames = filenames.filter(
+                (filename) => SUPPORTED_FILE_EXTENSIONS.find(
+                    (ext) => filename.endsWith(ext)))
 
             filenames = filenames.map(filename =>
                 path.isAbsolute(filename) ? path.normalize(filename) : path.resolve(process.cwd(), filename))

--- a/packages/wdio-config/tests/configparser.test.js
+++ b/packages/wdio-config/tests/configparser.test.js
@@ -370,6 +370,15 @@ describe('ConfigParser', () => {
             expect(specs).toContain(path.resolve(FIXTURES_PATH, 'test.mjs'))
         })
 
+        it('should include cjs files', () => {
+            const configParser = new ConfigParser()
+            configParser.addConfigFile(FIXTURES_CONF)
+
+            const cjsFile = path.resolve(FIXTURES_PATH, '*.cjs')
+            const specs = configParser.getSpecs([cjsFile])
+            expect(specs).toContain(path.resolve(FIXTURES_PATH, 'test.cjs'))
+        })
+
         it('should not include other file types', () => {
             const configParser = new ConfigParser()
             configParser.addConfigFile(FIXTURES_CONF)


### PR DESCRIPTION
closes #5121

## Proposed changes

For projects running on latest Node v13 and using ESM as module system it is important to be able to run `.cjs` files if test files still use `require`. This patch adds support to have `.cjs` test files.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

### Reviewers: @webdriverio/project-committers 
