### PR TITLE
feat: add cucumber step name in Sauce

### DIFF
--- a/packages/wdio-sauce-service/src/service.ts
+++ b/packages/wdio-sauce-service/src/service.ts
@@ -230,7 +230,7 @@ export default class SauceService implements Services.ServiceInstance {
             return
         }
 
-        return this.setAnnotation(`sauce:context=Feature:${this._suiteTitle}`)
+        return this.setAnnotation(`sauce:context=Feature: ${this._suiteTitle}`)
     }
 
     beforeScenario (world: Frameworks.World) {
@@ -244,6 +244,11 @@ export default class SauceService implements Services.ServiceInstance {
 
         const scenarioName = world.pickle.name || 'unknown scenario'
         return this.setAnnotation(`sauce:context=Scenario: ${scenarioName}`)
+    }
+
+    async beforeStep (step: Frameworks.PickleStep) {
+        const { keyword, text } = step
+        return this.setAnnotation(`sauce:context=--Step: ${keyword}${text}`)
     }
 
     /**

--- a/packages/wdio-sauce-service/src/service.ts
+++ b/packages/wdio-sauce-service/src/service.ts
@@ -243,7 +243,7 @@ export default class SauceService implements Services.ServiceInstance {
         }
 
         const scenarioName = world.pickle.name || 'unknown scenario'
-        return this.setAnnotation(`sauce:context=Scenario: ${scenarioName}`)
+        return this.setAnnotation(`sauce:context=-Scenario: ${scenarioName}`)
     }
 
     async beforeStep (step: Frameworks.PickleStep) {

--- a/packages/wdio-sauce-service/tests/service.test.ts
+++ b/packages/wdio-sauce-service/tests/service.test.ts
@@ -384,7 +384,7 @@ test('beforeScenario should set context', () => {
     service.setAnnotation = jest.fn()
     service.beforeSession()
     service.beforeScenario({ pickle: { name: 'foobar' } })
-    expect(service.setAnnotation).toBeCalledWith('sauce:context=Scenario: foobar')
+    expect(service.setAnnotation).toBeCalledWith('sauce:context=-Scenario: foobar')
 })
 
 test('beforeScenario should set context when no pickle name is provided', () => {
@@ -393,7 +393,7 @@ test('beforeScenario should set context when no pickle name is provided', () => 
     service.setAnnotation = jest.fn()
     service.beforeSession()
     service.beforeScenario({ pickle: { } })
-    expect(service.setAnnotation).toBeCalledWith('sauce:context=Scenario: unknown scenario')
+    expect(service.setAnnotation).toBeCalledWith('sauce:context=-Scenario: unknown scenario')
 })
 
 test('beforeScenario should not set context if no sauce user was applied', () => {
@@ -402,7 +402,7 @@ test('beforeScenario should not set context if no sauce user was applied', () =>
     service.setAnnotation = jest.fn()
     service.beforeSession()
     service.beforeScenario({ pickle: { name: 'foobar' } })
-    expect(service.setAnnotation).not.toBeCalledWith('sauce:context=Scenario: foobar')
+    expect(service.setAnnotation).not.toBeCalledWith('sauce:context=-Scenario: foobar')
 })
 
 test('beforeStep should set context', async () => {

--- a/packages/wdio-sauce-service/tests/service.test.ts
+++ b/packages/wdio-sauce-service/tests/service.test.ts
@@ -336,7 +336,7 @@ test('beforeFeature should set context', async () => {
     service.setAnnotation = jest.fn()
     service.beforeSession()
     await service.beforeFeature( uri, featureObject)
-    expect(service.setAnnotation).toBeCalledWith('sauce:context=Feature:Create a feature')
+    expect(service.setAnnotation).toBeCalledWith('sauce:context=Feature: Create a feature')
 })
 
 test('beforeFeature should not set context if RDC test', async () => {
@@ -346,7 +346,7 @@ test('beforeFeature should not set context if RDC test', async () => {
     upService['_isServiceEnabled'] = true
     upService.setAnnotation = jest.fn()
     await upService.beforeFeature(uri, featureObject)
-    expect(upService.setAnnotation).not.toBeCalledWith('sauce:context=Feature:Create a feature')
+    expect(upService.setAnnotation).not.toBeCalledWith('sauce:context=Feature: Create a feature')
 })
 
 test('beforeFeature should not set context if no sauce user was applied', async () => {
@@ -355,7 +355,7 @@ test('beforeFeature should not set context if no sauce user was applied', async 
     service.setAnnotation = jest.fn()
     service.beforeSession()
     await service.beforeFeature(uri, featureObject)
-    expect(service.setAnnotation).not.toBeCalledWith('sauce:context=Feature:Create a feature')
+    expect(service.setAnnotation).not.toBeCalledWith('sauce:context=Feature: Create a feature')
 })
 
 test('afterScenario', () => {
@@ -403,6 +403,21 @@ test('beforeScenario should not set context if no sauce user was applied', () =>
     service.beforeSession()
     service.beforeScenario({ pickle: { name: 'foobar' } })
     expect(service.setAnnotation).not.toBeCalledWith('sauce:context=Scenario: foobar')
+})
+
+test('beforeStep should set context', async () => {
+    const service = new SauceService({}, {}, { user: 'foobar', key: '123' } as any)
+    const step = {
+        id: '5',
+        text: 'I am a step',
+        astNodeIds: ['0'],
+        keyword: 'Given ',
+    }
+    service['_browser'] = browser
+    service.setAnnotation = jest.fn()
+    service.beforeSession()
+    await service.beforeStep(step)
+    expect(service.setAnnotation).toBeCalledWith('sauce:context=--Step: Given I am a step')
 })
 
 test('after', async () => {

--- a/packages/wdio-types/src/Frameworks.ts
+++ b/packages/wdio-types/src/Frameworks.ts
@@ -75,3 +75,25 @@ export interface PickleResult {
      */
     duration?: number
 }
+
+/**
+ * Info on of a pick (step)
+ */
+export interface PickleStep {
+    /**
+     * line number in the feature file
+     */
+    id: string
+    /**
+     * text of the step
+     */
+    text: string
+    /**
+     * Array of line numbers
+     */
+    astNodeIds: string[]
+    /**
+     * 'Given|When|Then|And' followed by a space
+     */
+    keyword: string
+}


### PR DESCRIPTION
## Proposed changes
Cucumber has a feature, scenario and a step. We now only push the feature and scenario name to Sauce Labs. This PR will also push the test step. This makes it "easier" to debug which command belongs to which step, see also below.

**NOTE:** I've added `--` to have an _indentation_ in Sauce, spaces will be trimmed and `&nbsp;` will not be translated to spaces in Sauce Labs

![image](https://user-images.githubusercontent.com/11979740/144599002-c35ffefc-4776-4881-9448-0f3612477daa.png)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments
-

### Reviewers: @webdriverio/project-committers
