### PR TITLE
The ability to use devtools-service in the launches on the selenoid

### DIFF
--- a/packages/wdio-types/src/Options.ts
+++ b/packages/wdio-types/src/Options.ts
@@ -259,6 +259,11 @@ export interface WebdriverIO extends Omit<WebDriver, 'capabilities'> {
      * visibility) has been changed.
      */
     waitforInterval?: number
+    /**
+     * If the parameter is true, devtools-service will connect to the WebSocket using the
+     * ws://${hostname}scheme:4444/devtools/${sessionID}
+     */
+     selenoidWSEndpoint?: boolean
 }
 
 export interface Testrunner extends Hooks, Omit<WebdriverIO, 'capabilities'>, WebdriverIO.HookFunctionExtension {

--- a/packages/webdriverio/src/commands/browser/getPuppeteer.ts
+++ b/packages/webdriverio/src/commands/browser/getPuppeteer.ts
@@ -48,6 +48,17 @@ export default async function getPuppeteer (this: WebdriverIO.Browser) {
         return this.puppeteer
     }
 
+    /**
+     * To connect to a WebSocket when running in selenoid
+     */
+    if (this.config?.selenoidWSEndpoint) {
+        this.puppeteer = await puppeteer.connect({
+            browserWSEndpoint: `ws://${this.config.hostname}:4444/devtools/${this.sessionId}`,
+        }) as any as PuppeteerBrowser
+
+        return this.puppeteer
+    }
+
     const caps = (this.capabilities as Capabilities.W3CCapabilities).alwaysMatch || this.capabilities as Capabilities.DesiredCapabilities
     /**
      * attach to a Selenium 4 CDP Session if it's returned in the capabilities


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

This Pull Request fixes WebSocket connection issue when running on Selenoid. To test this fix, you need to specify `selenoidWSEndpoint: true` in wdio.conf.js

I described a similar problem in https://github.com/webdriverio/webdriverio/issues/6665, where I wanted to use the attach function to get the devtools session, but I managed to completely avoid this by fixing the error at the start of WDIO

### Reviewers: @webdriverio/project-committers
