### PR TITLE
fixed typo in the wdio exec command

### DIFF
--- a/website/docs/GettingStarted.md
+++ b/website/docs/GettingStarted.md
@@ -36,19 +36,19 @@ This will prompt a set questions that guides you through the setup. You can pass
 You can start your test suite by using the `run` command and pointing to the WebdriverIO config that you just created:
 
 ```bash
-npx wdio run ./wdio.config.js
+npx wdio run ./wdio.conf.js
 ```
 
 If you like to run specific test files you can add a `--spec` parameter:
 
 ```bash
-npx wdio run ./wdio.config.js --spec checkout.e2e.js
+npx wdio run ./wdio.conf.js --spec example.e2e.js
 ```
 
 or define suites in your config file and run just the test files defined by in a suite:
 
 ```bash
-npx wdio run ./wdio.config.js --suite checkoutflow
+npx wdio run ./wdio.conf.js --suite exampleSuiteName
 ```
 
 ## Run in a script


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

This PR fixes a typo of getting started page in website. In the auto generated project, we create the config file as `wdio.conf.js` but doc says `wdio.config.js`

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
