### PR TITLE
selenium-standalone: simplify config

### DIFF
--- a/packages/wdio-selenium-standalone-service/README.md
+++ b/packages/wdio-selenium-standalone-service/README.md
@@ -14,7 +14,7 @@ The easiest way is to keep `@wdio/selenium-standalone-service` as a devDependenc
 ```json
 {
     "devDependencies": {
-        "@wdio/selenium-standalone-service": "^6.6.1"
+        "@wdio/selenium-standalone-service": "^6.11.0"
     }
 }
 ```
@@ -29,8 +29,20 @@ Instructions on how to install `WebdriverIO` can be found [here.](https://webdri
 
 ## Configuration
 
-By default, Google Chrome and Firefox are available when installed on the host system. In order to use the service you need to add `selenium-standalone` to your service array:
+By default, ChromeDriver, geckodriver and some other browser drivers based on the OS are available when installed on the host system. In order to use the service you need to add `selenium-standalone` to your service array:
 
+```js
+// simplified mode (available since v6.11.0)
+export.config = {
+    // ...
+    services: [
+        ['selenium-standalone', { drivers: { firefox: 'latest', chrome: 'latest' } }]
+    ],
+    // ...
+};
+```
+
+Control browser driver installation/running separately.
 ```js
 // wdio.conf.js
 const drivers = {
@@ -44,8 +56,8 @@ export.config = {
     services: [
         ['selenium-standalone', {
             logPath: 'logs',
-            installArgs: { drivers },
-            args: { drivers }
+            installArgs: { drivers }, // drivers to install
+            args: { drivers } // drivers to use
         }]
     ],
     // ...

--- a/packages/wdio-selenium-standalone-service/README.md
+++ b/packages/wdio-selenium-standalone-service/README.md
@@ -32,11 +32,14 @@ Instructions on how to install `WebdriverIO` can be found [here.](https://webdri
 By default, ChromeDriver, geckodriver and some other browser drivers based on the OS are available when installed on the host system. In order to use the service you need to add `selenium-standalone` to your service array:
 
 ```js
-// simplified mode (available since v6.11.0)
+/**
+ * simplified mode (available since v6.11.0)
+ * set `true` to use the version provided by `selenium-standalone`, 'latest' by default
+*/
 export.config = {
     // ...
     services: [
-        ['selenium-standalone', { drivers: { firefox: 'latest', chrome: 'latest' } }]
+        ['selenium-standalone', { drivers: { firefox: '0.28.0', chrome: true, chromiumedge: 'latest' } }]
     ],
     // ...
 };

--- a/packages/wdio-selenium-standalone-service/package.json
+++ b/packages/wdio-selenium-standalone-service/package.json
@@ -32,7 +32,7 @@
     "@wdio/config": "6.10.0",
     "@wdio/logger": "6.8.0",
     "fs-extra": "^9.0.1",
-    "selenium-standalone": "^6.22.0"
+    "selenium-standalone": "^6.22.1"
   },
   "peerDependencies": {
     "@wdio/cli": "^6.0.1"

--- a/packages/wdio-selenium-standalone-service/package.json
+++ b/packages/wdio-selenium-standalone-service/package.json
@@ -32,7 +32,7 @@
     "@wdio/config": "6.10.0",
     "@wdio/logger": "6.8.0",
     "fs-extra": "^9.0.1",
-    "selenium-standalone": "^6.20.1"
+    "selenium-standalone": "^6.22.0"
   },
   "peerDependencies": {
     "@wdio/cli": "^6.0.1"

--- a/packages/wdio-selenium-standalone-service/selenium-standalone-service.d.ts
+++ b/packages/wdio-selenium-standalone-service/selenium-standalone-service.d.ts
@@ -23,4 +23,14 @@ interface SeleniumStandaloneOptions {
      * Boolean for skipping `selenium-standalone` server install.
      */
     skipSeleniumInstall?: boolean;
+    /**
+     * simplified way to pass browser driver versions
+     */
+    drivers?: {
+        chrome?: string
+        firefox?: string
+        chromiumedge?: string
+        ie?: string
+        edge?: string
+    };
 }

--- a/packages/wdio-selenium-standalone-service/selenium-standalone-service.d.ts
+++ b/packages/wdio-selenium-standalone-service/selenium-standalone-service.d.ts
@@ -27,10 +27,10 @@ interface SeleniumStandaloneOptions {
      * simplified way to pass browser driver versions
      */
     drivers?: {
-        chrome?: string
-        firefox?: string
-        chromiumedge?: string
-        ie?: string
-        edge?: string
+        chrome?: string | boolean
+        firefox?: string | boolean
+        chromiumedge?: string | boolean
+        ie?: string | boolean
+        edge?: string | boolean
     };
 }

--- a/packages/wdio-selenium-standalone-service/src/launcher.ts
+++ b/packages/wdio-selenium-standalone-service/src/launcher.ts
@@ -17,21 +17,52 @@ const DEFAULT_CONNECTION = {
     path: '/wd/hub'
 }
 
+type SeleniumStartArgs = Partial<import('selenium-standalone').StartOpts>
+type SeleniumInstallArgs = Partial<import('selenium-standalone').InstallOpts>
+type BrowserDrivers = {
+    chrome?: string
+    firefox?: string
+    chromiumedge?: string
+    ie?: string
+    edge?: string
+}
+
 export default class SeleniumStandaloneLauncher {
-    capabilities: WebDriver.DesiredCapabilities[] | WebdriverIO.MultiRemoteCapabilities;
+    capabilities: WebDriver.DesiredCapabilities[] | WebdriverIO.MultiRemoteCapabilities
     logPath?: string
-    args: Partial<import('selenium-standalone').StartOpts>;
-    installArgs: Partial<import('selenium-standalone').InstallOpts>;
+    args: SeleniumStartArgs
+    installArgs: SeleniumInstallArgs
     skipSeleniumInstall: boolean
     watchMode: boolean = false
     process!: SeleniumStandalone.ChildProcess
+    drivers?: {
+        chrome?: string
+        firefox?: string
+        chromiumedge?: string
+        ie?: string
+        edge?: string
+    }
 
-    constructor(options: WebdriverIO.ServiceOption, capabilities: WebDriver.DesiredCapabilities[] | WebdriverIO.MultiRemoteCapabilities, config: WebdriverIO.Config) {
+    constructor(
+        options: WebdriverIO.ServiceOption,
+        capabilities: WebDriver.DesiredCapabilities[] | WebdriverIO.MultiRemoteCapabilities,
+        config: WebdriverIO.Config
+    ) {
         this.capabilities = capabilities
         this.logPath = options.logPath || config.outputDir
-        this.args = options.args || {}
-        this.installArgs = options.installArgs || {}
         this.skipSeleniumInstall = Boolean(options.skipSeleniumInstall)
+
+        // simplified mode
+        if (options.drivers) {
+            this.args = Object.entries(options.drivers as BrowserDrivers).reduce((acc, [browserDriver, version]) => {
+                acc.drivers![browserDriver] = { version }
+                return acc
+            }, { drivers: {} } as SeleniumStartArgs)
+            this.installArgs = { ...this.args } as SeleniumInstallArgs
+        } else {
+            this.args = options.args || {}
+            this.installArgs = options.installArgs || {}
+        }
     }
 
     async onPrepare(config: WebdriverIO.Config): Promise<void> {
@@ -46,11 +77,11 @@ export default class SeleniumStandaloneLauncher {
          * update capability connection options to connect
          * to standalone server
          */
-        (
-            Array.isArray(this.capabilities)
-                ? this.capabilities
-                : Object.values(this.capabilities)
-        ).forEach((cap: WebDriver.DesiredCapabilities | WebdriverIO.MultiRemoteBrowserOptions) => !isCloudCapability(cap) && Object.assign(cap, DEFAULT_CONNECTION, { ...cap }))
+        const capabilities = Array.isArray(this.capabilities) ? this.capabilities : Object.values(this.capabilities)
+        capabilities.forEach(
+            (cap: WebDriver.DesiredCapabilities | WebdriverIO.MultiRemoteBrowserOptions) =>
+                !isCloudCapability(cap) && Object.assign(cap, DEFAULT_CONNECTION, { ...cap })
+        )
 
         /**
          * start Selenium Standalone server

--- a/packages/wdio-selenium-standalone-service/src/launcher.ts
+++ b/packages/wdio-selenium-standalone-service/src/launcher.ts
@@ -53,7 +53,7 @@ export default class SeleniumStandaloneLauncher {
         this.skipSeleniumInstall = Boolean(options.skipSeleniumInstall)
 
         // simplified mode
-        if (options.drivers) {
+        if (options.drivers && Object.keys(options.drivers).length > 1) {
             this.args = Object.entries(options.drivers as BrowserDrivers).reduce((acc, [browserDriver, version]) => {
                 if (typeof version === 'string') {
                     acc.drivers![browserDriver] = { version }

--- a/packages/wdio-selenium-standalone-service/src/launcher.ts
+++ b/packages/wdio-selenium-standalone-service/src/launcher.ts
@@ -20,11 +20,11 @@ const DEFAULT_CONNECTION = {
 type SeleniumStartArgs = Partial<import('selenium-standalone').StartOpts>
 type SeleniumInstallArgs = Partial<import('selenium-standalone').InstallOpts>
 type BrowserDrivers = {
-    chrome?: string
-    firefox?: string
-    chromiumedge?: string
-    ie?: string
-    edge?: string
+    chrome?: string | boolean
+    firefox?: string | boolean
+    chromiumedge?: string | boolean
+    ie?: string | boolean
+    edge?: string | boolean
 }
 
 export default class SeleniumStandaloneLauncher {
@@ -55,7 +55,11 @@ export default class SeleniumStandaloneLauncher {
         // simplified mode
         if (options.drivers) {
             this.args = Object.entries(options.drivers as BrowserDrivers).reduce((acc, [browserDriver, version]) => {
-                acc.drivers![browserDriver] = { version }
+                if (typeof version === 'string') {
+                    acc.drivers![browserDriver] = { version }
+                } else if (version === true) {
+                    acc.drivers![browserDriver] = {}
+                }
                 return acc
             }, { drivers: {} } as SeleniumStartArgs)
             this.installArgs = { ...this.args } as SeleniumInstallArgs

--- a/packages/wdio-selenium-standalone-service/tests/launcher.test.ts
+++ b/packages/wdio-selenium-standalone-service/tests/launcher.test.ts
@@ -166,7 +166,7 @@ describe('Selenium standalone launcher', () => {
         test('simplified mode - multiple browser drivers', async () => {
             const options = {
                 logPath: './',
-                drivers: { chrome: 'latest', firefox: '0.28.0', ie: true, chromiumedge: '87.0.637.0' },
+                drivers: { chrome: 'latest', firefox: '0.28.0', ie: true, chromiumedge: '87.0.637.0', edge: false },
             }
             const capabilities: any = [{ port: 1234 }]
             const launcher = new SeleniumStandaloneLauncher(options, capabilities, {})

--- a/packages/wdio-selenium-standalone-service/tests/launcher.test.ts
+++ b/packages/wdio-selenium-standalone-service/tests/launcher.test.ts
@@ -162,6 +162,32 @@ describe('Selenium standalone launcher', () => {
             expect(processOnSpy).toHaveBeenCalledWith('exit', launcher._stopProcess)
             expect(processOnSpy).toHaveBeenCalledWith('uncaughtException', launcher._stopProcess)
         })
+
+        test('simplified mode - multiple browser drivers', async () => {
+            const options = {
+                logPath: './',
+                drivers: { chrome: 'latest', firefox: '0.28.0', ie: true, chromiumedge: '87.0.637.0' },
+            }
+            const capabilities: any = [{ port: 1234 }]
+            const launcher = new SeleniumStandaloneLauncher(options, capabilities, {})
+
+            const seleniumArgs = { drivers: { chrome: { version: 'latest' }, firefox: { version: '0.28.0' }, ie: {}, chromiumedge: { version: '87.0.637.0' } } }
+            expect(launcher.args).toEqual(seleniumArgs)
+            expect(launcher.installArgs).toEqual(seleniumArgs)
+        })
+
+        test('simplified mode - no drivers', async () => {
+            const options = {
+                logPath: './',
+                drivers: {},
+            }
+            const capabilities: any = [{ port: 1234 }]
+            const launcher = new SeleniumStandaloneLauncher(options, capabilities, {})
+
+            const seleniumArgs = {}
+            expect(launcher.args).toEqual(seleniumArgs)
+            expect(launcher.installArgs).toEqual(seleniumArgs)
+        })
     })
 
     describe('onComplete', () => {


### PR DESCRIPTION
## Proposed changes

Allow simplified selenium-standalone config #5946 

### examples
#### several latest versions
```js
['selenium-standalone', { drivers: { chrome: 'latest', firefox: 'latest' } }]
```
#### single specific version
```js
['selenium-standalone', { drivers: { chromiumedge: '87.0.637.0' } }]
```
#### boolean
```js
['selenium-standalone', { drivers: { ie: true } }] // use version provided by selenium-standalone
```

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] New feature (non-breaking change which adds functionality)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

Only chrome, geckodriver and chromiumedge support `latest` as version.

### Reviewers: @webdriverio/project-committers
