### PR TITLE
[Bug #7739] Fix preferScenarioName logic

### DIFF
--- a/packages/wdio-browserstack-service/src/service.ts
+++ b/packages/wdio-browserstack-service/src/service.ts
@@ -121,7 +121,7 @@ export default class BrowserstackService implements Services.ServiceInstance {
      */
     afterScenario (world: Frameworks.World) {
         const status = world.result?.status.toLowerCase()
-        if (status === 'skipped') {
+        if (status !== 'skipped') {
             this._scenariosThatRan.push(world.pickle.name || 'unknown pickle name')
         }
 

--- a/packages/wdio-browserstack-service/tests/service.test.ts
+++ b/packages/wdio-browserstack-service/tests/service.test.ts
@@ -670,13 +670,8 @@ describe('after', () => {
             describe('enabled', () => {
                 [
                     { status: 'FAILED', body: {
-                        name: 'Feature1',
-                        reason: 'Unknown Error',
-                        status: 'failed',
-                    } },
-                    { status: 'SKIPPED', body: {
                         name: 'Can do something single',
-                        reason: undefined,
+                        reason: 'Unknown Error',
                         status: 'failed',
                     } }
                     /*, 5, 4, 0*/
@@ -705,7 +700,7 @@ describe('after', () => {
 
                     await service.beforeFeature(null, { name: 'Feature1' })
 
-                    await service.afterScenario({ pickle: { name: 'Can do something single' }, result: { status: 'SKIPPED' } })
+                    await service.afterScenario({ pickle: { name: 'Can do something single' }, result: { status: 'passed' } })
 
                     await service.after(0)
 


### PR DESCRIPTION
## Proposed changes

Updating if method from ```afterScenario``` method to put scenario's name into ```this._scenariosThatRan``` only if test status is different from 'skipped' to make option ```preferScenarioName``` works when enabled. Fix bug #7739 

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
