### PR TITLE
Remove `browser.options` across the code base

### DIFF
--- a/docs/BrowserObject.md
+++ b/docs/BrowserObject.md
@@ -91,42 +91,6 @@ console.log(browser.config)
 console.log(browser.config.fakeUser) // outputs: "maxmustermann"
 ```
 
-### Configurations versus Options
-
-Custom configurations should not be confused with [Options](Options.md), which are accessed separately.
-
-```js
-console.log(browser.options)
-/**
- * outputs:
- * {
-        protocol: 'http',
-        port: 4444,
-        hostname: 'localhost',
-        baseUrl: 'example.com',
-        // ...
- */
-```
-
-When using the WDIO testrunner, if any configuration and option keys conflict in name (e.g. `baseUrl` in the following code snippets) the option value will take precedence and overwrite the config value.
-
-```js
-// wdio.conf.js
-exports.config = {
-    baseUrl: 'example.com'
-}
-```
-
-```bash
-# testrunner invocation
-$ npm wdio wdio.conf.js --baseUrl foobar.com
-```
-
-```js
-console.log(browser.config.baseUrl) // 'foobar.com', despite being set as 'example.com'
-console.log(browser.options.baseUrl) // 'foobar.com'
-```
-
 ## Mobile Flags
 
 If you need to modify your test based on whether or not your session runs on a mobile device, you can access the mobile flags to check.

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -7,7 +7,7 @@ WebdriverIO is not just a binding for the WebDriver protocol (like Selenium). It
 
 WebdriverIO takes the protocol commands and creates smart user commands that makes using the protocol for test automation much easier.
 
-WebdriverIO also enhances the WebDriver package with additional commands. They share the same set of options when run in a standalone script. But when testing starts from `@wdio/cli` (the WDIO testrunner), there are some additional options available for you to use in `browser.options`.
+WebdriverIO also enhances the WebDriver package with additional commands. They share the same set of options when run in a standalone script. But when testing starts from `@wdio/cli` (the WDIO testrunner), there are some additional options available for you to use in `browser.config`.
 
 ## WebDriver Options
 

--- a/packages/wdio-runner/src/index.js
+++ b/packages/wdio-runner/src/index.js
@@ -128,7 +128,7 @@ export default class Runner extends EventEmitter {
         /**
          * report sessionId and target connection information to worker
          */
-        const { protocol, hostname, port, path, queryParams } = browser.options
+        const { protocol, hostname, port, path, queryParams } = this.config
         const { isW3C, sessionId } = browser
         process.send({
             origin: 'worker',

--- a/packages/wdio-runner/src/utils.js
+++ b/packages/wdio-runner/src/utils.js
@@ -137,7 +137,7 @@ export function getInstancesData(browser, isMultiremote) {
     if (isMultiremote) {
         instances = {}
         browser.instances.forEach(i => {
-            const { protocol, hostname, port, path, queryParams } = browser[i].options
+            const { protocol, hostname, port, path, queryParams } = browser[i].config
             const { isW3C, sessionId } = browser[i]
 
             instances[i] = { sessionId, isW3C, protocol, hostname, port, path, queryParams }

--- a/packages/wdio-runner/tests/utils.test.js
+++ b/packages/wdio-runner/tests/utils.test.js
@@ -198,7 +198,7 @@ describe('utils', () => {
                 foo: {
                     isW3C,
                     sessionId,
-                    options: { protocol, hostname, port, path, queryParams }
+                    config: { protocol, hostname, port, path, queryParams }
                 }
             }, true)).toEqual({ foo: { sessionId, isW3C, protocol, hostname, port, path, queryParams } })
         })

--- a/packages/wdio-sync/tests/wrapCommand.test.js
+++ b/packages/wdio-sync/tests/wrapCommand.test.js
@@ -21,7 +21,7 @@ describe('wrapCommand:runCommand', () => {
         global.WDIO_WORKER = '1'
         const fn = jest.fn(x => (x + x))
         const runCommand = wrapCommand('foo', fn)
-        const result = await runCommand.call({ options: {} }, 'bar')
+        const result = await runCommand.call({ config: {} }, 'bar')
         expect(result).toEqual('barbar')
         process.emit('WDIO_TIMER', { id: 0 })
     })
@@ -29,7 +29,7 @@ describe('wrapCommand:runCommand', () => {
     it('should set _NOT_FIBER to false if elementId is missing', async () => {
         const fn = jest.fn()
         const runCommand = wrapCommand('foo', fn)
-        const context = { options: {}, _NOT_FIBER: true }
+        const context = { config: {}, _NOT_FIBER: true }
         await runCommand.call(context, 'bar')
         expect(context._NOT_FIBER).toBe(false)
     })
@@ -37,14 +37,14 @@ describe('wrapCommand:runCommand', () => {
     it('should set _NOT_FIBER to true if elementId is exist', async () => {
         const fn = jest.fn()
         const runCommand = wrapCommand('foo', fn)
-        const context = { options: {}, _NOT_FIBER: true, elementId: 'foo' }
+        const context = { config: {}, _NOT_FIBER: true, elementId: 'foo' }
         await runCommand.call(context, 'bar')
         expect(context._NOT_FIBER).toBe(true)
     })
 
     it('should set _NOT_FIBER to false if elementId is exist but function is anonymous', async () => {
         const runCommand = wrapCommand('foo', () => { })
-        const context = { options: {}, _NOT_FIBER: true, elementId: 'foo' }
+        const context = { config: {}, _NOT_FIBER: true, elementId: 'foo' }
         await runCommand.call(context, 'bar')
         expect(context._NOT_FIBER).toBe(false)
     })
@@ -52,7 +52,7 @@ describe('wrapCommand:runCommand', () => {
     it('should set _NOT_FIBER to true if parent.elementId is exist', async () => {
         const fn = jest.fn()
         const runCommand = wrapCommand('foo', fn)
-        const context = { options: {}, _NOT_FIBER: true, parent: { elementId: 'foo' } }
+        const context = { config: {}, _NOT_FIBER: true, parent: { elementId: 'foo' } }
         await runCommand.call(context, 'bar')
         expect(context._NOT_FIBER).toBe(true)
     })
@@ -62,7 +62,7 @@ describe('wrapCommand:runCommand', () => {
         const runCommand = wrapCommand('foo', jest.fn())
 
         const context = {
-            options: {}, elementId: 'foo', parent: { _NOT_FIBER: true }
+            config: {}, elementId: 'foo', parent: { _NOT_FIBER: true }
         }
 
         await runCommand.call(context)
@@ -75,7 +75,7 @@ describe('wrapCommand:runCommand', () => {
         const runCommand = wrapCommand('foo', () => {})
 
         const context = {
-            options: {}, elementId: 'foo', _hidden_: null, _hidden_changes_: [],
+            config: {}, elementId: 'foo', _hidden_: null, _hidden_changes_: [],
             get _NOT_FIBER () { return this._hidden_ },
             set _NOT_FIBER (val) {
                 this._hidden_changes_.push(val)
@@ -128,14 +128,14 @@ describe('wrapCommand:runCommand', () => {
     it('should throw error with proper message', async () => {
         const fn = jest.fn(x => { throw new Error(x) })
         const runCommand = wrapCommand('foo', fn)
-        const result = runCommand.call({ options: {} }, 'bar')
+        const result = runCommand.call({ config: {} }, 'bar')
         await expect(result).rejects.toEqual(new Error('bar'))
     })
 
     it('should contain merged error stack', async () => {
         const fn = jest.fn(() => { throw anotherError })
         const runCommand = wrapCommand('foo', fn)
-        const result = runCommand.call({ options: {} }, 'bar')
+        const result = runCommand.call({ config: {} }, 'bar')
         try {
             await result
         } catch (err) {
@@ -150,7 +150,7 @@ describe('wrapCommand:runCommand', () => {
     it('should accept non Error objects', async () => {
         const fn = jest.fn(x => Promise.reject(x))
         const runCommand = wrapCommand('foo', fn)
-        const result = runCommand.call({ options: {} }, 'bar')
+        const result = runCommand.call({ config: {} }, 'bar')
         try {
             await result
         } catch (err) {
@@ -164,7 +164,7 @@ describe('wrapCommand:runCommand', () => {
     it('should accept undefined', async () => {
         const fn = jest.fn(() => Promise.reject())
         const runCommand = wrapCommand('foo', fn)
-        const result = runCommand.call({ options: {} })
+        const result = runCommand.call({ config: {} })
         try {
             await result
         } catch (err) {
@@ -183,7 +183,7 @@ describe('wrapCommand:runCommand', () => {
         it('should throw regular error', () => {
             const fn = jest.fn(() => {})
             const runCommand = wrapCommand('foo', fn)
-            const context = { options: {} }
+            const context = { config: {} }
             try {
                 runCommand.call(context, 'bar')
             } catch (err) {

--- a/packages/wdio-sync/webdriverio-core.d.ts
+++ b/packages/wdio-sync/webdriverio-core.d.ts
@@ -1111,7 +1111,6 @@ declare namespace WebdriverIO {
 
     interface Browser extends WebDriver.BaseClient {
         config: Config;
-        options: RemoteOptions;
 
         /**
          * add command to `browser` or `element` scope

--- a/packages/wdio-utils/src/monad.ts
+++ b/packages/wdio-utils/src/monad.ts
@@ -36,6 +36,7 @@ export default function WebDriver (options: Record<string, any>, modifier?: Func
          * logging the instance
          */
         propertiesObject.commandList = { value: Object.keys(propertiesObject) }
+        propertiesObject.config = { value: options }
         propertiesObject.requestedCapabilities = { value: options.requestedCapabilities }
 
         /**

--- a/packages/wdio-utils/src/monad.ts
+++ b/packages/wdio-utils/src/monad.ts
@@ -36,7 +36,6 @@ export default function WebDriver (options: Record<string, any>, modifier?: Func
          * logging the instance
          */
         propertiesObject.commandList = { value: Object.keys(propertiesObject) }
-        propertiesObject.options = { value: options }
         propertiesObject.requestedCapabilities = { value: options.requestedCapabilities }
 
         /**

--- a/packages/wdio-utils/src/shim.ts
+++ b/packages/wdio-utils/src/shim.ts
@@ -67,9 +67,9 @@ let runFnInFiberContext = function (fn: Function) {
 let wrapCommand = function wrapCommand<T>(commandName: string, fn: Function): (...args: any) => Promise<T> {
     return async function wrapCommandFn(this: WebdriverIO.BrowserObject, ...args: any[]) {
         const beforeHookArgs = [commandName, args]
-        if (!inCommandHook && this.options.beforeCommand) {
+        if (!inCommandHook && this.config.beforeCommand) {
             inCommandHook = true
-            await executeHooksWithArgs.call(this, this.options.beforeCommand, beforeHookArgs)
+            await executeHooksWithArgs.call(this, this.config.beforeCommand, beforeHookArgs)
             inCommandHook = false
         }
 
@@ -81,10 +81,10 @@ let wrapCommand = function wrapCommand<T>(commandName: string, fn: Function): (.
             commandError = err
         }
 
-        if (!inCommandHook && this.options.afterCommand) {
+        if (!inCommandHook && this.config.afterCommand) {
             inCommandHook = true
             const afterHookArgs = [...beforeHookArgs, commandResult, commandError]
-            await executeHooksWithArgs.call(this, this.options.afterCommand, afterHookArgs)
+            await executeHooksWithArgs.call(this, this.config.afterCommand, afterHookArgs)
             inCommandHook = false
         }
 

--- a/packages/wdio-utils/tests/shim-async.test.ts
+++ b/packages/wdio-utils/tests/shim-async.test.ts
@@ -190,7 +190,7 @@ describe('wrapCommand', () => {
         const commandA = wrapCommand('foobar', rawCommand)
         const commandB = wrapCommand('barfoo', rawCommand)
         const scope: Partial<WebdriverIO.BrowserObject> = {
-            options: {
+            config: {
                 beforeCommand: jest.fn(),
                 afterCommand: jest.fn().mockImplementation(
                     () => commandB.call(scope, 123))
@@ -198,8 +198,8 @@ describe('wrapCommand', () => {
         }
 
         expect(await commandA.call(scope, true, false, '!!')).toBe('Yayy!')
-        expect(scope.options!.beforeCommand).toBeCalledTimes(1)
-        expect(scope.options!.afterCommand).toBeCalledTimes(1)
+        expect(scope.config!.beforeCommand).toBeCalledTimes(1)
+        expect(scope.config!.afterCommand).toBeCalledTimes(1)
         expect(rawCommand).toBeCalledTimes(2)
     })
 
@@ -209,7 +209,7 @@ describe('wrapCommand', () => {
         const commandA = wrapCommand('foobar', rawCommand)
         const commandB = wrapCommand('barfoo', rawCommand)
         const scope: Partial<WebdriverIO.BrowserObject> = {
-            options: {
+            config: {
                 beforeCommand: jest.fn(),
                 afterCommand: jest.fn().mockImplementation(
                     () => commandB.call(scope, 123))
@@ -219,8 +219,8 @@ describe('wrapCommand', () => {
         const error = await commandA.call(scope, true, false, '!!')
             .catch((err: Error) => err)
         expect((error as Error).message).toBe('Uppsi!')
-        expect(scope.options!.beforeCommand).toBeCalledTimes(1)
-        expect(scope.options!.afterCommand).toBeCalledTimes(1)
+        expect(scope.config!.beforeCommand).toBeCalledTimes(1)
+        expect(scope.config!.afterCommand).toBeCalledTimes(1)
         expect(rawCommand).toBeCalledTimes(2)
     })
 })

--- a/packages/wdio-utils/tests/shim.test.ts
+++ b/packages/wdio-utils/tests/shim.test.ts
@@ -6,7 +6,7 @@ describe('wrapCommand', () => {
         const beforeHook = jest.fn()
         const afterHook = jest.fn()
         const scope = {
-            options: {
+            config: {
                 beforeCommand: [beforeHook, beforeHook],
                 afterCommand: [afterHook, afterHook, afterHook]
             }
@@ -28,7 +28,7 @@ describe('wrapCommand', () => {
         const commandFn = jest.fn().mockReturnValue(Promise.reject(error))
         const afterHook = jest.fn()
         const scope = {
-            options: {
+            config: {
                 beforeCommand: [],
                 afterCommand: [afterHook, afterHook, afterHook]
             }

--- a/packages/webdriver/src/command.ts
+++ b/packages/webdriver/src/command.ts
@@ -90,7 +90,7 @@ export default function (
         const request = new WebDriverRequest(method, endpoint, body, isHubCommand)
         this.emit('command', { method, endpoint, body })
         log.info('COMMAND', commandCallStructure(command, args))
-        return request.makeRequest(this.options, this.sessionId).then((result) => {
+        return request.makeRequest(this.config, this.sessionId).then((result) => {
             if (result.value != null) {
                 log.info('RESULT', /screenshot|recording/i.test(command)
                     && typeof result.value === 'string' && result.value.length > 64

--- a/packages/webdriver/src/index.ts
+++ b/packages/webdriver/src/index.ts
@@ -97,7 +97,7 @@ export default class WebDriver {
     */
     static async reloadSession (instance: Client) {
         const params: Options = {
-            ...instance.options,
+            ...instance.config,
             capabilities: instance.requestedCapabilities as DesiredCapabilities
         }
         const { sessionId, capabilities } = await startWebDriverSession(params)

--- a/packages/webdriver/src/types.ts
+++ b/packages/webdriver/src/types.ts
@@ -813,12 +813,14 @@ export interface SessionFlags {
 }
 
 export interface BaseClient extends EventEmitter, SessionFlags {
+    // instance configurations
+    config: Options
     // id of WebDriver session
-    sessionId: string;
+    sessionId: string
     // assigned capabilities by the browser driver / WebDriver server
-    capabilities: DesiredCapabilities | W3CCapabilities;
+    capabilities: DesiredCapabilities | W3CCapabilities
     // original requested capabilities
-    requestedCapabilities: DesiredCapabilities | W3CCapabilities;
+    requestedCapabilities: DesiredCapabilities | W3CCapabilities
 }
 
 export interface Client extends BaseClient {}

--- a/packages/webdriver/src/types.ts
+++ b/packages/webdriver/src/types.ts
@@ -819,8 +819,6 @@ export interface BaseClient extends EventEmitter, SessionFlags {
     capabilities: DesiredCapabilities | W3CCapabilities;
     // original requested capabilities
     requestedCapabilities: DesiredCapabilities | W3CCapabilities;
-    // framework options
-    options: Options
 }
 
 export interface Client extends BaseClient {}

--- a/packages/webdriverio/src/commands/browser/reloadSession.ts
+++ b/packages/webdriverio/src/commands/browser/reloadSession.ts
@@ -39,11 +39,11 @@ export default async function reloadSession (this: WebdriverIO.BrowserObject) {
         log.warn(`Suppressing error closing the session: ${err.stack}`)
     }
 
-    const ProtocolDriver = require(this.options.automationProtocol!).default
+    const ProtocolDriver = require(this.config.automationProtocol!).default
     await ProtocolDriver.reloadSession(this)
 
-    if (Array.isArray(this.options.onReload) && this.options.onReload.length) {
-        await Promise.all(this.options.onReload.map((hook) => hook(oldSessionId, this.sessionId)))
+    if (Array.isArray(this.config.onReload) && this.config.onReload.length) {
+        await Promise.all(this.config.onReload.map((hook) => hook(oldSessionId, this.sessionId)))
     }
 
     return this.sessionId

--- a/packages/webdriverio/src/commands/browser/url.ts
+++ b/packages/webdriverio/src/commands/browser/url.ts
@@ -43,8 +43,8 @@ export default function url (
         throw new Error('Parameter for "url" command needs to be type of string')
     }
 
-    if (typeof this.options.baseUrl === 'string') {
-        path = nodeUrl.resolve(this.options.baseUrl, path)
+    if (typeof this.config.baseUrl === 'string') {
+        path = nodeUrl.resolve(this.config.baseUrl, path)
     }
 
     return this.navigateTo(validateUrl(path))

--- a/packages/webdriverio/src/commands/browser/waitUntil.ts
+++ b/packages/webdriverio/src/commands/browser/waitUntil.ts
@@ -46,8 +46,8 @@ export default function waitUntil(
     this: WebdriverIO.BrowserObject,
     condition: () => boolean | Promise<boolean>,
     {
-        timeout = this.options.waitforTimeout,
-        interval = this.options.waitforInterval,
+        timeout = this.config.waitforTimeout,
+        interval = this.config.waitforInterval,
         timeoutMsg
     }: Partial<WebdriverIO.WaitUntilOptions> = {}
 ) {
@@ -59,11 +59,11 @@ export default function waitUntil(
      * ensure that timeout and interval are set properly
      */
     if (typeof timeout !== 'number') {
-        timeout = this.options.waitforTimeout as number
+        timeout = this.config.waitforTimeout as number
     }
 
     if (typeof interval !== 'number') {
-        interval = this.options.waitforInterval as number
+        interval = this.config.waitforInterval as number
     }
 
     const fn = condition.bind(this)

--- a/packages/webdriverio/src/commands/element/waitForClickable.ts
+++ b/packages/webdriverio/src/commands/element/waitForClickable.ts
@@ -29,8 +29,8 @@ import type { WaitForOptions } from '../../types'
 export default async function waitForClickable (
     this: WebdriverIO.Element,
     {
-        timeout = this.options.waitforTimeout,
-        interval = this.options.waitforInterval,
+        timeout = this.config.waitforTimeout,
+        interval = this.config.waitforInterval,
         reverse = false,
         timeoutMsg = `element ("${this.selector}") still ${reverse ? '' : 'not '}clickable after ${timeout}ms`
     }: WaitForOptions = {}

--- a/packages/webdriverio/src/commands/element/waitForDisplayed.ts
+++ b/packages/webdriverio/src/commands/element/waitForDisplayed.ts
@@ -39,8 +39,8 @@ import type { WaitForOptions } from '../../types'
 export default async function waitForDisplayed (
     this: WebdriverIO.Element,
     {
-        timeout = this.options.waitforTimeout,
-        interval = this.options.waitforInterval,
+        timeout = this.config.waitforTimeout,
+        interval = this.config.waitforInterval,
         reverse = false,
         timeoutMsg = `element ("${this.selector}") still ${reverse ? '' : 'not '}displayed after ${timeout}ms`
     }: WaitForOptions = {}

--- a/packages/webdriverio/src/commands/element/waitForEnabled.ts
+++ b/packages/webdriverio/src/commands/element/waitForEnabled.ts
@@ -39,8 +39,8 @@ import type { WaitForOptions } from '../../types'
 export default async function waitForEnabled(
     this: WebdriverIO.Element,
     {
-        timeout = this.options.waitforTimeout,
-        interval = this.options.waitforInterval,
+        timeout = this.config.waitforTimeout,
+        interval = this.config.waitforInterval,
         reverse = false,
         timeoutMsg = `element ("${this.selector}") still ${reverse ? '' : 'not '}enabled after ${timeout}ms`
     }: WaitForOptions = {}

--- a/packages/webdriverio/src/commands/element/waitForExist.ts
+++ b/packages/webdriverio/src/commands/element/waitForExist.ts
@@ -40,8 +40,8 @@ import type { WaitForOptions } from '../../types'
 export default function waitForExist (
     this: WebdriverIO.Element,
     {
-        timeout = this.options.waitforTimeout,
-        interval = this.options.waitforInterval,
+        timeout = this.config.waitforTimeout,
+        interval = this.config.waitforInterval,
         reverse = false,
         timeoutMsg = `element ("${this.selector}") still ${reverse ? '' : 'not '}existing after ${timeout}ms`
     }: WaitForOptions = {}

--- a/packages/webdriverio/src/index.ts
+++ b/packages/webdriverio/src/index.ts
@@ -100,7 +100,7 @@ export const multiremote = async function (params: MultiRemoteOptions, { automat
     const sessionParams = isStub(automationProtocol) ? undefined : {
         sessionId: '',
         isW3C: multibrowser.instances[browserNames[0]].isW3C,
-        logLevel: multibrowser.instances[browserNames[0]].options.logLevel
+        logLevel: multibrowser.instances[browserNames[0]].config.logLevel
     }
 
     const ProtocolDriver = automationProtocol && isStub(automationProtocol)

--- a/packages/webdriverio/src/utils/getElementObject.ts
+++ b/packages/webdriverio/src/utils/getElementObject.ts
@@ -25,7 +25,7 @@ export const getElement = function findElement(
         scope: { value: 'element' }
     }
 
-    const element = webdriverMonad(this.options, (client: ElementObject) => {
+    const element = webdriverMonad(this.config, (client: ElementObject) => {
         const elementId = getElementFromResponse(res as ElementReference)
 
         if (elementId) {
@@ -85,7 +85,7 @@ export const getElements = function getElements(
 
     const elements = elemResponse.map((res: ElementReference | Error, i) => {
         propertiesObject.scope = { value: 'element' }
-        const element = webdriverMonad(this.options, (client: ElementObject) => {
+        const element = webdriverMonad(this.config, (client: ElementObject) => {
             const elementId = getElementFromResponse(res as ElementReference)
 
             if (elementId) {

--- a/packages/webdriverio/src/utils/interception/index.ts
+++ b/packages/webdriverio/src/utils/interception/index.ts
@@ -23,19 +23,19 @@ export default class Interception {
     }
 
     waitForResponse ({
-        timeout = this.browser.options.waitforTimeout,
-        interval = this.browser.options.waitforInterval,
+        timeout = this.browser.config.waitforTimeout,
+        interval = this.browser.config.waitforInterval,
         timeoutMsg,
     }: WebdriverIO.WaitForOptions = {}) {
         /*!
          * ensure that timeout and interval are set properly
          */
         if (typeof timeout !== 'number') {
-            timeout = this.browser.options.waitforTimeout as number
+            timeout = this.browser.config.waitforTimeout as number
         }
 
         if (typeof interval !== 'number') {
-            interval = this.browser.options.waitforInterval as number
+            interval = this.browser.config.waitforInterval as number
         }
 
         /* istanbul ignore next */

--- a/packages/webdriverio/tests/multiremote.test.ts
+++ b/packages/webdriverio/tests/multiremote.test.ts
@@ -47,7 +47,6 @@ test('should properly create stub instance', async () => {
     Object.values(params).forEach(cap => { cap.automationProtocol = './protocol-stub' })
     const browser = await multiremote(params, { automationProtocol: './protocol-stub' })
     expect(browser.$).toBeUndefined()
-    expect(browser.options).toBeUndefined()
     expect(browser.commandList).toHaveLength(0)
     expect(browser.browserA).toBeDefined()
     expect(browser.browserB).toBeDefined()

--- a/packages/webdriverio/webdriverio-core.d.ts
+++ b/packages/webdriverio/webdriverio-core.d.ts
@@ -1111,7 +1111,6 @@ declare namespace WebdriverIO {
 
     interface Browser extends WebDriver.BaseClient {
         config: Config;
-        options: RemoteOptions;
 
         /**
          * add command to `browser` or `element` scope

--- a/scripts/templates/webdriverio.tpl.d.ts
+++ b/scripts/templates/webdriverio.tpl.d.ts
@@ -683,7 +683,6 @@ declare namespace WebdriverIO {
 
     interface Browser extends WebDriver.BaseClient {
         config: Config;
-        options: RemoteOptions;
 
         /**
          * add command to `browser` or `element` scope


### PR DESCRIPTION
This issue is based on conversations we had in https://github.com/webdriverio/webdriverio/pull/5919

Basically we currently have `browser.config` and `browser.options` which both represent a similar data structure. It seems there is a lot of ambiguity. I would say let's get rid of one of them.