### PR TITLE
Fixing a few typos on homepage

### DIFF
--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -171,7 +171,7 @@ const AutomationProtocolSupport = () => (
         {[
             {
                 content: '' +
-                    'WebdriverIO is always up to date with the latest automation frameworks and therefor supports not only capabilities ' +
+                    'WebdriverIO is always up to date with the latest automation frameworks and therefore, supports not only capabilities ' +
                     'of the <a href="https://w3c.github.io/webdriver/">WebDriver</a> but also commands of the <a href="https://chromedevtools.github.io/devtools-protocol/">Chrome DevTools</a> ' +
                     'protocol using tools like <a href="https://pptr.dev/">Puppeteer</a>. The framework allows you to freely switch between ' +
                     'running remote WebDriver commands as well stubbing and mocking features of Puppeteer. Have a look into the <a href="https://github.com/webdriverio/webdriverio/blob/master/examples/devtools/intercept.js">examples</a> ' +
@@ -194,7 +194,7 @@ const ReactSupport = () => (
                     'or [Vue.js](https://vuejs.org/) as well as native mobile applications for Android and iOS.<br><br>' +
                     'It comes with smart selector strategies that can, e.g. using the [`react$`](/docs/api/element/react$.html) ' +
                     'command, fetch React components by its component name and filter it by its props or states. A similar command called ' +
-                    '[`$shadow`](/docs/api/element/shadow$.html) provides the ability to fetch elements within the shadow ' +
+                    '[`$shadow`](/docs/api/element/shadow$.html) provides the ability to fetch elements within the ' +
                     '[shadow DOM](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_shadow_DOM) of a web component.<br>' +
                     '<br>' +
                     '<p>Native Support for:<p>' +
@@ -440,7 +440,7 @@ class Index extends React.Component {
                             }, {
                                 content: (
                                     <translate>
-                                        The huge of variety of community plugins allows you to easily integrate
+                                        The huge variety of community plugins allows you to easily integrate
                                         and extend your setup to fulfill your requirements.
                                     </translate>
                                 ),


### PR DESCRIPTION
I stumbled upon this site recently when researching some browser automation tools, and these are a few typos I encountered on the homepage.

## Proposed changes

Just some typos on homepage:
"therefor" -> "therefore"
"huge of variety of" -> "huge variety of"
"shadow shadow DOM" -> "shadow DOM"

## Types of changes
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments
Hope this helps!

### Reviewers: @webdriverio/project-committers
