### PR TITLE
fix: Only log when the entry is not a string or array

### DIFF
--- a/packages/wdio-config/src/lib/ConfigParser.ts
+++ b/packages/wdio-config/src/lib/ConfigParser.ts
@@ -297,8 +297,9 @@ export default class ConfigParser {
                                 filesToFilter.add(subFile)
                             }
                         })
+                    } else {
+                        log.warn('Unexpected entry in specs that is neither string nor array: ', file)
                     }
-                    log.warn('Unexpected entry in specs that is neither string nor array: ', file)
                 })
             }
         })


### PR DESCRIPTION
## Proposed changes

There is a bug in the logic that causes us to always log instead of only when the `file` is not a string or array.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

Based on the size of the change I have not created an Issue. Please let me know if you'd like one.

### Reviewers: @webdriverio/project-committers
