### PR TITLE
Further TypeScript CLI improvements

### DIFF
--- a/docs/Frameworks.md
+++ b/docs/Frameworks.md
@@ -298,10 +298,6 @@ cucumberOpts: {
                 ignore: ['node_modules']
             }
         ]
-    ],
-    // or
-    requireModule: [
-        () => { require('ts-node').register({ files: true }) }
     ]
  }
  ```

--- a/packages/wdio-cli/src/commands/config.ts
+++ b/packages/wdio-cli/src/commands/config.ts
@@ -5,7 +5,7 @@ import yarnInstall from 'yarn-install'
 import {
     CONFIG_HELPER_INTRO, CLI_EPILOGUE, COMPILER_OPTIONS,
     TS_COMPILER_INSTRUCTIONS, SUPPORTED_PACKAGES,
-    CONFIG_HELPER_SUCCESS_MESSAGE
+    CONFIG_HELPER_SUCCESS_MESSAGE, TS_SETUP_NOTE
 } from '../constants'
 import {
     addServiceDeps, convertPackageHashToObject, renderConfigurationFile,
@@ -61,6 +61,7 @@ const runConfig = async function (useYarn: boolean, yes: boolean, exit = false) 
     /**
      * add ts-node if TypeScript is desired but not installed
      */
+    let isTypeScriptInstalled = false
     if (answers.isUsingCompiler === COMPILER_OPTIONS.ts) {
         try {
             /**
@@ -71,8 +72,9 @@ const runConfig = async function (useYarn: boolean, yes: boolean, exit = false) 
                 throw new Error('resolve error')
             }
             require.resolve('ts-node')
+            isTypeScriptInstalled = true
         } catch (e) {
-            packagesToInstall.push('ts-node')
+            packagesToInstall.push('ts-node', 'typescript')
         }
     }
 
@@ -104,6 +106,7 @@ const runConfig = async function (useYarn: boolean, yes: boolean, exit = false) 
         services: servicePackages.map(({ short }) => short),
         packagesToInstall,
         isUsingTypeScript: answers.isUsingCompiler === COMPILER_OPTIONS.ts,
+        isTypeScriptInstalled,
         isUsingBabel: answers.isUsingCompiler === COMPILER_OPTIONS.babel,
         isSync: syncExecution,
         _async: syncExecution ? '' : 'async ',
@@ -143,6 +146,10 @@ const runConfig = async function (useYarn: boolean, yes: boolean, exit = false) 
                 .filter(service => service.startsWith('@wdio'))
         ].join('", "')}"`
         console.log(util.format(TS_COMPILER_INSTRUCTIONS, tsPkgs))
+    }
+
+    if (answers.isUsingCompiler === COMPILER_OPTIONS.ts) {
+        console.log(util.format(TS_SETUP_NOTE, syncExecution ? '@wdio/sync' : 'webdriverio', frameworkPackage.package))
     }
 
     console.log(CONFIG_HELPER_SUCCESS_MESSAGE)

--- a/packages/wdio-cli/src/commands/config.ts
+++ b/packages/wdio-cli/src/commands/config.ts
@@ -61,7 +61,6 @@ const runConfig = async function (useYarn: boolean, yes: boolean, exit = false) 
     /**
      * add ts-node if TypeScript is desired but not installed
      */
