### PR TITLE
wdio-allure-reporter: Prevent errors when mocha hooks are called with undefined as title

### DIFF
--- a/packages/wdio-allure-reporter/src/utils.js
+++ b/packages/wdio-allure-reporter/src/utils.js
@@ -44,7 +44,7 @@ export const isEmpty = (object) => !object || Object.keys(object).length === 0
  * @returns {boolean}
  * @private
  */
-export const isMochaEachHooks = title => mochaEachHooks.some(hook => title.includes(hook))
+export const isMochaEachHooks = title => mochaEachHooks.some(hook => typeof title === 'string' && title.includes(hook))
 
 /**
  * Is mocha beforeAll / afterAll hook
@@ -52,7 +52,7 @@ export const isMochaEachHooks = title => mochaEachHooks.some(hook => title.inclu
  * @returns {boolean}
  * @private
  */
-export const isMochaAllHooks = title => mochaAllHooks.some(hook => title.includes(hook))
+export const isMochaAllHooks = title => mochaAllHooks.some(hook => typeof title === 'string' && title.includes(hook))
 
 /**
  * Call reporter


### PR DESCRIPTION
This is necessary as otherwise the following error was occuring:

```
2021-02-15T11:53:41.988Z ERROR @wdio/runner: TypeError: Cannot read property 'includes' of undefined
    at /Users/rickschubert/Documents/github/app/e2e/cucumber-browser-tests/node_modules/@wdio/allure-reporter/build/utils.js:48:85
    at Array.some (<anonymous>)
    at Object.exports.isMochaEachHooks (/Users/rickschubert/Documents/github/app/e2e/cucumber-browser-tests/node_modules/@wdio/allure-reporter/build/utils.js:48:66)
    at AllureReporter.onHookStart (/Users/rickschubert/Documents/github/app/e2e/cucumber-browser-tests/node_modules/@wdio/allure-reporter/build/index.js:237:56)
    at AllureReporter.<anonymous> (/Users/rickschubert/Documents/github/app/e2e/cucumber-browser-tests/node_modules/@wdio/allure-reporter/node_modules/@wdio/reporter/build/index.js:72:18)
    at AllureReporter.emit (events.js:311:20)
    at AllureReporter.EventEmitter.emit (domain.js:482:12)
    at /Users/rickschubert/Documents/github/app/e2e/cucumber-browser-tests/node_modules/@wdio/runner/build/reporter.js:36:56
    at Array.forEach (<anonymous>)
    at BaseReporter.emit (/Users/rickschubert/Documents/github/app/e2e/cucumber-browser-tests/node_modules/@wdio/runner/build/reporter.js:36:25)
    at CucumberReporter.emit (/Users/rickschubert/Documents/github/app/e2e/cucumber-browser-tests/node_modules/@wdio/cucumber-framework/build/reporter.js:194:24)
    at CucumberReporter.handleBeforeStep (/Users/rickschubert/Documents/github/app/e2e/cucumber-browser-tests/node_modules/@wdio/cucumber-framework/build/reporter.js:57:14)
    at CucumberEventListener.emit (events.js:311:20)
    at CucumberEventListener.EventEmitter.emit (domain.js:482:12)
    at CucumberEventListener.onTestStepStarted (/Users/rickschubert/Documents/github/app/e2e/cucumber-browser-tests/node_modules/@wdio/cucumber-framework/build/cucumberEventListener.js:280:14)
    at EventEmitter.<anonymous> (/Users/rickschubert/Documents/github/app/e2e/cucumber-browser-tests/node_modules/@wdio/cucumber-framework/build/cucumberEventListener.js:40:22)
```

A similar error occurred with the `isMochaAllHooks` but I cannot provide a stack trace at the moment.

