### PR TITLE
Added Novus Visual Regression Service

### DIFF
--- a/packages/wdio-cli/src/constants.js
+++ b/packages/wdio-cli/src/constants.js
@@ -103,7 +103,8 @@ export const SUPPORTED_PACKAGES = {
         { name: 'slack', value: 'wdio-slack-service$--$slack' },
         { name: 'intercept', value: 'wdio-intercept-service$--$intercept' },
         { name: 'docker', value: 'wdio-docker-service$--$docker' },
-        { name: 'visual-regression-testing', value: 'wdio-image-comparison-service$--$visual-regression-testing' }
+        { name: 'visual-regression-testing', value: 'wdio-image-comparison-service$--$visual-regression-testing' },
+        { name: 'novus-visual-regression', value: 'wdio-novus-visual-regression-service$--$novus-visual-regression' }
     ]
 }
 

--- a/scripts/docs-generation/3rd-party/services.json
+++ b/scripts/docs-generation/3rd-party/services.json
@@ -64,5 +64,11 @@
     "title": "Ng-apimock",
     "githubUrl": "https://github.com/ng-apimock/webdriverio-plugin",
     "npmUrl": "https://www.npmjs.com/package/wdio-ng-apimock-service"
+  },
+  {
+    "packageName": "wdio-novus-visual-regression-service",
+    "title": "Novus Visual Regression Service",
+    "githubUrl": "https://github.com/Jnegrier/wdio-novus-visual-regression-service",
+    "npmUrl": "https://www.npmjs.com/package/wdio-novus-visual-regression-service"
   }
 ]


### PR DESCRIPTION
## Proposed changes

Hi, I'm the maintainer of Novus Visual Regression Service which is based on [this](https://github.com/zinserjan/wdio-visual-regression-service) visual regression service for WDIO V4, since that's project seems abandoned, I took the liberty to fork it and make it compatible with WDIO v5 and v6. I see that there is still a lot of downloads of that service as can be seen [here](https://www.npmjs.com/package/wdio-visual-regression-service), so I imagine that this service would be beneficial for people that want to update to the latest WDIO and that can use this service to update their visual regression tests using the old service. thanks!

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

### Reviewers: @webdriverio/project-committers
