### PR TITLE
Propagate chrome flags and user data dir to `chrome-launcher`

### DIFF
--- a/packages/devtools/tests/__snapshots__/launcher.test.ts.snap
+++ b/packages/devtools/tests/__snapshots__/launcher.test.ts.snap
@@ -168,6 +168,7 @@ Array [
       ],
       "chromePath": "/foo/bar",
       "ignoreDefaultFlags": true,
+      "userDataDir": false,
     },
   ],
 ]
@@ -209,6 +210,51 @@ Array [
       "chromePath": undefined,
       "ignoreDefaultFlags": true,
       "port": 8041,
+      "userDataDir": false,
+    },
+  ],
+]
+`;
+
+exports[`launch chrome with custom user data dir 1`] = `
+Array [
+  Array [
+    Object {
+      "chromeFlags": Array [
+        "--enable-automation",
+        "--disable-popup-blocking",
+        "--disable-extensions",
+        "--disable-background-networking",
+        "--disable-background-timer-throttling",
+        "--disable-backgrounding-occluded-windows",
+        "--disable-sync",
+        "--metrics-recording-only",
+        "--disable-default-apps",
+        "--mute-audio",
+        "--no-first-run",
+        "--no-default-browser-check",
+        "--disable-hang-monitor",
+        "--disable-prompt-on-repost",
+        "--disable-client-side-phishing-detection",
+        "--password-store=basic",
+        "--use-mock-keychain",
+        "--disable-component-extensions-with-background-pages",
+        "--disable-breakpad",
+        "--disable-dev-shm-usage",
+        "--disable-ipc-flooding-protection",
+        "--disable-renderer-backgrounding",
+        "--force-fieldtrials=*BackgroundTracing/default/",
+        "--enable-features=NetworkService,NetworkServiceInProcess",
+        "--disable-features=site-per-process,TranslateUI,BlinkGenPropertyTrees",
+        "--window-position=0,0",
+        "--window-size=1200,900",
+        "--enable-features=NetworkService",
+        "--someOtherFlag",
+        "--anotherFlag",
+      ],
+      "chromePath": undefined,
+      "ignoreDefaultFlags": true,
+      "userDataDir": "/foo/bar",
     },
   ],
 ]
@@ -249,6 +295,7 @@ Array [
       ],
       "chromePath": undefined,
       "ignoreDefaultFlags": true,
+      "userDataDir": false,
     },
   ],
 ]
@@ -275,6 +322,7 @@ Array [
       ],
       "chromePath": undefined,
       "ignoreDefaultFlags": true,
+      "userDataDir": false,
     },
   ],
 ]
@@ -327,6 +375,7 @@ Array [
       ],
       "chromePath": undefined,
       "ignoreDefaultFlags": true,
+      "userDataDir": false,
     },
   ],
 ]
@@ -366,6 +415,7 @@ Array [
       ],
       "chromePath": undefined,
       "ignoreDefaultFlags": true,
+      "userDataDir": false,
     },
   ],
 ]

--- a/packages/devtools/tests/launcher.test.ts
+++ b/packages/devtools/tests/launcher.test.ts
@@ -122,6 +122,16 @@ test('overriding chrome default flags (backwards compat)', async () => {
     expect(pages[1].close).toBeCalledTimes(0)
 })
 
+test('launch chrome with custom user data dir', async () => {
+    await launch({
+        browserName: 'chrome',
+        'goog:chromeOptions': {
+            args: ['enable-features=NetworkService', 'someOtherFlag', 'user-data-dir=/foo/bar', 'anotherFlag']
+        }
+    })
+    expect(launchChromeBrowser.mock.calls).toMatchSnapshot()
+})
+
 test('launch chrome with chrome port', async () => {
     const browser = await launch({
         browserName: 'chrome',


### PR DESCRIPTION
When running a session through devtools with the following capabilities:

```js
capabilities: [{
    browserName: 'chrome',
    'goog:chromeOptions': {
        args: ['userdata-dir=foobar', 'otherflags']
    }
}]
```

the userdata dir is not propagated into the `userDataDir` option of the `chrome-launcher` call. See also #7144