### PR TITLE
Allow to access Selenium v4 GraphQL data

### DIFF
--- a/packages/wdio-protocols/protocols/selenium.json
+++ b/packages/wdio-protocols/protocols/selenium.json
@@ -80,5 +80,43 @@
         "description": "Command to call on Selenium Hub. The only implemented action is to 'shutdown' the hub."
       }]
     }
+  },
+  "/graphql": {
+    "POST": {
+      "isHubCommand": true,
+      "command": "queryGrid",
+      "description": "Send GraphQL queries to the Selenium (hub or node) server to fetch data. (Only supported with Selenium v4 Server)",
+      "ref": "https://www.selenium.dev/documentation/grid/advanced_features/graphql_support/",
+      "parameters": [{
+        "name": "query",
+        "type": "string",
+        "description": "A GraphQL query to be send to the server.",
+        "required": true
+      }],
+      "examples": [
+        [
+          "const result = await browser.queryGrid('{ nodesInfo { nodes { status, uri } } }');",
+          "console.log(JSON.stringify(result, null, 4))",
+          "/**",
+          " * outputs:",
+          " * {",
+          " *   \"data\": {",
+          " *     \"nodesInfo\": {",
+          " *       \"nodes\": [{",
+          " *         \"status\": \"UP\",",
+          " *         \"uri\": \"http://192.168.0.39:4444\"",
+          " *       }]",
+          " *     }",
+          " *   }",
+          " * }",
+          " */"
+        ]
+      ],
+      "returns": {
+        "type": "Object",
+        "name": "data",
+        "description": "Result of the GraphQL query."
+      }
+    }
   }
 }


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
Selenium v4 grid uses GraphQL to store data about sessions. There just to be grid API endpoints that now don't work anymore (see #7444). We should allow users to make requests to this GraphQL endpoint.

**Describe the solution you'd like**
I suggest add a new [Selenium protocol command](https://github.com/webdriverio/webdriverio/blob/main/packages/wdio-protocols/protocols/selenium.json) that allows to make this request.

**Describe alternatives you've considered**
None

**Additional context**
https://www.selenium.dev/documentation/grid/advanced_features/graphql_support/
