### PR TITLE
cucumber framework: warn if scenario outline name is missing

### DIFF
--- a/packages/wdio-cucumber-framework/src/utils.js
+++ b/packages/wdio-cucumber-framework/src/utils.js
@@ -66,7 +66,10 @@ export function getUniqueIdentifier (target, sourceLocation) {
         let name = target.name || target.text
         const line = sourceLocation.line || ''
 
-        if (Array.isArray(target.examples)) {
+        if (!name) {
+            console.warn('missing name for ScenarioOutline:', sourceLocation.uri)
+            name = path.basename(sourceLocation.uri)
+        } else if (Array.isArray(target.examples)) {
             target.examples.forEach((example) => {
                 example.tableHeader.cells.forEach((header, idx) => {
                     if (name.indexOf('<' + header.value + '>') === -1) {

--- a/packages/wdio-cucumber-framework/tests/utils.test.js
+++ b/packages/wdio-cucumber-framework/tests/utils.test.js
@@ -273,6 +273,14 @@ describe('utils', () => {
     })
 
     describe('getUniqueIdentifier', () => {
+        const consoleWarn = console.warn
+        beforeAll(() => {
+            console.warn = jest.fn()
+        })
+        afterAll(() => {
+            console.warn = consoleWarn
+        })
+
         it('Hook', () => {
             expect(getUniqueIdentifier({
                 type: 'Hook',
@@ -288,6 +296,12 @@ describe('utils', () => {
                 type: 'ScenarioOutline',
                 text: 'no-name'
             }, {})).toBe('no-name')
+        })
+
+        it('ScenarioOutline without name', () => {
+            expect(getUniqueIdentifier({
+                type: 'ScenarioOutline',
+            }, { uri: 'some.feature', line: 3 })).toBe('some.feature3')
         })
 
         it('ScenarioOutline with <>', () => {


### PR DESCRIPTION
## Proposed changes

Warn if scenario outline name is missing

continuation of https://github.com/webdriverio/webdriverio/pull/5788

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

### Reviewers: @webdriverio/project-committers
