### PR TITLE
fix(webdriverio): isDisplayed not working in Safari STP

### DIFF
--- a/packages/webdriverio/src/commands/element/isDisplayed.js
+++ b/packages/webdriverio/src/commands/element/isDisplayed.js
@@ -44,7 +44,7 @@ import { ELEMENT_KEY } from '../../constants'
 import { getBrowserObject, hasElementId } from '../../utils'
 import isElementDisplayedScript from '../../scripts/isElementDisplayed'
 
-const noW3CEndpoint = ['microsoftedge', 'safari', 'chrome']
+const noW3CEndpoint = ['microsoftedge', 'safari', 'chrome', 'safari technology preview']
 
 export default async function isDisplayed() {
 

--- a/packages/webdriverio/tests/commands/element/isDisplayed.test.js
+++ b/packages/webdriverio/tests/commands/element/isDisplayed.test.js
@@ -107,6 +107,26 @@ describe('isDisplayed test', () => {
                 ELEMENT: 'some-elem-123'
             })
         })
+        it('should be used if stp and w3c', async () => {
+            browser = await remote({
+                baseUrl: 'http://foobar.com',
+                capabilities: {
+                    browserName: 'safari technology preview',
+                    keepBrowserName: true
+                }
+            })
+            elem = await browser.$('#foo')
+            got.mockClear()
+
+            expect(await elem.isDisplayed()).toBe(true)
+            expect(got).toBeCalledTimes(1)
+            expect(got.mock.calls[0][1].uri.pathname)
+                .toBe('/session/foobar-123/execute/sync')
+            expect(got.mock.calls[0][1].json.args[0]).toEqual({
+                'element-6066-11e4-a52e-4f735466cecf': 'some-elem-123',
+                ELEMENT: 'some-elem-123'
+            })
+        })
         it('should be used if edge and wc3', async () => {
             browser = await remote({
                 baseUrl: 'http://foobar.com',


### PR DESCRIPTION
## Proposed changes

Include STP in the list of browers not supporting displayed endpoint.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

### Reviewers: @webdriverio/project-committers
