### PR TITLE
Add any non-passing Cucumber test result to failure count

### DIFF
--- a/packages/wdio-browserstack-service/package.json
+++ b/packages/wdio-browserstack-service/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@wdio/logger": "6.0.12",
-    "browserstack-local": "^1.4.3",
+    "browserstack-local": "^1.4.5",
     "got": "^10.7.0"
   },
   "peerDependencies": {

--- a/packages/wdio-browserstack-service/src/service.js
+++ b/packages/wdio-browserstack-service/src/service.js
@@ -72,7 +72,7 @@ export default class BrowserstackService {
      */
 
     afterScenario(uri, feature, pickle, result) {
-        if (result.status === 'failed') {
+        if (result.status !== 'passed') {
             ++this.failures
         }
     }

--- a/packages/wdio-browserstack-service/tests/service.test.js
+++ b/packages/wdio-browserstack-service/tests/service.test.js
@@ -242,7 +242,7 @@ describe('afterTest', () => {
 })
 
 describe('afterScenario', () => {
-    it('should increment failures on "failed"', () => {
+    it('should increment failures on "failed" or any non-passing Cucumber tests', () => {
         const uri = '/some/uri'
         service.failures = 0
 
@@ -259,6 +259,21 @@ describe('afterScenario', () => {
 
         service.afterScenario(uri, {}, {}, { status: 'failed' })
         expect(service.failures).toBe(2)
+
+        service.afterScenario(uri, {}, {}, { status: 'passed' })
+        expect(service.failures).toBe(2)
+
+        service.afterScenario(uri, {}, {}, { status: 'timeout' })
+        expect(service.failures).toBe(3)
+
+        service.afterScenario(uri, {}, {}, { status: 'passed' })
+        expect(service.failures).toBe(3)
+
+        service.afterScenario(uri, {}, {}, { status: '' })
+        expect(service.failures).toBe(4)
+
+        service.afterScenario(uri, {}, {}, { status: 'passed' })
+        expect(service.failures).toBe(4)
     })
 })
 


### PR DESCRIPTION
## Proposed changes

Addresses https://github.com/webdriverio/webdriverio/issues/5256

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)
The Browserstack API does not always report test status as either 'passed' or 'failed'. Timeout failures may be reported as well: 
`curl -u "xxxx:yyyy" https://api.browserstack.com/automate/sessions/<my_session_id>.json {"automation_session":{"name":"","duration":375,"os":"Windows","os_version":"10","browser_version":"80.0","browser":"chrome","device":null,"status":"timeout", ... }`

This was causing our test execution numbers to fluctuate night by night. 

Also bumping the Browserstack local dep.

## Types of changes
For the Cucumber-js specific `afterScenario()` hook, modify to be in line with the Mocha/Jasmine bloc and add any test not explicitly marked as `passed` to the failure count.
[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
