### PR TITLE
Update examples with outdated waitForVisible method 

### DIFF
--- a/docs/Timeouts.md
+++ b/docs/Timeouts.md
@@ -65,7 +65,7 @@ const myElem = $('#myElem')
 myElem.waitForDisplayed()
 
 // you can also overwrite the default timeout if needed
-myElem.waitForDisplayed(10000)
+myElem.waitForDisplayed({ timeout: 10000 })
 ```
 
 ## Framework related timeouts

--- a/docs/Timeouts.md
+++ b/docs/Timeouts.md
@@ -62,10 +62,10 @@ In your tests, you now can do this:
 
 ```js
 const myElem = $('#myElem')
-myElem.waitForVisible()
+myElem.waitForDisplayed()
 
 // you can also overwrite the default timeout if needed
-myElem.waitForVisible(10000)
+myElem.waitForDisplayed(10000)
 ```
 
 ## Framework related timeouts

--- a/examples/pageobject/specs/form.spec.js
+++ b/examples/pageobject/specs/form.spec.js
@@ -16,7 +16,7 @@ describe('auth form', () => {
         FormPage.password.addValue('SuperSecretPassword!')
         FormPage.submit()
 
-        FormPage.flash.waitForVisible()
+        FormPage.flash.waitForDisplayed()
         expect(FormPage.flash).toHaveTextContaining('You logged into a secure area!')
     })
 })

--- a/packages/webdriverio/src/commands/element/waitForDisplayed.js
+++ b/packages/webdriverio/src/commands/element/waitForDisplayed.js
@@ -12,7 +12,7 @@
             document.getElementById('elem').style.visibility = 'visible';
         }, 2000);
     </script>
-    :waitForVisibleExample.js
+    :waitForDisplayedExample.js
     it('should detect when element is visible', () => {
         const elem = $('#elem')
         elem.waitForDisplayed({ timeout: 3000 });


### PR DESCRIPTION
## Proposed changes

Some examples had obsolete `waitForVisible` (renamed in dc94c4a144741979655b40cd33cfe3146a56bb81) and obsolete way to pass timeout as positional arg (changed in #4928).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

However, I haven't run tests / built docs locally.  Hoping for such small fix CI will suffice?

### Reviewers: @webdriverio/project-committers
