### PR TITLE
log warning if jasmine tests have no root describe

### DIFF
--- a/packages/wdio-jasmine-framework/src/reporter.js
+++ b/packages/wdio-jasmine-framework/src/reporter.js
@@ -36,7 +36,7 @@ export default class JasmineReporter {
         this.testStart = new Date()
         test.type = 'test'
         test.start = new Date()
-        let parentSuite = this.parent[this.parent.length - 1]
+        const parentSuite = this.parent[this.parent.length - 1]
 
         /**
          * if jasmine test has no root describe block, create one

--- a/packages/wdio-jasmine-framework/src/reporter.js
+++ b/packages/wdio-jasmine-framework/src/reporter.js
@@ -1,3 +1,7 @@
+import logger from '@wdio/logger'
+
+const log = logger('@wdio/jasmine-framework')
+
 const STACKTRACE_FILTER = /(node_modules(\/|\\)(\w+)*|@wdio\/sync\/(build|src)|- - - - -)/g
 
 export default class JasmineReporter {
@@ -32,7 +36,20 @@ export default class JasmineReporter {
         this.testStart = new Date()
         test.type = 'test'
         test.start = new Date()
-        this.parent[this.parent.length - 1].tests++
+        let parentSuite = this.parent[this.parent.length - 1]
+
+        /**
+         * if jasmine test has no root describe block, create one
+         */
+        if (!parentSuite) {
+            log.warn(
+                'No root suite was defined! This can cause reporters to malfunction. ' +
+                'Please always start a spec file with describe("...", () => { ... }).'
+            )
+        } else {
+            parentSuite.tests++
+        }
+
         this.emit('test:start', test)
     }
 

--- a/packages/wdio-jasmine-framework/tests/reporter.test.js
+++ b/packages/wdio-jasmine-framework/tests/reporter.test.js
@@ -1,4 +1,8 @@
+import logger from '@wdio/logger'
+
 import JasmineReporter from '../src/reporter'
+
+const log = logger()
 
 let jasmineReporter
 let runnerReporter
@@ -34,6 +38,12 @@ test('specStarted', () => {
     expect(runnerReporter.emit.mock.calls[1][1].title).toBe('some test spec')
     expect(runnerReporter.emit.mock.calls[1][1].type).toBe('test')
     expect(jasmineReporter.parent[0].tests).toBe(1)
+})
+
+test('specStarted without root describe', () => {
+    jasmineReporter.specStarted({ id: 24, description: 'some test spec' })
+    expect(jasmineReporter.parent).toHaveLength(0)
+    expect(log.warn).toBeCalledTimes(1)
 })
 
 test('specDone', () => {

--- a/tests/helpers/fixtures.js
+++ b/tests/helpers/fixtures.js
@@ -41,6 +41,9 @@ onRunnerEnd
 export const JASMINE_REPORTER_LOGS = `onRunnerStart
 onHookStart
 onHookEnd
+onTestStart
+onTestPass
+onTestEnd
 onSuiteStart
 onHookStart
 onHookEnd


### PR DESCRIPTION
## Proposed changes

fixes: #4582

If users don't start with a root describe block it might have negative effects on the reporting. We can't insert a describe nor mock the events therefor with this patch I suggest to just log a warning.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
