### PR TITLE
Fix TS return types for $ command

### DIFF
--- a/packages/webdriverio/async.d.ts
+++ b/packages/webdriverio/async.d.ts
@@ -11,11 +11,10 @@ declare namespace WebdriverIOAsync {
 declare namespace WebdriverIO {
     interface Browser extends BrowserSync, WebdriverIOAsync.Browser { }
     interface Element extends ElementSync, WebdriverIOAsync.Element { }
-    // @ts-expect-error
     interface MultiRemoteBrowser extends MultiRemoteBrowserAsync, WebdriverIOAsync.MultiRemoteBrowser { }
 }
 
-declare function $(...args: Parameters<WebdriverIO.Browser['$']>): WebdriverIO.Element
+declare function $(...args: Parameters<WebdriverIO.Browser['$']>): ReturnType<WebdriverIO.Browser['$']>
 declare function $$(...args: Parameters<WebdriverIO.Browser['$$']>): ReturnType<WebdriverIO.Browser['$$']>
 declare const browser: WebdriverIO.Browser
 declare const driver: WebdriverIO.Browser

--- a/packages/webdriverio/sync.d.ts
+++ b/packages/webdriverio/sync.d.ts
@@ -11,11 +11,10 @@ declare namespace WebdriverIOSync {
 declare namespace WebdriverIO {
     interface Browser extends BrowserSync, WebdriverIOSync.Browser { }
     interface Element extends ElementSync, WebdriverIOSync.Element { }
-    // @ts-expect-error
     interface MultiRemoteBrowser extends MultiRemoteBrowserSync, WebdriverIOSync.MultiRemoteBrowser { }
 }
 
-declare function $(...args: Parameters<WebdriverIO.Browser['$']>): WebdriverIO.Element
+declare function $(...args: Parameters<WebdriverIO.Browser['$']>): ReturnType<WebdriverIO.Browser['$']>
 declare function $$(...args: Parameters<WebdriverIO.Browser['$$']>): ReturnType<WebdriverIO.Browser['$$']>
 declare const browser: WebdriverIO.Browser
 declare const driver: WebdriverIO.Browser


### PR DESCRIPTION
## Proposed changes

The return types for the sync/async shims are inconsistent.

See also #6518

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

fixes #6518

### Reviewers: @webdriverio/project-committers
