### PR TITLE
fix: Sauce EmuSim can't work with sauce:options for Sauce Connect

### DIFF
--- a/packages/wdio-sauce-service/src/utils.js
+++ b/packages/wdio-sauce-service/src/utils.js
@@ -40,8 +40,19 @@ import { isW3C } from '@wdio/utils'
  * }
  */
 export function isUnifiedPlatform({ deviceName = '', platformName = '' }){
-    // If the string contains `simulator` or `emulator` it's a EMU/SIM session
+    // If the string contains `simulator` or `emulator` it's an EMU/SIM session
     return !deviceName.match(/(simulator)|(emulator)/gi) && !!platformName.match(/(ios)|(android)/gi)
+}
+
+/**
+ * Determine if this is an EMUSIM session
+ * @param {string} deviceName
+ * @param {string} platformName
+ * @returns {boolean}
+ */
+export function isEmuSim({ deviceName = '', platformName = '' }){
+    // If the string contains `simulator` or `emulator` it's an EMU/SIM session
+    return !!deviceName.match(/(simulator)|(emulator)/gi) && !!platformName.match(/(ios)|(android)/gi)
 }
 
 /** Ensure capabilities are in the correct format for Sauce Labs
@@ -59,21 +70,21 @@ export function makeCapabilityFactory(tunnelIdentifier, options) {
             !capability['sauce:options']
         )
 
-        // Unified Platform is currently not W3C ready, so the tunnel needs to be on the cap level
-        if (!capability['sauce:options'] && !isLegacy && !isUnifiedPlatform(capability)) {
+        // Unified Platform and EMUSIM is currently not W3C ready, so the tunnel needs to be on the cap level
+        if (!capability['sauce:options'] && !isLegacy && !isUnifiedPlatform(capability) && !isEmuSim(capability)) {
             capability['sauce:options'] = {}
         }
 
         Object.assign(capability, options)
 
-        const sauceOptions = !isLegacy && !isUnifiedPlatform(capability) ? capability['sauce:options'] : capability
+        const sauceOptions = !isLegacy && !isUnifiedPlatform(capability) && !isEmuSim(capability) ? capability['sauce:options'] : capability
         sauceOptions.tunnelIdentifier = (
             capability.tunnelIdentifier ||
             sauceOptions.tunnelIdentifier ||
             tunnelIdentifier
         )
 
-        if (!isLegacy && !isUnifiedPlatform(capability)) {
+        if (!isLegacy && !isUnifiedPlatform(capability) && !isEmuSim(capability)) {
             delete capability.tunnelIdentifier
         }
     }

--- a/packages/wdio-sauce-service/tests/launcher.test.js
+++ b/packages/wdio-sauce-service/tests/launcher.test.js
@@ -389,6 +389,13 @@ test('onPrepare with tunnel identifier and without w3c caps ', async () => {
     }, {
         deviceName: 'iPhone',
         platformName: 'iOS',
+    }, {
+        deviceName: 'iPhone Simulator',
+        platformName: 'iOS',
+        tunnelIdentifier: 'foo-bar'
+    }, {
+        deviceName: 'iPhone Simulator',
+        platformName: 'iOS',
     }]
     const config = {
         user: 'foobaruser',
@@ -424,6 +431,20 @@ test('onPrepare with tunnel identifier and without w3c caps ', async () => {
         hostname: 'localhost',
         port: 4446,
         deviceName: 'iPhone',
+        platformName: 'iOS',
+        tunnelIdentifier: 'my-tunnel'
+    }, {
+        protocol: 'http',
+        hostname: 'localhost',
+        port: 4446,
+        deviceName: 'iPhone Simulator',
+        platformName: 'iOS',
+        tunnelIdentifier: 'foo-bar'
+    }, {
+        protocol: 'http',
+        hostname: 'localhost',
+        port: 4446,
+        deviceName: 'iPhone Simulator',
         platformName: 'iOS',
         tunnelIdentifier: 'my-tunnel'
     }])

--- a/packages/wdio-sauce-service/tests/utils.test.js
+++ b/packages/wdio-sauce-service/tests/utils.test.js
@@ -1,4 +1,4 @@
-import { isUnifiedPlatform } from '../src/utils'
+import { isEmuSim, isUnifiedPlatform } from '../src/utils'
 
 test('isUnifiedPlatform should be false for no provided deviceName and platformName', () => {
     expect(isUnifiedPlatform({})).toEqual(false)
@@ -26,4 +26,32 @@ test('isUnifiedPlatform should be true for a real device iOS test', () => {
 
 test('isUnifiedPlatform should be true for real device Android test', () => {
     expect(isUnifiedPlatform({ deviceName: 'Google Pixel', platformName: 'Android' })).toEqual(true)
+})
+
+test('isEmuSim should be false for no provided deviceName and platformName', () => {
+    expect(isEmuSim({})).toEqual(false)
+})
+
+test('isEmuSim should be false for a non matching deviceName', () => {
+    expect(isEmuSim({ deviceName: 'foo' })).toEqual(false)
+})
+
+test('isEmuSim should be false for a non matching platformName', () => {
+    expect(isEmuSim({ platformName: 'foo' })).toEqual(false)
+})
+
+test('isEmuSim should be true for an emulator test', () => {
+    expect(isEmuSim({ deviceName: 'Google Pixel emulator', platformName: 'Android' })).toEqual(true)
+})
+
+test('isEmuSim should be true for a simulator test', () => {
+    expect(isEmuSim({ deviceName: 'iPhone XS simulator', platformName: 'iOS' })).toEqual(true)
+})
+
+test('isEmuSim should be false for a real device iOS test', () => {
+    expect(isEmuSim({ deviceName: 'iPhone XS', platformName: 'iOS' })).toEqual(false)
+})
+
+test('isEmuSim should be false for real device Android test', () => {
+    expect(isEmuSim({ deviceName: 'Google Pixel', platformName: 'Android' })).toEqual(false)
 })


### PR DESCRIPTION
## Proposed changes
Sauce Labs Emulators/Simulators currently can't work with `sauce:options`, especially if the automatically started tunnel from this service wants to add the `tunnelIdentifier` to the capabilities.
This fix will put the `tunnelIdentifier` on the caps level instead of the `sauce:options` level so the tunnel can be used.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)
