### PR TITLE
Fix legacy docs link to include file extension

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -5,7 +5,7 @@ title: API Docs
 
 Welcome to the WebdriverIO docs page. These pages contain reference materials for all implemented selenium bindings and commands. WebdriverIO has all [JSONWire protocol](https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol) commands implemented and also supports special bindings for [Appium](http://appium.io).
 
-> __Note:__ These are the docs for the latest version ([v6](https://webdriver.io/blog/2020/03/26/webdriverio-v6-released.html)) of WebdriverIO. If you are still using v5 or older please use the [legacy docs websites](versions)!
+> __Note:__ These are the docs for the latest version ([v6](https://webdriver.io/blog/2020/03/26/webdriverio-v6-released.html)) of WebdriverIO. If you are still using v5 or older please use the [legacy docs websites](versions.html)!
 
 ## Examples
 


### PR DESCRIPTION
Add missing .html file extension which was resulting in an invalid link

## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
