### PR TITLE
Add tsNodeOpts to enable configuring auto loaded ts-node

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,7 +140,9 @@ $ npm install
 $ npm start
 ```
 
-This will set up everything needed to run the page on [`localhost:3000`](http://localhost:3000/). You can now modify the content of the [`/docs`](https://github.com/webdriverio/webdriverio/tree/main/docs) files as well as change styles and templates. The page will be automatically updated. If you add documentation in other places, you have to rerun the `npm start` script to re-generate the docs.
+This will set up everything needed to run the page on [`localhost:3000`](http://localhost:3000/). If you need to run on a different host or port, pass them as additional arguments to npm start, like `-- --host 0.0.0.0`.
+
+You can now modify the content of the [`/docs`](https://github.com/webdriverio/webdriverio/tree/main/docs) files as well as change styles and templates. The page will be automatically updated. If you add documentation in other places, you have to rerun the `npm start` script to re-generate the docs.
 
 Every time a new release is pushed to GitHub the WebdriverIO docs are automatically generated and pushed to the project's S3 bucket. The process is defined in a GitHub Actions [pipeline](https://github.com/webdriverio/webdriverio/blob/main/.github/workflows/deploy.yml) and does not need to be done manually.
 

--- a/examples/wdio.conf.js
+++ b/examples/wdio.conf.js
@@ -182,6 +182,21 @@ exports.config = {
         ignoreUndefinedDefinitions: false, // <boolean> Enable this config to treat undefined definitions as warnings.
     },
     //
+    // Auto-compilation configuration
+    autoCompileOpts: {
+        // Enable/disable auto-compilation (enabled by default)
+        autoCompile: true,
+
+        // Configure how ts-node is automatically included when present
+        tsNodeOpts: {
+            transpileOnly: true,
+            project: 'tsconfig.json'
+        },
+
+        // Configure how @babel/register is automatically included when present (and ts-node isn't)
+        babelOpts: {}
+    },
+    //
     // =====
     // Hooks
     // =====

--- a/packages/wdio-cli/src/commands/repl.ts
+++ b/packages/wdio-cli/src/commands/repl.ts
@@ -9,7 +9,7 @@ import yargs from 'yargs'
 
 const IGNORED_ARGS = [
     'bail', 'framework', 'reporters', 'suite', 'spec', 'exclude',
-    'mochaOpts', 'jasmineNodeOpts', 'cucumberOpts'
+    'mochaOpts', 'jasmineNodeOpts', 'cucumberOpts', 'autoCompileOpts'
 ]
 
 export const command = 'repl <option> [capabilities]'

--- a/packages/wdio-cli/src/commands/run.ts
+++ b/packages/wdio-cli/src/commands/run.ts
@@ -90,6 +90,9 @@ export const cmdArgs = {
     },
     cucumberOpts: {
         desc: 'Cucumber options'
+    },
+    autoCompileOpts: {
+        desc: 'Auto compilation options'
     }
 } as const
 
@@ -99,6 +102,8 @@ export const builder = (yargs: yargs.Argv) => {
         .example('$0 run wdio.conf.js --suite foobar', 'Run suite on testsuite "foobar"')
         .example('$0 run wdio.conf.js --spec ./tests/e2e/a.js --spec ./tests/e2e/b.js', 'Run suite on specific specs')
         .example('$0 run wdio.conf.js --mochaOpts.timeout 60000', 'Run suite with custom Mocha timeout')
+        .example('$0 run wdio.conf.js --autoCompileOpts.autoCompile=false', 'Disable auto-loading of ts-node or @babel/register')
+        .example('$0 run wdio.conf.js --autoCompileOpts.tsNodeOpts.project=configs/bdd-tsconfig.json', 'Run suite with ts-node using custom tsconfig.json')
         .epilogue(CLI_EPILOGUE)
         .help()
 }

--- a/packages/wdio-cli/src/launcher.ts
+++ b/packages/wdio-cli/src/launcher.ts
@@ -56,6 +56,9 @@ class Launcher {
         private _isWatchMode = false
     ) {
         this.configParser = new ConfigParser()
+        if ( this.configParser.autoCompile ) {
+            this.configParser.autoCompile() // autocompile before parsing configs so we support ES6 features in configs
+        }
         this.configParser.addConfigFile(_configFilePath)
         this.configParser.merge(_args)
 
@@ -374,7 +377,7 @@ class Launcher {
             cid: runnerId,
             command: 'run',
             configFile: this._configFilePath,
-            args: this._args,
+            args: { ...this._args, ...(config?.autoCompileOpts ? { autoCompileOpts: config.autoCompileOpts } : {}) },
             caps,
             specs,
             execArgv,

--- a/packages/wdio-cli/src/types.ts
+++ b/packages/wdio-cli/src/types.ts
@@ -67,6 +67,7 @@ export interface RunCommandArguments {
     mochaOpts?: any
     jasmineNodeOpts?: any
     cucumberOpts?: any
+    autoCompileOpts?: any
     configPath: string
 
     /**

--- a/packages/wdio-cli/tests/watcher.test.ts
+++ b/packages/wdio-cli/tests/watcher.test.ts
@@ -13,6 +13,9 @@ jest.mock('../src/launcher', () => {
         interface: any
 
         constructor (configFile, args) {
+            if ( this.configParser.autoCompile ) {
+                this.configParser.autoCompile()
+            }
             this.configParser.addConfigFile(configFile)
             this.configParser.merge(args)
             this.isMultiremote = args.isMultiremote

--- a/packages/wdio-config/package.json
+++ b/packages/wdio-config/package.json
@@ -30,5 +30,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "devDependencies": {
+    "minimatch": "^3.0.4"
   }
 }

--- a/packages/wdio-config/src/constants.ts
+++ b/packages/wdio-config/src/constants.ts
@@ -88,3 +88,11 @@ export const SUPPORTED_HOOKS: (keyof Services.Hooks)[] = [
 export const SUPPORTED_FILE_EXTENSIONS = [
     '.js', '.mjs', '.es6', '.ts', '.feature', '.coffee', '.cjs'
 ]
+
+export const DEFAULT_AUTOCOMPILE_CONFIGS: () => Options.AutoCompileConfig = () => ({
+    autoCompile: true,
+    tsNodeOpts: {
+        transpileOnly: true
+    },
+    babelOpts: {}
+})

--- a/packages/wdio-config/src/index.ts
+++ b/packages/wdio-config/src/index.ts
@@ -1,7 +1,7 @@
 /* istanbul ignore file */
 
 import ConfigParser from './lib/ConfigParser'
-import { validateConfig, getSauceEndpoint, detectBackend, isCloudCapability } from './utils'
+import { validateConfig, getSauceEndpoint, detectBackend, isCloudCapability, ModuleRequireService } from './utils'
 import { DEFAULT_CONFIGS } from './constants'
 
 export {
@@ -14,5 +14,10 @@ export {
     /**
      * constants
      */
-    DEFAULT_CONFIGS
+    DEFAULT_CONFIGS,
+
+    /**
+     * types
+     */
+    ModuleRequireService
 }

--- a/packages/wdio-config/src/lib/ConfigParser.ts
+++ b/packages/wdio-config/src/lib/ConfigParser.ts
@@ -1,16 +1,21 @@
-import fs from 'fs'
-import path from 'path'
-import glob from 'glob'
 import merge from 'deepmerge'
 import logger from '@wdio/logger'
 import type { Capabilities, Options, Services } from '@wdio/types'
 
 import {
     detectBackend, removeLineNumbers, isCucumberFeatureWithLineNumber, validObjectOrArray,
-    loadTypeScriptCompiler, loadBabelCompiler
+    loadAutoCompilers, ModuleRequireService
 } from '../utils'
-import { DEFAULT_CONFIGS, SUPPORTED_HOOKS, SUPPORTED_FILE_EXTENSIONS } from '../constants'
-
+import {
+    SUPPORTED_HOOKS,
+    SUPPORTED_FILE_EXTENSIONS,
+    DEFAULT_AUTOCOMPILE_CONFIGS
+} from '../constants'
+import {
+    DEFAULT_CONFIGS
+} from '../'
+import FileSystemPathService from './FileSystemPathService'
+import RequireLibrary from './RequireLibrary'
 const log = logger('@wdio/config:ConfigParser')
 const MERGE_OPTIONS = { clone: false }
 
@@ -26,9 +31,54 @@ interface MergeConfig extends Omit<Partial<TestrunnerOptionsWithParameters>, 'sp
     exclude?: string | string[]
 }
 
+// Get current working directory
+interface CurrentPathFinder {
+    getcwd(): string
+}
+
+// Require a .js/.json/dotfile config file
+interface LoadConfigFile {
+    loadFile<T>(path: string): T
+}
+
+// Detect if a file is present
+interface IsFileDetector {
+    isFile(path: string): boolean
+}
+
+interface DeterminesAbsolutePath {
+    ensureAbsolutePath(path: string): string
+}
+
+// Glob to find file paths matching a pattern
+interface Globber {
+    glob(pattern: string): string[];
+}
+
+export interface PathService extends CurrentPathFinder, LoadConfigFile, IsFileDetector, Globber, DeterminesAbsolutePath {}
+
 export default class ConfigParser {
+    private _autocompileConfig : Options.AutoCompileConfig = DEFAULT_AUTOCOMPILE_CONFIGS()
     private _config: TestrunnerOptionsWithParameters = DEFAULT_CONFIGS()
     private _capabilities: Capabilities.RemoteCapabilities = [];
+    private _pathService: PathService;
+    private _moduleRequireService: ModuleRequireService;
+
+    constructor(pathService: PathService = new FileSystemPathService(), moduleRequireService:ModuleRequireService = new RequireLibrary()) {
+        this._pathService = pathService
+        this._moduleRequireService = moduleRequireService
+    }
+
+    autoCompile() {
+        /**
+         * on launcher compile files if Babel or TypeScript are installed using our defaults
+         */
+        if (!loadAutoCompilers(this._autocompileConfig, this._moduleRequireService)) {
+            if ( this._autocompileConfig.autoCompile ) {
+                log.debug('No compiler found, continue without compiling files')
+            }
+        }
+    }
 
     /**
      * merges config file with default values
@@ -39,20 +89,27 @@ export default class ConfigParser {
             throw new Error('addConfigFile requires filepath')
         }
 
-        const filePath = path.resolve(process.cwd(), filename)
+        const filePath = this._pathService.ensureAbsolutePath(filename)
 
         try {
+            const config = this._pathService.loadFile<{config: TestrunnerOptionsWithParameters}>(filePath).config
+
+            if (typeof config !== 'object') {
+                throw new Error('addConfigEntry requires config key')
+            }
+
             /**
-             * compile files if Babel or TypeScript are installed
+             * on launcher compile files if Babel or TypeScript are installed using our defaults
              */
-            if (!loadTypeScriptCompiler() && !loadBabelCompiler()) {
-                log.debug('No compiler found, continue without compiling files')
+            // Merge in config over defaults
+            if ( config.autoCompileOpts ) {
+                this._autocompileConfig = merge(this._autocompileConfig, config.autoCompileOpts, MERGE_OPTIONS)
             }
 
             /**
              * clone the original config
              */
-            const fileConfig = merge<Omit<Options.Testrunner, 'capabilities'> & { capabilities?: Capabilities.RemoteCapabilities }>(require(filePath).config, {}, MERGE_OPTIONS)
+            const fileConfig = merge<Omit<Options.Testrunner, 'capabilities'> & { capabilities?: Capabilities.RemoteCapabilities }>(config, {}, MERGE_OPTIONS)
 
             /**
              * merge capabilities
@@ -95,6 +152,11 @@ export default class ConfigParser {
         const spec = Array.isArray(object.spec) ? object.spec : []
         const exclude = Array.isArray(object.exclude) ? object.exclude : []
         this._config = merge(this._config, object, MERGE_OPTIONS) as TestrunnerOptionsWithParameters
+
+        // Merge in config over defaults
+        if ( object.autoCompileOpts ) {
+            this._autocompileConfig = merge(this._autocompileConfig, object.autoCompileOpts, MERGE_OPTIONS)
+        }
 
         /**
          * overwrite config specs that got piped into the wdio command
@@ -172,9 +234,9 @@ export default class ConfigParser {
      * get excluded files from config pattern
      */
     getSpecs (capSpecs?: string[], capExclude?: string[]) {
-        let specs = ConfigParser.getFilePaths(this._config.specs!)
+        let specs = ConfigParser.getFilePaths(this._config.specs!, undefined, this._pathService)
         let spec  = Array.isArray(this._config.spec) ? this._config.spec : []
-        let exclude = ConfigParser.getFilePaths(this._config.exclude!)
+        let exclude = ConfigParser.getFilePaths(this._config.exclude!, undefined, this._pathService)
         let suites = Array.isArray(this._config.suite) ? this._config.suite : []
 
         /**
@@ -188,7 +250,7 @@ export default class ConfigParser {
                     log.warn(`No suite was found with name "${suiteName}"`)
                 }
                 if (Array.isArray(suite)) {
-                    suiteSpecs = suiteSpecs.concat(ConfigParser.getFilePaths(suite))
+                    suiteSpecs = suiteSpecs.concat(ConfigParser.getFilePaths(suite, undefined, this._pathService))
                 }
             }
 
@@ -202,11 +264,11 @@ export default class ConfigParser {
             let tmpSpecs = spec.length > 0 ? [...specs, ...suiteSpecs] : suiteSpecs
 
             if (Array.isArray(capSpecs)) {
-                tmpSpecs = ConfigParser.getFilePaths(capSpecs)
+                tmpSpecs = ConfigParser.getFilePaths(capSpecs, undefined, this._pathService)
             }
 
             if (Array.isArray(capExclude)) {
-                exclude = ConfigParser.getFilePaths(capExclude)
+                exclude = ConfigParser.getFilePaths(capExclude, undefined, this._pathService)
             }
 
             specs = [...new Set(tmpSpecs)]
@@ -214,11 +276,11 @@ export default class ConfigParser {
         }
 
         if (Array.isArray(capSpecs)) {
-            specs = ConfigParser.getFilePaths(capSpecs)
+            specs = ConfigParser.getFilePaths(capSpecs, undefined, this._pathService)
         }
 
         if (Array.isArray(capExclude)) {
-            exclude = ConfigParser.getFilePaths(capExclude)
+            exclude = ConfigParser.getFilePaths(capExclude, undefined, this._pathService)
         }
 
         return specs.filter(spec => !exclude.includes(spec))
@@ -235,12 +297,12 @@ export default class ConfigParser {
      */
     setFilePathToFilterOptions (cliArgFileList: string[], config: string[]) {
         const filesToFilter = new Set<string>()
-        const fileList = ConfigParser.getFilePaths(config)
+        const fileList = ConfigParser.getFilePaths(config, undefined, this._pathService)
         cliArgFileList.forEach(filteredFile => {
             filteredFile = removeLineNumbers(filteredFile)
-            let globMatchedFiles = ConfigParser.getFilePaths(glob.sync(filteredFile))
-            if (fs.existsSync(filteredFile) && fs.lstatSync(filteredFile).isFile()) {
-                filesToFilter.add(path.resolve(process.cwd(), filteredFile))
+            let globMatchedFiles = ConfigParser.getFilePaths(this._pathService.glob(filteredFile), undefined, this._pathService)
+            if (this._pathService.isFile(filteredFile)) {
+                filesToFilter.add(this._pathService.ensureAbsolutePath(filteredFile))
             } else if (globMatchedFiles.length) {
                 globMatchedFiles.forEach(file => filesToFilter.add(file))
             } else {
@@ -281,7 +343,7 @@ export default class ConfigParser {
      * @param  {String[]} filenames  list of files to glob
      * @return {String[]} list of files
      */
-    static getFilePaths (patterns: string[], omitWarnings?: boolean) {
+    static getFilePaths (patterns: string[], omitWarnings?: boolean, findAndGlob: CurrentPathFinder & Globber & DeterminesAbsolutePath = new FileSystemPathService()) {
         let files: string[] = []
 
         if (typeof patterns === 'string') {
@@ -295,14 +357,12 @@ export default class ConfigParser {
         patterns = patterns.map(pattern => removeLineNumbers(pattern))
 
         for (let pattern of patterns) {
-            let filenames = glob.sync(pattern)
-
+            let filenames = findAndGlob.glob(pattern)
             filenames = filenames.filter(
                 (filename) => SUPPORTED_FILE_EXTENSIONS.find(
                     (ext) => filename.endsWith(ext)))
 
-            filenames = filenames.map(filename =>
-                path.isAbsolute(filename) ? path.normalize(filename) : path.resolve(process.cwd(), filename))
+            filenames = filenames.map(filename => findAndGlob.ensureAbsolutePath(filename))
 
             if (filenames.length === 0 && !omitWarnings) {
                 log.warn('pattern', pattern, 'did not match any file')

--- a/packages/wdio-config/src/lib/FileSystemPathService.ts
+++ b/packages/wdio-config/src/lib/FileSystemPathService.ts
@@ -1,0 +1,35 @@
+
+// Main implementation (tests contain other implementations)
+import fs from 'fs'
+import { PathService } from './ConfigParser'
+import path from 'path'
+import glob from 'glob'
+
+export default class FileSystemPathService implements PathService {
+    getcwd(): string {
+        const cwd = process.cwd()
+        if ( typeof cwd === 'undefined' ) {
+            throw new Error('Unable to find current working directory from process')
+        }
+        return cwd
+    }
+
+    loadFile<T>(path: string): T {
+        if ( !path) {
+            throw new Error('A path is required')
+        }
+        return require(path)
+    }
+
+    isFile(filepath: string): boolean {
+        return (fs.existsSync(filepath) && fs.lstatSync(filepath).isFile())
+    }
+
+    glob(pattern: string): string[] {
+        return glob.sync(pattern)
+    }
+
+    ensureAbsolutePath(filepath: string): string {
+        return path.isAbsolute(filepath) ? path.normalize(filepath) : path.resolve(this.getcwd(), filepath)
+    }
+}

--- a/packages/wdio-config/src/lib/RequireLibrary.ts
+++ b/packages/wdio-config/src/lib/RequireLibrary.ts
@@ -1,0 +1,11 @@
+import { ModuleRequireService } from '../utils'
+
+export default class RequireLibrary implements ModuleRequireService {
+    require<T>(module: string): T {
+        return require(module) as T
+    }
+
+    resolve(request: string, options: { paths?: string[] }): string {
+        return require.resolve(request, options)
+    }
+}

--- a/packages/wdio-config/tests/FileSystemPathService.test.ts
+++ b/packages/wdio-config/tests/FileSystemPathService.test.ts
@@ -1,0 +1,91 @@
+import path from 'path'
+import process from 'process'
+import FileSystemPathService from '../src/lib/FileSystemPathService'
+import glob from 'glob'
+
+const INDEX_PATH = path.resolve(__dirname, '..', 'src', 'index.ts')
+
+jest.mock('glob', () => ({
+    sync: jest.fn(() => 'glob result')
+}))
+
+describe('FileSystemPathService', () => {
+    afterEach(() => {
+        (glob.sync as jest.Mock).mockClear()
+        jest.clearAllMocks()
+    })
+
+    describe('getcwd', function () {
+
+        let oldCwd
+        beforeEach(() => {
+            oldCwd = process.cwd
+        })
+        afterEach(() => {
+            process.cwd = oldCwd
+        })
+
+        it('should return current working directory', function () {
+            var svc = new FileSystemPathService()
+            expect(svc.getcwd()).toEqual(process.cwd())
+        })
+
+        it('should throw if cwd returns undefined', function () {
+            process.cwd = () => undefined
+            var svc = new FileSystemPathService()
+            expect(() => svc.getcwd()).toThrowError('Unable to find current working directory from process')
+        })
+    })
+
+    describe('isFile', function () {
+        it('should return true if file esxists', function () {
+            var svc = new FileSystemPathService()
+            expect(svc.isFile(INDEX_PATH)).toBeTruthy()
+        })
+
+        it("should return false if file doesn't exist", function () {
+            var svc = new FileSystemPathService()
+            expect(svc.isFile(INDEX_PATH + '.tar.gz.non-existent')).toBeFalsy()
+        })
+    })
+
+    describe('ensureAbsolutePath', function () {
+        it('should return abs path given abs path', function () {
+            var svc = new FileSystemPathService()
+            expect(svc.ensureAbsolutePath(path.resolve(__dirname, 'absolutely')))
+                .toEqual(path.resolve(__dirname, 'absolutely'))
+        })
+
+        it('should return abs path given relative path', function () {
+            var svc = new FileSystemPathService()
+            expect(svc.ensureAbsolutePath('all_relativity')).toEqual(path.resolve(process.cwd(), 'all_relativity'))
+        })
+    })
+
+    describe('glob', function () {
+        it('should pass calls to glob', function () {
+            var svc = new FileSystemPathService()
+            expect(svc.glob('globtrotter')).toEqual('glob result')
+            expect(glob.sync).toHaveBeenCalledWith('globtrotter')
+        })
+    })
+
+    describe('loadFile', function () {
+
+        it('should throw if path not given', function () {
+            var svc = new FileSystemPathService()
+            expect(() => svc.loadFile(undefined as any)).toThrowError('A path is required')
+        })
+
+        it('should load files', function () {
+            var svc = new FileSystemPathService()
+            const loaded = svc.loadFile(INDEX_PATH)
+            expect(loaded.ConfigParser).toBeDefined()
+        })
+
+        it('should throw on non present files', function () {
+            var svc = new FileSystemPathService()
+            expect(() => svc.loadFile(INDEX_PATH + '.tar.gz.non-existent')).toThrowError(expect.objectContaining({ message: expect.stringContaining('Cannot find module') }))
+        })
+    })
+})

--- a/packages/wdio-config/tests/RequireLibrary.test.ts
+++ b/packages/wdio-config/tests/RequireLibrary.test.ts
@@ -1,0 +1,33 @@
+import RequireLibrary from '../src/lib/RequireLibrary'
+import path from 'path'
+jest.mock('ts-node', () => 'mock module')
+
+describe('RequireLibrary', () => {
+    describe('require', function () {
+
+        it('should try to require when module exists', function () {
+            const svc = new RequireLibrary()
+            expect(svc.require('ts-node')).toEqual('mock module')
+        })
+
+        it('should what to require', function () {
+            const svc = new RequireLibrary()
+            expect(() => svc.require('abcdef xyz')).toThrowError("Cannot find module 'abcdef xyz' from 'packages/wdio-config/src/lib/RequireLibrary.ts'")
+        })
+    })
+
+    describe('resolve', function () {
+
+        it('should try to resolve', function () {
+            const svc = new RequireLibrary()
+            expect(svc.resolve('ts-node')).toEqual(path.resolve(__dirname, '../../../node_modules/ts-node/dist/index.js'))
+        })
+
+        it('should try to resolve', function () {
+            const svc = new RequireLibrary()
+            expect(() => svc.resolve('abcdef xyz')).toThrowError("Cannot find module 'abcdef xyz' from 'packages/wdio-config/src/lib/RequireLibrary.ts'")
+        })
+
+    })
+
+})

--- a/packages/wdio-config/tests/lib/ConfigParserBuilder.ts
+++ b/packages/wdio-config/tests/lib/ConfigParserBuilder.ts
@@ -1,0 +1,64 @@
+import ConfigParser from '../../src/lib/ConfigParser'
+import MockedModules from './MockedModules'
+import MockPathService, { FilePathsAndContents, MockSystemFolderPath } from './MockPathService'
+
+export default class ConfigParserBuilder {
+    private f : MockPathService;
+    private m : MockedModules;
+
+    public constructor(baseDir: string, files: FilePathsAndContents = [], modules:[string, any][] = []) {
+        this.f = MockPathService.inWorkingDirectoryWithFiles({ cwd: baseDir, files })
+        this.m = MockedModules.withNoModules()
+        this.withBaseDir(baseDir)
+        this.withFiles(files)
+        this.withModules(modules)
+    }
+
+    static withBaseDir(baseDir: MockSystemFolderPath) : ConfigParserBuilder {
+        return new ConfigParserBuilder(baseDir)
+    }
+
+    withBaseDir(baseDir: MockSystemFolderPath):ConfigParserBuilder {
+        this.f.withCwd(baseDir)
+        return this
+    }
+
+    withFiles(files : FilePathsAndContents) :ConfigParserBuilder {
+        this.f.withFiles(files)
+        return this
+    }
+
+    withNoModules():ConfigParserBuilder {
+        this.m.resetModules()
+        return this
+    }
+
+    withModules(modulesAndValuesList: [string, any][]):ConfigParserBuilder {
+        this.m.withModules(modulesAndValuesList)
+        return this
+    }
+
+    withTsNodeModule(registerMock = jest.fn()) {
+        this.m.withTsNodeModule(registerMock)
+        return this
+    }
+
+    withBabelModule(registerMock = jest.fn()) {
+        this.m.withBabelModule(registerMock)
+        return this
+    }
+
+    getMocks() {
+        return {
+            finder: this.f,
+            modules: this.m
+        }
+    }
+
+    build(): ConfigParser {
+        return new ConfigParser(
+            this.f,
+            this.m
+        )
+    }
+}

--- a/packages/wdio-config/tests/lib/FileNamed.ts
+++ b/packages/wdio-config/tests/lib/FileNamed.ts
@@ -1,0 +1,36 @@
+import { MockSystemFilePath } from './MockPathService'
+import MockFileContentBuilder, { FilePathAndContent, MockFileContent } from './MockFileContentBuilder'
+
+/**
+ * Builder for a virtual file system file
+ * @param filename
+ * @constructor
+ */
+export function FileNamed(filename: MockSystemFilePath) {
+    function withContents(contents: MockFileContent) : FilePathAndContent {
+        return [
+            filename, contents
+        ]
+    }
+    return { withContents }
+}
+
+export type RealSystemPath = string;
+
+/**
+ * Mock a real config file by loading it in from the file system.
+ *
+ * @param f
+ */
+export function realRequiredFilePair(f: RealSystemPath) : FilePathAndContent {
+    return FileNamed(f).withContents(MockFileContentBuilder.FromRealConfigFile(f).build())
+}
+
+/**
+ * Mock a real file, without parsing it (allowing other languages, binary, etc)
+ *
+ * @param f
+ */
+export function realReadFilePair(f: RealSystemPath) : FilePathAndContent {
+    return FileNamed(f).withContents(MockFileContentBuilder.FromRealDataFile(f))
+}

--- a/packages/wdio-config/tests/lib/MockFileContentBuilder.ts
+++ b/packages/wdio-config/tests/lib/MockFileContentBuilder.ts
@@ -1,0 +1,59 @@
+import fs from 'fs'
+import merge from 'deepmerge'
+import { MockSystemFilePath } from './MockPathService'
+
+const MERGE_OPTIONS = { clone: false }
+
+export type MockFileContent = string|object;
+export type FilePathAndContent = [MockSystemFilePath, MockFileContent];
+
+/**
+ * Record builder for virtual file system for tests
+ */
+export default class MockFileContentBuilder {
+    private fileContents : MockFileContent;
+    private constructor(fileContents) {
+        this.fileContents = fileContents
+    }
+
+    /**
+     * Mock a real config file by loading it in from the file system.
+     *
+     * @param realConfigFilepath
+     * @constructor
+     */
+    static FromRealConfigFile(realConfigFilepath) : MockFileContentBuilder {
+        return new MockFileContentBuilder(require(realConfigFilepath))
+    }
+
+    /**
+     * Mock a real file, without parsing it (allowing other languages, binary, etc)
+     *
+     * Note: Returns MockFileContent instead of MockFileContentBuilder to prevent running
+     * withTheseContentsMergedOn which expects in memory object and as-is this will not parse
+     * any contents.
+     *
+     * @param realConfigFilepath
+     * @constructor
+     */
+    static FromRealDataFile(realConfigFilepath) : MockFileContent {
+        return new MockFileContentBuilder(fs.readFileSync(realConfigFilepath).toString()).build()
+    }
+
+    /**
+     * After loading a real config file, this allows modifying it so that when read
+     * it is a different config file than the one read off the file system.
+     *
+     * This should allow re-using one basic config and extrapolating different scenarios based of it.
+     *
+     * @param enhanceContents
+     */
+    withTheseContentsMergedOn( enhanceContents = {}) : MockFileContentBuilder {
+        this.fileContents = merge(this.fileContents, enhanceContents, MERGE_OPTIONS)
+        return this
+    }
+
+    build() : MockFileContent {
+        return this.fileContents
+    }
+}

--- a/packages/wdio-config/tests/lib/MockPathService.ts
+++ b/packages/wdio-config/tests/lib/MockPathService.ts
@@ -1,0 +1,101 @@
+import { PathService } from '../../src/lib/ConfigParser'
+import path from 'path'
+import { FilePathAndContent } from './MockFileContentBuilder'
+var Minimatch = require('minimatch').Minimatch
+
+export type MockSystemFolderPath = string;
+export type MockSystemFilePath = string;
+export type FilePathsAndContents = [FilePathAndContent][]
+
+/**
+ * Test implementation of PathService
+ *
+ * Avoids the SUT from hitting file system at all, instead using a small in-memory array representing a flat filepath
+ * list used as a pseudo directory structure.
+ */
+export default class MockPathService implements PathService {
+    private cwd : MockSystemFolderPath;
+    private files : FilePathsAndContents;
+
+    private constructor({ cwd, files } : {cwd: MockSystemFolderPath, files: FilePathsAndContents}) {
+        this.cwd = cwd
+        this.files = files
+        this.getcwdMock = jest.spyOn(this, 'getcwd')
+        this.loadFileMock = jest.spyOn(this, 'loadFile')
+        this.isFileMock = jest.spyOn(this, 'isFile')
+        this.globMock = jest.spyOn(this, 'glob')
+    }
+
+    /**
+     * Use the mocks if interested in low-level calls being made.
+     *
+     * A mock for each aspect of PathService is provided.
+     */
+    getMocks() {
+        return {
+            getcwdMock : this.getcwdMock,
+            loadFileMock : this.loadFileMock,
+            isFileMock : this.isFileMock,
+            globMock : this.globMock
+        }
+    }
+
+    withCwd(newCwd: MockSystemFolderPath) {
+        this.cwd = newCwd
+        return this
+    }
+
+    withFiles(newFiles:FilePathsAndContents) {
+        this.files = newFiles
+        return this
+    }
+
+    static inWorkingDirectoryWithFiles({ cwd, files } : {cwd: MockSystemFolderPath, files: FilePathsAndContents}) : MockPathService {
+        return new MockPathService({ cwd, files })
+    }
+
+    getcwd(): MockSystemFolderPath {
+        return this.cwd
+    }
+
+    loadFile<T>(filePath: string): T {
+        /**
+         * Some test values test double slashes in paths
+         * which is great, but will fail the simplistic exact string mock file matching,
+         * so remove the duplication so this logic should stay simple
+         */
+        let _path = path.normalize(filePath)
+        const filePathKey = this.lookupFilesIndex(_path)
+        const found = this.files.find(a => a[0] === filePathKey)
+        if ( found ) {
+            try {
+                // JS's require on JS files auto-parses so let's emulate
+                // so that test file values don't matter if they are stringed json or objects
+                return JSON.parse(found[1])
+            } catch (e) {
+                return found[1]
+            }
+        }
+        throw new Error(`File "${filePathKey}" does not exist in fake file system!`)
+    }
+
+    private lookupFilesIndex(filePath: MockSystemFilePath) {
+        let _path = path.normalize(filePath)
+        return path.isAbsolute(_path) ? _path : path.resolve(this.cwd, _path)
+    }
+
+    isFile(filePath: MockSystemFilePath): boolean {
+        let _path = path.normalize(filePath)
+        const filePathKey = this.lookupFilesIndex(_path)
+        return this.files.some(a => a[0] === filePathKey)
+    }
+
+    glob(pattern: string): string[] {
+        const mm = new Minimatch(pattern)
+        return this.files.filter(a => mm.match(a[0])).map(result => result[0])
+    }
+
+    ensureAbsolutePath(filepath: string) : string {
+        return filepath
+    }
+}

--- a/packages/wdio-config/tests/lib/MockedModules.ts
+++ b/packages/wdio-config/tests/lib/MockedModules.ts
@@ -1,0 +1,118 @@
+import { ModuleRequireService } from '../../src'
+
+/**
+ * Test implementation of ModuleRequireService
+ *
+ * Avoids the SUT from actually requiring files at all, instead using a small in-memory array representing virtual
+ * modules present in a virtual node_modules for the SUT.
+ *
+ * Normally will never call the real require functions and will throw if SUT requires something not mocked.
+ * Provide callThroughNotMockedModules as true to call through to real require function when not mocked instead of throwing.
+ */
+export default class MockedModules implements ModuleRequireService {
+    private constructor(callThroughNotMockedModules = false) {
+        this.mockLoadedModules = []
+        this.requireMock = jest.fn((m:string) => {
+            try {
+                return this.getModule(m)
+            } catch (e) {
+                if ( callThroughNotMockedModules ) {
+                    return require(m)
+                }
+                throw e
+
+            }
+        })
+        this.resolveMock = jest.fn((m:string) => {
+            try {
+                return this.hasModule(m)
+            } catch (e) {
+                if ( callThroughNotMockedModules ) {
+                    return require.resolve(m)
+                }
+                throw e
+
+            }
+        })
+    }
+
+    static withNoModules(callThroughNotMockedModules = false) {
+        return new MockedModules(callThroughNotMockedModules)
+
+    }
+
+    static withModules(moduleAndValuesList: [string, any][], callThroughNotMockedModules = false) {
+        let instance = new MockedModules(callThroughNotMockedModules)
+        return instance.withModules(moduleAndValuesList)
+    }
+
+    /**
+     * Use the mocks if interested in low-level calls being made.
+     *
+     * A mock for each aspect of ModuleRequireService is provided.
+     */
+    getMocks() {
+        return {
+            requireMock: this.requireMock,
+            resolveMock: this.resolveMock
+        }
+    }
+
+    withModules(moduleAndValuesList: [string, any][]) {
+        for (const [moduleName, moduleValue] of moduleAndValuesList) {
+            this.withModule(moduleName, moduleValue)
+        }
+        return this
+    }
+
+    withModule(module: string, mockModule: any) {
+        this.mockLoadedModules[module] = mockModule
+        return this
+    }
+    doesNotHaveModule(module: string) {
+        this.mockLoadedModules[module] = undefined
+        delete this.mockLoadedModules[module]
+        return this
+    }
+    resetModules() {
+        this.mockLoadedModules = []
+    }
+
+    withTsNodeModule(registerMock = jest.fn()) {
+        return this.withModule(
+            'ts-node', { register: registerMock }
+        )
+    }
+
+    withBabelModule(registerMock = jest.fn()) {
+        return this.withModule('@babel/register', registerMock)
+    }
+
+    // Helpers for resembling real implementation behavior respective to tests
+    private getModule(module: string) {
+        if ( this.hasModule(module) ) {
+            return this.mockLoadedModules[module]
+        }
+        throw new Error('FAKE_MODULE_NOT_FOUND')
+    }
+    private hasModule(module: string) {
+        if ( this.mockLoadedModules[module] ) {
+            return true
+        }
+        throw new Error('FAKE_MODULE_NOT_FOUND')
+    }
+
+    // Interface
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    require<T>(module: string): T {
+        // forward to jest mock
+        return this.requireMock.apply(this, arguments)
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    resolve(request: string, options: { paths?: string[] }): string {
+        // forward to jest mock
+        return this.resolveMock.apply(this, arguments)
+    }
+
+}

--- a/packages/wdio-runner/src/index.ts
+++ b/packages/wdio-runner/src/index.ts
@@ -101,6 +101,10 @@ export default class Runner extends EventEmitter {
          * merge cli arguments into config
          */
         this._configParser.merge(args)
+        // autocompile after parsing configs so we support ES6 features in tests with config driven by users
+        if ( this._configParser.autoCompile ) {
+            this._configParser.autoCompile()
+        }
 
         this._config = this._configParser.getConfig() as Options.Testrunner
         this._specFileRetryAttempts = (this._config.specFileRetries || 0) - (retries || 0)

--- a/packages/wdio-runner/tests/index.test.ts
+++ b/packages/wdio-runner/tests/index.test.ts
@@ -5,7 +5,6 @@ import { executeHooksWithArgs } from '@wdio/utils'
 import { attach } from 'webdriverio'
 import WDIORunner from '../src'
 import logger from '@wdio/logger'
-
 jest.mock('fs')
 jest.mock('util')
 

--- a/packages/wdio-types/src/Options.ts
+++ b/packages/wdio-types/src/Options.ts
@@ -403,6 +403,16 @@ export interface Testrunner extends Hooks, Omit<WebdriverIO, 'capabilities'>, We
     mochaOpts?: WebdriverIO.MochaOpts
     jasmineOpts?: WebdriverIO.JasmineOpts
     cucumberOpts?: WebdriverIO.CucumberOpts
+    /**
+     * autocompile options
+     */
+    autoCompileOpts?: AutoCompileConfig
+}
+
+export interface AutoCompileConfig {
+    autoCompile: boolean
+    tsNodeOpts: { [key: string]: any }
+    babelOpts: { [key: string]: any }
 }
 
 export interface MultiRemote extends Omit<Testrunner, 'capabilities'> {

--- a/website/docs/Babel.md
+++ b/website/docs/Babel.md
@@ -28,3 +28,5 @@ module.exports = {
 ```
 
 Once this is set up WebdriverIO will take care of the rest.
