### PR TITLE
fix: correct appium protocol use of app/bundle ID

### DIFF
--- a/packages/wdio-protocols/protocols/appium.json
+++ b/packages/wdio-protocols/protocols/appium.json
@@ -382,13 +382,8 @@
       "parameters": [{
         "name": "appId",
         "type": "string",
-        "description": "REQUIRED for Android",
-        "required": false
-      }, {
-        "name": "bundleId",
-        "type": "string",
-        "description": "REQUIRED for iOS",
-        "required": false
+        "description": "App ID (package ID for Android, bundle ID for iOS)",
+        "required": true
       }],
       "support": {
         "ios": {
@@ -408,13 +403,8 @@
       "parameters": [{
         "name": "appId",
         "type": "string",
-        "description": "REQUIRED for Android",
-        "required": false
-      }, {
-        "name": "bundleId",
-        "type": "string",
-        "description": "REQUIRED for iOS",
-        "required": false
+        "description": "App ID (package ID for Android, bundle ID for iOS)",
+        "required": true
       }],
       "support": {
         "ios": {
@@ -435,13 +425,8 @@
       "parameters": [{
         "name": "appId",
         "type": "string",
-        "description": "REQUIRED for Android",
-        "required": false
-      }, {
-        "name": "bundleId",
-        "type": "string",
-        "description": "REQUIRED for iOS",
-        "required": false
+        "description": "App ID (package ID for Android, bundle ID for iOS)",
+        "required": true
       }],
       "support": {
         "ios": {
@@ -461,13 +446,8 @@
       "parameters": [{
         "name": "appId",
         "type": "string",
-        "description": "REQUIRED for Android",
-        "required": false
-      }, {
-        "name": "bundleId",
-        "type": "string",
-        "description": "REQUIRED for iOS",
-        "required": false
+        "description": "App ID (package ID for Android, bundle ID for iOS)",
+        "required": true
       }],
       "returns": {
         "type": "boolean",
@@ -493,13 +473,8 @@
       "parameters": [{
         "name": "appId",
         "type": "string",
-        "description": "REQUIRED for Android",
-        "required": false
-      }, {
-        "name": "bundleId",
-        "type": "string",
-        "description": "REQUIRED for iOS",
-        "required": false
+        "description": "App ID (package ID for Android, bundle ID for iOS)",
+        "required": true
       }],
       "returns": {
         "type": "number",


### PR DESCRIPTION
I think the existing Appium protocol definitions for app-related commands was based on a misreading of Appium's routes.js. There are a few routes that, due to backwards compatibility, wanted to introduce new payload parameter names, while supporting the old ones. To signify this, we used an array of arrays for the 'required' value in the payload definition.

The way this is actually parsed is encoded [here](https://github.com/appium/appium/blob/2.0/packages/base-driver/lib/protocol/protocol.js#L149-L166).

Essentially, WDIO just needs to send one of these. I chose `appId` since that is the more generic term, and we may remove support for the less-generic `bundleId` in Appium at some future point.