### PR TITLE
chore: up puppeteer-core@10.1.0

### DIFF
--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -30,7 +30,7 @@
     "@wdio/utils": "7.7.5",
     "chrome-launcher": "^0.14.0",
     "edge-paths": "^2.1.0",
-    "puppeteer-core": "^9.1.0",
+    "puppeteer-core": "^10.1.0",
     "query-selector-shadow-dom": "^1.0.0",
     "ua-parser-js": "^0.7.21",
     "uuid": "^8.0.0"

--- a/packages/wdio-devtools-service/package.json
+++ b/packages/wdio-devtools-service/package.json
@@ -39,7 +39,7 @@
     "istanbul-lib-report": "^3.0.0",
     "istanbul-reports": "^3.0.2",
     "lighthouse": "7.3.0",
-    "puppeteer-core": "^9.1.0",
+    "puppeteer-core": "^10.1.0",
     "speedline": "^1.4.1",
     "stable": "^0.1.8",
     "webdriverio": "7.7.5"

--- a/packages/webdriverio/package.json
+++ b/packages/webdriverio/package.json
@@ -79,7 +79,7 @@
     "lodash.isplainobject": "^4.0.6",
     "lodash.zip": "^4.2.0",
     "minimatch": "^3.0.4",
-    "puppeteer-core": "^9.1.0",
+    "puppeteer-core": "^10.1.0",
     "query-selector-shadow-dom": "^1.0.0",
     "resq": "^1.9.1",
     "rgb2hex": "0.2.5",


### PR DESCRIPTION
## Proposed changes

I want to up puppeteer-core to 10.1.0 version in which added method `emulateCPUThrottling` - https://pptr.dev/#?product=Puppeteer&version=v10.1.0&show=api-pageemulatecputhrottlingfactor.

### Reviewers: @webdriverio/project-committers
