### PR TITLE
Import config types rather than using namespaces

### DIFF
--- a/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
+++ b/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
@@ -1,4 +1,11 @@
-<% if(!answers.isUsingTypeScript) { %>exports.config = {<% } else { %>export const config: WebdriverIO.Config = {<% } %>
+<%
+if(!answers.isUsingTypeScript) {
+    %>exports.config = {<%
+} else {
+    %>import type { Options } from '@wdio/types'
+
+export const config: Options.Testrunner = {<%
+} %>
     //
     // ====================
     // Runner Configuration


### PR DESCRIPTION
## Proposed changes

It is not recommended anymore to use global namespaces. Many projects have switched back to have users import types directly as it is more safe this way. This patch ensures this happens in the `wdio.conf.ts` when initiating a new project.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
