### PR TITLE
DevTools Service: Accept 'chromium' as the browserName 

### DIFF
--- a/packages/wdio-devtools-service/README.md
+++ b/packages/wdio-devtools-service/README.md
@@ -5,7 +5,7 @@ WebdriverIO DevTools Service
 
 With Chrome v63 and up the browser [started to support](https://developers.google.com/web/updates/2017/10/devtools-release-notes#multi-client) multi clients allowing arbitrary clients to access the [Chrome DevTools Protocol](https://chromedevtools.github.io/devtools-protocol/). This provides interesting opportunities to automate Chrome beyond the [WebDriver protocol](https://www.w3.org/TR/webdriver/). With this service you can enhance the wdio browser object to leverage that access and call Chrome DevTools commands within your tests to e.g. intercept requests, throttle network capabilities or take CSS/JS coverage.
 
-__Note:__ this service currently only supports Chrome v63 and up!
+_**Note:** this service currently only supports Chrome v63 and up, and Chromium (MicrosfotEdge is not yet supported)!_ 
 
 ## Installation
 

--- a/packages/wdio-devtools-service/src/index.js
+++ b/packages/wdio-devtools-service/src/index.js
@@ -10,7 +10,7 @@ import { NETWORK_STATES, DEFAULT_NETWORK_THROTTLING_STATE } from './constants'
 
 const log = logger('@wdio/devtools-service')
 const TRACE_COMMANDS = ['click', 'navigateTo', 'url']
-const UNSUPPORTED_ERROR_MESSAGE = 'The @wdio/devtools-service currently only supports Chrome version 64 and up, and Chromium as the browserName!'
+const UNSUPPORTED_ERROR_MESSAGE = 'The @wdio/devtools-service currently only supports Chrome version 63 and up, and Chromium as the browserName!'
 
 export default class DevToolsService {
     constructor (options) {

--- a/packages/wdio-devtools-service/src/index.js
+++ b/packages/wdio-devtools-service/src/index.js
@@ -5,12 +5,12 @@ import DevToolsDriver from './driver'
 import Auditor from './auditor'
 import TraceGatherer from './gatherer/trace'
 import DevtoolsGatherer from './gatherer/devtools'
-import { findCDPInterface, getCDPClient, isBrowserVersionLower } from './utils'
+import { findCDPInterface, getCDPClient, isBrowserSupported } from './utils'
 import { NETWORK_STATES, DEFAULT_NETWORK_THROTTLING_STATE } from './constants'
 
 const log = logger('@wdio/devtools-service')
-const UNSUPPORTED_ERROR_MESSAGE = 'The @wdio/devtools-service currently only supports Chrome version 63 and up'
 const TRACE_COMMANDS = ['click', 'navigateTo', 'url']
+const UNSUPPORTED_ERROR_MESSAGE = 'The @wdio/devtools-service currently only supports Chrome version 64 and up, and Chromium as the browserName!'
 
 export default class DevToolsService {
     constructor (options) {
@@ -20,10 +20,9 @@ export default class DevToolsService {
     }
 
     beforeSession (_, caps) {
-        if ((caps.browserName && caps.browserName.toLowerCase() !== 'chrome') || isBrowserVersionLower(caps, 63)) {
+        if (!isBrowserSupported(caps)){
             return log.error(UNSUPPORTED_ERROR_MESSAGE)
         }
-
         this.isSupported = true
     }
 

--- a/packages/wdio-devtools-service/src/utils.js
+++ b/packages/wdio-devtools-service/src/utils.js
@@ -13,6 +13,7 @@ const VERSION_PROPS = ['browserVersion', 'browser_version', 'version']
 const SUPPORTED_BROWSERS_AND_MIN_VERSIONS = {
     'chrome': 63,
     'chromium' : 63,
+    'googlechrome': 63,
     'google chrome': 63
 }
 

--- a/packages/wdio-devtools-service/src/utils.js
+++ b/packages/wdio-devtools-service/src/utils.js
@@ -10,6 +10,11 @@ const log = logger('@wdio/devtools-service:utils')
 const RE_DEVTOOLS_DEBUGGING_PORT_SWITCH = /--remote-debugging-port=(\d*)/
 const RE_USER_DATA_DIR_SWITCH = /--user-data-dir=([^-]*)/
 const VERSION_PROPS = ['browserVersion', 'browser_version', 'version']
+const SUPPORTED_BROWSERS_AND_MIN_VERSIONS = {
+    'chrome': 63,
+    'chromium' : 63,
+    'google chrome': 63
+}
 
 /**
  * Find Chrome DevTools Interface port by checking Chrome switches from the chrome://version
@@ -136,7 +141,7 @@ export function quantileAtValue (median, falloff, value) {
  * @param {number} minVersion minimal chrome browser version
  */
 export function isBrowserVersionLower (caps, minVersion) {
-    const browserVersion = getChromeMajorVersion(caps[VERSION_PROPS.find(prop => caps[prop])])
+    const browserVersion = getBrowserMajorVersion(caps[VERSION_PROPS.find(prop => caps[prop])])
     return typeof browserVersion === 'number' && browserVersion < minVersion
 }
 
@@ -145,11 +150,22 @@ export function isBrowserVersionLower (caps, minVersion) {
  * @param   {string|*}      version chromedriver version like `78.0.3904.11` or just `78`
  * @return  {number|*}              either major version, ex `78`, or whatever value is passed
  */
-export function getChromeMajorVersion (version) {
+export function getBrowserMajorVersion (version) {
     let majorVersion = version
     if (typeof version === 'string') {
         majorVersion = Number(version.split('.')[0])
         majorVersion = isNaN(majorVersion) ? version : majorVersion
     }
     return majorVersion
+}
+
+/**
+ * check if browser is supported based on caps.browserName and caps.version
+ * @param {object} caps capabilities
+ */
+export function isBrowserSupported(caps) {
+    if ((caps.browserName && !(caps.browserName.toLowerCase() in SUPPORTED_BROWSERS_AND_MIN_VERSIONS))
+    || (caps.browserName && isBrowserVersionLower(caps, SUPPORTED_BROWSERS_AND_MIN_VERSIONS[caps.browserName.toLowerCase()])))
+        return false
+    return true
 }

--- a/packages/wdio-devtools-service/src/utils.js
+++ b/packages/wdio-devtools-service/src/utils.js
@@ -164,8 +164,11 @@ export function getBrowserMajorVersion (version) {
  * @param {object} caps capabilities
  */
 export function isBrowserSupported(caps) {
-    if ((caps.browserName && !(caps.browserName.toLowerCase() in SUPPORTED_BROWSERS_AND_MIN_VERSIONS))
-    || (caps.browserName && isBrowserVersionLower(caps, SUPPORTED_BROWSERS_AND_MIN_VERSIONS[caps.browserName.toLowerCase()])))
+    if (
+        !caps.browserName ||
+        !(caps.browserName.toLowerCase() in SUPPORTED_BROWSERS_AND_MIN_VERSIONS) ||
+        isBrowserVersionLower(caps, SUPPORTED_BROWSERS_AND_MIN_VERSIONS[caps.browserName.toLowerCase()])){
         return false
+    }
     return true
 }

--- a/packages/wdio-devtools-service/tests/service.test.js
+++ b/packages/wdio-devtools-service/tests/service.test.js
@@ -62,8 +62,12 @@ test('beforeSession', () => {
     const service = new DevToolsService({}, [{}], {})
     expect(service.isSupported).toBe(false)
 
+    service.beforeSession(null, {})
+    expect(service.isSupported).toBe(false)
+
     service.beforeSession(null, { browserName: 'firefox' })
     expect(service.isSupported).toBe(false)
+
     service.beforeSession(null, { browserName: 'chrome', version: 62 })
     expect(service.isSupported).toBe(false)
 

--- a/packages/wdio-devtools-service/tests/service.test.js
+++ b/packages/wdio-devtools-service/tests/service.test.js
@@ -29,7 +29,7 @@ jest.mock('../src/auditor', () => {
 })
 
 jest.mock('../src/utils', () => {
-    const { isBrowserVersionLower } = jest.requireActual('../src/utils')
+    const { isBrowserSupported } = jest.requireActual('../src/utils')
     let wasCalled = false
 
     const cdpClientMock = {
@@ -48,7 +48,7 @@ jest.mock('../src/utils', () => {
             throw new Error('boom')
         }),
         getCDPClient: jest.fn().mockReturnValue(cdpClientMock),
-        isBrowserVersionLower
+        isBrowserSupported
     }
 })
 

--- a/packages/wdio-devtools-service/tests/utils.test.js
+++ b/packages/wdio-devtools-service/tests/utils.test.js
@@ -115,26 +115,26 @@ describe('getChromeMajorVersion', () => {
 describe('isBrowserSupported', () => {
 
     test('should return true when the browser and version are supported', () => {
-        const caps = { 'browserName': 'Chromium', 'version': 80 }
+        const caps = { browserName: 'Chromium', version: 80 }
         expect(isBrowserSupported(caps)).toEqual(true)
     })
 
     test('should return false when the browser us supported', () => {
-        const capsFirefox = { 'browserName': 'firefox', 'version': 80 }
+        const capsFirefox = { browserName: 'firefox', version: 80 }
         expect(isBrowserSupported(capsFirefox)).toEqual(false)
     })
 
     test('should return false when the version is not supported', () => {
-        const capsFirefox = { 'browserName': 'chrome', 'version': 50 }
+        const capsFirefox = { browserName: 'chrome', version: 50 }
         expect(isBrowserSupported(capsFirefox)).toEqual(false)
     })
 
     test('should return true when the browserName is not specified', () => {
-        const capsEmpty = { 'version': 83 }
-        expect(isBrowserSupported(capsEmpty)).toEqual(true)
+        const capsEmpty = { version: 83 }
+        expect(isBrowserSupported(capsEmpty)).toEqual(false)
     })
-    test('should return true when the browserName is not specified', () => {
-        const capsEmpty = { 'browserName': 'chrome' }
+    test('should return true when the version number is not specified', () => {
+        const capsEmpty = { browserName: 'chrome' }
         expect(isBrowserSupported(capsEmpty)).toEqual(true)
     })
 })

--- a/packages/wdio-devtools-service/tests/utils.test.js
+++ b/packages/wdio-devtools-service/tests/utils.test.js
@@ -113,9 +113,13 @@ describe('getChromeMajorVersion', () => {
 })
 
 describe('isBrowserSupported', () => {
-
     test('should return true when the browser and version are supported', () => {
         const caps = { browserName: 'Chromium', version: 80 }
+        expect(isBrowserSupported(caps)).toEqual(true)
+    })
+
+    test('should return true when the browser and version are supported', () => {
+        const caps = { browserName: 'Google Chrome', version: 80 }
         expect(isBrowserSupported(caps)).toEqual(true)
     })
 

--- a/packages/wdio-devtools-service/tests/utils.test.js
+++ b/packages/wdio-devtools-service/tests/utils.test.js
@@ -115,7 +115,7 @@ describe('getChromeMajorVersion', () => {
 describe('isBrowserSupported', () => {
 
     test('should return true when the browser and version are supported', () => {
-        const caps = { 'browserName': 'MicrosoftEdge', 'version': 80 }
+        const caps = { 'browserName': 'Chromium', 'version': 80 }
         expect(isBrowserSupported(caps)).toEqual(true)
     })
 

--- a/packages/wdio-devtools-service/tests/utils.test.js
+++ b/packages/wdio-devtools-service/tests/utils.test.js
@@ -1,5 +1,5 @@
 import { format } from 'util'
-import { findCDPInterface, getCDPClient, sumByKey, readIOStream, isBrowserVersionLower, getChromeMajorVersion } from '../src/utils'
+import { findCDPInterface, getCDPClient, sumByKey, readIOStream, isBrowserVersionLower, getBrowserMajorVersion, isBrowserSupported } from '../src/utils'
 
 import CDP from 'chrome-remote-interface'
 
@@ -99,15 +99,42 @@ describe('isBrowserVersionLower', () => {
 
 describe('getChromeMajorVersion', () => {
     test('should return whatever value is passed if not a string', () => {
-        expect(getChromeMajorVersion({})).toEqual({})
-        expect(getChromeMajorVersion(true)).toEqual(true)
-        expect(getChromeMajorVersion(78)).toEqual(78)
-        expect(getChromeMajorVersion('foobar')).toEqual('foobar')
+        expect(getBrowserMajorVersion({})).toEqual({})
+        expect(getBrowserMajorVersion(true)).toEqual(true)
+        expect(getBrowserMajorVersion(78)).toEqual(78)
+        expect(getBrowserMajorVersion('foobar')).toEqual('foobar')
     })
 
     test('should return major version if proper version is passed', () => {
-        expect(getChromeMajorVersion('78.0.3904.11')).toEqual(78)
-        expect(getChromeMajorVersion('100.0')).toEqual(100)
-        expect(getChromeMajorVersion('78')).toEqual(78)
+        expect(getBrowserMajorVersion('78.0.3904.11')).toEqual(78)
+        expect(getBrowserMajorVersion('100.0')).toEqual(100)
+        expect(getBrowserMajorVersion('78')).toEqual(78)
+    })
+})
+
+describe('isBrowserSupported', () => {
+
+    test('should return true when the browser and version are supported', () => {
+        const caps = { 'browserName': 'MicrosoftEdge', 'version': 80 }
+        expect(isBrowserSupported(caps)).toEqual(true)
+    })
+
+    test('should return false when the browser us supported', () => {
+        const capsFirefox = { 'browserName': 'firefox', 'version': 80 }
+        expect(isBrowserSupported(capsFirefox)).toEqual(false)
+    })
+
+    test('should return false when the version is not supported', () => {
+        const capsFirefox = { 'browserName': 'chrome', 'version': 50 }
+        expect(isBrowserSupported(capsFirefox)).toEqual(false)
+    })
+
+    test('should return true when the browserName is not specified', () => {
+        const capsEmpty = { 'version': 83 }
+        expect(isBrowserSupported(capsEmpty)).toEqual(true)
+    })
+    test('should return true when the browserName is not specified', () => {
+        const capsEmpty = { 'browserName': 'chrome' }
+        expect(isBrowserSupported(capsEmpty)).toEqual(true)
     })
 })


### PR DESCRIPTION
## Proposed changes

This PR moves the `browser validation` logic to the utils class and creates an array of supported browsers so that we can easily add more. 
I added `chromium` and `google chrome` as supported ones by default.

https://github.com/webdriverio/webdriverio/issues/5493

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

No extra comments.

### Reviewers: @webdriverio/project-committers
