### PR TITLE
Better support for Allure reporter using DevTools protocol

### DIFF
--- a/packages/devtools/src/devtoolsdriver.js
+++ b/packages/devtools/src/devtoolsdriver.js
@@ -103,7 +103,7 @@ export default class DevToolsDriver {
                 throw sanitizeError(err)
             }
 
-            this.emit('result', { command, params, retries, result })
+            this.emit('result', { command, params, retries, result: { value: result } })
             if (typeof result !== 'undefined') {
                 const isScreenshot = (
                     command.toLowerCase().includes('screenshot') &&

--- a/packages/devtools/tests/__snapshots__/devtoolsdriver.test.js.snap
+++ b/packages/devtools/tests/__snapshots__/devtoolsdriver.test.js.snap
@@ -65,7 +65,9 @@ Array [
           "some value",
         ],
       },
-      "result": null,
+      "result": Object {
+        "value": null,
+      },
       "retries": 1,
     },
   ],
@@ -100,11 +102,13 @@ Array [
         ],
       },
       "result": Object {
-        "elementId": "123",
-        "text": "some text",
-        "value": Array [
-          "some value",
-        ],
+        "value": Object {
+          "elementId": "123",
+          "text": "some text",
+          "value": Array [
+            "some value",
+          ],
+        },
       },
       "retries": 0,
     },

