### PR TITLE
docs: Don't have types being linked to their own pages

### DIFF
--- a/scripts/templates/api.tpl.ejs
+++ b/scripts/templates/api.tpl.ejs
@@ -29,7 +29,7 @@ title: <?= method.command ?>
 | ---- | ---- | ------- |
 <? method.paramTags.forEach((paramTag) => {
     var paramKey = paramTag.types
-        ? paramTag.types.map((type) => `<code>${type}</code>`).join('|')
+        ? paramTag.types.map((type) => `<code>${type.replace(/>/g, "&gt;").replace(/</g, "&lt;")}</code>`).join('|')
         : paramTag.type
     ?>| <code><var><?= paramTag.name ?></var></code><? if ((!paramTag.required && typeof paramTag.optional === 'undefined') || paramTag.optional) { ?><br><span class="label labelWarning">optional</span><? }
     ?> | <?= paramKey.split('|').join(', ').replace('(', '').replace(')', '')

--- a/scripts/templates/api.tpl.ejs
+++ b/scripts/templates/api.tpl.ejs
@@ -28,7 +28,9 @@ title: <?= method.command ?>
 | Name | Type | Details |
 | ---- | ---- | ------- |
 <? method.paramTags.forEach((paramTag) => {
-    var paramKey = (paramTag.types && paramTag.typesDescription) ? paramTag.typesDescription : paramTag.type
+    var paramKey = paramTag.types
+        ? paramTag.types.map((type) => `<code>${type}</code>`).join('|')
+        : paramTag.type
     ?>| <code><var><?= paramTag.name ?></var></code><? if ((!paramTag.required && typeof paramTag.optional === 'undefined') || paramTag.optional) { ?><br><span class="label labelWarning">optional</span><? }
     ?> | <?= paramKey.split('|').join(', ').replace('(', '').replace(')', '')
     ?> | <?= paramTag.description ?> |

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -98,6 +98,9 @@
       "wdio-reportportal-service": {
         "title": "Report Portal Service"
       },
+      "wdio-rerun-service": {
+        "title": "Re-run Service Service"
+      },
       "wdio-slack-service": {
         "title": "Slack Service"
       },
@@ -169,6 +172,9 @@
       },
       "api/browser/getCookies": {
         "title": "getCookies"
+      },
+      "api/browser/getPuppeteer": {
+        "title": "getPuppeteer"
       },
       "api/browser/getWindowSize": {
         "title": "getWindowSize"

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -90,7 +90,7 @@
         "title": "Ng-apimock Service"
       },
       "wdio-novus-visual-regression-service": {
-        "title": "Novus Visual Regression Service Service"
+        "title": "Novus Visual Regression Service"
       },
       "wdio-reportportal-reporter": {
         "title": "Report Portal Reporter"
@@ -99,7 +99,7 @@
         "title": "Report Portal Service"
       },
       "wdio-rerun-service": {
-        "title": "Re-run Service Service"
+        "title": "Re-run Service"
       },
       "wdio-slack-service": {
         "title": "Slack Service"


### PR DESCRIPTION
**Description of the improvement / report**
Our website is generated by Docusaurus (v1) and it is likely that it transforms the API markdown files so that such occurrences create links. We either need to modify the api template (in `/scripts/templates`) or need to find a way to create the markdown so that no such type link is created.

Before:
![Screenshot 2020-08-31 at 11 18 51](https://user-images.githubusercontent.com/731337/91704401-dbd69780-eb7b-11ea-8c6b-8f82a71374d9.png)

After:
![Screenshot 2020-08-31 at 11 18 43](https://user-images.githubusercontent.com/731337/91704411-ded18800-eb7b-11ea-976f-a248ecd9db1c.png)
