### PR TITLE
`checkPWA` command is broken

### DIFF
--- a/e2e/wdio/headless/test.e2e.js
+++ b/e2e/wdio/headless/test.e2e.js
@@ -9,4 +9,9 @@ describe('main suite 1', () => {
         browser.url('https://webdriver.io')
         expect(browser.checkPWA().passed).toBe(true)
     })
+
+    it('should also detect non PWAs', () => {
+        browser.url('https://json.org')
+        expect(browser.checkPWA().passed).toBe(false)
+    })
 })

--- a/packages/wdio-devtools-service/src/index.ts
+++ b/packages/wdio-devtools-service/src/index.ts
@@ -195,7 +195,7 @@ export default class DevToolsService implements Services.ServiceInstance {
         await this._session.send('Network.emulateNetworkConditions', NETWORK_STATES[networkThrottling])
     }
 
-    async _checkPWA (auditsToBeRun: PWAAudits[] = []) {
+    async _checkPWA (auditsToBeRun: PWAAudits[]) {
         const auditor = new Auditor()
         const artifacts = await this._pwaGatherer!.gatherData()
         return auditor._auditPWA(artifacts, auditsToBeRun)


### PR DESCRIPTION
Currently the `checkPWA` command in the devtools service is broken. It passes for all applications even though they aren't really PWA applications because the parameter to filter for PWA checks isn't being passed along properly which results in [filtering for all checks](https://github.com/webdriverio/webdriverio/blob/main/packages/wdio-devtools-service/src/auditor.ts#L171) and always results in passing.