### PR TITLE
fix: add null check for scenario outline

### DIFF
--- a/packages/wdio-cucumber-framework/src/utils.js
+++ b/packages/wdio-cucumber-framework/src/utils.js
@@ -69,7 +69,7 @@ export function getUniqueIdentifier (target, sourceLocation) {
         if (Array.isArray(target.examples)) {
             target.examples.forEach((example) => {
                 example.tableHeader.cells.forEach((header, idx) => {
-                    if (name.indexOf('<' + header.value + '>') === -1) {
+                    if (!name || name.indexOf('<' + header.value + '>') === -1) {
                         return
                     }
 


### PR DESCRIPTION
## Proposed changes

Fix the following error, which I encountered after the first case of a Scenario Outline: 

ERROR @wdio/runner: TypeError: Cannot read property 'indexOf' of undefined
at /.../test-project/node_modules/@wdio/cucumber-framework/build/utils.js:86:20
at Array.forEach (<anonymous>)

## Types of changes

- [x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
