### PR TITLE
Fix error diffing in Jasmine

### DIFF
--- a/packages/wdio-reporter/src/stats/test.ts
+++ b/packages/wdio-reporter/src/stats/test.ts
@@ -103,7 +103,11 @@ export default class TestStats extends RunnableStats {
             /**
              * only format if error object has either an "expected" or "actual" property set
              */
-            ((err as AssertionError).expected || (err as AssertionError).actual)
+            ((err as AssertionError).expected || (err as AssertionError).actual) &&
+            /**
+             * and if they aren't already formated, e.g. in Jasmine
+             */
+            (err.message && !err.message.includes('Expected: ') && !err.message.includes('Received: '))
                 ? this._stringifyDiffObjs(err as AssertionError)
                 : err
         ))

--- a/packages/wdio-reporter/tests/stats/test.test.ts
+++ b/packages/wdio-reporter/tests/stats/test.test.ts
@@ -92,4 +92,9 @@ describe('TestStats', () => {
         expect(stat.error?.message).not.toContain('actual')
         expect(stat.error?.message).not.toContain('expected')
     })
+
+    it('should not diff if error is already diffed', () => {
+        stat.fail([new AssertionError({ message: 'foobar\nExpected: foo\nReceived: bar42', actual: 'true', expected: 'false' })])
+        expect(stat.error?.message).toContain('bar42')
+    })
 })


### PR DESCRIPTION
## Proposed changes

In Jasmine we already get a nice error diff and there is no need to try to stringify an element promise which currently causes failures to get passed through.

fixes #7409

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
