### PR TITLE
Replacement of wdio-tesults-reporter with wdio-tesults-service

### DIFF
--- a/packages/wdio-cli/src/constants.ts
+++ b/packages/wdio-cli/src/constants.ts
@@ -94,8 +94,7 @@ export const SUPPORTED_PACKAGES = {
         { name: 'timeline', value: 'wdio-timeline-reporter$--$timeline' },
         { name: 'html', value: '@rpii/wdio-html-reporter$--$html' },
         { name: 'markdown', value: 'carmenmitru/wdio-markdown-reporter' },
-        { name: 'delta', value: '@delta-reporter/wdio-delta-reporter-service' },
-        { name: 'tesults', value: 'wdio-tesults-reporter$--$tesults' }
+        { name: 'delta', value: '@delta-reporter/wdio-delta-reporter-service' }
     ],
     plugin: [
         { name: 'wait-for', value: 'wdio-wait-for$--$wait-for' },
@@ -136,6 +135,7 @@ export const SUPPORTED_PACKAGES = {
         { name: 'aws-device-farm', value: 'wdio-aws-device-farm-service$--$aws-device-farm' },
         { name: 'ocr-native-apps', value: 'wdio-ocr-service$--$ocr-native-apps' },
         { name: 'ms-teams', value: 'wdio-ms-teams-service$--$ms-teams' },
+        { name: 'tesults', value: 'wdio-tesults-service$--$tesults' }
     ]
 } as const
 

--- a/scripts/docs-generation/3rd-party/reporters.json
+++ b/scripts/docs-generation/3rd-party/reporters.json
@@ -52,11 +52,5 @@
     "title": "Delta Reporter",
     "githubUrl": "https://github.com/delta-reporter/delta-reporter-wdio",
     "npmUrl": "https://www.npmjs.com/package/@delta-reporter/wdio-delta-reporter-service"
-  },
-  {
-    "packageName": "wdio-tesults-reporter",
-    "title": "Tesults",
-    "githubUrl": "https://github.com/tesults/wdio-tesults-reporter",
-    "npmUrl": "https://www.npmjs.com/package/wdio-tesults-reporter"
   }
 ]

--- a/scripts/docs-generation/3rd-party/services.json
+++ b/scripts/docs-generation/3rd-party/services.json
@@ -139,5 +139,11 @@
     "title": "Microsoft Teams",
     "githubUrl": "https://github.com/marcelblijleven/wdio-ms-teams-service",
     "npmUrl": "https://www.npmjs.com/package/wdio-ms-teams-service"
+  },
+  {
+    "packageName": "wdio-tesults-service",
+    "title": "Tesults",
+    "githubUrl": "https://github.com/tesults/wdio-tesults-service",
+    "npmUrl": "https://www.npmjs.com/package/wdio-tesults-service"
   }
 ]


### PR DESCRIPTION
## Proposed changes

The wdio-tesults-reporter has been deprecated in favor of wdio-tesults-service. To reflect this change the reporter has been removed from the documentation and cli and replaced with the service.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

- [x ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [  ] I have added tests that prove my fix is effective or that my feature works
- [x ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # This is a relatively minor change to keep wdio in sync with changes to a third-party service. The change updates documentation and cli for third party service install.

### Reviewers: @webdriverio/project-committers
