### PR TITLE
Don't report pending in Jasmine as error in Sauce

### DIFF
--- a/packages/wdio-sauce-service/src/service.ts
+++ b/packages/wdio-sauce-service/src/service.ts
@@ -133,7 +133,7 @@ export default class SauceService implements Services.ServiceInstance {
          * This should not be done for UP because it's not supported yet and
          * should be removed when UP supports `sauce:context`
          */
-        if (results.error && !this._isUP){
+        if (results.error && results.error.stack && !this._isUP){
             this._reportErrorLog(results.error)
         }
 
@@ -162,7 +162,8 @@ export default class SauceService implements Services.ServiceInstance {
             return
         }
 
-        if (!results.passed) {
+        const isJasminePendingError = typeof results.error === 'string' && results.error.includes('marked Pending')
+        if (!results.passed && !isJasminePendingError) {
             ++this._failures
         }
     }

--- a/packages/wdio-sauce-service/tests/service.test.ts
+++ b/packages/wdio-sauce-service/tests/service.test.ts
@@ -244,6 +244,20 @@ test('afterTest', () => {
         .forEach((line:string) => expect(browser.execute).toBeCalledWith(`sauce:context=${line}`))
 })
 
+test('afterTest should not mark test as fail if pending was called in Jasmine', () => {
+    const service = new SauceService({}, {}, {} as any)
+    service['_reportErrorLog'] = jest.fn()
+    expect(service['_failures']).toBe(0)
+    service.afterTest({} as any, {}, {
+        retries: { attempts: 0, limit: 0 },
+        error: '=> marked Pendingfoobar',
+        result: undefined,
+        duration: 0,
+        passed: false,
+    } as any)
+    expect(service['_failures']).toBe(0)
+})
+
 test('beforeFeature should set job-name', () => {
     const service = new SauceService({}, {}, { user: 'foobar', key: '123' } as any)
     service['_browser'] = browser


### PR DESCRIPTION
## Proposed changes

A test suite as follows:

```js
describe('webdriver.io page', () => {
    it('should have the right title', () => {
        if (some condition) {
            pending('foobar')
        }
        browser.url('https://webdriver.io')
        expect(browser).toHaveTitle('WebdriverIO · Next-gen browser and mobile automation test framework for Node.js | WebdriverIO')
    })
})
```

would be correctly marked as pending in WebdriverIO but would mark a Sauce Labs job as failing because `results.passed` is not `true`. This little fix ensures that pending errors in Jasmine are reported properly.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
