### PR TITLE
Move cucumber-framework supporting types to private declaration in browserstack-service

### DIFF
--- a/packages/wdio-browserstack-service/browserstack-service.d.ts
+++ b/packages/wdio-browserstack-service/browserstack-service.d.ts
@@ -1,10 +1,6 @@
 declare module WebdriverIO {
     interface ServiceOption extends BrowserstackConfig {}
 
-    interface Config extends CucumberOptsConfig {
-
-    }
-
     interface Suite {
         title: string;
         fullName: string;
@@ -44,16 +40,4 @@ interface BrowserstackConfig {
      * https://stackoverflow.com/questions/39040108/import-class-in-definition-file-d-ts
      */
     opts?: Partial<import('browserstack-local').Options>
-}
-
-interface CucumberOptsConfig {
-    cucumberOpts?: CucumberOpts
-}
-
-interface CucumberOpts {
-    /**
-     * Fail if there are any undefined or pending steps
-     * @default false
-     */
-    strict?: boolean
 }

--- a/packages/wdio-browserstack-service/src/@types/cucumber-framework.d.ts
+++ b/packages/wdio-browserstack-service/src/@types/cucumber-framework.d.ts
@@ -1,0 +1,15 @@
+declare module WebdriverIO {
+    interface Config extends CucumberOptsConfig {}
+}
+
+interface CucumberOptsConfig {
+    cucumberOpts?: CucumberOpts
+}
+
+interface CucumberOpts {
+    /**
+     * Fail if there are any undefined or pending steps
+     * @default false
+     */
+    strict?: boolean
+}


### PR DESCRIPTION
## Proposed changes

As note [here](https://github.com/webdriverio/webdriverio/pull/6172#issuecomment-763030289), when installing both `@wdio/browserstack-service` and `@wdio/cucumber-framework`, the type extensions will collide causing a build error for typescript users. To solve this issue, I have moved the supporting types needed by the browserstack-service package to a private declaration file, and then removed those same types from the public declarations file.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

N/A

### Reviewers: @webdriverio/project-committers
