### PR TITLE
Fix typo on selectors documentation page

### DIFF
--- a/website/docs/Selectors.md
+++ b/website/docs/Selectors.md
@@ -195,7 +195,7 @@ Current supported selector syntaxes for ID are:
 //css locator
 const button = await $('#someid')
 //xpath locator
-const button = await $('//*[@id="someid"'])
+const button = await $('//*[@id="someid"]')
 //id strategy 
 // Note: works only in Appium or similar frameworks which supports locator strategy "ID"
 const button = await $('id=resource-id/iosname')


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

This fixes a typo I found on the documentation page for selectors.

Currently it is:
```
const button = await $('//*[@id="someid"'])
```

It should be (note the swapped positions of the single quote and bracket at the end):
```
const button = await $('//*[@id="someid"]')
```
## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
