### PR TITLE
Automatically run worker with Babel if setup

### DIFF
--- a/docs/Babel.md
+++ b/docs/Babel.md
@@ -27,46 +27,4 @@ module.exports = {
 }
 ```
 
-There are multiple ways to setup Babel using the WDIO testrunner depending on the test framework you are using:
-
-<!--DOCUSAURUS_CODE_TABS-->
-<!--Mocha-->
-```js
-// wdio.conf.js
-exports.config = {
-    // ...
-    mochaOpts: {
-        ui: 'bdd',
-        require: ['@babel/register', './test/helpers/common.js'],
-        // ...
-    },
-    // ...
-}
-```
-<!--Jasmine-->
-```js
-// wdio.conf.js
-exports.config = {
-    // ...
-    jasmineNodeOpts: {
-        // Jasmine default timeout
-	    helpers: [require.resolve('@babel/register')],
-        // ...
-    },
-    // ...
-}
-```
-<!--Cucumber-->
-```js
-// wdio.conf.js
-exports.config = {
-    // ...
-    cucumberOpts: {
-        requireModule: ['@babel/register'],
-        require: ['./test/helpers/common.js'],
-        // ...
-    },
-    // ...
-}
-```
-<!--END_DOCUSAURUS_CODE_TABS-->
+Once this is set up WebdriverIO will take care of the rest.

--- a/packages/wdio-cli/src/commands/config.ts
+++ b/packages/wdio-cli/src/commands/config.ts
@@ -77,6 +77,24 @@ const runConfig = async function (useYarn: boolean, yes: boolean, exit = false) 
     }
 
     /**
+     * add @babel/register package if not installed
+     */
+    if (answers.isUsingCompiler === COMPILER_OPTIONS.babel) {
+        try {
+            /**
+             * this is only for testing purposes as we want to check whether
+             * we add `@babel/register` to the packages to install when resolving fails
+             */
+            if (process.env.JEST_WORKER_ID && process.env.WDIO_TEST_THROW_RESOLVE) {
+                throw new Error('resolve error')
+            }
+            require.resolve('@babel/register')
+        } catch (e) {
+            packagesToInstall.push('@babel/register')
+        }
+    }
+
+    /**
      * add packages that are required by services
      */
     addServiceDeps(servicePackages, packagesToInstall)

--- a/packages/wdio-cli/tests/commands/__snapshots__/config.test.ts.snap
+++ b/packages/wdio-cli/tests/commands/__snapshots__/config.test.ts.snap
@@ -89,3 +89,70 @@ $ npx wdio run wdio.conf.js
   ],
 ]
 `;
+
+exports[`should install @babel/register if not existing 1`] = `
+Array [
+  Array [
+    "
+=========================
+WDIO Configuration Helper
+=========================
+",
+  ],
+  Array [
+    "
+Installing wdio packages:
+-",
+    "@wdio/local-runner
+- @wdio/mocha-framework
+- @wdio/crossbrowsertesting-service
+- wdio-lambdatest-service
+- @wdio/sync
+- @babel/register",
+  ],
+  Array [
+    "
+Packages installed successfully, creating configuration file...",
+  ],
+  Array [
+    "
+Configuration file was created successfully!
+To run your tests, execute:
+$ npx wdio run wdio.conf.js
+",
+  ],
+]
+`;
+
+exports[`should not install @babel/register if existing 1`] = `
+Array [
+  Array [
+    "
+=========================
+WDIO Configuration Helper
+=========================
+",
+  ],
+  Array [
+    "
+Installing wdio packages:
+-",
+    "@wdio/local-runner
+- @wdio/mocha-framework
+- @wdio/crossbrowsertesting-service
+- wdio-lambdatest-service
+- @wdio/sync",
+  ],
+  Array [
+    "
+Packages installed successfully, creating configuration file...",
+  ],
+  Array [
+    "
+Configuration file was created successfully!
+To run your tests, execute:
+$ npx wdio run wdio.conf.js
+",
+  ],
+]
+`;

--- a/packages/wdio-cli/tests/commands/config.test.ts
+++ b/packages/wdio-cli/tests/commands/config.test.ts
@@ -132,6 +132,40 @@ test('prints TypeScript setup message with ts-node installed', async () => {
     expect(consoleLogSpy.mock.calls).toMatchSnapshot()
 })
 
