### PR TITLE
chore(wdio-types): remove implicit dependency on ts-node

### DIFF
--- a/packages/wdio-types/package.json
+++ b/packages/wdio-types/package.json
@@ -31,5 +31,8 @@
   "dependencies": {
     "@types/node": "^17.0.4",
     "got": "^11.8.1"
+  },
+  "peerDependencies": {
+    "typescript": "^4.6.2"
   }
 }

--- a/packages/wdio-types/src/Compiler.ts
+++ b/packages/wdio-types/src/Compiler.ts
@@ -1,0 +1,202 @@
+// These types are extracted from `ts-node` (`dist/index.d.ts`) to avoid the dependendy on `ts-node`
+// Copyright (c) 2014 Blake Embrey (hello@blakeembrey.com)
+// Licsense: MIT
+
+import type * as _ts from 'typescript'
+export type ModuleTypes = Record<string, 'cjs' | 'esm' | 'package'>
+
+interface CreateOptions {
+  /**
+   * Behave as if invoked within this working directory.  Roughly equivalent to `cd $dir && ts-node ...`
+   *
+   * @default process.cwd()
+   */
+  cwd?: string;
+  /**
+   * Legacy alias for `cwd`
+   *
+   * @deprecated use `projectSearchDir` or `cwd`
+   */
+  dir?: string;
+  /**
+   * Emit output files into `.ts-node` directory.
+   *
+   * @default false
+   */
+  emit?: boolean;
+  /**
+   * Scope compiler to files within `scopeDir`.
+   *
+   * @default false
+   */
+  scope?: boolean;
+  /**
+   * @default First of: `tsconfig.json` "rootDir" if specified, directory containing `tsconfig.json`, or cwd if no `tsconfig.json` is loaded.
+   */
+  scopeDir?: string;
+  /**
+   * Use pretty diagnostic formatter.
+   *
+   * @default false
+   */
+  pretty?: boolean;
+  /**
+   * Use TypeScript's faster `transpileModule`.
+   *
+   * @default false
+   */
+  transpileOnly?: boolean;
+  /**
+   * **DEPRECATED** Specify type-check is enabled (e.g. `transpileOnly == false`).
+   *
+   * @default true
+   */
+  typeCheck?: boolean;
+  /**
+   * Use TypeScript's compiler host API instead of the language service API.
+   *
+   * @default false
+   */
+  compilerHost?: boolean;
+  /**
+   * Logs TypeScript errors to stderr instead of throwing exceptions.
+   *
+   * @default false
+   */
+  logError?: boolean;
+  /**
+   * Load "files" and "include" from `tsconfig.json` on startup.
+   *
+   * Default is to override `tsconfig.json` "files" and "include" to only include the entrypoint script.
+   *
+   * @default false
+   */
+  files?: boolean;
+  /**
+   * Specify a custom TypeScript compiler.
+   *
+   * @default "typescript"
+   */
+  compiler?: string;
+  /**
+   * Specify a custom transpiler for use with transpileOnly
+   */
+  transpiler?: string | [string, object];
+  /**
+   * Transpile with swc instead of the TypeScript compiler, and skip typechecking.
+   *
+   * Equivalent to setting both `transpileOnly: true` and `transpiler: 'ts-node/transpilers/swc'`
+   *
+   * For complete instructions: https://typestrong.org/ts-node/docs/transpilers
+   */
+  swc?: boolean;
+  /**
+   * Paths which should not be compiled.
+   *
+   * Each string in the array is converted to a regular expression via `new RegExp()` and tested against source paths prior to compilation.
+   *
+   * Source paths are normalized to posix-style separators, relative to the directory containing `tsconfig.json` or to cwd if no `tsconfig.json` is loaded.
+   *
+   * Default is to ignore all node_modules subdirectories.
+   *
+   * @default ["(?:^|/)node_modules/"]
+   */
+  ignore?: string[];
+  /**
+   * Path to TypeScript config file or directory containing a `tsconfig.json`.
+   * Similar to the `tsc --project` flag: https://www.typescriptlang.org/docs/handbook/compiler-options.html
+   */
+  project?: string;
+  /**
+   * Search for TypeScript config file (`tsconfig.json`) in this or parent directories.
+   */
+  projectSearchDir?: string;
+  /**
+   * Skip project config resolution and loading.
+   *
+   * @default false
+   */
+  skipProject?: boolean;
+  /**
+   * Skip ignore check, so that compilation will be attempted for all files with matching extensions.
+   *
+   * @default false
+   */
+  skipIgnore?: boolean;
+  /**
+   * JSON object to merge with TypeScript `compilerOptions`.
+   *
+   * @allOf [{"$ref": "https://schemastore.azurewebsites.net/schemas/json/tsconfig.json#definitions/compilerOptionsDefinition/properties/compilerOptions"}]
+   */
+  compilerOptions?: object;
+  /**
+   * Ignore TypeScript warnings by diagnostic code.
+   */
+  ignoreDiagnostics?: Array<number | string>;
+  /**
+   * Modules to require, like node's `--require` flag.
+   *
+   * If specified in `tsconfig.json`, the modules will be resolved relative to the `tsconfig.json` file.
+   *
+   * If specified programmatically, each input string should be pre-resolved to an absolute path for
+   * best results.
+   */
+  require?: Array<string>;
+  readFile?: (path: string) => string | undefined;
+  fileExists?: (path: string) => boolean;
+  transformers?: _ts.CustomTransformers | ((p: _ts.Program) => _ts.CustomTransformers);
+  /**
+   * Allows the usage of top level await in REPL.
+   *
+   * Uses node's implementation which accomplishes this with an AST syntax transformation.
+   *
+   * Enabled by default when tsconfig target is es2018 or above. Set to false to disable.
+   *
+   * **Note**: setting to `true` when tsconfig target is too low will throw an Error.  Leave as `undefined`
+   * to get default, automatic behavior.
+   */
+  experimentalReplAwait?: boolean;
+  /**
+   * Override certain paths to be compiled and executed as CommonJS or ECMAScript modules.
+   * When overridden, the tsconfig "module" and package.json "type" fields are overridden.
+   * This is useful because TypeScript files cannot use the .cjs nor .mjs file extensions;
+   * it achieves the same effect.
+   *
+   * Each key is a glob pattern following the same rules as tsconfig's "include" array.
+   * When multiple patterns match the same file, the last pattern takes precedence.
+   *
+   * `cjs` overrides matches files to compile and execute as CommonJS.
+   * `esm` overrides matches files to compile and execute as native ECMAScript modules.
+   * `package` overrides either of the above to default behavior, which obeys package.json "type" and
+   * tsconfig.json "module" options.
+   */
+  moduleTypes?: ModuleTypes;
+  /**
+   * A function to collect trace messages from the TypeScript compiler, for example when `traceResolution` is enabled.
+   *
+   * @default console.log
+   */
+  tsTrace?: (str: string) => void;
+}
+
+/**
+ * Options for registering a TypeScript compiler instance globally.
+ */
+export interface RegisterOptions extends CreateOptions {
+  /**
+   * Re-order file extensions so that TypeScript imports are preferred.
+   *
+   * For example, when both `index.js` and `index.ts` exist, enabling this option causes `require('./index')` to resolve to `index.ts` instead of `index.js`
+   *
+   * @default false
+   */
+  preferTsExts?: boolean;
+  /**
+   * Enable experimental features that re-map imports and require calls to support:
+   * `baseUrl`, `paths`, `rootDirs`, `.js` to `.ts` file extension mappings,
+   * `outDir` to `rootDir` mappings for composite projects and monorepos.
+   *
+   * For details, see https://github.com/TypeStrong/ts-node/issues/1514
+   */
+  experimentalResolverFeatures?: boolean;
+}

