### PR TITLE
Check caps in `@wdio/selenium-standalone-server` before modifying capabilities

### DIFF
--- a/packages/wdio-selenium-standalone-service/src/launcher.ts
+++ b/packages/wdio-selenium-standalone-service/src/launcher.ts
@@ -6,7 +6,7 @@ import { promisify } from 'util'
 import fs from 'fs-extra'
 import * as SeleniumStandalone from 'selenium-standalone'
 
-import { getFilePath } from './utils'
+import { getFilePath, hasCapsWithSupportedBrowser } from './utils'
 import type { SeleniumStandaloneOptions } from './types'
 
 const DEFAULT_LOG_FILENAME = 'wdio-selenium-standalone.log'
@@ -84,7 +84,7 @@ export default class SeleniumStandaloneLauncher {
             const cap = (capability as Options.WebDriver).capabilities || capability
             const c = (cap as Capabilities.W3CCapabilities).alwaysMatch || cap
 
-            if (!isCloudCapability(c)) {
+            if (!isCloudCapability(c) && hasCapsWithSupportedBrowser(c)) {
                 Object.assign(c, DEFAULT_CONNECTION, { ...c })
             }
         }

--- a/packages/wdio-selenium-standalone-service/src/utils.ts
+++ b/packages/wdio-selenium-standalone-service/src/utils.ts
@@ -42,6 +42,6 @@ export function hasCapsWithSupportedBrowser (capabilities: Capabilities.Capabili
         return false
     }
     return SUPPORTED_CAPABILITIES.includes(
-        capabilities.browserName?.toLocaleLowerCase()
+        capabilities.browserName?.toLowerCase()
     )
 }

--- a/packages/wdio-selenium-standalone-service/src/utils.ts
+++ b/packages/wdio-selenium-standalone-service/src/utils.ts
@@ -1,6 +1,18 @@
+import { Capabilities } from '@wdio/types'
 import path from 'path'
 
 const FILE_EXTENSION_REGEX = /\.[0-9a-z]+$/i
+const SUPPORTED_CAPABILITIES = [
+    'chrome',
+    'googlechrome',
+    'firefox',
+    'edge',
+    'msedge',
+    'microsoftedge',
+    'microsoft edge',
+    'safari',
+    'webkit'
+]
 
 /**
  * Resolves the given path into a absolute path and appends the default filename as fallback when the provided path is a directory.
@@ -18,4 +30,18 @@ export function getFilePath (filePath: string, defaultFilename: string): string 
     }
 
     return absolutePath
+}
+
+/**
+ * find whether a browser session could be supported by the selenium-standalone service
+ * @param   {Capabilities.Capabilities} capabilities capabilities used for the session
+ * @returns {Boolean}                                true, if capabilities suggest a supported platform
+ */
+export function hasCapsWithSupportedBrowser (capabilities: Capabilities.Capabilities) {
+    if (!capabilities.browserName) {
+        return false
+    }
+    return SUPPORTED_CAPABILITIES.includes(
+        capabilities.browserName?.toLocaleLowerCase()
+    )
 }

--- a/packages/wdio-selenium-standalone-service/tests/launcher.test.ts
+++ b/packages/wdio-selenium-standalone-service/tests/launcher.test.ts
@@ -23,7 +23,7 @@ describe('Selenium standalone launcher', () => {
                 args: { drivers: { chrome: {} } },
                 installArgs: { drivers: { chrome: {} } },
             }
-            const capabilities: any = [{ port: 1234 }]
+            const capabilities: any = [{ port: 1234, browserName: 'firefox' }]
             const launcher = new SeleniumStandaloneLauncher(options, capabilities, {} as any)
             launcher._redirectLogStream = jest.fn()
             await launcher.onPrepare({ watch: true } as never)
@@ -45,8 +45,8 @@ describe('Selenium standalone launcher', () => {
                 installArgs: { drivers: { chrome: {} } },
             }
             const capabilities: any = {
-                browserA: { port: 1234 },
-                browserB: { port: 4321 }
+                browserA: { port: 1234, browserName: 'safari' },
+                browserB: { port: 4321, browserName: 'edge' }
             }
             const launcher = new SeleniumStandaloneLauncher(options, capabilities, {} as any)
             launcher._redirectLogStream = jest.fn()
@@ -68,19 +68,55 @@ describe('Selenium standalone launcher', () => {
                 installArgs: { drivers: { chrome: {} } },
             }
             const capabilities: any = {
-                browserA: { port: 1234 },
+                browserA: {
+                    port: 1234,
+                    capabilities: {
+                        browserName: 'chrome',
+                        acceptInsecureCerts: true
+                    }
+                },
                 browserB: { port: 4321, capabilities: { 'bstack:options': {} } }
             }
             const launcher = new SeleniumStandaloneLauncher(options, capabilities, {} as any)
             launcher._redirectLogStream = jest.fn()
             await launcher.onPrepare({ watch: true } as never)
-            expect(capabilities.browserA.protocol).toBe('http')
-            expect(capabilities.browserA.hostname).toBe('localhost')
+            expect(capabilities.browserA.capabilities.protocol).toBe('http')
+            expect(capabilities.browserA.capabilities.hostname).toBe('localhost')
+            expect(capabilities.browserA.capabilities.path).toBe('/wd/hub')
             expect(capabilities.browserA.port).toBe(1234)
-            expect(capabilities.browserA.path).toBe('/wd/hub')
             expect(capabilities.browserB.protocol).toBeUndefined()
             expect(capabilities.browserB.hostname).toBeUndefined()
             expect(capabilities.browserB.port).toBe(4321)
+            expect(capabilities.browserB.path).toBeUndefined()
+        })
+
+        test('should not override if capabilities do not match supported set of browser', async () => {
+            const options = {
+                logPath: './',
+                args: { drivers: { chrome: {} } },
+                installArgs: { drivers: { chrome: {} } },
+            }
+            const capabilities: any = {
+                browserA: {
+                    capabilities: {
+                        browserName: 'chrome',
+                        acceptInsecureCerts: true
+                    }
+                },
+                browserB: {
+                    capabilities: {
+                        platformName: 'Android',
+                        'appium:deviceName': 'pixel2',
+                        'appium:avd': 'pixel2',
+                    }
+                }
+            }
+            const launcher = new SeleniumStandaloneLauncher(options, capabilities, {} as any)
+            launcher._redirectLogStream = jest.fn()
+            await launcher.onPrepare({ watch: true } as never)
+            expect(capabilities.browserB.protocol).toBeUndefined()
+            expect(capabilities.browserB.hostname).toBeUndefined()
+            expect(capabilities.browserB.port).toBeUndefined()
             expect(capabilities.browserB.path).toBeUndefined()
         })
 


### PR DESCRIPTION
## Proposed changes

We modify the capabilities when a user applies a service like `@wdio/selenium-standalone-service` to ensure we can connect to the server that is being launched. Unfortunately we also do this for capabilities that were not suppose to run on the standalone server.

This patch adds a check to ensure caps are only changed that would be also run on Selenium Standalone.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

fixes #6445

### Reviewers: @webdriverio/project-committers
