### PR TITLE
Fix server mocking issues

### DIFF
--- a/packages/webdriverio/package.json
+++ b/packages/webdriverio/package.json
@@ -56,6 +56,7 @@
     "atob": "^2.1.2",
     "css-value": "^0.0.1",
     "devtools": "6.5.0",
+    "fs-extra": "^9.0.1",
     "get-port": "^5.1.1",
     "grapheme-splitter": "^1.0.2",
     "lodash.clonedeep": "^4.5.0",

--- a/packages/webdriverio/src/utils/interception/devtools.js
+++ b/packages/webdriverio/src/utils/interception/devtools.js
@@ -3,9 +3,12 @@ import path from 'path'
 import atob from 'atob'
 import minimatch from 'minimatch'
 
+import logger from '@wdio/logger'
 import Interception from './'
 import { containsHeaderObject } from '..'
 import { ERROR_REASON } from '../../constants'
+
+const log = logger('webdriverio')
 
 export default class DevtoolsInterception extends Interception {
     static handleRequestInterception (client, mocks) {
@@ -113,7 +116,7 @@ export default class DevtoolsInterception extends Interception {
                         responseHeaders,
                         /** do not mock body if it's undefined */
                         body: isBodyUndefined ? undefined : Buffer.from(newBody, 'binary').toString('base64')
-                    }).catch(/* istanbul ignore next */() => {})
+                    }).catch(/* istanbul ignore next */logFetchError)
                 }
 
                 /**
@@ -123,11 +126,11 @@ export default class DevtoolsInterception extends Interception {
                     return client.send('Fetch.failRequest', {
                         requestId,
                         errorReason
-                    }).catch(/* istanbul ignore next */() => {})
+                    }).catch(/* istanbul ignore next */logFetchError)
                 }
             }
 
-            return client.send('Fetch.continueRequest', { requestId }).catch(/* istanbul ignore next */() => {})
+            return client.send('Fetch.continueRequest', { requestId }).catch(/* istanbul ignore next */logFetchError)
         }
     }
 
@@ -252,4 +255,9 @@ const tryParseJson = (body) => {
     } catch {
         return body
     }
+}
+
+const logFetchError = (err) => {
+    /* istanbul ignore next */
+    log.debug(err && err.message ? err.message : err)
 }

--- a/packages/webdriverio/src/utils/interception/devtools.js
+++ b/packages/webdriverio/src/utils/interception/devtools.js
@@ -76,6 +76,10 @@ export default class DevtoolsInterception extends Interception {
                         newBody = await overwrite(request, client)
                     }
 
+                    if (typeof newBody === undefined) {
+                        newBody = ''
+                    }
+
                     if (typeof newBody !== 'string') {
                         newBody = JSON.stringify(newBody)
                     }
@@ -107,7 +111,7 @@ export default class DevtoolsInterception extends Interception {
                         requestId,
                         responseCode,
                         responseHeaders,
-                        body: Buffer.from(newBody).toString('base64')
+                        body: newBody ? Buffer.from(newBody).toString('base64') : undefined
                     })
                 }
 

--- a/packages/webdriverio/src/utils/interception/devtools.js
+++ b/packages/webdriverio/src/utils/interception/devtools.js
@@ -83,7 +83,7 @@ export default class DevtoolsInterception extends Interception {
                     let responseCode = params.statusCode || responseStatusCode
                     let responseHeaders = [
                         ...event.responseHeaders,
-                        ...Object.entries(params.headers || {}).map(([key, value]) => { key, value })
+                        ...Object.entries(params.headers || {}).map(([name, value]) => ({ name, value }))
                     ]
 
                     /**

--- a/packages/webdriverio/src/utils/interception/devtools.js
+++ b/packages/webdriverio/src/utils/interception/devtools.js
@@ -75,7 +75,8 @@ export default class DevtoolsInterception extends Interception {
                         newBody = await overwrite(request, client)
                     }
 
-                    if (typeof newBody === 'undefined') {
+                    const isBodyUndefined = typeof newBody === 'undefined'
+                    if (isBodyUndefined) {
                         newBody = ''
                     }
 
@@ -110,7 +111,8 @@ export default class DevtoolsInterception extends Interception {
                         requestId,
                         responseCode,
                         responseHeaders,
-                        body: newBody ? Buffer.from(newBody, 'binary').toString('base64') : undefined
+                        /** do not mock body if it's undefined */
+                        body: isBodyUndefined ? undefined : Buffer.from(newBody, 'binary').toString('base64')
                     })
                 }
 

