### PR TITLE
Dispatch event to trigger docs release

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,9 +3,9 @@
 name: Docs Deploy
 
 on:
-  release:
-    types:
-      - created
+  repository_dispatch:
+    types: [docs_release]
+  workflow_dispatch:
 
 jobs:
   deploy:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,3 +56,8 @@ jobs:
         env:
           NODE_ENV: production
           GITHUB_AUTH: ${{ secrets.GITHUB_TOKEN }}
+      - name: Trigger docs release
+        uses: mvasigh/dispatch-action@main
+        with:
+          token: ${{ secrets.GH_TOKEN }}
+          event_type: docs_release


### PR DESCRIPTION
## Proposed changes

After we fully automated our release pipeline for some reason the docs deploy workflow stopped being triggered. This patch tries to trigger it with a dispatch and also allows it to be run manually.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