+
+Alternatively you can configure how @babel/register is run through the environment variables for [@babel/register](Babel.md) or using wdio config's [autoCompileOpts section](ConfigurationFile.md).

--- a/website/docs/CLI.md
+++ b/website/docs/CLI.md
@@ -124,6 +124,8 @@ Options:
 --cucumberOpts        Cucumber options
 ```
 
+> Note: Autocompiling can be easily controlled with the appropriate library's ENV Vars. See also Test Runner's Auto Compilation functionality documented in [TypeScript (ts-node)](TypeScript.md) and [Babel (@babel/register)](Babel.md) pages.
+
 ### `wdio install`
 The `install` command allows you to add reporters and services to your WebdriverIO projects via the CLI.
 

--- a/website/docs/ConfigurationFile.md
+++ b/website/docs/ConfigurationFile.md
@@ -247,6 +247,35 @@ exports.config = {
         ignoreUndefinedDefinitions: false, // <boolean> Enable this config to treat undefined definitions as warnings.
         scenarioLevelReporter: false // Enable this to make webdriver.io behave as if scenarios and not steps were the tests.
     },
+    // For convenience, if ts-node or @babel/register modules are detected
+    // they are automatically loaded for config parsing so that TypeScript and
+    // future ES features can be used in wsdio configs, and are also
+    // automatically loaded for test running so that tests can be written
+    // using TypeScript and future ES features.
+    // Because this may not be ideal in every situation, the following options
+    // may be used to customize the loading for test running, incase it has
+    // other requirements. 
+    autoCompileOpts: {
+        //
+        // To disable auto-loading entirely set this to false.
+        autoCompile: true, // <boolean> Disable this to turn off autoloading. Note: When disabling, you will need to handle calling any such libraries yourself.
+        //
+        // If you have ts-node installed, you can customize how options are passed to it here:
+        // Any valid ts-node config option is allowed. Alternatively the ENV Vars could also be used instead of this.
+        // See also: https://github.com/TypeStrong/ts-node#cli-and-programmatic-options
+        // See also RegisterOptions in https://github.com/TypeStrong/ts-node/blob/master/src/index.ts
+        tsNodeOpts: {
+            transpileOnly: true,
+            project: 'tsconfig.json'
+        },
+        //
+        // If @babel/register is installed, you can customize how options are passed to it here:
+        // Any valid @babel/register config option is allowed.  
+        // https://babeljs.io/docs/en/babel-register#specifying-options
+        babelOpts: {
+            ignore: []
+        },
+    },
     //
     // =====
     // Hooks

--- a/website/docs/TypeScript.md
+++ b/website/docs/TypeScript.md
@@ -5,7 +5,7 @@ title: TypeScript Setup
 
 You can write tests using [TypeScript](http://www.typescriptlang.org) to get autocompletion and type safety.
 
-You will need [`typescript`](https://github.com/microsoft/TypeScript) and [`ts-node`](https://github.com/TypeStrong/ts-node) installed as `devDependencies`. WebdriverIO will automatically detect if these dependencies are installed and will compile your config and tests for you.
+You will need [`typescript`](https://github.com/microsoft/TypeScript) and [`ts-node`](https://github.com/TypeStrong/ts-node) installed as `devDependencies`. WebdriverIO will automatically detect if these dependencies are installed and will compile your config and tests for you. If you need to configure how ts-node runs please use the environment variables for [ts-node](TypeScript.md) or use wdio config's [autoCompileOpts section](ConfigurationFile.md).
 
 ```bash npm2yarn
 $ npm install typescript ts-node --save-dev


