### PR TITLE
waitForExist/waitForDisplayed: adjust examples

### DIFF
--- a/packages/webdriverio/src/commands/element/waitForDisplayed.js
+++ b/packages/webdriverio/src/commands/element/waitForDisplayed.js
@@ -19,7 +19,6 @@
     });
     it('should detect when element is no longer visible', () => {
         const elem = $('#elem')
-        // passing 'undefined' allows us to keep the default timeout value without overwriting it
         elem.waitForDisplayed({ reverse: true });
     });
  * </example>

--- a/packages/webdriverio/src/commands/element/waitForExist.js
+++ b/packages/webdriverio/src/commands/element/waitForExist.js
@@ -20,7 +20,6 @@
         const form = $('form');
         const message = $('.message');
         form.$(".send").click();
-        // passing 'undefined' allows us to keep the default timeout value without overwriting it
         message.waitForExist({ reverse: true });
     });
  * </example>


### PR DESCRIPTION
## Description

Adjust examples to named parameters.

The comment in the example made a lot of sense when parameters were
positional[1] and one needed to pass undefined as the first one - but this
is no longer the case.

[1]: https://github.com/webdriverio/webdriverio/commit/151fc3c#diff-94e5ad1f78caea726e656f04a782ed08R22

## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
