### PR TITLE
Forward service defined path (driver server endpoint) for Selenium server.

### DIFF
--- a/packages/wdio-cli/src/launcher.js
+++ b/packages/wdio-cli/src/launcher.js
@@ -161,7 +161,7 @@ class Launcher {
                     specs: this.configParser.getSpecs(capabilities.specs, capabilities.exclude).map(s => ({ files: [s], retries: specFileRetries })),
                     availableInstances: capabilities.maxInstances || config.maxInstancesPerCapability,
                     runningInstances: 0,
-                    seleniumServer: { hostname: config.hostname, port: config.port, protocol: config.protocol }
+                    seleniumServer: { hostname: config.hostname, port: config.port, protocol: config.protocol, path: config.path }
                 })
             }
         }


### PR DESCRIPTION
## Proposed changes

It is currently not possible for a custom service to update `path` using the `onPrepare` hook. The `wdio-clio` launcher does not include it in `seleniumServer` args. It only forwards `hostname`, `port`, and `protocol` from the service to the final config.

This PR updates the launcher to also forward the service defined `path` to Selenium.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

I didn't see any tests for this, so I haven't added/updated any in this PR. Let me know if this is a good opportunity to add any.

## Further comments

I am creating a AWS Device Farm service (`wdio-aws-device-farm-service`) and it is designed to fetch a remote URL using the `aws-sdk`, and then pass the `hostname`, `path`, `port`, and `protocol` to WebdriverIO.

This PR will allow my service to work. I still need to check if this same change needs to happen in v6, but that will be a different PR, if needed.

### Reviewers: @webdriverio/project-committers
