### PR TITLE
Implement restore/clear all mocks

### DIFF
--- a/packages/wdio-logger/tests/__mocks__/@wdio/logger.js
+++ b/packages/wdio-logger/tests/__mocks__/@wdio/logger.js
@@ -6,7 +6,8 @@ export const logMock = {
     error: jest.fn(),
     debug: jest.fn(),
     warn: jest.fn(),
-    info: jest.fn()
+    info: jest.fn(),
+    trace: jest.fn()
 }
 
 export default mock

--- a/packages/webdriverio/src/commands/browser.ts
+++ b/packages/webdriverio/src/commands/browser.ts
@@ -12,6 +12,8 @@ import getPuppeteer from './browser/getPuppeteer'
 import getWindowSize from './browser/getWindowSize'
 import keys from './browser/keys'
 import mock from './browser/mock'
+import mockClearAll from './browser/mockClearAll'
+import mockRestoreAll from './browser/mockRestoreAll'
 import newWindow from './browser/newWindow'
 import pause from './browser/pause'
 import react$$ from './browser/react$$'
@@ -32,7 +34,7 @@ import waitUntil from './browser/waitUntil'
 
 export default {
     $$, $, call, custom$$, custom$, debug, deleteCookies, execute, executeAsync, getCookies,
-    getPuppeteer, getWindowSize, keys, mock, newWindow, pause, react$$, react$, reloadSession,
-    savePDF, saveRecordingScreen, saveScreenshot, setCookies, setTimeout, setWindowSize,
-    switchWindow, throttle, touchAction, uploadFile, url, waitUntil
+    getPuppeteer, getWindowSize, keys, mock, mockClearAll, mockRestoreAll, newWindow, pause,
+    react$$, react$, reloadSession, savePDF, saveRecordingScreen, saveScreenshot, setCookies,
+    setTimeout, setWindowSize, switchWindow, throttle, touchAction, uploadFile, url, waitUntil
 }

--- a/packages/webdriverio/src/commands/browser/mock.ts
+++ b/packages/webdriverio/src/commands/browser/mock.ts
@@ -5,7 +5,7 @@ import { getBrowserObject } from '../../utils'
 import type { Mock } from '../../types'
 import type { MockFilterOptions } from '../../utils/interception/types'
 
-const SESSION_MOCKS: Record<string, Set<Interception>> = {}
+export const SESSION_MOCKS: Record<string, Set<Interception>> = {}
 
 /**
  * Mock the response of a request. You can define a mock based on a matching

--- a/packages/webdriverio/src/commands/browser/mockClearAll.ts
+++ b/packages/webdriverio/src/commands/browser/mockClearAll.ts
@@ -1,0 +1,38 @@
+import logger from '@wdio/logger'
+
+import { SESSION_MOCKS } from './mock'
+
+const log = logger('webdriverio:mockClearAll')
+
+/**
+ * Resets all information stored in all registered mocks of the session.
+ *
+ * <example>
+    :mockClearAll.js
+    it('should clear all mocks', () => {
+        const docMock = browser.mock('**', {
+            headers: { 'Content-Type': 'text/html' }
+        })
+        const jsMock = browser.mock('**', {
+            headers: { 'Content-Type': 'application/javascript' }
+        })
+
+        browser.url('http://guinea-pig.webdriver.io/')
+        console.log(docMock.calls.length, jsMock.calls.length) // returns "1 4"
+        browser.url('http://guinea-pig.webdriver.io/')
+        console.log(docMock.calls.length, jsMock.calls.length) // returns "2 4" (JavaScript comes from cache)
+        browser.mockClearAll()
+        console.log(docMock.calls.length, jsMock.calls.length) // returns "0 0"
+    })
+ * </example>
+ *
+ * @alias browser.mockClearAll
+ */
+export default async function mockClearAll () {
+    for (const [handle, mocks] of Object.entries(SESSION_MOCKS)) {
+        log.trace(`Clearing mocks for ${handle}`)
+        for (const mock of mocks) {
+            mock.clear()
+        }
+    }
+}

