### PR TITLE
Tracking doc: rewrite `@wdio/firefox-profile-service` package into TypeScript

### DIFF
--- a/packages/wdio-firefox-profile-service/firefox-profile-service.d.ts
+++ b/packages/wdio-firefox-profile-service/firefox-profile-service.d.ts
@@ -1,23 +1,5 @@
-declare module WebdriverIO {
-    interface ServiceOption extends FirefoxProfileConfig {}
-}
+import type { Options } from './build/types'
 
-interface FirefoxProfileConfig {
-    /**
-     * Add one or multiple extensions to the browser session. All entries can be either
-     * an absolute path to the `.xpi` file or the path to an unpacked Firefox extension directory.
-     */
-    extensions?: Array<string>;
-    /**
-     * Create Firefox profile based on an existing one by setting an absolute path to that profile.
-     */
-    profileDirectory?: string;
-    /**
-     * Set network proxy settings.
-     */
-    proxy?: object;
-    /**
-     * Please set this flag to `true` if you use Firefox v55 or lower.
-     */
-    legacy?: boolean;
+declare module WebdriverIO {
+    interface ServiceOption extends Options {}
 }

--- a/packages/wdio-firefox-profile-service/src/index.ts
+++ b/packages/wdio-firefox-profile-service/src/index.ts
@@ -1,5 +1,4 @@
 /* istanbul ignore file */
 
 import FirefoxProfileLauncher from './launcher'
-
 export const launcher = FirefoxProfileLauncher

--- a/packages/wdio-firefox-profile-service/src/types.ts
+++ b/packages/wdio-firefox-profile-service/src/types.ts
@@ -1,0 +1,105 @@
+/**
+ * Contains all settings as key value pair. You can find all available settings on the `about:config` page.
+ */
+type FirefoxSettings = Record<string, any>
+interface NoProxySettings {
+    proxyType: 'direct';
+}
+
+interface SystemProxySettings {
+    proxyType: 'system';
+}
+
+interface AutomaticProxySettings {
+    proxyType: 'pac';
+    autoConfigUrl: string;
+}
+
+interface ManualProxySettings {
+    proxyType: 'manual';
+    ftpProxy?: string;
+    httpProxy?: string;
+    sslProxy?: string;
+    socksProxy?: string;
+}
+
+type ProxySettings = NoProxySettings | SystemProxySettings | AutomaticProxySettings | ManualProxySettings;
+
+export interface Options extends FirefoxSettings {
+    /**
+     * Add one or multiple extensions to the browser session. All entries can be either an absolute path to the `.xpi`
+     * file or the path to an unpacked Firefox extension directory.
+     *
+     * @default []
+     */
+    extensions?: string[]
+    /**
+     * Create Firefox profile based on an existing one by setting an absolute path to that profile.
+     *
+     * @default null
+     */
+    profileDirectory?: string
+    /**
+     * Set network proxy settings. The parameter `proxy` is a hash which structure depends on the value of mandatory `proxyType` key,
+     * which takes one of the following string values:
+     *  * `direct` - direct connection (no proxy)
+     *  * `system` - use operating system proxy settings
+     *  * `pac` - use automatic proxy configuration set based on the value of `autoconfigUrl` key
+     *  * `manual` - manual proxy settings defined separately for different protocols using values from following keys: `ftpProxy`, `httpProxy`, `sslProxy`, `socksProxy`
+     *
+     * @example
+     * ```js
+     * // Automatic Proxy
+     * export.config = {
+     *     // ...
+     *     services: [
+     *         ['firefox-profile', {
+     *             proxy: {
+     *                 proxyType: 'pac',
+     *                 autoconfigUrl: 'http://myserver/proxy.pac'
+     *             }
+     *         }]
+     *     ],
+     *     // ...
+     * };
+     * ```
+     * ```js
+     * // Manual HTTP Proxy
+     * export.config = {
+     *     // ...
+     *     services: [
+     *         ['firefox-profile', {
+     *             proxy: {
+     *                 proxyType: 'manual',
+     *                 httpProxy: '127.0.0.1:8080'
+     *             }
+     *         }]
+     *     ],
+     *     // ...
+     * };
+     * ```
+     * ```js
+     * // Manual HTTP and HTTPS Proxy
+     * export.config = {
+     *     // ...
+     *     services: [
+     *         ['firefox-profile', {
+     *             proxy: {
+     *                 proxyType: 'manual',
+     *                 httpProxy: '127.0.0.1:8080',
+     *                 sslProxy: '127.0.0.1:8080'
+     *             }
+     *         }]
+     *     ],
+     *     // ...
+     * };
+     * ```
+     */
+    proxy?: ProxySettings
+    /**
+     * Please set this flag to `true` if you use Firefox v55 or lower.
+     *
+     * @default false
+     */
+    legacy?: boolean
+}

--- a/packages/wdio-firefox-profile-service/tests/__mocks__/firefox-profile.ts
+++ b/packages/wdio-firefox-profile-service/tests/__mocks__/firefox-profile.ts
@@ -10,7 +10,7 @@ const FirefoxProfile = jest.fn(() => ({
     }),
 }))
 
