### PR TITLE
webdriverio: mock respond in request stage

### DIFF
--- a/packages/wdio-sync/webdriverio-core.d.ts
+++ b/packages/wdio-sync/webdriverio-core.d.ts
@@ -525,7 +525,11 @@ declare namespace WebdriverIO {
 
     type MockResponseParams = {
         statusCode?: number,
-        headers?: Record<string, string>
+        headers?: Record<string, string>,
+        /**
+         * fetch real response before responding with mocked data. Default: true
+         */
+        fetchResponse?: boolean
     }
 
     type MockFilterOptions = {
@@ -940,26 +944,34 @@ declare namespace WebdriverIO {
 
         
         /**
-         * > This is a __beta__ feature. Please give us feedback and file [an issue](https://github.com/webdriverio/webdriverio/issues/new/choose) if certain scenarions don't work as expected!
+         * Abort the request with one of the following error codes:
+         * `Failed`, `Aborted`, `TimedOut`, `AccessDenied`, `ConnectionClosed`,
+         * `ConnectionReset`, `ConnectionRefused`, `ConnectionAborted`,
+         * `ConnectionFailed`, `NameNotResolved`, `InternetDisconnected`,
+         * `AddressUnreachable`, `BlockedByClient`, `BlockedByResponse`.
          */
         abort(
             errorCode: ErrorCode
         ): void;
 
         /**
-         * > This is a __beta__ feature. Please give us feedback and file [an issue](https://github.com/webdriverio/webdriverio/issues/new/choose) if certain scenarions don't work as expected!
+         * Abort the request once with one of the following error codes:
+         * `Failed`, `Aborted`, `TimedOut`, `AccessDenied`, `ConnectionClosed`,
+         * `ConnectionReset`, `ConnectionRefused`, `ConnectionAborted`,
+         * `ConnectionFailed`, `NameNotResolved`, `InternetDisconnected`,
+         * `AddressUnreachable`, `BlockedByClient`, `BlockedByResponse`.
          */
         abortOnce(
             errorCode: ErrorCode
         ): void;
 
         /**
-         * > This is a __beta__ feature. Please give us feedback and file [an issue](https://github.com/webdriverio/webdriverio/issues/new/choose) if certain scenarions don't work as expected!
+         * Resets all information stored in the `mock.calls` array.
          */
         clear(): void;
 
         /**
-         * > This is a __beta__ feature. Please give us feedback and file [an issue](https://github.com/webdriverio/webdriverio/issues/new/choose) if certain scenarions don't work as expected!
+         * Always respond with same overwrite.
          */
         respond(
             overwrites: MockOverwrite,
@@ -967,7 +979,10 @@ declare namespace WebdriverIO {
         ): void;
 
         /**
-         * > This is a __beta__ feature. Please give us feedback and file [an issue](https://github.com/webdriverio/webdriverio/issues/new/choose) if certain scenarions don't work as expected!
+         * Only respond once with given overwrite. You can call `respondOnce` multiple
+         * consecutive times and it will start with the respond you defined last. If you
+         * only use `respondOnce` and the resource is called more times a mock has been
+         * defined than it defaults back to the original resource.
          */
         respondOnce(
             overwrites: MockOverwrite,
@@ -975,7 +990,7 @@ declare namespace WebdriverIO {
         ): void;
 
         /**
-         * > This is a __beta__ feature. Please give us feedback and file [an issue](https://github.com/webdriverio/webdriverio/issues/new/choose) if certain scenarions don't work as expected!
+         * Does everything that `mock.clear()` does, and also removes any mocked return values or implementations.
          */
         restore(): void;
     }
@@ -1111,7 +1126,10 @@ declare namespace WebdriverIO {
         ): void;
 
         /**
-         * > This is a __beta__ feature. Please give us feedback and file [an issue](https://github.com/webdriverio/webdriverio/issues/new/choose) if certain scenarios don't work as expected!
+         * Mock the response of a request. You can define a mock based on a matching
+         * glob and corresponding header and status code. Calling the mock method
+         * returns a stub object that you can use to modify the response of the
+         * web resource.
          */
         mock(
             url: string,

--- a/packages/webdriverio/src/commands/browser/mock.js
+++ b/packages/webdriverio/src/commands/browser/mock.js
@@ -84,14 +84,14 @@
  * </example>
  *
  * @alias browser.mock
- * @param {String}             url                            url to mock
- * @param {MockFilterOptions=} filterOptions                  filter mock resource by additional options
- * @param {String=}            filterOptions.method           filter resource by HTTP method
- * @param {Object=}            filterOptions.headers          filter resource by specific request headers
- * @param {Object=}            filterOptions.responseHeaders  filter resource by specific response headers
- * @param {Object=}            filterOptions.postData         filter resource by request postData
- * @param {Object=}            filterOptions.statusCode       filter resource by response statusCode
- * @return {Mock}                                             a mock object to modify the response
+ * @param {String}              url                             url to mock
+ * @param {MockFilterOptions=}  filterOptions                   filter mock resource by additional options
+ * @param {String|Function=}    filterOptions.method            filter resource by HTTP method
+ * @param {Object|Function=}    filterOptions.headers           filter resource by specific request headers
+ * @param {Object|Function=}    filterOptions.responseHeaders   filter resource by specific response headers
+ * @param {String|Function=}    filterOptions.postData          filter resource by request postData
+ * @param {Number|Function=}    filterOptions.statusCode        filter resource by response statusCode
+ * @return {Mock}                                               a mock object to modify the response
  * @type utility
  *
  */

--- a/packages/webdriverio/src/commands/browser/mock.js
+++ b/packages/webdriverio/src/commands/browser/mock.js
@@ -1,10 +1,10 @@
 /**
- * > This is a __beta__ feature. Please give us feedback and file [an issue](https://github.com/webdriverio/webdriverio/issues/new/choose) if certain scenarios don't work as expected!
- *
  * Mock the response of a request. You can define a mock based on a matching
  * glob and corresponding header and status code. Calling the mock method
  * returns a stub object that you can use to modify the response of the
  * web resource.
+ *
+ * > This is a __beta__ feature. Please give us feedback and file [an issue](https://github.com/webdriverio/webdriverio/issues/new/choose) if certain scenarios don't work as expected!
  *
  * With the stub object you can then either return a custom response or
  * have the request fail.
@@ -89,6 +89,8 @@
  * @param {String=}            filterOptions.method           filter resource by HTTP method
  * @param {Object=}            filterOptions.headers          filter resource by specific request headers
  * @param {Object=}            filterOptions.responseHeaders  filter resource by specific response headers
+ * @param {Object=}            filterOptions.postData         filter resource by request postData
+ * @param {Object=}            filterOptions.statusCode       filter resource by response statusCode
  * @return {Mock}                                             a mock object to modify the response
  * @type utility
  *
@@ -113,7 +115,7 @@ export default async function mock (url, filterOptions) {
         const [page] = await this.puppeteer.pages()
         const client = await page.target().createCDPSession()
         await client.send('Fetch.enable', {
-            patterns: [{ requestStage: 'Response' }]
+            patterns: [{ requestStage: 'Request' }, { requestStage: 'Response' }]
         })
         client.on(
             'Fetch.requestPaused',

--- a/packages/webdriverio/src/commands/mock/abort.js
+++ b/packages/webdriverio/src/commands/mock/abort.js
@@ -1,11 +1,11 @@
 /**
- * > This is a __beta__ feature. Please give us feedback and file [an issue](https://github.com/webdriverio/webdriverio/issues/new/choose) if certain scenarions don't work as expected!
- *
  * Abort the request with one of the following error codes:
  * `Failed`, `Aborted`, `TimedOut`, `AccessDenied`, `ConnectionClosed`,
  * `ConnectionReset`, `ConnectionRefused`, `ConnectionAborted`,
  * `ConnectionFailed`, `NameNotResolved`, `InternetDisconnected`,
  * `AddressUnreachable`, `BlockedByClient`, `BlockedByResponse`.
+ *
+ * > This is a __beta__ feature. Please give us feedback and file [an issue](https://github.com/webdriverio/webdriverio/issues/new/choose) if certain scenarios don't work as expected!
  *
  * <example>
     :abort.js

--- a/packages/webdriverio/src/commands/mock/abortOnce.js
+++ b/packages/webdriverio/src/commands/mock/abortOnce.js
@@ -1,11 +1,11 @@
 /**
- * > This is a __beta__ feature. Please give us feedback and file [an issue](https://github.com/webdriverio/webdriverio/issues/new/choose) if certain scenarions don't work as expected!
- *
  * Abort the request once with one of the following error codes:
  * `Failed`, `Aborted`, `TimedOut`, `AccessDenied`, `ConnectionClosed`,
  * `ConnectionReset`, `ConnectionRefused`, `ConnectionAborted`,
  * `ConnectionFailed`, `NameNotResolved`, `InternetDisconnected`,
  * `AddressUnreachable`, `BlockedByClient`, `BlockedByResponse`.
+ *
+ * > This is a __beta__ feature. Please give us feedback and file [an issue](https://github.com/webdriverio/webdriverio/issues/new/choose) if certain scenarios don't work as expected!
  *
  * <example>
     :abortOnce.js

--- a/packages/webdriverio/src/commands/mock/clear.js
+++ b/packages/webdriverio/src/commands/mock/clear.js
@@ -1,7 +1,7 @@
 /**
- * > This is a __beta__ feature. Please give us feedback and file [an issue](https://github.com/webdriverio/webdriverio/issues/new/choose) if certain scenarions don't work as expected!
- *
  * Resets all information stored in the `mock.calls` array.
+ *
+ * > This is a __beta__ feature. Please give us feedback and file [an issue](https://github.com/webdriverio/webdriverio/issues/new/choose) if certain scenarios don't work as expected!
  *
  * <example>
     :clear.js

--- a/packages/webdriverio/src/commands/mock/respond.js
+++ b/packages/webdriverio/src/commands/mock/respond.js
@@ -1,7 +1,7 @@
 /**
- * > This is a __beta__ feature. Please give us feedback and file [an issue](https://github.com/webdriverio/webdriverio/issues/new/choose) if certain scenarions don't work as expected!
- *
  * Always respond with same overwrite.
+ *
+ * > This is a __beta__ feature. Please give us feedback and file [an issue](https://github.com/webdriverio/webdriverio/issues/new/choose) if certain scenarios don't work as expected!
  *
  * <example>
     :respond.js
@@ -18,7 +18,10 @@
             title: 'Injected completed Todo',
             order: null,
             completed: true
-        }])
+        }], {
+            statusCode: 200,
+            fetchResponse: true // default
+        })
 
         browser.url('https://todobackend.com/client/index.html?https://todo-backend-express-knex.herokuapp.com/')
 
@@ -40,9 +43,10 @@
  * </example>
  *
  * @alias mock.respond
- * @param {MockOverwrite}       overwrites         payload to overwrite the response
- * @param {MockResponseParams=} params             additional respond parameters to overwrite
- * @param {Object=}             params.header      overwrite specific headers
- * @param {Number=}              params.statusCode  overwrite response status code
+ * @param {MockOverwrite}       overwrites              payload to overwrite the response
+ * @param {MockResponseParams=} params                  additional respond parameters to overwrite
+ * @param {Object=}             params.header           overwrite specific headers
+ * @param {Number=}             params.statusCode       overwrite response status code
+ * @param {Boolean=}            params.fetchResponse    fetch real response before responding with mocked data
  */
 // actual implementation is located in packages/webdriverio/src/utils/interception

--- a/packages/webdriverio/src/commands/mock/respondOnce.js
+++ b/packages/webdriverio/src/commands/mock/respondOnce.js
@@ -1,10 +1,10 @@
 /**
- * > This is a __beta__ feature. Please give us feedback and file [an issue](https://github.com/webdriverio/webdriverio/issues/new/choose) if certain scenarions don't work as expected!
- *
  * Only respond once with given overwrite. You can call `respondOnce` multiple
  * consecutive times and it will start with the respond you defined last. If you
  * only use `respondOnce` and the resource is called more times a mock has been
  * defined than it defaults back to the original resource.
+ *
+ * > This is a __beta__ feature. Please give us feedback and file [an issue](https://github.com/webdriverio/webdriverio/issues/new/choose) if certain scenarios don't work as expected!
  *
  * <example>
     :respondOnce.js

--- a/packages/webdriverio/src/commands/mock/respondOnce.js
+++ b/packages/webdriverio/src/commands/mock/respondOnce.js
@@ -48,9 +48,10 @@
  * </example>
  *
  * @alias mock.respondOnce
- * @param {MockOverwrite}       overwrites         payload to overwrite the response
- * @param {MockResponseParams=} params             additional respond parameters to overwrite
- * @param {Object=}             params.header      overwrite specific headers
- * @param {Number=}             params.statusCode  overwrite response status code
+ * @param {MockOverwrite}       overwrites              payload to overwrite the response
+ * @param {MockResponseParams=} params                  additional respond parameters to overwrite
+ * @param {Object=}             params.header           overwrite specific headers
+ * @param {Number=}             params.statusCode       overwrite response status code
+ * @param {Boolean=}            params.fetchResponse    fetch real response before responding with mocked data
  */
 // actual implementation is located in packages/webdriverio/src/utils/interception

--- a/packages/webdriverio/src/commands/mock/restore.js
+++ b/packages/webdriverio/src/commands/mock/restore.js
@@ -1,7 +1,7 @@
 /**
- * > This is a __beta__ feature. Please give us feedback and file [an issue](https://github.com/webdriverio/webdriverio/issues/new/choose) if certain scenarions don't work as expected!
- *
  * Does everything that `mock.clear()` does, and also removes any mocked return values or implementations.
+ *
+ * > This is a __beta__ feature. Please give us feedback and file [an issue](https://github.com/webdriverio/webdriverio/issues/new/choose) if certain scenarios don't work as expected!
  *
  * <example>
     :addValue.js

--- a/packages/webdriverio/src/utils/interception/devtools.js
+++ b/packages/webdriverio/src/utils/interception/devtools.js
@@ -27,7 +27,13 @@ export default class DevtoolsInterception extends Interception {
                 /**
                  * skip response mocks in Request stage
                  */
-                if (isRequest && mock.filterOptions.fetchResponse !== false) {
+                if (isRequest && (
+                    mock.respondOverwrites.length === 0 || // nothing to do in Request stage
+                    (!mock.respondOverwrites[0].errorReason && // skip if not going to abort a request
+                    // or want to fetch response
+                    mock.respondOverwrites[0].params &&
+                    mock.respondOverwrites[0].params.fetchResponse !== false)
+                )) {
                     continue
                 }
 

--- a/packages/webdriverio/tests/utils/interception/__snapshots__/devtools.test.js.snap
+++ b/packages/webdriverio/tests/utils/interception/__snapshots__/devtools.test.js.snap
@@ -1,5 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`stub request do not fetch request 1`] = `
+Array [
+  "Fetch.fulfillRequest",
+  Object {
+    "body": "Zm9vYmFy",
+    "requestId": 123,
+    "responseCode": 200,
+    "responseHeaders": Array [],
+  },
+]
+`;
+
 exports[`stub request with a different web resource 1`] = `
 Array [
   Object {
@@ -32,7 +44,7 @@ Array [
   Object {
     "body": "Zm9vYmFy",
     "requestId": 123,
-    "responseCode": undefined,
+    "responseCode": 200,
     "responseHeaders": Array [
       Object {
         "name": "Content-Type",
@@ -49,7 +61,7 @@ Array [
   Object {
     "body": "",
     "requestId": 123,
-    "responseCode": undefined,
+    "responseCode": 200,
     "responseHeaders": Array [
       Object {
         "name": "Content-Type",
@@ -66,7 +78,7 @@ Array [
   Object {
     "body": undefined,
     "requestId": 123,
-    "responseCode": undefined,
+    "responseCode": 200,
     "responseHeaders": Array [
       Object {
         "name": "Content-Type",
@@ -83,7 +95,7 @@ Array [
   Object {
     "body": "Zm9vYmFy",
     "requestId": 123,
-    "responseCode": undefined,
+    "responseCode": 200,
     "responseHeaders": Array [
       Object {
         "name": "Content-Type",
@@ -100,7 +112,7 @@ Array [
   Object {
     "body": "eyJmb28iOiJiYXIifQ==",
     "requestId": 123,
-    "responseCode": undefined,
+    "responseCode": 200,
     "responseHeaders": Array [
       Object {
         "name": "Content-Type",
@@ -117,7 +129,7 @@ Array [
   Object {
     "body": "eyJmb28iOiJiYXIifQ==",
     "requestId": 123,
-    "responseCode": undefined,
+    "responseCode": 200,
     "responseHeaders": Array [
       Object {
         "name": "Content-Type",

--- a/packages/webdriverio/webdriverio-core.d.ts
+++ b/packages/webdriverio/webdriverio-core.d.ts
@@ -525,7 +525,11 @@ declare namespace WebdriverIO {
 
     type MockResponseParams = {
         statusCode?: number,
-        headers?: Record<string, string>
+        headers?: Record<string, string>,
+        /**
+         * fetch real response before responding with mocked data. Default: true
+         */
+        fetchResponse?: boolean
     }
 
     type MockFilterOptions = {
@@ -940,26 +944,34 @@ declare namespace WebdriverIO {
 
         
         /**
-         * > This is a __beta__ feature. Please give us feedback and file [an issue](https://github.com/webdriverio/webdriverio/issues/new/choose) if certain scenarions don't work as expected!
+         * Abort the request with one of the following error codes:
+         * `Failed`, `Aborted`, `TimedOut`, `AccessDenied`, `ConnectionClosed`,
+         * `ConnectionReset`, `ConnectionRefused`, `ConnectionAborted`,
+         * `ConnectionFailed`, `NameNotResolved`, `InternetDisconnected`,
+         * `AddressUnreachable`, `BlockedByClient`, `BlockedByResponse`.
          */
         abort(
             errorCode: ErrorCode
         ): Promise<void>;
 
         /**
-         * > This is a __beta__ feature. Please give us feedback and file [an issue](https://github.com/webdriverio/webdriverio/issues/new/choose) if certain scenarions don't work as expected!
+         * Abort the request once with one of the following error codes:
+         * `Failed`, `Aborted`, `TimedOut`, `AccessDenied`, `ConnectionClosed`,
+         * `ConnectionReset`, `ConnectionRefused`, `ConnectionAborted`,
+         * `ConnectionFailed`, `NameNotResolved`, `InternetDisconnected`,
+         * `AddressUnreachable`, `BlockedByClient`, `BlockedByResponse`.
          */
         abortOnce(
             errorCode: ErrorCode
         ): Promise<void>;
 
         /**
-         * > This is a __beta__ feature. Please give us feedback and file [an issue](https://github.com/webdriverio/webdriverio/issues/new/choose) if certain scenarions don't work as expected!
+         * Resets all information stored in the `mock.calls` array.
          */
         clear(): Promise<void>;
 
         /**
-         * > This is a __beta__ feature. Please give us feedback and file [an issue](https://github.com/webdriverio/webdriverio/issues/new/choose) if certain scenarions don't work as expected!
+         * Always respond with same overwrite.
          */
         respond(
             overwrites: MockOverwrite,
@@ -967,7 +979,10 @@ declare namespace WebdriverIO {
         ): Promise<void>;
 
         /**
-         * > This is a __beta__ feature. Please give us feedback and file [an issue](https://github.com/webdriverio/webdriverio/issues/new/choose) if certain scenarions don't work as expected!
+         * Only respond once with given overwrite. You can call `respondOnce` multiple
+         * consecutive times and it will start with the respond you defined last. If you
+         * only use `respondOnce` and the resource is called more times a mock has been
+         * defined than it defaults back to the original resource.
          */
         respondOnce(
             overwrites: MockOverwrite,
@@ -975,7 +990,7 @@ declare namespace WebdriverIO {
         ): Promise<void>;
 
         /**
-         * > This is a __beta__ feature. Please give us feedback and file [an issue](https://github.com/webdriverio/webdriverio/issues/new/choose) if certain scenarions don't work as expected!
+         * Does everything that `mock.clear()` does, and also removes any mocked return values or implementations.
          */
         restore(): Promise<void>;
     }
@@ -1111,7 +1126,10 @@ declare namespace WebdriverIO {
         ): Promise<void>;
 
         /**
-         * > This is a __beta__ feature. Please give us feedback and file [an issue](https://github.com/webdriverio/webdriverio/issues/new/choose) if certain scenarios don't work as expected!
+         * Mock the response of a request. You can define a mock based on a matching
+         * glob and corresponding header and status code. Calling the mock method
+         * returns a stub object that you can use to modify the response of the
+         * web resource.
          */
         mock(
             url: string,

--- a/scripts/templates/webdriverio.tpl.d.ts
+++ b/scripts/templates/webdriverio.tpl.d.ts
@@ -519,7 +519,11 @@ declare namespace WebdriverIO {
 
     type MockResponseParams = {
         statusCode?: number,
-        headers?: Record<string, string>
+        headers?: Record<string, string>,
+        /**
+         * fetch real response before responding with mocked data. Default: true
+         */
+        fetchResponse?: boolean
     }
 
     type MockFilterOptions = {


### PR DESCRIPTION
## Proposed changes

**Added**
Allow sending a mocked response in the Request stage. 
In other words, add an option to not wait for a backend to respond before sending a mocked response.

![image](https://user-images.githubusercontent.com/25589559/96506162-776cb600-1257-11eb-848c-743674dc7942.png)

#6004

**Changed**
`abort` and `abortOnce` commands are now aborting a **request** and not waiting for a response.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

still have to add tests...

### Reviewers: @webdriverio/project-committers
