### PR TITLE
Print custom error message if installing deps fails with no stderr

### DIFF
--- a/packages/wdio-cli/src/commands/config.ts
+++ b/packages/wdio-cli/src/commands/config.ts
@@ -113,7 +113,10 @@ const runConfig = async function (useYarn: boolean, yes: boolean, exit = false) 
     const result = yarnInstall({ deps: packagesToInstall, dev: true, respectNpm5: !useYarn })
 
     if (result.status !== 0) {
-        throw new Error(result.stderr)
+        const customError = 'An unknown error happened! Please retry ' +
+            `installing dependencies via "${useYarn ? 'yarn add --dev' : 'npm i --save-dev'} ` +
+            `${packagesToInstall.join(' ')}"`
+        throw new Error(result.stderr || customError)
     }
 
     console.log('\nPackages installed successfully, creating configuration file...')


### PR DESCRIPTION
## Proposed changes

It seems that installing dependencies can fail with `null` as stderr. To provide users a better error message this patch makes it print one.

refs #6757

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
