### PR TITLE
Added parent reference to wdio reporter suite and test stats

### DIFF
--- a/packages/wdio-reporter/src/stats/suite.ts
+++ b/packages/wdio-reporter/src/stats/suite.ts
@@ -46,7 +46,7 @@ export default class SuiteStats extends RunnableStats {
         this.title = suite.title
         this.fullTitle = suite.fullTitle
         this.tags = suite.tags
-        this.parent=suite.parent
+        this.parent= suite.parent
         /**
          * only Cucumber
          */

--- a/packages/wdio-reporter/src/stats/suite.ts
+++ b/packages/wdio-reporter/src/stats/suite.ts
@@ -31,6 +31,7 @@ export default class SuiteStats extends RunnableStats {
     tests: TestStats[] = []
     hooks: HookStats[] = []
     suites: SuiteStats[] = []
+    parent?: string
     /**
      * an array of hooks and tests stored in order as they happen
      */
@@ -45,6 +46,7 @@ export default class SuiteStats extends RunnableStats {
         this.title = suite.title
         this.fullTitle = suite.fullTitle
         this.tags = suite.tags
+        this.parent=suite.parent
         /**
          * only Cucumber
          */

--- a/packages/wdio-reporter/src/stats/test.ts
+++ b/packages/wdio-reporter/src/stats/test.ts
@@ -65,7 +65,7 @@ export default class TestStats extends RunnableStats {
         this.output = []
         this.argument = test.argument
         this.retries = test.retries
-        this.parent=test.parent
+        this.parent= test.parent
 
         /**
          * initial test state is pending

--- a/packages/wdio-reporter/src/stats/test.ts
+++ b/packages/wdio-reporter/src/stats/test.ts
@@ -46,6 +46,7 @@ export default class TestStats extends RunnableStats {
     output: Output[]
     argument?: string | Argument
     retries?: number
+    parent: string
     /**
      * initial test state is pending
      * the state can change to the following: passed, skipped, failed
@@ -64,6 +65,7 @@ export default class TestStats extends RunnableStats {
         this.output = []
         this.argument = test.argument
         this.retries = test.retries
+        this.parent=test.parent
 
         /**
          * initial test state is pending


### PR DESCRIPTION
To build a custom reporter, often it is necessary to track the parent references for nested test structure. This helps in the logical grouping or filtration of reporting stats. 