### PR TITLE
fix sync browser type for "call" method

### DIFF
--- a/packages/webdriverio/src/types.ts
+++ b/packages/webdriverio/src/types.ts
@@ -13,16 +13,17 @@ import type { Size } from './commands/element/getSize'
 
 export type BrowserCommandsType = typeof BrowserCommands
 export type BrowserCommandsTypeSync = {
-    [K in keyof Omit<BrowserCommandsType, 'execute'>]: (...args: Parameters<BrowserCommandsType[K]>) => ThenArg<ReturnType<BrowserCommandsType[K]>>
+    [K in keyof Omit<BrowserCommandsType, 'execute' | 'call'>]: (...args: Parameters<BrowserCommandsType[K]>) => ThenArg<ReturnType<BrowserCommandsType[K]>>
 } & {
     /**
      * we need to copy type definitions for execute and executeAsync as we can't copy over
      * generics with method used above
      */
+    call: <T>(fn: () => Promise<T>) => T,
     execute: <ReturnValue, InnerArguments extends any[] = any[], OuterArguments extends InnerArguments = any>(
         script: string | ((...innerArgs: OuterArguments) => ReturnValue),
         ...args: InnerArguments
-    ) => ReturnValue
+    ) => ReturnValue,
 }
 export type ElementCommandsType = typeof ElementCommands
 export type ElementCommandsTypeSync = {


### PR DESCRIPTION
## Proposed changes

Types for the sync `browser` object are set to `unknown`.
Copy types for the sync `browser` interface.

Issue: https://github.com/webdriverio/webdriverio/issues/6622

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
