### PR TITLE
bugfix: #6569 only install tagged version if requested spec doesnt match semver

### DIFF
--- a/packages/wdio-cli/src/commands/config.ts
+++ b/packages/wdio-cli/src/commands/config.ts
@@ -105,9 +105,12 @@ const runConfig = async function (useYarn: boolean, yes: boolean, exit = false) 
      * ensure wdio packages have the same dist tag as cli
      */
     if (pkg._requested && pkg._requested.fetchSpec) {
-        packagesToInstall = packagesToInstall.map((p) => p.startsWith('@wdio') || ['devtools', 'webdriver', 'webdriverio'].includes(p)
-            ? `${p}@${pkg._requested.fetchSpec}`
-            : p
+        const { fetchSpec } = pkg._requested
+        packagesToInstall = packagesToInstall.map((p) =>
+            (p.startsWith('@wdio') || ['devtools', 'webdriver', 'webdriverio'].includes(p)) &&
+            (fetchSpec.match(/(v)?\d+\.\d+\.\d+/) === null)
+                ? `${p}@${fetchSpec}`
+                : p
         )
     }
 

--- a/packages/wdio-cli/tests/commands/__snapshots__/config.test.ts.snap
+++ b/packages/wdio-cli/tests/commands/__snapshots__/config.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`install compliant NPM tag packages it should install tagged version if cli is tagged 1`] = `
+exports[`install compliant NPM tag packages it should install tagged version if cli is tagged with beta 1`] = `
 Array [
   Array [
     "
@@ -18,6 +18,138 @@ Installing wdio packages:
 - @wdio/crossbrowsertesting-service@beta
 - wdio-lambdatest-service
 - @wdio/sync@beta",
+  ],
+  Array [
+    "
+Packages installed successfully, creating configuration file...",
+  ],
+  Array [
+    "To have TypeScript support please add the following packages to your \\"types\\" list:
+{
+  \\"compilerOptions\\": {
+    \\"types\\": [\\"node\\", \\"webdriverio/sync\\", \\"@wdio/mocha-framework\\", \\"@wdio/crossbrowsertesting-service\\"]
+  }
+}
+
+For for information on TypeScript integration check out: https://webdriver.io/docs/typescript
+",
+  ],
+  Array [
+    "
+Configuration file was created successfully!
+To run your tests, execute:
+$ npx wdio run wdio.conf.js
+",
+  ],
+]
+`;
+
+exports[`install compliant NPM tag packages it should install tagged version if cli is tagged with latest 1`] = `
+Array [
+  Array [
+    "
+=========================
+WDIO Configuration Helper
+=========================
+",
+  ],
+  Array [
+    "
+Installing wdio packages:
+-",
+    "@wdio/local-runner@latest
+- @wdio/mocha-framework@latest
+- @wdio/crossbrowsertesting-service@latest
+- wdio-lambdatest-service
+- @wdio/sync@latest",
+  ],
+  Array [
+    "
+Packages installed successfully, creating configuration file...",
+  ],
+  Array [
+    "To have TypeScript support please add the following packages to your \\"types\\" list:
+{
+  \\"compilerOptions\\": {
+    \\"types\\": [\\"node\\", \\"webdriverio/sync\\", \\"@wdio/mocha-framework\\", \\"@wdio/crossbrowsertesting-service\\"]
+  }
+}
+
+For for information on TypeScript integration check out: https://webdriver.io/docs/typescript
+",
+  ],
+  Array [
+    "
+Configuration file was created successfully!
+To run your tests, execute:
+$ npx wdio run wdio.conf.js
+",
+  ],
+]
+`;
+
+exports[`install compliant NPM tag packages it should install tagged version if cli is tagged with next 1`] = `
+Array [
+  Array [
+    "
+=========================
+WDIO Configuration Helper
+=========================
+",
+  ],
+  Array [
+    "
+Installing wdio packages:
+-",
+    "@wdio/local-runner@next
+- @wdio/mocha-framework@next
+- @wdio/crossbrowsertesting-service@next
+- wdio-lambdatest-service
+- @wdio/sync@next",
+  ],
+  Array [
+    "
+Packages installed successfully, creating configuration file...",
+  ],
+  Array [
+    "To have TypeScript support please add the following packages to your \\"types\\" list:
+{
+  \\"compilerOptions\\": {
+    \\"types\\": [\\"node\\", \\"webdriverio/sync\\", \\"@wdio/mocha-framework\\", \\"@wdio/crossbrowsertesting-service\\"]
+  }
+}
+
+For for information on TypeScript integration check out: https://webdriver.io/docs/typescript
+",
+  ],
+  Array [
+    "
+Configuration file was created successfully!
+To run your tests, execute:
+$ npx wdio run wdio.conf.js
+",
+  ],
+]
+`;
+
+exports[`install compliant NPM tag packages it should not install tagged version if cli is tagged with a specific version 1`] = `
+Array [
+  Array [
+    "
+=========================
+WDIO Configuration Helper
+=========================
+",
+  ],
+  Array [
+    "
+Installing wdio packages:
+-",
+    "@wdio/local-runner
+- @wdio/mocha-framework
+- @wdio/crossbrowsertesting-service
+- wdio-lambdatest-service
+- @wdio/sync",
   ],
   Array [
     "

--- a/packages/wdio-cli/tests/commands/config.test.ts
+++ b/packages/wdio-cli/tests/commands/config.test.ts
@@ -98,28 +98,49 @@ test('it should install with yarn when flag is passed', async () => {
 })
 
 describe('install compliant NPM tag packages', () => {
-    beforeAll(() => {
-        // @ts-expect-error
-        pkg.setFetchSpec('beta')
-    })
+    // @ts-expect-error
+    const setFetchSpec = (fetchSpec) => pkg.setFetchSpec(fetchSpec)
+    const args = {
+        executionMode: 'sync',
+        framework: '@wdio/mocha-framework$--$mocha',
+        reporters: [],
+        services: [
+            '@wdio/crossbrowsertesting-service$--$crossbrowsertesting',
+            'wdio-lambdatest-service$--$lambdatest'
+        ],
+        generateTestFiles: false,
+        isUsingCompiler: 'TypeScript (https://www.typescriptlang.org/)'
+    }
 
-    test('it should install tagged version if cli is tagged', async () => {
-        (inquirer.prompt as any as jest.Mock).mockReturnValue(Promise.resolve({
-            executionMode: 'sync',
-            framework: '@wdio/mocha-framework$--$mocha',
-            reporters: [],
-            services: [
-                '@wdio/crossbrowsertesting-service$--$crossbrowsertesting',
-                'wdio-lambdatest-service$--$lambdatest'
-            ],
-            generateTestFiles: false,
-            isUsingCompiler: 'TypeScript (https://www.typescriptlang.org/)'
-        }))
+    test('it should install tagged version if cli is tagged with beta', async () => {
+        setFetchSpec('beta');
+        (inquirer.prompt as any as jest.Mock).mockReturnValue(Promise.resolve(args))
         await handler({} as any)
         expect(consoleLogSpy.mock.calls).toMatchSnapshot()
     })
 
-    afterAll(() => {
+    test('it should install tagged version if cli is tagged with next', async () => {
+        setFetchSpec('next');
+        (inquirer.prompt as any as jest.Mock).mockReturnValue(Promise.resolve(args))
+        await handler({} as any)
+        expect(consoleLogSpy.mock.calls).toMatchSnapshot()
+    })
+
+    test('it should install tagged version if cli is tagged with latest', async () => {
+        setFetchSpec('latest');
+        (inquirer.prompt as any as jest.Mock).mockReturnValue(Promise.resolve(args))
+        await handler({} as any)
+        expect(consoleLogSpy.mock.calls).toMatchSnapshot()
+    })
+
+    test('it should not install tagged version if cli is tagged with a specific version', async () => {
+        setFetchSpec('7.0.8');
+        (inquirer.prompt as any as jest.Mock).mockReturnValue(Promise.resolve(args))
+        await handler({} as any)
+        expect(consoleLogSpy.mock.calls).toMatchSnapshot()
+    })
+
+    afterEach(() => {
         // @ts-expect-error
         pkg.clearFetchSpec()
     })


### PR DESCRIPTION
## Proposed changes

- fixes #6569
- ~~to add a condition for dist tags `beta` and `next` when installing packages via the config command~~
- to add a condition to check if fetchSpec mathces semver

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

- ~~do we need to add it for uncommon tags too? looking at previous release tags, wdio has had `alpha` and `blm` tags before~~

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
