### PR TITLE
Have `remote` and `multiremote` return a promise

### DIFF
--- a/packages/webdriverio/webdriverio.d.ts
+++ b/packages/webdriverio/webdriverio.d.ts
@@ -4,7 +4,7 @@ declare namespace WebdriverIO {
     function remote(
         options?: RemoteOptions,
         modifier?: (...args: any[]) => any
-    ): BrowserObject;
+    ): Promise<BrowserObject>;
 
     function attach(
         options: WebDriver.AttachSessionOptions,
@@ -12,7 +12,7 @@ declare namespace WebdriverIO {
 
     function multiremote(
         options: MultiRemoteOptions
-    ): BrowserObject;
+    ): Promise<BrowserObject>;
 
     interface Browser {
         /**

--- a/tests/typings/webdriverio/async.ts
+++ b/tests/typings/webdriverio/async.ts
@@ -16,6 +16,12 @@ async function bar() {
         }
     })
 
+    multiremote({
+        myBrowserInstance: {
+            browserName: 'chrome'
+        }
+    }).then(() => {}, () => {})
+
     // interact with specific instance
     const mrSingleElem = await mr.myBrowserInstance.$('')
     await mrSingleElem.click()
@@ -31,6 +37,8 @@ async function bar() {
 
     // remote
     const r = await remote({ capabilities: { browserName: 'chrome' } })
+    remote({ capabilities: { browserName: 'chrome' } }).then(
+        () => {}, () => {})
     const rElem = await r.$('')
     await rElem.click()
 


### PR DESCRIPTION
## Proposed changes

@mohanraj-r has highlighted a bug in our type definition regarding `remote` and `multiremote` functions (see #5597). This patch fixes that.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
