### PR TITLE
docs: add extension to required ts conf path

### DIFF
--- a/docs/TypeScript.md
+++ b/docs/TypeScript.md
@@ -100,7 +100,7 @@ All you have to do is create a plain JS config file that registers TypeScript an
 
 ```javascript
 require('ts-node').register({ files: true })
-module.exports = require('./wdio.conf')
+module.exports = require('./wdio.conf.ts')
 ```
 
 And in your typed configuration file:


### PR DESCRIPTION
If you create a wdio.config.ts file next to the initial wdio.config.js file, the `require('./wdio.conf')` advised in the tutorial picks the .js file and not the TypeScript one.
It gives a very misleading ERROR @wdio/cli:launcher: Missing capabilities, exiting with failure from launcher.js.

## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