-FirefoxProfile.copy = jest.fn((profileDirectory, cb) => {
+FirefoxProfile['copy'] = jest.fn((profileDirectory, cb) => {
     cb(null, new FirefoxProfile())
 })
 

--- a/packages/wdio-firefox-profile-service/tests/launcher.test.ts
+++ b/packages/wdio-firefox-profile-service/tests/launcher.test.ts
@@ -1,5 +1,7 @@
 import Launcher from '../src/launcher'
 import FirefoxProfile from 'firefox-profile'
+import type WebDriver from 'webdriver'
+import type WebdriverIO from 'webdriverio'
 
 describe('Firefox profile service', () => {
     describe('onPrepare', () => {
@@ -17,17 +19,17 @@ describe('Firefox profile service', () => {
             const options = {
                 'browser.startup.homepage': 'https://webdriver.io',
             }
-            const capabilities = [{
+            const capabilities: WebDriver.DesiredCapabilities[] = [{
                 browserName : 'firefox',
             }]
 
             const service = new Launcher(options)
             await service.onPrepare({}, capabilities)
 
-            expect(service.profile.setPreference).toHaveBeenCalledTimes(1)
-            expect(service.profile.setPreference).toHaveBeenCalledWith('browser.startup.homepage', 'https://webdriver.io')
-            expect(service.profile.updatePreferences).toHaveBeenCalled()
-            expect(service.profile.addExtensions).not.toHaveBeenCalled()
+            expect(service['_profile'].setPreference).toHaveBeenCalledTimes(1)
+            expect(service['_profile'].setPreference).toHaveBeenCalledWith('browser.startup.homepage', 'https://webdriver.io')
+            expect(service['_profile'].updatePreferences).toHaveBeenCalled()
+            expect(service['_profile'].addExtensions).not.toHaveBeenCalled()
 
             expect(capabilities[0].firefox_profile).toBe(undefined)
             expect(capabilities[0]['moz:firefoxOptions']).toEqual({ profile : 'foobar' })
@@ -38,17 +40,17 @@ describe('Firefox profile service', () => {
                 'browser.startup.homepage': 'https://webdriver.io',
                 legacy: true
             }
-            const capabilities = [{
+            const capabilities: WebDriver.DesiredCapabilities[] = [{
                 browserName : 'firefox',
             }]
 
             const service = new Launcher(options)
             await service.onPrepare({}, capabilities)
 
-            expect(service.profile.setPreference).toHaveBeenCalledTimes(1)
-            expect(service.profile.setPreference).toHaveBeenCalledWith('browser.startup.homepage', 'https://webdriver.io')
-            expect(service.profile.updatePreferences).toHaveBeenCalled()
-            expect(service.profile.addExtensions).not.toHaveBeenCalled()
+            expect(service['_profile'].setPreference).toHaveBeenCalledTimes(1)
+            expect(service['_profile'].setPreference).toHaveBeenCalledWith('browser.startup.homepage', 'https://webdriver.io')
+            expect(service['_profile'].updatePreferences).toHaveBeenCalled()
+            expect(service['_profile'].addExtensions).not.toHaveBeenCalled()
 
             expect(capabilities[0].firefox_profile).toBe('foobar')
             expect(capabilities[0]['moz:firefoxOptions']).toEqual(undefined)
@@ -58,7 +60,7 @@ describe('Firefox profile service', () => {
             const options = {
                 'browser.startup.homepage': 'https://webdriver.io',
             }
-            const capabilities = [{
+            const capabilities: WebDriver.DesiredCapabilities[] = [{
                 browserName : 'firefox',
                 'moz:firefoxOptions': {
                     args: ['-headless']
@@ -68,30 +70,30 @@ describe('Firefox profile service', () => {
             const service = new Launcher(options)
             await service.onPrepare({}, capabilities)
 
-            expect(service.profile.setPreference).toHaveBeenCalledTimes(1)
-            expect(service.profile.setPreference).toHaveBeenCalledWith('browser.startup.homepage', 'https://webdriver.io')
-            expect(service.profile.updatePreferences).toHaveBeenCalled()
-            expect(service.profile.addExtensions).not.toHaveBeenCalled()
+            expect(service['_profile'].setPreference).toHaveBeenCalledTimes(1)
+            expect(service['_profile'].setPreference).toHaveBeenCalledWith('browser.startup.homepage', 'https://webdriver.io')
+            expect(service['_profile'].updatePreferences).toHaveBeenCalled()
+            expect(service['_profile'].addExtensions).not.toHaveBeenCalled()
 
             expect(capabilities[0]['moz:firefoxOptions']).toEqual({ args: ['-headless'], profile : 'foobar' })
         })
 
         test('should set preferences with extensions', async () => {
             const options = { extensions : ['/foo/bar.xpi'] }
-            const capabilities = [{ browserName : 'firefox' }]
+            const capabilities: WebDriver.DesiredCapabilities[] = [{ browserName : 'firefox' }]
 
             const service = new Launcher(options)
             await service.onPrepare({}, capabilities)
 
             expect(capabilities[0]['moz:firefoxOptions']).toEqual({ profile : 'foobar' })
-            expect(service.profile.addExtensions.mock.calls[0][0]).toBe(options.extensions)
+            expect((service['_profile'].addExtensions as jest.Mock).mock.calls[0][0]).toBe(options.extensions)
         })
 
         test('should not set capabilities when not firefox browser', async () => {
             const options = {
                 'browser.startup.homepage': 'https://webdriver.io',
             }
-            const capabilities = [{
+            const capabilities: WebDriver.DesiredCapabilities[] = [{
                 browserName : 'firefox',
             }, {
                 browserName : 'chrome'
@@ -109,7 +111,7 @@ describe('Firefox profile service', () => {
             const options = {
                 'browser.startup.homepage': 'https://webdriver.io',
             }
-            const capabilities = {
+            const capabilities: WebdriverIO.MultiRemoteCapabilities = {
                 firefox : {
                     capabilities : {
                         browserName : 'firefox',
@@ -127,9 +129,9 @@ describe('Firefox profile service', () => {
             const options = {
                 'browser.startup.homepage': 'https://webdriver.io',
             }
-            const capabilities = {
+            const capabilities: WebdriverIO.MultiRemoteCapabilities = {
                 foo : {
-                    capabilities : {
+                    capabilities: {
                         browserName : 'chrome',
                     }
                 }
@@ -146,28 +148,28 @@ describe('Firefox profile service', () => {
             const options = {
                 extensions : ['/foo/bar.xpi'],
                 'browser.startup.homepage': 'https://webdriver.io',
-                proxy : 'foo'
+                proxy : { proxyType: 'direct' as const }
             }
-            const capabilities = [{
+            const capabilities: WebDriver.DesiredCapabilities[] = [{
                 browserName : 'firefox',
             }]
 
             const service = new Launcher(options)
             await service.onPrepare({}, capabilities)
 
-            expect(service.profile.setProxy).toHaveBeenCalledTimes(1)
-            expect(service.profile.setProxy).toHaveBeenCalledWith(options.proxy)
+            expect(service['_profile'].setProxy).toHaveBeenCalledTimes(1)
+            expect(service['_profile'].setProxy).toHaveBeenCalledWith(options.proxy)
 
-            expect(service.profile.setPreference).toHaveBeenCalledTimes(1)
-            expect(service.profile.setPreference).toHaveBeenCalledWith('browser.startup.homepage', 'https://webdriver.io')
-            expect(service.profile.updatePreferences).toHaveBeenCalled()
+            expect(service['_profile'].setPreference).toHaveBeenCalledTimes(1)
+            expect(service['_profile'].setPreference).toHaveBeenCalledWith('browser.startup.homepage', 'https://webdriver.io')
+            expect(service['_profile'].updatePreferences).toHaveBeenCalled()
         })
 
         test('should load from directory if profileDirectory is set', async () => {
             const options = {
-                profileDirectory: '/tmp/firefox-profile',
+                profileDirectory: '/tmp/firefox-profile'
             }
-            const capabilities = [{
+            const capabilities: WebDriver.DesiredCapabilities[] = [{
                 browserName : 'firefox',
             }]
 
@@ -176,5 +178,24 @@ describe('Firefox profile service', () => {
 
             expect(FirefoxProfile.copy).toHaveBeenCalledWith(options.profileDirectory, expect.any(Function))
         })
+
+        test('should not continue if profile could not be created', async () => {
+            const options = {
+                profileDirectory: '/tmp/firefox-profile'
+            }
+            const capabilities: WebDriver.DesiredCapabilities[] = [{
+                browserName : 'firefox',
+            }]
+
+            ;(FirefoxProfile.copy as any as jest.Mock).mockImplementationOnce((profileDirectory: string, cb: Function) => cb())
+            const service = new Launcher(options)
+            await service.onPrepare({}, capabilities)
+        })
+    })
+
+    test('should return when no firefoxProfile set in the config', async () => {
+        const service = new Launcher({})
+        service['_setPreferences']()
+        service['_buildExtension']([])
     })
 })

--- a/packages/wdio-firefox-profile-service/tests/launcher.test.ts
+++ b/packages/wdio-firefox-profile-service/tests/launcher.test.ts
@@ -190,6 +190,8 @@ describe('Firefox profile service', () => {
             ;(FirefoxProfile.copy as any as jest.Mock).mockImplementationOnce((profileDirectory: string, cb: Function) => cb())
             const service = new Launcher(options)
             await service.onPrepare({}, capabilities)
+            // no assertion needed as we return early and no failure due to
+            // undefined profile is checked
         })
     })
 

--- a/packages/wdio-firefox-profile-service/tsconfig.json
+++ b/packages/wdio-firefox-profile-service/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "./build",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "types": ["webdriver", "webdriverio"]
   },
   "include": [
     "src/**/*"

--- a/packages/wdio-firefox-profile-service/tsconfig.prod.json
+++ b/packages/wdio-firefox-profile-service/tsconfig.prod.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "./build",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "types": ["webdriver", "webdriverio"]
   },
   "include": [
     "src/**/*"

--- a/packages/webdriver/src/types.ts
+++ b/packages/webdriver/src/types.ts
@@ -314,6 +314,8 @@ export interface VendorExtensions extends EdgeCapabilities {
 
     'goog:chromeOptions'?: ChromeOptions;
     'moz:firefoxOptions'?: FirefoxOptions;
+    // eslint-disable-next-line
+    firefox_profile?: string;
     'ms:edgeOptions'?: MicrosoftEdgeOptions;
     'ms:edgeChromium'?: MicrosoftEdgeOptions;
 

--- a/packages/webdriver/webdriver.d.ts
+++ b/packages/webdriver/webdriver.d.ts
@@ -333,6 +333,7 @@ declare namespace WebDriver {
 
         'goog:chromeOptions'?: ChromeOptions;
         'moz:firefoxOptions'?: FirefoxOptions;
+        firefox_profile?: string,
         'ms:edgeOptions'?: MicrosoftEdgeOptions;
         'ms:edgeChromium'?: MicrosoftEdgeOptions;
     }


### PR DESCRIPTION
This is a tracking issue for organising the effort of re-writing the code base from vanilla JS into TypeScript. If you are reading this and are interested getting involved, this is a great chance to do so. Here are the rules:

- if you are interested converting source files from `/packages/wdio-firefox-profile-service` into TypeScript please comment on this thread and mention the files you want to convert to avoid duplicate work
- there is no reason to convert the whole package at once - smaller PRs make it easier to review the code
- if you make a PR, reference this issue so we can keep track of the progress
- if you make a PR, label it with `TypeScript` and the package name `wdio-firefox-profile-service` so we can easier find all PRs
- if you make a PR, assign it to the `TypeScript Rewrite` project

Happy rewriting 😅