### PR TITLE
Enable Ability to Stop Execution when Error Occurs in Service Hook

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-v10.13.0
+lts/dubnium

--- a/docs/CustomServices.md
+++ b/docs/CustomServices.md
@@ -10,8 +10,9 @@ You can write your own custom service for the WDIO test runner to custom-fit you
 The basic construction of a custom service should look like this:
 
 ```js
-export default class CustomService {
-    onPrepare(config, capabilities) {
+export default class CustomService { 
+    // If a hook returns a promise, WebdriverIO will wait until that promise is resolved to continue.
+    async onPrepare(config, capabilities) {
         // TODO: something before all workers launch
     }
 
@@ -23,6 +24,22 @@ export default class CustomService {
         // TODO: something after the workers shutdown
     }
 
+    // custom service methods ...
+}
+```
+
+An Error thrown during a service hook will be logged while the runner continues. If a hook in your service is critical to the setup or teardown of the test runner, the `SevereServiceError` exposed from the `webdriverio` package can be used to stop the runner. 
+
+```js
+import { SevereServiceError } from 'webdriverio'
+
+export default class CustomService { 
+    async onPrepare(config, capabilities) {
+        // TODO: something critical for setup before all workers launch
+
+        throw new SevereServiceError('Something went wrong.')
+    }
+    
     // custom service methods ...
 }
 ```

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "test:eslint": "eslint --cache packages examples scripts tests",
     "test:typings": "npm run generate:typings && node tests/typings/copy && npm run ts && npm run clean:tests",
     "test:coverage": "node --max-old-space-size=8192 ./node_modules/.bin/jest --coverage --logHeapUsage",
+    "jest": "node --max-old-space-size=8192 ./node_modules/.bin/jest",
     "test:smoke": "babel-node ./tests/smoke.runner.js",
     "test:e2e": "jest --config e2e/jest.config.js",
     "ts": "run-p ts:*",
@@ -108,7 +109,6 @@
   "husky": {
     "hooks": {
       "pre-commit": "git diff-index --name-only --diff-filter=d HEAD | grep -E \"(.*)\\.js$\" | xargs node_modules/eslint/bin/eslint.js -c .eslintrc.js",
-      "pre-push": "npm run test:eslint"
     }
   },
   "jest": {
@@ -126,7 +126,7 @@
       "graceful-fs": "<rootDir>/tests/helpers/fs.js"
     },
     "coverageDirectory": "./coverage/",
