### PR TITLE
Update SauceLabs package and remove sauce-connect-launcher

### DIFF
--- a/packages/wdio-sauce-service/README.md
+++ b/packages/wdio-sauce-service/README.md
@@ -85,12 +85,6 @@ Default: `{ noAutodetect: true }`
 
 *(only for vm and or em/simulators)*
 
-### scRelay
-Use Sauce Connect as a Selenium Relay. See more [here](https://wiki.saucelabs.com/display/DOCS/Using+the+Selenium+Relay+with+Sauce+Connect+Proxy).
-
-Type: `Boolean`<br>
-Default: `false`
-
 ### setJobNameInBeforeSuite
 If true it updates the job name at the Sauce Labs job in the beforeSuite Hook. Attention: this comes at the cost of an additional call to Sauce Labs. The advantage of using this flag is the direct visibility of the job name in sauce labs also during the run time. This is especially useful for long running tests.
 

--- a/packages/wdio-sauce-service/package.json
+++ b/packages/wdio-sauce-service/package.json
@@ -32,8 +32,7 @@
   },
   "dependencies": {
     "@wdio/logger": "6.0.16",
-    "sauce-connect-launcher-update": "^1.3.2",
-    "saucelabs": "^4.0.0"
+    "saucelabs": "^4.2.0"
   },
   "peerDependencies": {
     "@wdio/cli": "^6.0.1"

--- a/packages/wdio-sauce-service/tests/__mocks__/sauce-connect-launcher-update.js
+++ b/packages/wdio-sauce-service/tests/__mocks__/sauce-connect-launcher-update.js
@@ -1,5 +1,0 @@
-export default jest.fn().mockImplementation((opts, cb) => {
-    cb(null, {
-        close: jest.fn()
-    })
-})


### PR DESCRIPTION
## Proposed changes

With https://github.com/saucelabs/node-saucelabs/releases/tag/v4.1.0 we have embedded Sauce Connect support into the node saucelabs package. With that we can remove `sauce-connect-launcher` as dependency.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

I removed the `scRealy` option as it will be deprecated with the next Sauce Connect Proxy release.

### Reviewers: @webdriverio/project-committers
