### PR TITLE
Better allow for manual TS transpiling

### DIFF
--- a/packages/wdio-cli/src/launcher.ts
+++ b/packages/wdio-cli/src/launcher.ts
@@ -58,20 +58,10 @@ class Launcher {
         this.configParser = new ConfigParser()
 
         /**
-         * autocompile before parsing configs so we support ES6 features in configs, only if
+         * merge auto compile opts to understand how to parse the config
          */
-        if (
-            /**
-             * the auto compile option is not define in this case we automatically compile
-             */
-            typeof _args.autoCompileOpts?.autoCompile === 'undefined' ||
-            /**
-             * or it was define and its value is not false
-             */
-            (_args.autoCompileOpts?.autoCompile as any as string) !== 'false'
-        ) {
-            this.configParser.autoCompile()
-        }
+        this.configParser.merge({ autoCompileOpts: _args.autoCompileOpts })
+        this.configParser.autoCompile()
 
         this.configParser.addConfigFile(_configFilePath)
         this.configParser.merge(_args)

--- a/packages/wdio-cli/tests/launcher.test.ts
+++ b/packages/wdio-cli/tests/launcher.test.ts
@@ -35,12 +35,16 @@ describe('launcher', () => {
         it('should not run auto compile if cli param was provided', () => {
             const otherLauncher = new Launcher('./', {
                 autoCompileOpts: {
-                    // @ts-expect-error cli params are always strings
-                    autoCompile: 'false'
+                    autoCompile: false
                 }
             })
 
-            expect(otherLauncher['configParser'].autoCompile).toBeCalledTimes(0)
+            expect(otherLauncher['configParser'].merge).toBeCalledWith({
+                autoCompileOpts: {
+                    autoCompile: false
+                }
+            })
+            expect(otherLauncher['configParser'].autoCompile).toBeCalledTimes(1)
         })
     })
 

--- a/website/docs/TypeScript.md
+++ b/website/docs/TypeScript.md
@@ -37,6 +37,25 @@ export const config = {
 }
 ```
 
+If you don't want to use WebdriverIO's internal transpiler functionality you can create your own `entrypoint.js` file where `ts-node` is defined manually:
+
+```ts title="entrypoint.js"
+require('ts-node').register(
+    {
+        transpileOnly: false,
+        files: true,
+        project: "./tsconfig.json"
+    }
+)
+module.exports = require('./configs/wdio.conf')
+```
+
+In this case you have to pass `--no-autoCompileOpts.autoCompile` as parameter to the `wdio` command to disable auto compiling, e.g.:
+
+```sh
+npx wdio run ./entrypoint.js --no-autoCompileOpts.autoCompile
+```
+
 ## Framework Setup
 
 And your `tsconfig.json` needs the following:


### PR DESCRIPTION
## Proposed changes

Disabling auto compiling wasn't really working properly. This patch fixes that and explains how a manual `entrypoint.js` file can be used if one would not like to us WebdriverIOs auto compile.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

closes #6925

### Reviewers: @webdriverio/project-committers
