### PR TITLE
Allow API descriptions

### DIFF
--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -32,11 +32,32 @@ const EDIT_WARNING = `// -------------------- ATTENTION --------------------
 //
 `
 
+const SAUCE_API_DESCRIPTION = `
+All commands are only supported on Chrome using Sauce Labs
+[Extended Debugging](https://wiki.saucelabs.com/pages/viewpage.action?pageId=70072943)
+capabilities. You can enable these by setting the following Sauce options:\n\n
+\`\`\`js
+{
+    browserName: 'Chrome',
+    browserVersion: 'latest',
+    platformName: 'Windows 10',
+    'sauce:options': {
+        extendedDebugging: true
+    }
+}
+\`\`\`
+`
+
+const PROTOCOL_API_DESCRIPTION = {
+    'saucelabs': SAUCE_API_DESCRIPTION
+}
+
 module.exports = {
     PROTOCOLS,
     EDIT_WARNING,
     PROTOCOL_NAMES,
     MOBILE_PROTOCOLS,
     VENDOR_PROTOCOLS,
-    IGNORED_SUBPACKAGES_FOR_DOCS
+    IGNORED_SUBPACKAGES_FOR_DOCS,
+    PROTOCOL_API_DESCRIPTION
 }

--- a/scripts/docs-generation/protocolDocs.js
+++ b/scripts/docs-generation/protocolDocs.js
@@ -4,7 +4,9 @@ const path = require('path')
 const ejs = require('../../packages/wdio-cli/node_modules/ejs')
 const config = require('../../website/siteConfig')
 const TEMPLATE_PATH = path.join(__dirname, '..', 'templates', 'api.tpl.ejs')
-const { PROTOCOLS, PROTOCOL_NAMES, MOBILE_PROTOCOLS, VENDOR_PROTOCOLS } = require('../constants')
+const {
+    PROTOCOLS, PROTOCOL_NAMES, MOBILE_PROTOCOLS, VENDOR_PROTOCOLS, PROTOCOL_API_DESCRIPTION
+} = require('../constants')
 
 /**
  * Generate Protocol docs
@@ -61,13 +63,21 @@ exports.generateProtocolDocs = (sidebars) => {
                         `custom_edit_url: https://github.com/webdriverio/webdriverio/edit/master/packages/wdio-protocols/protocols/${protocolName}.json`,
                         '---\n'
                     ].join('\n')]
+
+                    /**
+                     * include API description if existent
+                     */
+                    if (Object.keys(PROTOCOL_API_DESCRIPTION).includes(protocolName)) {
+                        protocolDocs[protocolName].push(PROTOCOL_API_DESCRIPTION[protocolName])
+                    }
                 }
                 protocolDocs[protocolName].push(markdown)
             }
         }
 
         const docPath = path.join(__dirname, '..', '..', 'docs', 'api', `_${protocolName}.md`)
-        fs.writeFileSync(docPath, protocolDocs[protocolName].join('\n---\n'), { encoding: 'utf-8' })
+        const [preemble, ...apiDocs] = protocolDocs[protocolName]
+        fs.writeFileSync(docPath, preemble + apiDocs.join('\n---\n'), { encoding: 'utf-8' })
 
         // eslint-disable-next-line no-console
         console.log(`Generated docs for ${protocolName} protocol`)

--- a/scripts/updateDocs.js
+++ b/scripts/updateDocs.js
@@ -23,12 +23,7 @@ const IGNORE_FILE_SUFFIX = ['*.rb']
     const { stdout } = shell.exec('git rev-parse --abbrev-ref HEAD', { silent: true })
     const currentBranch = stdout.trim()
 
-    if (currentBranch === 'master' || currentBranch.startsWith('v')) {
-        return console.log('No documentation update until v6 is released')
-    }
-
-    // const bucketName = currentBranch === 'master' ? BUCKET_NAME : `${currentBranch}.${BUCKET_NAME}`
-    const bucketName = BUCKET_NAME
+    const bucketName = currentBranch === 'master' ? BUCKET_NAME : `${currentBranch}.${BUCKET_NAME}`
 
     console.log(`Uploading ${BUILD_DIR} to S3 bucket ${bucketName}`)
     await Promise.all(files.map((file) => new Promise((resolve, reject) => s3.upload({


### PR DESCRIPTION
## Proposed changes

Every protocol API currently directly starts with the first command. Issue #5156 showed that there is a need to allow API description as an introduction. This patch allows to define API descriptions and also adds one for Sauce Labs stating that all their commands only work with Extended Debugging enabled on Chrome.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
