### PR TITLE
Fix DevToolsDriver elements storing

### DIFF
--- a/packages/devtools/src/devtoolsdriver.ts
+++ b/packages/devtools/src/devtoolsdriver.ts
@@ -152,11 +152,7 @@ export default class DevToolsDriver {
 
     framenavigatedHandler(frame: Frame) {
         this.currentFrameUrl = frame.url()
-        if (!frame.parentFrame()) {
-            this.elementStore.clear()
-        } else {
-            this.elementStore.clear(frame)
-        }
+        this.elementStore.clear(frame.parentFrame() ? frame : undefined)
     }
 
     setTimeouts(implicit?: number, pageLoad?: number, script?: number) {

--- a/packages/devtools/src/devtoolsdriver.ts
+++ b/packages/devtools/src/devtoolsdriver.ts
@@ -7,6 +7,7 @@ import type { Browser } from 'puppeteer-core/lib/cjs/puppeteer/common/Browser'
 import type { Dialog } from 'puppeteer-core/lib/cjs/puppeteer/common/Dialog'
 import type { Page } from 'puppeteer-core/lib/cjs/puppeteer/common/Page'
 import type { CommandEndpoint } from '@wdio/protocols'
+import type { Frame } from 'puppeteer-core/lib/cjs/puppeteer/common/FrameManager'
 
 import ElementStore from './elementstore'
 import { validate, sanitizeError } from './utils'
@@ -149,9 +150,13 @@ export default class DevToolsDriver {
         this.activeDialog = dialog
     }
 
-    framenavigatedHandler(frame: Page) {
+    framenavigatedHandler(frame: Frame) {
         this.currentFrameUrl = frame.url()
-        this.elementStore.clear()
+        if (!frame.parentFrame()) {
+            this.elementStore.clear()
+        } else {
+            this.elementStore.clear(frame)
+        }
     }
 
     setTimeouts(implicit?: number, pageLoad?: number, script?: number) {

--- a/packages/devtools/src/elementstore.ts
+++ b/packages/devtools/src/elementstore.ts
@@ -40,12 +40,13 @@ export default class ElementStore {
         if (!frame) {
             this._elementMap.clear()
             this._frameMap.clear()
-        } else {
-            const elementIndexes = this._frameMap.get(frame)
-            if (elementIndexes) {
-                elementIndexes.forEach((elementIndex) => this._elementMap.delete(elementIndex))
-                this._frameMap.delete(frame)
-            }
+            return
+        }
+
+        const elementIndexes = this._frameMap.get(frame)
+        if (elementIndexes) {
+            elementIndexes.forEach((elementIndex) => this._elementMap.delete(elementIndex))
+            this._frameMap.delete(frame)
         }
     }
 }

--- a/packages/devtools/src/elementstore.ts
+++ b/packages/devtools/src/elementstore.ts
@@ -1,12 +1,23 @@
 import type { ElementHandle } from 'puppeteer-core/lib/cjs/puppeteer/common/JSHandle'
+import type { Frame } from 'puppeteer-core/lib/cjs/puppeteer/common/FrameManager'
 
 export default class ElementStore {
     private _index = 0
     private _elementMap: Map<string, ElementHandle> = new Map()
+    private _frameMap: Map<Frame, Set<string>> = new Map()
 
     set (elementHandle: ElementHandle) {
         const index = `ELEMENT-${++this._index}`
         this._elementMap.set(index, elementHandle)
+        const frame = elementHandle.executionContext().frame()
+        if (frame) {
+            let elementIndexes = this._frameMap.get(frame)
+            if (!elementIndexes) {
+                elementIndexes = new Set()
+                this._frameMap.set(frame, elementIndexes)
+            }
+            elementIndexes.add(index)
+        }
         return index
     }
 
@@ -25,7 +36,16 @@ export default class ElementStore {
         return isElementAttachedToDOM ? elementHandle : undefined
     }
 
-    clear () {
-        this._elementMap.clear()
+    clear (frame?: Frame) {
+        if (!frame) {
+            this._elementMap.clear()
+            this._frameMap.clear()
+        } else {
+            const elementIndexes = this._frameMap.get(frame)
+            if (elementIndexes) {
+                elementIndexes.forEach((elementIndex) => this._elementMap.delete(elementIndex))
+                this._frameMap.delete(frame)
+            }
+        }
     }
 }

--- a/packages/devtools/tests/devtoolsdriver.test.ts
+++ b/packages/devtools/tests/devtoolsdriver.test.ts
@@ -279,13 +279,23 @@ test('dialogHandler', () => {
     expect(driver.activeDialog).toBe('foobar')
 })
 
-test('framenavigatedHandler', () => {
+test('framenavigatedHandler for main frame', () => {
     driver.elementStore.clear = jest.fn()
 
     const frameMock = { url: jest.fn().mockReturnValue('foobar'), parentFrame:jest.fn().mockReturnValue(null) }
     driver.framenavigatedHandler(frameMock as unknown as Frame)
     expect(driver.currentFrameUrl).toBe('foobar')
     expect(driver.elementStore.clear).toBeCalledTimes(1)
+})
+
+test('framenavigatedHandler for child frame', () => {
+    driver.elementStore.clear = jest.fn()
+
+    const frameMock = { url: jest.fn().mockReturnValue('foobar'), parentFrame:jest.fn().mockReturnValue({}) }
+    driver.framenavigatedHandler(frameMock as unknown as Frame)
+    expect(driver.currentFrameUrl).toBe('foobar')
+    expect(driver.elementStore.clear).toBeCalledTimes(1)
+    expect(driver.elementStore.clear).toBeCalledWith(frameMock)
 })
 
 test('setTimeouts with not value', () => {

--- a/packages/devtools/tests/devtoolsdriver.test.ts
+++ b/packages/devtools/tests/devtoolsdriver.test.ts
@@ -1,6 +1,6 @@
 import DevToolsDriver from '../src/devtoolsdriver'
 import type { Dialog } from 'puppeteer-core/lib/cjs/puppeteer/common/Dialog'
-import type { Page } from 'puppeteer-core/lib/cjs/puppeteer/common/Page'
+import type { Frame } from 'puppeteer-core/lib/cjs/puppeteer/common/FrameManager'
 
 const expect = global.expect as unknown as jest.Expect
 
@@ -282,8 +282,8 @@ test('dialogHandler', () => {
 test('framenavigatedHandler', () => {
     driver.elementStore.clear = jest.fn()
 
-    const frameMock = { url: jest.fn().mockReturnValue('foobar') }
-    driver.framenavigatedHandler(frameMock as unknown as Page)
+    const frameMock = { url: jest.fn().mockReturnValue('foobar'), parentFrame:jest.fn().mockReturnValue(null) }
+    driver.framenavigatedHandler(frameMock as unknown as Frame)
     expect(driver.currentFrameUrl).toBe('foobar')
     expect(driver.elementStore.clear).toBeCalledTimes(1)
 })

--- a/packages/devtools/tests/elementStore.test.ts
+++ b/packages/devtools/tests/elementStore.test.ts
@@ -1,12 +1,16 @@
 import ElementStore from '../src/elementstore'
 import type { ElementHandle } from 'puppeteer-core/lib/cjs/puppeteer/common/JSHandle'
+import type { Frame } from 'puppeteer-core/lib/cjs/puppeteer/common/FrameManager'
 
 const elementHandleFactory = (
-    { isConnected = true }: { isConnected?: boolean } = {}
+    { isConnected = true, frame = Symbol() }: { isConnected?: boolean, frame?: symbol } = {}
 ) => ({
     id: Math.random(),
     async evaluate(cb: any) {
         return cb({ isConnected })
+    },
+    executionContext() {
+        return { frame: () => frame }
     }
 })
 
@@ -30,4 +34,20 @@ test('should not return element if it is not attached to the DOM', async () => {
     const elementHandle = elementHandleFactory({ isConnected: false }) as any as ElementHandle
     store.set(elementHandle)
     expect(await store.get('ELEMENT-1')).toBe(undefined)
+})
+
+test('should clear elements of a specific frame', async () => {
+    const store = new ElementStore()
+    const frame1 = Symbol('frame1')
+    const frame2 = Symbol('frame2')
+    const elementHandle1 = elementHandleFactory({ frame: frame1 }) as any as ElementHandle
+    store.set(elementHandle1)
+    const elementHandle2 = elementHandleFactory({ frame: frame2 }) as any as ElementHandle
+    store.set(elementHandle2)
+    expect(store['_frameMap'].size).toBe(2)
+
+    store.clear(frame1 as any as Frame)
+
+    expect(await store.get('ELEMENT-1')).toBe(undefined)
+    expect(await store.get('ELEMENT-2')).toBe(elementHandle2)
 })


### PR DESCRIPTION
## Proposed changes

In this PR I propose a fix for a bug in `DevToolsDriver` that was described in this [issue](https://github.com/webdriverio/webdriverio/issues/6724).
I propose to store frames map of type `Map<Frame, string>` where value is generated element ids. And remove the only elements of a specific frame if this frame was reloaded/navigated, instead of completely clear the whole elements store.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

### Reviewers: @webdriverio/project-committers
