### PR TITLE
Update typescript examples, documentation and release notes

### DIFF
--- a/tests/typings/sync/tsconfig.json
+++ b/tests/typings/sync/tsconfig.json
@@ -21,5 +21,8 @@
       "@wdio/sumologic-reporter"
     ],
     "typeRoots": ["./node_modules"]
-  }
+  },
+  "include": [
+    "./ambient-definition.d.ts"
+  ]
 }

--- a/tests/typings/sync/tsconfig.json
+++ b/tests/typings/sync/tsconfig.json
@@ -21,8 +21,5 @@
       "@wdio/sumologic-reporter"
     ],
     "typeRoots": ["./node_modules"]
-  },
-  "include": [
-    "./ambient-definition.d.ts"
-  ]
+  }
 }

--- a/tests/typings/webdriverio/tsconfig.json
+++ b/tests/typings/webdriverio/tsconfig.json
@@ -20,5 +20,8 @@
       "@wdio/sumologic-reporter"
     ],
     "typeRoots": ["./node_modules"]
-  }
+  },
+  "include": [
+    "./ambient-definition.d.ts"
+  ]
 }

--- a/tests/typings/webdriverio/tsconfig.json
+++ b/tests/typings/webdriverio/tsconfig.json
@@ -20,8 +20,5 @@
       "@wdio/sumologic-reporter"
     ],
     "typeRoots": ["./node_modules"]
-  },
-  "include": [
-    "./ambient-definition.d.ts"
-  ]
+  }
 }

--- a/website/blog/2021-02-09-webdriverio-v7-released.md
+++ b/website/blog/2021-02-09-webdriverio-v7-released.md
@@ -52,7 +52,7 @@ or
 ],
 ```
 
-Lastly, if you define custom commands, you need to provide their types slightly different now:
+Lastly, if you define custom commands, you need to provide their types slightly different now, if using module-style type definition files (type definition file uses import/export; tsconfig.json contains `include` section):
 
 ```ts
 // define custom commands in v6
@@ -73,6 +73,7 @@ declare global {
     }
 }
 ```
+Otherwise, if using ambient type defintion files (no include section in tsconfig, no import/export in type definition file), then keep the custom command declaration the same as before, since including the `global` declaration as above will require the type definition file to be changed to a module.
 
 Alongside with this change we also equipped the testrunner to auto-compile your configuration if TypeScript is detected, this allows to leverage type safety in your WDIO configuration without any additional setup (big thanks for this contribution goes to [@r4j4h](https://github.com/r4j4h)). With that you also don't need `ts-node/register` to be required in your Mocha, Jasmine or Cucumber options, e.g.:
 

--- a/website/blog/2021-02-09-webdriverio-v7-released.md
+++ b/website/blog/2021-02-09-webdriverio-v7-released.md
@@ -52,7 +52,7 @@ or
 ],
 ```
 
-Lastly, if you define custom commands, you need to provide their types slightly different now, if using module-style type definition files (type definition file uses import/export; tsconfig.json contains `include` section):
+Lastly, if you define custom commands, you need to provide their types slightly different now:
 
 ```ts
 // define custom commands in v6
@@ -73,7 +73,6 @@ declare global {
     }
 }
 ```
