### PR TITLE
Fix depcrecated usage of rejectUnauthorized

### DIFF
--- a/packages/webdriver/src/request.js
+++ b/packages/webdriver/src/request.js
@@ -51,6 +51,7 @@ export default class WebDriverRequest extends EventEmitter {
 
     _createOptions (options, sessionId) {
         const requestOptions = {
+            https: {},
             agent: options.agent || agents,
             headers: {
                 ...DEFAULT_HEADERS,
@@ -97,7 +98,10 @@ export default class WebDriverRequest extends EventEmitter {
         /**
          * if the environment variable "STRICT_SSL" is defined as "false", it doesn't require SSL certificates to be valid.
          */
-        requestOptions.rejectUnauthorized = !(process.env.STRICT_SSL === 'false' || process.env.strict_ssl === 'false')
+        requestOptions.https.rejectUnauthorized = !(
+            process.env.STRICT_SSL === 'false' ||
+            process.env.strict_ssl === 'false'
+        )
 
         return requestOptions
     }

--- a/packages/webdriver/tests/request.test.js
+++ b/packages/webdriver/tests/request.test.js
@@ -199,48 +199,48 @@ describe('webdriver request', () => {
                 process.env['STRICT_SSL'] = 'false'
                 const req = new WebDriverRequest('POST', path)
                 const options = req._createOptions(defaults)
-                expect(options.rejectUnauthorized).toEqual(false)
+                expect(options.https.rejectUnauthorized).toEqual(false)
             })
 
             it('should contain key "rejectUnauthorized" with value "false" when environment variable "strict_ssl" is defined with value "false"', () => {
                 process.env['strict_ssl'] = 'false'
                 const req = new WebDriverRequest('POST', path)
                 const options = req._createOptions(defaults)
-                expect(options.rejectUnauthorized).toEqual(false)
+                expect(options.https.rejectUnauthorized).toEqual(false)
             })
 
             it('should contain key "rejectUnauthorized" with value "true" when environment variable "STRICT_SSL" is defined with value "true"', () => {
                 process.env['STRICT_SSL'] = 'true'
                 const req = new WebDriverRequest('POST', path)
                 const options = req._createOptions(defaults)
-                expect(options.rejectUnauthorized).toEqual(true)
+                expect(options.https.rejectUnauthorized).toEqual(true)
             })
 
             it('should contain key "rejectUnauthorized" with value "true" when environment variable "strict_ssl" is defined with value "true"', () => {
                 process.env['strict_ssl'] = 'true'
                 const req = new WebDriverRequest('POST', path)
                 const options = req._createOptions(defaults)
-                expect(options.rejectUnauthorized).toEqual(true)
+                expect(options.https.rejectUnauthorized).toEqual(true)
             })
 
             it('should contain key "rejectUnauthorized" with value "true" when environment variable "STRICT_SSL" / "strict_ssl" is not defined', () => {
                 const req = new WebDriverRequest('POST', path)
                 const options = req._createOptions(defaults)
-                expect(options.rejectUnauthorized).toEqual(true)
+                expect(options.https.rejectUnauthorized).toEqual(true)
             })
 
             it('should contain key "rejectUnauthorized" with value "true" when environment variable "STRICT_SSL" is defined with any other value than "false"', () => {
                 process.env['STRICT_SSL'] = 'foo'
                 const req = new WebDriverRequest('POST', path)
                 const options = req._createOptions(defaults)
-                expect(options.rejectUnauthorized).toEqual(true)
+                expect(options.https.rejectUnauthorized).toEqual(true)
             })
 
             it('should contain key "rejectUnauthorized" with value "true" when environment variable "strict_ssl" is defined with any other value than "false"', () => {
                 process.env['strict_ssl'] = 'foo'
                 const req = new WebDriverRequest('POST', path)
                 const options = req._createOptions(defaults)
-                expect(options.rejectUnauthorized).toEqual(true)
+                expect(options.https.rejectUnauthorized).toEqual(true)
             })
         })
     })


### PR DESCRIPTION
## Proposed changes

Currently WebDriver logs warnings like this:

> (node:33087) DeprecationWarning: Got: "options.rejectUnauthorized" is now deprecated, please use "options.https.rejectUnauthorized"

This patch fixes this deprecation warning.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
