### PR TITLE
fix(devtools): calling sendAlertText clears local driver state

### DIFF
--- a/packages/devtools/src/commands/sendAlertText.ts
+++ b/packages/devtools/src/commands/sendAlertText.ts
@@ -15,5 +15,7 @@ export default async function sendAlertText (
     }
 
     await this.activeDialog.accept(text)
+    delete this.activeDialog
+
     return null
 }


### PR DESCRIPTION
## Proposed changes

Upon calling accept(text), Puppeteer dismissed the dialog box, so the local state of the driver needs to be updated to reflect that.

This fix related to #7744

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers

@christian-bromann 