### PR TITLE
Propagate better result object in `afterScenario`

### DIFF
--- a/examples/pageobject/wdio.conf.js
+++ b/examples/pageobject/wdio.conf.js
@@ -143,37 +143,58 @@ exports.config = {
     // afterSuite: function (suite) {
     // },
     //
-    // Runs before a Cucumber Feature
+    // Cucumber Hooks
+    //
+    // Runs before a Cucumber Feature.
+    // @param {String}                   uri      path to feature file
+    // @param {GherkinDocument.IFeature} feature  Cucumber feature object
+    //
     // beforeFeature: function (uri, feature) {
     // },
     //
-    // Runs after a Cucumber Feature
-    // afterFeature: function (uri, feature) {
-    // }
     //
-    // Runs before a Cucumber Scenario
+    // Runs before a Cucumber Scenario.
+    // @param {ITestCaseHookParameter} world world object containing information on pickle and test step
+    //
     // beforeScenario: function (world) {
     // },
     //
-    // Runs after a Cucumber Scenario
-    // afterScenario: function (world) {
+    //
+    // Runs before a Cucumber Step.
+    // @param {Pickle.IPickleStep} step     step data
+    // @param {IPickle}            scenario scenario pickle
+    //
+    // beforeStep: function (step, scenario) {
     // },
     //
-    // Runs before a Cucumber Step
-    // beforeStep: function (step, context) {
+    //
+    // Runs after a Cucumber Step.
+    // @param {Pickle.IPickleStep} step     step data
+    // @param {IPickle}            scenario scenario pickle
+    // @param {Object}             result   results object containing scenario results
+    // @param {boolean}            result.passed   true if scenario has passed
+    // @param {string}             result.error    error stack if scenario failed
+    // @param {number}             result.duration duration of scenario in milliseconds
+    //
+    // afterStep: function (step, scenario, result) {
     // },
     //
-    // Runs after a Cucumber Step
-    // afterStep: function (step, context) {
+    //
+    // Runs before a Cucumber Scenario.
+    // @param {ITestCaseHookParameter} world  world object containing information on pickle and test step
+    // @param {Object}                 result results object containing scenario results
+    // @param {boolean}                result.passed   true if scenario has passed
+    // @param {string}                 result.error    error stack if scenario failed
+    // @param {number}                 result.duration duration of scenario in milliseconds
+    //
+    // afterScenario: function (world, result) {
     // },
     //
-    // Gets executed after all tests are done. You still have access to all global variables from
-    // the test.
-    // after: function (result, capabilities, specs) {
-    // },
     //
-    // Gets executed after all workers got shut down and the process is about to exit. An error
-    // thrown in the onComplete hook will result in the test run failing.
-    // onComplete: function(exitCode, config, capabilities, results) {
+    // Runs after a Cucumber Feature.
+    // @param {String}                   uri      path to feature file
+    // @param {GherkinDocument.IFeature} feature  Cucumber feature object
+    //
+    // afterFeature: function (uri, feature) {
     // }
 }

