### PR TITLE
7324 - added support for fragment identifiers (#) in 3rd party doc 

### DIFF
--- a/scripts/docs-generation/3rdPartyDocs.js
+++ b/scripts/docs-generation/3rdPartyDocs.js
@@ -38,7 +38,7 @@ exports.generate3rdPartyDocs = async (sidebars) => {
             const readme = await downloadFromGitHub(githubUrl, branch, location)
             const id = `${packageName}`.replace(/@/g, '').replace(/\//g, '-')
 
-            const doc = normalizeDoc(readme, githubUrl,
+            const doc = normalizeDoc(readme, githubUrl, branch,
                 buildPreface(id, title, nameSingular, `${githubUrl}/edit/${branch}/${location}`),
                 suppressBuildInfo ? [] : buildInfo(packageName, githubUrl, npmUrl))
             await fs.writeFile(path.join(categoryDir, `_${id}.md`), doc, { encoding: 'utf-8' })
@@ -64,11 +64,13 @@ exports.generate3rdPartyDocs = async (sidebars) => {
 /**
  * Removes header from README.md
  * @param {string}  readme      readme content
+ * @param {string}  githubUrl     repo url
+ * @param {string}  branch     repo branch
  * @param {string}  preface     docusaurus header
  * @param {string}  repoInfo    repoInfo
  * @return {string}             readme content without header
  */
-function normalizeDoc(readme, githubUrl, preface, repoInfo) {
+function normalizeDoc(readme, githubUrl, branch, preface, repoInfo) {
     /**
      * remove badges
      */
@@ -106,9 +108,9 @@ function normalizeDoc(readme, githubUrl, preface, repoInfo) {
         for (const mdLink of mdLinks) {
             const urlMatcher = mdLink.match(/\[([^[]+)\]\((.*)\)/)
             const stringInParentheses = urlMatcher[2]
-            const url = stringInParentheses.startsWith('http')
+            const url = ( stringInParentheses.startsWith('http') || stringInParentheses.startsWith('#') )
                 ? stringInParentheses
-                : urljoin(githubUrl, 'blob', 'master', stringInParentheses)
+                : urljoin(githubUrl, 'blob', branch, stringInParentheses)
             readmeArr[idx] = readmeArr[idx].replace(`](${stringInParentheses})`, `](${url})`)
         }
     })


### PR DESCRIPTION
https://github.com/webdriverio/webdriverio/issues/7324

1. support fragment identifiers (#) in readme

currently, the doc generator doesn't support fragment identifiers (#) in 3rd party doc

Observed ~14 such cases in 3rd party docs that have broken links because of this

2. removed hard code `master` while forming such URLs and to use any branch provided in JSON only if not provided will user `master`. 

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
