### PR TITLE
Chain custom commands end with $

### DIFF
--- a/packages/wdio-utils/src/shim.ts
+++ b/packages/wdio-utils/src/shim.ts
@@ -251,7 +251,7 @@ let wrapCommand = function wrapCommand<T>(commandName: string, fn: Function): (.
                      * await $('foo').$('bar')
                      * ```
                      */
-                    if (ELEMENT_QUERY_COMMANDS.includes(prop)) {
+                    if (ELEMENT_QUERY_COMMANDS.includes(prop) || prop.endsWith('$')) {
                         // this: WebdriverIO.Element
                         return wrapCommand(prop, function (this: any, ...args: any) {
                             return this[prop].apply(this, args)
@@ -336,7 +336,7 @@ let wrapCommand = function wrapCommand<T>(commandName: string, fn: Function): (.
          */
         const command = hasWdioSyncSupport && wdioSync && Boolean(global.browser) && !runAsync && !asyncSpec
             ? wdioSync!.wrapCommand(commandName, fn)
-            : ELEMENT_QUERY_COMMANDS.includes(commandName)
+            : ELEMENT_QUERY_COMMANDS.includes(commandName) || commandName.endsWith('$')
                 ? chainElementQuery
                 : wrapCommandFn
 

--- a/packages/wdio-utils/tests/shim-async.test.ts
+++ b/packages/wdio-utils/tests/shim-async.test.ts
@@ -246,6 +246,25 @@ describe('wrapCommand', () => {
         expect(scope.getTagName).toBeCalledTimes(1)
     })
 
+    it('allows to chain element promises for custom command', async () => {
+        const rawCommand = jest.fn()
+        const scope: Partial<BrowserObject> = {
+            options: {
+                beforeCommand: jest.fn(),
+                afterCommand: jest.fn()
+            },
+            getTagName: jest.fn().mockResolvedValue('Yayy'),
+            user$: rawCommand
+        }
+        rawCommand.mockReturnValue(Promise.resolve(scope))
+        const commandB = wrapCommand('user$', rawCommand)
+        expect(await commandB.call(scope, 'bar').user$('foo').getTagName()).toBe('Yayy')
+        expect(scope.user$).toBeCalledTimes(2)
+        expect(scope.user$).toBeCalledWith('bar')
+        expect(scope.user$).toBeCalledWith('foo')
+        expect(scope.getTagName).toBeCalledTimes(1)
+    })
+
     it('allows to access indexed element', async () => {
         const rawCommand$ = jest.fn()
         const rawCommand$$ = jest.fn()

--- a/website/docs/CustomCommands.md
+++ b/website/docs/CustomCommands.md
@@ -84,6 +84,13 @@ console.log(typeof browser.myCustomElementCommand2) // outputs "undefined"
 console.log(elem3.myCustomElementCommand2('foobar')) // outputs "function"
 ```
 
+__Note:__ If you need to chain a custom command, the command should end with `$`, 
+```js
+browser.addCommand("user$", (locator) => { return ele })
+browser.addCommand("user$", (locator) => { return ele }, true)
+await browser.user$('foo').user$('bar').click()
+```
+
 Be careful to not overload the `browser` scope with too many custom commands.
 
 We recommend defining custom logic in [page objects](PageObjects.md), so they are bound to a specific page.


### PR DESCRIPTION
## Proposed changes

Chaining custom command ends with `$`, https://github.com/webdriverio/webdriverio/issues/8043

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
