### PR TITLE
Sauce Service: Push error stack to Sauce

### DIFF
--- a/packages/wdio-sauce-service/README.md
+++ b/packages/wdio-sauce-service/README.md
@@ -7,6 +7,7 @@ WebdriverIO Sauce Service
 
 > - By default the Sauce Service will update the 'name' of the job when the job starts. This will give you the option to update the name at any given point in time.
 > - The only time when you can't update the name of the job is when you execute a retry or a session reload.
+> - The Sauce Service will also push the error stack of a failed test to the Sauce Labs commands tab
 
 ## Installation
 

--- a/packages/wdio-sauce-service/README.md
+++ b/packages/wdio-sauce-service/README.md
@@ -130,6 +130,15 @@ capabilities = [
 
 In order to authorize to the Sauce Labs service your config needs to contain a [`user`](https://webdriver.io/docs/options.html#user) and [`key`](https://webdriver.io/docs/options.html#key) option.
 
+### maxErrorStackLength
+This service will automatically push the error stack to Sauce Labs when a test fails. By default it will only push the first 5
+lines, but if needed this can be changed. Be aware that more lines will result in more WebDriver calls which might slow down the execution.
+
+Type: `number`<br>
+Default: `5`
+
+*(only for vm and or em/simulators)*
+
 ### sauceConnect
 If true it runs Sauce Connect and opens a secure connection between a Sauce Labs virtual machine running your browser tests.
 

--- a/packages/wdio-sauce-service/src/service.ts
+++ b/packages/wdio-sauce-service/src/service.ts
@@ -110,6 +110,17 @@ export default class SauceService implements WebdriverIO.ServiceInstance {
 
     afterTest (test: any, context: any, results: any) {
         /**
+         * If the test failed push the stack to Sauce Labs in separate lines
+         * This should not be done for UP because it's not supported yet and
+         * should be removed when UP supports `sauce:context`
+         */
+        const { error } = results
+        if (error && !this._isUP){
+            const lines = error.stack.split(/\r?\n/)
+            lines.forEach((line:string) => (this._browser as WebdriverIO.Browser).execute('sauce:context=' + line))
+        }
+
+        /**
          * remove failure if test was retried and passed
          * > Mocha only
          */

--- a/packages/wdio-sauce-service/src/service.ts
+++ b/packages/wdio-sauce-service/src/service.ts
@@ -10,6 +10,7 @@ const log = logger('@wdio/sauce-service')
 
 export default class SauceService implements WebdriverIO.ServiceInstance {
     private _testCnt = 0
+    private _maxErrorStackLength = 5
     private _failures = 0 // counts failures between reloads
     private _isServiceEnabled = true
     private _isJobNameSet = false;
@@ -27,6 +28,7 @@ export default class SauceService implements WebdriverIO.ServiceInstance {
     ) {
         this._api = new SauceLabs(this._config as unknown as SauceLabsOptions)
         this._isRDC = 'testobject_api_key' in this._capabilities
+        this._maxErrorStackLength = this._options.maxErrorStackLength || this._maxErrorStackLength
     }
 
     /**
@@ -116,7 +118,7 @@ export default class SauceService implements WebdriverIO.ServiceInstance {
          */
         const { error } = results
         if (error && !this._isUP){
-            const lines = error.stack.split(/\r?\n/)
+            const lines = error.stack.split(/\r?\n/).slice(0, this._maxErrorStackLength)
             lines.forEach((line:string) => (this._browser as WebdriverIO.Browser).execute('sauce:context=' + line))
         }
 

--- a/packages/wdio-sauce-service/src/types.ts
+++ b/packages/wdio-sauce-service/src/types.ts
@@ -2,6 +2,12 @@ import type { SauceConnectOptions } from 'saucelabs'
 
 export interface SauceServiceConfig {
     /**
+     * Specify the max error stack length represents the amount of error stack lines that will be
+     * pushed to Sauce Labs when a test fails
+     */
+    maxErrorStackLength?: number
+
+    /**
      * Specify tunnel identifier for Sauce Connect tunnel
      */
     tunnelIdentifier?: string

--- a/packages/wdio-sauce-service/tests/service.test.ts
+++ b/packages/wdio-sauce-service/tests/service.test.ts
@@ -182,8 +182,6 @@ test('afterTest', () => {
         _retries: 2
     }, {}, { passed: false })
     expect(service['_failures']).toBe(2)
-
-
     const stack = 'Error: Expected true to equal false.\n' +
         '    at <Jasmine>\n' +
         '    at UserContext.<anonymous> (/Users/test/specs/example.spec.js:12:44)\n' +

--- a/packages/wdio-sauce-service/tests/service.test.ts
+++ b/packages/wdio-sauce-service/tests/service.test.ts
@@ -199,6 +199,7 @@ test('afterTest', () => {
         }
     })
     expect(browser.execute).toBeCalledTimes(0)
+    browser.execute.mockClear()
     service['_isUP'] = false
     service.afterTest({}, {}, {
         error: {
@@ -212,6 +213,23 @@ test('afterTest', () => {
     })
     expect(browser.execute).toBeCalledTimes(5)
     stack.split(/\r?\n/).forEach((line:string) => expect(browser.execute).toBeCalledWith(`sauce:context=${line}`))
+    browser.execute.mockClear()
+    const maxErrorStackLength = 3
+    service['_maxErrorStackLength'] = maxErrorStackLength
+    service.afterTest({}, {}, {
+        error: {
+            matcherName: 'toEqual',
+            message: 'Expected true to equal false.',
+            stack,
+            passed: false,
+            expected: [false, 'LoginPage page was not shown'],
+            actual: true
+        }
+    })
+    expect(browser.execute).toBeCalledTimes(maxErrorStackLength)
+    stack.split(/\r?\n/)
+        .slice(0, maxErrorStackLength)
+        .forEach((line:string) => expect(browser.execute).toBeCalledWith(`sauce:context=${line}`))
 })
 
 test('beforeFeature should set context', () => {

--- a/packages/wdio-sauce-service/tests/service.test.ts
+++ b/packages/wdio-sauce-service/tests/service.test.ts
@@ -182,6 +182,38 @@ test('afterTest', () => {
         _retries: 2
     }, {}, { passed: false })
     expect(service['_failures']).toBe(2)
+
+
+    const stack = 'Error: Expected true to equal false.\n' +
+        '    at <Jasmine>\n' +
+        '    at UserContext.<anonymous> (/Users/test/specs/example.spec.js:12:44)\n' +
+        '    at UserContext.executeSync (/Users/node_modules/@wdio/sync/build/index.js:25:22)\n' +
+        '    at /Users/node_modules/@wdio/sync/build/index.js:46:68'
+    service['_isUP'] = true
+    service.afterTest({}, {}, {
+        error: {
+            matcherName: 'toEqual',
+            message: 'Expected true to equal false.',
+            stack,
+            passed: false,
+            expected: [false, 'LoginPage page was not shown'],
+            actual: true
+        }
+    })
+    expect(browser.execute).toBeCalledTimes(0)
+    service['_isUP'] = false
+    service.afterTest({}, {}, {
+        error: {
+            matcherName: 'toEqual',
+            message: 'Expected true to equal false.',
+            stack,
+            passed: false,
+            expected: [false, 'LoginPage page was not shown'],
+            actual: true
+        }
+    })
+    expect(browser.execute).toBeCalledTimes(5)
+    stack.split(/\r?\n/).forEach((line:string) => expect(browser.execute).toBeCalledWith(`sauce:context=${line}`))
 })
 
 test('beforeFeature should set context', () => {


### PR DESCRIPTION
## Proposed changes
Sauce Labs provides good insights for test failures, but never knows the context of an error. This PR adds the feature to push the error stack to Sauce Labs so users can also debug the test from the commands tab of Sauce Labs, see the example
![image](https://user-images.githubusercontent.com/11979740/105002600-d77b2000-5a31-11eb-890e-ea9a1c995915.png)


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)