--- a/packages/webdriverio/src/utils/interception/devtools.js
+++ b/packages/webdriverio/src/utils/interception/devtools.js
@@ -111,7 +111,7 @@ export default class DevtoolsInterception extends Interception {
                         requestId,
                         responseCode,
                         responseHeaders,
-                        body: newBody ? Buffer.from(newBody).toString('base64') : undefined
+                        body: newBody ? Buffer.from(newBody, 'binary').toString('base64') : undefined
                     })
                 }
 

--- a/packages/webdriverio/src/utils/interception/devtools.js
+++ b/packages/webdriverio/src/utils/interception/devtools.js
@@ -90,7 +90,7 @@ export default class DevtoolsInterception extends Interception {
                      * check if local file and load it
                      */
                     const responseFilePath = path.isAbsolute(newBody) ? newBody : path.join(process.cwd(), newBody)
-                    if (fs.existsSync(responseFilePath) && canAccess(responseFilePath)) {
+                    if (responseFilePath.length > 0 && fs.existsSync(responseFilePath) && canAccess(responseFilePath)) {
                         newBody = fs.readFileSync(responseFilePath).toString()
                     } else if (newBody.startsWith('http')) {
                         responseCode = 301

--- a/packages/webdriverio/tests/__mocks__/fs.js
+++ b/packages/webdriverio/tests/__mocks__/fs.js
@@ -1,4 +1,4 @@
 const fs = jest.genMockFromModule('fs')
 fs.writeFileSync = jest.fn()
 fs.existsSync = jest.fn(() => true)
-export default fs
+module.exports = fs

--- a/packages/webdriverio/tests/utils/interception/__snapshots__/devtools.test.js.snap
+++ b/packages/webdriverio/tests/utils/interception/__snapshots__/devtools.test.js.snap
@@ -43,6 +43,23 @@ Array [
 ]
 `;
 
+exports[`stub request with a function returning empty body 1`] = `
+Array [
+  "Fetch.fulfillRequest",
+  Object {
+    "body": "",
+    "requestId": 123,
+    "responseCode": undefined,
+    "responseHeaders": Array [
+      Object {
+        "name": "Content-Type",
+        "value": "application/json",
+      },
+    ],
+  },
+]
+`;
+
 exports[`stub request with a function returning undefined 1`] = `
 Array [
   "Fetch.fulfillRequest",

--- a/packages/webdriverio/tests/utils/interception/__snapshots__/devtools.test.js.snap
+++ b/packages/webdriverio/tests/utils/interception/__snapshots__/devtools.test.js.snap
@@ -43,6 +43,23 @@ Array [
 ]
 `;
 
+exports[`stub request with a function returning undefined 1`] = `
+Array [
+  "Fetch.fulfillRequest",
+  Object {
+    "body": undefined,
+    "requestId": 123,
+    "responseCode": undefined,
+    "responseHeaders": Array [
+      Object {
+        "name": "Content-Type",
+        "value": "application/json",
+      },
+    ],
+  },
+]
+`;
+
 exports[`stub request with a text 1`] = `
 Array [
   "Fetch.fulfillRequest",
@@ -67,6 +84,48 @@ Array [
     "body": "eyJmb28iOiJiYXIifQ==",
     "requestId": 123,
     "responseCode": undefined,
+    "responseHeaders": Array [
+      Object {
+        "name": "Content-Type",
+        "value": "application/json",
+      },
+    ],
+  },
+]
+`;
+
+exports[`stub request with modified headers 1`] = `
+Array [
+  "Fetch.fulfillRequest",
+  Object {
+    "body": "eyJmb28iOiJiYXIifQ==",
+    "requestId": 123,
+    "responseCode": undefined,
+    "responseHeaders": Array [
+      Object {
+        "name": "Content-Type",
+        "value": "application/json",
+      },
+      Object {
+        "name": "removed",
+        "value": undefined,
+      },
+      Object {
+        "name": "added",
+        "value": "string",
+      },
+    ],
+  },
+]
+`;
+
+exports[`stub request with modified status code 1`] = `
+Array [
+  "Fetch.fulfillRequest",
+  Object {
+    "body": "eyJmb28iOiJiYXIifQ==",
+    "requestId": 123,
+    "responseCode": 1234,
     "responseHeaders": Array [
       Object {
         "name": "Content-Type",

--- a/packages/webdriverio/tests/utils/interception/devtools.test.js
+++ b/packages/webdriverio/tests/utils/interception/devtools.test.js
@@ -214,6 +214,28 @@ test('decodes base64 responses', async () => {
     expect(mock.calls[1].body).toBe('{"foo":"bar"}')
 })
 
+test('undefined response', async () => {
+    const mock = new NetworkInterception('**/foobar/**')
+    cdpClient.send.mockReturnValueOnce(Promise.resolve({}))
+    await NetworkInterception.handleRequestInterception(cdpClient, [mock])({
+        request: { url: 'http://test.com/foobar/test.html' },
+        responseHeaders: [{ name: 'content-Type', value: 'application/json' }]
+    })
+
+    expect(mock.calls[0].body).toBeUndefined()
+})
+
+test('null response', async () => {
+    const mock = new NetworkInterception('**/foobar/**')
+    cdpClient.send.mockReturnValueOnce(Promise.resolve({ body: 'null' }))
+    await NetworkInterception.handleRequestInterception(cdpClient, [mock])({
+        request: { url: 'http://test.com/foobar/test.html' },
+        responseHeaders: [{ name: 'content-Type', value: 'application/json' }]
+    })
+
+    expect(mock.calls[0].body).toBe('null')
+})
+
 test('abort request', async () => {
     const request = {
         requestId: 123,

--- a/packages/webdriverio/tests/utils/interception/devtools.test.js
+++ b/packages/webdriverio/tests/utils/interception/devtools.test.js
@@ -281,6 +281,18 @@ describe('stub request', () => {
         expect(cdpClient.send.mock.calls.pop()).toMatchSnapshot()
     })
 
+    test('with a function returning empty body', async () => {
+        const mock = new NetworkInterception('**/foobar/**')
+        mock.respond(() => '')
+        await NetworkInterception.handleRequestInterception(cdpClient, [mock])({
+            requestId: 123,
+            request: { url: 'http://test.com/foobar/test.html' },
+            responseHeaders: [{ name: 'Content-Type', value: 'application/json' }]
+        })
+
+        expect(cdpClient.send.mock.calls.pop()).toMatchSnapshot()
+    })
+
     test('with an object', async () => {
         const mock = new NetworkInterception('**/foobar/**')
         mock.respond({ foo: 'bar' })


### PR DESCRIPTION
## Proposed changes

- fix headers issue `Invalid parameters responseHeaders.9.name: string value expected`
- fix an attempt to use an empty string as a local file
- fix an issue when user function returns `undefined`
- fix buffer issue causing images to be corrupted
- remove sync methods causing a slowdown when there are thousands of requests
- suppress exceptions on timeout, session close, etc

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

### Reviewers: @webdriverio/project-committers
