### PR TITLE
Properly scope deep selector calls

### DIFF
--- a/packages/webdriverio/src/utils/index.ts
+++ b/packages/webdriverio/src/utils/index.ts
@@ -241,7 +241,10 @@ export async function findElement(
         const notFoundError = new Error(`shadow selector "${selector.slice(DEEP_SELECTOR.length)}" did not return an HTMLElement`)
         let elem: ElementReference | ElementReference[] = await this.execute(
             locatorStrategy,
-            selector.slice(DEEP_SELECTOR.length)
+            ...[
+                selector.slice(DEEP_SELECTOR.length),
+                (this as WebdriverIO.Element).elementId ? this : undefined
+            ].filter(Boolean)
         )
         elem = Array.isArray(elem) ? elem[0] : elem
         return getElementFromResponse(elem) ? elem : notFoundError
@@ -284,7 +287,10 @@ export async function findElements(
     if (!this.isDevTools && typeof selector === 'string' && selector.startsWith(DEEP_SELECTOR)) {
         const elems: ElementReference | ElementReference[] = await this.execute(
             locatorStrategy,
-            selector.slice(DEEP_SELECTOR.length)
+            ...[
+                selector.slice(DEEP_SELECTOR.length),
+                (this as WebdriverIO.Element).elementId ? this : undefined
+            ].filter(Boolean)
         )
         const elemArray = Array.isArray(elems) ? elems : [elems]
         return elemArray.filter((elem) => elem && getElementFromResponse(elem))

--- a/packages/webdriverio/tests/utils.test.ts
+++ b/packages/webdriverio/tests/utils.test.ts
@@ -321,6 +321,20 @@ describe('utils', () => {
             )
             expect(elem[ELEMENT_KEY]).toBe('foobar')
         })
+
+        it('should use execute if shadow selector is used with element scope', async () => {
+            (scope.execute as jest.Mock).mockReturnValue(elementResponse)
+            scope.elementId = 'foobar'
+            const elem = await findElement.call(scope, '>>>.foobar') as WebdriverIO.Element
+            expect(scope.findElement).not.toBeCalled()
+            expect(scope.findElementFromElement).not.toBeCalled()
+            expect(scope.execute).toBeCalledWith(
+                expect.any(Function),
+                '.foobar',
+                scope
+            )
+            expect(elem[ELEMENT_KEY]).toBe('foobar')
+        })
     })
 
     describe('findElements', () => {
@@ -418,6 +432,21 @@ describe('utils', () => {
             expect(scope.execute).toBeCalledWith(
                 expect.any(Function),
                 '.foobar'
+            )
+            expect(elem).toHaveLength(1)
+            expect(elem[0][ELEMENT_KEY]).toBe('foobar')
+        })
+
+        it('fetches element using a function with element scope', async () => {
+            (scope.execute as jest.Mock).mockReturnValue(elementResponse)
+            scope.elementId = 'foobar'
+            const elem = await findElements.call(scope, '>>>.foobar')
+            expect(scope.findElements).not.toBeCalled()
+            expect(scope.findElementsFromElement).not.toBeCalled()
+            expect(scope.execute).toBeCalledWith(
+                expect.any(Function),
+                '.foobar',
+                scope
             )
             expect(elem).toHaveLength(1)
             expect(elem[0][ELEMENT_KEY]).toBe('foobar')


### PR DESCRIPTION
## Proposed changes

Currently using the deep selector with an element scope would still fetch the whole document rather than within the given element scope. This patch fixes this.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

fixes #6796

### Reviewers: @webdriverio/project-committers
