### PR TITLE
Sanitize script command logs

### DIFF
--- a/packages/wdio-utils/src/utils.ts
+++ b/packages/wdio-utils/src/utils.ts
@@ -5,6 +5,7 @@ import type { Services, Clients } from '@wdio/types'
 
 const SCREENSHOT_REPLACEMENT = '"<Screenshot[base64]>"'
 const SCRIPT_PLACEHOLDER = '"<Script[base64]>"'
+const REGEX_SCRIPT_NAME = /return \(function (\w+)/
 
 /**
  * overwrite native element commands with user defined
@@ -97,6 +98,9 @@ export function transformCommandLogResult (result: { file?: string, script?: str
         return SCREENSHOT_REPLACEMENT
     } else if (typeof result.script === 'string' && isBase64(result.script)) {
         return SCRIPT_PLACEHOLDER
+    } else if (typeof result.script === 'string' && result.script.match(REGEX_SCRIPT_NAME)) {
+        const newScript = result.script.match(REGEX_SCRIPT_NAME)![1]
+        return { ...result, script: `${newScript}(...) [${Buffer.byteLength(result.script, 'utf-8')} bytes]` }
     }
 
     return result

--- a/packages/wdio-utils/tests/utils.test.ts
+++ b/packages/wdio-utils/tests/utils.test.ts
@@ -46,6 +46,10 @@ describe('utils', () => {
         expect(transformCommandLogResult({ script: 'foo' })).toEqual({ script: 'foo' })
         expect(transformCommandLogResult({ script: (Buffer.from('some script payload')).toString('base64') }))
             .toBe('"<Script[base64]>"')
+
+        expect(transformCommandLogResult({ script: 'return foobar' })).toEqual({ script: 'return foobar' })
+        expect(transformCommandLogResult({ script: 'return (function isElementDisplayed(element) {\n...' }))
+            .toEqual({ script: 'isElementDisplayed(...) [50 bytes]' })
     })
 
     describe('overwriteElementCommands', () => {


### PR DESCRIPTION
## Proposed changes

Currently commands like `isDisplayed` or `isClickable` create massive amounts of log lines due to the script that is being executed. I added another if clause in the `transformCommandLogResult` function to sanitize this. Now it only outputs the following:

```
[0-0] 2022-03-29T10:42:54.337Z INFO webdriver: COMMAND executeScript(<fn>, <object>)
[0-0] 2022-03-29T10:42:54.338Z INFO webdriver: [POST] http://localhost:4444/session/fa980f6d37ebaa9d167686f5571c17ee/execute/sync
[0-0] 2022-03-29T10:42:54.338Z INFO webdriver: DATA {
[0-0]   script: 'isElementDisplayed(...) [7962 bytes]',
[0-0]   args: [
[0-0]     {
[0-0]       'element-6066-11e4-a52e-4f735466cecf': '5767af2b-37bb-4103-b5eb-6b4e0c058da8',
[0-0]       ELEMENT: '5767af2b-37bb-4103-b5eb-6b4e0c058da8'
[0-0]     }
[0-0]   ]
[0-0] }
[0-0] 2022-03-29T10:42:54.341Z INFO webdriver: RESULT true
[0-0] 2022-03-29T10:42:54.341Z INFO webdriver: COMMAND executeScript(<fn>, <object>)
[0-0] 2022-03-29T10:42:54.341Z INFO webdriver: [POST] http://localhost:4444/session/fa980f6d37ebaa9d167686f5571c17ee/execute/sync
[0-0] 2022-03-29T10:42:54.341Z INFO webdriver: DATA {
[0-0]   script: 'isElementClickable(...) [5349 bytes]',
[0-0]   args: [
[0-0]     {
[0-0]       'element-6066-11e4-a52e-4f735466cecf': '5767af2b-37bb-4103-b5eb-6b4e0c058da8',
[0-0]       ELEMENT: '5767af2b-37bb-4103-b5eb-6b4e0c058da8'
[0-0]     }
[0-0]   ]
[0-0] }
[0-0] 2022-03-29T10:42:54.345Z INFO webdriver: RESULT true
````

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
