### PR TITLE
exposing defaultTimeoutInterval for jasmine framework

### DIFF
--- a/docs/Frameworks.md
+++ b/docs/Frameworks.md
@@ -190,7 +190,7 @@ commands the screenshot is taken anyway, which still gives _some_ valuable infor
 The following options can be applied in your `wdio.conf.js` to configure your Jasmine environment using the `jasmineNodeOpts` property:
 
 #### defaultTimeoutInterval
-Array of filepaths (and globs) relative to spec_dir to include before jasmine specs.
+Default Timeout Interval for Jasmine operations.
 
 Type: `number`<br>
 Default: `60000`
@@ -405,4 +405,3 @@ Here you have some examples of this syntax:
 - `@skip(browserName="firefox";platformName="linux")`: will skip the test in firefox over linux executions.
 - `@skip(browserName=["chrome","firefox"])`: tagged items will be skipped for both chrome and firefox browsers.
 - `@skip(browserName=/i.*explorer/`: capabilities with browsers matching the regexp will be skipped (like `iexplorer`, `internet explorer`, `internet-explorer`, ...).
-

--- a/docs/Frameworks.md
+++ b/docs/Frameworks.md
@@ -189,6 +189,12 @@ commands the screenshot is taken anyway, which still gives _some_ valuable infor
 
 The following options can be applied in your `wdio.conf.js` to configure your Jasmine environment using the `jasmineNodeOpts` property:
 
+#### defaultTimeoutInterval
+Array of filepaths (and globs) relative to spec_dir to include before jasmine specs.
+
+Type: `number`<br>
+Default: `60000`
+
 #### helpers
 Array of filepaths (and globs) relative to spec_dir to include before jasmine specs.
 

--- a/packages/wdio-jasmine-framework/jasmine-framework.d.ts
+++ b/packages/wdio-jasmine-framework/jasmine-framework.d.ts
@@ -16,22 +16,27 @@ declare module WebdriverIO {
 }
 
 interface JasmineNodeOptsConfig {
-    jasmineNodeOpts?: JasmineNodeOpts
+    jasmineNodeOpts?: JasmineNodeOpts;
 }
 
 interface JasmineNodeOpts {
+    /**
+     * Default Timeout Interval for Jasmine operations.
+     * @default `60000`
+     */
+    defaultTimeoutInterval?: number;
     /**
      * Array of filepaths (and globs) relative to spec_dir to include before
      * jasmine specs.
      * @default `[]`
      */
-    helpers?: string[]
+    helpers?: string[];
     /**
      * The `requires` option is useful when you want to add or extend some
      * basic functionality.
      * @default `[]`
      */
-    requires?: string[]
+    requires?: string[];
     /**
      * Whether to stop execution of the suite after the first spec failure
      * Since Jasmine v3.3.0


### PR DESCRIPTION
## Proposed changes
Just exposing  jasmineNodeOpts.defaultTimeoutInterval. index.js (below) seems to be utilizing the value already but it can't be used in typed configuration because not exposed in types. 
```
...
jasmine.DEFAULT_TIMEOUT_INTERVAL = this.jasmineNodeOpts.defaultTimeoutInterval || DEFAULT_TIMEOUT_INTERVAL
...
```

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
