### PR TITLE
Upload WDIO logs to Sauce Labs via Sauce Service

### DIFF
--- a/packages/wdio-sauce-service/README.md
+++ b/packages/wdio-sauce-service/README.md
@@ -160,7 +160,7 @@ Default: `{ noAutodetect: true }`
 
 ### uploadLogs
 
-If `true` this options uploads all WebdriverIO log files to the Sauce Labs platform for further inspection.
+If `true` this options uploads all WebdriverIO log files to the Sauce Labs platform for further inspection. Make sure you have [`outputDir`](https://webdriver.io/docs/options#outputdir) set in your wdio config to write logs into files, otherwise data will be streamed to stdout and can't get uploaded.
 
 Type: `Boolean`<br />
 Default: `true`

--- a/packages/wdio-sauce-service/README.md
+++ b/packages/wdio-sauce-service/README.md
@@ -148,15 +148,22 @@ Default: `false`
 *(only for vm and or em/simulators)*
 
 ### sauceConnectOpts
-Apply Sauce Connect options (e.g. to change port number or logFile settings). See [this list](https://wiki.saucelabs.com/display/DOCS/Sauce+Connect+Proxy+Command-Line+Quick+Reference+Guide) for more information. Per default the service disables SC proxy auto-detection as via `noAutodetect` as this can be unreliable for some machines.  
+Apply Sauce Connect options (e.g. to change port number or logFile settings). See [this list](https://wiki.saucelabs.com/display/DOCS/Sauce+Connect+Proxy+Command-Line+Quick+Reference+Guide) for more information. Per default the service disables SC proxy auto-detection as via `noAutodetect` as this can be unreliable for some machines.
 
-NOTE: When specifying the options the `--` should be omitted.  
+NOTE: When specifying the options the `--` should be omitted.
 It can also be turned into camelCase (e.g. `shared-tunnel` or `sharedTunnel`).
 
 Type: `Object`<br />
 Default: `{ noAutodetect: true }`
 
 *(only for vm and or em/simulators)*
+
+### uploadLogs
+
+If `true` this options uploads all WebdriverIO log files to the Sauce Labs platform for further inspection.
+
+Type: `Boolean`<br />
+Default: `true`
 
 ----
 

--- a/packages/wdio-sauce-service/src/constants.ts
+++ b/packages/wdio-sauce-service/src/constants.ts
@@ -1,0 +1,5 @@
+import type { SauceServiceConfig } from './types'
+
+export const DEFAULT_OPTIONS: Partial<SauceServiceConfig> = {
+    uploadLogs: true
+}

--- a/packages/wdio-sauce-service/src/service.ts
+++ b/packages/wdio-sauce-service/src/service.ts
@@ -8,6 +8,7 @@ import type { Browser, MultiRemoteBrowser } from 'webdriverio'
 
 import { isUnifiedPlatform } from './utils'
 import { SauceServiceConfig } from './types'
+import { DEFAULT_OPTIONS } from './constants'
 
 const jobDataProperties = ['name', 'tags', 'public', 'build', 'custom-data'] as const
 
@@ -20,6 +21,7 @@ export default class SauceService implements Services.ServiceInstance {
     private _isServiceEnabled = true
     private _isJobNameSet = false;
 
+    private _options: SauceServiceConfig
     private _api: SauceLabs
     private _isRDC: boolean
     private _browser?: Browser<'async'> | MultiRemoteBrowser<'async'>
@@ -27,10 +29,11 @@ export default class SauceService implements Services.ServiceInstance {
     private _suiteTitle?: string
 
     constructor (
-        private _options: SauceServiceConfig,
+        options: SauceServiceConfig,
         private _capabilities: Capabilities.RemoteCapability,
         private _config: Options.Testrunner
     ) {
+        this._options = { ...DEFAULT_OPTIONS, ...options }
         this._api = new SauceLabs(this._config as unknown as SauceLabsOptions)
         this._isRDC = 'testobject_api_key' in this._capabilities
         this._maxErrorStackLength = this._options.maxErrorStackLength || this._maxErrorStackLength

--- a/packages/wdio-sauce-service/src/types.ts
+++ b/packages/wdio-sauce-service/src/types.ts
@@ -24,6 +24,7 @@ export interface SauceServiceConfig {
      * @default false
      */
     sauceConnect?: boolean
+
     /**
      * Apply Sauce Connect options (e.g. to change port number or logFile settings). See this
      * list for more information: https://github.com/bermi/sauce-connect-launcher#advanced-usage
@@ -31,6 +32,13 @@ export interface SauceServiceConfig {
      * @default {}
      */
     sauceConnectOpts?: SauceConnectOptions
+
+    /**
+     * Upload WebdriverIO logs to the Sauce Labs platform.
+     * @default false
+     */
+    uploadLogs?: boolean
+
     /**
      * Use Sauce Connect as a Selenium Relay. See more [here](https://wiki.saucelabs.com/display/DOCS/Using+the+Selenium+Relay+with+Sauce+Connect+Proxy).
      * @deprecated

--- a/packages/wdio-sauce-service/src/types.ts
+++ b/packages/wdio-sauce-service/src/types.ts
@@ -35,7 +35,7 @@ export interface SauceServiceConfig {
 
     /**
      * Upload WebdriverIO logs to the Sauce Labs platform.
-     * @default false
+     * @default true
      */
     uploadLogs?: boolean
 

--- a/packages/wdio-sauce-service/tests/service.test.ts
+++ b/packages/wdio-sauce-service/tests/service.test.ts
@@ -1,14 +1,30 @@
+import fs from 'fs'
 import got from 'got'
+import logger from '@wdio/logger'
 import type { MultiRemoteBrowser } from 'webdriverio'
 import type { Capabilities, Options } from '@wdio/types'
 
 import SauceService from '../src'
 import { isUnifiedPlatform } from '../src/utils'
 
+const log = logger('test')
 const uri = '/some/uri'
 const featureObject = {
     name: 'Create a feature'
 }
+
+jest.createMockFromModule('fs')
+fs.createReadStream = jest.fn()
+fs.promises.stat = jest.fn().mockReturnValue(Promise.resolve({ size: 123 }))
+fs.promises.readdir = jest.fn().mockReturnValue(Promise.resolve([
+    'fileA.log',
+    'fileB.log',
+    'fileC.log'
+]))
+
+jest.mock('form-data', () => jest.fn().mockReturnValue({
+    append: jest.fn()
+}))
 
 jest.mock('../src/utils', () => {
     return {
@@ -25,6 +41,7 @@ beforeEach(() => {
         chromeC: { sessionId: 'sessionChromeC' },
         instances: ['chromeA', 'chromeB', 'chromeC'],
     } as any as MultiRemoteBrowser<'async'>
+    ;(log.error as jest.Mock).mockClear()
 })
 
 test('before should call isUnifiedPlatform', () => {
@@ -291,23 +308,25 @@ test('beforeScenario should not set context if no sauce user was applied', () =>
     expect(browser.execute).not.toBeCalledWith('sauce:context=Scenario: foobar')
 })
 
-test('after', () => {
+test('after', async () => {
     const service = new SauceService({}, {}, { user: 'foobar', key: '123' } as any)
     service['_browser'] = browser
     service.beforeSession()
     service['_failures'] = 5
     service.updateJob = jest.fn()
+    service['_uploadLogs'] = jest.fn()
 
     // @ts-expect-error
     browser.isMultiremote = false
     // @ts-expect-error
     browser.sessionId = 'foobar'
-    service.after({})
+    await service.after(1)
 
     expect(service.updateJob).toBeCalledWith('foobar', 5)
+    expect(service['_uploadLogs']).toBeCalledWith('foobar')
 })
 
-test('after for RDC', () => {
+test('after for RDC', async () => {
     const service = new SauceService({}, { testobject_api_key: '1' }, {} as any)
     service['_browser'] = browser
     service.beforeSession()
@@ -318,12 +337,12 @@ test('after for RDC', () => {
     browser.isMultiremote = false
     // @ts-expect-error
     browser.sessionId = 'foobar'
-    service.after({})
+    await service.after(1)
 
     expect(service.updateJob).toBeCalledWith('foobar', 5)
 })
 
-test('after for UP', () => {
+test('after for UP', async () => {
     const service = new SauceService({}, {}, {} as any)
     service['_browser'] = browser
     browser.capabilities = {}
@@ -334,12 +353,12 @@ test('after for UP', () => {
 
     // @ts-expect-error
     browser.isMultiremote = false
-    service.after({})
+    await service.after(1)
 
     expect(service.updateUP).toBeCalledWith(5)
 })
 
-test('after for UP with multi remote', () => {
+test('after for UP with multi remote', async () => {
     const caps: Capabilities.MultiRemoteCapabilities = {
         chromeA: { capabilities: {} },
         chromeB: { capabilities: {} },
@@ -357,16 +376,57 @@ test('after for UP with multi remote', () => {
     service['_isServiceEnabled'] = true
     service['_isUP'] = true
     service['_failures'] = 0
+    service['_uploadLogs'] = jest.fn()
 
     browser.isMultiremote = true
     // @ts-expect-error
     browser.sessionId = 'foobar'
-    service.after({})
+    await service.after(123)
 
     expect(service.updateUP).toBeCalledTimes(3)
+    expect(service['_uploadLogs']).toBeCalledTimes(3)
+    expect(service['_uploadLogs']).toBeCalledWith('sessionChromeA')
+    expect(service['_uploadLogs']).toBeCalledWith('sessionChromeB')
+    expect(service['_uploadLogs']).toBeCalledWith('sessionChromeC')
 })
 
-test('after with bail set', () => {
+test('_uploadLogs should not upload if option is not set in config', async () => {
+    const service = new SauceService(
+        {},
+        {},
+        { outputDir: '/foo/bar' } as any
+    )
+    await service['_uploadLogs']('123')
+    expect((got as any as jest.Mock).mock.calls).toHaveLength(0)
+})
+
+test('_uploadLogs should upload', async () => {
+    const service = new SauceService(
+        { uploadLogs: true },
+        {},
+        { outputDir: '/foo/bar' } as any
+    )
+    await service['_uploadLogs']('123')
+    expect((got as any as jest.Mock).mock.calls).toHaveLength(1)
+    expect((got as any as jest.Mock)).toHaveBeenCalledWith(
+        'https://api.us-west-1.saucelabs.com/v1/testrunner/jobs/123/assets',
+        expect.any(Object)
+    )
+})
+
+test('_uploadLogs should not fail in case of a platform error', async () => {
+    const service = new SauceService(
+        { uploadLogs: true },
+        {},
+        { outputDir: '/foo/bar' } as any
+    )
+    ;(got as any as jest.Mock).mockRejectedValueOnce(new Error('upps'))
+    expect(log.error).toHaveBeenCalledTimes(0)
+    await service['_uploadLogs']('123')
+    expect(log.error).toHaveBeenCalledTimes(1)
+})
+
+test('after with bail set', async () => {
     const service = new SauceService({}, {}, { user: 'foobar', key: '123', mochaOpts: { bail: 1 } } as any)
     service['_browser'] = browser
     service.beforeSession()
@@ -377,12 +437,12 @@ test('after with bail set', () => {
     browser.isMultiremote = false
     // @ts-expect-error
     browser.sessionId = 'foobar'
-    service.after(1)
+    await service.after(1)
 
     expect(service.updateJob).toBeCalledWith('foobar', 1)
 })
 
-test('beforeScenario should not set context if no sauce user was applied', () => {
+test('beforeScenario should not set context if no sauce user was applied', async () => {
     const service = new SauceService({}, {}, {} as any)
     service['_browser'] = browser
     service.beforeSession()
@@ -393,12 +453,12 @@ test('beforeScenario should not set context if no sauce user was applied', () =>
     browser.isMultiremote = false
     // @ts-expect-error
     browser.sessionId = 'foobar'
-    service.after({})
+    await service.after(1)
 
     expect(service.updateJob).not.toBeCalled()
 })
 
-test('after in multiremote', () => {
+test('after in multiremote', async () => {
     const caps: Capabilities.MultiRemoteCapabilities = {
         chromeA: { capabilities: {} },
         chromeB: { capabilities: {} },
@@ -413,7 +473,7 @@ test('after in multiremote', () => {
     browser.isMultiremote = true
     // @ts-expect-error
     browser.sessionId = 'foobar'
-    service.after({})
+    await service.after(1)
 
     expect(service.updateJob).toBeCalledWith('sessionChromeA', 5, false, 'chromeA')
     expect(service.updateJob).toBeCalledWith('sessionChromeB', 5, false, 'chromeB')

--- a/packages/wdio-sauce-service/tests/service.test.ts
+++ b/packages/wdio-sauce-service/tests/service.test.ts
@@ -392,7 +392,7 @@ test('after for UP with multi remote', async () => {
 
 test('_uploadLogs should not upload if option is not set in config', async () => {
     const service = new SauceService(
-        {},
+        { uploadLogs: false },
         {},
         { outputDir: '/foo/bar' } as any
     )
@@ -402,7 +402,7 @@ test('_uploadLogs should not upload if option is not set in config', async () =>
 
 test('_uploadLogs should upload', async () => {
     const service = new SauceService(
-        { uploadLogs: true },
+        {},
         {},
         { outputDir: '/foo/bar' } as any
     )
@@ -416,7 +416,7 @@ test('_uploadLogs should upload', async () => {
 
 test('_uploadLogs should not fail in case of a platform error', async () => {
     const service = new SauceService(
-        { uploadLogs: true },
+        {},
         {},
         { outputDir: '/foo/bar' } as any
     )


### PR DESCRIPTION
It would be useful for Sauce Labs user to have their WDIO logs uploaded to the platform so in case of an issue support people have the ability to get more insights about what is going on in the test.