### PR TITLE
Strip color ascii characters when uploading error message to Sauce Labs job

### DIFF
--- a/packages/wdio-sauce-service/src/service.ts
+++ b/packages/wdio-sauce-service/src/service.ts
@@ -6,7 +6,7 @@ import logger from '@wdio/logger'
 import type { Services, Capabilities, Options, Frameworks } from '@wdio/types'
 import type { Browser, MultiRemoteBrowser } from 'webdriverio'
 
-import { isUnifiedPlatform } from './utils'
+import { isUnifiedPlatform, ansiRegex } from './utils'
 import { SauceServiceConfig } from './types'
 import { DEFAULT_OPTIONS } from './constants'
 
@@ -120,7 +120,7 @@ export default class SauceService implements Services.ServiceInstance {
 
     private _reportErrorLog (error: Error) {
         const lines = (error.stack || '').split(/\r?\n/).slice(0, this._maxErrorStackLength)
-        lines.forEach((line:string) => this._browser!.execute('sauce:context=' + line))
+        lines.forEach((line:string) => this._browser!.execute(`sauce:context=${line.replace(ansiRegex(), '')}`))
     }
 
     afterTest (test: Frameworks.Test, context: unknown, results: Frameworks.TestResult) {

--- a/packages/wdio-sauce-service/src/utils.ts
+++ b/packages/wdio-sauce-service/src/utils.ts
@@ -100,3 +100,12 @@ export function makeCapabilityFactory(tunnelIdentifier: string, options: any) {
         }
     }
 }
+
+export function ansiRegex () {
+    const pattern = [
+        '[\\u001B\\u009B][[\\]()#;?]*(?:(?:(?:[a-zA-Z\\d]*(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]*)*)?\\u0007)',
+        '(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PR-TZcf-ntqry=><~]))'
+    ].join('|')
+
+    return new RegExp(pattern, 'g')
+}

--- a/packages/wdio-sauce-service/tests/service.test.ts
+++ b/packages/wdio-sauce-service/tests/service.test.ts
@@ -29,6 +29,7 @@ jest.mock('form-data', () => jest.fn().mockReturnValue({
 jest.mock('../src/utils', () => {
     return {
         isUnifiedPlatform: jest.fn().mockReturnValue(true),
+        ansiRegex: jest.requireActual('../src/utils').ansiRegex
     }
 })
 
@@ -788,6 +789,14 @@ test('afterHook', () => {
     })
     expect(service['_failures']).toBe(1)
     expect(service['_reportErrorLog']).toHaveBeenCalledTimes(1)
+})
+
+test('strip ansi from _reportErrorLog', () => {
+    const service = new SauceService({}, {}, {} as any)
+    service['_browser'] = { execute: jest.fn() } as any
+    const error = new Error('Received: [31m""[39m')
+    service['_reportErrorLog'](error)
+    expect(service['_browser'].execute).toBeCalledWith('sauce:context=Error: Received: ""')
 })
 
 afterEach(() => {


### PR DESCRIPTION
The Sauce service updates the job details page command tab with an error message in case the test fails (see code lines [here](https://github.com/webdriverio/webdriverio/blob/main/packages/wdio-sauce-service/src/service.ts#L122-L131)). When using our `expect-webdriverio` assertion library we have color ascii characters in that  message, making it look as follows:

![Screenshot 2021-04-06 at 16 58 36](https://user-images.githubusercontent.com/731337/113732507-f10b3a00-96f9-11eb-9263-bc4db8ad7da4.png)

Let's strip these characters from being uploaded and just send text.