### PR TITLE
Fix data argument must be string in shared-store-service

### DIFF
--- a/packages/wdio-shared-store-service/src/launcher.js
+++ b/packages/wdio-shared-store-service/src/launcher.js
@@ -17,7 +17,7 @@ export default class SharedStoreLauncher {
         const result = await server.startServer()
 
         log.info(`Started shared server on port ${result.port}`)
-        await writeFile(this.pidFile, result.port)
+        await writeFile(this.pidFile, result.port.toString())
     }
 
     async onComplete () {

--- a/packages/wdio-shared-store-service/tests/launcher.test.js
+++ b/packages/wdio-shared-store-service/tests/launcher.test.js
@@ -21,7 +21,7 @@ const storeLauncher = new SharedStoreLauncher()
 describe('SharedStoreService', () => {
     it('onPrepare', async () => {
         await storeLauncher.onPrepare()
-        expect(writeFile).toBeCalledWith(process.pid, 3000)
+        expect(writeFile).toBeCalledWith(process.pid, '3000')
     })
 
     it('onComplete', async () => {


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

Encountered this issue with shared-store-service:

wdio.log
```
2020-08-07T06:48:36.223Z INFO @wdio/shared-store-service: Started shared server on port 54383
"
2020-08-07T06:48:36.150Z DEBUG @wdio/utils:initialiseServices: initialise wdio service "shared-store"
2020-08-07T06:48:36.207Z INFO @wdio/cli:launcher: Run onPrepare hook
2020-08-07T06:48:36.209Z DEBUG @wdio/appium-service: Will spawn Appium process: node /Users/stevo/workspace/native/e2e/node_modules/appium/build/lib/main.js --address 127.0.0.1 --command-timeout 7200 --session-override --debug-log-spacing --platform-version 12.2 --platform-name iOS --show-ios-log --device-name 'iPhone 7' --native-instruments-lib --isolate-sim-device
2020-08-07T06:48:36.225Z ERROR @wdio/cli:utils: A service failed in the 'onPrepare' hook
TypeError [ERR_INVALID_ARG_TYPE]: The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView. Received type number (54383)
    at writeFile (fs.js:1356:5)
    at internal/util.js:297:30
    at new Promise (<anonymous>)
    at writeFile (internal/util.js:296:12)
    at SharedStoreLauncher.onPrepare (/Users/stevo/workspace/native/e2e/node_modules/@wdio/shared-store-service/build/launcher.js:26:32)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
    at async Promise.all (index 1)
    at async runServiceHook (/Users/stevo/workspace/native/e2e/node_modules/@wdio/cli/build/utils.js:49:12)
    at async Launcher.run (/Users/stevo/workspace/native/e2e/node_modules/@wdio/cli/build/launcher.js:75:7)
```

My environment:
Node v14.4.0
OSX 10.14.5

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works

### Reviewers: @webdriverio/project-committers
