### PR TITLE
wdio-cli: Update tsconfig target version to es2019 for new projects

### DIFF
--- a/packages/wdio-cli/src/commands/config.ts
+++ b/packages/wdio-cli/src/commands/config.ts
@@ -102,7 +102,7 @@ const runConfig = async function (useYarn: boolean, yes: boolean, exit = false) 
                     frameworkPackage.package,
                     'expect-webdriverio'
                 ],
-                target: 'ES5',
+                target: 'es2019',
             }
         }
 

--- a/packages/wdio-cli/tests/commands/config.test.ts
+++ b/packages/wdio-cli/tests/commands/config.test.ts
@@ -217,7 +217,7 @@ test('prints TypeScript setup message with ts-node installed', async () => {
                 '@wdio/mocha-framework',
                 'expect-webdriverio'
             ],
-            target: 'ES5',
+            target: 'es2019',
         }
     }
 


### PR DESCRIPTION
## Proposed changes

When creating a new TypeScript project from the CLI set the target version to es2019 which supports node 12+. This fixes an issue where the stacktraces would not list the the test file in the result, only the wdio files would be showing.

Before
```js
[chrome 99.0.4844.74 linux #0-0] » /test/specs/example.e2e.ts
[chrome 99.0.4844.74 linux #0-0] My Login application
[chrome 99.0.4844.74 linux #0-0]    ✖ should login with valid credentials
[chrome 99.0.4844.74 linux #0-0]
[chrome 99.0.4844.74 linux #0-0] 1 failing (11s)
[chrome 99.0.4844.74 linux #0-0]
[chrome 99.0.4844.74 linux #0-0] 1) My Login application should login with valid credentials
[chrome 99.0.4844.74 linux #0-0] Can't call setValue on element with selector ".adfsadfs" because element wasn't found
[chrome 99.0.4844.74 linux #0-0] Error: Can't call setValue on element with selector ".adfsadfs" because element wasn't found
[chrome 99.0.4844.74 linux #0-0]     at implicitWait (/home/will/dev/wdio-st/node_modules/webdriverio/build/utils/implicitWait.js:34:19)
[chrome 99.0.4844.74 linux #0-0]     at async Element.elementErrorHandlerCallbackFn (/home/will/dev/wdio-st/node_modules/webdriverio/build/middlewares.js:20:29)
[chrome 99.0.4844.74 linux #0-0]     at async Element.wrapCommandFn (/home/will/dev/wdio-st/node_modules/@wdio/utils/build/shim.js:137:29)
```

After:
```js
[chrome 99.0.4844.74 linux #0-0] » /test/specs/example.e2e.ts
[chrome 99.0.4844.74 linux #0-0] My Login application
[chrome 99.0.4844.74 linux #0-0]    ✖ should login with valid credentials
[chrome 99.0.4844.74 linux #0-0]
[chrome 99.0.4844.74 linux #0-0] 1 failing (10.9s)
[chrome 99.0.4844.74 linux #0-0]
[chrome 99.0.4844.74 linux #0-0] 1) My Login application should login with valid credentials
[chrome 99.0.4844.74 linux #0-0] Can't call setValue on element with selector ".adfsadfs" because element wasn't found
[chrome 99.0.4844.74 linux #0-0] Error: Can't call setValue on element with selector ".adfsadfs" because element wasn't found
[chrome 99.0.4844.74 linux #0-0]     at implicitWait (/home/will/dev/wdio-st/node_modules/webdriverio/build/utils/implicitWait.js:34:19)
[chrome 99.0.4844.74 linux #0-0]     at async Element.elementErrorHandlerCallbackFn (/home/will/dev/wdio-st/node_modules/webdriverio/build/middlewares.js:20:29)
[chrome 99.0.4844.74 linux #0-0]     at async Element.wrapCommandFn (/home/will/dev/wdio-st/node_modules/@wdio/utils/build/shim.js:137:29)
[chrome 99.0.4844.74 linux #0-0]     at async Context.<anonymous> (/home/will/dev/wdio-st/test/specs/example.e2e.ts:8:9)
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

### Reviewers: @webdriverio/project-committers
