### PR TITLE
Add optional delay between spec file retry attempts

### DIFF
--- a/docs/ConfigurationFile.md
+++ b/docs/ConfigurationFile.md
@@ -179,6 +179,8 @@ exports.config = {
     //
     // The number of times to retry the entire specfile when it fails as a whole
     specFileRetries: 1,
+    // Delay in seconds between the spec file retry attempts
+    specFileRetriesDelay: 0,
     // Whether or not retried specfiles should be retried immediately or deferred to the end of the queue
     specFileRetriesDeferred: false,
     //

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -184,6 +184,12 @@ The number of times to retry an entire specfile when it fails as a whole.
 Type: `Number`<br>
 Default: `0`
 
+### specFileRetriesDelay
+Delay in seconds between the spec file retry attempts
+
+Type: `Number`<br>
+Default: `0`
+
 ### specFileRetriesDeferred
 Whether or not retried specfiles should be retried immediately or deferred to the end of the queue.
 

--- a/docs/Retry.md
+++ b/docs/Retry.md
@@ -103,6 +103,10 @@ module.exports = function () {
      */
     specFileRetries: 1,
     /**
+     * Delay in seconds between the spec file retry attempts
+     */
+    specFileRetriesDelay: 0,
+    /**
      * Retried specfiles are inserted at the beginning of the queue and retried immediately
      */
     specFileRetriesDeferred: false

--- a/examples/wdio.conf.js
+++ b/examples/wdio.conf.js
@@ -120,6 +120,9 @@ exports.config = {
     // The number of times to retry the entire specfile when it fails as a whole
     specFileRetries: 1,
     //
+    // Delay in seconds between the spec file retry attempts
+    specFileRetriesDelay: 0,
+    //
     // Retried specfiles are inserted at the beginning of the queue and retried immediately
     specFileRetriesDeferred: false,
     //

--- a/packages/wdio-cli/src/interface.js
+++ b/packages/wdio-cli/src/interface.js
@@ -21,6 +21,7 @@ export default class WDIOCLInterface extends EventEmitter {
         this.isWatchMode = isWatchMode
         this.inDebugMode = false
         this.specFileRetries = config.specFileRetries || 0
+        this.specFileRetriesDelay = config.specFileRetriesDelay || 0
         this.skippedSpecs = 0
 
         this.on('job:start', this.addJob.bind(this))
@@ -72,7 +73,8 @@ export default class WDIOCLInterface extends EventEmitter {
     }
 
     onSpecRetry(cid, job, retries) {
-        this.onJobComplete(cid, job, retries, chalk.bold.yellow('RETRYING'))
+        const delayMsg = this.specFileRetriesDelay > 0 ? ` after ${this.specFileRetriesDelay}s` : ''
+        this.onJobComplete(cid, job, retries, chalk.bold(chalk.yellow('RETRYING') + delayMsg))
     }
 
     onSpecPass(cid, job, retries) {

--- a/packages/wdio-cli/src/launcher.js
+++ b/packages/wdio-cli/src/launcher.js
@@ -4,7 +4,7 @@ import exitHook from 'async-exit-hook'
 
 import logger from '@wdio/logger'
 import { ConfigParser } from '@wdio/config'
-import { initialisePlugin, initialiseLauncherService } from '@wdio/utils'
+import { initialisePlugin, initialiseLauncherService, sleep } from '@wdio/utils'
 
 import CLInterface from './interface'
 import { runLauncherHook, runOnCompleteHook, runServiceHook } from './utils'
@@ -282,6 +282,12 @@ class Launcher {
      */
     async startInstance(specs, caps, cid, rid, retries) {
         let config = this.configParser.getConfig()
+
+        // wait before retrying the spec file
+        if (typeof config.specFileRetriesDelay === 'number' && config.specFileRetries > 0 && config.specFileRetries !== retries) {
+            await sleep(config.specFileRetriesDelay * 1000)
+        }
+
         // Retried tests receive the cid of the failing test as rid
         // so they can run with the same cid of the failing test.
         cid = rid || this.getRunnerId(cid)

--- a/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
+++ b/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
@@ -168,6 +168,9 @@ exports.config = {
     // The number of times to retry the entire specfile when it fails as a whole
     // specFileRetries: 1,
     //
+    // Delay in seconds between the spec file retry attempts
+    // specFileRetriesDelay: 0,
+    //
     // Whether or not retried specfiles should be retried immediately or deferred to the end of the queue
     // specFileRetriesDeferred: false,
     //

--- a/packages/wdio-cli/tests/interface.test.js
+++ b/packages/wdio-cli/tests/interface.test.js
@@ -289,7 +289,7 @@ describe('cli interface', () => {
             cid,
             job,
             retries,
-            message: chalk.bold.yellow('RETRYING')
+            message: chalk.bold(chalk.yellow('RETRYING'))
         }, {
             method: 'onSpecPass',
             cid,
@@ -318,6 +318,14 @@ describe('cli interface', () => {
             wdioClInterface.jobs.set('cid', job)
             wdioClInterface.onSpecSkip(cid, job)
             expect(wdioClInterface.onJobComplete).toBeCalledWith(cid, job, 0, 'SKIPPED', expect.any(Function))
+        })
+
+        it('onSpecRetry with delay', () => {
+            wdioClInterface.onJobComplete = jest.fn()
+            wdioClInterface.specFileRetriesDelay = 2
+            wdioClInterface.jobs.set('cid', job)
+            wdioClInterface.onSpecRetry(cid, job, 3)
+            expect(wdioClInterface.onJobComplete).toBeCalledWith(cid, job, 3, chalk.bold(chalk.yellow('RETRYING') + ' after 2s'))
         })
     })
 
@@ -441,6 +449,7 @@ describe('cli interface', () => {
     })
 
     afterEach(() => {
+        wdioClInterface.specFileRetriesDelay = 0
         global.console.log.mockRestore()
     })
 })

--- a/packages/wdio-cli/tests/launcher.test.js
+++ b/packages/wdio-cli/tests/launcher.test.js
@@ -1,5 +1,6 @@
 import Launcher from '../src/launcher'
 import logger from '@wdio/logger'
+import { sleep } from '@wdio/utils'
 import fs from 'fs-extra'
 
 const caps = { maxInstances: 1, browserName: 'chrome' }
@@ -442,6 +443,7 @@ describe('launcher', () => {
                 0
             )
 
+            expect(sleep).not.toHaveBeenCalled()
             expect(launcher.runnerStarted).toBe(1)
             expect(launcher.runner.run.mock.calls[0][0]).toHaveProperty('cid', '0-5')
             expect(launcher.getRunnerId(0)).toBe('0-0')
@@ -451,6 +453,71 @@ describe('launcher', () => {
                 caps,
                 ['/foo.test.js'],
                 { hostname: '127.0.0.2' },
+                expect.arrayContaining(['--foo', 'bar'])
+            )
+        })
+
+        it('should wait before starting an instance on retry', async () => {
+            const onWorkerStartMock = jest.fn()
+            const caps = {
+                browserName: 'chrome',
+                execArgv: ['--foo', 'bar']
+            }
+            launcher.configParser = { getConfig: jest.fn().mockReturnValue({
+                onWorkerStart: onWorkerStartMock,
+                specFileRetries: 2,
+                specFileRetriesDelay: 0.01
+            }) }
+            launcher.args.hostname = '127.0.0.3'
+
+            await launcher.startInstance(
+                ['/foo.test.js'],
+                caps,
+                0,
+                '0-6',
+                3
+            )
+
+            expect(sleep).toHaveBeenCalledTimes(1)
+            expect(sleep).toHaveBeenCalledWith(10)
+
+            expect(onWorkerStartMock).toHaveBeenCalledWith(
+                '0-6',
+                caps,
+                ['/foo.test.js'],
+                { hostname: '127.0.0.3' },
+                expect.arrayContaining(['--foo', 'bar'])
+            )
+        })
+
+        it('should not wait before starting an instance on the first run', async () => {
+            const onWorkerStartMock = jest.fn()
+            const caps = {
+                browserName: 'chrome',
+                execArgv: ['--foo', 'bar']
+            }
+            launcher.configParser = { getConfig: jest.fn().mockReturnValue({
+                onWorkerStart: onWorkerStartMock,
+                specFileRetries: 4,
+                specFileRetriesDelay: 0.01
+            }) }
+            launcher.args.hostname = '127.0.0.4'
+
+            await launcher.startInstance(
+                ['/foo.test.js'],
+                caps,
+                0,
+                '0-7',
+                4
+            )
+
+            expect(sleep).not.toHaveBeenCalled()
+
+            expect(onWorkerStartMock).toHaveBeenCalledWith(
+                '0-7',
+                caps,
+                ['/foo.test.js'],
+                { hostname: '127.0.0.4' },
                 expect.arrayContaining(['--foo', 'bar'])
             )
         })
@@ -537,5 +604,6 @@ describe('launcher', () => {
 
     afterEach(() => {
         global.console.log.mockRestore()
+        sleep.mockClear()
     })
 })

--- a/packages/wdio-sync/webdriverio-core.d.ts
+++ b/packages/wdio-sync/webdriverio-core.d.ts
@@ -137,6 +137,10 @@ declare namespace WebdriverIO {
         specFileRetries?: number;
         readonly specFileRetryAttempts?: number;
         /**
+         * Delay in seconds between the spec file retry attempts
+         */
+        specFileRetriesDelay?: number;
+        /**
          * Default timeout for all `waitFor*` commands. (Note the lowercase f in the option name.)
          * This timeout only affects commands starting with `waitFor*` and their default wait time.
          */

--- a/packages/wdio-utils/src/index.js
+++ b/packages/wdio-utils/src/index.js
@@ -5,7 +5,7 @@ import { initialiseWorkerService, initialiseLauncherService } from './initialise
 import webdriverMonad from './monad'
 import {
     commandCallStructure, isValidParameter, getArgumentType, safeRequire,
-    isFunctionAsync, transformCommandLogResult, canAccess
+    isFunctionAsync, transformCommandLogResult, canAccess, sleep
 } from './utils'
 import {
     wrapCommand, runFnInFiberContext, executeHooksWithArgs,
@@ -29,6 +29,7 @@ export {
     getArgumentType,
     safeRequire,
     canAccess,
+    sleep,
 
     /**
      * wdio-sync shim

--- a/packages/wdio-utils/src/utils.js
+++ b/packages/wdio-utils/src/utils.js
@@ -241,3 +241,9 @@ export const canAccess = (file) => {
         return false
     }
 }
+
+/**
+ * sleep
+ * @param {number=0} ms number in ms to sleep
+ */
+export const sleep = (ms = 0) => new Promise((r) => setTimeout(r, ms))

--- a/packages/wdio-utils/tests/__mocks__/@wdio/utils.js
+++ b/packages/wdio-utils/tests/__mocks__/@wdio/utils.js
@@ -94,3 +94,4 @@ export const capabilitiesEnvironmentDetector = capabilitiesEnvDetector
 export const devtoolsEnvironmentDetector = devtoolsEnvDetector
 export const transformCommandLogResult = jest.fn().mockImplementation((data) => data)
 export const canAccess = jest.fn()
+export const sleep = jest.fn().mockImplementation(jest.requireActual('@wdio/utils/src/utils').sleep)

--- a/packages/webdriverio/webdriverio-core.d.ts
+++ b/packages/webdriverio/webdriverio-core.d.ts
@@ -137,6 +137,10 @@ declare namespace WebdriverIO {
         specFileRetries?: number;
         readonly specFileRetryAttempts?: number;
         /**
+         * Delay in seconds between the spec file retry attempts
+         */
+        specFileRetriesDelay?: number;
+        /**
          * Default timeout for all `waitFor*` commands. (Note the lowercase f in the option name.)
          * This timeout only affects commands starting with `waitFor*` and their default wait time.
          */

--- a/scripts/templates/webdriverio.tpl.d.ts
+++ b/scripts/templates/webdriverio.tpl.d.ts
@@ -131,6 +131,10 @@ declare namespace WebdriverIO {
         specFileRetries?: number;
         readonly specFileRetryAttempts?: number;
         /**
+         * Delay in seconds between the spec file retry attempts
+         */
+        specFileRetriesDelay?: number;
+        /**
          * Default timeout for all `waitFor*` commands. (Note the lowercase f in the option name.)
          * This timeout only affects commands starting with `waitFor*` and their default wait time.
          */

--- a/tests/smoke.runner.js
+++ b/tests/smoke.runner.js
@@ -3,6 +3,8 @@ import path from 'path'
 import assert from 'assert'
 import { promisify } from 'util'
 
+import { sleep } from '../packages/wdio-utils/src/utils'
+
 const fs = {
     readFile: promisify(readFile),
     unlink: promisify(unlink),
@@ -18,8 +20,6 @@ import {
     JASMINE_REPORTER_LOGS,
     CUCUMBER_REPORTER_LOGS,
 } from './helpers/fixtures'
-
-const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms))
 
 async function runTests (tests) {
     /**
@@ -289,6 +289,7 @@ const retryPass = async () => {
             specs: [path.resolve(__dirname, 'mocha', 'retry_and_pass.js')],
             outputDir: path.dirname(logfiles[0]),
             specFileRetries: 1,
+            specFileRetriesDelay: 1,
             retryFilename
         })
     if (!await fs.exists(logfiles[0])) {


### PR DESCRIPTION
## Proposed changes

Add optional `specFileRetriesDelay` parameter to the config to adjust the delay between the spec file retry attempts.

```js
{
  specFileRetries: 2,
  specFileRetriesDelay: 3 // 3 seconds delay between spec file retry attempts
}
```
![image](https://user-images.githubusercontent.com/25589559/92944405-37463680-f454-11ea-9b13-e617267b303e.png)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

### Reviewers: @webdriverio/project-committers
