### PR TITLE
better type and document `wdio:devtoolsOptions`

### DIFF
--- a/packages/devtools/README.md
+++ b/packages/devtools/README.md
@@ -24,7 +24,10 @@ let browser;
     browser = await remote({
         automationProtocol: 'devtools',
         capabilities: {
-            browserName: 'chrome'
+            browserName: 'chrome',
+            'wdio:devtoolsOptions': {
+                headless: true
+            }
         }
     })
 
@@ -61,6 +64,25 @@ let browser;
     console.error(e)
     await browser.deleteSession()
 })
+```
+
+## `wdio:devtoolsOptions` Capability
+
+In order to set [Puppeteer specific configurations](https://pptr.dev/#?product=Puppeteer&version=v5.5.0&show=api-puppeteerlaunchoptions) you can use the `wdio:devtoolsOptions` capability which is a custom property (compliant to the WebDriver protocol), e.g.:
+
+```js
+{
+    browserName: 'chrome',
+    'wdio:devtoolsOptions': {
+        headless: true,
+        defaultViewport: {
+            width: 800,
+            height: 600,
+            deviceScaleFactor: 1,
+            isMobile: false
+        }
+    }
+}
 ```
 
 ### Commands

--- a/packages/devtools/src/index.ts
+++ b/packages/devtools/src/index.ts
@@ -14,7 +14,7 @@ import DevToolsDriver from './devtoolsdriver'
 import launch from './launcher'
 import { DEFAULTS, SUPPORTED_BROWSER, VENDOR_PREFIX } from './constants'
 import { getPrototype, patchDebug } from './utils'
-import type { ExtendedCapabilities } from './types'
+import type { ExtendedCapabilities, WDIODevtoolsOptions as WDIODevtoolsOptionsExtension } from './types'
 
 const log = logger('devtools:puppeteer')
 
@@ -132,3 +132,10 @@ export default class DevTools {
 }
 
 export { SUPPORTED_BROWSER }
+export * from './types'
+
+declare global {
+    namespace WebdriverIO {
+        interface WDIODevtoolsOptions extends WDIODevtoolsOptionsExtension {}
+    }
+}

--- a/packages/devtools/src/types.ts
+++ b/packages/devtools/src/types.ts
@@ -1,6 +1,8 @@
 import type { Capabilities } from '@wdio/types'
 
-export interface ExtendedCapabilities extends Capabilities.Capabilities {
+export interface ExtendedCapabilities extends Capabilities.Capabilities, WDIODevtoolsOptions {}
+
+export interface WDIODevtoolsOptions {
     'wdio:devtoolsOptions'?: DevToolsOptions
 }
 

--- a/packages/devtools/src/types.ts
+++ b/packages/devtools/src/types.ts
@@ -1,4 +1,5 @@
 import type { Capabilities } from '@wdio/types'
+import { LaunchOptions, ChromeArgOptions, BrowserOptions, ConnectOptions } from 'puppeteer-core'
 
 export interface ExtendedCapabilities extends Capabilities.Capabilities, WDIODevtoolsOptions {}
 
@@ -6,11 +7,4 @@ export interface WDIODevtoolsOptions {
     'wdio:devtoolsOptions'?: DevToolsOptions
 }
 
-export interface DevToolsOptions {
-    ignoreDefaultArgs?: string[] | boolean
-    headless?: boolean,
-    defaultViewport?: {
-        width: number,
-        height: number
-    }
-}
+export interface DevToolsOptions extends LaunchOptions, ChromeArgOptions, BrowserOptions, ConnectOptions {}

--- a/packages/wdio-types/src/Capabilities.ts
+++ b/packages/wdio-types/src/Capabilities.ts
@@ -130,7 +130,7 @@ export interface DesiredCapabilities extends Capabilities, SauceLabsCapabilities
     excludeDriverLogs?: string[];
 }
 
-export interface VendorExtensions extends EdgeCapabilities, AppiumW3CCapabilities {
+export interface VendorExtensions extends EdgeCapabilities, AppiumW3CCapabilities, WebdriverIO.WDIODevtoolsOptions {
     // Selenoid specific
     'selenoid:options'?: SelenoidOptions
     // Testingbot w3c specific

--- a/packages/wdio-types/src/index.ts
+++ b/packages/wdio-types/src/index.ts
@@ -26,6 +26,7 @@ declare global {
         interface ReporterOption extends Reporters.Options {}
         interface Config extends Options.Testrunner {}
         interface HookFunctionExtension {}
+        interface WDIODevtoolsOptions {}
     }
 
     namespace WebDriver {

--- a/tests/typings/webdriverio/config.ts
+++ b/tests/typings/webdriverio/config.ts
@@ -163,6 +163,10 @@ const config: WebdriverIO.Config = {
             logName: 'test.log',
             videoName: 'test.mp4'
         }
+    }, {
+        'wdio:devtoolsOptions': {
+            ignoreDefaultArgs: false
+        }
     }] as WebDriver.DesiredCapabilities[],
 
     filesToWatch: [


### PR DESCRIPTION
## Proposed changes

With v7 we have created the capability `wdio:devtoolsOptions` to define Puppeteer options in the WebDriver capability format. That hasn't been very well documented nor typed. This patch fixes that.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
