### PR TITLE
Add AWS Device Farm service to docs and CLI

### DIFF
--- a/packages/wdio-cli/src/constants.ts
+++ b/packages/wdio-cli/src/constants.ts
@@ -117,7 +117,8 @@ export const SUPPORTED_PACKAGES = {
         { name: 'rerun', value: 'wdio-rerun-service$--$rerun' },
         { name: 'winappdriver', value: 'wdio-winappdriver-service$--$winappdriver' },
         { name: 'ywinappdriver', value: 'wdio-ywinappdriver-service$--$ywinappdriver' },
-        { name: 'performancetotal', value: 'wdio-performancetotal-service$--$performancetotal' }
+        { name: 'performancetotal', value: 'wdio-performancetotal-service$--$performancetotal' },
+        { name: 'aws-device-farm', value: 'wdio-aws-device-farm-service$--$aws-device-farm' }
     ]
 } as const
 

--- a/scripts/docs-generation/3rd-party/services.json
+++ b/scripts/docs-generation/3rd-party/services.json
@@ -104,5 +104,12 @@
     "title": "PerformanceTotal",
     "githubUrl": "https://github.com/tzurp/performance-total",
     "npmUrl": "https://www.npmjs.com/package/wdio-performancetotal-service"
+  },
+  {
+    "packageName": "wdio-aws-device-farm-service",
+    "title": "AWS Device Farm",
+    "githubUrl": "https://github.com/awslabs/wdio-aws-device-farm-service",
+    "branch": "main",
+    "npmUrl": "https://www.npmjs.com/package/wdio-aws-device-farm-service"
   }
 ]


### PR DESCRIPTION
Add AWS Device Farm service to docs and CLI.

See more: https://github.com/awslabs/wdio-aws-device-farm-service

## Proposed changes

* Add the [AWS Device Farm service](https://github.com/awslabs/wdio-aws-device-farm-service) service we open sourced last week to the docs and CLI

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments


### Reviewers: @webdriverio/project-committers
