### PR TITLE
Correct wrong example for `watch` in `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,7 @@ $ npm run watch
 If you only work on a single package you can watch only for that one by calling:
 
 ```sh
-# e.g. `$ npm run watch:pkg @wdio/runner`
+# e.g. `$ npm run watch wdio-runner`
 $ npm run watch <package-name>
 ```
 


### PR DESCRIPTION
## Proposed changes
I noticed the `CONTRIBUTING.md` mentions:
```
npm run watch:pkg @wdio/runner
```

While the following line mentions:
```
npm run watch <package-name>
```

Since the npm script `watch:pkg` doesn't exist, I guess it was probably refactored at some time to `watch` (as this is the one that works and is present) and it was accidentally only changed in one place. Also, `@wdio/runner` doesn't work, `wdio-runner` must be used in this instance. I updated the `CONTRIBUTING.md` to reflect this.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
