### PR TITLE
demonstration of duplicate failedExpectation issue and illustrative "fix"

### DIFF
--- a/packages/wdio-jasmine-framework/src/reporter.js
+++ b/packages/wdio-jasmine-framework/src/reporter.js
@@ -44,6 +44,9 @@ export default class JasmineReporter {
             test.status = 'pending'
         }
 
+        // This removes the dupe
+        test.failedExpectations = test.failedExpectations.filter(exp => !(exp.matcherName == ''))
+
         if (test.failedExpectations.length) {
             let errors = test.failedExpectations
             if (this.shouldCleanStack) {


### PR DESCRIPTION
This demonstrates an issue where failedExpectations array can contain a duplicate for the 'toBe' matcher. Trying to figure out where this array is built so I can find the root of the issue. This isn't actually a fix as much as a conversation helper.