### PR TITLE
Fixed broken links for browser.call page

### DIFF
--- a/docs/Frameworks.md
+++ b/docs/Frameworks.md
@@ -51,7 +51,7 @@ it('should test something', () => {
 })
 ```
 
-If you want to run something asynchronously, you can either use the [`browser.call`](call) command or [custom commands](CustomCommands.md).
+If you want to run something asynchronously, you can either use the [`browser.call`](api/browser/call.html) command or [custom commands](CustomCommands.md).
 
 ### Mocha Options
 

--- a/docs/SyncVsAsync.md
+++ b/docs/SyncVsAsync.md
@@ -44,7 +44,7 @@ await el.click()
 
 ## Sync mode
 
-If you're using [`@wdio/sync`](https://www.npmjs.com/package/@wdio/sync) then you can avoid awaiting for browser/element calls. It is still required to deal with Promises from 3rd-party libraries, you should use [browser.call](docs/api/browser/call.html) for this.
+If you're using [`@wdio/sync`](https://www.npmjs.com/package/@wdio/sync) then you can avoid awaiting for browser/element calls. It is still required to deal with Promises from 3rd-party libraries, you should use [browser.call](api/browser/call.html) for this.
 
 Example
 


### PR DESCRIPTION
## Proposed changes

I found some broken links referencing a wrong browser.call page. This PR fixes them.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation update

## Checklist

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

### Reviewers: @webdriverio/project-committers
