### PR TITLE
webdriverio: Add Espresso ViewMatcher strategy

### DIFF
--- a/docs/Selectors.md
+++ b/docs/Selectors.md
@@ -211,7 +211,7 @@ const Button = $(`android=${selector}`)
 Button.click()
 ```
 
-### Android DataMatcher (Espresso only)
+### Android DataMatcher and ViewMatcher (Espresso only)
 
 Android's DataMatcher strategy provides a way to find elements by [Data Matcher](https://developer.android.com/reference/android/support/test/espresso/DataInteraction)
 
@@ -219,6 +219,17 @@ Android's DataMatcher strategy provides a way to find elements by [Data Matcher]
 const menuItem = $({
   "name": "hasEntry",
   "args": ["title", "ViewTitle"]
+})
+menuItem.click()
+```
+
+And similarly [View Matcher](https://developer.android.com/reference/android/support/test/espresso/ViewInteraction)
+
+```js
+const menuItem = $({
+  "name": "hasEntry",
+  "args": ["title", "ViewTitle"],
+  "class": "androidx.test.espresso.matcher.ViewMatchers"
 })
 menuItem.click()
 ```

--- a/packages/wdio-sync/webdriverio-core.d.ts
+++ b/packages/wdio-sync/webdriverio-core.d.ts
@@ -384,9 +384,10 @@ declare namespace WebdriverIO {
         reverse?: boolean,
     }
 
-    type DataMatcher = {
+    type Matcher = {
         name: string,
-        args: Array<string>
+        args: Array<string | object>
+        class?: string
     }
 
     type ReactSelectorOptions = {
@@ -459,7 +460,7 @@ declare namespace WebdriverIO {
          * it from an element scope is that the driver will look within the children of that element.
          */
         $$(
-            selector: string | Function | DataMatcher
+            selector: string | Function | Matcher
         ): ElementArray;
 
         /**
@@ -470,7 +471,7 @@ declare namespace WebdriverIO {
          * to an element. The command will then transform the reference to an extended WebdriverIO element.
          */
         $(
-            selector: string | Function | DataMatcher
+            selector: string | Function | Matcher
         ): Element;
 
         /**

--- a/packages/webdriverio/src/commands/element/$$.js
+++ b/packages/webdriverio/src/commands/element/$$.js
@@ -32,7 +32,7 @@
  * </example>
  *
  * @alias $$
- * @param {String|Function|DataMatcher} selector  selector, JS Function or DataMatcher object to fetch multiple elements
+ * @param {String|Function|Matcher} selector  selector, JS Function, or Matcher object to fetch multiple elements
  * @return {ElementArray}
  * @type utility
  *

--- a/packages/webdriverio/src/commands/element/$.js
+++ b/packages/webdriverio/src/commands/element/$.js
@@ -43,7 +43,7 @@
  * </example>
  *
  * @alias $
- * @param {String|Function|DataMatcher} selector  selector, JS Function or DataMatcher object to fetch a certain element
+ * @param {String|Function|Matcher} selector  selector, JS Function, or Matcher object to fetch a certain element
  * @return {Element}
  * @type utility
  *

--- a/packages/webdriverio/src/utils.js
+++ b/packages/webdriverio/src/utils.js
@@ -8,6 +8,7 @@ import logger from '@wdio/logger'
 import isObject from 'lodash.isobject'
 import { URL } from 'url'
 import { SUPPORTED_BROWSER } from 'devtools'
+import isPlainObject from 'lodash.isplainobject'
 
 import { ELEMENT_KEY, UNICODE_CHARACTERS, DRIVER_DEFAULT_ENDPOINT } from './constants'
 import { findStrategy } from './utils/findStrategy'
@@ -207,7 +208,7 @@ export async function findElement(selector) {
     /**
      * fetch element using regular protocol command
      */
-    if (typeof selector === 'string') {
+    if (typeof selector === 'string' || isPlainObject(selector)) {
         const { using, value } = findStrategy(selector, this.isW3C, this.isMobile)
         return this.elementId
             ? this.findElementFromElement(this.elementId, using, value)
@@ -234,7 +235,7 @@ export async function findElements(selector) {
     /**
      * fetch element using regular protocol command
      */
-    if (typeof selector === 'string') {
+    if (typeof selector === 'string' || isPlainObject(selector)) {
         const { using, value } = findStrategy(selector, this.isW3C, this.isMobile)
         return this.elementId
             ? this.findElementsFromElement(this.elementId, using, value)

--- a/packages/webdriverio/src/utils/findStrategy.js
+++ b/packages/webdriverio/src/utils/findStrategy.js
@@ -2,7 +2,7 @@ import { W3C_SELECTOR_STRATEGIES } from '../constants'
 import isPlainObject from 'lodash.isplainobject'
 
 const DEFAULT_STRATEGY = 'css selector'
-const DIRECT_SELECTOR_REGEXP = /^(id|css selector|xpath|link text|partial link text|name|tag name|class name|-android uiautomator|-android datamatcher|-ios uiautomation|-ios predicate string|-ios class chain|accessibility id):(.+)/
+const DIRECT_SELECTOR_REGEXP = /^(id|css selector|xpath|link text|partial link text|name|tag name|class name|-android uiautomator|-android datamatcher|-android viewmatcher|-ios uiautomation|-ios predicate string|-ios class chain|accessibility id):(.+)/
 const XPATH_SELECTORS_START = [
     '/', '(', '../', './', '*/'
 ]
@@ -24,9 +24,11 @@ const defineStrategy = function (selector) {
     // Condition with checking isPlainObject(selector) should be first because
     // in case of "selector" argument is a plain object then .match() will cause
     // an error like "selector.match is not a function"
-    // Use '-android datamatcher' strategy if selector is a plain object (Android only)
+    // Use '-android datamatcher' or '-android viewmatcher' strategy if selector is a plain object (Android only)
     if (isPlainObject(selector)) {
-        return '-android datamatcher'
+        if (JSON.stringify(selector).indexOf('test.espresso.matcher.ViewMatchers') < 0)
+            return '-android datamatcher'
+        return '-android viewmatcher'
     }
     // Check if user has specified locator strategy directly
     if (selector.match(DIRECT_SELECTOR_REGEXP)) {
@@ -128,6 +130,11 @@ export const findStrategy = function (selector, isW3C, isMobile) {
     }
     case '-android datamatcher': {
         using = '-android datamatcher'
+        value = JSON.stringify(value)
+        break
+    }
+    case '-android viewmatcher': {
+        using = '-android viewmatcher'
         value = JSON.stringify(value)
         break
     }

--- a/packages/webdriverio/tests/findStrategy.test.js
+++ b/packages/webdriverio/tests/findStrategy.test.js
@@ -218,6 +218,13 @@ describe('selector strategies helper', () => {
         expect(element.value).toBe('{"name":"startsWith","args":"aFakeString"}')
     })
 
+    it('should find an element by viewmatcher strategy (android only)', () => {
+        const selector = { 'name': 'startsWith', 'args': 'aFakeString', 'class': 'androidx.test.espresso.matcher.ViewMatchers' }
+        const element = findStrategy(selector)
+        expect(element.using).toBe('-android viewmatcher')
+        expect(element.value).toBe('{"name":"startsWith","args":"aFakeString","class":"androidx.test.espresso.matcher.ViewMatchers"}')
+    })
+
     it('should find an element by ui automation strategy (ios only)', () => {
         const element = findStrategy('ios=foo')
         expect(element.using).toBe('-ios uiautomation')
@@ -328,6 +335,9 @@ describe('selector strategies helper', () => {
         element = findStrategy('-android datamatcher:foobar -android datamatcher')
         expect(element.using).toBe('-android datamatcher')
         expect(element.value).toBe('foobar -android datamatcher')
+        element = findStrategy('-android viewmatcher:foobar -android viewmatcher')
+        expect(element.using).toBe('-android viewmatcher')
+        expect(element.value).toBe('foobar -android viewmatcher')
         element = findStrategy('-ios uiautomation:foobar -ios uiautomation')
         expect(element.using).toBe('-ios uiautomation')
         expect(element.value).toBe('foobar -ios uiautomation')

--- a/packages/webdriverio/webdriverio-core.d.ts
+++ b/packages/webdriverio/webdriverio-core.d.ts
@@ -384,9 +384,10 @@ declare namespace WebdriverIO {
         reverse?: boolean,
     }
 
-    type DataMatcher = {
+    type Matcher = {
         name: string,
-        args: Array<string>
+        args: Array<string | object>
+        class?: string
     }
 
     type ReactSelectorOptions = {
@@ -459,7 +460,7 @@ declare namespace WebdriverIO {
          * it from an element scope is that the driver will look within the children of that element.
          */
         $$(
-            selector: string | Function | DataMatcher
+            selector: string | Function | Matcher
         ): Promise<ElementArray>;
 
         /**
@@ -470,7 +471,7 @@ declare namespace WebdriverIO {
          * to an element. The command will then transform the reference to an extended WebdriverIO element.
          */
         $(
-            selector: string | Function | DataMatcher
+            selector: string | Function | Matcher
         ): Promise<Element>;
 
         /**

--- a/scripts/templates/webdriverio.tpl.d.ts
+++ b/scripts/templates/webdriverio.tpl.d.ts
@@ -378,9 +378,10 @@ declare namespace WebdriverIO {
         reverse?: boolean,
     }
 
-    type DataMatcher = {
+    type Matcher = {
         name: string,
-        args: Array<string>
+        args: Array<string | object>
+        class?: string
     }
 
     type ReactSelectorOptions = {

--- a/scripts/type-generation/constants.js
+++ b/scripts/type-generation/constants.js
@@ -2,7 +2,7 @@ const CUSTOM_INTERFACES = [
     'Buffer', 'Function', 'RegExp', 'WaitForOptions', 'ReactSelectorOptions',
     'MoveToOptions', 'DragAndDropOptions', 'NewWindowOptions', 'Element',
     'ElementArray', 'ClickOptions', 'WaitUntilOptions', 'Cookie', 'Timeouts',
-    'CSSProperty', 'TouchActions', 'DataMatcher', 'WebDriver.Cookie'
+    'CSSProperty', 'TouchActions', 'Matcher', 'WebDriver.Cookie'
 ]
 
 module.exports = {


### PR DESCRIPTION
## Proposed changes

Per [appium/appium#13747](https://github.com/appium/appium/issues/13747), This is for Espresso's ViewMatcher strategy, similar to DataMatcher.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

I have to make both datamatcher and viewmatcher use 'directly' strategy because both of them have more or less the same object structure, and there is no way to tell from the object passing in if it's for datamatcher or viewmatcher. I have already done integration test using the feature.

### Reviewers: @webdriverio/project-committers
