### PR TITLE
Add Sauce Connect support for EU

### DIFF
--- a/packages/wdio-sauce-service/src/launcher.js
+++ b/packages/wdio-sauce-service/src/launcher.js
@@ -38,6 +38,7 @@ export default class SauceLauncher {
             accessKey: config.key,
             logger: log.debug,
             tunnelIdentifier: sauceConnectTunnelIdentifier,
+            ...(config.region === 'eu' ? { '-x': 'https://eu-central-1.saucelabs.com/rest/v1' } : {}),
             ...sauceConnectOpts
         }
 

--- a/packages/wdio-sauce-service/tests/launcher.test.js
+++ b/packages/wdio-sauce-service/tests/launcher.test.js
@@ -68,6 +68,43 @@ test('onPrepare w/ SauceConnect w/o scRelay', async () => {
     expect(config.hostname).toBe(undefined)
 })
 
+test('onPrepare w/ SauceConnect w/ region EU', async () => {
+    const options = {
+        sauceConnect: true
+    }
+    const caps = [{}]
+    const config = {
+        user: 'foobaruser',
+        key: '12345',
+        region: 'eu',
+        sauceConnect: true
+    }
+    const service = new SauceServiceLauncher(options)
+    expect(service.sauceConnectProcess).toBeUndefined()
+    await service.onPrepare(config, caps)
+
+    expect(service.sauceConnectProcess).not.toBeUndefined()
+    expect(service.sauceConnectOpts['-x']).toContain('https://eu-central-1.saucelabs.com/rest/v1')
+})
+
+test('onPrepare w/ SauceConnect w/ default region', async () => {
+    const options = {
+        sauceConnect: true
+    }
+    const caps = [{}]
+    const config = {
+        user: 'foobaruser',
+        key: '12345',
+        sauceConnect: true
+    }
+    const service = new SauceServiceLauncher(options)
+    expect(service.sauceConnectProcess).toBeUndefined()
+    await service.onPrepare(config, caps)
+
+    expect(service.sauceConnectProcess).not.toBeUndefined()
+    expect(service.sauceConnectOpts['-x']).toBeUndefined()
+})
+
 test('onPrepare multiremote', async () => {
     const options = {
         sauceConnect: true,

--- a/packages/wdio-sauce-service/tests/launcher.test.js
+++ b/packages/wdio-sauce-service/tests/launcher.test.js
@@ -68,6 +68,25 @@ test('onPrepare w/ SauceConnect w/o scRelay', async () => {
     expect(config.hostname).toBe(undefined)
 })
 
+test('onPrepare w/ SauceConnect w/ scRelay w/ default port', async () => {
+    const options = {
+        sauceConnect: true,
+        scRelay: true,
+    }
+    const caps = [{}]
+    const config = {
+        user: 'foobaruser',
+        key: '12345',
+        sauceConnect: true
+    }
+    const service = new SauceServiceLauncher(options)
+    expect(service.sauceConnectProcess).toBeUndefined()
+    await service.onPrepare(config, caps)
+
+    expect(service.sauceConnectProcess).not.toBeUndefined()
+    expect(caps[0].port).toEqual(4445)
+})
+
 test('onPrepare w/ SauceConnect w/ region EU', async () => {
     const options = {
         sauceConnect: true


### PR DESCRIPTION
## Proposed changes
This PR will add the EU DC Sauce Connect endpoint automatically if the region is provided. 

I also added an extra test for the scRelay to get 🚀  coverage 

## Types of changes
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)
