### PR TITLE
Shorten screenshot base64 strings from logs

### DIFF
--- a/packages/wdio-utils/package.json
+++ b/packages/wdio-utils/package.json
@@ -31,7 +31,8 @@
     "url": "https://github.com/webdriverio/webdriverio/issues"
   },
   "dependencies": {
-    "@wdio/logger": "6.0.12"
+    "@wdio/logger": "6.0.12",
+    "is-base64": "^1.1.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/wdio-utils/src/index.js
+++ b/packages/wdio-utils/src/index.js
@@ -5,7 +5,7 @@ import { initialiseWorkerService, initialiseLauncherService } from './initialise
 import webdriverMonad from './monad'
 import {
     commandCallStructure, isValidParameter, getArgumentType, safeRequire,
-    isFunctionAsync
+    isFunctionAsync, transformCommandLogResult
 } from './utils'
 import {
     wrapCommand, runFnInFiberContext, executeHooksWithArgs,
@@ -19,6 +19,7 @@ export {
     initialiseLauncherService,
     initialiseWorkerService,
     isFunctionAsync,
+    transformCommandLogResult,
     webdriverMonad,
     commandCallStructure,
     isValidParameter,

--- a/packages/wdio-utils/src/utils.js
+++ b/packages/wdio-utils/src/utils.js
@@ -1,5 +1,7 @@
 import isBase64 from 'is-base64'
 
+const SCREENSHOT_REPLACEMENT = '"<Screenshot[base64]>"'
+
 /**
  * overwrite native element commands with user defined
  * @param {object} propertiesObject propertiesObject
@@ -53,7 +55,7 @@ export function commandCallStructure (commandName, args) {
         if (typeof arg === 'string' && (arg.startsWith('!function(') || arg.startsWith('return (function'))) {
             arg = '<fn>'
         } else if (typeof arg === 'string' && isBase64(arg)) {
-            arg = '"<Screenshot[base64]>"'
+            arg = SCREENSHOT_REPLACEMENT
         } else if (typeof arg === 'string') {
             arg = `"${arg}"`
         } else if (typeof arg === 'function') {
@@ -79,7 +81,7 @@ export function commandCallStructure (commandName, args) {
  */
 export function transformCommandLogResult (result) {
     if (typeof result.file === 'string' && isBase64(result.file)) {
-        return '"<Screenshot[base64]>"'
+        return SCREENSHOT_REPLACEMENT
     }
 
     return result

--- a/packages/wdio-utils/src/utils.js
+++ b/packages/wdio-utils/src/utils.js
@@ -1,3 +1,5 @@
+import isBase64 from 'is-base64'
+
 /**
  * overwrite native element commands with user defined
  * @param {object} propertiesObject propertiesObject
@@ -50,6 +52,8 @@ export function commandCallStructure (commandName, args) {
     const callArgs = args.map((arg) => {
         if (typeof arg === 'string' && (arg.startsWith('!function(') || arg.startsWith('return (function'))) {
             arg = '<fn>'
+        } else if (typeof arg === 'string' && isBase64(arg)) {
+            arg = '"<Screenshot[base64]>"'
         } else if (typeof arg === 'string') {
             arg = `"${arg}"`
         } else if (typeof arg === 'function') {
@@ -66,6 +70,19 @@ export function commandCallStructure (commandName, args) {
     }).join(', ')
 
     return `${commandName}(${callArgs})`
+}
+
+/**
+ * transforms WebDriver result for log stream to avoid unnecessary long
+ * result strings e.g. if it contains a screenshot
+ * @param {Object} result WebDriver response body
+ */
+export function transformCommandLogResult (result) {
+    if (typeof result.file === 'string' && isBase64(result.file)) {
+        return '"<Screenshot[base64]>"'
+    }
+
+    return result
 }
 
 /**

--- a/packages/wdio-utils/tests/__mocks__/@wdio/utils.js
+++ b/packages/wdio-utils/tests/__mocks__/@wdio/utils.js
@@ -90,3 +90,4 @@ export const testFnWrapper = jest.fn()
 export const sessionEnvironmentDetector = sessionEnvDetector
 export const capabilitiesEnvironmentDetector = capabilitiesEnvDetector
 export const devtoolsEnvironmentDetector = devtoolsEnvDetector
+export const transformCommandLogResult = jest.fn().mockImplementation((data) => data)

--- a/packages/wdio-utils/tests/test-framework/__snapshots__/testFnWrapper-sync.test.js.snap
+++ b/packages/wdio-utils/tests/test-framework/__snapshots__/testFnWrapper-sync.test.js.snap
@@ -103,7 +103,6 @@ Array [
       },
       "context",
       Object {
-        "duration": 0,
         "error": undefined,
         "passed": true,
         "result": "@wdio/sync: FooBar 0 0",

--- a/packages/wdio-utils/tests/test-framework/testFnWrapper-sync.test.js
+++ b/packages/wdio-utils/tests/test-framework/testFnWrapper-sync.test.js
@@ -31,6 +31,9 @@ describe('testFnWrapper', () => {
         const result = await testFnWrapper.call({ test: { fullTitle: () => 'full title' } }, ...args)
 
         expect(result).toBe('@wdio/sync: FooBar 0 0')
+        expect(executeHooksWithArgs).toBeCalledTimes(2)
+
+        delete executeHooksWithArgs.mock.calls[1][1][2].duration
         expect(executeHooksWithArgs.mock.calls).toMatchSnapshot()
     })
 
@@ -54,6 +57,9 @@ describe('testFnWrapper', () => {
         const result = await testFnWrapper(...args)
 
         expect(result).toBe('@wdio/sync: FooBar 0 0')
+        expect(executeHooksWithArgs).toBeCalledTimes(2)
+
+        delete executeHooksWithArgs.mock.calls[1][1][2].duration
         expect(executeHooksWithArgs.mock.calls).toMatchSnapshot()
     })
 

--- a/packages/wdio-utils/tests/utils.test.js
+++ b/packages/wdio-utils/tests/utils.test.js
@@ -1,6 +1,6 @@
 import {
     overwriteElementCommands, commandCallStructure, isValidParameter,
-    getArgumentType, isFunctionAsync, filterSpecArgs
+    getArgumentType, isFunctionAsync, filterSpecArgs, transformCommandLogResult
 } from '../src/utils'
 
 describe('utils', () => {
@@ -18,9 +18,16 @@ describe('utils', () => {
                 stringFunction,
                 anotherStringFunction,
                 null,
-                undefined
+                undefined,
+                (Buffer.from('some screenshot')).toString('base64')
             ]
-        )).toBe('foobar("param", 1, true, <object>, <fn>, <fn>, <fn>, null, undefined)')
+        )).toBe('foobar("param", 1, true, <object>, <fn>, <fn>, <fn>, null, undefined, "<Screenshot[base64]>")')
+    })
+
+    it('transformCommandLogResult', () => {
+        expect(transformCommandLogResult({ foo: 'bar' })).toEqual({ foo: 'bar' })
+        expect(transformCommandLogResult({ file: (Buffer.from('some screenshot')).toString('base64') }))
+            .toBe('"<Screenshot[base64]>"')
     })
 
     describe('overwriteElementCommands', () => {

--- a/packages/webdriver/src/request.js
+++ b/packages/webdriver/src/request.js
@@ -5,6 +5,7 @@ import EventEmitter from 'events'
 
 import got from 'got'
 import logger from '@wdio/logger'
+import { transformCommandLogResult } from '@wdio/utils'
 
 import { isSuccessfulResponse, getErrorFromResponseBody } from './utils'
 import pkg from '../package.json'
@@ -104,7 +105,7 @@ export default class WebDriverRequest extends EventEmitter {
         log.info(`[${fullRequestOptions.method}] ${fullRequestOptions.uri.href}`)
 
         if (fullRequestOptions.json && Object.keys(fullRequestOptions.json).length) {
-            log.info('DATA', fullRequestOptions.json)
+            log.info('DATA', transformCommandLogResult(fullRequestOptions.json))
         }
 
         let response = await got(fullRequestOptions.uri, { ...fullRequestOptions })


### PR DESCRIPTION
## Proposed changes

Currently we log the whole screenshot base64 string in the wdio logs which can be pretty verbose and doesn't make much sense. This patch tries to shorten them to make these logs more readable.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
