### PR TITLE
Change sauce update jobname order

### DIFF
--- a/packages/wdio-sauce-service/README.md
+++ b/packages/wdio-sauce-service/README.md
@@ -6,7 +6,7 @@ WebdriverIO Sauce Service
 > - the Sauce Labs Real Device cloud (iOS and Android) and can **ONLY** update the job status to passed / failed
 
 > - By default the Sauce Service will update the 'name' of the job when the job starts. This will give you the option to update the name at any given point in time.
->The only time when you can't update the name of the job is when you execute a retry or a session reload.
+> - The only time when you can't update the name of the job is when you execute a retry or a session reload.
 
 ## Installation
 

--- a/packages/wdio-sauce-service/README.md
+++ b/packages/wdio-sauce-service/README.md
@@ -5,7 +5,7 @@ WebdriverIO Sauce Service
 > - the Sauce Labs virtual machine cloud (desktop web and em/simulators) and can update the job metadata ('name'*, 'passed', 'tags', 'public', 'build', 'custom-data') and runs Sauce Connect if desired.
 > - the Sauce Labs Real Device cloud (iOS and Android) and can **ONLY** update the job status to passed / failed
 
-> \* By default the Sauce Service will update the 'name' of the job when the job starts. This will give you the option to update the name at any given point in time.
+> - By default the Sauce Service will update the 'name' of the job when the job starts. This will give you the option to update the name at any given point in time.
 >The only time when you can't update the name of the job is when you execute a retry or a session reload.
 
 ## Installation

--- a/packages/wdio-sauce-service/README.md
+++ b/packages/wdio-sauce-service/README.md
@@ -2,8 +2,11 @@ WebdriverIO Sauce Service
 =========================
 
 > WebdriverIO service that provides a better integration into Sauce Labs. This service can be used for:
-> - the Sauce Labs virtual machine cloud (desktop web and em/simulators) and can update the job metadata ('name', 'passed', 'tags', 'public', 'build', 'custom-data') and runs Sauce Connect if desired.
+> - the Sauce Labs virtual machine cloud (desktop web and em/simulators) and can update the job metadata ('name'*, 'passed', 'tags', 'public', 'build', 'custom-data') and runs Sauce Connect if desired.
 > - the Sauce Labs Real Device cloud (iOS and Android) and can **ONLY** update the job status to passed / failed
+
+> \* By default the Sauce Service will update the 'name' of the job when the job starts. This will give you the option to update the name at any given point in time.
+>The only time when you can't update the name of the job is when you execute a retry or a session reload.
 
 ## Installation
 

