### PR TITLE
Edit pull-file return type

### DIFF
--- a/packages/wdio-protocols/protocols/appium.json
+++ b/packages/wdio-protocols/protocols/appium.json
@@ -619,6 +619,11 @@
         "description": "path on the device to pull file from",
         "required": true
       }],
+      "returns": {
+        "type": "string",
+        "name": "response",
+        "description": "Contents of file in base64"
+      },
       "support": {
         "ios": {
           "XCUITest": "9.3+",

--- a/packages/webdriver/webdriver.d.ts
+++ b/packages/webdriver/webdriver.d.ts
@@ -1196,7 +1196,7 @@ declare namespace WebDriver {
          * Retrieve a file from the device's file system.
          * http://appium.io/docs/en/commands/device/files/pull-file/
          */
-        pullFile(path: string): void;
+        pullFile(path: string): string;
 
         /**
          * [appium]


### PR DESCRIPTION

## Proposed changes

According to this document (http://appium.io/docs/en/commands/device/files/pull-file/)
pull-file response of command is base64(string) but pull-file of webdriver.d.ts is void so i change void to string

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
