### PR TITLE
Initiate `expect-webdriverio` after framework got initiated

### DIFF
--- a/packages/wdio-runner/src/index.js
+++ b/packages/wdio-runner/src/index.js
@@ -3,8 +3,6 @@ import path from 'path'
 import util from 'util'
 import EventEmitter from 'events'
 
-import { setOptions } from 'expect-webdriverio'
-
 import logger from '@wdio/logger'
 import { initialiseWorkerService, initialisePlugin, executeHooksWithArgs } from '@wdio/utils'
 import { ConfigParser } from '@wdio/config'
@@ -78,14 +76,6 @@ export default class Runner extends EventEmitter {
         initialiseWorkerService(this.config, caps, args.ignoredWorkerServices)
             .map(::this.configParser.addService)
 
-        /**
-         * set options for `expect-webdriverio` assertion lib
-         */
-        setOptions({
-            wait: this.config.waitforTimeout, // ms to wait for expectation to succeed
-            interval: this.config.waitforInterval, // interval between attempts
-        })
-
         await runHook('beforeSession', this.config, this.caps, this.specs)
         browser = await this._initSession(this.config, this.caps, browser)
 
@@ -142,6 +132,16 @@ export default class Runner extends EventEmitter {
             origin: 'worker',
             name: 'sessionStarted',
             content: { sessionId, isW3C, protocol, hostname, port, path, queryParams, isMultiremote, instances }
+        })
+
+        /**
+         * import and set options for `expect-webdriverio` assertion lib once
+         * the framework was initiated so that it can detect the environment
+         */
+        const { setOptions } = require('expect-webdriverio')
+        setOptions({
+            wait: this.config.waitforTimeout, // ms to wait for expectation to succeed
+            interval: this.config.waitforInterval, // interval between attempts
         })
 
         /**

--- a/tests/cucumber/step-definitions/then.js
+++ b/tests/cucumber/step-definitions/then.js
@@ -9,8 +9,7 @@ Then('the title of the page should be {string}', (expectedTitle) => {
 })
 
 Then('the title of the page should be {string} async', async (expectedTitle) => {
-    const actualTitle = await browser.getTitle()
-    assert.equal(actualTitle, expectedTitle)
+    expect(browser).toHaveTitle(expectedTitle)
 })
 
 let hasRun = false

--- a/tests/jasmine/test.js
+++ b/tests/jasmine/test.js
@@ -2,7 +2,7 @@ const assert = require('assert')
 
 describe('Jasmine smoke test', () => {
     it('should return sync value', () => {
-        expect(browser.getTitle()).toBe('Mock Page Title')
+        expect(browser).toHaveTitle('Mock Page Title')
     })
 
     let hasRun = false
@@ -13,6 +13,6 @@ describe('Jasmine smoke test', () => {
             throw new Error('booom!')
         }
 
-        assert.equal(this.wdioRetries, 1)
+        expect(this.wdioRetries).toBe(1)
     }, 1)
 })

--- a/tests/mocha/test.js
+++ b/tests/mocha/test.js
@@ -13,7 +13,7 @@ describe('Mocha smoke test', () => {
     })
 
     it('should return sync value', () => {
-        assert.equal(browser.getTitle(), 'Mock Page Title')
+        expect(browser).toHaveTitle('Mock Page Title')
     })
 
     let hasRun = false


### PR DESCRIPTION
## Proposed changes

Currently the `expect-webdriverio` lib doesn't work in Jasmine because the assertion lib is required to early at a point where `global.jasmine` is not yet initiated.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
