### PR TITLE
Allow more options to connect to a remote devtools connection

### DIFF
--- a/packages/devtools/src/launcher.ts
+++ b/packages/devtools/src/launcher.ts
@@ -35,7 +35,7 @@ const DEVICE_NAMES = Object.values(puppeteer.devices).map((device) => device.nam
 async function launchChrome (capabilities: ExtendedCapabilities) {
     const chromeOptions: Capabilities.ChromeOptions = capabilities[VENDOR_PREFIX.chrome] || {}
     const mobileEmulation = chromeOptions.mobileEmulation || {}
-    const devtoolsOptions = capabilities['wdio:devtoolsOptions']
+    const devtoolsOptions = capabilities['wdio:devtoolsOptions'] || {}
 
     /**
      * `ignoreDefaultArgs` and `headless` are currently expected to be part of the capabilities
@@ -43,21 +43,8 @@ async function launchChrome (capabilities: ExtendedCapabilities) {
      * This should be cleaned up for v7 release
      * ToDo(Christian): v7 cleanup
      */
-    let ignoreDefaultArgs = (capabilities as any).ignoreDefaultArgs
-
-    let debuggerAddress = chromeOptions.debuggerAddress
-    let port
-    if (debuggerAddress) {
-        const requestedPort = debuggerAddress.split(':')[1]
-        port = parseInt(requestedPort, 10)
-    }
-
-    let headless = (chromeOptions as any).headless
-
-    if (devtoolsOptions) {
-        ignoreDefaultArgs = devtoolsOptions.ignoreDefaultArgs
-        headless = devtoolsOptions.headless
-    }
+    let ignoreDefaultArgs = (capabilities as any).ignoreDefaultArgs || devtoolsOptions.ignoreDefaultArgs
+    let headless = (chromeOptions as any).headless || devtoolsOptions.headless
 
     if (typeof mobileEmulation.deviceName === 'string') {
         const deviceProperties = Object.values(puppeteer.devices).find(device => device.name === mobileEmulation.deviceName)
@@ -97,24 +84,18 @@ async function launchChrome (capabilities: ExtendedCapabilities) {
         chromeFlags.push(`--user-agent=${mobileEmulation.userAgent}`)
     }
 
-    if (port) {
-        log.info(`Requesting to connect to Google Chrome on port: ${port}`)
-    }
     log.info(`Launch Google Chrome with flags: ${chromeFlags.join(' ')}`)
-
     const chrome = await launchChromeBrowser({
         chromePath: chromeOptions.binary,
         ignoreDefaultFlags: true,
         chromeFlags,
-        ...(port ? { port } : {})
+        ...(devtoolsOptions.customPort ? { port: devtoolsOptions.customPort } : {})
     })
 
     log.info(`Connect Puppeteer with browser on port ${chrome.port}`)
     const browser = await puppeteer.connect({
         ...chromeOptions,
-        browserURL: `http://localhost:${chrome.port}`,
-        // @ts-ignore ToDo(@L0tso): remove once https://github.com/puppeteer/puppeteer/pull/6942 is merged
-        defaultViewport: null
+        browserURL: `http://localhost:${chrome.port}`
     }) as unknown as Browser // casting from @types/puppeteer to built in type
 
     /**
@@ -189,8 +170,14 @@ function launchBrowser (capabilities: ExtendedCapabilities, browserType: 'edge' 
     return puppeteer.launch(puppeteerOptions) as unknown as Promise<Browser>
 }
 
-function connectBrowser (browserURL: string) {
-    return puppeteer.connect({ browserURL }) as unknown as Promise<Browser>
+function connectBrowser (connectionUrl: string, capabilities: ExtendedCapabilities) {
+    const connectionProp = connectionUrl.startsWith('http') ? 'browserURL' : 'browserWSEndpoint'
+    const devtoolsOptions = capabilities['wdio:devtoolsOptions']
+    const options: puppeteer.ConnectOptions = {
+        [connectionProp]: connectionUrl,
+        ...devtoolsOptions
+    }
+    return puppeteer.connect(options) as unknown as Promise<Browser>
 }
 
 export default function launch (capabilities: ExtendedCapabilities) {
@@ -201,8 +188,14 @@ export default function launch (capabilities: ExtendedCapabilities) {
      * to that rather than starting a new browser
      */
     const browserOptions = capabilities['goog:chromeOptions'] || capabilities['ms:edgeOptions']
-    if (browserOptions?.debuggerAddress && !capabilities['wdio:devtoolsOptions']?.customDebuggerAddress) {
-        return connectBrowser(`http://${browserOptions?.debuggerAddress}`)
+    const devtoolsOptions = capabilities['wdio:devtoolsOptions'] || {}
+    const connectionUrl = (
+        (browserOptions?.debuggerAddress && `http://${browserOptions?.debuggerAddress}`) ||
+        devtoolsOptions.browserURL ||
+        devtoolsOptions.browserWSEndpoint
+    )
+    if (connectionUrl) {
+        return connectBrowser(connectionUrl, capabilities)
     }
 
     if (browserName && CHROME_NAMES.includes(browserName)) {

--- a/packages/devtools/src/types.ts
+++ b/packages/devtools/src/types.ts
@@ -9,11 +9,9 @@ export interface WDIODevtoolsOptions {
 
 export interface DevToolsOptions extends LaunchOptions, ChromeArgOptions, BrowserOptions, ConnectOptions {
     /**
-     * if you want to connect to custom chrome debugger address you
-     * need to set this flag otherwise WebdriverIO will try to connect
-     * to this address.
+     * If you want to start Google Chrome on a custom port
      */
-    customDebuggerAddress?: boolean
+    customPort?: number
 }
 
 export interface AttachOptions {

--- a/packages/devtools/tests/__snapshots__/launcher.test.ts.snap
+++ b/packages/devtools/tests/__snapshots__/launcher.test.ts.snap
@@ -259,7 +259,6 @@ Array [
   Array [
     Object {
       "browserURL": "http://localhost:1234",
-      "defaultViewport": null,
     },
   ],
 ]
@@ -285,7 +284,6 @@ Array [
   Array [
     Object {
       "browserURL": "http://localhost:1234",
-      "defaultViewport": null,
     },
   ],
 ]

--- a/packages/devtools/tests/launcher.test.ts
+++ b/packages/devtools/tests/launcher.test.ts
@@ -118,11 +118,9 @@ test('overriding chrome default flags (backwards compat)', async () => {
 test('launch chrome with chrome port', async () => {
     const browser = await launch({
         browserName: 'chrome',
-        'goog:chromeOptions': {
-            debuggerAddress: '127.0.0.1:8041'
-        },
+        'goog:chromeOptions': {},
         'wdio:devtoolsOptions': {
-            customDebuggerAddress: true
+            customPort: 8041
         }
     })
     expect(launchChromeBrowser.mock.calls).toMatchSnapshot()
@@ -337,4 +335,32 @@ test('connect to existing browser session', async () => {
     expect(puppeteer.launch).not.toBeCalled()
     expect(puppeteer.connect as jest.Mock)
         .toBeCalledWith({ browserURL: 'http://localhost:12345' })
+})
+
+test('connect to an existing devtools websocket', async () => {
+    await launch({
+        browserName: 'edge',
+        'ms:edgeOptions': {},
+        'wdio:devtoolsOptions': {
+            browserWSEndpoint: 'wss://cloud.vendor.com'
+        }
+    })
+    expect(puppeteer.launch).not.toBeCalled()
+    expect(puppeteer.connect as jest.Mock)
+        .toBeCalledWith({ browserWSEndpoint: 'wss://cloud.vendor.com' })
+})
+
+test('connect to an existing devtools browser url', async () => {
+    const devtoolsOptions = {
+        browserURL: 'http://localhost:1234',
+        ignoreHTTPSErrors: true
+    }
+    await launch({
+        browserName: 'edge',
+        'ms:edgeOptions': {},
+        'wdio:devtoolsOptions': devtoolsOptions
+    })
+    expect(puppeteer.launch).not.toBeCalled()
+    expect(puppeteer.connect as jest.Mock)
+        .toBeCalledWith(devtoolsOptions)
 })

--- a/website/docs/AutomationProtocols.md
+++ b/website/docs/AutomationProtocols.md
@@ -59,7 +59,7 @@ The communication happens without any proxy, directly to the browser using WebSo
 
 WebdriverIO allows you to use the DevTools capabilities as an alternative automation technology for WebDriver if you have special requirements to automate the browser. With the [`devtools`](https://www.npmjs.com/package/devtools) NPM package, you can use the same commands that WebDriver provides, which then can be used by WebdriverIO and the WDIO testrunner to run its useful commands on top of that protocol. It uses Puppeteer to under the hood and allows you to run a sequence of commands with Puppeteer if needed.
 
-To use DevTools as your automation protocol switch the `automationProtocol` flag to `devtools` in your configurations.
+To use DevTools as your automation protocol switch the `automationProtocol` flag to `devtools` in your configurations or just run WebdriverIO without a browser driver run in the background.
 
 <Tabs
   defaultValue="testrunner"
@@ -160,6 +160,44 @@ const { remote } = require('webdriverio')
 </Tabs>
 
 By accessing the Puppeteer interface, you have access to a variety of new capabilities to automate or inspect the browser and your application, e.g. intercepting network requests (see above), tracing the browser, throttle CPU or network capabilities, and much more.
+
+### `wdio:devtoolsOptions` Capability
+
+If you run WebdriverIO tests through the DevTools package, you can apply [custom Puppeteer options](https://pptr.dev/#?product=Puppeteer&version=v8.0.0&show=api-puppeteerlaunchoptions). These options will be directly passed into the [`launch`](https://pptr.dev/#?product=Puppeteer&version=v8.0.0&show=api-puppeteerlaunchoptions) or [`connect`](https://pptr.dev/#?product=Puppeteer&version=v8.0.0&show=api-puppeteerconnectoptions) methods of Puppeteer. Other custom devtools options are the following:
+
+#### customPort
+Start Chrome on a custom port.
+
+Type: `number`<br />
+Default: `9222` (default of Puppeteer)
+
+Note: if you pass in `goog:chromeOptions/debuggerAddress`, `wdio:devtoolsOptions/browserWSEndpoint` or `wdio:devtoolsOptions/browserURL` options, WebdriverIO will try to connect with given connection details rather than starting a browser. For example you can connect to Testingbots cloud via:
+
+```js
+import { format } from 'util'
+import { remote } from 'webdriverio'
+
+(async () => {
+    const browser = await remote({
+        capabilities: {
+            'wdio:devtoolsOptions': {
+                browserWSEndpoint: format(
+                    `wss://cloud.testingbot.com?key=%s&secret=%s&browserName=chrome&browserVersion=latest`,
+                    process.env.TESTINGBOT_KEY,
+                    process.env.TESTINGBOT_SECRET
+                )
+            }
+        }
+    })
+
+    await browser.url('https://webdriver.io')
+
+    const title = await browser.getTitle()
+    console.log(title) // returns "should return "WebdriverIO - click""
+
+    await browser.deleteSession()
+})()
+```
 
 ### Advantages
 


### PR DESCRIPTION
## Proposed changes

The devtools package is unable to allow attaching itself through `browserWSEndpoint`. I stumbled upon this reading about the [Testingbot announcement](https://twitter.com/testingb0t/status/1380499645097463811?s=20) that they support Puppeteer now. You can now connect to the Testingbot cloud via:

```js
import { format } from 'util'
import { remote } from 'webdriverio'

(async () => {
    const browser = await remote({
        capabilities: {
            'wdio:devtoolsOptions': {
                browserWSEndpoint: format(
                    `wss://cloud.testingbot.com?key=%s&secret=%s&browserName=chrome&browserVersion=latest`,
                    process.env.TESTINGBOT_KEY,
                    process.env.TESTINGBOT_SECRET
                )
            }
        }
    })

    await browser.url('https://webdriver.io')

    const title = await browser.getTitle()
    console.log(title) // returns "should return "WebdriverIO - click""

    await browser.deleteSession()
})()
```

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

This will break current behavior of how to start Chrome though the devtools package with a custom port (see #6371). I have commented on the issue.

### Reviewers: @webdriverio/project-committers
