### PR TITLE
Only apply base url if not empty string

### DIFF
--- a/packages/webdriverio/src/commands/browser/url.ts
+++ b/packages/webdriverio/src/commands/browser/url.ts
@@ -42,7 +42,7 @@ export default function url (
         throw new Error('Parameter for "url" command needs to be type of string')
     }
 
-    if (typeof this.options.baseUrl === 'string') {
+    if (typeof this.options.baseUrl === 'string' && this.options.baseUrl) {
         path = (new URL(path, this.options.baseUrl)).href
     }
 

--- a/packages/webdriverio/tests/commands/browser/url.test.ts
+++ b/packages/webdriverio/tests/commands/browser/url.test.ts
@@ -40,6 +40,19 @@ describe('url', () => {
         }
     })
 
+    it('should not fail with empty baseurl', async () => {
+        browser = await remote({
+            baseUrl: '',
+            capabilities: {
+                browserName: 'foobar'
+            }
+        })
+
+        await browser.url('/foobar')
+        expect(got.mock.calls[1][1].json)
+            .toEqual({ url: 'http://foobar/' })
+    })
+
     afterEach(() => {
         got.mockClear()
     })


### PR DESCRIPTION
## Proposed changes

If someone has an empty string in their base url it would have cause WebdriverIO to throw an error:

```
   "TypeError [ERR_INVALID_URL]: Invalid URL:
     at onParseError (internal/url.js:256:9)
     at new URL (internal/url.js:332:5)
     at new URL (internal/url.js:329:22)
    at Browser.url (/xxxxx/node_modules/webdriverio/build/commands/browser/url.js:43:17)"
```

This patch ensure that the string is not empty.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

refs #6460

### Reviewers: @webdriverio/project-committers
