### PR TITLE
Add section on reporting and include OpenJS Foundation excalation path

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -49,7 +49,7 @@ Project maintainers who do not follow or enforce the Code of Conduct in good fai
 
 ### Project Spaces
 
-For reporting issues in spaces related to WebdriverIO please use the email `christian@saucelabs.com`. WebdriverIO handles CoC issues related to the spaces that it maintains. Projects maintainers commit to:
+For reporting issues in spaces related to WebdriverIO please contact any of the members of the [Technical Steering Committee (TSC)](/AUTHORS.md). WebdriverIO handles CoC issues related to the spaces that it maintains. Projects maintainers commit to:
 
 - maintain the confidentiality with regard to the reporter of an incident
 - to participate in the path for escalation as outlined in the section on Escalation when required.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -58,7 +58,7 @@ For reporting issues in spaces related to WebdriverIO please contact any of the 
 
 For reporting issues in spaces managed by the OpenJS Foundation, for example, repositories within the OpenJS organization, use the email `report@lists.openjsf.org`. The Cross Project Council (CPC) is responsible for managing these reports and commits to:
 
-- maintain the confidentiality with regard to the reporter of an incident
+- maintain confidentiality with regard to the reporter of an incident
 - to participate in the path for escalation as outlined in
   the section on Escalation when required.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -45,9 +45,28 @@ Instances of abusive, harassing, or otherwise unacceptable behavior may be repor
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 
-## Contact Info
+## Reporting
 
-If you need to report an incident, please contact any of the members of the [Technical Steering Committee (TSC)](/AUTHORS.md).
+### Project Spaces
+
+For reporting issues in spaces related to WebdriverIO please use the email `christian@saucelabs.com`. WebdriverIO handles CoC issues related to the spaces that it maintains. Projects maintainers commit to:
+
+- maintain the confidentiality with regard to the reporter of an incident
+- to participate in the path for escalation as outlined in the section on Escalation when required.
+
+### Foundation Spaces
+
+For reporting issues in spaces managed by the OpenJS Foundation, for example, repositories within the OpenJS organization, use the email `report@lists.openjsf.org`. The Cross Project Council (CPC) is responsible for managing these reports and commits to:
+
+- maintain the confidentiality with regard to the reporter of an incident
+- to participate in the path for escalation as outlined in
+  the section on Escalation when required.
+
+## Escalation
+
+The OpenJS Foundation maintains a Code of Conduct Panel (CoCP). This is a foundation-wide team established to manage escalation when a reporter believes that a report to a member project or the CPC has not been properly handled. In order to escalate to the CoCP send an email to `coc-escalation@lists.openjsf.org`.
+
+For more information, refer to the full [Code of Conduct governance document](https://github.com/openjs-foundation/bootstrap/blob/master/proposals/stage-1/CODE_OF_CONDUCT/FOUNDATION_CODE_OF_CONDUCT_REQUIREMENTS.md).
 
 ## Attribution
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -51,7 +51,7 @@ Project maintainers who do not follow or enforce the Code of Conduct in good fai
 
 For reporting issues in spaces related to WebdriverIO please contact any of the members of the [Technical Steering Committee (TSC)](/AUTHORS.md). WebdriverIO handles CoC issues related to the spaces that it maintains. Projects maintainers commit to:
 
-- maintain the confidentiality with regard to the reporter of an incident
+- maintain confidentiality with regard to the reporter of an incident
 - to participate in the path for escalation as outlined in the section on Escalation when required.
 
 ### Foundation Spaces


### PR DESCRIPTION
## Proposed changes

To finish our OpenJS Foundation onboarding we need to include an escalation path including the OpenJS Foundation. I copied this text from the Fastify project (thanks ❤️ ).

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

See openjs-foundation/project-onboarding#21

### Reviewers: @webdriverio/project-committers
