### PR TITLE
repaired mocha/multiremote example

### DIFF
--- a/examples/wdio/multiremote/mocha.test.js
+++ b/examples/wdio/multiremote/mocha.test.js
@@ -1,6 +1,6 @@
 describe('multiremote example', () => {
     it('should open chat application', () => {
-        browser.url('https://socket-io-chat.now.sh/')
+        browser.url('https://socketio-chat-h9jt.herokuapp.com/')
     })
 
     it('should login the browser', () => {

--- a/examples/wdio/multiremote/wdio.conf.js
+++ b/examples/wdio/multiremote/wdio.conf.js
@@ -5,7 +5,6 @@ exports.config = {
      * server configurations
      */
     hostname: 'localhost',
-    port: 4444,
 
     /**
      * specify test files
@@ -17,11 +16,13 @@ exports.config = {
      */
     capabilities: {
         browserA: {
+            port: 4444,
             capabilities: {
                 browserName: 'chrome'
             }
         },
         browserB: {
+            port: 4445,
             capabilities: {
                 browserName: 'chrome'
             }


### PR DESCRIPTION
## Proposed changes

Chromedriver no longer supports running multiple sessions on a single port. I modified the multiremote example to run against multiple Chromedriver ports. Also the socket.io page originally used in the test was no longer valid, so I updated its url destination.

I've managed to reproduce the issue, I'm still working on the fix.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
