### PR TITLE
Implement`attachToSession` for devtools package

### DIFF
--- a/e2e/jest.config.js
+++ b/e2e/jest.config.js
@@ -2,7 +2,7 @@ module.exports = {
     testRunner: 'jest-circus/runner',
     testEnvironment: 'node',
     testMatch: [
-        '<rootDir>/*.test.js'
+        '<rootDir>/**/*.test.js'
     ],
     moduleFileExtensions: ['js', 'ts'],
     setupFilesAfterEnv: ['./jest.setup.js'],

--- a/e2e/wdio/attach.test.js
+++ b/e2e/wdio/attach.test.js
@@ -7,9 +7,9 @@
  */
 import { remote, attach } from '../../packages/webdriverio'
 
-let browser;
+let browser
 
-(async () => {
+test('allow to attach to an existing session', async () => {
     browser = await remote({
         capabilities: {
             browserName: 'chrome'
@@ -23,7 +23,4 @@ let browser;
     expect(await otherBrowser.getTitle()).toBe('WebdriverJS Testpage')
 
     await otherBrowser.deleteSession()
-})().catch(async (e) => {
-    console.error(e)
-    await browser.deleteSession()
 })

--- a/e2e/wdio/attach.test.js
+++ b/e2e/wdio/attach.test.js
@@ -12,7 +12,8 @@ let browser
 test('allow to attach to an existing session', async () => {
     browser = await remote({
         capabilities: {
-            browserName: 'chrome'
+            browserName: 'chrome',
+            'wdio:devtoolsOptions': { headless: true, dumpio: true }
         }
     })
 

--- a/e2e/wdio/attach.test.js
+++ b/e2e/wdio/attach.test.js
@@ -1,0 +1,29 @@
+/**
+ * in order to run this file make sure you have `webdriverio`
+ * installed using NPM before running it:
+ *
+ *   $ npm install webdriverio
+ *
+ */
+import { remote, attach } from '../../packages/webdriverio'
+
+let browser;
+
+(async () => {
+    browser = await remote({
+        capabilities: {
+            browserName: 'chrome'
+        }
+    })
+
+    await browser.url('http://guinea-pig.webdriver.io')
+    expect(await browser.getTitle()).toBe('WebdriverJS Testpage')
+
+    const otherBrowser = await attach(browser)
+    expect(await otherBrowser.getTitle()).toBe('WebdriverJS Testpage')
+
+    await otherBrowser.deleteSession()
+})().catch(async (e) => {
+    console.error(e)
+    await browser.deleteSession()
+})

--- a/packages/devtools/src/constants.ts
+++ b/packages/devtools/src/constants.ts
@@ -129,10 +129,12 @@ export const BROWSER_ERROR_MESSAGES = {
 
 export const VENDOR_PREFIX: {
     chrome: 'goog:chromeOptions',
+    'chrome headless': 'goog:chromeOptions',
     firefox: 'moz:firefoxOptions',
     edge: 'ms:edgeOptions'
 } = {
     chrome: 'goog:chromeOptions',
+    'chrome headless': 'goog:chromeOptions',
     firefox: 'moz:firefoxOptions',
     edge: 'ms:edgeOptions'
 }

--- a/packages/devtools/src/index.ts
+++ b/packages/devtools/src/index.ts
@@ -163,7 +163,7 @@ export default class DevTools {
         }
 
         const monad = webdriverMonad(
-            { ...options },
+            options,
             modifier,
             prototype
         )

--- a/packages/devtools/src/index.ts
+++ b/packages/devtools/src/index.ts
@@ -14,7 +14,11 @@ import DevToolsDriver from './devtoolsdriver'
 import launch from './launcher'
 import { DEFAULTS, SUPPORTED_BROWSER, VENDOR_PREFIX } from './constants'
 import { getPrototype, patchDebug } from './utils'
-import type { ExtendedCapabilities, WDIODevtoolsOptions as WDIODevtoolsOptionsExtension } from './types'
+import type {
+    AttachOptions,
+    ExtendedCapabilities,
+    WDIODevtoolsOptions as WDIODevtoolsOptionsExtension
+} from './types'
 
 const log = logger('devtools:puppeteer')
 
@@ -59,6 +63,8 @@ export default class DevTools {
             .find(
                 (capKey: ValueOf<typeof VENDOR_PREFIX>) => availableVendorPrefixes.includes(capKey)
             ) as keyof Capabilities.Capabilities
+            ||
+            VENDOR_PREFIX[userAgent.browser.name?.toLocaleLowerCase() as keyof typeof VENDOR_PREFIX]
 
         params.capabilities = {
             browserName: userAgent.browser.name,
@@ -125,9 +131,43 @@ export default class DevTools {
     /**
      * allows user to attach to existing sessions
      */
-    /* istanbul ignore next */
-    static attachToSession () {
-        throw new Error('not yet implemented')
+    static async attachToSession (
+        options: AttachOptions,
+        modifier?: Function,
+        userPrototype = {},
+        customCommandWrapper?: Function
+    ) {
+        const browser = await launch(options.capabilities as ExtendedCapabilities)
+        const pages = await browser.pages()
+        const driver = new DevToolsDriver(browser, pages)
+        const sessionId = uuidv4()
+        const uaParser = new UAParser(await browser.userAgent())
+        const userAgent = uaParser.getResult()
+
+        const environmentPrototype: Record<string, { value: Browser | boolean }> = { puppeteer: { value: browser } }
+        Object.entries(devtoolsEnvironmentDetector({
+            browserName: userAgent?.browser?.name?.toLowerCase()
+        })).forEach(([name, value]) => {
+            environmentPrototype[name] = { value }
+        })
+        const commandWrapper = (
+            method: string,
+            endpoint: string,
+            commandInfo: CommandEndpoint
+        ) => driver.register(commandInfo)
+        const protocolCommands = getPrototype(commandWrapper)
+        const prototype = {
+            ...protocolCommands,
+            ...userPrototype,
+            ...environmentPrototype
+        }
+
+        const monad = webdriverMonad(
+            { ...options },
+            modifier,
+            prototype
+        )
+        return monad(sessionId, customCommandWrapper)
     }
 }
 

--- a/packages/devtools/src/launcher.ts
+++ b/packages/devtools/src/launcher.ts
@@ -189,8 +189,21 @@ function launchBrowser (capabilities: ExtendedCapabilities, browserType: 'edge' 
     return puppeteer.launch(puppeteerOptions) as unknown as Promise<Browser>
 }
 
+function connectBrowser (browserURL: string) {
+    return puppeteer.connect({ browserURL }) as unknown as Promise<Browser>
+}
+
 export default function launch (capabilities: ExtendedCapabilities) {
     const browserName = capabilities.browserName?.toLowerCase()
+
+    /**
+     * check if capabilities already contains connection details and connect
+     * to that rather than starting a new browser
+     */
+    const browserOptions = capabilities['goog:chromeOptions'] || capabilities['ms:edgeOptions']
+    if (browserOptions?.debuggerAddress && !capabilities['wdio:devtoolsOptions']?.customDebuggerAddress) {
+        return connectBrowser(`http://${browserOptions?.debuggerAddress}`)
+    }
 
     if (browserName && CHROME_NAMES.includes(browserName)) {
         return launchChrome(capabilities)

--- a/packages/devtools/src/types.ts
+++ b/packages/devtools/src/types.ts
@@ -7,4 +7,23 @@ export interface WDIODevtoolsOptions {
     'wdio:devtoolsOptions'?: DevToolsOptions
 }
 
-export interface DevToolsOptions extends LaunchOptions, ChromeArgOptions, BrowserOptions, ConnectOptions {}
+export interface DevToolsOptions extends LaunchOptions, ChromeArgOptions, BrowserOptions, ConnectOptions {
+    /**
+     * if you want to connect to custom chrome debugger address you
+     * need to set this flag otherwise WebdriverIO will try to connect
+     * to this address.
+     */
+    customDebuggerAddress?: boolean
+}
+
+export interface AttachOptions {
+    capabilities: {
+        'goog:chromeOptions': {
+            debuggerAddress: string
+        }
+    } | {
+        'ms:edgeOptions': {
+            debuggerAddress: string
+        }
+    }
+}

--- a/packages/devtools/tests/__snapshots__/devtools.test.ts.snap
+++ b/packages/devtools/tests/__snapshots__/devtools.test.ts.snap
@@ -1,5 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`attachSession 1`] = `
+Object {
+  "browserName": "Chrome",
+  "browserVersion": "80.0.3987.149",
+  "goog:chromeOptions": Object {
+    "debuggerAddress": "localhost:49375",
+  },
+}
+`;
+
+exports[`attachSession 2`] = `
+Object {
+  "browserName": "chrome",
+}
+`;
+
 exports[`newSession 1`] = `
 Object {
   "browserName": "Chrome",

--- a/packages/devtools/tests/devtools.test.ts
+++ b/packages/devtools/tests/devtools.test.ts
@@ -2,7 +2,7 @@ import launch from '../src/launcher'
 import DevTools from '../src'
 
 jest.mock('../src/launcher', () => jest.fn().mockImplementation((capabilities) => {
-    capabilities['goog:chromeOptions'] = {}
+    capabilities['goog:chromeOptions'] = capabilities['goog:chromeOptions'] || {}
     return {
         pages: jest.fn().mockReturnValue(Promise.resolve([{
             on: jest.fn(),
@@ -14,6 +14,10 @@ jest.mock('../src/launcher', () => jest.fn().mockImplementation((capabilities) =
         userAgent: jest.fn().mockReturnValue(Promise.resolve('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.149 Safari/537.36'))
     }
 }))
+
+beforeEach(() => {
+    (launch as jest.Mock).mockClear()
+})
 
 test('newSession', async () => {
     const client = await DevTools.newSession({
@@ -47,4 +51,27 @@ test('reloadSession', async () => {
     const origSessionId = client.sessionId
     const newClient = await DevTools.reloadSession(client)
     expect(origSessionId).toBe(newClient)
+})
+
+test('attachSession', async () => {
+    const client = await DevTools.newSession({
+        logLevel: 'trace',
+        capabilities: {
+            browserName: 'chrome'
+        }
+    })
+    const otherClient = await DevTools.attachToSession(client)
+
+    /**
+     * don't include platform specific information in snapshot
+     */
+    delete otherClient.options.capabilities.platformName
+    delete otherClient.options.capabilities.platformVersion
+
+    expect(otherClient.capabilities).toMatchSnapshot()
+    expect(otherClient.requestedCapabilities).toMatchSnapshot()
+    expect(otherClient.isDevTools).toBe(true)
+    expect(otherClient.isChrome).toBe(true)
+    expect(otherClient.isW3C).toBe(true)
+    expect(launch).toBeCalledTimes(2)
 })

--- a/packages/devtools/tests/launcher.test.ts
+++ b/packages/devtools/tests/launcher.test.ts
@@ -335,6 +335,6 @@ test('connect to existing browser session', async () => {
         }
     })
     expect(puppeteer.launch).not.toBeCalled()
-    expect((puppeteer.connect as jest.Mock))
+    expect(puppeteer.connect as jest.Mock)
         .toBeCalledWith({ browserURL: 'http://localhost:12345' })
 })

--- a/packages/devtools/tests/launcher.test.ts
+++ b/packages/devtools/tests/launcher.test.ts
@@ -120,6 +120,9 @@ test('launch chrome with chrome port', async () => {
         browserName: 'chrome',
         'goog:chromeOptions': {
             debuggerAddress: '127.0.0.1:8041'
+        },
+        'wdio:devtoolsOptions': {
+            customDebuggerAddress: true
         }
     })
     expect(launchChromeBrowser.mock.calls).toMatchSnapshot()
@@ -322,4 +325,16 @@ test('launch Edge without Puppeteer default args (backwards compat)', async () =
         }
     })
     expect((puppeteer.launch as jest.Mock).mock.calls).toMatchSnapshot()
+})
+
+test('connect to existing browser session', async () => {
+    await launch({
+        browserName: 'edge',
+        'ms:edgeOptions': {
+            debuggerAddress: 'localhost:12345'
+        }
+    })
+    expect(puppeteer.launch).not.toBeCalled()
+    expect((puppeteer.connect as jest.Mock))
+        .toBeCalledWith({ browserURL: 'http://localhost:12345' })
 })

--- a/packages/webdriverio/src/index.ts
+++ b/packages/webdriverio/src/index.ts
@@ -49,10 +49,9 @@ export const remote = async function (params: RemoteOptions, remoteModifier?: Fu
     }
 
     const prototype = getPrototype('browser')
-    const ProtocolDriver = require(automationProtocol).default
+    const ProtocolDriver = (await import(automationProtocol)).default
 
     params = Object.assign({}, detectBackend(params), params)
-    params.automationProtocol = automationProtocol
     await updateCapabilities(params, automationProtocol)
     const instance: WebdriverIO.Browser = await ProtocolDriver.newSession(params, modifier, prototype, wrapCommand)
 
@@ -77,14 +76,14 @@ export const remote = async function (params: RemoteOptions, remoteModifier?: Fu
     return instance
 }
 
-export const attach = function (params: AttachOptions): Browser<'async'> {
+export const attach = async function (params: AttachOptions): Promise<Browser<'async'>> {
     const prototype = getPrototype('browser')
 
     let automationProtocol = 'webdriver'
     if (params.options?.automationProtocol) {
         automationProtocol = params.options?.automationProtocol
     }
-    const ProtocolDriver = require(automationProtocol).default
+    const ProtocolDriver = (await import(automationProtocol)).default
     return ProtocolDriver.attachToSession(params, undefined, prototype, wrapCommand) as WebdriverIO.Browser
 }
 

--- a/packages/webdriverio/src/types.ts
+++ b/packages/webdriverio/src/types.ts
@@ -1,6 +1,6 @@
 import type { EventEmitter } from 'events'
-
-import type { SessionFlags } from 'webdriver'
+import type { AttachOptions as DevToolsAttachOptions } from 'devtools'
+import type { SessionFlags, AttachOptions as WebDriverAttachOptions } from 'webdriver'
 import type { Options, Capabilities, FunctionProperties, ThenArg } from '@wdio/types'
 import type { ElementReference, ProtocolCommandsAsync, ProtocolCommands, RectReturn } from '@wdio/protocols'
 import type { Browser as PuppeteerBrowser } from 'puppeteer-core/lib/cjs/puppeteer/common/Browser'
@@ -399,3 +399,10 @@ export type DragAndDropCoordinate = {
 type MockFunctions = FunctionProperties<DevtoolsInterception>
 type MockProperties = Pick<DevtoolsInterception, 'calls'>
 export interface Mock extends MockFunctions, MockProperties {}
+
+export interface AttachOptions extends Omit<DevToolsAttachOptions, 'capabilities'>, Omit<WebDriverAttachOptions, 'capabilities'> {
+    options?: {
+        automationProtocol?: Options.SupportedProtocols,
+    }
+    capabilities: DevToolsAttachOptions['capabilities'] | WebDriverAttachOptions['capabilities']
+}

--- a/packages/webdriverio/src/utils/index.ts
+++ b/packages/webdriverio/src/utils/index.ts
@@ -526,8 +526,13 @@ export const getAutomationProtocol = async (config: Options.WebdriverIO | Option
  *
  * NOTE: this method is executed twice when running the WDIO testrunner
  */
-export const updateCapabilities = async (params: Options.WebdriverIO | Options.Testrunner, automationProtocol?: string) => {
+export const updateCapabilities = async (params: Options.WebdriverIO | Options.Testrunner, automationProtocol?: Options.SupportedProtocols) => {
     const caps = params.capabilities as Capabilities.Capabilities
+
+    if (automationProtocol && !params.automationProtocol) {
+        params.automationProtocol = automationProtocol
+    }
+
     /**
      * attach remote debugging port options to Firefox sessions
      * (this will be ignored if not supported)

--- a/packages/webdriverio/tests/__snapshots__/utils.test.ts.snap
+++ b/packages/webdriverio/tests/__snapshots__/utils.test.ts.snap
@@ -19,6 +19,7 @@ Object {
 
 exports[`utils updateCapabilities setting devtools port in Firefox should set firefox options if there aren't any 1`] = `
 Object {
+  "automationProtocol": "webdriver",
   "capabilities": Object {
     "browserName": "firefox",
     "moz:firefoxOptions": Object {
@@ -33,6 +34,7 @@ Object {
 
 exports[`utils updateCapabilities setting devtools port in Firefox should set firefox options if there aren't any 2`] = `
 Object {
+  "automationProtocol": "devtools",
   "capabilities": Object {
     "browserName": "firefox",
   },

--- a/packages/webdriverio/tests/module.test.ts
+++ b/packages/webdriverio/tests/module.test.ts
@@ -300,8 +300,8 @@ describe('WebdriverIO module interface', () => {
     })
 
     describe('attach', () => {
-        it('attaches', () => {
-            attach({ sessionId: 'foobar' })
+        it('attaches', async () => {
+            await attach({ sessionId: 'foobar', capabilities: {} })
             expect(WebDriver.attachToSession).toBeCalled()
         })
     })


### PR DESCRIPTION
## Proposed changes

Currently it was not possible to attach to a running devtools session. This patch adds this functionality.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

closes #6459

### Reviewers: @webdriverio/project-committers
