### PR TITLE
Remove extra space introduced by prior PR https://github.com/webdriverio/webdriverio/pull/5483

### DIFF
--- a/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
+++ b/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
@@ -337,7 +337,7 @@ exports.config = {
     /**
      * Runs before a Cucumber scenario
      */
-    // beforeScenario: function (uri, feature, scenario, sourceLocation,c ontext) {
+    // beforeScenario: function (uri, feature, scenario, sourceLocation,context) {
     // },
     /**
      * Runs before a Cucumber step

--- a/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
+++ b/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
@@ -337,7 +337,7 @@ exports.config = {
     /**
      * Runs before a Cucumber scenario
      */
-    // beforeScenario: function (uri, feature, scenario, sourceLocation,context) {
+    // beforeScenario: function (uri, feature, scenario, sourceLocation, context) {
     // },
     /**
      * Runs before a Cucumber step


### PR DESCRIPTION
## Proposed changes
Correct extra space in "context" at line 340 of wdio.conf.tpl.ejs introduced with https://github.com/webdriverio/webdriverio/pull/5483:
    // beforeScenario: function (uri, feature, scenario, sourceLocation,c ontext) {

change to
    // beforeScenario: function (uri, feature, scenario, sourceLocation,context) {

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments


### Reviewers: @webdriverio/project-committers
