### PR TITLE
Disable password manager prompt by default in devtools

### DIFF
--- a/packages/devtools/src/constants.js
+++ b/packages/devtools/src/constants.js
@@ -5,7 +5,12 @@ export const DEFAULT_Y_POSITION = 0
 
 export const ELEMENT_KEY = 'element-6066-11e4-a52e-4f735466cecf'
 
+// https://github.com/puppeteer/puppeteer/blob/083ea41e943e2a20014279fcfceb23c98a1e4491/src/node/Launcher.ts#L168
 export const DEFAULT_FLAGS = [
+    // suppresses Save Password prompt window
+    '--enable-automation',
+    // do not block popups
+    '--disable-popup-blocking',
     // Disable all chrome extensions entirely
     '--disable-extensions',
     // Disable various background network services, including extension updating,

--- a/packages/devtools/tests/__snapshots__/launcher.test.js.snap
+++ b/packages/devtools/tests/__snapshots__/launcher.test.js.snap
@@ -98,6 +98,8 @@ Array [
   Array [
     Object {
       "chromeFlags": Array [
+        "--enable-automation",
+        "--disable-popup-blocking",
         "--disable-extensions",
         "--disable-background-networking",
         "--disable-background-timer-throttling",
@@ -141,6 +143,8 @@ Array [
   Array [
     Object {
       "chromeFlags": Array [
+        "--enable-automation",
+        "--disable-popup-blocking",
         "--disable-extensions",
         "--disable-background-networking",
         "--disable-background-timer-throttling",
@@ -216,6 +220,8 @@ Array [
   Array [
     Object {
       "chromeFlags": Array [
+        "--enable-automation",
+        "--disable-popup-blocking",
         "--disable-extensions",
         "--disable-background-networking",
         "--disable-background-timer-throttling",


### PR DESCRIPTION
## Proposed changes

Add `'--enable-automation'` and `'--disable-popup-blocking'` to the `DEFAULT_FLAGS`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

### Reviewers: @webdriverio/project-committers
