### PR TITLE
fix for wdio-testingbot-service not correctly handling MultiRemoteCap…

### DIFF
--- a/packages/wdio-testingbot-service/src/launcher.ts
+++ b/packages/wdio-testingbot-service/src/launcher.ts
@@ -37,7 +37,7 @@ export default class TestingBotLauncher implements WebdriverIO.ServiceInstance {
             }
         } else {
             for (const browserName of Object.keys(capabilities)) {
-                const capability = (capabilities as WebdriverIO.MultiRemoteOptions)[browserName]
+                const capability = (capabilities as WebdriverIO.MultiRemoteCapabilities)[browserName].capabilities
                 if (!capability['tb:options']) {
                     capability['tb:options'] = {} as WebDriver.TestingbotCapabilities
                 }

--- a/packages/wdio-testingbot-service/tests/launcher.test.ts
+++ b/packages/wdio-testingbot-service/tests/launcher.test.ts
@@ -87,15 +87,19 @@ describe('wdio-testingbot-service', () => {
             user: 'user',
             key: 'key'
         }
-        const caps = {
+        const caps: WebdriverIO.MultiRemoteCapabilities = {
             browserA: {
-                'tb:options': {
-                    build: 'unit-test',
+                capabilities: {
+                    'tb:options': {
+                        build: 'unit-test',
+                    }
                 }
             } as any,
             browserB: {
-                'tb:options': {
-                    build: 'other-unit-test',
+                capabilities: {
+                    'tb:options': {
+                        build: 'other-unit-test',
+                    }
                 }
             } as any
         }
@@ -104,15 +108,19 @@ describe('wdio-testingbot-service', () => {
         await tbLauncher.onPrepare(config, caps as any)
         expect(caps).toEqual({
             browserA: {
-                'tb:options': {
-                    'tunnel-identifier': 'my-tunnel',
-                    build: 'unit-test',
+                capabilities: {
+                    'tb:options': {
+                        'tunnel-identifier': 'my-tunnel',
+                        build: 'unit-test',
+                    }
                 }
             },
             browserB: {
-                'tb:options': {
-                    'tunnel-identifier': 'my-tunnel',
-                    build: 'other-unit-test',
+                capabilities: {
+                    'tb:options': {
+                        'tunnel-identifier': 'my-tunnel',
+                        build: 'other-unit-test',
+                    }
                 }
             }
         })
@@ -154,19 +162,23 @@ describe('wdio-testingbot-service', () => {
             user: 'user',
             key: 'key'
         }
-        const caps = {
-            browserA: {},
+        const caps: WebdriverIO.MultiRemoteCapabilities = {
+            browserA: {
+                capabilities: {}
+            },
             browserB: {
-                'tb:options': {
-                    build: 'other-unit-test',
+                capabilities: {
+                    'tb:options': {
+                        build: 'other-unit-test',
+                    }
                 }
             }
         }
         const tbLauncher = new TestingBotLauncher(options)
 
         await tbLauncher.onPrepare(config, caps as any)
-        expect(Object.keys(caps.browserA['tb:options'])).toContain('tunnel-identifier')
-        expect(Object.keys(caps.browserB['tb:options'])).toContain('build')
+        expect(Object.keys(caps.browserA.capabilities['tb:options'])).toContain('tunnel-identifier')
+        expect(Object.keys(caps.browserB.capabilities['tb:options'])).toContain('build')
     })
 
     it('onComplete', () => {


### PR DESCRIPTION
## Proposed changes

wdio-testingbot-service is not correctly using the multi remote capabilities since it has been refactored to use TypeScript. 
This PR fixes the problem, together with the tests.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
