### PR TITLE
Add type definition for filesToWatch

### DIFF
--- a/packages/wdio-sync/webdriverio-core.d.ts
+++ b/packages/wdio-sync/webdriverio-core.d.ts
@@ -94,6 +94,10 @@ declare namespace WebdriverIO {
          */
         exclude?: string[];
         /**
+         * Files to watch when running `wdio` with the `--watch` flag.
+         */
+        filesToWatch?: string[],
+        /**
          * An object describing various of suites, which you can then specify
          * with the --suite option on the wdio CLI.
          */

--- a/packages/webdriverio/webdriverio-core.d.ts
+++ b/packages/webdriverio/webdriverio-core.d.ts
@@ -94,6 +94,10 @@ declare namespace WebdriverIO {
          */
         exclude?: string[];
         /**
+         * Files to watch when running `wdio` with the `--watch` flag.
+         */
+        filesToWatch?: string[],
+        /**
          * An object describing various of suites, which you can then specify
          * with the --suite option on the wdio CLI.
          */

--- a/scripts/templates/webdriverio.tpl.d.ts
+++ b/scripts/templates/webdriverio.tpl.d.ts
@@ -88,6 +88,10 @@ declare namespace WebdriverIO {
          */
         exclude?: string[];
         /**
+         * Files to watch when running `wdio` with the `--watch` flag.
+         */
+        filesToWatch?: string[],
+        /**
          * An object describing various of suites, which you can then specify
          * with the --suite option on the wdio CLI.
          */

--- a/tests/typings/sync/config.ts
+++ b/tests/typings/sync/config.ts
@@ -40,5 +40,9 @@ const conf: WebdriverIO.Config = {
         }
 
         return response
-    }
+    },
+
+    filesToWatch: [
+        '/foo/page-objects/**/*.page.js',
+    ],
 }

--- a/tests/typings/webdriverio/config.ts
+++ b/tests/typings/webdriverio/config.ts
@@ -71,5 +71,9 @@ const config: WebdriverIO.Config = {
             },
             log: { level: 'error' }
         }
-    }]
+    }],
+
+    filesToWatch: [
+        '/foo/page-objects/**/*.page.js',
+    ],
 }


### PR DESCRIPTION
## Proposed changes

* Add a type definition for `filesToWatch` to `WebdriverIO.Config`
* Resolves #5665

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [-] I have added necessary documentation (if appropriate)
- [-] I have added proper type definitions for new commands (if appropriate)

## Further comments

- I think that should have it covered. 🤞 
- The CI build is failing the unit tests on `master`.

### Reviewers: @webdriverio/project-committers
