### PR TITLE
Add TypeScript types for SevereServiceError

### DIFF
--- a/packages/webdriverio/src/utils/SevereServiceError.js
+++ b/packages/webdriverio/src/utils/SevereServiceError.js
@@ -1,8 +1,8 @@
 /**
- * Error to be thrown when a sever error was encountered when a Service is being ran.
+ * Error to be thrown when a severe error was encountered when a Service is being ran.
  */
 export default class SevereServiceError extends Error {
-    constructor(message = 'Sever Service Error occurred.') {
+    constructor(message = 'Severe Service Error occurred.') {
         super(message)
         this.name = 'SevereServiceError'
     }

--- a/packages/webdriverio/tests/index.test.js
+++ b/packages/webdriverio/tests/index.test.js
@@ -1,19 +1,26 @@
 import * as webdriverio from '../src'
 
+// If you're making a change here, like adding a new export, the TypeScript
+// typings may need an update : packages/webdriverio/webdriverio.d.ts
+
 describe('index.js', () => {
-    it('exports attach method', () => {
-        expect(webdriverio.attach).toBeDefined()
-    })
-
-    it('exports attach method', () => {
-        expect(webdriverio.multiremote).toBeDefined()
-    })
-
-    it('exports attach method', () => {
+    it('exports remote method', () => {
         expect(webdriverio.remote).toBeDefined()
     })
 
     it('exports attach method', () => {
+        expect(webdriverio.attach).toBeDefined()
+    })
+
+    it('exports multiremote method', () => {
+        expect(webdriverio.multiremote).toBeDefined()
+    })
+
+    it('exports remote method', () => {
+        expect(webdriverio.remote).toBeDefined()
+    })
+
+    it('exports SevereServiceError class', () => {
         expect(webdriverio.SevereServiceError).toBeDefined()
     })
 })

--- a/packages/webdriverio/tests/utils/SevereServiceError.test.js
+++ b/packages/webdriverio/tests/utils/SevereServiceError.test.js
@@ -8,7 +8,7 @@ describe('SevereServiceError', () => {
 
     it('should provide a default error message', () => {
         const err = new SevereServiceError()
-        expect(err.message).toBe('Sever Service Error occurred.')
+        expect(err.message).toBe('Severe Service Error occurred.')
     })
 
     it('should accept a custom error message', () => {

--- a/packages/webdriverio/webdriverio.d.ts
+++ b/packages/webdriverio/webdriverio.d.ts
@@ -40,6 +40,11 @@ declare namespace WebdriverIO {
     }
 
     interface BrowserObject extends WebDriver.ClientOptions, WebDriver.ClientAsync, Browser { }
+
+    /**
+     * Error to be thrown when a severe error was encountered when a Service is being ran.
+     */
+    class SevereServiceError extends Error { }
 }
 
 declare var browser: WebdriverIO.BrowserObject;

--- a/tests/typings/webdriverio/async.ts
+++ b/tests/typings/webdriverio/async.ts
@@ -1,7 +1,7 @@
 import allure from '@wdio/allure-reporter'
 import { remote, multiremote, MockOverwriteFunction } from 'webdriverio'
 
-// An example of adding command withing ts file to WebdriverIO (async)
+// An example of adding command within ts file to WebdriverIO (async)
 declare module "webdriverio" {
     interface Browser {
         browserCustomCommand: (arg: unknown) => Promise<void>

--- a/tests/typings/webdriverio/async.ts
+++ b/tests/typings/webdriverio/async.ts
@@ -1,5 +1,5 @@
 import allure from '@wdio/allure-reporter'
-import { remote, multiremote, MockOverwriteFunction } from 'webdriverio'
+import { remote, multiremote, MockOverwriteFunction, SevereServiceError } from 'webdriverio'
 
 // An example of adding command within ts file to WebdriverIO (async)
 declare module "webdriverio" {
@@ -249,6 +249,14 @@ async function bar() {
     const match = mock.calls[0]
     match.body
     match.headers
+}
+
+function testSevereServiceError_noParameters() {
+    throw new SevereServiceError();
+}
+
+function testSevereServiceError_stringParameter() {
+    throw new SevereServiceError("Something happened.");
 }
 
 // allure-reporter

--- a/tests/typings/webdriverio/types/async.d.ts
+++ b/tests/typings/webdriverio/types/async.d.ts
@@ -1,5 +1,5 @@
 /**
- * An example of adding command withing d.ts file to WebdriverIO (async)
+ * An example of adding command within d.ts file to WebdriverIO (async)
  */
 
 // module should be "webdriverio" if used within `ts` file instead of `d.ts`


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

Fixes #5648 by adding TypeScript types for SevereServiceError, which was added recently by #5565.

Also addresses a couple minor typos and adds a missing test.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

See the 5 commits, I scoped them to individually capture the changes being made.

### Reviewers: @webdriverio/project-committers 

CC @emilyrohrbough, since she added the error.
