### PR TITLE
Fix for Console log note added to failed cucumber step

### DIFF
--- a/packages/wdio-allure-reporter/src/index.ts
+++ b/packages/wdio-allure-reporter/src/index.ts
@@ -222,6 +222,7 @@ class AllureReporter extends WDIOReporter {
 
     onTestFail(test: TestStats | HookStats) {
         if (this._options.useCucumberStepReporter) {
+            attachConsoleLogs(this._consoleOutput, this._allure)
             const testStatus = getTestStatus(test, this._config)
             const stepStatus: Status = Object.values(stepStatuses).indexOf(testStatus) >= 0 ?
                 testStatus : 'failed'

--- a/packages/wdio-allure-reporter/tests/cucumber.suite.test.ts
+++ b/packages/wdio-allure-reporter/tests/cucumber.suite.test.ts
@@ -122,6 +122,7 @@ describe('reporter option "useCucumberStepReporter" set to true', () => {
             reporter.onTestStart(cucumberHelper.testStart())
             reporter.onBeforeCommand(commandStart())
             reporter.onAfterCommand(commandEnd())
+            reporter._consoleOutput = 'some console output'
             reporter.onTestPass()
             reporter.onHookStart(cucumberHelper.hookStart())
             reporter.addAttachment(attachmentHelper.xmlAttachment())
@@ -139,6 +140,11 @@ describe('reporter option "useCucumberStepReporter" set to true', () => {
         afterAll(() => {
             clean(outputDir)
             jest.resetAllMocks()
+        })
+
+        it('should have the console log add', () => {
+            expect(allureXml('test-case > steps > step > attachments > attachment')).toHaveLength(1)
+            expect(allureXml('test-case > steps > step > attachments > attachment').eq(0).attr('title')).toBe('Console Logs')
         })
 
         it('should report one suite', () => {
@@ -203,6 +209,7 @@ describe('reporter option "useCucumberStepReporter" set to true', () => {
             reporter._allure.getCurrentSuite = jest.fn()
             reporter._allure.endStep = jest.fn()
             reporter._allure.endCase = jest.fn()
+            reporter._allure.addAttachment = jest.fn()
 
             reporter.onTestPass()
             expect(reporter._allure.endStep).not.toHaveBeenCalled()
@@ -222,6 +229,7 @@ describe('reporter option "useCucumberStepReporter" set to true', () => {
             reporter.onSuiteStart(cucumberHelper.featureStart())
             reporter.onSuiteStart(cucumberHelper.scenarioStart())
             reporter.onTestStart(cucumberHelper.testStart())
+            reporter._consoleOutput = 'some console output'
             reporter.onTestSkip(cucumberHelper.testSkipped())
             const suiteResults: any = { tests: [cucumberHelper.testSkipped()] }
             reporter.onSuiteEnd(cucumberHelper.scenarioEnd(suiteResults))
@@ -254,10 +262,15 @@ describe('reporter option "useCucumberStepReporter" set to true', () => {
             expect(allureXml('step').length).toEqual(1)
         })
 
+        it('should have the console log add', () => {
+            expect(allureXml('test-case > steps > step > attachments > attachment')).toHaveLength(1)
+            expect(allureXml('test-case > steps > step > attachments > attachment').eq(0).attr('title')).toBe('Console Logs')
+        })
+
         it('should not call endStep if currentStep is not `Step` instance', () => {
             reporter._allure.getCurrentSuite = jest.fn()
             reporter._allure.endStep = jest.fn()
-
+            reporter._allure.addAttachment = jest.fn()
             reporter.onTestSkip(cucumberHelper.testSkipped())
             expect(reporter._allure.endStep).not.toHaveBeenCalled()
         })
@@ -336,6 +349,7 @@ describe('reporter option "useCucumberStepReporter" set to true', () => {
             reporter.onTestStart(cucumberHelper.testStart())
             reporter.onBeforeCommand(commandStart())
             reporter.onAfterCommand(commandEnd())
+            reporter._consoleOutput = 'some console output'
             reporter.onTestFail(cucumberHelper.testFail())
             const suiteResults: any = { tests: ['failed'] }
             reporter.onSuiteEnd(cucumberHelper.scenarioEnd(suiteResults))
@@ -351,6 +365,8 @@ describe('reporter option "useCucumberStepReporter" set to true', () => {
             expect(allureXml('step').attr('status')).toEqual('failed')
             expect(allureXml('test-case parameter[kind="argument"]')).toHaveLength(1)
             expect(allureXml('test-case parameter[name="browser"]').eq(0).attr('value')).toEqual('chrome-68')
+            expect(allureXml('test-case > steps > step > attachments > attachment')).toHaveLength(1)
+            expect(allureXml('test-case > steps > step > attachments > attachment').eq(0).attr('title')).toBe('Console Logs')
         })
 
         it('should handle failed hook', () => {
@@ -385,6 +401,7 @@ describe('reporter option "useCucumberStepReporter" set to true', () => {
             reporter._allure.getCurrentSuite = jest.fn()
             reporter._allure.endStep = jest.fn()
             reporter._allure.endCase = jest.fn()
+            reporter._allure.addAttachment = jest.fn()
 
             reporter.onTestFail(cucumberHelper.testSkipped())
             expect(reporter._allure.endStep).not.toHaveBeenCalled()


### PR DESCRIPTION
## Proposed changes

Fix for  [🐛 Bug]: Console.Logs not attaching to AllureReport on a failed cucumber step #7686

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
