### PR TITLE
Removing extra comma (,) from waitUntil docs

### DIFF
--- a/packages/webdriverio/src/commands/element/waitUntil.js
+++ b/packages/webdriverio/src/commands/element/waitUntil.js
@@ -19,7 +19,7 @@
     it('should wait until text has changed', () => {
         const elem = $('#someText')
         elem.waitUntil(function () {
-            return this.getText() === 'I am now different',
+            return this.getText() === 'I am now different'
         }, {
             timeout: 5000,
             timeoutMsg: 'expected text to be different after 5s'


### PR DESCRIPTION
## Proposed changes

As I was reading the docs I found an extra , character on the waitUntil documentation. Not a big deal but I am all in for getting it right! 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x ] Documentation update

## Checklist


- [ x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

Sorry for this small PRs that might be resources and time consuming. If you want I can start making bigger ones, but this is so I don't forget. Up to you. @christian-bromann 

### Reviewers: @webdriverio/project-committers
