### PR TITLE
Add skipFiles section to example VS Code debugging configuration

### DIFF
--- a/website/docs/Debugging.md
+++ b/website/docs/Debugging.md
@@ -91,7 +91,12 @@ It's possible to run all or selected spec file(s). Debug configuration(s) have t
     "cwd": "${workspaceFolder}",
     "autoAttachChildProcesses": true,
     "program": "${workspaceRoot}/node_modules/@wdio/cli/bin/wdio.js",
-    "console": "integratedTerminal"
+    "console": "integratedTerminal",
+    "skipFiles": [
+        "${workspaceFolder}/node_modules/**/*.js",
+        "${workspaceFolder}/lib/**/*.js",
+        "<node_internals>/**/*.js"
+    ]
 },
 ```
 


### PR DESCRIPTION
## Proposed changes

Added "skipFiles" section to VS Code debugging configuration that ignores node internals and code from node_modules. Without it debugging is nearly impossible since whenever you use "Step over" it goes straight into  fibers.js or other WDIO internals, which is very misleading and it took me a while to figure out why it does that.  

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
