### PR TITLE
Eslint: Fix error when using recommended rules

### DIFF
--- a/packages/eslint-plugin-wdio/src/index.ts
+++ b/packages/eslint-plugin-wdio/src/index.ts
@@ -18,7 +18,11 @@ const configs = {
             expect             : false,
             multiremotebrowser : false,
         },
-        rules
+        rules : {
+            'wdio/await-expect' : 'error',
+            'wdio/no-debug'     : 'error',
+            'wdio/no-pause'     : 'error',
+        }
     }
 }
 


### PR DESCRIPTION
## Proposed changes

When using recommended in a eslintrc file it is getting an error. This fixes the config object to use the string name of the rules instead of the imported rules.

```
Error: wdio/.eslintrc.js » plugin:wdio/recommended:
        Configuration for rule "await-expect" is invalid:
        Severity should be one of the following: 0 = off, 1 = warn, 2 = error (you passed '{  meta: {    type: "prob
lem",    docs: {      description: "expect must be prefixed with await",      category: "Possible Errors",      url:
 "https://github.com/webdriverio/packages/eslint-plugin-wdio/docs/rules/await-expect.md",      recommended: false
 },    messages: { missingAwait: "Missing await before an expect statement" },    hasSuggestions: true  },  create:
[Function: create]}').
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

### Reviewers: @webdriverio/project-committers
