### PR TITLE
@wdio/cli should log the entire stack trace if available

### DIFF
--- a/packages/wdio-cli/src/interface.js
+++ b/packages/wdio-cli/src/interface.js
@@ -102,12 +102,14 @@ export default class WDIOCLInterface extends EventEmitter {
     }
 
     onTestError(payload) {
-        let error = { type: 'Error', message: typeof payload.error === 'string' ? payload.error : 'Unknown error.' }
+        let error = { type: 'Error', message: typeof payload.error === 'string' ? payload.error : 'Unknown error.', stack: null }
         if (payload.error) {
             error.type = payload.error.type || error.type
             error.message = payload.error.message || error.message
+            error.stack = payload.error.stack || error.stack
         }
-        return this.log(`[${payload.cid}]`, `${chalk.red(error.type)} in "${payload.fullTitle}"\n${chalk.red(error.message)}`)
+
+        return this.log(`[${payload.cid}]`, `${chalk.red(error.type)} in "${payload.fullTitle}"\n${chalk.red(error.stack || error.message)}`)
     }
 
     getFilenames(specs = []) {

--- a/packages/wdio-cli/tests/interface.test.js
+++ b/packages/wdio-cli/tests/interface.test.js
@@ -426,6 +426,23 @@ describe('cli interface', () => {
             expect(result[1]).toContain('FULL_TITLE')
         })
 
+        it('error with stack trace', () => {
+            const result = wdioClInterface.onTestError({
+                cid: 'CID',
+                fullTitle: 'FULL_TITLE',
+                error: {
+                    type: 'ERROR_TYPE',
+                    message: 'ERROR_MESSAGE',
+                    stack: 'ERROR_STACK',
+                },
+            })
+
+            expect(result[0]).toContain('CID')
+            expect(result[1]).toContain('ERROR_TYPE')
+            expect(result[1]).toContain('ERROR_STACK')
+            expect(result[1]).toContain('FULL_TITLE')
+        })
+
         it('no error', () => {
             const result = wdioClInterface.onTestError({
                 cid: 'CID',


### PR DESCRIPTION
## Proposed changes
`@wdio/cli` logs the execution of every test suite and logs when a test fails. When it does fail with an error, it only logs the message. For example:

```
[0-0] TypeError in "Bla bla my test"
TypeError: Cannot read property 'test' of undefined
```

This does not tell the user where the error came from. This change logs the stack trace if available, thus changing the output to be more like this:

```
[0-0] TypeError in "Bla bla my test"
TypeError: Cannot read property 'test' of undefined
    at Function.selectValueFromFilter (/Users/swen/Code/somerepo/frontend/e2e/test/desktopPages/pages/filters.js:136:27)
    at Context.<anonymous> (/Users/swen/Code/somerepo/frontend/e2e/test/specs/project/filters/search_page/verifySomething.desktop.test.js:34:17)
    at Context.sync (/Users/swen/Code/project/frontend/node_modules/mocha-steps/lib/step.js:29:24)
```

If no stack trace is available, it'll still just log the error's message.

## Types of changes
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments
An alternative solution is for users to add a custom reporter that only logs stack traces:

```
class ErrorReporter extends WDIOReporter {
    onTestFail(test) {
        if (test.error.stack) {
            console.error(test.error.stack);
        }
    }
}
```

Unfortunately, this results in the message being printed twice because there is no way to turn off the behaviour in `@wdi/cli`:

```
[0-0] TypeError in "Bla bla my test"
TypeError: Cannot read property 'test' of undefined
[0-0] TypeError: Cannot read property 'test' of undefined
    at Function.selectValueFromFilter (/Users/swen/Code/somerepo/frontend/e2e/test/desktopPages/pages/filters.js:136:27)
    at Context.<anonymous> (/Users/swen/Code/somerepo/frontend/e2e/test/specs/project/filters/search_page/verifySomething.desktop.test.js:34:17)
    at Context.sync (/Users/swen/Code/project/frontend/node_modules/mocha-steps/lib/step.js:29:24)
```