### PR TITLE
Allow to set custom job name in Sauce Labs service

### DIFF
--- a/packages/wdio-sauce-service/README.md
+++ b/packages/wdio-sauce-service/README.md
@@ -2,12 +2,17 @@ WebdriverIO Sauce Service
 =========================
 
 > WebdriverIO service that provides a better integration into Sauce Labs. This service can be used for:
-> - the Sauce Labs virtual machine cloud (desktop web and em/simulators) and can update the job metadata ('name'*, 'passed', 'tags', 'public', 'build', 'custom-data') and runs Sauce Connect if desired.
-> - the Sauce Labs Real Device cloud (iOS and Android) and can **ONLY** update the job status to passed / failed
 
-> - By default the Sauce Service will update the 'name' of the job when the job starts. This will give you the option to update the name at any given point in time.
-> - The only time when you can't update the name of the job is when you execute a retry or a session reload.
-> - The Sauce Service will also push the error stack of a failed test to the Sauce Labs commands tab
+- the Sauce Labs virtual machine cloud (desktop web and emu/simulators) and can update the job metadata ('name'*, 'passed', 'tags', 'public', 'build', 'custom-data') and runs Sauce Connect if desired.
+- the Sauce Labs Real Device cloud (iOS and Android) and can **ONLY** update the job status to passed / failed
+
+What else will this service do for you:
+
+- By default the Sauce Service will update the 'name' of the job when the job starts. This will give you the option to update the name at any given point in time.
+- You can define a `setJobName` parameter and customise the job name according to your capabilities, options and suite title
+- The Sauce Service will also push the error stack of a failed test to the Sauce Labs commands tab
+- It will allow you to automatically configure and spin up [Sauce Connect](https://wiki.saucelabs.com/display/DOCS/Sauce+Connect+Proxy)
+- And it will set context points in your command list to identify which commands were executed in what test
 
 ## Installation
 
@@ -31,17 +36,11 @@ Instructions on how to install `WebdriverIO` can be found [here.](https://webdri
 
 ## Configuration
 
-In order to use the service for the virtual machine and em/simulator cloud you need to set `user` and `key` in your `wdio.conf.js` file. It will automatically
-use Sauce Labs to run your integration tests.
-If you run your tests on Sauce Labs you can specify the region you want to run your tests in via the `region` property.
-Available short handles for regions are `us` (default), `eu` and `apac`. These regions are used for the Sauce Labs VM cloud and the Sauce Labs Real Device Cloud. If you don't provide the region, it defaults to `us`.
+In order to use the service for the virtual machine and em/simulator cloud you need to set `user` and `key` in your `wdio.conf.js` file. It will automatically use Sauce Labs to run your integration tests. If you run your tests on Sauce Labs you can specify the region you want to run your tests in via the `region` property. Available short handles for regions are `us` (default), `eu` and `apac`. These regions are used for the Sauce Labs VM cloud and the Sauce Labs Real Device Cloud. If you don't provide the region, it defaults to `us`.
 
-> NOTE:\
-> By default the `ondemand.us-west-1.saucelabs.com` US endpoint will be used. This is the new Unified Platform endpoint. If you want to use the *old* endpoint then
-> don't provide a region and add `hostname: ondemand.saucelabs.com` to your configuration file.
+> NOTE: By default the `ondemand.us-west-1.saucelabs.com` US endpoint will be used. This is the new Unified Platform endpoint. If you want to use the *old* endpoint then don't provide a region and add `hostname: ondemand.saucelabs.com` to your configuration file.
 
-If you want WebdriverIO to automatically spin up a [Sauce Connect](https://wiki.saucelabs.com/display/DOCS/Sauce+Connect+Proxy) tunnel,
-you just need to set `sauceConnect: true`. If you would like to change data center to EU add `region:'eu'` or APAC add `region:'apac'` as US data center is set as default (region only works on ^4.14.1 or ^5.0.0).
+If you want WebdriverIO to automatically spin up a [Sauce Connect](https://wiki.saucelabs.com/display/DOCS/Sauce+Connect+Proxy) tunnel, you just need to set `sauceConnect: true`. If you would like to change data center to EU add `region:'eu'` or APAC add `region:'apac'` as US data center is set as default (region only works on ^4.14.1 or ^5.0.0).
 
 ```js
 // wdio.conf.js
@@ -131,8 +130,7 @@ capabilities = [
 In order to authorize to the Sauce Labs service your config needs to contain a [`user`](https://webdriver.io/docs/options#user) and [`key`](https://webdriver.io/docs/options#key) option.
 
 ### maxErrorStackLength
-This service will automatically push the error stack to Sauce Labs when a test fails. By default it will only push the first 5
-lines, but if needed this can be changed. Be aware that more lines will result in more WebDriver calls which might slow down the execution.
+This service will automatically push the error stack to Sauce Labs when a test fails. By default it will only push the first 5 lines, but if needed this can be changed. Be aware that more lines will result in more WebDriver calls which might slow down the execution.
 
 Type: `number`<br />
 Default: `5`
@@ -150,8 +148,7 @@ Default: `false`
 ### sauceConnectOpts
 Apply Sauce Connect options (e.g. to change port number or logFile settings). See [this list](https://wiki.saucelabs.com/display/DOCS/Sauce+Connect+Proxy+Command-Line+Quick+Reference+Guide) for more information. Per default the service disables SC proxy auto-detection as via `noAutodetect` as this can be unreliable for some machines.
 
-NOTE: When specifying the options the `--` should be omitted.
-It can also be turned into camelCase (e.g. `shared-tunnel` or `sharedTunnel`).
+NOTE: When specifying the options the `--` should be omitted. It can also be turned into camelCase (e.g. `shared-tunnel` or `sharedTunnel`).
 
 Type: `Object`<br />
 Default: `{ noAutodetect: true }`

--- a/packages/wdio-sauce-service/src/service.ts
+++ b/packages/wdio-sauce-service/src/service.ts
@@ -91,7 +91,16 @@ export default class SauceService implements Services.ServiceInstance {
         }
 
         if (this._browser && !this._isJobNameSet) {
-            this._browser.execute('sauce:job-name=' + this._suiteTitle)
+            let jobName = this._suiteTitle
+            if (this._options.setJobName) {
+                jobName = this._options.setJobName(
+                    this._config,
+                    this._capabilities,
+                    this._suiteTitle!
+                )
+            }
+
+            this._browser.execute(`sauce:job-name=${jobName}`)
             this._isJobNameSet = true
         }
 
@@ -358,6 +367,14 @@ export default class SauceService implements Services.ServiceInstance {
             }
 
             body[prop] = caps[prop]
+        }
+
+        if (this._options.setJobName) {
+            body.name = this._options.setJobName(
+                this._config,
+                this._capabilities,
+                this._suiteTitle!
+            )
         }
 
         body.passed = failures === 0

--- a/packages/wdio-sauce-service/src/types.ts
+++ b/packages/wdio-sauce-service/src/types.ts
@@ -1,4 +1,5 @@
 import type { SauceConnectOptions } from 'saucelabs'
+import type { Capabilities, Options } from '@wdio/types'
 
 export interface SauceServiceConfig {
     /**
@@ -44,4 +45,13 @@ export interface SauceServiceConfig {
      * @deprecated
      */
     scRelay?: boolean
+
+    /**
+     * Dynamically control the name of the job
+     */
+    setJobName?: (
+        config: Options.Testrunner,
+        capabilities: Capabilities.RemoteCapability,
+        suiteTitle: string
+    ) => string
 }

--- a/packages/wdio-sauce-service/tests/service.test.ts
+++ b/packages/wdio-sauce-service/tests/service.test.ts
@@ -69,20 +69,43 @@ test('beforeSession should set to unknown creds if no sauce user and key are fou
 })
 
 test('beforeTest should set job-name', () => {
-    const service = new SauceService({}, {}, { user: 'foobar', key: '123' })
+    const service = new SauceService({}, {}, { user: 'foobar', key: '123', capabilities: {} })
     service['_browser'] = browser
     service['_suiteTitle'] = 'Suite Title'
     expect(service['_isJobNameSet']).toBe(false)
     service.beforeTest({
         fullName: 'my test can do something',
         description: 'foobar'
-    })
+    } as any)
     expect(service['_isJobNameSet']).toBe(true)
     expect(browser.execute).toBeCalledWith('sauce:job-name=Suite Title')
 })
 
+test('beforeTest should set job-name via custom setJobName method', () => {
+    const service = new SauceService({
+        setJobName: (config, caps, title) => {
+            return `${config.region}-${(caps as any).browserName}-${title}`
+        }
+    }, {
+        browserName: 'foobar'
+    }, {
+        user: 'foobar',
+        key: '123',
+        region: 'barfoo' as any
+    } as any)
+    service['_browser'] = browser
+    service['_suiteTitle'] = 'Suite Title'
+    expect(service['_isJobNameSet']).toBe(false)
+    service.beforeTest({
+        fullName: 'my test can do something',
+        description: 'foobar'
+    } as any)
+    expect(service['_isJobNameSet']).toBe(true)
+    expect(browser.execute).toBeCalledWith('sauce:job-name=barfoo-foobar-Suite Title')
+})
+
 test('beforeTest not should set job-name when it has already been set', () => {
-    const service = new SauceService({}, {}, { user: 'foobar', key: '123' })
+    const service = new SauceService({}, {}, { user: 'foobar', key: '123', capabilities: {} })
     service['_browser'] = browser
     service['_suiteTitle'] = 'Suite Title'
     service['_isJobNameSet'] = true
@@ -90,7 +113,7 @@ test('beforeTest not should set job-name when it has already been set', () => {
     service.beforeTest({
         fullName: 'my test can do something',
         description: 'foobar'
-    })
+    } as any)
     expect(service['_isJobNameSet']).toBe(true)
     expect(browser.execute).not.toBeCalledWith('sauce:job-name=Suite Title')
 })
@@ -200,7 +223,7 @@ test('afterTest', () => {
         '    at UserContext.executeSync (/Users/node_modules/@wdio/sync/build/index.js:25:22)\n' +
         '    at /Users/node_modules/@wdio/sync/build/index.js:46:68'
     service['_isUP'] = true
-    service.afterTest({}, {}, {
+    service.afterTest({} as any, {}, {
         error: {
             matcherName: 'toEqual',
             message: 'Expected true to equal false.',
@@ -209,11 +232,11 @@ test('afterTest', () => {
             expected: [false, 'LoginPage page was not shown'],
             actual: true
         }
-    })
+    } as any)
     expect(browser.execute).toBeCalledTimes(0)
-    browser.execute.mockClear()
+    ;(browser.execute as jest.Mock).mockClear()
     service['_isUP'] = false
-    service.afterTest({}, {}, {
+    service.afterTest({} as any, {}, {
         error: {
             matcherName: 'toEqual',
             message: 'Expected true to equal false.',
@@ -222,13 +245,13 @@ test('afterTest', () => {
             expected: [false, 'LoginPage page was not shown'],
             actual: true
         }
-    })
+    } as any)
     expect(browser.execute).toBeCalledTimes(5)
     stack.split(/\r?\n/).forEach((line:string) => expect(browser.execute).toBeCalledWith(`sauce:context=${line}`))
-    browser.execute.mockClear()
+    ;(browser.execute as jest.Mock).mockClear()
     const maxErrorStackLength = 3
     service['_maxErrorStackLength'] = maxErrorStackLength
-    service.afterTest({}, {}, {
+    service.afterTest({} as any, {}, {
         error: {
             matcherName: 'toEqual',
             message: 'Expected true to equal false.',
@@ -237,7 +260,7 @@ test('afterTest', () => {
             expected: [false, 'LoginPage page was not shown'],
             actual: true
         }
-    })
+    } as any)
     expect(browser.execute).toBeCalledTimes(maxErrorStackLength)
     stack.split(/\r?\n/)
         .slice(0, maxErrorStackLength)
@@ -753,6 +776,24 @@ test('getBody with name Capability (W3C)', () => {
     })
 })
 
+test('getBody with custom setJobName method', () => {
+    const service = new SauceService({
+        setJobName: () => 'foobarloo'
+    }, {
+        'sauce:options': {
+            name: 'bizarre'
+        }
+    }, {} as any)
+    service['_browser'] = browser
+    service['_suiteTitle'] = 'jojo'
+    service.beforeSession()
+
+    expect(service.getBody(1)).toEqual({
+        name: 'foobarloo',
+        passed: false
+    })
+})
+
 test('getBody without multiremote', () => {
     const service = new SauceService({}, {
         tags: ['jobTag'],
@@ -816,10 +857,11 @@ test('strip ansi from _reportErrorLog', () => {
     service['_browser'] = { execute: jest.fn() } as any
     const error = new Error('Received: [31m""[39m')
     service['_reportErrorLog'](error)
-    expect(service['_browser'].execute).toBeCalledWith('sauce:context=Error: Received: ""')
+    expect(service['_browser']!.execute).toBeCalledWith('sauce:context=Error: Received: ""')
 })
 
 afterEach(() => {
+    // @ts-ignore
     browser = undefined
     ;(got.put as jest.Mock).mockClear()
 })


### PR DESCRIPTION
## Proposed changes

Users want to have more options to set the job name. This patch adds this capability. It might not have all the data someone needs but we can see what people report and add more parameter if necessary.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
