### PR TITLE
Fix typings for got and its tests

### DIFF
--- a/packages/wdio-browserstack-service/package.json
+++ b/packages/wdio-browserstack-service/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@wdio/logger": "6.0.1",
     "browserstack-local": "^1.4.3",
-    "got": "^10.2.1"
+    "got": "^10.7.0"
   },
   "peerDependencies": {
     "@wdio/cli": "^5.0.0"

--- a/packages/wdio-sumologic-reporter/package.json
+++ b/packages/wdio-sumologic-reporter/package.json
@@ -33,7 +33,7 @@
     "@wdio/logger": "6.0.1",
     "@wdio/reporter": "6.0.1",
     "dateformat": "^3.0.3",
-    "got": "^10.2.1",
+    "got": "^10.7.0",
     "json-stringify-safe": "^5.0.1"
   },
   "peerDependencies": {

--- a/packages/wdio-testingbot-service/package.json
+++ b/packages/wdio-testingbot-service/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@wdio/logger": "6.0.1",
-    "got": "^10.2.1",
+    "got": "^10.7.0",
     "testingbot-tunnel-launcher": "^1.1.7"
   },
   "peerDependencies": {

--- a/packages/webdriver/package.json
+++ b/packages/webdriver/package.json
@@ -34,7 +34,7 @@
     "@wdio/logger": "6.0.1",
     "@wdio/protocols": "6.0.1",
     "@wdio/utils": "6.0.1",
-    "got": "^10.2.1",
+    "got": "^10.7.0",
     "lodash.merge": "^4.6.1"
   },
   "devDependencies": {

--- a/packages/webdriver/webdriver.d.ts
+++ b/packages/webdriver/webdriver.d.ts
@@ -10,8 +10,8 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 /// <reference types="node"/>
 
-declare type HTTPRequestOptions = import('got').GotOptions<any>;
-declare type HTTPResponse = import('got').Response<any>;
+declare type HTTPRequestOptions = import('got').GotOptions;
+declare type HTTPResponse = import('got').Response;
 
 declare namespace WebDriver {
     type PageLoadingStrategy = 'none' | 'eager' | 'normal';

--- a/scripts/templates/webdriver.tpl.d.ts
+++ b/scripts/templates/webdriver.tpl.d.ts
@@ -4,8 +4,8 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 /// <reference types="node"/>
 
-declare type HTTPRequestOptions = import('got').GotOptions<any>;
-declare type HTTPResponse = import('got').Response<any>;
+declare type HTTPRequestOptions = import('got').GotOptions;
+declare type HTTPResponse = import('got').Response;
 
 declare namespace WebDriver {
     type PageLoadingStrategy = 'none' | 'eager' | 'normal';

--- a/tests/typings/copy.js
+++ b/tests/typings/copy.js
@@ -1,6 +1,10 @@
-const rimraf = require('rimraf')
-const copyfiles = require('copyfiles')
+const fs = require('fs')
 const path = require('path')
+
+const { ln, mkdir } = require('shelljs')
+const rimraf = require('rimraf')
+
+const ROOT = path.resolve(__dirname, '..', '..')
 
 // TypeScript project root for testing particular typings
 const outDirs = [
@@ -16,31 +20,14 @@ const packages = {
     'webdriverio': 'packages/webdriverio',
     '@wdio/allure-reporter': 'packages/wdio-allure-reporter',
     '@wdio/reporter': 'packages/wdio-reporter',
-
-    '@applitools/visual-grid-client': 'packages/wdio-applitools-service/node_modules/@applitools/visual-grid-client',
     '@wdio/applitools-service': 'packages/wdio-applitools-service',
-
-    'browserstack-local': 'packages/wdio-browserstack-service/node_modules/browserstack-local',
     '@wdio/browserstack-service': 'packages/wdio-browserstack-service',
     '@wdio/sauce-service': 'packages/wdio-sauce-service',
-
-    '@types/got': 'packages/webdriver/node_modules/@types/got',
-    '@types/tough-cookie': 'packages/webdriver/node_modules/@types/tough-cookie',
-
-    '@types/mocha': 'packages/wdio-mocha-framework/node_modules/@types/mocha',
     '@wdio/mocha-framework': 'packages/wdio-mocha-framework',
-
-    '@types/cucumber': 'packages/wdio-cucumber-framework/node_modules/@types/cucumber',
     '@wdio/cucumber-framework': 'packages/wdio-cucumber-framework',
-
-    '@types/jasmine': 'packages/wdio-jasmine-framework/node_modules/@types/jasmine',
-    '@types/jasmine/ts3.1': 'packages/wdio-jasmine-framework/node_modules/@types/jasmine/ts3.1',
     '@wdio/jasmine-framework': 'packages/wdio-jasmine-framework',
-
-    '@types/selenium-standalone': 'packages/wdio-selenium-standalone-service/node_modules/@types/selenium-standalone',
     '@wdio/selenium-standalone-service': 'packages/wdio-selenium-standalone-service',
-
-    '@wdio/shared-store-service': 'packages/wdio-shared-store-service',
+    '@wdio/shared-store-service': 'packages/wdio-shared-store-service'
 }
 
 /**
@@ -49,12 +36,15 @@ const packages = {
 async function copy() {
     for (const outDir of outDirs) {
         for (const packageName of Object.keys(packages)) {
-            const packageDir = packages[packageName]
-            const packageJson = path.join(packageDir, 'package.json')
-            const typings = path.join(packageDir, '*.d.ts')
             const destination = path.join(__dirname, outDir, 'node_modules', packageName)
+            const packageDir = packages[packageName]
 
-            await new Promise(resolve => copyfiles([packageJson, typings, destination], { up: packageDir.split('/').length }, resolve))
+            const destDir = destination.split('/').slice(0, -1).join('/')
+            if (!fs.existsSync(destDir)) {
+                mkdir('-p', destDir)
+            }
+
+            ln('-s', path.join(ROOT, packageDir), destination)
         }
     }
 }

--- a/tests/typings/sync/config.ts
+++ b/tests/typings/sync/config.ts
@@ -27,7 +27,7 @@ const conf: WebdriverIO.Config = {
     },
     transformResponse: (response, requestOptions) => {
         if (requestOptions.method === 'DELETE' && response.statusCode === 200) {
-            response.body.deleted = true
+            console.log(response.body)
         }
 
         return response


### PR DESCRIPTION
## Proposed changes

As described in #5157 we used the wrong set of typings for our tests which caused TypeScript to error out as `got` introduced their own typings what we still checked against `@types/got`. This patch:

- makes the typing checks more robust by linking whole directories instead of copying single files
- fixes the got typings in `webdriver.d.ts`

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
