### PR TITLE
wdio-browserstack-service: do not overwrite name by test title

### DIFF
--- a/packages/wdio-browserstack-service/src/service.js
+++ b/packages/wdio-browserstack-service/src/service.js
@@ -7,6 +7,7 @@ const log = logger('@wdio/browserstack-service')
 
 export default class BrowserstackService {
     constructor (options, caps, config) {
+        this.caps = caps
         this.config = config
         this.failures = 0
         this.sessionBaseUrl = 'https://api.browserstack.com/automate/sessions'
@@ -97,7 +98,7 @@ export default class BrowserstackService {
     _getBody() {
         return {
             status: this.failures === 0 ? 'passed' : 'failed',
-            name: this.fullTitle,
+            name: this.caps.name !== undefined ? this.caps.name : this.fullTitle,
             reason: this.failReason
         }
     }


### PR DESCRIPTION
## Proposed changes

Session name is overridden at the end of the execution by the last executed spec full title.
Keep this behavior only if session name is not defined.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
