### PR TITLE
Add proper multi-remote session support for Browserstack service

### DIFF
--- a/packages/wdio-browserstack-service/src/service.js
+++ b/packages/wdio-browserstack-service/src/service.js
@@ -1,7 +1,7 @@
 import logger from '@wdio/logger'
 import got from 'got'
 
-import { BROWSER_DESCRIPTION } from './constants'
+import { getBrowserDescription, getBrowserCapabilities, isBrowserstackCapability } from './util'
 
 const log = logger('@wdio/browserstack-service')
 
@@ -39,8 +39,6 @@ export default class BrowserstackService {
     }
 
     before() {
-        this.sessionId = global.browser.sessionId
-
         // Ensure capabilities are not null in case of multiremote
         const capabilities = global.browser.capabilities || {}
         if (capabilities.app || this.caps.app) {
@@ -54,12 +52,12 @@ export default class BrowserstackService {
 
     beforeSuite (suite) {
         this.fullTitle = suite.title
-        this._update(this.sessionId, { name: this.fullTitle })
+        return this._updateJob({ name: this.fullTitle })
     }
 
     beforeFeature(uri, feature) {
         this.fullTitle = feature.document.feature.name
-        this._update(this.sessionId, { name: this.fullTitle })
+        return this._updateJob({ name: this.fullTitle })
     }
 
     afterTest(test, context, results) {
@@ -90,7 +88,7 @@ export default class BrowserstackService {
 
         const hasReasons = Boolean(this.failReasons.filter(Boolean).length)
 
-        return this._update(this.sessionId, {
+        return this._updateJob({
             status: result === 0 ? 'passed' : 'failed',
             name: this.fullTitle,
             reason: hasReasons ? this.failReasons.join('\n') : undefined
@@ -120,10 +118,18 @@ export default class BrowserstackService {
     async onReload(oldSessionId, newSessionId) {
         const hasReasons = Boolean(this.failReasons.filter(Boolean).length)
 
-        this.sessionId = newSessionId
+        let status = hasReasons ? 'failed' : 'passed'
+        if (!global.browser.isMultiremote) {
+            log.info(`Update (reloaded) job with sessionId ${oldSessionId}, ${status}`)
+        } else {
+            const browserName = global.browser.instances.filter(
+                (browserName) => global.browser[browserName].sessionId === newSessionId)[0]
+            log.info(`Update (reloaded) multiremote job for browser "${browserName}" and sessionId ${oldSessionId}, ${status}`)
+        }
+
         await this._update(oldSessionId, {
             name: this.fullTitle,
-            status: hasReasons ? 'failed' : 'passed',
+            status,
             reason: hasReasons ? this.failReasons.join('\n') : undefined
         })
         this.scenariosThatRan = []
@@ -132,8 +138,31 @@ export default class BrowserstackService {
         await this._printSessionURL()
     }
 
+    _updateJob(requestBody) {
+        return this._multiRemoteAction((sessionId) => this._update(sessionId, requestBody))
+    }
+
+    _multiRemoteAction(action) {
+        if (!global.browser.isMultiremote) {
+            log.info(`Update job with sessionId ${global.browser.sessionId}`)
+            return action(global.browser.sessionId)
+        }
+
+        return Promise.all(global.browser.instances
+            .filter(browserName => {
+                const cap = getBrowserCapabilities(this.caps, browserName)
+                return isBrowserstackCapability(cap)
+            })
+            .map((browserName) => {
+                log.info(`Update multiremote job for browser "${browserName}" and sessionId ${global.browser[browserName].sessionId}`)
+                return action(global.browser[browserName].sessionId, browserName)
+            }))
+    }
+
     _update(sessionId, requestBody) {
-        return got.put(`${this.sessionBaseUrl}/${sessionId}.json`, {
+        const sessionUrl = `${this.sessionBaseUrl}/${sessionId}.json`
+        log.debug(`Updating Browserstack session at ${sessionUrl} with request body: `, requestBody)
+        return got.put(sessionUrl, {
             json: requestBody,
             username: this.config.user,
             password: this.config.key
@@ -141,24 +170,18 @@ export default class BrowserstackService {
     }
 
     async _printSessionURL() {
-        // Ensure capabilities are not null in case of multiremote
-        const capabilities = global.browser.capabilities || {}
+        await this._multiRemoteAction(async (sessionId, browserName) => {
+            const sessionUrl = `${this.sessionBaseUrl}/${sessionId}.json`
+            log.debug(`Requesting Browserstack session URL at ${sessionUrl}`)
+            const response = await got(sessionUrl, {
+                username: this.config.user,
+                password: this.config.key,
+                responseType: 'json'
+            })
 
-        const response = await got(`${this.sessionBaseUrl}/${this.sessionId}.json`, {
-            username: this.config.user,
-            password: this.config.key,
-            responseType: 'json'
+            const capabilities = getBrowserCapabilities(this.caps, browserName)
+            const browserString = getBrowserDescription(capabilities)
+            log.info(`${browserString} session: ${response.body.automation_session.browser_url}`)
         })
-
-        /**
-         * These keys describe the browser the test was run on
-         */
-        const browserString = BROWSER_DESCRIPTION
-            .map(k => capabilities[k])
-            .filter(v => !!v)
-            .join(' ')
-
-        log.info(`${browserString} session: ${response.body.automation_session.browser_url}`)
-        return response.body
     }
 }

--- a/packages/wdio-browserstack-service/src/util.js
+++ b/packages/wdio-browserstack-service/src/util.js
@@ -1,0 +1,43 @@
+import { BROWSER_DESCRIPTION } from './constants'
+
+/**
+ * get browser description for Browserstack service
+ * @param {*} cap browser capablities
+ */
+export function getBrowserDescription(cap) {
+    cap = cap || {}
+    if (cap['bstack:options']) {
+        cap = { ...cap, ...cap['bstack:options'] }
+    }
+
+    /**
+     * These keys describe the browser the test was run on
+     */
+    return BROWSER_DESCRIPTION
+        .map(k => cap[k])
+        .filter(v => !!v)
+        .join(' ')
+}
+
+/**
+ * get correct browser capabilities object in both multiremote and normal setups
+ * @param {*} caps browser capbilities object. In case of multiremote, the object itself should have a property named 'capabilities'
+ * @param {*} browserName browser name in case of multiremote
+ */
+export function getBrowserCapabilities(caps, browserName) {
+    if (!global.browser.isMultiremote) {
+        return { ...global.browser.capabilities, ...caps }
+    }
+
+    const globalCap = global.browser[browserName] ? global.browser[browserName].capabilities : {}
+    const cap = caps[browserName] ? caps[browserName].capabilities : {}
+    return { ...globalCap, ...cap }
+}
+
+/**
+ * check for browserstack W3C capabilities. Does not support legacy capabilities
+ * @param {*} cap browser capabilities
+ */
+export function isBrowserstackCapability(cap) {
+    return Boolean(cap && cap['bstack:options'])
+}

--- a/packages/wdio-browserstack-service/tests/util.test.js
+++ b/packages/wdio-browserstack-service/tests/util.test.js
@@ -1,0 +1,121 @@
+import { getBrowserDescription, getBrowserCapabilities, isBrowserstackCapability } from '../src/util'
+
+describe('getBrowserCapabilities', () => {
+    it('should get default browser capabilities', () => {
+        global.browser = {
+            capabilities: {
+                browser: 'browser'
+            }
+        }
+        expect(getBrowserCapabilities()).toEqual(global.browser.capabilities)
+    })
+
+    it('should get multiremote browser capabilities', () => {
+        global.browser = {
+            isMultiremote: true,
+            browserA: {
+                capabilities: {
+                    browser: 'browser'
+                }
+            }
+        }
+        expect(getBrowserCapabilities({}, 'browserA')).toEqual({
+            browser: 'browser'
+        })
+    })
+
+    it('should handle null multiremote browser capabilities', () => {
+        global.browser = {
+            isMultiremote: true,
+            browserA: {}
+        }
+        global.browserA = {}
+        expect(getBrowserCapabilities({}, 'browserB')).toEqual({})
+    })
+
+    it('should merge service capabilities and browser capabilities', () => {
+        global.browser = {
+            capabilities: {
+                browser: 'browser',
+                os: 'OS X',
+            }
+        }
+        expect(getBrowserCapabilities({ os: 'Windows' })).toEqual({ os:'Windows', browser: 'browser' })
+    })
+
+    it('should merge multiremote service capabilities and browser capabilities', () => {
+        global.browser = {
+            isMultiremote: true,
+            browserA: {
+                capabilities: {
+                    browser: 'browser',
+                    os: 'OS X',
+                }
+            }
+        }
+        expect(getBrowserCapabilities({ browserA: { capabilities: { os: 'Windows' } } }, 'browserA')).toEqual({ os:'Windows', browser: 'browser' })
+    })
+
+    it('should handle null multiremote browser capabilities', () => {
+        global.browser = {
+            isMultiremote: true,
+            browserA: {}
+        }
+        expect(getBrowserCapabilities({}, 'browserB')).toEqual({})
+    })
+
+    it('should handle null multiremote browser capabilities', () => {
+        global.browser = {
+            isMultiremote: true,
+            browserA: {}
+        }
+        expect(getBrowserCapabilities({ browserB: {} }, 'browserB')).toEqual({})
+    })
+})
+
+describe('getBrowserDescription', () => {
+    global.browser = {}
+    const defaultCap = {
+        'device': 'device',
+        'os': 'os',
+        'osVersion': 'osVersion',
+        'browserName': 'browserName',
+        'browser': 'browser',
+        'browserVersion': 'browserVersion',
+    }
+    const defaultDesc = 'device os osVersion browserName browser browserVersion'
+    const legacyCap = {
+        'os_version': 'os_version',
+        'browser_version': 'browser_version'
+    }
+
+    it('should get correct description for default capabilities', () => {
+        expect(getBrowserDescription(defaultCap)).toEqual(defaultDesc)
+    })
+
+    it('should get correct description for legacy capabilities', () => {
+        expect(getBrowserDescription(legacyCap)).toEqual('os_version browser_version')
+    })
+
+    it('should get correct description for W3C capabilities', () => {
+        expect(getBrowserDescription({ 'bstack:options': defaultCap })).toEqual(defaultDesc)
+    })
+
+    it('should merge W3C and lecacy capabilities', () => {
+        expect(getBrowserDescription({ 'bstack:options': defaultCap })).toEqual(defaultDesc)
+    })
+
+    it('should not crash when capabilities is null or undefined', () => {
+        expect(getBrowserDescription(undefined)).toEqual('')
+        expect(getBrowserDescription(null, 'browserA')).toEqual('')
+    })
+})
+
+describe('isBrowserstackCapability', () => {
+    it('should detect browserstack W3C capabilities', () => {
+        expect(isBrowserstackCapability({})).toBe(false)
+        expect(isBrowserstackCapability()).toBe(false)
+        expect(isBrowserstackCapability({ 'bstack:options': null })).toBe(false)
+        expect(isBrowserstackCapability({ 'bstack:options': {} })).toBe(true)
+    })
+})


### PR DESCRIPTION
## Proposed changes

Fix #5990 by sending correct session id per browser to Browserstack service in case of multiremote
## Types of changes
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist
- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
- [X] I have added proper type definitions for new commands (if appropriate)

## Further comments

- `this.sessionId` is always null, and we have more than 1 session id in case of multiremote, so we need to drop this property
- `global.browser.capabilities` does not provide everything we need for Browserstack service. We need the service's own `caps` object
### Reviewers: @webdriverio/project-committers
