### PR TITLE
feat(shared-store-service): export set and get value globally

### DIFF
--- a/packages/wdio-shared-store-service/README.md
+++ b/packages/wdio-shared-store-service/README.md
@@ -31,14 +31,14 @@ Get/set a value (plain object) to/from the store by key (string).
 
 `browser.sharedStore.get('key')` get value from store (returns `'value'`)
 
-You could also directly access to `setValue` and `getValue` handlers.
+You could also directly access to `setValue` and `getValue` async handlers.
 
 ```js
 import { setValue } from '@wdio/shared-store-service'
 
 // ...
-onPrepare: [function (config, capabilities) {
-    setValue('foo', 'bar')
+onPrepare: [async function (config, capabilities) {
+    await setValue('foo', 'bar')
 }],
 ```
 

--- a/packages/wdio-shared-store-service/README.md
+++ b/packages/wdio-shared-store-service/README.md
@@ -31,6 +31,17 @@ Get/set a value (plain object) to/from the store by key (string).
 
 `browser.sharedStore.get('key')` get value from store (returns `'value'`)
 
+You could also directly access to `setValue` and `getValue` handlers.
+
+```js
+import { setValue } from '@wdio/shared-store-service'
+
+// ...
+onPrepare: [function (config, capabilities) {
+    setValue('foo', 'bar')
+}],
+```
+
 IMPORTANT! Every spec file should be atomic and isolated from others specs.
 The idea of the service is to deal with very specific environment setup issues.
 Please avoid sharing test execution data!

--- a/packages/wdio-shared-store-service/src/index.ts
+++ b/packages/wdio-shared-store-service/src/index.ts
@@ -3,6 +3,7 @@ import type { JsonPrimitive, JsonCompatible } from '@wdio/types'
 import SharedStoreLauncher from './launcher'
 import SharedStoreService from './service'
 
+export { getValue, setValue } from './client'
 export default SharedStoreService
 export const launcher = SharedStoreLauncher
 

--- a/packages/wdio-shared-store-service/tests/index.test.ts
+++ b/packages/wdio-shared-store-service/tests/index.test.ts
@@ -1,10 +1,16 @@
 import * as WdioSharedStoreService from '../src'
 import SharedStoreLauncher from '../src/launcher'
 import SharedStoreService from '../src/service'
+import * as SharedStoreClient from '../src/client'
 
 describe('WdioSharedStoreService exports', () => {
     it('should export service and launcher', async () => {
         expect(WdioSharedStoreService.launcher).toBe(SharedStoreLauncher)
         expect(WdioSharedStoreService.default).toBe(SharedStoreService)
+    })
+
+    it('should export set and get value handler', () => {
+        expect(WdioSharedStoreService.getValue).toBe(SharedStoreClient.getValue)
+        expect(WdioSharedStoreService.setValue).toBe(SharedStoreClient.setValue)
     })
 })


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

Close #4723

In order to let user be able to store data in shared store service onPrepare and onComplete task, it was ask in the issue if we could export those handler directly in the index scope.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
