### PR TITLE
fix: Sauce EmuSim testname and tests context are not updated

### DIFF
--- a/packages/wdio-sauce-service/src/service.js
+++ b/packages/wdio-sauce-service/src/service.js
@@ -42,7 +42,12 @@ export default class SauceService {
         this.browser = browser
 
         // Ensure capabilities are not null in case of multiremote
-        const capabilities = this.browser.capabilities || {}
+        // Changed from `this.browser.capabilities` to this to get the correct
+        // capabilities for EMUSIM (with the postfix) to determine ff the string
+        // contains `simulator` or `emulator` it's an EMU/SIM session
+        // `this.browser.capabilities` returns the process data from Sauce which is without
+        // the postfix
+        const capabilities = this.browser.requestedCapabilities || {}
         this.isUP = isUnifiedPlatform(capabilities)
     }
 

--- a/packages/wdio-sauce-service/src/utils.js
+++ b/packages/wdio-sauce-service/src/utils.js
@@ -1,7 +1,11 @@
 import { isW3C } from '@wdio/utils'
 
 /**
- * Determine if the current instance is a Unified Platform instance
+ * Determine if the current instance is a Unified Platform instance. UP tests are Real Device tests
+ * that can be started with different sets of capabilities. A deviceName is not mandatory, the only mandatory cap for
+ * UP is the platformName. Downside of the platformName is that is can also be EMUSIM. EMUSIM can be distinguished by
+ * the `Emulator|Simulator` postfix
+ *
  * @param {string} deviceName
  * @param {string} platformName
  * @returns {boolean}


### PR DESCRIPTION
## Proposed changes
This PR fixes the issue that EMUSIM jobs on Sauce don't have a testname and test context updated. The problem is that Sauce removed the post-fix from the deviceName, so the requested caps needed to be checked.

I've also updated the docs to make it more clear for future fixes

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

