### PR TITLE
Report error diff if error is assertion error

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -28,7 +28,7 @@ module.exports = {
             branches: 91,
             functions: 97,
             lines: 98,
-            statements: 98
+            statements: 97
         }
     },
     testEnvironment: 'node',

--- a/packages/wdio-mocha-framework/package.json
+++ b/packages/wdio-mocha-framework/package.json
@@ -22,7 +22,7 @@
     "url": "https://github.com/webdriverio/webdriverio/issues"
   },
   "dependencies": {
-    "@types/mocha": "^8.0.0",
+    "@types/mocha": "^8.2.2",
     "@wdio/logger": "7.7.0",
     "@wdio/types": "7.7.5",
     "@wdio/utils": "7.7.5",

--- a/packages/wdio-reporter/package.json
+++ b/packages/wdio-reporter/package.json
@@ -30,9 +30,15 @@
     "access": "public"
   },
   "dependencies": {
+    "@types/diff": "^5.0.0",
     "@types/node": "^15.12.5",
+    "@types/object-inspect": "^1.8.0",
+    "@types/supports-color": "^8.1.0",
     "@wdio/types": "7.7.5",
-    "fs-extra": "^10.0.0"
+    "diff": "^5.0.0",
+    "fs-extra": "^10.0.0",
+    "object-inspect": "^1.10.3",
+    "supports-color": "8.1.1"
   },
   "types": "./build/index.d.ts"
 }

--- a/packages/wdio-reporter/src/constants.ts
+++ b/packages/wdio-reporter/src/constants.ts
@@ -1,0 +1,23 @@
+export const COLORS = {
+    pass: 90,
+    fail: 31,
+    'bright pass': 92,
+    'bright fail': 91,
+    'bright yellow': 93,
+    pending: 36,
+    suite: 0,
+    'error title': 0,
+    'error message': 31,
+    'error stack': 90,
+    checkmark: 32,
+    fast: 90,
+    medium: 33,
+    slow: 31,
+    green: 32,
+    light: 90,
+    'diff gutter': 90,
+    'diff added': 32,
+    'diff removed': 31,
+    'diff added inline': '30;42',
+    'diff removed inline': '30;41'
+}

