### PR TITLE
Issue 7651: add Cucumber World object back to step/scenario hooks

### DIFF
--- a/examples/pageobject/wdio.conf.js
+++ b/examples/pageobject/wdio.conf.js
@@ -152,17 +152,19 @@ exports.config = {
     //
     //
     // Runs before a Cucumber Scenario.
-    // @param {ITestCaseHookParameter} world world object containing information on pickle and test step
+    // @param {ITestCaseHookParameter} world    world object containing information on pickle and test step
+    // @param {Object}                 context  Cucumber World object
     //
-    // beforeScenario: function (world) {
+    // beforeScenario: function (world, context) {
     // },
     //
     //
     // Runs before a Cucumber Step.
     // @param {Pickle.IPickleStep} step     step data
     // @param {IPickle}            scenario scenario pickle
+    // @param {Object}             context  Cucumber World object
     //
-    // beforeStep: function (step, scenario) {
+    // beforeStep: function (step, scenario, context) {
     // },
     //
     //
@@ -173,17 +175,19 @@ exports.config = {
     // @param {boolean}            result.passed   true if scenario has passed
     // @param {string}             result.error    error stack if scenario failed
     // @param {number}             result.duration duration of scenario in milliseconds
+    // @param {Object}             context  Cucumber World object
     //
-    // afterStep: function (step, scenario, result) {
+    // afterStep: function (step, scenario, result, context) {
     // },
     //
     //
-    // Runs before a Cucumber Scenario.
+    // Runs after a Cucumber Scenario.
     // @param {ITestCaseHookParameter} world  world object containing information on pickle and test step
     // @param {Object}                 result results object containing scenario results
     // @param {boolean}                result.passed   true if scenario has passed
     // @param {string}                 result.error    error stack if scenario failed
     // @param {number}                 result.duration duration of scenario in milliseconds
+    // @param {Object}                 context  Cucumber World object
     //
     // afterScenario: function (world, result) {
     // },

--- a/examples/wdio.conf.js
+++ b/examples/wdio.conf.js
@@ -361,17 +361,19 @@ exports.config = {
     /**
      *
      * Runs before a Cucumber Scenario.
-     * @param {ITestCaseHookParameter} world world object containing information on pickle and test step
+     * @param {ITestCaseHookParameter} world    world object containing information on pickle and test step
+     * @param {Object}                 context  Cucumber World object
      */
-    beforeScenario: function (world) {
+    beforeScenario: function (world, context) {
     },
     /**
      *
      * Runs before a Cucumber Step.
      * @param {Pickle.IPickleStep} step     step data
      * @param {IPickle}            scenario scenario pickle
+     * @param {Object}             context  Cucumber World object
      */
-    beforeStep: function (step, scenario) {
+    beforeStep: function (step, scenario, context) {
     },
     /**
      *
@@ -382,19 +384,21 @@ exports.config = {
      * @param {boolean}            result.passed   true if scenario has passed
      * @param {string}             result.error    error stack if scenario failed
      * @param {number}             result.duration duration of scenario in milliseconds
+     * @param {Object}             context Cucumber World object
      */
-    afterStep: function (step, scenario, result) {
+    afterStep: function (step, scenario, result, context) {
     },
     /**
      *
-     * Runs before a Cucumber Scenario.
+     * Runs after a Cucumber Scenario.
      * @param {ITestCaseHookParameter} world  world object containing information on pickle and test step
      * @param {Object}                 result results object containing scenario results
      * @param {boolean}                result.passed   true if scenario has passed
      * @param {string}                 result.error    error stack if scenario failed
      * @param {number}                 result.duration duration of scenario in milliseconds
+     * @param {Object}                 context Cucumber World object
      */
-    afterScenario: function (world, result) {
+    afterScenario: function (world, result, context) {
     },
     /**
      *

--- a/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
+++ b/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
@@ -330,40 +330,44 @@
     /**
      *
      * Runs before a Cucumber Scenario.
-     * @param {ITestCaseHookParameter} world world object containing information on pickle and test step
+     * @param {ITestCaseHookParameter} world    world object containing information on pickle and test step
+     * @param {Object}                 context  Cucumber World object
      */
-    // beforeScenario: function (world) {
+    // beforeScenario: function (world, context) {
     // },
     /**
      *
      * Runs before a Cucumber Step.
      * @param {Pickle.IPickleStep} step     step data
      * @param {IPickle}            scenario scenario pickle
+     * @param {Object}             context  Cucumber World object
      */
-    // beforeStep: function (step, scenario) {
+    // beforeStep: function (step, scenario, context) {
     // },
     /**
      *
      * Runs after a Cucumber Step.
-     * @param {Pickle.IPickleStep} step     step data
-     * @param {IPickle}            scenario scenario pickle
-     * @param {Object}             result   results object containing scenario results
-     * @param {boolean}            result.passed   true if scenario has passed
-     * @param {string}             result.error    error stack if scenario failed
-     * @param {number}             result.duration duration of scenario in milliseconds
+     * @param {Pickle.IPickleStep} step             step data
+     * @param {IPickle}            scenario         scenario pickle
+     * @param {Object}             result           results object containing scenario results
+     * @param {boolean}            result.passed    true if scenario has passed
+     * @param {string}             result.error     error stack if scenario failed
+     * @param {number}             result.duration  duration of scenario in milliseconds
+     * @param {Object}             context          Cucumber World object
      */
-    // afterStep: function (step, scenario, result) {
+    // afterStep: function (step, scenario, result, context) {
     // },
     /**
      *
-     * Runs before a Cucumber Scenario.
-     * @param {ITestCaseHookParameter} world  world object containing information on pickle and test step
-     * @param {Object}                 result results object containing scenario results
-     * @param {boolean}                result.passed   true if scenario has passed
-     * @param {string}                 result.error    error stack if scenario failed
-     * @param {number}                 result.duration duration of scenario in milliseconds
+     * Runs after a Cucumber Scenario.
+     * @param {ITestCaseHookParameter} world            world object containing information on pickle and test step
+     * @param {Object}                 result           results object containing scenario results
+     * @param {boolean}                result.passed    true if scenario has passed
+     * @param {string}                 result.error     error stack if scenario failed
+     * @param {number}                 result.duration  duration of scenario in milliseconds
+     * @param {Object}                 context          Cucumber World object
      */
-    // afterScenario: function (world, result) {
+    // afterScenario: function (world, result, context) {
     // },
     /**
      *

--- a/packages/wdio-cucumber-framework/src/index.ts
+++ b/packages/wdio-cucumber-framework/src/index.ts
@@ -257,7 +257,7 @@ class CucumberAdapter {
     }
 
     /**
-     * set `beforeScenario`, `afterScenario`, `beforeFeature`, `afterFeature`
+     * set `beforeFeature`, `afterFeature`, `beforeScenario`, `afterScenario`, 'beforeStep', 'afterStep'
      * @param {object} config config
      */
     addWdioHooks(config: Options.Testrunner) {
@@ -282,14 +282,14 @@ class CucumberAdapter {
             await executeHooksWithArgs(
                 'beforeScenario',
                 config.beforeScenario,
-                [world]
+                [world, this]
             )
         })
         Cucumber.After(async function wdioHookAfterScenario(world: ITestCaseHookParameter) {
             await executeHooksWithArgs(
                 'afterScenario',
                 config.afterScenario,
-                [world, getResultObject(world)]
+                [world, getResultObject(world), this]
             )
         })
         Cucumber.BeforeStep(async function wdioHookBeforeStep() {
@@ -297,7 +297,7 @@ class CucumberAdapter {
             await executeHooksWithArgs(
                 'beforeStep',
                 config.beforeStep,
-                [params?.step, params?.scenario]
+                [params?.step, params?.scenario, this]
             )
         })
         Cucumber.AfterStep(async function wdioHookAfterStep(world: ITestCaseHookParameter) {
@@ -305,7 +305,7 @@ class CucumberAdapter {
             await executeHooksWithArgs(
                 'afterStep',
                 config.afterStep,
-                [params?.step, params?.scenario, getResultObject(world)]
+                [params?.step, params?.scenario, getResultObject(world), this]
             )
         })
     }

--- a/packages/wdio-cucumber-framework/src/types.ts
+++ b/packages/wdio-cucumber-framework/src/types.ts
@@ -153,40 +153,44 @@ export interface HookFunctionExtension {
     /**
      *
      * Runs before a Cucumber Scenario.
-     * @param world world object containing information on pickle and test step
+     * @param world     world object containing information on pickle and test step
+     * @param context   Cucumber World object
      */
-    beforeScenario?(world: ITestCaseHookParameter): void;
+    beforeScenario?(world: ITestCaseHookParameter, context: Object): void;
 
     /**
      *
      * Runs before a Cucumber Step.
      * @param step     step data
      * @param scenario scenario data
+     * @param context  Cucumber World object
      */
-    beforeStep?(step: PickleStep, scenario: Pickle): void;
+    beforeStep?(step: PickleStep, scenario: Pickle, context: Object): void;
 
     /**
      *
      * Runs after a Cucumber Step.
-     * @param step     step data
-     * @param scenario scenario data
-     * @param result result object containing
+     * @param step            step data
+     * @param scenario        scenario data
+     * @param result          result object containing
      * @param result.passed   true if scenario has passed
      * @param result.error    error stack if scenario failed
      * @param result.duration duration of scenario in milliseconds
+     * @param context         Cucumber World object
      */
-    afterStep?(step: PickleStep, scenario: Pickle, result: Frameworks.PickleResult): void;
+    afterStep?(step: PickleStep, scenario: Pickle, result: Frameworks.PickleResult, context: Object): void;
 
     /**
      *
-     * Runs before a Cucumber Scenario.
-     * @param world world object containing information on pickle and test step
-     * @param result result object containing
-     * @param result.passed   true if scenario has passed
-     * @param result.error    error stack if scenario failed
-     * @param result.duration duration of scenario in milliseconds
+     * Runs after a Cucumber Scenario.
+     * @param world             world object containing information on pickle and test step
+     * @param result            result object containing
+     * @param result.passed     true if scenario has passed
+     * @param result.error      error stack if scenario failed
+     * @param result.duration   duration of scenario in milliseconds
+     * @param context           Cucumber World object
      */
-    afterScenario?(world: ITestCaseHookParameter, result: Frameworks.PickleResult): void;
+    afterScenario?(world: ITestCaseHookParameter, result: Frameworks.PickleResult, context: Object): void;
 
     /**
      *

--- a/packages/wdio-cucumber-framework/tests/adapter.test.ts
+++ b/packages/wdio-cucumber-framework/tests/adapter.test.ts
@@ -190,6 +190,11 @@ describe('CucumberAdapter', () => {
     })
 
     it('addWdioHooks', async () => {
+        class CustomWorld {
+            public foo = 'bar';
+        }
+        const cukeWorld = new CustomWorld();
+
         const adapter = await CucumberAdapter.init('0-0', {}, ['/foo/bar'], {}, {})
         adapter.addWdioHooks({
             beforeFeature: 'beforeFeature',
@@ -207,24 +212,24 @@ describe('CucumberAdapter', () => {
         expect(Cucumber.AfterStep).toBeCalledTimes(1)
         expect(executeHooksWithArgs).toBeCalledTimes(0)
 
-        ;(Cucumber.AfterStep as jest.Mock).mock.calls[0][0]('world')
+        ;(Cucumber.AfterStep as jest.Mock).mock.calls[0][0].bind(cukeWorld)('world')
         expect(executeHooksWithArgs)
-            .toBeCalledWith('afterStep', 'afterStep', ['step', 'scenario', { 'duration': NaN, 'error': undefined, 'passed': false }])
-        ;(Cucumber.BeforeStep as jest.Mock).mock.calls[0][0]()
+            .toBeCalledWith('afterStep', 'afterStep', ['step', 'scenario', { 'duration': NaN, 'error': undefined, 'passed': false }, cukeWorld])
+        ;(Cucumber.BeforeStep as jest.Mock).mock.calls[0][0].bind(cukeWorld)()
         expect(executeHooksWithArgs)
-            .toBeCalledWith('beforeStep', 'beforeStep', ['step', 'scenario'])
+            .toBeCalledWith('beforeStep', 'beforeStep', ['step', 'scenario', cukeWorld])
         ;(Cucumber.BeforeAll as jest.Mock).mock.calls[0][0]()
         expect(executeHooksWithArgs)
             .toBeCalledWith('beforeFeature', 'beforeFeature', ['uri', 'feature'])
         ;(Cucumber.AfterAll as jest.Mock).mock.calls[0][0]()
         expect(executeHooksWithArgs)
             .toBeCalledWith('afterFeature', 'afterFeature', ['uri', 'feature'])
-        ;(Cucumber.Before as jest.Mock).mock.calls[0][0]('world')
+        ;(Cucumber.Before as jest.Mock).mock.calls[0][0].bind(cukeWorld)('world')
         expect(executeHooksWithArgs)
-            .toBeCalledWith('beforeScenario', 'beforeScenario', ['world'])
-        ;(Cucumber.After as jest.Mock).mock.calls[0][0]('world')
+            .toBeCalledWith('beforeScenario', 'beforeScenario', ['world', cukeWorld])
+        ;(Cucumber.After as jest.Mock).mock.calls[0][0].bind(cukeWorld)('world')
         expect(executeHooksWithArgs)
-            .toBeCalledWith('afterScenario', 'afterScenario', ['world', { 'duration': NaN, 'error': undefined, 'passed': false }])
+            .toBeCalledWith('afterScenario', 'afterScenario', ['world', { 'duration': NaN, 'error': undefined, 'passed': false }, cukeWorld])
     })
 
     it('wrapSteps', async () => {

--- a/packages/wdio-cucumber-framework/tests/adapter.test.ts
+++ b/packages/wdio-cucumber-framework/tests/adapter.test.ts
@@ -191,9 +191,9 @@ describe('CucumberAdapter', () => {
 
     it('addWdioHooks', async () => {
         class CustomWorld {
-            public foo = 'bar';
+            public foo = 'bar'
         }
-        const cukeWorld = new CustomWorld();
+        const cukeWorld = new CustomWorld()
 
         const adapter = await CucumberAdapter.init('0-0', {}, ['/foo/bar'], {}, {})
         adapter.addWdioHooks({

--- a/packages/wdio-cucumber-framework/tests/utils.test.ts
+++ b/packages/wdio-cucumber-framework/tests/utils.test.ts
@@ -236,7 +236,7 @@ describe('utils', () => {
         expect(addKeywordToStep(steps, feature)).toMatchSnapshot()
     })
 
-    it('getRule should get the rule for an specific scenrio id', ()=>{
+    it('getRule should get the rule for an specific scenario id', ()=>{
         const feature = featureWithRules
 
         expect(getRule(feature, '1')).toBe(undefined)

--- a/website/docs/ConfigurationFile.md
+++ b/website/docs/ConfigurationFile.md
@@ -438,40 +438,44 @@ exports.config = {
     /**
      *
      * Runs before a Cucumber Scenario.
-     * @param {ITestCaseHookParameter} world world object containing information on pickle and test step
+     * @param {ITestCaseHookParameter} world    world object containing information on pickle and test step
+     * @param {Object}                 context  Cucumber World object
      */
-    beforeScenario: function (world) {
+    beforeScenario: function (world, context) {
     },
     /**
      *
      * Runs before a Cucumber Step.
      * @param {Pickle.IPickleStep} step     step data
      * @param {IPickle}            scenario scenario pickle
+     * @param {Object}             context  Cucumber World object
      */
-    beforeStep: function (step, scenario) {
+    beforeStep: function (step, scenario, context) {
     },
     /**
      *
      * Runs after a Cucumber Step.
-     * @param {Pickle.IPickleStep} step     step data
-     * @param {IPickle}            scenario scenario pickle
-     * @param {Object}             result   results object containing scenario results
-     * @param {boolean}            result.passed   true if scenario has passed
-     * @param {string}             result.error    error stack if scenario failed
-     * @param {number}             result.duration duration of scenario in milliseconds
+     * @param {Pickle.IPickleStep} step             step data
+     * @param {IPickle}            scenario         scenario pickle
+     * @param {Object}             result           results object containing scenario results
+     * @param {boolean}            result.passed    true if scenario has passed
+     * @param {string}             result.error     error stack if scenario failed
+     * @param {number}             result.duration  duration of scenario in milliseconds
+     * @param {Object}             context          Cucumber World object
      */
-    afterStep: function (step, scenario, result) {
+    afterStep: function (step, scenario, result, context) {
     },
     /**
      *
-     * Runs before a Cucumber Scenario.
-     * @param {ITestCaseHookParameter} world  world object containing information on pickle and test step
-     * @param {Object}                 result results object containing scenario results `{passed: boolean, error: string, duration: number}`
-     * @param {boolean}                result.passed   true if scenario has passed
-     * @param {string}                 result.error    error stack if scenario failed
-     * @param {number}                 result.duration duration of scenario in milliseconds
+     * Runs after a Cucumber Scenario.
+     * @param {ITestCaseHookParameter} world            world object containing information on pickle and test step
+     * @param {Object}                 result           results object containing scenario results `{passed: boolean, error: string, duration: number}`
+     * @param {boolean}                result.passed    true if scenario has passed
+     * @param {string}                 result.error     error stack if scenario failed
+     * @param {number}                 result.duration  duration of scenario in milliseconds
+     * @param {Object}                 context          Cucumber World object
      */
-    afterScenario: function (world, result) {
+    afterScenario: function (world, result, context) {
     },
     /**
      *

--- a/website/docs/Options.md
+++ b/website/docs/Options.md
@@ -242,7 +242,7 @@ Type: `Object`|`Object[]`<br />
 Default: `[{ maxInstances: 5, browserName: 'firefox' }]`
 
 ### maxInstances
-Maximum number of total parallel running workers. 
+Maximum number of total parallel running workers.
 
 __Note:__ that it may be a number as high as `100`, when the tests are being performed on some external vendors such as Sauce Labs's machines. There, the tests are not tested on a single machine, but rather, on multiple VMs. If the tests are to be run on a local development machine, use a number that is more reasonable, such as `3`, `4`, or `5`. Essentially, this is the number of browsers that will be concurrently started and running your tests at the same time, so it depends on how much RAM there is on your machine, and how many other apps are running on your machine.
 
@@ -519,6 +519,7 @@ Runs before a Cucumber Scenario.
 
 Parameters:
 - `world` ([`ITestCaseHookParameter`](https://github.com/cucumber/cucumber-js/blob/ac124f7b2be5fa54d904c7feac077a2657b19440/src/support_code_library_builder/types.ts#L10-L15)): world object containing information on pickle and test step
+- `context` (`object`): Cucumber World object
 
 ### afterScenario
 
@@ -530,6 +531,7 @@ Parameters:
 - `result.passed` (`boolean`): true if scenario has passed
 - `result.error` (`string`): error stack if scenario failed
 - `result.duration` (`number`): duration of scenario in milliseconds
+- `context` (`object`): Cucumber World object
 
 ### beforeStep
 
@@ -538,6 +540,7 @@ Runs before a Cucumber Step.
 Parameters:
 - `step` ([`Pickle.IPickleStep`](https://github.com/cucumber/common/blob/b94ce625967581de78d0fc32d84c35b46aa5a075/messages/jsonschema/Pickle.json#L20-L49)): Cucumber step object
 - `scenario` ([`IPickle`](https://github.com/cucumber/common/blob/b94ce625967581de78d0fc32d84c35b46aa5a075/messages/jsonschema/Pickle.json#L137-L175)): Cucumber scenario object
+- `context` (`object`): Cucumber World object
 
 ### afterStep
 
@@ -550,4 +553,5 @@ Parameters:
 - `result.passed` (`boolean`): true if scenario has passed
 - `result.error` (`string`): error stack if scenario failed
 - `result.duration` (`number`): duration of scenario in milliseconds
+- `context` (`object`): Cucumber World object
 


### PR DESCRIPTION
## Proposed changes

* Fixes issue https://github.com/webdriverio/webdriverio/issues/7651 by including Cucumber's World object in the Before/After Step/Scenario hooks 
* Updates adapter unit test.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have ~added~ updated tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

### Reviewers: @webdriverio/project-committers
