### PR TITLE
allure-reporter: fix mime type

### DIFF
--- a/packages/wdio-allure-reporter/src/index.js
+++ b/packages/wdio-allure-reporter/src/index.js
@@ -444,7 +444,8 @@ class AllureReporter extends WDIOReporter {
     }
 
     dumpJSON(name, json) {
-        this.allure.addAttachment(name, JSON.stringify(json, null, 2), 'application/json')
+        const content = JSON.stringify(json, null, 2)
+        this.allure.addAttachment(name, typeof content === 'string' ? content : `${content}`, 'application/json')
     }
 
     attachScreenshot() {
@@ -535,9 +536,9 @@ class AllureReporter extends WDIOReporter {
      * @param {*} content           - attachment content
      * @param {string=} mimeType    - attachment mime type
      */
-    static addAttachment = (name, content, type = 'application/json') => {
-        if (typeof content === 'string' || Buffer.isBuffer(content)) {
-            type = 'text/plain'
+    static addAttachment = (name, content, type) => {
+        if (!type) {
+            type = content instanceof Buffer ? 'image/png' : typeof content === 'string' ? 'text/plain' : 'application/json'
         }
         tellReporter(events.addAttachment, { name, content, type })
     }

--- a/packages/wdio-allure-reporter/src/index.js
+++ b/packages/wdio-allure-reporter/src/index.js
@@ -445,7 +445,8 @@ class AllureReporter extends WDIOReporter {
 
     dumpJSON(name, json) {
         const content = JSON.stringify(json, null, 2)
-        this.allure.addAttachment(name, typeof content === 'string' ? content : `${content}`, 'application/json')
+        const isStr = typeof content === 'string'
+        this.allure.addAttachment(name, isStr ? content : `${content}`, isStr ? 'application/json' : 'text/plain')
     }
 
     attachScreenshot() {

--- a/packages/wdio-allure-reporter/tests/runtime.test.js
+++ b/packages/wdio-allure-reporter/tests/runtime.test.js
@@ -173,7 +173,7 @@ describe('dumpJSON', () => {
 
     it('undefined value', () => {
         reporterInstance.dumpJSON('barfoo', undefined)
-        expect(reporterInstance.allure.addAttachment).toBeCalledWith('barfoo', 'undefined', 'application/json')
+        expect(reporterInstance.allure.addAttachment).toBeCalledWith('barfoo', 'undefined', 'text/plain')
     })
 })
 


### PR DESCRIPTION
## Proposed changes

fix #6053

- allows user to override the default types
- assume a Buffer is an image unless the type is explicitly provided
- added tests to cover all the scenarios

works like this: `AllureReporter.addAttachment('scr', Buffer.from(browser.takeScreenshot(), 'base64'))`

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works

## Further comments

### Reviewers: @webdriverio/project-committers
