### PR TITLE
Webdriver: Fix stacktrace not being displayed on some errors

### DIFF
--- a/packages/webdriver/src/utils.ts
+++ b/packages/webdriver/src/utils.ts
@@ -243,9 +243,7 @@ export class CustomRequestError extends Error {
             this.name = errorObj.name || 'WebDriver Error'
         }
 
-        if (errorObj.stacktrace) {
-            this.stack = errorObj.stacktrace
-        }
+        Error.captureStackTrace(this, CustomRequestError)
     }
 }
 

--- a/packages/webdriver/tests/utils.test.ts
+++ b/packages/webdriver/tests/utils.test.ts
@@ -140,22 +140,32 @@ describe('utils', () => {
         error = new CustomRequestError({ value: { message: 'stale element reference' } })
         expect(error.name).toBe('stale element reference')
         expect(error.message).toBe('stale element reference')
+        expect(error.stack).toMatch('stale element reference')
+        expect(error.stack).toMatch('stale element reference')
 
         error = new CustomRequestError({ value: { message: 'message' } } )
         expect(error.name).toBe('WebDriver Error')
         expect(error.message).toBe('message')
+        expect(error.stack).toMatch('WebDriver Error')
+        expect(error.stack).toMatch('message')
 
         error = new CustomRequestError({ value: { class: 'class' } } )
         expect(error.name).toBe('WebDriver Error')
         expect(error.message).toBe('class')
+        expect(error.stack).toMatch('WebDriver Error')
+        expect(error.stack).toMatch('class')
 
         error = new CustomRequestError({ value: { name: 'Protocol Error' } } )
         expect(error.name).toBe('Protocol Error')
         expect(error.message).toBe('unknown error')
+        expect(error.stack).toMatch('Protocol Error')
+        expect(error.stack).toMatch('unknown error')
 
         error = new CustomRequestError({ value: { } } )
         expect(error.name).toBe('WebDriver Error')
         expect(error.message).toBe('unknown error')
+        expect(error.stack).toMatch('WebDriver Error')
+        expect(error.stack).toMatch('unknown error')
     })
 
     describe('setupDirectConnect', () => {


### PR DESCRIPTION
## Proposed changes

Fixes #7771 

Stacktraces are not always being shown when thrown from CustomRequestError.

A couple examples are an invalid xpath selector and errors inside browser.execute()

This can be reproduced with the following code.

Invalid xpath:
```javascript
describe('Test', () => {
    it('xpath', async () => {
        await browser.url('https://webdriver.io');
        await $(`.foo[test]="test"`);
    });
});
```

Error in browser.execute
```javascript
describe('Test', () => {
    it('execute', async () => {
        await browser.url('https://webdriver.io');
        await browser.execute(() => {
            $('.foo').something();
        });
    });
});
```

Before:
![image](https://user-images.githubusercontent.com/1300981/154330701-9076ba06-57c1-44e5-b37b-38a69dcdc609.png)

After:
![image](https://user-images.githubusercontent.com/1300981/154330907-9a0580eb-eca7-4aaf-9e2d-cbbd5ba8dfa4.png)


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

I'm not sure if there is a good way to update the tests for validating stacktraces. If there is let me know and I can create them. 

### Reviewers: @webdriverio/project-committers
