### PR TITLE
Implement Network Wait Commands

### DIFF
--- a/docs/MocksAndSpies.md
+++ b/docs/MocksAndSpies.md
@@ -1,0 +1,276 @@
+---
+id: mocksandspies
+title: Mocks and Spies (Beta)
+---
+
+> This feature was introduced with WebdriverIO v6.2 as a __beta__ and is only supported running tests locally on __Chrome__, __Firefox Nightly__ or __Edge (Chromium)__ as well as on [Sauce Labs](https://saucelabs.com/). If you encounter problems using it please file [an issue](https://github.com/webdriverio/webdriverio/issues/new/choose) and let us know!
+
+WebdriverIO comes with built in support for modifying network responses that allows you to focus testing your frontend application without having to setup your backend or a mock server. You can define custom responses for web resources like REST API requests in your test and modify them dynamically.
+
+## Creating a mock
+
+Before you can modify any responses you have define a mock first. This mock is described by the resource url and can be filtered by the [request method](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods) or [headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers). The resource supports glob expressions by [minimatch](https://www.npmjs.com/package/minimatch):
+
+<!--DOCUSAURUS_CODE_TABS-->
+<!--Sync-->
+```js
+// mock all resources ending with "/users/list"
+const userListMock = browser.network.mock('**/users/list')
+
+// or you can specify the mock by filtering resources by headers or
+// status code, only mock successful requests to json resources
+const strictMock = browser.network.mock('**', {
+    // mock all json responses
+    headers: { 'Content-Type': 'application/json' },
+    // that were successful
+    statusCode: 200
+})
+```
+<!--Async-->
+```js
+// mock all resources ending with "/users/list"
+const userListMock = await browser.network.mock('**/users/list')
+
+// or you can specify the mock by filtering resources by headers or
+// status code, only mock successful requests to json resources
+const strictMock = await browser.network.mock('**', {
+    // mock all json responses
+    headers: { 'Content-Type': 'application/json' },
+    // that were successful
+    statusCode: 200
+})
+```
+<!--END_DOCUSAURUS_CODE_TABS-->
+
+## Specifying custom responses
+
+Once you have defined a mock you can define custom responses for it. Those custom responses can be either an object to respond a JSON, a local file to respond with a custom fixture or a web resource to replace the response with a resource from the internet.
+
+### Mocking API Requests
+
+In order to mock API requests where you expect a JSON response all you need to do is to call `response` on the mock object with an arbitrary object you want to return, e.g.:
+
+<!--DOCUSAURUS_CODE_TABS-->
+<!--Sync-->
+```js
+const mock = browser.network.mock('https://todo-backend-express-knex.herokuapp.com/', {
+    method: 'get'
+})
+
+mock.respond([{
+    title: 'Injected (non) completed Todo',
+    order: null,
+    completed: false
+}, {
+    title: 'Injected completed Todo',
+    order: null,
+    completed: true
+}])
+
+browser.url('https://todobackend.com/client/index.html?https://todo-backend-express-knex.herokuapp.com/')
+
+$('#todo-list li').waitForExist()
+console.log($$('#todo-list li').map(el => el.getText()))
+// outputs: "[ 'Injected (non) completed Todo', 'Injected completed Todo' ]"
+```
+<!--Async-->
+```js
+const mock = await browser.network.mock('https://todo-backend-express-knex.herokuapp.com/', {
+    method: 'get'
+})
+
+await mock.respond([{
+    title: 'Injected (non) completed Todo',
+    order: null,
+    completed: false
+}, {
+    title: 'Injected completed Todo',
+    order: null,
+    completed: true
+}])
+
+await browser.url('https://todobackend.com/client/index.html?https://todo-backend-express-knex.herokuapp.com/')
+
+await (await browser.$('#todo-list li')).waitForExist()
+console.log(Promise.all((await $$('#todo-list li')).map(el => el.getText())))
+// outputs: "[ 'Injected (non) completed Todo', 'Injected completed Todo' ]"
+```
+<!--END_DOCUSAURUS_CODE_TABS-->
+
+You can also modify the response headers as well as the status code by passing in some mock response params as follows:
+
+```js
+mock.response({ ... }, {
+    // respond with status code 404
+    statusCode: 404,
+    // merge response headers with following headers
+    headers: { 'x-custom-header': 'foobar' }
+})
+```
+
+It is recommend to store custom responses in fixture files so you can just require them in your test as follows:
+
+```js
+const responseFixture = require('./__fixtures__/apiResponse.json')
+mock.response(responseFixture)
+```
+
+### Mocking text resources
+
+If you like to modify text resources like JavaScript, CSS files or other text based resources you can just pass in a file path and WebdriverIO will replaces the original resource with it, e.g.:
+
+```js
+const scriptMock = browser.network.mock('**/script.min.js')
+scriptMock.respond('./tests/fixtures/script.js')
+```
+
+### Redirect web resources
+
+You can also just replace a web resource with another web resource if your desired response is already hosted on the web. This works with individual page resources as well as with a webpage itself, e.g.:
+
+<!--DOCUSAURUS_CODE_TABS-->
+<!--Sync-->
+```js
+const pageMock = browser.network.mock('https://google.com/')
+pageMock.respond('https://webdriver.io')
+browser.url('https://google.com')
+console.log(browser.getTitle()) // returns "WebdriverIO · Next-gen browser and mobile automation test framework for Node.js"
+```
+<!--Async-->
+```js
+const pageMock = await browser.network.mock('https://google.com/')
+await pageMock.respond('https://webdriver.io')
+await browser.url('https://google.com')
+console.log(await browser.getTitle()) // returns "WebdriverIO · Next-gen browser and mobile automation test framework for Node.js"
+```
+<!--END_DOCUSAURUS_CODE_TABS-->
+
+### Dynamic responses
+
+If your mock response depends on the original resource response you can also dynamically modify the resource by passing in a function receives the original response as parameter and sets the mock based on the return value, e.g.:
+
+<!--DOCUSAURUS_CODE_TABS-->
+<!--Sync-->
+```js
+const mock = browser.network.mock('https://todo-backend-express-knex.herokuapp.com/', {
+    method: 'get'
+})
+
+mock.respond((req) => {
+    // replace todo content with their list number
+    return req.body.map((item, i) => ({ ...item, title: i }))
+})
+
+browser.url('https://todobackend.com/client/index.html?https://todo-backend-express-knex.herokuapp.com/')
+
+$('#todo-list li').waitForExist()
+console.log($$('#todo-list li label').map((el) => el.getText()))
+// returns
+// [
+//   '0',  '1',  '2',  '19', '20',
+//   '21', '3',  '4',  '5',  '6',
+//   '7',  '8',  '9',  '10', '11',
+//   '12', '13', '14', '15', '16',
+//   '17', '18', '22'
+// ]
+```
+<!--Async-->
+```js
+const mock = await browser.network.mock('https://todo-backend-express-knex.herokuapp.com/', {
+    method: 'get'
+})
+
+await mock.respond((req) => {
+    // replace todo content with their list number
+    return req.body.map((item, i) => ({ ...item, title: i }))
+})
+
+await browser.url('https://todobackend.com/client/index.html?https://todo-backend-express-knex.herokuapp.com/')
+
+await (await $('#todo-list li')).waitForExist()
+console.log(await Promise.all((await $$('#todo-list li label')).map((el) => el.getText())))
+// returns
+// [
+//   '0',  '1',  '2',  '19', '20',
+//   '21', '3',  '4',  '5',  '6',
+//   '7',  '8',  '9',  '10', '11',
+//   '12', '13', '14', '15', '16',
+//   '17', '18', '22'
+// ]
+```
+<!--END_DOCUSAURUS_CODE_TABS-->
+
+## Aborting mocks
+
+Instead of returning a custom response you can also just abort the request with one of the following HTTP errors:
+
+- Failed
+- Aborted
+- TimedOut
+- AccessDenied
+- ConnectionClosed
+- ConnectionReset
+- ConnectionRefused
+- ConnectionAborted
+- ConnectionFailed
+- NameNotResolved
+- InternetDisconnected
+- AddressUnreachable
+- BlockedByClient
+- BlockedByResponse
+
+This is very useful if you want to block 3rd party script from your page that have a negative influence on your functional test. You can abort a mock by just calling `abort` or `abortOnce`, e.g.:
+
+<!--DOCUSAURUS_CODE_TABS-->
+<!--Sync-->
+```js
+const mock = browser.network.mock('https://www.google-analytics.com/**')
+mock.abort('Failed')
+```
+<!--Async-->
+```js
+const mock = await browser.network.mock('https://www.google-analytics.com/**')
+await mock.abort('Failed')
+```
+<!--END_DOCUSAURUS_CODE_TABS-->
+
+## Spies
+
+Every mock is automatically a spy that counts the amount of requests the browser made to that resource. If you don't apply a custom response or abort reason to the mock it continues with the default response you would normally receive. This allows you to check how many times the browser made the request, e.g. to a certain API endpoint.
+
+<!--DOCUSAURUS_CODE_TABS-->
+<!--Sync-->
+```js
+const mock = browser.network.mock('**/user', { method: 'post' })
+console.log(mock.calls.length) // returns 0
+
+// register user
+$('#username').setValue('randomUser')
+$('password').setValue('password123')
+$('password_repeat').setValue('password123')
+$('button[type="submit"]').click()
+
+// check if API request was made
+expect(mock.calls.length).toBe(1)
+
+// assert response
+expect(mock.calls[0].body).toEqual({ success: true })
+```
+<!--Async-->
+```js
+const mock = await browser.network.mock('**/user', { method: 'post' })
+console.log(mock.calls.length) // returns 0
+
+// register user
+await (await $('#username')).setValue('randomUser')
+await (await $('password')).setValue('password123')
+await (await $('password_repeat')).setValue('password123')
+await (await $('button[type="submit"]')).click()
+
+// check if API request was made
+expect(mock.calls.length).toBe(1)
+
+// assert response
+expect(mock.calls[0].body).toEqual({ success: true })
+```
+<!--END_DOCUSAURUS_CODE_TABS-->

--- a/packages/devtools/src/launcher.js
+++ b/packages/devtools/src/launcher.js
@@ -30,7 +30,11 @@ const DEVICE_NAMES = Object.values(devicesMap).map((device) => device.name)
  * @return {object}               puppeteer browser instance
  */
 async function launchChrome (capabilities) {
-    const chromeOptions = capabilities[VENDOR_PREFIX.chrome] || {}
+    if (!capabilities[VENDOR_PREFIX.chrome]) {
+        capabilities[VENDOR_PREFIX.chrome] = {}
+    }
+
+    const chromeOptions = capabilities[VENDOR_PREFIX.chrome]
     const mobileEmulation = chromeOptions.mobileEmulation || {}
     const ignoreDefaultArgs = capabilities.ignoreDefaultArgs
 

--- a/packages/wdio-sync/package.json
+++ b/packages/wdio-sync/package.json
@@ -34,6 +34,7 @@
     "url": "https://github.com/webdriverio/webdriverio/issues"
   },
   "dependencies": {
+    "@types/puppeteer": "^3.0.1",
     "@wdio/logger": "6.0.16",
     "fibers": "^4.0.1"
   },

--- a/packages/wdio-sync/webdriverio-core.d.ts
+++ b/packages/wdio-sync/webdriverio-core.d.ts
@@ -7,6 +7,11 @@
 /// <reference types="node"/>
 /// <reference types="webdriver"/>
 
+// See https://github.com/DefinitelyTyped/DefinitelyTyped/issues/24419
+interface Element { }
+interface Node { }
+interface NodeListOf<TNode = Node> { }
+
 declare namespace WebdriverIO {
     type LocationParam = 'x' | 'y';
 
@@ -435,6 +440,72 @@ declare namespace WebdriverIO {
         y: number
     }
 
+    /**
+     * HTTP request data. (copied from the puppeteer-core package as there is currently
+     * no way to access these types otherwise)
+     */
+    type ResourcePriority = 'VeryLow' | 'Low' | 'Medium' | 'High' | 'VeryHigh';
+    type MixedContentType = 'blockable' | 'optionally-blockable' | 'none';
+    type ReferrerPolicy = 'unsafe-url' | 'no-referrer-when-downgrade' | 'no-referrer' | 'origin' | 'origin-when-cross-origin' | 'same-origin' | 'strict-origin' | 'strict-origin-when-cross-origin';
+    interface Request {
+        /**
+         * Request URL (without fragment).
+         */
+        url: string;
+        /**
+         * Fragment of the requested URL starting with hash, if present.
+         */
+        urlFragment?: string;
+        /**
+         * HTTP request method.
+         */
+        method: string;
+        /**
+         * HTTP request headers.
+         */
+        headers: Record<string, string>;
+        /**
+         * HTTP POST request data.
+         */
+        postData?: string;
+        /**
+         * True when the request has POST data. Note that postData might still be omitted when this flag is true when the data is too long.
+         */
+        hasPostData?: boolean;
+        /**
+         * The mixed content type of the request.
+         */
+        mixedContentType?: MixedContentType;
+        /**
+         * Priority of the resource request at the time request is sent.
+         */
+        initialPriority: ResourcePriority;
+        /**
+         * The referrer policy of the request, as defined in https://www.w3.org/TR/referrer-policy/
+         */
+        referrerPolicy: ReferrerPolicy;
+        /**
+         * Whether is loaded via link preload.
+         */
+        isLinkPreload?: boolean;
+    }
+
+    type CDPSession = Partial<import('puppeteer').CDPSession>;
+    type MockOverwriteFunction = (request: Request, client: CDPSession) => Promise<string | Record<string, any>>;
+    type MockOverwrite = string | Record<string, any> | MockOverwriteFunction;
+
+    type MockResponseParams = {
+        statusCode?: number,
+        headers?: Record<string, string>
+    }
+
+    type MockFilterOptions = {
+        method?: string,
+        headers?: Record<string, string>
+    }
+
+    type ErrorCode = 'Failed' | 'Aborted' | 'TimedOut' | 'AccessDenied' | 'ConnectionClosed' | 'ConnectionReset' | 'ConnectionRefused' | 'ConnectionAborted' | 'ConnectionFailed' | 'NameNotResolved' | 'InternetDisconnected' | 'AddressUnreachable' | 'BlockedByClient' | 'BlockedByResponse'
+
     interface Element {
         selector: string;
         elementId: string;
@@ -813,6 +884,71 @@ declare namespace WebdriverIO {
         ): boolean;
     }
 
+    interface Network {
+        
+        /**
+         * Mock the response of a request. You can define a mock based on a matching
+         * glob and corresponding header and status code. Calling the mock method
+         * returns a stub object that you can use to modify the response of the
+         * web resource.
+         */
+        mock(
+            url: string,
+            filterOptions?: MockFilterOptions
+        ): Mock;
+
+        /**
+         * some description
+         */
+        throttle(): void;
+    }
+
+    interface Mock {
+        
+        /**
+         * Abort the request with an error code.
+         */
+        abort(
+            errorCode: ErrorCode
+        ): void;
+
+        /**
+         * Abort the request once with an error code.
+         */
+        abortOnce(
+            errorCode: ErrorCode
+        ): void;
+
+        /**
+         * Resets all information stored in the `mock.calls` array.
+         */
+        clear(): void;
+
+        /**
+         * Always respond with same overwrite.
+         */
+        respond(
+            overwrites: MockOverwrite,
+            params?: MockResponseParams
+        ): void;
+
+        /**
+         * Only respond once with given overwrite. You can call `respondOnce` multiple
+         * consecutive times and it will start with the respond you defined last. If you
+         * only use `respondOnce` and the resource is called more times a mock has been
+         * defined than it defaults back to the original resource.
+         */
+        respondOnce(
+            overwrites: MockOverwrite,
+            params?: MockResponseParams
+        ): void;
+
+        /**
+         * Does everything that `mock.clear()` does, and also removes any mocked return values or implementations.
+         */
+        restore(): void;
+    }
+
     interface ElementArray extends Array<Element> {
         selector: string | Function;
         parent: Element | WebdriverIO.BrowserObject;
@@ -829,6 +965,7 @@ declare namespace WebdriverIO {
     interface Browser extends WebDriver.BaseClient {
         config: Config;
         options: RemoteOptions;
+        network: Network;
 
         /**
          * add command to `browser` or `element` scope

--- a/packages/webdriver/webdriver.d.ts
+++ b/packages/webdriver/webdriver.d.ts
@@ -2437,21 +2437,21 @@ declare namespace WebDriver {
          * Receive request information about requests that match the mocked resource.
          * https://wiki.saucelabs.com/display/DOCS/Custom+Sauce+Labs+WebDriver+Extensions+for+Network+and+Log+Commands
          */
-        mockCalls(): ProtocolCommandResponse;
+        getMockCalls(mockId: string): ProtocolCommandResponse;
 
         /**
          * [saucelabs]
          * Clear list of mock calls.
          * https://wiki.saucelabs.com/display/DOCS/Custom+Sauce+Labs+WebDriver+Extensions+for+Network+and+Log+Commands
          */
-        clearMockCalls(restore: boolean): void;
+        clearMockCalls(mockId: string, restore: boolean): void;
 
         /**
          * [saucelabs]
          * Respond if mock matches a specific resource.
          * https://wiki.saucelabs.com/display/DOCS/Custom+Sauce+Labs+WebDriver+Extensions+for+Network+and+Log+Commands
          */
-        respondMock(payload: object): void;
+        respondMock(mockId: string, payload: object): void;
     }
 
     // selenium types

--- a/packages/webdriverio/package.json
+++ b/packages/webdriverio/package.json
@@ -55,6 +55,7 @@
     "test:unit": "jest"
   },
   "dependencies": {
+    "@types/puppeteer": "^3.0.1",
     "@wdio/config": "6.1.14",
     "@wdio/logger": "6.0.16",
     "@wdio/repl": "6.1.17",

--- a/packages/webdriverio/src/commands/mock/abort.js
+++ b/packages/webdriverio/src/commands/mock/abort.js
@@ -1,0 +1,21 @@
+/**
+ * > This is a __beta__ feature. Please give us feedback and file [an issue](https://github.com/webdriverio/webdriverio/issues/new/choose) if certain scenarions don't work as expected!
+ *
+ * Abort the request with one of the following error codes:
+ * `Failed`, `Aborted`, `TimedOut`, `AccessDenied`, `ConnectionClosed`,
+ * `ConnectionReset`, `ConnectionRefused`, `ConnectionAborted`,
+ * `ConnectionFailed`, `NameNotResolved`, `InternetDisconnected`,
+ * `AddressUnreachable`, `BlockedByClient`, `BlockedByResponse`.
+ *
+ * <example>
+    :abort.js
+    it('should block Google Analytics from page', () => {
+        const mock = browser.network.mock('https://www.google-analytics.com/**')
+        mock.abort('Failed')
+    })
+ * </example>
+ *
+ * @alias mock.abort
+ * @param {ErrorCode} errorCode  error code of the response, can be one of: `Failed`, `Aborted`, `TimedOut`, `AccessDenied`, `ConnectionClosed`, `ConnectionReset`, `ConnectionRefused`, `ConnectionAborted`, `ConnectionFailed`, `NameNotResolved`, `InternetDisconnected`, `AddressUnreachable`, `BlockedByClient`, `BlockedByResponse`
+ */
+// actual implementation is located in packages/webdriverio/src/utils/interception

--- a/packages/webdriverio/src/commands/mock/abortOnce.js
+++ b/packages/webdriverio/src/commands/mock/abortOnce.js
@@ -1,0 +1,29 @@
+/**
+ * > This is a __beta__ feature. Please give us feedback and file [an issue](https://github.com/webdriverio/webdriverio/issues/new/choose) if certain scenarions don't work as expected!
+ *
+ * Abort the request once with one of the following error codes:
+ * `Failed`, `Aborted`, `TimedOut`, `AccessDenied`, `ConnectionClosed`,
+ * `ConnectionReset`, `ConnectionRefused`, `ConnectionAborted`,
+ * `ConnectionFailed`, `NameNotResolved`, `InternetDisconnected`,
+ * `AddressUnreachable`, `BlockedByClient`, `BlockedByResponse`.
+ *
+ * <example>
+    :abortOnce.js
+    it('should block mock only once', () => {
+        const mock = browser.network.mock('https://webdriver.io')
+        mock.abortOnce('Failed')
+
+        browser.url('https://webdriver.io')
+            // catch failing command as page can't be loaded
+            .catch(() => {})
+        console.log(browser.getTitle()) // outputs: ""
+
+        browser.url('https://webdriver.io')
+        console.log(browser.getTitle()) // outputs: "WebdriverIO · Next-gen browser and mobile automation test framework for Node.js"
+    })
+ * </example>
+ *
+ * @alias mock.abort
+ * @param {ErrorCode} errorCode  error code of the response, can be one of: `Failed`, `Aborted`, `TimedOut`, `AccessDenied`, `ConnectionClosed`, `ConnectionReset`, `ConnectionRefused`, `ConnectionAborted`, `ConnectionFailed`, `NameNotResolved`, `InternetDisconnected`, `AddressUnreachable`, `BlockedByClient`, `BlockedByResponse`
+ */
+// actual implementation is located in packages/webdriverio/src/utils/interception

--- a/packages/webdriverio/src/commands/mock/clear.js
+++ b/packages/webdriverio/src/commands/mock/clear.js
@@ -1,0 +1,20 @@
+/**
+ * > This is a __beta__ feature. Please give us feedback and file [an issue](https://github.com/webdriverio/webdriverio/issues/new/choose) if certain scenarions don't work as expected!
+ *
+ * Resets all information stored in the `mock.calls` array.
+ *
+ * <example>
+    :clear.js
+    it('should clear mock', () => {
+        const mock = browser.network.mock('https://google.com/')
+        browser.url('https://google.com')
+
+        console.log(mock.calls.length) // returns 1
+        mock.clear()
+        console.log(mock.calls.length) // returns 0
+    })
+ * </example>
+ *
+ * @alias mock.clear
+ */
+// actual implementation is located in packages/webdriverio/src/utils/interception

--- a/packages/webdriverio/src/commands/mock/respond.js
+++ b/packages/webdriverio/src/commands/mock/respond.js
@@ -1,0 +1,35 @@
+/**
+ * > This is a __beta__ feature. Please give us feedback and file [an issue](https://github.com/webdriverio/webdriverio/issues/new/choose) if certain scenarions don't work as expected!
+ *
+ * Always respond with same overwrite.
+ *
+ * <example>
+    :respond.js
+    it('should demonstrate the addValue command', () => {
+        const mock = browser.network.mock('https://todo-backend-express-knex.herokuapp.com/', {
+            method: 'get'
+        })
+
+        mock.respond([{
+            title: 'Injected (non) completed Todo',
+            order: null,
+            completed: false
+        }, {
+            title: 'Injected completed Todo',
+            order: null,
+            completed: true
+        }])
+
+        browser.url('https://todobackend.com/client/index.html?https://todo-backend-express-knex.herokuapp.com/')
+
+        $('#todo-list li').waitForExist()
+        console.log($$('#todo-list li').map(el => el.getText()))
+        // outputs: "[ 'Injected (non) completed Todo', 'Injected completed Todo' ]"
+    })
+ * </example>
+ *
+ * @alias mock.respond
+ * @param {MockOverwrite}       overwrites  payload to overwrite the response
+ * @param {MockResponseParams=} params      additional respond parameters to overwrite
+ */
+// actual implementation is located in packages/webdriverio/src/utils/interception

--- a/packages/webdriverio/src/commands/mock/respondOnce.js
+++ b/packages/webdriverio/src/commands/mock/respondOnce.js
@@ -1,0 +1,54 @@
+/**
+ * > This is a __beta__ feature. Please give us feedback and file [an issue](https://github.com/webdriverio/webdriverio/issues/new/choose) if certain scenarions don't work as expected!
+ *
+ * Only respond once with given overwrite. You can call `respondOnce` multiple
+ * consecutive times and it will start with the respond you defined last. If you
+ * only use `respondOnce` and the resource is called more times a mock has been
+ * defined than it defaults back to the original resource.
+ *
+ * <example>
+    :respondOnce.js
+    function getToDos () {
+        $('#todo-list li').waitForExist()
+        return $$('#todo-list li').map(el => el.getText())
+    }
+
+    it('should demonstrate the respondOnce command', () => {
+        const mock = browser.network.mock('https://todo-backend-express-knex.herokuapp.com/', {
+            method: 'get'
+        })
+
+        mock.respondOnce([{
+            title: '3'
+        }, {
+            title: '2'
+        }, {
+            title: '1'
+        }])
+
+        mock.respondOnce([{
+            title: '2'
+        }, {
+            title: '1'
+        }])
+
+        mock.respondOnce([{
+            title: '1'
+        }])
+
+        browser.url('https://todobackend.com/client/index.html?https://todo-backend-express-knex.herokuapp.com/')
+        console.log(getToDos()) // outputs [ '3', '2', '1' ]
+        browser.url('https://todobackend.com/client/index.html?https://todo-backend-express-knex.herokuapp.com/')
+        console.log(getToDos()) // outputs [ '2', '1' ]
+        browser.url('https://todobackend.com/client/index.html?https://todo-backend-express-knex.herokuapp.com/')
+        console.log(getToDos()) // outputs [ '1' ]
+        browser.url('https://todobackend.com/client/index.html?https://todo-backend-express-knex.herokuapp.com/')
+        console.log(getToDos()) // outputs actual resource response
+    })
+ * </example>
+ *
+ * @alias mock.respondOnce
+ * @param {MockOverwrite}       overwrites  payload to overwrite the response
+ * @param {MockResponseParams=} params      additional respond parameters to overwrite
+ */
+// actual implementation is located in packages/webdriverio/src/utils/interception

--- a/packages/webdriverio/src/commands/mock/restore.js
+++ b/packages/webdriverio/src/commands/mock/restore.js
@@ -1,0 +1,20 @@
+/**
+ * > This is a __beta__ feature. Please give us feedback and file [an issue](https://github.com/webdriverio/webdriverio/issues/new/choose) if certain scenarions don't work as expected!
+ *
+ * Does everything that `mock.clear()` does, and also removes any mocked return values or implementations.
+ *
+ * <example>
+    :addValue.js
+    it('should demonstrate the addValue command', () => {
+        const mock = browser.network.mock('**\/googlelogo_color_272x92dp.png')
+        mock.respond('https://webdriver.io/img/webdriverio.png')
+        browser.url('https://google.com') // shows WebdriverIO logo instead of Google
+
+        mock.restore()
+        browser.url('https://google.com') // shows normal Google logo again
+    })
+ * </example>
+ *
+ * @alias mock.restore
+ */
+// actual implementation is located in packages/webdriverio/src/utils/interception

--- a/packages/webdriverio/src/commands/network/mock.js
+++ b/packages/webdriverio/src/commands/network/mock.js
@@ -1,4 +1,6 @@
 /**
+ * > This is a __beta__ feature. Please give us feedback and file [an issue](https://github.com/webdriverio/webdriverio/issues/new/choose) if certain scenarions don't work as expected!
+ *
  * Mock the response of a request. You can define a mock based on a matching
  * glob and corresponding header and status code. Calling the mock method
  * returns a stub object that you can use to modify the response of the
@@ -16,18 +18,18 @@
     :mock.js
     it('should mock network resources', () => {
         // via static string
-        const userListMock = browser.network.mock('**\/users/list')
+        const userListMock = browser.network.mock('**' + '/users/list')
         // you can also specifying the mock even more by filtering resources
         // by headers or status code, e.g. mock only responses with specific
         // header set
         const strictMock = browser.network.mock('**', {
             // mock all json responses
-            headers: { 'Content-Type: 'application/json' }
+            headers: { 'Content-Type': 'application/json' }
         })
     })
 
     it('should modify API responses', () => {
-        const todoMock = browser.network.mock('**\/todos', {
+        const todoMock = browser.network.mock('**' + '/todos', {
             method: 'get'
         })
 
@@ -54,12 +56,12 @@
     })
 
     it('should modify text assets', () => {
-        const scriptMock = browser.network.mock('**\/script.min.js')
+        const scriptMock = browser.network.mock('**' + '/script.min.js')
         scriptMock.respond('./tests/fixtures/script.js')
     })
 
     it('should redirect web resources', () => {
-        const headerMock = browser.network.mock('**\/header.png')
+        const headerMock = browser.network.mock('**' + '/header.png')
         headerMock.respond('https://media.giphy.com/media/F9hQLAVhWnL56/giphy.gif')
 
         const pageMock = browser.network.mock('https://google.com/')
@@ -70,8 +72,9 @@
  * </example>
  *
  * @alias browser.mock
- * @param {String}            url            url to mock
- * @param {MockFilterOptions} filterOptions  more filters
+ * @param {String}             url            url to mock
+ * @param {MockFilterOptions=} filterOptions  more filters
+ * @return {Mock}                             a mock object to modify the response
  * @type utility
  *
  */

--- a/packages/webdriverio/src/commands/network/mock.js
+++ b/packages/webdriverio/src/commands/network/mock.js
@@ -99,11 +99,11 @@ export default async function mock (url, filterOptions) {
         )
     }
 
-    const networkInterception = new NetworkInterception(url, filterOptions)
+    const browser = getBrowserObject(this)
+    const networkInterception = new NetworkInterception(url, filterOptions, browser)
     SESSION_MOCKS.add(networkInterception)
 
     if (this.isSauce) {
-        const browser = getBrowserObject(this)
         await networkInterception.init(browser)
     }
 

--- a/packages/webdriverio/src/commands/network/mock.js
+++ b/packages/webdriverio/src/commands/network/mock.js
@@ -104,7 +104,7 @@ export default async function mock (url, filterOptions) {
     SESSION_MOCKS.add(networkInterception)
 
     if (this.isSauce) {
-        await networkInterception.init(browser)
+        await networkInterception.init()
     }
 
     return networkInterception

--- a/packages/webdriverio/src/commands/network/throttle.js
+++ b/packages/webdriverio/src/commands/network/throttle.js
@@ -1,4 +1,8 @@
-/* istanbul ignore file */
+/**
+ * some description
+ *
+ */
+
 export default async function throttle () {
     return null
 }

--- a/packages/webdriverio/src/utils/interception/devtools.js
+++ b/packages/webdriverio/src/utils/interception/devtools.js
@@ -4,17 +4,11 @@ import atob from 'atob'
 import minimatch from 'minimatch'
 import { canAccess } from '@wdio/utils'
 
+import Interception from './'
 import { containsHeaderObject } from '..'
 import { ERROR_REASON } from '../../constants'
 
-export default class DevtoolsInterception {
-    constructor (url, filterOptions = {}) {
-        this.url = url
-        this.filterOptions = filterOptions
-        this.respondOverwrites = []
-        this.matches = []
-    }
-
+export default class DevtoolsInterception extends Interception {
     static handleRequestInterception (client, mocks) {
         return async (event) => {
             const responseHeaders = event.responseHeaders.reduce((headers, { name, value }) => {

--- a/packages/webdriverio/src/utils/interception/index.js
+++ b/packages/webdriverio/src/utils/interception/index.js
@@ -1,0 +1,42 @@
+import Timer from '../Timer'
+
+export default class Interception {
+    constructor (url, filterOptions = {}, browser) {
+        this.url = url
+        this.filterOptions = filterOptions
+        this.browser = browser
+        this.respondOverwrites = []
+        this.matches = []
+    }
+
+    waitForResponse ({
+        timeout = this.browser.options.waitforTimeout,
+        interval = this.browser.options.waitforInterval,
+        timeoutMsg
+    } = {}) {
+        /*!
+         * ensure that timeout and interval are set properly
+         */
+        if (typeof timeout !== 'number') {
+            timeout = this.browser.options.waitforTimeout
+        }
+
+        if (typeof interval !== 'number') {
+            interval = this.browser.options.waitforInterval
+        }
+
+        const fn = () => this.calls.length > 0
+        const timer = new Timer(interval, timeout, fn, true)
+
+        return this.browser.call(() => timer.catch((e) => {
+            if (e.message === 'timeout') {
+                if (typeof timeoutMsg === 'string') {
+                    throw new Error(timeoutMsg)
+                }
+                throw new Error(`waitForResponse timed out after ${timeout}ms`)
+            }
+
+            throw new Error(`waitForResponse failed with the following reason: ${(e && e.message) || e}`)
+        }))
+    }
+}

--- a/packages/webdriverio/src/utils/interception/webdriver.js
+++ b/packages/webdriverio/src/utils/interception/webdriver.js
@@ -1,3 +1,4 @@
+import Interception from './'
 import { ERROR_REASON } from '../../constants'
 
 /**
@@ -6,18 +7,10 @@ import { ERROR_REASON } from '../../constants'
  * class uses a WebDriver extension to trigger the same behavior on a
  * compliant backend.
  */
-export default class WebDriverInterception {
-    constructor (url, filterOptions = {}) {
-        this.url = url
-        this.filterOptions = filterOptions
-        this.respondOverwrites = []
-        this.matches = []
-    }
-
-    async init (browser) {
-        const { mockId } = await browser.mockRequest(this.url, this.filterOptions)
+export default class WebDriverInterception extends Interception {
+    async init () {
+        const { mockId } = await this.browser.mockRequest(this.url, this.filterOptions)
         this.mockId = mockId
-        this.browser = browser
     }
 
     /**

--- a/packages/webdriverio/tests/commands/network/mock.test.js
+++ b/packages/webdriverio/tests/commands/network/mock.test.js
@@ -54,6 +54,6 @@ describe('custom$', () => {
 
         browser.network.puppeteer = puppeteerMock
         const mock = await browser.network.mock('/foobar')
-        expect(mock.init).toBeCalledWith(browser)
+        expect(mock.init).toBeCalledWith()
     })
 })

--- a/packages/webdriverio/tests/utils/interception/interception.test.js
+++ b/packages/webdriverio/tests/utils/interception/interception.test.js
@@ -1,0 +1,51 @@
+import NetworkInterception from '../../../src/utils/interception'
+import Timer from '../../../src/utils/Timer'
+
+const browserMock = {
+    call: jest.fn((cb) => cb()),
+    options: {
+        waitforTimeout: 123,
+        waitforInterval: 321
+    }
+}
+
+jest.mock('../../../src/utils/Timer',
+    () => jest.fn().mockReturnValue(Promise.resolve()))
+
+test('should use default interval and timeout if invalid', () => {
+    const mock = new NetworkInterception('**/foo', { method: 'post' }, browserMock)
+    mock.waitForResponse()
+    expect(Timer).toBeCalledWith(321, 123, expect.any(Function), true)
+
+    Timer.mockClear()
+    mock.waitForResponse({
+        timeout: 'foo',
+        interval: 'bar'
+    })
+    expect(Timer).toBeCalledWith(321, 123, expect.any(Function), true)
+
+    Timer.mockClear()
+    mock.waitForResponse({
+        timeout: 111,
+        interval: 444
+    })
+    expect(Timer).toBeCalledWith(444, 111, expect.any(Function), true)
+})
+
+test('allows custom error message', async () => {
+    const mock = new NetworkInterception('**/foo', { method: 'post' }, browserMock)
+    Timer.mockReturnValue(Promise.reject(new Error('timeout')))
+    let err = await mock.waitForResponse({
+        timeoutMsg: 'uups'
+    }).catch((err) => err)
+    expect(err.message).toBe('uups')
+
+    Timer.mockClear()
+    err = await mock.waitForResponse().catch((err) => err)
+    expect(err.message).toContain('waitForResponse timed out after')
+
+    Timer.mockClear()
+    Timer.mockReturnValue(Promise.reject(new Error('bug')))
+    err = await mock.waitForResponse().catch((err) => err)
+    expect(err.message).toBe('waitForResponse failed with the following reason: bug')
+})

--- a/packages/webdriverio/tests/utils/interception/webdriver.test.js
+++ b/packages/webdriverio/tests/utils/interception/webdriver.test.js
@@ -19,36 +19,36 @@ beforeEach(() => {
 })
 
 test('init', async () => {
-    const mock = new NetworkInterception('**/foobar/**', { foo: 'bar' })
-    await mock.init(browserMock)
+    const mock = new NetworkInterception('**/foobar/**', { foo: 'bar' }, browserMock)
+    await mock.init()
     expect(browserMock.mockRequest).toBeCalledWith('**/foobar/**', { foo: 'bar' })
     expect(mock.mockId).toBe(123)
 })
 
 test('calls', async () => {
-    const mock = new NetworkInterception('**/foobar/**')
-    await mock.init(browserMock)
+    const mock = new NetworkInterception('**/foobar/**', {}, browserMock)
+    await mock.init()
     expect(await mock.calls).toEqual([1, 2, 3])
     expect(browserMock.mockCalls).toBeCalledWith(123)
 })
 
 test('clear', async () => {
-    const mock = new NetworkInterception('**/foobar/**')
-    await mock.init(browserMock)
+    const mock = new NetworkInterception('**/foobar/**', {}, browserMock)
+    await mock.init()
     expect(await mock.clear()).toEqual({})
     expect(browserMock.clearMockCalls).toBeCalledWith(123)
 })
 
 test('restore', async () => {
-    const mock = new NetworkInterception('**/foobar/**')
-    await mock.init(browserMock)
+    const mock = new NetworkInterception('**/foobar/**', {}, browserMock)
+    await mock.init()
     expect(await mock.restore()).toEqual({})
     expect(browserMock.clearMockCalls).toBeCalledWith(123, true)
 })
 
 test('respond', async () => {
-    const mock = new NetworkInterception('**/foobar/**')
-    await mock.init(browserMock)
+    const mock = new NetworkInterception('**/foobar/**', {}, browserMock)
+    await mock.init()
     expect(await mock.respond('foo', 'bar')).toEqual({})
     expect(browserMock.respondMock).toBeCalledWith(
         123,
@@ -61,8 +61,8 @@ test('respond', async () => {
 })
 
 test('respond without params', async () => {
-    const mock = new NetworkInterception('**/foobar/**')
-    await mock.init(browserMock)
+    const mock = new NetworkInterception('**/foobar/**', {}, browserMock)
+    await mock.init()
     expect(await mock.respond('foo')).toEqual({})
     expect(browserMock.respondMock).toBeCalledWith(
         123,
@@ -75,8 +75,8 @@ test('respond without params', async () => {
 })
 
 test('respondOnce', async () => {
-    const mock = new NetworkInterception('**/foobar/**')
-    await mock.init(browserMock)
+    const mock = new NetworkInterception('**/foobar/**', {}, browserMock)
+    await mock.init()
     expect(await mock.respondOnce('foo', 'bar')).toEqual({})
     expect(browserMock.respondMock).toBeCalledWith(
         123,
@@ -88,8 +88,8 @@ test('respondOnce', async () => {
 })
 
 test('respondOnce without params', async () => {
-    const mock = new NetworkInterception('**/foobar/**')
-    await mock.init(browserMock)
+    const mock = new NetworkInterception('**/foobar/**', {}, browserMock)
+    await mock.init()
     expect(await mock.respondOnce('foo')).toEqual({})
     expect(browserMock.respondMock).toBeCalledWith(
         123,
@@ -101,8 +101,8 @@ test('respondOnce without params', async () => {
 })
 
 test('abort', async () => {
-    const mock = new NetworkInterception('**/foobar/**')
-    await mock.init(browserMock)
+    const mock = new NetworkInterception('**/foobar/**', {}, browserMock)
+    await mock.init()
 
     expect(await mock.abort('InternetDisconnected')).toEqual({})
     expect(browserMock.respondMock).toBeCalledWith(
@@ -126,8 +126,8 @@ test('abort fails if invalid error reason was provided', async () => {
 })
 
 test('abortOnce', async () => {
-    const mock = new NetworkInterception('**/foobar/**')
-    await mock.init(browserMock)
+    const mock = new NetworkInterception('**/foobar/**', {}, browserMock)
+    await mock.init()
 
     expect(await mock.abortOnce('InternetDisconnected')).toEqual({})
     expect(browserMock.respondMock).toBeCalledWith(

--- a/packages/webdriverio/webdriverio-core.d.ts
+++ b/packages/webdriverio/webdriverio-core.d.ts
@@ -7,6 +7,11 @@
 /// <reference types="node"/>
 /// <reference types="webdriver"/>
 
+// See https://github.com/DefinitelyTyped/DefinitelyTyped/issues/24419
+interface Element { }
+interface Node { }
+interface NodeListOf<TNode = Node> { }
+
 declare namespace WebdriverIO {
     type LocationParam = 'x' | 'y';
 
@@ -435,6 +440,72 @@ declare namespace WebdriverIO {
         y: number
     }
 
+    /**
+     * HTTP request data. (copied from the puppeteer-core package as there is currently
+     * no way to access these types otherwise)
+     */
+    type ResourcePriority = 'VeryLow' | 'Low' | 'Medium' | 'High' | 'VeryHigh';
+    type MixedContentType = 'blockable' | 'optionally-blockable' | 'none';
+    type ReferrerPolicy = 'unsafe-url' | 'no-referrer-when-downgrade' | 'no-referrer' | 'origin' | 'origin-when-cross-origin' | 'same-origin' | 'strict-origin' | 'strict-origin-when-cross-origin';
+    interface Request {
+        /**
+         * Request URL (without fragment).
+         */
+        url: string;
+        /**
+         * Fragment of the requested URL starting with hash, if present.
+         */
+        urlFragment?: string;
+        /**
+         * HTTP request method.
+         */
+        method: string;
+        /**
+         * HTTP request headers.
+         */
+        headers: Record<string, string>;
+        /**
+         * HTTP POST request data.
+         */
+        postData?: string;
+        /**
+         * True when the request has POST data. Note that postData might still be omitted when this flag is true when the data is too long.
+         */
+        hasPostData?: boolean;
+        /**
+         * The mixed content type of the request.
+         */
+        mixedContentType?: MixedContentType;
+        /**
+         * Priority of the resource request at the time request is sent.
+         */
+        initialPriority: ResourcePriority;
+        /**
+         * The referrer policy of the request, as defined in https://www.w3.org/TR/referrer-policy/
+         */
+        referrerPolicy: ReferrerPolicy;
+        /**
+         * Whether is loaded via link preload.
+         */
+        isLinkPreload?: boolean;
+    }
+
+    type CDPSession = Partial<import('puppeteer').CDPSession>;
+    type MockOverwriteFunction = (request: Request, client: CDPSession) => Promise<string | Record<string, any>>;
+    type MockOverwrite = string | Record<string, any> | MockOverwriteFunction;
+
+    type MockResponseParams = {
+        statusCode?: number,
+        headers?: Record<string, string>
+    }
+
+    type MockFilterOptions = {
+        method?: string,
+        headers?: Record<string, string>
+    }
+
+    type ErrorCode = 'Failed' | 'Aborted' | 'TimedOut' | 'AccessDenied' | 'ConnectionClosed' | 'ConnectionReset' | 'ConnectionRefused' | 'ConnectionAborted' | 'ConnectionFailed' | 'NameNotResolved' | 'InternetDisconnected' | 'AddressUnreachable' | 'BlockedByClient' | 'BlockedByResponse'
+
     interface Element {
         selector: string;
         elementId: string;
@@ -813,6 +884,71 @@ declare namespace WebdriverIO {
         ): Promise<boolean>;
     }
 
+    interface Network {
+        
+        /**
+         * Mock the response of a request. You can define a mock based on a matching
+         * glob and corresponding header and status code. Calling the mock method
+         * returns a stub object that you can use to modify the response of the
+         * web resource.
+         */
+        mock(
+            url: string,
+            filterOptions?: MockFilterOptions
+        ): Promise<Mock>;
+
+        /**
+         * some description
+         */
+        throttle(): Promise<void>;
+    }
+
+    interface Mock {
+        
+        /**
+         * Abort the request with an error code.
+         */
+        abort(
+            errorCode: ErrorCode
+        ): Promise<void>;
+
+        /**
+         * Abort the request once with an error code.
+         */
+        abortOnce(
+            errorCode: ErrorCode
+        ): Promise<void>;
+
+        /**
+         * Resets all information stored in the `mock.calls` array.
+         */
+        clear(): Promise<void>;
+
+        /**
+         * Always respond with same overwrite.
+         */
+        respond(
+            overwrites: MockOverwrite,
+            params?: MockResponseParams
+        ): Promise<void>;
+
+        /**
+         * Only respond once with given overwrite. You can call `respondOnce` multiple
+         * consecutive times and it will start with the respond you defined last. If you
+         * only use `respondOnce` and the resource is called more times a mock has been
+         * defined than it defaults back to the original resource.
+         */
+        respondOnce(
+            overwrites: MockOverwrite,
+            params?: MockResponseParams
+        ): Promise<void>;
+
+        /**
+         * Does everything that `mock.clear()` does, and also removes any mocked return values or implementations.
+         */
+        restore(): Promise<void>;
+    }
+
     interface ElementArray extends Array<Element> {
         selector: string | Function;
         parent: Element | WebdriverIO.BrowserObject;
@@ -829,6 +965,7 @@ declare namespace WebdriverIO {
     interface Browser extends WebDriver.BaseClient {
         config: Config;
         options: RemoteOptions;
+        network: Network;
 
         /**
          * add command to `browser` or `element` scope

--- a/scripts/docs-generation/wdioDocs.js
+++ b/scripts/docs-generation/wdioDocs.js
@@ -19,7 +19,9 @@ exports.generateWdioDocs = (sidebars) => {
     const COMMAND_DIR = path.join(__dirname, '..', '..', 'packages', 'webdriverio', 'src', 'commands')
     const COMMANDS = {
         browser: fs.readdirSync(path.join(COMMAND_DIR, 'browser')),
-        element: fs.readdirSync(path.join(COMMAND_DIR, 'element'))
+        element: fs.readdirSync(path.join(COMMAND_DIR, 'element')),
+        network: fs.readdirSync(path.join(COMMAND_DIR, 'network')),
+        mock: fs.readdirSync(path.join(COMMAND_DIR, 'mock'))
     }
 
     for (const [scope, files] of Object.entries(COMMANDS)) {

--- a/scripts/templates/api.tpl.ejs
+++ b/scripts/templates/api.tpl.ejs
@@ -17,7 +17,9 @@ title: <?= method.command ?>
 
 ```js
 <? if (method.isElementScope) {
-?>$(selector).<?= method.command ?>(<?= method.paramString ?>)<? } else {
+?>$(selector).<?= method.command ?>(<?= method.paramString ?>)<? } else if (method.isNetworkScope) {
+?>browser.network.<?= method.command ?>(<?= method.paramString ?>)<? } else if (method.isMockScope) {
+?>mock.<?= method.command ?>(<?= method.paramString ?>)<? } else {
 ?><?= method.isMobile ? 'driver' : 'browser' ?>.<?= method.command ?>(<?= method.paramString ?>)<? } ?>
 ```
 

--- a/scripts/templates/webdriverio.tpl.d.ts
+++ b/scripts/templates/webdriverio.tpl.d.ts
@@ -1,6 +1,11 @@
 /// <reference types="node"/>
 /// <reference types="webdriver"/>
 
+// See https://github.com/DefinitelyTyped/DefinitelyTyped/issues/24419
+interface Element { }
+interface Node { }
+interface NodeListOf<TNode = Node> { }
+
 declare namespace WebdriverIO {
     type LocationParam = 'x' | 'y';
 
@@ -429,6 +434,72 @@ declare namespace WebdriverIO {
         y: number
     }
 
+    /**
+     * HTTP request data. (copied from the puppeteer-core package as there is currently
+     * no way to access these types otherwise)
+     */
+    type ResourcePriority = 'VeryLow' | 'Low' | 'Medium' | 'High' | 'VeryHigh';
+    type MixedContentType = 'blockable' | 'optionally-blockable' | 'none';
+    type ReferrerPolicy = 'unsafe-url' | 'no-referrer-when-downgrade' | 'no-referrer' | 'origin' | 'origin-when-cross-origin' | 'same-origin' | 'strict-origin' | 'strict-origin-when-cross-origin';
+    interface Request {
+        /**
+         * Request URL (without fragment).
+         */
+        url: string;
+        /**
+         * Fragment of the requested URL starting with hash, if present.
+         */
+        urlFragment?: string;
+        /**
+         * HTTP request method.
+         */
+        method: string;
+        /**
+         * HTTP request headers.
+         */
+        headers: Record<string, string>;
+        /**
+         * HTTP POST request data.
+         */
+        postData?: string;
+        /**
+         * True when the request has POST data. Note that postData might still be omitted when this flag is true when the data is too long.
+         */
+        hasPostData?: boolean;
+        /**
+         * The mixed content type of the request.
+         */
+        mixedContentType?: MixedContentType;
+        /**
+         * Priority of the resource request at the time request is sent.
+         */
+        initialPriority: ResourcePriority;
+        /**
+         * The referrer policy of the request, as defined in https://www.w3.org/TR/referrer-policy/
+         */
+        referrerPolicy: ReferrerPolicy;
+        /**
+         * Whether is loaded via link preload.
+         */
+        isLinkPreload?: boolean;
+    }
+
+    type CDPSession = Partial<import('puppeteer').CDPSession>;
+    type MockOverwriteFunction = (request: Request, client: CDPSession) => Promise<string | Record<string, any>>;
+    type MockOverwrite = string | Record<string, any> | MockOverwriteFunction;
+
+    type MockResponseParams = {
+        statusCode?: number,
+        headers?: Record<string, string>
+    }
+
+    type MockFilterOptions = {
+        method?: string,
+        headers?: Record<string, string>
+    }
+
+    type ErrorCode = 'Failed' | 'Aborted' | 'TimedOut' | 'AccessDenied' | 'ConnectionClosed' | 'ConnectionReset' | 'ConnectionRefused' | 'ConnectionAborted' | 'ConnectionFailed' | 'NameNotResolved' | 'InternetDisconnected' | 'AddressUnreachable' | 'BlockedByClient' | 'BlockedByResponse'
+
     interface Element {
         selector: string;
         elementId: string;
@@ -464,6 +535,14 @@ declare namespace WebdriverIO {
         // ... element commands ...
     }
 
+    interface Network {
+        // ... network commands ...
+    }
+
+    interface Mock {
+        // ... mock commands ...
+    }
+
     interface ElementArray extends Array<Element> {
         selector: string | Function;
         parent: Element | WebdriverIO.BrowserObject;
@@ -480,6 +559,7 @@ declare namespace WebdriverIO {
     interface Browser extends WebDriver.BaseClient {
         config: Config;
         options: RemoteOptions;
+        network: Network;
 
         /**
          * add command to `browser` or `element` scope

--- a/scripts/type-generation/constants.js
+++ b/scripts/type-generation/constants.js
@@ -2,7 +2,8 @@ const CUSTOM_INTERFACES = [
     'Buffer', 'Function', 'RegExp', 'WaitForOptions', 'ReactSelectorOptions',
     'MoveToOptions', 'DragAndDropOptions', 'NewWindowOptions', 'Element',
     'ElementArray', 'ClickOptions', 'WaitUntilOptions', 'Cookie', 'Timeouts',
-    'CSSProperty', 'TouchActions', 'Matcher', 'WebDriver.Cookie', 'DragAndDropCoordinate'
+    'CSSProperty', 'TouchActions', 'Matcher', 'WebDriver.Cookie', 'DragAndDropCoordinate',
+    'ErrorCode', 'MockResponseParams', 'Mock', 'MockFilterOptions', 'MockOverwrite'
 ]
 
 module.exports = {

--- a/scripts/utils/formatter.js
+++ b/scripts/utils/formatter.js
@@ -187,6 +187,8 @@ module.exports = function (docfile) {
         hasDocusaurusHeader: true,
         originalId: `api/${scope}/${name}`,
         isElementScope : scope === 'element',
+        isNetworkScope : scope === 'network',
+        isMockScope : scope === 'mock'
     }
 
     return commandDescription

--- a/tests/typings/copy.js
+++ b/tests/typings/copy.js
@@ -36,7 +36,8 @@ const packages = {
     '@wdio/selenium-standalone-service': 'packages/wdio-selenium-standalone-service',
     '@wdio/shared-store-service': 'packages/wdio-shared-store-service',
     '@wdio/static-server-service': 'packages/wdio-static-server-service',
-    '@wdio/testingbot-service': 'packages/wdio-testingbot-service'
+    '@wdio/testingbot-service': 'packages/wdio-testingbot-service',
+    '@types/puppeteer': 'packages/webdriverio/node_modules/@types/puppeteer'
 }
 
 const artifactDirs = ['node_modules', 'dist']

--- a/tests/typings/sync/sync.ts
+++ b/tests/typings/sync/sync.ts
@@ -1,4 +1,5 @@
 import allure from '@wdio/allure-reporter'
+import { MockOverwrite, MockOverwriteFunction } from '@wdio/sync'
 
 // An example of adding command withing ts file with @wdio/sync
 declare module "@wdio/sync" {
@@ -176,5 +177,38 @@ browser.isIOS
 
 // allure-reporter
 allure.addFeature('')
+
+// network mocking
+browser.network.throttle()
+browser.network.mock('**/image.jpg')
+const mock = browser.network.mock('**/image.jpg', {
+    method: 'get',
+    headers: { foo: 'bar' }
+})
+mock.abort('Aborted')
+mock.abortOnce('AccessDenied')
+mock.clear()
+mock.respond('/other/resource.jpg')
+mock.respond('/other/resource.jpg', {
+    statusCode: 100,
+    headers: { foo: 'bar' }
+})
+const res: MockOverwriteFunction = async function (req, client) {
+    const url:string = req.url
+    await client.send('foo', { bar: 1 })
+    return url
+}
+mock.respond(res)
+mock.respond(async (req, client) => {
+    const url:string = req.url
+    await client.send('foo', { bar: 1 })
+    return true
+})
+mock.respondOnce('/other/resource.jpg')
+mock.respondOnce('/other/resource.jpg', {
+    statusCode: 100,
+    headers: { foo: 'bar' }
+})
+mock.restore()
 
 export default {}

--- a/tests/typings/webdriverio/async.ts
+++ b/tests/typings/webdriverio/async.ts
@@ -1,5 +1,5 @@
 import allure from '@wdio/allure-reporter'
-import { remote, multiremote } from 'webdriverio'
+import { remote, multiremote, MockOverwriteFunction } from 'webdriverio'
 
 // An example of adding command withing ts file to WebdriverIO (async)
 declare module "webdriverio" {
@@ -199,6 +199,39 @@ async function bar() {
     browser.isMobile
     browser.isAndroid
     browser.isIOS
+
+    // network mocking
+    browser.network.throttle()
+    browser.network.mock('**/image.jpg')
+    const mock = await browser.network.mock('**/image.jpg', {
+        method: 'get',
+        headers: { foo: 'bar' }
+    })
+    mock.abort('Aborted')
+    mock.abortOnce('AccessDenied')
+    mock.clear()
+    mock.respond('/other/resource.jpg')
+    mock.respond('/other/resource.jpg', {
+        statusCode: 100,
+        headers: { foo: 'bar' }
+    })
+    const res: MockOverwriteFunction = async function (req, client) {
+        const url:string = req.url
+        await client.send('foo', { bar: 1 })
+        return url
+    }
+    mock.respond(res)
+    mock.respond(async (req, client) => {
+        const url:string = req.url
+        await client.send('foo', { bar: 1 })
+        return true
+    })
+    mock.respondOnce('/other/resource.jpg')
+    mock.respondOnce('/other/resource.jpg', {
+        statusCode: 100,
+        headers: { foo: 'bar' }
+    })
+    mock.restore()
 }
 
 // allure-reporter

--- a/website/_sidebars.json
+++ b/website/_sidebars.json
@@ -34,6 +34,7 @@
       "timeouts",
       "organizingsuites",
       "retry",
+      "mocksandspies",
       "debugging",
       "repl",
       "watcher",

--- a/website/blog/2020-07-10-network-primitives.md
+++ b/website/blog/2020-07-10-network-primitives.md
@@ -1,0 +1,68 @@
+---
+title: New Network Primitives (Beta)
+author: Christian Bromann
+authorURL: http://twitter.com/bromann
+authorImageURL: https://s.gravatar.com/avatar/d98b16d7c93d15865f34a225dd4b1254?s=80
+---
+
+The WebdriverIO team continues its efforts to provide more functionality to its automation interface by shipping new network primitives to its API. With the latest v6.2. update you can now easily mock web resources in your test and define custom responses that allow you to drastically reduce testing time as you can now better test individual scenarios. With that WebdriverIO catches up with other popular testing tools like [Puppeteer](https://pptr.dev/), [Playwright](https://playwright.dev/) or [Cypress](https://www.cypress.io/) and even simplifies mocking further.
+
+Replacing a REST API request from a browser can now be as simple as follows:
+
+```js
+const mock = browser.network.mock('https://todo-backend-express-knex.herokuapp.com/')
+
+mock.respond([{
+    title: 'Injected (non) completed Todo',
+    order: null,
+    completed: false
+}, {
+    title: 'Injected completed Todo',
+    order: null,
+    completed: true
+}])
+
+browser.url('https://todobackend.com/client/index.html?https://todo-backend-express-knex.herokuapp.com/')
+
+$('#todo-list li').waitForExist()
+console.log($$('#todo-list li').map(el => el.getText()))
+// outputs: "[ 'Injected (non) completed Todo', 'Injected completed Todo' ]"
+```
+
+In addition to that you can als modify JavaScript of CSS files as well as abort requests or modify responses dynamically based on the original reponse. You can find more information on all features in the [Mocks and Spies](/docs/mocksandspies.html) section of the docs.
+
+## Throttling
+
+Aside mocking the new version also ships with another network command that allows to modify the network throughput of the browser allowing to test under different network condition, e.g. Regular 3G or even Offline mode:
+
+```js
+// throttle to Regular 3G
+browser.network.throttle('Regular 3G')
+// disable network completely
+browser.network.throttle('Offline')
+// set custom network throughput
+browser.network.throttle({
+    'offline': false,
+    'downloadThroughput': 200 * 1024 / 8,
+    'uploadThroughput': 200 * 1024 / 8,
+    'latency': 20
+})
+```
+
+This can open up interesting use case where you want to ensure that your progressive web app (PWA) stores all essential resources for offline users to use the application.
+
+## Support
+
+This feature uses Chrome DevTools capabilities to enable such behavior. Therefor it can only be supported where such an interface is available which is __Chrome__, __Firefox Nightly__ and __Chromium Edge__ right now. The Firefox team at Mozilla is working hard to ship this into the stable build of Firefox, therefor support for it can be expected soon.
+
+On top of that the folks at [Sauce Labs](https://saucelabs.com/) working on various of WebDriver extensions that even allow this functionality to be support in the cloud. More updates on this will follow soon.
+
+## Implementation
+
+With this feature WebdriverIO now always incorperates [Puppeteer](https://pptr.dev/) as second automation driver allowing these extra features whenever possible. Moving forward the team is looking into more opportunities to enable Chrome DevTools features into the built in API.
+
+Please let us know what you think! We are expecting some bugs here and there but will make sure to fix them immediately. While we are pretty confident with the current interface design it might be still possible that some tweaks will be applied to make it even more user friendly.
+
+## Give us feedback!
+
+We are releasing this as `beta` feature and hope that you can help us identify weaknesses in the implementation and support. Please give it a try and create an issue if things are unclear or just don't work. We hope with the help of the community and you we are able to ship this as stable within the next months!

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -350,6 +350,30 @@
       "api/expect": {
         "title": "Expect"
       },
+      "api/mock/abort": {
+        "title": "abort"
+      },
+      "api/mock/abortOnce": {
+        "title": "abortOnce"
+      },
+      "api/mock/clear": {
+        "title": "clear"
+      },
+      "api/mock/respond": {
+        "title": "respond"
+      },
+      "api/mock/respondOnce": {
+        "title": "respondOnce"
+      },
+      "api/mock/restore": {
+        "title": "restore"
+      },
+      "api/network/mock": {
+        "title": "mock"
+      },
+      "api/network/throttle": {
+        "title": "throttle"
+      },
       "assertion": {
         "title": "Assertion"
       },
@@ -422,6 +446,9 @@
       "jenkins": {
         "title": "Jenkins Integration"
       },
+      "mocksandspies": {
+        "title": "Mocks and Spies (Beta)"
+      },
       "multiremote": {
         "title": "Multiremote"
       },
@@ -488,6 +515,8 @@
       "Protocols": "Protocols",
       "browser": "browser",
       "element": "element",
+      "network": "network",
+      "mock": "mock",
       "Flowcharts": "Flowcharts"
     }
   },


### PR DESCRIPTION
It would be useful to have some wait commands to ensure a certain network activity was triggered before continuing.

```js
/**
 * or wait until a response with certain parameters was received
 */
const mock = browser.network.mock('/foo/**/bar', {
  method: 'post'
})
mock.waitForResponse(4000)
```
