### PR TITLE
Switch window query strings

### DIFF
--- a/packages/webdriverio/src/commands/browser/switchWindow.ts
+++ b/packages/webdriverio/src/commands/browser/switchWindow.ts
@@ -37,6 +37,14 @@ export default async function switchWindow (this: WebdriverIO.BrowserObject, url
 
     const tabs = await this.getWindowHandles()
 
+    const matchesTarget = (target: string): boolean => {
+        if (typeof urlOrTitleToMatch ==='string') {
+            return target.includes(urlOrTitleToMatch)
+        }
+        return !!target.match(urlOrTitleToMatch)
+
+    }
+
     for (const tab of tabs) {
         await this.switchToWindow(tab)
 
@@ -44,7 +52,7 @@ export default async function switchWindow (this: WebdriverIO.BrowserObject, url
          * check if url matches
          */
         const url = await this.getUrl()
-        if (url.match(urlOrTitleToMatch)) {
+        if (matchesTarget(url)) {
             return tab
         }
 
@@ -52,7 +60,7 @@ export default async function switchWindow (this: WebdriverIO.BrowserObject, url
          * check title
          */
         const title = await this.getTitle()
-        if (title.match(urlOrTitleToMatch)) {
+        if (matchesTarget(title)) {
             return tab
         }
     }

--- a/packages/webdriverio/src/commands/browser/switchWindow.ts
+++ b/packages/webdriverio/src/commands/browser/switchWindow.ts
@@ -42,7 +42,6 @@ export default async function switchWindow (this: WebdriverIO.BrowserObject, url
             return target.includes(urlOrTitleToMatch)
         }
         return !!target.match(urlOrTitleToMatch)
-
     }
 
     for (const tab of tabs) {

--- a/packages/webdriverio/tests/commands/browser/switchWindow.test.js
+++ b/packages/webdriverio/tests/commands/browser/switchWindow.test.js
@@ -51,4 +51,10 @@ describe('switchWindow', () => {
             expect(e.message).toContain('Unsupported parameter')
         }
     })
+
+    it('should find url with query string', async () => {
+        got.setMockResponse([null, null, 'foo.com?foo=bar', 'bar', null, 'hello', 'world', null, 'some', 'url'])
+        const tabId = await browser.switchWindow('foo.com?foo=bar')
+        expect(tabId).toBe('window-handle-1')
+    })
 })


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)
Fix #6012 
SwitchWindow was set to use `String.match(url)` for both Regex and string arguments, which will fail when called with a string containing regex characters.
Created a type based matching function that uses `String.includes()` for string type arguments.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
