### PR TITLE
Issue# 5521 - unskipped mocha test re-ran it several times

### DIFF
--- a/tests/mocha/test.js
+++ b/tests/mocha/test.js
@@ -27,14 +27,7 @@ describe('Mocha smoke test', () => {
         assert.equal(this.wdioRetries, 1)
     }, 1)
 
-    /**
-     * ToDo(Christian): remove .skip once: https://github.com/nodejs/node/issues/32851
-     * is resolved. This bug is causing the test to end twice, once with a failure
-     * "socket hang up" due to the bug above and the other with a pass, making the
-     * test ultimatively fail as done() is being called twice. I looked into possible
-     * workarounds but it seems like some sort of inconsistency between Node.js <> got <> nock
-     */
-    it.skip('should work fine after catching an error', () => {
+    it('should work fine after catching an error', () => {
         browser.clickScenario()
 
         let err


### PR DESCRIPTION
## Proposed changes

Unskipping mocha test that was failing previously.  Re-ran the test with the latest changes with `npm run test:smoke -- mochaTestrunner`.  Didn't see the test exit twice.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
