### PR TITLE
Fix checkPendingNavigations memory leak in devtools

### DIFF
--- a/packages/devtools/src/devtoolsdriver.ts
+++ b/packages/devtools/src/devtoolsdriver.ts
@@ -190,7 +190,7 @@ export default class DevToolsDriver {
         return pageHandle
     }
 
-    async checkPendingNavigations (pendingNavigationStart?: number): Promise<void> {
+    async checkPendingNavigations (pendingNavigationStart = Date.now()) {
         /**
          * ensure there is no page transition happening and an execution context
          * is available
@@ -204,9 +204,6 @@ export default class DevToolsDriver {
         if (this.activeDialog || !page) {
             return
         }
-
-        pendingNavigationStart = pendingNavigationStart || Date.now()
-        const pageloadTimeout = this.timeouts.get('pageLoad') || 0
 
         /**
          * if current page is a frame we have to get the page from the browser
@@ -223,17 +220,19 @@ export default class DevToolsDriver {
             }
         }
 
-        const pageloadTimeoutReached = (Date.now() - pendingNavigationStart) > pageloadTimeout
-        const executionContext = await page.mainFrame().executionContext()
+        const pageloadTimeout = this.timeouts.get('pageLoad')
+        const pageloadTimeoutReached = Date.now() - pendingNavigationStart > pageloadTimeout
+
         try {
+            const executionContext = await page.mainFrame().executionContext()
             await executionContext.evaluate('1')
 
             /**
              * if we have an execution context, also check for the ready state
              */
             const readyState = await executionContext.evaluate('document.readyState')
-            if (readyState !== 'complete' && !pageloadTimeoutReached) {
-                return this.checkPendingNavigations(pendingNavigationStart)
+            if (readyState === 'complete' || pageloadTimeoutReached) {
+                return
             }
         } catch (err) {
             /**
@@ -242,8 +241,13 @@ export default class DevToolsDriver {
             if (pageloadTimeoutReached) {
                 throw err
             }
-
-            return this.checkPendingNavigations(pendingNavigationStart)
         }
+
+        /***
+         * Avoid looping so quickly we run out of memory before the timeout.
+         * https://github.com/webdriverio/webdriverio/issues/5048
+         */
+        await new Promise(resolve => setTimeout(resolve, 100));
+        await this.checkPendingNavigations(pendingNavigationStart)
     }
 }

--- a/packages/devtools/src/devtoolsdriver.ts
+++ b/packages/devtools/src/devtoolsdriver.ts
@@ -221,6 +221,9 @@ export default class DevToolsDriver {
         }
 
         const pageloadTimeout = this.timeouts.get('pageLoad')
+        if (pageloadTimeout == null) {
+            throw new Error('missing pageLoad timeout')
+        }
         const pageloadTimeoutReached = Date.now() - pendingNavigationStart > pageloadTimeout
 
         try {

--- a/packages/devtools/src/devtoolsdriver.ts
+++ b/packages/devtools/src/devtoolsdriver.ts
@@ -249,7 +249,7 @@ export default class DevToolsDriver {
          * Avoid looping so quickly we run out of memory before the timeout.
          * https://github.com/webdriverio/webdriverio/issues/5048
          */
-        await new Promise(resolve => setTimeout(resolve, 100))
+        await new Promise(resolve => setTimeout(resolve, Math.min(100, pageloadTimeout != null ? pageloadTimeout / 10 : 100)))
         await this.checkPendingNavigations(pendingNavigationStart)
     }
 }

--- a/packages/devtools/src/devtoolsdriver.ts
+++ b/packages/devtools/src/devtoolsdriver.ts
@@ -247,7 +247,7 @@ export default class DevToolsDriver {
          * Avoid looping so quickly we run out of memory before the timeout.
          * https://github.com/webdriverio/webdriverio/issues/5048
          */
-        await new Promise(resolve => setTimeout(resolve, pageloadTimeout/5))
+        await new Promise(resolve => setTimeout(resolve, 100))
         await this.checkPendingNavigations(pendingNavigationStart)
     }
 }

--- a/packages/devtools/src/devtoolsdriver.ts
+++ b/packages/devtools/src/devtoolsdriver.ts
@@ -247,7 +247,6 @@ export default class DevToolsDriver {
 
         /***
          * Avoid looping so quickly we run out of memory before the timeout.
-         * https://github.com/webdriverio/webdriverio/issues/5048
          */
         await new Promise(resolve => setTimeout(resolve, Math.min(100, pageloadTimeout != null ? pageloadTimeout / 10 : 100)))
         await this.checkPendingNavigations(pendingNavigationStart)

--- a/packages/devtools/src/devtoolsdriver.ts
+++ b/packages/devtools/src/devtoolsdriver.ts
@@ -247,7 +247,7 @@ export default class DevToolsDriver {
          * Avoid looping so quickly we run out of memory before the timeout.
          * https://github.com/webdriverio/webdriverio/issues/5048
          */
-        await new Promise(resolve => setTimeout(resolve, 100))
+        await new Promise(resolve => setTimeout(resolve, pageloadTimeout/5))
         await this.checkPendingNavigations(pendingNavigationStart)
     }
 }

