### PR TITLE
Speedup Firefox Nightly startup on MacOS with devtools protocol

### DIFF
--- a/packages/devtools/src/finder/edge.js
+++ b/packages/devtools/src/finder/edge.js
@@ -21,8 +21,16 @@ function darwin() {
         '/Contents/MacOS/Microsoft Edge'
     ]
 
-    const appPaths = darwinGetAppPaths('Microsoft Edge')
-    const installations = darwinGetInstallations(appPaths, suffixes)
+    const appName = 'Microsoft Edge'
+    const defaultPath = `/Applications/${appName}.app${suffixes[0]}`
+
+    let installations
+    if (canAccess(defaultPath)) {
+        installations = [defaultPath]
+    } else {
+        const appPaths = darwinGetAppPaths(appName)
+        installations = darwinGetInstallations(appPaths, suffixes)
+    }
 
     // Retains one per line to maintain readability.
     // clang-format off

--- a/packages/devtools/src/finder/edge.js
+++ b/packages/devtools/src/finder/edge.js
@@ -10,6 +10,7 @@ import { execSync } from 'child_process'
 import { canAccess } from '@wdio/utils'
 
 import { sort, findByWhich } from '../utils'
+import { darwinGetAppPaths, darwinGetInstallations } from './finder'
 
 const newLineRegex = /\r?\n/
 const EDGE_BINARY_NAMES = ['edge', 'msedge', 'microsoftedge']
@@ -20,27 +21,8 @@ function darwin() {
         '/Contents/MacOS/Microsoft Edge'
     ]
 
-    const LSREGISTER = '/System/Library/Frameworks/CoreServices.framework' +
-        '/Versions/A/Frameworks/LaunchServices.framework' +
-        '/Versions/A/Support/lsregister'
-
-    const installations = []
-
-    execSync(
-        `${LSREGISTER} -dump` +
-        ' | grep -i \'microsoft edge\\?.app.*$\'' +
-        ' | awk \'{$1=""; print $0}\''
-    )
-        .toString()
-        .split(newLineRegex)
-        .forEach((inst) => {
-            suffixes.forEach(suffix => {
-                const execPath = path.join(inst.substring(0, inst.indexOf('.app') + 4).trim(), suffix)
-                if (canAccess(execPath) && installations.indexOf(execPath) === -1) {
-                    installations.push(execPath)
-                }
-            })
-        })
+    const appPaths = darwinGetAppPaths('Microsoft Edge')
+    const installations = darwinGetInstallations(appPaths, suffixes)
 
     // Retains one per line to maintain readability.
     // clang-format off

--- a/packages/devtools/src/finder/finder.js
+++ b/packages/devtools/src/finder/finder.js
@@ -1,0 +1,28 @@
+import path from 'path'
+import { execSync } from 'child_process'
+
+import { canAccess } from '@wdio/utils'
+
+const DARWIN_LIST_APPS = 'system_profiler SPApplicationsDataType -json'
+
+export const darwinGetAppPaths = (app) => {
+    const apps = JSON.parse(execSync(DARWIN_LIST_APPS))
+    const appPaths = apps.SPApplicationsDataType
+        .filter(inst => inst.info && inst.info.startsWith(app))
+        .map(inst => inst.path)
+
+    return appPaths
+}
+
+export const darwinGetInstallations = (appPaths, suffixes) => {
+    const installations = []
+    appPaths.forEach((inst) => {
+        suffixes.forEach(suffix => {
+            const execPath = path.join(inst.substring(0, inst.indexOf('.app') + 4).trim(), suffix)
+            if (canAccess(execPath) && installations.indexOf(execPath) === -1) {
+                installations.push(execPath)
+            }
+        })
+    })
+    return installations
+}

--- a/packages/devtools/src/finder/firefox.js
+++ b/packages/devtools/src/finder/firefox.js
@@ -10,6 +10,7 @@ import { execSync } from 'child_process'
 import { canAccess } from '@wdio/utils'
 
 import { sort, findByWhich } from '../utils'
+import { darwinGetAppPaths, darwinGetInstallations } from './finder'
 
 const newLineRegex = /\r?\n/
 
@@ -18,27 +19,8 @@ function darwin() {
         '/Contents/MacOS/firefox-bin'
     ]
 
