### PR TITLE
allure-reporter: mime type types

### DIFF
--- a/packages/wdio-allure-reporter/src/index.js
+++ b/packages/wdio-allure-reporter/src/index.js
@@ -529,11 +529,14 @@ class AllureReporter extends WDIOReporter {
     /**
      * Add attachment
      * @name addAttachment
-     * @param {string} name - attachment file name
-     * @param {string | Buffer} content - attachment content
-     * @param {string} [type='text/plain'] - attachment mime type
+     * @param {string} name         - attachment file name
+     * @param {*} content           - attachment content
+     * @param {string=} mimeType    - attachment mime type
      */
-    static addAttachment = (name, content, type = 'text/plain') => {
+    static addAttachment = (name, content, type = 'application/json') => {
+        if (typeof content === 'string' || Buffer.isBuffer(content)) {
+            type = 'text/plain'
+        }
         tellReporter(events.addAttachment, { name, content, type })
     }
 
@@ -549,7 +552,7 @@ class AllureReporter extends WDIOReporter {
     /**
      * End current allure step
      * @name endStep
-     * @param {string} [status='passed'] - step status
+     * @param {StepStatus} [status='passed'] - step status
      */
     static endStep = (status = stepStatuses.PASSED) => {
         if (!Object.values(stepStatuses).includes(status)) {

--- a/packages/wdio-allure-reporter/tests/runtime.test.js
+++ b/packages/wdio-allure-reporter/tests/runtime.test.js
@@ -59,15 +59,21 @@ describe('reporter reporter api', () => {
     })
 
     it('should pass correct data from addAttachment', () => {
-        reporter.addAttachment('foo', 'bar', 'baz')
+        reporter.addAttachment('foo', 123, 'baz')
         expect(utils.tellReporter).toHaveBeenCalledTimes(1)
-        expect(utils.tellReporter).toHaveBeenCalledWith(events.addAttachment, { name: 'foo', content: 'bar', type: 'baz' })
+        expect(utils.tellReporter).toHaveBeenCalledWith(events.addAttachment, { name: 'foo', content: 123, type: 'baz' })
     })
 
-    it('should support default type from addAttachment', () => {
+    it('should support default string type from addAttachment', () => {
         reporter.addAttachment('foo', 'bar')
         expect(utils.tellReporter).toHaveBeenCalledTimes(1)
         expect(utils.tellReporter).toHaveBeenCalledWith(events.addAttachment, { name: 'foo', content: 'bar', type: 'text/plain' })
+    })
+
+    it('should support default json type from addAttachment', () => {
+        reporter.addAttachment('foo', { foo: 'bar' })
+        expect(utils.tellReporter).toHaveBeenCalledTimes(1)
+        expect(utils.tellReporter).toHaveBeenCalledWith(events.addAttachment, { name: 'foo', content: { foo: 'bar' }, type: 'application/json' })
     })
 
     it('should pass correct data from addStep', () => {

--- a/scripts/templates/allure-reporter.tpl.d.ts
+++ b/scripts/templates/allure-reporter.tpl.d.ts
@@ -1,5 +1,7 @@
 
 declare namespace AllureReporter {
+    type StepStatus = 'passed' | 'failed' | 'broken' | 'canceled' | 'skipped'
+
     // ... AllureReporter commands ...
 }
 

--- a/scripts/type-generation/constants.js
+++ b/scripts/type-generation/constants.js
@@ -4,7 +4,7 @@ const CUSTOM_INTERFACES = [
     'ElementArray', 'ClickOptions', 'WaitUntilOptions', 'Cookie', 'Timeouts',
     'CSSProperty', 'TouchActions', 'Matcher', 'WebDriver.Cookie', 'DragAndDropCoordinate',
     'ErrorCode', 'MockResponseParams', 'Mock', 'MockFilterOptions', 'MockOverwrite',
-    'ThrottleOptions', 'PuppeteerBrowser', 'AddValueOptions'
+    'ThrottleOptions', 'PuppeteerBrowser', 'AddValueOptions', 'StepStatus'
 ]
 
 module.exports = {


### PR DESCRIPTION
## Proposed changes

- better handle attachment type in `addAttachment`
- fix `content` type
- add `StepStatus` type for `endStep`

## Types of changes

- [x] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

### Reviewers: @webdriverio/project-committers
