### PR TITLE
devtools: fix infinite loop on timeout

### DIFF
--- a/packages/devtools/src/commands/deleteSession.js
+++ b/packages/devtools/src/commands/deleteSession.js
@@ -8,5 +8,6 @@
 
 export default async function deleteSession () {
     await this.browser.close()
+    this.windows.clear()
     return null
 }


### PR DESCRIPTION
## Proposed changes

When a test is in progress and timeout occurs the execution hangs forever in `checkPendingNavigations`, CPU usage is 100%

To fix that it's required to clear `windows` Map after deleting a session.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works

## Further comments

Steps to reproduce
```
describe('suite', () => {
  it('test', () => {
    browser.url('http://guinea-pig.webdriver.io')
    browser.waitUntil(() => $$('div').length === 33)
  })
})
```

### Reviewers: @webdriverio/project-committers
