### PR TITLE
Print cid in logger and not in the stream transform.

### DIFF
--- a/packages/wdio-local-runner/src/transformStream.js
+++ b/packages/wdio-local-runner/src/transformStream.js
@@ -15,7 +15,7 @@ export default class RunnerTransformStream extends Transform {
             return callback()
         }
 
-        this.push(`[${this.cid}] ${logMsg}`)
+        this.push(logMsg)
         callback()
     }
 

--- a/packages/wdio-local-runner/src/worker.js
+++ b/packages/wdio-local-runner/src/worker.js
@@ -61,6 +61,8 @@ export default class WorkerInstance extends EventEmitter {
             runnerEnv.WDIO_LOG_PATH = path.join(this.config.outputDir, `wdio-${cid}.log`)
         }
 
+        runnerEnv.cid = cid
+
         log.info(`Start worker ${cid} with arg: ${argv}`)
         const childProcess = this.childProcess = child.fork(path.join(__dirname, 'run.js'), argv, {
             cwd: process.cwd(),

--- a/packages/wdio-local-runner/tests/transformStream.test.js
+++ b/packages/wdio-local-runner/tests/transformStream.test.js
@@ -1,13 +1,13 @@
 import RunnerTransformStream from '../src/transformStream'
 import { DEBUGGER_MESSAGES } from '../src/constants'
 
-test('should add cid to message', () => {
+test('should pass regular message', () => {
     const stream = new RunnerTransformStream('0-5')
     const cb = jest.fn()
     const pushSpy = jest.spyOn(stream, 'push')
 
     stream._transform('foobar', null, cb)
-    expect(pushSpy).toBeCalledWith('[0-5] foobar')
+    expect(pushSpy).toBeCalledWith('foobar')
     expect(cb).toBeCalled()
 })
 

--- a/packages/wdio-logger/src/node.js
+++ b/packages/wdio-logger/src/node.js
@@ -119,7 +119,7 @@ export default function getLogger (name) {
     loggers[name].setLevel(logLevel)
     loggers[name].methodFactory = wdioLoggerMethodFactory
     prefix.apply(loggers[name], {
-        template: `[${process.env.cid}] %t %l %n:`,
+        template: `${process.env.cid ? '[' + process.env.cid + '] ' : ''}%t %l %n:`,
         timestampFormatter: (date) => chalk.gray(date.toISOString()),
         levelFormatter: (level) => chalk[COLORS[level]](level.toUpperCase()),
         nameFormatter: (name) => chalk.whiteBright(name)

--- a/packages/wdio-logger/src/node.js
+++ b/packages/wdio-logger/src/node.js
@@ -119,7 +119,7 @@ export default function getLogger (name) {
     loggers[name].setLevel(logLevel)
     loggers[name].methodFactory = wdioLoggerMethodFactory
     prefix.apply(loggers[name], {
-        template: '%t %l %n:',
+        template: `[${process.env.cid}] %t %l %n:`,
         timestampFormatter: (date) => chalk.gray(date.toISOString()),
         levelFormatter: (level) => chalk[COLORS[level]](level.toUpperCase()),
         nameFormatter: (name) => chalk.whiteBright(name)


### PR DESCRIPTION
## Proposed changes

[//]: # This change will print the worker cid in the logger and will not use the transform stream for that.
This should resolve #5479 
## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
