### PR TITLE
Run after hook even if session initiation fails

### DIFF
--- a/packages/wdio-runner/src/index.ts
+++ b/packages/wdio-runner/src/index.ts
@@ -157,6 +157,11 @@ export default class Runner extends EventEmitter {
          * return if session initialisation failed
          */
         if (!browser) {
+            await executeHooksWithArgs(
+                'after',
+                this._config.after as Function,
+                [1, this._caps, this._specs]
+            )
             return this._shutdown(1, retries)
         }
 

--- a/packages/wdio-runner/tests/index-initSession.test.ts
+++ b/packages/wdio-runner/tests/index-initSession.test.ts
@@ -1,6 +1,6 @@
 import WDIORunner from '../src'
 import BaseReporter from '../src/reporter'
-import type { SingleConfigOption, Capability } from '@wdio/config'
+import type { Options, Capabilities } from '@wdio/types'
 
 jest.mock('../src/utils', () => ({
     __esModule: true,
@@ -19,8 +19,8 @@ jest.mock('../src/utils', () => ({
     }
 }))
 
-const config = {} as any as SingleConfigOption
-const capability: Capability = { browserName: 'foo' }
+const config: Options.WebdriverIO = { capabilities: {} }
+const capability: Capabilities.Capabilities = { browserName: 'foo' }
 
 describe('wdio-runner', () => {
     describe('_initSession', () => {
@@ -34,7 +34,7 @@ describe('wdio-runner', () => {
         })
 
         it('command event', async () => {
-            const browser = await runner._initSession(config, capability)
+            const browser = await runner['_initSession'](config, capability)
 
             const command = { foo: 'bar' }
             // @ts-ignore mock feature
@@ -44,7 +44,7 @@ describe('wdio-runner', () => {
         })
 
         it('result event', async () => {
-            const browser = await runner._initSession(config, capability)
+            const browser = await runner['_initSession'](config, capability)
 
             const result = { bar: 'foo' }
             // @ts-ignore mock feature
@@ -55,7 +55,7 @@ describe('wdio-runner', () => {
 
         it('should add user flags to browser but not overwrite', async () => {
             // @ts-ignore test scenario
-            const browser = await runner._initSession(undefined, undefined, { isFoo: true, $: true, $$: false, isBar: true })
+            const browser = await runner['_initSession'](undefined, undefined, { isFoo: true, $: true, $$: false, isBar: true })
 
             expect(typeof browser!.$).toBe('function')
             expect(typeof browser!.$$).toBe('function')


### PR DESCRIPTION
## Proposed changes

If session initiation fails WebdriverIO currently omits to run the after hook. This seems inconsistent.

Fixes #7261

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
