### PR TITLE
Use expectAsync for jasmine tests

### DIFF
--- a/packages/wdio-cli/src/commands/config.ts
+++ b/packages/wdio-cli/src/commands/config.ts
@@ -158,6 +158,9 @@ const runConfig = async function (useYarn: boolean, yes: boolean, exit = false) 
         isSync: false,
         _async: 'async ',
         _await: 'await ',
+        _expect: frameworkPackage.package === '@wdio/jasmine-framework'
+            ? 'expectAsync'
+            : 'expect',
         destSpecRootPath: parsedPaths.destSpecRootPath,
         destPageObjectRootPath: parsedPaths.destPageObjectRootPath,
         relativePath : parsedPaths.relativePath

--- a/packages/wdio-cli/src/templates/exampleFiles/mochaJasmine/example.e2e.js.ejs
+++ b/packages/wdio-cli/src/templates/exampleFiles/mochaJasmine/example.e2e.js.ejs
@@ -15,8 +15,8 @@ describe('My Login application', () => {
         <%= _await %>LoginPage.open();
 
         <%= _await %>LoginPage.login('tomsmith', 'SuperSecretPassword!');
-        <%= _await %>expect(SecurePage.flashAlert).toBeExisting();
-        <%= _await %>expect(SecurePage.flashAlert).toHaveTextContaining(
+        <%= _await %><%= _expect %>(SecurePage.flashAlert).toBeExisting();
+        <%= _await %><%= _expect %>(SecurePage.flashAlert).toHaveTextContaining(
             'You logged into a secure area!');
     });
 });
@@ -39,8 +39,8 @@ describe('My Login application', () => {
         await (await $('button[type="submit"]')).click();<%
         } %>
 
-        <%= _await %>expect($('#flash')).toBeExisting();
-        <%= _await %>expect($('#flash')).toHaveTextContaining(
+        <%= _await %><%= _expect %>($('#flash')).toBeExisting();
+        <%= _await %><%= _expect %>($('#flash')).toHaveTextContaining(
             'You logged into a secure area!');
     });
 });

--- a/packages/wdio-cli/src/types.ts
+++ b/packages/wdio-cli/src/types.ts
@@ -43,6 +43,7 @@ export interface ParsedAnswers extends Omit<Questionnair, 'runner' | 'framework'
     isSync: boolean
     _async: string
     _await: string
+    _expect: string
     destSpecRootPath: string
     destPageObjectRootPath: string
     relativePath: string

--- a/packages/wdio-cli/tests/commands/__snapshots__/config.test.ts.snap
+++ b/packages/wdio-cli/tests/commands/__snapshots__/config.test.ts.snap
@@ -281,6 +281,7 @@ Object {
   "parsedAnswers": Object {
     "_async": "async ",
     "_await": "await ",
+    "_expect": "expect",
     "framework": "mocha",
     "isSync": false,
     "isUsingBabel": false,


### PR DESCRIPTION
## Proposed changes

Jasmine uses async matchers called `expectAsync`. We should use them when folks generate a project from the CLI wizard.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

fixes #6839

### Reviewers: @webdriverio/project-committers
