### PR TITLE
Improve documentation and type support for spec grouping

### DIFF
--- a/packages/wdio-config/src/lib/ConfigParser.ts
+++ b/packages/wdio-config/src/lib/ConfigParser.ts
@@ -28,8 +28,8 @@ interface TestrunnerOptionsWithParameters extends Omit<Options.Testrunner, 'capa
 }
 
 interface MergeConfig extends Omit<Partial<TestrunnerOptionsWithParameters>, 'specs' | 'exclude'> {
-    specs?: Spec
-    exclude?: Spec
+    specs?: Spec[]
+    exclude?: string[]
 }
 
 // Get current working directory
@@ -272,7 +272,7 @@ export default class ConfigParser {
      * cli argument
      * @return {String[]} List of files that should be included or excluded
      */
-    setFilePathToFilterOptions(cliArgFileList: string[], config: string[]) {
+    setFilePathToFilterOptions(cliArgFileList: string[], config: Spec[]) {
         const filesToFilter = new Set<string>()
         const fileList = ConfigParser.getFilePaths(config, undefined, this._pathService)
         cliArgFileList.forEach(filteredFile => {

--- a/packages/wdio-runner/src/utils.ts
+++ b/packages/wdio-runner/src/utils.ts
@@ -24,7 +24,7 @@ export interface ConfigWithSessionId extends Omit<Options.Testrunner, 'capabilit
 export function sanitizeCaps (
     caps: Capabilities.RemoteCapability,
     filterOut?: boolean
-): Omit<Capabilities.RemoteCapability, 'logLevel'> | Partial<Options.Testrunner> {
+): Omit<Capabilities.RemoteCapability, 'logLevel'> {
     const defaultConfigsKeys = [
         // WDIO config keys
         ...Object.keys(DEFAULT_CONFIGS()),

--- a/packages/wdio-types/src/Options.ts
+++ b/packages/wdio-types/src/Options.ts
@@ -263,8 +263,6 @@ export interface WebdriverIO extends Omit<WebDriver, 'capabilities'> {
     waitforInterval?: number
 }
 
-type SpecFile = string | string[]
-
 export interface Testrunner extends Hooks, Omit<WebdriverIO, 'capabilities'>, WebdriverIO.HookFunctionExtension {
     /**
      * Defines a set of capabilities you want to run in your testrunner session. Check out the
@@ -320,8 +318,7 @@ export interface Testrunner extends Hooks, Omit<WebdriverIO, 'capabilities'>, We
      * pattern to match multiple files at once or wrap a glob or set of
      * paths into an array to run them within a single worker process.
      */
-    // specs?: SpecFile[]
-    specs?: string[]
+    specs?: (string | string[])[]
     /**
      * Exclude specs from test execution.
      */

--- a/packages/wdio-types/src/Options.ts
+++ b/packages/wdio-types/src/Options.ts
@@ -316,7 +316,9 @@ export interface Testrunner extends Hooks, Omit<WebdriverIO, 'capabilities'>, We
      */
     runner?: 'local'
     /**
-     * Define specs for test execution.
+     * Define specs for test execution. You can either specify a glob
+     * pattern to match multiple files at once or wrap a glob or set of
+     * paths into an array to run them within a single worker process.
      */
     // specs?: SpecFile[]
     specs?: string[]

--- a/packages/wdio-types/src/Options.ts
+++ b/packages/wdio-types/src/Options.ts
@@ -263,6 +263,8 @@ export interface WebdriverIO extends Omit<WebDriver, 'capabilities'> {
     waitforInterval?: number
 }
 
+type SpecFile = string | string[]
+
 export interface Testrunner extends Hooks, Omit<WebdriverIO, 'capabilities'>, WebdriverIO.HookFunctionExtension {
     /**
      * Defines a set of capabilities you want to run in your testrunner session. Check out the
@@ -316,6 +318,7 @@ export interface Testrunner extends Hooks, Omit<WebdriverIO, 'capabilities'>, We
     /**
      * Define specs for test execution.
      */
+    // specs?: SpecFile[]
     specs?: string[]
     /**
      * Exclude specs from test execution.

--- a/packages/webdriverio/src/constants.ts
+++ b/packages/webdriverio/src/constants.ts
@@ -51,7 +51,9 @@ export const WDIO_DEFAULTS: Options.Definition<Options.WebdriverIO & Options.Tes
         }
     },
     /**
-     * define specs for test execution
+     * Define specs for test execution. You can either specify a glob
+     * pattern to match multiple files at once or wrap a glob or set of
+     * paths into an array to run them within a single worker process.
      */
     specs: {
         type: 'object',

--- a/tests/typings/sync/config.ts
+++ b/tests/typings/sync/config.ts
@@ -1,5 +1,14 @@
 const config: WebdriverIO.Config = {
     capabilities: [{}],
+
+    specs: [
+        'foobar.js',
+        [
+            'foo.js',
+            'bar.js'
+        ]
+    ],
+
     beforeTest () {
         const size = browser.getWindowSize()
         size.height.toFixed(2)

--- a/website/docs/Options.md
+++ b/website/docs/Options.md
@@ -207,9 +207,9 @@ Default: `false`
 The following options (including the ones listed above) are defined only for running WebdriverIO with the WDIO testrunner:
 
 ### specs
-Define specs for test execution.
+Define specs for test execution. You can either specify a glob pattern to match multiple files at once or wrap a glob or set of paths into an array to run them within a single worker process.
 
-Type: `String[]`<br />
+Type: `(String | String[])[]`<br />
 Default: `[]`
 
 ### exclude


### PR DESCRIPTION
## Proposed changes

As mentioned in a [recent blog post](https://webdriver.io/blog/2021/03/23/grouping-specs) WebdriverIO supports grouping spec files by wrapping them into an array. Unfortunately we don't have TS support for this nor updated our docs.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

work in progress

### Reviewers: @webdriverio/project-committers
