### PR TITLE
docs: folder structure for typescript docs

### DIFF
--- a/docs/TypeScript.md
+++ b/docs/TypeScript.md
@@ -70,12 +70,12 @@ And your `tsconfig.json` needs the following:
         "baseUrl": ".",
         "paths": {
             "*": [ "./*" ],
-            "src/*": ["./src/*"]
+            "test/*": ["./test/*"]
         },
         "types": ["node", "webdriverio"]
     },
     "include": [
-        "./src/**/*.ts"
+        "./test/**/*.ts"
     ]
 }
 ```
@@ -129,12 +129,12 @@ For instance, if you decide to use the Mocha framework, you need to install `@ty
         "baseUrl": ".",
         "paths": {
             "*": [ "./*" ],
-            "src/*": ["./src/*"]
+            "test/*": ["./test/*"]
         },
         "types": ["node", "webdriverio", "@wdio/mocha-framework"]
     },
     "include": [
-        "./src/**/*.ts"
+        "./test/**/*.ts"
     ]
 }
 ```
@@ -145,12 +145,12 @@ For instance, if you decide to use the Mocha framework, you need to install `@ty
         "baseUrl": ".",
         "paths": {
             "*": [ "./*" ],
-            "src/*": ["./src/*"]
+            "test/*": ["./test/*"]
         },
         "types": ["node", "webdriverio", "@wdio/jasmine-framework"]
     },
     "include": [
-        "./src/**/*.ts"
+        "./test/**/*.ts"
     ]
 }
 ```
@@ -161,12 +161,12 @@ For instance, if you decide to use the Mocha framework, you need to install `@ty
         "baseUrl": ".",
         "paths": {
             "*": [ "./*" ],
-            "src/*": ["./src/*"]
+            "test/*": ["./test/*"]
         },
         "types": ["node", "webdriverio", "@wdio/cucumber-framework"]
     },
     "include": [
-        "./src/**/*.ts"
+        "./test/**/*.ts"
     ]
 }
 ```


### PR DESCRIPTION
Currently, the TypeScipt docs do not use the same folder structure as the one used on the Getting Started page or the CLI config command. It could confuse some new users (and has).

## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
