### PR TITLE
Add new Sauce Labs Unified Platform endpoint

### DIFF
--- a/packages/wdio-config/src/utils.js
+++ b/packages/wdio-config/src/utils.js
@@ -5,7 +5,7 @@ const DEFAULT_PATH = '/'
 const LEGACY_PATH = '/wd/hub'
 
 const REGION_MAPPING = {
-    'us': '', // default endpoint
+    'us': 'us-west-1.', // default endpoint
     'eu': 'eu-central-1.',
     'eu-central-1': 'eu-central-1.',
     'us-east-1': 'us-east-1.'

--- a/packages/wdio-config/tests/configparser.test.js
+++ b/packages/wdio-config/tests/configparser.test.js
@@ -173,7 +173,7 @@ describe('ConfigParser', () => {
             configParser.merge({ user: 'barfoo', key: '50fa1411-3121-4gb0-9p07-8q326vvbq7b0' })
 
             const config = configParser.getConfig()
-            expect(config.hostname).toBe('ondemand.saucelabs.com')
+            expect(config.hostname).toBe('ondemand.us-west-1.saucelabs.com')
             expect(config.port).toBe(443)
             expect(config.protocol).toBe('https')
             expect(config.user).toBe('barfoo')
@@ -417,7 +417,7 @@ describe('ConfigParser', () => {
             configParser.addConfigFile(FIXTURES_CONF)
 
             const config = configParser.getConfig()
-            expect(config.hostname).toBe('ondemand.saucelabs.com')
+            expect(config.hostname).toBe('ondemand.us-west-1.saucelabs.com')
             expect(config.port).toBe(443)
             expect(config.user).toBe('foobar')
             expect(config.key).toBe('50fa142c-3121-4gb0-9p07-8q326vvbq7b0')

--- a/packages/wdio-config/tests/detectBackend.test.js
+++ b/packages/wdio-config/tests/detectBackend.test.js
@@ -67,7 +67,7 @@ describe('detectBackend', () => {
             user: 'foobar',
             key: '50aa152c-1932-B2f0-9707-18z46q2n1mb0'
         })
-        expect(caps.hostname).toBe('ondemand.saucelabs.com')
+        expect(caps.hostname).toBe('ondemand.us-west-1.saucelabs.com')
         expect(caps.port).toBe(443)
         expect(caps.path).toBe('/wd/hub')
         expect(caps.protocol).toBe('https')
@@ -79,7 +79,7 @@ describe('detectBackend', () => {
             key: '50aa152c-1932-B2f0-9707-18z46q2n1mb0',
             region: 'us'
         })
-        expect(caps.hostname).toBe('ondemand.saucelabs.com')
+        expect(caps.hostname).toBe('ondemand.us-west-1.saucelabs.com')
         expect(caps.port).toBe(443)
         expect(caps.path).toBe('/wd/hub')
         expect(caps.protocol).toBe('https')
@@ -103,7 +103,7 @@ describe('detectBackend', () => {
             key: '50aa152c-1932-B2f0-9707-18z46q2n1mb0',
             region: 'foobar'
         })
-        expect(caps.hostname).toBe('ondemand.saucelabs.com')
+        expect(caps.hostname).toBe('ondemand.us-west-1.saucelabs.com')
         expect(caps.port).toBe(443)
         expect(caps.path).toBe('/wd/hub')
         expect(caps.protocol).toBe('https')

--- a/packages/wdio-sauce-service/README.md
+++ b/packages/wdio-sauce-service/README.md
@@ -28,7 +28,15 @@ Instructions on how to install `WebdriverIO` can be found [here.](https://webdri
 ## Configuration
 
 In order to use the service for the virtual machine and em/simulator cloud you need to set `user` and `key` in your `wdio.conf.js` file. It will automatically
-use Sauce Labs to run your integration tests. If you want to use [Sauce Connect](https://wiki.saucelabs.com/display/DOCS/Sauce+Connect+Proxy)
+use Sauce Labs to run your integration tests.
+If you run your tests on Sauce Labs you can specify the region you want to run your tests in via the `region` property.
+Available short handles for regions are `us` (default) and `eu`. These regions are used for the Sauce Labs VM cloud and the Sauce Labs Real Device Cloud. If you don't provide the region, it defaults to `us`.
+
+> NOTE:\
+> By default the `ondemand.us-west-1.saucelabs.com` US endpoint will be used. This is the new Unified Platform endpoint. If you want to use the *old* endpoint then
+> don't provide a region and add `hostName: ondemand.saucelabs.com` to your configuration file.
+
+If you want to use [Sauce Connect](https://wiki.saucelabs.com/display/DOCS/Sauce+Connect+Proxy)
 you just need to set `sauceConnect: true`. If you would like to change data center to EU add `region:'eu'` as US data center is set as default (region only works on ^4.14.1 or ^5.0.0).
 
 ```js
@@ -37,6 +45,7 @@ export.config = {
     // ...
     user: process.env.SAUCE_USERNAME,
     key: process.env.SAUCE_ACCESS_KEY,
+    region: 'us',
     services: [
         ['sauce', {
             sauceConnect: true,

--- a/packages/wdio-sauce-service/README.md
+++ b/packages/wdio-sauce-service/README.md
@@ -34,7 +34,7 @@ Available short handles for regions are `us` (default) and `eu`. These regions a
 
 > NOTE:\
 > By default the `ondemand.us-west-1.saucelabs.com` US endpoint will be used. This is the new Unified Platform endpoint. If you want to use the *old* endpoint then
-> don't provide a region and add `hostName: ondemand.saucelabs.com` to your configuration file.
+> don't provide a region and add `hostname: ondemand.saucelabs.com` to your configuration file.
 
 If you want to use [Sauce Connect](https://wiki.saucelabs.com/display/DOCS/Sauce+Connect+Proxy)
 you just need to set `sauceConnect: true`. If you would like to change data center to EU add `region:'eu'` as US data center is set as default (region only works on ^4.14.1 or ^5.0.0).


### PR DESCRIPTION
## Proposed changes
Sauce Labs is busy unifying the platforms (RDC and VM) and the US got a new endpoint. This endpoint will be the default on and works with the new Sauce Storage if people use Real Devices or Emulators/Simulators together with apps.
This PR will add the new default endpoint and adds a note in the service if people still want to use the old end point.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

It would be nice if we can also port this change to V5
