### PR TITLE
Rename `jasmineNodeOpts` into `jasmineOpts`

### DIFF
--- a/examples/wdio.conf.js
+++ b/examples/wdio.conf.js
@@ -146,8 +146,8 @@ exports.config = {
     },
     //
     // Options to be passed to Jasmine.
-    // See also: https://github.com/webdriverio/webdriverio/tree/main/packages/wdio-jasmine-framework#jasminenodeopts-options
-    jasmineNodeOpts: {
+    // See also: https://github.com/webdriverio/webdriverio/tree/main/packages/wdio-jasmine-framework#jasmineopts-options
+    jasmineOpts: {
         //
         // Jasmine default timeout
         defaultTimeoutInterval: 5000,

--- a/examples/wdio/jasmine/wdio.conf.js
+++ b/examples/wdio/jasmine/wdio.conf.js
@@ -30,7 +30,7 @@ exports.config = {
 
     reporters: ['spec'],
 
-    jasmineNodeOpts: {
+    jasmineOpts: {
         defaultTimeoutInterval: 1000 * 60 * 3
     },
 

--- a/packages/wdio-cli/src/commands/repl.ts
+++ b/packages/wdio-cli/src/commands/repl.ts
@@ -9,7 +9,7 @@ import yargs from 'yargs'
 
 const IGNORED_ARGS = [
     'bail', 'framework', 'reporters', 'suite', 'spec', 'exclude',
-    'mochaOpts', 'jasmineNodeOpts', 'cucumberOpts', 'autoCompileOpts'
+    'mochaOpts', 'jasmineOpts', 'cucumberOpts', 'autoCompileOpts'
 ]
 
 export const command = 'repl <option> [capabilities]'

--- a/packages/wdio-cli/src/commands/run.ts
+++ b/packages/wdio-cli/src/commands/run.ts
@@ -85,7 +85,7 @@ export const cmdArgs = {
     mochaOpts: {
         desc: 'Mocha options'
     },
-    jasmineNodeOpts: {
+    jasmineOpts: {
         desc: 'Jasmine options'
     },
     cucumberOpts: {

--- a/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
+++ b/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
@@ -191,7 +191,7 @@ exports.config = {
     if(answers.framework === 'jasmine') { %>
     //
     // Options to be passed to Jasmine.
-    jasmineNodeOpts: {
+    jasmineOpts: {
         <% if(answers.isUsingBabel) {
         %>// Babel setup
         helpers: [require.resolve('@babel/register')],

--- a/packages/wdio-cli/src/types.ts
+++ b/packages/wdio-cli/src/types.ts
@@ -65,7 +65,7 @@ export interface RunCommandArguments {
     spec?: string[]
     exclude?: string[]
     mochaOpts?: any
-    jasmineNodeOpts?: any
+    jasmineOpts?: any
     cucumberOpts?: any
     autoCompileOpts?: any
     configPath: string

--- a/packages/wdio-config/src/constants.ts
+++ b/packages/wdio-config/src/constants.ts
@@ -39,7 +39,7 @@ export const DEFAULT_CONFIGS: () => Omit<Options.Testrunner, 'capabilities'> = (
     mochaOpts: {
         timeout: DEFAULT_TIMEOUT
     },
-    jasmineNodeOpts: {
+    jasmineOpts: {
         defaultTimeoutInterval: DEFAULT_TIMEOUT
     },
     cucumberOpts: {

--- a/packages/wdio-jasmine-framework/README.md
+++ b/packages/wdio-jasmine-framework/README.md
@@ -32,14 +32,14 @@ Following code shows the default wdio test runner configuration...
 module.exports = {
   // ...
   framework: 'jasmine'
-  jasmineNodeOpts: {
+  jasmineOpts: {
     defaultTimeoutInterval: 10000
   }
   // ...
 };
 ```
 
-## `jasmineNodeOpts` Options
+## `jasmineOpts` Options
 
 ### defaultTimeoutInterval
 Timeout until specs will be marked as failed.

--- a/packages/wdio-jasmine-framework/src/types.ts
+++ b/packages/wdio-jasmine-framework/src/types.ts
@@ -53,7 +53,7 @@ export interface FormattedMessage {
     errors?: jasmine.FailedExpectation[]
 }
 
-export interface JasmineNodeOpts {
+export interface JasmineOpts {
     /**
      * Default Timeout Interval for Jasmine operations.
      * @default 60000

--- a/packages/wdio-jasmine-framework/tests/adapter.test.ts
+++ b/packages/wdio-jasmine-framework/tests/adapter.test.ts
@@ -142,7 +142,7 @@ test('should properly configure the jasmine environment', async () => {
     const seed = false
 
     const adapter = adapterFactory({
-        jasmineNodeOpts: {
+        jasmineOpts: {
             stopOnSpecFailure,
             stopSpecOnExpectationFailure,
             random,
@@ -165,7 +165,7 @@ test('should properly configure the jasmine environment', async () => {
 
 test('set custom ', async () => {
     const config = {
-        jasmineNodeOpts: { expectationResultHandler: jest.fn() },
+        jasmineOpts: { expectationResultHandler: jest.fn() },
         beforeHook: [],
         afterHook: []
     }
@@ -173,7 +173,7 @@ test('set custom ', async () => {
     await adapter.init()
     await adapter.run()
     adapter['_jrunner']!.jasmine.Spec.prototype.addExpectationResult('foobar')
-    expect(config.jasmineNodeOpts.expectationResultHandler).toBeCalledWith('foobar', undefined)
+    expect(config.jasmineOpts.expectationResultHandler).toBeCalledWith('foobar', undefined)
 })
 
 test('get data from beforeAll hook', async () => {
@@ -217,23 +217,23 @@ test('customSpecFilter', () => {
         pend: jest.fn()
     } as any
     const config = {
-        jasmineNodeOpts: { grepMatch: '@smoke' }
+        jasmineOpts: { grepMatch: '@smoke' }
     }
     const adapter = adapterFactory(config)
 
     expect(adapter.customSpecFilter(specMock)).toBe(true)
     expect(specMock.pend.mock.calls).toHaveLength(0)
 
-    adapter['_jasmineNodeOpts'].grep = '@random'
+    adapter['_jasmineOpts'].grep = '@random'
     expect(adapter.customSpecFilter(specMock)).toBe(false)
     expect(specMock.pend.mock.calls).toHaveLength(1)
 
-    adapter['_jasmineNodeOpts'].invertGrep = true
+    adapter['_jasmineOpts'].invertGrep = true
     expect(adapter.customSpecFilter(specMock)).toBe(true)
     expect(specMock.pend.mock.calls).toHaveLength(1)
 
-    adapter['_jasmineNodeOpts'].grep = '@smoke'
-    adapter['_jasmineNodeOpts'].invertGrep = true
+    adapter['_jasmineOpts'].grep = '@smoke'
+    adapter['_jasmineOpts'].invertGrep = true
     expect(adapter.customSpecFilter(specMock)).toBe(false)
     expect(specMock.pend.mock.calls).toHaveLength(2)
 })
@@ -329,7 +329,7 @@ test('formatMessage should pass all failedExpectations as errors', () => {
 
 test('getExpectationResultHandler returns origHandler if none is given', () => {
     const jasmine = { Spec: { prototype: { addExpectationResult: 'foobar' } } }
-    const config = { jasmineNodeOpts: {} }
+    const config = { jasmineOpts: {} }
     const adapter = adapterFactory(config)
 
     adapter.expectationResultHandler = jest.fn().mockImplementation(() => 'barfoo')
@@ -339,7 +339,7 @@ test('getExpectationResultHandler returns origHandler if none is given', () => {
 
 test('getExpectationResultHandler returns modified origHandler if expectationResultHandler is given', () => {
     const jasmine = { Spec: { prototype: { addExpectationResult: 'foobar' } } }
-    const config = { jasmineNodeOpts: { expectationResultHandler: jest.fn() } }
+    const config = { jasmineOpts: { expectationResultHandler: jest.fn() } }
     const adapter = adapterFactory(config)
 
     adapter.expectationResultHandler = jest.fn().mockImplementation(() => 'barfoo')
@@ -350,20 +350,20 @@ test('getExpectationResultHandler returns modified origHandler if expectationRes
 
 test('expectationResultHandler', () => {
     const origHandler = jest.fn()
-    const config = { jasmineNodeOpts: { expectationResultHandler: jest.fn() } }
+    const config = { jasmineOpts: { expectationResultHandler: jest.fn() } }
     const adapter = adapterFactory(config)
 
     const resultHandler = adapter.expectationResultHandler(origHandler)
     // @ts-ignore mock feature
     resultHandler(true, 'foobar')
-    expect(config.jasmineNodeOpts.expectationResultHandler).toBeCalledWith(true, 'foobar')
+    expect(config.jasmineOpts.expectationResultHandler).toBeCalledWith(true, 'foobar')
     expect(origHandler).toBeCalledWith(true, 'foobar')
 })
 
 test('expectationResultHandler failing', () => {
     const origHandler = jest.fn()
     const err = new Error('uuups')
-    const config = { jasmineNodeOpts: { expectationResultHandler: () => {
+    const config = { jasmineOpts: { expectationResultHandler: () => {
         throw err
     } } }
     const adapter = adapterFactory(config)
@@ -383,7 +383,7 @@ test('expectationResultHandler failing', () => {
 
 test('expectationResultHandler failing with failing test', () => {
     const origHandler = jest.fn()
-    const config = { jasmineNodeOpts: { expectationResultHandler: () => {
+    const config = { jasmineOpts: { expectationResultHandler: () => {
         throw new Error('uuups')
     } } }
     const adapter = adapterFactory(config)
@@ -465,8 +465,8 @@ describe('loadFiles', () => {
         // @ts-ignore test scenario
         delete adapter['_hasTests']
         adapter['_jrunner'] = {} as any
-        adapter['_jasmineNodeOpts'].requires = ['r']
-        adapter['_jasmineNodeOpts'].helpers = ['h']
+        adapter['_jasmineOpts'].requires = ['r']
+        adapter['_jasmineOpts'].helpers = ['h']
         // @ts-ignore outdated types
         adapter['_jrunner']!.addRequires = jest.fn()
         // @ts-ignore outdated types
@@ -481,9 +481,9 @@ describe('loadFiles', () => {
         adapter._loadFiles()
 
         // @ts-ignore outdated types
-        expect(adapter['_jrunner']!.addRequires).toHaveBeenCalledWith(adapter['_jasmineNodeOpts'].requires)
+        expect(adapter['_jrunner']!.addRequires).toHaveBeenCalledWith(adapter['_jasmineOpts'].requires)
         // @ts-ignore outdated types
-        expect(adapter['_jrunner']!.addHelperFiles).toHaveBeenCalledWith(adapter['_jasmineNodeOpts'].helpers)
+        expect(adapter['_jrunner']!.addHelperFiles).toHaveBeenCalledWith(adapter['_jasmineOpts'].helpers)
         expect(adapter['_hasTests']).toBe(false)
     })
 

--- a/packages/wdio-junit-reporter/tests/__fixtures__/cucumber-runner-browserstack-android-missing-os.json
+++ b/packages/wdio-junit-reporter/tests/__fixtures__/cucumber-runner-browserstack-android-missing-os.json
@@ -81,7 +81,7 @@
             "tagExpression": "@run",
             "ignoreUndefinedDefinitions": false
         },
-        "jasmineNodeOpts": {
+        "jasmineOpts": {
             "defaultTimeoutInterval": 10000
         },
         "before": [],

--- a/packages/wdio-junit-reporter/tests/__fixtures__/cucumber-runner-browserstack-android.json
+++ b/packages/wdio-junit-reporter/tests/__fixtures__/cucumber-runner-browserstack-android.json
@@ -82,7 +82,7 @@
             "tagExpression": "@run",
             "ignoreUndefinedDefinitions": false
         },
-        "jasmineNodeOpts": {
+        "jasmineOpts": {
             "defaultTimeoutInterval": 10000
         },
         "before": [],

--- a/packages/wdio-junit-reporter/tests/__fixtures__/cucumber-runner-browserstack-ios.json
+++ b/packages/wdio-junit-reporter/tests/__fixtures__/cucumber-runner-browserstack-ios.json
@@ -82,7 +82,7 @@
             "tagExpression": "@run",
             "ignoreUndefinedDefinitions": false
         },
-        "jasmineNodeOpts": {
+        "jasmineOpts": {
             "defaultTimeoutInterval": 10000
         },
         "before": [],

--- a/packages/wdio-junit-reporter/tests/__fixtures__/cucumber-runner.json
+++ b/packages/wdio-junit-reporter/tests/__fixtures__/cucumber-runner.json
@@ -73,7 +73,7 @@
             "tagExpression": "@run",
             "ignoreUndefinedDefinitions": false
         },
-        "jasmineNodeOpts": {
+        "jasmineOpts": {
             "defaultTimeoutInterval": 10000
         },
         "before": [],

--- a/packages/wdio-junit-reporter/tests/__fixtures__/mocha-runner.json
+++ b/packages/wdio-junit-reporter/tests/__fixtures__/mocha-runner.json
@@ -67,7 +67,7 @@
                 "/path/to/project/test/specs/sync.spec.js"
             ]
         },
-        "jasmineNodeOpts": {
+        "jasmineOpts": {
             "defaultTimeoutInterval": 10000
         },
         "before": [],

--- a/tests/helpers/config.js
+++ b/tests/helpers/config.js
@@ -24,7 +24,7 @@ exports.config = {
         invert: true
     },
 
-    jasmineNodeOpts: {
+    jasmineOpts: {
         defaultTimeoutInterval: 1000 * 60 * 3,
         grep: 'SKIPPED_GREP',
         invertGrep: true,

--- a/website/docs/CLI.md
+++ b/website/docs/CLI.md
@@ -120,7 +120,7 @@ Options:
 --exclude             exclude spec file(s) from a run - overrides specs piped
                         from stdin                                       [array]
 --mochaOpts           Mocha options
---jasmineNodeOpts     Jasmine options
+--jasmineOpts         Jasmine options
 --cucumberOpts        Cucumber options
 ```
 

--- a/website/docs/ConfigurationFile.md
+++ b/website/docs/ConfigurationFile.md
@@ -211,8 +211,8 @@ exports.config = {
     },
     //
     // Options to be passed to Jasmine.
-    // See also: https://github.com/webdriverio/webdriverio/tree/main/packages/wdio-jasmine-framework#jasminenodeopts-options
-    jasmineNodeOpts: {
+    // See also: https://github.com/webdriverio/webdriverio/tree/main/packages/wdio-jasmine-framework#jasmineopts-options
+    jasmineOpts: {
         //
         // Jasmine default timeout
         defaultTimeoutInterval: 5000,

--- a/website/docs/Debugging.md
+++ b/website/docs/Debugging.md
@@ -35,7 +35,7 @@ When using `browser.debug()`, you will likely need to increase the timeout of th
 In `wdio.conf`:
 
 ```js
-jasmineNodeOpts: {
+jasmineOpts: {
     defaultTimeoutInterval: (24 * 60 * 60 * 1000)
 }
 ```
@@ -60,7 +60,7 @@ exports.config = {
     maxInstances: debug ? 1 : 100,
     capabilities: debug ? [{ browserName: 'chrome' }] : defaultCapabilities,
     execArgv: debug ? ['--inspect'] : [],
-    jasmineNodeOpts: {
+    jasmineOpts: {
       defaultTimeoutInterval: debug ? (24 * 60 * 60 * 1000) : defaultTimeoutInterval
     }
     // ...

--- a/website/docs/Frameworks.md
+++ b/website/docs/Frameworks.md
@@ -155,18 +155,18 @@ First, install the adapter package from NPM:
 npm install @wdio/jasmine-framework --save-dev
 ```
 
-You can then configure your Jasmine environment by setting a `jasmineNodeOpts` property in your config. A list of all options can be found on the [Jasmine project website](https://jasmine.github.io/api/3.5/Configuration.html).
+You can then configure your Jasmine environment by setting a `jasmineOpts` property in your config. A list of all options can be found on the [Jasmine project website](https://jasmine.github.io/api/3.5/Configuration.html).
 
 ### Intercept Assertion
 
 The Jasmine framework allows it to intercept each assertion in order to log the state of the application or website, depending on the result.
 
-For example, it is pretty handy to take a screenshot every time an assertion fails. In your `jasmineNodeOpts` you can add a property called `expectationResultHandler` that takes a function to execute. The function’s parameters provide information about the result of the assertion.
+For example, it is pretty handy to take a screenshot every time an assertion fails. In your `jasmineOpts` you can add a property called `expectationResultHandler` that takes a function to execute. The function’s parameters provide information about the result of the assertion.
 
 The following example demonstrates how to take a screenshot if an assertion fails:
 
 ```js
-jasmineNodeOpts: {
+jasmineOpts: {
     defaultTimeoutInterval: 10000,
     expectationResultHandler: function(passed, assertion) {
         /**
@@ -187,7 +187,7 @@ commands the screenshot is taken anyway, which still gives _some_ valuable infor
 
 ### Jasmine Options
 
-The following options can be applied in your `wdio.conf.js` to configure your Jasmine environment using the `jasmineNodeOpts` property:
+The following options can be applied in your `wdio.conf.js` to configure your Jasmine environment using the `jasmineOpts` property:
 
 #### defaultTimeoutInterval
 Default Timeout Interval for Jasmine operations.

--- a/website/docs/Options.md
+++ b/website/docs/Options.md
@@ -274,7 +274,7 @@ Type: `String`<br />
 Default: `mocha`<br />
 Options: `mocha` | `jasmine`
 
-### mochaOpts, jasmineNodeOpts and cucumberOpts
+### mochaOpts, jasmineOpts and cucumberOpts
 
 Specific framework-related options. See the framework adapter documentation on which options are available. Read more on this in [Frameworks](./Frameworks.md).
 

--- a/website/docs/Timeouts.md
+++ b/website/docs/Timeouts.md
@@ -113,7 +113,7 @@ exports.config = {
 exports.config = {
     // ...
     framework: 'jasmine',
-    jasmineNodeOpts: {
+    jasmineOpts: {
         defaultTimeoutInterval: 20000
     },
     // ...


### PR DESCRIPTION
## Proposed changes

There is currently a bug where TypeScript expects a `jasmineOpts` in the config while the framework adapter expects `jasmineNodeOpts`. Given that `mochaOpts` and `cucumberOpts` don't have `Node` in their property name I think it is time to consolidate this.

Note: I made sure that we still accept a `jasmineNodeOpts` property in the framework adapter so this change is still backwards compatible.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
