### PR TITLE
Add sauce sharable report links

### DIFF
--- a/packages/wdio-spec-reporter/README.md
+++ b/packages/wdio-spec-reporter/README.md
@@ -39,13 +39,41 @@ module.exports = {
 };
 ```
 
-### Custom report symbols
+## Spec Reporter Options
+### symbols
+Provide custom symbols for `passed`, `failed` and or `skipped` tests
+
+Type: `object`
+Default: `{passed: '✓', skipped: '-', failed: '✖'}`
+
+#### Example
 ```js
 [
   "spec",
   {
-    symbols: { passed: '[PASS]', failed: '[FAIL]' },
-    // skipped set to default '-'
-  }
+    symbols: {
+      passed: '[PASS]',
+      failed: '[FAIL]',
+    },
+  },
+]
+```
+
+### sauceLabsSharableLinks
+Be default the test results in Sauce Labs can only be viewed by a team member from the same team, not by a team member
+from a different team. This options will enable [sharable links](https://wiki.saucelabs.com/display/DOCS/Building+Sharable+Links+to+Test+Results)
+by default, which means that all tests that are executed in Sauce Labs can be viewed by everybody.
+Jest add `sauceLabsSharableLinks: false`, as shown below, in the reporter options to disable this feature.
+
+Type: `boolean`
+Default: `true`
+
+#### Example
+```js
+[
+  "spec",
+  {
+    sauceLabsSharableLinks: false,
+  },
 ]
 ```

--- a/packages/wdio-spec-reporter/README.md
+++ b/packages/wdio-spec-reporter/README.md
@@ -63,7 +63,7 @@ Default: `{passed: '✓', skipped: '-', failed: '✖'}`
 Be default the test results in Sauce Labs can only be viewed by a team member from the same team, not by a team member
 from a different team. This options will enable [sharable links](https://wiki.saucelabs.com/display/DOCS/Building+Sharable+Links+to+Test+Results)
 by default, which means that all tests that are executed in Sauce Labs can be viewed by everybody.
-Jest add `sauceLabsSharableLinks: false`, as shown below, in the reporter options to disable this feature.
+Just add `sauceLabsSharableLinks: false`, as shown below, in the reporter options to disable this feature.
 
 Type: `boolean`
 Default: `true`

--- a/packages/wdio-spec-reporter/src/index.ts
+++ b/packages/wdio-spec-reporter/src/index.ts
@@ -27,7 +27,7 @@ export default class SpecReporter extends WDIOReporter {
         failed: '✖'
     }
 
-    private _sauceLabsSharableLinks:boolean = true
+    private _sauceLabsSharableLinks = true
 
     constructor (options: SpecReporterOptions) {
         /**

--- a/packages/wdio-spec-reporter/src/index.ts
+++ b/packages/wdio-spec-reporter/src/index.ts
@@ -35,9 +35,9 @@ export default class SpecReporter extends WDIOReporter {
          */
         super(Object.assign({ stdout: true }, options))
         this._symbols = { ...this._symbols, ...this.options.symbols || {} }
-        this._sauceLabsSharableLinks = <boolean>('sauceLabsSharableLinks' in options
-            ? options.sauceLabsSharableLinks
-            : this._sauceLabsSharableLinks)
+        this._sauceLabsSharableLinks = 'sauceLabsSharableLinks' in options
+            ? options.sauceLabsSharableLinks as boolean
+            : this._sauceLabsSharableLinks
     }
 
     onSuiteStart (suite: SuiteStats) {
@@ -140,13 +140,13 @@ export default class SpecReporter extends WDIOReporter {
             )
         )
 
-        if (isSauceJob) {
+        if (isSauceJob && config.user && config.key && sessionId) {
             const dc = config.headless
                 ? '.us-east-1'
                 : ['eu', 'eu-central-1'].includes(config.region || '') ? '.eu-central-1' : ''
             const multiremoteNote = isMultiremote ? ` ${instanceName}` : ''
             const sauceLabsSharableLinks = this._sauceLabsSharableLinks
-                ? sauceAuthenticationToken( <string>config.user, <string>config.key, <string>sessionId )
+                ? sauceAuthenticationToken( config.user, config.key, sessionId )
                 : ''
             return [`Check out${multiremoteNote} job at https://app${dc}.saucelabs.com/tests/${sessionId}${sauceLabsSharableLinks}`]
         }