--- a/examples/wdio.conf.js
+++ b/examples/wdio.conf.js
@@ -345,46 +345,54 @@ exports.config = {
      * Cucumber Hooks
      *
      * Runs before a Cucumber Feature.
-     * @param uri      path to feature file
-     * @param feature  Cucumber feature object
+     * @param {String}                   uri      path to feature file
+     * @param {GherkinDocument.IFeature} feature  Cucumber feature object
      */
     beforeFeature: function (uri, feature) {
     },
     /**
      *
      * Runs before a Cucumber Scenario.
-     * @param world world object containing information on pickle and test step
+     * @param {ITestCaseHookParameter} world world object containing information on pickle and test step
      */
     beforeScenario: function (world) {
     },
     /**
      *
      * Runs before a Cucumber Step.
-     * @param step    step data
-     * @param context Cucumber world
+     * @param {Pickle.IPickleStep} step     step data
+     * @param {IPickle}            scenario scenario pickle
      */
-    beforeStep: function (step, context) {
+    beforeStep: function (step, scenario) {
     },
     /**
      *
      * Runs after a Cucumber Step.
-     * @param step    step data
-     * @param context Cucumber world
+     * @param {Pickle.IPickleStep} step     step data
+     * @param {IPickle}            scenario scenario pickle
+     * @param {Object}             result   results object containing scenario results
+     * @param {boolean}            result.passed   true if scenario has passed
+     * @param {string}             result.error    error stack if scenario failed
+     * @param {number}             result.duration duration of scenario in milliseconds
      */
-    afterStep: function (step, context) {
+    afterStep: function (step, scenario, result) {
     },
     /**
      *
      * Runs before a Cucumber Scenario.
-     * @param world world object containing information on pickle and test step
+     * @param {ITestCaseHookParameter} world  world object containing information on pickle and test step
+     * @param {Object}                 result results object containing scenario results
+     * @param {boolean}                result.passed   true if scenario has passed
+     * @param {string}                 result.error    error stack if scenario failed
+     * @param {number}                 result.duration duration of scenario in milliseconds
      */
-    afterScenario: function (world) {
+    afterScenario: function (world, result) {
     },
     /**
      *
      * Runs after a Cucumber Feature.
-     * @param uri      path to feature file
-     * @param feature  Cucumber feature object
+     * @param {String}                   uri      path to feature file
+     * @param {GherkinDocument.IFeature} feature  Cucumber feature object
      */
     afterFeature: function (uri, feature) {
     }

--- a/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
+++ b/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
@@ -332,32 +332,57 @@
     // },<% }
     if(answers.framework === 'cucumber') { %>
     /**
-     * Runs before a Cucumber feature
+     * Cucumber Hooks
+     *
+     * Runs before a Cucumber Feature.
+     * @param {String}                   uri      path to feature file
+     * @param {GherkinDocument.IFeature} feature  Cucumber feature object
      */
     // beforeFeature: function (uri, feature) {
     // },
     /**
-     * Runs before a Cucumber scenario
+     *
+     * Runs before a Cucumber Scenario.
+     * @param {ITestCaseHookParameter} world world object containing information on pickle and test step
      */
     // beforeScenario: function (world) {
     // },
     /**
-     * Runs before a Cucumber step
+     *
+     * Runs before a Cucumber Step.
+     * @param {Pickle.IPickleStep} step     step data
+     * @param {IPickle}            scenario scenario pickle
      */
-    // beforeStep: function (step, context) {
+    // beforeStep: function (step, scenario) {
     // },
     /**
-     * Runs after a Cucumber step
+     *
+     * Runs after a Cucumber Step.
+     * @param {Pickle.IPickleStep} step     step data
+     * @param {IPickle}            scenario scenario pickle
+     * @param {Object}             result   results object containing scenario results
+     * @param {boolean}            result.passed   true if scenario has passed
+     * @param {string}             result.error    error stack if scenario failed
+     * @param {number}             result.duration duration of scenario in milliseconds
      */
-    // afterStep: function (step, context) {
+    // afterStep: function (step, scenario, result) {
     // },
     /**
-     * Runs after a Cucumber scenario
+     *
+     * Runs before a Cucumber Scenario.
+     * @param {ITestCaseHookParameter} world  world object containing information on pickle and test step
+     * @param {Object}                 result results object containing scenario results
+     * @param {boolean}                result.passed   true if scenario has passed
+     * @param {string}                 result.error    error stack if scenario failed
+     * @param {number}                 result.duration duration of scenario in milliseconds
      */
-    // afterScenario: function (world) {
+    // afterScenario: function (world, result) {
     // },
     /**
-     * Runs after a Cucumber feature
+     *
+     * Runs after a Cucumber Feature.
+     * @param {String}                   uri      path to feature file
+     * @param {GherkinDocument.IFeature} feature  Cucumber feature object
      */
     // afterFeature: function (uri, feature) {
     // },

--- a/packages/wdio-crossbrowsertesting-service/src/service.ts
+++ b/packages/wdio-crossbrowsertesting-service/src/service.ts
@@ -91,12 +91,17 @@ export default class CrossBrowserTestingService implements Services.ServiceInsta
         this._suiteTitle = feature.name
     }
     /**
-     * After step
-     * @param {world} world
+     *
+     * Runs before a Cucumber Scenario.
+     * @param {ITestCaseHookParameter} world  world object containing information on pickle and test step
+     * @param {Object}                 result results object containing scenario results
+     * @param {boolean}                result.passed   true if scenario has passed
+     * @param {string}                 result.error    error stack if scenario failed
+     * @param {number}                 result.duration duration of scenario in milliseconds
      */
-    afterScenario(world: Frameworks.World) {
+    afterScenario(world: Frameworks.World, result: Frameworks.PickleResult) {
         // check if scenario has failed
-        if (world.result && world.result.status === 6) {
+        if (!result.passed) {
             ++this._failures
         }
     }

--- a/packages/wdio-crossbrowsertesting-service/tests/service.test.ts
+++ b/packages/wdio-crossbrowsertesting-service/tests/service.test.ts
@@ -211,16 +211,16 @@ describe('wdio-crossbrowsertesting-service', () => {
 
         expect(cbtService['_failures']).toBe(0)
 
-        cbtService.afterScenario({ pickle: {}, result: { status: 1 } })
+        cbtService.afterScenario({} as any, { passed: true })
         expect(cbtService['_failures']).toBe(0)
 
-        cbtService.afterScenario({ pickle: {}, result: { status: 6 } })
+        cbtService.afterScenario({} as any, { passed: false })
         expect(cbtService['_failures']).toBe(1)
 
-        cbtService.afterScenario({ pickle: {}, result: { status: 1 } })
+        cbtService.afterScenario({} as any, { passed: true })
         expect(cbtService['_failures']).toBe(1)
 
-        cbtService.afterScenario({ pickle: {}, result: { status: 6 } })
+        cbtService.afterScenario({} as any, { passed: false })
         expect(cbtService['_failures']).toBe(2)
     })
 

--- a/packages/wdio-cucumber-framework/src/index.ts
+++ b/packages/wdio-cucumber-framework/src/index.ts
@@ -24,8 +24,6 @@ import { setUserHookNames } from './utils'
 const { incrementing } = IdGenerator
 
 function getResultObject (world: ITestCaseHookParameter): Frameworks.PickleResult {
-    console.log(world.result);
-
     return {
         passed: world.result?.status === Cucumber.Status.PASSED,
         error: world.result?.message as string,

--- a/packages/wdio-cucumber-framework/src/types.ts
+++ b/packages/wdio-cucumber-framework/src/types.ts
@@ -1,4 +1,4 @@
-import type { Capabilities } from '@wdio/types'
+import type { Capabilities, Frameworks } from '@wdio/types'
 import type { messages } from '@cucumber/messages'
 import type { ITestCaseHookParameter } from '@cucumber/cucumber/lib/support_code_library_builder/types'
 
@@ -160,16 +160,23 @@ export interface HookFunctionExtension {
      * Runs after a Cucumber Step.
      * @param step     step data
      * @param scenario scenario data
-     * @param result result object containing {passed: boolean, error: string, duration: messages.IDuration}
+     * @param result result object containing
+     * @param result.passed   true if scenario has passed
+     * @param result.error    error stack if scenario failed
+     * @param result.duration duration of scenario in milliseconds
      */
-    afterStep?(step: messages.Pickle.IPickleStep, scenario: messages.IPickle, result: { passed: boolean, duration: messages.IDuration, error: string }): void;
+    afterStep?(step: messages.Pickle.IPickleStep, scenario: messages.IPickle, result: Frameworks.PickleResult): void;
 
     /**
      *
      * Runs before a Cucumber Scenario.
      * @param world world object containing information on pickle and test step
+     * @param result result object containing
+     * @param result.passed   true if scenario has passed
+     * @param result.error    error stack if scenario failed
+     * @param result.duration duration of scenario in milliseconds
      */
-    afterScenario?(world: ITestCaseHookParameter): void;
+    afterScenario?(world: ITestCaseHookParameter, result: Frameworks.PickleResult): void;
 
     /**
      *

--- a/packages/wdio-cucumber-framework/tests/adapter.test.ts
+++ b/packages/wdio-cucumber-framework/tests/adapter.test.ts
@@ -210,7 +210,7 @@ describe('CucumberAdapter', () => {
             .toBeCalledWith('beforeScenario', 'beforeScenario', ['world'])
         ;(Cucumber.After as jest.Mock).mock.calls[0][0]('world')
         expect(executeHooksWithArgs)
-            .toBeCalledWith('afterScenario', 'afterScenario', ['world'])
+            .toBeCalledWith('afterScenario', 'afterScenario', ['world', { 'duration': undefined, 'error': undefined, 'passed': false }])
     })
 
     it('wrapSteps', async () => {

--- a/packages/wdio-cucumber-framework/tests/adapter.test.ts
+++ b/packages/wdio-cucumber-framework/tests/adapter.test.ts
@@ -195,7 +195,7 @@ describe('CucumberAdapter', () => {
 
         ;(Cucumber.AfterStep as jest.Mock).mock.calls[0][0]('world')
         expect(executeHooksWithArgs)
-            .toBeCalledWith('afterStep', 'afterStep', ['step', 'scenario', { 'duration': undefined, 'error': undefined, 'passed': false }])
+            .toBeCalledWith('afterStep', 'afterStep', ['step', 'scenario', { 'duration': NaN, 'error': undefined, 'passed': false }])
         ;(Cucumber.BeforeStep as jest.Mock).mock.calls[0][0]()
         expect(executeHooksWithArgs)
             .toBeCalledWith('beforeStep', 'beforeStep', ['step', 'scenario'])

--- a/packages/wdio-cucumber-framework/tests/adapter.test.ts
+++ b/packages/wdio-cucumber-framework/tests/adapter.test.ts
@@ -210,7 +210,7 @@ describe('CucumberAdapter', () => {
             .toBeCalledWith('beforeScenario', 'beforeScenario', ['world'])
         ;(Cucumber.After as jest.Mock).mock.calls[0][0]('world')
         expect(executeHooksWithArgs)
-            .toBeCalledWith('afterScenario', 'afterScenario', ['world', { 'duration': undefined, 'error': undefined, 'passed': false }])
+            .toBeCalledWith('afterScenario', 'afterScenario', ['world', { 'duration': NaN, 'error': undefined, 'passed': false }])
     })
 
     it('wrapSteps', async () => {

--- a/packages/wdio-sauce-service/src/service.ts
+++ b/packages/wdio-sauce-service/src/service.ts
@@ -213,9 +213,18 @@ export default class SauceService implements Services.ServiceInstance {
         ;(this._browser as Browser<'async'>).execute('sauce:context=Scenario: ' + scenarioName)
     }
 
-    afterScenario(world: Frameworks.World) {
+    /**
+     *
+     * Runs before a Cucumber Scenario.
+     * @param world world object containing information on pickle and test step
+     * @param result result object containing
+     * @param result.passed   true if scenario has passed
+     * @param result.error    error stack if scenario failed
+     * @param result.duration duration of scenario in milliseconds
+     */
+    afterScenario(world: Frameworks.World, result: Frameworks.PickleResult) {
         // check if scenario has failed
-        if (world.result && world.result.status === 6) {
+        if (!result.passed) {
             ++this._failures
         }
     }

--- a/packages/wdio-sauce-service/tests/service.test.ts
+++ b/packages/wdio-sauce-service/tests/service.test.ts
@@ -271,16 +271,16 @@ test('afterScenario', () => {
 
     expect(service['_failures']).toBe(0)
 
-    service.afterScenario({ result: { status: 1 } })
+    service.afterScenario({} as any, { passed: true })
     expect(service['_failures']).toBe(0)
 
-    service.afterScenario({ result: { status: 6 } })
+    service.afterScenario({} as any, { passed: false })
     expect(service['_failures']).toBe(1)
 
-    service.afterScenario({ result: { status: 1 } })
+    service.afterScenario({} as any, { passed: true })
     expect(service['_failures']).toBe(1)
 
-    service.afterScenario({ result: { status: 6 } })
+    service.afterScenario({} as any, { passed: false })
     expect(service['_failures']).toBe(2)
 })
 

--- a/packages/wdio-testingbot-service/src/service.ts
+++ b/packages/wdio-testingbot-service/src/service.ts
@@ -126,15 +126,17 @@ export default class TestingBotService implements Services.ServiceInstance {
     }
 
     /**
-     * After scenario
-     * @param {string} uri
-     * @param {Object} feature
-     * @param {Object} pickle
-     * @param {Object} result
+     *
+     * Runs before a Cucumber Scenario.
+     * @param world world object containing information on pickle and test step
+     * @param result result object containing
+     * @param result.passed   true if scenario has passed
+     * @param result.error    error stack if scenario failed
+     * @param result.duration duration of scenario in milliseconds
      */
-    afterScenario(world: Frameworks.World) {
+    afterScenario(world: Frameworks.World, result: Frameworks.PickleResult) {
         // check if scenario has failed
-        if (world.result && world.result.status === 6) {
+        if (!result.passed) {
             ++this._failures
         }
     }

--- a/packages/wdio-testingbot-service/tests/service.test.ts
+++ b/packages/wdio-testingbot-service/tests/service.test.ts
@@ -192,16 +192,16 @@ describe('wdio-testingbot-service', () => {
 
         expect(tbService['_failures']).toBe(0)
 
-        tbService.afterScenario({ pickle: {}, result: { status: 2 } })
+        tbService.afterScenario({} as any, { passed: true })
         expect(tbService['_failures']).toBe(0)
 
-        tbService.afterScenario({ pickle: {}, result: { status: 6 } })
+        tbService.afterScenario({} as any, { passed: false })
         expect(tbService['_failures']).toBe(1)
 
-        tbService.afterScenario({ pickle: {}, result: { status: 2 } })
+        tbService.afterScenario({} as any, { passed: true })
         expect(tbService['_failures']).toBe(1)
 
-        tbService.afterScenario({ pickle: {}, result: { status: 6 } })
+        tbService.afterScenario({} as any, { passed: false })
         expect(tbService['_failures']).toBe(2)
     })
 

--- a/packages/wdio-types/src/Frameworks.ts
+++ b/packages/wdio-types/src/Frameworks.ts
@@ -52,3 +52,21 @@ export interface World {
         message?: string
     }
 }
+
+/**
+ * Result of a pick (scenario or step)
+ */
+export interface PickleResult {
+    /**
+     * true if scenario has passed
+     */
+    passed: boolean
+    /**
+     * error stack if scenario failed
+     */
+    error?: string
+    /**
+     * duration of scenario in milliseconds
+     */
+    duration?: number
+}

--- a/website/docs/ConfigurationFile.md
+++ b/website/docs/ConfigurationFile.md
@@ -425,49 +425,54 @@ exports.config = {
      * Cucumber Hooks
      *
      * Runs before a Cucumber Feature.
-     * @param uri      path to feature file
-     * @param feature  Cucumber feature object
+     * @param {String}                   uri      path to feature file
+     * @param {GherkinDocument.IFeature} feature  Cucumber feature object
      */
     beforeFeature: function (uri, feature) {
     },
     /**
      *
      * Runs before a Cucumber Scenario.
-     * @param world world object containing information on pickle and test step
+     * @param {ITestCaseHookParameter} world world object containing information on pickle and test step
      */
     beforeScenario: function (world) {
     },
     /**
      *
      * Runs before a Cucumber Step.
-     * @param step    step data
-     * @param scenario Cucumber scenario
+     * @param {Pickle.IPickleStep} step     step data
+     * @param {IPickle}            scenario scenario pickle
      */
     beforeStep: function (step, scenario) {
     },
     /**
      *
      * Runs after a Cucumber Step.
-     * @param step    step data
-     * @param scenario Cucumber scenario
-     * @param error if executed step failed, prints the error
-     * @param duration step duration, in ms
-     * @param passed boolean value if executed step passed
+     * @param {Pickle.IPickleStep} step     step data
+     * @param {IPickle}            scenario scenario pickle
+     * @param {Object}             result   results object containing scenario results
+     * @param {boolean}            result.passed   true if scenario has passed
+     * @param {string}             result.error    error stack if scenario failed
+     * @param {number}             result.duration duration of scenario in milliseconds
      */
-    afterStep: function (step, scenario, { error, duration, passed }) {
+    afterStep: function (step, scenario, result) {
     },
     /**
      *
-     * Runs after a Cucumber Scenario.
-     * @param world world object containing information on pickle and test step
+     * Runs before a Cucumber Scenario.
+     * @param {ITestCaseHookParameter} world  world object containing information on pickle and test step
+     * @param {Object}                 result results object containing scenario results `{passed: boolean, error: string, duration: number}`
+     * @param {boolean}                result.passed   true if scenario has passed
+     * @param {string}                 result.error    error stack if scenario failed
+     * @param {number}                 result.duration duration of scenario in milliseconds
      */
-    afterScenario: function (world) {
+    afterScenario: function (world, result) {
     },
     /**
      *
      * Runs after a Cucumber Feature.
-     * @param uri      path to feature file
-     * @param feature  Cucumber feature object
+     * @param {String}                   uri      path to feature file
+     * @param {GherkinDocument.IFeature} feature  Cucumber feature object
      */
     afterFeature: function (uri, feature) {
     }

--- a/website/docs/Options.md
+++ b/website/docs/Options.md
@@ -488,45 +488,52 @@ Parameters:
 Runs before a Cucumber Feature.
 
 Parameters:
-- `uri`: (`string`): path to feature file
-- `feature`: (`GherkinDocument.IFeature`): Cucumber feature object
+- `uri` (`string`): path to feature file
+- `feature` ([`GherkinDocument.IFeature`](https://github.com/cucumber/common/blob/b94ce625967581de78d0fc32d84c35b46aa5a075/json-to-messages/javascript/src/cucumber-generic/JSONSchema.ts#L8-L17)): Cucumber feature object
 
 ### afterFeature
 
 Runs after a Cucumber Feature.
 
 Parameters:
-- `uri`: (`string`): path to feature file
-- `feature`: (`GherkinDocument.IFeature`): Cucumber feature object
+- `uri` (`string`): path to feature file
+- `feature` ([`GherkinDocument.IFeature`](https://github.com/cucumber/common/blob/b94ce625967581de78d0fc32d84c35b46aa5a075/json-to-messages/javascript/src/cucumber-generic/JSONSchema.ts#L8-L17)): Cucumber feature object
 
 ### beforeScenario
 
 Runs before a Cucumber Scenario.
 
 Parameters:
-- `world`: (`ITestCaseHookParameter`): world object containing information on pickle and test step
+- `world` ([`ITestCaseHookParameter`](https://github.com/cucumber/cucumber-js/blob/ac124f7b2be5fa54d904c7feac077a2657b19440/src/support_code_library_builder/types.ts#L10-L15)): world object containing information on pickle and test step
 
 ### afterScenario
 
 Runs after a Cucumber Scenario.
 
 Parameters:
-- `world`: (`ITestCaseHookParameter`): world object containing information on pickle and test step
+- `world` ([`ITestCaseHookParameter`](https://github.com/cucumber/cucumber-js/blob/ac124f7b2be5fa54d904c7feac077a2657b19440/src/support_code_library_builder/types.ts#L10-L15)): world object containing information on pickle and test step
+- `result` (`object`): results object containing scenario results
+- `result.passed` (`boolean`): true if scenario has passed
+- `result.error` (`string`): error stack if scenario failed
+- `result.duration` (`number`): duration of scenario in milliseconds
 
 ### beforeStep
 
 Runs before a Cucumber Step.
 
 Parameters:
-- `step`: (`Pickle.IPickleStep`): Cucumber step object
-- `scenario`: (`IPickle`): Cucumber scenario object
+- `step` ([`Pickle.IPickleStep`](https://github.com/cucumber/common/blob/b94ce625967581de78d0fc32d84c35b46aa5a075/messages/jsonschema/Pickle.json#L20-L49)): Cucumber step object
+- `scenario` ([`IPickle`](https://github.com/cucumber/common/blob/b94ce625967581de78d0fc32d84c35b46aa5a075/messages/jsonschema/Pickle.json#L137-L175)): Cucumber scenario object
 
 ### afterStep
 
 Runs after a Cucumber Step.
 
 Parameters:
-- `step`: (`Pickle.IPickleStep`): Cucumber step object
-- `scenario`: (`IPickle`): Cucumber scenario object
-- `result`: (`object`): results object containing step results {passed: boolean, error: string, duration: messages.IDuration}
+- `step` ([`Pickle.IPickleStep`](https://github.com/cucumber/common/blob/b94ce625967581de78d0fc32d84c35b46aa5a075/messages/jsonschema/Pickle.json#L20-L49)): Cucumber step object
+- `scenario` ([`IPickle`](https://github.com/cucumber/common/blob/b94ce625967581de78d0fc32d84c35b46aa5a075/messages/jsonschema/Pickle.json#L137-L175)): Cucumber scenario object
+- `result`: (`object`): results object containing step results
+- `result.passed` (`boolean`): true if scenario has passed
+- `result.error` (`string`): error stack if scenario failed
+- `result.duration` (`number`): duration of scenario in milliseconds
 


### PR DESCRIPTION
## Proposed changes

fixes #6494

This patch adds a result object to `afterScenario` to easier work with its result. I also took the chance to improve the docs around the types.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
