### PR TITLE
Improve behavior fetching CSS shorthand properties

### DIFF
--- a/packages/webdriverio/package.json
+++ b/packages/webdriverio/package.json
@@ -59,6 +59,7 @@
     "@wdio/utils": "6.8.0",
     "archiver": "^5.0.0",
     "atob": "^2.1.2",
+    "css-shorthand-properties": "^1.1.1",
     "css-value": "^0.0.1",
     "devtools": "6.10.0",
     "fs-extra": "^9.0.1",

--- a/packages/webdriverio/src/types/css-shorthand-properties.d.ts
+++ b/packages/webdriverio/src/types/css-shorthand-properties.d.ts
@@ -1,0 +1,14 @@
+declare module "css-shorthand-properties" {
+    declare const cssShortHand: {
+        /**
+         * Returns a boolean indicating if a CSS property is a shorthand.
+         */
+        isShorthand: (property: string) => boolean
+        /**
+         * Takes a CSS shorthand property and returns a list of longhand properties.
+         */
+        expand: (property: string, recurse = false) => string[]
+    }
+
+    export = cssShortHand
+}

--- a/packages/webdriverio/tests/__mocks__/got.js
+++ b/packages/webdriverio/tests/__mocks__/got.js
@@ -148,6 +148,20 @@ const requestMock = jest.fn().mockImplementation((uri, params) => {
     case `${path}/${sessionId}/element/${genericElementId}/css/width`:
         value = '1250px'
         break
+    case `${path}/${sessionId}/element/${genericElementId}/css/margin-top`:
+    case `${path}/${sessionId}/element/${genericElementId}/css/margin-right`:
+    case `${path}/${sessionId}/element/${genericElementId}/css/margin-bottom`:
+    case `${path}/${sessionId}/element/${genericElementId}/css/margin-left`:
+        value = '42px'
+        break
+    case `${path}/${sessionId}/element/${genericElementId}/css/padding-top`:
+    case `${path}/${sessionId}/element/${genericElementId}/css/padding-bottom`:
+        value = '4px'
+        break
+    case `${path}/${sessionId}/element/${genericElementId}/css/padding-right`:
+    case `${path}/${sessionId}/element/${genericElementId}/css/padding-left`:
+        value = '2px'
+        break
     case `${path}/${sessionId}/element/${genericElementId}/property/tagName`:
         value = 'BODY'
         break

--- a/packages/webdriverio/tests/commands/element/getCSSProperty.test.js
+++ b/packages/webdriverio/tests/commands/element/getCSSProperty.test.js
@@ -18,6 +18,25 @@ describe('getCSSProperty test', () => {
         expect(property.parsed.value).toBe(1250)
     })
 
+    it('should expand shorthand property and fetch for all', async () => {
+        const browser = await remote({
+            baseUrl: 'http://foobar.com',
+            capabilities: {
+                browserName: 'foobar'
+            }
+        })
+        const elem = await browser.$('#foo')
+        const margin = await elem.getCSSProperty('margin')
+        expect(margin.value).toBe('42px')
+        expect(margin.parsed.value).toBe(42)
+
+        const padding = await elem.getCSSProperty('padding')
+        expect(padding.value).toBe('4px 2px')
+        expect(padding.parsed.length).toBe(2)
+        expect(padding.parsed[0].value).toBe(4)
+        expect(padding.parsed[1].value).toBe(2)
+    })
+
     afterEach(() => {
         got.mockClear()
     })


### PR DESCRIPTION
## Proposed changes

This patch improves the behavior documented in #6161. Instead of just returning an empty result in Firefox it is now behaving the same.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