-    "collectCoverage": true,
+    "collectCoverage": false,
     "coverageThreshold": {
       "global": {
         "branches": 96,

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "test:eslint": "eslint --cache packages examples scripts tests",
     "test:typings": "npm run generate:typings && node tests/typings/copy && npm run ts && npm run clean:tests",
     "test:coverage": "node --max-old-space-size=8192 ./node_modules/.bin/jest --coverage --logHeapUsage",
-    "jest": "node --max-old-space-size=8192 ./node_modules/.bin/jest",
     "test:smoke": "babel-node ./tests/smoke.runner.js",
     "test:e2e": "jest --config e2e/jest.config.js",
     "ts": "run-p ts:*",
@@ -109,6 +108,7 @@
   "husky": {
     "hooks": {
       "pre-commit": "git diff-index --name-only --diff-filter=d HEAD | grep -E \"(.*)\\.js$\" | xargs node_modules/eslint/bin/eslint.js -c .eslintrc.js",
+      "pre-push": "npm run test:eslint"
     }
   },
   "jest": {
@@ -126,7 +126,7 @@
       "graceful-fs": "<rootDir>/tests/helpers/fs.js"
     },
     "coverageDirectory": "./coverage/",
-    "collectCoverage": false,
+    "collectCoverage": true,
     "coverageThreshold": {
       "global": {
         "branches": 96,

--- a/packages/wdio-cli/src/utils.js
+++ b/packages/wdio-cli/src/utils.js
@@ -24,7 +24,7 @@ export async function runServiceHook(launcher, hookName, ...args) {
         } catch (e) {
             const message = `A service failed in the '${hookName}' hook\n${e.stack}\n\n`
 
-            if (e instanceof wdio.SevereServiceError) {
+            if (e instanceof SevereServiceError) {
                 return { status: 'rejected', reason: message }
             }
 

--- a/packages/wdio-cli/src/utils.js
+++ b/packages/wdio-cli/src/utils.js
@@ -2,6 +2,7 @@ import fs from 'fs'
 import ejs from 'ejs'
 import path from 'path'
 import logger from '@wdio/logger'
+import { SevereServiceError } from 'webdriverio'
 import { execSync } from 'child_process'
 import { promisify } from 'util'
 
@@ -14,16 +15,27 @@ const log = logger('@wdio/cli:utils')
 /**
  * run service launch sequences
  */
-export async function runServiceHook (launcher, hookName, ...args) {
-    try {
-        return await Promise.all(launcher.map((service) => {
+export async function runServiceHook(launcher, hookName, ...args) {
+    return Promise.all(launcher.map(async (service) => {
+        try {
             if (typeof service[hookName] === 'function') {
-                return service[hookName](...args)
+                await service[hookName](...args)
             }
-        }))
-    } catch (e) {
-        log.error(`A service failed in the '${hookName}' hook\n${e.stack}\n\nContinue...`)
-    }
+        } catch (e) {
+            const message = `A service failed in the '${hookName}' hook\n${e.stack}\n\n`
+
+            if (e instanceof wdio.SevereServiceError) {
+                return { status: 'rejected', reason: message }
+            }
+
+            log.error(`${message}Continue...`)
+        }
+    })).then(results => {
+        const rejectedHooks = results.filter(p => p && p.status === 'rejected')
+        if (rejectedHooks.length) {
+            return Promise.reject(`\n${rejectedHooks.map(p => p.reason).join()}\n\nStopping runner...`)
+        }
+    })
 }
 
 /**

--- a/packages/wdio-cli/tests/launcher.test.js
+++ b/packages/wdio-cli/tests/launcher.test.js
@@ -420,6 +420,7 @@ describe('launcher', () => {
     describe('startInstance', () => {
         beforeEach(() => {
             launcher.runner.run = jest.fn().mockReturnValue({ on: () => {} })
+            launcher.launcher = []
             launcher.interface.emit = jest.fn()
         })
 

--- a/packages/wdio-cli/tests/utils.test.js
+++ b/packages/wdio-cli/tests/utils.test.js
@@ -1,6 +1,8 @@
 import fs from 'fs'
 import ejs from 'ejs'
 import childProcess from 'child_process'
+// import { SevereServerError } from 'webdriverio'
+
 
 import {
     runLauncherHook,

--- a/packages/wdio-cli/tests/utils.test.js
+++ b/packages/wdio-cli/tests/utils.test.js
@@ -3,7 +3,6 @@ import ejs from 'ejs'
 import childProcess from 'child_process'
 // import { SevereServerError } from 'webdriverio'
 
-
 import {
     runLauncherHook,
     runOnCompleteHook,

--- a/packages/webdriverio/src/index.js
+++ b/packages/webdriverio/src/index.js
@@ -7,6 +7,7 @@ import { wrapCommand, runFnInFiberContext } from '@wdio/utils'
 import MultiRemote from './multiremote'
 import { WDIO_DEFAULTS } from './constants'
 import { getPrototype, addLocatorStrategyHandler, isStub, getAutomationProtocol } from './utils'
+import SevereServiceError from './utils/SevereServiceError'
 
 const log = logger('webdriverio')
 
@@ -124,3 +125,5 @@ export const multiremote = async function (params = {}, config = {}) {
 
     return driver
 }
+
+export { SevereServiceError }

--- a/packages/webdriverio/src/utils/SevereServiceError.js
+++ b/packages/webdriverio/src/utils/SevereServiceError.js
@@ -1,0 +1,9 @@
+/**
+ * Error to be thrown when a sever error was encountered when a Service is being ran.
+ */
+export default class SevereServiceError extends Error {
+    constructor(message = 'Sever Service Error occurred.') {
+        super(message)
+        this.name = 'SevereServiceError'
+    }
+}

--- a/packages/webdriverio/tests/__mocks__/webdriverio.js
+++ b/packages/webdriverio/tests/__mocks__/webdriverio.js
@@ -1,3 +1,5 @@
+const{ SevereServiceError } = jest.requireActual('webdriverio')
+
 const getWdioMock = () => {
     const mock = {
         $: jest.fn(),
@@ -22,3 +24,5 @@ export const remote = jest.fn().mockImplementation(() => {
     return getWdioMock()
 })
 export const multiremote = jest.fn().mockImplementation(() => (getWdioMock()))
+
+export { SevereServiceError }

--- a/packages/webdriverio/tests/index.test.js
+++ b/packages/webdriverio/tests/index.test.js
@@ -1,0 +1,19 @@
+import * as webdriverio from '../src'
+
+describe('index.js', () => {
+    it('exports attach method', () => {
+        expect(webdriverio.attach).toBeDefined()
+    })
+
+    it('exports attach method', () => {
+        expect(webdriverio.multiremote).toBeDefined()
+    })
+
+    it('exports attach method', () => {
+        expect(webdriverio.remote).toBeDefined()
+    })
+
+    it('exports attach method', () => {
+        expect(webdriverio.SevereServiceError).toBeDefined()
+    })
+})

--- a/packages/webdriverio/tests/utils/SevereServiceError.test.js
+++ b/packages/webdriverio/tests/utils/SevereServiceError.test.js
@@ -1,0 +1,18 @@
+import { SevereServiceError } from '../../src'
+
+describe('SevereServiceError', () => {
+    it('should provide unique error name', () => {
+        const err = new SevereServiceError()
+        expect(err.name).toBe('SevereServiceError')
+    })
+
+    it('should provide a default error message', () => {
+        const err = new SevereServiceError()
+        expect(err.message).toBe('Sever Service Error occurred.')
+    })
+
+    it('should accept a custom error message', () => {
+        const err = new SevereServiceError('Something happened.')
+        expect(err.message).toBe('Something happened.')
+    })
+})


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

Closes #5398

### Bug Fix
- Current implementation expects the runner to continue when a service hook has an error. The runner will continue, however, using Promise.all cause the runServiceHook to stop execution of all hooks when an error occurs. This change ensures all service hooks are ran and completed.

### New Feature
- Added `SevereServiceError` to give custom services the ability to stop the runner if a service hook is essential for the service.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
