### PR TITLE
Add sharable Sauce Labs report links

### DIFF
--- a/docs/CustomServices.md
+++ b/docs/CustomServices.md
@@ -40,13 +40,12 @@ export default class CustomWorkerService {
      *
      * the `serviceOptions` parameter will be: `{ foo: 'bar' }`
      */
-    constructor (serviceOptions, capabilities, config, browser) {
-        this.browser = browser
+    constructor (serviceOptions, capabilities, config) {
     }
 
-    before(config, capabilities) {
+    before(config, capabilities, browser) {
         // TODO: something before all tests are run, e.g.:
-        this.browser.setWindowSize(1024, 768)
+        browser.setWindowSize(1024, 768)
     }
 
     after(exitCode, config, capabilities) {

--- a/packages/wdio-cli/src/constants.ts
+++ b/packages/wdio-cli/src/constants.ts
@@ -117,7 +117,8 @@ export const SUPPORTED_PACKAGES = {
         { name: 'rerun', value: 'wdio-rerun-service$--$rerun' },
         { name: 'winappdriver', value: 'wdio-winappdriver-service$--$winappdriver' },
         { name: 'ywinappdriver', value: 'wdio-ywinappdriver-service$--$ywinappdriver' },
-        { name: 'performancetotal', value: 'wdio-performancetotal-service$--$performancetotal' }
+        { name: 'performancetotal', value: 'wdio-performancetotal-service$--$performancetotal' },
+        { name: 'aws-device-farm', value: 'wdio-aws-device-farm-service$--$aws-device-farm' }
     ]
 } as const
 

--- a/packages/wdio-protocols/protocols/appium.json
+++ b/packages/wdio-protocols/protocols/appium.json
@@ -619,6 +619,11 @@
         "description": "path on the device to pull file from",
         "required": true
       }],
+      "returns": {
+        "type": "string",
+        "name": "response",
+        "description": "Contents of file in base64"
+      },
       "support": {
         "ios": {
           "XCUITest": "9.3+",

--- a/packages/wdio-spec-reporter/README.md
+++ b/packages/wdio-spec-reporter/README.md
@@ -38,14 +38,41 @@ module.exports = {
   // ...
 };
 ```
+## Spec Reporter Options
+### symbols
+Provide custom symbols for `passed`, `failed` and or `skipped` tests
 
-### Custom report symbols
+Type: `object`
+Default: `{passed: '✓', skipped: '-', failed: '✖'}`
+
+#### Example
 ```js
 [
   "spec",
   {
-    symbols: { passed: '[PASS]', failed: '[FAIL]' },
-    // skipped set to default '-'
-  }
+    symbols: {
+      passed: '[PASS]',
+      failed: '[FAIL]',
+    },
+  },
+]
+```
+
+### sauceLabsSharableLinks
+Be default the test results in Sauce Labs can only be viewed by a team member from the same team, not by a team member
+from a different team. This options will enable [sharable links](https://wiki.saucelabs.com/display/DOCS/Building+Sharable+Links+to+Test+Results)
+by default, which means that all tests that are executed in Sauce Labs can be viewed by everybody.
+Jest add `sauceLabsSharableLinks: false`, as shown below, in the reporter options to disable this feature.
+
+Type: `boolean`
+Default: `true`
+
+#### Example
+```js
+[
+  "spec",
+  {
+    sauceLabsSharableLinks: false,
+  },
 ]
 ```

--- a/packages/wdio-spec-reporter/src/index.js
+++ b/packages/wdio-spec-reporter/src/index.js
@@ -1,7 +1,7 @@
 import WDIOReporter from '@wdio/reporter'
 import chalk from 'chalk'
 import prettyMs from 'pretty-ms'
-import { buildTableData, printTable, getFormattedRows } from './utils'
+import { buildTableData, printTable, getFormattedRows, sauceAuthenticationToken } from './utils'
 
 class SpecReporter extends WDIOReporter {
     constructor (options) {
@@ -16,6 +16,7 @@ class SpecReporter extends WDIOReporter {
             skipped: options.symbols?.skipped || '-',
             failed: options.symbols?.failed || '✖'
         }
+        this.sauceLabsSharableLinks = 'sauceLabsSharableLinks' in options ? options.sauceLabsSharableLinks : true
 
         // Keep track of the order that suites were called
         this.suiteUids = []
@@ -133,7 +134,10 @@ class SpecReporter extends WDIOReporter {
                 ? '.us-east-1'
                 : ['eu', 'eu-central-1'].includes(config.region) ? '.eu-central-1' : ''
             const multiremoteNote = isMultiremote ? ` ${instanceName}` : ''
-            return [`Check out${multiremoteNote} job at https://app${dc}.saucelabs.com/tests/${sessionId}`]
+            const sauceLabsSharableLinks = this.sauceLabsSharableLinks
+                ? sauceAuthenticationToken( { user:config.user, key:config.key, sessionId } )
+                : ''
+            return [`Check out${multiremoteNote} job at https://app${dc}.saucelabs.com/tests/${sessionId}${sauceLabsSharableLinks}`]
         }
 
         return []

--- a/packages/wdio-spec-reporter/src/utils.js
+++ b/packages/wdio-spec-reporter/src/utils.js
@@ -1,4 +1,5 @@
 import Table from 'easy-table'
+import * as Crypto from 'crypto'
 
 const SEPARATOR = '│'
 
@@ -32,3 +33,25 @@ export const printTable = (data) => Table.print(data, null, (table) => {
  */
 export const getFormattedRows = (table, testIndent) =>
     table.split('\n').filter(Boolean).map((line) => `${testIndent}  ${line}`.trimRight())
+
+/**
+ * Get Sauce Labs Authentication url
+ * @param user
+ * @param key
+ * @param sessionId
+ * @returns {string}
+ */
+export const sauceAuthenticationToken = ({ user, key, sessionId }) => {
+    const secret = `${user}:${key}`
+
+    // Create the token
+    const token = Crypto
+        // Calling createHmac method
+        .createHmac('md5', secret)
+        // Update data
+        .update(sessionId)
+        // Encoding to be used
+        .digest('hex')
+
+    return `?auth=${token}`
+}

--- a/packages/wdio-spec-reporter/tests/__snapshots__/index.test.js.snap
+++ b/packages/wdio-spec-reporter/tests/__snapshots__/index.test.js.snap
@@ -58,6 +58,44 @@ Array [
 ]
 `;
 
+exports[`SpecReporter printReport with disabled sharable Sauce report links should print the default Sauce Labs job details page link 1`] = `
+Array [
+  Array [
+    "------------------------------------------------------------------
+[loremipsum 50 Windows 10 #0-0] Spec: /foo/bar/baz.js
+[loremipsum 50 Windows 10 #0-0] Running: loremipsum (v50) on Windows 10
+[loremipsum 50 Windows 10 #0-0] Session ID: foobar
+[loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] Foo test
+[loremipsum 50 Windows 10 #0-0]    green ✓ foo
+[loremipsum 50 Windows 10 #0-0]    green ✓ bar
+[loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] Bar test
+[loremipsum 50 Windows 10 #0-0]    green ✓ some test
+[loremipsum 50 Windows 10 #0-0]    red ✖ a failed test
+[loremipsum 50 Windows 10 #0-0]    red ✖ a failed test with no stack
+[loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] Baz test
+[loremipsum 50 Windows 10 #0-0]    green ✓ foo bar baz
+[loremipsum 50 Windows 10 #0-0]    cyan - a skipped test
+[loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] green 4 passing (5s)
+[loremipsum 50 Windows 10 #0-0] red 1 failing
+[loremipsum 50 Windows 10 #0-0] cyan 1 skipped
+[loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] 1) Bar test a failed test
+[loremipsum 50 Windows 10 #0-0] red expected foo to equal bar
+[loremipsum 50 Windows 10 #0-0] gray Failed test stack trace
+[loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] 2) Bar test a failed test with no stack
+[loremipsum 50 Windows 10 #0-0] red expected foo to equal bar
+[loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] Check out job at https://app.saucelabs.com/tests/ba86cbcb70774ef8a0757c1702c3bdf9
+",
+  ],
+]
+`;
+
 exports[`SpecReporter printReport with normal setup should print jobs of all instance when run with multiremote 1`] = `
 Array [
   Array [
@@ -89,8 +127,8 @@ Array [
 [MultiremoteBrowser (unknown) #0-0] 2) Bar test a failed test with no stack
 [MultiremoteBrowser (unknown) #0-0] red expected foo to equal bar
 [MultiremoteBrowser (unknown) #0-0]
-[MultiremoteBrowser (unknown) #0-0] Check out browserA job at https://app.saucelabs.com/tests/foobar
-[MultiremoteBrowser (unknown) #0-0] Check out browserB job at https://app.saucelabs.com/tests/barfoo
+[MultiremoteBrowser (unknown) #0-0] Check out browserA job at https://app.saucelabs.com/tests/foobar?auth=5195037bb62a3ddd920a54c82358a281
+[MultiremoteBrowser (unknown) #0-0] Check out browserB job at https://app.saucelabs.com/tests/barfoo?auth=b5dc960c52116ec73122aeee2d431c5f
 ",
   ],
 ]
@@ -128,7 +166,7 @@ Array [
 [loremipsum 50 Windows 10 #0-0] 2) Bar test a failed test with no stack
 [loremipsum 50 Windows 10 #0-0] red expected foo to equal bar
 [loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] Check out job at https://app.eu-central-1.saucelabs.com/tests/ba86cbcb70774ef8a0757c1702c3bdf9
+[loremipsum 50 Windows 10 #0-0] Check out job at https://app.eu-central-1.saucelabs.com/tests/ba86cbcb70774ef8a0757c1702c3bdf9?auth=364414eae3ee11cb8b8bb3fc3e3b5e12
 ",
   ],
 ]
@@ -166,7 +204,7 @@ Array [
 [loremipsum 50 Windows 10 #0-0] 2) Bar test a failed test with no stack
 [loremipsum 50 Windows 10 #0-0] red expected foo to equal bar
 [loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] Check out job at https://app.eu-central-1.saucelabs.com/tests/ba86cbcb70774ef8a0757c1702c3bdf9
+[loremipsum 50 Windows 10 #0-0] Check out job at https://app.eu-central-1.saucelabs.com/tests/ba86cbcb70774ef8a0757c1702c3bdf9?auth=364414eae3ee11cb8b8bb3fc3e3b5e12
 ",
   ],
 ]
@@ -204,7 +242,7 @@ Array [
 [loremipsum 50 Windows 10 #0-0] 2) Bar test a failed test with no stack
 [loremipsum 50 Windows 10 #0-0] red expected foo to equal bar
 [loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] Check out job at https://app.eu-central-1.saucelabs.com/tests/ba86cbcb70774ef8a0757c1702c3bdf9
+[loremipsum 50 Windows 10 #0-0] Check out job at https://app.eu-central-1.saucelabs.com/tests/ba86cbcb70774ef8a0757c1702c3bdf9?auth=364414eae3ee11cb8b8bb3fc3e3b5e12
 ",
   ],
   Array [
@@ -237,7 +275,7 @@ Array [
 [loremipsum 50 Windows 10 #0-0] 2) Bar test a failed test with no stack
 [loremipsum 50 Windows 10 #0-0] red expected foo to equal bar
 [loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] Check out job at https://app.us-east-1.saucelabs.com/tests/ba86cbcb70774ef8a0757c1702c3bdf9
+[loremipsum 50 Windows 10 #0-0] Check out job at https://app.us-east-1.saucelabs.com/tests/ba86cbcb70774ef8a0757c1702c3bdf9?auth=364414eae3ee11cb8b8bb3fc3e3b5e12
 ",
   ],
 ]
@@ -275,7 +313,7 @@ Array [
 [loremipsum 50 Windows 10 #0-0] 2) Bar test a failed test with no stack
 [loremipsum 50 Windows 10 #0-0] red expected foo to equal bar
 [loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] Check out job at https://app.saucelabs.com/tests/ba86cbcb70774ef8a0757c1702c3bdf9
+[loremipsum 50 Windows 10 #0-0] Check out job at https://app.saucelabs.com/tests/ba86cbcb70774ef8a0757c1702c3bdf9?auth=364414eae3ee11cb8b8bb3fc3e3b5e12
 ",
   ],
 ]
@@ -313,7 +351,7 @@ Array [
 [loremipsum 50 Windows 10 #0-0] 2) Bar test a failed test with no stack
 [loremipsum 50 Windows 10 #0-0] red expected foo to equal bar
 [loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] Check out job at https://app.saucelabs.com/tests/ba86cbcb70774ef8a0757c1702c3bdf9
+[loremipsum 50 Windows 10 #0-0] Check out job at https://app.saucelabs.com/tests/ba86cbcb70774ef8a0757c1702c3bdf9?auth=df58c8ddea836c98710dbb1119625de8
 ",
   ],
 ]
@@ -351,7 +389,7 @@ Array [
 [loremipsum 50 Windows 10 #0-0] 2) Bar test a failed test with no stack
 [loremipsum 50 Windows 10 #0-0] red expected foo to equal bar
 [loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] Check out job at https://app.saucelabs.com/tests/ba86cbcb70774ef8a0757c1702c3bdf9
+[loremipsum 50 Windows 10 #0-0] Check out job at https://app.saucelabs.com/tests/ba86cbcb70774ef8a0757c1702c3bdf9?auth=df58c8ddea836c98710dbb1119625de8
 ",
   ],
 ]

--- a/packages/wdio-spec-reporter/tests/index.test.js
+++ b/packages/wdio-spec-reporter/tests/index.test.js
@@ -172,7 +172,9 @@ describe('SpecReporter', () => {
 
             it('should print link to Sauce Labs job details page', () => {
                 const runner = getRunnerConfig({
-                    hostname: 'ondemand.saucelabs.com'
+                    hostname: 'ondemand.saucelabs.com',
+                    user: 'foobar',
+                    key: '123',
                 })
                 printReporter.printReport(runner)
                 expect(printReporter.write.mock.calls).toMatchSnapshot()
@@ -218,6 +220,8 @@ describe('SpecReporter', () => {
             it('should print link to Sauce Labs EU job details page', () => {
                 printReporter.printReport(getRunnerConfig({
                     hostname: 'ondemand.saucelabs.com',
+                    user: 'foobar',
+                    key: '123',
                     region: 'eu'
                 }))
                 expect(printReporter.write.mock.calls).toMatchSnapshot()
@@ -226,15 +230,44 @@ describe('SpecReporter', () => {
 
                 printReporter.printReport(getRunnerConfig({
                     hostname: 'ondemand.saucelabs.com',
+                    user: 'foobar',
+                    key: '123',
                     region: 'eu-central-1'
                 }))
                 expect(printReporter.write.mock.calls).toMatchSnapshot()
 
                 printReporter.printReport(getRunnerConfig({
                     hostname: 'ondemand.saucelabs.com',
+                    user: 'foobar',
+                    key: '123',
                     headless: true
                 }))
                 expect(printReporter.write.mock.calls).toMatchSnapshot()
+            })
+        })
+
+        describe('with disabled sharable Sauce report links', ()=>{
+            const options = { sauceLabsSharableLinks: false }
+            beforeEach(() => {
+                tmpReporter = new SpecReporter(options)
+                tmpReporter.suiteUids = SUITE_UIDS
+                tmpReporter.suites = SUITES
+                tmpReporter.stateCounts = {
+                    passed : 4,
+                    failed : 1,
+                    skipped : 1,
+                }
+                tmpReporter.write = jest.fn()
+            })
+
+            it('should print the default Sauce Labs job details page link', () => {
+                const runner = getRunnerConfig({
+                    hostname: 'ondemand.saucelabs.com',
+                    user: 'foobar',
+                    key: '123',
+                })
+                tmpReporter.printReport(runner)
+                expect(tmpReporter.write.mock.calls).toMatchSnapshot()
             })
         })
 

--- a/packages/webdriver/webdriver.d.ts
+++ b/packages/webdriver/webdriver.d.ts
@@ -1542,7 +1542,7 @@ declare namespace WebDriver {
          * Retrieve a file from the device's file system.
          * http://appium.io/docs/en/commands/device/files/pull-file/
          */
-        pullFile(path: string): void;
+        pullFile(path: string): string;
 
         /**
          * [appium]

--- a/scripts/docs-generation/3rd-party/services.json
+++ b/scripts/docs-generation/3rd-party/services.json
@@ -104,5 +104,12 @@
     "title": "PerformanceTotal",
     "githubUrl": "https://github.com/tzurp/performance-total",
     "npmUrl": "https://www.npmjs.com/package/wdio-performancetotal-service"
+  },
+  {
+    "packageName": "wdio-aws-device-farm-service",
+    "title": "AWS Device Farm",
+    "githubUrl": "https://github.com/awslabs/wdio-aws-device-farm-service",
+    "branch": "main",
+    "npmUrl": "https://www.npmjs.com/package/wdio-aws-device-farm-service"
   }
 ]


### PR DESCRIPTION
## Proposed changes
By default the report links from Sauce Labs are not sharable between teams. This feature will enable this by default (as agreed with @christian-bromann ) and can be disabled

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)
