### PR TITLE
Fix re-attach devtools service if `reloadSession` was called

### DIFF
--- a/packages/wdio-devtools-service/src/index.js
+++ b/packages/wdio-devtools-service/src/index.js
@@ -34,7 +34,6 @@ export default class DevToolsService {
         return this._setDevtools()
     }
 
-
     async beforeCommand (commandName, params) {
         if (!this.shouldRunPerformanceAudits || !this.traceGatherer || this.traceGatherer.isTracing || !TRACE_COMMANDS.includes(commandName)) {
             return

--- a/packages/wdio-devtools-service/tests/service.test.js
+++ b/packages/wdio-devtools-service/tests/service.test.js
@@ -81,7 +81,7 @@ test('if not supported by browser', async () => {
     const service = new DevToolsService({}, [{}], {})
     service.isSupported = false
 
-    await service.before()
+    await service._setDevtools()
     expect(global.browser.addCommand.mock.calls).toHaveLength(1)
     expect(global.browser.addCommand.mock.calls[0][0]).toBe('cdp')
     expect(global.browser.addCommand.mock.calls[0][1].toString()).toContain('throw new Error')
@@ -91,7 +91,7 @@ test('if supported by browser', async () => {
     global.browser = { addCommand: jest.fn() }
     const service = new DevToolsService({}, [{}], {})
     service.isSupported = true
-    await service.before()
+    await service._setDevtools()
     expect(service.client.Network.enable).toBeCalledTimes(1)
     service.client.Network.enable.mockClear()
     expect(service.client.Console.enable).toBeCalledTimes(1)
@@ -107,7 +107,7 @@ test('initialised with the debuggerAddress as option', async () => {
     global.browser = { addCommand: jest.fn() }
     const service = new DevToolsService(options)
     service.isSupported = true
-    await service.before()
+    await service._setDevtools()
     expect(getCDPClient).toBeCalledWith({ host: 'localhost', port: 4444 })
     expect(service.client.Network.enable).toBeCalledTimes(1)
     expect(service.client.Console.enable).toBeCalledTimes(1)
@@ -132,7 +132,7 @@ test('initialization fails', async () => {
 
     const service = new DevToolsService({}, [{}], {})
     service.isSupported = true
-    await service.before()
+    await service._setDevtools()
 
     expect(service.commandHandler).toBe(undefined)
     expect(log.error.mock.calls.pop()[0]).toContain('Couldn\'t connect to chrome: Error: boom')
@@ -317,6 +317,20 @@ test('_emulateDevice', async () => {
         () => true,
         () => false)
     expect(isSuccessful).toBe(false)
+})
+
+test('before hook', async () => {
+    const service = new DevToolsService({}, [{}], {})
+    service._setDevtools = jest.fn()
+    service.before()
+    expect(service._setDevtools).toBeCalledTimes(1)
+})
+
+test('onReload hook', async () => {
+    const service = new DevToolsService({}, [{}], {})
+    service._setDevtools = jest.fn()
+    service.onReload()
+    expect(service._setDevtools).toBeCalledTimes(1)
 })
 
 afterEach(() => {

--- a/packages/webdriver/src/index.js
+++ b/packages/webdriver/src/index.js
@@ -59,10 +59,11 @@ export default class WebDriver {
     }
 
     /**
-     * Changes The instance id and browser capabilities for the new session
+     * Changes The instance session id and browser capabilities for the new session
      * directly into the passed in browser object
-     * @param {Object} instance - the object we get from a new browser session.
-     * @returns {string} - the new session id of the browser
+     *
+     * @param   {Object} instance  the object we get from a new browser session.
+     * @returns {string}           the new session id of the browser
     */
     static async reloadSession (instance) {
         const params = {

--- a/packages/webdriver/src/index.js
+++ b/packages/webdriver/src/index.js
@@ -58,6 +58,12 @@ export default class WebDriver {
         return monad(options.sessionId, commandWrapper)
     }
 
+    /**
+     * Changes The instance id and browser capabilities for the new session
+     * directly into the passed in browser object
+     * @param {Object} instance - the object we get from a new browser session.
+     * @returns {string} - the new session id of the browser
+    */
     static async reloadSession (instance) {
         const params = {
             ...instance.options,
@@ -65,6 +71,7 @@ export default class WebDriver {
         }
         const sessionId = await startWebDriverSession(params)
         instance.sessionId = sessionId
+        instance.capabilities = params.capabilities
         return sessionId
     }
 


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)
refreshes browser capabilities on `reloadSession()` so devtools won't try to hook to old session
fixes issue #5524 

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)
later on i'll move `deleteSession` from wdio to webdriver

### Reviewers: @webdriverio/project-committers
