### PR TITLE
Better expose config handler

### DIFF
--- a/packages/wdio-cli/src/commands/config.ts
+++ b/packages/wdio-cli/src/commands/config.ts
@@ -154,9 +154,7 @@ const runConfig = async function (useYarn: boolean, yes: boolean, exit = false) 
             await generateTestFiles(parsedAnswers)
         }
     } catch (e) {
-        console.error(`Couldn't write config file: ${e.stack}`)
-        /* istanbul ignore next */
-        return !process.env.JEST_WORKER_ID && process.exit(1)
+        throw new Error(`Couldn't write config file: ${e.stack}`)
     }
 
     /**
@@ -187,14 +185,16 @@ const runConfig = async function (useYarn: boolean, yes: boolean, exit = false) 
         /* istanbul ignore next */
         process.exit(0)
     }
+
+    return {
+        success: true,
+        parsedAnswers,
+        installedPackages: packagesToInstall.map((pkg) => pkg.split('--')[0])
+    }
 }
 
-export async function handler(argv: ConfigCommandArguments) {
-    try {
-        await runConfig(argv.yarn, argv.yes)
-    } catch (error) {
-        throw new Error(`something went wrong during setup: ${error.stack.slice(7)}`)
-    }
+export function handler(argv: ConfigCommandArguments) {
+    return runConfig(argv.yarn, argv.yes)
 }
 
 /**

--- a/packages/wdio-cli/tests/commands/__snapshots__/config.test.ts.snap
+++ b/packages/wdio-cli/tests/commands/__snapshots__/config.test.ts.snap
@@ -277,7 +277,6 @@ Object {
   "parsedAnswers": Object {
     "_async": "async ",
     "_await": "await ",
-    "destPageObjectRootPath": "",
     "destSpecRootPath": "/Users/christianbromann/Sites/WebdriverIO/webdriverio",
     "framework": "mocha",
     "isSync": false,

--- a/packages/wdio-cli/tests/commands/__snapshots__/config.test.ts.snap
+++ b/packages/wdio-cli/tests/commands/__snapshots__/config.test.ts.snap
@@ -266,6 +266,42 @@ $ npx wdio run wdio.conf.js
 ]
 `;
 
+exports[`should create config file 1`] = `
+Object {
+  "installedPackages": Array [
+    "@wdio/local-runner",
+    "@wdio/mocha-framework",
+    "@wdio/spec-reporter",
+    "@wdio/sauce-service",
+  ],
+  "parsedAnswers": Object {
+    "_async": "async ",
+    "_await": "await ",
+    "destPageObjectRootPath": "",
+    "destSpecRootPath": "/Users/christianbromann/Sites/WebdriverIO/webdriverio",
+    "framework": "mocha",
+    "isSync": false,
+    "isUsingBabel": false,
+    "isUsingTypeScript": false,
+    "packagesToInstall": Array [
+      "@wdio/local-runner--$local",
+      "@wdio/mocha-framework",
+      "@wdio/spec-reporter",
+      "@wdio/sauce-service--$sauce",
+    ],
+    "relativePath": "",
+    "reporters": Array [
+      "spec",
+    ],
+    "runner": undefined,
+    "services": Array [
+      undefined,
+    ],
+  },
+  "success": true,
+}
+`;
+
 exports[`should install @babel/register if not existing 1`] = `
 Array [
   Array [

--- a/packages/wdio-cli/tests/commands/__snapshots__/config.test.ts.snap
+++ b/packages/wdio-cli/tests/commands/__snapshots__/config.test.ts.snap
@@ -277,7 +277,6 @@ Object {
   "parsedAnswers": Object {
     "_async": "async ",
     "_await": "await ",
-    "destSpecRootPath": "/Users/christianbromann/Sites/WebdriverIO/webdriverio",
     "framework": "mocha",
     "isSync": false,
     "isUsingBabel": false,

--- a/packages/wdio-cli/tests/commands/config.test.ts
+++ b/packages/wdio-cli/tests/commands/config.test.ts
@@ -45,6 +45,7 @@ afterEach(() => {
 test('should create config file', async () => {
     const result = await handler({} as any)
     delete result.parsedAnswers.destPageObjectRootPath
+    delete result.parsedAnswers.destSpecRootPath
     expect(result).toMatchSnapshot()
     expect(addServiceDeps).toBeCalledTimes(1)
     expect(convertPackageHashToObject).toBeCalledTimes(4)

--- a/packages/wdio-cli/tests/commands/config.test.ts
+++ b/packages/wdio-cli/tests/commands/config.test.ts
@@ -44,6 +44,7 @@ afterEach(() => {
 
 test('should create config file', async () => {
     const result = await handler({} as any)
+    delete result.parsedAnswers.destPageObjectRootPath
     expect(result).toMatchSnapshot()
     expect(addServiceDeps).toBeCalledTimes(1)
     expect(convertPackageHashToObject).toBeCalledTimes(4)

--- a/packages/wdio-cli/tests/commands/config.test.ts
+++ b/packages/wdio-cli/tests/commands/config.test.ts
@@ -43,7 +43,8 @@ afterEach(() => {
 })
 
 test('should create config file', async () => {
-    await handler({} as any)
+    const result = await handler({} as any)
+    expect(result).toMatchSnapshot()
     expect(addServiceDeps).toBeCalledTimes(1)
     expect(convertPackageHashToObject).toBeCalledTimes(4)
     expect(renderConfigurationFile).toBeCalledTimes(1)
@@ -64,10 +65,10 @@ test('it should properly build command', () => {
     expect(yargs.help).toHaveBeenCalled()
 })
 
-test('should log error if creating config file fails', async () => {
+test('should throw error if creating config file fails', async () => {
     (renderConfigurationFile as jest.Mock).mockReturnValueOnce(Promise.reject(new Error('boom!')))
-    await handler({} as any)
-    expect(errorLogSpy).toHaveBeenCalledTimes(1)
+    const err = await handler({} as any).catch((err) => err)
+    expect(err.message).toContain('Error: boom!')
 })
 
 test('installs @wdio/sync if user requests to run in sync mode', async () => {
@@ -144,20 +145,6 @@ describe('install compliant NPM tag packages', () => {
         // @ts-expect-error
         pkg.clearFetchSpec()
     })
-})
-
-test('should throw an error if something goes wrong', async () => {
-    // @ts-ignore uses expect-webdriverio
-    expect.assertions(1)
-    ;(yarnInstall as any as jest.Mock).mockReturnValueOnce({ status: 1, stderr: 'uups' })
-
-    try {
-        await handler({} as any)
-    } catch (err) {
-        expect(
-            err.message.startsWith('something went wrong during setup: uups')
-        ).toBe(true)
-    }
 })
 
 test('prints TypeScript setup message', async () => {


### PR DESCRIPTION
In order to allow CLI tools to better integrate with WebdriverIO it would be useful if `@wdio/cli` would expose the config wizard. In addition to that it would be useful which packages the config wizard did install.

I will assign this to me as I am working on the Angular CLI integration and found need for this.