### PR TITLE
Fix version 4 doc links

### DIFF
--- a/docs/Versions.md
+++ b/docs/Versions.md
@@ -18,4 +18,4 @@ Here you can find documentation for previous versions of WebdriverIO.
 | | | | |
 |----|-------------------------------------------|----------------------------------------------------------------------------------------------|-----|
 | v5 | [Documentation](https://v5.webdriver.io/) | [Release Notes](https://github.com/webdriverio/webdriverio/blob/v5/CHANGELOG.md#changelog) | __LTS__ (until April 2021) |
-| v4 | [Documentation](https://v4.webdriver.io/) | [Release Notes](https://github.com/webdriverio-boneyard/v4/blob/master/CHANGELOG.md#unreleased) | __Deprecated__ (since December 2019) |
+| v4 | [Documentation](http://v4.webdriver.io/) | [Release Notes](https://github.com/webdriverio-boneyard/v4/blob/master/CHANGELOG.md#unreleased) | __Deprecated__ (since December 2019) |


### PR DESCRIPTION
The webdriver.IO version 4 doc links to https, but documentation site only responds to http, and does not dynamically forward the browser to the http variant.

This changes the documentation to point to http.

## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
