### PR TITLE
removing Contributor Guide reference link

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ WebdriverIO is a test automation framework that allows you to run tests based on
 
 ## Contributing
 
-You like WebdriverIO and want to help making it better? Awesome! Have a look into our [Contributor Guide](website/docs/Contribute.md) and check out our [Contributor Documentation](CONTRIBUTING.md) to get started with setting up the repo.
+You like WebdriverIO and want to help making it better? Awesome! Have a look into our [Contributor Documentation](CONTRIBUTING.md) to get started with setting up the repo.
 
 If you're looking for issues to help out with, check out [the issues labelled "good first pick"](https://github.com/webdriverio/webdriverio/issues?q=is%3Aopen+is%3Aissue+label%3A"good+first+pick"). You can also reach out in our [Gitter Channel](https://gitter.im/webdriverio/webdriverio) if you have question on where to start contributing.
 


### PR DESCRIPTION
## Proposed changes
As part of [PR-6598](https://github.com/webdriverio/webdriverio/pull/6598/commits/9ed383f166453652df9889b6a67102ccd59e0512) contributing documentation was merged, hence removing the link of old documentation

## Types of changes
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
