### PR TITLE
browser.mock use utf8 by default

### DIFF
--- a/packages/wdio-sync/webdriverio-core.d.ts
+++ b/packages/wdio-sync/webdriverio-core.d.ts
@@ -544,7 +544,7 @@ declare namespace WebdriverIO {
         /**
          * body response of actual resource
          */
-        body: string | JsonCompatible
+        body: string | Buffer | JsonCompatible
         /**
          * HTTP response headers.
          */

--- a/packages/webdriverio/tests/utils/interception/devtools.test.js
+++ b/packages/webdriverio/tests/utils/interception/devtools.test.js
@@ -357,12 +357,12 @@ describe('stub request', () => {
     })
 
     test('with a missing file', async () => {
-        const fileContent = (await fse.readFile(__filename)).toString('base64')
-        mock.respond(__filename)
+        const filepath = __filename + '/missing/mock-file.txt'
+        mock.respond(filepath)
         await fetchListenerWrapper()
 
         const response = cdpClient.send.mock.calls.pop()[1]
-        expect(response.body).toEqual(fileContent)
+        expect(response.body).toEqual(Buffer.from(filepath, 'binary').toString('base64'))
     })
 
     test('utf8 chars', async () => {

--- a/packages/webdriverio/tests/utils/interception/devtools.test.js
+++ b/packages/webdriverio/tests/utils/interception/devtools.test.js
@@ -356,7 +356,7 @@ describe('stub request', () => {
         expect(response.body).toEqual(fileContent)
     })
 
-    test('utf8 chars', async () => {
+    test('with a missing file', async () => {
         const fileContent = (await fse.readFile(__filename)).toString('base64')
         mock.respond(__filename)
         await fetchListenerWrapper()
@@ -365,7 +365,7 @@ describe('stub request', () => {
         expect(response.body).toEqual(fileContent)
     })
 
-    test('with a missing file', async () => {
+    test('utf8 chars', async () => {
         const inputStr = 'Coöperatief'
         mock.respond(inputStr)
         await fetchListenerWrapper()

--- a/packages/webdriverio/tests/utils/interception/devtools.test.js
+++ b/packages/webdriverio/tests/utils/interception/devtools.test.js
@@ -356,13 +356,22 @@ describe('stub request', () => {
         expect(response.body).toEqual(fileContent)
     })
 
-    test('with a missing file', async () => {
-        const filepath = __filename + '/missing/mock-file.txt'
-        mock.respond(filepath)
+    test('utf8 chars', async () => {
+        const fileContent = (await fse.readFile(__filename)).toString('base64')
+        mock.respond(__filename)
         await fetchListenerWrapper()
 
         const response = cdpClient.send.mock.calls.pop()[1]
-        expect(response.body).toEqual(Buffer.from(filepath, 'binary').toString('base64'))
+        expect(response.body).toEqual(fileContent)
+    })
+
+    test('with a missing file', async () => {
+        const inputStr = 'Coöperatief'
+        mock.respond(inputStr)
+        await fetchListenerWrapper()
+
+        const response = cdpClient.send.mock.calls.pop()[1]
+        expect(Buffer.from(response.body, 'base64').toString()).toEqual(inputStr)
     })
 
     test('with a different web resource', async () => {

--- a/packages/webdriverio/webdriverio-core.d.ts
+++ b/packages/webdriverio/webdriverio-core.d.ts
@@ -544,7 +544,7 @@ declare namespace WebdriverIO {
         /**
          * body response of actual resource
          */
-        body: string | JsonCompatible
+        body: string | Buffer | JsonCompatible
         /**
          * HTTP response headers.
          */

--- a/scripts/templates/webdriverio.tpl.d.ts
+++ b/scripts/templates/webdriverio.tpl.d.ts
@@ -538,7 +538,7 @@ declare namespace WebdriverIO {
         /**
          * body response of actual resource
          */
-        body: string | JsonCompatible
+        body: string | Buffer | JsonCompatible
         /**
          * HTTP response headers.
          */


### PR DESCRIPTION
## Proposed changes

Defect: Chars like `ö` in the mocked body are converted to `�`.

let's use utf8 encoding by default and do not convert file buffer to string and back.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

### Reviewers: @webdriverio/project-committers
