### PR TITLE
Setup Babel and TypeScript if config files are found

### DIFF
--- a/packages/wdio-cli/src/commands/config.js
+++ b/packages/wdio-cli/src/commands/config.js
@@ -1,8 +1,9 @@
+import util from 'util'
 import inquirer from 'inquirer'
 import yarnInstall from 'yarn-install'
 
-import { CONFIG_HELPER_INTRO, QUESTIONNAIRE, CLI_EPILOGUE } from '../constants'
-import { addServiceDeps, convertPackageHashToObject, renderConfigurationFile } from '../utils'
+import { CONFIG_HELPER_INTRO, QUESTIONNAIRE, CLI_EPILOGUE, COMPILER_OPTIONS, TS_COMPILER_INSTRUCTIONS } from '../constants'
+import { addServiceDeps, convertPackageHashToObject, renderConfigurationFile, hasFile } from '../utils'
 
 export const command = 'config'
 export const desc = 'Initialize WebdriverIO and setup configuration in your current project.'
@@ -11,7 +12,7 @@ export const cmdArgs = {
     yarn: {
         type: 'boolean',
         desc: 'Install packages via yarn package manager.',
-        default: false
+        default: hasFile('yarn.lock')
     },
     yes: {
         alias: 'y',
@@ -44,13 +45,14 @@ export const runConfig = async function (useYarn, yes, exit) {
     })
 
     const packagesToInstall = [
-        answers.runner.package,
+        (answers.runner && answers.runner.package) || '@wdio/local-runner',
         answers.framework.package,
         ...answers.reporters.map(reporter => reporter.package),
         ...answers.services.map(service => service.package)
     ]
 
-    if (answers.executionMode === 'sync') {
+    const syncExection = answers.executionMode === 'sync'
+    if (syncExection) {
         packagesToInstall.push('@wdio/sync')
     }
 
@@ -69,18 +71,39 @@ export const runConfig = async function (useYarn, yes, exit) {
     console.log('\nPackages installed successfully, creating configuration file...')
     const parsedAnswers = {
         ...answers,
-        runner: answers.runner.short,
+        runner: answers.runner && answers.runner.short,
         framework: answers.framework.short,
         reporters: answers.reporters.map(({ short }) => short),
         services: answers.services.map(({ short }) => short),
         packagesToInstall,
+        isUsingTypeScript: answers.isUsingCompiler === COMPILER_OPTIONS.ts,
+        isUsingBabel: answers.isUsingCompiler === COMPILER_OPTIONS.babel
     }
 
     try {
         await renderConfigurationFile(parsedAnswers)
     } catch (e) {
-        console.error(`Couldn't write config file: ${e.message}`)
+        console.error(`Couldn't write config file: ${e.stack}`)
         return !process.env.JEST_WORKER_ID && process.exit(1)
+    }
+
+    /**
+     * print TypeScript configuration message
+     */
+    if (answers.isUsingCompiler === COMPILER_OPTIONS.ts) {
+        const wdioTypes = syncExection ? '@wdio/sync' : 'webdriverio'
+        const tsPkgs = `"${[
+            wdioTypes,
+            answers.framework.package,
+            ...answers.services
+                .map(service => service.package)
+                /**
+                 * given that we know that all "offical" services have
+                 * typescript support we only include them
+                 */
+                .filter(service => service.startsWith('@wdio'))
+        ].join('", "')}"`
+        console.log(util.format(TS_COMPILER_INSTRUCTIONS, tsPkgs))
     }
 
     /**

--- a/packages/wdio-cli/src/constants.js
+++ b/packages/wdio-cli/src/constants.js
@@ -1,5 +1,5 @@
 import { version } from '../package.json'
-import { validateServiceAnswers } from './utils'
+import { validateServiceAnswers, hasFile } from './utils'
 
 export const CLI_EPILOGUE = `Documentation: https://webdriver.io\n@wdio/cli (v${version})`
 
@@ -33,6 +33,21 @@ export const IOS_CONFIG = {
     automationName: 'XCUITest',
     deviceName: 'iPhone Simulator'
 }
+
+export const COMPILER_OPTIONS = {
+    babel: 'Babel (https://babeljs.io/)',
+    ts: 'TypeScript (https://www.typescriptlang.org/)',
+    nil: 'No!'
+}
+export const TS_COMPILER_INSTRUCTIONS = `To have TypeScript support please add the following packages to your "types" list:
+{
+  "compilerOptions": {
+    "types": ["node", %s]
+  }
+}
+
+For for information on TypeScript integration check out: https://webdriver.io/docs/typescript.html
+`
 
 /**
  * We have to use a string hash for value because InquirerJS default values do not work if we have
@@ -96,6 +111,8 @@ export const QUESTIONNAIRE = [{
     name: 'runner',
     message: 'Where should your tests be launched?',
     choices: SUPPORTED_PACKAGES.runner,
+    // only ask if there are more than 1 runner to pick from
+    when: /* istanbul ignore next */ () => SUPPORTED_PACKAGES.runner.length > 1
 }, {
     type: 'list',
     name: 'backend',
@@ -236,6 +253,16 @@ export const QUESTIONNAIRE = [{
     message: 'Where are your step definitions located?',
     default: './features/step-definitions',
     when: /* istanbul ignore next */ (answers) => answers.framework.includes('cucumber')
+}, {
+    type: 'list',
+    name: 'isUsingCompiler',
+    message: 'Are you using a compiler?',
+    choices: Object.values(COMPILER_OPTIONS),
+    default: /* istanbul ignore next */ () => hasFile('babel.config.js')
+        ? COMPILER_OPTIONS.babel // default to Babel
+        : hasFile('tsconfig.json')
+            ? COMPILER_OPTIONS.ts // default to TypeScript
+            : COMPILER_OPTIONS.nil // default to no compiler
 }, {
     type: 'checkbox',
     name: 'reporters',

--- a/packages/wdio-cli/src/templates/reporters.ejs
+++ b/packages/wdio-cli/src/templates/reporters.ejs
@@ -8,7 +8,7 @@ if (reporters.length) { %>
     } else {
         return `'${reporter}'`
     }
-  })%>],
+})%>],
 <%} else { %>
     // reporters: ['dot'],
 <%}%>

