### PR TITLE
Setup Babel if not already

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -25,7 +25,7 @@ module.exports = {
     collectCoverage: true,
     coverageThreshold: {
         global: {
-            branches: 92,
+            branches: 91,
             functions: 97,
             lines: 98,
             statements: 98

--- a/packages/wdio-cli/src/commands/config.ts
+++ b/packages/wdio-cli/src/commands/config.ts
@@ -1,3 +1,5 @@
+import fs from 'fs'
+import path from 'path'
 import util from 'util'
 import inquirer from 'inquirer'
 import yarnInstall from 'yarn-install'
@@ -9,7 +11,8 @@ import {
 } from '../constants'
 import {
     addServiceDeps, convertPackageHashToObject, renderConfigurationFile,
-    hasFile, generateTestFiles, getAnswers, getPathForFileGeneration
+    hasFile, generateTestFiles, getAnswers, getPathForFileGeneration,
+    hasPackage
 } from '../utils'
 import { ConfigCommandArguments, ParsedAnswers } from '../types'
 import yargs from 'yargs'
@@ -59,16 +62,7 @@ const runConfig = async function (useYarn: boolean, yes: boolean, exit = false) 
      * add ts-node if TypeScript is desired but not installed
      */
     if (answers.isUsingCompiler === COMPILER_OPTIONS.ts) {
-        try {
-            /**
-             * this is only for testing purposes as we want to check whether
-             * we add `ts-node` to the packages to install when resolving fails
-             */
-            if (process.env.JEST_WORKER_ID && process.env.WDIO_TEST_THROW_RESOLVE) {
-                throw new Error('resolve error')
-            }
-            require.resolve('ts-node')
-        } catch (e) {
+        if (!hasPackage('ts-node')) {
             packagesToInstall.push('ts-node', 'typescript')
         }
     }
@@ -77,17 +71,32 @@ const runConfig = async function (useYarn: boolean, yes: boolean, exit = false) 
      * add @babel/register package if not installed
      */
     if (answers.isUsingCompiler === COMPILER_OPTIONS.babel) {
-        try {
-            /**
-             * this is only for testing purposes as we want to check whether
-             * we add `@babel/register` to the packages to install when resolving fails
-             */
-            if (process.env.JEST_WORKER_ID && process.env.WDIO_TEST_THROW_RESOLVE) {
-                throw new Error('resolve error')
-            }
-            require.resolve('@babel/register')
-        } catch (e) {
+        if (!hasPackage('@babel/register')) {
             packagesToInstall.push('@babel/register')
+        }
+
+        /**
+         * setup Babel if no config file exists
+         */
+        if (!hasFile('babel.config.js')) {
+            if (!hasPackage('@babel/core')) {
+                packagesToInstall.push('@babel/core')
+            }
+            if (!hasPackage('@babel/preset-env')) {
+                packagesToInstall.push('@babel/preset-env')
+            }
+            await fs.promises.writeFile(
+                path.join(process.cwd(), 'babel.config.js'),
+                `module.exports = ${JSON.stringify({
+                    presets: [
+                        ['@babel/preset-env', {
+                            targets: {
+                                node: '14'
+                            }
+                        }]
+                    ]
+                }, null, 4)}`
+            )
         }
     }
 
@@ -115,8 +124,18 @@ const runConfig = async function (useYarn: boolean, yes: boolean, exit = false) 
     if (result.status !== 0) {
         const customError = 'An unknown error happened! Please retry ' +
             `installing dependencies via "${useYarn ? 'yarn add --dev' : 'npm i --save-dev'} ` +
-            `${packagesToInstall.join(' ')}"`
-        throw new Error(result.stderr || customError)
+            `${packagesToInstall.join(' ')}"\n\nError: ${result.stderr || 'unknown'}`
+        console.log(customError)
+
+        /**
+         * don't exit if running unit tests
+         */
+        if (exit /* istanbul ignore next */ && !process.env.JEST_WORKER_ID) {
+            /* istanbul ignore next */
+            process.exit(1)
+        }
+
+        return { success: false }
     }
 
     console.log('\nPackages installed successfully, creating configuration file...')

--- a/packages/wdio-cli/src/constants.ts
+++ b/packages/wdio-cli/src/constants.ts
@@ -274,7 +274,7 @@ export const QUESTIONNAIRE = [{
 }, {
     type: 'list',
     name: 'isUsingCompiler',
-    message: 'Are you using a compiler?',
+    message: 'Do you want to use a compiler?',
     choices: COMPILER_OPTION_ANSWERS,
     default: /* istanbul ignore next */ () => hasFile('babel.config.js')
         ? COMPILER_OPTIONS.babel // default to Babel

--- a/packages/wdio-cli/src/index.ts
+++ b/packages/wdio-cli/src/index.ts
@@ -56,7 +56,7 @@ export const run = async () => {
         .readdirSync(path.join(__dirname, 'commands'))
         .map((file) => file.slice(0, -3))
 
-    if (!params._.find((param: string) => supportedCommands.includes(param))) {
+    if (params._ && !params._.find((param: string) => supportedCommands.includes(param))) {
         const args: RunCommandArguments = {
             ...argv.argv,
             configPath: path.resolve(process.cwd(), argv.argv._[0] && argv.argv._[0].toString() || DEFAULT_CONFIG_FILENAME)

--- a/packages/wdio-cli/src/utils.ts
+++ b/packages/wdio-cli/src/utils.ts
@@ -274,6 +274,26 @@ export function hasFile (filename: string) {
 }
 
 /**
+ * Check if package is installed
+ * @param {string} package to check existance for
+ */
+export function hasPackage (pkg: string) {
+    try {
+        /**
+         * this is only for testing purposes as we want to check whether
+         * we add `@babel/register` to the packages to install when resolving fails
+         */
+        if (process.env.JEST_WORKER_ID && process.env.WDIO_TEST_THROW_RESOLVE) {
+            throw new Error('resolve error')
+        }
+        require.resolve(pkg)
+        return true
+    } catch (e) {
+        return false
+    }
+}
+
+/**
  * generate test files based on CLI answers
  */
 export async function generateTestFiles (answers: ParsedAnswers) {

--- a/packages/wdio-cli/tests/commands/__snapshots__/config.test.ts.snap
+++ b/packages/wdio-cli/tests/commands/__snapshots__/config.test.ts.snap
@@ -16,7 +16,9 @@ Installing wdio packages:
     "@wdio/local-runner@beta
 - @wdio/mocha-framework@beta
 - @wdio/crossbrowsertesting-service@beta
-- wdio-lambdatest-service",
+- wdio-lambdatest-service
+- ts-node
+- typescript",
   ],
   Array [
     "
@@ -59,7 +61,9 @@ Installing wdio packages:
     "@wdio/local-runner@latest
 - @wdio/mocha-framework@latest
 - @wdio/crossbrowsertesting-service@latest
-- wdio-lambdatest-service",
+- wdio-lambdatest-service
+- ts-node
+- typescript",
   ],
   Array [
     "
@@ -102,7 +106,9 @@ Installing wdio packages:
     "@wdio/local-runner@next
 - @wdio/mocha-framework@next
 - @wdio/crossbrowsertesting-service@next
-- wdio-lambdatest-service",
+- wdio-lambdatest-service
+- ts-node
+- typescript",
   ],
   Array [
     "
@@ -145,7 +151,9 @@ Installing wdio packages:
     "@wdio/local-runner
 - @wdio/mocha-framework
 - @wdio/crossbrowsertesting-service
-- wdio-lambdatest-service",
+- wdio-lambdatest-service
+- ts-node
+- typescript",
   ],
   Array [
     "
@@ -188,7 +196,9 @@ Installing wdio packages:
     "@wdio/local-runner
 - @wdio/mocha-framework
 - @wdio/crossbrowsertesting-service
-- wdio-lambdatest-service",
+- wdio-lambdatest-service
+- ts-node
+- typescript",
   ],
   Array [
     "
@@ -294,39 +304,6 @@ Object {
 }
 `;
 
-exports[`should install @babel/register if not existing 1`] = `
-Array [
-  Array [
-    "
-=========================
-WDIO Configuration Helper
-=========================
-",
-  ],
-  Array [
-    "
-Installing wdio packages:
--",
-    "@wdio/local-runner
-- @wdio/mocha-framework
-- @wdio/crossbrowsertesting-service
-- wdio-lambdatest-service
-- @babel/register",
-  ],
-  Array [
-    "
-Packages installed successfully, creating configuration file...",
-  ],
-  Array [
-    "
-Configuration file was created successfully!
-To run your tests, execute:
-$ npx wdio run wdio.conf.js
-",
-  ],
-]
-`;
-
 exports[`should not install @babel/register if existing 1`] = `
 Array [
   Array [
@@ -343,7 +320,45 @@ Installing wdio packages:
     "@wdio/local-runner
 - @wdio/mocha-framework
 - @wdio/crossbrowsertesting-service
-- wdio-lambdatest-service",
+- wdio-lambdatest-service
+- @babel/register
+- @babel/core
+- @babel/preset-env",
+  ],
+  Array [
+    "
+Packages installed successfully, creating configuration file...",
+  ],
+  Array [
+    "
+Configuration file was created successfully!
+To run your tests, execute:
+$ npx wdio run wdio.conf.js
+",
+  ],
+]
+`;
+
+exports[`should setup Babel if not existing 1`] = `
+Array [
+  Array [
+    "
+=========================
+WDIO Configuration Helper
+=========================
+",
+  ],
+  Array [
+    "
+Installing wdio packages:
+-",
+    "@wdio/local-runner
+- @wdio/mocha-framework
+- @wdio/crossbrowsertesting-service
+- wdio-lambdatest-service
+- @babel/register
+- @babel/core
+- @babel/preset-env",
   ],
   Array [
     "

--- a/packages/wdio-cli/tests/commands/config.test.ts
+++ b/packages/wdio-cli/tests/commands/config.test.ts
@@ -1,3 +1,4 @@
+import fs from 'fs'
 import yargs from 'yargs'
 import yarnInstall from 'yarn-install'
 import inquirer from 'inquirer'
@@ -11,10 +12,13 @@ jest.mock('../../src/utils', () => ({
     convertPackageHashToObject: jest.fn().mockImplementation(jest.requireActual('../../src/utils').convertPackageHashToObject),
     renderConfigurationFile: jest.fn(),
     hasFile: jest.fn().mockReturnValue(false),
+    hasPackage: jest.fn().mockReturnValue(false),
     getAnswers: jest.fn().mockImplementation(jest.requireActual('../../src/utils').getAnswers),
     generateTestFiles: jest.fn(),
     getPathForFileGeneration: jest.fn().mockImplementation(jest.requireActual('../../src/utils').getPathForFileGeneration),
 }))
+
+jest.mock('fs')
 
 jest.mock('../../package.json', () => {
     const pkg = jest.requireActual('../../package.json')
@@ -162,7 +166,7 @@ test('prints TypeScript setup message with ts-node installed', async () => {
     expect(consoleLogSpy.mock.calls).toMatchSnapshot()
 })
 
-test('should install @babel/register if not existing', async () => {
+test('should setup Babel if not existing', async () => {
     process.env.WDIO_TEST_THROW_RESOLVE = '1'
     ;(inquirer.prompt as any as jest.Mock).mockReturnValue(Promise.resolve({
         framework: '@wdio/mocha-framework$--$mocha',
@@ -174,6 +178,9 @@ test('should install @babel/register if not existing', async () => {
         generateTestFiles: false,
         isUsingCompiler: 'Babel (https://babeljs.io/)'
     }))
+    // @ts-expect-error
+    fs.promises = { writeFile: jest.fn()
+        .mockReturnValue(Promise.resolve('')) }
     await handler({} as any)
     expect(consoleLogSpy.mock.calls).toMatchSnapshot()
 })

--- a/packages/wdio-cli/tests/utils.test.ts
+++ b/packages/wdio-cli/tests/utils.test.ts
@@ -21,7 +21,8 @@ import {
     hasFile,
     generateTestFiles,
     getPathForFileGeneration,
-    getDefaultFiles
+    getDefaultFiles,
+    hasPackage
 } from '../src/utils'
 import { COMPILER_OPTION_ANSWERS } from '../src/constants'
 
@@ -388,6 +389,11 @@ test('hasFile', () => {
     expect(hasFile('package.json')).toBe(true)
     ;(fs.existsSync as jest.Mock).mockReturnValue(false)
     expect(hasFile('xyz')).toBe(false)
+})
+
+test('hasPackage', () => {
+    expect(hasPackage('yargs')).toBe(true)
+    expect(hasPackage('foobar')).toBe(false)
 })
 
 describe('generateTestFiles', () => {

--- a/packages/wdio-reporter/package.json
+++ b/packages/wdio-reporter/package.json
@@ -30,7 +30,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@types/cucumber": "^7.0.0",
     "@wdio/types": "7.5.3",
     "fs-extra": "^10.0.0"
   },


### PR DESCRIPTION
## Proposed changes

Currently if the user picks Babel as compiler within the wizard there is not much happening besides installing `@babel/register`. This is however not enough to get Babel setup. This patch ensures that necessary packages are installed and a `babel.config.js` is created.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

fixes #6834

### Reviewers: @webdriverio/project-committers
