### PR TITLE
Fix unable to use nativeWebTap in capabilities

### DIFF
--- a/packages/wdio-types/src/Capabilities.ts
+++ b/packages/wdio-types/src/Capabilities.ts
@@ -439,7 +439,6 @@ export interface AppiumIOSCapabilities {
     autoAcceptAlerts?: boolean;
     autoDismissAlerts?: boolean;
     nativeInstrumentsLib?: boolean;
-    nativeWebTap?: boolean;
     safariInitialUrl?: string;
     safariAllowPopups?: boolean;
     safariIgnoreFraudWarning?: boolean;
@@ -460,6 +459,7 @@ export interface AppiumIOSCapabilities {
     enableAsyncExecuteFromHttps?: boolean;
     skipLogCapture?: boolean;
     webkitDebugProxyPort?: number;
+    'appium:nativeWebTap'?: boolean;
 }
 
 // IE specific

--- a/packages/wdio-types/src/Capabilities.ts
+++ b/packages/wdio-types/src/Capabilities.ts
@@ -356,6 +356,7 @@ export interface AppiumW3CCapabilities {
     'appium:eventTimings'?: boolean;
     'appium:enablePerformanceLogging'?: boolean;
     'appium:printPageSourceOnFindFailure'?: boolean;
+    'appium:nativeWebTap'?: boolean;
 }
 
 export interface AppiumAndroidCapabilities {
@@ -439,6 +440,7 @@ export interface AppiumIOSCapabilities {
     autoAcceptAlerts?: boolean;
     autoDismissAlerts?: boolean;
     nativeInstrumentsLib?: boolean;
+    nativeWebTap?: boolean;
     safariInitialUrl?: string;
     safariAllowPopups?: boolean;
     safariIgnoreFraudWarning?: boolean;
@@ -459,7 +461,6 @@ export interface AppiumIOSCapabilities {
     enableAsyncExecuteFromHttps?: boolean;
     skipLogCapture?: boolean;
     webkitDebugProxyPort?: number;
-    'appium:nativeWebTap'?: boolean;
 }
 
 // IE specific


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

Adding `nativeWebTap` to `capabilities` will result in an error:

```
Invalid or unsupported WebDriver capabilities found ("nativeWebTap"). Ensure to only use valid W3C WebDriver capabilities (see https://w3c.github.io/webdriver/#capabilities).
```

This is because `nativeWebTap` is not in the valid [capabilities list](https://github.com/lukyth/webdriverio/blob/cf06843fb1add1645d98b4dd4a1c50c35ec8d8ad/packages/webdriver/src/constants.ts#L153-L157) which is used in this [capabilities validation](https://github.com/lukyth/webdriverio/blob/01f045635ad191db89b6ba4117549edaa8081b00/packages/webdriver/src/utils.ts#L28-L48).

It could be fixed by adding `nativeWebTap` to the list. But seeing this [table of standard capabilities](https://w3c.github.io/webdriver/#capabilities), I think is not appropriate to do so.

So I decided to fix this by adding type definition for `appium:nativeWebTap`, which will pass the capablities validation but its type was missing before. And remove type definition for `nativeWebTap` since it'll cause an error when used.

I tested using BrowserStack with iOS capabilities locally, with something like:
```ts
await browser.url(urlWithATag)
const currentHandles = await browser.getWindowHandles()
await browser.click("a") // <a href="otherpage.html" target="_blank" rel="noreferrer noopener">Open</a>
const newHandles = await browser.getWindowHandles()
expect(newHandles.length).toBeGreaterThan(currentHandles.length)
```
This will fail without `nativeWebTap`. And with this I confirmed that `appium:nativeWebTap` and `nativeWebTap` can be used interchangeably.

I'm not sure how should I add a test for this here. Please let me know if you want me to add a test for this anywhere.

I could also add `appium:` prefix to `AppiumAndroidCapabilities` and `AppiumIOSCapabilities` (since using any other capabilities in there will probably cause the same error), but I only tested `nativeWebTap` so far, so I only updated that. Please let me know if want me to update those twos as well, or if you think I should update the validation logic to allow non-prefix capabilities instead. But personally, I think having a prefix is better since it's more clear what it is.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
