### PR TITLE
Don't think XPath selector is a base64 screenshot

### DIFF
--- a/packages/wdio-utils/src/utils.js
+++ b/packages/wdio-utils/src/utils.js
@@ -52,7 +52,16 @@ export function commandCallStructure (commandName, args) {
     const callArgs = args.map((arg) => {
         if (typeof arg === 'string' && (arg.startsWith('!function(') || arg.startsWith('return (function'))) {
             arg = '<fn>'
-        } else if (typeof arg === 'string' && !commandName.startsWith('findElement') && isBase64(arg)) {
+        } else if (
+            typeof arg === 'string' &&
+            /**
+             * the isBase64 method returns for xPath values like
+             * "/html/body/a" a true value which is why we should
+             * include a command check in here.
+             */
+            !commandName.startsWith('findElement') &&
+            isBase64(arg)
+        ) {
             arg = SCREENSHOT_REPLACEMENT
         } else if (typeof arg === 'string') {
             arg = `"${arg}"`

--- a/packages/wdio-utils/src/utils.js
+++ b/packages/wdio-utils/src/utils.js
@@ -52,7 +52,7 @@ export function commandCallStructure (commandName, args) {
     const callArgs = args.map((arg) => {
         if (typeof arg === 'string' && (arg.startsWith('!function(') || arg.startsWith('return (function'))) {
             arg = '<fn>'
-        } else if (typeof arg === 'string' && isBase64(arg)) {
+        } else if (typeof arg === 'string' && !commandName.startsWith('findElement') && isBase64(arg)) {
             arg = SCREENSHOT_REPLACEMENT
         } else if (typeof arg === 'string') {
             arg = `"${arg}"`

--- a/packages/wdio-utils/tests/utils.test.js
+++ b/packages/wdio-utils/tests/utils.test.js
@@ -22,6 +22,16 @@ describe('utils', () => {
                 (Buffer.from('some screenshot')).toString('base64')
             ]
         )).toBe('foobar("param", 1, true, <object>, <fn>, <fn>, <fn>, null, undefined, "<Screenshot[base64]>")')
+        expect(commandCallStructure('foobar', ['/html/body/a']))
+            .toBe('foobar("<Screenshot[base64]>")')
+        expect(commandCallStructure('findElement', ['/html/body/a']))
+            .toBe('findElement("/html/body/a")')
+        expect(commandCallStructure('findElements', ['/html/body/a']))
+            .toBe('findElements("/html/body/a")')
+        expect(commandCallStructure('findElementFromElement', ['/html/body/a']))
+            .toBe('findElementFromElement("/html/body/a")')
+        expect(commandCallStructure('findElementsFromElement', ['/html/body/a']))
+            .toBe('findElementsFromElement("/html/body/a")')
     })
 
     it('transformCommandLogResult', () => {


### PR DESCRIPTION
## Proposed changes

When calling a command like:

```js
$('/html/body/a').click();
```

You will see in the logs the following:

```log
2020-06-02T18:30:43.050Z INFO webdriver: COMMAND findElement("xpath", "<Screenshot[base64]>")
2020-06-02T18:30:43.050Z INFO webdriver: [POST] http://localhost:9515/session/ba80a2c9d202c2b8b7637a5b3e4c357e/element
2020-06-02T18:30:43.050Z INFO webdriver: DATA { using: 'xpath', value: '/html/body/a' }
```

The logs say that the findElement parameter is a base64 screenshot. Apparently this is what our `isBase64` helper things. While it would be better to fix the `isBase64` helper we unfortunately don't have an extensive test suite for it which makes this change much more convenient.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
