### PR TITLE
Add mochaOpts.grep documentation

### DIFF
--- a/docs/OrganizingTestSuites.md
+++ b/docs/OrganizingTestSuites.md
@@ -174,6 +174,17 @@ grep -r -l --include "*.js" "myText" | wdio wdio.conf.js
 
 _**Note:** This will_ not _override the `--spec` flag for running a single spec._
 
+## Running Specific Tests with MochaOpts
+
+You can also filter which specific `suite|describe` and/or `it|test` you want to run by passing a mocha specific argument: `--mochaOpts.grep` to the wdio CLI.
+
+```sh
+wdio wdio.conf.js --mochaOpts.grep myText
+wdio wdio.conf.js --mochaOpts.grep "Text with spaces"
+```
+
+_**Note:** Mocha will filter the tests after the WDIO test runner creates the instances, so you might see several instances being spawned but not actually executed._
+
 ## Stop testing after failure
 
 With the `bail` option, you can tell WebdriverIO to stop testing after any test fails. 


### PR DESCRIPTION
## Proposed changes

This is a simple PR to add instructions on how we can use the mochaOpts flag to filter specific tests cases using the `.grep` flag.


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X ] Documentation update

## Checklist

- [X ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ X] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

I have seen people looking for this feature and just throwing the towel because there is no explicit instructions. 

### Reviewers: @webdriverio/project-committers
