### PR TITLE
Added possibility to disable automatic strings to unicode translation

### DIFF
--- a/packages/wdio-sync/webdriverio-core.d.ts
+++ b/packages/wdio-sync/webdriverio-core.d.ts
@@ -608,10 +608,12 @@ declare namespace WebdriverIO {
          * characters like Left arrow or Back space. WebdriverIO will take care of
          * translating them into unicode characters. You’ll find all supported characters
          * [here](https://w3c.github.io/webdriver/webdriver-spec.html#keyboard-actions).
-         * To do that, the value has to correspond to a key from the table.
+         * To do that, the value has to correspond to a key from the table. It can be disabled
+         * by setting `translateToUnicode` optional parameter to false.
          */
         addValue(
-            value: string | number | boolean | object | any[]
+            value: string | number | boolean | object | any[],
+            options: AddValueOptions
         ): void;
 
         /**
@@ -851,10 +853,12 @@ declare namespace WebdriverIO {
          * unicode characters like Left arrow or Back space. WebdriverIO will take care of
          * translating them into unicode characters. You’ll find all supported characters
          * [here](https://w3c.github.io/webdriver/webdriver-spec.html#keyboard-actions).
-         * To do that, the value has to correspond to a key from the table.
+         * To do that, the value has to correspond to a key from the table. It can be disabled
+         * by setting `translateToUnicode` optional parameter to false.
          */
         setValue(
-            value: string | number | boolean | object | any[]
+            value: string | number | boolean | object | any[],
+            options: AddValueOptions
         ): void;
 
         /**
@@ -1259,4 +1263,8 @@ declare namespace WebdriverIO {
     }
 
     interface Config extends Options, Omit<WebDriver.Options, "capabilities">, Hooks {}
+
+    interface AddValueOptions {
+        translateToUnicode?: boolean
+    }
 }

--- a/packages/webdriverio/src/commands/element/addValue.js
+++ b/packages/webdriverio/src/commands/element/addValue.js
@@ -4,7 +4,8 @@
  * characters like Left arrow or Back space. WebdriverIO will take care of
  * translating them into unicode characters. You’ll find all supported characters
  * [here](https://w3c.github.io/webdriver/webdriver-spec.html#keyboard-actions).
- * To do that, the value has to correspond to a key from the table.
+ * To do that, the value has to correspond to a key from the table. It can be disabled
+ * by setting `translateToUnicode` optional parameter to false.
  *
  * <example>
     :addValue.js
@@ -20,15 +21,17 @@
  *
  * @alias element.addValue
  * @param {string | number | boolean | object | Array<any>}      value     value to be added
+ * @param {AddValueOptions} options                    command options (optional)
+ * @param {boolean}         options.translateToUnicode enable translation string to unicode value automatically
  *
  */
 
 import { transformToCharString } from '../../utils'
 
-export default function addValue (value) {
+export default function addValue (value, { translateToUnicode = true } = {}) {
     if (!this.isW3C) {
-        return this.elementSendKeys(this.elementId, transformToCharString(value))
+        return this.elementSendKeys(this.elementId, transformToCharString(value, translateToUnicode))
     }
 
-    return this.elementSendKeys(this.elementId, transformToCharString(value).join(''))
+    return this.elementSendKeys(this.elementId, transformToCharString(value, translateToUnicode).join(''))
 }

--- a/packages/webdriverio/src/commands/element/setValue.js
+++ b/packages/webdriverio/src/commands/element/setValue.js
@@ -5,7 +5,8 @@
  * unicode characters like Left arrow or Back space. WebdriverIO will take care of
  * translating them into unicode characters. You’ll find all supported characters
  * [here](https://w3c.github.io/webdriver/webdriver-spec.html#keyboard-actions).
- * To do that, the value has to correspond to a key from the table.
+ * To do that, the value has to correspond to a key from the table. It can be disabled
+ * by setting `translateToUnicode` optional parameter to false.
  *
  * <example>
     :setValue.js
@@ -19,10 +20,12 @@
  *
  * @alias element.setValue
  * @param {string | number | boolean | object | Array<any>}      value    Value to be added
+ * @param {AddValueOptions} options                    command options (optional)
+ * @param {boolean}         options.translateToUnicode enable translation string to unicode value automatically
  *
  */
 
-export default async function setValue (value) {
+export default async function setValue (value, { translateToUnicode = true } = {}) {
     await this.clearValue()
-    return this.addValue(value)
+    return this.addValue(value, { translateToUnicode: translateToUnicode })
 }

--- a/packages/webdriverio/src/utils/index.js
+++ b/packages/webdriverio/src/utils/index.js
@@ -95,7 +95,7 @@ export function getBrowserObject (elem) {
 /**
  * transform whatever value is into an array of char strings
  */
-export function transformToCharString (value) {
+export function transformToCharString (value, translateToUnicode = true) {
     const ret = []
 
     if (!Array.isArray(value)) {
@@ -104,7 +104,7 @@ export function transformToCharString (value) {
 
     for (const val of value) {
         if (typeof val === 'string') {
-            ret.push(...checkUnicode(val))
+            translateToUnicode ? ret.push(...checkUnicode(val)) : ret.push(...`${val}`.split(''))
         } else if (typeof val === 'number') {
             const entry = `${val}`.split('')
             ret.push(...entry)

--- a/packages/webdriverio/tests/commands/element/addValue.test.js
+++ b/packages/webdriverio/tests/commands/element/addValue.test.js
@@ -134,4 +134,29 @@ describe('addValue test', () => {
             expect(got.mock.calls[2][1].json.text).toEqual(undefined)
         })
     })
+
+    describe('should allow to add value to an input element as workaround for /webdriverio/issues/4936', () => {
+        let browser
+
+        beforeEach(async () => {
+            browser = await remote({
+                baseUrl: 'http://foobar.com',
+                capabilities: {
+                    browserName: 'foobar'
+                }
+            })
+        })
+
+        afterEach(() => {
+            got.mockClear()
+        })
+
+        it('add string', async () => {
+            const elem = await browser.$('#foo')
+
+            await elem.addValue('Delete', { translateToUnicode: false })
+            expect(got.mock.calls[2][1].uri.pathname).toBe('/session/foobar-123/element/some-elem-123/value')
+            expect(got.mock.calls[2][1].json.text).toEqual('Delete')
+        })
+    })
 })

--- a/packages/webdriverio/tests/commands/element/setValue.test.js
+++ b/packages/webdriverio/tests/commands/element/setValue.test.js
@@ -45,4 +45,13 @@ describe('setValue', () => {
         await elem.setValue([1, '2', true, [1, 2]])
         expect(got.mock.calls[3][1].json.text).toEqual('12true[1,2]')
     })
+
+    test('should set the value clearning the element first', async () => {
+        const elem = await browser.$('#foo')
+
+        await elem.setValue('Delete', { translateToUnicode: false })
+        expect(got.mock.calls[2][1].uri.pathname).toBe('/session/foobar-123/element/some-elem-123/clear')
+        expect(got.mock.calls[3][1].uri.pathname).toBe('/session/foobar-123/element/some-elem-123/value')
+        expect(got.mock.calls[3][1].json.text).toEqual('Delete')
+    })
 })

--- a/packages/webdriverio/tests/utils.test.js
+++ b/packages/webdriverio/tests/utils.test.js
@@ -110,6 +110,24 @@ describe('utils', () => {
             expect(transformToCharString('Backspace')).toEqual(['\uE003'])
             expect(transformToCharString('Pageup')).toEqual(['\uE00E'])
         })
+
+        it('should transform string without converting to unicode', () => {
+            expect(transformToCharString('Delete', false)).toEqual(
+                ['D', 'e', 'l', 'e', 't', 'e'])
+            expect(transformToCharString('Back space', false)).toEqual(
+                ['B', 'a', 'c', 'k', ' ', 's', 'p', 'a', 'c', 'e'])
+            expect(transformToCharString('Backspace', false)).toEqual(
+                ['B', 'a', 'c', 'k', 's', 'p', 'a', 'c', 'e'])
+            expect(transformToCharString('Pageup', false)).toEqual(
+                ['P', 'a', 'g', 'e', 'u', 'p'])
+        })
+
+        it('should transform string with converting to unicode', () => {
+            expect(transformToCharString('Delete', true)).toEqual(['\uE017'])
+            expect(transformToCharString('Back space', true)).toEqual(['\uE003'])
+            expect(transformToCharString('Backspace', true)).toEqual(['\uE003'])
+            expect(transformToCharString('Pageup', true)).toEqual(['\uE00E'])
+        })
     })
 
     describe('parseCSS', () => {

--- a/packages/webdriverio/webdriverio-core.d.ts
+++ b/packages/webdriverio/webdriverio-core.d.ts
@@ -608,10 +608,12 @@ declare namespace WebdriverIO {
          * characters like Left arrow or Back space. WebdriverIO will take care of
          * translating them into unicode characters. You’ll find all supported characters
          * [here](https://w3c.github.io/webdriver/webdriver-spec.html#keyboard-actions).
-         * To do that, the value has to correspond to a key from the table.
+         * To do that, the value has to correspond to a key from the table. It can be disabled
+         * by setting `translateToUnicode` optional parameter to false.
          */
         addValue(
-            value: string | number | boolean | object | any[]
+            value: string | number | boolean | object | any[],
+            options: AddValueOptions
         ): Promise<void>;
 
         /**
@@ -851,10 +853,12 @@ declare namespace WebdriverIO {
          * unicode characters like Left arrow or Back space. WebdriverIO will take care of
          * translating them into unicode characters. You’ll find all supported characters
          * [here](https://w3c.github.io/webdriver/webdriver-spec.html#keyboard-actions).
-         * To do that, the value has to correspond to a key from the table.
+         * To do that, the value has to correspond to a key from the table. It can be disabled
+         * by setting `translateToUnicode` optional parameter to false.
          */
         setValue(
-            value: string | number | boolean | object | any[]
+            value: string | number | boolean | object | any[],
+            options: AddValueOptions
         ): Promise<void>;
 
         /**
@@ -1259,4 +1263,8 @@ declare namespace WebdriverIO {
     }
 
     interface Config extends Options, Omit<WebDriver.Options, "capabilities">, Hooks {}
+
+    interface AddValueOptions {
+        translateToUnicode?: boolean
+    }
 }

--- a/scripts/templates/webdriverio.tpl.d.ts
+++ b/scripts/templates/webdriverio.tpl.d.ts
@@ -636,6 +636,6 @@ declare namespace WebdriverIO {
     interface Config extends Options, Omit<WebDriver.Options, "capabilities">, Hooks {}
 
     interface AddValueOptions {
-        translateToUnicode: boolean
+        translateToUnicode?: boolean
     }
 }

--- a/scripts/templates/webdriverio.tpl.d.ts
+++ b/scripts/templates/webdriverio.tpl.d.ts
@@ -634,4 +634,8 @@ declare namespace WebdriverIO {
     }
 
     interface Config extends Options, Omit<WebDriver.Options, "capabilities">, Hooks {}
+
+    interface AddValueOptions {
+        translateToUnicode: boolean
+    }
 }

--- a/scripts/type-generation/constants.js
+++ b/scripts/type-generation/constants.js
@@ -4,7 +4,7 @@ const CUSTOM_INTERFACES = [
     'ElementArray', 'ClickOptions', 'WaitUntilOptions', 'Cookie', 'Timeouts',
     'CSSProperty', 'TouchActions', 'Matcher', 'WebDriver.Cookie', 'DragAndDropCoordinate',
     'ErrorCode', 'MockResponseParams', 'Mock', 'MockFilterOptions', 'MockOverwrite',
-    'ThrottleOptions', 'PuppeteerBrowser'
+    'ThrottleOptions', 'PuppeteerBrowser', 'AddValueOptions'
 ]
 
 module.exports = {

--- a/tests/typings/sync/sync.ts
+++ b/tests/typings/sync/sync.ts
@@ -112,6 +112,16 @@ const el5 = el4.$('')
 el4.getAttribute('class')
 el5.scrollIntoView(false)
 
+// An examples of addValue command with enabled/disabled translation to Unicode
+const el = $('')
+el.addValue('Delete', { translateToUnicode: true })
+el.addValue('Delete', { translateToUnicode: false })
+
+// An examples of setValue command with enabled/disabled translation to Unicode
+const elem1 = $('')
+elem1.setValue('Delete', { translateToUnicode: true })
+elem1.setValue('Delete', { translateToUnicode: false })
+
 const selector$$: string | Function = elems.selector
 const parent$$: WebdriverIO.Element | WebdriverIO.BrowserObject = elems.parent
 

--- a/tests/typings/webdriverio/async.ts
+++ b/tests/typings/webdriverio/async.ts
@@ -154,6 +154,16 @@ async function bar() {
     await el4.getAttribute('class')
     await el5.scrollIntoView(false)
 
+    // An examples of addValue command with enabled/disabled translation to Unicode
+    const elem = await $('')
+    await elem.addValue('Delete', { translateToUnicode: true })
+    await elem.addValue('Delete', { translateToUnicode: false })
+
+    // An examples of setValue command with enabled/disabled translation to Unicode
+    const elem1 = await $('')
+    elem1.setValue('Delete', { translateToUnicode: true })
+    elem1.setValue('Delete', { translateToUnicode: false })
+
     const selector$$: string | Function = elems.selector
     const parent$$: WebdriverIO.Element | WebdriverIO.BrowserObject = elems.parent
 


### PR DESCRIPTION
## Proposed changes
This is a fix for wdio automatic translation to [unicode issue](https://github.com/webdriverio/webdriverio/issues/4936). In general, user can't send keys that are predefined in the UNICODE_CHARACTERS [list](https://github.com/webdriverio/webdriverio/blob/master/packages/webdriverio/src/constants.js).

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [X] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
