### PR TITLE
Fix issue with auto-genarated tests for Cucumber

### DIFF
--- a/packages/wdio-cli/src/commands/config.js
+++ b/packages/wdio-cli/src/commands/config.js
@@ -9,7 +9,7 @@ import {
 } from '../constants'
 import {
     addServiceDeps, convertPackageHashToObject, renderConfigurationFile,
-    hasFile, generateTestFiles, getAnswers
+    hasFile, generateTestFiles, getAnswers, getPathForFileGeneration
 } from '../utils'
 
 export const command = 'config'
@@ -81,22 +81,8 @@ export const runConfig = async function (useYarn, yes, exit) {
     /**
      * find relative paths between tests and pages
      */
-    const destSpecRootPath = path.join(
-        process.cwd(),
-        path.dirname(answers.specs || '').replace(/\*\*$/, ''))
 
-    const destStepRootPath = path.join(process.cwd(), path.dirname(answers.stepDefinitions || ''))
-
-    const destPageObjectRootPath = answers.usePageObjects
-        ?  path.join(
-            process.cwd(),
-            path.dirname(answers.pages || '').replace(/\*\*$/, ''))
-        : ''
-    const relativePath = (answers.generateTestFiles && answers.usePageObjects)
-        ? !(answers.framework === 'cucumber')
-            ? path.relative(destSpecRootPath, destPageObjectRootPath)
-            : path.relative(destStepRootPath, destPageObjectRootPath)
-        : ''
+    const parsedPaths = getPathForFileGeneration(answers)
 
     const parsedAnswers = {
         ...answers,
@@ -110,9 +96,9 @@ export const runConfig = async function (useYarn, yes, exit) {
         isSync: syncExecution,
         _async: syncExecution ? '' : 'async ',
         _await: syncExecution ? '' : 'await ',
-        destSpecRootPath: destSpecRootPath,
-        destPageObjectRootPath: destPageObjectRootPath,
-        relativePath : relativePath
+        destSpecRootPath: parsedPaths.destSpecRootPath,
+        destPageObjectRootPath: parsedPaths.destPageObjectRootPath,
+        relativePath : parsedPaths.relativePath
     }
 
     try {

--- a/packages/wdio-cli/src/commands/config.js
+++ b/packages/wdio-cli/src/commands/config.js
@@ -1,4 +1,3 @@
-import path from 'path'
 import util from 'util'
 import yarnInstall from 'yarn-install'
 

--- a/packages/wdio-cli/src/utils.js
+++ b/packages/wdio-cli/src/utils.js
@@ -340,3 +340,30 @@ export async function getAnswers(yes) {
         ), {})
         : await inquirer.prompt(QUESTIONNAIRE)
 }
+
+export function getPathForFileGeneration(answers){
+
+    const destSpecRootPath = path.join(
+        process.cwd(),
+        path.dirname(answers.specs || '').replace(/\*\*$/, ''))
+
+    const destStepRootPath = path.join(process.cwd(), path.dirname(answers.stepDefinitions || ''))
+
+    const destPageObjectRootPath = answers.usePageObjects
+        ?  path.join(
+            process.cwd(),
+            path.dirname(answers.pages || '').replace(/\*\*$/, ''))
+        : ''
+    const relativePath = (answers.generateTestFiles && answers.usePageObjects)
+        ? !(answers.framework.short === 'cucumber')
+            ? path.relative(destSpecRootPath, destPageObjectRootPath)
+            : path.relative(destStepRootPath, destPageObjectRootPath)
+        : ''
+
+    return {
+        destSpecRootPath : destSpecRootPath,
+        destStepRootPath : destStepRootPath,
+        destPageObjectRootPath : destPageObjectRootPath,
+        relativePath : relativePath
+    }
+}

--- a/packages/wdio-cli/tests/commands/config.test.js
+++ b/packages/wdio-cli/tests/commands/config.test.js
@@ -3,7 +3,7 @@ import yarnInstall from 'yarn-install'
 import inquirer from 'inquirer'
 
 import { handler, builder } from './../../src/commands/config'
-import { addServiceDeps, convertPackageHashToObject, renderConfigurationFile, generateTestFiles } from '../../src/utils'
+import { addServiceDeps, convertPackageHashToObject, renderConfigurationFile, generateTestFiles, getPathForFileGeneration } from '../../src/utils'
 
 jest.mock('../../src/utils', () => ({
     addServiceDeps: jest.fn(),
@@ -11,7 +11,8 @@ jest.mock('../../src/utils', () => ({
     renderConfigurationFile: jest.fn(),
     hasFile: jest.fn().mockReturnValue(false),
     getAnswers: jest.fn().mockImplementation(jest.requireActual('../../src/utils').getAnswers),
-    generateTestFiles: jest.fn()
+    generateTestFiles: jest.fn(),
+    getPathForFileGeneration: jest.fn().mockImplementation(jest.requireActual('../../src/utils').getPathForFileGeneration),
 }))
 
 const errorLogSpy = jest.spyOn(console, 'error')
@@ -33,6 +34,7 @@ test('should create config file', async () => {
     expect(convertPackageHashToObject).toBeCalledTimes(4)
     expect(renderConfigurationFile).toBeCalledTimes(1)
     expect(generateTestFiles).toBeCalledTimes(0)
+    expect(getPathForFileGeneration).toBeCalledTimes(1)
     expect(errorLogSpy).toHaveBeenCalledTimes(0)
     expect(yarnInstall).toHaveBeenCalledWith({
         deps: expect.any(Object),

--- a/packages/wdio-cli/tests/utils.test.js
+++ b/packages/wdio-cli/tests/utils.test.js
@@ -19,7 +19,9 @@ import {
     validateServiceAnswers,
     getCapabilities,
     hasFile,
-    generateTestFiles
+    generateTestFiles,
+    getPathForFileGeneration
+
 } from '../src/utils'
 
 import { runConfig } from '../src/commands/config'
@@ -555,4 +557,84 @@ afterEach(() => {
     fs.writeFileSync.mockClear()
     fs.ensureDirSync.mockClear()
     ejs.renderFile.mockClear()
+})
+
+describe('getPathForFileGeneration', () => {
+    it('Cucumber with pageobjects default values', () => {
+        const generatedPaths = getPathForFileGeneration({
+            stepDefinitions: './features/step-definitions/steps.js',
+            pages: './features/pageobjects/**/*.js',
+            generateTestFiles: true,
+            usePageObjects: true,
+            framework : {
+                short:'cucumber'
+            }
+        })
+        expect(generatedPaths.relativePath).toEqual('../pageobjects')
+    })
+
+    it('Cucumber with pageobjects default different path', () => {
+        const generatedPaths = getPathForFileGeneration({
+            stepDefinitions: './features/step-definitions/steps.js',
+            pages: './features/page/objects/**/*.js',
+            generateTestFiles: true,
+            usePageObjects: true,
+            framework : {
+                short:'cucumber'
+            }
+        })
+        expect(generatedPaths.relativePath).toEqual('../page/objects')
+    })
+
+    it('Mocha with pageobjects default values', () => {
+        const generatedPaths = getPathForFileGeneration({
+            specs: './test/specs/**/*.js',
+            pages: './test/pageobjects/**/*.js',
+            generateTestFiles: true,
+            usePageObjects: true,
+            framework : {
+                short:'mocha'
+            }
+        })
+        expect(generatedPaths.relativePath).toEqual('../pageobjects')
+    })
+
+    it('Mocha with pageobjects different path', () => {
+        const generatedPaths = getPathForFileGeneration({
+            specs: './test/specs/files/**/*.js',
+            pages: './test/pageobjects/**/*.js',
+            generateTestFiles: true,
+            usePageObjects: true,
+            framework : {
+                short:'mocha'
+            }
+        })
+        expect(generatedPaths.relativePath).toEqual('../../pageobjects')
+    })
+
+    it('Do not auto generate file', () => {
+        const generatedPaths = getPathForFileGeneration({
+            specs: './test/specs/files/**/*.js',
+            pages: './test/pageobjects/**/*.js',
+            generateTestFiles: false,
+            usePageObjects: true,
+            framework : {
+                short:'mocha'
+            }
+        })
+        expect(generatedPaths.relativePath).toEqual('')
+    })
+
+    it('Do not use PageObjects', () => {
+        const generatedPaths = getPathForFileGeneration({
+            specs: './test/specs/files/**/*.js',
+            pages: './test/pageobjects/**/*.js',
+            generateTestFiles: true,
+            usePageObjects: false,
+            framework : {
+                short:'mocha'
+            }
+        })
+        expect(generatedPaths.relativePath).toEqual('')
+    })
 })


### PR DESCRIPTION
## Proposed changes

I found a bug that during file generation the relative path between steps and pages (only for cucumber) was not being generated correctly which made the auto-generated cucumber files to not work as expected.

The code was validating for `framework === 'cucumber'` instead of `framework.short ==='cucumber'`. This was introduced during my last PR after refactoring the code after one of the revisions.

I created a method for the paths generation so that I can easily add unit tests for it. 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

None

### Reviewers: @webdriverio/project-committers
