### PR TITLE
Fix #5197 - Devtools' launcher should respect "binary" field from moz:firefoxOptions

### DIFF
--- a/packages/devtools/src/launcher.js
+++ b/packages/devtools/src/launcher.js
@@ -69,7 +69,7 @@ function launchBrowser (capabilities, executablePath, vendorCapKey) {
     }, capabilities[vendorCapKey] || {})
 
     if (!executablePath) {
-        throw new Error('Couldn\'t find executeable for browser')
+        throw new Error('Couldn\'t find executable for browser')
     }
 
     log.info(`Launch ${executablePath} with config: ${JSON.stringify(puppeteerOptions)}`)
@@ -77,13 +77,16 @@ function launchBrowser (capabilities, executablePath, vendorCapKey) {
 }
 
 function launchFirefox (capabilities) {
-    const executablePath = firefoxFinder[process.platform]()[0]
     const vendorPrefix = 'moz:firefoxOptions'
+
     if (!capabilities[vendorPrefix]) {
         capabilities[vendorPrefix] = {}
     }
 
+    const executablePath = capabilities[vendorPrefix].binary || firefoxFinder[process.platform]()[0]
+
     capabilities[vendorPrefix].product = 'firefox'
+
     return launchBrowser(capabilities, executablePath, vendorPrefix, { product: 'firefox' })
 }
 

--- a/packages/devtools/tests/__snapshots__/launcher.test.js.snap
+++ b/packages/devtools/tests/__snapshots__/launcher.test.js.snap
@@ -39,11 +39,12 @@ Array [
       "args": Array [
         "foobar",
       ],
+      "binary": "/foo/bar",
       "defaultViewport": Object {
         "height": 456,
         "width": 123,
       },
-      "executablePath": "/path/to/firefox",
+      "executablePath": "/foo/bar",
       "headless": true,
       "product": "firefox",
     },

--- a/packages/devtools/tests/launcher.test.js
+++ b/packages/devtools/tests/launcher.test.js
@@ -58,6 +58,7 @@ test('launch Firefox with custom arguments', async () => {
         browserName: 'firefox',
         'moz:firefoxOptions': {
             args: ['foobar'],
+            binary: '/foo/bar',
             headless: true,
             defaultViewport: {
                 width: 123,


### PR DESCRIPTION
## Proposed changes

Fixes #5197 

The `binary` field from browser config should take precedence over the default per-platform path.

Also - a sneaky fix for a typo in error message (executeable -> executable)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] ~~I have added necessary documentation (if appropriate)~~
- [ ] ~~I have added proper type definitions for new commands (if appropriate)~~

### Reviewers: @webdriverio/project-committers
