### PR TITLE
Click x and y are actually counted from center of element

### DIFF
--- a/packages/webdriverio/src/commands/element/click.ts
+++ b/packages/webdriverio/src/commands/element/click.ts
@@ -44,7 +44,7 @@ import { ClickOptions } from '../../types'
     :example.js
     it('should demonstrate a click using an offset', () => {
         const myButton = $('#myButton')
-        myButton.click({ x: 30 }) // clicks 30 horizontal pixels away from location of the button
+        myButton.click({ x: 30 }) // clicks 30 horizontal pixels away from location of the button (from center point of element)
     })
  * </example>
  *
@@ -58,7 +58,7 @@ import { ClickOptions } from '../../types'
     })
     it('should demonstrate a right click passed as number while adding an offset', () => {
         const myButton = $('#myButton')
-        myButton.click({ button: 2, x: 30, y: 40 }) // opens the contextmenu 30 horizontal and 40 vertical pixels away from location of the button
+        myButton.click({ button: 2, x: 30, y: 40 }) // opens the contextmenu 30 horizontal and 40 vertical pixels away from location of the button (from the center of element)
     })
  * </example>
  *


### PR DESCRIPTION
Click x and y are actually counted from center of element, and not from left-top corner as I've expected (same as in moveTo), so probably pointing out that it's actually from center of element will save someone hour of trying to understand why moveTo works but click  on same coordinates returns "move target out of bounds".

## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
