### PR TITLE
Fix #5647 : add other check for app capability in browserstack-service

### DIFF
--- a/packages/wdio-browserstack-service/src/service.js
+++ b/packages/wdio-browserstack-service/src/service.js
@@ -18,6 +18,7 @@ export default class BrowserstackService {
         // See https://github.com/cucumber/cucumber-js/blob/master/src/runtime/index.ts#L136
         this.failureStatuses = ['failed', 'ambiguous', 'undefined', 'unknown']
         this.strict && this.failureStatuses.push('pending')
+        this.caps = caps
     }
 
     /**
@@ -40,7 +41,7 @@ export default class BrowserstackService {
     before() {
         this.sessionId = global.browser.sessionId
 
-        if (global.browser.capabilities.app) {
+        if (global.browser.capabilities.app || this.caps.app) {
             this.sessionBaseUrl = 'https://api-cloud.browserstack.com/app-automate/sessions'
         }
 

--- a/packages/wdio-browserstack-service/tests/service.test.js
+++ b/packages/wdio-browserstack-service/tests/service.test.js
@@ -197,6 +197,23 @@ describe('before', () => {
         expect(service.sessionBaseUrl).toEqual('https://api-cloud.browserstack.com/app-automate/sessions')
     })
 
+    it('should initialize correctly for appium without global browser capabilities', () => {
+        const service = new BrowserstackService({}, {
+            app: 'bs://BrowserStackMobileAppId'
+        }, {
+            user: 'foo',
+            key: 'bar',
+            capabilities: {
+                app: 'test-app'
+            }
+        })
+        service.before()
+
+        expect(service.sessionId).toEqual(12)
+        expect(service.failReasons).toEqual([])
+        expect(service.sessionBaseUrl).toEqual('https://api-cloud.browserstack.com/app-automate/sessions')
+    })
+
     it('should log the url', async () => {
         const service = new BrowserstackService({}, [{}], { capabilities: {} })
 


### PR DESCRIPTION
## Proposed changes
This PR is a proposal to fix #5647. The issue is that `global.browser.capabilities.` doesn't contain an `app`. I've added `this.caps.app` which in fact does exist. I kept `global.browser.capabilities.app` in place for backward compatibility. 

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
