### PR TITLE
Enable multiremote screenshot capturing for wdio-allure-reporter

### DIFF
--- a/packages/wdio-allure-reporter/src/index.js
+++ b/packages/wdio-allure-reporter/src/index.js
@@ -209,10 +209,6 @@ class AllureReporter extends WDIOReporter {
     }
 
     onAfterCommand(command) {
-        if (this.isMultiremote) {
-            return
-        }
-
         const { disableWebdriverStepsReporting, disableWebdriverScreenshotsReporting, useCucumberStepReporter } = this.options
         if (this.isScreenshotCommand(command) && command.result.value) {
             if (!disableWebdriverScreenshotsReporting) {
@@ -225,6 +221,10 @@ class AllureReporter extends WDIOReporter {
         }
 
         this.attachScreenshot()
+
+        if (this.isMultiremote) {
+            return
+        }
 
         if (!disableWebdriverStepsReporting && !useCucumberStepReporter) {
             if (command.result && command.result.value && !this.isScreenshotCommand(command)) {


### PR DESCRIPTION
## Proposed changes
Enable mutliremote screenshot attachment in `wdio-allure-reporter` ( fixes #5991 )

## Types of changes
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
- [X] I have added proper type definitions for new commands (if appropriate)

## Further comments

Screenshot name might duplicates. Currently there's no way to detect which command belongs to which browser because sessionId is undefined in case of multiremote

### Reviewers: @webdriverio/project-committers
