### PR TITLE
wdio-browserstack-service: do not update session name on success

### DIFF
--- a/packages/wdio-browserstack-service/src/service.js
+++ b/packages/wdio-browserstack-service/src/service.js
@@ -95,8 +95,11 @@ export default class BrowserstackService {
     }
 
     _getBody() {
+        if (this.failures === 0) {
+            return { status: 'passed' }
+        }
         return {
-            status: this.failures === 0 ? 'passed' : 'failed',
+            status: 'failed',
             name: this.fullTitle,
             reason: this.failReason
         }

--- a/packages/wdio-browserstack-service/tests/service.test.js
+++ b/packages/wdio-browserstack-service/tests/service.test.js
@@ -292,8 +292,7 @@ describe('_getBody', () => {
 
     it('should return "passed" if no errors', () => {
         service.failures = 0
-        service.fullTitle = 'foo - bar'
 
-        expect(service._getBody()).toEqual({ status: 'passed', name: 'foo - bar', reason: undefined })
+        expect(service._getBody()).toEqual({ status: 'passed' })
     })
 })


### PR DESCRIPTION
## Proposed changes

session name is supposed to be updated with last failing test (#3691).
However if the session is successful, the session name is updated with the last test name.

Changes to not update the session name is the session is successful.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
