### PR TITLE
feat: enable new printPage command via webdriver protocol binding

### DIFF
--- a/packages/wdio-protocols/protocols/webdriver.json
+++ b/packages/wdio-protocols/protocols/webdriver.json
@@ -227,7 +227,7 @@
       }, {
         "name": "height",
         "type": "number",
-        "description": "page height in cm. Default: 27.94 from page",
+        "description": "page height in cm. Default: `27.94` from page",
         "required": false
       }, {
         "name": "top",

--- a/packages/wdio-protocols/protocols/webdriver.json
+++ b/packages/wdio-protocols/protocols/webdriver.json
@@ -232,7 +232,7 @@
       }, {
         "name": "top",
         "type": "number",
-        "description": "page margin in cm from top margin. Default: 1",
+        "description": "page margin in cm from top margin. Default: `1`",
         "required": false
       }, {
         "name": "bottom",

--- a/packages/wdio-protocols/protocols/webdriver.json
+++ b/packages/wdio-protocols/protocols/webdriver.json
@@ -252,7 +252,7 @@
       }, {
         "name": "shrinkToFit",
         "type": "boolean",
-        "description": "shrink pdf to fit in page. Default: true",
+        "description": "shrink pdf to fit in page. Default: `true`",
         "required": false
       }, {
         "name": "pageRanges",

--- a/packages/wdio-protocols/protocols/webdriver.json
+++ b/packages/wdio-protocols/protocols/webdriver.json
@@ -258,7 +258,7 @@
         "name": "pageRanges",
         "type": "object[]",
         "description": "page ranges.",
-        "required": true
+        "required": false
       }],
       "returns": {
         "type": "string",

--- a/packages/wdio-protocols/protocols/webdriver.json
+++ b/packages/wdio-protocols/protocols/webdriver.json
@@ -207,7 +207,7 @@
       "parameters": [{
         "name": "orientation",
         "type": "string",
-        "description": "page orientation. Default: 'portrait'",
+        "description": "page orientation. Default: `portrait`",
         "required": false
       }, {
         "name": "scale",

--- a/packages/wdio-protocols/protocols/webdriver.json
+++ b/packages/wdio-protocols/protocols/webdriver.json
@@ -237,7 +237,7 @@
       }, {
         "name": "bottom",
         "type": "number",
-        "description": "page margin in cm from bottom margin. Default: 1",
+        "description": "page margin in cm from bottom margin. Default: `1`",
         "required": false
       }, {
         "name": "left",

--- a/packages/wdio-protocols/protocols/webdriver.json
+++ b/packages/wdio-protocols/protocols/webdriver.json
@@ -222,7 +222,7 @@
       }, {
         "name": "width",
         "type": "number",
-        "description": "page width in cm. Default: 21.59 from page",
+        "description": "page width in cm. Default: `21.59` from page",
         "required": false
       }, {
         "name": "height",

--- a/packages/wdio-protocols/protocols/webdriver.json
+++ b/packages/wdio-protocols/protocols/webdriver.json
@@ -256,7 +256,7 @@
         "required": false
       }, {
         "name": "pageRanges",
-        "type": "Array<Object>",
+        "type": "object[]",
         "description": "page ranges.",
         "required": true
       }],

--- a/packages/wdio-protocols/protocols/webdriver.json
+++ b/packages/wdio-protocols/protocols/webdriver.json
@@ -242,7 +242,7 @@
       }, {
         "name": "left",
         "type": "number",
-        "description": "page margin in cm from left margin. Default: 1",
+        "description": "page margin in cm from left margin. Default: `1`",
         "required": false
       }, {
         "name": "right",

--- a/packages/wdio-protocols/protocols/webdriver.json
+++ b/packages/wdio-protocols/protocols/webdriver.json
@@ -217,7 +217,7 @@
       }, {
         "name": "background",
         "type": "boolean",
-        "description": "page background. Default: false",
+        "description": "page background. Default: `false`",
         "required": false
       }, {
         "name": "width",

--- a/packages/wdio-protocols/protocols/webdriver.json
+++ b/packages/wdio-protocols/protocols/webdriver.json
@@ -212,7 +212,7 @@
       }, {
         "name": "scale",
         "type": "number",
-        "description": "page scale. Default: 1",
+        "description": "page scale. Default: `1`",
         "required": false
       }, {
         "name": "background",

--- a/packages/wdio-protocols/protocols/webdriver.json
+++ b/packages/wdio-protocols/protocols/webdriver.json
@@ -257,7 +257,7 @@
       }, {
         "name": "pageRanges",
         "type": "object[]",
-        "description": "page ranges.",
+        "description": "page ranges. Default `[]`",
         "required": false
       }],
       "returns": {

--- a/packages/wdio-protocols/protocols/webdriver.json
+++ b/packages/wdio-protocols/protocols/webdriver.json
@@ -247,7 +247,7 @@
       }, {
         "name": "right",
         "type": "number",
-        "description": "page margin in cm from right margin. Default: 1",
+        "description": "page margin in cm from right margin. Default: `1`",
         "required": false
       }, {
         "name": "shrinkToFit",

--- a/packages/wdio-protocols/protocols/webdriver.json
+++ b/packages/wdio-protocols/protocols/webdriver.json
@@ -199,6 +199,74 @@
       }
     }
   },
