### PR TITLE
Ensure correct reporting when a thread runs more then 1 Cucumber feature (spec)

### DIFF
--- a/packages/wdio-junit-reporter/src/index.ts
+++ b/packages/wdio-junit-reporter/src/index.ts
@@ -63,12 +63,7 @@ class JunitReporter extends WDIOReporter {
         return suite
     }
 
-    private _addCucumberFeatureToBuilder(
-        builder: any,
-        runner: RunnerStats,
-        specFileName: string,
-        suite: SuiteStats
-    ) {
+    private _addCucumberFeatureToBuilder(builder: any, runner: RunnerStats, specFileName: string, suite: SuiteStats) {
         const featureName = !this.options.suiteNameFormat || this.options.suiteNameFormat instanceof RegExp
             ? this._prepareName(suite.title)
             : this.options.suiteNameFormat({ name: this.options.suiteNameFormat.name, suite })
@@ -89,7 +84,6 @@ class JunitReporter extends WDIOReporter {
         } else if (this._activeFeature) {
             let scenario = suite
             const testName = this._prepareName(suite.title)
-
             const classNameFormat = this.options.classNameFormat ? this.options.classNameFormat({ packageName: this._packageName, activeFeatureName: this._activeFeatureName }): `${this._packageName}.${this._activeFeatureName}`
             const testCase = this._activeFeature.testCase()
                 .className(classNameFormat)
@@ -237,7 +231,6 @@ class JunitReporter extends WDIOReporter {
         } else {
             this._packageName = this.options.packageName || runner.sanitizedCapabilities
         }
-
         const isCucumberFrameworkRunner = runner.config.framework === 'cucumber'
         if (isCucumberFrameworkRunner) {
             this._packageName = `CucumberJUnitReport-${this._packageName}`
@@ -248,15 +241,14 @@ class JunitReporter extends WDIOReporter {
             this._fileNameLabel = 'file'
         }
 
-        // there should only be one spec file per runner so we can safely take the first element of the array
-        const specFileName = runner.specs[0]
-        if (isCucumberFrameworkRunner) {
-            this._buildOrderedReport(builder, runner, specFileName, 'feature', isCucumberFrameworkRunner)
-            this._buildOrderedReport(builder, runner, specFileName, 'scenario', isCucumberFrameworkRunner)
-        } else {
-            this._buildOrderedReport(builder, runner, specFileName, '', isCucumberFrameworkRunner)
-        }
-
+        runner.specs.forEach((specFileName) => {
+            if (isCucumberFrameworkRunner) {
+                this._buildOrderedReport(builder, runner, specFileName, 'feature', isCucumberFrameworkRunner)
+                this._buildOrderedReport(builder, runner, specFileName, 'scenario', isCucumberFrameworkRunner)
+            } else {
+                this._buildOrderedReport(builder, runner, specFileName, '', isCucumberFrameworkRunner)
+            }
+        })
         return builder.build()
     }
 
@@ -270,7 +262,7 @@ class JunitReporter extends WDIOReporter {
                 continue
             }
             const suite = this.suites[suiteKey]
-            if (isCucumberFrameworkRunner && suite.type === type) {
+            if (isCucumberFrameworkRunner && suite.type === type && specFileName === suite.file) {
                 builder = this._addCucumberFeatureToBuilder(builder, runner, specFileName, suite)
             } else if (!isCucumberFrameworkRunner) {
                 builder = this._addSuiteToBuilder(builder, runner, specFileName, suite)


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

When grouping specs the reporter goes wacky and does not assign test cases to test suites properly, original code which I wrote assumed 1 spec per thread worker which is an incorrect assumption.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
- [X] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
