### PR TITLE
wdio-browserstack-service: fix session status always failed

### DIFF
--- a/packages/wdio-browserstack-service/src/service.js
+++ b/packages/wdio-browserstack-service/src/service.js
@@ -45,7 +45,7 @@ export default class BrowserstackService {
         }
     }
 
-    afterTest(test) {
+    afterTest(test, context, results) {
         this.fullTitle = (
             /**
              * Jasmine
@@ -57,7 +57,7 @@ export default class BrowserstackService {
             `${test.parent} - ${test.title}`
         )
 
-        if (!test.passed) {
+        if (!results.passed) {
             this.failures++
             this.failReason = (test.error && test.error.message ? test.error.message : 'Unknown Error')
         }

--- a/packages/wdio-browserstack-service/tests/service.test.js
+++ b/packages/wdio-browserstack-service/tests/service.test.js
@@ -218,7 +218,7 @@ describe('afterTest', () => {
         service.fullTitle = ''
         service.failReason = ''
 
-        service.afterTest({ passed: false, fullName: 'foo bar', error: { message: 'error message' } })
+        service.afterTest({ fullName: 'foo bar', error: { message: 'error message' } }, {}, { passed: false })
         expect(service.failures).toBe(1)
         expect(service.fullTitle).toBe('foo bar')
         expect(service.failReason).toBe('error message')
@@ -229,14 +229,14 @@ describe('afterTest', () => {
         service.fullTitle = ''
         service.failReason = ''
 
-        service.afterTest({ passed: true, fullName: 'foo bar' })
+        service.afterTest({ fullName: 'foo bar' }, {}, { passed: true })
         expect(service.failures).toBe(0)
         expect(service.fullTitle).toBe('foo bar')
     })
 
     it('should set title for Mocha tests', () => {
         service.fullTitle = ''
-        service.afterTest({ title: 'foo', parent: 'bar' })
+        service.afterTest({ title: 'foo', parent: 'bar' }, {}, { passed: false })
         expect(service.fullTitle).toBe('bar - foo')
     })
 })


### PR DESCRIPTION
## Proposed changes

Tests do not have a `passed` property (at least on jasmine), so the session status is always updated as 'failed'.
Retrieve test status from results instead of test, cf [typings](https://github.com/webdriverio/webdriverio/blob/master/packages/webdriverio/webdriverio-core.d.ts#L355), [wdio-cbt](https://github.com/webdriverio/webdriverio/blob/master/packages/wdio-crossbrowsertesting-service/src/service.js#L65), [wdio-sauce](https://github.com/webdriverio/webdriverio/blob/master/packages/wdio-sauce-service/src/service.js#L81).

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
