### PR TITLE
docs(typings): #6549 improve typings using overloads - getLocation, getSize

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -41,7 +41,9 @@ module.exports = {
             // see https://stackoverflow.com/questions/55280555/typescript-eslint-eslint-plugin-error-route-is-defined-but-never-used-no-un
             'no-unused-vars': 'off',
             '@typescript-eslint/no-unused-vars': 'error',
-            'no-undef': 'off'
+            'no-undef': 'off',
+            // allow overloads
+            'no-redeclare': 'off'
         }
     }]
 }

--- a/packages/wdio-jasmine-framework/package.json
+++ b/packages/wdio-jasmine-framework/package.json
@@ -25,7 +25,7 @@
     "url": "https://github.com/webdriverio/webdriverio/issues"
   },
   "dependencies": {
-    "@types/jasmine": "^3.6.2",
+    "@types/jasmine": "3.6.4",
     "@wdio/logger": "7.0.0",
     "@wdio/types": "7.0.7",
     "@wdio/utils": "7.0.7",

--- a/packages/webdriverio/src/commands/element/getLocation.ts
+++ b/packages/webdriverio/src/commands/element/getLocation.ts
@@ -1,13 +1,11 @@
 import type { RectReturn } from '@wdio/protocols'
 import { getElementRect } from '../../utils'
 
-export type Coordinates = Pick<RectReturn, 'x' | 'y'>;
+export type Location = Pick<RectReturn, 'x' | 'y'>;
 
-export type Location<T> = T extends keyof Coordinates ? number : Coordinates
+function getLocation (this: WebdriverIO.Element): Promise<Location>
 
-function getLocation<T extends undefined> (this: WebdriverIO.Element): Promise<Location<T>>
-
-function getLocation<T extends keyof Coordinates> (this: WebdriverIO.Element, prop: T): Promise<Location<T>>
+function getLocation (this: WebdriverIO.Element, prop: keyof Location): Promise<number>
 
 /**
  *
@@ -36,10 +34,10 @@ function getLocation<T extends keyof Coordinates> (this: WebdriverIO.Element, pr
  * @uses protocol/elementIdLocation
  * @type property
  */
-async function getLocation<T extends keyof Coordinates> (
+async function getLocation (
     this: WebdriverIO.Element,
-    prop?: T
-): Promise<Location<T>> {
+    prop?: keyof Location
+): Promise<Location | number> {
     let location: Partial<RectReturn> = {}
 
     if (this.isW3C) {
@@ -51,10 +49,10 @@ async function getLocation<T extends keyof Coordinates> (
     }
 
     if (prop === 'x' || prop === 'y') {
-        return location[prop] as Location<T>
+        return location[prop] as number
     }
 
-    return location as Location<T>
+    return location as Location
 }
 
 export default getLocation

--- a/packages/webdriverio/src/commands/element/getLocation.ts
+++ b/packages/webdriverio/src/commands/element/getLocation.ts
@@ -1,4 +1,13 @@
+import type { RectReturn } from '@wdio/protocols'
 import { getElementRect } from '../../utils'
+
+export type Coordinates = Pick<RectReturn, 'x' | 'y'>;
+
+export type Location<T> = T extends keyof Coordinates ? number : Coordinates
+
+export function getLocation<T extends undefined> (this: WebdriverIO.Element): Promise<Location<T>>
+
+export function getLocation<T extends keyof Coordinates> (this: WebdriverIO.Element, prop: T): Promise<Location<T>>
 
 /**
  *
@@ -27,16 +36,11 @@ import { getElementRect } from '../../utils'
  * @uses protocol/elementIdLocation
  * @type property
  */
-export default async function getLocation (
+export async function getLocation<T extends keyof Coordinates> (
     this: WebdriverIO.Element,
-    prop?: 'x' | 'y'
+    prop?: T
 ) {
-    let location: {
-        x?: number,
-        y?: number,
-        width?: number
-        height?: number
-    } = {}
+    let location: Partial<RectReturn> = {}
 
     if (this.isW3C) {
         location = await getElementRect(this)
@@ -47,11 +51,10 @@ export default async function getLocation (
     }
 
     if (prop === 'x' || prop === 'y') {
-        return location[prop] as number
+        return location[prop] as Location<T>
     }
 
-    return location as {
-        x: number
-        y: number
-    }
+    return location as Location<T>
 }
+
+export default getLocation

--- a/packages/webdriverio/src/commands/element/getLocation.ts
+++ b/packages/webdriverio/src/commands/element/getLocation.ts
@@ -5,9 +5,9 @@ export type Coordinates = Pick<RectReturn, 'x' | 'y'>;
 
 export type Location<T> = T extends keyof Coordinates ? number : Coordinates
 
-export function getLocation<T extends undefined> (this: WebdriverIO.Element): Promise<Location<T>>
+function getLocation<T extends undefined> (this: WebdriverIO.Element): Promise<Location<T>>
 
-export function getLocation<T extends keyof Coordinates> (this: WebdriverIO.Element, prop: T): Promise<Location<T>>
+function getLocation<T extends keyof Coordinates> (this: WebdriverIO.Element, prop: T): Promise<Location<T>>
 
 /**
  *
@@ -36,10 +36,10 @@ export function getLocation<T extends keyof Coordinates> (this: WebdriverIO.Elem
  * @uses protocol/elementIdLocation
  * @type property
  */
-export async function getLocation<T extends keyof Coordinates> (
+async function getLocation<T extends keyof Coordinates> (
     this: WebdriverIO.Element,
     prop?: T
-) {
+): Promise<Location<T>> {
     let location: Partial<RectReturn> = {}
 
     if (this.isW3C) {

--- a/packages/webdriverio/src/commands/element/getSize.ts
+++ b/packages/webdriverio/src/commands/element/getSize.ts
@@ -2,11 +2,11 @@ import type { RectReturn } from '@wdio/protocols'
 
 import { getElementRect } from '../../utils'
 
-export type Size<T> = T extends keyof RectReturn ? number : Pick<RectReturn, 'width' | 'height'>
+export type Size = Pick<RectReturn, 'width' | 'height'>;
 
-function getSize<T extends undefined> (this: WebdriverIO.Element): Promise<Size<T>>;
+function getSize (this: WebdriverIO.Element): Promise<Size>;
 
-function getSize<T extends keyof RectReturn> (this: WebdriverIO.Element, prop: T): Promise<Size<T>>;
+function getSize (this: WebdriverIO.Element, prop: keyof RectReturn): Promise<number>;
 
 /**
  *
@@ -35,10 +35,10 @@ function getSize<T extends keyof RectReturn> (this: WebdriverIO.Element, prop: T
  * @type property
  *
  */
-async function getSize<T extends keyof RectReturn> (
+async function getSize (
     this: WebdriverIO.Element,
-    prop?: T
-): Promise<Size<T>> {
+    prop?: keyof RectReturn
+): Promise<Size | number> {
     let rect: Partial<RectReturn> = {}
 
     if (this.isW3C) {
@@ -48,13 +48,13 @@ async function getSize<T extends keyof RectReturn> (
     }
 
     if (prop && rect[prop]) {
-        return rect[prop] as Size<T>
+        return rect[prop] as number
     }
 
     return {
         width: rect.width,
         height: rect.height
-    } as Size<T>
+    } as Size
 }
 
 export default getSize

--- a/packages/webdriverio/src/commands/element/getSize.ts
+++ b/packages/webdriverio/src/commands/element/getSize.ts
@@ -2,6 +2,12 @@ import type { RectReturn } from '@wdio/protocols'
 
 import { getElementRect } from '../../utils'
 
+export type Size<T> = T extends keyof RectReturn ? number : Pick<RectReturn, 'width' | 'height'>
+
+export function getSize<T extends undefined> (this: WebdriverIO.Element): Promise<Size<T>>;
+
+export function getSize<T extends keyof RectReturn> (this: WebdriverIO.Element, prop: T): Promise<Size<T>>;
+
 /**
  *
  * Get the width and height for an DOM-element.
@@ -29,9 +35,9 @@ import { getElementRect } from '../../utils'
  * @type property
  *
  */
-export default async function getSize (
+export async function getSize<T extends keyof RectReturn> (
     this: WebdriverIO.Element,
-    prop?: keyof RectReturn
+    prop?: T
 ) {
     let rect: Partial<RectReturn> = {}
 
@@ -42,11 +48,13 @@ export default async function getSize (
     }
 
     if (prop && rect[prop]) {
-        return rect[prop]
+        return rect[prop] as Size<T>
     }
 
     return {
         width: rect.width,
         height: rect.height
-    }
+    } as Size<T>
 }
+
+export default getSize

--- a/packages/webdriverio/src/commands/element/getSize.ts
+++ b/packages/webdriverio/src/commands/element/getSize.ts
@@ -4,9 +4,9 @@ import { getElementRect } from '../../utils'
 
 export type Size<T> = T extends keyof RectReturn ? number : Pick<RectReturn, 'width' | 'height'>
 
-export function getSize<T extends undefined> (this: WebdriverIO.Element): Promise<Size<T>>;
+function getSize<T extends undefined> (this: WebdriverIO.Element): Promise<Size<T>>;
 
-export function getSize<T extends keyof RectReturn> (this: WebdriverIO.Element, prop: T): Promise<Size<T>>;
+function getSize<T extends keyof RectReturn> (this: WebdriverIO.Element, prop: T): Promise<Size<T>>;
 
 /**
  *
@@ -35,10 +35,10 @@ export function getSize<T extends keyof RectReturn> (this: WebdriverIO.Element, 
  * @type property
  *
  */
-export async function getSize<T extends keyof RectReturn> (
+async function getSize<T extends keyof RectReturn> (
     this: WebdriverIO.Element,
     prop?: T
-) {
+): Promise<Size<T>> {
     let rect: Partial<RectReturn> = {}
 
     if (this.isW3C) {

--- a/packages/webdriverio/src/types.ts
+++ b/packages/webdriverio/src/types.ts
@@ -28,9 +28,9 @@ export type ElementCommandsType = typeof ElementCommands
 export type ElementCommandsTypeSync = {
     [K in keyof Omit<ElementCommandsType, 'getLocation' | 'getSize'>]: (...args: Parameters<ElementCommandsType[K]>) => ThenArg<ReturnType<ElementCommandsType[K]>>
 } & {
-    /**
-     * same as execute, because generics
-     */
+    //
+    // same as execute, because generics
+    //
     getLocation: (<T extends undefined>(
         this: WebdriverIO.Element,
     ) => Location<T>) & (<T extends keyof Coordinates>(

--- a/packages/webdriverio/src/types.ts
+++ b/packages/webdriverio/src/types.ts
@@ -2,12 +2,14 @@ import type { EventEmitter } from 'events'
 
 import type { SessionFlags } from 'webdriver'
 import type { Options, Capabilities, FunctionProperties, ThenArg } from '@wdio/types'
-import type { ElementReference, ProtocolCommandsAsync, ProtocolCommands } from '@wdio/protocols'
+import type { ElementReference, ProtocolCommandsAsync, ProtocolCommands, RectReturn } from '@wdio/protocols'
 import type { Browser as PuppeteerBrowser } from 'puppeteer-core/lib/cjs/puppeteer/common/Browser'
 
 import type BrowserCommands from './commands/browser'
 import type ElementCommands from './commands/element'
 import type DevtoolsInterception from './utils/interception/devtools'
+import type { Coordinates, Location } from './commands/element/getLocation'
+import type { Size } from './commands/element/getSize'
 
 export type BrowserCommandsType = typeof BrowserCommands
 export type BrowserCommandsTypeSync = {
@@ -24,7 +26,30 @@ export type BrowserCommandsTypeSync = {
 }
 export type ElementCommandsType = typeof ElementCommands
 export type ElementCommandsTypeSync = {
-    [K in keyof ElementCommandsType]: (...args: Parameters<ElementCommandsType[K]>) => ThenArg<ReturnType<ElementCommandsType[K]>>
+    [K in keyof Omit<ElementCommandsType, 'getLocation' | 'getSize'>]: (...args: Parameters<ElementCommandsType[K]>) => ThenArg<ReturnType<ElementCommandsType[K]>>
+} & {
+    /**
+     * same as execute, because generics
+     */
+    getLocation: (<T extends undefined>(
+        this: WebdriverIO.Element,
+    ) => Location<T>) & (<T extends keyof Coordinates>(
+        this: WebdriverIO.Element,
+        prop: T
+    ) => Location<T>) & (<T extends keyof Coordinates> (
+        this: WebdriverIO.Element,
+        prop?: T
+    ) => Location<T>),
+
+    getSize: (<T extends undefined>(
+        this: WebdriverIO.Element,
+    ) => Size<T>) & (<T extends keyof RectReturn>(
+        this: WebdriverIO.Element,
+        prop: T
+    ) => Size<T>) & (<T extends keyof RectReturn> (
+        this: WebdriverIO.Element,
+        prop?: T
+    ) => Size<T>)
 }
 
 /**

--- a/packages/webdriverio/src/types.ts
+++ b/packages/webdriverio/src/types.ts
@@ -2,7 +2,7 @@ import type { EventEmitter } from 'events'
 
 import type { SessionFlags } from 'webdriver'
 import type { Options, Capabilities, FunctionProperties, ThenArg } from '@wdio/types'
-import type { ElementReference, ProtocolCommandsAsync, ProtocolCommands } from '@wdio/protocols'
+import type { ElementReference, ProtocolCommandsAsync, ProtocolCommands, RectReturn } from '@wdio/protocols'
 import type { Browser as PuppeteerBrowser } from 'puppeteer-core/lib/cjs/puppeteer/common/Browser'
 
 import type BrowserCommands from './commands/browser'
@@ -42,10 +42,10 @@ export type ElementCommandsTypeSync = {
         this: WebdriverIO.Element,
     ) => Size) & ((
         this: WebdriverIO.Element,
-        prop: keyof Size
+        prop: keyof RectReturn
     ) => number) & ((
         this: WebdriverIO.Element,
-        prop?: keyof Size
+        prop?: keyof RectReturn
     ) => Size | number),
 }
 

--- a/packages/webdriverio/src/types.ts
+++ b/packages/webdriverio/src/types.ts
@@ -2,13 +2,13 @@ import type { EventEmitter } from 'events'
 
 import type { SessionFlags } from 'webdriver'
 import type { Options, Capabilities, FunctionProperties, ThenArg } from '@wdio/types'
-import type { ElementReference, ProtocolCommandsAsync, ProtocolCommands, RectReturn } from '@wdio/protocols'
+import type { ElementReference, ProtocolCommandsAsync, ProtocolCommands } from '@wdio/protocols'
 import type { Browser as PuppeteerBrowser } from 'puppeteer-core/lib/cjs/puppeteer/common/Browser'
 
 import type BrowserCommands from './commands/browser'
 import type ElementCommands from './commands/element'
 import type DevtoolsInterception from './utils/interception/devtools'
-import type { Coordinates, Location } from './commands/element/getLocation'
+import type { Location } from './commands/element/getLocation'
 import type { Size } from './commands/element/getSize'
 
 export type BrowserCommandsType = typeof BrowserCommands
@@ -28,28 +28,25 @@ export type ElementCommandsType = typeof ElementCommands
 export type ElementCommandsTypeSync = {
     [K in keyof Omit<ElementCommandsType, 'getLocation' | 'getSize'>]: (...args: Parameters<ElementCommandsType[K]>) => ThenArg<ReturnType<ElementCommandsType[K]>>
 } & {
-    //
-    // same as execute, because generics
-    //
-    getLocation: (<T extends undefined>(
+    getLocation: ((
         this: WebdriverIO.Element,
-    ) => Location<T>) & (<T extends keyof Coordinates>(
+    ) => Location) & ((
         this: WebdriverIO.Element,
-        prop: T
-    ) => Location<T>) & (<T extends keyof Coordinates> (
+        prop: keyof Location
+    ) => number) & ((
         this: WebdriverIO.Element,
-        prop?: T
-    ) => Location<T>),
+        prop?: keyof Location
+    ) => Location | number),
 
-    getSize: (<T extends undefined>(
+    getSize: ((
         this: WebdriverIO.Element,
-    ) => Size<T>) & (<T extends keyof RectReturn>(
+    ) => Size) & ((
         this: WebdriverIO.Element,
-        prop: T
-    ) => Size<T>) & (<T extends keyof RectReturn> (
+        prop: keyof Size
+    ) => number) & ((
         this: WebdriverIO.Element,
-        prop?: T
-    ) => Size<T>)
+        prop?: keyof Size
+    ) => Size | number),
 }
 
 /**

--- a/tests/typings/sync/sync.ts
+++ b/tests/typings/sync/sync.ts
@@ -154,6 +154,7 @@ const elementClickable: boolean = el2.waitForClickable({
 el1.getLocation('x').toFixed() // as number
 el1.getLocation().y // as Location
 
+el1.getSize('y').toFixed() // as number
 el1.getSize('width').toFixed() // as number
 el1.getSize().height // as Size
 

--- a/tests/typings/sync/sync.ts
+++ b/tests/typings/sync/sync.ts
@@ -150,6 +150,13 @@ const elementClickable: boolean = el2.waitForClickable({
     interval: 1,
     reverse: true
 })
+
+el1.getLocation('x').toFixed() // as number
+el1.getLocation().y // as Location
+
+el1.getSize('width').toFixed() // as number
+el1.getSize().height // as Size
+
 // element custom command
 const el2result = el3.elementCustomCommand(4)
 el2result.toFixed(2)

--- a/tests/typings/webdriverio/async.ts
+++ b/tests/typings/webdriverio/async.ts
@@ -220,7 +220,14 @@ async function bar() {
         timeoutMsg: '',
         interval: 1,
         reverse: true
-    })
+    });
+
+    (await el1.getLocation('x')).toFixed(); // as number
+    (await el1.getLocation()).y; // as Location
+
+    (await el1.getSize('width')).toFixed(); // as number
+    (await el1.getSize()).height; // as Size
+
     // element custom command
     const el2result = await el3.elementCustomCommand(4)
     el2result.toFixed(2)

--- a/tests/typings/webdriverio/async.ts
+++ b/tests/typings/webdriverio/async.ts
@@ -225,6 +225,7 @@ async function bar() {
     (await el1.getLocation('x')).toFixed(); // as number
     (await el1.getLocation()).y; // as Location
 
+    (await el1.getSize('y')).toFixed(); // as number
     (await el1.getSize('width')).toFixed(); // as number
     (await el1.getSize()).height; // as Size
 


### PR DESCRIPTION
## Proposed changes

- function overloads as suggested [here](https://github.com/webdriverio/webdriverio/issues/6549#issue-822350507)

the idea is to have something like this as a result:
<img width="372" alt="Screenshot 2021-03-06 at 11 14 45 PM" src="https://user-images.githubusercontent.com/21245218/110211546-f5152380-7ed1-11eb-8c8d-6f77aa9a3d5e.png">


[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (typings)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

1. The [issue](https://github.com/webdriverio/webdriverio/issues/6549) we're aiming to fix gave `getLocation` and `getSize` as examples. I skimmed other browser and element commands under the webdriverio package that may need the same change and couldn't find others. I could be mistaken though so would appreciate if someone can check that.

2. ~~Not really sure if I would need to add tests for this either, for now I did without.~~

3. There's a completely unrelated [commit](https://github.com/webdriverio/webdriverio/pull/6558/commits/413b4e2465752f01df182a7126995ac83a05faed) in this PR; i had to add this in because of [this recent change](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/51520/files) that broke the tests 

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
