### PR TITLE
Update fibers to v5 and drop Node.js support for v10

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
+          node-version: '14.x'
       - run: npm install
       - run: npm run docs
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v1
         with:
-          node-version: 12.x
+          node-version: 14.x
       - name: NPM Setup
         run: |
           npm set registry "https://registry.npmjs.org/"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x, 15.x]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
@@ -26,10 +26,10 @@ jobs:
       - name: Lint / Dependencies / Unit / Smoke Tests
         run: npm run test
       - name: E2E Protocol Tests
-        if: ${{ matrix.node-version == '12.x' }}
+        if: ${{ matrix.node-version == '14.x' }}
         run: npm run test:e2e
       - name: E2E Firefox Launch Tests
-        if: ${{ matrix.node-version == '12.x' }}
+        if: ${{ matrix.node-version == '14.x' }}
         run: |
           sudo add-apt-repository ppa:ubuntu-mozilla-daily/ppa
           sudo apt-get update
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 12.x
+          node-version: 14.x
       - name: Install Dependencies
         run: npm ci
       - name: Bootstrap Packages
@@ -58,7 +58,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 12.x
+          node-version: 14.x
       - name: Install Dependencies
         run: npm ci
       - name: Bootstrap Packages

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,8 +23,11 @@ jobs:
         run: npm ci
       - name: Bootstrap Packages
         run: npm run setup-full
