### PR TITLE
Document setting download paths with browser.cdp()

### DIFF
--- a/packages/wdio-devtools-service/README.md
+++ b/packages/wdio-devtools-service/README.md
@@ -320,8 +320,8 @@ The `cdp` command can be used to call the [`Page.setDownloadBehavior`](https://c
 
 ```js
 browser.cdp('Page', 'setDownloadBehavior', {
-            behavior: 'allow',
-            downloadPath: '/home/root/webdriverio-project/',
+    behavior: 'allow',
+    downloadPath: '/home/root/webdriverio-project/',
 });
 ```
 

--- a/packages/wdio-devtools-service/README.md
+++ b/packages/wdio-devtools-service/README.md
@@ -314,6 +314,17 @@ console.log(browser.getPageWeight())
 // }
 ```
 
+### Setting Download Paths for the Browser
+
+The `cdp` command can be used to call the [`Page.setDownloadBehavior`](https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-setDownloadBehavior) command of Devtools Protocol to set the behavior when downloading a file. Make sure the `downloadPath` is an absolute path and the `browser.cdp()` call is made before the file is downloaded.
+
+```js
+browser.cdp('Page', 'setDownloadBehavior', {
+            behavior: 'allow',
+            downloadPath: '/home/root/webdriverio-project/',
+        });
+```
+
 ### Access Puppeteer Instance
 
 The service uses Puppeteer for its automation under the hood. You can get access to the used instance by calling the [`getPuppeteer`](/docs/api/browser/getPuppeteer.html) command. __Note:__ Puppeteer commands are async and either needs to be called within the `call` command or handled via `async/await`:

--- a/packages/wdio-devtools-service/README.md
+++ b/packages/wdio-devtools-service/README.md
@@ -322,7 +322,7 @@ The `cdp` command can be used to call the [`Page.setDownloadBehavior`](https://c
 browser.cdp('Page', 'setDownloadBehavior', {
             behavior: 'allow',
             downloadPath: '/home/root/webdriverio-project/',
-        });
+});
 ```
 
 ### Access Puppeteer Instance


### PR DESCRIPTION
## Proposed changes

Solves #5727 
Added information, links, and code snippet on setting download paths in Devtools Service with browser.cdp() command.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments
If this was tested or we can suggest other solutions, that be great too. 

@christian-bromann 
