### PR TITLE
Update resq to latest

### DIFF
--- a/packages/webdriverio/package.json
+++ b/packages/webdriverio/package.json
@@ -80,7 +80,7 @@
     "minimatch": "^3.0.4",
     "puppeteer-core": "^7.1.0",
     "query-selector-shadow-dom": "^1.0.0",
-    "resq": "^1.9.1",
+    "resq": "^1.10.0",
     "rgb2hex": "0.2.3",
     "serialize-error": "^8.0.0",
     "webdriver": "7.5.3"


### PR DESCRIPTION
## Proposed changes

Update resq version which handles frameworks that used High-Order-Components(HoC) such as Styled, or Material UI. The fix was introduced in version 1.10.0 of resq and discussed here: https://github.com/baruchvlz/resq/pull/48

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

None

### Reviewers: @webdriverio/project-committers
