### PR TITLE
Update documentation for tagExpression usage

### DIFF
--- a/docs/ConfigurationFile.md
+++ b/docs/ConfigurationFile.md
@@ -233,7 +233,7 @@ exports.config = {
         source: true,       // <boolean> hide source URIs
         profile: [],        // <string[]> (name) specify the profile to use
         strict: false,      // <boolean> fail if there are any undefined or pending steps
-        tagExpression: "",  // <string> (expression) only execute the features or scenarios with tags matching the expression
+        tagExpression: '',  // <string> (expression) only execute the features or scenarios with tags matching the expression
         timeout: 20000,     // <number> timeout for step definitions
         ignoreUndefinedDefinitions: false, // <boolean> Enable this config to treat undefined definitions as warnings.
         scenarioLevelReporter: false // Enable this to make webdriver.io behave as if scenarios and not steps were the tests.

--- a/docs/ConfigurationFile.md
+++ b/docs/ConfigurationFile.md
@@ -233,7 +233,7 @@ exports.config = {
         source: true,       // <boolean> hide source URIs
         profile: [],        // <string[]> (name) specify the profile to use
         strict: false,      // <boolean> fail if there are any undefined or pending steps
-        tagExpression: [],  // <string[]> (expression) only execute the features or scenarios with tags matching the expression
+        tagExpression: "",  // <string> (expression) only execute the features or scenarios with tags matching the expression
         timeout: 20000,     // <number> timeout for step definitions
         ignoreUndefinedDefinitions: false, // <boolean> Enable this config to treat undefined definitions as warnings.
         scenarioLevelReporter: false // Enable this to make webdriver.io behave as if scenarios and not steps were the tests.

--- a/examples/wdio.conf.js
+++ b/examples/wdio.conf.js
@@ -174,7 +174,7 @@ exports.config = {
         source: true,       // <boolean> hide source uris
         profile: [],        // <string[]> (name) specify the profile to use
         strict: false,      // <boolean> fail if there are any undefined or pending steps
-        tagExpression: '',           // <string> (expression) only execute the features or scenarios with tags matching the expression
+        tagExpression: '',  // <string> (expression) only execute the features or scenarios with tags matching the expression
         timeout: 20000,     // <number> timeout for step definitions
         ignoreUndefinedDefinitions: false, // <boolean> Enable this config to treat undefined definitions as warnings.
     },

--- a/examples/wdio.conf.js
+++ b/examples/wdio.conf.js
@@ -174,7 +174,7 @@ exports.config = {
         source: true,       // <boolean> hide source uris
         profile: [],        // <string[]> (name) specify the profile to use
         strict: false,      // <boolean> fail if there are any undefined or pending steps
-        tags: [],           // <string[]> (expression) only execute the features or scenarios with tags matching the expression
+        tagExpression: '',           // <string> (expression) only execute the features or scenarios with tags matching the expression
         timeout: 20000,     // <number> timeout for step definitions
         ignoreUndefinedDefinitions: false, // <boolean> Enable this config to treat undefined definitions as warnings.
     },

--- a/packages/wdio-cucumber-framework/README.md
+++ b/packages/wdio-cucumber-framework/README.md
@@ -121,7 +121,9 @@ Default: `false`
 Only execute the features or scenarios with tags matching the expression. Note that untagged
 features will still spawn a Selenium session (see issue [webdriverio/webdriverio#1247](https://github.com/webdriverio/webdriverio/issues/1247)).
 Please see the [Cucumber documentation](https://docs.cucumber.io/cucumber/api/#tag-expressions) for more details.
-If passing as a command-line argument (--cucumberOpts.tagExpression), compound expressions may need to be enclosed in three sets of double quotes if WebdriverIO is invoked using `npx` on Windows.
+If passing as a command-line argument, compound expressions may need to be enclosed in three sets of double quotes if WebdriverIO is invoked using `npx` on Windows.
+
+E.g.: `npx wdio wdio.config.js --cucumberOpts.tagExpression """@Smoke and not @Pending"""`
 
 Type: `String`<br>
 Default: ``

--- a/packages/wdio-cucumber-framework/README.md
+++ b/packages/wdio-cucumber-framework/README.md
@@ -121,7 +121,7 @@ Default: `false`
 Only execute the features or scenarios with tags matching the expression. Note that untagged
 features will still spawn a Selenium session (see issue [webdriverio/webdriverio#1247](https://github.com/webdriverio/webdriverio/issues/1247)).
 Please see the [Cucumber documentation](https://docs.cucumber.io/cucumber/api/#tag-expressions) for more details.
-If passing as a command-line argument (--cucumberOpts.tagExpression), coumpond expressions may need to be enclosed in three sets of double quotes if wdio is invoked using npx on Windows.
+If passing as a command-line argument (--cucumberOpts.tagExpression), compound expressions may need to be enclosed in three sets of double quotes if WebdriverIO is invoked using `npx` on Windows.
 
 Type: `String`<br>
 Default: ``

--- a/packages/wdio-cucumber-framework/README.md
+++ b/packages/wdio-cucumber-framework/README.md
@@ -121,6 +121,7 @@ Default: `false`
 Only execute the features or scenarios with tags matching the expression. Note that untagged
 features will still spawn a Selenium session (see issue [webdriverio/webdriverio#1247](https://github.com/webdriverio/webdriverio/issues/1247)).
 Please see the [Cucumber documentation](https://docs.cucumber.io/cucumber/api/#tag-expressions) for more details.
+If passing as a command-line argument (--cucumberOpts.tagExpression), coumpond expressions may need to be enclosed in three sets of double quotes if wdio is invoked using npx on Windows.
 
 Type: `String`<br>
 Default: ``


### PR DESCRIPTION
## Proposed changes

Update documentation to reflect that cucumberOpts.tagExpression accepts a string and not an array of strings.  Add caveat about possible need to use three sets of double quotes on Windows with npx.

Addresses https://github.com/webdriverio/webdriverio/issues/5751  and https://github.com/webdriverio/webdriverio/issues/5752

## Types of changes
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
