### PR TITLE
Ensure that 'title' property is passed down by cucumber framework to reporters

### DIFF
--- a/packages/wdio-cucumber-framework/src/utils.ts
+++ b/packages/wdio-cucumber-framework/src/utils.ts
@@ -88,13 +88,6 @@ export function getFeatureId (uri: string, feature: messages.GherkinDocument.IFe
     return `${path.basename(uri)}:${feature.location?.line}:${feature.location?.column}`
 }
 
-function createStepTitle(step: ExtendedPickleStep): string {
-    if (isStepTypeHook(step)) {
-        return `hook-${step.hookId}`
-    }
-    return step.text
-}
-
 /**
  * build payload for test/hook event
  */
@@ -102,7 +95,7 @@ export function buildStepPayload(
     uri: string,
     feature: messages.GherkinDocument.IFeature,
     scenario: messages.IPickle,
-    step: messages.Pickle.IPickleStep,
+    step: ExtendedPickleStep,
     params: {
         type: string
         state?: messages.TestStepFinished.TestStepResult.Status | string | null
@@ -115,7 +108,7 @@ export function buildStepPayload(
 ) {
     return {
         uid: step.id,
-        title: createStepTitle(step),
+        title: isStepTypeHook(step) ? `hook-${step.hookId}` : step.text,
         parent: scenario.id,
         argument: createStepArgument(step),
         file: uri,

--- a/packages/wdio-cucumber-framework/src/utils.ts
+++ b/packages/wdio-cucumber-framework/src/utils.ts
@@ -64,15 +64,20 @@ export function formatMessage ({ payload = {} }: any) {
 }
 
 function isStepTypeHook(step: messages.TestCase.ITestStep): boolean {
-    return step.hookId !== undefined && step.hookId !== null && step.hookId !== false
+    return step.hookId !== undefined && step.hookId !== null
+}
+
+enum StepType {
+    hook = 'hook',
+    test = 'test'
 }
 
 /**
  * Get step type
  * @param {string} type `Step` or `Hook`
  */
-export function getStepType (step: messages.TestCase.ITestStep) {
-    return isStepTypeHook(step) ? 'hook' : 'test'
+export function getStepType (step: messages.TestCase.ITestStep): StepType[keyof StepType] {
+    return isStepTypeHook(step) ? StepType.hook : StepType.test
 }
 
 export function getFeatureId (uri: string, feature: messages.GherkinDocument.IFeature) {

--- a/packages/wdio-cucumber-framework/src/utils.ts
+++ b/packages/wdio-cucumber-framework/src/utils.ts
@@ -63,17 +63,9 @@ export function formatMessage ({ payload = {} }: any) {
     return content
 }
 
-function isStepTypeHook(step: messages.TestCase.ITestStep): boolean {
-    return step.hookId !== undefined && step.hookId !== null
-}
-
 enum StepType {
     hook = 'hook',
     test = 'test'
-}
-
-interface ExtendedPickleStep extends messages.Pickle.IPickleStep {
-    hookId?: string | null
 }
 
 /**
@@ -81,7 +73,7 @@ interface ExtendedPickleStep extends messages.Pickle.IPickleStep {
  * @param {string} type `Step` or `Hook`
  */
 export function getStepType (step: messages.TestCase.ITestStep): StepType[keyof StepType] {
-    return isStepTypeHook(step) ? StepType.hook : StepType.test
+    return step.hookId ? StepType.hook : StepType.test
 }
 
 export function getFeatureId (uri: string, feature: messages.GherkinDocument.IFeature) {
@@ -95,7 +87,7 @@ export function buildStepPayload(
     uri: string,
     feature: messages.GherkinDocument.IFeature,
     scenario: messages.IPickle,
-    step: ExtendedPickleStep,
+    step: messages.Pickle.IPickleStep,
     params: {
         type: string
         state?: messages.TestStepFinished.TestStepResult.Status | string | null
@@ -108,7 +100,7 @@ export function buildStepPayload(
 ) {
     return {
         uid: step.id,
-        title: isStepTypeHook(step) ? 'Hook' : step.text,
+        title: step.text || 'Hook',
         parent: scenario.id,
         argument: createStepArgument(step),
         file: uri,
@@ -121,7 +113,8 @@ export function buildStepPayload(
 }
 
 /**
- * wrap every user defined hook with function named `userHookFn`
+ * wrap ever
+ * y user defined hook with function named `userHookFn`
  * to identify later on is function a step, user hook or wdio hook.
  * @param {object} options `Cucumber.supportCodeLibraryBuilder.options`
  */

--- a/packages/wdio-cucumber-framework/src/utils.ts
+++ b/packages/wdio-cucumber-framework/src/utils.ts
@@ -108,7 +108,7 @@ export function buildStepPayload(
 ) {
     return {
         uid: step.id,
-        title: isStepTypeHook(step) ? `hook-${step.hookId}` : step.text,
+        title: isStepTypeHook(step) ? 'Hook' : step.text,
         parent: scenario.id,
         argument: createStepArgument(step),
         file: uri,

--- a/packages/wdio-cucumber-framework/src/utils.ts
+++ b/packages/wdio-cucumber-framework/src/utils.ts
@@ -113,8 +113,7 @@ export function buildStepPayload(
 }
 
 /**
- * wrap ever
- * y user defined hook with function named `userHookFn`
+ * wrap every user defined hook with function named `userHookFn`
  * to identify later on is function a step, user hook or wdio hook.
  * @param {object} options `Cucumber.supportCodeLibraryBuilder.options`
  */

--- a/packages/wdio-cucumber-framework/src/utils.ts
+++ b/packages/wdio-cucumber-framework/src/utils.ts
@@ -72,6 +72,10 @@ enum StepType {
     test = 'test'
 }
 
+interface ExtendedPickleStep extends messages.Pickle.IPickleStep {
+    hookId?: string | null
+}
+
 /**
  * Get step type
  * @param {string} type `Step` or `Hook`
@@ -84,7 +88,7 @@ export function getFeatureId (uri: string, feature: messages.GherkinDocument.IFe
     return `${path.basename(uri)}:${feature.location?.line}:${feature.location?.column}`
 }
 
-function createStepTitle(step: messages.Pickle.IPickleStep): string {
+function createStepTitle(step: ExtendedPickleStep): string {
     if (isStepTypeHook(step)) {
         return `hook-${step.hookId}`
     }

--- a/packages/wdio-cucumber-framework/src/utils.ts
+++ b/packages/wdio-cucumber-framework/src/utils.ts
@@ -63,16 +63,27 @@ export function formatMessage ({ payload = {} }: any) {
     return content
 }
 
+function isStepTypeHook(step: messages.TestCase.ITestStep): boolean {
+    return step.hookId !== undefined && step.hookId !== null && step.hookId !== false
+}
+
 /**
  * Get step type
  * @param {string} type `Step` or `Hook`
  */
 export function getStepType (step: messages.TestCase.ITestStep) {
-    return step.hookId ? 'hook' : 'test'
+    return isStepTypeHook(step) ? 'hook' : 'test'
 }
 
 export function getFeatureId (uri: string, feature: messages.GherkinDocument.IFeature) {
     return `${path.basename(uri)}:${feature.location?.line}:${feature.location?.column}`
+}
+
+function createStepTitle(step: messages.Pickle.IPickleStep): string {
+    if (isStepTypeHook(step)) {
+        return `hook-${step.hookId}`
+    }
+    return step.text
 }
 
 /**
@@ -95,7 +106,7 @@ export function buildStepPayload(
 ) {
     return {
         uid: step.id,
-        title: step.text,
+        title: createStepTitle(step),
         parent: scenario.id,
         argument: createStepArgument(step),
         file: uri,

--- a/packages/wdio-cucumber-framework/tests/__snapshots__/reporter.test.ts.snap
+++ b/packages/wdio-cucumber-framework/tests/__snapshots__/reporter.test.ts.snap
@@ -10,7 +10,7 @@ Array [
       "error": undefined,
       "featureName": "Example feature",
       "file": "/some/path/to/features/my-feature.feature",
-      "fullTitle": "0: hook-21",
+      "fullTitle": "0: Hook",
       "parent": "0",
       "scenarioName": "Get size of an element",
       "specs": Array [
@@ -39,7 +39,7 @@ Array [
           "name": "@scenario-tag2",
         },
       ],
-      "title": "hook-21",
+      "title": "Hook",
       "type": "hook",
       "uid": "24",
     },

--- a/packages/wdio-cucumber-framework/tests/__snapshots__/reporter.test.ts.snap
+++ b/packages/wdio-cucumber-framework/tests/__snapshots__/reporter.test.ts.snap
@@ -10,6 +10,7 @@ Array [
       "error": undefined,
       "featureName": "Example feature",
       "file": "/some/path/to/features/my-feature.feature",
+      "fullTitle": "0: hook-21",
       "parent": "0",
       "scenarioName": "Get size of an element",
       "specs": Array [
@@ -38,7 +39,7 @@ Array [
           "name": "@scenario-tag2",
         },
       ],
-      "title": undefined,
+      "title": "hook-21",
       "type": "hook",
       "uid": "24",
     },

--- a/packages/wdio-cucumber-framework/tests/utils.test.ts
+++ b/packages/wdio-cucumber-framework/tests/utils.test.ts
@@ -103,7 +103,7 @@ describe('utils', () => {
             hookId: '728'
         }
         const params = { type: 'hook' }
-        expect(buildStepPayload(uri, feature, scenario, step, params).title).toBe(`hook-${step.hookId}`)
+        expect(buildStepPayload(uri, feature, scenario, step, params).title).toBe('Hook')
     })
 
     it('buildStepPayload creates a title property if called in a step context', () => {

--- a/packages/wdio-cucumber-framework/tests/utils.test.ts
+++ b/packages/wdio-cucumber-framework/tests/utils.test.ts
@@ -112,7 +112,7 @@ describe('utils', () => {
         const scenario = {}
         const stepTitle = 'I do some things'
         const step = {
-            astNodeIds: [ '23' ],
+            astNodeIds: ['23'],
             id: '51',
             text: stepTitle
         }

--- a/packages/wdio-cucumber-framework/tests/utils.test.ts
+++ b/packages/wdio-cucumber-framework/tests/utils.test.ts
@@ -92,6 +92,34 @@ describe('utils', () => {
         }, { type: 'hook' })).toMatchSnapshot()
     })
 
+    it('buildStepPayload creates a title property if called in a hook context', () => {
+        const uri = '/long/path/to/file.feature'
+        const feature = {}
+        const scenario = {}
+        const step = {
+            stepDefinitionIds: [],
+            stepMatchArgumentsLists: [],
+            id: '731',
+            hookId: '728'
+        }
+        const params = { type: 'hook' }
+        expect(buildStepPayload(uri, feature, scenario, step, params).title).toBe(`hook-${step.hookId}`)
+    })
+
+    it('buildStepPayload creates a title property if called in a step context', () => {
+        const uri = '/long/path/to/file.feature'
+        const feature = {}
+        const scenario = {}
+        const stepTitle = 'I do some things'
+        const step = {
+            astNodeIds: [ '23' ],
+            id: '51',
+            text: stepTitle
+        }
+        const params = { type: 'test' }
+        expect(buildStepPayload(uri, feature, scenario, step, params).title).toBe(stepTitle)
+    })
+
     it('setUserHookNames', () => {
         const options = {
             beforeTestRunHookDefinitionConfigs: [{ code: function wdioHookFoo () { } }, { code: async function someHookFoo () { } }, { code: () => { } }],


### PR DESCRIPTION
This resolves the problem which was reported earlier at #6438 . The problem was that the cucumber-framework did create an undefined `title` property for hooks as these do not possess a `step.text` property.