### PR TITLE
Retry connection refused errors

### DIFF
--- a/packages/webdriver/src/request.ts
+++ b/packages/webdriver/src/request.ts
@@ -195,6 +195,13 @@ export default class WebDriverRequest extends EventEmitter {
         const error = getErrorFromResponseBody(response.body)
 
         /**
+         * retry connection refused errors
+         */
+        if (error.message === 'java.net.ConnectException: Connection refused: connect') {
+            return retry(error, 'Connection to Selenium Standalone server was refused.')
+        }
+
+        /**
          * hub commands don't follow standard response formats
          * and can have empty bodies
          */

--- a/packages/webdriver/tests/request.test.ts
+++ b/packages/webdriver/tests/request.test.ts
@@ -3,8 +3,8 @@ import * as gotOrig from 'got'
 import http from 'http'
 import https from 'https'
 
+import { Options } from '@wdio/types'
 import WebDriverRequest from '../src/request'
-import { WebDriverLogTypes } from '../src/types'
 
 type LogMock = {
     warn: jest.Mock,
@@ -237,7 +237,7 @@ describe('webdriver request', () => {
                 ...defaultOptions,
                 path: '/',
                 headers: { foo: 'bar' },
-                logLevel: 'warn' as WebDriverLogTypes
+                logLevel: 'warn' as Options.WebDriverLogTypes
             }
 
             beforeEach(function() {
@@ -436,6 +436,26 @@ describe('webdriver request', () => {
                 (e) => e
             )
             expect(result).toEqual({ value: { value: {} } })
+            expect(reqRetryCnt).toBeCalledTimes(5)
+        })
+
+        it('should retry on connection refused error', async () => {
+            const retryCnt = 7
+            const req = new WebDriverRequest('POST', '/connectionRefused', {}, true)
+            const reqRetryCnt = jest.fn()
+            req.on('retry', reqRetryCnt)
+            const result = await req.makeRequest({
+                protocol: 'https',
+                hostname: 'localhost',
+                port: 4445,
+                path: '/connectionRefused',
+                connectionRetryCount: retryCnt,
+                logLevel: 'warn'
+            }, 'foobar').then(
+                (res) => res,
+                (e) => e
+            )
+            expect(result).toEqual({ value: { value: { foo: 'bar' } } })
             expect(reqRetryCnt).toBeCalledTimes(5)
         })
 

--- a/packages/webdriverio/tests/__mocks__/got.ts
+++ b/packages/webdriverio/tests/__mocks__/got.ts
@@ -262,6 +262,18 @@ const requestMock: any = jest.fn().mockImplementation((uri, params) => {
     case '/grid/api/testsession':
         value = '<!DOCTYPE html><html lang="en"></html>'
         break
+    case '/connectionRefused':
+        if (requestMock.retryCnt < 5) {
+            ++requestMock.retryCnt
+            value = {
+                stacktrace: 'java.lang.RuntimeException: java.net.ConnectException: Connection refused',
+                stackTrace: [],
+                message: 'java.net.ConnectException: Connection refused: connect',
+                error: 'unknown error'
+            }
+        } else {
+            value = { foo: 'bar' }
+        }
     }
 
     if (uri.pathname.endsWith('timeout') && requestMock.retryCnt < 5) {


### PR DESCRIPTION
## Proposed changes

There seems to be cases where the Selenium Standalone server returns with an error such as:

```json
{
  "value": {
    "stacktrace": "java.lang.RuntimeException: java.net.ConnectException: Connection refused: connect\r\n\tat org.openqa.selenium.remote.server.WebDriverServlet.lambda$handle$0(WebDriverServlet.java:240)\r\n\tat java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source)\r\n\tat java.util.concurrent.FutureTask.run(Unknown Source)\r\n\tat java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)\r\n\tat java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)\r\n\tat java.lang.Thread.run(Unknown Source)\r\nCaused by: java.net.ConnectException: Connection refused: connect\r\n\tat java.net.DualStackPlainSocketImpl.connect0(Native Method)\r\n\tat java.net.DualStackPlainSocketImpl.socketConnect(Unknown Source)\r\n\tat java.net.AbstractPlainSocketImpl.doConnect(Unknown Source)\r\n\tat java.net.AbstractPlainSocketImpl.connectToAddress(Unknown Source)\r\n\tat java.net.AbstractPlainSocketImpl.connect(Unknown Source)\r\n\tat java.net.PlainSocketImpl.connect(Unknown Source)\r\n\tat java.net.SocksSocketImpl.connect(Unknown Source)\r\n\tat java.net.Socket.connect(Unknown Source)\r\n\tat java.net.Socket.connect(Unknown Source)\r\n\tat sun.net.NetworkClient.doConnect(Unknown Source)\r\n\tat sun.net.www.http.HttpClient.openServer(Unknown Source)\r\n\tat sun.net.www.http.HttpClient.openServer(Unknown Source)\r\n\tat sun.net.www.http.HttpClient.\u003cinit>(Unknown Source)\r\n\tat sun.net.www.http.HttpClient.New(Unknown Source)\r\n\tat sun.net.www.http.HttpClient.New(Unknown Source)\r\n\tat sun.net.www.protocol.http.HttpURLConnection.getNewHttpClient(Unknown Source)\r\n\tat sun.net.www.protocol.http.HttpURLConnection.plainConnect0(Unknown Source)\r\n\tat sun.net.www.protocol.http.HttpURLConnection.plainConnect(Unknown Source)\r\n\tat sun.net.www.protocol.http.HttpURLConnection.connect(Unknown Source)\r\n\tat sun.net.www.protocol.http.HttpURLConnection.getInputStream0(Unknown Source)\r\n\tat sun.net.www.protocol.http.HttpURLConnection.getInputStream(Unknown Source)\r\n\tat java.net.HttpURLConnection.getResponseCode(Unknown Source)\r\n\tat org.openqa.selenium.grid.web.ReverseProxyHandler.execute(ReverseProxyHandler.java:111)\r\n\tat org.openqa.selenium.grid.session.remote.Passthrough.handle(Passthrough.java:35)\r\n\tat org.openqa.selenium.grid.session.remote.RemoteSession.execute(RemoteSession.java:129)\r\n\tat org.openqa.selenium.remote.server.WebDriverServlet.lambda$handle$0(WebDriverServlet.java:235)\r\n\t... 5 more\r\n",
    "stackTrace": [
      {
        "fileName": "WebDriverServlet.java",
        "methodName": "lambda$handle$0",
        "className": "org.openqa.selenium.remote.server.WebDriverServlet",
        "lineNumber": 240
      },
      {
        "fileName": null,
        "methodName": "call",
        "className": "java.util.concurrent.Executors$RunnableAdapter",
        "lineNumber": -1
      },
      {
        "fileName": null,
        "methodName": "run",
        "className": "java.util.concurrent.FutureTask",
        "lineNumber": -1
      },
      {
        "fileName": null,
        "methodName": "runWorker",
        "className": "java.util.concurrent.ThreadPoolExecutor",
        "lineNumber": -1
      },
      {
        "fileName": null,
        "methodName": "run",
        "className": "java.util.concurrent.ThreadPoolExecutor$Worker",
        "lineNumber": -1
      },
      {
        "fileName": null,
        "methodName": "run",
        "className": "java.lang.Thread",
        "lineNumber": -1
      }
    ],
    "message": "java.net.ConnectException: Connection refused: connect",
    "error": "unknown error"
  },
  "status": 13
}
```

WebdriverIO currently didn't had any retry mechanism for them. This patch adds one.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

fixes #6728

### Reviewers: @webdriverio/project-committers
