### PR TITLE
Have a single implementation for $ command

### DIFF
--- a/packages/webdriverio/src/commands/browser/$.ts
+++ b/packages/webdriverio/src/commands/browser/$.ts
@@ -49,16 +49,31 @@ import type { Selector } from '../../types'
         const activeElement = browser.getActiveElement();
         console.log($(activeElement).getTagName()); // outputs active element
     });
+
+    it('should use Androids DataMatcher or ViewMatcher selector', () => {
+        const menuItem = $({
+            "name": "hasEntry",
+            "args": ["title", "ViewTitle"],
+            "class": "androidx.test.espresso.matcher.ViewMatchers"
+        });
+        menuItem.click();
+
+        const menuItem = $({
+            "name": "hasEntry",
+            "args": ["title", "ViewTitle"]
+        });
+        menuItem.click();
+    });
  * </example>
  *
  * @alias $
- * @param {String|Function|Object} selector  selector or JS Function to fetch a certain element
+ * @param {String|Function|Matcher} selector  selector, JS Function, or Matcher object to fetch a certain element
  * @return {Element}
  * @type utility
  *
  */
 export default async function $ (
-    this: WebdriverIO.Browser,
+    this: WebdriverIO.Browser | WebdriverIO.Element,
     selector: Selector
 ) {
     /**

--- a/packages/webdriverio/src/commands/element/$.ts
+++ b/packages/webdriverio/src/commands/element/$.ts
@@ -1,10 +1,3 @@
-import type { ElementReference } from '@wdio/protocols'
-
-import { findElement } from '../../utils'
-import { getElement } from '../../utils/getElementObject'
-import { ELEMENT_KEY } from '../../constants'
-import type { Selector } from '../../types'
-
 /**
  * The `$` command is a short way to call the [`findElement`](/docs/api/webdriver#findelement) command in order
  * to fetch a single element on the page similar to the `$` command from the browser scope. The difference when calling
@@ -51,6 +44,21 @@ import type { Selector } from '../../types'
         const activeElement = browser.getActiveElement();
         console.log($(activeElement).getTagName()); // outputs active element
     });
+
+    it('should use Androids DataMatcher or ViewMatcher selector', () => {
+        const menuItem = $({
+            "name": "hasEntry",
+            "args": ["title", "ViewTitle"],
+            "class": "androidx.test.espresso.matcher.ViewMatchers"
+        });
+        menuItem.click();
+
+        const menuItem = $({
+            "name": "hasEntry",
+            "args": ["title", "ViewTitle"]
+        });
+        menuItem.click();
+    });
  * </example>
  *
  * @alias $
@@ -59,18 +67,5 @@ import type { Selector } from '../../types'
  * @type utility
  *
  */
-export default async function $ (
-    this: WebdriverIO.Element,
-    selector: Selector
-): Promise<WebdriverIO.Element> {
-    /**
-     * convert protocol result into WebdriverIO element
-     * e.g. when element was fetched with `getActiveElement`
-     */
-    if (selector && typeof (selector as ElementReference)[ELEMENT_KEY] === 'string') {
-        return getElement.call(this, undefined, selector as ElementReference)
-    }
-
-    const res = await findElement.call(this, selector)
-    return getElement.call(this, selector, res)
-}
+import $ from '../browser/$'
+export default $


### PR DESCRIPTION
## Proposed changes

Currently `packages/webdriverio/src/commands/browser/$.ts` and `packages/webdriverio/src/commands/element/$.ts` have the same implementation. It makes sense to merge them as we have done it with `$$` already.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

closes #6773 and #6772

### Reviewers: @webdriverio/project-committers
