### PR TITLE
feat(ui5-service): add UI5 support to wdio

### DIFF
--- a/packages/wdio-cli/src/constants.ts
+++ b/packages/wdio-cli/src/constants.ts
@@ -99,6 +99,7 @@ export const SUPPORTED_PACKAGES = {
         { name: 'zafira-listener', value: 'wdio-zafira-listener-service$--$zafira-listener' },
         { name: 'reportportal', value: 'wdio-reportportal-service$--$reportportal' },
         { name: 'docker', value: 'wdio-docker-service$--$docker' },
+        { name: 'wdio-ui5', value: 'wdio-ui5-service$--$wdio-ui5' },
         { name: 'wiremock', value: 'wdio-wiremock-service$--$wiremock' },
         { name: 'ng-apimock', value: 'wdio-ng-apimock-service$--ng-apimock' },
         { name: 'slack', value: 'wdio-slack-service$--$slack' },

--- a/scripts/docs-generation/3rd-party/services.json
+++ b/scripts/docs-generation/3rd-party/services.json
@@ -30,6 +30,12 @@
     "npmUrl": "https://www.npmjs.com/package/wdio-docker-service"
   },
   {
+    "packageName": "wdio-ui5-service",
+    "title": "WDIO UI5 Service",
+    "githubUrl": "https://github.com/js-soft/wdi5/tree/develop/wdio-ui5-service",
+    "npmUrl": "https://www.npmjs.com/package/wdio-ui5-service"
+  },
+  {
     "packageName": "wdio-wiremock-service",
     "title": "WireMock",
     "githubUrl": "https://github.com/erwinheitzman/wdio-wiremock-service",


### PR DESCRIPTION
## Proposed changes

[UI5](https://openui5.org/) is an Open-Source UI framework by SAP, powering the UI layer of its' enterprise ERP S/4 software. This PR adds the capability of test-driving UI5 web applications via Webdriver.IO, by using wdio's `services` capability. Plus it is the basis for [wdi5](https://github.com/js-soft/wdi5), an extension to wdio, capable of running tests against packaged (hybrid) UI5 applications on iOS, Android, and Electron.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
(yes, the tests reside inside the repo, at https://github.com/js-soft/wdi5/tree/develop/wdio-ui5-service/test, specifically https://github.com/js-soft/wdi5/blob/develop/wdio-ui5-service/test/wdio-ui5.conf.js and https://github.com/js-soft/wdi5/blob/develop/wdio-ui5-service/test/ui5.test.js)
- [x] I have added necessary documentation (see `README.md` of `wdio-ui5-service`)
- [ ] `n/a` I have added proper type definitions for new commands (if appropriate)

### Reviewers: @webdriverio/project-committers
