### PR TITLE
Try to fix @wdio/testingbot-service not using the Tunnel

### DIFF
--- a/packages/wdio-testingbot-service/src/@types/testingbot-tunnel-launcher.d.ts
+++ b/packages/wdio-testingbot-service/src/@types/testingbot-tunnel-launcher.d.ts
@@ -30,7 +30,19 @@ interface TunnelLauncherOptions {
  
     // Change the tunnel version - see versions on https://testingbot.com/support/other/tunnel
     // "1.19" // or 2.1 (Java 8)
-    tunnelVersion?: string 
+    tunnelVersion?: string,
+
+    // A unique identifier for this tunnel (optional)
+    tunnelIdentifier?: string,
+
+    // This file will be touched when the tunnel is ready for usage (optional)
+    readyFile?: string,
+
+    // Use a custom DNS server. For example: 8.8.8.8 (optional)
+    dns?: string,
+
+    // Bypass the Caching Proxy running on the TestingBot tunnel VM.
+    noproxy?: string,
 }
 
 interface TestingbotTunnel {

--- a/packages/wdio-testingbot-service/src/launcher.ts
+++ b/packages/wdio-testingbot-service/src/launcher.ts
@@ -4,7 +4,7 @@ import { promisify } from 'util'
 import testingbotTunnel from 'testingbot-tunnel-launcher'
 import logger from '@wdio/logger'
 
-const log = logger('@wdio/sauce-service')
+const log = logger('@wdio/testingbot-service')
 
 export default class TestingBotLauncher {
     options: TestingbotOptions;
@@ -14,20 +14,24 @@ export default class TestingBotLauncher {
         this.options = options
     }
 
-    async onPrepare (config: WebdriverIO.Config) {
+    async onPrepare (config: WebdriverIO.Config, capabilities: WebDriver.Capabilities) {
         if (!this.options.tbTunnel || !config.user || !config.key) {
             return
         }
 
+        const tbTunnelIdentifier = `TB-tunnel-${Math.random().toString().slice(2)}`
+
         this.tbTunnelOpts = Object.assign({
             apiKey: config.user,
-            apiSecret: config.key
+            apiSecret: config.key,
+            'tunnel-identifier': tbTunnelIdentifier,
         }, this.options.tbTunnelOpts)
 
-        config.protocol = 'http'
-        config.hostname = 'localhost'
-        config.port = 4445
-        config.path = '/wd/hub'
+        if (!capabilities['tb:options']) {
+            capabilities['tb:options'] = {}
+        }
+
+        capabilities['tb:options'].tunnelIdentifier = tbTunnelIdentifier
 
         /**
          * measure TestingBot tunnel boot time

--- a/packages/wdio-testingbot-service/src/launcher.ts
+++ b/packages/wdio-testingbot-service/src/launcher.ts
@@ -27,11 +27,20 @@ export default class TestingBotLauncher {
             'tunnel-identifier': tbTunnelIdentifier,
         }, this.options.tbTunnelOpts)
 
-        if (!capabilities['tb:options']) {
-            capabilities['tb:options'] = {}
+        let tbOptions = capabilities['tb:options']
+        if (!tbOptions) {
+            tbOptions = {}
         }
 
-        capabilities['tb:options'].tunnelIdentifier = tbTunnelIdentifier
+        tbOptions = {
+            'tunnel-identifier': tbTunnelIdentifier,
+        } as WebDriver.TestingbotCapabilities
+
+        (
+            Array.isArray(capabilities)
+                ? capabilities
+                : Object.values(capabilities)
+        ).forEach((cap: WebDriver.DesiredCapabilities) => Object.assign(cap, { 'tb:options': tbOptions }, { ...cap }))
 
         /**
          * measure TestingBot tunnel boot time

--- a/packages/wdio-testingbot-service/src/launcher.ts
+++ b/packages/wdio-testingbot-service/src/launcher.ts
@@ -32,15 +32,10 @@ export default class TestingBotLauncher {
             tbOptions = {}
         }
 
-        tbOptions = {
-            'tunnel-identifier': tbTunnelIdentifier,
-        } as WebDriver.TestingbotCapabilities
+        tbOptions['tunnel-identifier'] = tbTunnelIdentifier
 
-        (
-            Array.isArray(capabilities)
-                ? capabilities
-                : Object.values(capabilities)
-        ).forEach((cap: WebDriver.DesiredCapabilities) => Object.assign(cap, { 'tb:options': tbOptions }, { ...cap }))
+        const caps = Array.isArray(capabilities) ? capabilities : Object.values(capabilities)
+        caps.forEach((cap: WebDriver.DesiredCapabilities) => Object.assign(cap, { 'tb:options': tbOptions }, { ...cap }))
 
         /**
          * measure TestingBot tunnel boot time

--- a/packages/wdio-testingbot-service/tests/launcher.test.ts
+++ b/packages/wdio-testingbot-service/tests/launcher.test.ts
@@ -27,8 +27,8 @@ describe('wdio-testingbot-service', () => {
     it('onPrepare: tbTunnel is undefined', async () => {
         const options = { tbTunnel: undefined } as any
         const tbLauncher = new TestingBotLauncher(options)
-
-        await tbLauncher.onPrepare({})
+        const caps = {} as any
+        await tbLauncher.onPrepare({}, caps)
         expect(tbLauncher.tbTunnelOpts).toBeUndefined()
         expect(tbLauncher.tunnel).toBeUndefined()
         expect(options.protocol).toBeUndefined()
@@ -48,14 +48,11 @@ describe('wdio-testingbot-service', () => {
             user: 'user',
             key: 'key'
         }
+        const caps = {} as any
         const tbLauncher = new TestingBotLauncher(options)
 
-        await tbLauncher.onPrepare(config)
-        expect(tbLauncher.tbTunnelOpts).toEqual({ apiKey: 'user', apiSecret: 'key', options: 'some options' })
-        expect(config.protocol).toEqual('http')
-        expect(config.hostname).toEqual('localhost')
-        expect(config.port).toEqual(4445)
-        expect(config.path).toEqual('/wd/hub')
+        await tbLauncher.onPrepare(config, caps)
+        expect(tbLauncher.tbTunnelOpts).toMatchObject({ apiKey: 'user', apiSecret: 'key', options: 'some options' })
         expect((log.info as jest.Mock).mock.calls[0][0]).toContain('TestingBot tunnel successfully started after')
     })
 

--- a/packages/webdriver/src/types.ts
+++ b/packages/webdriver/src/types.ts
@@ -304,9 +304,7 @@ export interface VendorExtensions extends EdgeCapabilities {
     // Selenoid specific
     'selenoid:options'?: SelenoidOptions
     // Testingbot w3c specific
-    'tb:options'?: {
-        [name: string]: any
-    }
+    'tb:options'?: TestingbotCapabilities
     // Saucelabs w3c specific
     'sauce:options'?: SauceLabsCapabilities
     // Browserstack w3c specific

--- a/packages/webdriver/webdriver.d.ts
+++ b/packages/webdriver/webdriver.d.ts
@@ -323,9 +323,7 @@ declare namespace WebDriver {
         // Selenoid specific
         'selenoid:options'?: SelenoidOptions
         // Testingbot w3c specific
-        'tb:options'?: {
-            [name: string]: any
-        }
+        'tb:options'?: TestingbotCapabilities
         // Saucelabs w3c specific
         'sauce:options'?: SauceLabsCapabilities
         // Browserstack w3c specific
@@ -552,6 +550,7 @@ declare namespace WebDriver {
         tags?: string[];
         build?: string | number;
         public?: boolean;
+        tunnelIdentifier?: string
     }
 
     export interface SeleniumRCCapabilities {

--- a/packages/webdriver/webdriver.d.ts
+++ b/packages/webdriver/webdriver.d.ts
@@ -550,7 +550,7 @@ declare namespace WebDriver {
         tags?: string[];
         build?: string | number;
         public?: boolean;
-        tunnelIdentifier?: string
+        'tunnel-identifier'?: string
     }
 
     export interface SeleniumRCCapabilities {


### PR DESCRIPTION
## Proposed changes

The latest versions of @wdio/testingbot-service are no longer forwarding requests through http://localhost:4445
As a result, webdriverio tests will no longer use the TestingBot Tunnel.

This change includes a `tunnelIdentifier` instead, which should be passed through as a capability.
I tried to use `tb:options` for this, but for some reason this gets stripped out further down by webdriverio.

This PR does not fix the problem yet. If someone could guide me in how to pass this through the capabilities, then I can adjust this PR.

Many thanks

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)


### Reviewers: @webdriverio/project-committers
