### PR TITLE
Switch 'Getting Started' example to use wdio expect

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -86,25 +86,20 @@ Open that file, and write the following code in it:
 <!--DOCUSAURUS_CODE_TABS-->
 <!--Sync Mode-->
 ```js
-const assert = require('assert')
-
 describe('webdriver.io page', () => {
     it('should have the right title', () => {
         browser.url('https://webdriver.io')
         const title = browser.getTitle()
-        assert.strictEqual(title, 'WebdriverIO · Next-gen browser automation test framework for Node.js')
+        expect(browser).toHaveTitle('WebdriverIO · Next-gen browser automation test framework for Node.js');
     })
 })
 ```
 <!--Async Mode-->
 ```js
-const assert = require('assert')
-
 describe('webdriver.io page', () => {
     it('should have the right title', async () => {
         await browser.url('https://webdriver.io')
-        const title = await browser.getTitle()
-        assert.strictEqual(title, 'WebdriverIO · Next-gen browser automation test framework for Node.js')
+        expect(browser).toHaveTitle('WebdriverIO · Next-gen browser automation test framework for Node.js');
     })
 })
 ```

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -99,7 +99,7 @@ describe('webdriver.io page', () => {
 describe('webdriver.io page', () => {
     it('should have the right title', async () => {
         await browser.url('https://webdriver.io')
-        expect(browser).toHaveTitle('WebdriverIO · Next-gen browser automation test framework for Node.js');
+        await expect(browser).toHaveTitle('WebdriverIO · Next-gen browser automation test framework for Node.js');
     })
 })
 ```


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

This switches the Getting Started example to use the expect-webdriverio library. I tested this in async mode and the expect statement seems to work just fine, but I wasn't able to find any documentation stating that it works in async mode. @mgrybyk can you confirm this?

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
