### PR TITLE
Documentation fix: Removed $ sign in commands so it wont be copied

### DIFF
--- a/website/docs/ProtractorMigration.md
+++ b/website/docs/ProtractorMigration.md
@@ -14,7 +14,7 @@ The Protractor and WebdriverIO API is actually very similar, to a point where th
 To install the codemod, run:
 
 ```sh
-$ npm install jscodeshift @wdio/codemod
+npm install jscodeshift @wdio/codemod
 ```
 
 #### Commits:
@@ -32,7 +32,7 @@ After we have installed the codemod we can start transforming the first file. Ha
 For the first migration we only transform the config file and run:
 
 ```sh
-$ npx jscodeshift -t ./node_modules/@wdio/codemod/protractor ./conf.ts
+npx jscodeshift -t ./node_modules/@wdio/codemod/protractor ./conf.ts
 ```
 
 :::info
@@ -50,13 +50,13 @@ This migration tutorial uses an example Protractor [boilerplate project](https:/
 Next step is to configure a minimal WebdriverIO setup that we start building up as we migrate from one framework to another. First we install the WebdriverIO CLI via:
 
 ```sh
-$ npm install --save-dev @wdio/cli
+npm install --save-dev @wdio/cli
 ```
 
 Next we run the configuration wizard:
 
 ```sh
-$ npx wdio config
+npx wdio config
 ```
 
 This will walk you through a couple of questions. For this migration scenario you:
@@ -92,14 +92,14 @@ We will now continue with our `wdio.conf.ts` file only and therefor won't need a
 We are now set to port over the first test file. To start simple, let's start with one that has not many dependencies to 3rd party packages or other files like PageObjects. In our example the first file to migrate is `first-test.spec.ts`. First create the directory where the new WebdriverIO configuration expects its files and then move it over:
 
 ```sh
-$ mv mkdir -p ./test/specs/
-$ mv test-suites/first-test.spec.ts ./test/specs
+mv mkdir -p ./test/specs/
+mv test-suites/first-test.spec.ts ./test/specs
 ```
 
 Now let's transform this file:
 
 ```sh
-$ npx jscodeshift -t ./node_modules/@wdio/codemod/protractor ./test/specs/first-test.spec.ts
+npx jscodeshift -t ./node_modules/@wdio/codemod/protractor ./test/specs/first-test.spec.ts
 ```
 
 That's it! This file is so simple that we don't need any additional changes anymore and directly can try to run WebdriverIO via:


### PR DESCRIPTION
Documentation fix: Removed $ sign in commands so it wont be copied
When using copy button it copies $ sign as well.

## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
