### PR TITLE
Support for @wdio/sync alongside the new v7.9.x Async API

### DIFF
--- a/packages/wdio-utils/src/shim.ts
+++ b/packages/wdio-utils/src/shim.ts
@@ -367,7 +367,8 @@ export function switchSyncFlag (fn: Function) {
         const result = fn.apply(this, args)
 
         if (typeof result.finally === 'function') {
-            return result.finally(() => (runAsync = switchFlag))
+            runAsync = switchFlag
+            return result
         }
 
         if (typeof result === 'function') {


### PR DESCRIPTION
### Discussed in https://github.com/webdriverio/webdriverio/discussions/7268

<div type='discussions-op-text'>

<sup>Originally posted by **RossVertizan** August 11, 2021</sup>
This discussion follows on from a question I asked in the #6702 (Replacement for Node-Fibers) discussion.

In converting some of my tests to the new (v7.9.x) Async API, I encountered some problems in which the Page Objects did not appear to be working.  I was seeing errors of the form "somePage.button.click" is not a function.  This is the telltale sign that a Promise is being returned, which does not have a click function, rather than an element that does (if it's a button).  This caused me to ask my two questions:
1. Is the new "chained-await" syntax supported in Page Objects?
2. Do we need to do anything with the @wdio/sync package - such as uninstall it?

The answer to the first question is yes.
The answer to the second question is no.  There is no need to uninstall @wdio/sync, it should exist alongside the new async API.  In his answer to me, @christian-bromann provided an example of a sync and an async test in the same suite.

However, I still had my problem, so I started digging and I found an error that is caused when the @wdio/sync package is still installed when 'expect' is being used.

This is what I did to create my testing environment:
```text
mkdir async_api
cd async_api
npm init -y
npm install @wdio/cli
.\node_modules\.bin\wdio
[Accpeted default answers to all questions and selected to have test cases created]
.\node_modules\.bin\wdio
```
The test runs to completion and passes.

I then modified the example.e2e.js file to make a sync test, a standard await test, a chained await (new API) test without expects and then a chained await (new API) with expects, as follows:
```javascript
const LoginPage = require('../pageobjects/login.page');
const SecurePage = require('../pageobjects/secure.page');

describe('My Login application', () => {
    it('should open the browser at the correct page', async () => {
        await LoginPage.open();
    })

    // it('should demonstrate the use of sync mode (@wdio/sync)', () => {
    //     LoginPage.login('tomsmith', 'SuperSecretPassword!');
    //     expect(SecurePage.flashAlert).toBeExisting();
    //     expect(SecurePage.flashAlert).toHaveTextContaining(
    //         'You logged into a secure area!');
    //     SecurePage.btnSubmit.click()
    // });

    it('should demonstrate the use of standard await calls', async () => {
        await LoginPage.login('tomsmith', 'SuperSecretPassword!');
        expect(await SecurePage.flashAlert).toBeExisting();
        expect(await SecurePage.flashAlert).toHaveTextContaining(
            'You logged into a secure area!');
        await( await SecurePage.btnSubmit).click();
    });

    it('should demonstrate the use of new chained await API - excluding expect calls', async () => {
        await LoginPage.login('tomsmith', 'SuperSecretPassword!');
        await(SecurePage.btnSubmit).click();
    });

    it('should demonstrate the use of new chained await API', async () => {
        await LoginPage.login('tomsmith', 'SuperSecretPassword!');
        expect(await SecurePage.flashAlert).toBeExisting();
        expect(await SecurePage.flashAlert).toHaveTextContaining(
            'You logged into a secure area!');
        await(SecurePage.btnSubmit).click();
    });
});
```

and I modified the secure.page.js to give access to the logout button, so we come back to the login page as follows:
```javascript
const Page = require('./page');

/**
 * sub page containing specific selectors and methods for a specific page
 */
class SecurePage extends Page {
    /**
     * define selectors using getter methods
     */
    get flashAlert () { return $('#flash') }
    get btnSubmit () { return $('a[class=\'button secondary radius\']') }
}

module.exports = new SecurePage();
```

Note that the sync test is commented out, this is because we have not installed the @wdio/sync package.  If we now run the test, we get 4 passing tests.

If we now install the @wdio/sync package:
```text
npm install @wdio/sync
```
and re-run the test, then the final test fails with the message:
```text
SecurePage.btnSubmit.click is not a function
```

As a side comment, at this stage it should be possible to uncomment the sync test.  However, when I do that it fills in the username, but does not fill in the password field and the test hangs and eventually fails.

Uninstalling @wdio/sync corrects the issue.

A couple of other notes:
1. I am not clear what the syntax should be for the expect statement, I have tried:
```text
expect(await SecurePage.flashAlert).toBeExisting();
```
and
```text
await expect(SecurePage.flashAlert).toBeExisting();
```
and
```text
await expect(await SecurePage.flashAlert).toBeExisting();
```
they all have the same effect i.e. cause the test to fail.

2. I have used the Page Object files as they are other than the modification to secure.page.js mentioned above.  Specifically, the class method 'login' in login.page.js has not been marked as async.

This feels a bit more like an issue than a discussion, but comments are welcome. </div>