### PR TITLE
Fix multi remote capabilities for mixed backends

### DIFF
--- a/docs/Multiremote.md
+++ b/docs/Multiremote.md
@@ -65,7 +65,36 @@ export.config = {
 }
 ```
 
-This will create two WebDriver sessions with Chrome and Firefox. Instead of just Chrome and Firefox you can also boot up two mobile devices using [Appium](http://appium.io).
+This will create two WebDriver sessions with Chrome and Firefox. Instead of just Chrome and Firefox you can also boot up two mobile devices using [Appium](http://appium.io). 
+
+You can even boot up one of the [cloud services backend](https://webdriver.io/docs/cloudservices.html) together with local Webdriver/Appium, or Selenium Standalone instances. Wdio automatically detect cloud backend capabilities if you specified either of `bstack:options` ([Browserstack](https://webdriver.io/docs/browserstack-service.html)), `sauce:options` ([SauceLabs](https://webdriver.io/docs/sauce-service.html)), or `tb:options` ([TestingBot](https://webdriver.io/docs/testingbot-service.html)) in browser capbilities.
+
+```js
+export.config = {
+    // ...
+    user: process.env.BROWSERSTACK_USERNAME,
+    key: process.env.BROWSERSTACK_ACCESS_KEY,
+    capabilities: {
+        myChromeBrowser: {
+            capabilities: {
+                browserName: 'chrome'
+            }
+        },
+        myBrowserStackFirefoxBrowser: {
+            capabilities: {
+                browserName: 'firefox',
+                'bstack:options': {
+                    // ...
+                }
+            }
+        }
+    },
+    services: [
+        ['browserstack', 'selenium-standalone']
+    ],
+    // ...
+}
+```
 
 Any kind of OS/browser combination is possible here (including mobile and desktop browsers). All commands your tests call via the `browser` variable are executed in parallel with each instance. This helps streamline your integration tests and speed up their execution.
 

--- a/examples/wdio/multiremote/mocha.test.js
+++ b/examples/wdio/multiremote/mocha.test.js
@@ -3,10 +3,16 @@ describe('multiremote example', () => {
         browser.url('https://socketio-chat-h9jt.herokuapp.com/')
     })
 
-    it('should login the browser', () => {
-        const nameInput = $('.usernameInput')
+    it('should login the browser A', () => {
+        const nameInput = browserA.$('.usernameInput')
         nameInput.addValue('Browser A')
-        browser.keys('Enter')
+        browserA.keys('Enter')
+    })
+
+    it('should login the browser B', () => {
+        const nameInput = browserB.$('.usernameInput')
+        nameInput.addValue('Browser B')
+        browserB.keys('Enter')
     })
 
     it('should post something in browserA', () => {
@@ -21,7 +27,7 @@ describe('multiremote example', () => {
     })
 
     it('should read the message in browserB', () => {
-        const msgElemBrowserB = browserA.$('.inputMessage')
+        const msgElemBrowserB = browserB.$('.inputMessage')
         const chatLineBrowserB = browserB.$('.messageBody*=My name is')
         const message = chatLineBrowserB.getText()
         const name = message.slice(11)

--- a/packages/wdio-appium-service/package.json
+++ b/packages/wdio-appium-service/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "@wdio/logger": "6.6.0",
+    "@wdio/config": "6.6.0",
     "fs-extra": "^9.0.0",
     "param-case": "^3.0.0"
   },

--- a/packages/wdio-appium-service/src/launcher.js
+++ b/packages/wdio-appium-service/src/launcher.js
@@ -1,4 +1,6 @@
 import logger from '@wdio/logger'
+import { isCloudCapability } from '@wdio/config'
+
 import { spawn } from 'child_process'
 import { createWriteStream, ensureFileSync } from 'fs-extra'
 import { promisify } from 'util'
@@ -60,7 +62,7 @@ export default class AppiumLauncher {
             Array.isArray(this.capabilities)
                 ? this.capabilities
                 : Object.values(this.capabilities)
-        ).forEach((cap) => Object.assign(
+        ).forEach((cap) => !isCloudCapability(cap.capabilities) && Object.assign(
             cap,
             DEFAULT_CONNECTION,
             this.args.port ? { port: this.args.port } : {},

--- a/packages/wdio-browserstack-service/src/service.js
+++ b/packages/wdio-browserstack-service/src/service.js
@@ -41,7 +41,9 @@ export default class BrowserstackService {
     before() {
         this.sessionId = global.browser.sessionId
 
-        if (global.browser.capabilities.app || this.caps.app) {
+        // Ensure capabilities are not null in case of multiremote
+        const capabilities = global.browser.capabilities || {}
+        if (capabilities.app || this.caps.app) {
             this.sessionBaseUrl = 'https://api-cloud.browserstack.com/app-automate/sessions'
         }
 
@@ -139,7 +141,8 @@ export default class BrowserstackService {
     }
 
     async _printSessionURL() {
-        const capabilities = global.browser.capabilities
+        // Ensure capabilities are not null in case of multiremote
+        const capabilities = global.browser.capabilities || {}
 
         const response = await got(`${this.sessionBaseUrl}/${this.sessionId}.json`, {
             username: this.config.user,

--- a/packages/wdio-config/src/index.js
+++ b/packages/wdio-config/src/index.js
@@ -1,11 +1,12 @@
 import ConfigParser from './lib/ConfigParser'
-import { validateConfig, getSauceEndpoint, detectBackend } from './utils'
+import { validateConfig, getSauceEndpoint, detectBackend, isCloudCapability } from './utils'
 import { DEFAULT_CONFIGS } from './constants'
 
 export {
     validateConfig,
     getSauceEndpoint,
     detectBackend,
+    isCloudCapability,
     ConfigParser,
 
     /**

--- a/packages/wdio-config/src/utils.js
+++ b/packages/wdio-config/src/utils.js
@@ -47,6 +47,10 @@ export function isCucumberFeatureWithLineNumber(spec) {
     return specs.some((s) => s.match(/:\d+(:\d+$|$)/))
 }
 
+export function isCloudCapability(cap) {
+    return Boolean(cap && (cap['bstack:options'] || cap['sauce:options'] || cap['tb:options']))
+}
+
 /**
  * helper to detect the Selenium backend according to given capabilities
  */

--- a/packages/wdio-config/tests/utils.test.js
+++ b/packages/wdio-config/tests/utils.test.js
@@ -1,4 +1,4 @@
-import { removeLineNumbers, validObjectOrArray } from '../src/utils'
+import { isCloudCapability, removeLineNumbers, validObjectOrArray } from '../src/utils'
 
 describe('utils', () => {
     describe('removeLineNumbers', () => {
@@ -40,6 +40,29 @@ describe('utils', () => {
             it('returns false if empty', () => {
                 expect(validObjectOrArray([])).toBeFalsy()
             })
+        })
+    })
+
+    describe('isCloudCapability', () => {
+        it('should detect Browserstack capabilities', ()  => {
+            expect(isCloudCapability({ 'bstack:options': {} })).toBe(true)
+        })
+
+        it('should detect Saucelabs capabilities', ()  => {
+            expect(isCloudCapability({ 'sauce:options': {} })).toBe(true)
+        })
+
+        it('should detect Testingbot capabilities', ()  => {
+            expect(isCloudCapability({ 'tb:options': {} })).toBe(true)
+        })
+
+        it('should detect non-cloud capabilities', ()  => {
+            expect(isCloudCapability({ 'selenoid:options': {} })).toBe(false)
+        })
+
+        it('should handle null or empty capabilities', ()  => {
+            expect(isCloudCapability()).toBe(false)
+            expect(isCloudCapability({})).toBe(false)
         })
     })
 })

--- a/packages/wdio-sauce-service/src/service.js
+++ b/packages/wdio-sauce-service/src/service.js
@@ -39,7 +39,9 @@ export default class SauceService {
     }
 
     before() {
-        this.isUP = isUnifiedPlatform(global.browser.capabilities)
+        // Ensure capabilities are not null in case of multiremote
+        const capabilities = global.browser.capabilities || {}
+        this.isUP = isUnifiedPlatform(capabilities)
     }
 
     beforeSuite (suite) {

--- a/packages/wdio-selenium-standalone-service/package.json
+++ b/packages/wdio-selenium-standalone-service/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@types/selenium-standalone": "^6.15.2",
     "@wdio/logger": "6.6.0",
+    "@wdio/config": "6.6.0",
     "fs-extra": "^9.0.1",
     "selenium-standalone": "^6.20.1"
   },

--- a/packages/wdio-selenium-standalone-service/src/launcher.js
+++ b/packages/wdio-selenium-standalone-service/src/launcher.js
@@ -1,4 +1,5 @@
 import logger from '@wdio/logger'
+import { isCloudCapability } from '@wdio/config'
 
 import { promisify } from 'util'
 import fs from 'fs-extra'
@@ -40,7 +41,7 @@ export default class SeleniumStandaloneLauncher {
             Array.isArray(this.capabilities)
                 ? this.capabilities
                 : Object.values(this.capabilities)
-        ).forEach((cap) => Object.assign(cap, DEFAULT_CONNECTION, { ...cap }))
+        ).forEach((cap) => !isCloudCapability(cap.capabilities) && Object.assign(cap, DEFAULT_CONNECTION, { ...cap }))
 
         /**
          * start Selenium Standalone server

--- a/packages/wdio-selenium-standalone-service/tests/launcher.test.js
+++ b/packages/wdio-selenium-standalone-service/tests/launcher.test.js
@@ -2,7 +2,7 @@ import path from 'path'
 import fs from 'fs-extra'
 import Selenium from 'selenium-standalone'
 import SeleniumStandaloneLauncher from '../src/launcher'
-
+jest.unmock('@wdio/config')
 jest.mock('fs-extra', () => ({
     createWriteStream : jest.fn(),
     ensureFileSync : jest.fn(),
@@ -58,6 +58,29 @@ describe('Selenium standalone launcher', () => {
             expect(capabilities.browserB.hostname).toBe('localhost')
             expect(capabilities.browserB.port).toBe(4321)
             expect(capabilities.browserB.path).toBe('/wd/hub')
+        })
+
+        test('should not override cloud config using multiremote', async () => {
+            const options = {
+                logPath : './',
+                args : { foo : 'foo' },
+                installArgs : { bar : 'bar' },
+            }
+            const capabilities = {
+                browserA: { port: 1234 },
+                browserB: { port: 4321, capabilities: { 'bstack:options': {} } }
+            }
+            const launcher = new SeleniumStandaloneLauncher(options, capabilities, {})
+            launcher._redirectLogStream = jest.fn()
+            await launcher.onPrepare({ watch: true })
+            expect(capabilities.browserA.protocol).toBe('http')
+            expect(capabilities.browserA.hostname).toBe('localhost')
+            expect(capabilities.browserA.port).toBe(1234)
+            expect(capabilities.browserA.path).toBe('/wd/hub')
+            expect(capabilities.browserB.protocol).toBeUndefined()
+            expect(capabilities.browserB.hostname).toBeUndefined()
+            expect(capabilities.browserB.port).toBe(4321)
+            expect(capabilities.browserB.path).toBeUndefined()
         })
 
         test('should call selenium install and start', async () => {


### PR DESCRIPTION
## Proposed changes

[//]: # Fix #5906 Multi remote capabilities for mixed backends/services scenario does not work by default because selenium standalone service and appium service will always override hostname parameters in capabilties. This PR fixed the issue by only setting default capability when none of the cloud capabilities config (`bstacks:options, sauces:options, tb:options`) exists.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
- [X] I have added proper type definitions for new commands (if appropriate)

### Reviewers: @webdriverio/project-committers