-      - name: Lint / Dependencies / Unit / Smoke Tests
-        run: npm run test
+      - name: Dependency Check
+        if: ${{ matrix.node-version == '14.x' }}
+        run: npm run test:depcheck
+      - name: Lint / Typings / Unit / Smoke Tests
+        run: npx run-s test:eslint test:typings test:coverage test:smoke
       - name: E2E Protocol Tests
         if: ${{ matrix.node-version == '14.x' }}
         run: npm run test:e2e

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,17 +1,3 @@
-/**
- * workaround for bug
- * https://github.com/jsdom/jsdom/issues/2795
- * https://github.com/jsdom/jsdom/issues/2961
- */
-const SKIPPED_NODE_10_TESTS = process.version.startsWith('v10')
-    ? [
-        '<rootDir>/packages/webdriverio/tests/commands/browser/newWindow.test.ts',
-        '<rootDir>/packages/webdriverio/tests/commands/element/isFocused.test.ts',
-        '<rootDir>/packages/webdriverio/tests/scripts/resq.test.ts',
-        '<rootDir>/packages/webdriverio/tests/scripts/isFocused.test.ts'
-    ]
-    : []
-
 module.exports = {
     globals: {
         'ts-jest': {
@@ -26,8 +12,7 @@ module.exports = {
     },
     testPathIgnorePatterns: [
         '<rootDir>/tests/',
-        '<rootDir>/node_modules/',
-        ...SKIPPED_NODE_10_TESTS
+        '<rootDir>/node_modules/'
     ],
     collectCoverageFrom: [
         'packages/**/src/**/*.(js|ts)',

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./build/index",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "types": "./devtools.d.ts",
   "typeScriptVersion": "3.8.3",

--- a/packages/eslint-plugin-wdio/package.json
+++ b/packages/eslint-plugin-wdio/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "index.js",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-allure-reporter/package.json
+++ b/packages/wdio-allure-reporter/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./build/index",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "types": "./allure-reporter.d.ts",
   "repository": {

--- a/packages/wdio-appium-service/package.json
+++ b/packages/wdio-appium-service/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./build/index",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-applitools-service/package.json
+++ b/packages/wdio-applitools-service/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./build/index",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-browserstack-service/package.json
+++ b/packages/wdio-browserstack-service/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./build",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-cli/package.json
+++ b/packages/wdio-cli/package.json
@@ -10,7 +10,7 @@
     "wdio": "./bin/wdio.js"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "scripts": {
     "copy": "copyfiles -u 1 -V \"src/templates/**/*\" ./build/"

--- a/packages/wdio-concise-reporter/package.json
+++ b/packages/wdio-concise-reporter/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./build/index",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-config/package.json
+++ b/packages/wdio-config/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./build/index",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-crossbrowsertesting-service/package.json
+++ b/packages/wdio-crossbrowsertesting-service/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./build",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-cucumber-framework/package.json
+++ b/packages/wdio-cucumber-framework/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./build/index",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-devtools-service/package.json
+++ b/packages/wdio-devtools-service/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./build/index",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-dot-reporter/package.json
+++ b/packages/wdio-dot-reporter/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./build/index",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-firefox-profile-service/package.json
+++ b/packages/wdio-firefox-profile-service/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./build/index",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-jasmine-framework/package.json
+++ b/packages/wdio-jasmine-framework/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./build/index",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-junit-reporter/package.json
+++ b/packages/wdio-junit-reporter/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./build/index",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-local-runner/package.json
+++ b/packages/wdio-local-runner/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./build/index",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-logger/package.json
+++ b/packages/wdio-logger/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./build/node",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-mocha-framework/package.json
+++ b/packages/wdio-mocha-framework/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./build/index",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-protocols/package.json
+++ b/packages/wdio-protocols/package.json
@@ -8,7 +8,7 @@
   "main": "./index",
   "types": "./index.d.ts",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-repl/package.json
+++ b/packages/wdio-repl/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./build/index",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-reporter/package.json
+++ b/packages/wdio-reporter/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./build/index",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-runner/package.json
+++ b/packages/wdio-runner/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./build/index",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-sauce-service/package.json
+++ b/packages/wdio-sauce-service/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./build",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-selenium-standalone-service/package.json
+++ b/packages/wdio-selenium-standalone-service/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./build",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-shared-store-service/package.json
+++ b/packages/wdio-shared-store-service/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./build",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-smoke-test-reporter/package.json
+++ b/packages/wdio-smoke-test-reporter/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./build/index",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-smoke-test-service/package.json
+++ b/packages/wdio-smoke-test-service/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./build/index",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-spec-reporter/package.json
+++ b/packages/wdio-spec-reporter/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./build/index",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-static-server-service/package.json
+++ b/packages/wdio-static-server-service/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./build/index",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-sumologic-reporter/package.json
+++ b/packages/wdio-sumologic-reporter/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./build/index",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-sync/package.json
+++ b/packages/wdio-sync/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./build/index",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "types": "./webdriverio.d.ts",
   "typeScriptVersion": "3.8.3",

--- a/packages/wdio-sync/package.json
+++ b/packages/wdio-sync/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@types/puppeteer": "^5.4.0",
     "@wdio/logger": "6.10.10",
-    "fibers": "^4.0.1"
+    "fibers": "^5.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/wdio-sync/src/fibers.js
+++ b/packages/wdio-sync/src/fibers.js
@@ -21,7 +21,7 @@ try {
     Fiber = require('fibers')
     Future = require('fibers/future')
 } catch (e) {
-    log.debug('Couldn\'t load fibers package for Node v10 and above')
+    log.debug('Couldn\'t load fibers package for Node v12 and above')
 }
 
 console.error = origErrorFn

--- a/packages/wdio-testingbot-service/package.json
+++ b/packages/wdio-testingbot-service/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./build",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-utils/package.json
+++ b/packages/wdio-utils/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./build/index",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-webdriver-mock-service/package.json
+++ b/packages/wdio-webdriver-mock-service/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./build/index",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/webdriver/package.json
+++ b/packages/webdriver/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./build",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "types": "./webdriver.d.ts",
   "typeScriptVersion": "3.8.3",

--- a/packages/webdriverio/package.json
+++ b/packages/webdriverio/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/webdriverio/webdriverio/issues"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "tags": [
     "webdriver",

--- a/scripts/generateSubPackage.js
+++ b/scripts/generateSubPackage.js
@@ -71,7 +71,7 @@ inquirer.prompt(questions).then(answers => {
   "license": "MIT",
   "main": "./build/index",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Proposed changes

Even though v10 will be maintained for one more year we should drop support now so that we can update Fibers.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
