### PR TITLE
Make `requestedCapabilities` better accessible

### DIFF
--- a/docs/BrowserObject.md
+++ b/docs/BrowserObject.md
@@ -15,7 +15,7 @@ Besides all commands from the [API](API.md), the `browser` object provides some 
 console.log(browser.sessionId) // outputs: "57b15c6ea81d0edb9e5b372da3d9ce28"
 console.log(browser.capabilities)
 /**
- * outputs:
+ * outputs capabilities returned by the browser driver, e.g.:
    { acceptInsecureCerts: false,
      acceptSslCerts: false,
      applicationCacheEnabled: false,
@@ -43,11 +43,18 @@ console.log(browser.capabilities)
      version: '68.0.3440.106',
      webStorageEnabled: true }
  */
+console.log(browser.requestedCapabilities)
+/**
+ * outputs original capabilities set by the user, e.g.:
+ * {
+ *   browserName: 'chrome'
+ * }
+ */
 ```
 
 ## Get Config Options
 
-You can always define custom options within your WDIO config:
+If using the WDIO testrunner you can always define custom options within your WDIO config:
 
 ```js
 // wdio.conf.js

--- a/packages/devtools/src/index.js
+++ b/packages/devtools/src/index.js
@@ -41,6 +41,12 @@ export default class DevTools {
         const vendorCapPrefix = Object.keys(params.capabilities).find(
             (capKey) => availableVendorPrefixes.includes(capKey))
 
+        /**
+         * save original set of capabilities to allow to request the same session again
+         * (e.g. for reloadSession command in WebdriverIO)
+         */
+        params.requestedCapabilities = { ...params.capabilities }
+
         params.capabilities = {
             browserName: userAgent.browser.name,
             browserVersion: userAgent.browser.version,
@@ -50,15 +56,6 @@ export default class DevTools {
                 { debuggerAddress: browser._connection.url().split('/')[2] },
                 params.capabilities[vendorCapPrefix]
             )
-        }
-
-        /**
-         * save original set of capabilities to allow to request the same session again
-         * (e.g. for reloadSession command in WebdriverIO)
-         */
-        params.requestedCapabilities = {
-            w3cCaps: params.capabilities,
-            jsonwpCaps: params.capabilities
         }
 
         sessionMap.set(sessionId, { browser, session: driver })
@@ -76,8 +73,7 @@ export default class DevTools {
 
     static async reloadSession (instance) {
         const { session } = sessionMap.get(instance.sessionId)
-        const { w3cCaps } = instance.options.requestedCapabilities
-        const browser = await launch(w3cCaps)
+        const browser = await launch(instance.requestedCapabilities)
         const pages = await browser.pages()
 
         session.elementStore.clear()

--- a/packages/devtools/tests/__snapshots__/devtools.test.js.snap
+++ b/packages/devtools/tests/__snapshots__/devtools.test.js.snap
@@ -12,19 +12,7 @@ Object {
 
 exports[`newSession 2`] = `
 Object {
-  "jsonwpCaps": Object {
-    "browserName": "Chrome",
-    "browserVersion": "80.0.3987.149",
-    "goog:chromeOptions": Object {
-      "debuggerAddress": "localhost:49375",
-    },
-  },
-  "w3cCaps": Object {
-    "browserName": "Chrome",
-    "browserVersion": "80.0.3987.149",
-    "goog:chromeOptions": Object {
-      "debuggerAddress": "localhost:49375",
-    },
-  },
+  "browserName": "chrome",
+  "goog:chromeOptions": Object {},
 }
 `;

--- a/packages/wdio-sync/webdriverio-core.d.ts
+++ b/packages/wdio-sync/webdriverio-core.d.ts
@@ -827,7 +827,7 @@ declare namespace WebdriverIO {
         script?: number
     }
 
-    interface Browser {
+    interface Browser extends WebDriver.BaseClient {
         config: Config;
         options: RemoteOptions;
 

--- a/packages/wdio-utils/src/envDetector.js
+++ b/packages/wdio-utils/src/envDetector.js
@@ -164,7 +164,7 @@ export function sessionEnvironmentDetector ({ capabilities, requestedCapabilitie
         isMobile: isMobile(capabilities),
         isIOS: isIOS(capabilities),
         isAndroid: isAndroid(capabilities),
-        isSauce: isSauce(requestedCapabilities.w3cCaps.alwaysMatch),
+        isSauce: isSauce(requestedCapabilities),
         isSeleniumStandalone: isSeleniumStandalone(capabilities)
     }
 }

--- a/packages/wdio-utils/src/monad.js
+++ b/packages/wdio-utils/src/monad.js
@@ -33,7 +33,7 @@ export default function WebDriver (options, modifier, propertiesObject = {}) {
          */
         propertiesObject.commandList = { value: Object.keys(propertiesObject) }
         propertiesObject.options = { value: options }
-        propertiesObject.requestedCapabilities = options.requestedCapabilities
+        propertiesObject.requestedCapabilities = { value: options.requestedCapabilities }
 
         /**
          * allow to wrap commands if necessary

--- a/packages/wdio-utils/src/monad.js
+++ b/packages/wdio-utils/src/monad.js
@@ -27,8 +27,13 @@ export default function WebDriver (options, modifier, propertiesObject = {}) {
      * WebDriver monad
      */
     function unit (sessionId, commandWrapper) {
+        /**
+         * capabilities attached to the instance prototype not being shown if
+         * logging the instance
+         */
         propertiesObject.commandList = { value: Object.keys(propertiesObject) }
         propertiesObject.options = { value: options }
+        propertiesObject.requestedCapabilities = options.requestedCapabilities
 
         /**
          * allow to wrap commands if necessary

--- a/packages/wdio-utils/tests/envDetector.test.js
+++ b/packages/wdio-utils/tests/envDetector.test.js
@@ -51,18 +51,18 @@ describe('sessionEnvironmentDetector', () => {
 
     it('isSauce', () => {
         const capabilities = { browserName: 'chrome' }
-        let requestedCapabilities = { w3cCaps: { alwaysMatch: {} } }
+        let requestedCapabilities = {}
         let hostname = 'localhost' // isSauce should also be true if run through Sauce Connect
 
         expect(sessionEnvironmentDetector({ capabilities, requestedCapabilities }).isSauce).toBe(false)
         expect(sessionEnvironmentDetector({ capabilities, hostname, requestedCapabilities }).isSauce).toBe(false)
 
-        requestedCapabilities.w3cCaps.alwaysMatch.extendedDebugging = true
+        requestedCapabilities.extendedDebugging = true
         expect(sessionEnvironmentDetector({ capabilities, hostname, requestedCapabilities }).isSauce).toBe(true)
-        requestedCapabilities = { w3cCaps: { alwaysMatch: {} } }
+        requestedCapabilities = {}
         expect(sessionEnvironmentDetector({ capabilities, hostname, requestedCapabilities }).isSauce).toBe(false)
 
-        requestedCapabilities.w3cCaps.alwaysMatch['sauce:options'] = { extendedDebugging: true }
+        requestedCapabilities['sauce:options'] = { extendedDebugging: true }
         expect(sessionEnvironmentDetector({ capabilities, hostname, requestedCapabilities }).isSauce).toBe(true)
         expect(sessionEnvironmentDetector({ capabilities, requestedCapabilities }).isSauce).toBe(true)
     })

--- a/packages/webdriver/src/index.js
+++ b/packages/webdriver/src/index.js
@@ -59,7 +59,10 @@ export default class WebDriver {
     }
 
     static async reloadSession (instance) {
-        const params = { ...instance.requestedCapabilities }
+        const params = {
+            ...instance.options,
+            capabilities: instance.requestedCapabilities
+        }
         const sessionId = await startWebDriverSession(params)
         instance.sessionId = sessionId
         return sessionId

--- a/packages/webdriver/src/index.js
+++ b/packages/webdriver/src/index.js
@@ -3,7 +3,6 @@ import logger from '@wdio/logger'
 import { webdriverMonad, sessionEnvironmentDetector } from '@wdio/utils'
 import { validateConfig } from '@wdio/config'
 
-import WebDriverRequest from './request'
 import { DEFAULTS } from './constants'
 import { startWebDriverSession, getPrototype, getEnvironmentVars, setupDirectConnect } from './utils'
 
@@ -60,21 +59,10 @@ export default class WebDriver {
     }
 
     static async reloadSession (instance) {
-        const { w3cCaps, jsonwpCaps } = instance.options.requestedCapabilities
-        const sessionRequest = new WebDriverRequest(
-            'POST',
-            '/session',
-            {
-                capabilities: w3cCaps, // W3C compliant
-                desiredCapabilities: jsonwpCaps // JSONWP compliant
-            }
-        )
-
-        const response = await sessionRequest.makeRequest(instance.options)
-        const newSessionId = response.sessionId || (response.value && response.value.sessionId)
-        instance.sessionId = newSessionId
-
-        return newSessionId
+        const params = { ...instance.requestedCapabilities }
+        const sessionId = await startWebDriverSession(params)
+        instance.sessionId = sessionId
+        return sessionId
     }
 
     static get WebDriver () {

--- a/packages/webdriver/src/utils.js
+++ b/packages/webdriver/src/utils.js
@@ -60,7 +60,7 @@ export async function startWebDriverSession (params) {
      * save original set of capabilities to allow to request the same session again
      * (e.g. for reloadSession command in WebdriverIO)
      */
-    params.requestedCapabilities = { w3cCaps, jsonwpCaps }
+    params.requestedCapabilities = params.capabilities
 
     /**
      * save actual receveived session details

--- a/packages/webdriver/tests/index.test.js
+++ b/packages/webdriver/tests/index.test.js
@@ -68,6 +68,15 @@ describe('WebDriver', () => {
 
             expect(logger.setLevel).toBeCalled()
         })
+
+        it('propagates capabilities and requestedCapabilities', async () => {
+            const browser = await WebDriver.newSession({
+                path: '/',
+                capabilities: { browserName: 'firefox' }
+            })
+            expect(browser.capabilities.browserName).toBe('mockBrowser')
+            expect(browser.requestedCapabilities.browserName).toBe('firefox')
+        })
     })
 
     describe('attachToSession', () => {

--- a/packages/webdriver/tests/utils.test.js
+++ b/packages/webdriver/tests/utils.test.js
@@ -240,14 +240,25 @@ describe('utils', () => {
     })
 
     describe('startWebDriverSession', () => {
-        it('should handle sessionRequest error', async () => {
-            let error
-            try {
-                await startWebDriverSession({})
-            } catch (err) {
-                error = err
+        it('attaches capabilities to the params object', async () => {
+            const params = {
+                hostname: 'localhost',
+                port: 4444,
+                path: '/',
+                protocol: 'http',
+                capabilities: {
+                    browserName: 'chrome',
+                }
             }
+            const sessionId = await startWebDriverSession(params)
+            expect(sessionId).toBe('foobar-123')
+            expect(params.capabilities.browserName).toBe('mockBrowser')
+            expect(params.requestedCapabilities.browserName).toBe('chrome')
 
+        })
+
+        it('should handle sessionRequest error', async () => {
+            let error = await startWebDriverSession({}).catch((err) => err)
             expect(error.message).toContain('Failed to create session')
         })
     })

--- a/packages/webdriver/webdriver.d.ts
+++ b/packages/webdriver/webdriver.d.ts
@@ -495,6 +495,7 @@ declare namespace WebDriver {
          * Defines the [capabilities](https://w3c.github.io/webdriver/webdriver-spec.html#capabilities) you want to run in your Selenium session.
          */
         capabilities?: DesiredCapabilities;
+        requestedCapabilities?: DesiredCapabilities;
         /**
          * Level of logging verbosity.
          */
@@ -610,9 +611,28 @@ declare namespace WebDriver {
         mjpegScalingFactor?: number,
     }
 
+    interface BaseClient {
+        // id of WebDriver session
+        sessionId: string;
+        // assigned capabilities by the browser driver / WebDriver server
+        capabilities: DesiredCapabilities;
+        // original requested capabilities
+        requestedCapabilities: DesiredCapabilities;
+
+        /**
+         * browser flags
+         */
+        // true if session runs on a mobile device
+        isMobile: boolean;
+        // true if mobile session runs on iOS
+        isIOS: boolean;
+        // true if mobile session runs on Android
+        isAndroid: boolean;
+    }
+
     // generated typings
         // webdriver types
-    interface Client {
+    interface Client extends BaseClient {
 
         /**
          * [webdriver]
@@ -1008,7 +1028,7 @@ declare namespace WebDriver {
     }
 
     // appium types
-    interface Client {
+    interface Client extends BaseClient {
 
         /**
          * [appium]
@@ -1446,7 +1466,7 @@ declare namespace WebDriver {
     }
 
     // jsonwp types
-    interface Client {
+    interface Client extends BaseClient {
 
         /**
          * [jsonwp]
@@ -2115,7 +2135,7 @@ declare namespace WebDriver {
     }
 
     // mjsonwp types
-    interface Client {
+    interface Client extends BaseClient {
 
         /**
          * [mjsonwp]
@@ -2182,7 +2202,7 @@ declare namespace WebDriver {
     }
 
     // chromium types
-    interface Client {
+    interface Client extends BaseClient {
 
         /**
          * [chromium]
@@ -2354,7 +2374,7 @@ declare namespace WebDriver {
     }
 
     // saucelabs types
-    interface Client {
+    interface Client extends BaseClient {
 
         /**
          * [saucelabs]
@@ -2400,7 +2420,7 @@ declare namespace WebDriver {
     }
 
     // selenium types
-    interface Client {
+    interface Client extends BaseClient {
 
         /**
          * [selenium]

--- a/packages/webdriver/webdriver.d.ts
+++ b/packages/webdriver/webdriver.d.ts
@@ -2463,7 +2463,7 @@ declare namespace WebDriver {
 }
 
 type AsyncClient = {
-    [K in keyof WebDriver.Client]:
+    [K in keyof Pick<WebDriver.Client, Exclude<keyof WebDriver.Client, keyof WebDriver.BaseClient>>]:
     (...args: Parameters<WebDriver.Client[K]>) => Promise<ReturnType<WebDriver.Client[K]>>;
 }
 

--- a/packages/webdriver/webdriver.d.ts
+++ b/packages/webdriver/webdriver.d.ts
@@ -2459,7 +2459,7 @@ declare namespace WebDriver {
     }
 
 
-    interface ClientAsync extends AsyncClient { }
+    interface ClientAsync extends AsyncClient, BaseClient { }
 }
 
 type AsyncClient = {

--- a/packages/webdriverio/tests/commands/browser/reloadSession.test.js
+++ b/packages/webdriverio/tests/commands/browser/reloadSession.test.js
@@ -23,7 +23,7 @@ describe('reloadSession test', () => {
         name: 'should be sessionId if sessionId and value.sessionId are present',
         sessionIdMock: 'foobar-456',
         requestMock: [{}, { sessionId: 'foobar-567' }],
-        newSessionId: 'foobar-456',
+        newSessionId: 'foobar-567',
         jsonwpMode: true
     }]
 

--- a/packages/webdriverio/webdriverio-core.d.ts
+++ b/packages/webdriverio/webdriverio-core.d.ts
@@ -827,7 +827,7 @@ declare namespace WebdriverIO {
         script?: number
     }
 
-    interface Browser {
+    interface Browser extends WebDriver.BaseClient {
         config: Config;
         options: RemoteOptions;
 

--- a/scripts/templates/webdriver.tpl.d.ts
+++ b/scripts/templates/webdriver.tpl.d.ts
@@ -631,7 +631,7 @@ declare namespace WebDriver {
 }
 
 type AsyncClient = {
-    [K in keyof WebDriver.Client]:
+    [K in keyof Pick<WebDriver.Client, Exclude<keyof WebDriver.Client, keyof WebDriver.BaseClient>>]:
     (...args: Parameters<WebDriver.Client[K]>) => Promise<ReturnType<WebDriver.Client[K]>>;
 }
 

--- a/scripts/templates/webdriver.tpl.d.ts
+++ b/scripts/templates/webdriver.tpl.d.ts
@@ -489,6 +489,7 @@ declare namespace WebDriver {
          * Defines the [capabilities](https://w3c.github.io/webdriver/webdriver-spec.html#capabilities) you want to run in your Selenium session.
          */
         capabilities?: DesiredCapabilities;
+        requestedCapabilities?: DesiredCapabilities;
         /**
          * Level of logging verbosity.
          */
@@ -602,6 +603,25 @@ declare namespace WebDriver {
         mjpegServerFramerate?: number,
         screenshotQuality?: number,
         mjpegScalingFactor?: number,
+    }
+
+    interface BaseClient {
+        // id of WebDriver session
+        sessionId: string;
+        // assigned capabilities by the browser driver / WebDriver server
+        capabilities: DesiredCapabilities;
+        // original requested capabilities
+        requestedCapabilities: DesiredCapabilities;
+
+        /**
+         * browser flags
+         */
+        // true if session runs on a mobile device
+        isMobile: boolean;
+        // true if mobile session runs on iOS
+        isIOS: boolean;
+        // true if mobile session runs on Android
+        isAndroid: boolean;
     }
 
     // generated typings

--- a/scripts/templates/webdriver.tpl.d.ts
+++ b/scripts/templates/webdriver.tpl.d.ts
@@ -627,7 +627,7 @@ declare namespace WebDriver {
     // generated typings
     // ... insert here ...
 
-    interface ClientAsync extends AsyncClient { }
+    interface ClientAsync extends AsyncClient, BaseClient { }
 }
 
 type AsyncClient = {

--- a/scripts/templates/webdriverio.tpl.d.ts
+++ b/scripts/templates/webdriverio.tpl.d.ts
@@ -478,7 +478,7 @@ declare namespace WebdriverIO {
         script?: number
     }
 
-    interface Browser {
+    interface Browser extends WebDriver.BaseClient {
         config: Config;
         options: RemoteOptions;
 

--- a/scripts/type-generation/webdriver-generate-typings.js
+++ b/scripts/type-generation/webdriver-generate-typings.js
@@ -18,7 +18,7 @@ ${INDENTATION} */`
 const lines = []
 for (const [protocolName, definition] of Object.entries(PROTOCOLS)) {
     lines.push(`    // ${protocolName} types`)
-    lines.push('    interface Client {')
+    lines.push('    interface Client extends BaseClient {')
 
     for (const [, methods] of Object.entries(definition)) {
         for (const [, description] of Object.entries(methods)) {

--- a/tests/typings/sync/sync.ts
+++ b/tests/typings/sync/sync.ts
@@ -166,6 +166,14 @@ browser.addLocatorStrategy('myStrat', () => {})
 browser.sharedStore.get('foo')
 browser.sharedStore.set('foo', ['q', 1, true, null, {'w' : {}, 'e': [] }, [{}]])
 
+// test access to base client properties
+browser.sessionId
+browser.capabilities.browserName
+browser.requestedCapabilities.browserName
+browser.isMobile
+browser.isAndroid
+browser.isIOS
+
 // allure-reporter
 allure.addFeature('')
 

--- a/tests/typings/webdriverio/async.ts
+++ b/tests/typings/webdriverio/async.ts
@@ -191,6 +191,14 @@ async function bar() {
 
     // addLocatorStrategy
     browser.addLocatorStrategy('myStrat', () => {})
+
+    // test access to base client properties
+    browser.sessionId
+    browser.capabilities.browserName
+    browser.requestedCapabilities.browserName
+    browser.isMobile
+    browser.isAndroid
+    browser.isIOS
 }
 
 // allure-reporter


### PR DESCRIPTION
## Proposed changes

A lot of user have asked how to access their original capabilities from the browser object. So far we have given advise to access it via an un-documented way using: `browser.options.requestedCapabilities.w3cCaps` which we used internally to allow reloading the session with the same set of caps. This PR improves the access to this object by just calling `browser.requestedCapabilities`.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
