### PR TITLE
Improve newWindow documentation

### DIFF
--- a/packages/webdriverio/src/commands/browser/newWindow.js
+++ b/packages/webdriverio/src/commands/browser/newWindow.js
@@ -9,13 +9,14 @@
  * <example>
     :newWindowSync.js
     it('should open a new tab', () => {
-        browser.url('http://google.com')
+        browser.url('https://google.com')
         console.log(browser.getTitle()) // outputs: "Google"
 
         browser.newWindow('https://webdriver.io', 'WebdriverIO window', 'width=420,height=230,resizable,scrollbars=yes,status=1')
         console.log(browser.getTitle()) // outputs: "WebdriverIO · Next-gen browser automation test framework for Node.js"
 
         browser.closeWindow()
+        browser.switchWindow('https://google.com')
         console.log(browser.getTitle()) // outputs: "Google"
     });
  * </example>


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)
Documentation of `newWindow` is missing `switchWindow` part after closing new tab which results in invalid webdriver.io context. Without adding it, you can see following error:
```
[chrome  mac os x #0-0] no such window: target window already closed
from unknown error: web view not found
  (Session info: chrome=81.0.4044.122)
```

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
