### PR TITLE
Bugfix #8116 - Unable to access store key in onPrepare and beforeSession hooks

### DIFF
--- a/packages/wdio-shared-store-service/src/launcher.ts
+++ b/packages/wdio-shared-store-service/src/launcher.ts
@@ -1,30 +1,23 @@
 import logger from '@wdio/logger'
 
-import { writeFile, deleteFile, getPidPath } from './utils'
 import { setPort } from './client'
+import type { SharedStoreServiceCapabilities } from './types'
 
 const log = logger('@wdio/shared-store-service')
 
 let server: SharedStoreServer
 
 export default class SharedStoreLauncher {
-    pidFile: string
-    constructor() {
-        // current process pid
-        this.pidFile = getPidPath(process.pid)
-    }
-
-    async onPrepare () {
+    async onPrepare (_: never, capabilities: SharedStoreServiceCapabilities[]) {
         server = require('./server').default
         const result = await server.startServer()
         setPort(result.port)
+        capabilities.forEach(capability => {capability['wdio:sharedStoreServicePort'] = result.port})
 
         log.info(`Started shared server on port ${result.port}`)
-        await writeFile(this.pidFile, result.port.toString())
     }
 
     async onComplete () {
         await server.stopServer()
-        await deleteFile(this.pidFile)
     }
 }

--- a/packages/wdio-shared-store-service/src/service.ts
+++ b/packages/wdio-shared-store-service/src/service.ts
@@ -1,9 +1,9 @@
 import { Browser } from 'webdriverio'
 import { BrowserExtension } from './index'
-import { readFile, getPidPath } from './utils'
 import { getValue, setValue, setPort } from './client'
 
 import type { JsonCompatible, JsonPrimitive, Services } from '@wdio/types'
+import type { SharedStoreServiceCapabilities } from './types'
 
 /**
  * ToDo(Christian): make this public accessible
@@ -13,13 +13,8 @@ interface ServiceBrowser extends Browser<'async'>, BrowserExtension { }
 export default class SharedStoreService implements Services.ServiceInstance {
     private _browser?: ServiceBrowser
 
-    async beforeSession () {
-        /**
-         * get port from parent's pid file saved in `onPrepare` hook
-         */
-        const port = await readFile(getPidPath(process.ppid))
-
-        setPort(port.toString())
+    constructor(_: never, caps: SharedStoreServiceCapabilities) {
+        setPort(caps['wdio:sharedStoreServicePort']!)
     }
 
     before (

--- a/packages/wdio-shared-store-service/src/types.ts
+++ b/packages/wdio-shared-store-service/src/types.ts
@@ -1,0 +1,5 @@
+import { Capabilities } from '@wdio/types'
+
+export interface SharedStoreServiceCapabilities extends Capabilities.Capabilities {
+    'wdio:sharedStoreServicePort': string
+}

--- a/packages/wdio-shared-store-service/src/utils.ts
+++ b/packages/wdio-shared-store-service/src/utils.ts
@@ -1,9 +1,0 @@
-import { join as pathJoin } from 'path'
-import { promisify } from 'util'
-import { readFile as readFileCb, writeFile as writeFileCb, unlink  } from 'fs'
-
-export const readFile = promisify(readFileCb)
-export const writeFile = promisify(writeFileCb)
-export const deleteFile = promisify(unlink)
-
-export const getPidPath = (pid: number) => pathJoin(__dirname, `/${pid}.pid`)

--- a/packages/wdio-shared-store-service/tests/client.test.ts
+++ b/packages/wdio-shared-store-service/tests/client.test.ts
@@ -28,6 +28,7 @@ describe('client', () => {
             await setValue('foo', 'bar')
             await setValue('bar', 'foo')
             expect(got.post).toBeCalledTimes(0)
+            await new Promise((resolve) => setTimeout(resolve, 300))
             setPort(port)
             await new Promise((resolve) => setTimeout(resolve, 300))
             expect(got.post).toBeCalledTimes(2)

--- a/packages/wdio-shared-store-service/tests/launcher.test.ts
+++ b/packages/wdio-shared-store-service/tests/launcher.test.ts
@@ -1,4 +1,4 @@
-import { writeFile, deleteFile } from '../src/utils'
+import type { SharedStoreServiceCapabilities } from '../build/types'
 import { setPort } from '../src/client'
 import SharedStoreLauncher from '../src/launcher'
 import StoreServerType from '../src/server'
@@ -12,11 +12,6 @@ jest.mock('../src/server', () => ({
         stopServer: jest.fn(),
     }
 }))
-jest.mock('../src/utils', () => ({
-    writeFile: jest.fn(),
-    deleteFile: jest.fn(),
-    getPidPath: (pid: number) => pid,
-}))
 jest.mock('../src/client', () => ({
     setPort: jest.fn()
 }))
@@ -25,20 +20,17 @@ const storeLauncher = new SharedStoreLauncher()
 
 describe('SharedStoreService', () => {
     it('onPrepare', async () => {
-        await storeLauncher.onPrepare()
-        expect(writeFile).toBeCalledWith(process.pid, '3000')
+        const capabilities = [{ browserName: 'chrome', acceptInsecureCerts: true }] as SharedStoreServiceCapabilities[]
+        await storeLauncher.onPrepare(null as never, capabilities)
         expect(setPort).toBeCalledWith(3000)
     })
 
     it('onComplete', async () => {
         await storeLauncher.onComplete()
         expect(stopServer).toBeCalled()
-        expect(deleteFile).toBeCalledWith(process.pid)
     })
 
     afterEach(() => {
-        (writeFile as jest.Mock).mockClear()
-        ;(deleteFile as jest.Mock).mockClear()
-        ;(stopServer as jest.Mock).mockClear()
+        (stopServer as jest.Mock).mockClear()
     })
 })

--- a/packages/wdio-shared-store-service/tests/service.test.ts
+++ b/packages/wdio-shared-store-service/tests/service.test.ts
@@ -1,28 +1,23 @@
-import { getPidPath } from '../src/utils'
 import { getValue, setValue, setPort } from '../src/client'
 import SharedStoreService from '../src/service'
+import type { SharedStoreServiceCapabilities } from '../build/types'
 
 jest.mock('../src/client', () => ({
     getValue: jest.fn(),
     setValue: jest.fn(),
     setPort: jest.fn(),
 }))
-jest.mock('../src/utils', () => ({
-    readFile: () => 44444,
-    getPidPath: jest.fn(),
-}))
 
 describe('SharedStoreService', () => {
     let storeService: SharedStoreService
 
     beforeEach(() => {
-        storeService = new SharedStoreService()
+        const capabilities = { browserName: 'chrome', acceptInsecureCerts: true, 'wdio:sharedStoreServicePort': '65209' } as SharedStoreServiceCapabilities
+        storeService = new SharedStoreService(null as never, capabilities)
     })
 
-    it('beforeSession', async () => {
-        await storeService.beforeSession()
-        expect(getPidPath).toBeCalledWith(process.ppid)
-        expect(setPort).toBeCalledWith('44444')
+    it('constructor', async () => {
+        expect(setPort).toBeCalledWith('65209')
     })
 
     it('beforeSession', () => {
@@ -35,8 +30,7 @@ describe('SharedStoreService', () => {
     })
 
     afterEach(() => {
-        (getPidPath as jest.Mock).mockClear()
-        ;(setPort as jest.Mock).mockClear()
+        (setPort as jest.Mock).mockClear()
         ;(getValue as jest.Mock).mockClear()
         ;(setValue as jest.Mock).mockClear()
     })

--- a/packages/wdio-shared-store-service/tests/utils.test.ts
+++ b/packages/wdio-shared-store-service/tests/utils.test.ts
@@ -1,7 +1,0 @@
-import { getPidPath } from '../src/utils'
-
-describe('utils', () => {
-    it('getPidPath should build proper path', () => {
-        expect(getPidPath(123)).toContain('123.pid')
-    })
-})


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)
Fix for bug https://github.com/webdriverio/webdriverio/issues/8116.
Sharing the server port with the service is now done via capabilities.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
