### PR TITLE
Multiple Multiremote sessions in parallel

### DIFF
--- a/packages/wdio-cli/src/launcher.js
+++ b/packages/wdio-cli/src/launcher.js
@@ -44,7 +44,7 @@ class Launcher {
         this.interface = new CLInterface(config, totalWorkerCnt, this.isWatchMode)
         config.runnerEnv.FORCE_COLOR = Number(this.interface.hasAnsiSupport)
 
-        this.isMultiremote = !Array.isArray(capabilities)
+        this.isMultiremote = config.parallelMultiremote ? true : !Array.isArray(capabilities)
         this.exitCode = 0
         this.hasTriggeredExitRoutine = false
         this.hasStartedAnyProcess = false
@@ -140,9 +140,9 @@ class Launcher {
          * schedule test runs
          */
         let cid = 0
-        if (this.isMultiremote) {
+        if (this.isMultiremote && !config.parallelMultiremote) {
             /**
-             * Multiremote mode
+             * Single Multiremote mode (compatibility with previous multiremote logic)
              */
             this.schedule.push({
                 cid: cid++,
@@ -153,7 +153,7 @@ class Launcher {
             })
         } else {
             /**
-             * Regular mode
+             * Single or Multi remote in parallel
              */
             for (let capabilities of caps) {
                 this.schedule.push({

--- a/packages/wdio-runner/src/index.js
+++ b/packages/wdio-runner/src/index.js
@@ -51,7 +51,9 @@ export default class Runner extends EventEmitter {
         this.config = this.configParser.getConfig()
         this.config.specFileRetryAttempts = (this.config.specFileRetries || 0) - (retries || 0)
         logger.setLogLevelsConfig(this.config.logLevels, this.config.logLevel)
-        const isMultiremote = this.isMultiremote = !Array.isArray(this.configParser.getCapabilities())
+        const isMultiremote = this.isMultiremote = this.config.parallelMultiremote
+            ?  true
+            : !Array.isArray(this.configParser.getCapabilities())
 
         /**
          * create `browser` stub only if `specFiltering` feature is enabled

--- a/packages/wdio-selenium-standalone-service/src/launcher.js
+++ b/packages/wdio-selenium-standalone-service/src/launcher.js
@@ -36,11 +36,17 @@ export default class SeleniumStandaloneLauncher {
          * update capability connection options to connect
          * to standalone server
          */
-        (
-            Array.isArray(this.capabilities)
-                ? this.capabilities
-                : Object.values(this.capabilities)
-        ).forEach((cap) => Object.assign(cap, DEFAULT_CONNECTION, { ...cap }))
+        if (config.parallelMultiremote) {
+            this.capabilities.forEach(caps => {
+                Object.values(caps).forEach(cap => Object.assign(cap, DEFAULT_CONNECTION, { ...cap }))
+            })
+        } else {
+            (
+                Array.isArray(this.capabilities)
+                    ? this.capabilities
+                    : Object.values(this.capabilities)
+            ).forEach((cap) => Object.assign(cap, DEFAULT_CONNECTION, { ...cap }))
+        }
 
         /**
          * start Selenium Standalone server


### PR DESCRIPTION
## Proposed changes

Allow running Multiremote in parallel by passing an array of multiremote capabilities - https://github.com/webdriverio/webdriverio/issues/5445
So that something like this is possible:
```
capabilities: [
        {
            browser1: { capabilities: { browserName: 'chrome' } },
            browser2: { capabilities: { browserName: 'chrome' } }
        },
        {
            browser1: { capabilities: { browserName: 'firefox' } },
            browser2: { capabilities: { browserName: 'firefox' } }
        },
        {
            browser1: { capabilities: { browserName: 'chrome' } },
            browser2: { capabilities: { browserName: 'firefox' } }
        }
    ],
```

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)
As I see it, there is no problem for runner to execute multiple Multiremote sessions in parallel. It can be accomplished by simply pushing multiple tests into @wdio/cli/launcher.js's schedule array. The main problem is getting capabilities there in correct format, which is a little problematic because all of services are made to only support array as singleremote and object as multiremote. 

Here in these changes I have modified @wdio/selenium-standalone-service to also handle multiremote array, which has to be done everywhere if this change makes sense.

To use parallel multiremote, capabilities can be passed like this:
```
parallelMultiremote: true,
capabilities: [
    {
        browser1: { capabilities: { browserName: 'chrome' } },
        browser2: { capabilities: { browserName: 'chrome' } }
    },
    {
        browser1: { capabilities: { browserName: 'firefox' } },
        browser2: { capabilities: { browserName: 'firefox' } }
    }
],
```
Here you can see a new test runner option `parallelMultiremote`. When it's absent/false, capabilities will be treated just like before but when it's true, it will use new logic. This is the way which resulted in least changes needed for it to work.

I have only tested in one simple case and it worked very well, but there is something probably broken by this.

### Reviewers: @webdriverio/project-committers
