### PR TITLE
Browserstack service changes

### DIFF
--- a/packages/wdio-cli/src/constants.ts
+++ b/packages/wdio-cli/src/constants.ts
@@ -114,7 +114,7 @@ export const SUPPORTED_PACKAGES = {
         { name: 'vscode', value: 'wdio-vscode-service$--$vscode' },
         { name: 'electron', value: 'wdio-electron-service$--$electron' },
         { name: 'devtools', value: '@wdio/devtools-service$--$devtools' },
-        { name: 'browserstack', value: '@wdio/browserstack-service$--$browserstack' },
+        { name: 'browserstack', value: '@browserstack/wdio-browserstack-service$--$browserstack' },
         { name: 'appium', value: '@wdio/appium-service$--$appium' },
         { name: 'firefox-profile', value: '@wdio/firefox-profile-service$--$firefox-profile' },
         { name: 'crossbrowsertesting', value: '@wdio/crossbrowsertesting-service$--$crossbrowsertesting' },
@@ -235,7 +235,7 @@ export const QUESTIONNAIRE = [{
     type: 'input',
     name: 'env_user',
     message: 'Environment variable for username',
-    default: 'BROWSERSTACK_USER',
+    default: 'BROWSERSTACK_USERNAME',
     when: /* istanbul ignore next */ (answers: Questionnair) => answers.backend.toString().startsWith('In the cloud using Browserstack')
 }, {
     type: 'input',

--- a/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
+++ b/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
@@ -60,8 +60,8 @@ export const config: Options.Testrunner = {<%
     // backend you should define the host address, port, and path here.
     //
     hostname: '<%- answers.hostname %>',
-    port: <%- answers.port %>,
-    path: '<%- answers.path %>',<% } else if (answers.services.includes('appium')) { %>
+    port: <%- answers.port %>, <% if(answers.path) { %>
+    path: '<%- answers.path %>',<% } } else if (answers.services.includes('appium')) { %>
     port: 4723,<% }
 
     // Protocol: http | https


### PR DESCRIPTION
## Proposed changes

1. Moving browserstack-service to browserstack maintained fork of `@wdio/browserstack-service`.
2. Update the default env variable for browserstack username.
3. Update template of conf file to add path only when provided by user as default value was empty string which gives an error by itself.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
