### PR TITLE
Add expect-webdriverio to tsconfig types

### DIFF
--- a/docs/TypeScript.md
+++ b/docs/TypeScript.md
@@ -66,7 +66,7 @@ And your `tsconfig.json` needs the following:
             "*": [ "./*" ],
             "src/*": ["./src/*"]
         },
-        "types": ["node", "webdriverio"]
+        "types": ["node", "webdriverio", "expect-webdriverio"]
     },
     "include": [
         "./src/**/*.ts"
@@ -121,7 +121,7 @@ For instance, if you decide to use the Mocha framework, you need to install `@ty
             "*": [ "./*" ],
             "src/*": ["./src/*"]
         },
-        "types": ["node", "webdriverio", "@wdio/mocha-framework"]
+        "types": ["node", "webdriverio", "expect-webdriverio", "@wdio/mocha-framework"]
     },
     "include": [
         "./src/**/*.ts"


### PR DESCRIPTION
## Proposed changes

I was confused as to why `expect` name could not be found. It was because I was missing `expect-webdriverio` in tsconfig types. This adds that info to the docs.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation update

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

### Reviewers: @webdriverio/project-committers
