### PR TITLE
docs: Fix simple typo, specifc -> specific

### DIFF
--- a/docs/api/expect.md
+++ b/docs/api/expect.md
@@ -42,7 +42,7 @@ This options can be applied in addition to the command options when numbers are 
 
 ### toHaveUrl
 
-Checks if browser is on a specifc page.
+Checks if browser is on a specific page.
 
 ##### Usage
 
@@ -291,7 +291,7 @@ expect(elem).toBeChecked()
 
 ### toHaveHref
 
-Checks if link element has a specifc link target.
+Checks if link element has a specific link target.
 
 ##### Usage
 
@@ -313,7 +313,7 @@ expect(link).toHaveLink('https://webdriver.io')
 
 ### toHaveHrefContaining
 
-Checks if link element contains a specifc link target.
+Checks if link element contains a specific link target.
 
 ##### Usage
 


### PR DESCRIPTION
There is a small typo in docs/api/expect.md.

Should read `specific` rather than `specifc`.