-    let isTypeScriptInstalled = false
     if (answers.isUsingCompiler === COMPILER_OPTIONS.ts) {
         try {
             /**
@@ -72,7 +71,6 @@ const runConfig = async function (useYarn: boolean, yes: boolean, exit = false) 
                 throw new Error('resolve error')
             }
             require.resolve('ts-node')
-            isTypeScriptInstalled = true
         } catch (e) {
             packagesToInstall.push('ts-node', 'typescript')
         }
@@ -106,7 +104,6 @@ const runConfig = async function (useYarn: boolean, yes: boolean, exit = false) 
         services: servicePackages.map(({ short }) => short),
         packagesToInstall,
         isUsingTypeScript: answers.isUsingCompiler === COMPILER_OPTIONS.ts,
-        isTypeScriptInstalled,
         isUsingBabel: answers.isUsingCompiler === COMPILER_OPTIONS.babel,
         isSync: syncExecution,
         _async: syncExecution ? '' : 'async ',

--- a/packages/wdio-cli/src/constants.ts
+++ b/packages/wdio-cli/src/constants.ts
@@ -17,6 +17,14 @@ WDIO Configuration Helper
 =========================
 `
 
+export const TS_SETUP_NOTE = `
+To enable TypeScript support please add the following types to your tsconfig.json:
+- %s
+- %s
+
+For more information, see https://webdriver.io/docs/typescript.html!
+`
+
 export const CONFIG_HELPER_SUCCESS_MESSAGE = `
 Configuration file was created successfully!
 To run your tests, execute:

--- a/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
+++ b/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
@@ -180,10 +180,7 @@ exports.config = {
     // Options to be passed to Mocha.
     // See the full list at http://mochajs.org/
     mochaOpts: {
-        <% if(answers.isUsingTypeScript) {
-        %>// TypeScript setup
-        require: ['ts-node/register'],
-        <% } else if(answers.isUsingBabel) {
+        <% if(answers.isUsingBabel) {
         %>// Babel setup
         require: ['@babel/register'],
         <% }
@@ -195,10 +192,7 @@ exports.config = {
     //
     // Options to be passed to Jasmine.
     jasmineNodeOpts: {
-        <% if(answers.isUsingTypeScript) {
-        %>// TypeScript setup
-        requires: ['ts-node/register'],
-        <% } else if(answers.isUsingBabel) {
+        <% if(answers.isUsingBabel) {
         %>// Babel setup
         helpers: [require.resolve('@babel/register')],
         <% }
@@ -221,11 +215,7 @@ exports.config = {
         // <boolean> show full backtrace for errors
         backtrace: false,
         // <string[]> ("extension:module") require files with the given EXTENSION after requiring MODULE (repeatable)
-        <% if(answers.isUsingTypeScript) {
-        %>requireModule: [
-            () => { require('ts-node').register({ files: true }) },
-        ],
-        <% } else if(answers.isUsingBabel) {
+        <% if(answers.isUsingBabel) {
         %>requireModule: ['@babel/register'],
         <% } else {
         %>requireModule: [],

--- a/packages/wdio-cli/src/types.ts
+++ b/packages/wdio-cli/src/types.ts
@@ -39,6 +39,7 @@ export interface ParsedAnswers extends Omit<Questionnair, 'runner' | 'framework'
     services: string[]
     packagesToInstall: string[]
     isUsingTypeScript: boolean
+    isTypeScriptInstalled: boolean
     isUsingBabel: boolean
     isSync: boolean
     _async: string

--- a/packages/wdio-cli/src/types.ts
+++ b/packages/wdio-cli/src/types.ts
@@ -39,7 +39,6 @@ export interface ParsedAnswers extends Omit<Questionnair, 'runner' | 'framework'
     services: string[]
     packagesToInstall: string[]
     isUsingTypeScript: boolean
-    isTypeScriptInstalled: boolean
     isUsingBabel: boolean
     isSync: boolean
     _async: string

--- a/packages/wdio-cli/tests/commands/__snapshots__/config.test.ts.snap
+++ b/packages/wdio-cli/tests/commands/__snapshots__/config.test.ts.snap
@@ -36,6 +36,15 @@ For for information on TypeScript integration check out: https://webdriver.io/do
   ],
   Array [
     "
+To enable TypeScript support please add the following types to your tsconfig.json:
+- @wdio/sync
+- @wdio/mocha-framework
+
+For more information, see https://webdriver.io/docs/typescript.html!
+",
+  ],
+  Array [
+    "
 Configuration file was created successfully!
 To run your tests, execute:
 $ npx wdio run wdio.conf.js
@@ -62,7 +71,8 @@ Installing wdio packages:
 - @wdio/crossbrowsertesting-service
 - wdio-lambdatest-service
 - @wdio/sync
-- ts-node",
+- ts-node
+- typescript",
   ],
   Array [
     "
@@ -77,6 +87,15 @@ Packages installed successfully, creating configuration file...",
 }
 
 For for information on TypeScript integration check out: https://webdriver.io/docs/typescript.html
+",
+  ],
+  Array [
+    "
+To enable TypeScript support please add the following types to your tsconfig.json:
+- @wdio/sync
+- @wdio/mocha-framework
+
+For more information, see https://webdriver.io/docs/typescript.html!
 ",
   ],
   Array [

--- a/packages/wdio-cucumber-framework/README.md
+++ b/packages/wdio-cucumber-framework/README.md
@@ -52,7 +52,7 @@ Require modules prior to requiring any support files.
 
 Type: `String[]`<br>
 Default: `[]`<br>
-Example: `['@babel/register']` or `[['@babel/register', { rootMode: 'upward', ignore: ['node_modules'] }]] or [() => { require('ts-node').register({ files: true }) }]`
+Example: `['@babel/register']` or `[['@babel/register', { rootMode: 'upward', ignore: ['node_modules'] }]]`
 
 ### failAmbiguousDefinitions
 **Please note that this is a @wdio/cucumber-framework specific option and not recognized by cucumber-js itself**

--- a/packages/wdio-cucumber-framework/cucumber-framework.d.ts
+++ b/packages/wdio-cucumber-framework/cucumber-framework.d.ts
@@ -47,7 +47,7 @@ interface CucumberOpts {
     /**
      * Require modules prior to requiring any support files.
      * @default []
-     * @example `['@babel/register']` or `[['@babel/register', { rootMode: 'upward', ignore: ['node_modules'] }]] or [() => { require('ts-node').register({ files: true }) }]`
+     * @example `['@babel/register']` or `[['@babel/register', { rootMode: 'upward', ignore: ['node_modules'] }]]`
      */
     requireModule?: string[];
     /**

--- a/packages/wdio-cucumber-framework/src/index.js
+++ b/packages/wdio-cucumber-framework/src/index.js
@@ -186,7 +186,7 @@ class CucumberAdapter {
      * Pass an array with path to module and its configuration instead:
      * Usage: `[['module', {}]]`
      * Or pass your own function
-     * Usage: `[() => { require('ts-node').register({ files: true }) }]`
+     * Usage: `[() => { require('@babel/register')({ ignore: [] }) }]`
      */
     registerRequiredModules() {
         this.cucumberOpts.requireModule.map(requiredModule => {


### PR DESCRIPTION
After #6275 we still can't bootstrap a TypeScript project due to the following issues:

- `typescript` package is missing and needs to be installed
- `types` in `tsconfig.json` needs to be modified
- no framework options are required

I suggest to check if a `tsconfig.json` is existing, then:

- if yes, don't install typescript dependencies (we should assume that the user has set this up correctly) and print out info message that WebdriverIO types should be added to the config
- if no, install `ts-node` and `typescript` and generate a `tsconfig.json`