### PR TITLE
Filter postData, responseHeaders, statusCode

### DIFF
--- a/packages/wdio-shared-store-service/shared-store-service.d.ts
+++ b/packages/wdio-shared-store-service/shared-store-service.d.ts
@@ -1,13 +1,8 @@
-type jsonPrimitive = string | number | boolean | null;
-type jsonObject = { [x: string]: jsonPrimitive | jsonObject | jsonArray };
-type jsonArray = Array<jsonPrimitive | jsonObject | jsonArray>;
-type jsonCompatible = jsonPrimitive | jsonObject | jsonArray;
-
 declare namespace WebdriverIO {
     interface BrowserObject {
         sharedStore: {
-            get: (key: string) => jsonCompatible;
-            set: (key: string, value: jsonCompatible) => void;
+            get: (key: string) => JsonPrimitive | JsonCompatible;
+            set: (key: string, value: JsonPrimitive | JsonCompatible) => void;
         }
     }
 }

--- a/packages/wdio-sync/webdriverio-core.d.ts
+++ b/packages/wdio-sync/webdriverio-core.d.ts
@@ -44,6 +44,11 @@ declare namespace WebdriverIO {
         }
     }
 
+    type JsonPrimitive = string | number | boolean | null;
+    type JsonObject = { [x: string]: JsonPrimitive | JsonObject | JsonArray };
+    type JsonArray = Array<JsonPrimitive | JsonObject | JsonArray>;
+    type JsonCompatible = JsonObject | JsonArray;
+
     interface MultiRemoteCapabilities {
         [instanceName: string]: {
             capabilities: WebDriver.DesiredCapabilities;
@@ -498,7 +503,7 @@ declare namespace WebdriverIO {
         /**
          * body response of actual resource
          */
-        body: any
+        body: string | JsonCompatible
     }
 
     type PuppeteerBrowser = Partial<import('puppeteer').Browser>;
@@ -513,7 +518,10 @@ declare namespace WebdriverIO {
 
     type MockFilterOptions = {
         method?: string,
-        headers?: Record<string, string>
+        headers?: Record<string, string>,
+        responseHeaders?: Record<string, string>,
+        statusCode?: number,
+        postData?: string | ((payload: string | undefined) => boolean)
     }
 
     type ErrorCode = 'Failed' | 'Aborted' | 'TimedOut' | 'AccessDenied' | 'ConnectionClosed' | 'ConnectionReset' | 'ConnectionRefused' | 'ConnectionAborted' | 'ConnectionFailed' | 'NameNotResolved' | 'InternetDisconnected' | 'AddressUnreachable' | 'BlockedByClient' | 'BlockedByResponse'
@@ -1087,7 +1095,7 @@ declare namespace WebdriverIO {
         ): void;
 
         /**
-         * > This is a __beta__ feature. Please give us feedback and file [an issue](https://github.com/webdriverio/webdriverio/issues/new/choose) if certain scenarions don't work as expected!
+         * > This is a __beta__ feature. Please give us feedback and file [an issue](https://github.com/webdriverio/webdriverio/issues/new/choose) if certain scenarios don't work as expected!
          */
         mock(
             url: string,

--- a/packages/wdio-sync/webdriverio-core.d.ts
+++ b/packages/wdio-sync/webdriverio-core.d.ts
@@ -504,6 +504,14 @@ declare namespace WebdriverIO {
          * body response of actual resource
          */
         body: string | JsonCompatible
+        /**
+         * HTTP response headers.
+         */
+        responseHeaders: Record<string, string>;
+        /**
+         * HTTP response status code.
+         */
+        statusCode: number;
     }
 
     type PuppeteerBrowser = Partial<import('puppeteer').Browser>;

--- a/packages/webdriverio/src/commands/browser/mock.js
+++ b/packages/webdriverio/src/commands/browser/mock.js
@@ -1,5 +1,5 @@
 /**
- * > This is a __beta__ feature. Please give us feedback and file [an issue](https://github.com/webdriverio/webdriverio/issues/new/choose) if certain scenarions don't work as expected!
+ * > This is a __beta__ feature. Please give us feedback and file [an issue](https://github.com/webdriverio/webdriverio/issues/new/choose) if certain scenarios don't work as expected!
  *
  * Mock the response of a request. You can define a mock based on a matching
  * glob and corresponding header and status code. Calling the mock method
@@ -11,7 +11,7 @@
  *
  * There are 3 ways to modify the response:
  * - return a custom JSON object (for stubbing API request)
- * - replace web resource with a local file (service a modifed JavaScript file) or
+ * - replace web resource with a local file (service a modified JavaScript file) or
  * - redirect resource to a different url
  *
  * <example>
@@ -20,15 +20,28 @@
         // via static string
         const userListMock = browser.mock('**' + '/users/list')
         // you can also specifying the mock even more by filtering resources
-        // by headers or status code, e.g. mock only responses with specific
-        // header set
+        // by request or response headers, status code, postData, e.g. mock only responses with specific
+        // header set and statusCode
         const strictMock = browser.mock('**', {
             // mock all json responses
-            headers: { 'Content-Type': 'application/json' }
+            statusCode: 200,
+            headers: { 'Content-Type': 'application/json' },
+            responseHeaders: { 'Cache-Control': 'no-cache' }
+        })
+
+        // postData comparator function
+        const apiV1Mock = browser.mock('**' + '/api/v1', {
+            postData: (data) => typeof data === 'string' && data.includes('foo')
+        })
+
+        // postData exact match
+        const apiV2Mock = browser.mock('**' + '/api/v2', {
+            postData: 'foobar'
         })
     })
 
     it('should modify API responses', () => {
+        // filter by method
         const todoMock = browser.mock('**' + '/todos', {
             method: 'get'
         })
@@ -72,11 +85,12 @@
  * </example>
  *
  * @alias browser.mock
- * @param {String}             url                    url to mock
- * @param {MockFilterOptions=} filterOptions          filter mock resource by additional options
- * @param {String=}            filterOptions.method   filter resource by HTTP method
- * @param {Object=}            filterOptions.headers  filter resource by specific request headers
- * @return {Mock}                                     a mock object to modify the response
+ * @param {String}             url                            url to mock
+ * @param {MockFilterOptions=} filterOptions                  filter mock resource by additional options
+ * @param {String=}            filterOptions.method           filter resource by HTTP method
+ * @param {Object=}            filterOptions.headers          filter resource by specific request headers
+ * @param {Object=}            filterOptions.responseHeaders  filter resource by specific response headers
+ * @return {Mock}                                             a mock object to modify the response
  * @type utility
  *
  */

--- a/packages/webdriverio/src/utils/interception/devtools.js
+++ b/packages/webdriverio/src/utils/interception/devtools.js
@@ -25,7 +25,11 @@ export default class DevtoolsInterception extends Interception {
                     continue
                 }
 
+                /**
+                 * Add statusCode and responseHeaders to request to be used in expect-webdriverio
+                 */
                 request.statusCode = responseStatusCode
+                request.responseHeaders = { ...responseHeaders }
 
                 /**
                  * match filter options
@@ -45,7 +49,6 @@ export default class DevtoolsInterception extends Interception {
                     { requestId }
                 ).catch(() => ({}))
 
-                mock.responseHeaders = { ...responseHeaders }
                 request.body = base64Encoded ? atob(body) : body
                 request.body = responseHeaders['Content-Type'] && responseHeaders['Content-Type'].includes('application/json')
                     ? JSON.parse(request.body)

--- a/packages/webdriverio/webdriverio-core.d.ts
+++ b/packages/webdriverio/webdriverio-core.d.ts
@@ -504,6 +504,14 @@ declare namespace WebdriverIO {
          * body response of actual resource
          */
         body: string | JsonCompatible
+        /**
+         * HTTP response headers.
+         */
+        responseHeaders: Record<string, string>;
+        /**
+         * HTTP response status code.
+         */
+        statusCode: number;
     }
 
     type PuppeteerBrowser = Partial<import('puppeteer').Browser>;

--- a/packages/webdriverio/webdriverio-core.d.ts
+++ b/packages/webdriverio/webdriverio-core.d.ts
@@ -44,6 +44,11 @@ declare namespace WebdriverIO {
         }
     }
 
+    type JsonPrimitive = string | number | boolean | null;
+    type JsonObject = { [x: string]: JsonPrimitive | JsonObject | JsonArray };
+    type JsonArray = Array<JsonPrimitive | JsonObject | JsonArray>;
+    type JsonCompatible = JsonObject | JsonArray;
+
     interface MultiRemoteCapabilities {
         [instanceName: string]: {
             capabilities: WebDriver.DesiredCapabilities;
@@ -498,7 +503,7 @@ declare namespace WebdriverIO {
         /**
          * body response of actual resource
          */
-        body: any
+        body: string | JsonCompatible
     }
 
     type PuppeteerBrowser = Partial<import('puppeteer').Browser>;
@@ -513,7 +518,10 @@ declare namespace WebdriverIO {
 
     type MockFilterOptions = {
         method?: string,
-        headers?: Record<string, string>
+        headers?: Record<string, string>,
+        responseHeaders?: Record<string, string>,
+        statusCode?: number,
+        postData?: string | ((payload: string | undefined) => boolean)
     }
 
     type ErrorCode = 'Failed' | 'Aborted' | 'TimedOut' | 'AccessDenied' | 'ConnectionClosed' | 'ConnectionReset' | 'ConnectionRefused' | 'ConnectionAborted' | 'ConnectionFailed' | 'NameNotResolved' | 'InternetDisconnected' | 'AddressUnreachable' | 'BlockedByClient' | 'BlockedByResponse'
@@ -1087,7 +1095,7 @@ declare namespace WebdriverIO {
         ): Promise<void>;
 
         /**
-         * > This is a __beta__ feature. Please give us feedback and file [an issue](https://github.com/webdriverio/webdriverio/issues/new/choose) if certain scenarions don't work as expected!
+         * > This is a __beta__ feature. Please give us feedback and file [an issue](https://github.com/webdriverio/webdriverio/issues/new/choose) if certain scenarios don't work as expected!
          */
         mock(
             url: string,

--- a/scripts/templates/webdriverio.tpl.d.ts
+++ b/scripts/templates/webdriverio.tpl.d.ts
@@ -498,6 +498,14 @@ declare namespace WebdriverIO {
          * body response of actual resource
          */
         body: string | JsonCompatible
+        /**
+         * HTTP response headers.
+         */
+        responseHeaders: Record<string, string>;
+        /**
+         * HTTP response status code.
+         */
+        statusCode: number;
     }
 
     type PuppeteerBrowser = Partial<import('puppeteer').Browser>;

--- a/scripts/templates/webdriverio.tpl.d.ts
+++ b/scripts/templates/webdriverio.tpl.d.ts
@@ -38,6 +38,11 @@ declare namespace WebdriverIO {
         }
     }
 
+    type JsonPrimitive = string | number | boolean | null;
+    type JsonObject = { [x: string]: JsonPrimitive | JsonObject | JsonArray };
+    type JsonArray = Array<JsonPrimitive | JsonObject | JsonArray>;
+    type JsonCompatible = JsonObject | JsonArray;
+
     interface MultiRemoteCapabilities {
         [instanceName: string]: {
             capabilities: WebDriver.DesiredCapabilities;
@@ -492,7 +497,7 @@ declare namespace WebdriverIO {
         /**
          * body response of actual resource
          */
-        body: any
+        body: string | JsonCompatible
     }
 
     type PuppeteerBrowser = Partial<import('puppeteer').Browser>;
@@ -507,7 +512,10 @@ declare namespace WebdriverIO {
 
     type MockFilterOptions = {
         method?: string,
-        headers?: Record<string, string>
+        headers?: Record<string, string>,
+        responseHeaders?: Record<string, string>,
+        statusCode?: number,
+        postData?: string | ((payload: string | undefined) => boolean)
     }
 
     type ErrorCode = 'Failed' | 'Aborted' | 'TimedOut' | 'AccessDenied' | 'ConnectionClosed' | 'ConnectionReset' | 'ConnectionRefused' | 'ConnectionAborted' | 'ConnectionFailed' | 'NameNotResolved' | 'InternetDisconnected' | 'AddressUnreachable' | 'BlockedByClient' | 'BlockedByResponse'


### PR DESCRIPTION
## Proposed changes

- add `responseHeaders` to `mock` for verification purposes
- add `requestHeaders` similar to `request` filter that stands for `responseHeaders`
- add `statusCode` filter
- add `postData` filter (exact match, function comparator)

```js
browser.mock('**/api/*', {
  requestHeaders: { foo: 'bar' },
  postData: 'foobar' // exact match
})

browser.mock('**/api/*', {
  method: 'POST',
  postData: data => data && data.includes('foo')
})
```
#5796

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

### Reviewers: @webdriverio/project-committers