+test('should install @babel/register if not existing', async () => {
+    process.env.WDIO_TEST_THROW_RESOLVE = '1'
+    ;(inquirer.prompt as any as jest.Mock).mockReturnValue(Promise.resolve({
+        executionMode: 'sync',
+        framework: '@wdio/mocha-framework$--$mocha',
+        reporters: [],
+        services: [
+            '@wdio/crossbrowsertesting-service$--$crossbrowsertesting',
+            'wdio-lambdatest-service$--$lambdatest'
+        ],
+        generateTestFiles: false,
+        isUsingCompiler: 'Babel (https://babeljs.io/)'
+    }))
+    await handler({} as any)
+    expect(consoleLogSpy.mock.calls).toMatchSnapshot()
+})
+
+test('should not install @babel/register if existing', async () => {
+    delete process.env.WDIO_TEST_THROW_RESOLVE
+    ;(inquirer.prompt as any as jest.Mock).mockReturnValue(Promise.resolve({
+        executionMode: 'sync',
+        framework: '@wdio/mocha-framework$--$mocha',
+        reporters: [],
+        services: [
+            '@wdio/crossbrowsertesting-service$--$crossbrowsertesting',
+            'wdio-lambdatest-service$--$lambdatest'
+        ],
+        generateTestFiles: false,
+        isUsingCompiler: 'Babel (https://babeljs.io/)'
+    }))
+    await handler({} as any)
+    expect(consoleLogSpy.mock.calls).toMatchSnapshot()
+})
+
 describe('missingConfigurationPromp', () => {
     it('should prompt user', async () => {
         (inquirer.prompt as any as jest.Mock).mockImplementation(() => ({ config: true }))

--- a/packages/wdio-config/src/lib/ConfigParser.ts
+++ b/packages/wdio-config/src/lib/ConfigParser.ts
@@ -6,7 +6,7 @@ import logger from '@wdio/logger'
 
 import {
     detectBackend, removeLineNumbers, isCucumberFeatureWithLineNumber, validObjectOrArray,
-    loadTypeScriptCompiler
+    loadTypeScriptCompiler, loadBabelCompiler
 } from '../utils'
 import { DEFAULT_CONFIGS, SUPPORTED_HOOKS, SUPPORTED_FILE_EXTENSIONS } from '../constants'
 import type { Capabilities, ConfigOptions, Hooks } from '../types'
@@ -36,9 +36,11 @@ export default class ConfigParser {
 
         try {
             /**
-             * load TypeScript if existing
+             * compile files if Babel or TypeScript are installed
              */
-            loadTypeScriptCompiler()
+            if (!loadTypeScriptCompiler() && !loadBabelCompiler()) {
+                log.debug('No compiler found, continue without compiling files')
+            }
 
             /**
              * clone the original config

--- a/packages/wdio-config/src/utils.ts
+++ b/packages/wdio-config/src/utils.ts
@@ -217,7 +217,28 @@ export function loadTypeScriptCompiler () {
     try {
         require.resolve('ts-node')
         require('ts-node').register({ transpileOnly: true })
+        log.debug('Found \'ts-node\' package, auto-compiling TypeScript files')
+        return true
     } catch (e) {
-        return log.debug('Couldn\'t find ts-node package, no TypeScript compiling')
+        return false
+    }
+}
+
+export function loadBabelCompiler () {
+    try {
+        require.resolve('@babel/register')
+
+        /**
+         * only for testing purposes
+         */
+        if (process.env.JEST_WORKER_ID && process.env.THROW_BABEL_REGISTER) {
+            throw new Error('test fail')
+        }
+
+        require('@babel/register')
+        log.debug('Found \'@babel/register\' package, auto-compiling files with Babel')
+        return true
+    } catch (e) {
+        return false
     }
 }

--- a/packages/wdio-config/tests/__mocks__/@babel/register.ts
+++ b/packages/wdio-config/tests/__mocks__/@babel/register.ts
@@ -1,0 +1,1 @@
+export default jest.fn()

--- a/scripts/depcheck.js
+++ b/scripts/depcheck.js
@@ -16,8 +16,8 @@ const ROOT_DIR = path.join(__dirname, '..')
 const EXEC_OPTIONS = { silent: true, async: true }
 const IGNORE_PACKAGES = {
     'wdio-reporter': ['cucumber'],
-    'wdio-cli': ['ts-node'],
-    'wdio-config': ['ts-node']
+    'wdio-cli': ['ts-node', '@babel/register'],
+    'wdio-config': ['ts-node', '@babel/register']
 }
 
 ;(async () => {


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**

Currently it is rather difficult to have wdio.conf files in ESNext.

**Describe the solution you'd like**
It would be great if the wdio-runner could detect if babel is setup in the project and automatically compile the files.

**Describe alternatives you've considered**
Have proper documentation of how to do this.
