### PR TITLE
Don't show error diff if 'actual' and 'expected' are empty

### DIFF
--- a/packages/wdio-reporter/src/stats/test.ts
+++ b/packages/wdio-reporter/src/stats/test.ts
@@ -100,13 +100,10 @@ export default class TestStats extends RunnableStats {
          * and formats it if so. Otherwise, just leaves error as is
          */
         const formattedErrors = errors?.map((err: Error) => (
-            (
-                err instanceof AssertionError ||
-                (
-                    typeof (err as AssertionError).expected !== 'undefined' &&
-                    typeof (err as AssertionError).actual !== 'undefined'
-                )
-            )
+            /**
+             * only format if error object has either an "expected" or "actual" property set
+             */
+            ((err as AssertionError).expected || (err as AssertionError).actual)
                 ? this._stringifyDiffObjs(err as AssertionError)
                 : err
         ))

--- a/packages/wdio-reporter/tests/stats/test.test.ts
+++ b/packages/wdio-reporter/tests/stats/test.test.ts
@@ -86,4 +86,10 @@ describe('TestStats', () => {
         expect(stat.error?.message).toContain('actual')
         expect(stat.error?.message).toContain('expected')
     })
+
+    it('should not diff if "actual" and "expected" are empty', () => {
+        stat.fail([new AssertionError({ message: 'foobar', actual: '', expected: '' })])
+        expect(stat.error?.message).not.toContain('actual')
+        expect(stat.error?.message).not.toContain('expected')
+    })
 })


### PR DESCRIPTION
## Proposed changes

If someone would throw an error in an Jasmine suite, Jasmine would make an assertion error out of it with `actual` and `expected` properties set to nothing, resulting in the following message:

```
 "spec" Reporter:                                                                                                     
------------------------------------------------------------------                                                    
[Chrome 94.0.4604.0 darwin #0-0] Running: Chrome (v94.0.4604.0) on darwin                                             
[Chrome 94.0.4604.0 darwin #0-0] Session ID: 4ebc517c-e651-470a-84e6-ec294f0eb21c                                     
[Chrome 94.0.4604.0 darwin #0-0]                                                                                      
[Chrome 94.0.4604.0 darwin #0-0] » /jasmine/foo.spec.js                                                               
[Chrome 94.0.4604.0 darwin #0-0] webdriver.io page                                                                    
[Chrome 94.0.4604.0 darwin #0-0]    ✖ should have the right title                                                     
[Chrome 94.0.4604.0 darwin #0-0]                                                                                      
[Chrome 94.0.4604.0 darwin #0-0] 1 failing (24ms)                                                                     
[Chrome 94.0.4604.0 darwin #0-0]                                                                                      
[Chrome 94.0.4604.0 darwin #0-0] 1) webdriver.io page should have the right title                                     
[Chrome 94.0.4604.0 darwin #0-0] Error: foobar                                                                        
      actual expected                                                                                                 
                                                                                                                      
      ''                                                                                                              
                                                                                                                      
[Chrome 94.0.4604.0 darwin #0-0] Error: foobar                                                                        
[Chrome 94.0.4604.0 darwin #0-0]     at UserContext.<anonymous> (/path/to/examples/wdio/jasmine/foo.spec.js:7:19)                                                                              
[Chrome 94.0.4604.0 darwin #0-0]     at UserContext.executeSync (/path/to/packages/wdio-sync/src/index.ts:39:22)                                                                               
[Chrome 94.0.4604.0 darwin #0-0]     at /path/to/packages/wdio-sync/src/index.ts:74:33
```

This doesn't help anyone, so I modified the logic to ensure one of the properties is set.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
