### PR TITLE
Correctly bind browserstackLocal this-context

### DIFF
--- a/packages/wdio-browserstack-service/src/launcher.js
+++ b/packages/wdio-browserstack-service/src/launcher.js
@@ -48,7 +48,7 @@ export default class BrowserstackLauncherService {
         let timer
         performance.mark('tbTunnelStart')
         return Promise.race([
-            promisify(this.browserstackLocal.start)(opts),
+            promisify(this.browserstackLocal.start.bind(this.browserstackLocal))(opts),
             new Promise((resolve, reject) => {
                 /* istanbul ignore next */
                 timer = setTimeout(function () {

--- a/packages/wdio-browserstack-service/tests/launcher.test.js
+++ b/packages/wdio-browserstack-service/tests/launcher.test.js
@@ -93,6 +93,21 @@ describe('onPrepare', () => {
         expect(service.browserstackLocal.start).toHaveBeenCalled()
         expect(log.info.mock.calls[0][0]).toContain('Browserstack Local successfully started after')
     })
+
+    it('should correctly set up this-binding for local.start', async () => {
+        const service = new BrowserstackLauncher(options, caps, config)
+        Browserstack.Local.mockImplementationOnce(function () {
+            this.start = jest.fn().mockImplementationOnce(function (options, cb) {
+                this.addArgs(options)
+                cb()
+            })
+            this.addArgs = jest.fn().mockImplementationOnce(() => undefined)
+        })
+
+        await service.onPrepare(config, caps)
+        expect(service.browserstackLocal.start).toHaveBeenCalled()
+        expect(service.browserstackLocal.addArgs).toHaveBeenCalled()
+    })
 })
 
 describe('onComplete', () => {


### PR DESCRIPTION
`browserstackLocal.start()` tries to call `this.addArgs()`. However the
`this`-binding gets lost when just calling
`promisify(this.browserstackLocal)` so the `this`-binding has to be
restored manually. See:
https://github.com/browserstack/browserstack-local-nodejs/blob/d238484416e7ea6dfb51aede7d84d09339a8032a/lib/Local.js#L28-L31

Fixes #5186

~~I am unsure how to add a proper test for this bug since the whole launcher test suite entirely mocks the `browserstack-local` npm module. This is also why the bug doesn't become visible in the test suite. Any ideas how to test this?~~

Edit: I was able to build a reproduction test case:

![image](https://user-images.githubusercontent.com/508118/78078196-00023280-73aa-11ea-92d6-c6f101cc196d.png)

## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
