### PR TITLE
feat(ui5-service): add UI5 support to wdio

### DIFF
--- a/packages/wdio-ui5-service/CHANGELOG.md
+++ b/packages/wdio-ui5-service/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+### [0.0.2](https://github.com/js-soft/wdi5/compare/v0.2.1...v0.0.2) (2020-11-02)
+
+
+### Bug Fixes
+
+* reference node module instead of file ([1c2fab7](https://github.com/js-soft/wdi5/commit/1c2fab7ae919610d4b06b6f948678874c6087059))
+* **android:** cordova plugin registry ([e77312c](https://github.com/js-soft/wdi5/commit/e77312cf80ff4b490020ad8a85cd111f3345fe45))
+* **cordova:** add missing barcode scan plugin ([69a0b89](https://github.com/js-soft/wdi5/commit/69a0b8959fff7aa87638ae28f9419d360076e9fb))
+* **cordova:** pre-define namespaces for plugins ([878e8dc](https://github.com/js-soft/wdi5/commit/878e8dccb58dcbc4dffe5804058b7a09ca982280))
+* **electron:** navigation + ui5 promise sync ([71b8df0](https://github.com/js-soft/wdi5/commit/71b8df0e0a9ca895063a8adc13f447a31aa08a86))
+* path to binary needs full path ([b6523c1](https://github.com/js-soft/wdi5/commit/b6523c176d01ee7b1aa668ee8759862c6460d1cc))
+* **plugin:** dynamic mock plugin response structure update ([757e1b7](https://github.com/js-soft/wdi5/commit/757e1b7f9d4b426500c8b168b113e5324d852e9c))
+
+### [0.0.1](https://github.com/js-soft/wdi5/compare/v0.2.0...v0.0.1) (2020-10-30)
+
+
+### Features
+
+* **goto:** navigation via ui5 router ([28897ee](https://github.com/js-soft/wdi5/commit/28897ee965dacd16326dbbf83372ad683d4803c2))
+* **restucture:** utils for ui5 service separation ([30db602](https://github.com/js-soft/wdi5/commit/30db6020dbb258cbb40a03daac68e59afad3c09f))
+* **service:** wdio custom service ([2950ea6](https://github.com/js-soft/wdi5/commit/2950ea65ff10ce39795cbd73b30f9e4fd8274194))
+* **wdioui5service:** add dual support for include via ([84c119f](https://github.com/js-soft/wdi5/commit/84c119f82d72495eb96125fa0cf9bc28f808b6f7))
+
+
+### Bug Fixes
+
+* **screenshot:** screenshot on native devices ([f3050dc](https://github.com/js-soft/wdi5/commit/f3050dc01e36fa720bbb90966ef05c3c8a0ef601))
+* path to wdi5, rm unused require ([a70bda8](https://github.com/js-soft/wdi5/commit/a70bda8c2ef137c80aee8e7044ab8be5f5cdb97f))
+* typo ([b7f86a6](https://github.com/js-soft/wdi5/commit/b7f86a635f7379254dca6b023db86220489780ef))
+* typo ([b756d04](https://github.com/js-soft/wdi5/commit/b756d04a74366e2472e8fd8869df02cf1e557f0b))
+* **todos:** removed old todo comments ([88458b1](https://github.com/js-soft/wdi5/commit/88458b155ecd7eeab5224dca65a22c7e60cd2fc0))

--- a/packages/wdio-ui5-service/README.md
+++ b/packages/wdio-ui5-service/README.md
@@ -1,0 +1,104 @@
+# wdio-ui5-service ![npm](https://img.shields.io/npm/v/wdio-ui5-service)
+
+`WebdriverIO`-plugin for `wdi5`.
+
+It provides the `ui5`-service to `WebdriverIO`, running tests in the browser.
+
+## Prerequisites
+
+- UI5 app running in the browser, accessbile via `http(s)://host.ext:port`.
+  Recommended tooling for this is either the official [UI5 tooling](https://github.com/SAP/ui5-tooling) (`ui5 serve`) or some standalone http server like [`soerver`](https://github.com/vobu/soerver) or [`http-server`](https://www.npmjs.com/package/http-server).
+- node version >= `12.x` (`lts/erbium`)
+- (optional) `yarn`
+  during development, we rely on `yarn`’s workspace-features - that’s why we refer to `yarn` instead of `npm` in the docs, even though using `npm` as an equivalent shold be fine too
+
+## Installation
+
+To keep the module lightweight, `wdio-ui5-service` has zero dependencies.
+This means you have to setup `WebdriverIO` as a prerequisite as described in https://webdriver.io/docs/gettingstarted.html.
+
+```bash
+$> npm i --save-dev @wdio/cli
+$> npx wdio config # do the config boogie - this will also install dependencies
+```
+
+Add `wdio-ui5-service` as a (dev)dependency to your `package.json` via
+
+`$> npm install wdio-ui5-service --save-dev`
+or
+`$> yarn add -D wdio-ui5-service`
+
+```json
+{
+    "dependencies": {
+        "wdio-ui5-service": "^0.0.1"
+    }
+}
+```
+
+Then add the `ui5`-service to the standard `wdio.conf.js`:
+
+```javascript
+...
+services: [
+    // other services like 'chromedriver'
+    // ...
+    'ui5'
+]
+...
+```
+
+Finally, pass in configuration options for `wdi5` in your `WebdriverIO`-conf file:
+
+```javascript
+wdi5: {
+    screenshotPath: require('path').join('test', 'report', 'screenshots'),
+    logLevel: 'verbose', // error | verbose | silent
+    platform: 'browser', // browser | android | ios | electron
+    url: 'index.html', // path to your bootstrap html file
+    deviceType: 'web' // native | web
+}
+```
+
+See [test/wdio-ui5.conf.js](test/wdio-ui5.conf.js) for a sample configuration file for browser-scope testing.
+
+Run the tests via the `webdriver.io`-cli:
+
+```javascript
+$> npx wdio
+```
+
+
+
+## Usage
+
+Run-(Test-)Time usage of `wdi5` is agnostic to its' test-scope (browser or native) and centers around the global `browser`-object, be it in the browser or on a real mobile device.
+
+Please see the top-level [README](../README.md#Usage) for API-methods and usage instructions.
+
+## Features specific to `wdio-ui5-service` (vs. `wdi5`)
+
+## Navigation
+
+In the test, you can navigate the UI5 webapp via `goTo(options)` in one of two ways:
+
+-   updating the browser hash
+    ```javascript
+    browser.goTo({sHash: '#/test'});
+    ```
+-   using the UI5 router [navTo](https://openui5.netweaver.ondemand.com/api/sap.ui.core.routing.Router#methods/navTo) function
+    ```javascript
+    browser.goTo(
+        oRoute: {
+            sComponentId,
+            sName,
+            oParameters,
+            oComponentTargetInfo,
+            bReplace
+        }
+    )
+    ```
+
+## License
+
+see [top-level LICENSE file](../LICENSE)

--- a/packages/wdio-ui5-service/index.js
+++ b/packages/wdio-ui5-service/index.js
@@ -1,0 +1,19 @@
+
+const Launcher = require('./src/launcher');
+const Service = require('./src/service');
+
+// detect if wdio-ui5-service is loaded by wdio config or manually injected
+const runStandalone = !module.parent.parent.filename.includes("ConfigParser");
+// detect if wdio-ui5-service is laoded by WDI5
+const runByWDI5 = !module.parent.parent.filename.includes("wdi5.service.js");
+const isWDIOService = runStandalone && runByWDI5;
+
+if (isWDIOService) {
+    // TODO: for wdio config utility PR
+    module.exports = {
+        default: Service,
+        launcher: Launcher
+    }
+} else {
+    module.exports = new Service();
+}

--- a/packages/wdio-ui5-service/package.json
+++ b/packages/wdio-ui5-service/package.json
@@ -1,0 +1,34 @@
+{
+    "name": "wdio-ui5-service",
+    "description": "WebdriverIO plugin for testing UI5 browser-based apps",
+    "author": "Dominik Feininger <dominik.feininger@js-soft.com> (https://www.js-soft.com/)",
+    "contributors": [
+        "Volker Buzek <volker.buzek@js-soft.com> (https://www.js-soft.com/)"
+    ],
+    "license": "(DERIVED BEER-WARE OR Apache-2.0)",
+    "version": "0.0.2",
+    "dependencies": {},
+    "main": "./index.js",
+    "peerDependencies": {},
+    "screenshotPath": "./../test/report/screenshots",
+    "keywords": [
+        "webdriver",
+        "wdio",
+        "wdio-service",
+        "ui5",
+        "openui5"
+    ],
+    "scripts": {
+        "release": "standard-version"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com:js-soft/wdi5.git"
+    },
+    "engines": {
+        "node": ">=12"
+    },
+    "devDependencies": {
+        "standard-version": "^9.0.0"
+    }
+}

--- a/packages/wdio-ui5-service/src/launcher.js
+++ b/packages/wdio-ui5-service/src/launcher.js
@@ -1,0 +1,17 @@
+// export a launcher that handles onPrepare, onWorkerStart and onComplete
+module.exports = class Launcher {
+    // If a hook returns a promise, WebdriverIO will wait until that promise is resolved to continue.
+    async onPrepare(config, capabilities) {
+        // something before all workers launch
+    }
+
+    onWorkerStart(cid, caps, specs, args, execArgv) {
+        // something before specific worker launch
+    }
+
+    onComplete(exitCode, config, capabilities) {
+        // something after the workers shutdown
+    }
+
+    // custom service methods ...
+}

--- a/packages/wdio-ui5-service/src/lib/WDI5.js
+++ b/packages/wdio-ui5-service/src/lib/WDI5.js
@@ -1,0 +1,476 @@
+/**
+ * This is a bridge object to use from selector to UI5 control
+ * This can be seen as a generic representation of a UI5 control used to interact with the UI5 control
+ * This does not adjust the funcitonality based on a UI5 control type
+ */
+module.exports = class WDI5 {
+    /** @type {WebdriverIO.BrowserObject} */
+    _context = null;
+    /**
+     * control retrieved from browser-/native-context,
+     * transferred to node-context
+     * @typedef {Object} WDI5ControlSelector selected UI5 control
+     * @property {String} wdio_ui5_key unique (wdi5-internal) key representing the UI5 control (selector)
+     *
+     */
+    /** @type {WDI5ControlSelector} */
+    _controlSelector = null;
+    /** @type {[WebdriverIO.Element | String]} */
+    _webElement = null;
+    /** @type {[WebdriverIO.Element | String]} */
+    _webdriverRepresentation = null;
+    /** @type {String} */
+    _wdio_ui5_key = null;
+    /** @type {Array | String} */
+    _generatedUI5Methods = null;
+
+    /**
+     * create a new bridge return object for a UI5 control
+     */
+    constructor(controlSelector, context) {
+        this._context = context;
+        this._controlSelector = controlSelector;
+        this._wdio_ui5_key = controlSelector.wdio_ui5_key;
+
+        // fire getControl just once when creating this webui5 object
+        const controlResult = this._getControl()
+        this._webElement = controlResult[0];
+
+        // dynamic function bridge
+        this._generatedUI5Methods = controlResult[1];
+        this._attachControlBridge(this._generatedUI5Methods);
+
+        return this;
+    }
+
+    // --- public methods Getter ---
+
+    /**
+     * @return the webdriver Element
+     */
+    getWebElement() {
+        return this._webdriverRepresentation;
+    }
+
+    /**
+     * bridge to UI5 control getAggregation Method
+     * @param {String} name
+     * @return {any} content of the UI5 aggregation with name of parameter
+     */
+    getAggregation(name) {
+        return this._getAggregation(name);
+    }
+
+    /**
+     * enters a text into this UI5 control
+     * @param {*} text
+     * @return {WDI5} this for method chaining
+     */
+    enterText(text) {
+        const oOptions = {
+            enterText: text,
+            selector: this._controlSelector.selector,
+            clearTextFirst: true,
+            interactionType: 'ENTER_TEXT'
+        };
+        this._interactWithControl(oOptions);
+        return this;
+    }
+
+    // --- private methods ---
+
+    /**
+     * retrieve UI5 control represenation of a UI5 control's aggregation
+     *
+     * @param {Array} aControls strings of IDs of aggregation items
+     * @param {WebdriverIO.BrowserObject} context
+     * @returns {WDI5[]} instances of wdi5 class per control in the aggregation
+     */
+    _retrieveElements(aControls, context = this._context) {
+        let aResult = [];
+        // loop through items
+        aControls.forEach((item) => {
+            // item id -> create selector
+            const selector = {
+                wdio_ui5_key: item.id, // plugin-internal, not part of RecordReplay.ControlSelector
+                selector: {
+                    id: item.id
+                }
+            };
+
+            // get WDI5 control
+            aResult.push(context.asControl(selector));
+        });
+
+        return aResult;
+    }
+
+    /**
+     * attaches to the instance of this class the functions given in the parameter sReplFunctionNames
+     *
+     * @param {Array} sReplFunctionNames
+     */
+    _attachControlBridge(sReplFunctionNames) {
+        sReplFunctionNames.forEach(sMethodName => {
+            this[sMethodName] = this._executeControlMethod.bind(this, sMethodName, this._webElement, this._context);
+        });
+    }
+
+    /**
+     * runtime - proxied browser-time UI5 controls' method at Node.js-runtime
+     *
+     * @param {String} methodName UI5 control method
+     * @param {WebdriverIO.Element} webElement representation of selected UI5 control in wdio
+     * @param {WebdriverIO.BrowserObject} context points to either browser- or native-runtime context
+     * @param  {...any} args proxied arguments to UI5 control method at runtime
+     */
+    _executeControlMethod(methodName, webElement = this._webElement, context = this._context, ...args) {
+        // special case for custom data attached to a UI5 control:
+        // pass the arguments to the event handler (like UI5 handles and expects them) also
+        // also here in Node.js runtime
+        if (methodName === "fireEvent") {
+            if (typeof args[1]["eval"] === "function") {
+                return this._fireEvent(args[0], args[1], webElement, context);
+            }
+        }
+        // returns the array of [0: "status", 1: result]
+
+        // regular browser-time execution of UI5 control method
+        const result = context.executeAsync(
+            (webElement, methodName, args, done) => {
+                window.bridge.waitForUI5().then(() => {
+                    // DOM to UI5
+                    const oControl = window.wdi5.getUI5CtlForWebObj(webElement);
+                    // execute the function
+                    let result = oControl[methodName].apply(oControl, args);
+                    const metadata = oControl.getMetadata();
+
+                    if (Array.isArray(result)) {
+                        // expect the method call delivers non-primitive results (like getId())
+                        // but delivers a complex/structured type
+                        // -> currenlty, only getAggregation(...) is supported
+                        result = window.wdi5.createControlIdMap(result);
+                        done(['success', result, 'aggregation']);
+                    } else {
+                        if (result === undefined || result === null) {
+                            done(['error', `function ${methodName} does not exist on control ${metadata.getElementName()}!`, 'none']);
+                        } else {
+                            // result mus be a primitive
+                            if (window.wdi5.isPrimitive(result)) {
+                                // getter
+                                done(['success', result, 'result']);
+                            } else {
+                                // object, replacer function
+                                // TODO: create usefull content from result
+                                // result = JSON.stringify(result, window.wdi5.circularReplacer());
+                                done(['success', `instance of wdi5 representation of a ${metadata.getElementName()}`, 'element']);
+                            }
+                        }
+                    }
+                });
+            },
+            webElement,
+            methodName,
+            args
+        );
+
+        // create logging
+        this._writeResultLog(result, methodName);
+
+        switch (result[2]) {
+            case "element":
+                // return $self after a called method of the wdi5 instance to allow method chaining
+                return this;
+            case "result":
+                // return result on array index 1 anyways
+                return result[1];
+            case "aggregation": // also applies for getAggregation convenience methods such as $ui5control.getItems()
+                return this._retrieveElements(result[1]);
+            case "none":
+                return null;
+            default:
+                return null;
+        }
+    }
+
+    /**
+     * time itensive
+     * @param {String} aggregationName
+     * @param {WebdriverIO.Element} webElement
+     * @param {WebdriverIO.BrowserObject} context
+     * @return {any}
+     */
+    _getAggregation(aggregationName, webElement = this._webElement, context = this._context) {
+        const result = context.executeAsync(
+            (webElement, aggregationName, done) => {
+                window.bridge.waitForUI5().then(() => {
+                    // DOM to UI5
+                    try {
+                        let oControl = window.wdi5.getUI5CtlForWebObj(webElement);
+                        let cAggregation = oControl.getAggregation(aggregationName);
+                        let result = window.wdi5.createControlIdMap(cAggregation);
+                        done(['success', result]);
+                    } catch (e) {
+                        done(['error', e.toString()]);
+                    }
+                });
+            },
+            webElement,
+            aggregationName
+        );
+
+        this._writeResultLog(result, '_getAggregation()');
+
+        let wdiItems = [];
+        if (result[0] === 'success') {
+            wdiItems = this._retrieveElements(result[1]);
+        }
+
+        // else return empty array
+        return wdiItems;
+    }
+
+    /**
+     *
+     * @param {String} propertyName
+     * @param {any} propertyValue
+     * @param {WebdriverIO.Element} webElement
+     * @param {WebdriverIO.BrowserObject} context
+     */
+    _setProperty(propertyName, propertyValue, webElement = this._webElement, context = this._context) {
+        const result = context.executeAsync(
+            (webElement, propertyName, propertyValue, done) => {
+                window.bridge.waitForUI5().then(() => {
+                    try {
+                        let oControl = window.wdi5.getUI5CtlForWebObj(webElement);
+                        oControl.setProperty(propertyName, propertyValue);
+                        done(['success', ` '${propertyName}' is now '${propertyValue.toString()}'`]);
+                    } catch (error) {
+                        window.wdi5.Log.error(`[browser wido-ui5] setProperty failed because of: ${error}`);
+                        done(['error', error.toString()]);
+                    }
+                });
+            },
+            webElement,
+            propertyName,
+            propertyValue
+        );
+
+        this._writeResultLog(result, '_setProperty()');
+        return result[1];
+    }
+
+    /**
+     *
+     * @param {String} className
+     * @param {WebdriverIO.Element} webElement
+     * @param {WebdriverIO.BrowserObject} context
+     */
+    _hasStyleClass(className, webElement = this._webElement, context = this._context) {
+        const result = context.executeAsync(
+            (webElement, className, done) => {
+                window.bridge.waitForUI5().then(() => {
+                    try {
+                        const foundUI5Control = window.wdi5.getUI5CtlForWebObj(webElement);
+                        done(['success', foundUI5Control.hasStyleClass(className)]);
+                    } catch (e) {
+                        done(['error', e.toString()]);
+                    }
+                });
+            },
+            webElement,
+            className
+        );
+
+        this._writeResultLog(result, '_hasStyleClass()');
+        return result[1];
+    }
+
+    /**
+     * get the property value of a UI5 control
+     * @param {WebdriverIO.Element} webElement
+     * @param {String} propertyName
+     * @param {WebdriverIO.BrowserObject} context
+     * @return {any} value of the UI5 property
+     */
+    _getProperty(propertyName, webElement = this._webElement, context = this._context) {
+        // returns the array of [0: "status", 1: result]
+        const result = context.executeAsync(
+            (webElement, propertyName, done) => {
+                window.bridge.waitForUI5().then(() => {
+                    // DOM to UI5
+                    let oControl = window.wdi5.getUI5CtlForWebObj(webElement);
+                    let sProperty = '';
+                    switch (propertyName) {
+                        case 'id':
+                            sProperty = oControl.getId();
+                            break;
+
+                        default:
+                            sProperty = oControl.getProperty(propertyName);
+                            break;
+                    }
+                    if (sProperty === undefined || sProperty === null) {
+                        done(['error', `property ${propertyName} not existent in control !`]);
+                    } else {
+                        done(['success', sProperty]);
+                    }
+                });
+            },
+            webElement,
+            propertyName
+        );
+
+        // create logging
+        this._writeResultLog(result, '_getProperty()');
+        // return result on array index 1 anyways
+        return result[1];
+    }
+
+    // --- private actions ---
+
+    /**
+     * Interact with specific control.
+     * @param {object} oOptions
+     * @param {sap.ui.test.RecordReplay.ControlSelector} oOptions.selector - UI5 type
+     * @param {sap.ui.test.RecordReplay.InteractionType} oOptions.interactionType - UI5 type
+     * @param {string} oOptions.enterText
+     * @param {boolean} oOptions.clearTextFirst
+     * @param {object} context
+     */
+    _interactWithControl(oOptions, context = this._context) {
+        const result = context.executeAsync((oOptions, done) => {
+            window.bridge
+                .waitForUI5()
+                .then(() => {
+                    window.wdi5.Log.info('[browser wdio-ui5] locating controlSelector');
+                    oOptions.selector = window.wdi5.createMatcher(oOptions.selector);
+                    return window.bridge.interactWithControl(oOptions);
+                })
+                .then((result) => {
+                    window.wdi5.Log.info('[browser wdio-ui5] interaction complete! - Message: ' + result);
+                    done(['success', result]);
+                })
+                .catch((error) => {
+                    window.wdi5.Log.error('[browser wdio-ui5] ERR: ', error);
+                    done(['error', error.toString()]);
+                });
+        }, oOptions);
+
+        this._writeResultLog(result, '_interactWithControl()');
+        return result[1];
+    }
+
+    /**
+     * fire a named event on a UI5 control
+     * @param {String} eventName
+     * @param {any} oOptions
+     * @param {WebdriverIO.Element} webElement
+     * @param {WebdriverIO.BrowserObject} context
+     */
+    _fireEvent(eventName, oOptions, webElement = this._webElement, context = this._context) {
+
+        // Check the options have a eval property
+        if (oOptions && oOptions.eval) {
+            oOptions = '(' + oOptions.eval.toString() + ')'
+        }
+
+        const result = context.executeAsync(
+            (webElement, eventName, oOptions, done) => {
+                window.bridge.waitForUI5().then(() => {
+                    window.wdi5.Log.info('[browser wdio-ui5] working ' + eventName + ' for ' + webElement);
+                    // DOM to ui5
+                    let oControl = window.wdi5.getUI5CtlForWebObj(webElement);
+                    if (oControl && oControl.hasListeners(eventName)) {
+
+                        window.wdi5.Log.info('[browser wdio-ui5] firing ' + eventName + ' on ' + webElement);
+                        // element existent and has the target event
+                        try {
+
+                            // eval the options indicated by option of type string
+                            if (typeof oOptions === "string") {
+                                oOptions = eval(oOptions)();
+                            }
+                            oControl.fireEvent(eventName, oOptions);
+                            // convert to boolean
+                            done(['success', true]);
+                        } catch (e) {
+                            done(['error', e.toString()]);
+                        }
+                    } else {
+                        window.wdi5.Log.error("[browser wdio-ui5] couldn't find " + webElement);
+                        done(['error', false]);
+                    }
+                });
+            },
+            webElement,
+            eventName,
+            oOptions
+        );
+        this._writeResultLog(result, '_fireEvent()');
+        return result[1];
+    }
+
+    // --- private internal ---
+
+    /**
+     * retrieve a DOM element via UI5 locator
+     * @param {sap.ui.test.RecordReplay.ControlSelector} controlSelector
+     * @param {WebdriverIO.BrowserObject} context
+     * @return {[WebdriverIO.Element | String, [aProtoFunctions]]} UI5 control or error message, array of function names of this control
+     */
+    _getControl(controlSelector = this._controlSelector, context = this._context) {
+        const result = context.executeAsync((controlSelector, done) => {
+
+            window.bridge
+                .waitForUI5()
+                .then(() => {
+                    window.wdi5.Log.info('[browser wdio-ui5] locating ' + JSON.stringify(controlSelector));
+                    controlSelector.selector = window.wdi5.createMatcher(controlSelector.selector);
+                    const control = window.bridge.findDOMElementByControlSelector(controlSelector);
+                    return control;
+                })
+                .then((domElement) => {
+                    window.wdi5.Log.info(
+                        '[browser wdio-ui5] control located! - Message: ' + JSON.stringify(domElement)
+                    );
+
+                    // ui5 control
+                    const ui5Control = window.wdi5.getUI5CtlForWebObj(domElement);
+                    const id = ui5Control.getId();
+                    const aProtoFunctions = window.wdi5.retrieveControlMethods(ui5Control);
+                    // @type [String, String?, String, "Array of Strings"]
+                    done(['success', domElement, id, aProtoFunctions]);
+                })
+                .catch((error) => {
+                    window.wdi5.Log.error('[browser wdio-ui5] ERR: ', error);
+                    done(['error', error.toString()]);
+                });
+        }, controlSelector);
+
+        // save the webdriver representation by control id
+        if (result[2]) {
+            // only if the result is valid
+            this._webdriverRepresentation = $(`#${result[2]}`);
+        }
+
+        this._writeResultLog(result, '_getControl()');
+
+        return [result[1], result[3]];
+    }
+
+    /**
+     * create log based on the status of result[0]
+     * @param {Array} result
+     * @param {*} functionName
+     */
+    _writeResultLog(result, functionName) {
+        if (result[0] === 'error') {
+            console.error(`ERROR: call of ${functionName} failed because of: ${result[1]}`);
+        } else if (result[0] === 'success') {
+            console.log(`SUCCESS: call of function ${functionName} returned: ${JSON.stringify(result[1])}`);
+        } else {
+            console.warn(`Unknown status: ${functionName} returned: ${JSON.stringify(result[1])}`);
+        }
+    }
+};

--- a/packages/wdio-ui5-service/src/lib/wdioUi5-index.js
+++ b/packages/wdio-ui5-service/src/lib/wdioUi5-index.js
@@ -1,0 +1,611 @@
+// @ts-check
+const WDI5 = require('./WDI5');
+const path = require('path');
+const fs = require('fs');
+
+/** @type {WebdriverIO.BrowserObject} store the context */
+let _context = null;
+/** @type {Boolean} store the status of initialization */
+let _isInitialized = false;
+/** @type {Boolean} store the status of UI5.waitForUI5 */
+let _isUI5Ready = false;
+/** @type {Boolean} stores the status of the setup process */
+let _setupComplete = false;
+
+/** @type {Object} */
+const pjsonPackage = require(`./../../package.json`);
+
+// --------- public functions ------------ //
+
+/**
+ * function library to setup the webdriver to UI5 bridge, it runs alle the initial setup
+ * make sap/ui/test/RecordReplay accessible via wdio
+ * attach the sap/ui/test/RecordReplay object to the application context window object as 'bridge'
+ */
+function injectUI5() {
+    // expect boolean
+    const result = _context.executeAsync((done) => {
+        if (window.bridge) {
+            // setup sap testing already done
+            done(true);
+        }
+
+        if (!window.sap || !window.sap.ui) {
+            // setup sap testing already cant be done due to sap namespace not present on the page
+            console.error('[browser wdio-ui5] ERR: no ui5 present on page');
+
+            // only condition where to cancel the setup process
+            done(false);
+        }
+
+        // attach the function to be able to use the extracted method later
+        if (!window.bridge) {
+            // create empty
+            window.wdi5 = {
+                createMatcher: null,
+                isInitialized: false,
+                Log: null
+            };
+
+            // load UI5 logger
+            sap.ui.require(['sap/base/Log'], (Log) => {
+                // Logger is loaded -> can be use internally
+                // attach logger to wdi5 to be able to use it globally
+                window.wdi5.Log = Log;
+                window.wdi5.Log.info('[browser wdio-ui5] injected!');
+            });
+
+            // attach new bridge
+            sap.ui.require(['sap/ui/test/RecordReplay'], (RecordReplay) => {
+                window.bridge = RecordReplay;
+                window.wdi5.Log.info('[browser wdio-ui5] injected!');
+                window.wdi5.isInitialized = true;
+
+                // here setup is successfull
+                // known side effect this call triggers the back to node scope, the other sap.ui.require continue to run in background in browser scope
+                done(true);
+            });
+            // make sure the resources are required
+            sap.ui.require(
+                [
+                    'sap/ui/test/matchers/BindingPath',
+                    'sap/ui/test/matchers/I18NText',
+                    'sap/ui/test/matchers/Properties',
+                    'sap/ui/test/matchers/Ancestor',
+                    'sap/ui/test/matchers/LabelFor'
+                ],
+                (BindingPath, I18NText, Properties, Ancestor, LabelFor) => {
+                    /**
+                     * used to dynamically create new control matchers when searching for elements
+                     */
+                    window.wdi5.createMatcher = (oSelector) => {
+                        // Before version 1.60, the only available criteria is binding context path.
+                        // As of version 1.72, it is available as a declarative matcher
+                        const fVersion = 1.6;
+
+                        if (oSelector.bindingPath) {
+                            // TODO: for the binding Path there is no object creation
+                            // fix (?) for 'leading slash issue' in propertyPath w/ a named model
+                            // openui5 issue in github is open
+                            const hasNamedModel =
+                                oSelector.bindingPath.modelName && oSelector.bindingPath.modelName.length > 0;
+                            const isRootProperty =
+                                oSelector.bindingPath.propertyPath &&
+                                oSelector.bindingPath.propertyPath.charAt(0) === '/';
+                            if (hasNamedModel && isRootProperty && parseFloat(sap.ui.version) < 1.81) {
+                                // attach the double leading /
+                                // for UI5 < 1.81
+                                oSelector.bindingPath.propertyPath = `/${oSelector.bindingPath.propertyPath}`;
+                            }
+                            if (fVersion > parseFloat(sap.ui.version)) {
+                                // for version < 1.60 create the matcher
+                                oSelector.bindingPath = new BindingPath(oSelector.bindingPath);
+                            }
+                        }
+                        if (oSelector.properties) {
+                            if (fVersion > parseFloat(sap.ui.version)) {
+                                // for version < 1.60 create the matcher
+                                oSelector.properties = new Properties(oSelector.properties);
+                            }
+                        }
+                        if (oSelector.i18NText) {
+                            if (fVersion > parseFloat(sap.ui.version)) {
+                                // for version < 1.60 create the matcher
+                                oSelector.i18NText = new I18NText(oSelector.i18NText);
+                            }
+                        }
+                        if (oSelector.labelFor) {
+                            if (fVersion > parseFloat(sap.ui.version)) {
+                                // for version < 1.60 create the matcher
+                                oSelector.labelFor = new LabelFor(oSelector.labelFor);
+                            }
+                        }
+                        if (oSelector.ancestor) {
+                            if (fVersion > parseFloat(sap.ui.version)) {
+                                // for version < 1.60 create the matcher
+                                oSelector.ancestor = new Ancestor(oSelector.ancestor);
+                            }
+                        }
+                        return oSelector;
+                    };
+
+
+                    /**
+                     * extract the multi use function to get a UI5 Control from a JSON Webobejct
+                     */
+                    window.wdi5.getUI5CtlForWebObj = (ui5Control) => {
+                        return jQuery(ui5Control).control(0);
+                    };
+
+                    /**
+                     * gets a UI5 controls' methods to proxy from browser- to Node.js-runtime
+                     *
+                     * @param {sap.<lib>.<Control>} control UI5 control
+                     * @returns {String[]} UI5 control's method names
+                     */
+                    window.wdi5.retrieveControlMethods = (control) => {
+                        // create keys of all parent prototypes
+                        let properties = new Set();
+                        let currentObj = control;
+                        do {
+                            Object.getOwnPropertyNames(currentObj).map((item) => properties.add(item));
+                        } while ((currentObj = Object.getPrototypeOf(currentObj)));
+
+                        // filter for:
+                        let controlMethodsToProxy = [...properties.keys()].filter((item) => {
+                            if (typeof control[item] === 'function') {
+                                // function
+
+                                // filter private methods
+                                if (item.startsWith('_')) {
+                                    return false;
+                                }
+
+                                if (item.indexOf('Render') !== -1) {
+                                    return false
+                                }
+
+                                // filter not working mehtods
+                                const aFilterFunctions = [
+                                    '$',
+                                    'getAggregation',
+                                    'constructor',
+                                    'getMetadata'
+                                ]
+
+                                if (aFilterFunctions.includes(item)) {
+                                    return false;
+                                }
+
+                                // if not already discarded -> should be in the result
+                                return true;
+                            }
+                            return false;
+                        });
+
+                        return controlMethodsToProxy;
+                    };
+
+                    /**
+                     * replaces circular referneces in objects
+                     * @returns function (key, value)
+                     */
+                    window.wdi5.circularReplacer = () => {
+                        const seen = new WeakSet();
+                        return (key, value) => {
+                            if (typeof value === 'object' && value !== null) {
+                                if (seen.has(value)) {
+                                    return
+                                }
+                                seen.add(value)
+                            }
+                            return value
+                        }
+                    }
+
+                    /**
+                     * if parameter is JS primitive type
+                     * returns {boolean}
+                     * @param {*} test
+                     */
+                    window.wdi5.isPrimitive = (test) => {
+                        return test !== Object(test);
+                    };
+
+                    /**
+                     * creates a array of objects containing their id as a property
+                     * @param {[sap.ui.core.Control]} aControls
+                     * @return {Array} Object
+                     */
+                    window.wdi5.createControlIdMap = (aControls) => {
+                        // the array of UI5 controls need to be mapped (remove circular reference)
+                        return aControls.map((element) => {
+                            // just use the absolute ID of the control
+                            let item = {
+                                id: element.getId()
+                            };
+                            return item;
+                        });
+                    };
+                }
+            );
+        }
+    });
+
+    if (result) {
+        // set when call returns
+        _isInitialized = true;
+        console.log('sucessfully initialized wdio-ui5 bridge');
+    } else {
+        console.error('bridge was not initialized correctly');
+    }
+    return result;
+}
+
+/**
+ *
+ */
+async function checkForUI5Page() {
+    _context.waitUntil(() => {
+        const readyState = _context.executeAsync((done) => {
+            setTimeout(() => {
+                if (document.location.href != 'data:,') {
+                    // make sure we are not on the initial page
+                    done(document.readyState)
+                }
+            }, 400)
+        })
+        return readyState === 'complete';
+    }, { interval: 500, timeout: 8000 });
+
+    // test for ui5
+    let result = _context.execute(() => {
+        // browser context - you may not access client or console
+        return !!window.sap;
+    })
+    return result;
+}
+
+/**
+ * internally used to execute the attach the new function calls to the wdio context object
+ * https://webdriver.io/docs/customcommands.html#overwriting-native-commands
+ * use wdio's hooks for setting up custom commands in the context
+ * @param {WebdriverIO.BrowserObject} context
+ */
+function setup(context) {
+
+    if (_setupComplete) {
+        // already setup done
+        return;
+    }
+
+    if (!_context) {
+        _context = context;
+    }
+
+    // create an internal store of already retrieved UI5 elements
+    // in the form of their wdio counterparts
+    // for faster subsequent access
+    if (!_context._controls) {
+        console.info('creating internal control map');
+        _context._controls = {};
+    }
+
+    /**
+     * Find the best control selector for a DOM element. A selector uniquely represents a single element.
+     * The 'best' selector is the one with which it is most likely to uniquely identify a control with the least possible inspection of the control tree.
+     * @param {object} oOptions
+     * @param {object} oOptions.domElement - DOM Element to search for
+     * @param {object} oOptions.settings - ui5 settings object
+     * @param {boolean} oOptions.settings.preferViewId
+     * @param {WebdriverIO.BrowserObject} _context
+     */
+    _context.addCommand('getSelectorForElement', (oOptions) => {
+        const result = _context.executeAsync((oOptions, done) => {
+            window.bridge
+                .waitForUI5()
+                .then(() => {
+                    window.wdi5.Log.info('[browser wdio-ui5] locating domElement');
+                    return window.bridge.findControlSelectorByDOMElement(oOptions);
+                })
+                .then((controlSelector) => {
+                    window.wdi5.Log.info('[browser wdio-ui5] controlLocator created!');
+                    done(['success', controlSelector]);
+                    return controlSelector;
+                })
+                .catch((error) => {
+                    window.wdi5.Log.error('[browser wdio-ui5] ERR: ', error);
+                    done(['error', error.toString()]);
+                    return error;
+                });
+        }, oOptions);
+
+        if (Array.isArray(result)) {
+            if (result[0] === 'error') {
+                console.error('ERROR: getSelectorForElement() failed because of: ' + result[1]);
+                return result[1];
+            } else if (result[0] === 'success') {
+                console.log(`SUCCESS: getSelectorForElement() returned:  ${JSON.stringify(result[0])}`);
+                return result[1];
+            }
+        } else {
+            // Guess: was directly returned
+            return result;
+        }
+    });
+
+    /**
+     * uses the UI5 native waitForUI5 function to wait for all promises to be settled
+     */
+    _context.addCommand('waitForUI5', () => {
+        return _waitForUI5();
+    });
+
+    /**
+     * wait for ui5 and take a screenshot
+     */
+    _context.addCommand('screenshot', (fileAppendix) => {
+        _waitForUI5();
+        _writeScreenshot(fileAppendix);
+    });
+
+    /**
+     * take a screenshot without waiting for UI5 app using the CURRENT wdio context
+     */
+    _context.addCommand('writescreenshot', (fileAppendix) => {
+        _writeScreenshot(fileAppendix);
+    });
+
+    /**
+     * do a navigation by changing the url hash
+     * or
+     * using the UI5 router with full standard parameter set
+     * @param {Object} oOptions {sHash: '#/test', oRoute: {sComponentId, sName, oParameters, oComponentTargetInfo, bReplace}}
+     */
+    _context.addCommand('goTo', (oOptions) => {
+
+        // destruct the oOptions
+        const sHash = oOptions.sHash;
+        const oRoute = oOptions.oRoute;
+
+        if (sHash && sHash.length > 0) {
+            // navigate via hash if defined
+            _context.url(`${sHash}`);
+        } else if (oRoute && oRoute.sName) {
+            // navigate using the ui5 router
+            // sComponentId, sName, oParameters, oComponentTargetInfo, bReplace
+            _navTo(oRoute.sComponentId, oRoute.sName, oRoute.oParameters, oRoute.oComponentTargetInfo, oRoute.bReplace);
+        } else {
+            console.error("ERROR: navigaing to another page");
+        }
+    });
+
+    /**
+     * this function is the main method to enable the communication with the UI5 application
+     * can be accessed via the browser object in the test case `browser.asControl(selector)` whereas the selector is of type WDI5Selector
+     *
+     * wdio_ui5_key internally used key to store the already retrieved controls and prevent double browser access.
+     * Check for object type, if wdio_ui5_key is present.
+     *
+     * const wdi5Selector = {
+     *     wdio_ui5_key: „someCutomControlIdentifier“,
+     *     selector: <sap.ui.test.RecordReplay.ControlSelector>
+     * }
+     *
+     * wdio_ui5_key is generated based on the givven selector.
+     * If wdio_ui5_key is provided with the selector the provided wdio_ui5_key is used.
+     * You can force to load the control freshly from browser context by setting the 'forceSelect' parameter to true
+     *
+     * @param {WDI5Selector} wdi5Selector custom selector object with property wdio_ui5_key and sap.ui.test.RecordReplay.ControlSelector
+     */
+    _context.addCommand('asControl', (wdi5Selector) => {
+        if (!wdi5Selector.hasOwnProperty('wdio_ui5_key')) {
+            // has not a wdio_ui5_key -> generate one
+            wdi5Selector['wdio_ui5_key'] = _createWdioUI5KeyFromSelector(wdi5Selector.selector);
+        }
+
+        const internalKey = wdi5Selector.wdio_ui5_key;
+        if (!_context._controls[internalKey] || wdi5Selector['forceSelect']) {
+            // if control is not yet existent or force parameter is set -> load control
+
+            // create WDI5 control
+            const wdi5Control = new WDI5(wdi5Selector, _context);
+
+            // save control
+            _context._controls[internalKey] = wdi5Control;
+            console.info(`creating internal control with id ${internalKey}`);
+
+            return wdi5Control;
+        } else {
+            console.info(`reusing internal control with id ${internalKey}`);
+            // return webui5 control from storage map
+            return _context._controls[internalKey];
+        }
+    });
+
+    // store the status
+    _setupComplete = true;
+}
+
+
+// public
+module.exports = {
+    injectUI5,
+    setup,
+    checkForUI5Page
+};
+
+// --------- private functions ------------ //
+
+/**
+ * can be called to make sure before you access any eg. DOM Node the ui5 framework is done loading
+ * @returns {Boolean} if the UI5 page is fully loaded and ready to interact.
+ */
+function _waitForUI5() {
+    if (_isInitialized) {
+        // injectUI5 was already called and was successful attached
+        return _checkForUI5Ready();
+    } else {
+        if (injectUI5()) {
+            return _checkForUI5Ready();
+        } else {
+            return false;
+        }
+    }
+}
+
+/**
+ * check for UI5 via the RecordReplay.waitForUI5 method
+ */
+function _checkForUI5Ready() {
+    if (_isInitialized) {
+        // can only be executed when RecordReplay is attached
+        const result = _context.executeAsync((done) => {
+            window.bridge
+                .waitForUI5()
+                .then(() => {
+                    window.wdi5.Log.info('[browser wdio-ui5] UI5 is ready');
+                    console.log('[browser wdio-ui5] UI5 is ready');
+                    done(true);
+                })
+                .catch((error) => {
+                    console.error(error);
+                });
+        });
+        return result;
+    }
+    return false;
+}
+
+/**
+   * generates date string with format M-d-hh-mm-ss
+   * @returns {String}
+   */
+function _getDateString() {
+    var x = new Date();
+    return `${x.getMonth() + 1}-${x.getDate()}-${x.getHours()}-${x.getMinutes()}-${x.getSeconds()}`;
+}
+
+/**
+ *
+ * @param {*} fileAppendix
+ */
+function _writeScreenshot(fileAppendix) {
+
+    // browser.screenshot returns the screenshot as a base64 string
+    const screenshot = _context.takeScreenshot();
+    const seed = _getDateString();
+
+    let _path = _context.config.wdi5['screenshotPath'];
+    if (_path === undefined || _path.length === 0) {
+        _path = this.pjsonPackage.screenshotPath;
+    }
+
+    if (fileAppendix.length > 0) {
+        fileAppendix = '-' + fileAppendix;
+    }
+
+    const platform = _context.config.wdi5['platform'];
+
+    // make path cross-platform
+    _path = path.resolve(_path, `${seed}-${platform}-${fileAppendix}.png`);
+    // async
+    fs.writeFile(_path, screenshot, 'base64', function (err) {
+        if (err) {
+            console.error(err);
+        } else {
+            console.log(`screenshot at ${_path} created`);
+        }
+    });
+}
+
+/**
+ * creates a string valid as object key from a selector
+ * @param {sap.ui.test.RecordReplay.ControlSelector} selector
+ * @returns {String} wdio_ui5_key
+ */
+function _createWdioUI5KeyFromSelector(selector) {
+    const orEmpty = (string) => {
+        return string || '-';
+    };
+    const wdi5_ui5_key = _stripNonValidCharactersForKey(
+        `${orEmpty(selector.id)}_${orEmpty(selector.viewName)}_${orEmpty(selector.controlType)}_${orEmpty(
+            JSON.stringify(selector.bindingPath)
+        )}_${orEmpty(JSON.stringify(selector.I18NText))}_${orEmpty(selector.labelFor)}_${orEmpty(
+            JSON.stringify(selector.properties)
+        )}`
+    );
+    return wdi5_ui5_key;
+}
+
+/**
+ * to generate an object key from any string
+ * @param {String} key
+ * @returns {String}
+ */
+function _stripNonValidCharactersForKey(key) {
+    return key
+        .split('.')
+        .join('')
+        .split('/')
+        .join('')
+        .split(' ')
+        .join('')
+        .split('>')
+        .join('')
+        .split('_-')
+        .join('')
+        .split('-')
+        .join('')
+        .toLowerCase();
+}
+
+/**
+ * navigates to a UI5 route using the Component router
+ * @param {String} sComponentId
+ * @param {String} sName
+ * @param {Object} oParameters
+ * @param {Object} oComponentTargetInfo
+ * @param {Boolean} bReplace
+ */
+function _navTo(sComponentId, sName, oParameters, oComponentTargetInfo, bReplace) {
+    const result = _context.executeAsync((sComponentId, sName, oParameters, oComponentTargetInfo, bReplace, done) => {
+        window.bridge
+            .waitForUI5()
+            .then(() => {
+                window.wdi5.Log.info(`[browser wdio-ui5] navigation to ${sName} triggered`);
+
+                const router = sap.ui.getCore().getComponent(sComponentId).getRouter();
+                const hashChanger = router.getHashChanger();
+
+                // on success result is the router
+                router.getHashChanger().attachEvent('hashChanged', function (oEvent) {
+                    done(['success', hashChanger.hash]);
+                });
+
+                // get component and trigger router
+                // sName, oParameters?, oComponentTargetInfo?, bReplace?
+                router.navTo(sName, oParameters, oComponentTargetInfo, bReplace);
+                return hashChanger.hash;
+
+                // if the navigation was not executed the done event wont be called -> running into the wdio timout
+                const error = 'Navigation via UI5 router failed';
+                window.wdi5.Log.error(`[browser wdio-ui5] ERR: ${error}`);
+                done(['error', error]);
+
+            });
+    }, sComponentId, sName, oParameters, oComponentTargetInfo, bReplace);
+
+    if (Array.isArray(result)) {
+        if (result[0] === 'error') {
+            console.error('ERROR: navigation using UI5 router failed because of: ' + result[1]);
+            return result[1];
+        } else if (result[0] === 'success') {
+            console.log(`SUCCESS: navigation using UI5 router to hash:  ${JSON.stringify(result[0])} was successfull`);
+            return result[1];
+        }
+    } else {
+        // Guess: was directly returned
+        return result;
+    }
+}

--- a/packages/wdio-ui5-service/src/service.js
+++ b/packages/wdio-ui5-service/src/service.js
@@ -1,0 +1,43 @@
+// The rest of the hooks will be handled by the service (the default export), as normal.
+
+const SevereServiceError = require('webdriverio')
+const wdioUI5 = require('./lib/wdioUi5-index');
+
+module.exports = class Service {
+
+    before(capabilities, specs) {
+
+        // call the start function
+        this.startWDI5()
+    };
+
+    /**
+     * separate the start funtion for felxibility
+     */
+    startWDI5() {
+
+        // UI5 bridge setup
+        const context = driver ? driver : browser;
+        const wdi5config = context.config.wdi5;
+
+        // this is only to run in browser
+        if (wdi5config && wdi5config.url) {
+            browser.url(wdi5config.url);
+        }
+
+        console.log("wdio-ui5-service before hook")
+
+        wdioUI5.setup(context); // use wdio hooks for setting up wdio<->ui5 bridge
+
+        // returns promise
+        let status = wdioUI5.checkForUI5Page();
+        status.then(() => {
+            wdioUI5.injectUI5(context); // needed to let the instance know that UI5 is now available for work
+        })
+    }
+
+    after(result, capabilities, specs) {
+
+    };
+}
+

--- a/packages/wdio-ui5-service/tsconfig.json
+++ b/packages/wdio-ui5-service/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "extends": "../../tsconfig",
+    "compilerOptions": {
+      "baseUrl": ".",
+      "outDir": "./build",
+      "rootDir": "./src"
+    },
+    "include": [
+      "src/**/*"
+    ]
+  }


### PR DESCRIPTION
## Proposed changes

[UI5](https://openui5.org) is an Open-Source UI framework by SAP, powering the UI layer of its' enterprise ERP S/4 software. This PR adds the capability of test-driving UI5 web applications via Webdriver.IO, by using wdio's `services` capability. Plus it is the basis for [`wdi5`](https://github.com/js-soft/wdi5), an extension to wdio, capable of running tests against packaged (hybrid) UI5 applications on iOS, Android, and Electron.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works   
  (yes, but tests reside in a different repo, at https://github.com/js-soft/wdi5/tree/develop/test, specifically https://github.com/js-soft/wdi5/blob/develop/test/wdio-ui5.conf.js and https://github.com/js-soft/wdi5/blob/develop/test/test-ui5/ui5.test.js)
- [x] I have added necessary documentation (see `README.md` of `wdio-ui5-service`)
- `n/a` I have added proper type definitions for new commands (if appropriate)

### Reviewers: @webdriverio/project-committers
