### PR TITLE
Support Selenium 4.0 Grid CDP for Devtools Service

### DIFF
--- a/packages/wdio-types/src/Capabilities.ts
+++ b/packages/wdio-types/src/Capabilities.ts
@@ -155,6 +155,11 @@ export interface VendorExtensions extends EdgeCapabilities, AppiumW3CCapabilitie
         [name: string]: any;
     };
 
+    // Selenium 4 Specific
+    'se:options'?: {
+        [cdp: string]: string;
+    };
+
     /**
      * @deprecated
      */

--- a/packages/wdio-types/src/Capabilities.ts
+++ b/packages/wdio-types/src/Capabilities.ts
@@ -155,9 +155,11 @@ export interface VendorExtensions extends EdgeCapabilities, AppiumW3CCapabilitie
         [name: string]: any;
     };
 
-    // Selenium 4 Specific
+    /**
+     * Selenium 4.0 Specific
+     */
     'se:options'?: {
-        [cdp: string]: string;
+        cdp?: string;
     };
 
     /**

--- a/packages/webdriverio/src/commands/browser/getPuppeteer.ts
+++ b/packages/webdriverio/src/commands/browser/getPuppeteer.ts
@@ -48,10 +48,21 @@ export default async function getPuppeteer (this: WebdriverIO.Browser) {
         return this.puppeteer
     }
 
+    const caps = (this.capabilities as Capabilities.W3CCapabilities).alwaysMatch || this.capabilities as Capabilities.DesiredCapabilities
+    /**
+     * attach to a Selenium 4 CDP Session if it's returned in the capabilities
+     */
+    const cdpEndpoint = caps['se:options']?.cdp
+    if (cdpEndpoint) {
+        this.puppeteer = await puppeteer.connect({
+            browserWSEndpoint: cdpEndpoint
+        }) as any as PuppeteerBrowser
+        return this.puppeteer
+    }
+
     /**
      * attach to Chromium debugger session
      */
-    const caps = (this.capabilities as Capabilities.W3CCapabilities).alwaysMatch || this.capabilities as Capabilities.DesiredCapabilities
     const chromiumOptions = caps['goog:chromeOptions'] || caps['ms:edgeOptions']
     if (chromiumOptions && chromiumOptions.debuggerAddress) {
         this.puppeteer = await puppeteer.connect({

--- a/packages/webdriverio/src/commands/browser/getPuppeteer.ts
+++ b/packages/webdriverio/src/commands/browser/getPuppeteer.ts
@@ -55,7 +55,9 @@ export default async function getPuppeteer (this: WebdriverIO.Browser) {
     const cdpEndpoint = caps['se:options']?.cdp
     if (cdpEndpoint) {
         this.puppeteer = await puppeteer.connect({
-            browserWSEndpoint: cdpEndpoint
+            browserWSEndpoint: cdpEndpoint,
+            // @ts-ignore ToDo(@L0tso): remove once https://github.com/puppeteer/puppeteer/pull/6942 is merged
+            defaultViewport: null
         }) as any as PuppeteerBrowser
         return this.puppeteer
     }

--- a/packages/webdriverio/tests/commands/browser/__snapshots__/getPuppeteer.test.ts.snap
+++ b/packages/webdriverio/tests/commands/browser/__snapshots__/getPuppeteer.test.ts.snap
@@ -49,6 +49,7 @@ Array [
   Array [
     Object {
       "browserWSEndpoint": "http://my.grid:1234/session/mytestsession/se/cdp",
+      "defaultViewport": null,
     },
   ],
 ]

--- a/packages/webdriverio/tests/commands/browser/__snapshots__/getPuppeteer.test.ts.snap
+++ b/packages/webdriverio/tests/commands/browser/__snapshots__/getPuppeteer.test.ts.snap
@@ -43,3 +43,13 @@ Array [
   ],
 ]
 `;
+
+exports[`attach Puppeteer should pass for Selenium CDP 1`] = `
+Array [
+  Array [
+    Object {
+      "browserWSEndpoint": "http://my.grid:1234/session/mytestsession/se/cdp",
+    },
+  ],
+]
+`;

--- a/packages/webdriverio/tests/commands/browser/getPuppeteer.test.ts
+++ b/packages/webdriverio/tests/commands/browser/getPuppeteer.test.ts
@@ -120,4 +120,17 @@ describe('attach Puppeteer', () => {
         expect(pptr).toBe('foobar')
         expect(puppeteerConnect).toHaveBeenCalledTimes(0)
     })
+
+    it('should pass for Selenium CDP', async () => {
+        const pptr = await browser.getPuppeteer.call({
+            ...browser,
+            capabilities: {
+                'se:options': {
+                    'cdp': 'http://my.grid:1234/session/mytestsession/se/cdp'
+                }
+            }
+        })
+        expect(typeof pptr).toBe('object')
+        expect(puppeteerConnect.mock.calls).toMatchSnapshot()
+    })
 })


### PR DESCRIPTION
## Proposed changes
Addresses https://github.com/webdriverio/webdriverio/issues/6470. This PR allows using the devtools service with Selenium 4.0 Grid (beta-1).

When creating a new session, Selenium 4.0 Beta 1 will respond with an endpoint that can be used to make direct websocket requests with (see below for example response).

Puppeteer takes that as `browserWSEndpoint` as [described here](https://github.com/puppeteer/puppeteer/blob/main/docs/api.md#puppeteerconnectoptions).

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments
1) I have read discussions that potentially in a future Se4 Beta, the structure of `"se:options"` may change. However, I figured we can at least get the ball rolling now and make tweaks as needed.

2) The conditional precedence is very important in this PR. A response can have both `se:options` and the `debuggerAddress` that gets tacked on by Chromedriver.

Full response example here:
```
{
    "status": 0,
    "sessionId": "c8adfc6384648299d726d9c63d4e7a15",
    "value": {
        "acceptInsecureCerts": false,
        "browserName": "chrome",
        "browserVersion": "88.0.4324.182",
        "chrome": {
            "chromedriverVersion": "87.0.4280.20 (c99e81631faa0b2a448e658c0dbd8311fb04ddbd-refs/branch-heads/4280@{#355})",
            "userDataDir": "/var/folders/kx/c8_k_9q17qngwmlbc282nhc0bnj1_9/T/.com.google.Chrome.WKVL7Y"
        },
        "goog:chromeOptions": {
            "debuggerAddress": "localhost:52810"
        },
        "networkConnectionEnabled": false,
        "pageLoadStrategy": "normal",
        "platformName": "mac os x",
        "proxy": {},
        "se:options": {
            "cdp": "http://my.grid:5555/session/c8adfc6384648299d726d9c63d4e7a15/se/cdp"
        },
        "setWindowRect": true,
        "strictFileInteractability": false,
        "timeouts": {
            "implicit": 0,
            "pageLoad": 300000,
            "script": 30000
        },
        "unhandledPromptBehavior": "dismiss and notify",
        "webauthn:virtualAuthenticators": true
    }
}
```

3) (just for note) I'm hoping https://github.com/SeleniumHQ/selenium/issues/9202 is addressed. Personally I prefer the Selenium Hub to proxy all cdp requests. Beta 1 currently returns a direct endpoint to the Node. However, I feel it would be irresponsible in this PR to hardcode the hub (via something like `ws://${this.config.hostname}:${this.config.port}/session/${this.sessionId}/se/cdp`, which works) instead of utilizing what is returned by Selenium.

### Reviewers: @webdriverio/project-committers
