### PR TITLE
Validate W3C Capabilities

### DIFF
--- a/packages/webdriver/src/constants.ts
+++ b/packages/webdriver/src/constants.ts
@@ -144,3 +144,9 @@ export const DEFAULTS: DefaultOptions<Options> = {
         default: true
     }
 }
+
+export const VALID_CAPS = [
+    'browserName', 'browserVersion', 'platformName', 'acceptInsecureCerts',
+    'pageLoadStrategy', 'proxy', 'setWindowRect', 'timeouts', 'strictFileInteractability',
+    'unhandledPromptBehavior'
+]

--- a/packages/webdriver/src/utils.ts
+++ b/packages/webdriver/src/utils.ts
@@ -28,22 +28,22 @@ export async function startWebDriverSession (params: Options): Promise<{ session
      * validate capabilities to check if there are no obvious mix between
      * JSONWireProtocol and WebDriver protoocol, e.g.
      */
-    if (
-        params.capabilities &&
+    if (params.capabilities) {
+        const extensionCaps = Object.keys(params.capabilities).filter((cap) => cap.includes(':'))
+        const invalidWebDriverCaps = Object.keys(params.capabilities)
+            .filter((cap) => !VALID_CAPS.includes(cap) && !cap.includes(':'))
+
         /**
          * if there are vendor extensions, e.g. sauce:options or appium:app
          * used (only WebDriver compatible) and caps that aren't defined
          * in the WebDriver spec
          */
-        (
-            Object.keys(params.capabilities).find((cap) => cap.includes(':')) &&
-            Object.keys(params.capabilities).find((cap) => !VALID_CAPS.includes(cap))
-        )
-    ) {
-        throw new Error(
-            'Detected mix of WebDriver and JSONWire protocol capabilities. ' +
-            'Ensure to only use valid W3C WebDriver capabilities (see https://w3c.github.io/webdriver/#capabilities).'
-        )
+        if (extensionCaps.length && invalidWebDriverCaps.length) {
+            throw new Error(
+                `Invalid or unsupported WebDriver capabilities found ("${invalidWebDriverCaps.join('", "')}"). ` +
+                'Ensure to only use valid W3C WebDriver capabilities (see https://w3c.github.io/webdriver/#capabilities).'
+            )
+        }
     }
 
     /**

--- a/packages/webdriver/src/utils.ts
+++ b/packages/webdriver/src/utils.ts
@@ -8,6 +8,7 @@ import Protocols from '@wdio/protocols'
 
 import WebDriverRequest, { WebDriverResponse } from './request'
 import command from './command'
+import { VALID_CAPS } from './constants'
 import { Options, JSONWPCommandError, W3CCapabilities, SessionFlags, DesiredCapabilities } from './types'
 
 const log = logger('webdriver')
@@ -23,6 +24,28 @@ const BROWSER_DRIVER_ERRORS = [
  * start browser session with WebDriver protocol
  */
 export async function startWebDriverSession (params: Options): Promise<{ sessionId: string, capabilities: DesiredCapabilities }> {
+    /**
+     * validate capabilities to check if there are no obvious mix between
+     * JSONWireProtocol and WebDriver protoocol, e.g.
+     */
+    if (
+        params.capabilities &&
+        /**
+         * if there are vendor extensions, e.g. sauce:options or appium:app
+         * used (only WebDriver compatible) and caps that aren't defined
+         * in the WebDriver spec
+         */
+        (
+            Object.keys(params.capabilities).find((cap) => cap.includes(':')) &&
+            Object.keys(params.capabilities).find((cap) => !VALID_CAPS.includes(cap))
+        )
+    ) {
+        throw new Error(
+            'Detected mix of WebDriver and JSONWire protocol capabilities. ' +
+            'Ensure to only use valid W3C WebDriver capabilities (see https://w3c.github.io/webdriver/#capabilities).'
+        )
+    }
+
     /**
      * the user could have passed in either w3c style or jsonwp style caps
      * and we want to pass both styles to the server, which means we need

--- a/packages/webdriver/tests/utils.test.ts
+++ b/packages/webdriver/tests/utils.test.ts
@@ -209,6 +209,7 @@ describe('utils', () => {
                 logLevel: 'warn',
                 capabilities: {
                     browserName: 'chrome',
+                    platform: 'Windows'
                 }
             }
             const { sessionId, capabilities } = await startWebDriverSession(params)
@@ -237,11 +238,16 @@ describe('utils', () => {
                 capabilities: {
                     browserName: 'chrome',
                     'sauce:options': {},
-                    platform: 'Windows'
+                    platform: 'Windows',
+                    // @ts-ignore test invalid cap
+                    foo: 'bar'
                 }
             }
             const err: Error = await startWebDriverSession(params).catch((err) => err)
-            expect(err.message).toContain('Detected mix')
+            expect(err.message).toContain(
+                'Invalid or unsupported WebDriver capabilities found ' +
+                '("platform", "foo").'
+            )
         })
     })
 })

--- a/packages/webdriver/tests/utils.test.ts
+++ b/packages/webdriver/tests/utils.test.ts
@@ -226,5 +226,22 @@ describe('utils', () => {
             }).catch((err) => err)
             expect(error.message).toContain('Failed to create session')
         })
+
+        it('should break if JSONWire and WebDriver caps are mixed together', async () => {
+            const params: Options = {
+                hostname: 'localhost',
+                port: 4444,
+                path: '/',
+                protocol: 'http',
+                logLevel: 'warn',
+                capabilities: {
+                    browserName: 'chrome',
+                    'sauce:options': {},
+                    platform: 'Windows'
+                }
+            }
+            const err: Error = await startWebDriverSession(params).catch((err) => err)
+            expect(err.message).toContain('Detected mix')
+        })
     })
 })

--- a/packages/webdriverio/tests/commands/element/isDisplayed.test.ts
+++ b/packages/webdriverio/tests/commands/element/isDisplayed.test.ts
@@ -183,9 +183,6 @@ describe('isDisplayed test', () => {
                 baseUrl: 'http://foobar.com',
                 capabilities: {
                     browserName: 'firefox',
-                    // @ts-ignore mock feature
-                    keepBrowserName: true,
-                    mobileMode: true
                 }
             })
             elem = await browser.$('#foo')


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
As cloud providers transition from JSONWire Protocol to W3C WebDriver it is very hard for them to treat a job as W3C or JSONWire Protocol compatible.

**Describe the solution you'd like**
To be very clear in this regards we should validate capabilities to be W3C conform.

**Describe alternatives you've considered**
Some other libraries might strip invalid capabilities away but I would prefer to explicitly tell the user this error.

**Additional context**
Created some initial work in the `cb-validate-caps` branch but realised that this could be a breaking change for a lot of people. Therefor discarding this to the v7 release.
