### PR TITLE
Fix for Jasmine webdriverio exception not failing suite 

### DIFF
--- a/packages/wdio-reporter/src/stats/test.ts
+++ b/packages/wdio-reporter/src/stats/test.ts
@@ -5,6 +5,7 @@ import RunnableStats from './runnable'
 import { Argument } from '../types'
 import { pad, color, colorLines } from '../utils'
 import { AssertionError } from 'assert'
+import { types as nodeUtilTypes } from 'util'
 
 const maxStringLength = 2048
 
@@ -103,7 +104,7 @@ export default class TestStats extends RunnableStats {
             /**
              * only format if error object has either an "expected" or "actual" property set
              */
-            ((err as AssertionError).expected || (err as AssertionError).actual) &&
+            (((err as AssertionError).expected || (err as AssertionError).actual) && nodeUtilTypes.isProxy((err as AssertionError).actual)) &&
             /**
              * and if they aren't already formated, e.g. in Jasmine
              */

--- a/packages/wdio-reporter/src/stats/test.ts
+++ b/packages/wdio-reporter/src/stats/test.ts
@@ -104,7 +104,7 @@ export default class TestStats extends RunnableStats {
             /**
              * only format if error object has either an "expected" or "actual" property set
              */
-            (((err as AssertionError).expected || (err as AssertionError).actual) && nodeUtilTypes.isProxy((err as AssertionError).actual)) &&
+            (((err as AssertionError).expected || (err as AssertionError).actual) && !nodeUtilTypes.isProxy((err as AssertionError).actual)) &&
             /**
              * and if they aren't already formated, e.g. in Jasmine
              */

--- a/packages/wdio-reporter/tests/stats/test.test.ts
+++ b/packages/wdio-reporter/tests/stats/test.test.ts
@@ -97,4 +97,49 @@ describe('TestStats', () => {
         stat.fail([new AssertionError({ message: 'foobar\nExpected: foo\nReceived: bar42', actual: 'true', expected: 'false' })])
         expect(stat.error?.message).toContain('bar42')
     })
+
+    it('should not call stringifyDiffObjs if actual is a Proxy', () => {
+        const TestStatsSpy = jest.spyOn(TestStats.prototype as any, '_stringifyDiffObjs')
+        const orderBuilder = new TestStats({
+            type: 'test:start',
+            title: 'should can do something',
+            parent: 'My awesome feature',
+            fullTitle: 'My awesome feature should can do something',
+            pending: false,
+            cid: '0-0',
+            specs: ['/path/to/test/specs/sync.spec.js'],
+            uid: 'should can do something3',
+            argument: { rows: [{ cells: ['hello'] }] }
+        })
+        orderBuilder.complete = jest.fn()
+        stat.fail([new AssertionError({
+            message: 'Expect $(`#flash`) to be existing\n\nExpected \u001b[32m"existing"\u001b[39m\nReceived \u001b[31m"\u001b[7mnot \u001b[27mexisting"\u001b[39m',
+            expected: 'hi',
+            actual: new Proxy(new Promise(()=>{}), {})
+        })])
+        expect(TestStatsSpy).not.toHaveBeenCalled()
+    })
+
+    it('should call stringifyDiffObjs if actual is not a Proxy', () => {
+        const TestStatsSpy = jest.spyOn(TestStats.prototype as any, '_stringifyDiffObjs')
+        const orderBuilder = new TestStats({
+            type: 'test:start',
+            title: 'should can do something',
+            parent: 'My awesome feature',
+            fullTitle: 'My awesome feature should can do something',
+            pending: false,
+            cid: '0-0',
+            specs: ['/path/to/test/specs/sync.spec.js'],
+            uid: 'should can do something3',
+            argument: { rows: [{ cells: ['hello'] }] }
+        })
+        orderBuilder.complete = jest.fn()
+        stat.fail([new AssertionError({
+            message: 'Expect $(`#flash`) to be existing\n\nExpected \u001b[32m"existing"\u001b[39m\nReceived \u001b[31m"\u001b[7mnot \u001b[27mexisting"\u001b[39m',
+            expected: 'hi',
+            actual: 'false'
+        })])
+        expect(TestStatsSpy).toHaveBeenCalled()
+    })
+
 })

--- a/packages/wdio-reporter/tests/stats/test.test.ts
+++ b/packages/wdio-reporter/tests/stats/test.test.ts
@@ -100,18 +100,6 @@ describe('TestStats', () => {
 
     it('should not call stringifyDiffObjs if actual is a Proxy', () => {
         const TestStatsSpy = jest.spyOn(TestStats.prototype as any, '_stringifyDiffObjs')
-        const orderBuilder = new TestStats({
-            type: 'test:start',
-            title: 'should can do something',
-            parent: 'My awesome feature',
-            fullTitle: 'My awesome feature should can do something',
-            pending: false,
-            cid: '0-0',
-            specs: ['/path/to/test/specs/sync.spec.js'],
-            uid: 'should can do something3',
-            argument: { rows: [{ cells: ['hello'] }] }
-        })
-        orderBuilder.complete = jest.fn()
         stat.fail([new AssertionError({
             message: 'Expect $(`#flash`) to be existing\n\nExpected \u001b[32m"existing"\u001b[39m\nReceived \u001b[31m"\u001b[7mnot \u001b[27mexisting"\u001b[39m',
             expected: 'hi',
@@ -122,18 +110,6 @@ describe('TestStats', () => {
 
     it('should call stringifyDiffObjs if actual is not a Proxy', () => {
         const TestStatsSpy = jest.spyOn(TestStats.prototype as any, '_stringifyDiffObjs')
-        const orderBuilder = new TestStats({
-            type: 'test:start',
-            title: 'should can do something',
-            parent: 'My awesome feature',
-            fullTitle: 'My awesome feature should can do something',
-            pending: false,
-            cid: '0-0',
-            specs: ['/path/to/test/specs/sync.spec.js'],
-            uid: 'should can do something3',
-            argument: { rows: [{ cells: ['hello'] }] }
-        })
-        orderBuilder.complete = jest.fn()
         stat.fail([new AssertionError({
             message: 'Expect $(`#flash`) to be existing\n\nExpected \u001b[32m"existing"\u001b[39m\nReceived \u001b[31m"\u001b[7mnot \u001b[27mexisting"\u001b[39m',
             expected: 'hi',


### PR DESCRIPTION
## Proposed changes

This fixes [🐛 Bug]: Spec status shows passed even if one spec failed #7822 . The emit(e,) was throwing erro because internally  we were using difference check between actual and expectd , the actual in this case was proxy instead of string

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
