### PR TITLE
Implement `>>>` (deep) selector for WebdriverIO

### DIFF
--- a/@types/query-selector-shadow-dom.d.ts
+++ b/@types/query-selector-shadow-dom.d.ts
@@ -1,0 +1,30 @@
+const ExecuteMethod = (element: Element | Document, selector: string) => Element | null;
+
+/**
+ * Contains two functions `queryOne` and `queryAll` that can
+ * be {@link Puppeteer.registerCustomQueryHandler | registered}
+ * as alternative querying strategies. The functions `queryOne` and `queryAll`
+ * are executed in the page context.  `queryOne` should take an `Element` and a
+ * selector string as argument and return a single `Element` or `null` if no
+ * element is found. `queryAll` takes the same arguments but should instead
+ * return a `NodeListOf<Element>` or `Array<Element>` with all the elements
+ * that match the given query selector.
+ * @public
+ */
+interface CustomQueryHandler {
+    queryOne?: ExecuteMethod
+    queryAll?: (element: Element | Document, selector: string) => Element[] | NodeListOf<Element>;
+}
+
+declare const querySelectorShadowDom: {
+    QueryHandler: CustomQueryHandler
+    locatorStrategy: ExecuteMethod
+}
+
+declare module "query-selector-shadow-dom/plugins/puppeteer" {
+    export = querySelectorShadowDom
+}
+
+declare module "query-selector-shadow-dom/plugins/webdriverio" {
+    export = querySelectorShadowDom
+}

--- a/e2e/element.test.js
+++ b/e2e/element.test.js
@@ -229,12 +229,11 @@ describe('elements', () => {
     })
 
     it('should support deep selectors', async () => {
-        await browser.navigateTo('chrome://downloads')
-        const moreActions = await browser.findElement('shadow', '#moreActions')
-        await browser.elementClick(moreActions[ELEMENT_KEY])
-        const span = await browser.findElement('shadow', '.dropdown-item:not([hidden])')
-        const text = await browser.getElementText(span[ELEMENT_KEY])
-        expect(text).toBe('Open downloads folder')
+        await browser.navigateTo('https://www.chromestatus.com/feature/5191745052606464')
+        const headerSlot = await browser.findElement('shadow', '#headerSlot')
+        expect(
+            await browser.getElementProperty(headerSlot[ELEMENT_KEY], 'name')
+        ).toBe('header')
     })
 })
 

