### PR TITLE
Set connection details in selenium-standalone properly

### DIFF
--- a/packages/wdio-config/src/lib/ConfigParser.js
+++ b/packages/wdio-config/src/lib/ConfigParser.js
@@ -126,13 +126,15 @@ export default class ConfigParser {
          */
         let defaultBackend = detectBackend({})
         if (
+            (this._config.protocol === defaultBackend.protocol) &&
             (this._config.hostname === defaultBackend.hostname) &&
             (this._config.port === defaultBackend.port) &&
-            (this._config.protocol === defaultBackend.protocol)
+            (this._config.path === defaultBackend.path)
         ) {
+            delete this._config.protocol
             delete this._config.hostname
             delete this._config.port
-            delete this._config.protocol
+            delete this._config.path
         }
 
         this._config = merge(detectBackend(this._config), this._config, MERGE_OPTIONS)

--- a/packages/wdio-selenium-standalone-service/README.md
+++ b/packages/wdio-selenium-standalone-service/README.md
@@ -1,7 +1,9 @@
 WebdriverIO Selenium Standalone Service
 =======================================
 
-Handling the Selenium server is out of scope of the actual WebdriverIO project. This service helps you to run Selenium seamlessly when running tests with the [WDIO testrunner](https://webdriver.io/guide/testrunner/gettingstarted.html). It uses the well know [selenium-standalone](https://www.npmjs.com/package/selenium-standalone) NPM package that automatically sets up the standalone server and all required driver for you.
+Handling the Selenium server is out of scope of the actual WebdriverIO project. This service helps you to run Selenium seamlessly when running tests with the [WDIO testrunner](https://webdriver.io/guide/testrunner/gettingstarted.html). It uses the well known [selenium-standalone](https://www.npmjs.com/package/selenium-standalone) NPM package that automatically sets up the standalone server and all required driver for you.
+
+__Note:__ If you use this service you don't need any other driver services (e.g. [wdio-chromedriver-service](https://www.npmjs.com/package/wdio-chromedriver-service)) anymore. All local browser can be started using this service.
 
 ## Installation
 

--- a/packages/wdio-selenium-standalone-service/src/launcher.js
+++ b/packages/wdio-selenium-standalone-service/src/launcher.js
@@ -9,6 +9,13 @@ import { getFilePath } from './utils'
 const DEFAULT_LOG_FILENAME = 'wdio-selenium-standalone.log'
 const log = logger('@wdio/selenium-standalone-service')
 
+const DEFAULT_CONNECTION = {
+    protocol: 'http',
+    hostname: 'localhost',
+    port: 4444,
+    path: '/wd/hub'
+}
+
 export default class SeleniumStandaloneLauncher {
     constructor (options, capabilities, config) {
         this.capabilities = capabilities
@@ -29,7 +36,7 @@ export default class SeleniumStandaloneLauncher {
          * update capability connection options to connect
          * to standalone server
          */
-        this.capabilities.forEach((cap) => !cap.path && (cap.path = '/wd/hub'))
+        this.capabilities.forEach((cap) => Object.assign(cap, DEFAULT_CONNECTION))
         this.process = await promisify(SeleniumStandalone.start)(this.args)
 
         if (typeof this.logPath === 'string') {

--- a/packages/wdio-selenium-standalone-service/tests/launcher.test.js
+++ b/packages/wdio-selenium-standalone-service/tests/launcher.test.js
@@ -21,7 +21,7 @@ describe('Selenium standalone launcher', () => {
                 args : { foo : 'foo' },
                 installArgs : { bar : 'bar' },
             }
-            const capabilities = [{}]
+            const capabilities = [{ port: 1234 }]
             const launcher = new SeleniumStandaloneLauncher(options, capabilities, {})
             launcher._redirectLogStream = jest.fn()
             await launcher.onPrepare({ watch: true })
@@ -31,6 +31,9 @@ describe('Selenium standalone launcher', () => {
             expect(launcher.args).toBe(options.args)
             expect(launcher.skipSeleniumInstall).toBe(false)
             expect(launcher.watchMode).toEqual(true)
+            expect(capabilities[0].protocol).toBe('http')
+            expect(capabilities[0].hostname).toBe('localhost')
+            expect(capabilities[0].port).toBe(4444)
             expect(capabilities[0].path).toBe('/wd/hub')
         })
 


### PR DESCRIPTION
## Proposed changes

Fixes an issue where setting the `@wdio/selenium-standalone-server` would start the session but fails with every consecutive request. This happens because we would usually default to WebDriver default connection values `http://localhost:4444`. In v6 we don't do this anymore since it is possible to run tests straight with Puppeteer.

As solution the service will implicitly set default WebDriver connection values if it is being used (for all capabilities).

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
