### PR TITLE
Fix #5291(@wdio/allure-reporter) - return status failed when an assertion failed with expect-webdriverio

### DIFF
--- a/packages/wdio-allure-reporter/src/utils.js
+++ b/packages/wdio-allure-reporter/src/utils.js
@@ -14,13 +14,18 @@ export const getTestStatus = (test, config) => {
         return testStatuses.FAILED
     }
 
+    if (test.error.name && test.error.message) {
+        const message = test.error.message.trim()
+        return (test.error.name === 'AssertionError' || message.startsWith('Expect'))  ? testStatuses.FAILED : testStatuses.BROKEN
+    }
+
     if (test.error.name) {
         return test.error.name === 'AssertionError' ? testStatuses.FAILED : testStatuses.BROKEN
     }
 
     if (test.error.stack) {
         const stackTrace = test.error.stack.trim()
-        return stackTrace.startsWith('AssertionError') ? testStatuses.FAILED : testStatuses.BROKEN
+        return (stackTrace.startsWith('AssertionError') || stackTrace.startsWith('Error: Expect'))  ? testStatuses.FAILED : testStatuses.BROKEN
     }
 
     return testStatuses.BROKEN

--- a/packages/wdio-allure-reporter/src/utils.js
+++ b/packages/wdio-allure-reporter/src/utils.js
@@ -16,7 +16,7 @@ export const getTestStatus = (test, config) => {
 
     if (test.error.name && test.error.message) {
         const message = test.error.message.trim()
-        return (test.error.name === 'AssertionError' || message.startsWith('Expect'))  ? testStatuses.FAILED : testStatuses.BROKEN
+        return (test.error.name === 'AssertionError' || message.includes('Expect'))  ? testStatuses.FAILED : testStatuses.BROKEN
     }
 
     if (test.error.name) {
@@ -25,7 +25,7 @@ export const getTestStatus = (test, config) => {
 
     if (test.error.stack) {
         const stackTrace = test.error.stack.trim()
-        return (stackTrace.startsWith('AssertionError') || stackTrace.startsWith('Error: Expect'))  ? testStatuses.FAILED : testStatuses.BROKEN
+        return (stackTrace.startsWith('AssertionError') || stackTrace.includes('Expect'))  ? testStatuses.FAILED : testStatuses.BROKEN
     }
 
     return testStatuses.BROKEN

--- a/packages/wdio-allure-reporter/tests/__fixtures__/testState.js
+++ b/packages/wdio-allure-reporter/tests/__fixtures__/testState.js
@@ -47,7 +47,7 @@ export function testFailedWithMultipleErrors() {
     return Object.assign(testState(), { errors, state: 'failed', end: '2018-05-14T15:17:21.631Z', _duration: 2730 })
 }
 
-export function testFailedWithAssertionErrorFormExpectWebdriverIO() {
+export function testFailedWithAssertionErrorFromExpectWebdriverIO() {
     const errors =
     [
         {

--- a/packages/wdio-allure-reporter/tests/__fixtures__/testState.js
+++ b/packages/wdio-allure-reporter/tests/__fixtures__/testState.js
@@ -47,7 +47,7 @@ export function testFailedWithMultipleErrors() {
     return Object.assign(testState(), { errors, state: 'failed', end: '2018-05-14T15:17:21.631Z', _duration: 2730 })
 }
 
-export function testFailedWithASCIIColorCode() {
+export function testFailedWithAssertionErrorFormExpectWebdriverIO() {
     const errors =
     [
         {
@@ -61,7 +61,7 @@ export function testFailedWithASCIIColorCode() {
             '    at World.<anonymous> (then.js:271:21)\n' +
             '    at World.executeSync (node_modules/@wdio/sync/build/index.js:56:18)\n' +
             '    at node_modules/@wdio/sync/build/index.js:82:70',
-            name: 'AssertionError',
+            name: 'Error',
         }
     ]
     const error =
@@ -76,7 +76,7 @@ export function testFailedWithASCIIColorCode() {
             '    at World.<anonymous> (then.js:271:21)\n' +
             '    at World.executeSync (node_modules/@wdio/sync/build/index.js:56:18)\n' +
             '    at node_modules/@wdio/sync/build/index.js:82:70',
-            name: 'AssertionError',
+            name: 'Error',
         }
     return Object.assign(testState(), { errors, error, state: 'failed', end: '2018-05-14T15:17:21.631Z', _duration: 2730 })
 }

--- a/packages/wdio-allure-reporter/tests/suite.test.js
+++ b/packages/wdio-allure-reporter/tests/suite.test.js
@@ -10,7 +10,7 @@ import { clean, getResults } from 'wdio-allure-helper'
 import AllureReporter from '../src/'
 import { runnerEnd, runnerStart } from './__fixtures__/runner'
 import { suiteEnd, suiteStart } from './__fixtures__/suite'
-import { testFailed, testPassed, testPending, testStart, testFailedWithMultipleErrors, testFailedWithAssertionErrorFormExpectWebdriverIO } from './__fixtures__/testState'
+import { testFailed, testPassed, testPending, testStart, testFailedWithMultipleErrors, testFailedWithAssertionErrorFromExpectWebdriverIO } from './__fixtures__/testState'
 import { commandStart, commandEnd, commandEndScreenShot, commandStartScreenShot } from './__fixtures__/command'
 
 let processOn
@@ -211,7 +211,7 @@ describe('Failed tests', () => {
         reporter.onRunnerStart(runnerEvent)
         reporter.onSuiteStart(suiteStart())
         reporter.onTestStart(testStart())
-        reporter.onTestFail(testFailedWithAssertionErrorFormExpectWebdriverIO())
+        reporter.onTestFail(testFailedWithAssertionErrorFromExpectWebdriverIO())
         reporter.onSuiteEnd(suiteEnd())
         reporter.onRunnerEnd(runnerEnd())
 

--- a/packages/wdio-allure-reporter/tests/suite.test.js
+++ b/packages/wdio-allure-reporter/tests/suite.test.js
@@ -10,7 +10,7 @@ import { clean, getResults } from 'wdio-allure-helper'
 import AllureReporter from '../src/'
 import { runnerEnd, runnerStart } from './__fixtures__/runner'
 import { suiteEnd, suiteStart } from './__fixtures__/suite'
-import { testFailed, testPassed, testPending, testStart, testFailedWithMultipleErrors, testFailedWithASCIIColorCode } from './__fixtures__/testState'
+import { testFailed, testPassed, testPending, testStart, testFailedWithMultipleErrors, testFailedWithAssertionErrorFormExpectWebdriverIO } from './__fixtures__/testState'
 import { commandStart, commandEnd, commandEndScreenShot, commandStartScreenShot } from './__fixtures__/command'
 
 let processOn
@@ -201,7 +201,7 @@ describe('Failed tests', () => {
         expect(lines[3].trim()).toBe('InternalError: Abandon Hope')
     })
 
-    it('should detect failed test case with ASCII color code', () => {
+    it('should detect failed test case with Assertion failed from expect-webdriverIO', () => {
         const reporter = new AllureReporter({ stdout: true, outputDir })
 
         const runnerEvent = runnerStart()
@@ -211,7 +211,7 @@ describe('Failed tests', () => {
         reporter.onRunnerStart(runnerEvent)
         reporter.onSuiteStart(suiteStart())
         reporter.onTestStart(testStart())
-        reporter.onTestFail(testFailedWithASCIIColorCode())
+        reporter.onTestFail(testFailedWithAssertionErrorFormExpectWebdriverIO())
         reporter.onSuiteEnd(suiteEnd())
         reporter.onRunnerEnd(runnerEnd())
 


### PR DESCRIPTION
## Proposed changes

Fixed #5291 

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
