### PR TITLE
Attach chromium protocol commands to msedge sessions

### DIFF
--- a/packages/devtools/tests/devtools.test.js
+++ b/packages/devtools/tests/devtools.test.js
@@ -32,7 +32,7 @@ test('newSession', async () => {
     expect(client.options.capabilities).toMatchSnapshot()
     expect(client.options.requestedCapabilities).toMatchSnapshot()
     expect(client.isDevTools).toBe(true)
-    expect(client.isChrome).toBe(true)
+    expect(client.isChromium).toBe(true)
     expect(client.isW3C).toBe(true)
     expect(launch).toBeCalledTimes(1)
 })

--- a/packages/wdio-utils/src/envDetector.js
+++ b/packages/wdio-utils/src/envDetector.js
@@ -42,12 +42,12 @@ function isW3C (capabilities) {
  * @param  {Object}  capabilities  caps of session response
  * @return {Boolean}               true if run by Chromedriver
  */
-function isChrome (caps) {
+function isChromium (caps) {
     if (!caps) {
         return false
     }
     return (
-        Boolean(caps.chrome) ||
+        Boolean(caps.chrome || caps.msedge) ||
         Boolean(caps['goog:chromeOptions'])
     )
 }
@@ -160,7 +160,7 @@ export function capabilitiesEnvironmentDetector (capabilities, automationProtoco
 export function sessionEnvironmentDetector ({ capabilities, requestedCapabilities }) {
     return {
         isW3C: isW3C(capabilities),
-        isChrome: isChrome(capabilities),
+        isChromium: isChromium(capabilities),
         isMobile: isMobile(capabilities),
         isIOS: isIOS(capabilities),
         isAndroid: isAndroid(capabilities),
@@ -181,7 +181,7 @@ export function devtoolsEnvironmentDetector ({ browserName }) {
         isMobile: false,
         isIOS: false,
         isAndroid: false,
-        isChrome: browserName === 'chrome',
+        isChromium: browserName === ('chrome' || 'msedge'),
         isSauce: false,
         isSeleniumStandalone: false,
     }
@@ -195,7 +195,7 @@ export function devtoolsEnvironmentDetector ({ browserName }) {
  */
 export function webdriverEnvironmentDetector (capabilities) {
     return {
-        isChrome: isChrome(capabilities),
+        isChromium: isChromium(capabilities),
         isMobile: isMobile(capabilities),
         isIOS: isIOS(capabilities),
         isAndroid: isAndroid(capabilities),

--- a/packages/wdio-utils/tests/__fixtures__/edgechromiumdriver.response.json
+++ b/packages/wdio-utils/tests/__fixtures__/edgechromiumdriver.response.json
@@ -1,0 +1,28 @@
+{
+  "value": {
+    "acceptInsecureCerts": false,
+    "browserName": "msedge",
+    "browserVersion": "81.0.416.53",
+    "ms:edgeOptions": {
+      "debuggerAddress": "localhost:49808"
+    },
+    "msedge": {
+      "msedgedriverVersion": "80.0.361.103 (5454f92735729153a6142d0de005e0848877a8c4)",
+      "userDataDir": "C:\\Users\\jexotic\\AppData\\Local\\Temp\\scoped_dir2272_1541282495"
+    },
+    "networkConnectionEnabled": false,
+    "pageLoadStrategy": "normal",
+    "platformName": "windows",
+    "proxy": {},
+    "setWindowRect": true,
+    "strictFileInteractability": false,
+    "timeouts": {
+      "implicit": 0,
+      "pageLoad": 300000,
+      "script": 30000
+    },
+    "unhandledPromptBehavior": "dismiss and notify",
+    "webdriver.remote.sessionid": "cc338836b7b4bc25e1fd027042f86533"
+  }
+}
+

--- a/packages/wdio-utils/tests/envDetector.test.js
+++ b/packages/wdio-utils/tests/envDetector.test.js
@@ -8,6 +8,7 @@ import ghostdriverResponse from './__fixtures__/ghostdriver.response.json'
 import safaridriverResponse from './__fixtures__/safaridriver.response.json'
 import safaridriverLegacyResponse from './__fixtures__/safaridriver.legacy.response.json'
 import edgedriverResponse from './__fixtures__/edgedriver.response.json'
+import edgechromiumdriverResponse from './__fixtures__/edgechromiumdriver.response.json'
 import seleniumstandaloneResponse from './__fixtures__/standaloneserver.response.json'
 
 describe('sessionEnvironmentDetector', () => {
@@ -16,6 +17,7 @@ describe('sessionEnvironmentDetector', () => {
     const experitestAppiumCaps = experitestResponse.appium.capabilities
     const geckoCaps = geckodriverResponse.value.capabilities
     const edgeCaps = edgedriverResponse.value.capabilities
+    const edgeChromiumCaps = edgechromiumdriverResponse.value
     const phantomCaps = ghostdriverResponse.value
     const safariCaps = safaridriverResponse.value.capabilities
     const safariLegacyCaps = safaridriverLegacyResponse.value
@@ -41,12 +43,13 @@ describe('sessionEnvironmentDetector', () => {
         expect(sessionEnvironmentDetector({ requestedCapabilities }).isW3C).toBe(false)
     })
 
-    it('isChrome', () => {
+    it('isChromium', () => {
         const requestedCapabilities = { w3cCaps: { alwaysMatch: {} } }
-        expect(sessionEnvironmentDetector({ capabilities: appiumCaps, requestedCapabilities }).isChrome).toBe(false)
-        expect(sessionEnvironmentDetector({ capabilities: chromeCaps, requestedCapabilities }).isChrome).toBe(true)
-        expect(sessionEnvironmentDetector({ capabilities: geckoCaps, requestedCapabilities }).isChrome).toBe(false)
-        expect(sessionEnvironmentDetector({ capabilities: phantomCaps, requestedCapabilities }).isChrome).toBe(false)
+        expect(sessionEnvironmentDetector({ capabilities: appiumCaps, requestedCapabilities }).isChromium).toBe(false)
+        expect(sessionEnvironmentDetector({ capabilities: chromeCaps, requestedCapabilities }).isChromium).toBe(true)
+        expect(sessionEnvironmentDetector({ capabilities: edgeChromiumCaps, requestedCapabilities }).isChromium).toBe(true)
+        expect(sessionEnvironmentDetector({ capabilities: geckoCaps, requestedCapabilities }).isChromium).toBe(false)
+        expect(sessionEnvironmentDetector({ capabilities: phantomCaps, requestedCapabilities }).isChromium).toBe(false)
     })
 
     it('isSauce', () => {
@@ -157,7 +160,7 @@ describe('capabilitiesEnvironmentDetector', () => {
 
         expect(capabilitiesFlags.isDevTools).toBe(true)
         expect(capabilitiesFlags.isSeleniumStandalone).toBe(false)
-        expect(capabilitiesFlags.isChrome).toBe(false)
+        expect(capabilitiesFlags.isChromium).toBe(false)
         expect(capabilitiesFlags.isMobile).toBe(false)
     })
 })

--- a/packages/webdriverio/tests/module.test.js
+++ b/packages/webdriverio/tests/module.test.js
@@ -228,7 +228,7 @@ describe('WebdriverIO module interface', () => {
             })
             expect(flags).toEqual({
                 isAndroid: false,
-                isChrome: true,
+                isChromium: true,
                 isIOS: false,
                 isMobile: false,
                 isSauce: false

--- a/packages/webdriverio/tests/protocol-stub.test.js
+++ b/packages/webdriverio/tests/protocol-stub.test.js
@@ -12,7 +12,7 @@ describe('newSession', () => {
         const session = await ProtocolStub.newSession({ capabilities: { 'appium:deviceName': 'Some Device', platformName: 'iOS', foo: 'bar' } })
         expect(Object.keys(session)).toHaveLength(8)
         expect(session.isAndroid).toBe(false)
-        expect(session.isChrome).toBe(false)
+        expect(session.isChromium).toBe(false)
         expect(session.isIOS).toBe(true)
         expect(session.isMobile).toBe(true)
         expect(session.isSauce).toBe(false)
@@ -24,7 +24,7 @@ describe('newSession', () => {
     it('should create stub for devtools automationProtocol', async () => {
         const session = await ProtocolStub.newSession({ capabilities: { browserName: 'chrome' }, _automationProtocol: 'devtools' })
         expect(Object.keys(session)).toHaveLength(11)
-        expect(session.isChrome).toBe(true)
+        expect(session.isChromium).toBe(true)
         expect(session.isW3C).toBe(true)
         expect(session.isSeleniumStandalone).toBe(false)
     })
@@ -35,7 +35,7 @@ describe('attachToSession', () => {
         const modifier = jest.fn()
         const session = await ProtocolStub.attachToSession({ capabilities: { browserName: 'chrome' } }, modifier)
         expect(modifier).not.toBeCalled()
-        expect(session.isChrome).toBe(true)
+        expect(session.isChromium).toBe(true)
     })
 
     it('should return newSession if modifier was not passed', async () => {


### PR DESCRIPTION
## Proposed changes

Allows Chromium Edge to use Chromium Protocol commands.   Also changed isChrome to isChromium since Chrome and Edge both use it.  

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

My first contribution!  Take it easy on me ;-) 

### Reviewers: @webdriverio/project-committers
