### PR TITLE
docs: fix links, images and typos

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -5,7 +5,7 @@ title: API Docs
 
 Welcome to the WebdriverIO docs page. These pages contain reference materials for all implemented selenium bindings and commands. WebdriverIO has all [JSONWire protocol](https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol) commands implemented and also supports special bindings for [Appium](http://appium.io).
 
-> __Note:__ These are the docs for the latest version ([v6](https://webdriver.io/blog/2020/03/26/webdriverio-v6-released.html)) of WebdriverIO. If you are still using v5 or older please use the [legacy docs websites](https://webdriver.io/docs/versions.html)!
+> __Note:__ These are the docs for the latest version ([v6](https://webdriver.io/blog/2020/03/26/webdriverio-v6-released.html)) of WebdriverIO. If you are still using v5 or older please use the [legacy docs websites](Versions.md)!
 
 ## Examples
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -5,7 +5,7 @@ title: API Docs
 
 Welcome to the WebdriverIO docs page. These pages contain reference materials for all implemented selenium bindings and commands. WebdriverIO has all [JSONWire protocol](https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol) commands implemented and also supports special bindings for [Appium](http://appium.io).
 
-> __Note:__ These are the docs for the latest version ([v6](https://webdriver.io/blog/2020/03/26/webdriverio-v6-released.html)) of WebdriverIO. If you are still using v5 or older please use the [legacy docs websites](versions.html)!
+> __Note:__ These are the docs for the latest version ([v6](https://webdriver.io/blog/2020/03/26/webdriverio-v6-released.html)) of WebdriverIO. If you are still using v5 or older please use the [legacy docs websites](https://webdriver.io/docs/versions.html)!
 
 ## Examples
 
@@ -40,7 +40,7 @@ it('can handle commands using async/await', async function () {
 })
 ```
 
-However, it is recommended to use the testrunner to scale up your test suite, as it comes with a lot of useful add-ons like the [Sauce Service](_sauce-service.md) that save you from writing a lot of boilerplate code by yourself.
+However, it is recommended to use the testrunner to scale up your test suite, as it comes with a lot of useful add-ons like the [Cloud Services](CloudServices.md) that save you from writing a lot of boilerplate code by yourself.
 
 ## Contribute
 

--- a/docs/Assertion.md
+++ b/docs/Assertion.md
@@ -43,7 +43,7 @@ For the full list, see the [expect API doc](/docs/api/expect.md).
 
 ## Migrating from Chai
 
-[Chai](https://www.chaijs.com/) and [expect-webdriverio](https://github.com/webdriverio/expect-webdriverio#readme) can coexist, and with some minor adjustments a smooth transition to expect-webdriverio can be achieved. If you've upgraded to wdio v6 then by default you will have access to all the assertions from expect-webdriverio out of the box. This means that globally wherever you use `expect` you would call an expect-webdriverio assertion. That is, unless you have explicitly overriden the global `expect` to use Chai. In this case you would not have access to any of the expect-webdriverio assertions without explicitly importing the expect-webdriverio package where you need it.
+[Chai](https://www.chaijs.com/) and [expect-webdriverio](https://github.com/webdriverio/expect-webdriverio#readme) can coexist, and with some minor adjustments a smooth transition to expect-webdriverio can be achieved. If you've upgraded to wdio v6 then by default you will have access to all the assertions from expect-webdriverio out of the box. This means that globally wherever you use `expect` you would call an expect-webdriverio assertion. That is, unless you have explicitly overridden the global `expect` to use Chai. In this case you would not have access to any of the expect-webdriverio assertions without explicitly importing the expect-webdriverio package where you need it.
 
 This guide will show examples of how to migrate from Chai if it has been overridden locally and how to migrate from Chai if it has been overridden globally.
 

--- a/docs/Assertion.md
+++ b/docs/Assertion.md
@@ -127,4 +127,4 @@ describe('Other element', () => {
 });
 ```
 
-To migrate you would slowly move each Chai assertion over to expect-webdriverio. Once all Chai assertions have been replaced thoughout the code base the "before" hook can be deleted. A global find and replace to replace all instances of `wdioExpect` to `expect` will then finish off the migration.
+To migrate you would slowly move each Chai assertion over to expect-webdriverio. Once all Chai assertions have been replaced throughout the code base the "before" hook can be deleted. A global find and replace to replace all instances of `wdioExpect` to `expect` will then finish off the migration.

--- a/docs/Assertion.md
+++ b/docs/Assertion.md
@@ -39,7 +39,7 @@ await expect(selectOptions).toHaveChildren({ gte: 1 })
 ```
 <!--END_DOCUSAURUS_CODE_TABS-->
 
-For the full list, see the [expect API doc](/docs/api/expect.html).
+For the full list, see the [expect API doc](/docs/api/expect.md).
 
 ## Migrating from Chai
 

--- a/docs/Autocompletion.md
+++ b/docs/Autocompletion.md
@@ -9,21 +9,21 @@ Autocompletion works out of the box in IDEA and WebStorm.
 
 If you have been writing program code for a while, you probably like autocompletion. Autocomplete is available out of the box in many code editors.
 
-![Autocompletion](/img/autocompletion/0.png)
+![Autocompletion](https://webdriver.io/img/autocompletion/0.png)
 
 Type definitions based on [JSDoc](http://usejsdoc.org/) is used for documenting code. It helps to see more additional details about parameters and their types.
 
-![Autocompletion](/img/autocompletion/1.png)
+![Autocompletion](https://webdriver.io/img/autocompletion/1.png)
 
 Use standard shortcuts <kbd>⇧ + ⌥ + SPACE</kbd> on IntelliJ Platform to see available documentation:
 
-![Autocompletion](/img/autocompletion/2.png)
+![Autocompletion](https://webdriver.io/img/autocompletion/2.png)
 
 ## Visual Studio Code (VSCode)
 
 It's required to create `jsconfig.json` in project root and refer to used wdio packages to make autocompletion work in vanilla js. See examples below.
 
-![Autocompletion](/img/autocompletion/14.png)
+![Autocompletion](https://webdriver.io/img/autocompletion/14.png)
 
 Sync version (you have `@wdio/sync` package installed) with Mocha
 ```json

--- a/docs/AutomationProtocols.md
+++ b/docs/AutomationProtocols.md
@@ -29,7 +29,7 @@ For any kind of mobile automation, you’ll need to install and setup [Appium](h
 
 There are also plenty of services that allow you to run your automation test in the cloud at high scale. Instead of having to setup all these drivers locally, you can just talk to these services (e.g. [Sauce Labs](https://saucelabs.com)) in the cloud and inspect the results on their platform. The communication between test script and automation environment will look as follows:
 
-![WebDriver Setup](/img/webdriver.png)
+![WebDriver Setup](https://webdriver.io/img/webdriver.png)
 
 ### Advantages
 
@@ -51,7 +51,7 @@ While every browser used to have its own internal DevTools interface that was no
 
 The communication happens without any proxy, directly to the browser using WebSockets:
 
-![DevTools Setup](/img/devtools.png)
+![DevTools Setup](https://webdriver.io/img/devtools.png)
 
 WebdriverIO allows you to use the DevTools capabilities as an alternative automation technology for WebDriver if you have special requirements to automate the browser. With the [`devtools`](https://www.npmjs.com/package/devtools) NPM package, you can use the same commands that WebDriver provides, which then can be used by WebdriverIO and the WDIO testrunner to run its useful commands on top of that protocol. It uses Puppeteer to under the hood and allows you to run a sequence of commands with Puppeteer if needed.
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -49,7 +49,7 @@ $ npx wdio config
 
 It will ask you questions and generate a config file for you in less than a minute.
 
-![WDIO configuration utility](/img/config-utility.gif)
+![WDIO configuration utility](https://webdriver.io/img/config-utility.gif)
 
 Once you have your configuration file set up, you can start your tests by running:
 

--- a/docs/CustomServices.md
+++ b/docs/CustomServices.md
@@ -103,4 +103,4 @@ exports.config = {
 > export const launcher = Launcher
 > ```
 
-We really appreciate every new plugin that could help other people run better tests! If you have created such a plugin, please create a Pull Request to our [configuration utility](https://github.com/webdriverio/webdriverio/blob/master/packages/wdio-cli/src/commands/config.js) so that your package will be suggested whenever someone runs `wdio config`.
+We really appreciate every new plugin that could help other people run better tests! If you have created such a plugin, please create a Pull Request to our [configuration utility](https://github.com/webdriverio/webdriverio/blob/master/packages/wdio-cli/src/constants.js#L82-L108) so that your package will be suggested whenever someone runs `wdio config`.

--- a/docs/CustomServices.md
+++ b/docs/CustomServices.md
@@ -10,7 +10,7 @@ You can write your own custom service for the WDIO test runner to custom-fit you
 The basic construction of a custom service should look like this:
 
 ```js
-export default class CustomService { 
+export default class CustomService {
     // If a hook returns a promise, WebdriverIO will wait until that promise is resolved to continue.
     async onPrepare(config, capabilities) {
         // TODO: something before all workers launch
@@ -28,18 +28,18 @@ export default class CustomService {
 }
 ```
 
-An Error thrown during a service hook will be logged while the runner continues. If a hook in your service is critical to the setup or teardown of the test runner, the `SevereServiceError` exposed from the `webdriverio` package can be used to stop the runner. 
+An Error thrown during a service hook will be logged while the runner continues. If a hook in your service is critical to the setup or teardown of the test runner, the `SevereServiceError` exposed from the `webdriverio` package can be used to stop the runner.
 
 ```js
 import { SevereServiceError } from 'webdriverio'
 
-export default class CustomService { 
+export default class CustomService {
     async onPrepare(config, capabilities) {
         // TODO: something critical for setup before all workers launch
 
         throw new SevereServiceError('Something went wrong.')
     }
-    
+
     // custom service methods ...
 }
 ```
@@ -103,4 +103,4 @@ exports.config = {
 > export const launcher = Launcher
 > ```
 
-We really appreciate every new plugin that could help other people run better tests! If you have created such a plugin, please create a Pull Request to our [configuration utility](https://github.com/webdriverio/webdriverio/blob/master/packages/wdio-cli/src/config.js#L20-L34) so that your package will be suggested whenever someone runs `wdio config`.
+We really appreciate every new plugin that could help other people run better tests! If you have created such a plugin, please create a Pull Request to our [configuration utility](https://github.com/webdriverio/webdriverio/blob/master/packages/wdio-cli/src/commands/config.js) so that your package will be suggested whenever someone runs `wdio config`.

--- a/docs/Debugging.md
+++ b/docs/Debugging.md
@@ -26,7 +26,7 @@ exports.config = {
 
 ## The Debug Command
 
-In many cases, you can use [`browser.debug()`](/docs/api/browser/debug.html) to pause your test and inspect the browser.
+In many cases, you can use [`browser.debug()`](https://webdriver.io/docs/api/browser/debug.html) to pause your test and inspect the browser.
 
 Your command line interface will also switch into REPL mode. This mode allows you to fiddle around with commands and elements on the page. In REPL mode, you can access the `browser` object&mdash;or `$` and `$$` functions&mdash;just like you can in your tests.
 
@@ -77,9 +77,9 @@ $ DEBUG=true npx wdio wdio.conf.js --spec ./tests/e2e/myspec.test.js
 
 ## Debugging with Visual Studio Code (VSCode)
 
-If you want to debug your tests with breakpoints in latest VSCode, you have to install and enable the [nightly version of the JavaScript Debugger](https://marketplace.visualstudio.com/items?itemName=ms-vscode.js-debug-nightly).  
+If you want to debug your tests with breakpoints in latest VSCode, you have to install and enable the [nightly version of the JavaScript Debugger](https://marketplace.visualstudio.com/items?itemName=ms-vscode.js-debug-nightly).
 
-> according to https://github.com/microsoft/vscode/issues/82523#issuecomment-609934308 this is only needed for windows and linux. mac os x is working without the nightly version.  
+> according to https://github.com/microsoft/vscode/issues/82523#issuecomment-609934308 this is only needed for windows and linux. mac os x is working without the nightly version.
 
 It's possible to run all or selected spec file(s). Debug configuration(s) have to be added to `.vscode/launch.json`, to debug selected spec add the following config:
 ```

--- a/docs/Frameworks.md
+++ b/docs/Frameworks.md
@@ -51,7 +51,7 @@ it('should test something', () => {
 })
 ```
 
-If you want to run something asynchronously, you can either use the [`browser.call`](call) command or [custom commands](CustomCommands.md).
+If you want to run something asynchronously, you can either use the [`browser.call`](https://webdriver.io/docs/api/browser/call.html) command or [custom commands](CustomCommands.md).
 
 ### Mocha Options
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -5,7 +5,7 @@ title: Getting Started
 
 Welcome to the WebdriverIO documentation. It will help you to get started fast. If you run into problems, you can find help and answers on our [Gitter Channel](https://gitter.im/webdriverio/webdriverio) or you can hit me on [Twitter](https://twitter.com/webdriverio).
 
-> __Note:__ These are the docs for the latest version (>=6.x) of WebdriverIO. If you are still using an older version, please visit the [old documentation websites](versions.html)!
+> __Note:__ These are the docs for the latest version (>=6.x) of WebdriverIO. If you are still using an older version, please visit the [old documentation websites](https://webdriver.io/docs/versions.html)!
 
 The following short step-by-step introduction will help you get your first WebdriverIO script up and running:
 
@@ -106,7 +106,7 @@ describe('webdriver.io page', () => {
 ```
 <!--END_DOCUSAURUS_CODE_TABS-->
 
-Now save the file and return to your terminal. Learn more about [the differences between Sync and Async Mode](sync-vs-async.html).
+Now save the file and return to your terminal. Learn more about [the differences between Sync and Async Mode](https://webdriver.io/docs/sync-vs-async.html).
 
 ### Start the Testrunner
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -5,7 +5,7 @@ title: Getting Started
 
 Welcome to the WebdriverIO documentation. It will help you to get started fast. If you run into problems, you can find help and answers on our [Gitter Channel](https://gitter.im/webdriverio/webdriverio) or you can hit me on [Twitter](https://twitter.com/webdriverio).
 
-> __Note:__ These are the docs for the latest version (>=6.x) of WebdriverIO. If you are still using an older version, please visit the [old documentation websites](https://webdriver.io/docs/versions.html)!
+> __Note:__ These are the docs for the latest version (>=6.x) of WebdriverIO. If you are still using an older version, please visit the [old documentation websites](Versions.md)!
 
 The following short step-by-step introduction will help you get your first WebdriverIO script up and running:
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -106,7 +106,7 @@ describe('webdriver.io page', () => {
 ```
 <!--END_DOCUSAURUS_CODE_TABS-->
 
-Now save the file and return to your terminal. Learn more about [the differences between Sync and Async Mode](https://webdriver.io/docs/sync-vs-async.html).
+Now save the file and return to your terminal. Learn more about [the differences between Sync and Async Mode](SyncVsAsync.md).
 
 ### Start the Testrunner
 

--- a/docs/JenkinsIntegration.md
+++ b/docs/JenkinsIntegration.md
@@ -23,31 +23,31 @@ module.exports = {
 }
 ```
 
-It is up to you which framework to choose. The reports will be similar. 
-For this tutorial, we’ll use Jasmine. 
+It is up to you which framework to choose. The reports will be similar.
+For this tutorial, we’ll use Jasmine.
 
 After you have written couple of tests, you can setup a new Jenkins job. Give it a name and a description:
 
-![Name And Description](/img/jenkins/jobname.png "Name And Description")
+![Name And Description](https://webdriver.io/img/jenkins/jobname.png "Name And Description")
 
 Then make sure it grabs always the newest version of your repository:
 
-![Jenkins Git Setup](/img/jenkins/gitsetup.png "Jenkins Git Setup")
+![Jenkins Git Setup](https://webdriver.io/img/jenkins/gitsetup.png "Jenkins Git Setup")
 
 **Now the important part:** Create a `build` step to execute shell commands. The `build` step needs to build your project. Since this demo project only tests an external app, you don't need to build anything. Just install the node dependencies and run the command `npm test` (which is an alias for `node_modules/.bin/wdio test/wdio.conf.js`).
 
 If you have installed a plugin like AnsiColor, but logs are still not colored, run tests with environment variable `FORCE_COLOR=1` (e.g., `FORCE_COLOR=1 npm test`).
 
-![Build Step](/img/jenkins/runjob.png "Build Step")
+![Build Step](https://webdriver.io/img/jenkins/runjob.png "Build Step")
 
-After your test, you’ll want Jenkins to track your XUnit report. To do so, you have to add a post-build action called _"Publish JUnit test result report"_. 
+After your test, you’ll want Jenkins to track your XUnit report. To do so, you have to add a post-build action called _"Publish JUnit test result report"_.
 
 You could also install an external XUnit plugin to track your reports. The JUnit one comes with the basic Jenkins installation and is sufficient enough for now.
 
 According to the config file, the XUnit reports will be saved in the project’s root directory. These reports are XML files. So, all you need to do in order to track the reports is to point Jenkins to all XML files in your root directory:
 
-![Post-build Action](/img/jenkins/postjob.png "Post-build Action")
+![Post-build Action](https://webdriver.io/img/jenkins/postjob.png "Post-build Action")
 
 That's it! You’ve now set up Jenkins to run your WebdriverIO jobs. Your job will now provide detailed test results with history charts, stacktrace information on failed jobs, and a list of commands with payload that got used in each test.
 
-![Jenkins Final Integration](/img/jenkins/final.png "Jenkins Final Integration")
+![Jenkins Final Integration](https://webdriver.io/img/jenkins/final.png "Jenkins Final Integration")

--- a/docs/Multiremote.md
+++ b/docs/Multiremote.md
@@ -5,7 +5,7 @@ title: Multiremote
 
 WebdriverIO allows you to run multiple WebDriver/Appium sessions in a single test. This becomes handy when you’re testing features that require multiple users (for example, chat or WebRTC applications).
 
-Instead of creating a couple of remote instances where you need to execute common commands like [`newSession`](/docs/api/webdriver.html#newsession) or [`url`](/docs/api/browser/url.html) on each instance, you can simply create a **multiremote** instance and control all browsers at the same time.
+Instead of creating a couple of remote instances where you need to execute common commands like [`newSession`](https://webdriver.io/docs/api/webdriver.html#newsession) or [`url`](https://webdriver.io/docs/api/browser/url.html) on each instance, you can simply create a **multiremote** instance and control all browsers at the same time.
 
 To do so, just use the `multiremote()` function, and pass in an object with names keyed to `capabilities` for values. By giving each capability a name, you can easily select and access that single instance when executing commands on a single instance.
 

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -219,7 +219,7 @@ Options: `mocha` | `jasmine`
 
 ### mochaOpts, jasmineNodeOpts and cucumberOpts
 
-Specific framework-related options. See the framework adapter documentation on which options are available. Read more on this in [Frameworks](frameworks.html).
+Specific framework-related options. See the framework adapter documentation on which options are available. Read more on this in [Frameworks](Frameworks.md).
 
 Type: `Object`<br>
 Default: `{ timeout: 10000 }`

--- a/docs/Selectors.md
+++ b/docs/Selectors.md
@@ -482,4 +482,4 @@ const pluginWrapper = browser.custom$$('myStrat', '.pluginWrapper')
 console.log(pluginWrapper.length) // 4
 ```
 
-**Note:** this only works in an web environment in which the [`execute`](/docs/api/browser/execute.html) command can be run.
+**Note:** this only works in an web environment in which the [`execute`](https://webdriver.io/docs/api/browser/execute.html) command can be run.

--- a/docs/SyncVsAsync.md
+++ b/docs/SyncVsAsync.md
@@ -44,7 +44,7 @@ await el.click()
 
 ## Sync mode
 
-If you're using [`@wdio/sync`](https://www.npmjs.com/package/@wdio/sync) then you can avoid awaiting for browser/element calls. It is still required to deal with Promises from 3rd-party libraries, you should use [browser.call](/api/browser/call.html) for this.
+If you're using [`@wdio/sync`](https://www.npmjs.com/package/@wdio/sync) then you can avoid awaiting for browser/element calls. It is still required to deal with Promises from 3rd-party libraries, you should use [browser.call](https://webdriver.io/docs/api/browser/call.html) for this.
 
 Example
 

--- a/docs/Timeouts.md
+++ b/docs/Timeouts.md
@@ -35,7 +35,7 @@ browser.setTimeout({ 'pageLoad': 10000 })
 
 ### Session Implicit Wait Timeout
 
-A session has an associated session implicit wait timeout. This specifies the time to wait for the implicit element location strategy when locating elements using the [`findElement`](/docs/api/webdriver.html#findelement) or [`findElements`](/docs/api/webdriver.html#findelements) commands ([`$`](/docs/api/browser/$.html) or [`$$`](/docs/api/browser/$$.html), respectively, when running WebdriverIO with or without the WDIO testrunner). Unless stated otherwise, it is 0 milliseconds.
+A session has an associated session implicit wait timeout. This specifies the time to wait for the implicit element location strategy when locating elements using the [`findElement`](https://webdriver.io/docs/api/webdriver.html#findelement) or [`findElements`](https://webdriver.io/docs/api/webdriver.html#findelements) commands ([`$`](https://webdriver.io/docs/api/browser/$.html) or [`$$`](https://webdriver.io/docs/api/browser/$$.html), respectively, when running WebdriverIO with or without the WDIO testrunner). Unless stated otherwise, it is 0 milliseconds.
 
 You can set this timeout via:
 

--- a/docs/Versions.md
+++ b/docs/Versions.md
@@ -9,7 +9,7 @@ The project team releases new major versions roughly on a yearly cadence. LTS re
 
 | | | | |
 |----|--------------------|--------------------------------------------------------------------------------------|-----------------|
-| v6 | [Documentation](/) | [Release Notes](https://github.com/webdriverio/webdriverio/blob/master/CHANGELOG.md) | __Stable__ |
+| v6 | [Documentation](https://github.com/webdriverio/webdriverio/blob/master/docs) | [Release Notes](https://github.com/webdriverio/webdriverio/blob/master/CHANGELOG.md) | __Stable__ |
 
 ## Past Versions
 

--- a/docs/repl.md
+++ b/docs/repl.md
@@ -60,4 +60,4 @@ You can apply any options (see `wdio repl --help`) available for your REPL sessi
 
 ![WebdriverIO REPL](https://webdriver.io/img/repl.gif)
 
-Another way to use the REPL is in inside your tests via the [`debug`](/api/utility/debug.html) command. This will stop the browser when called, and enables you to jump into the application (e.g. to the dev tools) or control the browser from the command line. This is helpful when some commands don't trigger a certain action as expected. With the REPL, you can then try out the commands to see which are working most reliably.
+Another way to use the REPL is in inside your tests via the [`debug`](Debugging.md) command. This will stop the browser when called, and enables you to jump into the application (e.g. to the dev tools) or control the browser from the command line. This is helpful when some commands don't trigger a certain action as expected. With the REPL, you can then try out the commands to see which are working most reliably.


### PR DESCRIPTION
I've updated the documentation:
 * Fix the links
 * Fix the typos

I've split all commits into one commit per file to easily discard the changes. Before merging we can do squash the commits into one.