### PR TITLE
Fix double click

### DIFF
--- a/packages/webdriverio/src/commands/element/doubleClick.js
+++ b/packages/webdriverio/src/commands/element/doubleClick.js
@@ -34,7 +34,7 @@ export default async function doubleClick () {
     /**
      * W3C way of handle the double click actions
      */
-    await this.performActions([{
+    return this.performActions([{
         type: 'pointer',
         id: 'pointer1',
         parameters: { pointerType: 'mouse' },
@@ -47,6 +47,4 @@ export default async function doubleClick () {
             { type: 'pointerUp', button: 0 }
         ]
     }])
-
-    return this.releaseActions()
 }

--- a/scripts/type-generation/webdriverio-generate-typings.js
+++ b/scripts/type-generation/webdriverio-generate-typings.js
@@ -9,7 +9,7 @@ const specifics = require('./specific-types.json')
 const { EDIT_WARNING } = require('../constants')
 
 const TYPING_SCOPES = ['element', 'browser', 'mock']
-const EXCLUDED_COMMANDS = ['execute', 'executeAsync', 'call']
+const EXCLUDED_COMMANDS = ['execute', 'executeAsync', 'call', 'addCommand', 'overwriteCommand']
 const INDENTATION = ' '.repeat(8)
 
 const jsDocTemplate = `


### PR DESCRIPTION
## Proposed changes

Issue: if there is a need to open an alert with a double click, the alert closes immediately because `releaseActions` fails due to "unexpected alert" error.

Do not call release actions after double click.

Calling `releaseActions` command is only needed to release previously pressed buttons, in case of double click, it's not needed because we do it within `performAction` actions.


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

updated "type generate" script.

### Reviewers: @webdriverio/project-committers
