### PR TITLE
Add WebDriver protocol commands to fetch shadow elements

### DIFF
--- a/packages/devtools/tests/__snapshots__/utils.test.ts.snap
+++ b/packages/devtools/tests/__snapshots__/utils.test.ts.snap
@@ -25,10 +25,10 @@ Array [
 exports[`getPrototype 1`] = `
 Object {
   "acceptAlert": Object {
-    "value": 53,
+    "value": 56,
   },
   "addCookie": Object {
-    "value": 46,
+    "value": 49,
   },
   "back": Object {
     "value": 8,
@@ -40,42 +40,48 @@ Object {
     "value": 15,
   },
   "deleteAllCookies": Object {
-    "value": 47,
+    "value": 50,
   },
   "deleteCookie": Object {
-    "value": 49,
+    "value": 52,
   },
   "deleteSession": Object {
     "value": 2,
   },
   "dismissAlert": Object {
-    "value": 52,
+    "value": 55,
   },
   "elementClear": Object {
-    "value": 40,
+    "value": 43,
   },
   "elementClick": Object {
-    "value": 39,
+    "value": 42,
   },
   "elementSendKeys": Object {
-    "value": 41,
-  },
-  "executeAsyncScript": Object {
     "value": 44,
   },
+  "executeAsyncScript": Object {
+    "value": 47,
+  },
   "executeScript": Object {
-    "value": 43,
+    "value": 46,
   },
   "findElement": Object {
     "value": 25,
   },
   "findElementFromElement": Object {
-    "value": 27,
+    "value": 29,
   },
-  "findElements": Object {
+  "findElementFromShadowRoot": Object {
     "value": 26,
   },
+  "findElements": Object {
+    "value": 27,
+  },
   "findElementsFromElement": Object {
+    "value": 30,
+  },
+  "findElementsFromShadowRoots": Object {
     "value": 28,
   },
   "forward": Object {
@@ -85,43 +91,46 @@ Object {
     "value": 24,
   },
   "getActiveElement": Object {
-    "value": 29,
-  },
-  "getAlertText": Object {
-    "value": 54,
-  },
-  "getAllCookies": Object {
-    "value": 45,
-  },
-  "getElementAttribute": Object {
     "value": 32,
   },
-  "getElementCSSValue": Object {
-    "value": 34,
+  "getAlertText": Object {
+    "value": 57,
   },
-  "getElementComputedLabel": Object {
-    "value": 59,
-  },
-  "getElementComputedRole": Object {
-    "value": 58,
-  },
-  "getElementProperty": Object {
-    "value": 33,
-  },
-  "getElementRect": Object {
-    "value": 37,
-  },
-  "getElementTagName": Object {
-    "value": 36,
-  },
-  "getElementText": Object {
-    "value": 35,
-  },
-  "getNamedCookie": Object {
+  "getAllCookies": Object {
     "value": 48,
   },
+  "getElementAttribute": Object {
+    "value": 35,
+  },
+  "getElementCSSValue": Object {
+    "value": 37,
+  },
+  "getElementComputedLabel": Object {
+    "value": 62,
+  },
+  "getElementComputedRole": Object {
+    "value": 61,
+  },
+  "getElementProperty": Object {
+    "value": 36,
+  },
+  "getElementRect": Object {
+    "value": 40,
+  },
+  "getElementShadowRoot": Object {
+    "value": 31,
+  },
+  "getElementTagName": Object {
+    "value": 39,
+  },
+  "getElementText": Object {
+    "value": 38,
+  },
+  "getNamedCookie": Object {
+    "value": 51,
+  },
   "getPageSource": Object {
-    "value": 42,
+    "value": 45,
   },
   "getTimeouts": Object {
     "value": 4,
@@ -142,13 +151,13 @@ Object {
     "value": 20,
   },
   "isElementDisplayed": Object {
-    "value": 31,
+    "value": 34,
   },
   "isElementEnabled": Object {
-    "value": 38,
+    "value": 41,
   },
   "isElementSelected": Object {
-    "value": 30,
+    "value": 33,
   },
   "maximizeWindow": Object {
     "value": 22,
@@ -163,7 +172,7 @@ Object {
     "value": 1,
   },
   "performActions": Object {
-    "value": 50,
+    "value": 53,
   },
   "printPage": Object {
     "value": 17,
@@ -172,10 +181,10 @@ Object {
     "value": 10,
   },
   "releaseActions": Object {
-    "value": 51,
+    "value": 54,
   },
   "sendAlertText": Object {
-    "value": 55,
+    "value": 58,
   },
   "setTimeouts": Object {
     "value": 5,
@@ -196,10 +205,10 @@ Object {
     "value": 14,
   },
   "takeElementScreenshot": Object {
-    "value": 57,
+    "value": 60,
   },
   "takeScreenshot": Object {
-    "value": 56,
+    "value": 59,
   },
 }
 `;

--- a/packages/wdio-protocols/protocols/webdriver.json
+++ b/packages/wdio-protocols/protocols/webdriver.json
@@ -398,7 +398,49 @@
       "returns": {
         "type": "object",
         "name": "element",
-        "description": "A JSON representation of an element object."
+        "description": "A JSON representation of an element object, e.g. `{ 'element-6066-11e4-a52e-4f735466cecf': 'ELEMENT_1' }`."
+      }
+    }
+  },
+  "/session/:sessionId/shadow/:shadowId/element": {
+    "POST": {
+      "command": "findElementFromShadowRoot",
+      "description": "The Find Element From Shadow Root command is used to find an element within the shadow root of an element that can be used for future commands. This command returns JSON representation of the element that can be passed to $ command to transform the reference to an extended WebdriverIO element.",
+      "ref": "https://w3c.github.io/webdriver/#find-element-from-shadow-root",
+      "examples": [
+        [
+          "// get shadow root",
+          "const element = await browser.findElement('xpath', '//div')",
+          "const shadowRoot = await browser.getElementShadowRoot(",
+          "    element['element-6066-11e4-a52e-4f735466cecf']",
+          ")",
+          "// fetch element within that shadow root",
+          "const elementRef = await browser.findElementFromShadowRoot(",
+          "    shadowRoot['shadow-6066-11e4-a52e-4f735466cecf'],",
+          "    'xpath',",
+          "    '//div'",
+          ")"
+        ]
+      ],
+      "variables": [{
+        "name": "shadowId",
+        "description": "element id of a shadow root element"
+      }],
+      "parameters": [{
+        "name": "using",
+        "type": "string",
+        "description": "a valid element location strategy",
+        "required": true
+      }, {
+        "name": "value",
+        "type": "string",
+        "description": "the actual selector that will be used to find an element",
+        "required": true
+      }],
+      "returns": {
+        "type": "object",
+        "name": "element",
+        "description": "A JSON representation of an element shadow object, e.g. `{ 'element-6066-11e4-a52e-4f735466cecf': 'ELEMENT_1' }`."
       }
     }
   },
