### PR TITLE
Correctly bind this when promisifying static server listen method

### DIFF
--- a/packages/wdio-static-server-service/src/launcher.js
+++ b/packages/wdio-static-server-service/src/launcher.js
@@ -39,7 +39,7 @@ export default class StaticServerLauncher {
         this.middleware.forEach(
             (ware) => this.server.use(ware.mount, ware.middleware))
 
-        await promisify(this.server.listen)(this.port)
+        await promisify(this.server.listen.bind(this.server))(this.port)
         log.info(`Static server running at http://localhost:${this.port}`)
     }
 }


### PR DESCRIPTION
Very much like #5187 the promisified server.listen method is lacking the
correct this-binding. This leads to the server effectively NOT listening
on the specified port.

I found that promisify is used in quite a few other occasions. In some of them I'm confident that a this-binding is not necessary, but I'm not 100% if that's always the case.

Currently I'm only using the static server service and the browserstack service which is why I fixed those two. I can't test the others right now.

Other occurences I found worthwhile checking:

* https://github.com/webdriverio/webdriverio/blob/f2a242e14093bd01a429b5a05bc6f16114d60773/packages/wdio-testingbot-service/src/launcher.js#L39
* https://github.com/webdriverio/webdriverio/blob/f2a242e14093bd01a429b5a05bc6f16114d60773/packages/wdio-firefox-profile-service/src/launcher.js#L31
* https://github.com/webdriverio/webdriverio/blob/f2a242e14093bd01a429b5a05bc6f16114d60773/packages/wdio-firefox-profile-service/src/launcher.js#L55
* https://github.com/webdriverio/webdriverio/blob/f2a242e14093bd01a429b5a05bc6f16114d60773/packages/wdio-selenium-standalone-service/src/launcher.js#L40
* https://github.com/webdriverio/webdriverio/blob/f2a242e14093bd01a429b5a05bc6f16114d60773/packages/wdio-appium-service/src/launcher.js#L47
* https://github.com/webdriverio/webdriverio/blob/f2a242e14093bd01a429b5a05bc6f16114d60773/packages/wdio-sauce-service/src/launcher.js#L92
* https://github.com/webdriverio/webdriverio/blob/f2a242e14093bd01a429b5a05bc6f16114d60773/packages/wdio-crossbrowsertesting-service/src/launcher.js#L36

## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