-    const LSREGISTER = '/System/Library/Frameworks/CoreServices.framework' +
-        '/Versions/A/Frameworks/LaunchServices.framework' +
-        '/Versions/A/Support/lsregister'
-
-    const installations = []
-
-    execSync(
-        `${LSREGISTER} -dump` +
-        ' | grep -i \'Firefox Nightly\\?.app.*$\'' +
-        ' | awk \'{$1=""; print $0}\''
-    )
-        .toString()
-        .split(newLineRegex)
-        .forEach((inst) => {
-            suffixes.forEach(suffix => {
-                const execPath = path.join(inst.substring(0, inst.indexOf('.app') + 4).trim(), suffix)
-                if (canAccess(execPath) && installations.indexOf(execPath) === -1) {
-                    installations.push(execPath)
-                }
-            })
-        })
+    const appPaths = darwinGetAppPaths('Firefox Nightly')
+    const installations = darwinGetInstallations(appPaths, suffixes)
 
     /**
      * Retains one per line to maintain readability.

--- a/packages/devtools/src/finder/firefox.js
+++ b/packages/devtools/src/finder/firefox.js
@@ -19,8 +19,16 @@ function darwin() {
         '/Contents/MacOS/firefox-bin'
     ]
 
-    const appPaths = darwinGetAppPaths('Firefox Nightly')
-    const installations = darwinGetInstallations(appPaths, suffixes)
+    const appName = 'Firefox Nightly'
+    const defaultPath = `/Applications/${appName}.app${suffixes[0]}`
+
+    let installations
+    if (canAccess(defaultPath)) {
+        installations = [defaultPath]
+    } else {
+        const appPaths = darwinGetAppPaths(appName)
+        installations = darwinGetInstallations(appPaths, suffixes)
+    }
 
     /**
      * Retains one per line to maintain readability.

--- a/packages/devtools/src/launcher.js
+++ b/packages/devtools/src/launcher.js
@@ -134,7 +134,7 @@ function launchBrowser (capabilities, product) {
 
     if (!executablePath) {
         throw new Error('Couldn\'t find executable for browser')
-    } else if (product === BROWSER_TYPE.firefox && !executablePath.toLowerCase().includes(CHANNEL_FIREFOX_NIGHTLY)) {
+    } else if (product === BROWSER_TYPE.firefox && executablePath !== 'firefox' && !executablePath.toLowerCase().includes(CHANNEL_FIREFOX_NIGHTLY)) {
         throw new Error(BROWSER_ERROR_MESSAGES.firefoxNightly)
     }
 

--- a/packages/devtools/tests/__snapshots__/launcher.test.js.snap
+++ b/packages/devtools/tests/__snapshots__/launcher.test.js.snap
@@ -54,6 +54,24 @@ Array [
 ]
 `;
 
+exports[`launch Firefox Nightly binary without Puppeteer default args 1`] = `
+Array [
+  Array [
+    Object {
+      "binary": "firefox",
+      "defaultViewport": Object {
+        "height": 900,
+        "width": 1200,
+      },
+      "executablePath": "firefox",
+      "headless": true,
+      "ignoreDefaultArgs": true,
+      "product": "firefox",
+    },
+  ],
+]
+`;
+
 exports[`launch Firefox Nightly with custom arguments 1`] = `
 Array [
   Array [

--- a/packages/devtools/tests/finder/finder.test.js
+++ b/packages/devtools/tests/finder/finder.test.js
@@ -1,0 +1,30 @@
+import { canAccess } from '@wdio/utils'
+
+import { darwinGetAppPaths, darwinGetInstallations } from '../../src/finder/finder'
+
+const systemProfiler = require('./systemProfiler.json')
+
+jest.mock('child_process',  jest.fn().mockImplementation(() => ({
+    execSync() {
+        return JSON.stringify(systemProfiler)
+    }
+})))
+
+describe('darwinGetAppPaths', () => {
+    test('Firefox Nightly', () => {
+        expect(darwinGetAppPaths('Firefox Nightly')).toEqual(['/Applications/Someone Renamed Firefox.app'])
+    })
+
+    test('Microsoft Edge', () => {
+        expect(darwinGetAppPaths('Microsoft Edge')).toEqual(['/Applications/Microsoft Edge.app'])
+    })
+})
+
+describe('darwinGetInstallations', () => {
+    beforeAll(() => {
+        canAccess.mockImplementation((s = '') => s.startsWith('/ok'))
+    })
+    test('darwinGetInstallations', () => {
+        expect(darwinGetInstallations(['/ok', '/not-ok'], ['foobar'])).toEqual(['/ok/foobar'])
+    })
+})

--- a/packages/devtools/tests/finder/systemProfiler.json
+++ b/packages/devtools/tests/finder/systemProfiler.json
@@ -1,0 +1,60 @@
+{
+  "SPApplicationsDataType": [
+    {
+      "_name": "Firefox",
+      "arch_kind": "arch_i64",
+      "info": "Firefox 81.0.1",
+      "lastModified": "2020-10-02T07:43:53Z",
+      "obtained_from": "identified_developer",
+      "path": "/Applications/Firefox.app",
+      "signed_by": [
+        "Developer ID Application: Mozilla Corporation (43AQ936H96)",
+        "Developer ID Certification Authority",
+        "Apple Root CA"
+      ],
+      "version": "81.0.1"
+    },
+    {
+      "_name": "Someone Renamed Firefox",
+      "arch_kind": "arch_i64",
+      "info": "Firefox Nightly 83.0a1",
+      "lastModified": "2020-10-01T11:33:37Z",
+      "obtained_from": "identified_developer",
+      "path": "/Applications/Someone Renamed Firefox.app",
+      "signed_by": [
+        "Developer ID Application: Mozilla Corporation (43AQ936H96)",
+        "Developer ID Certification Authority",
+        "Apple Root CA"
+      ],
+      "version": "83.0a1"
+    },
+    {
+      "_name": "Microsoft Edge",
+      "arch_kind": "arch_i64",
+      "info": "Microsoft Edge 85.0.564.68, © 2020 Microsoft Corporation. All rights reserved.",
+      "lastModified": "2020-10-02T12:04:44Z",
+      "obtained_from": "identified_developer",
+      "path": "/Applications/Microsoft Edge.app",
+      "signed_by": [
+        "Developer ID Application: Microsoft Corporation (UBF8T346G9)",
+        "Developer ID Certification Authority",
+        "Apple Root CA"
+      ],
+      "version": "85.0.564.68"
+    },
+    {
+      "_name": "Google Chrome",
+      "arch_kind": "arch_i64",
+      "info": "Google Chrome 85.0.4183.121, Copyright 2020 Google LLC. All rights reserved.",
+      "lastModified": "2020-09-19T04:09:51Z",
+      "obtained_from": "identified_developer",
+      "path": "/Applications/Google Chrome.app",
+      "signed_by": [
+        "Developer ID Application: Google, Inc. (EQHXZ8M8AV)",
+        "Developer ID Certification Authority",
+        "Apple Root CA"
+      ],
+      "version": "85.0.4183.121"
+    }
+  ]
+}

--- a/packages/devtools/tests/launcher.test.js
+++ b/packages/devtools/tests/launcher.test.js
@@ -187,6 +187,18 @@ test('launch Firefox Nightly without Puppeteer default args', async () => {
     expect(puppeteer.launch.mock.calls).toMatchSnapshot()
 })
 
+test('launch Firefox Nightly binary without Puppeteer default args', async () => {
+    await launch({
+        browserName: 'firefox',
+        'moz:firefoxOptions': {
+            binary: 'firefox',
+            headless: true
+        },
+        ignoreDefaultArgs: true
+    })
+    expect(puppeteer.launch.mock.calls).toMatchSnapshot()
+})
+
 test('launch Firefox without Puppeteer default args', async () => {
     expect.assertions(1)
 


### PR DESCRIPTION
## Proposed changes

Speedup firefox/edge startup on MacOS
fixes #5916

results on my machine:
- before 5.5s
- after 1.5s

If the browser installed to the default location no waiting is required!

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

Decided to use JSON format intentionally, ti takes ~300ms less than text and ~100ms less than XML output types.
Sorry to say there are no other reliable ways to get an app installation path on MacOS.

### Reviewers: @webdriverio/project-committers
