### PR TITLE
CLI : Update visual-regression-testing to image-comparison

### DIFF
--- a/packages/wdio-cli/src/constants.ts
+++ b/packages/wdio-cli/src/constants.ts
@@ -116,7 +116,7 @@ export const SUPPORTED_PACKAGES = {
         { name: 'slack', value: 'wdio-slack-service$--$slack' },
         { name: 'intercept', value: 'wdio-intercept-service$--$intercept' },
         { name: 'docker', value: 'wdio-docker-service$--$docker' },
-        { name: 'visual-regression-testing', value: 'wdio-image-comparison-service$--$visual-regression-testing' },
+        { name: 'image-comparison', value: 'wdio-image-comparison-service$--$image-comparison' },
         { name: 'novus-visual-regression', value: 'wdio-novus-visual-regression-service$--$novus-visual-regression' },
         { name: 'rerun', value: 'wdio-rerun-service$--$rerun' },
         { name: 'winappdriver', value: 'wdio-winappdriver-service$--$winappdriver' },

--- a/scripts/docs-generation/3rd-party/services.json
+++ b/scripts/docs-generation/3rd-party/services.json
@@ -63,7 +63,7 @@
   },
   {
     "packageName": "wdio-image-comparison-service",
-    "title": "Visual Regression Testing",
+    "title": "Image Comparison (Visual Regression Testing)",
     "githubUrl": "https://github.com/wswebcreation/wdio-image-comparison-service",
     "npmUrl": "https://www.npmjs.com/package/wdio-image-comparison-service"
   },


### PR DESCRIPTION
## Proposed changes

The real name of the visual-regression-testing service is `image-comparison` service. Having a wrong name causes wdio to throw an error when selecting it during configuration.

## Types of changes

- Update the name of the service in the contants file on the cli package.
- Update the title of the service to match it name in the documentation.

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
