### PR TITLE
feat(hooks): add onWorkerEnd hook implementation

### DIFF
--- a/examples/pageobject/wdio.conf.js
+++ b/examples/pageobject/wdio.conf.js
@@ -101,6 +101,9 @@ exports.config = {
     // for that worker as well as modify runtime environments in an async fashion.
     // onWorkerStart: function (cid, caps, specs, args, execArgv) {
     // },
+    // Gets executed just after a worker process has exited.
+    // onWorkerEnd: function (cid, caps, specs, args, execArgv) {
+    // },
     //
     // Gets executed before test execution begins. At this point you can access to all global
     // variables like `browser`. It is the perfect place to define custom commands.

--- a/examples/pageobject/wdio.conf.js
+++ b/examples/pageobject/wdio.conf.js
@@ -102,7 +102,7 @@ exports.config = {
     // onWorkerStart: function (cid, caps, specs, args, execArgv) {
     // },
     // Gets executed just after a worker process has exited.
-    // onWorkerEnd: function (cid, caps, specs, args, execArgv) {
+    // onWorkerEnd: function (cid, caps, specs, args, exitCode, retries) {
     // },
     //
     // Gets executed before test execution begins. At this point you can access to all global

--- a/examples/wdio.conf.js
+++ b/examples/wdio.conf.js
@@ -242,9 +242,10 @@ exports.config = {
      * @param  {[type]} caps     object containing capabilities for session that will be spawn in the worker
      * @param  {[type]} specs    specs to be run in the worker process
      * @param  {[type]} args     object that will be merged with the main configuration once worker is initialized
-     * @param  {[type]} execArgv list of string arguments passed to the worker process
+     * @param  {Number} exitCode 0 - success, 1 - fail
+     * @param  {Number} retries  number of retries used
      */
-    onWorkerEnd: function (cid, caps, specs, args, execArgv) {
+    onWorkerEnd: function (cid, caps, specs, args, exitCode, retries) {
     },
     /**
      * Gets executed just before initialising the webdriver session and test framework. It allows you

--- a/examples/wdio.conf.js
+++ b/examples/wdio.conf.js
@@ -237,6 +237,16 @@ exports.config = {
     onWorkerStart: function (cid, caps, specs, args, execArgv) {
     },
     /**
+     * Gets executed just after a worker process has exited.
+     * @param  {String} cid      capability id (e.g 0-0)
+     * @param  {[type]} caps     object containing capabilities for session that will be spawn in the worker
+     * @param  {[type]} specs    specs to be run in the worker process
+     * @param  {[type]} args     object that will be merged with the main configuration once worker is initialized
+     * @param  {[type]} execArgv list of string arguments passed to the worker process
+     */
+    onWorkerEnd: function (cid, caps, specs, args, execArgv) {
+    },
+    /**
      * Gets executed just before initialising the webdriver session and test framework. It allows you
      * to manipulate configurations depending on the capability or spec.
      * @param {Object} config wdio configuration object

--- a/examples/wdio/custom-service/my.custom.service.js
+++ b/examples/wdio/custom-service/my.custom.service.js
@@ -14,7 +14,7 @@ module.exports = class CustomService {
         console.log('execute onWorkerStart(cid, caps, specs, args, execArgv)')
     }
     onWorkerEnd () {
-        console.log('execute onWorkerEnd(cid, caps, specs, args, execArgv)')
+        console.log('execute onWorkerEnd(cid, caps, specs, args, exitCode, retries)')
     }
     beforeSession () {
         console.log('execute beforeSession(config, capabilities, specs, cid)')

--- a/examples/wdio/custom-service/my.custom.service.js
+++ b/examples/wdio/custom-service/my.custom.service.js
@@ -13,6 +13,9 @@ module.exports = class CustomService {
     onWorkerStart () {
         console.log('execute onWorkerStart(cid, caps, specs, args, execArgv)')
     }
+    onWorkerEnd () {
+        console.log('execute onWorkerEnd(cid, caps, specs, args, execArgv)')
+    }
     beforeSession () {
         console.log('execute beforeSession(config, capabilities, specs, cid)')
     }

--- a/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
+++ b/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
@@ -250,26 +250,26 @@
     // onPrepare: function (config, capabilities) {
     // },
     /**
-    * Gets executed before a worker process is spawned and can be used to initialise specific service
-    * for that worker as well as modify runtime environments in an async fashion.
-    * @param  {String} cid      capability id (e.g 0-0)
-    * @param  {[type]} caps     object containing capabilities for session that will be spawn in the worker
-    * @param  {[type]} specs    specs to be run in the worker process
-    * @param  {[type]} args     object that will be merged with the main configuration once worker is initialized
-    * @param  {[type]} execArgv list of string arguments passed to the worker process
-    */
+     * Gets executed before a worker process is spawned and can be used to initialise specific service
+     * for that worker as well as modify runtime environments in an async fashion.
+     * @param  {String} cid      capability id (e.g 0-0)
+     * @param  {[type]} caps     object containing capabilities for session that will be spawn in the worker
+     * @param  {[type]} specs    specs to be run in the worker process
+     * @param  {[type]} args     object that will be merged with the main configuration once worker is initialized
+     * @param  {[type]} execArgv list of string arguments passed to the worker process
+     */
     // onWorkerStart: function (cid, caps, specs, args, execArgv) {
     // },
     /**
-    * Gets executed before a worker process is spawned and can be used to initialise specific service
-    * for that worker as well as modify runtime environments in an async fashion.
-    * @param  {String} cid      capability id (e.g 0-0)
-    * @param  {[type]} caps     object containing capabilities for session that will be spawn in the worker
-    * @param  {[type]} specs    specs to be run in the worker process
-    * @param  {[type]} args     object that will be merged with the main configuration once worker is initialised
-    * @param  {[type]} execArgv list of string arguments passed to the worker process
-    */
-    // onWorkerEnd: function (cid, caps, specs, args, execArgv) {
+     * Gets executed just after a worker process has exited.
+     * @param  {String} cid      capability id (e.g 0-0)
+     * @param  {[type]} caps     object containing capabilities for session that will be spawn in the worker
+     * @param  {[type]} specs    specs to be run in the worker process
+     * @param  {[type]} args     object that will be merged with the main configuration once worker is initialised
+     * @param  {Number} exitCode 0 - success, 1 - fail
+     * @param  {Number} retries  number of retries used
+     */
+    // onWorkerEnd: function (cid, caps, specs, args, exitCode, retries) {
     // },
     /**
      * Gets executed just before initialising the webdriver session and test framework. It allows you

--- a/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
+++ b/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
@@ -250,15 +250,25 @@
     // onPrepare: function (config, capabilities) {
     // },
     /**
-     * Gets executed before a worker process is spawned and can be used to initialise specific service
-     * for that worker as well as modify runtime environments in an async fashion.
-     * @param  {String} cid      capability id (e.g 0-0)
-     * @param  {[type]} caps     object containing capabilities for session that will be spawn in the worker
-     * @param  {[type]} specs    specs to be run in the worker process
-     * @param  {[type]} args     object that will be merged with the main configuration once worker is initialised
-     * @param  {[type]} execArgv list of string arguments passed to the worker process
-     */
+    * Gets executed just after a worker process has exited.
+    * @param  {String} cid      capability id (e.g 0-0)
+    * @param  {[type]} caps     object containing capabilities for session that will be spawn in the worker
+    * @param  {[type]} specs    specs to be run in the worker process
+    * @param  {[type]} args     object that will be merged with the main configuration once worker is initialized
+    * @param  {[type]} execArgv list of string arguments passed to the worker process
+    */
     // onWorkerStart: function (cid, caps, specs, args, execArgv) {
+    // },
+    /**
+    * Gets executed before a worker process is spawned and can be used to initialise specific service
+    * for that worker as well as modify runtime environments in an async fashion.
+    * @param  {String} cid      capability id (e.g 0-0)
+    * @param  {[type]} caps     object containing capabilities for session that will be spawn in the worker
+    * @param  {[type]} specs    specs to be run in the worker process
+    * @param  {[type]} args     object that will be merged with the main configuration once worker is initialised
+    * @param  {[type]} execArgv list of string arguments passed to the worker process
+    */
+    // onWorkerEnd: function (cid, caps, specs, args, execArgv) {
     // },
     /**
      * Gets executed just before initialising the webdriver session and test framework. It allows you

--- a/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
+++ b/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
@@ -250,7 +250,8 @@
     // onPrepare: function (config, capabilities) {
     // },
     /**
-    * Gets executed just after a worker process has exited.
+    * Gets executed before a worker process is spawned and can be used to initialise specific service
+    * for that worker as well as modify runtime environments in an async fashion.
     * @param  {String} cid      capability id (e.g 0-0)
     * @param  {[type]} caps     object containing capabilities for session that will be spawn in the worker
     * @param  {[type]} specs    specs to be run in the worker process

--- a/packages/wdio-config/src/constants.ts
+++ b/packages/wdio-config/src/constants.ts
@@ -58,6 +58,7 @@ export const DEFAULT_CONFIGS: () => Omit<Options.Testrunner, 'capabilities'> = (
      */
     onPrepare: [],
     onWorkerStart: [],
+    onWorkerEnd: [],
     before: [],
     beforeSession: [],
     beforeSuite: [],
@@ -89,7 +90,7 @@ export const SUPPORTED_HOOKS: (keyof Services.Hooks)[] = [
     'afterCommand', 'afterTest', 'afterHook', 'afterSuite', 'afterSession', 'after',
     // @ts-ignore not defined in core hooks but added with cucumber
     'beforeFeature', 'beforeScenario', 'beforeStep', 'afterStep', 'afterScenario', 'afterFeature',
-    'onReload', 'onPrepare', 'onWorkerStart', 'onComplete'
+    'onReload', 'onPrepare', 'onWorkerStart', 'onWorkerEnd', 'onComplete'
 ]
 
 export const SUPPORTED_FILE_EXTENSIONS = [

--- a/packages/wdio-smoke-test-service/src/index.ts
+++ b/packages/wdio-smoke-test-service/src/index.ts
@@ -27,6 +27,7 @@ class SmokeServiceLauncher {
     }
     onPrepare () { this.logFile.write('onPrepare called\n') } // eslint-disable-line no-console
     onWorkerStart () { this.logFile.write('onWorkerStart called\n')} // eslint-disable-line no-console
+    onWorkerEnd () { this.logFile.write('onWorkerEnd called\n')} // eslint-disable-line no-console
     onComplete () { this.logFile.write('onComplete called\n') } // eslint-disable-line no-console
 }
 

--- a/packages/wdio-types/src/Services.ts
+++ b/packages/wdio-types/src/Services.ts
@@ -102,6 +102,22 @@ export interface HookFunctions {
     ): void;
 
     /**
+     * Gets executed just after a worker process has exited.
+     * @param  {String} cid      capability id (e.g 0-0)
+     * @param  {[type]} caps     object containing capabilities for session that will be spawn in the worker
+     * @param  {[type]} specs    specs to be run in the worker process
+     * @param  {[type]} args     object that will be merged with the main configuration once worker is initialized
+     * @param  {[type]} execArgv list of string arguments passed to the worker process
+     */
+    onWorkerEnd?(
+        cid: string,
+        caps: DesiredCapabilities,
+        specs: string[],
+        args: TestrunnerOptions,
+        execArgv: string[]
+    ): void;
+
+    /**
      * Gets executed after all workers got shut down and the process is about to exit. An error
      * thrown in the onComplete hook will result in the test run failing.
      * @param exitCode      runner exit code

--- a/packages/wdio-types/src/Services.ts
+++ b/packages/wdio-types/src/Services.ts
@@ -107,14 +107,16 @@ export interface HookFunctions {
      * @param  {[type]} caps     object containing capabilities for session that will be spawn in the worker
      * @param  {[type]} specs    specs to be run in the worker process
      * @param  {[type]} args     object that will be merged with the main configuration once worker is initialized
-     * @param  {[type]} execArgv list of string arguments passed to the worker process
+     * @param  {Number} exitCode 0 - success, 1 - fail
+     * @param  {Number} retries  number of retries used
      */
     onWorkerEnd?(
         cid: string,
         caps: DesiredCapabilities,
         specs: string[],
         args: TestrunnerOptions,
-        execArgv: string[]
+        exitCode: number,
+        retries: number,
     ): void;
 
     /**

--- a/packages/webdriverio/src/constants.ts
+++ b/packages/webdriverio/src/constants.ts
@@ -276,6 +276,7 @@ export const WDIO_DEFAULTS: Options.Definition<Options.WebdriverIO & Options.Tes
      */
     onPrepare: HOOK_DEFINITION,
     onWorkerStart: HOOK_DEFINITION,
+    onWorkerEnd: HOOK_DEFINITION,
     before: HOOK_DEFINITION,
     beforeSession: HOOK_DEFINITION,
     beforeSuite: HOOK_DEFINITION,

--- a/tests/helpers/fixtures.js
+++ b/tests/helpers/fixtures.js
@@ -15,6 +15,7 @@ afterSession called
 export const LAUNCHER_LOGS = `onPrepare called
 onWorkerStart called
 onComplete called
+onWorkerEnd called
 `
 
 export const REPORTER_LOGS = `onRunnerStart

--- a/website/docs/ConfigurationFile.md
+++ b/website/docs/ConfigurationFile.md
@@ -320,9 +320,10 @@ exports.config = {
      * @param  {[type]} caps     object containing capabilities for session that will be spawn in the worker
      * @param  {[type]} specs    specs to be run in the worker process
      * @param  {[type]} args     object that will be merged with the main configuration once worker is initialized
-     * @param  {[type]} execArgv list of string arguments passed to the worker process
+     * @param  {Number} exitCode 0 - success, 1 - fail
+     * @param  {Number} retries  number of retries used
      */
-    onWorkerEnd: function (cid, caps, specs, args, execArgv) {
+    onWorkerEnd: function (cid, caps, specs, args, exitCode, retries) {
     },
     /**
      * Gets executed just before initializing the webdriver session and test framework. It allows you

--- a/website/docs/ConfigurationFile.md
+++ b/website/docs/ConfigurationFile.md
@@ -315,6 +315,16 @@ exports.config = {
     onWorkerStart: function (cid, caps, specs, args, execArgv) {
     },
     /**
+     * Gets executed just after a worker process has exited.
+     * @param  {String} cid      capability id (e.g 0-0)
+     * @param  {[type]} caps     object containing capabilities for session that will be spawn in the worker
+     * @param  {[type]} specs    specs to be run in the worker process
+     * @param  {[type]} args     object that will be merged with the main configuration once worker is initialized
+     * @param  {[type]} execArgv list of string arguments passed to the worker process
+     */
+    onWorkerEnd: function (cid, caps, specs, args, execArgv) {
+    },
+    /**
      * Gets executed just before initializing the webdriver session and test framework. It allows you
      * to manipulate configurations depending on the capability or spec.
      * @param {Object} config wdio configuration object

--- a/website/docs/CustomServices.md
+++ b/website/docs/CustomServices.md
@@ -7,7 +7,7 @@ You can write your own custom service for the WDIO test runner to custom-fit you
 
 Services are add-ons that are created for reusable logic to simplify tests, manage your test suite and integrate results. Services have access to all the same [hooks](/docs/configurationfile) available in the `wdio.conf.js`.
 
-There are two types of services that can be defined: a launcher service that only has access to the `onPrepare`, `onWorkerStart` and `onComplete` hook which are only executed once per test run, and a worker service that has access to all other hooks and is being executed for each worker. Note that you can not share (global) variables between both types of services as worker services run in a different (worker) process.
+There are two types of services that can be defined: a launcher service that only has access to the `onPrepare`, `onWorkerStart`, `onWorkerEnd`  and `onComplete` hook which are only executed once per test run, and a worker service that has access to all other hooks and is being executed for each worker. Note that you can not share (global) variables between both types of services as worker services run in a different (worker) process.
 
 A launcher service can be defined as follows:
 

--- a/website/docs/Options.md
+++ b/website/docs/Options.md
@@ -350,7 +350,7 @@ The WDIO testrunner allows you to set hooks to be triggered at specific times of
 
 Every hook has as parameter specific information about the lifecycle (e.g. information about the test suite or test). Read more about all hook properties in [our example config](https://github.com/webdriverio/webdriverio/blob/master/examples/wdio.conf.js#L183-L326).
 
-__Note:__ Some hooks (`onPrepare`, `onWorkerStart` and `onComplete`) are executed in a different process and therefore can not share any global data with the other hooks that live in the worker process.
+__Note:__ Some hooks (`onPrepare`, `onWorkerStart`, `onWorkerEnd` and `onComplete`) are executed in a different process and therefore can not share any global data with the other hooks that live in the worker process.
 
 ### onPrepare
 
@@ -363,6 +363,17 @@ Parameters:
 ### onWorkerStart
 
 Gets executed before a worker process is spawned and can be used to initialize specific service for that worker as well as modify runtime environments in an async fashion.
+
+Parameters:
+- `cid` (`string`): capability id (e.g 0-0)
+- `caps` (`object`): containing capabilities for session that will be spawn in the worker
+- `specs` (`string[]`): specs to be run in the worker process
+- `args` (`object`): object that will be merged with the main configuration once worker is initialized
+- `execArgv` (`string[]`): list of string arguments passed to the worker process
+
+### onWorkerEnd
+
+Gets executed just after a worker process has exited.
 
 Parameters:
 - `cid` (`string`): capability id (e.g 0-0)

--- a/website/docs/Options.md
+++ b/website/docs/Options.md
@@ -380,7 +380,8 @@ Parameters:
 - `caps` (`object`): containing capabilities for session that will be spawn in the worker
 - `specs` (`string[]`): specs to be run in the worker process
 - `args` (`object`): object that will be merged with the main configuration once worker is initialized
-- `execArgv` (`string[]`): list of string arguments passed to the worker process
+- `exitCode` (`number`): 0 - success, 1 - fail
+- `retries` (`number`): number of retries used
 
 ### beforeSession
 


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

I wanted to solve this issue (#6356) in order to implement a new hook to perform an effect at the end of the execution of a worker.

I was very inspired by what was done when creating the `onWorkerStart` hook. (#4926)

I still have a few things to study:

- Should we give the same parameter to the `onWorkerStart` ? Should we add new ones ?
- Still need to implement unit test with jest to cover this new feature
- Where should I hook the implementation of this hook ? (I am a new contributor of this project and I don't really know where to make it correctly 😊 )
  - onExit ? 
  - onEnd ?
  - onError ?

I think the solution will be here.

https://github.com/webdriverio/webdriverio/blob/c049615763126177866b8b5b2ec3524449691d0a/packages/wdio-cli/src/launcher.ts#L106-L163


## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
