### PR TITLE
Run user hooks before service hooks

### DIFF
--- a/packages/wdio-cli/src/launcher.ts
+++ b/packages/wdio-cli/src/launcher.ts
@@ -135,11 +135,14 @@ class Launcher {
 
             /**
              * run onComplete hook
-             * even if it fails we still want to see result and end logger stream
+             * Even if it fails we still want to see result and end logger stream.
+             * Also ensure that user hooks are run before service hooks so that e.g.
+             * a user can use plugin service, e.g. shared store service is still
+             * available running hooks in this order
              */
             log.info('Run onComplete hook')
-            await runServiceHook(this._launcher, 'onComplete', exitCode, config, caps)
             const onCompleteResults = await runOnCompleteHook(config.onComplete!, config, caps, exitCode, this.interface.result)
+            await runServiceHook(this._launcher, 'onComplete', exitCode, config, caps)
 
             // if any of the onComplete hooks failed, update the exit code
             exitCode = onCompleteResults.includes(1) ? 1 : exitCode


### PR DESCRIPTION
## Proposed changes

fixes #7915

Currently the `onComplete` hook of a user is run after all service hooks. I see this order problematic because it wouldn't allow to leverage services created by plugins, e.g. shared-store-service

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
