### PR TITLE
Use proper Chrome version in headless mode

### DIFF
--- a/packages/wdio-allure-reporter/src/index.js
+++ b/packages/wdio-allure-reporter/src/index.js
@@ -113,7 +113,7 @@ class AllureReporter extends WDIOReporter {
             const { browserName, deviceName } = this.capabilities
             const targetName = browserName || deviceName || cid
             const browserstackVersion = this.capabilities.os_version || this.capabilities.osVersion
-            const version = browserstackVersion || this.capabilities.version || this.capabilities.platformVersion || ''
+            const version = browserstackVersion || this.capabilities.browserVersion || this.capabilities.version || this.capabilities.platformVersion || ''
             const paramName = deviceName ? 'device' : 'browser'
             const paramValue = version ? `${targetName}-${version}` : targetName
             currentTest.addParameter('argument', paramName, paramValue)

--- a/packages/wdio-allure-reporter/tests/allureFeatures.test.js
+++ b/packages/wdio-allure-reporter/tests/allureFeatures.test.js
@@ -333,6 +333,13 @@ describe('reporter runtime implementation', () => {
             expect(addParameter).toHaveBeenCalledWith('argument', 'browser', 'firefox-1.2.3')
         })
 
+        it('should correctly set proper browser version for chrome headless in devtools', () => {
+            reporter.onRunnerStart({ config: { }, capabilities: { browserName: 'Chrome Headless', browserVersion: '85.0.4183.84' } })
+            reporter.onTestStart({ cid: '0-0', title: 'SomeTest' })
+            expect(addParameter).toHaveBeenCalledTimes(1)
+            expect(addParameter).toHaveBeenCalledWith('argument', 'browser', 'Chrome Headless-85.0.4183.84')
+        })
+
         it('should correctly add argument for appium', () => {
             reporter.onRunnerStart({ config: { }, capabilities: { deviceName: 'Android Emulator', platformVersion: '8.0' } })
             reporter.onTestStart({ cid: '0-0', title: 'SomeTest' })


### PR DESCRIPTION
## Proposed changes

Chrome browser version is not shown in the allure reporter if chrome is in headless mode and automation protocol is `devtools`.

Before: `Chrome Headless-19.6.0`
Now: `Chrome Headless-85.0.4183.83`

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments
`wdio.conf`
```js
{
  automationProtocol: 'devtools',
  capabilities: [{
      browserName: 'chrome',
      'goog:chromeOptions': { args: ['--headless', '--no-sandbox'] },
  }],
}
```

`browser.capabilities`
```
browserName:'Chrome Headless'
browserVersion:'85.0.4183.83'
platformName:'darwin'
platformVersion:'19.6.0'
...
```
### Reviewers: @webdriverio/project-committers
