### PR TITLE
Add documentation for accessing browser instances via strings

### DIFF
--- a/website/docs/Multiremote.md
+++ b/website/docs/Multiremote.md
@@ -154,8 +154,7 @@ Multiremote makes it easy and convenient to control multiple browsers, whether y
 
 ## Accessing browser instances using strings via the browser object
 In addition to accessing browser instance via their global variables (eg `myChromeBrowser`, `myFirefoxBrowser`), you can also access them via the `browser` object - eg `browser["myChromeBrowser"]` or `browser["myFirefoxBrowser"]`.
-This is especially useful when writing re-usable test steps that can be performed in either browser:  
-eg  
+This is especially useful when writing re-usable test steps that can be performed in either browser, e.g.:
 
 wdio.conf.js:
 ```js

--- a/website/docs/Multiremote.md
+++ b/website/docs/Multiremote.md
@@ -180,7 +180,7 @@ Cucumber file:
 Step definition file:
 ```
 When(/^User (.) types a message into the chat/, (userId) => {
-    browser["user" userId].$('#message').setValue('Hi, I am Chrome')
-    browser["user" userId].$('#send').click()
+    browser[`user${userId}`].$('#message').setValue('Hi, I am Chrome')
+    browser[`user${userId}`].$('#send').click()
 })
 ```

--- a/website/docs/Multiremote.md
+++ b/website/docs/Multiremote.md
@@ -153,8 +153,7 @@ In this example, the `myFirefoxBrowser` instance will start waiting on a message
 Multiremote makes it easy and convenient to control multiple browsers, whether you want them doing the same thing in parallel, or different things in concert.
 
 ## Accessing browser instances using strings via the browser object
-In addition to accessing the browser instance via their global variables (e.g. `myChromeBrowser`, `myFirefoxBrowser`), you can also access them via the `browser` object, e.g. `browser["myChromeBrowser"]` or `browser["myFirefoxBrowser"]`.
-This is especially useful when writing re-usable test steps that can be performed in either browser, e.g.:
+In addition to accessing the browser instance via their global variables (e.g. `myChromeBrowser`, `myFirefoxBrowser`), you can also access them via the `browser` object, e.g. `browser["myChromeBrowser"]` or `browser["myFirefoxBrowser"]`. You can get a list of all your instances via `browser.instances`. This is especially useful when writing re-usable test steps that can be performed in either browser, e.g.:
 
 wdio.conf.js:
 ```js

--- a/website/docs/Multiremote.md
+++ b/website/docs/Multiremote.md
@@ -173,9 +173,9 @@ wdio.conf.js:
 ```
 
 Cucumber file:
-```js
-When User A types a message into the chat
-```
+    ```feature
+    When User A types a message into the chat
+    ```
 
 Step definition file:
 ```

--- a/website/docs/Multiremote.md
+++ b/website/docs/Multiremote.md
@@ -153,7 +153,7 @@ In this example, the `myFirefoxBrowser` instance will start waiting on a message
 Multiremote makes it easy and convenient to control multiple browsers, whether you want them doing the same thing in parallel, or different things in concert.
 
 ## Accessing browser instances using strings via the browser object
-In addition to accessing browser instance via their global variables (eg `myChromeBrowser`, `myFirefoxBrowser`), you can also access them via the `browser` object - eg `browser["myChromeBrowser"]` or `browser["myFirefoxBrowser"]`  
+In addition to accessing browser instance via their global variables (eg `myChromeBrowser`, `myFirefoxBrowser`), you can also access them via the `browser` object - eg `browser["myChromeBrowser"]` or `browser["myFirefoxBrowser"]`.
 This is especially useful when writing re-usable test steps that can be performed in either browser:  
 eg  
 

--- a/website/docs/Multiremote.md
+++ b/website/docs/Multiremote.md
@@ -153,7 +153,7 @@ In this example, the `myFirefoxBrowser` instance will start waiting on a message
 Multiremote makes it easy and convenient to control multiple browsers, whether you want them doing the same thing in parallel, or different things in concert.
 
 ## Accessing browser instances using strings via the browser object
-In addition to accessing browser instance via their global variables (eg `myChromeBrowser`, `myFirefoxBrowser`), you can also access them via the `browser` object - eg `browser["myChromeBrowser"]` or `browser["myFirefoxBrowser"]`.
+In addition to accessing the browser instance via their global variables (e.g. `myChromeBrowser`, `myFirefoxBrowser`), you can also access them via the `browser` object, e.g. `browser["myChromeBrowser"]` or `browser["myFirefoxBrowser"]`.
 This is especially useful when writing re-usable test steps that can be performed in either browser, e.g.:
 
 wdio.conf.js:

--- a/website/docs/Multiremote.md
+++ b/website/docs/Multiremote.md
@@ -178,7 +178,7 @@ Cucumber file:
     ```
 
 Step definition file:
-```
+```js
 When(/^User (.) types a message into the chat/, (userId) => {
     browser[`user${userId}`].$('#message').setValue('Hi, I am Chrome')
     browser[`user${userId}`].$('#send').click()

--- a/website/docs/Multiremote.md
+++ b/website/docs/Multiremote.md
@@ -151,3 +151,37 @@ assert.true(
 In this example, the `myFirefoxBrowser` instance will start waiting on a message once the `myChromeBrowser` instance has clicked on `#send` button.
 
 Multiremote makes it easy and convenient to control multiple browsers, whether you want them doing the same thing in parallel, or different things in concert.
+
+## Accessing browser instances using strings via the browser object
+In addition to accessing browser instance via their global variables (eg `myChromeBrowser`, `myFirefoxBrowser`), you can also access them via the `browser` object - eg `browser["myChromeBrowser"]` or `browser["myFirefoxBrowser"]`  
+This is especially useful when writing re-usable test steps that can be performed in either browser:  
+eg  
+
+wdio.conf.js:
+```js
+    capabilities: {
+        userA: {
+            capabilities: {
+                browserName: 'chrome'
+            }
+        },
+        userB: {
+            capabilities: {
+                browserName: 'chrome'
+            }
+        }
+    }
+```
+
+Cucumber file:
+```js
+When User A types a message into the chat
+```
+
+Step definition file:
+```
+When(/^User (.) types a message into the chat/, (userId) => {
+    browser["user" userId].$('#message').setValue('Hi, I am Chrome')
+    browser["user" userId].$('#send').click()
+})
+```


### PR DESCRIPTION
## Proposed changes

Documents accessing Multiremote browser instances via the browser object using strings

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
