### PR TITLE
allure-reporter: attach screenshot to 'all' hooks on failure

### DIFF
--- a/packages/wdio-allure-reporter/tests/__fixtures__/testState.js
+++ b/packages/wdio-allure-reporter/tests/__fixtures__/testState.js
@@ -84,3 +84,31 @@ export function testFailedWithAssertionErrorFromExpectWebdriverIO() {
 export function testPending() {
     return Object.assign(testState(), { state: 'pending', end: '2018-05-14T15:17:21.631Z', _duration: 0 })
 }
+
+const hookState = () => ({
+    type: 'hook',
+    start: '2018-05-14T15:17:18.914Z',
+    _duration: 0,
+    uid: 'hook-00-0',
+    cid: '0-0',
+    title: '"before all" hook for "should login with valid credentials"',
+    parent: 'Login',
+})
+
+export function hookStart() {
+    return hookState()
+}
+
+export function hookPassed() {
+    return Object.assign(hookState(), { state: 'passed', end: '2018-05-14T15:17:21.631Z', _duration: 2730 })
+}
+
+export function hookFailed() {
+    const error =
+    {
+        message: 'element ("body") still existing after 100ms',
+        stack: 'Error: element ("body") still existing after 100ms',
+        type: 'Error',
+    }
+    return Object.assign(hookState(), { error, errors: [error], state: 'failed', end: '2018-05-14T15:17:21.631Z', _duration: 2730 })
+}


### PR DESCRIPTION
## Proposed changes

Add a screenshot to "before all" / "after all"  hooks on failure.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works

## Further comments

not sure if it's a bug fix or not but for me it looks like a bug because failures in beforeEach and afterEach hooks are attached to the report.

Steps to reproduce:
1. add `disableMochaHooks: true,` to allure reporter config
2. trigger failure in before all / after all hook, ex:
```
  before('open login page', () => {
    $('body').waitForExist({ reverse: true, timeout: 100 })
  })
```

### Reviewers: @webdriverio/project-committers