--- a/packages/devtools/src/devtoolsdriver.ts
+++ b/packages/devtools/src/devtoolsdriver.ts
@@ -221,10 +221,9 @@ export default class DevToolsDriver {
         }
 
         const pageloadTimeout = this.timeouts.get('pageLoad')
-        if (pageloadTimeout == null) {
-            throw new Error('missing pageLoad timeout')
-        }
-        const pageloadTimeoutReached = Date.now() - pendingNavigationStart > pageloadTimeout
+        const pageloadTimeoutReached = pageloadTimeout != null
+            ? Date.now() - pendingNavigationStart > pageloadTimeout
+            : false
 
         try {
             const executionContext = await page.mainFrame().executionContext()

--- a/packages/devtools/src/devtoolsdriver.ts
+++ b/packages/devtools/src/devtoolsdriver.ts
@@ -248,7 +248,7 @@ export default class DevToolsDriver {
         /***
          * Avoid looping so quickly we run out of memory before the timeout.
          */
-        await new Promise(resolve => setTimeout(resolve, Math.min(100, pageloadTimeout != null ? pageloadTimeout / 10 : 100)))
+        await new Promise(resolve => setTimeout(resolve, Math.min(100, typeof pageloadTimeout === 'number' ? pageloadTimeout / 10 : 100)))
         await this.checkPendingNavigations(pendingNavigationStart)
     }
 }

--- a/packages/devtools/src/devtoolsdriver.ts
+++ b/packages/devtools/src/devtoolsdriver.ts
@@ -247,7 +247,7 @@ export default class DevToolsDriver {
          * Avoid looping so quickly we run out of memory before the timeout.
          * https://github.com/webdriverio/webdriverio/issues/5048
          */
-        await new Promise(resolve => setTimeout(resolve, 100));
+        await new Promise(resolve => setTimeout(resolve, 100))
         await this.checkPendingNavigations(pendingNavigationStart)
     }
 }

--- a/packages/devtools/tests/devtoolsdriver.test.ts
+++ b/packages/devtools/tests/devtoolsdriver.test.ts
@@ -236,8 +236,8 @@ test('should use page from target if we are currently in a frame', async () => {
 test('should rerun command if no execution context could be found', async () => {
     executionContext.evaluate.mockReset()
     executionContext.evaluate = jest.fn()
-        .mockReturnValueOnce(Promise.reject(new Error('ups')))
-        .mockReturnValueOnce(Promise.reject(new Error('ups')))
+        .mockImplementationOnce(() => Promise.reject(new Error('ups')))
+        .mockImplementationOnce(() => Promise.reject(new Error('ups')))
         .mockReturnValueOnce(Promise.resolve('1'))
         .mockReturnValueOnce(Promise.resolve('complete'))
 

--- a/packages/devtools/tests/devtoolsdriver.test.ts
+++ b/packages/devtools/tests/devtoolsdriver.test.ts
@@ -236,10 +236,10 @@ test('should use page from target if we are currently in a frame', async () => {
 test('should rerun command if no execution context could be found', async () => {
     executionContext.evaluate.mockReset()
     executionContext.evaluate = jest.fn()
-        .mockImplementationOnce(() => Promise.reject(new Error('ups')))
-        .mockImplementationOnce(() => Promise.reject(new Error('ups')))
-        .mockReturnValueOnce(Promise.resolve('1'))
-        .mockReturnValueOnce(Promise.resolve('complete'))
+        .mockRejectedValueOnce(new Error('ups'))
+        .mockRejectedValueOnce(new Error('ups'))
+        .mockResolvedValueOnce('1')
+        .mockResolvedValueOnce('complete')
 
     driver.commands.elementClick = (...args: any[]) => new Promise(
         (resolve) => setTimeout(() => resolve(...args), 100))

--- a/packages/devtools/tests/devtoolsdriver.test.ts
+++ b/packages/devtools/tests/devtoolsdriver.test.ts
@@ -203,14 +203,14 @@ test('throws error if navigation takes too long', async () => {
 test('should wait for page load to be complete before executing the command', async () => {
     executionContext.evaluate.mockReset()
     executionContext.evaluate = jest.fn()
-        .mockReturnValueOnce('1')
-        .mockReturnValueOnce('loading')
-        .mockReturnValueOnce('1')
-        .mockReturnValueOnce('loading')
-        .mockReturnValueOnce('1')
-        .mockReturnValueOnce('interactive')
-        .mockReturnValueOnce('1')
-        .mockReturnValueOnce('complete')
+        .mockResolvedValueOnce('1')
+        .mockResolvedValueOnce('loading')
+        .mockResolvedValueOnce('1')
+        .mockResolvedValueOnce('loading')
+        .mockResolvedValueOnce('1')
+        .mockResolvedValueOnce('interactive')
+        .mockResolvedValueOnce('1')
+        .mockResolvedValueOnce('complete')
 
     driver.commands.elementClick = (...args: any[]) => new Promise(
         (resolve) => setTimeout(() => resolve(...args), 100))


### PR DESCRIPTION
Replaces #5404

## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

Waits before retrying `checkPendingNavigations`.  Same as in #5404 but with the recheck interval lowered to `min(100, pageloadTimeout / 10)`.  (Should I do some kind of exponential backoff when the `pageLoad` timeout is really high?)

Also I'm not sure if the `pageLoad` timeout can be missing, but if so, `checkPendingNavigations` will never time out.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
