### PR TITLE
bump puppeteer-core (CVE-2022-0235)

### DIFF
--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -31,7 +31,7 @@
     "@wdio/utils": "7.16.14",
     "chrome-launcher": "^0.15.0",
     "edge-paths": "^2.1.0",
-    "puppeteer-core": "^13.0.0",
+    "puppeteer-core": "^13.1.3",
     "query-selector-shadow-dom": "^1.0.0",
     "ua-parser-js": "^1.0.1",
     "uuid": "^8.0.0"

--- a/packages/wdio-devtools-service/package.json
+++ b/packages/wdio-devtools-service/package.json
@@ -38,7 +38,7 @@
     "istanbul-lib-report": "^3.0.0",
     "istanbul-reports": "^3.0.2",
     "lighthouse": "8.6.0",
-    "puppeteer-core": "^13.0.0",
+    "puppeteer-core": "^13.1.3",
     "speedline": "^1.4.1",
     "stable": "^0.1.8",
     "webdriverio": "7.16.14"

--- a/packages/webdriverio/package.json
+++ b/packages/webdriverio/package.json
@@ -77,7 +77,7 @@
     "lodash.isplainobject": "^4.0.6",
     "lodash.zip": "^4.2.0",
     "minimatch": "^3.0.4",
-    "puppeteer-core": "^13.0.0",
+    "puppeteer-core": "^13.1.3",
     "query-selector-shadow-dom": "^1.0.0",
     "resq": "^1.9.1",
     "rgb2hex": "0.2.5",


### PR DESCRIPTION
## Proposed changes

Bumps puppeteer-core to ensure that transitive dependency on `node-fetch` is updated to `2.6.7`, to resolve [CVE-2022-0235](https://github.com/advisories/GHSA-r683-j2x4-v87g)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
