### PR TITLE
Fix for isW3C

### DIFF
--- a/packages/wdio-utils/src/envDetector.ts
+++ b/packages/wdio-utils/src/envDetector.ts
@@ -32,7 +32,6 @@ export function isW3C (capabilities?: Capabilities.DesiredCapabilities) {
         capabilities.appiumVersion
     )
     const hasW3CCaps = Boolean(
-        capabilities.platformName &&
         capabilities.browserVersion &&
         /**
          * local safari and BrowserStack don't provide platformVersion therefor

--- a/packages/wdio-utils/src/envDetector.ts
+++ b/packages/wdio-utils/src/envDetector.ts
@@ -32,9 +32,13 @@ export function isW3C (capabilities?: Capabilities.DesiredCapabilities) {
         capabilities.appiumVersion
     )
     const hasW3CCaps = Boolean(
-        capabilities.browserVersion &&
         /**
-         * local safari and BrowserStack don't provide platformVersion therefor
+         * safari docker image may not provide a platformName therefore
+         * check one of the available "platformName" or "browserVersion"
+         */
+        (capabilities.platformName || capabilities.browserVersion) &&
+        /**
+         * local safari and BrowserStack don't provide platformVersion therefore
          * check also if setWindowRect is provided
          */
         (capabilities.platformVersion || Object.prototype.hasOwnProperty.call(capabilities, 'setWindowRect'))

--- a/packages/wdio-utils/tests/__fixtures__/safaridriverdockerNbV.response.json
+++ b/packages/wdio-utils/tests/__fixtures__/safaridriverdockerNbV.response.json
@@ -1,0 +1,11 @@
+{
+  "value": {
+    "sessionId": "867A8C76-537F-4F2B-897C-85F87DF2C995",
+    "capabilities": {
+      "acceptInsecureCerts": false,
+      "setWindowRect": true,
+      "browserName": "Safari",
+      "platformName": "macOS"
+    }
+  }
+}

--- a/packages/wdio-utils/tests/__fixtures__/safaridriverdockerNpN.response.json
+++ b/packages/wdio-utils/tests/__fixtures__/safaridriverdockerNpN.response.json
@@ -1,0 +1,11 @@
+{
+  "value": {
+    "sessionId": "867A8C76-537F-4F2B-897C-85F87DF2C995",
+    "capabilities": {
+      "browserVersion": "14.0",
+      "acceptInsecureCerts": false,
+      "setWindowRect": true,
+      "browserName": "Safari"
+    }
+  }
+}

--- a/packages/wdio-utils/tests/envDetector.test.ts
+++ b/packages/wdio-utils/tests/envDetector.test.ts
@@ -6,6 +6,8 @@ import chromedriverResponse from './__fixtures__/chromedriver.response.json'
 import geckodriverResponse from './__fixtures__/geckodriver.response.json'
 import ghostdriverResponse from './__fixtures__/ghostdriver.response.json'
 import safaridriverResponse from './__fixtures__/safaridriver.response.json'
+import safaridriverdockerNpNResponse from './__fixtures__/safaridriverdockerNpN.response.json'
+import safaridriverdockerNbVResponse from './__fixtures__/safaridriverdockerNbV.response.json'
 import safaridriverLegacyResponse from './__fixtures__/safaridriver.legacy.response.json'
 import edgedriverResponse from './__fixtures__/edgedriver.response.json'
 import seleniumstandaloneResponse from './__fixtures__/standaloneserver.response.json'
@@ -18,6 +20,8 @@ describe('sessionEnvironmentDetector', () => {
     const edgeCaps = edgedriverResponse.value.capabilities as WebDriver.Capabilities
     const phantomCaps = ghostdriverResponse.value as WebDriver.Capabilities
     const safariCaps = safaridriverResponse.value.capabilities as WebDriver.Capabilities
+    const safariDockerNpNCaps = safaridriverdockerNpNResponse.value.capabilities as WebDriver.Capabilities // absent capability.platformName
+    const safariDockerNbVCaps = safaridriverdockerNbVResponse.value.capabilities as WebDriver.Capabilities // absent capability.browserVersion
     const safariLegacyCaps = safaridriverLegacyResponse.value as WebDriver.Capabilities
     const standaloneCaps = seleniumstandaloneResponse.value as WebDriver.DesiredCapabilities
 
@@ -37,6 +41,8 @@ describe('sessionEnvironmentDetector', () => {
         expect(sessionEnvironmentDetector({ capabilities: chromeCaps, requestedCapabilities }).isW3C).toBe(true)
         expect(sessionEnvironmentDetector({ capabilities: geckoCaps, requestedCapabilities }).isW3C).toBe(true)
         expect(sessionEnvironmentDetector({ capabilities: safariCaps, requestedCapabilities }).isW3C).toBe(true)
+        expect(sessionEnvironmentDetector({ capabilities: safariDockerNbVCaps, requestedCapabilities }).isW3C).toBe(true)
+        expect(sessionEnvironmentDetector({ capabilities: safariDockerNpNCaps, requestedCapabilities }).isW3C).toBe(true)
         expect(sessionEnvironmentDetector({ capabilities: edgeCaps, requestedCapabilities }).isW3C).toBe(true)
         expect(sessionEnvironmentDetector({ capabilities: safariLegacyCaps, requestedCapabilities }).isW3C).toBe(false)
         expect(sessionEnvironmentDetector({ capabilities: phantomCaps, requestedCapabilities }).isW3C).toBe(false)


### PR DESCRIPTION
Remove verification of "capabilities.platformName" from "isW3C" method.
Source of request (discussion) : https://gitter.im/webdriverio/webdriverio?at=60b6086379350e7f9276d9e9

## Proposed changes

[//]: # (Hi, I have a question regarding determination of W3C standart in webdriverIO (WebDriver version "7.6.1", NodeJS version 14) The thing is:
I am using Docker image "browsers/safari:14.0" and when "utils.js: startWebDriverSession" sends request in response we have only "browserVersion", "browserName" and "pageLoadStrategy" variables. "platformName" is not present in response.

Than when we call "envDetector.js: sessionEnvironmentDetector" and decide if it is a W3C or not we are getting "capabilities.platformName" variable as undefined and isW3C gets "false"....
And after couple blocs of code we get to browser.executeScript() method which makes a call to endpoint: "/session/{sessionid}/execute" and receive:
"Request failed with status 404 due to unknown command: Unknown command: /session/...../execute" and this is wrong endpoint, correct is (which is used if we hardcode W3C as true) "/session/..../sync"

So, the questing is.... how can we force to use W3C standart. Or overwrite determination of "isW3C" variable... may be there is a way we can overwrite "startWebDriverSession" and make hook to add "platformName" into returned capabilities.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