--- a/packages/webdriverio/src/commands/browser/mockRestoreAll.ts
+++ b/packages/webdriverio/src/commands/browser/mockRestoreAll.ts
@@ -1,0 +1,38 @@
+import logger from '@wdio/logger'
+
+import { SESSION_MOCKS } from './mock'
+
+const log = logger('webdriverio:mockRestoreAll')
+
+/**
+ * Restores all mock information and behavior stored in all registered
+ * mocks of the session.
+ *
+ * <example>
+    :mockRestoreAll.js
+    it('should restore all mocks', () => {
+        const googleMock = browser.mock('https://google.com/')
+        googleMock.respond('https://webdriver.io')
+        const wdioMock = browser.mock('https://webdriver.io')
+        wdioMock.respond('http://json.org')
+
+        browser.url('https://google.com/')
+        console.log(browser.getTitle()) // JSON
+
+        browser.mockRestoreAll()
+
+        browser.url('https://google.com/')
+        console.log(browser.getTitle()) // Google
+    })
+ * </example>
+ *
+ * @alias browser.mockRestoreAll
+ */
+export default async function mockRestoreAll () {
+    for (const [handle, mocks] of Object.entries(SESSION_MOCKS)) {
+        log.trace(`Clearing mocks for ${handle}`)
+        for (const mock of mocks) {
+            mock.restore()
+        }
+    }
+}

--- a/packages/webdriverio/src/utils/interception/index.ts
+++ b/packages/webdriverio/src/utils/interception/index.ts
@@ -4,7 +4,15 @@ import { WaitForOptions } from '../../types'
 import { MockFilterOptions, MockOverwrite, MockResponseParams, Matches } from './types'
 import type Protocol from 'devtools-protocol'
 
