### PR TITLE
Fix repl.js platformVersion must be a string for appium

### DIFF
--- a/packages/wdio-cli/src/commands/repl.js
+++ b/packages/wdio-cli/src/commands/repl.js
@@ -16,7 +16,7 @@ export const cmdArgs = {
     platformVersion: {
         alias: 'v',
         desc: 'Version of OS for mobile devices',
-        type: 'number',
+        type: 'string',
     },
     deviceName: {
         alias: 'd',


### PR DESCRIPTION
## Proposed changes

REPL is failing with probably an up to date appium server due to the platformVersion being given to appium as a number but expected to be a string. 

```
[Appium] Could not parse fixed W3C capabilities: 'platformVersion' must be of type string. Falling back to JSONWP protocol
[Appium] Appium v1.17.1 creating new XCUITestDriver (v3.22.0) session
```


## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

### Reviewers: @webdriverio/project-committers
