### PR TITLE
Add Sauce Labs Visual capability types

### DIFF
--- a/packages/webdriver/src/types.ts
+++ b/packages/webdriver/src/types.ts
@@ -305,8 +305,10 @@ export interface VendorExtensions extends EdgeCapabilities {
     'selenoid:options'?: SelenoidOptions
     // Testingbot w3c specific
     'tb:options'?: TestingbotCapabilities
-    // Saucelabs w3c specific
-    'sauce:options'?: SauceLabsCapabilities & SauceLabsVisualCapabilities
+    // Sauce Labs w3c specific
+    'sauce:options'?: SauceLabsCapabilities
+    // Sauce Labs Visual
+    'sauce:visual'?: SauceLabsVisualCapabilities
     // Browserstack w3c specific
     'bstack:options'?: {
         [name: string]: any

--- a/packages/webdriver/src/types.ts
+++ b/packages/webdriver/src/types.ts
@@ -260,7 +260,7 @@ export interface W3CCapabilities {
     firstMatch: Capabilities[];
 }
 
-export interface DesiredCapabilities extends Capabilities, SauceLabsCapabilities, TestingbotCapabilities, SeleniumRCCapabilities, AppiumIOSCapabilities, GeckodriverCapabilities, IECapabilities, AppiumAndroidCapabilities, AppiumCapabilities, VendorExtensions, GridCapabilities, ChromeCapabilities {
+export interface DesiredCapabilities extends Capabilities, SauceLabsCapabilities, SauceLabsVisualCapabilities, TestingbotCapabilities, SeleniumRCCapabilities, AppiumIOSCapabilities, GeckodriverCapabilities, IECapabilities, AppiumAndroidCapabilities, AppiumCapabilities, VendorExtensions, GridCapabilities, ChromeCapabilities {
     // Read-only capabilities
     cssSelectorsEnabled?: boolean;
     handlesAlerts?: boolean;
@@ -306,7 +306,7 @@ export interface VendorExtensions extends EdgeCapabilities {
     // Testingbot w3c specific
     'tb:options'?: TestingbotCapabilities
     // Saucelabs w3c specific
-    'sauce:options'?: SauceLabsCapabilities
+    'sauce:options'?: SauceLabsCapabilities & SauceLabsVisualCapabilities
     // Browserstack w3c specific
     'bstack:options'?: {
         [name: string]: any
@@ -546,6 +546,93 @@ export interface SauceLabsCapabilities {
     maxDuration?: number
     commandTimeout?: number
     idleTimeout?: number
+}
+
+export interface SauceLabsVisualCapabilities {
+    /**
+     * Project name
+     */
+    projectName?: string
+    /**
+     * API Key for user's Screener account.
+     */
+    apiKey?: string
+    /**
+     * A <width>x<height> representation of desired viewport size.
+     * @default "1024x768"
+     */
+    viewportSize?: string
+    /**
+     * Branch or environment name.
+     * @example "main"
+     */
+    branch?: string
+    /**
+     * Branch name of project's base branch. Used for baseline branching and merging.
+     * @example "main"
+     */
+    baseBranch?: string
+    /**
+     * Visual diff options to control validations.
+     * @default
+     * ```js
+     * {
+     *   structure: true,
+     *   layout: true,
+     *   style: true,
+     *   content: true,
+     *   minLayoutPosition: 4,
+     *   minLayoutDimension: 10
+     * }
+     * ```
+     */
+    diffOptions?: {
+        structure?: boolean
+        layout?: boolean
+        style?: boolean
+        content?: boolean
+        minLayoutPosition?: number
+        minLayoutDimension?: number
+    }
+    /**
+     * A comma-delimited list of css selectors to ignore when performing visual diffs.
+     * @example "#some-id, .some-selector"
+     */
+    ignore?: string
+    /**
+     * Option to set build to failure when new states are found, and to disable
+     * using new states as a baseline.
+     *
+     * This option defaults to true, and can be set to false if user wants new
+     * states to automatically be the visual baseline without needing to review
+     * and accept them.
+     * @default true
+     */
+    failOnNewStates?: boolean
+    /**
+     * Option to automatically accept new and changed states in base branch.
+     * Assumes base branch should always be correct.
+     * @default false
+     */
+    alwaysAcceptBaseBranch?: boolean
+    /**
+     * Option to disable independent baseline for each feature branch, and
+     * only use base branch as baseline. Must be used with "baseBranch" option.
+     * @default false
+     */
+    disableBranchBaseline?: boolean
+    /**
+     * Option to capture a full-page screenshot using a scrolling and stitching
+     * strategy instead of using native browser full-page screenshot capabilities.
+     * @default false
+     */
+    scrollAndStitchScreenshots?: boolean
+    /**
+     * Option to disable adding CORS headers. By default, CORS headers are set
+     * for all cross-origin requests.
+     * @default false
+     */
+    disableCORS?: boolean
 }
 
 /**

--- a/packages/webdriver/webdriver.d.ts
+++ b/packages/webdriver/webdriver.d.ts
@@ -326,8 +326,10 @@ declare namespace WebDriver {
         'selenoid:options'?: SelenoidOptions
         // Testingbot w3c specific
         'tb:options'?: TestingbotCapabilities
-        // Saucelabs w3c specific
-        'sauce:options'?: SauceLabsCapabilities & SauceLabsVisualCapabilities
+        // Sauce Labs w3c specific
+        'sauce:options'?: SauceLabsCapabilities
+        // Sauce Labs Visual
+        'sauce:visual'?: SauceLabsVisualCapabilities
         // Browserstack w3c specific
         'bstack:options'?: {
             [name: string]: any

--- a/packages/webdriver/webdriver.d.ts
+++ b/packages/webdriver/webdriver.d.ts
@@ -276,7 +276,7 @@ declare namespace WebDriver {
         firstMatch: Capabilities[];
     }
 
-    export interface DesiredCapabilities extends Capabilities, SauceLabsCapabilities, TestingbotCapabilities, SeleniumRCCapabilities, AppiumIOSCapabilities, GeckodriverCapabilities, IECapabilities, AppiumAndroidCapabilities, AppiumCapabilities, VendorExtensions, GridCapabilities, ChromeCapabilities {
+    export interface DesiredCapabilities extends Capabilities, SauceLabsCapabilities, SauceLabsVisualCapabilities, TestingbotCapabilities, SeleniumRCCapabilities, AppiumIOSCapabilities, GeckodriverCapabilities, IECapabilities, AppiumAndroidCapabilities, AppiumCapabilities, VendorExtensions, GridCapabilities, ChromeCapabilities {
         // Read-only capabilities
         cssSelectorsEnabled?: boolean;
         handlesAlerts?: boolean;
@@ -327,7 +327,7 @@ declare namespace WebDriver {
         // Testingbot w3c specific
         'tb:options'?: TestingbotCapabilities
         // Saucelabs w3c specific
-        'sauce:options'?: SauceLabsCapabilities
+        'sauce:options'?: SauceLabsCapabilities & SauceLabsVisualCapabilities
         // Browserstack w3c specific
         'bstack:options'?: {
             [name: string]: any
@@ -561,6 +561,93 @@ declare namespace WebDriver {
         maxDuration?: number
         commandTimeout?: number
         idleTimeout?: number
+    }
+
+    export interface SauceLabsVisualCapabilities {
+        /**
+         * Project name
+         */
+        projectName?: string
+        /**
+         * API Key for user's Screener account.
+         */
+        apiKey?: string
+        /**
+         * A <width>x<height> representation of desired viewport size.
+         * @default "1024x768"
+         */
+        viewportSize?: string
+        /**
+         * Branch or environment name.
+         * @example "main"
+         */
+        branch?: string
+        /**
+         * Branch name of project's base branch. Used for baseline branching and merging.
+         * @example "main"
+         */
+        baseBranch?: string
+        /**
+         * Visual diff options to control validations.
+         * @default
+         * ```js
+         * {
+         *   structure: true,
+         *   layout: true,
+         *   style: true,
+         *   content: true,
+         *   minLayoutPosition: 4,
+         *   minLayoutDimension: 10
+         * }
+         * ```
+         */
+        diffOptions?: {
+            structure?: boolean
+            layout?: boolean
+            style?: boolean
+            content?: boolean
+            minLayoutPosition?: number
+            minLayoutDimension?: number
+        }
+        /**
+         * A comma-delimited list of css selectors to ignore when performing visual diffs.
+         * @example "#some-id, .some-selector"
+         */
+        ignore?: string
+        /**
+         * Option to set build to failure when new states are found, and to disable
+         * using new states as a baseline.
+         *
+         * This option defaults to true, and can be set to false if user wants new
+         * states to automatically be the visual baseline without needing to review
+         * and accept them.
+         * @default true
+         */
+        failOnNewStates?: boolean
+        /**
+         * Option to automatically accept new and changed states in base branch.
+         * Assumes base branch should always be correct.
+         * @default false
+         */
+        alwaysAcceptBaseBranch?: boolean
+        /**
+         * Option to disable independent baseline for each feature branch, and
+         * only use base branch as baseline. Must be used with "baseBranch" option.
+         * @default false
+         */
+        disableBranchBaseline?: boolean
+        /**
+         * Option to capture a full-page screenshot using a scrolling and stitching
+         * strategy instead of using native browser full-page screenshot capabilities.
+         * @default false
+         */
+        scrollAndStitchScreenshots?: boolean
+        /**
+         * Option to disable adding CORS headers. By default, CORS headers are set
+         * for all cross-origin requests.
+         * @default false
+         */
+        disableCORS?: boolean
     }
 
     export interface TestingbotCapabilities {


### PR DESCRIPTION
## Proposed changes

Sauce Labs visual accepts a different set of capabilities. Let's add them.

cc: @loyalchow

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

We currently have two maintain two types for WebDriver capabilities. Once we finish our TypeScript rewrite we will get rid of one of it.

### Reviewers: @webdriverio/project-committers
