### PR TITLE
Fix running Firefox

### DIFF
--- a/packages/wdio-types/src/Capabilities.ts
+++ b/packages/wdio-types/src/Capabilities.ts
@@ -77,6 +77,10 @@ export interface Capabilities extends VendorExtensions, ConnectionOptions {
      * Describes the current session’s user prompt handler. Defaults to the dismiss and notify state.
      */
     unhandledPromptBehavior?: string;
+    /**
+     * WebDriver clients opt in to a bidirectional connection by requesting a capability with the name "webSocketUrl" and value true.
+     */
+    webSocketUrl?: boolean
 }
 
 export interface W3CCapabilities {

--- a/packages/webdriverio/package.json
+++ b/packages/webdriverio/package.json
@@ -70,7 +70,6 @@
     "devtools": "7.19.3",
     "devtools-protocol": "^0.0.982423",
     "fs-extra": "^10.0.0",
-    "get-port": "^5.1.1",
     "grapheme-splitter": "^1.0.2",
     "lodash.clonedeep": "^4.5.0",
     "lodash.isobject": "^3.0.2",

--- a/packages/webdriverio/src/utils/index.ts
+++ b/packages/webdriverio/src/utils/index.ts
@@ -3,7 +3,6 @@ import http from 'http'
 import path from 'path'
 import cssValue from 'css-value'
 import rgb2hex from 'rgb2hex'
-import getPort from 'get-port'
 import GraphemeSplitter from 'grapheme-splitter'
 import logger from '@wdio/logger'
 import isObject from 'lodash.isobject'
@@ -15,7 +14,7 @@ import type { ElementReference } from '@wdio/protocols'
 import type { Options, Capabilities } from '@wdio/types'
 import { locatorStrategy } from 'query-selector-shadow-dom/plugins/webdriverio'
 
-import { ELEMENT_KEY, DRIVER_DEFAULT_ENDPOINT, FF_REMOTE_DEBUG_ARG, DEEP_SELECTOR } from '../constants'
+import { ELEMENT_KEY, DRIVER_DEFAULT_ENDPOINT, DEEP_SELECTOR } from '../constants'
 import { findStrategy } from './findStrategy'
 import type { ElementArray, ElementFunction, Selector, ParsedCSSValue, CustomLocatorReturnValue } from '../types'
 import { CustomStrategyReference } from '../types'
@@ -582,31 +581,8 @@ export const getAutomationProtocol = async (config: Options.WebdriverIO | Option
  * NOTE: this method is executed twice when running the WDIO testrunner
  */
 export const updateCapabilities = async (params: Options.WebdriverIO | Options.Testrunner, automationProtocol?: Options.SupportedProtocols) => {
-    const caps = params.capabilities as Capabilities.Capabilities
-
     if (automationProtocol && !params.automationProtocol) {
         params.automationProtocol = automationProtocol
-    }
-
-    /**
-     * attach remote debugging port options to Firefox sessions
-     * (this will be ignored if not supported)
-     */
-    if (automationProtocol === 'webdriver' && caps.browserName === 'firefox') {
-        if (!caps['moz:firefoxOptions']) {
-            caps['moz:firefoxOptions'] = {}
-        }
-
-        if (!caps['moz:firefoxOptions'].args) {
-            caps['moz:firefoxOptions'].args = []
-        }
-
-        if (!caps['moz:firefoxOptions'].args.includes(FF_REMOTE_DEBUG_ARG)) {
-            caps['moz:firefoxOptions'].args.push(
-                FF_REMOTE_DEBUG_ARG,
-                (await getPort()).toString()
-            )
-        }
     }
 }
 

--- a/packages/webdriverio/tests/__snapshots__/utils.test.ts.snap
+++ b/packages/webdriverio/tests/__snapshots__/utils.test.ts.snap
@@ -1,46 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`utils updateCapabilities setting devtools port in Firefox should not overwrite if already set 1`] = `
-Object {
-  "capabilities": Object {
-    "browserName": "firefox",
-    "moz:firefoxOptions": Object {
-      "args": Array [
-        "foo",
-        "bar",
-        "-remote-debugging-port",
-        "1234",
-        "barfoo",
-      ],
-    },
-  },
-}
-`;
-
-exports[`utils updateCapabilities setting devtools port in Firefox should set firefox options if there aren't any 1`] = `
-Object {
-  "automationProtocol": "webdriver",
-  "capabilities": Object {
-    "browserName": "firefox",
-    "moz:firefoxOptions": Object {
-      "args": Array [
-        "-remote-debugging-port",
-        "9222",
-      ],
-    },
-  },
-}
-`;
-
-exports[`utils updateCapabilities setting devtools port in Firefox should set firefox options if there aren't any 2`] = `
-Object {
-  "automationProtocol": "devtools",
-  "capabilities": Object {
-    "browserName": "firefox",
-  },
-}
-`;
-
 exports[`utils updateCapabilities should do nothing if no browser specified 1`] = `
 Object {
   "capabilities": Object {},

--- a/packages/webdriverio/tests/utils.test.ts
+++ b/packages/webdriverio/tests/utils.test.ts
@@ -619,30 +619,5 @@ describe('utils', () => {
             await updateCapabilities(params)
             expect(params).toMatchSnapshot()
         })
-
-        describe('setting devtools port in Firefox', () => {
-            it('should set firefox options if there aren\'t any', async () => {
-                const params = { capabilities: { browserName: 'firefox' } }
-                await updateCapabilities(params, 'webdriver')
-                expect(params).toMatchSnapshot()
-
-                const params2 = { capabilities: { browserName: 'firefox' } }
-                await updateCapabilities(params2, 'devtools')
-                expect(params2).toMatchSnapshot()
-            })
-
-            it('should not overwrite if already set', async () => {
-                const params: Options.WebdriverIO = {
-                    capabilities: {
-                        browserName: 'firefox',
-                        'moz:firefoxOptions': {
-                            args: ['foo', 'bar', '-remote-debugging-port', '1234', 'barfoo']
-                        }
-                    }
-                }
-                await updateCapabilities(params)
-                expect(params).toMatchSnapshot()
-            })
-        })
     })
 })


### PR DESCRIPTION
## Proposed changes

The new Geckodriver doesn't support setting the `remote-debugging-port` anymore and fails doing so. Let's remove it and figure out later how we can use the old marionette features at some point later.

fixes #8207

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
