### PR TITLE
wdio-utils: Filter out internal stacktraces

### DIFF
--- a/packages/wdio-utils/src/test-framework/testFnWrapper.ts
+++ b/packages/wdio-utils/src/test-framework/testFnWrapper.ts
@@ -10,6 +10,11 @@ import type {
     JasmineContext
 } from './types'
 
+const STACKTRACE_FILTER = [
+    'node_modules',
+    '(internal/process/task',
+]
+
 /**
  * wraps test framework spec/hook function with WebdriverIO before/after hooks
  *
@@ -77,6 +82,10 @@ export const testFrameworkFnWrapper = async function (
     try {
         result = await promise
     } catch (err: any) {
+        if (err.stack) {
+            err.stack = filterStackTrace(err.stack)
+        }
+
         error = err
     }
     const duration = Date.now() - testStart
@@ -105,4 +114,16 @@ export const testFrameworkFnWrapper = async function (
         throw error
     }
     return result
+}
+
+/**
+ * Filter out internal stacktraces. exporting to allow testing of the function
+ * @param   {string} stack Stacktrace
+ * @returns {string}
+ */
+export const filterStackTrace = (stack: string): string => {
+    return stack
+        .split('\n')
+        .filter(line => !STACKTRACE_FILTER.some(l => line.includes(l)))
+        .join('\n')
 }


### PR DESCRIPTION
## Proposed changes

Filters out internal stacktraces. This is the same concept we had for sync in https://github.com/webdriverio/webdriverio/pull/3750 but is needed for async now.

Before
```js
[chrome 99.0.4844.74 linux #0-0] 1) My Login application should login with valid credentials
[chrome 99.0.4844.74 linux #0-0] Can't call setValue on element with selector ".adfsadfs" because element wasn't found
[chrome 99.0.4844.74 linux #0-0] Error: Can't call setValue on element with selector ".adfsadfs" because element wasn't found
[chrome 99.0.4844.74 linux #0-0]     at implicitWait (/home/will/dev/wdio-st/node_modules/webdriverio/build/utils/implicitWait.js:34:19)
[chrome 99.0.4844.74 linux #0-0]     at async Element.elementErrorHandlerCallbackFn (/home/will/dev/wdio-st/node_modules/webdriverio/build/middlewares.js:20:29)
[chrome 99.0.4844.74 linux #0-0]     at async Element.wrapCommandFn (/home/will/dev/wdio-st/node_modules/@wdio/utils/build/shim.js:137:29)
[chrome 99.0.4844.74 linux #0-0]     at async Context.<anonymous> (/home/will/dev/wdio-st/test/specs/example.e2e.ts:8:9)
```

After
```js
[chrome 99.0.4844.74 linux #0-0] 1) My Login application should login with valid credentials
[chrome 99.0.4844.74 linux #0-0] Can't call setValue on element with selector ".adfsadfs" because element wasn't found
[chrome 99.0.4844.74 linux #0-0] Error: Can't call setValue on element with selector ".adfsadfs" because element wasn't found
[chrome 99.0.4844.74 linux #0-0]     at async Context.<anonymous> (/home/will/dev/wdio-st/test/specs/example.e2e.ts:8:9)
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

### Reviewers: @webdriverio/project-committers
