### PR TITLE
Fix dependency of @wdio/sauce-service on @wdio/utils

### DIFF
--- a/packages/wdio-sauce-service/package.json
+++ b/packages/wdio-sauce-service/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@wdio/logger": "6.0.16",
-    "@wdio/utils": "6.0.16",
+    "@wdio/utils": "^6.3.0",
     "saucelabs": "^4.2.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
`@wdio/sauce-service` needs `@wdio/utils` v6.3.0 or later (with `isW3C` exported).

Otherwise you will get an error `TypeError: (0, _utils.isW3C) is not a function` from the `onPrepare` hook of `@wdio/sauce-service`.

## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

Bump dependency `@wdio/utils` to `^6.3.0`.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

Sorry, I introduced this bug in my PR #5610, as I didn't think about how the version numbers should look when adding `@wdio/utils` as a dependency to `@wdio/sauce-service`. 

### Reviewers: @webdriverio/project-committers
