### PR TITLE
chore: remove obsolete puppeteer types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3645,24 +3645,6 @@
       "integrity": "sha512-DxZZbyMAM9GWEzXL+BMZROWz9oo6A9EilwwOMET2UVu2uZTqMWS5S69KVtuVKaRjCUpcrOXRalet86/OpG4kqw==",
       "dev": true
     },
-    "@types/puppeteer": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/@types/puppeteer/-/puppeteer-5.4.3.tgz",
-      "integrity": "sha512-3nE8YgR9DIsgttLW+eJf6mnXxq8Ge+27m5SU3knWmrlfl6+KOG0Bf9f7Ua7K+C4BnaTMAh3/UpySqdAYvrsvjg==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
-    "@types/puppeteer-core": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@types/puppeteer-core/-/puppeteer-core-5.4.0.tgz",
-      "integrity": "sha512-yqRPuv4EFcSkTyin6Yy17pN6Qz2vwVwTCJIDYMXbE3j8vTPhv0nCQlZOl5xfi0WHUkqvQsjAR8hAfjeMCoetwg==",
-      "dev": true,
-      "requires": {
-        "@types/puppeteer": "*"
-      }
-    },
     "@types/stack-utils": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "@types/lodash.merge": "^4.6.6",
     "@types/lodash.zip": "^4.2.6",
     "@types/node": "^14.14.13",
-    "@types/puppeteer-core": "^5.4.0",
     "@types/tmp": "^0.2.0",
     "@types/ua-parser-js": "^0.7.35",
     "@types/uuid": "^8.3.0",

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -34,7 +34,6 @@
     "uuid": "^8.0.0"
   },
   "devDependencies": {
-    "@types/puppeteer-core": "^2.0.0",
     "@types/ua-parser-js": "^0.7.33",
     "@types/uuid": "^8.3.0"
   }

--- a/packages/wdio-devtools-service/package.json
+++ b/packages/wdio-devtools-service/package.json
@@ -28,7 +28,6 @@
   "dependencies": {
     "@babel/core": "^7.12.10",
     "@tracerbench/trace-event": "^5.1.0",
-    "@types/puppeteer-core": "^2.0.0",
     "@wdio/logger": "7.0.0",
     "@wdio/types": "7.0.4",
     "atob": "^2.1.2",

--- a/packages/webdriverio/package.json
+++ b/packages/webdriverio/package.json
@@ -56,7 +56,6 @@
     "@types/lodash.zip": "^4.2.6"
   },
   "dependencies": {
-    "@types/puppeteer-core": "^5.4.0",
     "@wdio/config": "7.0.4",
     "@wdio/logger": "7.0.0",
     "@wdio/protocols": "7.0.0",


### PR DESCRIPTION
## Proposed changes

Removed no longer needed `@types/puppeteer-core` as the new version updated by #6436 provides types out of the box.
## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

This is an internal change which should not affect consumers and IMO can be considered a patch release.

### Reviewers: @webdriverio/project-committers
