### PR TITLE
Change type of _interval, TypeScript build steps will not work with it as 'number'

### DIFF
--- a/packages/wdio-sumologic-reporter/src/index.ts
+++ b/packages/wdio-sumologic-reporter/src/index.ts
@@ -17,7 +17,7 @@ const DATE_FORMAT = 'yyyy-mm-dd HH:mm:ss,l o'
  */
 export default class SumoLogicReporter extends WDIOReporter {
     private _options: Options
-    private _interval: number
+    private _interval: NodeJS.Timeout
 
     private _unsynced: string[] = []
     private _isSynchronising = false


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

Using `npm run setup-all` would fail due to a TypeScript error

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
- [X] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
