### PR TITLE
Better integrate Sauce visual

### DIFF
--- a/packages/wdio-config/src/lib/ConfigParser.ts
+++ b/packages/wdio-config/src/lib/ConfigParser.ts
@@ -64,7 +64,7 @@ export default class ConfigParser {
             this._config = merge(this._config, fileConfig, MERGE_OPTIONS)
 
             /**
-             * detect Selenium backend
+             * detect WebDriver backend
              */
             this._config = merge(detectBackend(this._config), this._config, MERGE_OPTIONS)
 

--- a/packages/wdio-config/src/lib/ConfigParser.ts
+++ b/packages/wdio-config/src/lib/ConfigParser.ts
@@ -64,17 +64,9 @@ export default class ConfigParser {
             this._config = merge(this._config, fileConfig, MERGE_OPTIONS)
 
             /**
-             * For Sauce Labs RDC we need to determine if the config file has a `testobject_api_key`
-             * If so, we need to provide a boolean to the `detectBackend` to set the correct hostname
-             *
-             * NOTE: This will not work for multi remote
-             */
-            const isRDC = Array.isArray(this._capabilities) && this._capabilities.some(capability => 'testobject_api_key' in capability)
-
-            /**
              * detect Selenium backend
              */
-            this._config = merge(detectBackend(this._config, isRDC), this._config, MERGE_OPTIONS)
+            this._config = merge(detectBackend(this._config), this._config, MERGE_OPTIONS)
 
             /**
              * remove `watch` from config as far as it can be only passed as command line argument

--- a/packages/wdio-config/src/utils.ts
+++ b/packages/wdio-config/src/utils.ts
@@ -115,7 +115,7 @@ export function detectBackend(options: BackendConfigurations = {}) {
      * Same for Sauce Visual where an apiKey can be passed in through the capabilities (soon to be legacy too).
      */
     const isRDC = Boolean(!Array.isArray(capabilities) && (capabilities as WebDriver.DesiredCapabilities)?.testobject_api_key)
-    const isVisual = Boolean(!Array.isArray(capabilities) && (capabilities as WebDriver.DesiredCapabilities)['sauce:visual']?.apiKey)
+    const isVisual = Boolean(!Array.isArray(capabilities) && capabilities && (capabilities as WebDriver.DesiredCapabilities)['sauce:visual']?.apiKey)
     if ((typeof user === 'string' && typeof key === 'string' && key.length === 36) ||
         // Or only RDC or visual
         (isRDC || isVisual)

--- a/packages/wdio-config/src/utils.ts
+++ b/packages/wdio-config/src/utils.ts
@@ -1,6 +1,6 @@
 import logger from '@wdio/logger'
 
-import type { DefaultOptions } from './types'
+import type { DefaultOptions, Capabilities } from './types'
 
 const log = logger('@wdio/config:utils')
 
@@ -72,7 +72,7 @@ interface BackendConfigurations {
     region?: string
     headless?: boolean
     path?: string
-    capabilities?: WebDriver.DesiredCapabilities
+    capabilities?: Capabilities | WebDriver.DesiredCapabilities | WebDriver.W3CCapabilities
 }
 
 /**
@@ -114,8 +114,8 @@ export function detectBackend(options: BackendConfigurations = {}) {
      * For Sauce Labs RDC we only need to determine if the sauce option has a `testobject_api_key`.
      * Same for Sauce Visual where an apiKey can be passed in through the capabilities.
      */
-    const isRDC = Boolean(capabilities && capabilities.testobject_api_key)
-    const isVisual = Boolean(capabilities && capabilities['sauce:visual'] && capabilities['sauce:visual'].apiKey)
+    const isRDC = Boolean(!Array.isArray(capabilities) && (capabilities as WebDriver.DesiredCapabilities)?.testobject_api_key)
+    const isVisual = Boolean(!Array.isArray(capabilities) && (capabilities as WebDriver.DesiredCapabilities)['sauce:visual']?.apiKey)
     if ((typeof user === 'string' && typeof key === 'string' && key.length === 36) ||
         // Or only RDC or visual
         (isRDC || isVisual)

--- a/packages/wdio-config/src/utils.ts
+++ b/packages/wdio-config/src/utils.ts
@@ -20,10 +20,15 @@ const REGION_MAPPING = {
 export const validObjectOrArray = (object: any): object is object | Array<any> => (Array.isArray(object) && object.length > 0) ||
     (typeof object === 'object' && Object.keys(object).length > 0)
 
-export function getSauceEndpoint (region: keyof typeof REGION_MAPPING, isRDC?: boolean) {
+export function getSauceEndpoint (
+    region: keyof typeof REGION_MAPPING,
+    { isRDC, isVisual }: { isRDC?: boolean, isVisual?: boolean } = {}
+) {
     const shortRegion = REGION_MAPPING[region] ? region : 'us'
-    if (isRDC){
+    if (isRDC) {
         return `${shortRegion}1.appium.testobject.com`
+    } else if (isVisual) {
+        return 'hub.screener.io'
     }
 
     return `ondemand.${REGION_MAPPING[shortRegion]}saucelabs.com`
@@ -67,13 +72,14 @@ interface BackendConfigurations {
     region?: string
     headless?: boolean
     path?: string
+    capabilities?: WebDriver.DesiredCapabilities
 }
 
 /**
  * helper to detect the Selenium backend according to given capabilities
  */
-export function detectBackend(options: BackendConfigurations = {}, isRDC = false) {
-    let { port, hostname, user, key, protocol, region, headless, path } = options
+export function detectBackend(options: BackendConfigurations = {}) {
+    let { port, hostname, user, key, protocol, region, headless, path, capabilities } = options
 
     /**
      * browserstack
@@ -104,19 +110,22 @@ export function detectBackend(options: BackendConfigurations = {}, isRDC = false
     /**
      * Sauce Labs
      * e.g. 50aa152c-1932-B2f0-9707-18z46q2n1mb0
+     *
+     * For Sauce Labs RDC we only need to determine if the sauce option has a `testobject_api_key`.
+     * Same for Sauce Visual where an apiKey can be passed in through the capabilities.
      */
+    const isRDC = Boolean(capabilities && capabilities.testobject_api_key)
+    const isVisual = Boolean(capabilities && capabilities['sauce:visual'] && capabilities['sauce:visual'].apiKey)
     if ((typeof user === 'string' && typeof key === 'string' && key.length === 36) ||
-        // When SC is used a user needs to be provided and `isRDC` needs to be true
-        (typeof user === 'string' && isRDC) ||
-        // Or only RDC
-        isRDC
+        // Or only RDC or visual
+        (isRDC || isVisual)
     ) {
         // Sauce headless is currently only in us-east-1
         const sauceRegion = headless ? 'us-east-1' : region as keyof typeof REGION_MAPPING
 
         return {
             protocol: protocol || 'https',
-            hostname: hostname || getSauceEndpoint(sauceRegion, isRDC),
+            hostname: hostname || getSauceEndpoint(sauceRegion, { isRDC, isVisual }),
             port: port || 443,
             path: path || LEGACY_PATH
         }

--- a/packages/wdio-config/src/utils.ts
+++ b/packages/wdio-config/src/utils.ts
@@ -111,8 +111,8 @@ export function detectBackend(options: BackendConfigurations = {}) {
      * Sauce Labs
      * e.g. 50aa152c-1932-B2f0-9707-18z46q2n1mb0
      *
-     * For Sauce Labs RDC we only need to determine if the sauce option has a `testobject_api_key`.
-     * Same for Sauce Visual where an apiKey can be passed in through the capabilities.
+     * For Sauce Labs Legacy RDC we only need to determine if the sauce option has a `testobject_api_key`.
+     * Same for Sauce Visual where an apiKey can be passed in through the capabilities (soon to be legacy too).
      */
     const isRDC = Boolean(!Array.isArray(capabilities) && (capabilities as WebDriver.DesiredCapabilities)?.testobject_api_key)
     const isVisual = Boolean(!Array.isArray(capabilities) && (capabilities as WebDriver.DesiredCapabilities)['sauce:visual']?.apiKey)

--- a/packages/wdio-config/tests/configparser.test.ts
+++ b/packages/wdio-config/tests/configparser.test.ts
@@ -9,7 +9,6 @@ import ConfigParser from '../src/lib/ConfigParser'
 const FIXTURES_PATH = path.resolve(__dirname, '__fixtures__')
 const FIXTURES_CONF = path.resolve(FIXTURES_PATH, 'wdio.conf.ts')
 const FIXTURES_CONF_RDC = path.resolve(FIXTURES_PATH, 'wdio.conf.rdc.ts')
-const FIXTURES_CONF_MULTIREMOTE_RDC = path.resolve(FIXTURES_PATH, 'wdio.conf.multiremote.rdc.ts')
 const FIXTURES_LOCAL_CONF = path.resolve(FIXTURES_PATH, 'wdio.local.conf.ts')
 const FIXTURES_CUCUMBER_FEATURE_A_LINE_2 = path.resolve(FIXTURES_PATH, 'test-a.feature:2')
 const FIXTURES_CUCUMBER_FEATURE_A_LINE_2_AND_12 = path.resolve(FIXTURES_PATH, 'test-a.feature:2:12')
@@ -34,18 +33,6 @@ describe('ConfigParser', () => {
         it('should throw if config file does not exist', () => {
             const configParser = new ConfigParser()
             expect(() => configParser.addConfigFile(path.resolve(__dirname, 'foobar.conf.ts'))).toThrow()
-        })
-
-        it('should add the rdc hostname when a rdc conf is provided', () => {
-            const configParser = new ConfigParser()
-            configParser.addConfigFile(FIXTURES_CONF_RDC)
-            expect(configParser['_config'].hostname).toContain('appium.testobject.com')
-        })
-
-        it('should default to the vm hostname when a multiremote conf with rdc props is provided', () => {
-            const configParser = new ConfigParser()
-            configParser.addConfigFile(FIXTURES_CONF_MULTIREMOTE_RDC)
-            expect(configParser['_config'].hostname).not.toContain('appium.testobject.com')
         })
 
         describe('TypeScript integration', () => {

--- a/packages/wdio-config/tests/detectBackend.test.ts
+++ b/packages/wdio-config/tests/detectBackend.test.ts
@@ -122,28 +122,45 @@ describe('detectBackend', () => {
         expect(caps.protocol).toBe('tcp')
     })
 
-    it('should detect saucelabs rdc user that had not defaulted a region', () => {
-        const caps = detectBackend({}, true)
-        expect(caps.hostname).toBe('us1.appium.testobject.com')
-        expect(caps.port).toBe(443)
-        expect(caps.path).toBe('/wd/hub')
-        expect(caps.protocol).toBe('https')
+    describe('saucelabs legacy rdc', () => {
+        it('should detect saucelabs rdc user that had not defaulted a region', () => {
+            const caps = detectBackend({ capabilities: { testobject_api_key: '123' } })
+            expect(caps.hostname).toBe('us1.appium.testobject.com')
+            expect(caps.port).toBe(443)
+            expect(caps.path).toBe('/wd/hub')
+            expect(caps.protocol).toBe('https')
+        })
+
+        it('should detect saucelabs us rdc user', () => {
+            const caps = detectBackend({ region: 'us', capabilities: { testobject_api_key: '123' } })
+            expect(caps.hostname).toBe('us1.appium.testobject.com')
+            expect(caps.port).toBe(443)
+            expect(caps.path).toBe('/wd/hub')
+            expect(caps.protocol).toBe('https')
+        })
+
+        it('should detect saucelabs eu rdc user', () => {
+            const caps = detectBackend({ region: 'eu', capabilities: { testobject_api_key: '123' } })
+            expect(caps.hostname).toBe('eu1.appium.testobject.com')
+            expect(caps.port).toBe(443)
+            expect(caps.path).toBe('/wd/hub')
+            expect(caps.protocol).toBe('https')
+        })
     })
 
-    it('should detect saucelabs us rdc user', () => {
-        const caps = detectBackend({ region: 'us' }, true)
-        expect(caps.hostname).toBe('us1.appium.testobject.com')
-        expect(caps.port).toBe(443)
-        expect(caps.path).toBe('/wd/hub')
-        expect(caps.protocol).toBe('https')
-    })
+    describe('saucelabs visual', () => {
+        it('should not detect sauce visual if api key is missing', () => {
+            const caps = detectBackend({ capabilities: { 'sauce:visual': {} } })
+            expect(typeof caps.hostname).toBe('undefined')
+        })
 
-    it('should detect saucelabs eu rdc user', () => {
-        const caps = detectBackend({ region: 'eu' }, true)
-        expect(caps.hostname).toBe('eu1.appium.testobject.com')
-        expect(caps.port).toBe(443)
-        expect(caps.path).toBe('/wd/hub')
-        expect(caps.protocol).toBe('https')
+        it('should detect sauce visual if api key is existing', () => {
+            const caps = detectBackend({ capabilities: { 'sauce:visual': { apiKey: 'foobar' } } })
+            expect(caps.hostname).toBe('hub.screener.io')
+            expect(caps.port).toBe(443)
+            expect(caps.path).toBe('/wd/hub')
+            expect(caps.protocol).toBe('https')
+        })
     })
 
     it('should detect saucelabs headless user', () => {


### PR DESCRIPTION
## Proposed changes

Right now user that want to run Sauce Visual test need to apply a soon to be legacy hostname to the config. By checking the `sauce:visual` capability it should be enough to determine whether someone wants to use Sauce visual and automatically set the correct connection credentials.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
