### PR TITLE
Execute beforeSession hook before everything is initiated

### DIFF
--- a/packages/wdio-runner/src/index.js
+++ b/packages/wdio-runner/src/index.js
@@ -54,6 +54,13 @@ export default class Runner extends EventEmitter {
         const isMultiremote = this.isMultiremote = !Array.isArray(this.configParser.getCapabilities())
 
         /**
+         * run `beforeSession` command before framework and browser are initiated
+         */
+        initialiseWorkerService(this.config, caps, args.ignoredWorkerServices)
+            .map(this.configParser.addService.bind(this.configParser))
+        await runHook('beforeSession', this.config, this.caps, this.specs)
+
+        /**
          * create `browser` stub only if `specFiltering` feature is enabled
          */
         let browser = await this._startSession({
@@ -73,12 +80,7 @@ export default class Runner extends EventEmitter {
             return this._shutdown(0)
         }
 
-        initialiseWorkerService(this.config, caps, args.ignoredWorkerServices)
-            .map(this.configParser.addService.bind(this.configParser))
-
-        await runHook('beforeSession', this.config, this.caps, this.specs)
         browser = await this._initSession(this.config, this.caps, browser)
-
         this.inWatchMode = Boolean(this.config.watch)
 
         /**


### PR DESCRIPTION
## Proposed changes

We recently had two issues #6118 and #6119 with reports to not be able to run code and setup the framework before the test session got initialised. There might be use cases where you want to run async code before the test files are being interpreted. Therefor this patch tries to move the `beforeSession` hook a bit up the chain to be run before everything gets initialised.

This will also help to easier upgrade from previous versions of WebdriverIO.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
