### PR TITLE
Ensure that default connection is not overwritten

### DIFF
--- a/packages/webdriverio/src/index.js
+++ b/packages/webdriverio/src/index.js
@@ -23,7 +23,12 @@ export const remote = async function (params = {}, remoteModifier) {
     const config = validateConfig(WDIO_DEFAULTS, params, Object.keys(WebDriver.DEFAULTS))
     const automationProtocol = await getAutomationProtocol(config)
     const modifier = (client, options) => {
-        Object.assign(options, config)
+        /**
+         * overwrite instance options with default values of the protocol
+         * package (without undefined properties)
+         */
+        Object.assign(options, Object.entries(config)
+            .reduce((a, [k, v]) => (v == null ? a : { ...a, [k]:v }), {}))
 
         if (typeof remoteModifier === 'function') {
             client = remoteModifier(client, options)

--- a/tests/helpers/config.js
+++ b/tests/helpers/config.js
@@ -1,12 +1,5 @@
 exports.config = {
     /**
-     * server configurations
-     */
-    hostname: 'localhost',
-    port: 4444,
-    path: '/',
-
-    /**
      * capabilities
      */
     capabilities: [{


### PR DESCRIPTION
## Proposed changes

When running a setup where no connection details are defined (no hostname, port etc.) but it finds a driver server running and therefor defaults to WebDriver on `localhost:4444` due to default values of the WebDriver package, the connection values were overwritten to `undefined` again. This patch fixes that.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

Note that my change in the smoke test actually simulates the same condition and therefor would fail without this patch.

### Reviewers: @webdriverio/project-committers
