### PR TITLE
Ignore errors in releaseActions click command

### DIFF
--- a/packages/webdriverio/src/commands/element/click.ts
+++ b/packages/webdriverio/src/commands/element/click.ts
@@ -1,4 +1,8 @@
+import logger from '@wdio/logger'
+
 import { ClickOptions } from '../../types'
+
+const log = logger('webdriverio/click')
 
 /**
  *
@@ -129,8 +133,15 @@ export default async function click (
                 button
             }]
         }])
+        const err = await this.releaseActions().then(
+            () => null,
+            (err) => err)
 
-        return this.releaseActions()
+        if (err) {
+            log.warn(`Failed to call "releaseAction" command due to: ${err.message}, ignoring!`)
+        }
+
+        return
     }
 
     const { width, height } = await this.getElementSize(this.elementId)

--- a/packages/webdriverio/tests/commands/element/click.test.ts
+++ b/packages/webdriverio/tests/commands/element/click.test.ts
@@ -333,6 +333,24 @@ describe('click test', () => {
         expect(elem.click({ button: 'not-suppported' })).rejects.toThrow('Button type not supported.')
     })
 
+    it('should ignore errors in releaseAction', async () => {
+        const browser = await remote({
+            baseUrl: 'http://foobar.com',
+            capabilities: {
+                browserName: 'foobar'
+            }
+        })
+        const elem = await browser.$('#foo')
+
+        await elem.click.call({
+            isW3C: true,
+            selector: 'foobar',
+            elementId: 'barfoo',
+            releaseActions: jest.fn().mockRejectedValue(new Error('some modal disturbs here')),
+            performActions: jest.fn().mockResolvedValue({})
+        }, {})
+    })
+
     afterEach(() => {
         got.mockClear()
     })


### PR DESCRIPTION
## Proposed changes

If a click command with parameters causing an alert to open the command fails as `releaseActions` fails due to a "modal open" error. We can safely ignore these errors.

fixes #6423

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
