### PR TITLE
Allow to customise connection in driver services

### DIFF
--- a/packages/wdio-appium-service/src/launcher.js
+++ b/packages/wdio-appium-service/src/launcher.js
@@ -52,7 +52,19 @@ export default class AppiumLauncher {
             this.command = 'cmd'
         }
 
-        this.capabilities.forEach((cap) => Object.assign(cap, DEFAULT_CONNECTION, { ...cap }))
+        /**
+         * update capability connection options to connect
+         * to Appium server
+         */
+        (
+            Array.isArray(this.capabilities)
+                ? this.capabilities
+                : Object.values(this.capabilities)
+        ).forEach((cap) => Object.assign(cap, DEFAULT_CONNECTION, { ...cap }))
+
+        /**
+         * start Appium
+         */
         this.process = await promisify(this._startAppium)(this.command, this.appiumArgs)
 
         if (typeof this.logPath === 'string') {

--- a/packages/wdio-appium-service/src/launcher.js
+++ b/packages/wdio-appium-service/src/launcher.js
@@ -10,7 +10,7 @@ const DEFAULT_LOG_FILENAME = 'wdio-appium.log'
 const DEFAULT_CONNECTION = {
     protocol: 'http',
     hostname: 'localhost',
-    port: 4444,
+    port: 4723,
     path: '/'
 }
 

--- a/packages/wdio-appium-service/src/launcher.js
+++ b/packages/wdio-appium-service/src/launcher.js
@@ -7,9 +7,17 @@ import { getFilePath, getAppiumCommand, cliArgsFromKeyValue } from './utils'
 const log = logger('@wdio/appium-service')
 const DEFAULT_LOG_FILENAME = 'wdio-appium.log'
 
+const DEFAULT_CONNECTION = {
+    protocol: 'http',
+    hostname: 'localhost',
+    port: 4444,
+    path: '/'
+}
+
 export default class AppiumLauncher {
-    constructor(options, caps, config) {
+    constructor(options, capabilities, config) {
         this.options = options
+        this.capabilities = capabilities
         this.args = {
             basePath: '/',
             ...(options.args || {})
@@ -44,6 +52,7 @@ export default class AppiumLauncher {
             this.command = 'cmd'
         }
 
+        this.capabilities.forEach((cap) => Object.assign(cap, DEFAULT_CONNECTION, { ...cap }))
         this.process = await promisify(this._startAppium)(this.command, this.appiumArgs)
 
         if (typeof this.logPath === 'string') {

--- a/packages/wdio-appium-service/tests/launcher.test.js
+++ b/packages/wdio-appium-service/tests/launcher.test.js
@@ -96,7 +96,7 @@ describe('Appium launcher', () => {
             }
             const capabilities = {
                 browserA: { port: 1234 },
-                browserB: { port: 4321 }
+                browserB: {}
             }
             const launcher = new AppiumLauncher(options, capabilities, {})
             launcher._startAppium = jest.fn().mockImplementation((cmd, args, cb) => cb(null, new MockProcess()))
@@ -107,7 +107,7 @@ describe('Appium launcher', () => {
             expect(capabilities.browserA.path).toBe('/')
             expect(capabilities.browserB.protocol).toBe('http')
             expect(capabilities.browserB.hostname).toBe('localhost')
-            expect(capabilities.browserB.port).toBe(4321)
+            expect(capabilities.browserB.port).toBe(4723)
             expect(capabilities.browserB.path).toBe('/')
         })
 

--- a/packages/wdio-appium-service/tests/launcher.test.js
+++ b/packages/wdio-appium-service/tests/launcher.test.js
@@ -88,6 +88,29 @@ describe('Appium launcher', () => {
             expect(capabilities[0].path).toBe('/')
         })
 
+        test('should set correct config properties using multiremote', async () => {
+            const options = {
+                logPath: './',
+                command: 'path/to/my_custom_appium',
+                args: { foo: 'bar' }
+            }
+            const capabilities = {
+                browserA: { port: 1234 },
+                browserB: { port: 4321 }
+            }
+            const launcher = new AppiumLauncher(options, capabilities, {})
+            launcher._startAppium = jest.fn().mockImplementation((cmd, args, cb) => cb(null, new MockProcess()))
+            await launcher.onPrepare()
+            expect(capabilities.browserA.protocol).toBe('http')
+            expect(capabilities.browserA.hostname).toBe('localhost')
+            expect(capabilities.browserA.port).toBe(1234)
+            expect(capabilities.browserA.path).toBe('/')
+            expect(capabilities.browserB.protocol).toBe('http')
+            expect(capabilities.browserB.hostname).toBe('localhost')
+            expect(capabilities.browserB.port).toBe(4321)
+            expect(capabilities.browserB.path).toBe('/')
+        })
+
         test('should set correct config properties for Windows', async () => {
             Object.defineProperty(process, 'platform', {
                 value: 'win32'

--- a/packages/wdio-appium-service/tests/launcher.test.js
+++ b/packages/wdio-appium-service/tests/launcher.test.js
@@ -68,11 +68,13 @@ describe('Appium launcher', () => {
 
     describe('onPrepare', () => {
         test('should set correct config properties', async () => {
-            const launcher = new AppiumLauncher({
+            const options = {
                 logPath: './',
                 command: 'path/to/my_custom_appium',
                 args: { foo: 'bar' }
-            }, [], {})
+            }
+            const capabilities = [{ port: 1234 }]
+            const launcher = new AppiumLauncher(options, capabilities, {})
             launcher._startAppium = jest.fn().mockImplementation((cmd, args, cb) => cb(null, new MockProcess()))
             await launcher.onPrepare()
 
@@ -80,6 +82,10 @@ describe('Appium launcher', () => {
             expect(launcher.logPath).toBe('./')
             expect(launcher.command).toBe('path/to/my_custom_appium')
             expect(launcher.appiumArgs).toEqual(['--foo', 'bar'])
+            expect(capabilities[0].protocol).toBe('http')
+            expect(capabilities[0].hostname).toBe('localhost')
+            expect(capabilities[0].port).toBe(1234)
+            expect(capabilities[0].path).toBe('/')
         })
 
         test('should set correct config properties for Windows', async () => {

--- a/packages/wdio-selenium-standalone-service/src/launcher.js
+++ b/packages/wdio-selenium-standalone-service/src/launcher.js
@@ -36,7 +36,7 @@ export default class SeleniumStandaloneLauncher {
          * update capability connection options to connect
          * to standalone server
          */
-        this.capabilities.forEach((cap) => Object.assign(cap, DEFAULT_CONNECTION))
+        this.capabilities.forEach((cap) => Object.assign(cap, DEFAULT_CONNECTION, { ...cap }))
         this.process = await promisify(SeleniumStandalone.start)(this.args)
 
         if (typeof this.logPath === 'string') {

--- a/packages/wdio-selenium-standalone-service/src/launcher.js
+++ b/packages/wdio-selenium-standalone-service/src/launcher.js
@@ -36,7 +36,15 @@ export default class SeleniumStandaloneLauncher {
          * update capability connection options to connect
          * to standalone server
          */
-        this.capabilities.forEach((cap) => Object.assign(cap, DEFAULT_CONNECTION, { ...cap }))
+        (
+            Array.isArray(this.capabilities)
+                ? this.capabilities
+                : Object.values(this.capabilities)
+        ).forEach((cap) => Object.assign(cap, DEFAULT_CONNECTION, { ...cap }))
+
+        /**
+         * start Selenium Standalone server
+         */
         this.process = await promisify(SeleniumStandalone.start)(this.args)
 
         if (typeof this.logPath === 'string') {

--- a/packages/wdio-selenium-standalone-service/tests/launcher.test.js
+++ b/packages/wdio-selenium-standalone-service/tests/launcher.test.js
@@ -33,7 +33,7 @@ describe('Selenium standalone launcher', () => {
             expect(launcher.watchMode).toEqual(true)
             expect(capabilities[0].protocol).toBe('http')
             expect(capabilities[0].hostname).toBe('localhost')
-            expect(capabilities[0].port).toBe(4444)
+            expect(capabilities[0].port).toBe(1234)
             expect(capabilities[0].path).toBe('/wd/hub')
         })
 

--- a/packages/wdio-selenium-standalone-service/tests/launcher.test.js
+++ b/packages/wdio-selenium-standalone-service/tests/launcher.test.js
@@ -37,6 +37,29 @@ describe('Selenium standalone launcher', () => {
             expect(capabilities[0].path).toBe('/wd/hub')
         })
 
+        test('should set correct config properties using multiremote', async () => {
+            const options = {
+                logPath : './',
+                args : { foo : 'foo' },
+                installArgs : { bar : 'bar' },
+            }
+            const capabilities = {
+                browserA: { port: 1234 },
+                browserB: { port: 4321 }
+            }
+            const launcher = new SeleniumStandaloneLauncher(options, capabilities, {})
+            launcher._redirectLogStream = jest.fn()
+            await launcher.onPrepare({ watch: true })
+            expect(capabilities.browserA.protocol).toBe('http')
+            expect(capabilities.browserA.hostname).toBe('localhost')
+            expect(capabilities.browserA.port).toBe(1234)
+            expect(capabilities.browserA.path).toBe('/wd/hub')
+            expect(capabilities.browserB.protocol).toBe('http')
+            expect(capabilities.browserB.hostname).toBe('localhost')
+            expect(capabilities.browserB.port).toBe(4321)
+            expect(capabilities.browserB.path).toBe('/wd/hub')
+        })
+
         test('should call selenium install and start', async () => {
             const options = {
                 logPath : './',


### PR DESCRIPTION
## Proposed changes

When using Appium service and no connection details are set the test will fail as it tries to run a DevTools test. Appium doesn't modify the connection capabilities to connect to the started Appium server. This patch also modifies the ability to set custom connection details in the capability if someone decides to run appium and selenium standalone service in one config.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

fixes #5236

### Reviewers: @webdriverio/project-committers
