### PR TITLE
Modifies the cucumberEventListener to emit before-feature and after-feature events differently when using spec grouping configurations

### DIFF
--- a/packages/wdio-cli/src/interface.ts
+++ b/packages/wdio-cli/src/interface.ts
@@ -95,7 +95,7 @@ export default class WDIOCLInterface extends EventEmitter {
     }
 
     onStart() {
-        this.log(chalk.bold(`\nExecution of ${chalk.blue(this.totalWorkerCnt)} spec files started at`), this._start.toISOString())
+        this.log(chalk.bold(`\nExecution of ${chalk.blue(this.totalWorkerCnt)} workers started at`), this._start.toISOString())
         if (this._inDebugMode) {
             this.log(chalk.bgYellow.black('DEBUG mode enabled!'))
         }

--- a/packages/wdio-cucumber-framework/src/cucumberEventListener.ts
+++ b/packages/wdio-cucumber-framework/src/cucumberEventListener.ts
@@ -396,6 +396,7 @@ export default class CucumberEventListener extends EventEmitter {
         delete this._currentTestCase
 
         if (this.usesSpecGrouping()) {
+            this.emit('after-feature', this._currentDoc.uri, this._currentDoc.feature)
             return
         }
 

--- a/packages/wdio-cucumber-framework/src/cucumberEventListener.ts
+++ b/packages/wdio-cucumber-framework/src/cucumberEventListener.ts
@@ -16,8 +16,8 @@ export default class CucumberEventListener extends EventEmitter {
     private _currentTestCase?: messages.ITestCaseStarted
     private _currentPickle?: HookParams = {}
     private _suiteMap: Map<string, string> = new Map()
-    private _currentFeature: messages.IGherkinDocument = {}
-    private _activeFeatures: messages.IGherkinDocument[] = []
+    private _currentDoc: messages.IGherkinDocument = {}
+    private _startedFeatures: string[] = []
 
     constructor (eventBroadcaster: EventEmitter, private _pickleFilter: PickleFilter) {
         super()
@@ -56,6 +56,14 @@ export default class CucumberEventListener extends EventEmitter {
                 log.debug(`Unknown envelope received: ${JSON.stringify(envelope, null, 4)}`)
             }
         })
+    }
+
+    usesSpecGrouping() {
+        return this._gherkinDocEvents.length > 1
+    }
+
+    featureIsStarted(feature: string) {
+        return this._startedFeatures.includes(feature)
     }
 
     // {
@@ -154,7 +162,7 @@ export default class CucumberEventListener extends EventEmitter {
     //     }
     // }
     onTestRunStarted () {
-        if ( this._gherkinDocEvents.length > 1) {
+        if (this.usesSpecGrouping()) {
             return
         }
         const doc = this._gherkinDocEvents[this._gherkinDocEvents.length - 1]
@@ -246,24 +254,26 @@ export default class CucumberEventListener extends EventEmitter {
     // }
     onTestCaseStarted (testcase: messages.ITestCaseStarted) {
         this._currentTestCase = testcase
-        const { uri, feature } = this._gherkinDocEvents[this._gherkinDocEvents.length - 1]
+
         const tc = this._testCases.find(tc => tc.id === testcase.testCaseId)
         const scenario = this._scenarios.find(sc => sc.id === this._suiteMap.get(tc?.pickleId as string))
-
         /* istanbul ignore if */
         if (!scenario) {
             return
         }
 
         const doc = this._gherkinDocEvents.find(gde => gde.uri === scenario?.uri)
-        if (this._currentFeature.uri && this._currentFeature.feature && this._currentFeature != doc) {
-            this.emit('after-feature', this._currentFeature.uri, this._currentFeature.feature)
-            this._activeFeatures = this._activeFeatures.filter(it => it !== doc)
+        const uri = doc?.uri
+        const feature = doc?.feature
+
+        if (this._currentDoc.uri && this._currentDoc.feature && this.usesSpecGrouping() && doc != this._currentDoc && this.featureIsStarted(this._currentDoc.uri)) {
+            this.emit('after-feature', this._currentDoc.uri, this._currentDoc.feature)
         }
-        if (this._gherkinDocEvents.length > 1 && doc && !this._activeFeatures.includes(doc)) {
-            this._currentFeature = doc
-            this.emit('before-feature', this._currentFeature.uri, this._currentFeature.feature)
-            this._activeFeatures.push(doc)
+
+        if (this.usesSpecGrouping() && doc && doc.uri && !this.featureIsStarted(doc.uri)) {
+            this.emit('before-feature', doc.uri, doc.feature)
+            this._currentDoc = doc
+            this._startedFeatures.push(doc.uri)
         }
         /**
          * The reporters need to have the keywords, like `Given|When|Then`. They are NOT available
@@ -289,11 +299,14 @@ export default class CucumberEventListener extends EventEmitter {
     //     }
     // }
     onTestStepStarted (testStepStartedEvent: messages.ITestStepStarted) {
-        const { uri, feature } = this._gherkinDocEvents[this._gherkinDocEvents.length - 1]
         const testcase = this._testCases.find((testcase) => this._currentTestCase && testcase.id === this._currentTestCase.testCaseId)
         const scenario = this._scenarios.find(sc => sc.id === this._suiteMap.get(testcase?.pickleId as string))
         const teststep = testcase?.testSteps?.find((step) => step.id === testStepStartedEvent.testStepId)
         const step = scenario?.steps?.find((s) => s.id === teststep?.pickleStepId) || teststep
+
+        const doc = this._gherkinDocEvents.find(gde => gde.uri === scenario?.uri)
+        const uri = doc?.uri
+        const feature = doc?.feature
 
         /* istanbul ignore if */
         if (!step) {
@@ -322,12 +335,15 @@ export default class CucumberEventListener extends EventEmitter {
     //     }
     // }
     onTestStepFinished (testStepFinishedEvent: messages.ITestStepFinished) {
-        const { uri, feature } = this._gherkinDocEvents[this._gherkinDocEvents.length - 1]
         const testcase = this._testCases.find((testcase) => testcase.id === this._currentTestCase?.testCaseId)
         const scenario = this._scenarios.find(sc => sc.id === this._suiteMap.get(testcase?.pickleId as string))
         const teststep = testcase?.testSteps?.find((step) => step.id === testStepFinishedEvent.testStepId)
         const step = scenario?.steps?.find((s) => s.id === teststep?.pickleStepId) || teststep
         const result = testStepFinishedEvent.testStepResult
+
+        const doc = this._gherkinDocEvents.find(gde => gde.uri === scenario?.uri)
+        const uri = doc?.uri
+        const feature = doc?.feature
 
         /* istanbul ignore if */
         if (!step) {
@@ -350,7 +366,6 @@ export default class CucumberEventListener extends EventEmitter {
     onTestCaseFinished (
         results: messages.TestStepFinished.ITestStepResult[]
     ) {
-        const { uri, feature } = this._gherkinDocEvents[this._gherkinDocEvents.length - 1]
         const tc = this._testCases.find(tc => tc.id === this._currentTestCase?.testCaseId)
         const scenario = this._scenarios.find(sc => sc.id === this._suiteMap.get(tc?.pickleId as string))
 
@@ -365,6 +380,8 @@ export default class CucumberEventListener extends EventEmitter {
         const finalResult = results.find((r) => r.status !== Status.PASSED) || results.pop()
 
         const doc = this._gherkinDocEvents.find(gde => gde.uri === scenario?.uri)
+        const uri = doc?.uri
+        const feature = doc?.feature
         this._currentPickle = { uri, feature, scenario }
         this.emit('after-scenario', doc?.uri, doc?.feature, scenario, finalResult)
     }
@@ -377,6 +394,10 @@ export default class CucumberEventListener extends EventEmitter {
     // }
     onTestRunFinished () {
         delete this._currentTestCase
+
+        if (this.usesSpecGrouping()) {
+            return
+        }
 
         const gherkinDocEvent = this._gherkinDocEvents.pop() // see .push() in `handleBeforeFeature()`
 

--- a/packages/wdio-spec-reporter/src/index.ts
+++ b/packages/wdio-spec-reporter/src/index.ts
@@ -49,7 +49,12 @@ export default class SpecReporter extends WDIOReporter {
 
     onSuiteStart (suite: SuiteStats) {
         this._suiteUids.add(suite.uid)
-        this._suiteIndents[suite.uid] = ++this._indents
+        if (suite.type === 'feature') {
+            this._indents = 0
+            this._suiteIndents[suite.uid] = this._indents
+        } else {
+            this._suiteIndents[suite.uid] = ++this._indents
+        }
     }
 
     onSuiteEnd () {


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

Changes cucumberEventListener to be able to handle spec grouping, without these changes reporting got all messed up for Cucumber in spec-reporter, allure-reporter, junit-reporter, etc. Since only 1 feature is ever "started"

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [X] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
- [X] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