+  "/session/:sessionId/print": {
+    "POST": {
+      "command": "printPage",
+      "description": "The Print Page command renders the document to a paginated PDF document.",
+      "ref": "https://w3c.github.io/webdriver/#print-page",
+      "parameters": [{
+        "name": "orientation",
+        "type": "string",
+        "description": "page orientation. Default: 'portrait'",
+        "required": false
+      }, {
+        "name": "scale",
+        "type": "number",
+        "description": "page scale. Default: 1",
+        "required": false
+      }, {
+        "name": "background",
+        "type": "boolean",
+        "description": "page background. Default: false",
+        "required": false
+      }, {
+        "name": "width",
+        "type": "number",
+        "description": "page width in cm. Default: 21.59 from page",
+        "required": false
+      }, {
+        "name": "height",
+        "type": "number",
+        "description": "page height in cm. Default: 27.94 from page",
+        "required": false
+      }, {
+        "name": "top",
+        "type": "number",
+        "description": "page margin in cm from top margin. Default: 1",
+        "required": false
+      }, {
+        "name": "bottom",
+        "type": "number",
+        "description": "page margin in cm from bottom margin. Default: 1",
+        "required": false
+      }, {
+        "name": "left",
+        "type": "number",
+        "description": "page margin in cm from left margin. Default: 1",
+        "required": false
+      }, {
+        "name": "right",
+        "type": "number",
+        "description": "page margin in cm from right margin. Default: 1",
+        "required": false
+      }, {
+        "name": "shrinkToFit",
+        "type": "boolean",
+        "description": "shrink pdf to fit in page. Default: true",
+        "required": false
+      }, {
+        "name": "pageRanges",
+        "type": "Array<Object>",
+        "description": "page ranges.",
+        "required": true
+      }],
+      "returns": {
+        "type": "string",
+        "name": "pdf",
+        "description": "The base64-encoded PDF representation of the paginated document."
+      }
+    }
+  },
   "/session/:sessionId/frame": {
     "POST": {
       "command": "switchToFrame",


### PR DESCRIPTION
## Proposed changes

This PR should complete #6096

It updates `packages/wdio-protocols/protocols/webdriver.json`, adding new protocol bindings for the **print** protocol command.

**NOTE: this is a work-in-progress, and is currently broken**

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
    - **the tests currently fail**
- [ ] I have added necessary documentation (if appropriate)
   - **is it appropriate?**
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

This is my first PR here, and I'm not super confident its correct. Please be brutal in your review & feedback. I'm happy to make whatever changes are necessary to get this in.

It's definitely *broken* right now

*output from `npm test`*:

```
../../../packages/devtools/devtools.d.ts:58:197 - error TS1016: A required parameter cannot follow an optional parameter.

58         printPage(orientation?: string, scale?: number, background?: boolean, width?: number, height?: number, top?: number, bottom?: number, left?: number, right?: number, shrinkToFit?: boolean, pageRanges: array<object>): string;
                                                                                                                                                                                                       ~~~~~~~~~~

../../../packages/devtools/devtools.d.ts:58:209 - error TS2304: Cannot find name 'array'.

58         printPage(orientation?: string, scale?: number, background?: boolean, width?: number, height?: number, top?: number, bottom?: number, left?: number, right?: number, shrinkToFit?: boolean, pageRanges: array<object>): string;
```

Per @christian-bromann, We should also add the protocol in the `devtools` package, implemented with Puppeteer. I have not yet looked into that. I think it probably can/should be a separate ticket.

#### Open Questions

- [ ] How can I *test* this?
- [ ] Documentation?

### Reviewers: @webdriverio/project-committers
