### PR TITLE
init expect-webdriverio before framework run

### DIFF
--- a/packages/wdio-cucumber-framework/src/index.js
+++ b/packages/wdio-cucumber-framework/src/index.js
@@ -62,14 +62,6 @@ class CucumberAdapter {
             throw runtimeError
         }
 
-        return this
-    }
-
-    hasTests() {
-        return this._hasTests
-    }
-
-    async run() {
         /**
          * import and set options for `expect-webdriverio` assertion lib once
          * the framework was initiated so that it can detect the environment
@@ -80,6 +72,14 @@ class CucumberAdapter {
             interval: this.config.waitforInterval, // interval between attempts
         })
 
+        return this
+    }
+
+    hasTests() {
+        return this._hasTests
+    }
+
+    async run() {
         let runtimeError
         let result
         try {

--- a/packages/wdio-jasmine-framework/src/index.js
+++ b/packages/wdio-jasmine-framework/src/index.js
@@ -139,6 +139,16 @@ class JasmineAdapter {
 
         this._loadFiles()
 
+        /**
+         * import and set options for `expect-webdriverio` assertion lib once
+         * the framework was initiated so that it can detect the environment
+         */
+        const { setOptions } = require('expect-webdriverio')
+        setOptions({
+            wait: this.config.waitforTimeout, // ms to wait for expectation to succeed
+            interval: this.config.waitforInterval, // interval between attempts
+        })
+
         return this
     }
 
@@ -182,16 +192,6 @@ class JasmineAdapter {
     }
 
     async run() {
-        /**
-         * import and set options for `expect-webdriverio` assertion lib once
-         * the framework was initiated so that it can detect the environment
-         */
-        const { setOptions } = require('expect-webdriverio')
-        setOptions({
-            wait: this.config.waitforTimeout, // ms to wait for expectation to succeed
-            interval: this.config.waitforInterval, // interval between attempts
-        })
-
         const result = await new Promise((resolve) => {
             this.jrunner.env.beforeAll(this.wrapHook('beforeSuite'))
             this.jrunner.env.afterAll(this.wrapHook('afterSuite'))

--- a/packages/wdio-mocha-framework/src/index.js
+++ b/packages/wdio-mocha-framework/src/index.js
@@ -55,6 +55,16 @@ class MochaAdapter {
         mocha.suite.on('pre-require', this.preRequire.bind(this))
         await this._loadFiles(mochaOpts)
 
+        /**
+         * import and set options for `expect-webdriverio` assertion lib once
+         * the framework was initiated so that it can detect the environment
+         */
+        const { setOptions } = require('expect-webdriverio')
+        setOptions({
+            wait: this.config.waitforTimeout, // ms to wait for expectation to succeed
+            interval: this.config.waitforInterval, // interval between attempts
+        })
+
         return this
     }
 
@@ -89,16 +99,6 @@ class MochaAdapter {
 
     async run() {
         const mocha = this.mocha
-
-        /**
-         * import and set options for `expect-webdriverio` assertion lib once
-         * the framework was initiated so that it can detect the environment
-         */
-        const { setOptions } = require('expect-webdriverio')
-        setOptions({
-            wait: this.config.waitforTimeout, // ms to wait for expectation to succeed
-            interval: this.config.waitforInterval, // interval between attempts
-        })
 
         let runtimeError
         const result = await new Promise((resolve) => {


### PR DESCRIPTION
## Proposed changes

- there is no way to set `expect-webdriverio` options in before/beforeSession hook because they are replaced with defaults on the framework run
- `expect-webdriverio` is initialized **after** before/beforeSession hooks are called. It's necessary to import `expect-webriverio` manually add custom matchers (because `expect` is not yet available).

The PR fixes all that.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments


### Reviewers: @webdriverio/project-committers
