### PR TITLE
feat: add support for Appium W3C caps

### DIFF
--- a/packages/wdio-sauce-service/src/utils.js
+++ b/packages/wdio-sauce-service/src/utils.js
@@ -6,8 +6,7 @@ import { isW3C } from '@wdio/utils'
  * UP is the platformName. Downside of the platformName is that is can also be EMUSIM. EMUSIM can be distinguished by
  * the `Emulator|Simulator` postfix
  *
- * @param {string} deviceName
- * @param {string} platformName
+ * @param {object} caps
  * @returns {boolean}
  *
  * This is what we get back from the UP (for now)
@@ -43,20 +42,25 @@ import { isW3C } from '@wdio/utils'
  *  deviceContextId: ''
  * }
  */
-export function isUnifiedPlatform({ deviceName = '', platformName = '' }){
+export function isUnifiedPlatform(caps){
+    const { 'appium:deviceName':appiumDeviceName = '', deviceName = '', platformName = '' } = caps
+    const name = appiumDeviceName || deviceName
+
     // If the string contains `simulator` or `emulator` it's an EMU/SIM session
-    return !deviceName.match(/(simulator)|(emulator)/gi) && !!platformName.match(/(ios)|(android)/gi)
+    return !name.match(/(simulator)|(emulator)/gi) && !!platformName.match(/(ios)|(android)/gi)
 }
 
 /**
  * Determine if this is an EMUSIM session
- * @param {string} deviceName
- * @param {string} platformName
+ * @param {object} caps
  * @returns {boolean}
  */
-export function isEmuSim({ deviceName = '', platformName = '' }){
+export function isEmuSim(caps){
+    const { 'appium:deviceName':appiumDeviceName = '', deviceName = '', platformName = '' } = caps
+    const name = appiumDeviceName || deviceName
+
     // If the string contains `simulator` or `emulator` it's an EMU/SIM session
-    return !!deviceName.match(/(simulator)|(emulator)/gi) && !!platformName.match(/(ios)|(android)/gi)
+    return !!name.match(/(simulator)|(emulator)/gi) && !!platformName.match(/(ios)|(android)/gi)
 }
 
 /** Ensure capabilities are in the correct format for Sauce Labs

--- a/packages/wdio-sauce-service/tests/utils.test.js
+++ b/packages/wdio-sauce-service/tests/utils.test.js
@@ -8,6 +8,10 @@ test('isUnifiedPlatform should be false for a non matching deviceName', () => {
     expect(isUnifiedPlatform({ deviceName: 'foo' })).toEqual(false)
 })
 
+test('isUnifiedPlatform should be false for a non matching W3C deviceName', () => {
+    expect(isUnifiedPlatform({ 'appium:deviceName': 'foo' })).toEqual(false)
+})
+
 test('isUnifiedPlatform should be false for a non matching platformName', () => {
     expect(isUnifiedPlatform({ platformName: 'foo' })).toEqual(false)
 })
@@ -16,16 +20,32 @@ test('isUnifiedPlatform should be false for an emulator test', () => {
     expect(isUnifiedPlatform({ deviceName: 'Google Pixel emulator', platformName: 'Android' })).toEqual(false)
 })
 
+test('isUnifiedPlatform should be false for an W3C emulator test', () => {
+    expect(isUnifiedPlatform({ 'appium:deviceName': 'Google Pixel emulator', platformName: 'Android' })).toEqual(false)
+})
+
 test('isUnifiedPlatform should be false for a simulator test', () => {
     expect(isUnifiedPlatform({ deviceName: 'iPhone XS simulator', platformName: 'iOS' })).toEqual(false)
+})
+
+test('isUnifiedPlatform should be false for a W3C simulator test', () => {
+    expect(isUnifiedPlatform({ 'appium:deviceName': 'iPhone XS simulator', platformName: 'iOS' })).toEqual(false)
 })
 
 test('isUnifiedPlatform should be true for a real device iOS test', () => {
     expect(isUnifiedPlatform({ deviceName: 'iPhone XS', platformName: 'iOS' })).toEqual(true)
 })
 
+test('isUnifiedPlatform should be true for a W3C real device iOS test', () => {
+    expect(isUnifiedPlatform({ 'appium:deviceName': 'iPhone XS', platformName: 'iOS' })).toEqual(true)
+})
+
 test('isUnifiedPlatform should be true for real device Android test', () => {
     expect(isUnifiedPlatform({ deviceName: 'Google Pixel', platformName: 'Android' })).toEqual(true)
+})
+
+test('isUnifiedPlatform should be true for a W3C real device Android test', () => {
+    expect(isUnifiedPlatform({ 'appium:deviceName': 'Google Pixel', platformName: 'Android' })).toEqual(true)
 })
 
 test('isEmuSim should be false for no provided deviceName and platformName', () => {
@@ -36,6 +56,10 @@ test('isEmuSim should be false for a non matching deviceName', () => {
     expect(isEmuSim({ deviceName: 'foo' })).toEqual(false)
 })
 
+test('isEmuSim should be false for a non matching W3C deviceName', () => {
+    expect(isEmuSim({ 'appium:deviceName': 'foo' })).toEqual(false)
+})
+
 test('isEmuSim should be false for a non matching platformName', () => {
     expect(isEmuSim({ platformName: 'foo' })).toEqual(false)
 })
@@ -44,14 +68,26 @@ test('isEmuSim should be true for an emulator test', () => {
     expect(isEmuSim({ deviceName: 'Google Pixel emulator', platformName: 'Android' })).toEqual(true)
 })
 
-test('isEmuSim should be true for a simulator test', () => {
-    expect(isEmuSim({ deviceName: 'iPhone XS simulator', platformName: 'iOS' })).toEqual(true)
+test('isEmuSim should be true for a W3C emulator test', () => {
+    expect(isEmuSim({ 'appium:deviceName': 'Google Pixel emulator', platformName: 'Android' })).toEqual(true)
+})
+
+test('isEmuSim should be true for a W3C simulator test', () => {
+    expect(isEmuSim({ 'appium:deviceName': 'iPhone XS simulator', platformName: 'iOS' })).toEqual(true)
 })
 
 test('isEmuSim should be false for a real device iOS test', () => {
     expect(isEmuSim({ deviceName: 'iPhone XS', platformName: 'iOS' })).toEqual(false)
 })
 
+test('isEmuSim should be false for a W3C real device iOS test', () => {
+    expect(isEmuSim({ 'appium:deviceName': 'iPhone XS', platformName: 'iOS' })).toEqual(false)
+})
+
 test('isEmuSim should be false for real device Android test', () => {
     expect(isEmuSim({ deviceName: 'Google Pixel', platformName: 'Android' })).toEqual(false)
+})
+
+test('isEmuSim should be false for a W3C real device Android test', () => {
+    expect(isEmuSim({ 'appium:deviceName': 'Google Pixel', platformName: 'Android' })).toEqual(false)
 })


### PR DESCRIPTION
## Proposed changes
When an Appium session with W3C caps is being requested the deviceName can't be determined because it's prefixed with `appium:`, this PR adds support for that

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)