### PR TITLE
Better define the "Contributor" path

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -18,7 +18,7 @@ Contributors have read-only access to source code and to submit changes via pull
 
 As Contributors gain experience and familiarity with the project, their profile within, and commitment to, the community will increase. At some stage, they may find themselves being nominated for committership by an existing Committer.
 
-To become a Committer:
+To become a Contributor:
 
 * you have to have at least one pull request proposed, approved and merged or
 * you have helped responding to a variety of issues that help close them

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -18,6 +18,15 @@ Contributors have read-only access to source code and to submit changes via pull
 
 As Contributors gain experience and familiarity with the project, their profile within, and commitment to, the community will increase. At some stage, they may find themselves being nominated for committership by an existing Committer.
 
+To become a Committer:
+
+* you have to have at least one pull request proposed, approved and merged or
+* you have helped responding to a variety of issues that help close them
+
+#### Process for Adding Contributors
+
+1. Add the GitHub user to the "Project Contributors" team
+
 ### Project Committers
 
 Committers are community members who have shown that they are committed to the continued development of the project through ongoing engagement with the community. Committers are given push access to the project's GitHub repos and must abide by the project's [Contribution Guidelines](/CONTRIBUTING.md).


### PR DESCRIPTION
The project wants to honour every contribution to the project.
This patch enhances the governance around how to become a
contributor and what defines it.

It makes the project overall more inclusive to people that start contributing to the project.