### PR TITLE
fix: Add config parameter for before session hook

### DIFF
--- a/packages/wdio-runner/src/index.ts
+++ b/packages/wdio-runner/src/index.ts
@@ -101,7 +101,7 @@ export default class Runner extends EventEmitter {
             caps as unknown as WebDriver.DesiredCapabilities,
             args.ignoredWorkerServices
         ).map(this._configParser.addService.bind(this._configParser))
-        await executeHooksWithArgs('beforeSession', this._config.beforeSession, [this._caps, this._specs])
+        await executeHooksWithArgs('beforeSession', this._config.beforeSession, [this._config, this._caps, this._specs])
 
         this._reporter = new BaseReporter(this._config, this._cid, { ...caps })
         /**

--- a/packages/wdio-runner/tests/index.test.ts
+++ b/packages/wdio-runner/tests/index.test.ts
@@ -246,7 +246,7 @@ describe('wdio-runner', () => {
             })
 
             expect(runner._shutdown).toBeCalledWith(123, 2)
-            expect(executeHooksWithArgs).toBeCalledWith('beforeSession', [beforeSession], [{
+            expect(executeHooksWithArgs).toBeCalledWith('beforeSession', [beforeSession], [config, {
                 browserName: '123'
             }, ['foobar']])
             expect(executeHooksWithArgs).toBeCalledWith('before', config.before, [caps, specs, stubBrowser])


### PR DESCRIPTION
## Proposed changes
Before session hook is missing "config" as first parameter. This causes issues for example in sauce-service because user and key are incorrectly parsed
The issue appeared after this commit:
https://github.com/webdriverio/webdriverio/pull/6216/files#diff-84608493ac5a71c7f4e0d78854aaa5920e875a89b3c6c88dad8f72621ea40ce3R104

``` 
beforeSession (config, capabilities) {
        this.config = config
        this.capabilities = capabilities
        this.api = new SauceLabs(this.config)
        this.isRDC = 'testobject_api_key' in this.capabilities // this always returns undefined because instead of capabilities code is reading specs
        this.isServiceEnabled = true

        /**
         * if no user and key is specified even though a sauce service was
         * provided set user and key with values so that the session request
         * will fail (not for RDC tho due to other auth mechansim)
         */
        if (!this.isRDC && !config.user) {
            this.isServiceEnabled = false
            config.user = 'unknown_user'
        }
        if (!this.isRDC && !config.key) {
            this.isServiceEnabled = false
            config.key = 'unknown_key'
        }
    }
```
## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
