### PR TITLE
docs: add import for typed configuration

### DIFF
--- a/docs/TypeScript.md
+++ b/docs/TypeScript.md
@@ -114,7 +114,6 @@ const config: Config = {
 
 export { config }
 ```
-<!--Async mode-->
 
 If you are using this approach for a typed configuration, you have to remove the line with 'ts-node/register' from your framework options in your config file.
 

--- a/docs/TypeScript.md
+++ b/docs/TypeScript.md
@@ -106,12 +106,15 @@ module.exports = require('./wdio.conf.ts')
 And in your typed configuration file:
 
 ```typescript
-const config: WebdriverIO.Config = {
+import { Config } from 'webdriverio';
+
+const config: Config = {
     // Put your webdriverio configuration here
 }
 
 export { config }
 ```
+<!--Async mode-->
 
 If you are using this approach for a typed configuration, you have to remove the line with 'ts-node/register' from your framework options in your config file.
 


### PR DESCRIPTION
The current solution from the docs (with TypeScript configured as recommended above) gives Cannot find namespace 'WebdriverIO'.ts(2503).
Do we need separate sync/async variants to import from @wdio/sync instead when using the sync API ?

## Proposed changes

Add import for typed configuration.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
