### PR TITLE
fix(wdio-cucumber-framework): add cucumber 6 retries support and scenario

### DIFF
--- a/docs/ConfigurationFile.md
+++ b/docs/ConfigurationFile.md
@@ -227,6 +227,7 @@ exports.config = {
         tagExpression: [],  // <string[]> (expression) only execute the features or scenarios with tags matching the expression
         timeout: 20000,     // <number> timeout for step definitions
         ignoreUndefinedDefinitions: false, // <boolean> Enable this config to treat undefined definitions as warnings.
+        scenarioLevelReporter: false // Enable this to make webdriver.io behave as if scenarios and not steps were the tests.
     },
     //
     // =====

--- a/docs/Retry.md
+++ b/docs/Retry.md
@@ -64,7 +64,13 @@ If you are using Jasmine, it also means that second parameter of both *test func
 
 It is __not__ possible to rerun whole suites with Jasmine&mdash;only hooks or test blocks.
 
-## Rerun Step Definitions in Cucumber
+## Rerunning in Cucumber
+
+### Rerun full suites in Cucumber
+
+For cucumber >=6 you can provide the [`retry`](https://github.com/cucumber/cucumber-js/blob/master/docs/cli.md#retry-failing-tests) configuration option along with a `retryTagFilter` optional parameter to have all or some of your failing scenarios get additional retries until succeeded. For this feature to work you need to set the `scenarioLevelReporter` to `true`.
+
+### Rerun Step Definitions in Cucumber
 
 To define a rerun rate for a certain step definitions just apply a retry option to it, like:
 

--- a/packages/wdio-cucumber-framework/cucumber-framework.d.ts
+++ b/packages/wdio-cucumber-framework/cucumber-framework.d.ts
@@ -119,4 +119,10 @@ interface CucumberOpts {
      * @default 30000
      */
     timeout?: number;
+    /**
+     * Enable this to make webdriver.io behave as if scenarios
+     * and not steps were the tests.
+     * @default false
+     */
+    scenarioLevelReporter?: boolean;
 }

--- a/packages/wdio-cucumber-framework/src/cucumberEventListener.js
+++ b/packages/wdio-cucumber-framework/src/cucumberEventListener.js
@@ -85,8 +85,10 @@ export default class CucumberEventListener extends EventEmitter {
         this.acceptedPickles.push(pickleEvent)
     }
 
-    onTestCaseStarted () {
-        const { uri, pickle } = this.acceptedPickles.shift()
+    onTestCaseStarted (pickleEvent) {
+        const { uri, pickle } = this.acceptedPickles.find(item =>
+            item.uri === pickleEvent.sourceLocation.uri &&
+            item.pickle.locations[0].line === pickleEvent.sourceLocation.line)
         const doc = this.gherkinDocEvents.find(gde => gde.uri === uri).document
         const feature = doc.feature
         this.currentPickle = pickle

--- a/packages/wdio-cucumber-framework/src/index.js
+++ b/packages/wdio-cucumber-framework/src/index.js
@@ -32,7 +32,8 @@ class CucumberAdapter {
                 capabilities: this.capabilities,
                 ignoreUndefinedDefinitions: Boolean(this.cucumberOpts.ignoreUndefinedDefinitions),
                 failAmbiguousDefinitions: Boolean(this.cucumberOpts.failAmbiguousDefinitions),
-                tagsInTitle: Boolean(this.cucumberOpts.tagsInTitle)
+                tagsInTitle: Boolean(this.cucumberOpts.tagsInTitle),
+                scenarioLevelReporter: Boolean(this.cucumberOpts.scenarioLevelReporter)
             }
             this.cucumberReporter = new CucumberReporter(this.eventBroadcaster, reporterOptions, this.cid, this.specs, this.reporter)
 

--- a/packages/wdio-cucumber-framework/src/reporter.js
+++ b/packages/wdio-cucumber-framework/src/reporter.js
@@ -167,7 +167,7 @@ class CucumberReporter {
         if(this.scenarioLevelReport) {
             return this.afterTest(uri, feature, scenario, undefined, result, sourceLocation)
         }
-        
+
         this.emit('suite:end', {
             uid: getUniqueIdentifier(scenario, sourceLocation),
             title: this.getTitle(scenario),

--- a/packages/wdio-cucumber-framework/src/reporter.js
+++ b/packages/wdio-cucumber-framework/src/reporter.js
@@ -165,18 +165,18 @@ class CucumberReporter {
 
     handleAfterScenario (uri, feature, scenario, result, sourceLocation) {
         if(this.scenarioLevelReport) {
-            this.afterTest(uri, feature, scenario, undefined, result, sourceLocation)
-        } else {
-            this.emit('suite:end', {
-                uid: getUniqueIdentifier(scenario, sourceLocation),
-                title: this.getTitle(scenario),
-                parent: getUniqueIdentifier(feature),
-                type: 'scenario',
-                file: uri,
-                duration: new Date() - this.scenarioStart,
-                tags: scenario.tags
-            })
+            return this.afterTest(uri, feature, scenario, undefined, result, sourceLocation)
         }
+        
+        this.emit('suite:end', {
+            uid: getUniqueIdentifier(scenario, sourceLocation),
+            title: this.getTitle(scenario),
+            parent: getUniqueIdentifier(feature),
+            type: 'scenario',
+            file: uri,
+            duration: new Date() - this.scenarioStart,
+            tags: scenario.tags
+        })
     }
 
     handleAfterFeature (uri, feature) {

--- a/packages/wdio-cucumber-framework/tests/reporter.test.js
+++ b/packages/wdio-cucumber-framework/tests/reporter.test.js
@@ -138,7 +138,7 @@ const acceptPickle = (eventBroadcaster) => eventBroadcaster.emit('pickle-accepte
     }
 })
 const prepareSuite = (eventBroadcaster) => eventBroadcaster.emit('test-case-prepared', {
-    sourceLocation: { uri: gherkinDocEvent.uri, line: 126 },
+    sourceLocation: SOURCE_LOCATION,
     steps: [
         {
             sourceLocation: { uri: gherkinDocEvent.uri, line: 125 },
@@ -154,7 +154,9 @@ const prepareSuite = (eventBroadcaster) => eventBroadcaster.emit('test-case-prep
         }
     ]
 })
-const startSuite = (eventBroadcaster) => eventBroadcaster.emit('test-case-started', {})
+
+const SOURCE_LOCATION = { uri: gherkinDocEvent.uri, line: 126 }
+const startSuite = (eventBroadcaster) => eventBroadcaster.emit('test-case-started', { sourceLocation: SOURCE_LOCATION })
 
 describe('cucumber reporter', () => {
     describe('emits messages for certain cucumber events', () => {
@@ -238,7 +240,7 @@ describe('cucumber reporter', () => {
                 eventBroadcaster.emit('test-step-started', {
                     index: 1,
                     testCase: {
-                        sourceLocation: { uri: gherkinDocEvent.uri, line: 126 }
+                        sourceLocation: SOURCE_LOCATION
                     }
                 })
 
@@ -293,7 +295,7 @@ describe('cucumber reporter', () => {
                     index: 1,
                     result: { duration: 10, status: 'passed' },
                     testCase: {
-                        sourceLocation: { uri: gherkinDocEvent.uri, line: 126 }
+                        sourceLocation: SOURCE_LOCATION
                     }
                 })
 
@@ -316,7 +318,7 @@ describe('cucumber reporter', () => {
                     index: 1,
                     result: { duration: 10, status: 'skipped' },
                     testCase: {
-                        sourceLocation: { uri: gherkinDocEvent.uri, line: 126 }
+                        sourceLocation: SOURCE_LOCATION
                     }
                 })
 
@@ -339,7 +341,7 @@ describe('cucumber reporter', () => {
                     index: 1,
                     result: { duration: 10, status: 'pending' },
                     testCase: {
-                        sourceLocation: { uri: gherkinDocEvent.uri, line: 126 }
+                        sourceLocation: SOURCE_LOCATION
                     }
                 })
 
@@ -367,7 +369,7 @@ describe('cucumber reporter', () => {
                         exception: err
                     },
                     testCase: {
-                        sourceLocation: { uri: gherkinDocEvent.uri, line: 126 }
+                        sourceLocation: SOURCE_LOCATION
                     }
                 })
 
@@ -398,7 +400,7 @@ describe('cucumber reporter', () => {
                         exception: 'string-error'
                     },
                     testCase: {
-                        sourceLocation: { uri: gherkinDocEvent.uri, line: 126 }
+                        sourceLocation: SOURCE_LOCATION
                     }
                 })
 
@@ -429,7 +431,7 @@ describe('cucumber reporter', () => {
                         exception: 'cucumber-ambiguous-error-message'
                     },
                     testCase: {
-                        sourceLocation: { uri: gherkinDocEvent.uri, line: 126 }
+                        sourceLocation: SOURCE_LOCATION
                     }
                 })
 
@@ -454,7 +456,7 @@ describe('cucumber reporter', () => {
             it('should send proper data on `test-case-finished` event', () => {
                 eventBroadcaster.emit('test-case-finished', {
                     result: { duration: 0, status: 'passed' },
-                    sourceLocation: { uri: gherkinDocEvent.uri, line: 126 }
+                    sourceLocation: SOURCE_LOCATION
                 })
 
                 expect(wdioReporter.emit).toHaveBeenCalledWith('suite:end', expect.objectContaining({
@@ -491,6 +493,101 @@ describe('cucumber reporter', () => {
         })
     })
 
+    describe('emits messages for certain cucumber events when executed in scenarioLeverReporter', () => {
+        const cid = '0-1'
+        const specs = ['/foobar.js']
+        let eventBroadcaster
+        let cucumberReporter
+
+        beforeEach(() => {
+            eventBroadcaster = new EventEmitter()
+            cucumberReporter = new CucumberReporter(eventBroadcaster, { failAmbiguousDefinitions: true, scenarioLevelReporter: true }, cid, specs, wdioReporter)
+        })
+
+        it('should not send any data on `gherkin-document` event', () => {
+            loadGherkin(eventBroadcaster)
+            expect(cucumberReporter.eventListener.gherkinDocEvents).toEqual([gherkinDocEvent])
+            expect(wdioReporter.emit).not.toHaveBeenCalled()
+        })
+
+        it('should send proper data on `test-run-started` event', () => {
+            loadGherkin(eventBroadcaster)
+            wdioReporter.emit.mockClear()
+            eventBroadcaster.emit('test-run-started')
+
+            expect(wdioReporter.emit).toHaveBeenCalledWith('suite:start', expect.objectContaining({
+                cid,
+                description: gherkinDocEvent.document.feature.description,
+                file: gherkinDocEvent.uri,
+                keyword: gherkinDocEvent.document.feature.keyword,
+                specs,
+                tags: [...gherkinDocEvent.document.feature.tags],
+                title: gherkinDocEvent.document.feature.name,
+                type: 'feature',
+                uid: 'feature123',
+            }))
+        })
+
+        it('should not send any data on `pickle-accepted` event', () => {
+            loadGherkin(eventBroadcaster)
+            wdioReporter.emit.mockClear()
+            acceptPickle(eventBroadcaster)
+
+            expect(wdioReporter.emit).not.toHaveBeenCalled()
+        })
+
+        it('should not be ok if line is missing', () => {
+            loadGherkinNoLine(eventBroadcaster)
+            wdioReporter.emit.mockClear()
+            acceptPickle(eventBroadcaster)
+
+            expect(wdioReporter.emit).not.toHaveBeenCalled()
+        })
+
+        it('should send accepted pickle\'s data on `test-case-started` event', () => {
+            loadGherkin(eventBroadcaster)
+            acceptPickle(eventBroadcaster)
+            prepareSuite(eventBroadcaster)
+            wdioReporter.emit.mockClear()
+            startSuite(eventBroadcaster)
+
+            expect(wdioReporter.emit).toHaveBeenCalledWith('test:start', expect.objectContaining({
+                type: 'scenario',
+                cid: '0-1',
+                parent: 'feature123',
+                uid: 'scenario126',
+                file: './any.feature',
+                tags: [{ name: 'abc' }]
+            }))
+        })
+
+        it('should send proper data on `test-case-finished` event', () => {
+            loadGherkin(eventBroadcaster)
+            acceptPickle(eventBroadcaster)
+            prepareSuite(eventBroadcaster)
+            startSuite(eventBroadcaster)
+            wdioReporter.emit.mockClear()
+
+            eventBroadcaster.emit('test-case-finished', {
+                result: { duration: 0, status: 'passed' },
+                sourceLocation: SOURCE_LOCATION
+            })
+
+            expect(wdioReporter.emit).toHaveBeenCalledWith('test:pass', expect.objectContaining({
+                type: 'scenario',
+                cid: '0-1',
+                parent: 'feature123',
+                uid: 'scenario126',
+                file: './any.feature',
+                tags: [
+                    { name: '@scenario-tag1' },
+                    { name: '@scenario-tag2' }
+                ]
+            }))
+        })
+
+    })
+
     describe('provides a fail counter', () => {
         let eventBroadcaster
         let reporter
@@ -514,7 +611,7 @@ describe('cucumber reporter', () => {
                     exception: new Error('exception-error')
                 },
                 testCase: {
-                    sourceLocation: { uri: gherkinDocEvent.uri, line: 126 }
+                    sourceLocation: SOURCE_LOCATION
                 }
             })
             expect(reporter.failedCount).toBe(1)
@@ -530,7 +627,7 @@ describe('cucumber reporter', () => {
                     stack: ''
                 },
                 testCase: {
-                    sourceLocation: { uri: gherkinDocEvent.uri, line: 126 }
+                    sourceLocation: SOURCE_LOCATION
                 }
             })
 
@@ -545,7 +642,7 @@ describe('cucumber reporter', () => {
                     status: 'undefined'
                 },
                 testCase: {
-                    sourceLocation: { uri: gherkinDocEvent.uri, line: 126 }
+                    sourceLocation: SOURCE_LOCATION
                 }
             })
 
@@ -562,7 +659,7 @@ describe('cucumber reporter', () => {
                     status: 'undefined'
                 },
                 testCase: {
-                    sourceLocation: { uri: gherkinDocEvent.uri, line: 126 }
+                    sourceLocation: SOURCE_LOCATION
                 }
             })
 
@@ -616,7 +713,7 @@ describe('cucumber reporter', () => {
                 }
             })
             prepareSuite(eventBroadcaster)
-            eventBroadcaster.emit('test-case-started', {})
+            eventBroadcaster.emit('test-case-started', { sourceLocation: SOURCE_LOCATION })
 
             expect(wdioReporter.emit).toHaveBeenCalledWith('suite:start', expect.objectContaining({
                 type: 'scenario',

--- a/tests/cucumber/reporter/reporter.config.js
+++ b/tests/cucumber/reporter/reporter.config.js
@@ -3,7 +3,7 @@ const { config } = require('../../helpers/config')
 
 const reporterConfig = Object.assign({}, config, {
     framework: 'cucumber',
-    reporters: [['smoke-test', { foo: 'bar' }]],
+    reporters: [['smoke-test', { foo: 'bar' }]]
 })
 
 reporterConfig.cucumberOpts.require = [path.join(__dirname, 'reporter.given.js')]

--- a/tests/cucumber/step-definitions/then.js
+++ b/tests/cucumber/step-definitions/then.js
@@ -30,3 +30,11 @@ Then('this is ambiguous', () => {
 Then('this test should fail', () => {
     assert.equal(true, false, 'This step should have never been executed :-(')
 })
+
+let fail = true
+Then('this steps fails only the first time used', () => {
+    if(fail) {
+        fail = false
+        assert.equal(true, false)
+    }
+})

--- a/tests/cucumber/test.feature
+++ b/tests/cucumber/test.feature
@@ -47,3 +47,7 @@ Feature: Example feature
 
     Scenario: failAmbiguousDefinitions
         Given this is ambiguous
+
+    @retry
+    Scenario: failsTheFirstTimeToCheckRetries
+        Then  this steps fails only the first time used

--- a/tests/smoke.runner.js
+++ b/tests/smoke.runner.js
@@ -124,7 +124,10 @@ const cucumberTestrunner = async () => {
             ],
             cucumberOpts: {
                 tagExpression: '(not @SKIPPED_TAG)',
-                ignoreUndefinedDefinitions: true
+                ignoreUndefinedDefinitions: true,
+                retry: 1,
+                retryTagFilter: '@retry',
+                scenarioLevelReporter: true
             }
         }
     )


### PR DESCRIPTION
… level reporting

## Proposed changes

Enable scenario level reporting and some minor fixes to allow cucumber v6 retry feature to work.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
