### PR TITLE
Properly report Sauce job for Mocha retries

### DIFF
--- a/packages/wdio-mocha-framework/src/index.js
+++ b/packages/wdio-mocha-framework/src/index.js
@@ -190,8 +190,6 @@ class MochaAdapter {
             break
         }
 
-        params.err = this.lastError
-        delete this.lastError
         return this.formatMessage(params)
     }
 
@@ -281,10 +279,6 @@ class MochaAdapter {
         message.cid = this.cid
         message.specs = this.specs
         message.uid = this.getUID(message)
-
-        if (message.error) {
-            this.lastError = message.error
-        }
 
         this.reporter.emit(message.type, message)
     }

--- a/packages/wdio-mocha-framework/tests/adapter.test.js
+++ b/packages/wdio-mocha-framework/tests/adapter.test.js
@@ -151,10 +151,8 @@ test('prepareMessage', async () => {
     await adapter.init()
     await adapter.run()
 
-    adapter.lastError = new Error('uuups')
     let result = adapter.prepareMessage('beforeSuite')
     expect(result.type).toBe('beforeSuite')
-    expect(result.error.message).toBe('uuups')
 
     adapter.runner.test = { title: 'foobar', file: '/foo/bar.test.js' }
     result = adapter.prepareMessage('afterTest')

--- a/packages/wdio-sauce-service/src/service.js
+++ b/packages/wdio-sauce-service/src/service.js
@@ -90,6 +90,23 @@ export default class SauceService {
     }
 
     afterTest (test, context, results) {
+        /**
+         * remove failure if test was retried and passted
+         * > Mocha only
+         */
+        if (test._retriedTest && results.passed) {
+            --this.failures
+            return
+        }
+
+        /**
+         * don't bump failure number if test was retried and still failed
+         * > Mocha only
+         */
+        if (test._retriedTest && !results.passed && test._currentRetry < test._retries) {
+            return
+        }
+
         if (!results.passed) {
             ++this.failures
         }

--- a/packages/wdio-sauce-service/src/service.js
+++ b/packages/wdio-sauce-service/src/service.js
@@ -91,7 +91,7 @@ export default class SauceService {
 
     afterTest (test, context, results) {
         /**
-         * remove failure if test was retried and passted
+         * remove failure if test was retried and passed
          * > Mocha only
          */
         if (test._retriedTest && results.passed) {

--- a/packages/wdio-sauce-service/tests/service.test.js
+++ b/packages/wdio-sauce-service/tests/service.test.js
@@ -154,6 +154,24 @@ test('afterTest', () => {
 
     service.afterTest({}, {}, { passed: false })
     expect(service.failures).toBe(1)
+
+    service.afterTest({ _retriedTest: {} }, {}, { passed: true })
+    expect(service.failures).toBe(0)
+
+    service.afterTest({}, {}, { passed: false })
+    expect(service.failures).toBe(1)
+    service.afterTest({
+        _retriedTest: {},
+        _currentRetry: 1,
+        _retries: 2
+    }, {}, { passed: false })
+    expect(service.failures).toBe(1)
+    service.afterTest({
+        _retriedTest: {},
+        _currentRetry: 2,
+        _retries: 2
+    }, {}, { passed: false })
+    expect(service.failures).toBe(2)
 })
 
 test('beforeFeature should set context', () => {


### PR DESCRIPTION
## Proposed changes

If Mocha retries a test and that test eventually passes the job is still reported as failure on Sauce Labs. This patch fixes this.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

fixes #5989

### Reviewers: @webdriverio/project-committers