--- a/packages/wdio-sauce-service/README.md
+++ b/packages/wdio-sauce-service/README.md
@@ -72,7 +72,7 @@ export.config = {
         // Sauce options can be found here https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options
         'sauce:options': {
             tunnelIdentifier: 'YourTunnelName',
-            
+
             // Example options
             build: 'your-build-name',
             screenResolution: '1600x1200',
@@ -94,7 +94,7 @@ export.config = {
         'sauce:options': {
             tunnelIdentifier: 'ParentTunnelName',
             parentTunnel: '<username of parent>,
-            
+
             // Example options
             build: 'your-build-name',
             screenResolution: '1600x1200',
@@ -141,12 +141,6 @@ Type: `Object`<br>
 Default: `{ noAutodetect: true }`
 
 *(only for vm and or em/simulators)*
-
-### setJobNameInBeforeSuite
-If true it updates the job name at the Sauce Labs job in the beforeSuite Hook. Attention: this comes at the cost of an additional call to Sauce Labs. The advantage of using this flag is the direct visibility of the job name in sauce labs also during the run time. This is especially useful for long running tests.
-
-Type: `Boolean`<br>
-Default: `false`
 
 ----
 

--- a/packages/wdio-sauce-service/sauce-service.d.ts
+++ b/packages/wdio-sauce-service/sauce-service.d.ts
@@ -142,10 +142,4 @@ interface SauceServiceConfig {
      * @deprecated
      */
     scRelay?: boolean;
-    /**
-     * If true it updates the job name at the Sauce Labs job in the beforeSuite Hook.
-     * Attention: this comes at the cost of an additional call to Sauce Labs
-     * Default: false
-     */
-    setJobNameInBeforeSuite?: boolean;
 }

--- a/packages/wdio-sauce-service/src/service.ts
+++ b/packages/wdio-sauce-service/src/service.ts
@@ -12,6 +12,7 @@ export default class SauceService implements WebdriverIO.ServiceInstance {
     private _testCnt = 0
     private _failures = 0 // counts failures between reloads
     private _isServiceEnabled = true
+    private _isJobNameSet = false;
 
     private _api: SauceLabs
     private _isRDC: boolean
@@ -62,9 +63,6 @@ export default class SauceService implements WebdriverIO.ServiceInstance {
 
     beforeSuite (suite: any) {
         this._suiteTitle = suite.title
-        if (this._browser && this._options.setJobNameInBeforeSuite && !this._isUP) {
-            this._browser.execute('sauce:job-name=' + this._suiteTitle)
-        }
     }
 
     beforeTest (test: any) {
@@ -84,6 +82,12 @@ export default class SauceService implements WebdriverIO.ServiceInstance {
         /* istanbul ignore if */
         if (this._suiteTitle === 'Jasmine__TopLevel__Suite') {
             this._suiteTitle = test.fullName.slice(0, test.fullName.indexOf(test.description) - 1)
+        }
+
+        /* istanbul ignore if */
+        if (this._browser && !this._isUP && !this._isJobNameSet) {
+            this._browser.execute('sauce:job-name=' + this._suiteTitle)
+            this._isJobNameSet = true
         }
 
         const fullTitle = (
@@ -232,18 +236,18 @@ export default class SauceService implements WebdriverIO.ServiceInstance {
         let body: Partial<Job> = {}
 
         /**
-         * set default values
-         */
-        body.name = this._suiteTitle
-
-        if (browserName) {
-            body.name = `${browserName}: ${body.name}`
-        }
-
-        /**
          * add reload count to title if reload is used
          */
         if (calledOnReload || this._testCnt) {
+            /**
+             * set default values
+             */
+            body.name = this._suiteTitle
+
+            if (browserName) {
+                body.name = `${browserName}: ${body.name}`
+            }
+
             let testCnt = ++this._testCnt
 
             const mulitremoteBrowser = this._browser as WebdriverIO.MultiRemoteBrowserObject

--- a/packages/wdio-sauce-service/src/service.ts
+++ b/packages/wdio-sauce-service/src/service.ts
@@ -84,7 +84,6 @@ export default class SauceService implements WebdriverIO.ServiceInstance {
             this._suiteTitle = test.fullName.slice(0, test.fullName.indexOf(test.description) - 1)
         }
 
-        /* istanbul ignore else */
         if (this._browser && !this._isUP && !this._isJobNameSet) {
             this._browser.execute('sauce:job-name=' + this._suiteTitle)
             this._isJobNameSet = true

--- a/packages/wdio-sauce-service/src/service.ts
+++ b/packages/wdio-sauce-service/src/service.ts
@@ -84,7 +84,7 @@ export default class SauceService implements WebdriverIO.ServiceInstance {
             this._suiteTitle = test.fullName.slice(0, test.fullName.indexOf(test.description) - 1)
         }
 
-        /* istanbul ignore if */
+        /* istanbul ignore else */
         if (this._browser && !this._isUP && !this._isJobNameSet) {
             this._browser.execute('sauce:job-name=' + this._suiteTitle)
             this._isJobNameSet = true

--- a/packages/wdio-sauce-service/src/types.ts
+++ b/packages/wdio-sauce-service/src/types.ts
@@ -26,10 +26,4 @@ export interface SauceServiceConfig {
      * @deprecated
      */
     scRelay?: boolean
-    /**
-     * If true it updates the job name at the Sauce Labs job in the beforeSuite Hook.
-     * Attention: this comes at the cost of an additional call to Sauce Labs
-     * Default: false
-     */
-    setJobNameInBeforeSuite?: boolean
 }


### PR DESCRIPTION
## Proposed changes
This PR changes the order of where the jobname is updated, see also this issue https://github.com/webdriverio/webdriverio/issues/6301
It also changes the following:
- remove `setJobNameInBeforeSuite`, because it's now set by default in the before hook for all frameworks
- only update job name in the after hook/reload for retries

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)
