### PR TITLE
retry if SC fails to start

### DIFF
--- a/packages/wdio-sauce-service/src/launcher.js
+++ b/packages/wdio-sauce-service/src/launcher.js
@@ -81,9 +81,10 @@ export default class SauceLauncher {
         performance.measure('bootTime', 'sauceConnectStart', 'sauceConnectEnd')
     }
 
-    startTunnel(retryCount = 0) {
+    async startTunnel(retryCount = 0) {
         try {
-            return this.api.startSauceConnect(this.sauceConnectOpts)
+            const scProcess = await this.api.startSauceConnect(this.sauceConnectOpts)
+            return scProcess
         } catch (err) {
             ++retryCount
             /**

--- a/packages/wdio-sauce-service/src/launcher.js
+++ b/packages/wdio-sauce-service/src/launcher.js
@@ -79,7 +79,7 @@ export default class SauceLauncher {
         performance.mark('sauceConnectStart')
 
         try {
-            this.sauceConnectProcess = await this.api.startSauceConnect(this.sauceConnectOpts)
+            this.sauceConnectProcess = await this.startTunnel()
         } catch (err) {
             ++this.scStartTrials
             /**
@@ -100,10 +100,14 @@ export default class SauceLauncher {
             }
             log.debug(`Failed to start Sauce Connect Proxy due to ${err.stack}`)
             log.debug(`Retrying ${this.scStartTrials}/${MAX_SC_START_TRIALS}`)
-            this.sauceConnectProcess = await this.api.startSauceConnect(this.sauceConnectOpts)
+            this.sauceConnectProcess = await this.startTunnel()
         }
         performance.mark('sauceConnectEnd')
         performance.measure('bootTime', 'sauceConnectStart', 'sauceConnectEnd')
+    }
+
+    startTunnel() {
+        return this.api.startSauceConnect(this.sauceConnectOpts)
     }
 
     /**

--- a/packages/wdio-sauce-service/src/launcher.js
+++ b/packages/wdio-sauce-service/src/launcher.js
@@ -98,6 +98,9 @@ export default class SauceLauncher {
             ) {
                 throw err
             }
+            log.debug(`Failed to start Sauce Connect Proxy due to ${err.stack}`)
+            log.debug(`Retrying ${this.scStartTrials}/${MAX_SC_START_TRIALS}`)
+            this.sauceConnectProcess = await this.api.startSauceConnect(this.sauceConnectOpts)
         }
         performance.mark('sauceConnectEnd')
         performance.measure('bootTime', 'sauceConnectStart', 'sauceConnectEnd')

--- a/packages/wdio-sauce-service/src/launcher.js
+++ b/packages/wdio-sauce-service/src/launcher.js
@@ -76,14 +76,14 @@ export default class SauceLauncher {
         obs.observe({ entryTypes: ['measure'], buffered: false })
 
         performance.mark('sauceConnectStart')
-        await this.startTunnel()
+        this.sauceConnectProcess = await this.startTunnel()
         performance.mark('sauceConnectEnd')
         performance.measure('bootTime', 'sauceConnectStart', 'sauceConnectEnd')
     }
 
-    async startTunnel(retryCount = 0) {
+    startTunnel(retryCount = 0) {
         try {
-            this.sauceConnectProcess = await this.api.startSauceConnect(this.sauceConnectOpts)
+            return this.api.startSauceConnect(this.sauceConnectOpts)
         } catch (err) {
             ++retryCount
             /**
@@ -104,7 +104,7 @@ export default class SauceLauncher {
             }
             log.debug(`Failed to start Sauce Connect Proxy due to ${err.stack}`)
             log.debug(`Retrying ${retryCount}/${MAX_SC_START_TRIALS}`)
-            this.sauceConnectProcess = await this.startTunnel(retryCount)
+            return this.startTunnel(retryCount)
         }
     }
 

--- a/packages/wdio-sauce-service/tests/launcher.test.js
+++ b/packages/wdio-sauce-service/tests/launcher.test.js
@@ -451,6 +451,40 @@ test('onPrepare with tunnel identifier and without w3c caps ', async () => {
     expect(service.sauceConnectProcess).not.toBeUndefined()
 })
 
+test('startTunnel fail twice and recover', async ()=> {
+    const options = {
+        sauceConnect: true,
+        sauceConnectOpts: {
+            tunnelIdentifier: 'my-tunnel'
+        }
+    }
+    const service = new SauceServiceLauncher(options)
+    service.api.startSauceConnect
+        .mockRejectedValueOnce(new Error('ENOENT'))
+        .mockRejectedValueOnce(new Error('ENOENT'))
+    await service.startTunnel()
+
+    expect(SauceLabs.instances[0].startSauceConnect).toBeCalledTimes(3)
+})
+
+test('startTunnel fail three and throws error', async ()=> {
+    const options = {
+        sauceConnect: true,
+        sauceConnectOpts: {
+            tunnelIdentifier: 'my-tunnel'
+        }
+    }
+    const service = new SauceServiceLauncher(options)
+    service.api.startSauceConnect
+        .mockRejectedValue(new Error('ENOENT'))
+
+    // await service.startTunnel()
+    expect(async () => {
+        await service.startTunnel()
+    }).rejects.toThrowError('ENOENT')
+
+})
+
 test('onComplete', async () => {
     const service = new SauceServiceLauncher({}, [], {})
     expect(service.onComplete()).toBeUndefined()

--- a/packages/wdio-sauce-service/tests/launcher.test.js
+++ b/packages/wdio-sauce-service/tests/launcher.test.js
@@ -476,7 +476,9 @@ test('startTunnel fail three and throws error', async ()=> {
     }
     const service = new SauceServiceLauncher(options)
     service.api.startSauceConnect
-        .mockRejectedValue(new Error('ENOENT'))
+        .mockRejectedValueOnce(new Error('ENOENT'))
+        .mockRejectedValueOnce(new Error('ENOENT'))
+        .mockRejectedValueOnce(new Error('ENOENT'))
 
     expect(async () => {
         await service.startTunnel()

--- a/packages/wdio-sauce-service/tests/launcher.test.js
+++ b/packages/wdio-sauce-service/tests/launcher.test.js
@@ -478,7 +478,6 @@ test('startTunnel fail three and throws error', async ()=> {
     service.api.startSauceConnect
         .mockRejectedValue(new Error('ENOENT'))
 
-    // await service.startTunnel()
     expect(async () => {
         await service.startTunnel()
     }).rejects.toThrowError('ENOENT')


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

Someone reported an issue of Sauce Connect launcher failing with ENOENT which is normally impossible because we download Sauce Connect before we run it. It seems that there is a race condition where checking if the Sauce Connect binary was downloaded fails when looking for the version. The execution happens as follows:

    check if the binary was downloaded
    if no -> download
    if yes continue
    check if version is the one that has been downloaded
    if no -> download expected version
    if yes finish

The race condition seem to happen when the check if the binary exists was successful but then the consecutive version check fails if in between someone cleaned the binary which can happen in an CI/CD environment where dependencies are shared.

This patch introduces a retry to see if this race condition can be caught.

See:
https://github.com/karma-runner/karma-sauce-launcher/pull/219
and
https://github.com/saucelabs/node-saucelabs/issues/86

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
