### PR TITLE
Expose ElementArray as type to the WebdriverIO namespace

### DIFF
--- a/packages/webdriverio/async.d.ts
+++ b/packages/webdriverio/async.d.ts
@@ -1,6 +1,7 @@
 type BrowserSync = import('./build/types').Browser<'async'>
 type ElementSync = import('./build/types').Element<'async'>
 type MultiRemoteBrowserAsync = import('./build/types').MultiRemoteBrowser<'async'>
+type ElementArrayImport = import('./build/types').ElementArray
 
 declare namespace WebdriverIOAsync {
     interface Browser {}
@@ -13,6 +14,7 @@ declare namespace WebdriverIO {
     interface Element extends ElementSync, WebdriverIOAsync.Element { }
     // @ts-expect-error
     interface MultiRemoteBrowser extends MultiRemoteBrowserAsync, WebdriverIOAsync.MultiRemoteBrowser { }
+    interface ElementArray extends ElementArrayImport {}
 }
 
 declare function $(...args: Parameters<WebdriverIO.Browser['$']>): WebdriverIO.Element

--- a/packages/webdriverio/sync.d.ts
+++ b/packages/webdriverio/sync.d.ts
@@ -1,6 +1,7 @@
 type BrowserSync = import('./build/types').Browser<'sync'>
 type ElementSync = import('./build/types').Element<'sync'>
 type MultiRemoteBrowserSync = import('./build/types').MultiRemoteBrowser<'sync'>
+type ElementArrayImport = import('./build/types').ElementArray
 
 declare namespace WebdriverIOSync {
     interface Browser {}
@@ -13,6 +14,7 @@ declare namespace WebdriverIO {
     interface Element extends ElementSync, WebdriverIOSync.Element { }
     // @ts-expect-error
     interface MultiRemoteBrowser extends MultiRemoteBrowserSync, WebdriverIOSync.MultiRemoteBrowser { }
+    interface ElementArray extends ElementArrayImport {}
 }
 
 declare function $(...args: Parameters<WebdriverIO.Browser['$']>): WebdriverIO.Element

--- a/tests/typings/sync/sync.ts
+++ b/tests/typings/sync/sync.ts
@@ -23,6 +23,9 @@ nsBrowser.clearMockCalls('')
 const nsElem: WebdriverIO.Element = {} as any
 nsElem.click()
 
+const nsElems: WebdriverIO.ElementArray = {} as any
+nsElems.foundWith.toUpperCase()
+
 // browser
 browser.pause(1)
 browser.newWindow('https://webdriver.io', {

--- a/tests/typings/webdriverio/async.ts
+++ b/tests/typings/webdriverio/async.ts
@@ -46,12 +46,15 @@ async function bar() {
     // const mrSingleElem = await mr.myBrowserInstance.$('')
     // await mrSingleElem.click()
 
-    // // interact with all instances
-    // const mrElem = await mr.$('')
-    // await mrElem.click()
+    // interact with all instances
+    const mrElem = await mr.$('')
+    await mrElem.click()
 
-    // // instances array
-    // mr.instances[0].substr(0, 1)
+    // instances array
+    mr.instances[0].substr(0, 1)
+
+    const nsElems: WebdriverIO.ElementArray = {} as any
+    nsElems.foundWith.toUpperCase()
 
     ////////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
## Proposed changes

Given that we have `Element` within the WebdriverIO global namespace I suggest to do the same for `ElementArray` given it can be used various times within the test and this would safe a lot of imports.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

refs: webdriverio/webdriverio#6502

### Reviewers: @webdriverio/project-committers
