### PR TITLE
Issue #6511 fix 

### DIFF
--- a/packages/wdio-utils/src/test-framework/testInterfaceWrapper.ts
+++ b/packages/wdio-utils/src/test-framework/testInterfaceWrapper.ts
@@ -165,7 +165,7 @@ export const wrapTestFunction = function (
          */
         let retryCnt = typeof specArguments[specArguments.length - 1] === 'number' ? specArguments.pop() : 0
         const specFn = typeof specArguments[0] === 'function' ? specArguments.shift()
-            : (typeof specArguments[1] === 'function' ? specArguments.pop() : undefined)
+            : (typeof specArguments[1] === 'function' ? specArguments[1] : undefined)
         const specTitle = specArguments[0]
 
         if (isSpec) {

--- a/packages/wdio-utils/tests/test-framework/testInterfaceWrapper.test.js
+++ b/packages/wdio-utils/tests/test-framework/testInterfaceWrapper.test.js
@@ -44,7 +44,7 @@ describe('wrapTestFunction', () => {
     it('should run spec', () => {
         const specFn = jest.fn()
         const fn = wrapTestFunction(testFunction, true, 'beforeFn', () => [], 'afterFn', () => [], 'cid')
-        fn('test title', specFn, {})
+        fn('test title', specFn, { options: { foo: 'bar' } })
         expect(testFnWrapper).toBeCalledWith(
             'Test',
             { specFn, specFnArgs: ['foo', 'bar'] },

--- a/packages/wdio-utils/tests/test-framework/testInterfaceWrapper.test.js
+++ b/packages/wdio-utils/tests/test-framework/testInterfaceWrapper.test.js
@@ -44,7 +44,7 @@ describe('wrapTestFunction', () => {
     it('should run spec', () => {
         const specFn = jest.fn()
         const fn = wrapTestFunction(testFunction, true, 'beforeFn', () => [], 'afterFn', () => [], 'cid')
-        fn('test title', specFn)
+        fn('test title', specFn, {})
         expect(testFnWrapper).toBeCalledWith(
             'Test',
             { specFn, specFnArgs: ['foo', 'bar'] },


### PR DESCRIPTION
## Proposed changes

This resolves the issue described in #6511 

Replace `specArguments.pop()` with `specArguments[1]` incase specArguments has more than two indexes.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
