### PR TITLE
Better typing for callback arguments in browser.execute

### DIFF
--- a/packages/wdio-sync/webdriverio.d.ts
+++ b/packages/wdio-sync/webdriverio.d.ts
@@ -12,7 +12,7 @@ declare namespace WebdriverIO {
          * The executed script is assumed to be synchronous and the result of evaluating the script is returned to
          * the client.
          */
-        execute: <T>(script: string | ((...arguments: any[]) => T), ...arguments: any[]) => T;
+        execute: <T, U extends any[]>(script: string | ((...arguments: U) => T), ...arguments: U) => T;
 
         // also there is no way to add callback as last parameter after `...args`.
         // https://github.com/Microsoft/TypeScript/issues/1360
@@ -23,7 +23,7 @@ declare namespace WebdriverIO {
          * the provided callback, which is always provided as the final argument to the function. The value
          * to this callback will be returned to the client.
          */
-        executeAsync: (script: string | ((...arguments: any[]) => void), ...arguments: any[]) => any;
+        executeAsync: <U extends any[]>(script: string | ((...arguments: U) => void), ...arguments: U) => any;
     }
 
     interface BrowserObject extends WebDriver.ClientOptions, WebDriver.Client, WebdriverIO.Browser { }

--- a/packages/wdio-sync/webdriverio.d.ts
+++ b/packages/wdio-sync/webdriverio.d.ts
@@ -12,7 +12,11 @@ declare namespace WebdriverIO {
          * The executed script is assumed to be synchronous and the result of evaluating the script is returned to
          * the client.
          */
-        execute: <T, U extends any[]>(script: string | ((...arguments: U) => T), ...arguments: U) => T;
+        execute: {
+            <T, U extends any[], V extends U>(script: string | ((...arguments: V) => T), ...arguments: U): T;
+            // This overload can be removed when typescript supports partial generics inference: https://github.com/microsoft/TypeScript/issues/26242
+            <T>(script: string | ((...arguments: any[]) => T), ...arguments: any[]): T;
+        };
 
         // also there is no way to add callback as last parameter after `...args`.
         // https://github.com/Microsoft/TypeScript/issues/1360
@@ -23,7 +27,7 @@ declare namespace WebdriverIO {
          * the provided callback, which is always provided as the final argument to the function. The value
          * to this callback will be returned to the client.
          */
-        executeAsync: <U extends any[]>(script: string | ((...arguments: U) => void), ...arguments: U) => any;
+        executeAsync: <U extends any[], V extends U>(script: string | ((...arguments: V) => void), ...arguments: U) => any;
     }
 
     interface BrowserObject extends WebDriver.ClientOptions, WebDriver.Client, WebdriverIO.Browser { }

--- a/packages/webdriverio/webdriverio.d.ts
+++ b/packages/webdriverio/webdriverio.d.ts
@@ -31,7 +31,11 @@ declare namespace WebdriverIO {
          * The executed script is assumed to be synchronous and the result of evaluating the script is returned to
          * the client.
          */
-        execute: <T, U extends any[]>(script: string | ((...arguments: U) => T), ...arguments: U) => Promise<T>;
+        execute: {
+            <T, U extends any[], V extends U>(script: string | ((...arguments: V) => T), ...arguments: U): Promise<T>;
+            // This overload can be removed when typescript supports partial generics inference: https://github.com/microsoft/TypeScript/issues/26242
+            <T>(script: string | ((...arguments: any[]) => T), ...arguments: any[]): Promise<T>;
+        };
 
         // there is no way to add callback as last parameter after `...args`.
         // https://github.com/Microsoft/TypeScript/issues/1360
@@ -42,7 +46,7 @@ declare namespace WebdriverIO {
          * the provided callback, which is always provided as the final argument to the function. The value
          * to this callback will be returned to the client.
          */
-        executeAsync: <U extends any[]>(script: string | ((...arguments: U) => void), ...arguments: U) => Promise<any>;
+        executeAsync: <U extends any[], V extends U>(script: string | ((...arguments: V) => void), ...arguments: U) => Promise<any>;
     }
 
 

--- a/packages/webdriverio/webdriverio.d.ts
+++ b/packages/webdriverio/webdriverio.d.ts
@@ -31,7 +31,7 @@ declare namespace WebdriverIO {
          * The executed script is assumed to be synchronous and the result of evaluating the script is returned to
          * the client.
          */
-        execute: <T>(script: string | ((...arguments: any[]) => T), ...arguments: any[]) => Promise<T>;
+        execute: <T, U extends any[]>(script: string | ((...arguments: U) => T), ...arguments: U) => Promise<T>;
 
         // there is no way to add callback as last parameter after `...args`.
         // https://github.com/Microsoft/TypeScript/issues/1360
@@ -42,7 +42,7 @@ declare namespace WebdriverIO {
          * the provided callback, which is always provided as the final argument to the function. The value
          * to this callback will be returned to the client.
          */
-        executeAsync: (script: string | ((...arguments: any[]) => void), ...arguments: any[]) => Promise<any>;
+        executeAsync: <U extends any[]>(script: string | ((...arguments: U) => void), ...arguments: U) => Promise<any>;
     }
 
 


### PR DESCRIPTION
Currently `arg1` gets typed as `any` whereas it should be better typed, using generics, to have the same type as the provided `val1`:
```
browser.execute((arg1) => {
            doSomething(arg1);
}, val1);
```
This PR fixes that. It even works for different types of args, so this:
```
browser.execute((arg1, arg2) => {
            doSomething(arg1, arg2);
}, `str1`, 2000);
```
This will correctly type `arg1` as `string` and `num2` as `number`

## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
