### PR TITLE
Bug Fix: Custom strategy arguments not provided when refetching a sta…

### DIFF
--- a/packages/webdriverio/src/commands/browser/$.ts
+++ b/packages/webdriverio/src/commands/browser/$.ts
@@ -2,6 +2,7 @@ import { findElement } from '../../utils'
 import { getElement } from '../../utils/getElementObject'
 import { ELEMENT_KEY } from '../../constants'
 import type { Selector } from '../../types'
+import type { ElementReference } from '@wdio/protocols'
 
 /**
  * The `$` command is a short way to call the [`findElement`](/docs/api/webdriver#findelement) command in order
@@ -85,8 +86,11 @@ export default async function $ (
      * convert protocol result into WebdriverIO element
      * e.g. when element was fetched with `getActiveElement`
      */
-    if (typeof selector === 'object' && typeof selector[ELEMENT_KEY] === 'string') {
-        return getElement.call(this, undefined, selector)
+    if (typeof selector === 'object') {
+        const elementRef = selector as ElementReference
+        if (typeof elementRef[ELEMENT_KEY] === 'string') {
+            return getElement.call(this, undefined, elementRef)
+        }
     }
 
     const res = await findElement.call(this, selector)

--- a/packages/webdriverio/src/commands/browser/custom$$.ts
+++ b/packages/webdriverio/src/commands/browser/custom$$.ts
@@ -37,8 +37,7 @@ export default async function custom$$ (
         throw Error('No strategy found for ' + strategyName)
     }
 
-    const strategyRef = { strategy, strategyName, strategyArguments }
-
+    const strategyRef: CustomStrategyReference = { strategy, strategyName, strategyArguments }
     let res = await this.execute(strategy, ...strategyArguments)
 
     /**

--- a/packages/webdriverio/src/commands/browser/custom$$.ts
+++ b/packages/webdriverio/src/commands/browser/custom$$.ts
@@ -1,7 +1,7 @@
 import { enhanceElementsArray } from '../../utils'
 import { getElements } from '../../utils/getElementObject'
 import { ELEMENT_KEY } from '../../constants'
-import type { ElementArray, CustomStrategyFunction } from '../../types'
+import type { ElementArray, CustomStrategyFunction, CustomStrategyReference } from '../../types'
 
 /**
  *

--- a/packages/webdriverio/src/commands/browser/custom$$.ts
+++ b/packages/webdriverio/src/commands/browser/custom$$.ts
@@ -1,8 +1,7 @@
-import { ElementReference } from '@wdio/protocols'
 import { enhanceElementsArray } from '../../utils'
 import { getElements } from '../../utils/getElementObject'
 import { ELEMENT_KEY } from '../../constants'
-import type { ElementArray } from '../../types'
+import type { ElementArray, CustomStrategyFunction } from '../../types'
 
 /**
  *
@@ -32,16 +31,15 @@ export default async function custom$$ (
     strategyName: string,
     ...strategyArguments: any[]
 ): Promise<ElementArray> {
-    const strategy = this.strategies.get(strategyName)
+    const strategy = this.strategies.get(strategyName) as CustomStrategyFunction
 
     if (!strategy) {
         throw Error('No strategy found for ' + strategyName)
     }
 
-    let res: ElementReference | ElementReference[] = await this.execute(
-        strategy,
-        ...strategyArguments
-    )
+    const strategyRef = { strategy, strategyName, strategyArguments }
+
+    let res = await this.execute(strategy, ...strategyArguments)
 
     /**
      * if the user's script return just one element
@@ -54,6 +52,6 @@ export default async function custom$$ (
 
     res = res.filter(el => !!el && typeof el[ELEMENT_KEY] === 'string')
 
-    const elements = res.length ? await getElements.call(this, strategy, res) : [] as any as ElementArray
-    return enhanceElementsArray(elements, this, strategy, 'custom$$', [strategyArguments])
+    const elements = res.length ? await getElements.call(this, strategyRef, res) : [] as any as ElementArray
+    return enhanceElementsArray(elements, this, strategy as any, 'custom$$', [strategyArguments])
 }

--- a/packages/webdriverio/src/commands/browser/custom$.ts
+++ b/packages/webdriverio/src/commands/browser/custom$.ts
@@ -1,7 +1,6 @@
-import type { ElementReference } from '@wdio/protocols'
-
 import { getElement } from '../../utils/getElementObject'
 import { ELEMENT_KEY } from '../../constants'
+import type { CustomStrategyFunction } from '../../types'
 
 /**
  *
@@ -31,16 +30,15 @@ export default async function custom$ (
     strategyName: string,
     ...strategyArguments: any[]
 ) {
-    const strategy = this.strategies.get(strategyName)
+    const strategy = this.strategies.get(strategyName) as CustomStrategyFunction
 
     if (!strategy) {
         throw Error('No strategy found for ' + strategyName)
     }
 
-    let res: ElementReference | ElementReference[] = await this.execute(
-        strategy,
-        ...strategyArguments
-    )
+    const strategyRef = { strategy, strategyName, strategyArguments }
+
+    let res = await this.execute(strategy, ...strategyArguments)
 
     /**
      * if the user's script returns multiple elements
@@ -52,7 +50,7 @@ export default async function custom$ (
     }
 
     if (res && typeof res[ELEMENT_KEY] === 'string') {
-        return await getElement.call(this, strategy, res)
+        return await getElement.call(this, strategyRef, res)
     }
 
     throw Error('Your locator strategy script must return an element')

--- a/packages/webdriverio/src/commands/element/custom$$.ts
+++ b/packages/webdriverio/src/commands/element/custom$$.ts
@@ -1,9 +1,7 @@
-import { ElementReference } from '@wdio/protocols'
-
 import { getElements } from '../../utils/getElementObject'
 import { getBrowserObject, enhanceElementsArray } from '../../utils'
 import { ELEMENT_KEY } from '../../constants'
-import type { ElementArray } from '../../types'
+import type { ElementArray, CustomStrategyFunction } from '../../types'
 
 /**
  *
@@ -32,10 +30,10 @@ import type { ElementArray } from '../../types'
 async function custom$$ (
     this: WebdriverIO.Element,
     strategyName: string,
-    strategyArguments: string
+    ...strategyArguments: any[]
 ): Promise<ElementArray> {
     const browserObject = getBrowserObject(this)
-    const strategy = browserObject.strategies.get(strategyName) as (arg: string, context: any) => HTMLElement[]
+    const strategy = browserObject.strategies.get(strategyName) as CustomStrategyFunction
 
     if (!strategy) {
         /* istanbul ignore next */
@@ -50,7 +48,9 @@ async function custom$$ (
         throw Error(`Can't call custom$ on element with selector "${this.selector}" because element wasn't found`)
     }
 
-    let res = await this.execute(strategy, strategyArguments, this) as any as ElementReference[]
+    const strategyRef = { strategy, strategyName, strategyArguments: [...strategyArguments, this] }
+
+    let res = await this.execute(strategy, ...strategyArguments, this)
 
     /**
      * if the user's script return just one element
@@ -63,7 +63,7 @@ async function custom$$ (
 
     res = res.filter((el) => !!el && typeof el[ELEMENT_KEY] === 'string')
 
-    const elements = res.length ? await getElements.call(this, strategy as any, res) : [] as any as ElementArray
+    const elements = res.length ? await getElements.call(this, strategyRef, res) : [] as any as ElementArray
     return enhanceElementsArray(elements, this, strategy as any, 'custom$$', [strategyArguments])
 }
 

--- a/packages/webdriverio/src/types.ts
+++ b/packages/webdriverio/src/types.ts
@@ -364,7 +364,13 @@ export type MultiRemoteBrowser<Mode extends 'sync' | 'async'> = Mode extends 'sy
 export type MultiRemoteElement<Mode extends 'sync' | 'async'> = Mode extends 'sync' ? MultiRemoteElementReferenceSync & MultiRemoteElementSync : MultiRemoteElementReferenceAsync & MultiRemoteElementAsync
 
 export type ElementFunction = ((elem: HTMLElement) => HTMLElement) | ((elem: HTMLElement) => HTMLElement[])
-export type Selector = string | ElementReference | ElementFunction
+export type CustomStrategyFunction = (...args: any) => ElementReference | ElementReference[]
+export type CustomStrategyReference = {
+    strategy: CustomStrategyFunction
+    strategyName: string
+    strategyArguments: any[]
+}
+export type Selector = string | ElementReference | ElementFunction | CustomStrategyReference
 
 interface CSSValue {
     type: string

--- a/packages/webdriverio/src/utils/index.ts
+++ b/packages/webdriverio/src/utils/index.ts
@@ -18,6 +18,7 @@ import { locatorStrategy } from 'query-selector-shadow-dom/plugins/webdriverio'
 import { ELEMENT_KEY, DRIVER_DEFAULT_ENDPOINT, FF_REMOTE_DEBUG_ARG, DEEP_SELECTOR } from '../constants'
 import { findStrategy } from './findStrategy'
 import type { ElementArray, ElementFunction, Selector, ParsedCSSValue, CustomLocatorReturnValue } from '../types'
+import { CustomStrategyReference } from '../types'
 
 const browserCommands = require('../commands/browser').default
 const elementCommands = require('../commands/element').default
@@ -247,6 +248,17 @@ export async function findElement(
                 (this as WebdriverIO.Element).elementId ? this : undefined
             ].filter(Boolean)
         )
+        elem = Array.isArray(elem) ? elem[0] : elem
+        return getElementFromResponse(elem) ? elem : notFoundError
+    }
+
+    /**
+     * fetch element using custom strategy function
+     */
+    if (isPlainObject(selector) && typeof (selector as CustomStrategyReference).strategy === 'function') {
+        const { strategy, strategyName, strategyArguments } = selector as CustomStrategyReference
+        const notFoundError = new Error(`Custom Strategy "${strategyName}" did not return an HTMLElement`)
+        let elem = await this.execute(strategy, ...strategyArguments)
         elem = Array.isArray(elem) ? elem[0] : elem
         return getElementFromResponse(elem) ? elem : notFoundError
     }

--- a/packages/webdriverio/tests/commands/browser/customSelector.test.ts
+++ b/packages/webdriverio/tests/commands/browser/customSelector.test.ts
@@ -13,13 +13,17 @@ describe('custom$', () => {
     })
 
     it('should fetch element', async () => {
-        browser.addLocatorStrategy('test', (selector) => (
+        browser.addLocatorStrategy('test', (selector: string) => (
             { 'element-6066-11e4-a52e-4f735466cecf': `${selector}-foobar` }
         ))
 
         const elem = await browser.custom$('test', '.test')
         expect(elem.elementId).toBe('.test-foobar')
-        expect(typeof elem.selector).toBe('function')
+        expect(typeof elem.selector).toBe('object')
+        expect(typeof elem.selector.strategy).toBe('function')
+        expect(elem.selector.strategyName).toBe('test')
+        expect(elem.selector.strategyArguments).toHaveLength(1)
+        expect(elem.selector.strategyArguments[0]).toBe('.test')
     })
 
     it('should error if no strategy found', async () => {

--- a/packages/webdriverio/tests/commands/browser/customSelectors.test.ts
+++ b/packages/webdriverio/tests/commands/browser/customSelectors.test.ts
@@ -13,7 +13,7 @@ describe('custom$', () => {
     })
 
     it('should fetch element', async () => {
-        browser.addLocatorStrategy('test', (selector) => [
+        browser.addLocatorStrategy('test', (selector: string) => [
             { 'element-6066-11e4-a52e-4f735466cecf': `${selector}-foobar` },
             { 'element-6066-11e4-a52e-4f735466cecf': `${selector}-other-foobar` }
         ])
@@ -22,7 +22,11 @@ describe('custom$', () => {
 
         expect(elems).toHaveLength(2)
         expect(typeof elems.selector).toBe('function')
-        expect(typeof elems[0].selector).toBe('function')
+        expect(typeof elems[0].selector).toBe('object')
+        expect(typeof elems[0].selector.strategy).toBe('function')
+        expect(elems[0].selector.strategyName).toBe('test')
+        expect(elems[0].selector.strategyArguments).toHaveLength(1)
+        expect(elems[0].selector.strategyArguments[0]).toBe('.test')
         expect(elems[0].elementId).toBe('.test-foobar')
         expect(elems[1].elementId).toBe('.test-other-foobar')
         expect(elems.foundWith).toBe('custom$$')
@@ -37,7 +41,7 @@ describe('custom$', () => {
     })
 
     it('should return array even if the script returns one element', async () => {
-        browser.addLocatorStrategy('test', (selector) => (
+        browser.addLocatorStrategy('test', (selector: string) => (
             { 'element-6066-11e4-a52e-4f735466cecf': `${selector}-foobar` }
         ))
 

--- a/packages/webdriverio/tests/commands/element/customSelectors.test.ts
+++ b/packages/webdriverio/tests/commands/element/customSelectors.test.ts
@@ -13,8 +13,7 @@ describe('custom$', () => {
     })
 
     it('should fetch element', async () => {
-        // @ts-ignore mock feature
-        browser.addLocatorStrategy('test', (selector, parent) => [
+        browser.addLocatorStrategy('test', (selector: string, parent: string) => [
             { 'element-6066-11e4-a52e-4f735466cecf': `${selector}-${parent}` },
             { 'element-6066-11e4-a52e-4f735466cecf': `${selector}-other-${parent}` }
         ] as any as HTMLElement[])
@@ -24,7 +23,12 @@ describe('custom$', () => {
 
         expect(elems).toHaveLength(2)
         expect(typeof elems.selector).toBe('function')
-        expect(typeof elems[0].selector).toBe('function')
+        expect(typeof elems[0].selector).toBe('object')
+        expect(typeof elems[0].selector.strategy).toBe('function')
+        expect(elems[0].selector.strategyName).toBe('test')
+        expect(elems[0].selector.strategyArguments).toHaveLength(2)
+        expect(elems[0].selector.strategyArguments[0]).toBe('.test')
+        expect(elems[0].selector.strategyArguments[1]).toBe(elem)
         expect(elems[0].elementId).toBe('.test-some-elem-123')
         expect(elems[1].elementId).toBe('.test-other-some-elem-123')
         expect(elems.foundWith).toBe('custom$$')
@@ -51,7 +55,7 @@ describe('custom$', () => {
 
     it('should return array even if the script returns one element', async () => {
         // @ts-ignore mock feature
-        browser.addLocatorStrategy('test', (selector, parent) => (
+        browser.addLocatorStrategy('test', (selector: string, parent: string) => (
             { 'element-6066-11e4-a52e-4f735466cecf': `${selector}-${parent}` }
         ))
 

--- a/tests/typings/webdriverio/async.ts
+++ b/tests/typings/webdriverio/async.ts
@@ -285,7 +285,7 @@ async function bar() {
     elem1.setValue('Delete', { translateToUnicode: true })
     elem1.setValue('Delete', { translateToUnicode: false })
 
-    const selector$$: string | Function | Record<'element-6066-11e4-a52e-4f735466cecf', string> = elems.selector
+    const selector$$: string | Function | Record<'element-6066-11e4-a52e-4f735466cecf', string> | {strategy: Function; strategyName: string; strategyArguments: any[]} = elems.selector
     ;(elems.parent as WebdriverIO.Element).click()
     ;(elems.parent as WebdriverIO.Browser).url('')
     ;(elems.parent as WebdriverIO.MultiRemoteBrowser).url('')
@@ -422,7 +422,7 @@ async function bar() {
     // promise chain API
     expectType<string>(
         await browser.$('foo').then(_ => _.getText()))
-  
+
     expectType<void>(
         await browser.$$('foo').forEach(() => true)
     )


### PR DESCRIPTION
Bug Fix for [🐛 Bug]: Custom strategy arguments not provided when refetching a stale element #8176

## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