-export default class Interception {
+export default abstract class Interception {
+    abstract calls: Matches[] | Promise<Matches[]>
+    abstract clear (): void
+    abstract restore (): void
+    abstract respond (overwrite: MockOverwrite, params: MockResponseParams): void
+    abstract respondOnce (overwrite: MockOverwrite, params: MockResponseParams): void
+    abstract abort (errorReason: Protocol.Network.ErrorReason, sticky: boolean): void
+    abstract abortOnce (errorReason: Protocol.Network.ErrorReason): void
+
     url: string
     filterOptions: MockFilterOptions
     browser: WebdriverIO.Browser
@@ -20,10 +28,6 @@ export default class Interception {
         this.url = url
         this.filterOptions = filterOptions
         this.browser = browser
-    }
-
-    get calls (): Matches[] | Promise<Matches[]> {
-        throw new Error('Implement me')
     }
 
     waitForResponse ({

--- a/packages/webdriverio/tests/commands/browser/mock.test.ts
+++ b/packages/webdriverio/tests/commands/browser/mock.test.ts
@@ -21,7 +21,7 @@ jest.mock('../../../src/utils/interception/webdriver', () => class {
     init = jest.fn()
 })
 
-describe('custom$', () => {
+describe('mock', () => {
     let browser
     beforeEach(async () => {
         clientMock.send.mockClear()

--- a/packages/webdriverio/tests/commands/browser/mockClearAll.test.ts
+++ b/packages/webdriverio/tests/commands/browser/mockClearAll.test.ts
@@ -1,0 +1,29 @@
+import { remote } from '../../../src'
+// @ts-expect-error mock feature
+import { getMockCalls } from '../../../src/commands/browser/mock'
+
+jest.mock('../../../src/commands/browser/mock', () => {
+    let clearedMocks = 0
+    const bumpCall = () => ++clearedMocks
+    const SESSION_MOCKS: Record<string, any> = {}
+    SESSION_MOCKS['foobar'] = new Set()
+    SESSION_MOCKS['foobar'].add({ clear: jest.fn(bumpCall) })
+    SESSION_MOCKS['foobar'].add({ clear: jest.fn(bumpCall) })
+    SESSION_MOCKS['barfoo'] = new Set()
+    SESSION_MOCKS['barfoo'].add({ clear: jest.fn(bumpCall) })
+    return { SESSION_MOCKS, getMockCalls: () => clearedMocks }
+})
+
+describe('mockClearAll', () => {
+    it('should clear all mocks', async () => {
+        const browser = await remote({
+            baseUrl: 'http://foobar.com',
+            capabilities: {
+                browserName: 'devtools'
+            }
+        })
+        expect(getMockCalls()).toBe(0)
+        await browser.mockClearAll()
+        expect(getMockCalls()).toBe(3)
+    })
+})

--- a/packages/webdriverio/tests/commands/browser/mockRestoreAll.test.ts
+++ b/packages/webdriverio/tests/commands/browser/mockRestoreAll.test.ts
@@ -1,0 +1,29 @@
+import { remote } from '../../../src'
+// @ts-expect-error mock feature
+import { getMockCalls } from '../../../src/commands/browser/mock'
+
+jest.mock('../../../src/commands/browser/mock', () => {
+    let clearedMocks = 0
+    const bumpCall = () => ++clearedMocks
+    const SESSION_MOCKS: Record<string, any> = {}
+    SESSION_MOCKS['foobar'] = new Set()
+    SESSION_MOCKS['foobar'].add({ restore: jest.fn(bumpCall) })
+    SESSION_MOCKS['foobar'].add({ restore: jest.fn(bumpCall) })
+    SESSION_MOCKS['barfoo'] = new Set()
+    SESSION_MOCKS['barfoo'].add({ restore: jest.fn(bumpCall) })
+    return { SESSION_MOCKS, getMockCalls: () => clearedMocks }
+})
+
+describe('mockClearAll', () => {
+    it('should clear all mocks', async () => {
+        const browser = await remote({
+            baseUrl: 'http://foobar.com',
+            capabilities: {
+                browserName: 'devtools'
+            }
+        })
+        expect(getMockCalls()).toBe(0)
+        await browser.mockRestoreAll()
+        expect(getMockCalls()).toBe(3)
+    })
+})

--- a/packages/webdriverio/tests/utils/interception/interception.test.ts
+++ b/packages/webdriverio/tests/utils/interception/interception.test.ts
@@ -7,12 +7,13 @@ const browserMock = {
         waitforTimeout: 123,
         waitforInterval: 321
     }
-} as any as WebdriverIO.BrowserObject
+}
 
 jest.mock('../../../src/utils/Timer',
     () => jest.fn().mockReturnValue(Promise.resolve()))
 
 test('should use default interval and timeout if invalid', () => {
+    // @ts-expect-error
     const mock = new NetworkInterception('**/foo', { method: 'post' }, browserMock)
     mock.waitForResponse()
     expect(Timer).toBeCalledWith(321, 123, expect.any(Function), true)
@@ -35,24 +36,20 @@ test('should use default interval and timeout if invalid', () => {
 })
 
 test('allows custom error message', async () => {
+    // @ts-expect-error
     const mock = new NetworkInterception('**/foo', { method: 'post' }, browserMock)
     ;(Timer as jest.Mock).mockReturnValue(Promise.reject(new Error('timeout')))
     let err = await mock.waitForResponse({
         timeoutMsg: 'uups'
-    }).catch((err) => err)
+    }).catch((err: Error) => err)
     expect(err.message).toBe('uups')
 
     ;(Timer as jest.Mock).mockClear()
-    err = await mock.waitForResponse().catch((err) => err)
+    err = await mock.waitForResponse().catch((err: Error) => err)
     expect(err.message).toContain('waitForResponse timed out after')
 
     ;(Timer as jest.Mock).mockClear()
     ;(Timer as jest.Mock).mockReturnValue(Promise.reject(new Error('bug')))
-    err = await mock.waitForResponse().catch((err) => err)
+    err = await mock.waitForResponse().catch((err: Error) => err)
     expect(err.message).toBe('waitForResponse failed with the following reason: bug')
-})
-
-test('should throw if calls command is not implement', () => {
-    const mock = new NetworkInterception('**/foo', undefined, browserMock)
-    expect(() => mock.calls).toThrow(/Implement me/)
 })


### PR DESCRIPTION
## Proposed changes

This patch implements two new commands to clear and restore all mocks registered in that session.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

fixes #6003

### Reviewers: @webdriverio/project-committers
