### PR TITLE
Prepend hash only for h1 in 3rd party docs

### DIFF
--- a/scripts/docs-generation/3rdPartyDocs.js
+++ b/scripts/docs-generation/3rdPartyDocs.js
@@ -112,7 +112,7 @@ function normalizeDoc(readme, githubUrl, preface, repoInfo) {
         /**
          * prepend # to header rows
          */
-        if (row.match(/^(#)\1* /)) {
+        if (row.match(/^(# )\1* /)) {
             readmeArr[idx] = `#${row}`
         }
 


### PR DESCRIPTION
## Proposed changes

Prepend hash only for h1 in 3rd party docs

**Before**
nothing...
- https://webdriver.io/docs/docs/wdio-wiremock-service.html
- https://webdriver.io/docs/api/expect-webdriverio.html

**After**
- ![image](https://user-images.githubusercontent.com/25589559/93144263-f1a29b80-f6e9-11ea-9e20-d4d87846653f.png)
- ![image](https://user-images.githubusercontent.com/25589559/93144278-fa936d00-f6e9-11ea-8928-696cfdcc5423.png)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

### Reviewers: @webdriverio/project-committers
