### PR TITLE
Improve documentation around WDIO options/configs

### DIFF
--- a/docs/BrowserObject.md
+++ b/docs/BrowserObject.md
@@ -52,9 +52,9 @@ console.log(browser.requestedCapabilities)
  */
 ```
 
-## Get Config Options
+## Custom Configurations
 
-If using the WDIO testrunner you can always define custom options within your WDIO config:
+If using the WDIO testrunner you can always define custom configurations within your WDIO config:
 
 ```js
 // wdio.conf.js
@@ -89,6 +89,18 @@ console.log(browser.config)
 
 console.log(browser.config.fakeUser) // outputs: "maxmustermann"
 ```
+
+### Versus Options
+
+Custom configurations should not be confused with [Options](Options.md), which are documented separately:
+
+```js
+browser.config.baseUrl; // Custom configuration
+browser.options.baseUrl; // WebdriverIO option
+```
+
+When using the WDIO testrunner, if keys conflict in name (e.g. `baseUrl` above) the option value will take precedence and overwrite the config value.
+
 
 ## Mobile Flags
 

--- a/docs/BrowserObject.md
+++ b/docs/BrowserObject.md
@@ -101,7 +101,6 @@ browser.options.baseUrl; // WebdriverIO option
 
 When using the WDIO testrunner, if keys conflict in name (e.g. `baseUrl` above) the option value will take precedence and overwrite the config value.
 
-
 ## Mobile Flags
 
 If you need to modify your test based on whether or not your session runs on a mobile device, you can access the mobile flags to check.

--- a/docs/BrowserObject.md
+++ b/docs/BrowserObject.md
@@ -62,6 +62,7 @@ exports.config = {
     // ...
     fakeUser: 'maxmustermann',
     fakePassword: 'foobar',
+    baseUrl: 'example.com',
     // ...
 }
 ```
@@ -82,24 +83,50 @@ console.log(browser.config)
         connectionRetryTimeout: 120000,
         connectionRetryCount: 3,
         specs: [ 'err.js' ],
-        fakeUser: 'maxmustermann', // <-- custom option
-        fakePassword: 'foobar', // <-- custom option
+        fakeUser: 'maxmustermann', // <-- custom configuration
+        fakePassword: 'foobar', // <-- custom configuration
+        baseUrl: 'example.com', // <-- custom configuration
         // ...
  */
 
 console.log(browser.config.fakeUser) // outputs: "maxmustermann"
 ```
 
-### Versus Options
+### Configurations versus Options
 
-Custom configurations should not be confused with [Options](Options.md), which are documented separately:
+Custom configurations should not be confused with [Options](Options.md), which are accessed separately.
 
 ```js
-browser.config.baseUrl; // Custom configuration
-browser.options.baseUrl; // WebdriverIO option
+console.log(browser.options)
+/**
+ * outputs:
+ * {
+        protocol: 'http',
+        port: 4444,
+        hostname: 'localhost',
+        baseUrl: 'example.com',
+        // ...
+ */
 ```
 
-When using the WDIO testrunner, if keys conflict in name (e.g. `baseUrl` above) the option value will take precedence and overwrite the config value.
+When using the WDIO testrunner, if any configuration and option keys conflict in name (e.g. `baseUrl` in the following code snippets) the option value will take precedence and overwrite the config value.
+
+```js
+// wdio.conf.js
+exports.config = {
+    baseUrl: 'example.com'
+}
+```
+
+```bash
+# testrunner invocation
+$ npm wdio wdio.conf.js --baseUrl foobar.com
+```
+
+```js
+console.log(browser.config.baseUrl) // 'foobar.com'
+console.log(browser.options.baseUrl) // 'foobar.com'
+```
 
 ## Mobile Flags
 

--- a/docs/BrowserObject.md
+++ b/docs/BrowserObject.md
@@ -79,7 +79,6 @@ console.log(browser.config)
         waitforTimeout: 10000,
         waitforInterval: 250,
         logLevel: 'debug',
-        baseUrl: 'http://localhost',
         connectionRetryTimeout: 120000,
         connectionRetryCount: 3,
         specs: [ 'err.js' ],

--- a/docs/BrowserObject.md
+++ b/docs/BrowserObject.md
@@ -124,7 +124,7 @@ $ npm wdio wdio.conf.js --baseUrl foobar.com
 ```
 
 ```js
-console.log(browser.config.baseUrl) // 'foobar.com'
+console.log(browser.config.baseUrl) // 'foobar.com', despite being set as 'example.com'
 console.log(browser.options.baseUrl) // 'foobar.com'
 ```
 

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -7,7 +7,7 @@ WebdriverIO is not just a binding for the WebDriver protocol (like Selenium). It
 
 WebdriverIO takes the protocol commands and creates smart user commands that makes using the protocol for test automation much easier.
 
-WebdriverIO also enhances the WebDriver package with additional commands. They share the same set of options when run in a standalone script. But when testing starts from `@wdio/cli` (the WDIO testrunner), there are some additional options available for you to use in `wdio.conf.js`.
+WebdriverIO also enhances the WebDriver package with additional commands. They share the same set of options when run in a standalone script. But when testing starts from `@wdio/cli` (the WDIO testrunner), there are some additional options available for you to use in `browser.options`.
 
 ## WebDriver Options
 


### PR DESCRIPTION
## Proposed changes

Improve documentation around WDIO configs and options.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

This change was inspired by confusion around the use of `browser.config` and `browser.options` (the latter of which I could not find documented anywhere).

Here's the behavior I've observed when a `browser.config` and `browser.option` key conflict in name:

| set in `wdio.conf.js` | set on CLI | `wdio.config` value | `wdio.options` value |
| --------------------- | ---------- | ------------------- | -------------------- |
| :white_check_mark: | :white_check_mark: | cli value | cli value |
| :white_check_mark: | :x: | `wdio.conf.js` value | `wdio.conf.js` value |
| :x: | :white_check_mark: | cli value | cli value |
| :x: | :x: | `undefined` | `undefined` |

which is why I added the sentence describing precedence.

Additionally, I couldn't find `browser.options` documented anywhere, so I added it on the Options page.

I feel these are most likely uncontentious improvements, but I'm very open to feedback.

### Reviewers: @webdriverio/project-committers