### PR TITLE
add missing comma for code coverage snippet for devtools service

### DIFF
--- a/packages/wdio-devtools-service/README.md
+++ b/packages/wdio-devtools-service/README.md
@@ -251,7 +251,7 @@ The service offers you to capture the code coverage of your application under te
 ```js
 // wdio.conf.js
 services: [
-    ['devtools' {
+    ['devtools', {
         coverageReporter: {
             enable: true,
             type: 'html',


### PR DESCRIPTION
## Proposed changes

Adds a missing comma for the code snippet for the coverage reporter documentation for the devtools service

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

### Reviewers: @webdriverio/project-committers
