### PR TITLE
Add missing documentation on returned Cucumber afterStep 'results' object

### DIFF
--- a/website/docs/ConfigurationFile.md
+++ b/website/docs/ConfigurationFile.md
@@ -450,12 +450,16 @@ exports.config = {
      * Runs after a Cucumber Step.
      * @param step    step data
      * @param context Cucumber world
+     * @param retries info on whether executed step had been retried and its retry limit, ex. { attempts: 0, limit: 0 }
+     * @param error if executed step failed, prints the error
+     * @param duration step duration, in ms
+     * @param passed boolean value if executed step passed
      */
-    afterStep: function (step, context) {
+    afterStep: function (step, context, { retries, error, duration, passed }) {
     },
     /**
      *
-     * Runs before a Cucumber Scenario.
+     * Runs after a Cucumber Scenario.
      * @param world world object containing information on pickle and test step
      */
     afterScenario: function (world) {

--- a/website/docs/Options.md
+++ b/website/docs/Options.md
@@ -521,4 +521,6 @@ Runs after a Cucumber Step.
 
 Parameters:
 - `step`: (`Pickle.IPickleStep`): Cucumber step object
-- `context`: (`object`): execution context
+- `context`: (`object`): execution context (Cucumber `world` object)
+- `result`: (`object`): results object containing step results (contains `retries`, `error`, `result`, `duration`, `passed` properties)
+


### PR DESCRIPTION
## Proposed changes
After upgrading to WDIO 7, I noticed some of the deconstructed properties from a "result" object (I'll assume that's what it is) in the `afterStep` Cucumber hook still worked, even though they seem to have been dropped from the documentation. 

These are very useful properties to utilize, so I logged the full object to see what was available:

```
    afterStep (step, context, result) {
        console.log ("RESULT: ", result) ... } 
```

Example Result from a failed step:

```
RESULT:  {
   retries: { attempts: 0, limit: 0 },
   error: AssertionError: ... ,
   result: undefined,  //note, this always seems to return 'undefined'
   duration: 15,
   passed: true
 }
```
Because the `result` property within this always seem to return `undefined`, I propose we present it as a deconstructed object, similar to how it was done in WDIO v6: 
`afterStep (step, context, { retries, error, duration, passed }) { }`

Also fixed a minor typo I noticed for `afterScenario`. 

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
