### PR TITLE
Added overload typings to getLocation function

### DIFF
--- a/packages/webdriverio/src/commands/element/getLocation.ts
+++ b/packages/webdriverio/src/commands/element/getLocation.ts
@@ -1,5 +1,10 @@
 import { getElementRect } from '../../utils'
 
+type Location = {
+    x: number,
+    y: number
+}
+
 /**
  *
  * Determine an element’s location on the page. The point (0, 0) refers to
@@ -27,10 +32,15 @@ import { getElementRect } from '../../utils'
  * @uses protocol/elementIdLocation
  * @type property
  */
+export default async function getLocation(
+    this: WebdriverIO.Element): Promise<Location>
+export default async function getLocation(
+    this: WebdriverIO.Element,
+    prop: 'x' | 'y'): Promise<number>
 export default async function getLocation (
     this: WebdriverIO.Element,
     prop?: 'x' | 'y'
-) {
+): Promise<number | Location> {
     let location: {
         x?: number,
         y?: number,
@@ -50,8 +60,5 @@ export default async function getLocation (
         return location[prop] as number
     }
 
-    return location as {
-        x: number
-        y: number
-    }
+    return location as Location
 }


### PR DESCRIPTION
## Proposed changes

Add more explicit typings where possible. Currently - `getLocation` function. Potentially resolves #6549.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Improvement for development (_well... It's kinda none of the above_)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

The checklist **will be** completed.

## Further comments

Does anyone have any specific pointers on which functions/files/etc could be changed according to this as well? One function might be _a little too little_. Or shall I just glance over a bunch of files to check what else could be changed?

Edit:
I've noticed now that the build fails because of `no-redeclare` rule. Any suggestions on that? Do we override the rule in some way? It looks like `@typescript-eslint/no-redeclare` should do the trick instead of the generic one.

### Reviewers: @webdriverio/project-committers
