### PR TITLE
feat: update Sauce Unified Platform (RDC on Sauce) with the JS-executor

### DIFF
--- a/packages/wdio-sauce-service/src/service.js
+++ b/packages/wdio-sauce-service/src/service.js
@@ -50,6 +50,10 @@ export default class SauceService {
     }
 
     beforeTest (test) {
+        /**
+         * Date:    20200714
+         * Remark:  Sauce Unified Platform doesn't support updating the context yet.
+         */
         if (!this.isServiceEnabled || this.isRDC || this.isUP) {
             return
         }
@@ -93,6 +97,10 @@ export default class SauceService {
      * For CucumberJS
      */
     beforeFeature (uri, feature) {
+        /**
+         * Date:    20200714
+         * Remark:  Sauce Unified Platform doesn't support updating the context yet.
+         */
         if (!this.isServiceEnabled || this.isRDC || this.isUP) {
             return
         }
@@ -102,6 +110,10 @@ export default class SauceService {
     }
 
     beforeScenario (uri, feature, scenario) {
+        /**
+         * Date:    20200714
+         * Remark:  Sauce Unified Platform doesn't support updating the context yet.
+         */
         if (!this.isServiceEnabled || this.isRDC || this.isUP) {
             return
         }

--- a/packages/wdio-sauce-service/src/service.js
+++ b/packages/wdio-sauce-service/src/service.js
@@ -1,5 +1,6 @@
 import SauceLabs from 'saucelabs'
 import logger from '@wdio/logger'
+import { isUnifiedPlatform } from './utils'
 
 const jobDataProperties = ['name', 'tags', 'public', 'build', 'custom-data']
 
@@ -38,7 +39,7 @@ export default class SauceService {
     }
 
     before() {
-        this.isUP = this.isUnifiedPlatform(global.browser.capabilities)
+        this.isUP = isUnifiedPlatform(global.browser.capabilities)
     }
 
     beforeSuite (suite) {
@@ -215,50 +216,6 @@ export default class SauceService {
 
         body.passed = failures === 0
         return body
-    }
-
-    /**
-     * Determine if the current instance is a Unified Platform instance
-     * @param {string} deviceName
-     * @param {string} platformName
-     * @returns {boolean}
-     *
-     * This is what we get back from the UP (for now)
-     *
-     * capabilities =  {
-     *  webStorageEnabled: false,
-     *  locationContextEnabled: false,
-     *  browserName: 'safari',
-     *  platform: 'MAC',
-     *  javascriptEnabled: true,
-     *  databaseEnabled: false,
-     *  takesScreenshot: true,
-     *  networkConnectionEnabled: false,
-     *  platformVersion: '12.1.2',
-     *  webDriverAgentUrl: 'http://127.0.0.1:5700',
-     *  testobject_platform_name: 'iOS',
-     *  orientation: 'PORTRAIT',
-     *  realDevice: true,
-     *  build: 'Sauce Real Device browser iOS - 1594732389756',
-     *  commandTimeouts: { default: 60000 },
-     *  testobject_device: 'iPhone_XS_ws',
-     *  automationName: 'XCUITest',
-     *  platformName: 'iOS',
-     *  udid: '',
-     *  deviceName: '',
-     *  testobject_test_report_api_url: '',
-     *  testobject_test_report_url: '',
-     *  testobject_user_id: 'wim.selles',
-     *  testobject_project_id: 'saucelabs-default',
-     *  testobject_test_report_id: 51,
-     *  testobject_device_name: 'iPhone XS',
-     *  testobject_device_session_id: '',
-     *  deviceContextId: ''
-     * }
-     */
-    isUnifiedPlatform({ deviceName = '', platformName = '' }){
-        // If the string contains `simulator` or `emulator` it's a EMU/SIM session
-        return !deviceName.match(/(simulator)|(emulator)/gi) && !!platformName.match(/(ios)|(android)/gi)
     }
 
     /**

--- a/packages/wdio-sauce-service/src/utils.js
+++ b/packages/wdio-sauce-service/src/utils.js
@@ -1,0 +1,43 @@
+/**
+ * Determine if the current instance is a Unified Platform instance
+ * @param {string} deviceName
+ * @param {string} platformName
+ * @returns {boolean}
+ *
+ * This is what we get back from the UP (for now)
+ *
+ * capabilities =  {
+ *  webStorageEnabled: false,
+ *  locationContextEnabled: false,
+ *  browserName: 'safari',
+ *  platform: 'MAC',
+ *  javascriptEnabled: true,
+ *  databaseEnabled: false,
+ *  takesScreenshot: true,
+ *  networkConnectionEnabled: false,
+ *  platformVersion: '12.1.2',
+ *  webDriverAgentUrl: 'http://127.0.0.1:5700',
+ *  testobject_platform_name: 'iOS',
+ *  orientation: 'PORTRAIT',
+ *  realDevice: true,
+ *  build: 'Sauce Real Device browser iOS - 1594732389756',
+ *  commandTimeouts: { default: 60000 },
+ *  testobject_device: 'iPhone_XS_ws',
+ *  automationName: 'XCUITest',
+ *  platformName: 'iOS',
+ *  udid: '',
+ *  deviceName: '',
+ *  testobject_test_report_api_url: '',
+ *  testobject_test_report_url: '',
+ *  testobject_user_id: 'wim.selles',
+ *  testobject_project_id: 'saucelabs-default',
+ *  testobject_test_report_id: 51,
+ *  testobject_device_name: 'iPhone XS',
+ *  testobject_device_session_id: '',
+ *  deviceContextId: ''
+ * }
+ */
+export function isUnifiedPlatform({ deviceName = '', platformName = '' }){
+    // If the string contains `simulator` or `emulator` it's a EMU/SIM session
+    return !deviceName.match(/(simulator)|(emulator)/gi) && !!platformName.match(/(ios)|(android)/gi)
+}

--- a/packages/wdio-sauce-service/tests/service.test.js
+++ b/packages/wdio-sauce-service/tests/service.test.js
@@ -247,6 +247,7 @@ test('after for UP', () => {
     const service = new SauceService()
     global.browser.capabilities = {}
     service.updateUP = jest.fn()
+    service.isServiceEnabled = true
     service.isUP = true
     service.failures = 5
 
@@ -256,17 +257,23 @@ test('after for UP', () => {
     expect(service.updateUP).toBeCalledWith(5)
 })
 
-test('after for UP with multi remove', () => {
+test('after for UP with multi remote', () => {
     const service = new SauceService()
+    service.beforeSession(
+        { user: 'foobar', key: '123' },
+        { chromeA: {}, chromeB: {}, chromeC: {} }
+    )
     global.browser.capabilities = {}
     service.updateUP = jest.fn()
+    service.isServiceEnabled = true
     service.isUP = true
-    service.failures = 5
+    service.failures = 0
 
     global.browser.isMultiremote = true
+    global.browser.sessionId = 'foobar'
     service.after()
 
-    expect(service.updateUP).toBeCalledWith(5)
+    expect(service.updateUP).toBeCalledTimes(3)
 })
 
 test('after with bail set', () => {
@@ -330,14 +337,14 @@ test('onReload', () => {
 test('onReload with RDC', () => {
     const service = new SauceService()
     service.beforeSession({}, { testobject_api_key: 1 })
-    service.failures = 5
+    service.failures = 0
     service.updateJob = jest.fn()
 
     global.browser.isMultiremote = false
     global.browser.sessionId = 'foobar'
     service.onReload('oldbar', 'newbar')
 
-    expect(service.updateJob).toBeCalledWith('oldbar', 5, true)
+    expect(service.updateJob).toBeCalledWith('oldbar', 0, true)
 })
 
 test('onReload should not set context if no sauce user was applied', () => {

--- a/packages/wdio-sauce-service/tests/service.test.js
+++ b/packages/wdio-sauce-service/tests/service.test.js
@@ -1,6 +1,7 @@
 import got from 'got'
 
 import SauceService from '../src'
+import { isUnifiedPlatform } from '../src/utils'
 
 const uri = '/some/uri'
 const featureObject = {
@@ -52,12 +53,16 @@ test('constructor should set setJobNameInBeforeSuite', () => {
     expect(service.options.setJobNameInBeforeSuite).toBeTruthy()
 })
 
+jest.mock('../src/utils', () => {
+    return {
+        isUnifiedPlatform: jest.fn().mockReturnValue(true),
+    }
+})
+
 test('before should call isUnifiedPlatform', () => {
     const service = new SauceService()
-    global.browser.capabilities = {}
-    service.isUnifiedPlatform = jest.fn()
     service.before()
-    expect(service.isUnifiedPlatform).toBeCalledTimes(1)
+    expect(isUnifiedPlatform).toBeCalledTimes(1)
 })
 
 test('beforeSuite', () => {
@@ -564,41 +569,6 @@ test('getBody without multiremote', () => {
         'custom-data': { some: 'data' },
         passed: true
     })
-})
-
-test('isUnifiedPlatform should be false for no provided deviceName and platformName', () => {
-    const service = new SauceService()
-    expect(service.isUnifiedPlatform({})).toEqual(false)
-})
-
-test('isUnifiedPlatform should be false for a non matching deviceName', () => {
-    const service = new SauceService()
-    expect(service.isUnifiedPlatform({ deviceName: 'foo' })).toEqual(false)
-})
-
-test('isUnifiedPlatform should be false for a non matching platformName', () => {
-    const service = new SauceService()
-    expect(service.isUnifiedPlatform({ platformName: 'foo' })).toEqual(false)
-})
-
-test('isUnifiedPlatform should be false for an emulator test', () => {
-    const service = new SauceService()
-    expect(service.isUnifiedPlatform({ deviceName: 'Google Pixel emulator', platformName: 'Android' })).toEqual(false)
-})
-
-test('isUnifiedPlatform should be false for a simulator test', () => {
-    const service = new SauceService()
-    expect(service.isUnifiedPlatform({ deviceName: 'iPhone XS simulator', platformName: 'iOS' })).toEqual(false)
-})
-
-test('isUnifiedPlatform should be true for a real device iOS test', () => {
-    const service = new SauceService()
-    expect(service.isUnifiedPlatform({ deviceName: 'iPhone XS', platformName: 'iOS' })).toEqual(true)
-})
-
-test('isUnifiedPlatform should be true for real device Android test', () => {
-    const service = new SauceService()
-    expect(service.isUnifiedPlatform({ deviceName: 'Google Pixel', platformName: 'Android' })).toEqual(true)
 })
 
 test('updateUP should set job status to false', () => {

--- a/packages/wdio-sauce-service/tests/utils.spec.js
+++ b/packages/wdio-sauce-service/tests/utils.spec.js
@@ -1,0 +1,29 @@
+import { isUnifiedPlatform } from '../src/utils'
+
+test('isUnifiedPlatform should be false for no provided deviceName and platformName', () => {
+    expect(isUnifiedPlatform({})).toEqual(false)
+})
+
+test('isUnifiedPlatform should be false for a non matching deviceName', () => {
+    expect(isUnifiedPlatform({ deviceName: 'foo' })).toEqual(false)
+})
+
+test('isUnifiedPlatform should be false for a non matching platformName', () => {
+    expect(isUnifiedPlatform({ platformName: 'foo' })).toEqual(false)
+})
+
+test('isUnifiedPlatform should be false for an emulator test', () => {
+    expect(isUnifiedPlatform({ deviceName: 'Google Pixel emulator', platformName: 'Android' })).toEqual(false)
+})
+
+test('isUnifiedPlatform should be false for a simulator test', () => {
+    expect(isUnifiedPlatform({ deviceName: 'iPhone XS simulator', platformName: 'iOS' })).toEqual(false)
+})
+
+test('isUnifiedPlatform should be true for a real device iOS test', () => {
+    expect(isUnifiedPlatform({ deviceName: 'iPhone XS', platformName: 'iOS' })).toEqual(true)
+})
+
+test('isUnifiedPlatform should be true for real device Android test', () => {
+    expect(isUnifiedPlatform({ deviceName: 'Google Pixel', platformName: 'Android' })).toEqual(true)
+})


### PR DESCRIPTION
## Proposed changes
Sauce Labs is implementing the Unified Platform in phases, meaning adding real devices on the Sauce UI platform.  This also means that certain features are implemented in phases, these are:

1. support updating job names / contexts with the JS-executor
2. update the job with the Sauce Rest API

This PR disables point 1 and enables a workaround for point 2


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

I'm only struggling with the 2 added `after` tests. It's working properly on EMUSIM/VM's and the UP. Some tips on fixing them would be great