### PR TITLE
Add support for feature description in reporters

### DIFF
--- a/packages/wdio-cli/tests/__mocks__/chalk.js
+++ b/packages/wdio-cli/tests/__mocks__/chalk.js
@@ -5,6 +5,7 @@ chalkMock.whiteBright = jest.fn().mockImplementation((msg) => `whiteBright ${msg
 chalkMock.redBright = jest.fn().mockImplementation((msg) => `redBright ${msg}`)
 chalkMock.cyan = jest.fn().mockImplementation((msg) => `cyan ${msg}`)
 chalkMock.blue = jest.fn().mockImplementation((msg) => `blue ${msg}`)
+chalkMock.grey = jest.fn().mockImplementation((msg) => `grey ${msg}`)
 chalkMock.green = jest.fn().mockImplementation((msg) => `green ${msg}`)
 chalkMock.red = jest.fn().mockImplementation((...msg) => `red ${msg.join(' ')}`)
 chalkMock.gray = jest.fn().mockImplementation((...msg) => `gray ${msg.join(' ')}`)

--- a/packages/wdio-reporter/src/stats/suite.js
+++ b/packages/wdio-reporter/src/stats/suite.js
@@ -18,5 +18,10 @@ export default class SuiteStats extends RunnableStats {
          * an array of hooks and tests stored in order as they happen
          */
         this.hooksAndTests = []
+
+        /**
+         * only Cucumber
+         */
+        this.description = suite.description
     }
 }

--- a/packages/wdio-reporter/tests/stats/__snapshots__/suite.test.js.snap
+++ b/packages/wdio-reporter/tests/stats/__snapshots__/suite.test.js.snap
@@ -8,7 +8,6 @@ SuiteStats {
   "fullTitle": "barfoo",
   "hooks": Array [],
   "hooksAndTests": Array [],
-  "start": 2020-04-06T12:13:43.748Z,
   "suites": Array [],
   "tags": Array [
     "foo",

--- a/packages/wdio-reporter/tests/stats/__snapshots__/suite.test.js.snap
+++ b/packages/wdio-reporter/tests/stats/__snapshots__/suite.test.js.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should get initialised 1`] = `
+SuiteStats {
+  "_duration": 0,
+  "cid": "0-0",
+  "description": "some description",
+  "fullTitle": "barfoo",
+  "hooks": Array [],
+  "hooksAndTests": Array [],
+  "start": 2020-04-06T12:13:43.748Z,
+  "suites": Array [],
+  "tags": Array [
+    "foo",
+    "bar",
+  ],
+  "tests": Array [],
+  "title": "foobar",
+  "type": "suite",
+  "uid": "foobar",
+}
+`;

--- a/packages/wdio-reporter/tests/stats/suite.test.js
+++ b/packages/wdio-reporter/tests/stats/suite.test.js
@@ -1,0 +1,13 @@
+import SuiteStats from '../../src/stats/suite'
+
+test('should get initialised', () => {
+    const suite = new SuiteStats({
+        cid: '0-0',
+        title: 'foobar',
+        fullTitle: 'barfoo',
+        description: 'some description',
+        tags: ['foo', 'bar']
+    })
+
+    expect(suite).toMatchSnapshot()
+})

--- a/packages/wdio-reporter/tests/stats/suite.test.js
+++ b/packages/wdio-reporter/tests/stats/suite.test.js
@@ -9,5 +9,6 @@ test('should get initialised', () => {
         tags: ['foo', 'bar']
     })
 
+    delete suite.start
     expect(suite).toMatchSnapshot()
 })

--- a/packages/wdio-spec-reporter/src/index.js
+++ b/packages/wdio-spec-reporter/src/index.js
@@ -195,6 +195,13 @@ class SpecReporter extends WDIOReporter {
             // Display the title of the suite
             output.push(`${suiteIndent}${suite.title}`)
 
+            // display suite description (Cucumber only)
+            if (suite.description) {
+                output.push(...suite.description.trim().split('\n')
+                    .map((l) => `${suiteIndent}${this.chalk.grey(l.trim())}`))
+                output.push('') // empty line
+            }
+
             const eventsToReport = this.getEventsToReport(suite)
             for (const test of eventsToReport) {
                 const testTitle = test.title

--- a/packages/wdio-spec-reporter/tests/__fixtures__/testdata.js
+++ b/packages/wdio-spec-reporter/tests/__fixtures__/testdata.js
@@ -75,6 +75,7 @@ SUITES.forEach(suite => {
 export const SUITES_WITH_DATA_TABLE = [{
     uid: SUITE_UIDS[0],
     title: SUITE_UIDS[0].slice(0, -1),
+    description: '\tSome important\ndescription to read!',
     hooks: [],
     tests: [{
         uid: 'foo1',

--- a/packages/wdio-spec-reporter/tests/__snapshots__/index.test.js.snap
+++ b/packages/wdio-spec-reporter/tests/__snapshots__/index.test.js.snap
@@ -3,6 +3,9 @@
 exports[`SpecReporter getResultDisplay should not print if data table format is not given 1`] = `
 Array [
   "Foo test",
+  "grey Some important",
+  "grey description to read!",
+  "",
   "   green ✓ foo",
   "   green ✓ bar",
   "",
@@ -12,6 +15,9 @@ Array [
 exports[`SpecReporter getResultDisplay should not print if data table is empty 1`] = `
 Array [
   "Foo test",
+  "grey Some important",
+  "grey description to read!",
+  "",
   "   green ✓ foo",
   "   green ✓ bar",
   "",
@@ -21,6 +27,9 @@ Array [
 exports[`SpecReporter getResultDisplay should print data tables 1`] = `
 Array [
   "Foo test",
+  "grey Some important",
+  "grey description to read!",
+  "",
   "   green ✓ foo",
   "     │ Vegetable │ Rating │",
   "     │ Apricot   │ 5      │",


### PR DESCRIPTION
## Proposed changes

This patch propagates the description property to the suite class so it can be used in reporters.

fixes: #4942

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

If you run the Cucumber example from the repo the spec reporter now outputs:

<img width="841" alt="Screenshot 2020-04-06 at 14 23 12" src="https://user-images.githubusercontent.com/731337/78558562-175e7700-7813-11ea-874f-7398d365be62.png">

(see description of feature file in grey)

### Reviewers: @webdriverio/project-committers
