### PR TITLE
Allow bundling of @wdio/repl

### DIFF
--- a/packages/wdio-repl/src/index.js
+++ b/packages/wdio-repl/src/index.js
@@ -1,143 +1,27 @@
+/* istanbul ignore file */
 
 /**
- *
- * This command helps you to debug your integration tests. It stops the running browser and gives
- * you time to jump into it and check the state of your application (e.g. using dev tools).
- * Your terminal transforms into a [REPL](https://en.wikipedia.org/wiki/Read%E2%80%93eval%E2%80%93print_loop)
- * interface that will allow you to try out certain commands, find elements and test actions on
- * them.
- *
- * [![WebdriverIO REPL](https://webdriver.io/images/repl.gif)](https://webdriver.io/images/repl.gif)
- *
- * If you run the WDIO testrunner make sure you increase the timeout property of the test framework
- * you are using (e.g. Mocha or Jasmine) in order to prevent test termination due to a test timeout.
- * Also avoid executing the command with multiple capabilities running at the same time.
- *
- * <iframe width="560" height="315" src="https://www.youtube.com/embed/xWwP-3B_YyE" frameborder="0" allowfullscreen></iframe>
- *
- * <example>
-    :debug.js
-    it('should demonstrate the debug command', () => {
-        $('#input').setValue('FOO')
-        browser.debug() // jumping into the browser and change value of #input to 'BAR'
-        const value = $('#input').getValue()
-        console.log(value) // outputs: "BAR"
-    })
- * </example>
- *
- * @alias browser.debug
- * @type utility
- *
+ * environment check to allow to use this package in a web context
  */
 