--- a/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
+++ b/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
@@ -170,16 +170,15 @@ exports.config = {
     // Whether or not retried specfiles should be retried immediately or deferred to the end of the queue
     // specFileRetriesDeferred: false,
     //
-    <%- include('reporters', { reporters: answers.reporters }) %> <%
-    if(answers.framework === 'mocha') { %>
+    <%- include('reporters', { reporters: answers.reporters }) %>
+    <% if(answers.framework === 'mocha') { %>
     //
     // Options to be passed to Mocha.
     // See the full list at http://mochajs.org/
     mochaOpts: {
         <% if(answers.isUsingTypeScript) {
         %>// TypeScript setup
-        require: 'ts-node/register',
-        compilers: ['tsconfig-paths/register'],
+        require: ['ts-node/register'],
         <% } else if(answers.isUsingBabel) {
         %>// Babel setup
         require: ['@babel/register'],
@@ -194,7 +193,7 @@ exports.config = {
     jasmineNodeOpts: {
         <% if(answers.isUsingTypeScript) {
         %>// TypeScript setup
-        requires: ['ts-node/register', 'tsconfig-paths/register'],
+        requires: ['ts-node/register'],
         <% } else if(answers.isUsingBabel) {
         %>// Babel setup
         helpers: [require.resolve('@babel/register')],
@@ -220,7 +219,6 @@ exports.config = {
         // <string[]> ("extension:module") require files with the given EXTENSION after requiring MODULE (repeatable)
         <% if(answers.isUsingTypeScript) {
         %>requireModule: [
-            'tsconfig-paths/register',
             () => { require('ts-node').register({ files: true }) },
         ],
         <% } else if(answers.isUsingBabel) {

--- a/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
+++ b/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
@@ -155,14 +155,6 @@ exports.config = {
     %>services: [<%- answers.services.map(service => `'${service}'`) %>],
     <% } else {
     %>// services: [],
-    //<% }
-
-    if (answers.services.includes('appium')) {%>
-    // Appium Service config
-    // see details: https://webdriver.io/docs/appium-service.html
-    appium: {
-        <%- answers.packagesToInstall.includes('appium') ? '// ' : '' %>command: 'appium',
-    },
     //<% } %>
     // Framework you want to run your specs with.
     // The following are supported: Mocha, Jasmine, and Cucumber
@@ -184,15 +176,30 @@ exports.config = {
     // Options to be passed to Mocha.
     // See the full list at http://mochajs.org/
     mochaOpts: {
-        ui: 'bdd',
+        <% if(answers.isUsingTypeScript) {
+        %>// TypeScript setup
+        require: 'ts-node/register',
+        compilers: ['tsconfig-paths/register'],
+        <% } else if(answers.isUsingBabel) {
+        %>// Babel setup
+        require: ['@babel/register'],
+        <% }
+        %>ui: 'bdd',
         timeout: 60000
-    },<% }
+    },<%
+    }
     if(answers.framework === 'jasmine') { %>
     //
     // Options to be passed to Jasmine.
     jasmineNodeOpts: {
-        //
-        // Jasmine default timeout
+        <% if(answers.isUsingTypeScript) {
+        %>// TypeScript setup
+        requires: ['ts-node/register', 'tsconfig-paths/register'],
+        <% } else if(answers.isUsingBabel) {
+        %>// Babel setup
+        helpers: [require.resolve('@babel/register')],
+        <% }
+        %>// Jasmine default timeout
         defaultTimeoutInterval: 60000,
         //
         // The Jasmine framework allows interception of each assertion in order to log the state of the application
@@ -206,19 +213,40 @@ exports.config = {
     if(answers.framework === 'cucumber') { %>//
     // If you are using Cucumber you need to specify the location of your step definitions.
     cucumberOpts: {
-        require: ['<%= answers.stepDefinitions %>'],        // <string[]> (file/dir) require files before executing features
-        backtrace: false,   // <boolean> show full backtrace for errors
-        requireModule: [],  // <string[]> ("extension:module") require files with the given EXTENSION after requiring MODULE (repeatable)
-        dryRun: false,      // <boolean> invoke formatters without executing steps
-        failFast: false,    // <boolean> abort the run on first failure
-        format: ['pretty'], // <string[]> (type[:path]) specify the output format, optionally supply PATH to redirect formatter output (repeatable)
-        snippets: true,     // <boolean> hide step definition snippets for pending steps
-        source: true,       // <boolean> hide source uris
-        profile: [],        // <string[]> (name) specify the profile to use
-        strict: false,      // <boolean> fail if there are any undefined or pending steps
-        tagExpression: '',  // <string> (expression) only execute the features or scenarios with tags matching the expression
-        timeout: 60000,     // <number> timeout for step definitions
-        ignoreUndefinedDefinitions: false, // <boolean> Enable this config to treat undefined definitions as warnings.
+        // <string[]> (file/dir) require files before executing features
+        require: ['<%= answers.stepDefinitions %>'],
+        // <boolean> show full backtrace for errors
+        backtrace: false,
+        // <string[]> ("extension:module") require files with the given EXTENSION after requiring MODULE (repeatable)
+        <% if(answers.isUsingTypeScript) {
+        %>requireModule: [
+            'tsconfig-paths/register',
+            () => { require('ts-node').register({ files: true }) },
+        ],
+        <% } else if(answers.isUsingBabel) {
+        %>requireModule: ['@babel/register'],
+        <% } else {
+        %>requireModule: [],
+        <% } %>// <boolean> invoke formatters without executing steps
+        dryRun: false,
+        // <boolean> abort the run on first failure
+        failFast: false,
+        // <string[]> (type[:path]) specify the output format, optionally supply PATH to redirect formatter output (repeatable)
+        format: ['pretty'],
+        // <boolean> hide step definition snippets for pending steps
+        snippets: true,
+        // <boolean> hide source uris
+        source: true,
+        // <string[]> (name) specify the profile to use
+        profile: [],
+        // <boolean> fail if there are any undefined or pending steps
+        strict: false,
+        // <string> (expression) only execute the features or scenarios with tags matching the expression
+        tagExpression: '',
+        // <number> timeout for step definitions
+        timeout: 60000,
+        // <boolean> Enable this config to treat undefined definitions as warnings.
+        ignoreUndefinedDefinitions: false
     },
     <% } %>
     //

--- a/packages/wdio-cli/src/utils.js
+++ b/packages/wdio-cli/src/utils.js
@@ -257,3 +257,11 @@ export function getCapabilities(arg) {
     }
     return { capabilities: { browserName: arg.option } }
 }
+
+/**
+ * Check if file exists in current work directory
+ * @param {string} filename to check existance for
+ */
+export function hasFile (filename) {
+    return fs.existsSync(path.join(process.cwd(), filename))
+}

--- a/packages/wdio-cli/tests/commands/__snapshots__/config.test.js.snap
+++ b/packages/wdio-cli/tests/commands/__snapshots__/config.test.js.snap
@@ -1,0 +1,38 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`prints TypeScript setup message 1`] = `
+Array [
+  Array [
+    "
+=========================
+WDIO Configuration Helper
+=========================
+",
+  ],
+  Array [
+    "
+Installing wdio packages:
+-",
+    "@wdio/local-runner
+- @wdio/mocha-framework
+- @wdio/crossbrowsertesting-service
+- wdio-lambdatest-service
+- @wdio/sync",
+  ],
+  Array [
+    "
+Packages installed successfully, creating configuration file...",
+  ],
+  Array [
+    "To have TypeScript support please add the following packages to your \\"types\\" list:
+{
+  \\"compilerOptions\\": {
+    \\"types\\": [\\"node\\", \\"@wdio/sync\\", \\"@wdio/mocha-framework\\", \\"@wdio/crossbrowsertesting-service\\"]
+  }
+}
+
+For for information on TypeScript integration check out: https://webdriver.io/docs/typescript.html
+",
+  ],
+]
+`;

--- a/packages/wdio-cli/tests/commands/config.test.js
+++ b/packages/wdio-cli/tests/commands/config.test.js
@@ -8,14 +8,16 @@ import { addServiceDeps, convertPackageHashToObject, renderConfigurationFile } f
 jest.mock('../../src/utils', () => ({
     addServiceDeps: jest.fn(),
     convertPackageHashToObject: jest.fn().mockReturnValue('foobar'),
-    renderConfigurationFile: jest.fn()
+    renderConfigurationFile: jest.fn(),
+    hasFile: jest.fn().mockReturnValue(false)
 }))
 
-let errorLogSpy
+let errorLogSpy, consoleLogSpy
 
 beforeEach(() => {
     yarnInstall.mockClear()
     errorLogSpy = jest.spyOn(console, 'error')
+    consoleLogSpy = jest.spyOn(console, 'log')
 })
 
 afterEach(() => {
@@ -85,4 +87,21 @@ test('should throw an error if something goes wrong', async () => {
             err.message.startsWith('something went wrong during setup: uups')
         ).toBe(true)
     }
+})
+
+test.only('prints TypeScript setup message', async () => {
+    convertPackageHashToObject.mockImplementation((input) => input)
+    inquirer.prompt.mockReturnValue(Promise.resolve({
+        executionMode: 'sync',
+        runner: '@wdio/local-runner--$local',
+        framework: { package: '@wdio/mocha-framework', short: 'mocha' },
+        reporters: [],
+        services: [
+            { package: '@wdio/crossbrowsertesting-service', short: 'crossbrowsertesting' },
+            { package: 'wdio-lambdatest-service', short: 'lambdatest' }
+        ],
+        isUsingCompiler: 'TypeScript (https://www.typescriptlang.org/)'
+    }))
+    await handler({})
+    expect(consoleLogSpy.mock.calls).toMatchSnapshot()
 })

--- a/packages/wdio-cli/tests/utils.test.js
+++ b/packages/wdio-cli/tests/utils.test.js
@@ -14,7 +14,8 @@ import {
     missingConfigurationPrompt,
     renderConfigurationFile,
     validateServiceAnswers,
-    getCapabilities
+    getCapabilities,
+    hasFile
 } from '../src/utils'
 
 import inquirer from 'inquirer'
@@ -333,6 +334,13 @@ describe('getCapabilities', () => {
     it('should return driver with capabilities for desktop', () => {
         expect(getCapabilities({ option: 'chrome' })).toMatchSnapshot()
     })
+})
+
+test('hasFile', () => {
+    fs.existsSync.mockReturnValue(true)
+    expect(hasFile('package.json')).toBe(true)
+    fs.existsSync.mockReturnValue(false)
+    expect(hasFile('xyz')).toBe(false)
 })
 
 afterEach(() => {


### PR DESCRIPTION
## Proposed changes

With this patch the CLI config wizard detects if TypeScript or Babel is setup in the project (by checking existence of `babel.config.js` or `tsconfig.json` in the working dir) and adds a question if these compilers should be integrated into the config file.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
