### PR TITLE
Tracking doc: rewrite `@wdio/cucumber-framework` package into TypeScript

### DIFF
--- a/packages/wdio-cucumber-framework/package.json
+++ b/packages/wdio-cucumber-framework/package.json
@@ -22,6 +22,9 @@
     "url": "https://github.com/webdriverio/webdriverio/issues"
   },
   "dependencies": {
+    "@cucumber/cucumber": "^7.0.0-rc.0",
+    "@types/is-glob": "^4.0.1",
+    "@types/mockery": "^1.4.29",
     "@wdio/logger": "6.7.3",
     "@wdio/utils": "6.7.3",
     "cucumber": "^6.0.5",

--- a/packages/wdio-cucumber-framework/src/constants.ts
+++ b/packages/wdio-cucumber-framework/src/constants.ts
@@ -1,6 +1,8 @@
+import type { CucumberOpts } from './types'
+
 export const DEFAULT_TIMEOUT = 60000
 
-export const DEFAULT_OPTS = {
+export const DEFAULT_OPTS: CucumberOpts = {
     backtrace: false, // <boolean> show full backtrace for errors
     requireModule: [], // <string[]> ("module") require MODULE files (repeatable)
     failAmbiguousDefinitions: false, // <boolean> treat ambiguous definitions as errors
@@ -9,7 +11,7 @@ export const DEFAULT_OPTS = {
     name: [], // <REGEXP[]> only execute the scenarios with name matching the expression (repeatable)
     profile: [], // <string> (name) specify the profile to use
     require: [], // <string> (file/dir/glob) require files before executing features
-    order: 'defined', // <string> switch between deterministic  and random feature execution. Either "defined", "random" or "random:42" whereas 42 is the seed for randomization
+    order: 'defined', // <string> switch between deterministic and random feature execution. Either "defined", "random" or "random:42" whereas 42 is the seed for randomization
     snippetSyntax: undefined, // <string> specify a custom snippet syntax
     snippets: true, // <boolean> hide step definition snippets for pending steps
     source: true, // <boolean> hide source uris

--- a/packages/wdio-cucumber-framework/src/cucumberEventListener.ts
+++ b/packages/wdio-cucumber-framework/src/cucumberEventListener.ts
@@ -10,7 +10,7 @@ export default class CucumberEventListener extends EventEmitter {
     currentSteps = null
     testCasePreparedEvents = []
 
-    constructor (eventBroadcaster) {
+    constructor (eventBroadcaster: any) {
         super()
         eventBroadcaster
             .on('gherkin-document', this.onGherkinDocument.bind(this))

--- a/packages/wdio-cucumber-framework/src/types.ts
+++ b/packages/wdio-cucumber-framework/src/types.ts
@@ -1,0 +1,96 @@
+export interface CucumberOpts {
+    /**
+     * Show full backtrace for errors.
+     * @default true
+     */
+    backtrace?: boolean
+    /**
+     * Require modules prior to requiring any support files.
+     * @default []
+     * @example `['@babel/register']` or `[['@babel/register', { rootMode: 'upward', ignore: ['node_modules'] }]] or [() => { require('ts-node').register({ files: true }) }]`
+     */
+    requireModule?: string[]
+    /**
+     * Treat ambiguous definitions as errors.
+     *
+     * Please note that this is a @wdio/cucumber-framework specific option
+     * and not recognized by cucumber-js itself.
+     * @default false
+     */
+    failAmbiguousDefinitions?: boolean
+    /**
+     * Abort the run on first failure.
+     * @default false
+     */
+    failFast?: boolean
+    /**
+     * Treat undefined definitions as warnings.
+     * Please note that this is a @wdio/cucumber-framework specific option and
+     * not recognized by cucumber-js itself.
+     * @default false
+     */
+    ignoreUndefinedDefinitions?: boolean
+    /**
+     * Only execute the scenarios with name matching the expression (repeatable).
+     * @default []
+     */
+    name?: string[]
+    /**
+     * Specify the profile to use.
+     * @default []
+     */
+    profile?: string[]
+    /**
+     * Require files containing your step definitions before executing features.
+     * You can also specify a glob to your step definitions.
+     * @default []
+     * @example `[path.join(__dirname, 'step-definitions', 'my-steps.js')]`
+     */
+    require?: string[]
+    /**
+     * Specify a custom snippet syntax.
+     */
+    snippetSyntax?: string
+    /**
+     * Hide step definition snippets for pending steps.
+     * @default true
+     */
+    snippets?: boolean
+    /**
+     * Hide source uris.
+     * @default true
+     */
+    source?: boolean
+    /**
+     * Fail if there are any undefined or pending steps
+     * @default false
+     */
+    strict?: boolean
+    /**
+     * Only execute the features or scenarios with tags matching the expression.
+     * Please see the [Cucumber documentation](https://docs.cucumber.io/cucumber/api/#tag-expressions) for more details.
+     */
+    tagExpression?: string
+    /**
+     * Add cucumber tags to feature or scenario name
+     * @default false
+     */
+    tagsInTitle?: boolean;
+    /**
+     * Timeout in milliseconds for step definitions.
+     * @default 30000
+     */
+    timeout?: number;
+    /**
+     * Enable this to make webdriver.io behave as if scenarios
+     * and not steps were the tests.
+     * @default false
+     */
+    scenarioLevelReporter?: boolean
+    /**
+     * switch between deterministic and random feature execution. Either "defined", "random" or
+     * "random:42" whereas 42 is the seed for randomization
+     * @default "defined"
+     */
+    order?: 'defined' | 'random' | string
+}

--- a/packages/wdio-cucumber-framework/src/utils.ts
+++ b/packages/wdio-cucumber-framework/src/utils.ts
@@ -2,10 +2,45 @@ import * as path from 'path'
 import { isFunctionAsync } from '@wdio/utils'
 import { CUCUMBER_HOOK_DEFINITION_TYPES } from './constants'
 
+interface Step {
+    type: string
+    content: string
+    name: string
+    text: string
+    location: SourceLocation
+    examples: {
+        tableHeader: {
+            cells: Cell[]
+        }
+        tableBody: Cell[]
+    }[]
+    rows: {
+        cells: Cell[]
+    }[]
+}
+
+interface Cell {
+    value: string
+    location: SourceLocation
+}
+
+interface SourceLocation {
+    uri: string
+    line: number
+}
+
+interface Feature {
+    name: string
+}
+
+interface Scenario {
+    name: string
+}
+
 /**
  * NOTE: this function is exported for testing only
  */
-export function createStepArgument ({ argument }) {
+export function createStepArgument ({ argument }: { argument: Step }) {
     if (!argument) {
         return undefined
     }
@@ -34,7 +69,7 @@ export function createStepArgument ({ argument }) {
  * @param {object} feature cucumber feature object
  * @param {object} scenario cucumber scenario object
  */
-export function getTestParent(feature, scenario) {
+export function getTestParent(feature: Feature, scenario: Scenario) {
     return `${feature.name || 'Undefined Feature'}: ${scenario.name || 'Undefined Scenario'}`
 }
 
@@ -42,7 +77,7 @@ export function getTestParent(feature, scenario) {
  * builds test title from step keyword and text
  * @param {object} step cucumber step object
  */
-export function getTestStepTitle (keyword = '', text = '', type) {
+export function getTestStepTitle (keyword = '', text = '', type: string) {
     const title = (!text && type !== 'hook') ? 'Undefined Step' : text
     return `${keyword.trim()} ${title.trim()}`.trim()
 }
@@ -53,11 +88,11 @@ export function getTestStepTitle (keyword = '', text = '', type) {
  * @param {string} parent parent suite/scenario
  * @param {string} stepTitle step/test title
  */
-export function getTestFullTitle(parent, stepTitle) {
+export function getTestFullTitle(parent: string, stepTitle: string) {
     return `${parent}: ${stepTitle}`
 }
 
-export function getUniqueIdentifier (target, sourceLocation) {
+export function getUniqueIdentifier (target: Step, sourceLocation: SourceLocation) {
     if (target.type === 'Hook') {
         return `${path.basename(target.location.uri)}${target.location.line}`
     }

--- a/packages/wdio-cucumber-framework/tsconfig.json
+++ b/packages/wdio-cucumber-framework/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "./build",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "types": ["@wdio/reporter"]
   },
   "include": [
     "src/**/*"


### PR DESCRIPTION
This is a tracking issue for organising the effort of re-writing the code base from vanilla JS into TypeScript. If you are reading this and are interested getting involved, this is a great chance to do so. Here are the rules:

- if you are interested converting source files from `/packages/wdio-cucumber-framework` into TypeScript please comment on this thread and mention the files you want to convert to avoid duplicate work
- there is no reason to convert the whole package at once - smaller PRs make it easier to review the code
- if you make a PR, reference this issue so we can keep track of the progress
- if you make a PR, label it with `TypeScript` and the package name `wdio-cucumber-framework` so we can easier find all PRs
- if you make a PR, assign it to the `TypeScript Rewrite` project

Happy rewriting 😅