### PR TITLE
fix appium image locator

### DIFF
--- a/packages/webdriverio/src/utils/findStrategy.js
+++ b/packages/webdriverio/src/utils/findStrategy.js
@@ -1,6 +1,7 @@
-import { W3C_SELECTOR_STRATEGIES } from '../constants'
-import isPlainObject from 'lodash.isplainobject'
 import fs from 'fs'
+import isPlainObject from 'lodash.isplainobject'
+
+import { W3C_SELECTOR_STRATEGIES } from '../constants'
 
 const DEFAULT_STRATEGY = 'css selector'
 const DIRECT_SELECTOR_REGEXP = /^(id|css selector|xpath|link text|partial link text|name|tag name|class name|-android uiautomator|-android datamatcher|-android viewmatcher|-android viewtag|-ios uiautomation|-ios predicate string|-ios class chain|accessibility id):(.+)/

--- a/packages/webdriverio/src/utils/findStrategy.js
+++ b/packages/webdriverio/src/utils/findStrategy.js
@@ -1,5 +1,6 @@
 import { W3C_SELECTOR_STRATEGIES } from '../constants'
 import isPlainObject from 'lodash.isplainobject'
+import fs from 'fs'
 
 const DEFAULT_STRATEGY = 'css selector'
 const DIRECT_SELECTOR_REGEXP = /^(id|css selector|xpath|link text|partial link text|name|tag name|class name|-android uiautomator|-android datamatcher|-android viewmatcher|-android viewtag|-ios uiautomation|-ios predicate string|-ios class chain|accessibility id):(.+)/
@@ -38,7 +39,7 @@ const defineStrategy = function (selector) {
         return 'directly'
     }
     // Use appium image strategy if selector ends with certain text(.jpg,.gif..)
-    if (IMAGEPATH_MOBILE_SELECTORS_ENDSWITH.some(path=> selector.toLowerCase().endsWith(path))) {
+    if (IMAGEPATH_MOBILE_SELECTORS_ENDSWITH.some(path => selector.toLowerCase().endsWith(path))) {
         return '-image'
     }
     // Use xPath strategy if selector starts with //
@@ -201,6 +202,7 @@ export const findStrategy = function (selector, isW3C, isMobile) {
     }
     case '-image': {
         using = '-image'
+        value = fs.readFileSync(selector, { encoding: 'base64' })
         break
     }
     }

--- a/packages/webdriverio/tests/findStrategy.test.js
+++ b/packages/webdriverio/tests/findStrategy.test.js
@@ -1,5 +1,6 @@
 import { findStrategy } from '../src/utils/findStrategy'
 import fs from 'fs'
+
 jest.mock('fs')
 
 describe('selector strategies helper', () => {

--- a/packages/webdriverio/tests/findStrategy.test.js
+++ b/packages/webdriverio/tests/findStrategy.test.js
@@ -381,7 +381,7 @@ describe('selector strategies helper', () => {
     })
 
     it('should find an mobile element using image string', () => {
-        fs.readFileSync = jest.fn(()=>'random string')
+        fs.readFileSync = jest.fn(() => 'random string')
         let element = findStrategy('/test.jpg')
         expect(element.using).toBe('-image')
         expect(element.value).toBe('random string')

--- a/packages/webdriverio/tests/findStrategy.test.js
+++ b/packages/webdriverio/tests/findStrategy.test.js
@@ -1,4 +1,5 @@
 import { findStrategy } from '../src/utils/findStrategy'
+import fs from 'fs'
 
 describe('selector strategies helper', () => {
     it('should find an element using "css selector" method', () => {
@@ -379,21 +380,19 @@ describe('selector strategies helper', () => {
     })
 
     it('should find an mobile element using image string', () => {
+        jest.mock('fs')
+        fs.readFileSync = jest.fn()
         let element = findStrategy('/test.jpg')
         expect(element.using).toBe('-image')
-        expect(element.value).toBe('/test.jpg')
 
         element = findStrategy('path/test.png')
         expect(element.using).toBe('-image')
-        expect(element.value).toBe('path/test.png')
 
         element = findStrategy('path/test.PNG')
         expect(element.using).toBe('-image')
-        expect(element.value).toBe('path/test.PNG')
 
         element = findStrategy('//path//test.svg')
         expect(element.using).toBe('-image')
-        expect(element.value).toBe('//path//test.svg')
 
         element = findStrategy('//xpath[@img="/test.png"]')
         expect(element.using).toBe('xpath')

--- a/packages/webdriverio/tests/findStrategy.test.js
+++ b/packages/webdriverio/tests/findStrategy.test.js
@@ -1,5 +1,6 @@
 import { findStrategy } from '../src/utils/findStrategy'
 import fs from 'fs'
+jest.mock('fs')
 
 describe('selector strategies helper', () => {
     it('should find an element using "css selector" method', () => {
@@ -380,21 +381,25 @@ describe('selector strategies helper', () => {
     })
 
     it('should find an mobile element using image string', () => {
-        jest.mock('fs')
-        fs.readFileSync = jest.fn()
+        fs.readFileSync = jest.fn(()=>'random string')
         let element = findStrategy('/test.jpg')
         expect(element.using).toBe('-image')
+        expect(element.value).toBe('random string')
 
         element = findStrategy('path/test.png')
         expect(element.using).toBe('-image')
+        expect(element.value).toBe('random string')
 
         element = findStrategy('path/test.PNG')
         expect(element.using).toBe('-image')
+        expect(element.value).toBe('random string')
 
         element = findStrategy('//path//test.svg')
         expect(element.using).toBe('-image')
+        expect(element.value).toBe('random string')
 
         element = findStrategy('//xpath[@img="/test.png"]')
         expect(element.using).toBe('xpath')
+        expect(element.value).not.toBe('random string')
     })
 })


### PR DESCRIPTION
## Proposed changes
The appium image locator didn't work properly, appium expects a base64 string of the image and not the image location.
I changed the using.value and changed the test accordingly.

this is my first pull request if there is anything else I should do let me know and I will change it

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
