### PR TITLE
webdriverio: Fix log path in standalone mode

### DIFF
--- a/packages/devtools/src/constants.ts
+++ b/packages/devtools/src/constants.ts
@@ -80,6 +80,12 @@ export const DEFAULTS: DefaultOptions<WebDriver.Options> = {
         match: /(trace|debug|info|warn|error|silent)/
     },
     /**
+     * directory for log files
+     */
+    outputDir: {
+        type: 'string'
+    },
+    /**
      * maxConnectionRetries in chrome-launcher
      */
     connectionRetryCount: {

--- a/packages/devtools/src/index.ts
+++ b/packages/devtools/src/index.ts
@@ -1,4 +1,5 @@
 import os from 'os'
+import path from 'path'
 import UAParser from 'ua-parser-js'
 import { v4 as uuidv4 } from 'uuid'
 
@@ -27,6 +28,13 @@ export default class DevTools {
 
         if (params.logLevel && (!options.logLevels || !(options.logLevels as any)['devtools'])) {
             logger.setLevel('devtools', params.logLevel)
+        }
+
+        /**
+         * Store all log events in a file
+         */
+        if (params.outputDir && !process.env.WDIO_LOG_PATH) {
+            process.env.WDIO_LOG_PATH = path.join(params.outputDir, 'wdio.log')
         }
 
         const browser = await launch(params.capabilities as WebDriver.Capabilities)

--- a/packages/devtools/src/index.ts
+++ b/packages/devtools/src/index.ts
@@ -37,6 +37,8 @@ export default class DevTools {
             process.env.WDIO_LOG_PATH = path.join(params.outputDir, 'wdio.log')
         }
 
+        log.info('Initiate new session using the DevTools protocol')
+
         const browser = await launch(params.capabilities as WebDriver.Capabilities)
         const pages = await browser.pages()
         const driver = new DevToolsDriver(browser, pages)

--- a/packages/devtools/tests/__mocks__/puppeteer-core.ts
+++ b/packages/devtools/tests/__mocks__/puppeteer-core.ts
@@ -45,6 +45,7 @@ class PageMock {
     url = jest.fn().mockReturnValue('about:blank')
     emulate = jest.fn()
     setViewport = jest.fn()
+    setDefaultTimeout = jest.fn()
     target = jest.fn().mockReturnValue(target)
 }
 const page = new PageMock()
@@ -58,6 +59,7 @@ class PuppeteerMock {
     waitForTarget = jest.fn().mockImplementation(() => target)
     getActivePage = jest.fn().mockImplementation(() => page)
     pages = jest.fn().mockReturnValue(Promise.resolve([page, page2]))
+    userAgent = jest.fn().mockImplementation(() => 'MOCK USER AGENT')
     _connection = { _transport: { _ws: { addEventListener: jest.fn() } } }
 }
 

--- a/packages/devtools/tests/index.test.ts
+++ b/packages/devtools/tests/index.test.ts
@@ -1,0 +1,77 @@
+jest.unmock('@wdio/config')
+
+import path from 'path'
+// @ts-ignore mock feature
+import { logMock } from '@wdio/logger'
+import DevTools from '../src'
+
+const OUTPUT_DIR = path.join('some', 'output', 'dir')
+const OUTPUT_FILE = path.join(OUTPUT_DIR, 'wdio.log')
+
+const setUpLogCheck = (conditionFunction: () => boolean) => {
+    const logCheck = (...args: string[]) => {
+        if (!conditionFunction()) {
+            throw new Error(
+                'Log function was called before setting ' +
+                'process.env.WDIO_LOG_PATH.\n' +
+                'Passed arguments to log function:\n' +
+                args.map((arg, index) => `  [${index}]: ${arg}`).join('\n')
+            )
+        }
+    }
+
+    logMock.error.mockImplementation(logCheck)
+    logMock.warn.mockImplementation(logCheck)
+    logMock.info.mockImplementation(logCheck)
+    logMock.debug.mockImplementation(logCheck)
+}
+
+describe('DevTools', () => {
+    describe('newSession', () => {
+        afterEach(() => {
+            delete process.env.WDIO_LOG_PATH
+
+            logMock.error.mockRestore()
+            logMock.warn.mockRestore()
+            logMock.info.mockRestore()
+            logMock.debug.mockRestore()
+        })
+
+        it('should be possible to skip setting outputDir', async () => {
+            setUpLogCheck(() => !('WDIO_LOG_PATH' in process.env))
+
+            await DevTools.newSession({
+                capabilities: { browserName: 'chrome' },
+            })
+
+            expect('WDIO_LOG_PATH' in process.env).toBe(false)
+        })
+
+        it('should be possible to set outputDir', async () => {
+            setUpLogCheck(() => process.env.WDIO_LOG_PATH === OUTPUT_FILE)
+
+            await DevTools.newSession({
+                capabilities: { browserName: 'chrome' },
+                outputDir: OUTPUT_DIR,
+            })
+
+            expect(process.env.WDIO_LOG_PATH).toBe(OUTPUT_FILE)
+        })
+
+        it('should be possible to override outputDir with env var', async () => {
+            const customPath = '/some/custom/path'
+
+            setUpLogCheck(() => process.env.WDIO_LOG_PATH === customPath)
+
+            process.env.WDIO_LOG_PATH = customPath
+
+            await DevTools.newSession({
+                capabilities: { browserName: 'chrome' },
+                outputDir: OUTPUT_DIR,
+            })
+
+            expect(process.env.WDIO_LOG_PATH).not.toBe(OUTPUT_DIR)
+            expect(process.env.WDIO_LOG_PATH).toBe(customPath)
+        })
+    })
+})

--- a/packages/wdio-utils/tests/test-framework/__snapshots__/testFnWrapper-sync.test.js.snap
+++ b/packages/wdio-utils/tests/test-framework/__snapshots__/testFnWrapper-sync.test.js.snap
@@ -68,7 +68,6 @@ Array [
       },
       "context",
       Object {
-        "duration": 0,
         "error": undefined,
         "passed": true,
         "result": "@wdio/sync: FooBar 0 0",

--- a/packages/wdio-utils/tests/test-framework/testFnWrapper-sync.test.js
+++ b/packages/wdio-utils/tests/test-framework/testFnWrapper-sync.test.js
@@ -33,7 +33,13 @@ describe('testFnWrapper', () => {
         expect(result).toBe('@wdio/sync: FooBar 0 0')
         expect(executeHooksWithArgs).toBeCalledTimes(2)
 
-        delete executeHooksWithArgs.mock.calls[1][1][2].duration
+        expect(
+            Object.prototype.hasOwnProperty.call(
+                executeHooksWithArgs.mock.calls[1][2][2],
+                'duration'
+            )
+        ).toBe(true)
+        delete executeHooksWithArgs.mock.calls[1][2][2].duration
         expect(executeHooksWithArgs.mock.calls).toMatchSnapshot()
     })
 

--- a/packages/webdriver/src/constants.ts
+++ b/packages/webdriver/src/constants.ts
@@ -63,6 +63,12 @@ export const DEFAULTS: DefaultOptions<Options> = {
         match: /(trace|debug|info|warn|error|silent)/
     },
     /**
+     * directory for log files
+     */
+    outputDir: {
+        type: 'string'
+    },
+    /**
      * Timeout for any WebDriver request to a driver or grid
      */
     connectionRetryTimeout: {

--- a/packages/webdriver/src/index.ts
+++ b/packages/webdriver/src/index.ts
@@ -27,6 +27,13 @@ export default class WebDriver {
         }
 
         /**
+         * Store all log events in a file
+         */
+        if (params.outputDir && !process.env.WDIO_LOG_PATH) {
+            process.env.WDIO_LOG_PATH = path.join(params.outputDir, 'wdio.log')
+        }
+
+        /**
          * if the server responded with direct connect information, update the
          * params to speak directly to the appium host instead of a load
          * balancer (see https://github.com/appium/python-client#direct-connect-urls
@@ -41,13 +48,6 @@ export default class WebDriver {
             params.hostname = directConnectHost
             params.port = directConnectPort
             params.path = directConnectPath
-        }
-
-        /**
-         * Store all log events in a file
-         */
-        if (params.outputDir) {
-            process.env.WDIO_LOG_PATH = path.join(params.outputDir, 'wdio.log')
         }
 
         const { sessionId, capabilities } = await startWebDriverSession(params)

--- a/packages/webdriver/src/index.ts
+++ b/packages/webdriver/src/index.ts
@@ -33,6 +33,8 @@ export default class WebDriver {
             process.env.WDIO_LOG_PATH = path.join(params.outputDir, 'wdio.log')
         }
 
+        log.info('Initiate new session using the WebDriver protocol')
+
         /**
          * if the server responded with direct connect information, update the
          * params to speak directly to the appium host instead of a load

--- a/packages/webdriverio/src/constants.ts
+++ b/packages/webdriverio/src/constants.ts
@@ -260,13 +260,6 @@ export const WDIO_DEFAULTS: Record<string, DefaultPropertyType> = {
         type: 'number'
     },
     /**
-     * directory for log files
-     */
-    outputDir: {
-        type: 'string',
-        default: process.cwd()
-    },
-    /**
      * list of strings to watch of `wdio` command is called with `--watch` flag
      */
     filesToWatch: {

--- a/packages/webdriverio/src/index.ts
+++ b/packages/webdriverio/src/index.ts
@@ -12,8 +12,6 @@ import {
 } from './utils'
 import type { Options, MultiRemoteOptions } from './types'
 
-const log = logger('webdriverio')
-
 /**
  * A method to create a new session with WebdriverIO
  *
@@ -47,7 +45,6 @@ export const remote = async function (params: Options = {}, remoteModifier?: Fun
     }
 
     const prototype = getPrototype('browser')
-    log.info(`Initiate new session using the ${automationProtocol} protocol`)
     const ProtocolDriver = require(automationProtocol).default
 
     await updateCapabilities(params, automationProtocol)

--- a/packages/webdriverio/tests/index.test.ts
+++ b/packages/webdriverio/tests/index.test.ts
@@ -1,9 +1,42 @@
+import path from 'path'
+// @ts-ignore mock feature
+import { logMock } from '@wdio/logger'
 import * as webdriverio from '../src'
 
 // If you're making a change here, like adding a new export, the TypeScript
 // typings may need an update : packages/webdriverio/webdriverio.d.ts
 
+const OUTPUT_DIR = path.join('some', 'output', 'dir')
+const OUTPUT_FILE = path.join(OUTPUT_DIR, 'wdio.log')
+
+const setUpLogCheck = (conditionFunction: () => boolean) => {
+    const logCheck = (...args: string[]) => {
+        if (!conditionFunction()) {
+            throw new Error(
+                'Log function was called before setting ' +
+                'process.env.WDIO_LOG_PATH.\n' +
+                'Passed arguments to log function:\n' +
+                args.map((arg, index) => `  [${index}]: ${arg}`).join('\n')
+            )
+        }
+    }
+
+    logMock.error.mockImplementation(logCheck)
+    logMock.warn.mockImplementation(logCheck)
+    logMock.info.mockImplementation(logCheck)
+    logMock.debug.mockImplementation(logCheck)
+}
+
 describe('index.js', () => {
+    afterEach(() => {
+        delete process.env.WDIO_LOG_PATH
+
+        logMock.error.mockRestore()
+        logMock.warn.mockRestore()
+        logMock.info.mockRestore()
+        logMock.debug.mockRestore()
+    })
+
     it('exports remote method', () => {
         expect(webdriverio.remote).toBeDefined()
     })
@@ -22,5 +55,48 @@ describe('index.js', () => {
 
     it('exports SevereServiceError class', () => {
         expect(webdriverio.SevereServiceError).toBeDefined()
+    })
+
+    describe('remote method', () => {
+        it('should be possible to skip setting outputDir', async () => {
+            setUpLogCheck(() => !('WDIO_LOG_PATH' in process.env))
+
+            await webdriverio.remote({
+                capabilities: {
+                    browserName: 'chrome'
+                }
+            })
+
+            expect('WDIO_LOG_PATH' in process.env).toBe(false)
+        })
+
+        it('should be possible to set outputDir', async () => {
+            setUpLogCheck(() => process.env.WDIO_LOG_PATH === OUTPUT_FILE)
+
+            await webdriverio.remote({
+                capabilities: {
+                    browserName: 'chrome'
+                },
+                outputDir: OUTPUT_DIR,
+            })
+
+            expect(process.env.WDIO_LOG_PATH).toBe(OUTPUT_FILE)
+        })
+
+        it('should be possible to override outputDir with env var', async () => {
+            const customPath = '/some/custom/path'
+
+            setUpLogCheck(() => process.env.WDIO_LOG_PATH === customPath)
+
+            process.env.WDIO_LOG_PATH = customPath
+
+            await webdriverio.remote({
+                capabilities: { browserName: 'chrome' },
+                outputDir: OUTPUT_DIR,
+            })
+
+            expect(process.env.WDIO_LOG_PATH).not.toBe(OUTPUT_DIR)
+            expect(process.env.WDIO_LOG_PATH).toBe(customPath)
+        })
     })
 })


### PR DESCRIPTION
## Proposed changes

When running in standalone mode (directly using the `remote` function), the logs started going to stdout instead of to a file in version 6.10.6. The issue started in this commit: e78ecef891b2de4a2f7c198117d35db8debf1c68

That commit moves the setting of `process.env.WDIO_LOG_PATH` into the `webdriver` package, but it still has to remain in the `webdriverio` package as well for standalone mode to work. Looks like this feature was introduced in PR #3583.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

### Reviewers: @webdriverio/project-committers