--- a/packages/wdio-spec-reporter/src/types.ts
+++ b/packages/wdio-spec-reporter/src/types.ts
@@ -14,7 +14,21 @@ export interface Symbols {
 }
 
 export interface SpecReporterOptions {
+    /**
+     * Be default the test results in Sauce Labs can only be viewed by a team member from the same team, not by a team
+     * member from a different team. This options will enable
+     * [sharable links](https://wiki.saucelabs.com/display/DOCS/Building+Sharable+Links+to+Test+Results)
+     * by default, which means that all tests that are executed in Sauce Labs can be viewed by everybody.
+     * Adding `sauceLabsSharableLinks: false`, in the reporter options will disable this feature.
+     *
+     * @default: true
+     */
     sauceLabsSharableLinks?: boolean
+    /**
+     * Provide custom symbols for `passed`, `failed` and or `skipped` tests
+     *
+     * @default: {passed: '✓', skipped: '-', failed: '✖'}
+     */
     symbols?: Partial<Symbols>
 }
 

--- a/packages/wdio-spec-reporter/src/types.ts
+++ b/packages/wdio-spec-reporter/src/types.ts
@@ -14,6 +14,7 @@ export interface Symbols {
 }
 
 export interface SpecReporterOptions {
+    sauceLabsSharableLinks?: boolean
     symbols?: Partial<Symbols>
 }
 

--- a/packages/wdio-spec-reporter/src/utils.ts
+++ b/packages/wdio-spec-reporter/src/utils.ts
@@ -1,4 +1,5 @@
 import Table from 'easy-table'
+import * as Crypto from 'crypto'
 
 const SEPARATOR = '│'
 
