### PR TITLE
Support Firefox 86+ in Devtools Service & Migrate from deprecated Console domain

### DIFF
--- a/packages/wdio-devtools-service/README.md
+++ b/packages/wdio-devtools-service/README.md
@@ -5,7 +5,9 @@ WebdriverIO DevTools Service
 
 With Chrome v63 and up the browser [started to support](https://developers.google.com/web/updates/2017/10/devtools-release-notes#multi-client) multi clients allowing arbitrary clients to access the [Chrome DevTools Protocol](https://chromedevtools.github.io/devtools-protocol/). This provides interesting opportunities to automate Chrome beyond the [WebDriver protocol](https://www.w3.org/TR/webdriver/). With this service you can enhance the wdio browser object to leverage that access and call Chrome DevTools commands within your tests to e.g. intercept requests, throttle network capabilities or take CSS/JS coverage.
 
-_**Note:** this service currently only supports Chrome v63 and up, and Chromium (Microsoft Edge is not yet supported)!_
+Since Firefox 86, [a subset of Chrome DevTools Protocol](https://firefox-source-docs.mozilla.org/remote/index.html) has been implemented by passing the capability `"moz:debuggerAddress": true`.
+
+_**Note:** this service currently only supports Chrome v63 and up, Chromium, and Firefox 86 and up (Microsoft Edge is not yet supported)!_
 
 ## Installation
 

--- a/packages/wdio-devtools-service/src/constants.ts
+++ b/packages/wdio-devtools-service/src/constants.ts
@@ -62,7 +62,7 @@ export const MAX_TRACE_WAIT_TIME = 45000
 export const NETWORK_IDLE_TIMEOUT = 5000
 export const DEFAULT_NETWORK_THROTTLING_STATE = 'online' as const
 export const DEFAULT_FORM_FACTOR = 'desktop' as const
-export const UNSUPPORTED_ERROR_MESSAGE = 'The @wdio/devtools-service currently only supports Chrome version 63 and up, and Chromium as the browserName!'
+export const UNSUPPORTED_ERROR_MESSAGE = 'The @wdio/devtools-service currently only supports Chrome version 63 and up, Firefox 86 and up, and Chromium as the browserName!'
 
 export const NETWORK_STATES = {
     offline: {

--- a/packages/wdio-devtools-service/src/index.ts
+++ b/packages/wdio-devtools-service/src/index.ts
@@ -245,7 +245,7 @@ export default class DevToolsService implements Services.ServiceInstance {
         /**
          * enable domains for client
          */
-        await Promise.all(['Page', 'Network', 'Console'].map(
+        await Promise.all(['Page', 'Network', 'Runtime'].map(
             (domain) => Promise.all([
                 this._session?.send(`${domain}.enable` as any)
             ])

--- a/packages/wdio-devtools-service/src/utils.ts
+++ b/packages/wdio-devtools-service/src/utils.ts
@@ -9,7 +9,8 @@ const SUPPORTED_BROWSERS_AND_MIN_VERSIONS = {
     'chrome': 63,
     'chromium' : 63,
     'googlechrome': 63,
-    'google chrome': 63
+    'google chrome': 63,
+    'firefox': 86
 }
 
 export function setUnsupportedCommand (browser: Browser<'async'> | MultiRemoteBrowser<'async'>) {

--- a/packages/wdio-devtools-service/tests/service.test.ts
+++ b/packages/wdio-devtools-service/tests/service.test.ts
@@ -84,7 +84,10 @@ test('beforeSession', () => {
     service.beforeSession({}, {})
     expect(service['_isSupported']).toBe(false)
 
-    service.beforeSession({}, { browserName: 'firefox' })
+    service.beforeSession({}, { browserName: 'firefox', version: 85 })
+    expect(service['_isSupported']).toBe(false)
+
+    service.beforeSession({}, { browserName: 'firefox', browserVersion: '85' })
     expect(service['_isSupported']).toBe(false)
 
     // @ts-ignore test with outdated version capability
@@ -99,6 +102,15 @@ test('beforeSession', () => {
     expect(service['_isSupported']).toBe(true)
 
     service.beforeSession({}, { browserName: 'chrome', browserVersion: '65' })
+    expect(service['_isSupported']).toBe(true)
+
+    service.beforeSession({}, { browserName: 'firefox' })
+    expect(service['_isSupported']).toBe(true)
+
+    service.beforeSession({}, { browserName: 'firefox', version: 86 })
+    expect(service['_isSupported']).toBe(true)
+
+    service.beforeSession({}, { browserName: 'firefox', browserVersion: '86' })
     expect(service['_isSupported']).toBe(true)
 })
 

--- a/packages/wdio-devtools-service/tests/service.test.ts
+++ b/packages/wdio-devtools-service/tests/service.test.ts
@@ -121,7 +121,7 @@ test('if supported by browser', async () => {
     service['_isSupported'] = true
     await service._setupHandler()
     expect(service['_session']?.send).toBeCalledWith('Network.enable')
-    expect(service['_session']?.send).toBeCalledWith('Console.enable')
+    expect(service['_session']?.send).toBeCalledWith('Runtime.enable')
     expect(service['_session']?.send).toBeCalledWith('Page.enable')
     expect(service['_browser']?.addCommand).toBeCalledWith(
         'enablePerformanceAudits', expect.any(Function))

--- a/packages/wdio-devtools-service/tests/utils.test.ts
+++ b/packages/wdio-devtools-service/tests/utils.test.ts
@@ -78,14 +78,19 @@ describe('isBrowserSupported', () => {
         expect(isBrowserSupported(caps)).toEqual(true)
     })
 
-    test('should return false when the browser us supported', () => {
+    test('should return true when the browser and version are supported', () => {
+        const caps = { browserName: 'Firefox', version: 86 }
+        expect(isBrowserSupported(caps)).toEqual(true)
+    })
+
+    test('should return false when the version is not supported', () => {
         const capsFirefox = { browserName: 'firefox', version: 80 }
         expect(isBrowserSupported(capsFirefox)).toEqual(false)
     })
 
     test('should return false when the version is not supported', () => {
-        const capsFirefox = { browserName: 'chrome', version: 50 }
-        expect(isBrowserSupported(capsFirefox)).toEqual(false)
+        const capsChrome = { browserName: 'chrome', version: 50 }
+        expect(isBrowserSupported(capsChrome)).toEqual(false)
     })
 
     test('should return true when the browserName is not specified', () => {
@@ -95,6 +100,11 @@ describe('isBrowserSupported', () => {
     })
     test('should return true when the version number is not specified', () => {
         const capsEmpty = { browserName: 'chrome' }
+        expect(isBrowserSupported(capsEmpty)).toEqual(true)
+    })
+
+    test('should return true when the version number is not specified', () => {
+        const capsEmpty = { browserName: 'firefox' }
         expect(isBrowserSupported(capsEmpty)).toEqual(true)
     })
 })


### PR DESCRIPTION
## Proposed changes

Addresses https://github.com/webdriverio/webdriverio/issues/7023. This PR will allow the devtools-service to connect with the [Firefox Remote Protocol](https://firefox-source-docs.mozilla.org/remote/index.html), which implements a subset of Chrome Devtools Protocol.

This is available since Firefox 86 ([source](https://firefox-source-docs.mozilla.org/remote/Usage.html)). You must include `"moz:debuggerAddress": true` in the capabilities like so:
```
  capabilities: [{
    browserName: 'firefox',
    "moz:debuggerAddress": true
  }],
```

This also changes from enabling the `Console` domain to the `Runtime` domain, as `Console` [is deprecated](https://chromedevtools.github.io/devtools-protocol/tot/Console/) and it is suggested to use `Runtime`. Firefox does not support `Console`. This might make this a breaking change if others rely on `Console` to already being enabled, so I'm open to suggestions how we should handle this.

I've tested this both locally (v86 and v89.0.1) using the `'selenium-standalone'` service, as well as on a remote Selenium 4 Beta 4 Grid with a test that receives `Runtime.consoleAPICalled` and `Runtime.exceptionThrown` events. All worked 🎉 

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments


### Reviewers: @webdriverio/project-committers
