### PR TITLE
Catch exception caused if deleteSession is called during test execution

### DIFF
--- a/packages/wdio-runner/src/index.js
+++ b/packages/wdio-runner/src/index.js
@@ -350,7 +350,7 @@ export default class Runner extends EventEmitter {
         try {
             await global.browser.deleteSession()
         } catch (err) {
-            console.log('Failed or delete session, it has either timed out or has been ended prior to test runner completion.')
+            console.log('Failed to delete session, it has either timed out or has been ended prior to test runner completion.')
         }
         
         /**

--- a/packages/wdio-runner/src/index.js
+++ b/packages/wdio-runner/src/index.js
@@ -346,9 +346,13 @@ export default class Runner extends EventEmitter {
         if (this.isMultiremote) {
             global.browser.instances.forEach(i => { capabilities[i] = global.browser[i].capabilities })
         }
-
-        await global.browser.deleteSession()
-
+        
+        try {
+            await global.browser.deleteSession()
+        } catch (err) {
+            console.log('Failed or delete session, it has either timed out or has been ended prior to test runner completion.')
+        }
+        
         /**
          * delete session(s)
          */

--- a/packages/wdio-runner/src/index.js
+++ b/packages/wdio-runner/src/index.js
@@ -346,13 +346,18 @@ export default class Runner extends EventEmitter {
         if (this.isMultiremote) {
             global.browser.instances.forEach(i => { capabilities[i] = global.browser[i].capabilities })
         }
-        
+
         try {
             await global.browser.deleteSession()
         } catch (err) {
-            console.log('Failed to delete session, it has either timed out or has been ended prior to test runner completion.')
+            /**
+             * ignoring all exceptions that could be caused by browser.deleteSession()
+             * there maybe times where session is ended remotely, browser.deleteSession() will fail in this case
+             * this can be worked around in code but requires a lot of overhead
+             */
+            log.warn(`Suppressing error closing the session: ${err.stack}`)
         }
-        
+
         /**
          * delete session(s)
          */

--- a/packages/webdriverio/src/commands/browser/reloadSession.js
+++ b/packages/webdriverio/src/commands/browser/reloadSession.js
@@ -33,7 +33,7 @@ export default async function reloadSession () {
     } catch (err) {
         /**
          * ignoring all exceptions that could be caused by browser.deleteSession()
-         * there maybe times where session is ended remotely, browser.deleteSession() will fail in this case)
+         * there maybe times where session is ended remotely, browser.deleteSession() will fail in this case
          * this can be worked around in code but requires a lot of overhead
          */
         log.warn(`Suppressing error closing the session: ${err.stack}`)


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

This PR will trap and discard exceptions causes by `deleteSession` at the end of the test runner life cycle.

My use case started as I wanted to inspect the network logs available from Browserstack to verify traffic was being sent and received properly. I wanted to fail the test if we were missing any of these items. In order to download the network logs, it is required to have closed the current session. I call `browser.deleteSession()` I am able to capture network logs but then at this stage (at the end of the runner lifecycle), there is a bunch of warnings and errors displayed, however, these are for a certain part known.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
- [X] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
