### PR TITLE
Add `calls` property to mock typings.

### DIFF
--- a/packages/wdio-sync/webdriverio-core.d.ts
+++ b/packages/wdio-sync/webdriverio-core.d.ts
@@ -490,6 +490,13 @@ declare namespace WebdriverIO {
         isLinkPreload?: boolean;
     }
 
+    interface Matches extends Request {
+        /**
+         * body response of actual resource
+         */
+        body: any
+    }
+
     type CDPSession = Partial<import('puppeteer').CDPSession>;
     type MockOverwriteFunction = (request: Request, client: CDPSession) => Promise<string | Record<string, any>>;
     type MockOverwrite = string | Record<string, any> | MockOverwriteFunction;
@@ -894,6 +901,11 @@ declare namespace WebdriverIO {
     }
 
     interface Mock {
+        /**
+         * list of requests made by the browser to that mock
+         */
+        calls: Matches[];
+
         
         /**
          * > This is a __beta__ feature. Please give us feedback and file [an issue](https://github.com/webdriverio/webdriverio/issues/new/choose) if certain scenarions don't work as expected!

--- a/packages/webdriverio/webdriverio-core.d.ts
+++ b/packages/webdriverio/webdriverio-core.d.ts
@@ -490,6 +490,13 @@ declare namespace WebdriverIO {
         isLinkPreload?: boolean;
     }
 
+    interface Matches extends Request {
+        /**
+         * body response of actual resource
+         */
+        body: any
+    }
+
     type CDPSession = Partial<import('puppeteer').CDPSession>;
     type MockOverwriteFunction = (request: Request, client: CDPSession) => Promise<string | Record<string, any>>;
     type MockOverwrite = string | Record<string, any> | MockOverwriteFunction;
@@ -894,6 +901,11 @@ declare namespace WebdriverIO {
     }
 
     interface Mock {
+        /**
+         * list of requests made by the browser to that mock
+         */
+        calls: Matches[];
+
         
         /**
          * > This is a __beta__ feature. Please give us feedback and file [an issue](https://github.com/webdriverio/webdriverio/issues/new/choose) if certain scenarions don't work as expected!

--- a/scripts/templates/webdriverio.tpl.d.ts
+++ b/scripts/templates/webdriverio.tpl.d.ts
@@ -484,6 +484,13 @@ declare namespace WebdriverIO {
         isLinkPreload?: boolean;
     }
 
+    interface Matches extends Request {
+        /**
+         * body response of actual resource
+         */
+        body: any
+    }
+
     type CDPSession = Partial<import('puppeteer').CDPSession>;
     type MockOverwriteFunction = (request: Request, client: CDPSession) => Promise<string | Record<string, any>>;
     type MockOverwrite = string | Record<string, any> | MockOverwriteFunction;
@@ -545,6 +552,11 @@ declare namespace WebdriverIO {
     }
 
     interface Mock {
+        /**
+         * list of requests made by the browser to that mock
+         */
+        calls: Matches[];
+
         // ... mock commands ...
     }
 

--- a/tests/typings/sync/sync.ts
+++ b/tests/typings/sync/sync.ts
@@ -216,5 +216,8 @@ mock.respondOnce('/other/resource.jpg', {
     headers: { foo: 'bar' }
 })
 mock.restore()
+const match = mock.calls[0]
+match.body
+match.headers
 
 export default {}

--- a/tests/typings/webdriverio/async.ts
+++ b/tests/typings/webdriverio/async.ts
@@ -246,6 +246,9 @@ async function bar() {
         headers: { foo: 'bar' }
     })
     mock.restore()
+    const match = mock.calls[0]
+    match.body
+    match.headers
 }
 
 // allure-reporter


### PR DESCRIPTION
## Proposed changes

I missed to add `calls` to the mock type definition.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

I will fast track this if test pass.

### Reviewers: @webdriverio/project-committers
