### PR TITLE
Fix unbound commands in devtools-service

### DIFF
--- a/packages/wdio-devtools-service/src/commands.js
+++ b/packages/wdio-devtools-service/src/commands.js
@@ -20,7 +20,7 @@ export default class CommandHandler {
          */
         const commands = Object.getOwnPropertyNames(Object.getPrototypeOf(this)).filter(
             fnName => fnName !== 'constructor' && !fnName.startsWith('_'))
-        commands.forEach(fnName => global.browser.addCommand(fnName, this[fnName]))
+        commands.forEach(fnName => global.browser.addCommand(fnName, this[fnName].bind(this)))
     }
 
     /**


### PR DESCRIPTION
## Proposed changes

When devtools was migrated from Babel to Typescript (in #5446 ) most places the :: scope operator was used were switched to .bind; however, one was missed.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
