### PR TITLE
Fix getSize if prop is 0

### DIFF
--- a/packages/webdriverio/src/commands/element/getSize.ts
+++ b/packages/webdriverio/src/commands/element/getSize.ts
@@ -47,7 +47,7 @@ async function getSize (
         rect = await this.getElementSize(this.elementId) as RectReturn
     }
 
-    if (prop && rect[prop]) {
+    if (prop && typeof rect[prop] === 'number') {
         return rect[prop] as number
     }
 

--- a/packages/webdriverio/tests/commands/element/getSize.test.ts
+++ b/packages/webdriverio/tests/commands/element/getSize.test.ts
@@ -55,7 +55,7 @@ describe('getSize test', () => {
         const height = await elem.getSize('height')
         expect(height).toBe(30)
         const invalid = await elem.getSize('foobar')
-        expect(invalid).toEqual({ width: 30, height: 30 })
+        expect(invalid).toEqual({ width: 50, height: 30 })
     })
 
     afterEach(() => {

--- a/packages/webdriverio/tests/commands/element/getSize.test.ts
+++ b/packages/webdriverio/tests/commands/element/getSize.test.ts
@@ -54,6 +54,8 @@ describe('getSize test', () => {
         expect(width).toBe(50)
         const height = await elem.getSize('height')
         expect(height).toBe(30)
+        const invalid = await elem.getSize('foobar')
+        expect(invalid).toEqual({ width: 30, height: 30 })
     })
 
     afterEach(() => {


### PR DESCRIPTION
## Proposed changes

If the height of an element would be `0` and someone would call `getSize("height")` the return value would be an object with width and height properties rather than `0` due to an invalid check.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
