### PR TITLE
fixing wrong variable call in error of devtools' cdp

### DIFF
--- a/packages/wdio-devtools-service/src/commands.js
+++ b/packages/wdio-devtools-service/src/commands.js
@@ -48,7 +48,7 @@ export default class CommandHandler {
         return new Promise((resolve, reject) => this.client[domain][command](args, (err, result) => {
             /* istanbul ignore if */
             if (err) {
-                return reject(new Error(`Chrome DevTools Error: ${result.message}`))
+                return reject(new Error(`Chrome DevTools Error: ${err.message}`))
             }
 
             return resolve(result)

--- a/packages/wdio-devtools-service/tests/commands.test.js
+++ b/packages/wdio-devtools-service/tests/commands.test.js
@@ -25,7 +25,8 @@ test('cdp', async () => {
     const clientMock = {
         on: jest.fn(),
         Network: {
-            enable: jest.fn().mockImplementation((args, cb) => cb(null, 'foobar'))
+            enable: jest.fn().mockImplementation((args, cb) => cb(null, 'foobar')),
+            error: jest.fn().mockImplementation((args, fn) => fn(new Error('this is an error')))
         }
     }
     const browserMock = { addCommand: jest.fn() }
@@ -34,6 +35,9 @@ test('cdp', async () => {
     expect(() => handler.cdp('foobar', 'enable')).toThrow()
     expect(() => handler.cdp('Network', 'foobar')).toThrow()
     expect(await handler.cdp('Network', 'enable')).toBe('foobar')
+
+    const errorTest = await handler.cdp('Network', 'error').catch(error => error)
+    expect(errorTest.message).toBe('Chrome DevTools Error: this is an error')
 })
 
 test('cdpConnection', () => {


### PR DESCRIPTION
## Proposed changes

Fixes #5518 - changed the call from the `result` variable to `err` variable.
to test it i've used an example that uses bug #5524, since i don't know how to add a false positive test specifically for this issue

```
describe('simple test', () => {
  it(`Simple test verification`, () => {
    browser.reloadSession();

    // @ts-ignore: browser.config does not have the property in types
    browser.cdp('Runtime', 'enable');
  });
});
```

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

### Reviewers: @webdriverio/project-committers
