### PR TITLE
Propagate error when loading suite

### DIFF
--- a/packages/wdio-mocha-framework/src/index.js
+++ b/packages/wdio-mocha-framework/src/index.js
@@ -41,6 +41,7 @@ class MochaAdapter {
         this.testCnt = new Map()
         this.suiteIds = ['0']
         this._hasTests = true
+        this.specLoadError = null
     }
 
     async init() {
@@ -71,13 +72,14 @@ class MochaAdapter {
 
             this._hasTests = mochaRunner.total > 0
         } catch (err) {
-            log.warn(
+            const error = '' +
                 'Unable to load spec files quite likely because they rely on `browser` object that is not fully initialised.\n' +
                 '`browser` object has only `capabilities` and some flags like `isMobile`.\n' +
                 'Helper files that use other `browser` commands have to be moved to `before` hook.\n' +
-                `Spec file(s): ${this.specs.join(',')}\n`,
-                'Error: ', err
-            )
+                `Spec file(s): ${this.specs.join(',')}\n` +
+                `Error: ${err.stack}`
+            this.specLoadError = new Error(error)
+            log.warn(error)
         }
     }
 
@@ -118,8 +120,8 @@ class MochaAdapter {
         /**
          * in case the spec has a runtime error throw after the wdio hook
          */
-        if (runtimeError) {
-            throw runtimeError
+        if (runtimeError || this.specLoadError) {
+            throw runtimeError || this.specLoadError
         }
 
         return result

--- a/packages/wdio-mocha-framework/tests/adapter.test.js
+++ b/packages/wdio-mocha-framework/tests/adapter.test.js
@@ -80,6 +80,14 @@ test('should throw runtime error if spec is invalid', async () => {
     await expect(adapter.run()).rejects.toEqual(runtimeError)
 })
 
+test('should throw runtime error if spec could not be loaded', async () => {
+    const runtimeError = new Error('Uuups')
+    const adapter = adapterFactory({ mochaOpts: { mockFailureCount: 0 } })
+    await adapter.init()
+    adapter.specLoadError = runtimeError
+    await expect(adapter.run()).rejects.toEqual(runtimeError)
+})
+
 test('options', () => {
     const adapter = adapterFactory()
     adapter.requireExternalModules = jest.fn()
@@ -380,7 +388,7 @@ describe('loadFiles', () => {
         expect(adapter._hasTests).toBe(false)
     })
 
-    test('should not fail on exception', async () => {
+    test('should propagate error', async () => {
         const adapter = adapterFactory({})
         adapter._hasTests = null
         adapter.mocha = {
@@ -391,6 +399,8 @@ describe('loadFiles', () => {
         await adapter._loadFiles({})
         expect(adapter.mocha.loadFilesAsync).toBeCalled()
         expect(adapter._hasTests).toBe(null)
+        expect(adapter.specLoadError.message)
+            .toContain('Unable to load spec files')
     })
 })
 


### PR DESCRIPTION
## Proposed changes

With the change we introduced in #5809 we started to ignore errors when loading the spec file. Let's say someone uses a command outside an `it` block or hook like this:

```js
describe('webdriver.io page', () => {
    it('should be a pending test')

    browser.setTimeout({ script: 60000 * 10 })

    it('should have the right title', () => {
        browser.url('https://webdriver.io')
        expect(browser).toHaveTitle('WebdriverIO · Next-gen browser and mobile automation test framework for Node.js')
    })
})
```

WebdriverIO would pass the suite with no error:

```txt
Execution of 1 spec files started at 2020-10-01T10:46:37.704Z

let's go
[0-0] RUNNING in chrome - /mocha/mocha.test.js
[0-0] PASSED in chrome - /mocha/mocha.test.js
that's it

"spec" Reporter:
------------------------------------------------------------------
[chrome 85.0.4183.121 mac os x #0-0] Spec: /path/to/webdriverio/examples/wdio/mocha/mocha.test.js
[chrome 85.0.4183.121 mac os x #0-0] Running: chrome (v85.0.4183.121) on mac os x
[chrome 85.0.4183.121 mac os x #0-0] Session ID: 7a2ac4601d5fd4a66f21bcf3506de0bb
[chrome 85.0.4183.121 mac os x #0-0]
[chrome 85.0.4183.121 mac os x #0-0] webdriver.io page
[chrome 85.0.4183.121 mac os x #0-0]    - should be a pending test
[chrome 85.0.4183.121 mac os x #0-0]
[chrome 85.0.4183.121 mac os x #0-0] 1 skipped (242ms)

Spec Files:      1 passed, 1 total (100% completed) in 00:00:02
```

This is rather suboptimal as there is clearly an issue in the spec that needs to be addressed. Instead of just ignoring it we should make users aware and have the test fail.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

We already catch the error and only need to propagate it. With this patch the test run now looks as follows:

```txt
Execution of 1 spec files started at 2020-10-01T10:47:53.778Z
                                                                                                                    
let's go
[0-0] RUNNING in chrome - /mocha/mocha.test.js
[0-0]  Error:  Unable to load spec files quite likely because they rely on `browser` object that is not fully initialised.
`browser` object has only `capabilities` and some flags like `isMobile`.
Helper files that use other `browser` commands have to be moved to `before` hook.
Spec file(s): /Users/christianbromann/Sites/webdriverio/webdriverio/examples/wdio/mocha/mocha.test.js
Error: TypeError: browser.setTimeout is not a function
    at Suite.describe (/path/to/webdriverio/examples/wdio/mocha/mocha.test.js:4:13)
    at Object.create (/path/to/webdriverio/packages/wdio-mocha-framework/node_modules/mocha/lib/interfaces/common.js:148:19)
    at context.describe.context.context (/path/to/webdriverio/packages/wdio-mocha-framework/node_modules/mocha/lib/interfaces/bdd.js:42:27)
    at Object.<anonymous> (/path/to/webdriverio/examples/wdio/mocha/mocha.test.js:1:1
    at Module._compile (internal/modules/cjs/loader.js:778:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:789:10)
    at Module.load (internal/modules/cjs/loader.js:653:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
    at Function.Module._load (internal/modules/cjs/loader.js:585:3)
    at Module.require (internal/modules/cjs/loader.js:692:17)
[0-0] FAILED in chrome - /mocha/mocha.test.js
that's it

 "spec" Reporter:
------------------------------------------------------------------
[chrome 85.0.4183.121 mac os x #0-0] Spec: /path/to/webdriverio/examples/wdio/mocha/mcha.test.js
[chrome 85.0.4183.121 mac os x #0-0] Running: chrome (v85.0.4183.121) on mac os x
[chrome 85.0.4183.121 mac os x #0-0] Session ID: 7aeb249aca663f4a1782fd64583ea56c
[chrome 85.0.4183.121 mac os x #0-0]
[chrome 85.0.4183.121 mac os x #0-0] webdriver.io page
[chrome 85.0.4183.121 mac os x #0-0]    - should be a pending test
[chrome 85.0.4183.121 mac os x #0-0]
[chrome 85.0.4183.121 mac os x #0-0] 1 skipped (243ms)


Spec Files:      0 passed, 1 failed, 1 total (100% completed) in 00:00:02
```

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

I am working on some tests for this.

### Reviewers: @webdriverio/project-committers
