### PR TITLE
W3C sauce metadata

### DIFF
--- a/packages/wdio-sauce-service/README.md
+++ b/packages/wdio-sauce-service/README.md
@@ -94,4 +94,11 @@ Default: `false`
 
 ----
 
+## Overriding generated name metadata
+The service automatically generates a name for each test from the suite name, browser name and other information.
+
+You can override this by providing a value for the `name` desired capability, but this will have the side effect of giving all tests the same name.
+
+----
+
 For more information on WebdriverIO see the [homepage](https://webdriver.io).

--- a/packages/wdio-sauce-service/src/service.js
+++ b/packages/wdio-sauce-service/src/service.js
@@ -196,14 +196,14 @@ export default class SauceService {
             body.name += ` (${testCnt})`
         }
 
-        let capabilities = this.capabilities['sauce:options'] || this.capabilities
+        let caps = this.capabilities['sauce:options'] || this.capabilities
 
         for (let prop of jobDataProperties) {
-            if (capabilities[prop]) {
+            if (!caps[prop]) {
                 continue
             }
 
-            body[prop] = capabilities[prop]
+            body[prop] = caps[prop]
         }
 
         body.passed = failures === 0

--- a/packages/wdio-sauce-service/src/service.js
+++ b/packages/wdio-sauce-service/src/service.js
@@ -196,12 +196,14 @@ export default class SauceService {
             body.name += ` (${testCnt})`
         }
 
+        let capabilities = this.capabilities['sauce:options'] || this.capabilities
+
         for (let prop of jobDataProperties) {
-            if (!this.capabilities[prop]) {
+            if (capabilities[prop]) {
                 continue
             }
 
-            body[prop] = this.capabilities[prop]
+            body[prop] = capabilities[prop]
         }
 
         body.passed = failures === 0

--- a/packages/wdio-sauce-service/tests/service.test.js
+++ b/packages/wdio-sauce-service/tests/service.test.js
@@ -374,6 +374,115 @@ test('getBody', () => {
     })
 })
 
+test('getBody', () => {
+    const service = new SauceService()
+    service.suiteTitle = 'jojo'
+    service.beforeSession({}, {
+        name: 'jobname',
+        tags: ['jobTag'],
+        public: true,
+        build: 'foobuild',
+        'custom-data': { some: 'data' }
+    })
+
+    expect(service.getBody(0)).toEqual({
+        name: 'jobname',
+        tags: ['jobTag'],
+        public: true,
+        build: 'foobuild',
+        'custom-data': { some: 'data' },
+        passed: true
+    })
+
+    service.capabilities = {}
+    expect(service.getBody(1)).toEqual({
+        name: 'jojo',
+        passed: false
+    })
+
+    expect(service.getBody(1, true)).toEqual({
+        name: 'jojo (1)',
+        passed: false
+    })
+
+    service.getBody(1, true)
+    service.getBody(1, true)
+    global.browser.isMultiremote = true
+    expect(service.getBody(12, true)).toEqual({
+        name: 'jojo (2)',
+        passed: false
+    })
+
+    expect(service.getBody(12, true, 'chrome')).toEqual({
+        name: 'chrome: jojo (2)',
+        passed: false
+    })
+})
+
+test('getBody with name Capability (JSON WP)', () => {
+    const service = new SauceService()
+    service.suiteTitle = 'jojo'
+    service.beforeSession({}, {
+        name: 'bizarre'
+    })
+
+    expect(service.getBody(1)).toEqual({
+        name: 'bizarre',
+        passed: false
+    })
+
+    expect(service.getBody(1, true)).toEqual({
+        name: 'bizarre',
+        passed: false
+    })
+
+    service.getBody(1, true)
+    service.getBody(1, true)
+    global.browser.isMultiremote = true
+    expect(service.getBody(12, true)).toEqual({
+        name: 'bizarre',
+        passed: false
+    })
+
+    expect(service.getBody(12, true, 'chrome')).toEqual({
+        name: 'bizarre',
+        passed: false
+    })
+})
+
+test('getBody with name Capability (W3C)', () => {
+    const service = new SauceService()
+    service.suiteTitle = 'jojo'
+    service.beforeSession({}, {
+        'sauce:options': {
+            name: 'bizarre'
+        }
+    })
+    
+    expect(service.getBody(1)).toEqual({
+        name: 'bizarre',
+        passed: false
+    })
+
+    expect(service.getBody(1, true)).toEqual({
+        name: 'bizarre',
+        passed: false
+    })
+
+    service.getBody(1, true)
+    service.getBody(1, true)
+    global.browser.isMultiremote = true
+    expect(service.getBody(12, true)).toEqual({
+        name: 'bizarre',
+        passed: false
+    })
+
+    expect(service.getBody(12, true, 'chrome')).toEqual({
+        name: 'bizarre',
+        passed: false
+    })
+})
+
 test('getBody without multiremote', () => {
     const service = new SauceService()
     service.suiteTitle = 'jojo'

--- a/packages/wdio-sauce-service/tests/service.test.js
+++ b/packages/wdio-sauce-service/tests/service.test.js
@@ -458,7 +458,7 @@ test('getBody with name Capability (W3C)', () => {
             name: 'bizarre'
         }
     })
-    
+
     expect(service.getBody(1)).toEqual({
         name: 'bizarre',
         passed: false


### PR DESCRIPTION
## Proposed changes

Current behaviour is for user-supplied metadata from desired capabilities to
superceed derived metadata. This change makes that work for both JSON-WP and
W3C Compliant metadata, eg, that under the sauce:options namespace.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
