### PR TITLE
Added ability to group specs in suites

### DIFF
--- a/packages/wdio-config/tests/__fixtures__/wdio.array.conf.ts
+++ b/packages/wdio-config/tests/__fixtures__/wdio.array.conf.ts
@@ -17,8 +17,9 @@ export const config: ConfigOptions = {
         unit: [path.join(TEST_ROOT, 'configparser.test.ts')],
         mobile: [path.join(TEST_ROOT, 'RequireLibrary.test.ts')],
         functional: [
-            path.join(TEST_ROOT, 'validateConfig.test.ts'),
-            path.join(TEST_ROOT, '..', 'src/index.ts')
+            [path.join(TEST_ROOT, 'validateConfig.test.ts'),
+                path.join(TEST_ROOT, '..', 'src/index.ts')],
+            [path.join(TEST_ROOT, '*.test.ts')]
         ]
     }
 }

--- a/packages/wdio-config/tests/configparser.test.ts
+++ b/packages/wdio-config/tests/configparser.test.ts
@@ -837,6 +837,17 @@ describe('ConfigParser', () => {
             expect(specs).toContain(INDEX_PATH)
         })
 
+        it('should handle grouped specs in suites', () => {
+            // const configParser = ConfigParserForTest()
+            const configParser = ConfigParserForTestWithAllFiles()
+            configParser.addConfigFile(FIXTURES_CONF)
+            configParser.merge({ suite: ['unit', 'mobile'] })
+
+            const specs = configParser.getSpecs([INDEX_PATH], [path.join(__dirname, 'RequireLibrary.test.ts')])
+            expect(specs).not.toContain(path.join(__dirname, 'RequireLibrary.test.ts'))
+            expect(specs).toContain(INDEX_PATH)
+        })
+
         it('should include typescript files', () => {
             const configParser = ConfigParserForTest()
             configParser.addConfigFile(FIXTURES_CONF)

--- a/packages/wdio-config/tests/configparser.test.ts
+++ b/packages/wdio-config/tests/configparser.test.ts
@@ -837,17 +837,6 @@ describe('ConfigParser', () => {
             expect(specs).toContain(INDEX_PATH)
         })
 
-        it('should handle grouped specs in suites', () => {
-            // const configParser = ConfigParserForTest()
-            const configParser = ConfigParserForTestWithAllFiles()
-            configParser.addConfigFile(FIXTURES_CONF)
-            configParser.merge({ suite: ['unit', 'mobile'] })
-
-            const specs = configParser.getSpecs([INDEX_PATH], [path.join(__dirname, 'RequireLibrary.test.ts')])
-            expect(specs).not.toContain(path.join(__dirname, 'RequireLibrary.test.ts'))
-            expect(specs).toContain(INDEX_PATH)
-        })
-
         it('should include typescript files', () => {
             const configParser = ConfigParserForTest()
             configParser.addConfigFile(FIXTURES_CONF)
@@ -890,7 +879,21 @@ describe('ConfigParser', () => {
 
             const specs = configParser.getSpecs()
             expect(Array.isArray(specs[0])).toBe(true)
+            // Answer here is 3 because FileSystemPathService.test.ts is not included
+            // in MockedFileSystem_LoadingAsMuchAsCanFromFileSystem
             expect(specs[0].length).toBe(3)
+        })
+
+        it('should handle grouped specs in suites', () => {
+            // const configParser = ConfigParserForTest()
+            const configParser = ConfigParserForTestWithAllFiles()
+            configParser.addConfigFile(FIXTURES_CONF_ARRAY)
+            configParser.merge({ suite: ['functional'] })
+
+            const specs = configParser.getSpecs()
+            expect(specs[0]).not.toContain(path.join(__dirname, 'validateConfig.test.ts'))
+            expect(specs[0]).toContain(INDEX_PATH)
+            expect(specs[1].length).toBe(3)
         })
 
         it('should not include other file types', () => {

--- a/website/blog/2021-03-23-grouping-specs.md
+++ b/website/blog/2021-03-23-grouping-specs.md
@@ -53,3 +53,19 @@ when run against the previously described directory tree would result in three i
 - A final instance would run test_b2.js
 
 It is only the specs definition that supports this syntax.
+
+**EDIT:**
+This syntax has now been extended to support specs defined in suites, so you can now also define suites like this:
+```json
+    "suites": {
+        end2end: [
+            [
+                "./test/specs/test_login.js",
+                "./test/specs/test_product_order.js",
+                "./test/specs/test_checkout.js"
+            ]
+        ],
+        allb: ["./test/specs/test_b*.js"]
+},
+```
+and in this case all of the tests of the "end2end" suite would be run in a single instance.

--- a/website/docs/OrganizingTestSuites.md
+++ b/website/docs/OrganizingTestSuites.md
@@ -120,6 +120,22 @@ To group tests to run in a single instance, simply define them as an array withi
 ```
 In the example above, the tests 'test_login.js', 'test_product_order.js' and 'test_checkout.js' will be run sequentially in a single instance and each of the "test_b*" tests will run concurrently in individual instances.
 
+It is also possible to group specs defined in suites, so you can now also define suites like this:
+```json
+    "suites": {
+        end2end: [
+            [
+                "./test/specs/test_login.js",
+                "./test/specs/test_product_order.js",
+                "./test/specs/test_checkout.js"
+            ]
+        ],
+        allb: ["./test/specs/test_b*.js"]
+},
+```
+and in this case all of the tests of the "end2end" suite would be run in a single instance.
+
+
 ## Run Selected Tests
 
 In some cases, you may wish to only execute a single test (or subset of tests) of your suites.


### PR DESCRIPTION
## Proposed changes
The ability to group specs to be run in a single worker instance was recently added in #6548. However, in that pull request, the work had not been done to facilitate the grouping of specs in suites.  Issue #6642 has been raised requesting that the grouping of specs in suites be supported.

The few changes required have now been made and the tests and documentation updated accordingly, and hence this PR.

## Types of changes
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation update

## Checklist
- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments
No additional comments

### Reviewers: @webdriverio/project-committers
