### PR TITLE
fix: update state for a skipped test

### DIFF
--- a/packages/wdio-cucumber-framework/src/index.ts
+++ b/packages/wdio-cucumber-framework/src/index.ts
@@ -43,7 +43,11 @@ const { incrementing } = IdGenerator
 
 function getResultObject (world: ITestCaseHookParameter): Frameworks.PickleResult {
     return {
-        passed: (world.result?.status === Cucumber.Status.PASSED || world.result?.status === Cucumber.Status.SKIPPED),
+        passed: (
+            world.result?.status === Cucumber.Status.PASSED
+            || world.result?.status === Cucumber.Status.SKIPPED
+            || world.result?.status === Cucumber.Status.PENDING
+        ),
         error: world.result?.message as string,
         duration: world.result?.duration?.nanos as number / 10e6 // convert into ms
     }

--- a/packages/wdio-cucumber-framework/src/index.ts
+++ b/packages/wdio-cucumber-framework/src/index.ts
@@ -43,11 +43,7 @@ const { incrementing } = IdGenerator
 
 function getResultObject (world: ITestCaseHookParameter): Frameworks.PickleResult {
     return {
-        passed: (
-            world.result?.status === Cucumber.Status.PASSED
-            || world.result?.status === Cucumber.Status.SKIPPED
-            || world.result?.status === Cucumber.Status.PENDING
-        ),
+        passed: (world.result?.status === Cucumber.Status.PASSED || world.result?.status === Cucumber.Status.SKIPPED),
         error: world.result?.message as string,
         duration: world.result?.duration?.nanos as number / 10e6 // convert into ms
     }

--- a/packages/wdio-cucumber-framework/src/index.ts
+++ b/packages/wdio-cucumber-framework/src/index.ts
@@ -43,7 +43,7 @@ const { incrementing } = IdGenerator
 
 function getResultObject (world: ITestCaseHookParameter): Frameworks.PickleResult {
     return {
-        passed: world.result?.status === Cucumber.Status.PASSED,
+        passed: (world.result?.status === Cucumber.Status.PASSED || world.result?.status === Cucumber.Status.SKIPPED),
         error: world.result?.message as string,
         duration: world.result?.duration?.nanos as number / 10e6 // convert into ms
     }

--- a/packages/wdio-cucumber-framework/src/reporter.ts
+++ b/packages/wdio-cucumber-framework/src/reporter.ts
@@ -199,7 +199,7 @@ class CucumberReporter {
             state,
             error,
             duration: Date.now() - this._testStart!?.getTime(),
-            passed: state === 'pass',
+            passed: ['pass', 'pending'].includes(state),
             file: uri
         }
 
@@ -215,6 +215,7 @@ class CucumberReporter {
                 tags: scenario.tags,
                 ...common
             }
+
         this.emit('test:' + state, payload)
     }
 

--- a/packages/wdio-cucumber-framework/src/reporter.ts
+++ b/packages/wdio-cucumber-framework/src/reporter.ts
@@ -204,7 +204,7 @@ class CucumberReporter {
             state,
             error,
             duration: Date.now() - this._testStart!?.getTime(),
-            passed: ['pass', 'pending', 'skip'].includes(state),
+            passed: ['pass', 'skip'].includes(state),
             file: uri
         }
 

--- a/packages/wdio-cucumber-framework/src/reporter.ts
+++ b/packages/wdio-cucumber-framework/src/reporter.ts
@@ -144,7 +144,7 @@ class CucumberReporter {
             state = 'pending'
             break
         case Status.SKIPPED:
-            state = 'skipp'
+            state = 'skip'
             break
         case Status.AMBIGUOUS:
             state = 'pending'

--- a/packages/wdio-cucumber-framework/src/reporter.ts
+++ b/packages/wdio-cucumber-framework/src/reporter.ts
@@ -141,9 +141,14 @@ class CucumberReporter {
             state = 'pass'
             break
         case Status.PENDING:
+            state = 'pending'
+            break
         case Status.SKIPPED:
+            state = 'skipp'
+            break
         case Status.AMBIGUOUS:
             state = 'pending'
+            break
         }
         let error = result.message ? new Error(result.message) : undefined
         let title = step
@@ -199,7 +204,7 @@ class CucumberReporter {
             state,
             error,
             duration: Date.now() - this._testStart!?.getTime(),
-            passed: ['pass', 'pending'].includes(state),
+            passed: ['pass', 'pending', 'skip'].includes(state),
             file: uri
         }
 


### PR DESCRIPTION
## Proposed changes

A `skipped` step state was seen as a failed test and thus was updating tests through services to failed, even though the spec reporter set the test to passed

```log
"spec" Reporter:
------------------------------------------------------------------
[chrome 96.0.4664.45 windows #0-0] Running: chrome (v96.0.4664.45) on windows
[chrome 96.0.4664.45 windows #0-0] Session ID: ef0f331920e7483b8d44cc4db327438c
[chrome 96.0.4664.45 windows #0-0]
[chrome 96.0.4664.45 windows #0-0] » /test/features/login.feature
[chrome 96.0.4664.45 windows #0-0] LoginPage
[chrome 96.0.4664.45 windows #0-0] As a user I want to verify that the login page loads
[chrome 96.0.4664.45 windows #0-0]    ✓ Given I load the Swag Labs demo website
[chrome 96.0.4664.45 windows #0-0]    - Then I should see the login page being loaded
[chrome 96.0.4664.45 windows #0-0]
[chrome 96.0.4664.45 windows #0-0] 1 passing (1.9s)
[chrome 96.0.4664.45 windows #0-0] 1 skipped
[chrome 96.0.4664.45 windows #0-0]

Spec Files:      1 passed, 1 total (100% completed) in 00:00:09
```

This PR changes the `failed` state for `skipped` steps|scenarios to `passed`

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments
Both functions that are touched didn't had UTs, the Cucumber UT are pretty complex and wondered if I need to adjust that now for this simple fix

### Reviewers: @webdriverio/project-committers