@@ -421,7 +463,49 @@
       "returns": {
         "type": "object[]",
         "name": "elements",
-        "description": "A (possibly empty) JSON list of representations of an element object."
+        "description": "A (possibly empty) JSON list of representations of an element object, e.g. `[{ 'element-6066-11e4-a52e-4f735466cecf': 'ELEMENT_1' }]`."
+      }
+    }
+  },
+  "/session/:sessionId/shadow/:shadowId/elements": {
+    "POST": {
+      "command": "findElementsFromShadowRoots",
+      "description": "The Find Elements command is used to find elements within the shadow root of an element that can be used for future commands. This command returns array of JSON representation of the elements that can be passed to $ command to transform the reference to an extended WebdriverIO element (See findElement).",
+      "ref": "https://w3c.github.io/webdriver/#find-elements-from-shadow-root",
+      "variables": [{
+        "name": "shadowId",
+        "description": "element id of a shadow root element"
+      }],
+      "parameters": [{
+        "name": "using",
+        "type": "string",
+        "description": "a valid element location strategy",
+        "required": true
+      }, {
+        "name": "value",
+        "type": "string",
+        "description": "the actual selector that will be used to find an element",
+        "required": true
+      }],
+      "examples": [
+        [
+          "// get shadow root",
+          "const element = await browser.findElement('xpath', '//div')",
+          "const shadowRoot = await browser.getElementShadowRoot(",
+          "    element['element-6066-11e4-a52e-4f735466cecf']",
+          ")",
+          "// fetch elements within that shadow root",
+          "const elementRef = await browser.findElementsFromShadowRoot(",
+          "    shadowRoot['shadow-6066-11e4-a52e-4f735466cecf'],",
+          "    'xpath',",
+          "    '//div'",
+          ")"
+        ]
+      ],
+      "returns": {
+        "type": "object[]",
+        "name": "elements",
+        "description": "A (possibly empty) JSON list of representations of an element object, e.g. `{ 'element-6066-11e4-a52e-4f735466cecf': 'ELEMENT_1' }`."
       }
     }
   },
@@ -448,7 +532,7 @@
       "returns": {
         "type": "object",
         "name": "element",
-        "description": "A JSON representation of an element object."
+        "description": "A JSON representation of an element object, e.g. `{ 'element-6066-11e4-a52e-4f735466cecf': 'ELEMENT_1' }`."
       }
     }
   },
@@ -475,7 +559,24 @@
       "returns": {
         "type": "object[]",
         "name": "elements",
-        "description": "A (possibly empty) JSON list of representations of an element object."
+        "description": "A (possibly empty) JSON list of representations of an element object, e.g. `[{ 'element-6066-11e4-a52e-4f735466cecf': 'ELEMENT_1' }]`."
+      }
+    }
+  },
+  "/session/:sessionId/element/:elementId/shadow": {
+    "GET": {
+      "command": "getElementShadowRoot",
+      "description": "Get the shadow root object of an element. The result object can be used to fetch elements within this shadow root using e.g. findElementFromShadowRoots or findElementsFromShadowRoots.",
+      "ref": "https://w3c.github.io/webdriver/#dfn-get-active-element",
+      "variables": [{
+        "name": "elementId",
+        "description": "the id of an element returned in a previous call to Find Element(s)"
+      }],
+      "parameters": [],
+      "returns": {
+        "type": "string",
+        "name": "element",
+        "description": "A JSON representation of an element shadow root, e.g. `{ 'shadow-6066-11e4-a52e-4f735466cecf': 'ELEMENT_1' }`."
       }
     }
   },
@@ -488,7 +589,7 @@
       "returns": {
         "type": "string",
         "name": "element",
-        "description": "A JSON representation of an element object."
+        "description": "A JSON representation of an element object, e.g. `{ 'element-6066-11e4-a52e-4f735466cecf': 'ELEMENT_1' }`."
       }
     }
   },


### PR DESCRIPTION
## Proposed changes

Fetching a shadow root and their elements inside was recently added to the [WebDriver spec](https://w3c.github.io/webdriver/#get-element-shadow-root). This patch adds these protocol commands to the `webdriver` package and makes them available in WebdriverIO.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
