### PR TITLE
feat(webdriver): extend timeout error with info about exec command

### DIFF
--- a/packages/webdriver/src/constants.ts
+++ b/packages/webdriver/src/constants.ts
@@ -152,3 +152,8 @@ export const VALID_CAPS = [
     'pageLoadStrategy', 'proxy', 'setWindowRect', 'timeouts', 'strictFileInteractability',
     'unhandledPromptBehavior'
 ]
+
+export const REG_EXPS = {
+    commandName: /.*\/session\/[0-9a-f-]+\/(.*)/,
+    execFn: /return \(([\s\S]*)\)\.apply\(null, arguments\)/
+}

--- a/packages/webdriver/src/request/index.ts
+++ b/packages/webdriver/src/request/index.ts
@@ -7,7 +7,7 @@ import logger from '@wdio/logger'
 import { transformCommandLogResult } from '@wdio/utils'
 import type { Options } from '@wdio/types'
 
-import { isSuccessfulResponse, getErrorFromResponseBody } from '../utils'
+import { isSuccessfulResponse, getErrorFromResponseBody, getTimeoutError } from '../utils'
 
 const pkg = require('../../package.json')
 
@@ -203,7 +203,9 @@ export default abstract class WebDriverRequest extends EventEmitter {
              * handle timeouts
              */
             if ((response as RequestLibError).code === 'ETIMEDOUT') {
-                return retry(response, 'Request timed out! Consider increasing the "connectionRetryTimeout" option.')
+                const error = getTimeoutError(response, fullRequestOptions)
+
+                return retry(error, 'Request timed out! Consider increasing the "connectionRetryTimeout" option.')
             }
 
             /**

--- a/packages/webdriver/tests/request.test.ts
+++ b/packages/webdriver/tests/request.test.ts
@@ -3,6 +3,7 @@ import * as gotOrig from 'got'
 import http from 'http'
 import https from 'https'
 
+import * as utils from '../src/utils'
 import { Options } from '@wdio/types'
 import WebDriverRequest from '../src/request/node'
 
@@ -399,24 +400,49 @@ describe('webdriver request', () => {
             expect(result.message).toBe('Command can only be called to a Selenium Hub')
         })
 
-        it('should throw if timeout happens too often', async () => {
-            const retryCnt = 3
-            const req = new WebDriverRequest('POST', '/timeout', {}, true)
-            const reqRetryCnt = jest.fn()
-            req.on('retry', reqRetryCnt)
-            const result = await req.makeRequest({
-                protocol: 'https',
-                hostname: 'localhost',
-                port: 4445,
-                path: '/timeout',
-                connectionRetryCount: retryCnt,
-                logLevel: 'warn'
-            }, 'foobar').then(
-                (res) => res,
-                (e) => e
-            )
-            expect(result.code).toBe('ETIMEDOUT')
-            expect(reqRetryCnt).toBeCalledTimes(retryCnt)
+        describe('"ETIMEDOUT" error', () => {
+            it('should throw if timeout happens too often', async () => {
+                const retryCnt = 3
+                const req = new WebDriverRequest('POST', '/timeout', {}, true)
+                const reqRetryCnt = jest.fn()
+                req.on('retry', reqRetryCnt)
+                const result = await req.makeRequest({
+                    protocol: 'https',
+                    hostname: 'localhost',
+                    port: 4445,
+                    path: '/',
+                    connectionRetryCount: retryCnt,
+                    logLevel: 'warn'
+                }, 'foobar').then(
+                    (res) => res,
+                    (e) => e
+                )
+                expect(result.code).toBe('ETIMEDOUT')
+                expect(reqRetryCnt).toBeCalledTimes(retryCnt)
+            })
+
+            it('should use error from "getTimeoutError" helper', async () => {
+                const timeoutErr = new Error('Timeout')
+                const spy = jest.spyOn(utils, 'getTimeoutError').mockReturnValue(timeoutErr)
+
+                const req = new WebDriverRequest('GET', '/timeout', {}, true)
+                req.emit = jest.fn()
+                const reqOpts = {
+                    protocol: 'https',
+                    hostname: 'localhost',
+                    port: 4445,
+                    path: '/',
+                } as Options.WebDriver
+                await req.makeRequest(reqOpts, 'foobar')
+                    // ignore error
+                    .catch((e) => e)
+
+                expect(spy).toBeCalledTimes(1)
+                expect(spy).toBeCalledWith(expect.any(Error), expect.objectContaining({ method: 'GET' }))
+                expect(req.emit).toBeCalledWith('response', { error: timeoutErr })
+
+                spy.mockRestore()
+            })
         })
 
         it('should return proper response if retry passes', async () => {


### PR DESCRIPTION
## Proposed changes

Detailed information about the problem is described here - https://github.com/webdriverio/webdriverio/issues/7544.

After these changes, the timeout error of one of the commands will look like this:
```
2021-11-25T09:30:07.853Z ERROR webdriver: Request failed with status undefined due to TimeoutError: Timeout awaiting 'request' for 5000ms when running "url" with method "POST" and args "{"url":"http://localhost:3000/"}"
(node:45219) UnhandledPromiseRejectionWarning: RequestError: Timeout awaiting 'request' for 5000ms when running "url" with method "POST" and args "{"url":"http://localhost:3000/"}"
// ... stack trace
```

Before the changes:
```
2021-11-25T09:30:07.853Z ERROR webdriver: Request failed with status undefined due to TimeoutError: Timeout awaiting 'request' for 5000ms
(node:45219) UnhandledPromiseRejectionWarning: RequestError: Timeout awaiting 'request' for 5000ms
// ... stack trace
```

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

### Reviewers: @webdriverio/project-committers
