### PR TITLE
include the automation protocol for webdriver

### DIFF
--- a/docs/AutomationProtocols.md
+++ b/docs/AutomationProtocols.md
@@ -43,6 +43,16 @@ There are also plenty of services that allow you to run your automation test in 
 - Not designed for in-depth browser analysis (e.g., tracing or intercepting network events)
 - Limited set of automation capabilities (e.g., no support to throttle CPU or network)
 
+To use webdriver as the automation protocol, you just need to switch the `automationProtocol` flag to `webdriverio` in your `wdio.conf.js`:
+```js
+// wdio.conf.js
+exports.config = {
+    // ...
+    automationProtocol: 'webdriver'
+    // ...
+}
+```
+
 ## DevTools Protocol
 
 The DevTools interface is a native browser interface that is usually being used to debug the browser from a remote application (e.g., [Chrome DevTools](https://developers.google.com/web/tools/chrome-devtools/)). Next to its capabilities to inspect the browser in nearly all possible forms, it can also be used to control it.


### PR DESCRIPTION
since the webdriverio upgrade to v6, the default protocol has been changed from webdriver to devtools. Hence it could be confusing for someone setting up wdio and wanting to use webdriver to figure out the protocol name. So this pull request explicitly defines the protocol name.

## Proposed changes

[//]: # the automation protocol value for webdriver is made explicit in config

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
