### PR TITLE
Fix wdio-junit-reporter runner.config.hostname bug

### DIFF
--- a/packages/wdio-junit-reporter/src/index.js
+++ b/packages/wdio-junit-reporter/src/index.js
@@ -169,7 +169,7 @@ class JunitReporter extends WDIOReporter {
 
     buildJunitXml (runner) {
         let builder = junit.newBuilder()
-        if (runner.config.hostname.indexOf('browserstack') > -1) {
+        if (runner.config.hostname !== undefined && runner.config.hostname.indexOf('browserstack') > -1) {
             // NOTE: deviceUUID is used to build sanitizedCapabilities resulting in a ever-changing package name in runner.sanitizedCapabilities when running Android tests under Browserstack. (i.e. ht79v1a03938.android.9)
             // NOTE: platformVersion is used to build sanitizedCapabilities which can be incorrect and includes a minor version for iOS which is not guaranteed to be the same under Browserstack.
             const browserstackSanitizedCapabilities = (runner.capabilities.device.toLowerCase() + '.' + runner.capabilities.os.toLowerCase() + '.' + runner.capabilities.os_version.replace(/\./g, '_')).replace(/ /g, '')


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

Fix an issue `[0-0] 2020-07-17T08:57:30.484Z ERROR @wdio/local-runner: Failed launching test session: TypeError: Cannot read property 'indexOf' of undefined` 
 https://github.com/webdriverio/webdriverio/blob/d1f9a1e56ec68b3fb4c74a67643e85bb1fea05f5/packages/wdio-junit-reporter/src/index.js#L172
Some configs may throw an error with https://github.com/webdriverio/webdriverio/pull/5540

On some projects, I saw custom runner.config, where hostname may be undefined:
```
[0-0] {
  hostname: undefined,
  port: undefined,
  protocol: undefined,
  path: undefined,
  specs: ...
```
```
[0-0] {
  hostname: '127.0.0.1',
  port: 4444,
  protocol: 'http',
  path: '/wd/hub',
```
## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)

### Reviewers: @webdriverio/project-committers
