### PR TITLE
docs: selectByVisibleText example inverse error

### DIFF
--- a/packages/webdriverio/src/commands/element/selectByVisibleText.js
+++ b/packages/webdriverio/src/commands/element/selectByVisibleText.js
@@ -14,10 +14,9 @@
     </select>
     :selectByVisibleText.js
     it('demonstrate the selectByVisibleText command', () => {
-        const selectBox = $('#selectbox');
-        console.log(selectBox.getText('option:checked')); // returns "uno"
-        selectBox.selectByVisibleText('cuatro');
-        console.log(selectBox.getText('option:checked')); // returns "cuatro"
+        console.log($('#selectbox option:checked').getText()); // returns "uno"
+        $('#selectbox').selectByVisibleText('cuatro');
+        console.log($('#selectbox option:checked').getText()); // returns "cuatro"
     })
  * </example>
  *


### PR DESCRIPTION

## Proposed changes

Fixing an error in the documentation accessible [here](https://webdriver.io/docs/api/element/selectByVisibleText.html).

 `option:checked` should be part of the selector not an argument to `getText()` because `getText()` takes no arguments.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
