### PR TITLE
Remove outdated double-await issue in docs

### DIFF
--- a/website/docs/SyncVsAsync.md
+++ b/website/docs/SyncVsAsync.md
@@ -110,9 +110,7 @@ There can be quite some confusion when handling asynchronous commands manually. 
 
     ```js
     const links = await $$('a')
-    const linksText = await Promise.all(
-        links.map(async function (link) {
-            return link.getText();
-        })
-    )
+    const linksText = await links.map((link) => {
+        return link.getText();
+    })
     ```

--- a/website/docs/SyncVsAsync.md
+++ b/website/docs/SyncVsAsync.md
@@ -89,10 +89,7 @@ describe('suite async', () => {
 
         console.log(browser.capabilities) // static properties should not be awaited
 
-        // this WON'T WORK! You can't chain functions like this.
         await $('body').click()
-        // instead you need to:
-        await (await $('body')).click()
     })
 })
 ```
@@ -101,23 +98,21 @@ describe('suite async', () => {
 
 There can be quite some confusion when handling asynchronous commands manually. The usual problems are:
 
-- chaining of element commands:
-
-    ```js
-    await $('body').click()` // throws `$(...).click is not a function`
-    ```
-
-    You can't chain element calls as you have to await multiple asynchronous functions. To fix this, first await element then trigger the click, like so:
-
-    ```js
-    const el = await $('body')
-    await el.click()
-    ```
-
 - previous command was not awaited:
 
     ```js
     const el = await $('body')
     el.waitForExist() // ERROR: await is missing here, you'll get `Unhandled promise rejection`.
     await el.click()
+    ```
+
+- Array loops (e.g., `forEach` & `map`) need `Promise.all`
+
+    ```js
+    const links = await $$('a')
+    const linksText = await Promise.all(
+        links.map(async function (link) {
+            return link.getText();
+        })
+    )
     ```


### PR DESCRIPTION
## Proposed changes

We no longer need to warn people about using double awaits when taking element actions, so I've removed it from the async guidance. I also added a section about using array loops with async.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
