### PR TITLE
Preference W3C user metadata when sauce service updates jobs.

### DIFF
--- a/packages/wdio-sauce-service/src/service.js
+++ b/packages/wdio-sauce-service/src/service.js
@@ -196,12 +196,14 @@ export default class SauceService {
             body.name += ` (${testCnt})`
         }
 
+        let capabilities = this.capabilities['sauce:options'] || this.capabilities
+
         for (let prop of jobDataProperties) {
-            if (!this.capabilities[prop]) {
+            if (capabilities[prop]) {
                 continue
             }
 
-            body[prop] = this.capabilities[prop]
+            body[prop] = capabilities[prop]
         }
 
         body.passed = failures === 0


### PR DESCRIPTION
## Proposed changes

Current behaviour is for user-supplied metadata from desired capabilities to
supercede derived metadata.  This change makes that work for both JSON-WP and
W3C Compliant metadata, eg, that under the `sauce:options` namespace.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
