### PR TITLE
Typescript/wdio junit reporter rewrite

### DIFF
--- a/packages/wdio-cli/src/constants.ts
+++ b/packages/wdio-cli/src/constants.ts
@@ -117,7 +117,8 @@ export const SUPPORTED_PACKAGES = {
         { name: 'rerun', value: 'wdio-rerun-service$--$rerun' },
         { name: 'winappdriver', value: 'wdio-winappdriver-service$--$winappdriver' },
         { name: 'ywinappdriver', value: 'wdio-ywinappdriver-service$--$ywinappdriver' },
-        { name: 'performancetotal', value: 'wdio-performancetotal-service$--$performancetotal' }
+        { name: 'performancetotal', value: 'wdio-performancetotal-service$--$performancetotal' },
+        { name: 'aws-device-farm', value: 'wdio-aws-device-farm-service$--$aws-device-farm' }
     ]
 } as const
 

--- a/packages/wdio-junit-reporter/src/index.ts
+++ b/packages/wdio-junit-reporter/src/index.ts
@@ -2,7 +2,7 @@
 import junit from 'junit-report-builder'
 import WDIOReporter, {
     RunnerStats,
-    SuiteStats,
+    SuiteStats
 } from '@wdio/reporter'
 import { limit } from './utils'
 import { Data, JunitReporterOptions } from './types'

--- a/packages/wdio-junit-reporter/src/types.ts
+++ b/packages/wdio-junit-reporter/src/types.ts
@@ -1,4 +1,4 @@
-import { WDIOReporterOptionsFromLogFile } from '@wdio/reporter'
+import WDIOReporter from '@wdio/reporter'
 
 export interface Data {
     type: any
@@ -10,7 +10,7 @@ export interface Data {
     params: string
 }
 
-export interface JunitReporterOptions extends WDIOReporterOptionsFromLogFile {
+export interface JunitReporterOptions extends WDIOReporter {
     configFile: string
     logLevel: string
     stdout?: boolean

--- a/packages/wdio-junit-reporter/src/types.ts
+++ b/packages/wdio-junit-reporter/src/types.ts
@@ -1,0 +1,21 @@
+import { WDIOReporterOptionsFromLogFile } from '@wdio/reporter'
+
+export interface Data {
+    type: any
+    method: string
+    endpoint: string
+    sessionId: any
+    body: string
+    command: any
+    params: string
+}
+
+export interface JunitReporterOptions extends WDIOReporterOptionsFromLogFile {
+    configFile: string
+    logLevel: string
+    stdout?: boolean
+    suiteNameFormat?: RegExp
+    packageName?: string
+    addFileAttribute?: any
+    errorOptions?: any
+}

--- a/packages/wdio-junit-reporter/src/utils.ts
+++ b/packages/wdio-junit-reporter/src/utils.ts
@@ -1,4 +1,6 @@
+// @ts-ignore
 import stringify from 'json-stringify-safe'
+// @ts-ignore
 import validator from 'validator'
 
 const OBJLENGTH = 10
@@ -6,7 +8,7 @@ const ARRLENGTH = 10
 const STRINGLIMIT = 1000
 const STRINGTRUNCATE = 200
 
-export const limit = function (rawVal) {
+export const limit = function (rawVal: string) {
     if (!rawVal) return rawVal
 
     // Ensure we're working with a copy

--- a/packages/wdio-protocols/protocols/appium.json
+++ b/packages/wdio-protocols/protocols/appium.json
@@ -619,6 +619,11 @@
         "description": "path on the device to pull file from",
         "required": true
       }],
+      "returns": {
+        "type": "string",
+        "name": "response",
+        "description": "Contents of file in base64"
+      },
       "support": {
         "ios": {
           "XCUITest": "9.3+",

--- a/scripts/docs-generation/3rd-party/services.json
+++ b/scripts/docs-generation/3rd-party/services.json
@@ -104,5 +104,12 @@
     "title": "PerformanceTotal",
     "githubUrl": "https://github.com/tzurp/performance-total",
     "npmUrl": "https://www.npmjs.com/package/wdio-performancetotal-service"
+  },
+  {
+    "packageName": "wdio-aws-device-farm-service",
+    "title": "AWS Device Farm",
+    "githubUrl": "https://github.com/awslabs/wdio-aws-device-farm-service",
+    "branch": "main",
+    "npmUrl": "https://www.npmjs.com/package/wdio-aws-device-farm-service"
   }
 ]


### PR DESCRIPTION
## Proposed changes

https://github.com/webdriverio/webdriverio/issues/5838 - wdio-junit-reporter typescript rewrite interim PR requested by @christian-bromann

## Types of changes

from the wdio-junit-reporter package util and index have rewrite in TypeScript. Tests still need to be rewritten to TS. Entire code is not yet correctly typed. Some "any"s are used but would require more indept code changes (e.g state in SuiteStates and mapping of Object.keys)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

Code change in collaboration with @woutdejong1986

PR opened to main not master, hope this is valid, some changes already approved got roped in as well. Please comment if not OK

### Reviewers: @webdriverio/project-committers
