### PR TITLE
Propagate connection details from capabilities

### DIFF
--- a/packages/wdio-runner/package.json
+++ b/packages/wdio-runner/package.json
@@ -28,14 +28,10 @@
     "@wdio/utils": "7.2.1",
     "deepmerge": "^4.0.0",
     "gaze": "^1.1.2",
-    "lodash.pick": "^4.4.0",
     "webdriver": "7.2.1",
     "webdriverio": "7.2.3"
   },
   "publishConfig": {
     "access": "public"
-  },
-  "devDependencies": {
-    "@types/lodash.pick": "^4.4.6"
   }
 }

--- a/packages/wdio-runner/package.json
+++ b/packages/wdio-runner/package.json
@@ -28,10 +28,14 @@
     "@wdio/utils": "7.2.1",
     "deepmerge": "^4.0.0",
     "gaze": "^1.1.2",
+    "lodash.pick": "^4.4.0",
     "webdriver": "7.2.1",
     "webdriverio": "7.2.3"
   },
   "publishConfig": {
     "access": "public"
+  },
+  "devDependencies": {
+    "@types/lodash.pick": "^4.4.6"
   }
 }

--- a/packages/wdio-runner/src/utils.ts
+++ b/packages/wdio-runner/src/utils.ts
@@ -1,4 +1,3 @@
-import pick from 'lodash.pick'
 import merge from 'deepmerge'
 import logger from '@wdio/logger'
 import { remote, multiremote, attach } from 'webdriverio'
@@ -69,10 +68,7 @@ export async function initialiseInstance (
         /**
          * propagate connection details defined by services or user in capabilities
          */
-        const { protocol, hostname, port, path } = pick(
-            capabilities as Capabilities.Capabilities,
-            ['protocol', 'hostname', 'port', 'path']
-        )
+        const { protocol, hostname, port, path } = capabilities as Capabilities.Capabilities
         return attach({ ...config, ...{ protocol, hostname, port, path } } as Required<ConfigWithSessionId>)
     }
 

--- a/packages/wdio-runner/src/utils.ts
+++ b/packages/wdio-runner/src/utils.ts
@@ -1,3 +1,4 @@
+import pick from 'lodash.pick'
 import merge from 'deepmerge'
 import logger from '@wdio/logger'
 import { remote, multiremote, attach } from 'webdriverio'
@@ -64,7 +65,15 @@ export async function initialiseInstance (
     if (config.sessionId) {
         log.debug(`attach to session with id ${config.sessionId}`)
         config.capabilities = sanitizeCaps(capabilities)
-        return attach({ ...config } as Required<ConfigWithSessionId>)
+
+        /**
+         * propagate connection details defined by services or user in capabilities
+         */
+        const { protocol, hostname, port, path } = pick(
+            capabilities as Capabilities.Capabilities,
+            ['protocol', 'hostname', 'port', 'path']
+        )
+        return attach({ ...config, ...{ protocol, hostname, port, path } } as Required<ConfigWithSessionId>)
     }
 
     if (!isMultiremote) {

--- a/packages/wdio-runner/tests/utils.test.ts
+++ b/packages/wdio-runner/tests/utils.test.ts
@@ -20,10 +20,18 @@ describe('utils', () => {
                 // @ts-ignore test invalid params
                 foo: 'bar'
             }
-            initialiseInstance(config, { browserName: 'chrome', maxInstances: 2 })
+            initialiseInstance(
+                config,
+                {
+                    browserName: 'chrome',
+                    maxInstances: 2,
+                    hostname: 'foobar'
+                }
+            )
             expect(attach).toBeCalledWith({
                 sessionId: '123',
                 foo: 'bar',
+                hostname: 'foobar',
                 capabilities: { browserName: 'chrome' }
             })
             expect(config.capabilities).toEqual({ browserName: 'chrome' })


### PR DESCRIPTION
## Proposed changes

When services like `@wdio/selenium-standalone-server` are used they modify connection details through setting them within the capabilities. When running in watch mode these details were not propagated correctly.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

fixes #6557

### Reviewers: @webdriverio/project-committers
