### PR TITLE
Add support for element screenshots to Allure reporter

### DIFF
--- a/packages/wdio-allure-reporter/src/index.js
+++ b/packages/wdio-allure-reporter/src/index.js
@@ -432,7 +432,7 @@ class AllureReporter extends WDIOReporter {
     }
 
     isScreenshotCommand(command) {
-        const isScrenshotEndpoint = /\/session\/[^/]*\/screenshot/
+        const isScrenshotEndpoint = /\/session\/[^/]*(\/element\/[^/]*)?\/screenshot/
         return (
             // WebDriver protocol
             isScrenshotEndpoint.test(command.endpoint) ||

--- a/packages/wdio-allure-reporter/tests/allureFeatures.test.js
+++ b/packages/wdio-allure-reporter/tests/allureFeatures.test.js
@@ -371,6 +371,7 @@ describe('auxiliary methods', () => {
         expect(reporter.isScreenshotCommand({ endpoint: '/session/id/click' })).toEqual(false)
         expect(reporter.isScreenshotCommand({ command: 'takeScreenshot' })).toEqual(true)
         expect(reporter.isScreenshotCommand({ command: 'elementClick' })).toEqual(false)
+        expect(reporter.isScreenshotCommand({ endpoint: '/session/id/element/id/screenshot' })).toEqual(true)
     })
 
     it('dumpJSON', () => {


### PR DESCRIPTION
## Proposed changes

Allure has a feature to attach captured screenshots to the steps of the report. This only works for full-screen shots. This PR adds support for element screenshots.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

This adds screenshot command detection based off https://www.w3.org/TR/webdriver/#take-element-screenshot

### Reviewers: @webdriverio/project-committers
