### PR TITLE
Spec Reporter - Display only failures

### DIFF
--- a/packages/wdio-spec-reporter/README.md
+++ b/packages/wdio-spec-reporter/README.md
@@ -60,7 +60,7 @@ Default: `{passed: '✓', skipped: '-', failed: '✖'}`
 ```
 
 ### sauceLabsSharableLinks
-Be default the test results in Sauce Labs can only be viewed by a team member from the same team, not by a team member
+By default the test results in Sauce Labs can only be viewed by a team member from the same team, not by a team member
 from a different team. This options will enable [sharable links](https://wiki.saucelabs.com/display/DOCS/Building+Sharable+Links+to+Test+Results)
 by default, which means that all tests that are executed in Sauce Labs can be viewed by everybody.
 Just add `sauceLabsSharableLinks: false`, as shown below, in the reporter options to disable this feature.
@@ -74,6 +74,22 @@ Default: `true`
   "spec",
   {
     sauceLabsSharableLinks: false,
+  },
+]
+```
+
+### onlyFailures
+Print only failed specs results.
+
+Type: `boolean`
+Default: `false`
+
+#### Example
+```js
+[
+  "spec",
+  {
+    onlyFailures: true,
   },
 ]
 ```

--- a/packages/wdio-spec-reporter/src/index.ts
+++ b/packages/wdio-spec-reporter/src/index.ts
@@ -41,7 +41,7 @@ export default class SpecReporter extends WDIOReporter {
         super(Object.assign({ stdout: true }, options))
 
         this._symbols = { ...this._symbols, ...this.options.symbols || {} }
-        this._onlyFailures = options.onlyFailures as boolean || false
+        this._onlyFailures = options.onlyFailures || false
         this._sauceLabsSharableLinks = 'sauceLabsSharableLinks' in options
             ? options.sauceLabsSharableLinks as boolean
             : this._sauceLabsSharableLinks

--- a/packages/wdio-spec-reporter/src/index.ts
+++ b/packages/wdio-spec-reporter/src/index.ts
@@ -31,6 +31,7 @@ export default class SpecReporter extends WDIOReporter {
         failed: '✖'
     }
 
+    private _displayOnlyFailures = false
     private _sauceLabsSharableLinks = true
 
     constructor (options: SpecReporterOptions) {
@@ -38,6 +39,7 @@ export default class SpecReporter extends WDIOReporter {
          * make spec reporter to write to output stream by default
          */
         super(Object.assign({ stdout: true }, options))
+        this._displayOnlyFailures = options.onlyFailures || false
         this._symbols = { ...this._symbols, ...this.options.symbols || {} }
         this._sauceLabsSharableLinks = 'sauceLabsSharableLinks' in options
             ? options.sauceLabsSharableLinks as boolean
@@ -79,6 +81,11 @@ export default class SpecReporter extends WDIOReporter {
      * Print the report to the screen
      */
     printReport(runner: RunnerStats) {
+        // Don't print non failed tests
+        if (this._displayOnlyFailures === true && runner.failures !== 0){
+            return
+        }
+
         const duration = `(${prettyMs(runner._duration)})`
         const preface = `[${this.getEnviromentCombo(runner.capabilities, false, runner.isMultiremote).trim()} #${runner.cid}]`
         const divider = '------------------------------------------------------------------'

--- a/packages/wdio-spec-reporter/src/index.ts
+++ b/packages/wdio-spec-reporter/src/index.ts
@@ -31,7 +31,7 @@ export default class SpecReporter extends WDIOReporter {
         failed: '✖'
     }
 
-    private _displayOnlyFailures = false
+    private _onlyFailures = false
     private _sauceLabsSharableLinks = true
 
     constructor (options: SpecReporterOptions) {
@@ -39,8 +39,9 @@ export default class SpecReporter extends WDIOReporter {
          * make spec reporter to write to output stream by default
          */
         super(Object.assign({ stdout: true }, options))
-        this._displayOnlyFailures = options.onlyFailures || false
+
         this._symbols = { ...this._symbols, ...this.options.symbols || {} }
+        this._onlyFailures = options.onlyFailures as boolean || false
         this._sauceLabsSharableLinks = 'sauceLabsSharableLinks' in options
             ? options.sauceLabsSharableLinks as boolean
             : this._sauceLabsSharableLinks
@@ -82,7 +83,7 @@ export default class SpecReporter extends WDIOReporter {
      */
     printReport(runner: RunnerStats) {
         // Don't print non failed tests
-        if (this._displayOnlyFailures === true && runner.failures !== 0){
+        if (runner.failures === 0 && this._onlyFailures === true){
             return
         }
 

--- a/packages/wdio-spec-reporter/src/types.ts
+++ b/packages/wdio-spec-reporter/src/types.ts
@@ -30,6 +30,12 @@ export interface SpecReporterOptions {
      * @default: {passed: '✓', skipped: '-', failed: '✖'}
      */
     symbols?: Partial<Symbols>
+    /**
+     * Ability to show only failed specs results
+     *
+     * @default: false
+     */
+    onlyFailures?: boolean
 }
 
 export interface TestLink {

--- a/packages/wdio-spec-reporter/tests/__snapshots__/index.test.ts.snap
+++ b/packages/wdio-spec-reporter/tests/__snapshots__/index.test.ts.snap
@@ -84,7 +84,7 @@ Array [
 ]
 `;
 
-exports[`SpecReporter onlyFailures false 1`] = `
+exports[`SpecReporter onlyFailures false 0 failures 1`] = `
 Array [
   Array [
     "------------------------------------------------------------------
@@ -119,7 +119,44 @@ Array [
 ]
 `;
 
-exports[`SpecReporter onlyFailures true 1`] = `
+exports[`SpecReporter onlyFailures false 1 failure 1`] = `
+Array [
+  Array [
+    "------------------------------------------------------------------
+[loremipsum 50 Windows 10 #0-0] Running: loremipsum (v50) on Windows 10
+[loremipsum 50 Windows 10 #0-0] Session ID: foobar
+[loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] » /foo/bar/loo.e2e.js
+[loremipsum 50 Windows 10 #0-0] Foo test
+[loremipsum 50 Windows 10 #0-0]    green ✓ foo
+[loremipsum 50 Windows 10 #0-0]    green ✓ bar
+[loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] » /bar/foo/loo.e2e.js
+[loremipsum 50 Windows 10 #0-0] Bar test
+[loremipsum 50 Windows 10 #0-0]    green ✓ some test
+[loremipsum 50 Windows 10 #0-0]    red ✖ a failed test
+[loremipsum 50 Windows 10 #0-0]    red ✖ a failed test with no stack
+[loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] » /bar/loo/foo.e2e.js
+[loremipsum 50 Windows 10 #0-0] Baz test
+[loremipsum 50 Windows 10 #0-0]    green ✓ foo bar baz
+[loremipsum 50 Windows 10 #0-0]    cyan - a skipped test
+[loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] 1) Bar test a failed test
+[loremipsum 50 Windows 10 #0-0] red expected foo to equal bar
+[loremipsum 50 Windows 10 #0-0] gray Failed test stack trace
+[loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] 2) Bar test a failed test with no stack
+[loremipsum 50 Windows 10 #0-0] red expected foo to equal bar
+",
+  ],
+]
+`;
+
+exports[`SpecReporter onlyFailures true 0 failures 1`] = `Array []`;
+
+exports[`SpecReporter onlyFailures true 1 failure 1`] = `
 Array [
   Array [
     "------------------------------------------------------------------

--- a/packages/wdio-spec-reporter/tests/__snapshots__/index.test.ts.snap
+++ b/packages/wdio-spec-reporter/tests/__snapshots__/index.test.ts.snap
@@ -84,6 +84,76 @@ Array [
 ]
 `;
 
+exports[`SpecReporter onlyFailures false 1`] = `
+Array [
+  Array [
+    "------------------------------------------------------------------
+[loremipsum 50 Windows 10 #0-0] Running: loremipsum (v50) on Windows 10
+[loremipsum 50 Windows 10 #0-0] Session ID: foobar
+[loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] » /foo/bar/loo.e2e.js
+[loremipsum 50 Windows 10 #0-0] Foo test
+[loremipsum 50 Windows 10 #0-0]    green ✓ foo
+[loremipsum 50 Windows 10 #0-0]    green ✓ bar
+[loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] » /bar/foo/loo.e2e.js
+[loremipsum 50 Windows 10 #0-0] Bar test
+[loremipsum 50 Windows 10 #0-0]    green ✓ some test
+[loremipsum 50 Windows 10 #0-0]    red ✖ a failed test
+[loremipsum 50 Windows 10 #0-0]    red ✖ a failed test with no stack
+[loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] » /bar/loo/foo.e2e.js
+[loremipsum 50 Windows 10 #0-0] Baz test
+[loremipsum 50 Windows 10 #0-0]    green ✓ foo bar baz
+[loremipsum 50 Windows 10 #0-0]    cyan - a skipped test
+[loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] 1) Bar test a failed test
+[loremipsum 50 Windows 10 #0-0] red expected foo to equal bar
+[loremipsum 50 Windows 10 #0-0] gray Failed test stack trace
+[loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] 2) Bar test a failed test with no stack
+[loremipsum 50 Windows 10 #0-0] red expected foo to equal bar
+",
+  ],
+]
+`;
+
+exports[`SpecReporter onlyFailures true 1`] = `
+Array [
+  Array [
+    "------------------------------------------------------------------
+[loremipsum 50 Windows 10 #0-0] Running: loremipsum (v50) on Windows 10
+[loremipsum 50 Windows 10 #0-0] Session ID: foobar
+[loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] » /foo/bar/loo.e2e.js
+[loremipsum 50 Windows 10 #0-0] Foo test
+[loremipsum 50 Windows 10 #0-0]    green ✓ foo
+[loremipsum 50 Windows 10 #0-0]    green ✓ bar
+[loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] » /bar/foo/loo.e2e.js
+[loremipsum 50 Windows 10 #0-0] Bar test
+[loremipsum 50 Windows 10 #0-0]    green ✓ some test
+[loremipsum 50 Windows 10 #0-0]    red ✖ a failed test
+[loremipsum 50 Windows 10 #0-0]    red ✖ a failed test with no stack
+[loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] » /bar/loo/foo.e2e.js
+[loremipsum 50 Windows 10 #0-0] Baz test
+[loremipsum 50 Windows 10 #0-0]    green ✓ foo bar baz
+[loremipsum 50 Windows 10 #0-0]    cyan - a skipped test
+[loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] 1) Bar test a failed test
+[loremipsum 50 Windows 10 #0-0] red expected foo to equal bar
+[loremipsum 50 Windows 10 #0-0] gray Failed test stack trace
+[loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] 2) Bar test a failed test with no stack
+[loremipsum 50 Windows 10 #0-0] red expected foo to equal bar
+",
+  ],
+]
+`;
+
 exports[`SpecReporter printReport with disabled sharable Sauce report links should print the default Sauce Labs job details page link 1`] = `Array []`;
 
 exports[`SpecReporter printReport with normal setup should print jobs of all instance when run with multiremote 1`] = `

--- a/packages/wdio-spec-reporter/tests/index.test.ts
+++ b/packages/wdio-spec-reporter/tests/index.test.ts
@@ -546,25 +546,54 @@ describe('SpecReporter', () => {
         let printReporter = null
         const runner = getRunnerConfig({ hostname: 'localhost' })
 
-        it('false', () => {
-            printReporter = new SpecReporter({ onlyFailures: false })
-            printReporter.write = jest.fn()
-            printReporter['_suiteUids'] = SUITE_UIDS
-            printReporter.suites = SUITES
-            printReporter.printReport(runner)
-            expect(printReporter['_onlyFailures']).toBe(false)
-            expect(printReporter.write.mock.calls).toMatchSnapshot()
+        describe('false', () => {
+            beforeEach(() => {
+                printReporter = new SpecReporter({ onlyFailures: false })
+                printReporter.write = jest.fn()
+                printReporter['_suiteUids'] = SUITE_UIDS
+                printReporter.suites = SUITES
+            })
+
+            it('1 failure', () => {
+                runner.failures = 1
+                printReporter.printReport(runner)
+
+                expect(printReporter['_onlyFailures']).toBe(false)
+                expect(printReporter.write.mock.calls).toMatchSnapshot()
+            })
+
+            it('0 failures', () => {
+                runner.failures = 0
+                printReporter.printReport(runner)
+
+                expect(printReporter['_onlyFailures']).toBe(false)
+                expect(printReporter.write.mock.calls).toMatchSnapshot()
+            })
         })
 
-        it('true', () => {
-            printReporter = new SpecReporter({ onlyFailures: true })
-            printReporter.write = jest.fn()
-            printReporter['_suiteUids'] = SUITE_UIDS
-            printReporter.suites = SUITES
-            const runner = getRunnerConfig({ hostname: 'localhost' })
-            printReporter.printReport(runner)
-            expect(printReporter['_onlyFailures']).toBe(true)
-            expect(printReporter.write.mock.calls).toMatchSnapshot()
+        describe('true', () => {
+            beforeEach(() => {
+                printReporter = new SpecReporter({ onlyFailures: true })
+                printReporter.write = jest.fn()
+                printReporter['_suiteUids'] = SUITE_UIDS
+                printReporter.suites = SUITES
+            })
+
+            it('1 failure', () => {
+                runner.failures = 1
+                printReporter.printReport(runner)
+
+                expect(printReporter['_onlyFailures']).toBe(true)
+                expect(printReporter.write.mock.calls).toMatchSnapshot()
+            })
+
+            it('0 failures', () => {
+                runner.failures = 0
+                printReporter.printReport(runner)
+
+                expect(printReporter['_onlyFailures']).toBe(true)
+                expect(printReporter.write.mock.calls).toMatchSnapshot()
+            })
         })
     })
 

--- a/packages/wdio-spec-reporter/tests/index.test.ts
+++ b/packages/wdio-spec-reporter/tests/index.test.ts
@@ -542,6 +542,17 @@ describe('SpecReporter', () => {
         })
     })
 
+    describe('onlyFailures', () => {
+        const options = { onlyFailures: true }
+        beforeEach(() => {
+            tmpReporter = new SpecReporter(options)
+        })
+
+        it('should get failures', () => {
+            expect(tmpReporter).not.toBe(undefined)
+        })
+    })
+
     describe('getColor', () => {
         it('should get green', () => {
             expect(tmpReporter.getColor('passed')).toBe('green')

--- a/packages/wdio-spec-reporter/tests/index.test.ts
+++ b/packages/wdio-spec-reporter/tests/index.test.ts
@@ -543,13 +543,28 @@ describe('SpecReporter', () => {
     })
 
     describe('onlyFailures', () => {
-        const options = { onlyFailures: true }
-        beforeEach(() => {
-            tmpReporter = new SpecReporter(options)
+        let printReporter = null
+        const runner = getRunnerConfig({ hostname: 'localhost' })
+
+        it('false', () => {
+            printReporter = new SpecReporter({ onlyFailures: false })
+            printReporter.write = jest.fn()
+            printReporter['_suiteUids'] = SUITE_UIDS
+            printReporter.suites = SUITES
+            printReporter.printReport(runner)
+            expect(printReporter['_onlyFailures']).toBe(false)
+            expect(printReporter.write.mock.calls).toMatchSnapshot()
         })
 
-        it('should get failures', () => {
-            expect(tmpReporter).not.toBe(undefined)
+        it('true', () => {
+            printReporter = new SpecReporter({ onlyFailures: true })
+            printReporter.write = jest.fn()
+            printReporter['_suiteUids'] = SUITE_UIDS
+            printReporter.suites = SUITES
+            const runner = getRunnerConfig({ hostname: 'localhost' })
+            printReporter.printReport(runner)
+            expect(printReporter['_onlyFailures']).toBe(true)
+            expect(printReporter.write.mock.calls).toMatchSnapshot()
         })
     })
 


### PR DESCRIPTION
## Proposed changes

Ability to display only failed specs after tests run. https://github.com/webdriverio/webdriverio/issues/6849

![image](https://user-images.githubusercontent.com/6696821/118027342-7a9dcf80-b36a-11eb-80f5-189c82ecf8b2.png)


<details>
  <summary>Before</summary>

![image](https://user-images.githubusercontent.com/6696821/118027146-45917d00-b36a-11eb-8635-a71466fd8184.png)

</details>
<details>
  <summary>After</summary>

![image](https://user-images.githubusercontent.com/6696821/118027056-2b579f00-b36a-11eb-95cf-76e9a3fd01f5.png)

</details>

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] New feature (non-breaking change which adds functionality)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)