### PR TITLE
Refactor devtools launcher to streamline behavior

### DIFF
--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -36,6 +36,7 @@
     "@wdio/utils": "6.0.12",
     "chrome-launcher": "^0.11.1",
     "puppeteer-core": "^2.1.1",
+    "ua-parser-js": "^0.7.21",
     "uuid": "^7.0.2"
   },
   "devDependencies": {

--- a/packages/devtools/src/constants.js
+++ b/packages/devtools/src/constants.js
@@ -92,3 +92,9 @@ export const ERROR_MESSAGES = {
         message: 'stale element reference: The element reference is stale; either the element is no longer attached to the DOM, it is not in the current frame context, or the document has been refreshed'
     }
 }
+
+export const VENDOR_PREFIX = {
+    chrome: 'goog:chromeOptions',
+    firefox: 'moz:firefoxOptions',
+    edge: 'ms:edgeOptions'
+}

--- a/packages/devtools/src/finder/index.js
+++ b/packages/devtools/src/finder/index.js
@@ -1,0 +1,7 @@
+import edgeFinder from './edge'
+import firefoxFinder from './firefox'
+
+export default {
+    firefox: firefoxFinder,
+    edge: edgeFinder
+}

--- a/packages/devtools/src/index.js
+++ b/packages/devtools/src/index.js
@@ -1,12 +1,14 @@
 import os from 'os'
+import uaParserJs from 'ua-parser-js'
 import { v4 as uuidv4 } from 'uuid'
+
 import logger from '@wdio/logger'
 import { webdriverMonad, devtoolsEnvironmentDetector } from '@wdio/utils'
 import { validateConfig } from '@wdio/config'
 
 import DevToolsDriver from './devtoolsdriver'
 import launch from './launcher'
-import { DEFAULTS, SUPPORTED_BROWSER } from './constants'
+import { DEFAULTS, SUPPORTED_BROWSER, VENDOR_PREFIX } from './constants'
 import { getPrototype, patchDebug } from './utils'
 
 const log = logger('devtools:puppeteer')
