### PR TITLE
Recognise element origin in actions

### DIFF
--- a/e2e/element.test.js
+++ b/e2e/element.test.js
@@ -183,6 +183,36 @@ describe('elements', () => {
         expect(await browser.getElementProperty(textarea[ELEMENT_KEY], 'value'))
             .toBe('foobar😉')
     })
+
+    it('should allow to click relative to the center of an element', async () => {
+        const message = await browser.findElement('css selector', '.btn1_right_clicked')
+        const btn2 = await browser.findElement('css selector', '.btn2')
+
+        expect(await browser.getElementCSSValue(message[ELEMENT_KEY], 'display'))
+            .toBe('none')
+        await browser.performActions([{
+            type: 'pointer',
+            id: 'pointer1',
+            parameters: { pointerType: 'mouse' },
+            actions: [{
+                type: 'pointerMove',
+                origin: {
+                    [ELEMENT_KEY]: btn2[ELEMENT_KEY]
+                },
+                x: -50,
+                y: 0
+            }, {
+                type: 'pointerDown',
+                button: 2
+            }, {
+                type: 'pointerUp',
+                button: 2
+            }]
+        }])
+        await new Promise((r) => setTimeout(r, 3000))
+        expect(await browser.getElementCSSValue(message[ELEMENT_KEY], 'display'))
+            .toBe('block')
+    })
 })
 
 afterAll(async () => {

--- a/packages/devtools/src/commands/performActions.js
+++ b/packages/devtools/src/commands/performActions.js
@@ -1,5 +1,8 @@
 import USKeyboardLayout from 'puppeteer-core/lib/USKeyboardLayout'
 
+import getElementRect from './getElementRect'
+import { ELEMENT_KEY } from '../constants'
+
 const KEY = 'key'
 const POINTER = 'pointer'
 
@@ -80,6 +83,15 @@ export default async function performActions ({ actions }) {
                     if (origin === 'pointer' && lastPointer.x && lastPointer.y) {
                         x += lastPointer.x
                         y += lastPointer.y
+                    }
+
+                    /**
+                     * set location relative from an element
+                     */
+                    if (origin && typeof origin[ELEMENT_KEY] === 'string' && typeof x === 'number' && typeof y === 'number') {
+                        const elemRect = await getElementRect.call(this, { elementId: origin[ELEMENT_KEY] })
+                        x += elemRect.x + (elemRect.width / 2)
+                        y += elemRect.y + (elemRect.height / 2)
                     }
 
                     lastPointer.x = x


### PR DESCRIPTION
## Proposed changes

The devtools and webdriver package had a difference in their `performAction` behavior where the devtools package wouldn't recognise an element origin. This patch fixes this.

Fixes: #5178

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
