### PR TITLE
devtools-service: upgrade lighthouse

### DIFF
--- a/packages/wdio-devtools-service/package.json
+++ b/packages/wdio-devtools-service/package.json
@@ -29,7 +29,7 @@
     "@types/puppeteer": "^3.0.1",
     "@wdio/logger": "6.4.7",
     "core-js": "~3.6.0",
-    "lighthouse": "^6.1.0",
+    "lighthouse": "^6.4.1",
     "puppeteer-core": "^5.1.0",
     "speedline": "^1.4.1",
     "stable": "^0.1.8"


### PR DESCRIPTION
## Proposed changes

Upgrade lighthouse to 6.4.1 as far as https://github.com/webdriverio/webdriverio/pull/5914 is breaking for the ones used elder version.

See also https://github.com/GoogleChrome/lighthouse/pull/11355

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

### Reviewers: @webdriverio/project-committers
