### PR TITLE
Add support for arguments via  _config

### DIFF
--- a/packages/wdio-appium-service/src/launcher.ts
+++ b/packages/wdio-appium-service/src/launcher.ts
@@ -35,6 +35,10 @@ export default class AppiumLauncher implements Services.ServiceInstance {
             basePath: DEFAULT_CONNECTION.path,
             ...(this._options.args || {})
         }
+        if (_config.hasOwnProperty('args') && typeof this._config['args'] === 'object') {
+            this._args = { ...this.args, ...this._config['args']}
+        }
+        
         this._logPath = _options.logPath || this._config?.outputDir
         this._command = this._getCommand(_options.command)
     }


### PR DESCRIPTION
## Proposed changes
In codeceptJS there is not an option to pass in appium args to the server since it does not support passing args via `services: ['appium']` (it uses the service name to load npm packages) to get around this issue we can check if the `_config` argument had `args` object an example displayed below.
```
plugins: {
    wdio: {
      enabled: true,
      services: ['appium'],
      args: {
        port: 4723,
        basePath: '/wd/hub/',
      }
    },
}
```
[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
