### PR TITLE
Ignore exceptions raised by browser.deleteSession() call in endSession() in the same fashion as in reloadSession()

### DIFF
--- a/packages/wdio-runner/src/index.js
+++ b/packages/wdio-runner/src/index.js
@@ -347,7 +347,19 @@ export default class Runner extends EventEmitter {
             global.browser.instances.forEach(i => { capabilities[i] = global.browser[i].capabilities })
         }
 
-        await global.browser.deleteSession()
+        /**
+         * end current running session, if session already gone suppress exceptions
+         */
+        try {
+            await global.browser.deleteSession()
+        } catch (err) {
+            /**
+             * ignoring all exceptions that could be caused by browser.deleteSession()
+             * there maybe times where session is ended remotely, browser.deleteSession() will fail in this case)
+             * this can be worked around in code but requires a lot of overhead
+             */
+            log.warn(`Suppressing error closing the session: ${err.stack}`)
+        }
 
         /**
          * delete session(s)

--- a/packages/wdio-runner/src/index.js
+++ b/packages/wdio-runner/src/index.js
@@ -356,7 +356,6 @@ export default class Runner extends EventEmitter {
             /**
              * ignoring all exceptions that could be caused by browser.deleteSession()
              * there maybe times where session is ended remotely, browser.deleteSession() will fail in this case)
-             * this can be worked around in code but requires a lot of overhead
              */
             log.warn(`Suppressing error closing the session: ${err.stack}`)
         }

--- a/packages/wdio-runner/tests/index.test.js
+++ b/packages/wdio-runner/tests/index.test.js
@@ -134,6 +134,17 @@ describe('wdio-runner', () => {
             expect(hook).toBeCalledTimes(0)
         })
 
+        it('should do nothing when triggered by run method with session that does not exist anymore', async () => {
+            const runner = new WDIORunner()
+            runner._shutdown = jest.fn()
+            global.browser = {
+                deleteSession: jest.fn().mockImplementation(() => Promise.reject(new Error('404 session not found'))),
+                sessionId: '123'
+            }
+            expect(runner.endSession()).not.reject
+            expect(global.browser.deleteSession).toBeCalledTimes(1)
+        })
+
         it('should work normally when called after framework run in multiremote', async () => {
             const hook = jest.fn()
             const runner = new WDIORunner()


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)
This enables the test run to end successfully in scenarios where there is a long running (>10 minutes) `browser.executeAsync` call in a test. The session is terminated remotely by the time `deleteSession` is called by the WDIO runner. Promise is rejected with "404 session not found".

The change is taken from https://github.com/webdriverio/webdriverio/blob/master/packages/webdriverio/src/commands/browser/reloadSession.js#L32 with shortened commentary.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