-Otherwise, if using ambient type defintion files (no include section in tsconfig, no import/export in type definition file), then keep the custom command declaration the same as before, since including the `global` declaration as above will require the type definition file to be changed to a module.
 
 Alongside with this change we also equipped the testrunner to auto-compile your configuration if TypeScript is detected, this allows to leverage type safety in your WDIO configuration without any additional setup (big thanks for this contribution goes to [@r4j4h](https://github.com/r4j4h)). With that you also don't need `ts-node/register` to be required in your Mocha, Jasmine or Cucumber options, e.g.:
 

--- a/website/docs/TypeScript.md
+++ b/website/docs/TypeScript.md
@@ -95,10 +95,7 @@ For instance, if you decide to use the Mocha framework, you need to install `@ty
 {
     "compilerOptions": {
         "types": ["node", "webdriverio/sync", "@wdio/mocha-framework"]
-    },
-    "include": [
-        "./test/**/*.ts"
-    ]
+    }
 }
 ```
 
@@ -109,10 +106,7 @@ For instance, if you decide to use the Mocha framework, you need to install `@ty
 {
     "compilerOptions": {
         "types": ["node", "webdriverio/sync", "@wdio/jasmine-framework"]
-    },
-    "include": [
-        "./test/**/*.ts"
-    ]
+    }
 }
 ```
 
@@ -123,10 +117,7 @@ For instance, if you decide to use the Mocha framework, you need to install `@ty
 {
     "compilerOptions": {
         "types": ["node", "webdriverio/sync", "@wdio/cucumber-framework"]
-    },
-    "include": [
-        "./test/**/*.ts"
-    ]
+    }
 }
 ```
 
@@ -146,10 +137,7 @@ If you use services that add commands to the browser scope you also need to incl
             "@wdio/mocha-framework",
             "@wdio/devtools-service"
         ]
-    },
-    "include": [
-        "./test/**/*.ts"
-    ]
+    }
 }
 ```
 
@@ -160,18 +148,40 @@ Adding services and reporters to your TypeScript config also strengthen the type
 With TypeScript, it's easy to extend WebdriverIO interfaces. Add types to your [custom commands](CustomCommands.md) like this:
 
 1. Create a type definition file (e.g., `./src/types/wdio.d.ts`)
-2. Make sure to include path in the `tsconfig.json`
+2. a. If using a module-style type definition file (using import/export and `declare global WebdriverIO` in the type definition file), make sure to include the file path in the `tsconfig.json` `include` property.
+
+   b.  If using ambient-style type definition files (no import/export in type definition files and `declare namespace WebdriverIO` for custom commands), make sure the `tsconfig.json` does *not* contain any `include` section, since this will cause all type definition files not listed in the `include` section to not be recognized by typescript.
+
+<Tabs
+  defaultValue="modules"
+  values={[
+    {label: 'Modules (using import/export)', value: 'modules'},
+    {label: 'Ambient Type Definitions (no tsconfig include)', value: 'ambient'},
+  ]
+}>
+<TabItem value="modules">
 
 ```json title="tsconfig.json"
 {
     "compilerOptions": { ... },
     "include": [
         "./test/**/*.ts",
-        "./src/**/*.ts"
+        "./src/types/**/*.ts"
     ]
 }
 ```
 
+</TabItem>
+<TabItem value="ambient">
+
+```json title="tsconfig.json"
+{
+    "compilerOptions": { ... }
+}
+```
+
+</TabItem>
+</Tabs>
 3. Add definitions for your commands according to your execution mode.
 
 <Tabs
@@ -290,6 +300,14 @@ declare namespace WebdriverIO {
 ## Tips and Hints
 
 ### tsconfig.json example
+<Tabs
+  defaultValue="modules"
+  values={[
+    {label: 'Modules (using import/export)', value: 'modules'},
+    {label: 'Ambient Type Definitions (no tsconfig include)', value: 'ambient'},
+  ]
+}>
+<TabItem value="modules">
 
 ```json
 {
@@ -306,13 +324,40 @@ declare namespace WebdriverIO {
       "node",
       "webdriverio/sync",
       "@wdio/mocha-framework"
-    ],
+    ]
   },
   "include": [
-    "./test/**/*.ts"
+    "./test/**/*.ts",
+    "./src/types/**/*.ts"
   ]
 }
 ```
+
+</TabItem>
+<TabItem value="ambient">
+
+```json
+{
+  "compilerOptionsY": {
+    "outDir": "./.tsbuild/",
+    "sourceMap": false,
+    "target": "es2019",
+    "module": "commonjs",
+    "removeComments": true,
+    "noImplicitAny": true,
+    "strictPropertyInitialization": true,
+    "strictNullChecks": true,
+    "types": [
+      "node",
+      "webdriverio/sync",
+      "@wdio/mocha-framework"
+    ]
+  }
+}
+```
+
+</TabItem>
+</Tabs>
 
 ### Compile & Lint
 

--- a/website/docs/TypeScript.md
+++ b/website/docs/TypeScript.md
@@ -95,7 +95,10 @@ For instance, if you decide to use the Mocha framework, you need to install `@ty
 {
     "compilerOptions": {
         "types": ["node", "webdriverio/sync", "@wdio/mocha-framework"]
-    }
+    },
+    "include": [
+        "./test/**/*.ts"
+    ]
 }
 ```
 
@@ -106,7 +109,10 @@ For instance, if you decide to use the Mocha framework, you need to install `@ty
 {
     "compilerOptions": {
         "types": ["node", "webdriverio/sync", "@wdio/jasmine-framework"]
-    }
+    },
+    "include": [
+        "./test/**/*.ts"
+    ]
 }
 ```
 
@@ -117,7 +123,10 @@ For instance, if you decide to use the Mocha framework, you need to install `@ty
 {
     "compilerOptions": {
         "types": ["node", "webdriverio/sync", "@wdio/cucumber-framework"]
-    }
+    },
+    "include": [
+        "./test/**/*.ts"
+    ]
 }
 ```
 
@@ -137,7 +146,10 @@ If you use services that add commands to the browser scope you also need to incl
             "@wdio/mocha-framework",
             "@wdio/devtools-service"
         ]
-    }
+    },
+    "include": [
+        "./test/**/*.ts"
+    ]
 }
 ```
 
