### PR TITLE
Spec Reporter - custom symbols for report

### DIFF
--- a/packages/wdio-spec-reporter/README.md
+++ b/packages/wdio-spec-reporter/README.md
@@ -38,3 +38,14 @@ module.exports = {
   // ...
 };
 ```
+
+### Custom report symbols
+```js
+[
+  "spec",
+  {
+    symbols: { passed: '[PASS]', failed: '[FAIL]' },
+    // skipped set to default '-'
+  }
+]
+```

--- a/packages/wdio-spec-reporter/src/index.js
+++ b/packages/wdio-spec-reporter/src/index.js
@@ -11,6 +11,12 @@ class SpecReporter extends WDIOReporter {
         options = Object.assign({ stdout: true }, options)
         super(options)
 
+        this.symbols = {
+            passed: options.symbol.passed ||'✓',
+            skipped: options.symbol.skipped || '-',
+            failed: options.symbol.passed || '✖'
+        }
+
         // Keep track of the order that suites were called
         this.suiteUids = []
 
@@ -336,21 +342,7 @@ class SpecReporter extends WDIOReporter {
      * @return {String}       Symbol to display
      */
     getSymbol (state) {
-        let symbol = '?' // in case of an unknown state
-
-        switch (state) {
-        case 'passed':
-            symbol = '✓'
-            break
-        case 'skipped':
-            symbol = '-'
-            break
-        case 'failed':
-            symbol = '✖'
-            break
-        }
-
-        return symbol
+        return this.symbols[state] || '?'
     }
 
     /**

--- a/packages/wdio-spec-reporter/src/index.js
+++ b/packages/wdio-spec-reporter/src/index.js
@@ -12,9 +12,9 @@ class SpecReporter extends WDIOReporter {
         super(options)
 
         this.symbols = {
-            passed: options.symbols.passed ||'✓',
-            skipped: options.symbols.skipped || '-',
-            failed: options.symbols.passed || '✖'
+            passed: options.symbols ? options.symbols.passed || '✓' : '✓',
+            skipped: options.symbols ? options.symbols.skipped || '-' : '-',
+            failed: options.symbols ? options.symbols.failed || '✖': '✖'
         }
 
         // Keep track of the order that suites were called

--- a/packages/wdio-spec-reporter/src/index.js
+++ b/packages/wdio-spec-reporter/src/index.js
@@ -12,9 +12,9 @@ class SpecReporter extends WDIOReporter {
         super(options)
 
         this.symbols = {
-            passed: options.symbols ? options.symbols.passed || '✓' : '✓',
-            skipped: options.symbols ? options.symbols.skipped || '-' : '-',
-            failed: options.symbols ? options.symbols.failed || '✖': '✖'
+            passed: options.symbols?.passed || '✓',
+            skipped: options.symbols?.skipped || '-',
+            failed: options.symbols?.failed || '✖'
         }
 
         // Keep track of the order that suites were called

--- a/packages/wdio-spec-reporter/src/index.js
+++ b/packages/wdio-spec-reporter/src/index.js
@@ -12,9 +12,9 @@ class SpecReporter extends WDIOReporter {
         super(options)
 
         this.symbols = {
-            passed: options.symbol.passed ||'✓',
-            skipped: options.symbol.skipped || '-',
-            failed: options.symbol.passed || '✖'
+            passed: options.symbols.passed ||'✓',
+            skipped: options.symbols.skipped || '-',
+            failed: options.symbols.passed || '✖'
         }
 
         // Keep track of the order that suites were called

--- a/packages/wdio-spec-reporter/tests/index.test.js
+++ b/packages/wdio-spec-reporter/tests/index.test.js
@@ -472,6 +472,25 @@ describe('SpecReporter', () => {
         })
     })
 
+    describe('custom getSymbol', () => {
+        const options = { symbols: { passed: 'Y', failed: 'N' } }
+        beforeEach(() => {
+            tmpReporter = new SpecReporter(options)
+        })
+
+        it('should get new passed symbol', () => {
+            expect(tmpReporter.getSymbol('passed')).toBe(options.symbols.passed)
+        })
+
+        it('should get new failed symbol', () => {
+            expect(tmpReporter.getSymbol('failed')).toBe(options.symbols.failed)
+        })
+
+        it('should get the skipped symbol that is not set', () => {
+            expect(tmpReporter.getSymbol('skipped')).toBe('-')
+        })
+    })
+
     describe('getColor', () => {
         it('should get green', () => {
             expect(tmpReporter.getColor('passed')).toBe('green')


### PR DESCRIPTION
## Proposed changes

Ability to use custom symbols for report results. Useful for batch, Jenkins on windows, etc
![image](https://user-images.githubusercontent.com/6696821/96465440-a53f0400-1231-11eb-88fd-97b8ebf3537e.png)

```js
reporters: [
    [
      "spec",
      {
        symbols: { passed: "[PASS]", failed: "[FAIL]" },
      },
    ],
..
```

![image](https://user-images.githubusercontent.com/6696821/96465295-7759bf80-1231-11eb-90ff-a52dd0890c48.png)

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] New feature (non-breaking change which adds functionality)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)




### Reviewers: @webdriverio/project-committers
