### PR TITLE
Add hint for modifiyng clicks

### DIFF
--- a/packages/webdriverio/src/commands/browser/keys.js
+++ b/packages/webdriverio/src/commands/browser/keys.js
@@ -6,7 +6,8 @@
  * To do that, the value has to correspond to a key from the table.
  *
  * Modifier like Ctrl, Shift, Alt and Meta will stay pressed so you need to trigger them again to release them.
- *
+ * Modifiying a click however requires you to use the Webdriver Actions API through the [performActions](https://webdriver.io/docs/api/webdriver.html#performactions) method.
+ * 
  * <example>
     :keys.js
     it('copies text out of active element', () => {

--- a/packages/webdriverio/src/commands/browser/keys.js
+++ b/packages/webdriverio/src/commands/browser/keys.js
@@ -7,7 +7,7 @@
  *
  * Modifier like Ctrl, Shift, Alt and Meta will stay pressed so you need to trigger them again to release them.
  * Modifiying a click however requires you to use the Webdriver Actions API through the [performActions](https://webdriver.io/docs/api/webdriver.html#performactions) method.
- * 
+ *
  * <example>
     :keys.js
     it('copies text out of active element', () => {


### PR DESCRIPTION
https://github.com/webdriverio/webdriverio/issues/5340#issue-609865015

## Proposed changes

Add a hint to the documentation of keys.js about modifying clicks, as there is misleading information about it on StackOverflow ([here](https://stackoverflow.com/questions/57870784/webdriver-io-highlighting-multiple-elements-with-ctrlclick-on-coffescript?rq=1) and [here] (https://stackoverflow.com/questions/30077667/how-to-simulate-ctrl-click-or-shift-click-with-webdriver-io)) and people could save time, facing the same issue.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further Comments

I will also comment on linked SO Questions, that v6 is different.

### Reviewers: @webdriverio/project-committers
