### PR TITLE
Add og:image and twitter:image

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -20,6 +20,8 @@ module.exports = {
         repoUrl
     },
     themeConfig: {
+        image: 'img/logo-webdriver-io.png',
+        metadatas: [{name: 'twitter:card', content: 'summary'}],
         colorMode: {
             defaultMode: 'light',
             disableSwitch: false,


### PR DESCRIPTION
## Proposed changes

Since `og:image` is not setted, logo is not displayed at Twitter card. This change adds `og:image` and `twitter:image`. 
https://v2.docusaurus.io/docs/api/themes/configuration#meta-image

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist


- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc


## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
