### PR TITLE
Properly type config file if TypeScript is being used

### DIFF
--- a/packages/wdio-cli/src/commands/config.ts
+++ b/packages/wdio-cli/src/commands/config.ts
@@ -165,6 +165,7 @@ const runConfig = async function (useYarn: boolean, yes: boolean, exit = false) 
         const tsPkgs = `"${[
             wdioTypes,
             frameworkPackage.package,
+            'expect-webdriverio',
             ...servicePackages
                 .map(service => service.package)
                 /**

--- a/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
+++ b/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
@@ -1,4 +1,4 @@
-exports.config = {
+<% if(answers.isUsingTypeScript) { %>exports.config = {<% } else { %>export const config: WebdriverIO.Config = {<% } %>
     //
     // ====================
     // Runner Configuration

--- a/packages/wdio-cli/src/utils.ts
+++ b/packages/wdio-cli/src/utils.ts
@@ -216,10 +216,9 @@ export function convertPackageHashToObject(pkg: string, hash = '$--$'): Supporte
 
 export async function renderConfigurationFile (answers: ParsedAnswers) {
     const tplPath = path.join(__dirname, 'templates/wdio.conf.tpl.ejs')
-
+    const filename = `wdio.conf.${answers.isUsingTypeScript ? 'ts' : 'js'}`
     const renderedTpl = await renderFile(tplPath, { answers })
-
-    fs.writeFileSync(path.join(process.cwd(), 'wdio.conf.js'), renderedTpl)
+    return fs.promises.writeFile(path.join(process.cwd(), filename), renderedTpl)
 }
 
 export const validateServiceAnswers = (answers: string[]): Boolean | string => {
@@ -302,7 +301,7 @@ export async function generateTestFiles (answers: ParsedAnswers) {
         ).replace(/\.ejs$/, '').replace(/\.js$/, answers.isUsingTypeScript ? '.ts' : '.js')
 
         fs.ensureDirSync(path.dirname(destPath))
-        fs.writeFileSync(destPath, renderedTpl)
+        await fs.promises.writeFile(destPath, renderedTpl)
     }
 }
 

--- a/packages/wdio-cli/tests/commands/__snapshots__/config.test.ts.snap
+++ b/packages/wdio-cli/tests/commands/__snapshots__/config.test.ts.snap
@@ -27,7 +27,7 @@ Packages installed successfully, creating configuration file...",
     "To have TypeScript support please add the following packages to your \\"types\\" list:
 {
   \\"compilerOptions\\": {
-    \\"types\\": [\\"node\\", \\"webdriverio/sync\\", \\"@wdio/mocha-framework\\", \\"@wdio/crossbrowsertesting-service\\"]
+    \\"types\\": [\\"node\\", \\"webdriverio/sync\\", \\"@wdio/mocha-framework\\", \\"expect-webdriverio\\", \\"@wdio/crossbrowsertesting-service\\"]
   }
 }
 
@@ -71,7 +71,7 @@ Packages installed successfully, creating configuration file...",
     "To have TypeScript support please add the following packages to your \\"types\\" list:
 {
   \\"compilerOptions\\": {
-    \\"types\\": [\\"node\\", \\"webdriverio/sync\\", \\"@wdio/mocha-framework\\", \\"@wdio/crossbrowsertesting-service\\"]
+    \\"types\\": [\\"node\\", \\"webdriverio/sync\\", \\"@wdio/mocha-framework\\", \\"expect-webdriverio\\", \\"@wdio/crossbrowsertesting-service\\"]
   }
 }
 
@@ -115,7 +115,7 @@ Packages installed successfully, creating configuration file...",
     "To have TypeScript support please add the following packages to your \\"types\\" list:
 {
   \\"compilerOptions\\": {
-    \\"types\\": [\\"node\\", \\"webdriverio/sync\\", \\"@wdio/mocha-framework\\", \\"@wdio/crossbrowsertesting-service\\"]
+    \\"types\\": [\\"node\\", \\"webdriverio/sync\\", \\"@wdio/mocha-framework\\", \\"expect-webdriverio\\", \\"@wdio/crossbrowsertesting-service\\"]
   }
 }
 
@@ -159,7 +159,7 @@ Packages installed successfully, creating configuration file...",
     "To have TypeScript support please add the following packages to your \\"types\\" list:
 {
   \\"compilerOptions\\": {
-    \\"types\\": [\\"node\\", \\"webdriverio/sync\\", \\"@wdio/mocha-framework\\", \\"@wdio/crossbrowsertesting-service\\"]
+    \\"types\\": [\\"node\\", \\"webdriverio/sync\\", \\"@wdio/mocha-framework\\", \\"expect-webdriverio\\", \\"@wdio/crossbrowsertesting-service\\"]
   }
 }
 
@@ -203,7 +203,7 @@ Packages installed successfully, creating configuration file...",
     "To have TypeScript support please add the following packages to your \\"types\\" list:
 {
   \\"compilerOptions\\": {
-    \\"types\\": [\\"node\\", \\"webdriverio/sync\\", \\"@wdio/mocha-framework\\", \\"@wdio/crossbrowsertesting-service\\"]
+    \\"types\\": [\\"node\\", \\"webdriverio/sync\\", \\"@wdio/mocha-framework\\", \\"expect-webdriverio\\", \\"@wdio/crossbrowsertesting-service\\"]
   }
 }
 
@@ -249,7 +249,7 @@ Packages installed successfully, creating configuration file...",
     "To have TypeScript support please add the following packages to your \\"types\\" list:
 {
   \\"compilerOptions\\": {
-    \\"types\\": [\\"node\\", \\"webdriverio/sync\\", \\"@wdio/mocha-framework\\", \\"@wdio/crossbrowsertesting-service\\"]
+    \\"types\\": [\\"node\\", \\"webdriverio/sync\\", \\"@wdio/mocha-framework\\", \\"expect-webdriverio\\", \\"@wdio/crossbrowsertesting-service\\"]
   }
 }
 


### PR DESCRIPTION
## Proposed changes

This patch adds 3 changes to the config wizard:

- it creates a `.ts` file if typescript is used
- it types the config if typescript is used, e.g. file starts with
   ```ts
   export const config: WebdriverIO.Config = {
   ```
- it adds `expect-webdriverio` to the types list in the confirmation note

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

fixes #5944

### Reviewers: @webdriverio/project-committers
