### PR TITLE
Fix broken iFrame e2e test

### DIFF
--- a/e2e/protocol.test.ts
+++ b/e2e/protocol.test.ts
@@ -304,16 +304,16 @@ describe('frames', () => {
         expect(await browser.getTitle()).toBe('The Internet')
     })
 
-    it.skip('allows to switch to parent frame even if there isn\'t any', async () => {
+    it('allows to switch to parent frame even if there isn\'t any', async () => {
         await browser.navigateTo('http://guinea-pig.webdriver.io/two.html')
-        expect(await browser.getTitle()).toBe('two')
+        expect(await browser.getPageSource()).toContain('<title>two</title>')
         const iframe = await browser.findElement('css selector', 'iframe')
         await browser.switchToFrame(iframe)
-        expect(await browser.getTitle()).toBe('Light Bikes from Eric Corriel on Vimeo')
+        expect(await browser.getPageSource()).toContain('<title>Light Bikes from Eric Corriel on Vimeo</title>')
         await browser.switchToFrame(null)
-        expect(await browser.getTitle()).toBe('two')
+        expect(await browser.getPageSource()).toContain('<title>two</title>')
         await browser.switchToFrame(null)
-        expect(await browser.getTitle()).toBe('two')
+        expect(await browser.getPageSource()).toContain('<title>two</title>')
     })
 })
 


### PR DESCRIPTION
This patch https://github.com/webdriverio/webdriverio/commit/b93e7f40fbda87cd77ec525b2a92c86cfb4c58cc disabled an e2e test that seem to start failing for unknown reasons. Running the test locally seems fine. I suggest instead of using a 3rd party page to replace it with an own blank page that allows us to verify that switching to the iframe was successul.