### PR TITLE
Improve Mocha timeout message

### DIFF
--- a/packages/wdio-jasmine-framework/src/index.js
+++ b/packages/wdio-jasmine-framework/src/index.js
@@ -214,7 +214,7 @@ class JasmineAdapter {
     }
 
     /**
-     * Hooks which are added as true Mocha hooks need to call done() to notify async
+     * Hooks which are added as true Jasmine hooks need to call done() to notify async
      */
     wrapHook (hookName) {
         return (done) => executeHooksWithArgs(

--- a/packages/wdio-mocha-framework/src/constants.js
+++ b/packages/wdio-mocha-framework/src/constants.js
@@ -20,3 +20,8 @@ export const EVENTS = {
 }
 
 export const NOOP = /* istanbul ignore next */ function () {}
+export const MOCHA_TIMEOUT_MESSAGE = 'For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.'
+export const MOCHA_TIMEOUT_MESSAGE_REPLACEMENT = [
+    'The execution in the test "%s %s" took too long. Try to reduce the run time or',
+    'increase your timeout for test specs (https://webdriver.io/docs/timeouts.html).'
+].join(' ')

--- a/packages/wdio-mocha-framework/src/index.js
+++ b/packages/wdio-mocha-framework/src/index.js
@@ -1,11 +1,12 @@
 import path from 'path'
 import Mocha from 'mocha'
+import { format } from 'util'
 
 import logger from '@wdio/logger'
 import { runTestInFiberContext, executeHooksWithArgs } from '@wdio/utils'
 
 import { loadModule } from './utils'
-import { INTERFACES, EVENTS, NOOP } from './constants'
+import { INTERFACES, EVENTS, NOOP, MOCHA_TIMEOUT_MESSAGE, MOCHA_TIMEOUT_MESSAGE_REPLACEMENT } from './constants'
 
 const log = logger('@wdio/mocha-framework')
 
@@ -198,6 +199,15 @@ class MochaAdapter {
         }
 
         if (params.err) {
+            /**
+             * replace "Ensure the done() callback is being called in this test." with a more meaningful message
+             */
+            if (params.err && params.err.message && params.err.message.includes(MOCHA_TIMEOUT_MESSAGE)) {
+                const replacement = format(MOCHA_TIMEOUT_MESSAGE_REPLACEMENT, params.payload.parent.title, params.payload.title)
+                params.err.message = params.err.message.replace(MOCHA_TIMEOUT_MESSAGE, replacement)
+                params.err.stack = params.err.stack.replace(MOCHA_TIMEOUT_MESSAGE, replacement)
+            }
+
             message.error = {
                 message: params.err.message,
                 stack: params.err.stack,

--- a/packages/wdio-mocha-framework/tests/__snapshots__/adapter.test.js.snap
+++ b/packages/wdio-mocha-framework/tests/__snapshots__/adapter.test.js.snap
@@ -1,0 +1,67 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`formatMessage should do nothing if no error or params are given 1`] = `
+Object {
+  "type": "foobar",
+}
+`;
+
+exports[`formatMessage should format an error message 1`] = `
+Object {
+  "error": Object {
+    "actual": undefined,
+    "expected": undefined,
+    "message": "uups",
+    "stack": "Error: uups
+    at Object.<anonymous> (/Users/christianbromann/Sites/WebdriverIO/webdriverio/packages/wdio-mocha-framework/tests/adapter.test.js:167:47)
+    at Object.asyncJestTest (/Users/christianbromann/Sites/WebdriverIO/webdriverio/node_modules/jest-jasmine2/build/jasmineAsyncInstall.js:100:37)
+    at /Users/christianbromann/Sites/WebdriverIO/webdriverio/node_modules/jest-jasmine2/build/queueRunner.js:45:12
+    at new Promise (<anonymous>)
+    at mapper (/Users/christianbromann/Sites/WebdriverIO/webdriverio/node_modules/jest-jasmine2/build/queueRunner.js:28:19)
+    at /Users/christianbromann/Sites/WebdriverIO/webdriverio/node_modules/jest-jasmine2/build/queueRunner.js:75:41
+    at processTicksAndRejections (internal/process/task_queues.js:94:5)",
+    "type": "Error",
+  },
+  "type": "foobar",
+}
+`;
+
+exports[`formatMessage should format an error message with timeout error 1`] = `
+Object {
+  "duration": undefined,
+  "error": Object {
+    "actual": undefined,
+    "expected": undefined,
+    "message": "The execution in the test \\"parentfoo barfoo\\" took too long. Try to reduce the run time or increase your timeout for test specs (https://webdriver.io/docs/timeouts.html).",
+    "stack": "Error: The execution in the test \\"parentfoo barfoo\\" took too long. Try to reduce the run time or increase your timeout for test specs (https://webdriver.io/docs/timeouts.html).
+    at Object.<anonymous> (/Users/christianbromann/Sites/WebdriverIO/webdriverio/packages/wdio-mocha-framework/tests/adapter.test.js:180:18)
+    at Object.asyncJestTest (/Users/christianbromann/Sites/WebdriverIO/webdriverio/node_modules/jest-jasmine2/build/jasmineAsyncInstall.js:100:37)
+    at /Users/christianbromann/Sites/WebdriverIO/webdriverio/node_modules/jest-jasmine2/build/queueRunner.js:45:12
+    at new Promise (<anonymous>)
+    at mapper (/Users/christianbromann/Sites/WebdriverIO/webdriverio/node_modules/jest-jasmine2/build/queueRunner.js:28:19)
+    at /Users/christianbromann/Sites/WebdriverIO/webdriverio/node_modules/jest-jasmine2/build/queueRunner.js:75:41
+    at processTicksAndRejections (internal/process/task_queues.js:94:5)",
+    "type": "Error",
+  },
+  "file": undefined,
+  "fullTitle": "parentfoo barfoo",
+  "parent": "parentfoo",
+  "pending": false,
+  "title": "barfoo",
+  "type": "foobar",
+}
+`;
+
+exports[`formatMessage should format payload 1`] = `
+Object {
+  "context": "some context",
+  "currentTest": "current test",
+  "duration": undefined,
+  "file": "/foo/bar.test.js",
+  "fullTitle": "parentfoo barfoo",
+  "parent": "parentfoo",
+  "pending": false,
+  "title": "barfoo",
+  "type": "foobar",
+}
+`;

--- a/packages/wdio-mocha-framework/tests/__snapshots__/adapter.test.js.snap
+++ b/packages/wdio-mocha-framework/tests/__snapshots__/adapter.test.js.snap
@@ -12,14 +12,6 @@ Object {
     "actual": undefined,
     "expected": undefined,
     "message": "uups",
-    "stack": "Error: uups
-    at Object.<anonymous> (/Users/christianbromann/Sites/WebdriverIO/webdriverio/packages/wdio-mocha-framework/tests/adapter.test.js:167:47)
-    at Object.asyncJestTest (/Users/christianbromann/Sites/WebdriverIO/webdriverio/node_modules/jest-jasmine2/build/jasmineAsyncInstall.js:100:37)
-    at /Users/christianbromann/Sites/WebdriverIO/webdriverio/node_modules/jest-jasmine2/build/queueRunner.js:45:12
-    at new Promise (<anonymous>)
-    at mapper (/Users/christianbromann/Sites/WebdriverIO/webdriverio/node_modules/jest-jasmine2/build/queueRunner.js:28:19)
-    at /Users/christianbromann/Sites/WebdriverIO/webdriverio/node_modules/jest-jasmine2/build/queueRunner.js:75:41
-    at processTicksAndRejections (internal/process/task_queues.js:94:5)",
     "type": "Error",
   },
   "type": "foobar",
@@ -33,14 +25,6 @@ Object {
     "actual": undefined,
     "expected": undefined,
     "message": "The execution in the test \\"parentfoo barfoo\\" took too long. Try to reduce the run time or increase your timeout for test specs (https://webdriver.io/docs/timeouts.html).",
-    "stack": "Error: The execution in the test \\"parentfoo barfoo\\" took too long. Try to reduce the run time or increase your timeout for test specs (https://webdriver.io/docs/timeouts.html).
-    at Object.<anonymous> (/Users/christianbromann/Sites/WebdriverIO/webdriverio/packages/wdio-mocha-framework/tests/adapter.test.js:180:18)
-    at Object.asyncJestTest (/Users/christianbromann/Sites/WebdriverIO/webdriverio/node_modules/jest-jasmine2/build/jasmineAsyncInstall.js:100:37)
-    at /Users/christianbromann/Sites/WebdriverIO/webdriverio/node_modules/jest-jasmine2/build/queueRunner.js:45:12
-    at new Promise (<anonymous>)
-    at mapper (/Users/christianbromann/Sites/WebdriverIO/webdriverio/node_modules/jest-jasmine2/build/queueRunner.js:28:19)
-    at /Users/christianbromann/Sites/WebdriverIO/webdriverio/node_modules/jest-jasmine2/build/queueRunner.js:75:41
-    at processTicksAndRejections (internal/process/task_queues.js:94:5)",
     "type": "Error",
   },
   "file": undefined,

--- a/packages/wdio-mocha-framework/tests/adapter.test.js
+++ b/packages/wdio-mocha-framework/tests/adapter.test.js
@@ -166,6 +166,10 @@ describe('formatMessage', () => {
         const adapter = adapterFactory()
         const params = { type: 'foobar', err: new Error('uups') }
         const message = adapter.formatMessage(params)
+
+        // delete stack to avoid differences in stack paths
+        delete message.error.stack
+
         expect(message).toMatchSnapshot()
     })
 
@@ -180,6 +184,10 @@ describe('formatMessage', () => {
             err: new Error('For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.')
         }
         const message = adapter.formatMessage(params)
+
+        // delete stack to avoid differences in stack paths
+        delete message.error.stack
+
         expect(message).toMatchSnapshot()
     })
 

--- a/packages/wdio-mocha-framework/tests/adapter.test.js
+++ b/packages/wdio-mocha-framework/tests/adapter.test.js
@@ -154,56 +154,81 @@ test('prepareMessage', async () => {
     expect(result.file).toBe('/foo/bar.test.js')
 })
 
-test('formatMessage', () => {
-    const adapter = adapterFactory()
+describe('formatMessage', () => {
+    test('should do nothing if no error or params are given', () => {
+        const adapter = adapterFactory()
+        let params = { type: 'foobar' }
+        let message = adapter.formatMessage(params)
+        expect(message).toMatchSnapshot()
+    })
 
-    let params = { type: 'foobar' }
-    let message = adapter.formatMessage(params)
-    expect(message).toEqual(params)
+    test('should format an error message', () => {
+        const adapter = adapterFactory()
+        const params = { type: 'foobar', err: new Error('uups') }
+        const message = adapter.formatMessage(params)
+        expect(message).toMatchSnapshot()
+    })
 
-    params = { type: 'foobar', err: new Error('uups') }
-    message = adapter.formatMessage(params)
-    expect(message.error.message).toEqual('uups')
-    expect(message.error.type).toEqual('Error')
+    test('should format an error message with timeout error', () => {
+        const adapter = adapterFactory()
+        const params = {
+            type: 'foobar',
+            payload: {
+                title: 'barfoo',
+                parent: { title: 'parentfoo' }
+            },
+            err: new Error('For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.')
+        }
+        const message = adapter.formatMessage(params)
+        expect(message).toMatchSnapshot()
+    })
 
-    params = { type: 'foobar', payload: {
-        title: 'barfoo',
-        parent: { title: 'parentfoo' },
-        context: 'some context',
-        ctx: { currentTest: { title: 'current test' } },
-        file: '/foo/bar.test.js'
-    } }
-    message = adapter.formatMessage(params)
-    expect(message.title).toEqual('barfoo')
-    expect(message.parent).toEqual('parentfoo')
-    expect(message.currentTest).toEqual('current test')
-    expect(message.fullTitle).toBe('parentfoo barfoo')
-    expect(message.file).toBe('/foo/bar.test.js')
+    test('should format payload', () => {
+        const adapter = adapterFactory()
+        const params = { type: 'foobar', payload: {
+            title: 'barfoo',
+            parent: { title: 'parentfoo' },
+            context: 'some context',
+            ctx: { currentTest: { title: 'current test' } },
+            file: '/foo/bar.test.js'
+        } }
+        const message = adapter.formatMessage(params)
+        expect(message).toMatchSnapshot()
+    })
 
-    params = { type: 'foobar', payload: {
-        title: 'barfoo',
-        parent: { title: '', suites: [{ title: 'first suite' }] }
-    } }
-    message = adapter.formatMessage(params)
-    expect(message.parent).toEqual('')
+    test('should format parent title', () => {
+        const adapter = adapterFactory()
+        const params = { type: 'foobar', payload: {
+            title: 'barfoo',
+            parent: { title: '', suites: [{ title: 'first suite' }] }
+        } }
+        const message = adapter.formatMessage(params)
+        expect(message.parent).toEqual('')
+    })
 
-    params = { type: 'foobar', payload: {
-        title: 'barfoo',
-        parent: {},
-        fullTitle: () => 'full title'
-    } }
-    message = adapter.formatMessage(params)
-    expect(message.fullTitle).toEqual('full title')
+    test('should use fullTitle function if given', () => {
+        const adapter = adapterFactory()
+        const params = { type: 'foobar', payload: {
+            title: 'barfoo',
+            parent: {},
+            fullTitle: () => 'full title'
+        } }
+        const message = adapter.formatMessage(params)
+        expect(message.fullTitle).toEqual('full title')
+    })
 
-    params = { type: 'afterTest', payload: {
-        title: 'barfoo',
-        parent: {},
-        state: 'failed',
-        duration: 123
-    } }
-    message = adapter.formatMessage(params)
-    expect(message.passed).toBe(false)
-    expect(message.duration).toBe(123)
+    test('should format test status', () => {
+        const adapter = adapterFactory()
+        const params = { type: 'afterTest', payload: {
+            title: 'barfoo',
+            parent: {},
+            state: 'failed',
+            duration: 123
+        } }
+        const message = adapter.formatMessage(params)
+        expect(message.passed).toBe(false)
+        expect(message.duration).toBe(123)
+    })
 })
 
 test('requireExternalModules', () => {

--- a/packages/wdio-reporter/src/constants.js
+++ b/packages/wdio-reporter/src/constants.js
@@ -1,4 +1,0 @@
-export const MOCHA_TIMEOUT_MESSAGE = 'Ensure the done() callback is being called in this test.'
-export const MOCHA_TIMEOUT_MESSAGE_REPLACEMENT = `
-    The execution in the test "%s %s" took too long. Try to reduce the run time or
-    increase your timeout for test specs (https://webdriver.io/docs/timeouts.html).`

--- a/packages/wdio-reporter/src/index.js
+++ b/packages/wdio-reporter/src/index.js
@@ -1,6 +1,5 @@
 import fs from 'fs'
 import fse from 'fs-extra'
-import { format } from 'util'
 import EventEmitter from 'events'
 
 import { getErrorsFromEvent } from './utils'
@@ -10,8 +9,6 @@ import HookStats from './stats/hook'
 import TestStats from './stats/test'
 
 import RunnerStats from './stats/runner'
-
-import { MOCHA_TIMEOUT_MESSAGE, MOCHA_TIMEOUT_MESSAGE_REPLACEMENT } from './constants'
 
 export default class WDIOReporter extends EventEmitter {
     constructor (options) {
@@ -101,16 +98,6 @@ export default class WDIOReporter extends EventEmitter {
 
         this.on('test:fail',  /* istanbul ignore next */ (test) => {
             const testStat = this.tests[test.uid]
-
-            /**
-             * replace "Ensure the done() callback is being called in this test." with more meaningful
-             * message (Mocha only)
-             */
-            if (test.error && test.error.message && test.error.message.includes(MOCHA_TIMEOUT_MESSAGE)) {
-                let replacement = format(MOCHA_TIMEOUT_MESSAGE_REPLACEMENT, test.parent, test.title)
-                test.error.message = test.error.message.replace(MOCHA_TIMEOUT_MESSAGE, replacement)
-                test.error.stack = test.error.stack.replace(MOCHA_TIMEOUT_MESSAGE, replacement)
-            }
 
             testStat.fail(getErrorsFromEvent(test))
             this.counts.failures++


### PR DESCRIPTION
## Proposed changes

WebdriverIO used to modify the Mocha timeout message to give a more WebdriverIO specific error. This was broken due to a change in the error message. This patch fixes that and also moves this logic to the Mocha adapter where it is better placed.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

Before the error message looked like:

```
------------------------------------------------------------------                                                     
[chrome 83.0.4103.61 mac os x #0-0] Spec: /Users/christianbromann/Sites/WebdriverIO/webdriverio/examples/wdio/mocha/mocha.test.js
[chrome 83.0.4103.61 mac os x #0-0] Running: chrome (v83.0.4103.61) on mac os x
[chrome 83.0.4103.61 mac os x #0-0] Session ID: d423ef5f84853311b0985c6cafa88724
[chrome 83.0.4103.61 mac os x #0-0]
[chrome 83.0.4103.61 mac os x #0-0] webdriver.io page
[chrome 83.0.4103.61 mac os x #0-0]    - should be a pending test
[chrome 83.0.4103.61 mac os x #0-0]    ✖ should have the right title
[chrome 83.0.4103.61 mac os x #0-0]
[chrome 83.0.4103.61 mac os x #0-0] 1 failing (5.2s)
[chrome 83.0.4103.61 mac os x #0-0] 1 skipped
[chrome 83.0.4103.61 mac os x #0-0]
[chrome 83.0.4103.61 mac os x #0-0] 1) webdriver.io page should have the right title
[chrome 83.0.4103.61 mac os x #0-0] Timeout of 5000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/mocha.test.js)
[chrome 83.0.4103.61 mac os x #0-0] Error: Timeout of 5000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/mocha.test.js)
[chrome 83.0.4103.61 mac os x #0-0]     at Test.Runnable._timeoutError (/node_modules/mocha/lib/runnable.js:442:10)
[chrome 83.0.4103.61 mac os x #0-0]     at Timeout.<anonymous> (/node_modules/mocha/lib/runnable.js:252:24)                                                
[chrome 83.0.4103.61 mac os x #0-0]     at listOnTimeout (internal/timers.js:531:17)
[chrome 83.0.4103.61 mac os x #0-0]     at processTimers (internal/timers.js:475:7)
```

Now it is:

```
------------------------------------------------------------------
[chrome 83.0.4103.61 mac os x #0-0] Spec: /Users/christianbromann/Sites/WebdriverIO/webdriverio/examples/wdio/mocha/mocha.test.js                                                                                                             
[chrome 83.0.4103.61 mac os x #0-0] Running: chrome (v83.0.4103.61) on mac os x
[chrome 83.0.4103.61 mac os x #0-0] Session ID: 2ef21862d4a157ab44b5702f4520ea48
[chrome 83.0.4103.61 mac os x #0-0]
[chrome 83.0.4103.61 mac os x #0-0] webdriver.io page
[chrome 83.0.4103.61 mac os x #0-0]    - should be a pending test
[chrome 83.0.4103.61 mac os x #0-0]    ✖ should have the right title
[chrome 83.0.4103.61 mac os x #0-0]
[chrome 83.0.4103.61 mac os x #0-0] 1 failing (5.3s)
[chrome 83.0.4103.61 mac os x #0-0] 1 skipped
[chrome 83.0.4103.61 mac os x #0-0]
[chrome 83.0.4103.61 mac os x #0-0] 1) webdriver.io page should have the right title
[chrome 83.0.4103.61 mac os x #0-0] Timeout of 5000ms exceeded. The execution in the test "webdriver.io page should have the right title" took too long. Try to reduce the run time or increase your timeout for test specs (https://webdriver.io/docs/timeouts.html). (/mocha.test.js)
[chrome 83.0.4103.61 mac os x #0-0] Error: Timeout of 5000ms exceeded. The execution in the test "webdriver.io page should have the right title" took too long. Try to reduce the run time or increase your timeout for test specs (https://webdriver.io/docs/timeouts.html). (/mocha.test.js)
[chrome 83.0.4103.61 mac os x #0-0]     at Test.Runnable._timeoutError (/mocha/lib/runnable.js:442:10)
[chrome 83.0.4103.61 mac os x #0-0]     at Timeout.<anonymous> (/mocha/lib/runnable.js:252:24)
[chrome 83.0.4103.61 mac os x #0-0]     at listOnTimeout (internal/timers.js:531:17)
[chrome 83.0.4103.61 mac os x #0-0]     at processTimers (internal/timers.js:475:7)
```

### Reviewers: @webdriverio/project-committers
