### PR TITLE
Fix Unified Platform and Sauce Connect bug

### DIFF
--- a/packages/wdio-sauce-service/src/utils.js
+++ b/packages/wdio-sauce-service/src/utils.js
@@ -59,20 +59,21 @@ export function makeCapabilityFactory(tunnelIdentifier, options) {
             !capability['sauce:options']
         )
 
-        if (!capability['sauce:options'] && !isLegacy) {
+        // Unified Platform is currently not W3C ready, so the tunnel needs to be on the cap level
+        if (!capability['sauce:options'] && !isLegacy && !isUnifiedPlatform(capability)) {
             capability['sauce:options'] = {}
         }
 
         Object.assign(capability, options)
 
-        const sauceOptions = !isLegacy ? capability['sauce:options'] : capability
+        const sauceOptions = !isLegacy && !isUnifiedPlatform(capability) ? capability['sauce:options'] : capability
         sauceOptions.tunnelIdentifier = (
             capability.tunnelIdentifier ||
             sauceOptions.tunnelIdentifier ||
             tunnelIdentifier
         )
 
-        if (!isLegacy) {
+        if (!isLegacy && !isUnifiedPlatform(capability)) {
             delete capability.tunnelIdentifier
         }
     }

--- a/packages/wdio-sauce-service/tests/launcher.test.js
+++ b/packages/wdio-sauce-service/tests/launcher.test.js
@@ -258,6 +258,13 @@ test('onPrepare without tunnel identifier and without w3c caps ', async () => {
     }, {
         browserName: 'firefox',
         tunnelIdentifier: 'fish'
+    }, {
+        deviceName: 'iPhone',
+        platformName: 'iOS',
+        tunnelIdentifier: 'fish-bar'
+    }, {
+        deviceName: 'iPhone',
+        platformName: 'iOS',
     }]
     const config = {
         user: 'foobaruser',
@@ -272,6 +279,13 @@ test('onPrepare without tunnel identifier and without w3c caps ', async () => {
     }, {
         browserName: 'firefox',
         tunnelIdentifier: 'fish'
+    }, {
+        deviceName: 'iPhone',
+        platformName: 'iOS',
+        tunnelIdentifier: 'fish-bar'
+    }, {
+        deviceName: 'iPhone',
+        platformName: 'iOS',
     }])
     expect(service.sauceConnectProcess).toBeUndefined()
 })

--- a/packages/wdio-sauce-service/tests/launcher.test.js
+++ b/packages/wdio-sauce-service/tests/launcher.test.js
@@ -258,13 +258,6 @@ test('onPrepare without tunnel identifier and without w3c caps ', async () => {
     }, {
         browserName: 'firefox',
         tunnelIdentifier: 'fish'
-    }, {
-        deviceName: 'iPhone',
-        platformName: 'iOS',
-        tunnelIdentifier: 'fish-bar'
-    }, {
-        deviceName: 'iPhone',
-        platformName: 'iOS',
     }]
     const config = {
         user: 'foobaruser',
@@ -279,13 +272,6 @@ test('onPrepare without tunnel identifier and without w3c caps ', async () => {
     }, {
         browserName: 'firefox',
         tunnelIdentifier: 'fish'
-    }, {
-        deviceName: 'iPhone',
-        platformName: 'iOS',
-        tunnelIdentifier: 'fish-bar'
-    }, {
-        deviceName: 'iPhone',
-        platformName: 'iOS',
     }])
     expect(service.sauceConnectProcess).toBeUndefined()
 })
@@ -396,6 +382,13 @@ test('onPrepare with tunnel identifier and without w3c caps ', async () => {
     }, {
         browserName: 'internet explorer',
         version: '9'
+    }, {
+        deviceName: 'iPhone',
+        platformName: 'iOS',
+        tunnelIdentifier: 'fish-bar'
+    }, {
+        deviceName: 'iPhone',
+        platformName: 'iOS',
     }]
     const config = {
         user: 'foobaruser',
@@ -418,6 +411,20 @@ test('onPrepare with tunnel identifier and without w3c caps ', async () => {
         port: 4446,
         browserName: 'internet explorer',
         version: '9',
+        tunnelIdentifier: 'my-tunnel'
+    }, {
+        protocol: 'http',
+        hostname: 'localhost',
+        port: 4446,
+        deviceName: 'iPhone',
+        platformName: 'iOS',
+        tunnelIdentifier: 'fish-bar'
+    }, {
+        protocol: 'http',
+        hostname: 'localhost',
+        port: 4446,
+        deviceName: 'iPhone',
+        platformName: 'iOS',
         tunnelIdentifier: 'my-tunnel'
     }])
     expect(service.sauceConnectProcess).not.toBeUndefined()


### PR DESCRIPTION
## Proposed changes
Sauce Labs Unified platform is not W3C ready. When using a SC tunnel (or started from the service or using an existing tunnel) the `tunnelIdentifier` was put into `sauce:options`. This PR fixes that issue so customer can use WDIO with UP and SC

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

