### PR TITLE
Edge types and selenium-standalone docs

### DIFF
--- a/packages/wdio-selenium-standalone-service/README.md
+++ b/packages/wdio-selenium-standalone-service/README.md
@@ -14,7 +14,7 @@ The easiest way is to keep `@wdio/selenium-standalone-service` as a devDependenc
 ```json
 {
     "devDependencies": {
-        "@wdio/selenium-standalone-service": "^6.1.14"
+        "@wdio/selenium-standalone-service": "^6.6.1"
     }
 }
 ```
@@ -33,23 +33,19 @@ By default, Google Chrome and Firefox are available when installed on the host s
 
 ```js
 // wdio.conf.js
+const drivers = {
+    chrome: { version: '86.0.4240.22' }, // https://chromedriver.chromium.org/
+    firefox: { version: '0.27.0' } // https://github.com/mozilla/geckodriver/releases
+    chromiumedge: { version: '85.0.564.70' } // https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/
+}
+
 export.config = {
     // ...
     services: [
         ['selenium-standalone', {
             logPath: 'logs',
-            installArgs: {
-                drivers: {
-                    chrome: { version: '79.0.3945.88' },
-                    firefox: { version: '0.26.0' }
-                }
-            },
-            args: {
-                drivers: {
-                    chrome: { version: '79.0.3945.88' },
-                    firefox: { version: '0.26.0' }
-                }
-            },
+            installArgs: { drivers },
+            args: { drivers },
         }]
     ],
     // ...
@@ -78,6 +74,9 @@ export.config = {
         port: 5555
     }, {
         browserName: 'firefox',
+        port: 5555
+    }, {
+        browserName: 'MicrosoftEdge',
         port: 5555
     }]
     // ...
@@ -114,7 +113,7 @@ args: {
     version : "3.141.59",
     drivers : {
         chrome : {
-            version : "79.0.3945.88",
+            version : "86.0.4240.22",
             arch    : process.arch,
         }
     }
@@ -137,7 +136,7 @@ installArgs: {
     baseURL : "https://selenium-release.storage.googleapis.com",
     drivers : {
         chrome : {
-            version : "77.0.3865.40",
+            version : "86.0.4240.22",
             arch    : process.arch,
             baseURL : "https://chromedriver.storage.googleapis.com",
         }

--- a/packages/wdio-selenium-standalone-service/package.json
+++ b/packages/wdio-selenium-standalone-service/package.json
@@ -27,10 +27,10 @@
     "url": "https://github.com/webdriverio/webdriverio/issues"
   },
   "dependencies": {
-    "@types/selenium-standalone": "^6.15.0",
+    "@types/selenium-standalone": "^6.15.2",
     "@wdio/logger": "6.6.0",
-    "fs-extra": "^9.0.0",
-    "selenium-standalone": "^6.15.1"
+    "fs-extra": "^9.0.1",
+    "selenium-standalone": "^6.20.1"
   },
   "peerDependencies": {
     "@wdio/cli": "^6.0.1"

--- a/packages/webdriver/webdriver.d.ts
+++ b/packages/webdriver/webdriver.d.ts
@@ -172,6 +172,11 @@ declare namespace WebDriver {
         windowTypes?: string[];
     }
 
+    /**
+     * Chromium Edge
+     */
+    interface MicrosoftEdgeOptions extends ChromeOptions {}
+
     interface FirefoxLogObject {
         level: FirefoxLogLevels
     }
@@ -359,6 +364,9 @@ declare namespace WebDriver {
         chromeOptions?: ChromeOptions;
         'goog:chromeOptions'?: ChromeOptions;
         mobileEmulationEnabled?: boolean;
+
+        // Edge chromium specific
+        'ms:edgeOptions'?: MicrosoftEdgeOptions;
 
         // webdriverio specific
         specs?: string[];

--- a/scripts/templates/devtools.tpl.d.ts
+++ b/scripts/templates/devtools.tpl.d.ts
@@ -19,6 +19,13 @@ declare namespace WebDriver {
          */
         headless?: boolean;
     }
+
+    interface MicrosoftEdgeOptions {
+        /**
+         * `devtools` only, switch headless mode by either `headless` flag or `--headless` argument but not both
+         */
+        headless?: boolean;
+    }
 }
 
 declare namespace DevTools {


### PR DESCRIPTION
## Proposed changes

- add `ms:edgeOptions` to capabilities
- update browser driver versions in selenium standalone doc
- add an example of how to use Edge
- update `selenium-standalone` to the latest version to fix Edge installation issues

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

Types were not added to `webdriver.tpl.d.ts` as far as it's generation is currently broken.

### Reviewers: @webdriverio/project-committers