--- a/packages/wdio-allure-reporter/README.md
+++ b/packages/wdio-allure-reporter/README.md
@@ -104,10 +104,45 @@ The results can be consumed by any of the [reporting tools](https://docs.qameta.
 ### Command-line
 
 Install the [Allure command-line tool](https://www.npmjs.com/package/allure-commandline), and process the results directory:
-```bash
+
+```sh
 allure generate [allure_output_dir] && allure open
 ```
+
 This will generate a report (by default in `./allure-report`), and open it in your browser.
+
+### Autogenerate Report
+
+You can also autogenerate the report by using the Allure command line tool programatically. To do so install the package in your project by:
+
+```sh
+$ npm i allure-commandline
+```
+
+Then add or extend your `onComplete` hook or create a [custom service](/docs/customservices.html) for this:
+
+```js
+    onComplete: function() {
+        const reportError = new Error('Could not generate Allure report')
+        const generation = allure(['generate', 'allure-results', '--clean'])
+        return new Promise((resolve, reject) => {
+            const generationTimeout = setTimeout(
+                () => reject(reportError),
+                5000)
+
+            generation.on('exit', function(exitCode) {
+                clearTimeout(generationTimeout)
+
+                if (exitCode !== 0) {
+                    return reject(reportError)
+                }
+
+                console.log('Allure report successfully generated')
+                resolve()
+            })
+        })
+    }
+```
 
 ### Jenkins
 

--- a/packages/wdio-allure-reporter/src/index.js
+++ b/packages/wdio-allure-reporter/src/index.js
@@ -420,13 +420,9 @@ class AllureReporter extends WDIOReporter {
     isScreenshotCommand(command) {
         const isScrenshotEndpoint = /\/session\/[^/]*\/screenshot/
         return (
-            /**
-             * WebDriver protocol
-             */
+            // WebDriver protocol
             isScrenshotEndpoint.test(command.endpoint) ||
-            /**
-             * DevTools protocol
-             */
+            // DevTools protocol
             command.command === 'takeScreenshot'
         )
     }

--- a/packages/wdio-allure-reporter/src/index.js
+++ b/packages/wdio-allure-reporter/src/index.js
@@ -191,10 +191,14 @@ class AllureReporter extends WDIOReporter {
             return
         }
 
-        this.allure.startStep(`${command.method} ${command.endpoint}`)
+        this.allure.startStep(command.method
+            ? `${command.method} ${command.endpoint}`
+            : command.command
+        )
 
-        if (!isEmpty(command.body)) {
-            this.dumpJSON('Request', command.body)
+        const payload = command.body || command.params
+        if (!isEmpty(payload)) {
+            this.dumpJSON('Request', payload)
         }
     }
 
@@ -415,7 +419,16 @@ class AllureReporter extends WDIOReporter {
 
     isScreenshotCommand(command) {
         const isScrenshotEndpoint = /\/session\/[^/]*\/screenshot/
-        return isScrenshotEndpoint.test(command.endpoint)
+        return (
+            /**
+             * WebDriver protocol
+             */
+            isScrenshotEndpoint.test(command.endpoint) ||
+            /**
+             * DevTools protocol
+             */
+            command.command === 'takeScreenshot'
+        )
     }
 
     dumpJSON(name, json) {

--- a/packages/wdio-allure-reporter/tests/__fixtures__/command.js
+++ b/packages/wdio-allure-reporter/tests/__fixtures__/command.js
@@ -7,6 +7,14 @@ const command = () => ({
     sessionId: '4d1707ae-820f-1645-8485-5a820b2a40da',
     capabilities: {}
 })
+const devtoolsCommand = () => ({
+    command: 'getTitle',
+    params: {},
+    retries: 0,
+    result: { value: 'WebdriverJS Testpage' },
+    sessionId: 'b1af7055-576c-4a77-b0a8-614c71b1e4ff',
+    cid: '0-0'
+})
 const screenShotCommand = () => ({
     method: 'GET',
     body: { using: 'css selector', value: 'img' },
@@ -16,19 +24,27 @@ const screenShotCommand = () => ({
     sessionId: '4d1707ae-820f-1645-8485-5a820b2a40da',
     capabilities: {}
 })
+const devtoolsScreenShotCommand = () => ({
+    command: 'takeScreenshot',
+    params: {},
+    retries: 0,
+    result: { value: 'WebdriverJS Testpage' },
+    sessionId: 'b1af7055-576c-4a77-b0a8-614c71b1e4ff',
+    cid: '0-0'
+})
 
-export function commandStart() {
-    return command()
+export function commandStart(isDevtools) {
+    return isDevtools ? devtoolsCommand() : command()
 }
 
-export function commandEnd() {
-    return command()
+export function commandEnd(isDevtools) {
+    return isDevtools ? devtoolsCommand() : command()
 }
 
-export function commandStartScreenShot() {
-    return screenShotCommand()
+export function commandStartScreenShot(isDevtools) {
+    return isDevtools ? devtoolsScreenShotCommand() : screenShotCommand()
 }
 
-export function commandEndScreenShot() {
-    return screenShotCommand()
+export function commandEndScreenShot(isDevtools) {
+    return isDevtools ? devtoolsScreenShotCommand() : screenShotCommand()
 }

--- a/packages/wdio-allure-reporter/tests/allureFeatures.test.js
+++ b/packages/wdio-allure-reporter/tests/allureFeatures.test.js
@@ -355,6 +355,8 @@ describe('auxiliary methods', () => {
         expect(reporter.isScreenshotCommand({ endpoint: '/session/id/screenshot' })).toEqual(true)
         expect(reporter.isScreenshotCommand({ endpoint: '/wdu/hub/session/id/screenshot' })).toEqual(true)
         expect(reporter.isScreenshotCommand({ endpoint: '/session/id/click' })).toEqual(false)
+        expect(reporter.isScreenshotCommand({ command: 'takeScreenshot' })).toEqual(true)
+        expect(reporter.isScreenshotCommand({ command: 'elementClick' })).toEqual(false)
     })
 
     it('dumpJSON', () => {

--- a/packages/wdio-allure-reporter/tests/suite.test.js
+++ b/packages/wdio-allure-reporter/tests/suite.test.js
@@ -10,8 +10,13 @@ import { clean, getResults } from 'wdio-allure-helper'
 import AllureReporter from '../src/'
 import { runnerEnd, runnerStart } from './__fixtures__/runner'
 import { suiteEnd, suiteStart } from './__fixtures__/suite'
-import { testFailed, testPassed, testPending, testStart, testFailedWithMultipleErrors, testFailedWithAssertionErrorFromExpectWebdriverIO } from './__fixtures__/testState'
-import { commandStart, commandEnd, commandEndScreenShot, commandStartScreenShot } from './__fixtures__/command'
+import {
+    testFailed, testPassed, testPending, testStart, testFailedWithMultipleErrors,
+    testFailedWithAssertionErrorFromExpectWebdriverIO
+} from './__fixtures__/testState'
+import {
+    commandStart, commandEnd, commandEndScreenShot, commandStartScreenShot
+} from './__fixtures__/command'
 
 let processOn
 beforeAll(() => {
@@ -307,204 +312,217 @@ describe('Pending tests', () => {
     })
 })
 
-describe('selenium command reporting', () => {
-    let outputDir
+const assertionResults = {
+    webdriver: {
+        commandTitle: 'GET /session/:sessionId/element',
+        screenshotTitle: 'GET /session/:sessionId/screenshot'
+    },
+    devtools: {
+        commandTitle: 'getTitle',
+        screenshotTitle: 'takeScreenshot'
+    }
+}
 
-    beforeEach(() => {
-        outputDir = directory()
+for (const protocol of ['webdriver', 'devtools']) {
+    describe(`${protocol} command reporting`, () => {
+        let outputDir
+
+        beforeEach(() => {
+            outputDir = directory()
+        })
+
+        afterEach(() => {
+            clean(outputDir)
+        })
+
+        it('should not add step if no tests started', () => {
+            const allureOptions = {
+                stdout: true,
+                outputDir
+            }
+            const reporter = new AllureReporter(allureOptions)
+            reporter.onRunnerStart(runnerStart())
+            reporter.onSuiteStart(suiteStart())
+            reporter.onBeforeCommand(commandStart(protocol === 'devtools'))
+            reporter.onAfterCommand(commandEnd(protocol === 'devtools'))
+            reporter.onTestSkip(testPending())
+            reporter.onSuiteEnd(suiteEnd())
+            reporter.onRunnerEnd(runnerEnd())
+
+            const results = getResults(outputDir)
+            expect(results).toHaveLength(1)
+            const allureXml = results[0]
+
+            expect(allureXml('step > name')).toHaveLength(0)
+        })
+
+        it('should not add step if isMultiremote = true', () => {
+            const allureOptions = {
+                stdout: true,
+                outputDir
+            }
+            const reporter = new AllureReporter(allureOptions)
+            reporter.onRunnerStart(Object.assign(runnerStart(), { isMultiremote: true }))
+            reporter.onSuiteStart(suiteStart())
+            reporter.onTestStart(testStart())
+            reporter.onBeforeCommand(commandStart(protocol === 'devtools'))
+            reporter.onAfterCommand(commandEnd(protocol === 'devtools'))
+            reporter.onTestSkip(testPending())
+            reporter.onSuiteEnd(suiteEnd())
+            reporter.onRunnerEnd(runnerEnd())
+
+            const results = getResults(outputDir)
+            expect(results).toHaveLength(1)
+            const allureXml = results[0]
+
+            expect(allureXml('step > name')).toHaveLength(0)
+        })
+
+        it('should not end step if it was not started', () => {
+            const allureOptions = {
+                stdout: true,
+                outputDir
+            }
+            const reporter = new AllureReporter(allureOptions)
+            reporter.onRunnerStart(Object.assign(runnerStart(), { isMultiremote: true }))
+            reporter.onSuiteStart(suiteStart())
+            reporter.onTestStart(testStart())
+            reporter.onAfterCommand(commandEnd(protocol === 'devtools'))
+            reporter.onTestSkip(testPending())
+            reporter.onSuiteEnd(suiteEnd())
+            reporter.onRunnerEnd(runnerEnd())
+
+            const results = getResults(outputDir)
+            expect(results).toHaveLength(1)
+            const allureXml = results[0]
+
+            expect(allureXml('step > name')).toHaveLength(0)
+        })
+
+        it('should not add step if disableWebdriverStepsReporting = true', () => {
+            const allureOptions = {
+                stdout: true,
+                outputDir,
+                disableWebdriverStepsReporting: true
+            }
+            const reporter = new AllureReporter(allureOptions)
+            reporter.onRunnerStart(Object.assign(runnerStart(), ))
+            reporter.onSuiteStart(suiteStart())
+            reporter.onTestStart(testStart())
+            reporter.onBeforeCommand(commandStart(protocol === 'devtools'))
+            reporter.onAfterCommand(commandEnd(protocol === 'devtools'))
+            reporter.onTestSkip(testPending())
+            reporter.onSuiteEnd(suiteEnd())
+            reporter.onRunnerEnd(runnerEnd())
+
+            const results = getResults(outputDir)
+            expect(results).toHaveLength(1)
+            const allureXml = results[0]
+
+            expect(allureXml('step > name')).toHaveLength(0)
+        })
+
+        it('should add step from command', () => {
+            const allureOptions = {
+                stdout: true,
+                outputDir,
+            }
+            const reporter = new AllureReporter(allureOptions)
+            reporter.onRunnerStart(runnerStart())
+            reporter.onSuiteStart(suiteStart())
+            reporter.onTestStart(testStart())
+            reporter.onBeforeCommand(commandStart(protocol === 'devtools'))
+            reporter.onAfterCommand(commandEnd(protocol === 'devtools'))
+            reporter.onTestSkip(testPending())
+            reporter.onSuiteEnd(suiteEnd())
+            reporter.onRunnerEnd(runnerEnd())
+
+            const results = getResults(outputDir)
+            expect(results).toHaveLength(1)
+            const allureXml = results[0]
+            expect(allureXml('step > name')).toHaveLength(1)
+            expect(allureXml('step > name').eq(0).text()).toEqual(assertionResults[protocol].commandTitle)
+            expect(allureXml('step > title').eq(0).text()).toEqual(assertionResults[protocol].commandTitle)
+            expect(allureXml('test-case attachment[title="Response"]')).toHaveLength(1)
+            expect(allureXml('step').eq(0).attr('status')).toEqual('passed')
+        })
+
+        it('should not empty attach for step from command', () => {
+            const allureOptions = {
+                stdout: true,
+                outputDir,
+            }
+            const reporter = new AllureReporter(allureOptions)
+            reporter.onRunnerStart(runnerStart())
+            reporter.onSuiteStart(suiteStart())
+            reporter.onTestStart(testStart())
+            const command = commandStart(protocol === 'devtools')
+            delete command.body
+            reporter.onBeforeCommand(command)
+            reporter.onAfterCommand(commandEnd(protocol === 'devtools'))
+            reporter.onTestSkip(testPending())
+            reporter.onSuiteEnd(suiteEnd())
+            reporter.onRunnerEnd(runnerEnd())
+
+            const results = getResults(outputDir)
+            expect(results).toHaveLength(1)
+            const allureXml = results[0]
+            expect(allureXml('step > name')).toHaveLength(1)
+            expect(allureXml('step > name').eq(0).text()).toEqual(assertionResults[protocol].commandTitle)
+            expect(allureXml('step > title').eq(0).text()).toEqual(assertionResults[protocol].commandTitle)
+            expect(allureXml('test-case attachment[title="Request"]')).toHaveLength(0)
+            expect(allureXml('step').eq(0).attr('status')).toEqual('passed')
+        })
+
+        it('should add step with screenshot command', () => {
+            const allureOptions = {
+                stdout: true,
+                outputDir,
+            }
+            const reporter = new AllureReporter(allureOptions)
+            reporter.onRunnerStart(runnerStart())
+            reporter.onSuiteStart(suiteStart())
+            reporter.onTestStart(testStart())
+            reporter.onBeforeCommand(commandStartScreenShot(protocol === 'devtools'))
+            reporter.onAfterCommand(commandEndScreenShot(protocol === 'devtools'))
+            reporter.onTestSkip(testPending())
+            reporter.onSuiteEnd(suiteEnd())
+            reporter.onRunnerEnd(runnerEnd())
+
+            const results = getResults(outputDir)
+            expect(results).toHaveLength(1)
+            const allureXml = results[0]
+            expect(allureXml('step > name')).toHaveLength(1)
+            expect(allureXml('step > name').eq(0).text()).toEqual(assertionResults[protocol].screenshotTitle)
+            expect(allureXml('step > title').eq(0).text()).toEqual(assertionResults[protocol].screenshotTitle)
+            expect(allureXml('test-case attachment[title="Screenshot"]')).toHaveLength(1)
+            expect(allureXml('step').eq(0).attr('status')).toEqual('passed')
+        })
+
+        it('should not add step with screenshot command when disableWebdriverScreenshotsReporting=true', () => {
+            const allureOptions = {
+                stdout: true,
+                outputDir,
+                disableWebdriverScreenshotsReporting: true
+            }
+            const reporter = new AllureReporter(allureOptions)
+            reporter.onRunnerStart(runnerStart())
+            reporter.onSuiteStart(suiteStart())
+            reporter.onTestStart(testStart())
+            reporter.onBeforeCommand(commandStartScreenShot(protocol === 'devtools'))
+            reporter.onAfterCommand(commandEndScreenShot(protocol === 'devtools'))
+            reporter.onTestSkip(testPending())
+            reporter.onSuiteEnd(suiteEnd())
+            reporter.onRunnerEnd(runnerEnd())
+
+            const results = getResults(outputDir)
+            expect(results).toHaveLength(1)
+            const allureXml = results[0]
+            expect(allureXml('step > name')).toHaveLength(1)
+            expect(allureXml('step > name').eq(0).text()).toEqual(assertionResults[protocol].screenshotTitle)
+            expect(allureXml('step > title').eq(0).text()).toEqual(assertionResults[protocol].screenshotTitle)
+            expect(allureXml('test-case attachment[title="Screenshot"]')).toHaveLength(0)
+            expect(allureXml('step').eq(0).attr('status')).toEqual('passed')
+        })
     })
-
-    afterEach(() => {
-        clean(outputDir)
-    })
-
-    it('should not add step if no tests started', () => {
-        const allureOptions = {
-            stdout: true,
-            outputDir
-        }
-        const reporter = new AllureReporter(allureOptions)
-        reporter.onRunnerStart(runnerStart())
-        reporter.onSuiteStart(suiteStart())
-        reporter.onBeforeCommand(commandStart())
-        reporter.onAfterCommand(commandEnd())
-        reporter.onTestSkip(testPending())
-        reporter.onSuiteEnd(suiteEnd())
-        reporter.onRunnerEnd(runnerEnd())
-
-        const results = getResults(outputDir)
-        expect(results).toHaveLength(1)
-        const allureXml = results[0]
-
-        expect(allureXml('step > name')).toHaveLength(0)
-    })
-
-    it('should not add step if isMultiremote = true', () => {
-        const allureOptions = {
-            stdout: true,
-            outputDir
-        }
-        const reporter = new AllureReporter(allureOptions)
-        reporter.onRunnerStart(Object.assign(runnerStart(), { isMultiremote: true }))
-        reporter.onSuiteStart(suiteStart())
-        reporter.onTestStart(testStart())
-        reporter.onBeforeCommand(commandStart())
-        reporter.onAfterCommand(commandEnd())
-        reporter.onTestSkip(testPending())
-        reporter.onSuiteEnd(suiteEnd())
-        reporter.onRunnerEnd(runnerEnd())
-
-        const results = getResults(outputDir)
-        expect(results).toHaveLength(1)
-        const allureXml = results[0]
-
-        expect(allureXml('step > name')).toHaveLength(0)
-    })
-
-    it('should not end step if it was not started', () => {
-        const allureOptions = {
-            stdout: true,
-            outputDir
-        }
-        const reporter = new AllureReporter(allureOptions)
-        reporter.onRunnerStart(Object.assign(runnerStart(), { isMultiremote: true }))
-        reporter.onSuiteStart(suiteStart())
-        reporter.onTestStart(testStart())
-        reporter.onAfterCommand(commandEnd())
-        reporter.onTestSkip(testPending())
-        reporter.onSuiteEnd(suiteEnd())
-        reporter.onRunnerEnd(runnerEnd())
-
-        const results = getResults(outputDir)
-        expect(results).toHaveLength(1)
-        const allureXml = results[0]
-
-        expect(allureXml('step > name')).toHaveLength(0)
-    })
-
-    it('should not add step if disableWebdriverStepsReporting = true', () => {
-        const allureOptions = {
-            stdout: true,
-            outputDir,
-            disableWebdriverStepsReporting: true
-        }
-        const reporter = new AllureReporter(allureOptions)
-        reporter.onRunnerStart(Object.assign(runnerStart(), ))
-        reporter.onSuiteStart(suiteStart())
-        reporter.onTestStart(testStart())
-        reporter.onBeforeCommand(commandStart())
-        reporter.onAfterCommand(commandEnd())
-        reporter.onTestSkip(testPending())
-        reporter.onSuiteEnd(suiteEnd())
-        reporter.onRunnerEnd(runnerEnd())
-
-        const results = getResults(outputDir)
-        expect(results).toHaveLength(1)
-        const allureXml = results[0]
-
-        expect(allureXml('step > name')).toHaveLength(0)
-    })
-
-    it('should add step from selenium command', () => {
-        const allureOptions = {
-            stdout: true,
-            outputDir,
-        }
-        const reporter = new AllureReporter(allureOptions)
-        reporter.onRunnerStart(runnerStart())
-        reporter.onSuiteStart(suiteStart())
-        reporter.onTestStart(testStart())
-        reporter.onBeforeCommand(commandStart())
-        reporter.onAfterCommand(commandEnd())
-        reporter.onTestSkip(testPending())
-        reporter.onSuiteEnd(suiteEnd())
-        reporter.onRunnerEnd(runnerEnd())
-
-        const results = getResults(outputDir)
-        expect(results).toHaveLength(1)
-        const allureXml = results[0]
-        expect(allureXml('step > name')).toHaveLength(1)
-        expect(allureXml('step > name').eq(0).text()).toEqual('GET /session/:sessionId/element')
-        expect(allureXml('step > title').eq(0).text()).toEqual('GET /session/:sessionId/element')
-        expect(allureXml('test-case attachment[title="Response"]')).toHaveLength(1)
-        expect(allureXml('step').eq(0).attr('status')).toEqual('passed')
-    })
-
-    it('should not empty attach for step from selenium command', () => {
-        const allureOptions = {
-            stdout: true,
-            outputDir,
-        }
-        const reporter = new AllureReporter(allureOptions)
-        reporter.onRunnerStart(runnerStart())
-        reporter.onSuiteStart(suiteStart())
-        reporter.onTestStart(testStart())
-        const command = commandStart()
-        delete command.body
-        reporter.onBeforeCommand(command)
-        reporter.onAfterCommand(commandEnd())
-        reporter.onTestSkip(testPending())
-        reporter.onSuiteEnd(suiteEnd())
-        reporter.onRunnerEnd(runnerEnd())
-
-        const results = getResults(outputDir)
-        expect(results).toHaveLength(1)
-        const allureXml = results[0]
-        expect(allureXml('step > name')).toHaveLength(1)
-        expect(allureXml('step > name').eq(0).text()).toEqual('GET /session/:sessionId/element')
-        expect(allureXml('step > title').eq(0).text()).toEqual('GET /session/:sessionId/element')
-        expect(allureXml('test-case attachment[title="Request"]')).toHaveLength(0)
-        expect(allureXml('step').eq(0).attr('status')).toEqual('passed')
-    })
-
-    it('should add step with screenshot command', () => {
-        const allureOptions = {
-            stdout: true,
-            outputDir,
-        }
-        const reporter = new AllureReporter(allureOptions)
-        reporter.onRunnerStart(runnerStart())
-        reporter.onSuiteStart(suiteStart())
-        reporter.onTestStart(testStart())
-        reporter.onBeforeCommand(commandStartScreenShot())
-        reporter.onAfterCommand(commandEndScreenShot())
-        reporter.onTestSkip(testPending())
-        reporter.onSuiteEnd(suiteEnd())
-        reporter.onRunnerEnd(runnerEnd())
-
-        const results = getResults(outputDir)
-        expect(results).toHaveLength(1)
-        const allureXml = results[0]
-        expect(allureXml('step > name')).toHaveLength(1)
-        expect(allureXml('step > name').eq(0).text()).toEqual('GET /session/:sessionId/screenshot')
-        expect(allureXml('step > title').eq(0).text()).toEqual('GET /session/:sessionId/screenshot')
-        expect(allureXml('test-case attachment[title="Screenshot"]')).toHaveLength(1)
-        expect(allureXml('step').eq(0).attr('status')).toEqual('passed')
-    })
-
-    it('should not add step with screenshot command when disableWebdriverScreenshotsReporting=true', () => {
-        const allureOptions = {
-            stdout: true,
-            outputDir,
-            disableWebdriverScreenshotsReporting: true
-        }
-        const reporter = new AllureReporter(allureOptions)
-        reporter.onRunnerStart(runnerStart())
-        reporter.onSuiteStart(suiteStart())
-        reporter.onTestStart(testStart())
-        reporter.onBeforeCommand(commandStartScreenShot())
-        reporter.onAfterCommand(commandEndScreenShot())
-        reporter.onTestSkip(testPending())
-        reporter.onSuiteEnd(suiteEnd())
-        reporter.onRunnerEnd(runnerEnd())
-
-        const results = getResults(outputDir)
-        expect(results).toHaveLength(1)
-        const allureXml = results[0]
-        expect(allureXml('step > name')).toHaveLength(1)
-        expect(allureXml('step > name').eq(0).text()).toEqual('GET /session/:sessionId/screenshot')
-        expect(allureXml('step > title').eq(0).text()).toEqual('GET /session/:sessionId/screenshot')
-        expect(allureXml('test-case attachment[title="Screenshot"]')).toHaveLength(0)
-        expect(allureXml('step').eq(0).attr('status')).toEqual('passed')
-    })
-})
+}


### PR DESCRIPTION
## Proposed changes

We had several issues using DevTools protocol and Allure reporter. This patch:

- fixes #4446 
- fixes #5366
- Adds some documentation to explain how to autogenerate the HTML report

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