--- a/packages/wdio-types/src/Options.ts
+++ b/packages/wdio-types/src/Options.ts
@@ -1,6 +1,6 @@
 import * as http from 'http'
 import * as https from 'https'
-import { RegisterOptions } from './Compiler'
+import type { RegisterOptions } from './Compiler'
 import type { URL } from 'url'
 
 import { W3CCapabilities, DesiredCapabilities, RemoteCapabilities, RemoteCapability, MultiRemoteCapabilities, Capabilities } from './Capabilities'

--- a/packages/wdio-types/src/Options.ts
+++ b/packages/wdio-types/src/Options.ts
@@ -1,6 +1,6 @@
 import * as http from 'http'
 import * as https from 'https'
-import type { RegisterOptions } from 'ts-node'
+import { RegisterOptions } from './Compiler'
 import type { URL } from 'url'
 
 import { W3CCapabilities, DesiredCapabilities, RemoteCapabilities, RemoteCapability, MultiRemoteCapabilities, Capabilities } from './Capabilities'


### PR DESCRIPTION
Before this, `@wdio/types` needs `ts-node` installed to be used (which is not present in its `dependencies`, `devDependencies` or otherwise). This is pretty annoying if you don't use `ts-node` otherwise.

I have copied the relevant types from `ts-node` and put them into `src/Compiler.ts`.

I have added `typescript` as a `peerDependency`, because `@wdio/types` now depends on types in the `typescript` package itself. Given that `typescript` is _probably installed anyway_ by consumers, it did not seem appropriate to add it to `dependencies`.  I can understand if we just want to drop this from `peerDependencies` altogether, but it _does_ mean that there's still an implicit dependency, which doesn't really solve the problem.

## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
