### PR TITLE
@wdio/sauce-service Job Names are not sliced when using Jasmine #5728

### DIFF
--- a/packages/wdio-sauce-service/src/service.js
+++ b/packages/wdio-sauce-service/src/service.js
@@ -65,7 +65,7 @@ export default class SauceService {
          */
         /* istanbul ignore if */
         if (this.suiteTitle === 'Jasmine__TopLevel__Suite') {
-            this.suiteTitle = test.fullName.slice(0, test.fullName.indexOf(test.title) - 1)
+            this.suiteTitle = test.fullName.slice(0, test.fullName.indexOf(test.description) - 1)
         }
 
         const fullTitle = (

--- a/packages/wdio-sauce-service/tests/service.test.js
+++ b/packages/wdio-sauce-service/tests/service.test.js
@@ -95,7 +95,7 @@ test('beforeTest should set context for jasmine test', () => {
     service.beforeSession({ user: 'foobar', key: '123' }, {})
     service.beforeTest({
         fullName: 'my test can do something',
-        title: 'foobar'
+        description: 'foobar'
     })
     expect(global.browser.execute).toBeCalledWith('sauce:context=my test can do something')
 })


### PR DESCRIPTION
## Proposed changes

* As per the Bug reported the value should be fetched from description and not the title
* referring the below link made the range to description
    https://jasmine.github.io/api/3.6/global.html#SpecResult

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
           The change would be in the sauce service and the display value
[//]: # (_Put an `x` in the boxes that apply_)

- [x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

this is one liner change

### Reviewers: @webdriverio/project-committers
