### PR TITLE
Add firefox nightly and chrome links to contributing doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -280,7 +280,8 @@ In order to test certain scenarios this project has a test directory that allows
 - *e2e Tests*
   Last but not least we run actual e2e tests with real browser to ensure that our WebDriver DevTools implementation is working as expected. These
   test spin up headless Chrome and Firefox browser to test the commands implemented in the `devtools` package. Given that WebDriver functionality
-  is already tested with [WPT](https://github.com/web-platform-tests/wpt) we don't need to do it there.
+  is already tested with [WPT](https://github.com/web-platform-tests/wpt) we don't need to do it there. 
+  In order to run these tests, an installation of [Firefox Nightly](https://www.mozilla.org/en-US/firefox/channel/desktop/#nightly) and [Google Chrome](https://www.google.com/chrome/) are required.
   You can manually trigger this check by calling:
   ```sh
   $ npm run test:e2e


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.) 
Let contributors know requirements of running e2e tests before they encounter errors.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
No code changes.
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)
Might be a simple change, but I spent some time figuring out why my firefox tests wouldn't run and its because we are explicitly looking for Nightly in https://github.com/webdriverio/webdriverio/blob/master/packages/devtools/src/finder/firefox.js#L29 
If nightly isn't installed, then https://github.com/webdriverio/webdriverio/blob/master/packages/devtools/src/launcher.js#L138 is never thrown because of https://github.com/webdriverio/webdriverio/blob/master/packages/devtools/src/launcher.js#L136 and the user is not returned any relevant information about the nightly requirement. 
### Reviewers: @webdriverio/project-committers
