### PR TITLE
[BUGFIX] wdio-browserstack-service using the wrong session url when w3c properties are enforced

### DIFF
--- a/packages/wdio-browserstack-service/src/service.ts
+++ b/packages/wdio-browserstack-service/src/service.ts
@@ -61,7 +61,8 @@ export default class BrowserstackService implements Services.ServiceInstance {
         this._browser = browser
 
         // Ensure capabilities are not null in case of multiremote
-        if ((this._browser.capabilities as Capabilities.DesiredCapabilities).app || (this._caps as Capabilities.DesiredCapabilities).app) {
+
+        if (this._isAppAutomate()) {
             this._sessionBaseUrl = 'https://api-cloud.browserstack.com/app-automate/sessions'
         }
 
@@ -162,6 +163,13 @@ export default class BrowserstackService implements Services.ServiceInstance {
         delete this._fullTitle
         this._failReasons = []
         await this._printSessionURL()
+    }
+
+    _isAppAutomate(): boolean {
+        const browserDesiredCapabilities = (this._browser?.capabilities ?? {}) as Capabilities.DesiredCapabilities
+        const desiredCapabilities = (this._caps ?? {})  as Capabilities.DesiredCapabilities
+
+        return !!browserDesiredCapabilities['appium:app'] || !!desiredCapabilities['appium:app'] || !!browserDesiredCapabilities.app || !!desiredCapabilities.app
     }
 
     _updateJob (requestBody: any) {

--- a/packages/wdio-browserstack-service/tests/service.test.ts
+++ b/packages/wdio-browserstack-service/tests/service.test.ts
@@ -275,6 +275,22 @@ describe('before', () => {
         expect(service['_sessionBaseUrl']).toEqual('https://api-cloud.browserstack.com/app-automate/sessions')
     })
 
+    it('should initialize correctly for appium if using valid W3C Webdriver capabilities', () => {
+        const service = new BrowserstackService({}, {
+            app: 'bs://BrowserStackMobileAppId'
+        }, {
+            user: 'foo',
+            key: 'bar',
+            capabilities: {
+                ['appium:app']: 'test-app'
+            }
+        }, browser)
+        service.before(service._config, [], browser)
+
+        expect(service._failReasons).toEqual([])
+        expect(service._sessionBaseUrl).toEqual('https://api-cloud.browserstack.com/app-automate/sessions')
+    })
+
     it('should log the url', async () => {
         const service = new BrowserstackService({}, [{}] as any, { capabilities: {} })
 


### PR DESCRIPTION
## Proposed changes


[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

With the webdriver upgrade to v7, W3C valid properties are enforced by default. This means we have to change `app` to `appium:app` when specifying capabilities for browserstack.

However, this change is not reflected in the actual wdio-browserstack-service, causing issues around updating sessions. Without this change, every update to the browserstack session will error with a 404 when only using `appium':app` property for capabilities

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
