### PR TITLE
Check array input parameter using Array.isArray

### DIFF
--- a/packages/webdriverio/src/commands/browser/keys.js
+++ b/packages/webdriverio/src/commands/browser/keys.js
@@ -35,7 +35,7 @@ export default function keys (value) {
      */
     if (typeof value === 'string') {
         keySequence = checkUnicode(value, this.isDevTools)
-    } else if (value instanceof Array) {
+    } else if (Array.isArray(value)) {
         for (const charSet of value) {
             keySequence = keySequence.concat(checkUnicode(charSet, this.isDevTools))
         }


### PR DESCRIPTION
Use Array.isArray for checking so that this API can work
with runners that run in new context of a node vm

Signed-off-by: Zabil Cheriya Maliackal <zabilcm@gmail.com>

## Proposed changes

While using webdriver with other runners like [Gauge](https://github.com/getgauge/gauge-js/issues/387#issuecomment-688772025) the `keys` API fails while checking the instance of an Array parameter. Gauge uses a [Virtual Machine Context](https://nodejs.org/api/vm.html#vm_vm_executing_javascript) and this could be an issue while integrating webdriver with other runners too.

The recommended way around this as per https://github.com/nodejs/node-v0.x-archive/issues/1277#issuecomment-1507839 is to check for if the value is an instance of an Array using `Array.isArray`

This pull request makes that change.
A quick grep shows that this is the only place using this check 

```
git grep -i "instanceof Array" master
master:packages/webdriverio/src/commands/browser/keys.js:    } else if (value instanceof Array) {
```

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