-import vm from 'vm'
-import repl from 'repl'
-
-import { runFnInFiberContext, hasWdioSyncSupport } from '@wdio/utils'
-
-import { STATIC_RETURNS, INTRO_MESSAGE } from './constants'
-
-export default class WDIORepl {
-    static introMessage = INTRO_MESSAGE
-
-    constructor (config) {
-        this.config = Object.assign({
-            commandTimeout: 5000,
-            eval: ::this.eval,
-            prompt: '\u203A ',
-            useGlobal: true,
-            useColor: true
-        }, config)
-
-        this.isCommandRunning = false
-    }
-
-    eval (cmd, context, filename, callback) {
-        if (this.isCommandRunning) {
-            return
-        }
-
-        if (cmd && STATIC_RETURNS[cmd.trim()]) {
-            return callback(null, STATIC_RETURNS[cmd.trim()])
-        }
-
-        vm.createContext(context)
-        this.isCommandRunning = true
-
-        /* istanbul ignore if */
-        if (hasWdioSyncSupport) {
-            return runFnInFiberContext(
-                () => this._runCmd(cmd, context, callback))()
-        }
-
-        return this._runCmd(cmd, context, callback)
-    }
-
-    _runCmd (cmd, context, callback) {
-        try {
-            const result = vm.runInContext(cmd, context)
-            return this._handleResult(result, callback)
-        } catch (e) {
-            this.isCommandRunning = false
-            return callback(e)
-        }
-    }
-
-    _handleResult (result, callback) {
-        if (!result || typeof result.then !== 'function') {
-            this.isCommandRunning = false
-            return callback(null, result)
-        }
-
-        const timeout = setTimeout(
-            () => {
-                callback(new Error('Command execution timed out'))
-                this.isCommandRunning = false
-                timeout._called = true
-            },
-            this.config.commandTimeout
-        )
-
-        result.then((res) => {
-            /**
-             * don't do anything if timeout was called
-             */
-            if (timeout._called) {
-                return
-            }
-            this.isCommandRunning = false
-            clearTimeout(timeout)
-            return callback(null, res)
-        }, (e) => {
-            /**
-             * don't do anything if timeout was called
-             */
-            if (timeout._called) {
-                return
-            }
-
-            this.isCommandRunning = false
-            clearTimeout(timeout)
-            const errorMessage = e ? e.message : 'Command execution timed out'
-            const commandError = new Error(errorMessage)
-            delete commandError.stack
-            return callback(commandError)
-        })
-    }
-
-    start (context) {
-        if (this.replServer) {
-            throw new Error('a repl was already initialised')
-        }
-
-        if (context) {
-            const evalFn = this.config.eval
-            this.config.eval = (cmd, _, filename, callback) => evalFn(cmd, context, filename, callback)
-        }
-
-        this.replServer = repl.start(this.config)
-
-        return new Promise(
-            (resolve) => this.replServer.on('exit', resolve))
+// By default, import the web code using a literal require, so that in webpack
+// contexts, it will always be bundled
+let mode = class WebRepl {
+    constructor () {
+        throw new Error('The WDIO REPL is not supported in a web environment')
     }
 }
+
+// Then, if we're in a Node.js context, require the node version of this module
+// using a variable, so that it will _not_ be included in a bundle, either
+// during compilation or execution
+if (typeof process !== 'undefined' && typeof process.release !== 'undefined' && process.release.name === 'node') {
+    const nodeMode = './repl'
+    mode = require(nodeMode).default
+}
+
+// The net result will be that in a Node context, we'll have required both
+// files but will use the correct one, and in the web context, we'll have only
+// required the web file, thus ensuring that the Node file and related
+// dependencies will not be bundled inadvertently.
+export default mode

--- a/packages/wdio-repl/src/repl.js
+++ b/packages/wdio-repl/src/repl.js
@@ -1,0 +1,143 @@
+
+/**
+ *
+ * This command helps you to debug your integration tests. It stops the running browser and gives
+ * you time to jump into it and check the state of your application (e.g. using dev tools).
+ * Your terminal transforms into a [REPL](https://en.wikipedia.org/wiki/Read%E2%80%93eval%E2%80%93print_loop)
+ * interface that will allow you to try out certain commands, find elements and test actions on
+ * them.
+ *
+ * [![WebdriverIO REPL](https://webdriver.io/images/repl.gif)](https://webdriver.io/images/repl.gif)
+ *
+ * If you run the WDIO testrunner make sure you increase the timeout property of the test framework
+ * you are using (e.g. Mocha or Jasmine) in order to prevent test termination due to a test timeout.
+ * Also avoid executing the command with multiple capabilities running at the same time.
+ *
+ * <iframe width="560" height="315" src="https://www.youtube.com/embed/xWwP-3B_YyE" frameborder="0" allowfullscreen></iframe>
+ *
+ * <example>
+    :debug.js
+    it('should demonstrate the debug command', () => {
+        $('#input').setValue('FOO')
+        browser.debug() // jumping into the browser and change value of #input to 'BAR'
+        const value = $('#input').getValue()
+        console.log(value) // outputs: "BAR"
+    })
+ * </example>
+ *
+ * @alias browser.debug
+ * @type utility
+ *
+ */
+
+import vm from 'vm'
+import repl from 'repl'
+
+import { runFnInFiberContext, hasWdioSyncSupport } from '@wdio/utils'
+
+import { STATIC_RETURNS, INTRO_MESSAGE } from './constants'
+
+export default class WDIORepl {
+    static introMessage = INTRO_MESSAGE
+
+    constructor (config) {
+        this.config = Object.assign({
+            commandTimeout: 5000,
+            eval: ::this.eval,
+            prompt: '\u203A ',
+            useGlobal: true,
+            useColor: true
+        }, config)
+
+        this.isCommandRunning = false
+    }
+
+    eval (cmd, context, filename, callback) {
+        if (this.isCommandRunning) {
+            return
+        }
+
+        if (cmd && STATIC_RETURNS[cmd.trim()]) {
+            return callback(null, STATIC_RETURNS[cmd.trim()])
+        }
+
+        vm.createContext(context)
+        this.isCommandRunning = true
+
+        /* istanbul ignore if */
+        if (hasWdioSyncSupport) {
+            return runFnInFiberContext(
+                () => this._runCmd(cmd, context, callback))()
+        }
+
+        return this._runCmd(cmd, context, callback)
+    }
+
+    _runCmd (cmd, context, callback) {
+        try {
+            const result = vm.runInContext(cmd, context)
+            return this._handleResult(result, callback)
+        } catch (e) {
+            this.isCommandRunning = false
+            return callback(e)
+        }
+    }
+
+    _handleResult (result, callback) {
+        if (!result || typeof result.then !== 'function') {
+            this.isCommandRunning = false
+            return callback(null, result)
+        }
+
+        const timeout = setTimeout(
+            () => {
+                callback(new Error('Command execution timed out'))
+                this.isCommandRunning = false
+                timeout._called = true
+            },
+            this.config.commandTimeout
+        )
+
+        result.then((res) => {
+            /**
+             * don't do anything if timeout was called
+             */
+            if (timeout._called) {
+                return
+            }
+            this.isCommandRunning = false
+            clearTimeout(timeout)
+            return callback(null, res)
+        }, (e) => {
+            /**
+             * don't do anything if timeout was called
+             */
+            if (timeout._called) {
+                return
+            }
+
+            this.isCommandRunning = false
+            clearTimeout(timeout)
+            const errorMessage = e ? e.message : 'Command execution timed out'
+            const commandError = new Error(errorMessage)
+            delete commandError.stack
+            return callback(commandError)
+        })
+    }
+
+    start (context) {
+        if (this.replServer) {
+            throw new Error('a repl was already initialised')
+        }
+
+        if (context) {
+            const evalFn = this.config.eval
+            this.config.eval = (cmd, _, filename, callback) => evalFn(cmd, context, filename, callback)
+        }
+
+        this.replServer = repl.start(this.config)
+
+        return new Promise(
+            (resolve) => this.replServer.on('exit', resolve))
+    }
+}

--- a/packages/wdio-repl/tests/repl.test.js
+++ b/packages/wdio-repl/tests/repl.test.js
@@ -1,7 +1,7 @@
 import vm from 'vm'
 import replMock from 'repl'
 
-import WDIORepl from '../src/index'
+import WDIORepl from '../src/repl'
 
 jest.mock('vm', () => {
     class VMMock {


### PR DESCRIPTION
refs #5139

## Proposed changes

As stated in our release blog post there is the opportunity to run `webdriverio` in a browser environment (using a cloud vendor like Sauce Labs). So far it was not possible to do that because the package had a dependency to `@wdio/repl` which can't be bundled due to its dependency to Node.js [`repl`](https://nodejs.org/docs/latest-v12.x/api/repl.html) interface.

This patch fixes this by only importing the repl package if a Node.js environment is detected.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
