### PR TITLE
Implementation of grouped spec files for a single worker instance

### DIFF
--- a/packages/wdio-cli/src/launcher.ts
+++ b/packages/wdio-cli/src/launcher.ts
@@ -199,7 +199,8 @@ class Launcher {
             this._schedule.push({
                 cid: cid++,
                 caps: caps as Capabilities.MultiRemoteCapabilities,
-                specs: this.configParser.getSpecs((caps as Capabilities.DesiredCapabilities).specs, (caps as Capabilities.DesiredCapabilities).exclude).map(s => ({ files: [s], retries: specFileRetries })),
+                // specs: this.configParser.getSpecs((caps as Capabilities.DesiredCapabilities).specs, (caps as Capabilities.DesiredCapabilities).exclude).map(s => ({ files: [s], retries: specFileRetries })),
+                specs: this.formatSpecs(caps, specFileRetries),
                 availableInstances: config.maxInstances || 1,
                 runningInstances: 0
             })
@@ -211,7 +212,7 @@ class Launcher {
                 this._schedule.push({
                     cid: cid++,
                     caps: capabilities as Capabilities.Capabilities,
-                    specs: this.configParser.getSpecs((capabilities as Capabilities.DesiredCapabilities).specs, (capabilities as Capabilities.DesiredCapabilities).exclude).map(s => ({ files: [s], retries: specFileRetries })),
+                    specs: this.formatSpecs(capabilities, specFileRetries),
                     availableInstances: (capabilities as Capabilities.DesiredCapabilities).maxInstances || config.maxInstancesPerCapability,
                     runningInstances: 0
                 })
@@ -237,6 +238,27 @@ class Launcher {
             }
         })
     }
+
+
+    /**
+     * Format the specs into an array of objects with files and retries
+     */
+    formatSpecs(capabilities, specFileRetries: number) {
+        let files: (string | string[])[] = []
+        let returnValue: WorkerSpecs[] = []
+
+        files = this.configParser.getSpecs((capabilities as Capabilities.DesiredCapabilities).specs, (capabilities as Capabilities.DesiredCapabilities).exclude)
+        files.forEach(file => {
+            if (typeof file === 'string') {
+                returnValue.push({ files: [file], retries: specFileRetries })
+            } else if (Array.isArray(file)){
+                returnValue.push({ files: file, retries: specFileRetries })
+            }
+        })
+        return returnValue
+    }
+
+
 
     /**
      * run multiple single remote tests

--- a/packages/wdio-cli/src/launcher.ts
+++ b/packages/wdio-cli/src/launcher.ts
@@ -243,7 +243,7 @@ class Launcher {
     /**
      * Format the specs into an array of objects with files and retries
      */
-    formatSpecs(capabilities, specFileRetries: number) {
+    formatSpecs(capabilities: (Capabilities.DesiredCapabilities | Capabilities.W3CCapabilities | Capabilities.RemoteCapabilities), specFileRetries: number) {
         let files: (string | string[])[] = []
         let returnValue: WorkerSpecs[] = []
 

--- a/packages/wdio-cli/src/watcher.ts
+++ b/packages/wdio-cli/src/watcher.ts
@@ -12,7 +12,7 @@ const log = logger('@wdio/cli:watch')
 
 export default class Watcher {
     private _launcher: Launcher
-    private _specs: string[]
+    private _specs: ( string | string[])[]
 
     constructor (
         private _configFile: string,
@@ -32,9 +32,11 @@ export default class Watcher {
         /**
          * listen on spec changes and rerun specific spec file
          */
-        chokidar.watch(this._specs, { ignoreInitial: true })
-            .on('add', this.getFileListener())
-            .on('change', this.getFileListener())
+        this._specs.forEach(file => {
+            chokidar.watch(file, { ignoreInitial: true })
+                .on('add', this.getFileListener())
+                .on('change', this.getFileListener())
+        })
 
         /**
          * listen on filesToWatch changes an rerun complete suite

--- a/packages/wdio-config/src/lib/ConfigParser.ts
+++ b/packages/wdio-config/src/lib/ConfigParser.ts
@@ -259,7 +259,6 @@ export default class ConfigParser {
         if (Array.isArray(capExclude)) {
             exclude = ConfigParser.getFilePaths(capExclude, undefined, this._pathService)
         }
-        console.log('ConfigParser: getSpecs: return value: ', specs.filter(spec => !exclude.includes(spec)))
         return specs.filter(spec => !exclude.includes(spec))
     }
 
@@ -358,7 +357,6 @@ export default class ConfigParser {
             }
         })
 
-        console.log('ConfigParser: patterns: ', patterns)
         for (let pattern of patterns) {
             // If pattern is an array, then call getFilePaths again
             // But only call one level deep, can't have multiple levels of hierarchy
@@ -382,7 +380,6 @@ export default class ConfigParser {
                 files = merge(files, filenames, MERGE_OPTIONS)
             }
         }
-        console.log('ConfigParser: getFilePaths: return value: ', files)
         return files
     }
 }


### PR DESCRIPTION
## Proposed changes
The code is an initial implementation of an ability to group spec files within the "specs' section of the config file using "[ ]", to implement the scheme proposed by @christian-bromann in #6469.  At the time of writing the documentation has not been updated and no unit tests have been created.  However, it does pass tests for mocha, jasmine and cucumber, tested by modifying the examples in the examples/wdio directory.

The main change is to support the array of string arrays structure (string[][]), as well as the existing array of strings (string[]) structure in the definition of the "specs" field in the config file.  This has required changes to the way the specs field is parsed in the configParser (wdio-config) (getFilePaths, getSpecs and setFilePathToFilter methods) to detect that when the items in "specs" are iterated over, that there is now the possibility that some will be arrays.

Also in the launcher (wdio-cli), it has required changes to the way the specs are formatted to be handed over to the workers.  Also a change was necessary in the watcher file (wdio-cli), now creating multiple chokidar.watch jobs (is this OK?).

Since the getSpecs function is shared with other elements e.g. the exclude files and the command line spec field, in places the return type of getSpecs has been asserted to be <string[]>, since we are not proposing supporting this structure in those other places and therefore the return type will always be string[].

First time with TypeScript - I apologise for any clumsiness.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

As per above checklist, no tests or documentation, but I'll add that as the next step.

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)
Solution proposed by @christian-bromann in #6469

### Reviewers: @webdriverio/project-committers