### PR DESCRIPTION
## Proposed changes

https://github.com/webdriverio/webdriverio/pull/6275 introduced automatic loading of ts-node. I believe that this was accidentally a breaking change for users who need to configure ts-node differently than the automatic loader. The proposed workaround is to remove custom loading code and rely on the automatic loader, which may not work for all users. Since webdriverio worked for them before the change, it should work them after.

I think we need the loadTypeScriptCompiler mechanism to look through the config file for something like a tsNodeOpts block and spread that with its defaults. The defaults can be the current value so that users who do not define it get the current behavior. Users who need to modify it could now modify their wdio.conf.js file as neede, remove their custom loading code, have everything working well.

There are more details described in my response to pull 6275: https://github.com/webdriverio/webdriverio/pull/6275#issuecomment-770051932

My change ended up being a little more expansive, in order to provide the config I had to reorder where loadTypeScriptCompiler is called in ConfigParser. I also updated the types.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

I am a little hesitant about the documentation part, otherwise I would love to add some. I tried to add it to the examples.

Please let me know if I missed any areas.

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [X] I have added proper type definitions for new commands (if appropriate)

## Further comments

- I refactored the non-loading logic from  ConfigParser's addConfigFile into addConfigEntry so that I could spread a modified config with tsConfigOpts in the test. This was not necessary, but would have required me adding another config file to the fixtures solely for this purpose and I did not want to muddy the waters especially in my first commit. Besides I do think this separates the logic a little more cleanly.

- I used ts-node's RegisterOptions type in packages/wdio-config/src/utils.ts but this could just as well be any. I call this out incase it might unknowingly make ts-node's types a dependency. If so let me know and I will set it to any.

### Reviewers: @webdriverio/project-committers
