### PR TITLE
fix(webdriver): browser request should use btoa for basic auth, not atob

### DIFF
--- a/packages/webdriver/src/request/browser.ts
+++ b/packages/webdriver/src/request/browser.ts
@@ -38,7 +38,7 @@ export default class BrowserRequest extends WebDriverRequest {
         }
 
         if (options.username && options.password) {
-            const encodedAuth = atob(`${options.username}:${options.password}`)
+            const encodedAuth = btoa(`${options.username}:${options.password}`)
             kyOptions.headers = {
                 ...kyOptions.headers,
                 Authorization: `Basic ${encodedAuth}`

--- a/packages/webdriver/tests/request-browser.test.ts
+++ b/packages/webdriver/tests/request-browser.test.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import logger from '@wdio/logger'
 import _ky from 'ky'
 
@@ -447,6 +451,21 @@ describe('webdriver request', () => {
                 (e) => e
             )
             expect(result.message).toBe('ups')
+        })
+
+        it('should correctly handle username and password options', async () => {
+            const expectedResponse = { value: { 'element-6066-11e4-a52e-4f735466cecf': 'some-elem-123' } }
+            const req = new BrowserRequest('POST', path, {})
+
+            const opts = Object.assign(
+                req.defaultOptions,
+                { url: { pathname: '/session/foobar-123/element' } },
+                { username: 'foo', password: 'bar' },
+            )
+            const res = await req['_request'](opts)
+
+            expect(res).toEqual(expectedResponse)
+            expect(ky.mock.calls[0][1].headers.Authorization).toEqual('Basic Zm9vOmJhcg==')
         })
     })
 


### PR DESCRIPTION
Oops :-) I thought "atob" meant "ascii to base64", but it does not!