### PR TITLE
Do not disable webdriver steps reporting when using cucumber step reporter

### DIFF
--- a/packages/wdio-allure-reporter/src/index.js
+++ b/packages/wdio-allure-reporter/src/index.js
@@ -193,7 +193,9 @@ class AllureReporter extends WDIOReporter {
             return
         }
 
-        if (this.options.disableWebdriverStepsReporting || this.options.useCucumberStepReporter || this.isMultiremote) {
+        const { disableWebdriverStepsReporting } = this.options
+
+        if (disableWebdriverStepsReporting || this.isMultiremote) {
             return
         }
 
@@ -209,7 +211,7 @@ class AllureReporter extends WDIOReporter {
     }
 
     onAfterCommand(command) {
-        const { disableWebdriverStepsReporting, disableWebdriverScreenshotsReporting, useCucumberStepReporter } = this.options
+        const { disableWebdriverStepsReporting, disableWebdriverScreenshotsReporting } = this.options
         if (this.isScreenshotCommand(command) && command.result.value) {
             if (!disableWebdriverScreenshotsReporting) {
                 this.lastScreenshot = command.result.value
@@ -226,7 +228,7 @@ class AllureReporter extends WDIOReporter {
             return
         }
 
-        if (!disableWebdriverStepsReporting && !useCucumberStepReporter) {
+        if (!disableWebdriverStepsReporting) {
             if (command.result && command.result.value && !this.isScreenshotCommand(command)) {
                 this.dumpJSON('Response', command.result.value)
             }

--- a/packages/wdio-allure-reporter/tests/cucumber.suite.test.js
+++ b/packages/wdio-allure-reporter/tests/cucumber.suite.test.js
@@ -25,6 +25,87 @@ afterAll(() => {
 
 describe('reporter option "useCucumberStepReporter" set to true', () => {
 
+    describe('reporter option "disableWebdriverStepsReporting" set to true', () => {
+        describe('Passing tests', () => {
+            const outputDir = directory()
+            let allureXml
+
+            beforeAll(() => {
+                const reporter = new AllureReporter({ stdout: true, outputDir, useCucumberStepReporter: true, disableWebdriverStepsReporting: true })
+
+                reporter.onRunnerStart(runnerStart())
+                reporter.onSuiteStart(cucumberHelper.featureStart())
+                reporter.onSuiteStart(cucumberHelper.scenarioStart())
+                reporter.onHookStart(cucumberHelper.hookStart())
+                reporter.onHookEnd(cucumberHelper.hookEnd())
+                reporter.onTestStart(cucumberHelper.testStart())
+                reporter.onBeforeCommand(commandStart())
+                reporter.onAfterCommand(commandEnd())
+                reporter.onTestPass(cucumberHelper.testPass())
+                reporter.onHookStart(cucumberHelper.hookStart())
+                reporter.addAttachment(attachmentHelper.xmlAttachment())
+                reporter.onHookEnd(cucumberHelper.hookEnd())
+                const suiteResults = { tests: [cucumberHelper.testPass()], hooks: new Array(2).fill(cucumberHelper.hookEnd()) }
+                reporter.onSuiteEnd(cucumberHelper.scenarioEnd(suiteResults))
+                reporter.onSuiteEnd(cucumberHelper.featureEnd(suiteResults))
+                reporter.onRunnerEnd(runnerEnd())
+
+                const results = getResults(outputDir)
+                expect(results).toHaveLength(2) // one for report, one for attachment
+                allureXml = results.find(xml => xml('ns2\\:test-suite').length >= 1)
+            })
+
+            afterAll(() => {
+                clean(outputDir)
+            })
+
+            it('should report one suite', () => {
+                expect(allureXml('ns2\\:test-suite > name').text()).toEqual('MyFeature')
+                expect(allureXml('ns2\\:test-suite > title').text()).toEqual('MyFeature')
+            })
+
+            it('should detect passed test case', () => {
+                expect(allureXml('test-case > name').text()).toEqual('MyScenario')
+                expect(allureXml('test-case').attr('status')).toEqual('passed')
+            })
+
+            it('should not report passing hook', () => {
+                expect(allureXml('step > name').eq(0).text()).not.toContain('Hook')
+                expect(allureXml('step > title').eq(0).text()).not.toContain('Hook')
+            })
+
+            it('should report one passing step', () => {
+                expect(allureXml('step > name').eq(0).text()).toEqual('I do something')
+                expect(allureXml('step > title').eq(0).text()).toEqual('I do something')
+                expect(allureXml('step').eq(0).attr('status')).toEqual('passed')
+                expect(allureXml('step').length).toEqual(1)
+            })
+
+            it('should detect analytics labels in test case', () => {
+                expect(allureXml('test-case label[name="language"]').eq(0).attr('value')).toEqual('javascript')
+                expect(allureXml('test-case label[name="framework"]').eq(0).attr('value')).toEqual('wdio')
+            })
+
+            it('should add browser name as test argument', () => {
+                expect(allureXml('test-case parameter[kind="argument"]')).toHaveLength(1)
+                expect(allureXml('test-case parameter[name="browser"]').eq(0).attr('value')).toEqual('chrome-68')
+            })
+
+            it('should detect tags labels on top in test case', () => {
+                expect(allureXml('test-case label[name="severity"]').eq(0).attr('value')).toEqual('critical')
+            })
+
+            it('should detect description on top in test case', () => {
+                expect(allureXml('test-case > description').eq(0).text()).toEqual('My scenario description')
+                expect(allureXml('test-case description[type="text"]')).toHaveLength(1)
+            })
+
+            it('should move attachments from successfull hook to test-case', () => {
+                expect(allureXml('test-case > attachments > attachment').length).toEqual(1)
+            })
+        })
+    })
+
     describe('Passing tests', () => {
         const outputDir = directory()
         let allureXml
@@ -73,11 +154,24 @@ describe('reporter option "useCucumberStepReporter" set to true', () => {
             expect(allureXml('step > title').eq(0).text()).not.toContain('Hook')
         })
 
-        it('should report one passing step', () => {
-            expect(allureXml('step > name').eq(0).text()).toEqual('I do something')
-            expect(allureXml('step > title').eq(0).text()).toEqual('I do something')
-            expect(allureXml('step').eq(0).attr('status')).toEqual('passed')
-            expect(allureXml('step').length).toEqual(1)
+        describe('steps', () => {
+            it('should report two passing steps', () => {
+                expect(allureXml('step').length).toEqual(2)
+            })
+
+            it('should report one passing step for test', () => {
+                expect(allureXml('step > name').eq(0).text()).toEqual('I do something')
+                expect(allureXml('step > title').eq(0).text()).toEqual('I do something')
+                expect(allureXml('step').eq(0).attr('status')).toEqual('passed')
+                expect(allureXml('step').length).toEqual(2)
+            })
+
+            it('should add step from command', () => {
+                expect(allureXml('step > name').eq(1).text()).toEqual('GET /session/:sessionId/element')
+                expect(allureXml('step > title').eq(1).text()).toEqual('GET /session/:sessionId/element')
+                expect(allureXml('test-case attachment[title="Response"]')).toHaveLength(1)
+                expect(allureXml('step').eq(1).attr('status')).toEqual('passed')
+            })
         })
 
         it('should detect analytics labels in test case', () => {


### PR DESCRIPTION
## Proposed changes

Resolves #6048

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

I have marked this as a breaking change as it will affect existing users that have `useCucumberStepReporter` turned on. If they want to preserve the existing behaviour then would need to also enable `disableWebdriverStepsReporting`

### Reviewers: @webdriverio/project-committers