@@ -32,3 +33,24 @@ export const printTable = (data: any) => Table.print(data, undefined, (table) =>
  */
 export const getFormattedRows = (table: string, testIndent: string) =>
     table.split('\n').filter(Boolean).map((line) => `${testIndent}  ${line}`.trimRight())
+
+/**
+ * Get Sauce Labs Authentication url
+ * @param {string} user
+ * @param {string} key
+ * @param {string} sessionId
+ */
+export const sauceAuthenticationToken = (user:string, key:string, sessionId:string) => {
+    const secret = `${user}:${key}`
+
+    // Create the token
+    const token = Crypto
+        // Calling createHmac method
+        .createHmac('md5', secret)
+        // Update data
+        .update(sessionId)
+        // Encoding to be used
+        .digest('hex')
+
+    return `?auth=${token}`
+}

--- a/packages/wdio-spec-reporter/tests/__snapshots__/index.test.ts.snap
+++ b/packages/wdio-spec-reporter/tests/__snapshots__/index.test.ts.snap
@@ -315,7 +315,7 @@ Array [
 [loremipsum 50 Windows 10 #0-0] 2) Bar test a failed test with no stack
 [loremipsum 50 Windows 10 #0-0] red expected foo to equal bar
 [loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] Check out job at https://app.saucelabs.com/tests/ba86cbcb70774ef8a0757c1702c3bdf9?auth=df58c8ddea836c98710dbb1119625de8
+[loremipsum 50 Windows 10 #0-0] Check out job at https://app.saucelabs.com/tests/ba86cbcb70774ef8a0757c1702c3bdf9?auth=364414eae3ee11cb8b8bb3fc3e3b5e12
 ",
   ],
 ]
@@ -353,7 +353,7 @@ Array [
 [loremipsum 50 Windows 10 #0-0] 2) Bar test a failed test with no stack
 [loremipsum 50 Windows 10 #0-0] red expected foo to equal bar
 [loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] Check out job at https://app.saucelabs.com/tests/ba86cbcb70774ef8a0757c1702c3bdf9?auth=df58c8ddea836c98710dbb1119625de8
+[loremipsum 50 Windows 10 #0-0] Check out job at https://app.saucelabs.com/tests/ba86cbcb70774ef8a0757c1702c3bdf9?auth=364414eae3ee11cb8b8bb3fc3e3b5e12
 ",
   ],
 ]

--- a/packages/wdio-spec-reporter/tests/__snapshots__/index.test.ts.snap
+++ b/packages/wdio-spec-reporter/tests/__snapshots__/index.test.ts.snap
@@ -58,12 +58,14 @@ Array [
 ]
 `;
 
+exports[`SpecReporter printReport with disabled sharable Sauce report links should print the default Sauce Labs job details page link 1`] = `Array []`;
+
 exports[`SpecReporter printReport with normal setup should print jobs of all instance when run with multiremote 1`] = `
 Array [
   Array [
     "------------------------------------------------------------------
 [MultiremoteBrowser #0-0] Spec: /foo/bar/baz.js
-[MultiremoteBrowser #0-0] Running: MultiremoteBrowser on
+[MultiremoteBrowser #0-0] Running: MultiremoteBrowser on ,
 [MultiremoteBrowser #0-0]
 [MultiremoteBrowser #0-0] Foo test
 [MultiremoteBrowser #0-0]    green ✓ foo
@@ -89,7 +91,8 @@ Array [
 [MultiremoteBrowser #0-0] 2) Bar test a failed test with no stack
 [MultiremoteBrowser #0-0] red expected foo to equal bar
 [MultiremoteBrowser #0-0]
-[MultiremoteBrowser #0-0] Check out myBrowser job at https://app.saucelabs.com/tests/undefined
+[MultiremoteBrowser #0-0] Check out browserA job at https://app.saucelabs.com/tests/foobar?auth=2d3c4ca3cae505723f2fa903563fe019
+[MultiremoteBrowser #0-0] Check out browserB job at https://app.saucelabs.com/tests/barfoo?auth=64012ad809cda36d46c5c2175bc212b4
 ",
   ],
 ]
@@ -127,7 +130,7 @@ Array [
 [loremipsum 50 Windows 10 #0-0] 2) Bar test a failed test with no stack
 [loremipsum 50 Windows 10 #0-0] red expected foo to equal bar
 [loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] Check out job at https://app.eu-central-1.saucelabs.com/tests/ba86cbcb70774ef8a0757c1702c3bdf9
+[loremipsum 50 Windows 10 #0-0] Check out job at https://app.eu-central-1.saucelabs.com/tests/ba86cbcb70774ef8a0757c1702c3bdf9?auth=364414eae3ee11cb8b8bb3fc3e3b5e12
 ",
   ],
 ]
@@ -165,7 +168,7 @@ Array [
 [loremipsum 50 Windows 10 #0-0] 2) Bar test a failed test with no stack
 [loremipsum 50 Windows 10 #0-0] red expected foo to equal bar
 [loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] Check out job at https://app.eu-central-1.saucelabs.com/tests/ba86cbcb70774ef8a0757c1702c3bdf9
+[loremipsum 50 Windows 10 #0-0] Check out job at https://app.eu-central-1.saucelabs.com/tests/ba86cbcb70774ef8a0757c1702c3bdf9?auth=364414eae3ee11cb8b8bb3fc3e3b5e12
 ",
   ],
 ]
@@ -203,7 +206,7 @@ Array [
 [loremipsum 50 Windows 10 #0-0] 2) Bar test a failed test with no stack
 [loremipsum 50 Windows 10 #0-0] red expected foo to equal bar
 [loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] Check out job at https://app.eu-central-1.saucelabs.com/tests/ba86cbcb70774ef8a0757c1702c3bdf9
+[loremipsum 50 Windows 10 #0-0] Check out job at https://app.eu-central-1.saucelabs.com/tests/ba86cbcb70774ef8a0757c1702c3bdf9?auth=364414eae3ee11cb8b8bb3fc3e3b5e12
 ",
   ],
   Array [
@@ -236,7 +239,7 @@ Array [
 [loremipsum 50 Windows 10 #0-0] 2) Bar test a failed test with no stack
 [loremipsum 50 Windows 10 #0-0] red expected foo to equal bar
 [loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] Check out job at https://app.us-east-1.saucelabs.com/tests/ba86cbcb70774ef8a0757c1702c3bdf9
+[loremipsum 50 Windows 10 #0-0] Check out job at https://app.us-east-1.saucelabs.com/tests/ba86cbcb70774ef8a0757c1702c3bdf9?auth=364414eae3ee11cb8b8bb3fc3e3b5e12
 ",
   ],
 ]
@@ -274,7 +277,7 @@ Array [
 [loremipsum 50 Windows 10 #0-0] 2) Bar test a failed test with no stack
 [loremipsum 50 Windows 10 #0-0] red expected foo to equal bar
 [loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] Check out job at https://app.saucelabs.com/tests/ba86cbcb70774ef8a0757c1702c3bdf9
+[loremipsum 50 Windows 10 #0-0] Check out job at https://app.saucelabs.com/tests/ba86cbcb70774ef8a0757c1702c3bdf9?auth=364414eae3ee11cb8b8bb3fc3e3b5e12
 ",
   ],
 ]
@@ -312,7 +315,7 @@ Array [
 [loremipsum 50 Windows 10 #0-0] 2) Bar test a failed test with no stack
 [loremipsum 50 Windows 10 #0-0] red expected foo to equal bar
 [loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] Check out job at https://app.saucelabs.com/tests/ba86cbcb70774ef8a0757c1702c3bdf9
+[loremipsum 50 Windows 10 #0-0] Check out job at https://app.saucelabs.com/tests/ba86cbcb70774ef8a0757c1702c3bdf9?auth=df58c8ddea836c98710dbb1119625de8
 ",
   ],
 ]
@@ -350,7 +353,7 @@ Array [
 [loremipsum 50 Windows 10 #0-0] 2) Bar test a failed test with no stack
 [loremipsum 50 Windows 10 #0-0] red expected foo to equal bar
 [loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] Check out job at https://app.saucelabs.com/tests/ba86cbcb70774ef8a0757c1702c3bdf9
+[loremipsum 50 Windows 10 #0-0] Check out job at https://app.saucelabs.com/tests/ba86cbcb70774ef8a0757c1702c3bdf9?auth=df58c8ddea836c98710dbb1119625de8
 ",
   ],
 ]

--- a/packages/wdio-spec-reporter/tests/index.test.ts
+++ b/packages/wdio-spec-reporter/tests/index.test.ts
@@ -15,9 +15,7 @@ const defaultCaps = { browserName: 'loremipsum', version: 50, platform: 'Windows
 const fakeSessionId = 'ba86cbcb70774ef8a0757c1702c3bdf9'
 const getRunnerConfig = (config: any = {}) => {
     return Object.assign({}, RUNNER, {
-        capabilities: config.isMultiremote
-            ? { myBrowser: config.capabilities || defaultCaps }
-            : config.capabilities || defaultCaps,
+        capabilities: config.capabilities || defaultCaps,
         config,
         sessionId: fakeSessionId,
         isMultiremote: Boolean(config.isMultiremote)
@@ -161,7 +159,9 @@ describe('SpecReporter', () => {
 
             it('should print link to Sauce Labs job details page', () => {
                 const runner = getRunnerConfig({
-                    hostname: 'ondemand.saucelabs.com'
+                    hostname: 'ondemand.saucelabs.com',
+                    user: 'foobar',
+                    key: '123',
                 })
                 printReporter.printReport(runner)
                 expect(printReporter.write.mock.calls).toMatchSnapshot()
@@ -170,6 +170,8 @@ describe('SpecReporter', () => {
             it('should print jobs of all instance when run with multiremote', () => {
                 const runner = getRunnerConfig({
                     hostname: 'ondemand.saucelabs.com',
+                    user: 'foobar',
+                    key: '123',
                     capabilities: {
                         browserA: { sessionId: 'foobar' },
                         browserB: { sessionId: 'barfoo' }
@@ -207,6 +209,8 @@ describe('SpecReporter', () => {
             it('should print link to Sauce Labs EU job details page', () => {
                 printReporter.printReport(getRunnerConfig({
                     hostname: 'ondemand.saucelabs.com',
+                    user: 'foobar',
+                    key: '123',
                     region: 'eu'
                 }))
                 expect(printReporter.write.mock.calls).toMatchSnapshot()
@@ -215,15 +219,44 @@ describe('SpecReporter', () => {
 
                 printReporter.printReport(getRunnerConfig({
                     hostname: 'ondemand.saucelabs.com',
+                    user: 'foobar',
+                    key: '123',
                     region: 'eu-central-1'
                 }))
                 expect(printReporter.write.mock.calls).toMatchSnapshot()
 
                 printReporter.printReport(getRunnerConfig({
                     hostname: 'ondemand.saucelabs.com',
+                    user: 'foobar',
+                    key: '123',
                     headless: true
                 }))
                 expect(printReporter.write.mock.calls).toMatchSnapshot()
+            })
+        })
+
+        describe('with disabled sharable Sauce report links', ()=>{
+            const options = { sauceLabsSharableLinks: false }
+            beforeEach(() => {
+                tmpReporter = new SpecReporter(options)
+                tmpReporter.suiteUids = SUITE_UIDS
+                tmpReporter.suites = SUITES
+                tmpReporter.stateCounts = {
+                    passed : 4,
+                    failed : 1,
+                    skipped : 1,
+                }
+                tmpReporter.write = jest.fn()
+            })
+
+            it('should print the default Sauce Labs job details page link', () => {
+                const runner = getRunnerConfig({
+                    hostname: 'ondemand.saucelabs.com',
+                    user: 'foobar',
+                    key: '123',
+                })
+                tmpReporter.printReport(runner)
+                expect(tmpReporter.write.mock.calls).toMatchSnapshot()
             })
         })
 
@@ -262,11 +295,17 @@ describe('SpecReporter', () => {
 
         it('should validate header output in multiremote', () => {
             const result = tmpReporter.getHeaderDisplay(
-                getRunnerConfig({ isMultiremote: true }))
+                getRunnerConfig({
+                    capabilities: {
+                        browserA: { browserName: 'chrome' },
+                        browserB: { browserName: 'firefox' }
+                    },
+                    isMultiremote: true,
+                }))
 
             expect(result.length).toBe(2)
             expect(result[0]).toBe('Spec: /foo/bar/baz.js')
-            expect(result[1]).toBe('Running: MultiremoteBrowser on loremipsum')
+            expect(result[1]).toBe('Running: MultiremoteBrowser on chrome, firefox')
         })
     })
 

--- a/packages/wdio-spec-reporter/tests/index.test.ts
+++ b/packages/wdio-spec-reporter/tests/index.test.ts
@@ -188,7 +188,10 @@ describe('SpecReporter', () => {
                         ...defaultCaps,
                         'sauce:options': 'foobar'
                     },
-                    hostname: 'localhost'
+                    hostname: 'ondemand.saucelabs.com',
+                    user: 'foobar',
+                    key: '123',
+                    sessionId: fakeSessionId
                 })
                 printReporter.printReport(runner)
                 expect(printReporter.write.mock.calls).toMatchSnapshot()
@@ -200,7 +203,10 @@ describe('SpecReporter', () => {
                         tunnelIdentifier: 'foobar',
                         ...defaultCaps
                     },
-                    hostname: 'localhost'
+                    hostname: 'ondemand.saucelabs.com',
+                    user: 'foobar',
+                    key: '123',
+                    sessionId: fakeSessionId
                 })
                 printReporter.printReport(runner)
                 expect(printReporter.write.mock.calls).toMatchSnapshot()


### PR DESCRIPTION
## Proposed changes

By default Sauce Labs is providing a report link which can only be viewed by a team member. This PR enables a sharable link so the reports can be seen by all teams.
This PR also fixes the multiRemote UT's that were not validating proper outcomes

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments
I had some challenges with TypeScript. Example

According to the types `user`, `key`,  `sessionId` can be option on the `config`
I use them all in the `getTestLink`
Then I get this
![image](https://user-images.githubusercontent.com/11979740/107123680-284a9f80-689f-11eb-94f7-3510ecfc3d9d.png)

I _fixed_ it by casting the props.

