### PR TITLE
Support custom tsconfig-paths options

### DIFF
--- a/examples/wdio.conf.js
+++ b/examples/wdio.conf.js
@@ -193,6 +193,12 @@ exports.config = {
             project: 'tsconfig.json'
         },
 
+        // If you have tsconfig-paths installed and provide a tsConfigPathsOpts
+        // option, it will be automatically registered during bootstrap.
+        tsConfigPathsOpts: {
+            baseUrl: './'
+        },
+
         // Configure how @babel/register is automatically included when present (and ts-node isn't)
         babelOpts: {}
     },

--- a/packages/wdio-config/package.json
+++ b/packages/wdio-config/package.json
@@ -32,6 +32,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "minimatch": "^3.0.4"
+    "minimatch": "^3.0.4",
+    "tsconfig-paths": "^3.9.0"
   }
 }

--- a/packages/wdio-config/src/utils.ts
+++ b/packages/wdio-config/src/utils.ts
@@ -96,18 +96,39 @@ export interface ModuleRequireService {
 }
 
 export function loadAutoCompilers(autoCompileConfig: Options.AutoCompileConfig, requireService: ModuleRequireService) {
-    return autoCompileConfig.autoCompile && (
-        loadTypeScriptCompiler(autoCompileConfig.tsNodeOpts, requireService)
-        ||
-        loadBabelCompiler(autoCompileConfig.babelOpts, requireService)
+    return (
+        autoCompileConfig.autoCompile &&
+        (
+            loadTypeScriptCompiler(
+                autoCompileConfig.tsNodeOpts,
+                autoCompileConfig.tsConfigPathsOpts,
+                requireService
+            )
+            ||
+            loadBabelCompiler(
+                autoCompileConfig.babelOpts,
+                requireService
+            )
+        )
     )
 }
 
-export function loadTypeScriptCompiler (tsNodeOpts: RegisterOptions = {}, requireService: ModuleRequireService) {
+export function loadTypeScriptCompiler (
+    tsNodeOpts: RegisterOptions = {},
+    tsConfigPathsOpts: Options.TSConfigPathsOptions | undefined,
+    requireService: ModuleRequireService
+) {
     try {
         requireService.resolve('ts-node') as any
         (requireService.require('ts-node') as any).register(tsNodeOpts)
         log.debug('Found \'ts-node\' package, auto-compiling TypeScript files')
+
+        if (tsConfigPathsOpts) {
+            log.debug('Found \'tsconfig-paths\' options, register paths')
+            const tsConfigPaths = require('tsconfig-paths')
+            tsConfigPaths.register(tsConfigPathsOpts)
+        }
+
         return true
     } catch (e) {
         return false

--- a/packages/wdio-config/tests/configparser.test.ts
+++ b/packages/wdio-config/tests/configparser.test.ts
@@ -1,5 +1,6 @@
 import path from 'path'
 import tsNode from 'ts-node'
+import tsConfigPath from 'tsconfig-paths'
 import logger from '@wdio/logger'
 import ConfigParser from '../src/lib/ConfigParser'
 import MockFileContentBuilder, { MockFileContent } from './lib/MockFileContentBuilder'
@@ -19,6 +20,10 @@ const FIXTURES_CUCUMBER_FEATURE_B_LINE_7 = path.resolve(FIXTURES_PATH, 'test-b.f
 const INDEX_PATH = path.resolve(__dirname, '..', 'src', 'index.ts')
 
 jest.mock('ts-node', () => ({
+    register: jest.fn()
+}))
+
+jest.mock('tsconfig-paths', () => ({
     register: jest.fn()
 }))
 
@@ -165,6 +170,7 @@ describe('ConfigParser', () => {
             beforeEach(() => {
                 (log.debug as jest.Mock).mockClear()
                 ;(tsNode.register as jest.Mock).mockClear()
+                ;(tsConfigPath.register as jest.Mock).mockClear()
                 process.env.THROW_BABEL_REGISTER = '1'
             })
 
@@ -266,9 +272,37 @@ describe('ConfigParser', () => {
                     .withTsNodeModule(tsNodeRegister).build()
                 configParser.addConfigFile('tests/cool.conf')
                 configParser.autoCompile()
+                expect(tsConfigPath.register).toBeCalledTimes(0)
                 expect(tsNodeRegister).toBeCalledTimes(1)
                 expect(tsNodeRegister).toHaveBeenCalledWith( {
                     'transpileOnly': false
+                } )
+            })
+
+            it('bootstraps tsconfig-paths if options are given', function () {
+                let configFileContents = MockFileContentBuilder.FromRealConfigFile(FIXTURES_CONF_RDC).withTheseContentsMergedOn(
+                    {
+                        config: {
+                            autoCompileOpts: {
+                                tsConfigPathsOpts: {
+                                    base: '/foo/bar'
+                                }
+                            }
+                        }
+                    }
+                ).build()
+                const tsNodeRegister = jest.fn()
+                const configParser = ConfigParserBuilder
+                    .withBaseDir(path.join(__dirname, '/tests/'))
+                    .withFiles([
+                        ...MockedFileSystem_OnlyLoadingConfig(path.join(__dirname, '/tests/'), '/path/to/config'),
+                        FileNamed(path.join(__dirname, '/tests/tests/cool.conf')).withContents(JSON.stringify(configFileContents))
+                    ])
+                    .withTsNodeModule(tsNodeRegister).build()
+                configParser.addConfigFile('tests/cool.conf')
+                configParser.autoCompile()
+                expect(tsConfigPath.register).toHaveBeenCalledWith( {
+                    base: '/foo/bar'
                 } )
             })
 

--- a/packages/wdio-types/src/Options.ts
+++ b/packages/wdio-types/src/Options.ts
@@ -410,10 +410,18 @@ export interface Testrunner extends Hooks, Omit<WebdriverIO, 'capabilities'>, We
     autoCompileOpts?: AutoCompileConfig
 }
 
+export interface TSConfigPathsOptions {
+    baseUrl: string
+    paths: Record<string, string[]>
+    mainFields?: string[]
+    addMatchAll?: boolean
+}
+
 export interface AutoCompileConfig {
     autoCompile?: boolean
     tsNodeOpts?: RegisterOptions
     babelOpts?: Record<string, any>
+    tsConfigPathsOpts?: TSConfigPathsOptions
 }
 
 export interface MultiRemote extends Omit<Testrunner, 'capabilities'> {

--- a/website/docs/ConfigurationFile.md
+++ b/website/docs/ConfigurationFile.md
@@ -268,6 +268,11 @@ exports.config = {
             transpileOnly: true,
             project: 'tsconfig.json'
         },
+        // If you have tsconfig-paths installed and provide a tsConfigPathsOpts
+        // option, it will be automatically registered during bootstrap.
+        tsConfigPathsOpts: {
+            baseUrl: './'
+        },
         //
         // If @babel/register is installed, you can customize how options are passed to it here:
         // Any valid @babel/register config option is allowed.

--- a/website/docs/TypeScript.md
+++ b/website/docs/TypeScript.md
@@ -11,7 +11,31 @@ You will need [`typescript`](https://github.com/microsoft/TypeScript) and [`ts-n
 $ npm install typescript ts-node --save-dev
 ```
 
-The minimum TypeScript version is 3.8.3.
+The minimum TypeScript version is `v4.0.5`.
+
+## Configuration
+
+You can provide custom `ts-node` and `tsconfig-paths` options through your `wdio.conf.ts`, e.g.:
+
+```ts title="wdio.conf.ts"
+export const config = {
+    // ...
+    autoCompileOpts: {
+        autoCompile: true,
+        // see https://github.com/TypeStrong/ts-node#cli-and-programmatic-options
+        // for all available options
+        tsNodeOpts: {
+            transpileOnly: true,
+            project: 'tsconfig.json'
+        },
+        // tsconfig-paths is only used if "tsConfigPathsOpts" are provided, if you
+        // do please make sure "tsconfig-paths" is installed as dependency
+        tsConfigPathsOpts: {
+            baseUrl: './'
+        }
+    }
+}
+```
 
 ## Framework Setup
 
@@ -49,7 +73,7 @@ And your `tsconfig.json` needs the following:
 </Tabs>
 
 Please avoid importing `webdriverio` or `@wdio/sync` explicitly.
-`WebdriverIO` and `WebDriver` types are accessible from anywhere once added to `types` in `tsconfig.json`.
+`WebdriverIO` and `WebDriver` types are accessible from anywhere once added to `types` in `tsconfig.json`. If you use additional WebdriverIO services or plugins, please also add them to the `types` list as many provide additional typings.
 
 ## Framework types
 


### PR DESCRIPTION
## Proposed changes

A lot of TypeScript users also like to use `tsconfig-paths`. This patch adds the ability to automatically use register it with custom options.

closes #6500

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

cc @r4j4h

### Reviewers: @webdriverio/project-committers
