### PR TITLE
git followTags

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -1,0 +1,2 @@
+[push]
+followTags = true

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
     "ts:webdriverio-reporter": "cd tests/typings/webdriverio-reporter && tsc --incremental",
     "watch": "node ./scripts/watch",
     "watch:pkg": "lerna exec 'npm run compile -- --watch' --scope",
-    "version": "npm run changelog && git add CHANGELOG.md"
+    "version": "npm run changelog && git add CHANGELOG.md",
+    "postinstall": "git config --local include.path '../.gitconfig'"
   },
   "devDependencies": {
     "@babel/cli": "^7.6.2",


### PR DESCRIPTION
## Proposed changes

I'd like to set `push.followTags = true` for the repo so that other users don't need to set it manually.

Users who have disabled `postinstall` scripts can run the command manually.

I believe this is only required for the users who can release webdriverio.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

### Reviewers: @webdriverio/project-committers