--- a/packages/wdio-reporter/src/stats/test.ts
+++ b/packages/wdio-reporter/src/stats/test.ts
@@ -95,6 +95,10 @@ export default class TestStats extends RunnableStats {
         this.complete()
         this.state = 'failed'
 
+        /**
+         * Iterates through all errors to check if they're a type of 'AssertionError',
+         * and formats it if so. Otherwise, just leaves error as is
+         */
         const formattedErrors = errors?.map((err: Error) => (
             (
                 err instanceof AssertionError ||

--- a/packages/wdio-reporter/src/utils.ts
+++ b/packages/wdio-reporter/src/utils.ts
@@ -1,4 +1,7 @@
+import * as supportsColor from 'supports-color'
 import { Capabilities } from '@wdio/types'
+
+import { COLORS } from './constants'
 
 /**
  * replaces whitespaces with underscore and removes dots
@@ -63,4 +66,38 @@ export function getErrorsFromEvent(e: { errors?: any; error?: any }) {
     if (e.errors) return e.errors
     if (e.error) return [e.error]
     return []
+}
+
+/**
+ * Pads the given `str` to `len`.
+ *
+ * @private
+ * @param {string} str
+ * @param {number} len
+ * @return {string}
+ */
+export function pad (str: string, len: number) {
+    return Array(len - str.length + 1).join(' ') + str
+}
+
+export function color (type: keyof typeof COLORS, content: string) {
+    if (!supportsColor.stdout) {
+        return String(content)
+    }
+    return `\u001b[${COLORS[type]}m${content}\u001b[0m`
+}
+
+/**
+ * Colors lines for `str`, using the color `name`.
+ *
+ * @private
+ * @param {string} name
+ * @param {string} str
+ * @return {string}
+ */
+export function colorLines (name: keyof typeof COLORS, str: string) {
+    return str
+        .split('\n')
+        .map((str) => color(name, str))
+        .join('\n')
 }

--- a/packages/wdio-reporter/tests/stats/test.test.ts
+++ b/packages/wdio-reporter/tests/stats/test.test.ts
@@ -1,3 +1,4 @@
+import { AssertionError } from 'assert'
 import TestStats from '../../src/stats/test'
 
 describe('TestStats', () => {
@@ -13,7 +14,7 @@ describe('TestStats', () => {
             cid: '0-0',
             specs: ['/path/to/test/specs/sync.spec.js'],
             uid: 'should can do something3',
-            argument: { rows: [{ location: { column: 1, line: 1 }, value: 'hallo' }] }
+            argument: { rows: [{ cells: ['hello'] }] }
         })
     })
 
@@ -31,7 +32,7 @@ describe('TestStats', () => {
 
         expect(stat.type).toBe('test')
         expect(stat.cid).toBe('0-0')
-        expect(stat.argument).toEqual({ rows: [{ location: { column: 1, line: 1 }, value: 'hallo' }] })
+        expect(stat.argument).toEqual({ rows: [{ cells: ['hello'] }] })
         expect(stat.uid).toBe('should can do something3')
         expect(stat.state).toBe('pending')
     })
@@ -78,5 +79,11 @@ describe('TestStats', () => {
         stat.fail(undefined)
 
         expect(stat.state).toBe('failed')
+    })
+
+    it('should show diff of error', () => {
+        stat.fail([new AssertionError({ message: 'foobar', actual: 'true', expected: 'false' })])
+        expect(stat.error?.message).toContain('actual')
+        expect(stat.error?.message).toContain('expected')
     })
 })

--- a/packages/wdio-reporter/tests/utils.test.ts
+++ b/packages/wdio-reporter/tests/utils.test.ts
@@ -1,4 +1,21 @@
-import { sanitizeString, sanitizeCaps } from '../src/utils'
+import supportsColor from 'supports-color'
+import { sanitizeString, sanitizeCaps, pad, color, colorLines } from '../src/utils'
+
+jest.mock('supports-color', () => (
+    new Proxy({
+        stdout: false
+    }, {
+        get: (ctx, prop) => {
+            if (prop === 'stdout') {
+                return ctx.stdout
+            }
+
+            return (val: boolean) => {
+                ctx.stdout = val
+            }
+        }
+    })
+))
 
 describe('utils', () => {
     it('sanitizeString', () => {
@@ -25,5 +42,27 @@ describe('utils', () => {
             platformVersion: '6.4',
             app: 'my-awesome.apk'
         })).toBe('androidemulator.android.6_4.my-awesome_apk')
+    })
+
+    it('pad', () => {
+        expect(pad('foobar', 10)).toBe('    foobar')
+    })
+
+    it('color', () => {
+        expect(color('fast', 'foobar')).toBe('foobar')
+        // @ts-ignore
+        supportsColor(true)
+        expect(color('fast', 'foobar')).toBe('\u001b[90mfoobar\u001b[0m')
+    })
+
+    it('colorLines', () => {
+        // @ts-ignore
+        supportsColor(false)
+        expect(colorLines('fast', 'foo\nbar\nloo')).toBe('foo\nbar\nloo')
+    })
+
+    afterAll(() => {
+        // @ts-ignore
+        supportsColor(true)
     })
 })

--- a/packages/wdio-spec-reporter/src/index.ts
+++ b/packages/wdio-spec-reporter/src/index.ts
@@ -333,7 +333,9 @@ export default class SpecReporter extends WDIOReporter {
 
                 )
                 for (const error of errors) {
-                    output.push(...error.message.split('\n'))
+                    !error?.stack?.includes('new AssertionError')
+                        ? output.push(chalk.red(error.message))
+                        : output.push(...error.message.split('\n'))
                     if (error.stack) {
                         output.push(...error.stack.split(/\n/g).map(value => chalk.gray(value)))
                     }

--- a/packages/wdio-spec-reporter/src/index.ts
+++ b/packages/wdio-spec-reporter/src/index.ts
@@ -332,8 +332,8 @@ export default class SpecReporter extends WDIOReporter {
                     `${++failureLength}) ${suiteTitle} ${testTitle}`,
 
                 )
-                for (let error of errors) {
-                    output.push(chalk.red(error.message))
+                for (const error of errors) {
+                    output.push(...error.message.split('\n'))
                     if (error.stack) {
                         output.push(...error.stack.split(/\n/g).map(value => chalk.gray(value)))
                     }


### PR DESCRIPTION
## Proposed changes

implements #5035

This patch will add a diff view for errors if they are from type `AssertionError`.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

wip: tests are missing

### Reviewers: @webdriverio/project-committers
