### PR TITLE
fix return type of getPuppeteer in typescript definitions

### DIFF
--- a/packages/wdio-devtools-service/devtools-service.d.ts
+++ b/packages/wdio-devtools-service/devtools-service.d.ts
@@ -1,5 +1,3 @@
-import { Browser } from 'puppeteer'
-
 declare module WebdriverIO {
   interface ServiceOption extends DevtoolsConfig { }
   interface Browser extends DevtoolsBrowser { }
@@ -142,5 +140,5 @@ interface DevtoolsBrowser {
   /**
    * Returns access to puppeteer instance. Allow user to work with Puppeteer directly.
    */
-  getPuppeteer(): Browser;
+  getPuppeteer(): Partial<import('puppeteer').Browser>;
 }

--- a/packages/wdio-devtools-service/devtools-service.d.ts
+++ b/packages/wdio-devtools-service/devtools-service.d.ts
@@ -1,3 +1,5 @@
+import { Browser } from 'puppeteer'
+
 declare module WebdriverIO {
   interface ServiceOption extends DevtoolsConfig { }
   interface Browser extends DevtoolsBrowser { }
@@ -140,5 +142,5 @@ interface DevtoolsBrowser {
   /**
    * Returns access to puppeteer instance. Allow user to work with Puppeteer directly.
    */
-  getPuppeteer(): object;
+  getPuppeteer(): Browser;
 }

--- a/packages/wdio-devtools-service/package.json
+++ b/packages/wdio-devtools-service/package.json
@@ -34,6 +34,7 @@
     "url": "https://github.com/webdriverio/webdriverio/issues"
   },
   "dependencies": {
+    "@types/puppeteer": "^3.0.1",
     "@wdio/logger": "6.0.16",
     "chrome-remote-interface": "^0.28.0",
     "core-js": "~3.6.0",

--- a/scripts/depcheck.js
+++ b/scripts/depcheck.js
@@ -32,7 +32,7 @@ const EXEC_OPTIONS = { silent: true, async: true }
         result.package = pkg
         result.packagePath = packagePath
         return result
-    }))).filter((result) => Object.keys(result.missing).length && Object.keys(result.missing) != 'puppeteer')
+    }))).filter((result) => Object.keys(result.missing).length)
 
     if (brokenPackages.length) {
         let message = ''

--- a/scripts/depcheck.js
+++ b/scripts/depcheck.js
@@ -32,7 +32,7 @@ const EXEC_OPTIONS = { silent: true, async: true }
         result.package = pkg
         result.packagePath = packagePath
         return result
-    }))).filter((result) => Object.keys(result.missing).length)
+    }))).filter((result) => Object.keys(result.missing).length && Object.keys(result.missing) != 'puppeteer')
 
     if (brokenPackages.length) {
         let message = ''


### PR DESCRIPTION
## Proposed changes

fix return type of getPuppeteer in typescript definitions

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
