### PR TITLE
Enable spec filtering as default functionality

### DIFF
--- a/packages/wdio-config/src/constants.js
+++ b/packages/wdio-config/src/constants.js
@@ -24,9 +24,6 @@ export const DEFAULT_CONFIGS = () => ({
     execArgv: [],
     runnerEnv: {},
     runner: 'local',
-    featureFlags: {
-        specFiltering: undefined
-    },
 
     /**
      * framework defaults

--- a/packages/wdio-cucumber-framework/src/index.js
+++ b/packages/wdio-cucumber-framework/src/index.js
@@ -65,11 +65,7 @@ class CucumberAdapter {
     }
 
     hasTests () {
-        /**
-         * Avoid spec filtering only if the feature is disabled explicitly
-         * The feature has no impact on how framework/browser session is initialised.
-         */
-        return this.config.featureFlags.specFiltering === false || this._hasTests
+        return this._hasTests
     }
 
     async run () {

--- a/packages/wdio-cucumber-framework/tests/adapter.test.js
+++ b/packages/wdio-cucumber-framework/tests/adapter.test.js
@@ -23,11 +23,10 @@ const wdioReporter = {
     on: jest.fn()
 }
 
-const adapterFactory = (cucumberOpts = {}, featureFlags = {}, capabilities = {}) => new CucumberAdapter(
+const adapterFactory = (cucumberOpts = {}, capabilities = {}) => new CucumberAdapter(
     '0-2',
     {
         cucumberOpts,
-        featureFlags,
         beforeStep: 'beforeStep',
         afterStep: 'afterStep',
         beforeHook: 'beforeHook',
@@ -157,13 +156,6 @@ describe('hasTests', () => {
         adapter.loadSpecFiles = jest.fn()
         await adapter.init()
         expect(adapter.hasTests()).toBe(false)
-    })
-
-    test('should return true if the feature is disabled', async () => {
-        const adapter = adapterFactory(undefined, { specFiltering: false })
-        adapter.loadSpecFiles = jest.fn()
-        await adapter.init()
-        expect(adapter.hasTests()).toBe(true)
     })
 
     test('should return true if there are tests', async () => {
@@ -310,12 +302,11 @@ describe('addHooks', () => {
 })
 
 describe('skip filters', () => {
-
     const CHROME = { browserName:'Chrome', platformName:'linux' }
     const FIREFOX = { browserName:'firefox', platformName:'linux' }
 
     test('should skip using single capabilities', () => {
-        const adapter = adapterFactory({}, {}, CHROME)
+        const adapter = adapterFactory({}, CHROME)
         expect(adapter.filter({
             pickle: {
                 tags: [{
@@ -338,7 +329,7 @@ describe('skip filters', () => {
     })
 
     test('should skip using multiple properties', () => {
-        const adapter = adapterFactory({}, {}, CHROME)
+        const adapter = adapterFactory({}, CHROME)
         expect(adapter.filter({
             pickle: {
                 tags: [{
@@ -363,7 +354,7 @@ describe('skip filters', () => {
     })
 
     test('should skip with lists', () => {
-        const adapter = adapterFactory({}, {}, CHROME)
+        const adapter = adapterFactory({}, CHROME)
         expect(adapter.filter({
             pickle: {
                 tags: [{
@@ -374,7 +365,7 @@ describe('skip filters', () => {
     })
 
     test('should skip all specs if empty', () => {
-        const adapter = adapterFactory({}, {}, CHROME)
+        const adapter = adapterFactory({}, CHROME)
         expect(adapter.filter({
             pickle: {
                 tags: [{
@@ -385,8 +376,8 @@ describe('skip filters', () => {
     })
 
     test('should skip with regexp', () => {
-        const chromeAdapter = adapterFactory({}, {}, CHROME)
-        const ffAdapter = adapterFactory({}, {}, FIREFOX)
+        const chromeAdapter = adapterFactory({}, CHROME)
+        const ffAdapter = adapterFactory({}, FIREFOX)
         expect(chromeAdapter.filter({
             pickle: {
                 tags: [{
@@ -405,7 +396,7 @@ describe('skip filters', () => {
     })
 
     test('should not cause failures if no pickles or tags are provided', () => {
-        const adapter = adapterFactory({}, {}, CHROME)
+        const adapter = adapterFactory({}, CHROME)
         expect(adapter.filter({})).toBeTruthy()
         expect(adapter.filter({ pickle: {} })).toBeTruthy()
     })

--- a/packages/wdio-jasmine-framework/src/index.js
+++ b/packages/wdio-jasmine-framework/src/index.js
@@ -147,9 +147,6 @@ class JasmineAdapter {
     }
 
     _loadFiles () {
-        if (this.config.featureFlags.specFiltering !== true) {
-            return false
-        }
         try {
             if (Array.isArray(this.jasmineNodeOpts.requires)) {
                 this.jrunner.addRequires(this.jasmineNodeOpts.requires)
@@ -185,11 +182,7 @@ class JasmineAdapter {
     }
 
     hasTests () {
-        /**
-         * filter specs only if feature enabled explicitly to avoid breaking changes.
-         * If the feature is enabled user should avoid interacting with `browser` object before session is started
-         */
-        return this.config.featureFlags.specFiltering !== true || this._hasTests
+        return this._hasTests
     }
 
     async run () {

--- a/packages/wdio-jasmine-framework/tests/adapter.test.js
+++ b/packages/wdio-jasmine-framework/tests/adapter.test.js
@@ -26,7 +26,7 @@ const hookPayload = (type, suite, error) => ({
 
 const adapterFactory = (config = {}) => new JasmineAdapter(
     '0-2',
-    { beforeHook: [], afterHook: [], beforeTest: 'beforeTest', afterTest: 'afterTest', featureFlags: {}, ...config },
+    { beforeHook: [], afterHook: [], beforeTest: 'beforeTest', afterTest: 'afterTest', ...config },
     ['/foo/bar.test.js'],
     { browserName: 'chrome' },
     wdioReporter
@@ -36,7 +36,7 @@ test('comes with a factory', async () => {
     expect(typeof JasmineAdapterFactory.init).toBe('function')
     const instance = await JasmineAdapterFactory.init(
         '0-2',
-        { beforeHook: [], afterHook: [], featureFlags: {} },
+        { beforeHook: [], afterHook: [] },
         ['/foo/bar.test.js'],
         { browserName: 'chrome' },
         wdioReporter
@@ -403,15 +403,8 @@ describe('_grep', () => {
 })
 
 describe('loadFiles', () => {
-    test('should do nothing if feature is not enabled', () => {
-        const adapter = adapterFactory()
-        adapter._hasTests = null
-        expect(adapter._loadFiles({})).toBe(false)
-        expect(adapter._hasTests).toBe(null)
-    })
-
     test('should set _hasTests to true if there are tests to run', () => {
-        const adapter = adapterFactory({ featureFlags: { specFiltering: true } })
+        const adapter = adapterFactory({})
         adapter._hasTests = null
         adapter.jrunner.loadRequires = jest.fn()
         adapter.jrunner.loadHelpers = jest.fn()
@@ -427,7 +420,7 @@ describe('loadFiles', () => {
     })
 
     test('should set _hasTests to false if there no tests to run', () => {
-        const adapter = adapterFactory({ featureFlags: { specFiltering: true } })
+        const adapter = adapterFactory()
         adapter._hasTests = null
         adapter.jasmineNodeOpts.requires = ['r']
         adapter.jasmineNodeOpts.helpers = ['h']
@@ -446,7 +439,7 @@ describe('loadFiles', () => {
     })
 
     test('should not fail on exception', () => {
-        const adapter = adapterFactory({ featureFlags: { specFiltering: true } })
+        const adapter = adapterFactory()
         adapter._hasTests = null
 
         adapter.jrunner.loadRequires = jest.fn().mockImplementation(() => { throw new Error('foo') }),
@@ -458,15 +451,12 @@ describe('loadFiles', () => {
 })
 
 describe('hasTests', () => {
-    test('should return true if feature is not enabled', () => {
+    test('should return flag result', () => {
         const adapter = adapterFactory()
-        adapter._hasTests = 'foobar'
+        adapter._hasTests = true
         expect(adapter.hasTests()).toBe(true)
-    })
-    test('should return _hasTests if feature is enabled', () => {
-        const adapter = adapterFactory({ featureFlags: { specFiltering: true } })
-        adapter._hasTests = 'foobar'
-        expect(adapter.hasTests()).toBe('foobar')
+        adapter._hasTests = false
+        expect(adapter.hasTests()).toBe(false)
     })
 })
 

--- a/packages/wdio-mocha-framework/src/index.js
+++ b/packages/wdio-mocha-framework/src/index.js
@@ -57,9 +57,6 @@ class MochaAdapter {
     }
 
     _loadFiles (mochaOpts) {
-        if (this.config.featureFlags.specFiltering !== true) {
-            return false
-        }
         try {
             this.mocha.loadFiles()
 
@@ -84,11 +81,7 @@ class MochaAdapter {
     }
 
     hasTests () {
-        /**
-         * filter specs only if feature enabled explicitly to avoid breaking changes.
-         * If the feature is enabled user should avoid interacting with `browser` object before session is started
-         */
-        return this.config.featureFlags.specFiltering !== true || this._hasTests
+        return this._hasTests
     }
 
     async run () {

--- a/packages/wdio-mocha-framework/tests/adapter.test.js
+++ b/packages/wdio-mocha-framework/tests/adapter.test.js
@@ -18,7 +18,7 @@ const wdioReporter = {
 }
 const adapterFactory = (config) => new MochaAdapter(
     '0-2',
-    { featureFlags: {}, ...config },
+    { ...config },
     ['/foo/bar.test.js'],
     { browserName: 'chrome' },
     wdioReporter
@@ -34,7 +34,7 @@ test('comes with a factory', async () => {
     expect(typeof MochaAdapterFactory.init).toBe('function')
     const instance = await MochaAdapterFactory.init(
         '0-2',
-        { featureFlags: {} },
+        {},
         ['/foo/bar.test.js'],
         { browserName: 'chrome' },
         wdioReporter
@@ -320,15 +320,8 @@ test('getUID', () => {
 })
 
 describe('loadFiles', () => {
-    test('should do nothing if feature is not enabled', () => {
-        const adapter = adapterFactory()
-        adapter._hasTests = null
-        expect(adapter._loadFiles({})).toBe(false)
-        expect(adapter._hasTests).toBe(null)
-    })
-
     test('should set _hasTests to true if there are tests to run', () => {
-        const adapter = adapterFactory({ featureFlags: { specFiltering: true } })
+        const adapter = adapterFactory({})
         adapter._hasTests = null
         adapter.mocha = {
             loadFiles: jest.fn(),
@@ -339,7 +332,7 @@ describe('loadFiles', () => {
     })
 
     test('should set _hasTests to false if there no tests to run', () => {
-        const adapter = adapterFactory({ featureFlags: { specFiltering: true } })
+        const adapter = adapterFactory({})
         adapter._hasTests = null
         adapter.mocha = {
             loadFiles: jest.fn(),
@@ -352,7 +345,7 @@ describe('loadFiles', () => {
     })
 
     test('should not fail on exception', () => {
-        const adapter = adapterFactory({ featureFlags: { specFiltering: true } })
+        const adapter = adapterFactory({})
         adapter._hasTests = null
         adapter.mocha = {
             loadFiles: jest.fn().mockImplementation(() => { throw new Error('foo') }),
@@ -366,13 +359,10 @@ describe('loadFiles', () => {
 describe('hasTests', () => {
     test('should return true if feature is not enabled', () => {
         const adapter = adapterFactory()
-        adapter._hasTests = 'foobar'
+        adapter._hasTests = true
         expect(adapter.hasTests()).toBe(true)
-    })
-    test('should return _hasTests if feature is enabled', () => {
-        const adapter = adapterFactory({ featureFlags: { specFiltering: true } })
-        adapter._hasTests = 'foobar'
-        expect(adapter.hasTests()).toBe('foobar')
+        adapter._hasTests = false
+        expect(adapter.hasTests()).toBe(false)
     })
 })
 

--- a/packages/wdio-runner/src/index.js
+++ b/packages/wdio-runner/src/index.js
@@ -58,11 +58,11 @@ export default class Runner extends EventEmitter {
         /**
          * create `browser` stub only if `specFiltering` feature is enabled
          */
-        let browser = this.config.featureFlags.specFiltering === true ? await this._startSession({
+        let browser = await this._startSession({
             ...this.config,
             _automationProtocol: this.config.automationProtocol,
             automationProtocol: './protocol-stub'
-        }, caps) : undefined
+        }, caps)
 
         this.reporter = new BaseReporter(this.config, this.cid, { ...caps })
         /**

--- a/packages/wdio-runner/tests/index.test.js
+++ b/packages/wdio-runner/tests/index.test.js
@@ -191,8 +191,7 @@ describe('wdio-runner', () => {
                 reporters: [],
                 before: [before],
                 beforeSession: [beforeSession],
-                framework: 'testWithFailures',
-                featureFlags: {}
+                framework: 'testWithFailures'
             }
             runner.configParser.getConfig = jest.fn().mockReturnValue(config)
             runner._shutdown = jest.fn()
@@ -221,8 +220,7 @@ describe('wdio-runner', () => {
             const config = {
                 framework: 'testNoFailures',
                 reporters: [],
-                beforeSession: [],
-                featureFlags: {}
+                beforeSession: []
             }
             runner.configParser.getConfig = jest.fn().mockReturnValue(config)
             runner._initSession = jest.fn().mockReturnValue({ options: { capabilities: {} } })
@@ -236,8 +234,7 @@ describe('wdio-runner', () => {
             const config = {
                 framework: 'testNoFailures',
                 reporters: [],
-                beforeSession: [],
-                featureFlags: {}
+                beforeSession: []
             }
             runner.configParser.getConfig = jest.fn().mockReturnValue(config)
             global.browser = { url: jest.fn(url => url) }
@@ -254,8 +251,7 @@ describe('wdio-runner', () => {
             const config = {
                 framework: 'testThrows',
                 reporters: [],
-                beforeSession: [],
-                featureFlags: {}
+                beforeSession: []
             }
             runner.configParser.getConfig = jest.fn().mockReturnValue(config)
             runner._initSession = jest.fn().mockReturnValue({ options: { capabilities: {} } })
@@ -273,8 +269,7 @@ describe('wdio-runner', () => {
             const config = {
                 framework: 'testThrows',
                 reporters: [],
-                beforeSession: [],
-                featureFlags: {}
+                beforeSession: []
             }
             runner.configParser.getConfig = jest.fn().mockReturnValue(config)
             runner._shutdown = jest.fn()
@@ -297,8 +292,7 @@ describe('wdio-runner', () => {
             const config = {
                 framework: 'testNoTests',
                 reporters: [],
-                beforeSession: [],
-                featureFlags: {}
+                beforeSession: []
             }
             runner.configParser.getConfig = jest.fn().mockReturnValue(config)
             runner._shutdown = jest.fn().mockImplementation((arg) => arg)
@@ -316,8 +310,7 @@ describe('wdio-runner', () => {
             const config = {
                 framework: 'testNoFailures',
                 reporters: [],
-                beforeSession: [],
-                featureFlags: {}
+                beforeSession: []
             }
             runner.configParser.getConfig = jest.fn().mockReturnValue(config)
             runner._shutdown = jest.fn().mockReturnValue('_shutdown')

--- a/packages/wdio-sauce-service/tests/service.test.js
+++ b/packages/wdio-sauce-service/tests/service.test.js
@@ -309,11 +309,9 @@ test('updateJob for VMs', () => {
 
     service.updateJob('12345', 23, true)
 
-    const reqUri = got.put.mock.calls[0][0]
-    const reqCall = got.put.mock.calls[0][1]
+    const [reqUri, reqCall] = got.put.mock.calls[0]
     expect(reqUri).toBe('https://saucelabs.com/rest/v1/foobar/jobs/12345')
-    expect(reqCall.body).toEqual({ name: 'my test (1)', passed: false })
-    expect(reqCall.auth).toEqual('foobar:123')
+    expect(reqCall.json).toEqual({ name: 'my test (1)', passed: false })
     expect(service.failures).toBe(0)
 })
 
@@ -323,10 +321,9 @@ test('updateJob for RDC', () => {
 
     service.updateJob('12345', 23)
 
-    const reqUri = got.put.mock.calls[0][0]
-    const reqCall = got.put.mock.calls[0][1]
+    const [reqUri, reqCall] = got.put.mock.calls[0]
     expect(reqUri).toBe('https://app.testobject.com/api/rest/v2/appium/session/12345/test')
-    expect(reqCall.body).toEqual({ passed: false })
+    expect(reqCall.json).toEqual({ passed: false })
     expect(service.failures).toBe(0)
 })
 

--- a/packages/wdio-sync/webdriverio-core.d.ts
+++ b/packages/wdio-sync/webdriverio-core.d.ts
@@ -452,7 +452,7 @@ declare namespace WebdriverIO {
             name: string,
             func: Function
         ): void;
-
+        
         /**
          * The `$$` command is a short way to call the [`findElements`](/docs/api/webdriver.html#findelements) command in order
          * to fetch multiple elements on the page similar to the `$$` command from the browser scope. The difference when calling
@@ -840,7 +840,7 @@ declare namespace WebdriverIO {
             name: string,
             func: (elementFetchingMethod: (selector: string) => any) => void
         ): void
-
+        
         /**
          * The `$$` command is a short way to call the [`findElements`](/docs/api/webdriver.html#findelements) command in order
          * to fetch multiple elements on the page. It returns an array with element results that will have an

--- a/packages/wdio-sync/webdriverio-core.d.ts
+++ b/packages/wdio-sync/webdriverio-core.d.ts
@@ -158,9 +158,6 @@ declare namespace WebdriverIO {
          * Node arguments to specify when launching child processes.
          */
         execArgv?: string[];
-        featureFlags?: {
-            specFiltering?: boolean
-        },
     }
 
     interface RemoteOptions extends WebDriver.Options, Omit<Options, 'capabilities'> { }
@@ -455,7 +452,7 @@ declare namespace WebdriverIO {
             name: string,
             func: Function
         ): void;
-        
+
         /**
          * The `$$` command is a short way to call the [`findElements`](/docs/api/webdriver.html#findelements) command in order
          * to fetch multiple elements on the page similar to the `$$` command from the browser scope. The difference when calling
@@ -843,7 +840,7 @@ declare namespace WebdriverIO {
             name: string,
             func: (elementFetchingMethod: (selector: string) => any) => void
         ): void
-        
+
         /**
          * The `$$` command is a short way to call the [`findElements`](/docs/api/webdriver.html#findelements) command in order
          * to fetch multiple elements on the page. It returns an array with element results that will have an

--- a/packages/webdriverio/tests/__mocks__/got.js
+++ b/packages/webdriverio/tests/__mocks__/got.js
@@ -329,6 +329,7 @@ const requestMock = jest.fn().mockImplementation((uri, params) => {
     })
 })
 
+requestMock.extend = jest.fn().mockReturnValue(requestMock)
 requestMock.put = jest.fn().mockReturnValue(Promise.resolve({}))
 requestMock.retryCnt = 0
 requestMock.setMockResponse = (value) => {

--- a/packages/webdriverio/webdriverio-core.d.ts
+++ b/packages/webdriverio/webdriverio-core.d.ts
@@ -452,7 +452,7 @@ declare namespace WebdriverIO {
             name: string,
             func: Function
         ): void;
-
+        
         /**
          * The `$$` command is a short way to call the [`findElements`](/docs/api/webdriver.html#findelements) command in order
          * to fetch multiple elements on the page similar to the `$$` command from the browser scope. The difference when calling
@@ -840,7 +840,7 @@ declare namespace WebdriverIO {
             name: string,
             func: (elementFetchingMethod: (selector: string) => any) => void
         ): void
-
+        
         /**
          * The `$$` command is a short way to call the [`findElements`](/docs/api/webdriver.html#findelements) command in order
          * to fetch multiple elements on the page. It returns an array with element results that will have an

--- a/packages/webdriverio/webdriverio-core.d.ts
+++ b/packages/webdriverio/webdriverio-core.d.ts
@@ -158,9 +158,6 @@ declare namespace WebdriverIO {
          * Node arguments to specify when launching child processes.
          */
         execArgv?: string[];
-        featureFlags?: {
-            specFiltering?: boolean
-        },
     }
 
     interface RemoteOptions extends WebDriver.Options, Omit<Options, 'capabilities'> { }
@@ -455,7 +452,7 @@ declare namespace WebdriverIO {
             name: string,
             func: Function
         ): void;
-        
+
         /**
          * The `$$` command is a short way to call the [`findElements`](/docs/api/webdriver.html#findelements) command in order
          * to fetch multiple elements on the page similar to the `$$` command from the browser scope. The difference when calling
@@ -843,7 +840,7 @@ declare namespace WebdriverIO {
             name: string,
             func: (elementFetchingMethod: (selector: string) => any) => void
         ): void
-        
+
         /**
          * The `$$` command is a short way to call the [`findElements`](/docs/api/webdriver.html#findelements) command in order
          * to fetch multiple elements on the page. It returns an array with element results that will have an

--- a/scripts/templates/webdriverio.tpl.d.ts
+++ b/scripts/templates/webdriverio.tpl.d.ts
@@ -152,9 +152,6 @@ declare namespace WebdriverIO {
          * Node arguments to specify when launching child processes.
          */
         execArgv?: string[];
-        featureFlags?: {
-            specFiltering?: boolean
-        },
     }
 
     interface RemoteOptions extends WebDriver.Options, Omit<Options, 'capabilities'> { }

--- a/tests/smoke.runner.js
+++ b/tests/smoke.runner.js
@@ -317,8 +317,7 @@ const mochaSpecFiltering = async () => {
                 path.resolve(__dirname, 'mocha', 'test-empty.js'),
                 path.resolve(__dirname, 'mocha', 'test-skipped.js'),
                 path.resolve(__dirname, 'mocha', 'test-skipped-grep.js')
-            ],
-            featureFlags: { specFiltering: true }
+            ]
         })
     assert.strictEqual(skippedSpecs, 2)
 }
@@ -335,8 +334,7 @@ const jasmineSpecFiltering = async () => {
                 path.resolve(__dirname, 'jasmine', 'test-skipped.js'),
                 path.resolve(__dirname, 'jasmine', 'test-skipped-grep.js')
             ],
-            framework: 'jasmine',
-            featureFlags: { specFiltering: true }
+            framework: 'jasmine'
         })
     assert.strictEqual(skippedSpecs, 2)
 }

--- a/tests/smoke.runner.js
+++ b/tests/smoke.runner.js
@@ -55,7 +55,7 @@ const mochaTestrunner = async () => {
                 path.resolve(__dirname, 'mocha', 'test-skipped.js')
             ]
         })
-    assert.strictEqual(skippedSpecs, 0)
+    assert.strictEqual(skippedSpecs, 1)
 }
 
 /**
@@ -79,10 +79,13 @@ const jasmineTestrunner = async () => {
     const { skippedSpecs } = await launch(
         path.resolve(__dirname, 'helpers', 'config.js'),
         {
-            specs: [path.resolve(__dirname, 'jasmine', 'test.js'), path.resolve(__dirname, 'jasmine', 'test-skipped.js')],
+            specs: [
+                path.resolve(__dirname, 'jasmine', 'test.js'),
+                path.resolve(__dirname, 'jasmine', 'test-skipped.js')
+            ],
             framework: 'jasmine'
         })
-    assert.strictEqual(skippedSpecs, 0)
+    assert.strictEqual(skippedSpecs, 1)
 }
 
 /**

--- a/website/blog/2020-02-22-webdriverio-v6-released.md
+++ b/website/blog/2020-02-22-webdriverio-v6-released.md
@@ -201,7 +201,7 @@ Next to all major updates that were described above there are also some minor ch
 - __TypeScript Support:__ we improved the typings for WebdriverIO and WebDriver to include better descriptions and more detail
 - __WebDriver Default Path:__ we changed default WebDriver path to from `/wd/hub` to `/` as most of the browser drivers now default to this, this should have now affect for you - however if you have trouble connecting to a WebDriver endpoint after the upgrade, this could be a reason for that issue
 - __Command Renaming:__ we renamed command `launchApp` to `launchChromeApp` for Chrome WebDriver sessions
-- __Spec Filtering:__ the [Spec Filtering](https://webdriver.io/blog/2019/11/01/spec-filtering.html) feature is no enabled by default so that browser sessions aren't started if the framework can't find a test to run in the file (this can not be disabled anymore)
+- __Spec Filtering:__ the [Spec Filtering](https://webdriver.io/blog/2019/11/01/spec-filtering.html) feature is now enabled by default so that browser sessions aren't started if the framework can't find a test to run in the file (this can not be disabled anymore)
 - __New Hook:__ we added a new hook to the testrunner called `onWorkerStart` which will be executed right before we launch the worker process
 - __Modified Hook Signature:__ we modified the signature of our before/after test/hook hooks to allow you to access the frameworks native event objects - please have a look into the config file [documentation](ConfigurationFile.md) and update your hooks accordingly
 - __Cucumber Update:__ we have updated the `@wdio/cucumber-framework` adapter to use v6 of Cucumber

--- a/website/blog/2020-02-22-webdriverio-v6-released.md
+++ b/website/blog/2020-02-22-webdriverio-v6-released.md
@@ -201,6 +201,7 @@ Next to all major updates that were described above there are also some minor ch
 - __TypeScript Support:__ we improved the typings for WebdriverIO and WebDriver to include better descriptions and more detail
 - __WebDriver Default Path:__ we changed default WebDriver path to from `/wd/hub` to `/` as most of the browser drivers now default to this, this should have now affect for you - however if you have trouble connecting to a WebDriver endpoint after the upgrade, this could be a reason for that issue
 - __Command Renaming:__ we renamed command `launchApp` to `launchChromeApp` for Chrome WebDriver sessions
+- __Spec Filtering:__ the [Spec Filtering](https://webdriver.io/blog/2019/11/01/spec-filtering.html) feature is no enabled by default so that browser sessions aren't started if the framework can't find a test to run in the file (this can not be disabled anymore)
 - __New Hook:__ we added a new hook to the testrunner called `onWorkerStart` which will be executed right before we launch the worker process
 - __Modified Hook Signature:__ we modified the signature of our before/after test/hook hooks to allow you to access the frameworks native event objects - please have a look into the config file [documentation](ConfigurationFile.md) and update your hooks accordingly
 - __Cucumber Update:__ we have updated the `@wdio/cucumber-framework` adapter to use v6 of Cucumber


### PR DESCRIPTION
## Proposed changes

Fixes #5058

Will enable spec filtering for all user as default and doesn't make it optional.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