@@ -148,40 +160,18 @@ Adding services and reporters to your TypeScript config also strengthen the type
 With TypeScript, it's easy to extend WebdriverIO interfaces. Add types to your [custom commands](CustomCommands.md) like this:
 
 1. Create a type definition file (e.g., `./src/types/wdio.d.ts`)
-2. a. If using a module-style type definition file (using import/export and `declare global WebdriverIO` in the type definition file), make sure to include the file path in the `tsconfig.json` `include` property.
-
-   b.  If using ambient-style type definition files (no import/export in type definition files and `declare namespace WebdriverIO` for custom commands), make sure the `tsconfig.json` does *not* contain any `include` section, since this will cause all type definition files not listed in the `include` section to not be recognized by typescript.
-
-<Tabs
-  defaultValue="modules"
-  values={[
-    {label: 'Modules (using import/export)', value: 'modules'},
-    {label: 'Ambient Type Definitions (no tsconfig include)', value: 'ambient'},
-  ]
-}>
-<TabItem value="modules">
+2. Make sure to include path in the `tsconfig.json`
 
 ```json title="tsconfig.json"
 {
     "compilerOptions": { ... },
     "include": [
         "./test/**/*.ts",
-        "./src/types/**/*.ts"
+        "./src/**/*.ts"
     ]
 }
 ```
 
-</TabItem>
-<TabItem value="ambient">
-
-```json title="tsconfig.json"
-{
-    "compilerOptions": { ... }
-}
-```
-
-</TabItem>
-</Tabs>
 3. Add definitions for your commands according to your execution mode.
 
 <Tabs
@@ -300,14 +290,6 @@ declare namespace WebdriverIO {
 ## Tips and Hints
 
 ### tsconfig.json example
-<Tabs
-  defaultValue="modules"
-  values={[
-    {label: 'Modules (using import/export)', value: 'modules'},
-    {label: 'Ambient Type Definitions (no tsconfig include)', value: 'ambient'},
-  ]
-}>
-<TabItem value="modules">
 
 ```json
 {
@@ -324,40 +306,13 @@ declare namespace WebdriverIO {
       "node",
       "webdriverio/sync",
       "@wdio/mocha-framework"
-    ]
+    ],
   },
   "include": [
-    "./test/**/*.ts",
-    "./src/types/**/*.ts"
+    "./test/**/*.ts"
   ]
 }
 ```
-
-</TabItem>
-<TabItem value="ambient">
-
-```json
-{
-  "compilerOptionsY": {
-    "outDir": "./.tsbuild/",
-    "sourceMap": false,
-    "target": "es2019",
-    "module": "commonjs",
-    "removeComments": true,
-    "noImplicitAny": true,
-    "strictPropertyInitialization": true,
-    "strictNullChecks": true,
-    "types": [
-      "node",
-      "webdriverio/sync",
-      "@wdio/mocha-framework"
-    ]
-  }
-}
-```
-
-</TabItem>
-</Tabs>
 
 ### Compile & Lint
 


### PR DESCRIPTION
To distinguish between module-style and ambient type definition files

## Proposed changes

Additional updates to typescript documentation, test typings and v7 release notes to distinguish between module- and ambient-style type definition files.  

Addresses https://github.com/webdriverio/webdriverio/commit/b458d998e5622181d7119694b4bbeeaeaecf2b97#commitcomment-50326717 

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

test:typings is failing with this error:

error TS2688: Cannot find type definition file for 'webdriver'.

But the same error occurs without the current changes also.  (no changes were made to the webdriver folder)

### Reviewers: @webdriverio/project-committers