--- a/e2e/element.test.js
+++ b/e2e/element.test.js
@@ -16,7 +16,7 @@ beforeAll(async () => {
 })
 
 describe('elements', () => {
-    beforeAll(async () => {
+    beforeEach(async () => {
         await browser.navigateTo('http://guinea-pig.webdriver.io')
     })
 

--- a/e2e/element.test.js
+++ b/e2e/element.test.js
@@ -227,6 +227,15 @@ describe('elements', () => {
         expect(await browser.getElementCSSValue(message[ELEMENT_KEY], 'display'))
             .toBe('block')
     })
+
+    it('should support deep selectors', async () => {
+        await browser.navigateTo('chrome://downloads')
+        const moreActions = await browser.findElement('shadow', '#moreActions')
+        await browser.elementClick(moreActions[ELEMENT_KEY])
+        const span = await browser.findElement('shadow', '.dropdown-item:not([hidden])')
+        const text = await browser.getElementText(span[ELEMENT_KEY])
+        expect(text).toBe('Open downloads folder')
+    })
 })
 
 afterAll(async () => {

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -30,6 +30,7 @@
     "chrome-launcher": "^0.13.1",
     "edge-paths": "^2.1.0",
     "puppeteer-core": "^7.1.0",
+    "query-selector-shadow-dom": "^1.0.0",
     "ua-parser-js": "^0.7.21",
     "uuid": "^8.0.0"
   },

--- a/packages/devtools/src/commands/findElement.ts
+++ b/packages/devtools/src/commands/findElement.ts
@@ -26,6 +26,9 @@ export default function findElement (
     } else if (using === 'partial link text') {
         using = 'xpath'
         value = `//a[contains(., "${value}")]`
+    } else if (using === 'shadow') {
+        using = 'css'
+        value = `shadow/${value}`
     }
 
     const page = this.getPageHandle(true)

--- a/packages/devtools/src/commands/findElement.ts
+++ b/packages/devtools/src/commands/findElement.ts
@@ -27,6 +27,10 @@ export default function findElement (
         using = 'xpath'
         value = `//a[contains(., "${value}")]`
     } else if (using === 'shadow') {
+        /**
+         * `shadow/<selector>` is the way query-selector-shadow-dom
+         * understands to query for shadow elements
+         */
         using = 'css'
         value = `shadow/${value}`
     }

--- a/packages/devtools/src/commands/findElementFromElement.ts
+++ b/packages/devtools/src/commands/findElementFromElement.ts
@@ -32,6 +32,13 @@ export default async function findElementFromElement (
     } else if (using === 'partial link text') {
         using = 'xpath'
         value = `.//a[contains(., "${value}")]`
+    } else if (using === 'shadow') {
+        /**
+         * `shadow/<selector>` is the way query-selector-shadow-dom
+         * understands to query for shadow elements
+         */
+        using = 'css'
+        value = `shadow/${value}`
     }
 
     return findElement.call(this, elementHandle, using, value)

--- a/packages/devtools/src/commands/findElements.ts
+++ b/packages/devtools/src/commands/findElements.ts
@@ -26,6 +26,13 @@ export default async function findElements (
     } else if (using === 'partial link text') {
         using = 'xpath'
         value = `//a[contains(., "${value}")]`
+    } else if (using === 'shadow') {
+        /**
+         * `shadow/<selector>` is the way query-selector-shadow-dom
+         * understands to query for shadow elements
+         */
+        using = 'css'
+        value = `shadow/${value}`
     }
 
     const page = this.getPageHandle(true)

--- a/packages/devtools/src/commands/findElementsFromElement.ts
+++ b/packages/devtools/src/commands/findElementsFromElement.ts
@@ -32,6 +32,13 @@ export default async function findElementFromElements (
     } else if (using === 'partial link text') {
         using = 'xpath'
         value = `.//a[contains(., "${value}")]`
+    } else if (using === 'shadow') {
+        /**
+         * `shadow/<selector>` is the way query-selector-shadow-dom
+         * understands to query for shadow elements
+         */
+        using = 'css'
+        value = `shadow/${value}`
     }
 
     return findElements.call(this, elementHandle, using, value)

--- a/packages/devtools/src/constants.ts
+++ b/packages/devtools/src/constants.ts
@@ -98,7 +98,7 @@ export const DEFAULT_IMPLICIT_TIMEOUT = 0
 export const DEFAULT_PAGELOAD_TIMEOUT = 5 * 60 * 1000 // 5 min
 export const DEFAULT_SCRIPT_TIMEOUT = 30 * 1000 // 30s
 
-export const SUPPORTED_SELECTOR_STRATEGIES = ['css selector', 'tag name', 'xpath', 'link text', 'partial link text']
+export const SUPPORTED_SELECTOR_STRATEGIES = ['css selector', 'tag name', 'xpath', 'link text', 'partial link text', 'shadow']
 export const SERIALIZE_PROPERTY = 'data-devtoolsdriver-fetchedElement'
 export const SERIALIZE_FLAG = '__executeElement'
 

--- a/packages/devtools/src/launcher.ts
+++ b/packages/devtools/src/launcher.ts
@@ -184,7 +184,8 @@ function connectBrowser (connectionUrl: string, capabilities: ExtendedCapabiliti
 }
 
 export default async function launch (capabilities: ExtendedCapabilities) {
-    await puppeteer.registerCustomQueryHandler('shadow', QueryHandler)
+    puppeteer.unregisterCustomQueryHandler('shadow')
+    puppeteer.registerCustomQueryHandler('shadow', QueryHandler)
     const browserName = capabilities.browserName?.toLowerCase()
 
     /**

--- a/packages/devtools/src/launcher.ts
+++ b/packages/devtools/src/launcher.ts
@@ -3,6 +3,8 @@ import puppeteer from 'puppeteer-core'
 import logger from '@wdio/logger'
 import type { Browser } from 'puppeteer-core/lib/cjs/puppeteer/common/Browser'
 import type { Capabilities } from '@wdio/types'
+// @ts-expect-error
+import { QueryHandler } from 'query-selector-shadow-dom/plugins/puppeteer'
 
 import browserFinder from './finder'
 import { getPages } from './utils'
@@ -182,7 +184,8 @@ function connectBrowser (connectionUrl: string, capabilities: ExtendedCapabiliti
     return puppeteer.connect(options) as unknown as Promise<Browser>
 }
 
-export default function launch (capabilities: ExtendedCapabilities) {
+export default async function launch (capabilities: ExtendedCapabilities) {
+    await puppeteer.registerCustomQueryHandler('shadow', QueryHandler)
     const browserName = capabilities.browserName?.toLowerCase()
 
     /**

--- a/packages/devtools/src/launcher.ts
+++ b/packages/devtools/src/launcher.ts
@@ -3,7 +3,6 @@ import puppeteer from 'puppeteer-core'
 import logger from '@wdio/logger'
 import type { Browser } from 'puppeteer-core/lib/cjs/puppeteer/common/Browser'
 import type { Capabilities } from '@wdio/types'
-// @ts-expect-error
 import { QueryHandler } from 'query-selector-shadow-dom/plugins/puppeteer'
 
 import browserFinder from './finder'

--- a/packages/devtools/src/utils.ts
+++ b/packages/devtools/src/utils.ts
@@ -100,7 +100,8 @@ export function getPrototype (commandWrapper: Function) {
 export async function findElement (
     this: DevToolsDriver,
     context: Frame | Page | ElementHandle,
-    using: string, value: string
+    using: string,
+    value: string
 ): Promise<ElementReference | Error>  {
     /**
      * implicitly wait for the element if timeout is set
@@ -206,7 +207,11 @@ export async function transformExecuteArgs (this: DevToolsDriver, args: any[] = 
 /**
  * fetch marked elements from execute script
  */
-export async function transformExecuteResult (this: DevToolsDriver, page: Page, result: any | any[]) {
+export async function transformExecuteResult (
+    this: DevToolsDriver,
+    page: Page,
+    result: any | any[]
+) {
     const isResultArray = Array.isArray(result)
     let tmpResult = isResultArray ? result : [result]
 

--- a/packages/devtools/tests/__mocks__/puppeteer-core.ts
+++ b/packages/devtools/tests/__mocks__/puppeteer-core.ts
@@ -76,6 +76,7 @@ export default {
     sendMock,
     listenerMock,
     devices,
+    registerCustomQueryHandler: jest.fn(),
     launch: jest.fn().mockImplementation(
         () => Promise.resolve(new PuppeteerMock())),
     connect: jest.fn().mockImplementation(

--- a/packages/devtools/tests/__mocks__/puppeteer-core.ts
+++ b/packages/devtools/tests/__mocks__/puppeteer-core.ts
@@ -77,6 +77,7 @@ export default {
     listenerMock,
     devices,
     registerCustomQueryHandler: jest.fn(),
+    unregisterCustomQueryHandler: jest.fn(),
     launch: jest.fn().mockImplementation(
         () => Promise.resolve(new PuppeteerMock())),
     connect: jest.fn().mockImplementation(

--- a/packages/devtools/tests/launcher.test.ts
+++ b/packages/devtools/tests/launcher.test.ts
@@ -30,6 +30,7 @@ test('launch chrome with default values', async () => {
     })
     expect(launchChromeBrowser.mock.calls).toMatchSnapshot()
     expect((puppeteer.connect as jest.Mock).mock.calls).toMatchSnapshot()
+    expect(puppeteer.registerCustomQueryHandler).toBeCalledWith('shadow', expect.any(Function))
 
     const pages = await browser.pages()
     expect(pages[0].close).toBeCalledTimes(1)

--- a/packages/devtools/tests/launcher.test.ts
+++ b/packages/devtools/tests/launcher.test.ts
@@ -30,7 +30,13 @@ test('launch chrome with default values', async () => {
     })
     expect(launchChromeBrowser.mock.calls).toMatchSnapshot()
     expect((puppeteer.connect as jest.Mock).mock.calls).toMatchSnapshot()
-    expect(puppeteer.registerCustomQueryHandler).toBeCalledWith('shadow', expect.any(Function))
+    expect(puppeteer.registerCustomQueryHandler).toBeCalledWith(
+        'shadow',
+        {
+            queryAll: expect.any(Function),
+            queryOne: expect.any(Function)
+        }
+    )
 
     const pages = await browser.pages()
     expect(pages[0].close).toBeCalledTimes(1)

--- a/packages/webdriverio/package.json
+++ b/packages/webdriverio/package.json
@@ -79,6 +79,7 @@
     "lodash.zip": "^4.2.0",
     "minimatch": "^3.0.4",
     "puppeteer-core": "^7.1.0",
+    "query-selector-shadow-dom": "^1.0.0",
     "resq": "^1.9.1",
     "rgb2hex": "0.2.3",
     "serialize-error": "^8.0.0",

--- a/packages/webdriverio/src/commands/element/shadow$$.ts
+++ b/packages/webdriverio/src/commands/element/shadow$$.ts
@@ -2,7 +2,7 @@ import { shadowFnFactory } from '../../scripts/shadowFnFactory'
 
 /**
  *
- * Access elements inside a given element's shadowRoot
+ * Access elements inside a given element's shadowRoot.
  *
  * <example>
     :shadow$$.js
@@ -13,8 +13,7 @@ import { shadowFnFactory } from '../../scripts/shadowFnFactory'
  * </example>
  *
  * If you are working with lots of nested shadow roots,
- * an alternative approach to `shadow$$` is to use a custom locator strategy,
- * for example: https://www.npmjs.com/package/query-selector-shadow-dom#webdriverio
+ * an alternative approach to `shadow$$` is to use the [deep selector](https://webdriver.io/docs/selectors#deep-selectors).
  *
  * @alias element.shadow$$
  * @param {String|Function} selector  selector or JS Function to fetch a certain element

--- a/packages/webdriverio/src/commands/element/shadow$.ts
+++ b/packages/webdriverio/src/commands/element/shadow$.ts
@@ -2,7 +2,7 @@ import { shadowFnFactory } from '../../scripts/shadowFnFactory'
 
 /**
  *
- * Access an element inside a given element's shadowRoot
+ * Access an element inside a given element's shadowRoot.
  *
  * <example>
     :shadow$$.js
@@ -13,8 +13,7 @@ import { shadowFnFactory } from '../../scripts/shadowFnFactory'
  * </example>
  *
  * If you are working with lots of nested shadow roots,
- * an alternative approach to `shadow$` is to use a custom locator strategy,
- * for example: https://www.npmjs.com/package/query-selector-shadow-dom#webdriverio
+ * an alternative approach to `shadow$` is to use the [deep selector](https://webdriver.io/docs/selectors#deep-selectors).
  *
  * @alias element.shadow$
  * @param {String|Function} selector  selector or JS Function to fetch a certain element

--- a/packages/webdriverio/src/constants.ts
+++ b/packages/webdriverio/src/constants.ts
@@ -382,6 +382,7 @@ export const DRIVER_DEFAULT_ENDPOINT = {
 }
 
 export const FF_REMOTE_DEBUG_ARG = '-remote-debugging-port'
+export const DEEP_SELECTOR = '>>>'
 
 export const ERROR_REASON = [
     'Failed', 'Aborted', 'TimedOut', 'AccessDenied', 'ConnectionClosed',

--- a/packages/webdriverio/src/utils/findStrategy.ts
+++ b/packages/webdriverio/src/utils/findStrategy.ts
@@ -2,7 +2,7 @@ import fs from 'fs'
 import isPlainObject from 'lodash.isplainobject'
 import { roleElements, ARIARoleDefintionKey, ARIARoleRelationConcept, ARIARoleRelationConceptAttribute } from 'aria-query'
 
-import { W3C_SELECTOR_STRATEGIES } from '../constants'
+import { W3C_SELECTOR_STRATEGIES, DEEP_SELECTOR } from '../constants'
 
 const DEFAULT_STRATEGY = 'css selector'
 const DIRECT_SELECTOR_REGEXP = /^(id|css selector|xpath|link text|partial link text|name|tag name|class name|-android uiautomator|-android datamatcher|-android viewmatcher|-android viewtag|-ios uiautomation|-ios predicate string|-ios class chain|accessibility id):(.+)/
@@ -63,6 +63,10 @@ const defineStrategy = function (selector: SelectorStrategy) {
     // Use id strategy if the selector starts with id=
     if (stringSelector.startsWith('id=')) {
         return 'id'
+    }
+    // use shadow dom selector
+    if (stringSelector.startsWith(DEEP_SELECTOR)) {
+        return 'shadow'
     }
     // Recursive element search using the UiAutomator library (Android only)
     if (stringSelector.startsWith('android=')) {
@@ -141,6 +145,10 @@ export const findStrategy = function (selector: SelectorStrategy, isW3C?: boolea
         value = stringSelector.slice(2)
         break
     }
+    case 'shadow':
+        using = 'shadow'
+        value = stringSelector.slice(DEEP_SELECTOR.length)
+        break
     case '-android uiautomator': {
         using = '-android uiautomator'
         value = stringSelector.slice(8)
@@ -236,7 +244,7 @@ export const findStrategy = function (selector: SelectorStrategy, isW3C?: boolea
     /**
      * ensure selector strategy is supported
      */
-    if (!isMobile && isW3C && !W3C_SELECTOR_STRATEGIES.includes(using)) {
+    if (!isMobile && isW3C && (using !== 'shadow') && !W3C_SELECTOR_STRATEGIES.includes(using)) {
         throw new Error('InvalidSelectorStrategy') // ToDo: move error to wdio-error package
     }
 

--- a/packages/webdriverio/src/utils/index.ts
+++ b/packages/webdriverio/src/utils/index.ts
@@ -279,6 +279,18 @@ export async function findElements(
     selector: Selector
 ) {
     /**
+     * check if shadow DOM integration is used
+     */
+    if (!this.isDevTools && typeof selector === 'string' && selector.startsWith(DEEP_SELECTOR)) {
+        const elems: ElementReference | ElementReference[] = await this.execute(
+            locatorStrategy,
+            selector.slice(DEEP_SELECTOR.length)
+        )
+        const elemArray = Array.isArray(elems) ? elems : [elems]
+        return elemArray.filter((elem) => elem && getElementFromResponse(elem))
+    }
+
+    /**
      * fetch element using regular protocol command
      */
     if (typeof selector === 'string' || isPlainObject(selector)) {

--- a/packages/webdriverio/src/utils/index.ts
+++ b/packages/webdriverio/src/utils/index.ts
@@ -12,7 +12,6 @@ import { URL } from 'url'
 import { SUPPORTED_BROWSER } from 'devtools'
 import type { ElementReference } from '@wdio/protocols'
 import type { Options, Capabilities } from '@wdio/types'
-// @ts-expect-error
 import { locatorStrategy } from 'query-selector-shadow-dom/plugins/webdriverio'
 
 import { ELEMENT_KEY, UNICODE_CHARACTERS, DRIVER_DEFAULT_ENDPOINT, FF_REMOTE_DEBUG_ARG, DEEP_SELECTOR } from '../constants'

--- a/packages/webdriverio/tests/findStrategy.test.ts
+++ b/packages/webdriverio/tests/findStrategy.test.ts
@@ -433,4 +433,10 @@ describe('selector strategies helper', () => {
         expect(element.using).toBe('css selector')
         expect(element.value).toBe('[role="abcd"]')
     })
+
+    it('should use shadow selector strategy if selector is prefixed with >>>', () => {
+        const element = findStrategy('>>>.foobar')
+        expect(element.using).toBe('shadow')
+        expect(element.value).toBe('.foobar')
+    })
 })

--- a/packages/webdriverio/tests/utils.test.ts
+++ b/packages/webdriverio/tests/utils.test.ts
@@ -309,6 +309,18 @@ describe('utils', () => {
             await expect(findElement.call(scope, false)).rejects.toEqual(new Error(expectedMatch))
             await expect(findElement.call(scope)).rejects.toEqual(new Error(expectedMatch))
         })
+
+        it('should use execute if shadow selector is used', async () => {
+            (scope.execute as jest.Mock).mockReturnValue(elementResponse)
+            const elem = await findElement.call(scope, '>>>.foobar') as WebdriverIO.Element
+            expect(scope.findElement).not.toBeCalled()
+            expect(scope.findElementFromElement).not.toBeCalled()
+            expect(scope.execute).toBeCalledWith(
+                expect.any(Function),
+                '.foobar'
+            )
+            expect(elem[ELEMENT_KEY]).toBe('foobar')
+        })
     })
 
     describe('findElements', () => {

--- a/packages/webdriverio/tests/utils.test.ts
+++ b/packages/webdriverio/tests/utils.test.ts
@@ -409,6 +409,19 @@ describe('utils', () => {
             await expect(findElements.call(scope, false)).rejects.toEqual(new Error(expectedMatch))
             await expect(findElements.call(scope)).rejects.toEqual(new Error(expectedMatch))
         })
+
+        it('fetches element using a function with browser scope', async () => {
+            (scope.execute as jest.Mock).mockReturnValue(elementResponse)
+            const elem = await findElements.call(scope, '>>>.foobar')
+            expect(scope.findElements).not.toBeCalled()
+            expect(scope.findElementsFromElement).not.toBeCalled()
+            expect(scope.execute).toBeCalledWith(
+                expect.any(Function),
+                '.foobar'
+            )
+            expect(elem).toHaveLength(1)
+            expect(elem[0][ELEMENT_KEY]).toBe('foobar')
+        })
     })
     describe('verifyArgsAndStripIfElement', () => {
         class Element {

--- a/website/docs/Selectors.md
+++ b/website/docs/Selectors.md
@@ -209,6 +209,21 @@ const elem = $('#elem') // or $(() => document.getElementById('elem'))
 elem.$(function () { return this.nextSibling.nextSibling }) // (first sibling is #text with value ("↵"))
 ```
 
+## Deep Selectors
+
+Many frontend applications heavily rely on elements with [shadow DOM](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_shadow_DOM). It is technically impossible to query elements within the shadow DOM without workarounds. The [`shadow$`](https://webdriver.io/docs/api/element/shadow$) and [`shadow$$`](https://webdriver.io/docs/api/element/shadow$$) have been such workarounds that had their [limitations](https://github.com/Georgegriff/query-selector-shadow-dom#how-is-this-different-to-shadow). With the deep selector you can now query all elements within any shadow DOM using the common query command.
+
+Given we have an application with the following structure:
+
+![Chrome Example](https://github.com/Georgegriff/query-selector-shadow-dom/raw/main/Chrome-example.png "Chrome Example")
+
+With this selector you can query the `<button />` element that is nested within another shadow DOM, e.g.:
+
+```js
+const button = $('>>>.dropdown-item:not([hidden])')
+console.log(button.getText()) // outputs: "Open downloads folder"
+```
+
 ## Mobile Selectors
 
 For hybrid mobile testing, it's important that the automation server is in the correct *context* before executing commands. For automating gestures, the driver ideally should be set to native context. But to select elements from the DOM, the driver will need to be set to the platform's webview context. Only *then* can the methods mentioned above can be used.


### PR DESCRIPTION
I just stumbled upon this amazing library again: https://github.com/Georgegriff/query-selector-shadow-dom and thing it is worth while to natively integrate it into WebdriverIO. My idea would be to add a "deep" selector that would work like this:

```js
$('>>>.btn-in-shadow-dom')
```

What do you think @Georgegriff ?