### PR TITLE
Update docs for Applitools

### DIFF
--- a/packages/wdio-applitools-service/README.md
+++ b/packages/wdio-applitools-service/README.md
@@ -37,6 +37,7 @@ export.config = {
         ['applitools', {
             key: '<APPLITOOLS_KEY>', // can be passed here or via environment variable `APPLITOOLS_KEY`
             serverUrl: 'https://<org>eyesapi.applitools.com', // optional, can be passed here or via environment variable `APPLITOOLS_SERVER_URL`
+            appName: 'myApp',
             // options
             proxy: { // optional
                 url: 'http://corporateproxy.com:8080'


### PR DESCRIPTION
Add missing appName to docs, as it's required https://github.com/applitools/eyes.sdk.javascript1/pull/201#discussion_r450613937