@@ -30,16 +32,23 @@ export default class DevTools {
         const pages = await browser.pages()
         const driver = new DevToolsDriver(browser, pages)
         const sessionId = uuidv4()
-        const [browserName, browserVersion] = (await browser.version()).split('/')
+        const userAgent = uaParserJs(await browser.userAgent())
+
+        /**
+         * find vendor key in capabilities
+         */
+        const availableVendorPrefixes = Object.values(VENDOR_PREFIX)
+        const vendorCapPrefix = Object.keys(params.capabilities).find(
+            (capKey) => availableVendorPrefixes.includes(capKey))
 
         params.capabilities = {
-            browserName,
-            browserVersion,
+            browserName: userAgent.browser.name,
+            browserVersion: userAgent.browser.version,
             platformName: os.platform(),
             platformVersion: os.release(),
-            'goog:chromeOptions': Object.assign(
+            [vendorCapPrefix]: Object.assign(
                 { debuggerAddress: browser._connection.url().split('/')[2] },
-                params.capabilities['goog:chromeOptions']
+                params.capabilities[vendorCapPrefix]
             )
         }
 
@@ -54,7 +63,7 @@ export default class DevTools {
 
         sessionMap.set(sessionId, { browser, session: driver })
         const environmentPrototype = { getPuppeteer: { value: /* istanbul ignore next */ () => browser } }
-        Object.entries(devtoolsEnvironmentDetector({ browserName })).forEach(([name, value]) => {
+        Object.entries(devtoolsEnvironmentDetector({ browserName: userAgent.browser.name.toLowerCase() })).forEach(([name, value]) => {
             environmentPrototype[name] = { value }
         })
         const commandWrapper = (_, __, commandInfo) => driver.register(commandInfo)

--- a/packages/devtools/src/launcher.js
+++ b/packages/devtools/src/launcher.js
@@ -2,12 +2,11 @@ import { launch as launchChromeBrowser } from 'chrome-launcher'
 import puppeteer from 'puppeteer-core'
 import logger from '@wdio/logger'
 
-import edgeFinder from './finder/edge'
-import firefoxFinder from './finder/firefox'
+import browserFinder from './finder'
 import { getPages } from './utils'
 import {
     CHROME_NAMES, FIREFOX_NAMES, EDGE_NAMES, DEFAULT_FLAGS, DEFAULT_WIDTH,
-    DEFAULT_HEIGHT, DEFAULT_X_POSITION, DEFAULT_Y_POSITION
+    DEFAULT_HEIGHT, DEFAULT_X_POSITION, DEFAULT_Y_POSITION, VENDOR_PREFIX
 } from './constants'
 
 const log = logger('devtools')
@@ -18,7 +17,7 @@ const log = logger('devtools')
  * @return {object}               puppeteer browser instance
  */
 async function launchChrome (capabilities) {
-    const chromeOptions = capabilities['goog:chromeOptions'] || {}
+    const chromeOptions = capabilities[VENDOR_PREFIX.chrome] || {}
     const chromeFlags = [
         ...DEFAULT_FLAGS,
         ...[
@@ -59,8 +58,20 @@ async function launchChrome (capabilities) {
     return browser
 }
 
-function launchBrowser (capabilities, executablePath, vendorCapKey) {
+function launchBrowser (capabilities, product) {
+    const vendorCapKey = VENDOR_PREFIX[product]
+
+    if (!capabilities[vendorCapKey]) {
+        capabilities[vendorCapKey] = {}
+    }
+
+    const executablePath = (
+        capabilities[vendorCapKey].binary ||
+        browserFinder[product][process.platform]()[0]
+    )
+
     const puppeteerOptions = Object.assign({
+        product,
         executablePath,
         defaultViewport: {
             width: DEFAULT_WIDTH,
@@ -76,25 +87,6 @@ function launchBrowser (capabilities, executablePath, vendorCapKey) {
     return puppeteer.launch(puppeteerOptions)
 }
 
-function launchFirefox (capabilities) {
-    const vendorPrefix = 'moz:firefoxOptions'
-
-    if (!capabilities[vendorPrefix]) {
-        capabilities[vendorPrefix] = {}
-    }
-
-    const executablePath = capabilities[vendorPrefix].binary || firefoxFinder[process.platform]()[0]
-
-    capabilities[vendorPrefix].product = 'firefox'
-
-    return launchBrowser(capabilities, executablePath, vendorPrefix, { product: 'firefox' })
-}
-
-function launchEdge (capabilities) {
-    const executablePath = edgeFinder[process.platform]()[0]
-    return launchBrowser(capabilities, executablePath, 'ms:edgeOptions')
-}
-
 export default function launch (capabilities) {
     const browserName = capabilities.browserName.toLowerCase()
 
@@ -103,12 +95,12 @@ export default function launch (capabilities) {
     }
 
     if (FIREFOX_NAMES.includes(browserName)) {
-        return launchFirefox(capabilities)
+        return launchBrowser(capabilities, 'firefox')
     }
 
     /* istanbul ignore next */
     if (EDGE_NAMES.includes(browserName)) {
-        return launchEdge(capabilities)
+        return launchBrowser(capabilities, 'edge')
     }
 
     throw new Error(`Couldn't identify browserName ${browserName}`)

--- a/packages/devtools/tests/__snapshots__/devtools.test.js.snap
+++ b/packages/devtools/tests/__snapshots__/devtools.test.js.snap
@@ -3,7 +3,7 @@
 exports[`newSession 1`] = `
 Object {
   "browserName": "Chrome",
-  "browserVersion": "78.0.3881.0",
+  "browserVersion": "80.0.3987.149",
   "goog:chromeOptions": Object {
     "debuggerAddress": "localhost:49375",
   },
@@ -14,14 +14,14 @@ exports[`newSession 2`] = `
 Object {
   "jsonwpCaps": Object {
     "browserName": "Chrome",
-    "browserVersion": "78.0.3881.0",
+    "browserVersion": "80.0.3987.149",
     "goog:chromeOptions": Object {
       "debuggerAddress": "localhost:49375",
     },
   },
   "w3cCaps": Object {
     "browserName": "Chrome",
-    "browserVersion": "78.0.3881.0",
+    "browserVersion": "80.0.3987.149",
     "goog:chromeOptions": Object {
       "debuggerAddress": "localhost:49375",
     },

--- a/packages/devtools/tests/__snapshots__/launcher.test.js.snap
+++ b/packages/devtools/tests/__snapshots__/launcher.test.js.snap
@@ -13,6 +13,7 @@ Array [
       },
       "executablePath": "/path/to/edge",
       "headless": true,
+      "product": "edge",
     },
   ],
 ]
@@ -27,6 +28,7 @@ Array [
         "width": 1200,
       },
       "executablePath": "/path/to/edge",
+      "product": "edge",
     },
   ],
 ]

--- a/packages/devtools/tests/devtools.test.js
+++ b/packages/devtools/tests/devtools.test.js
@@ -1,15 +1,18 @@
 import launch from '../src/launcher'
 import DevTools from '../src'
 
-jest.mock('../src/launcher', () => jest.fn().mockReturnValue({
-    pages: jest.fn().mockReturnValue(Promise.resolve([{
-        on: jest.fn(),
-        setDefaultTimeout: jest.fn()
-    }])),
-    _connection: {
-        url: () => 'ws://localhost:49375/devtools/browser/c4b017ea-f476-4026-a699-bc5d4858cfe1'
-    },
-    version: jest.fn().mockReturnValue(Promise.resolve('Chrome/78.0.3881.0'))
+jest.mock('../src/launcher', () => jest.fn().mockImplementation((capabilities) => {
+    capabilities['goog:chromeOptions'] = {}
+    return {
+        pages: jest.fn().mockReturnValue(Promise.resolve([{
+            on: jest.fn(),
+            setDefaultTimeout: jest.fn()
+        }])),
+        _connection: {
+            url: () => 'ws://localhost:49375/devtools/browser/c4b017ea-f476-4026-a699-bc5d4858cfe1'
+        },
+        userAgent: jest.fn().mockReturnValue(Promise.resolve('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.149 Safari/537.36'))
+    }
 }))
 
 test('newSession', async () => {
@@ -29,6 +32,7 @@ test('newSession', async () => {
     expect(client.options.capabilities).toMatchSnapshot()
     expect(client.options.requestedCapabilities).toMatchSnapshot()
     expect(client.isDevTools).toBe(true)
+    expect(client.isChrome).toBe(true)
     expect(client.isW3C).toBe(true)
     expect(launch).toBeCalledTimes(1)
 })


### PR DESCRIPTION
## Proposed changes

This patch addresses #5197 to streamline the behavior for Firefox and Edge when launching the browser through the DevTools package.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

Settings `edge` as product as Puppeteer options will use the Chrome launcher and will successful launch Edge if an edge executeable is provided.

### Reviewers: @webdriverio/project-committers
