### PR TITLE
Fix #8007 Cucumber skipped steps not appearing in report

### DIFF
--- a/packages/wdio-reporter/src/index.ts
+++ b/packages/wdio-reporter/src/index.ts
@@ -119,6 +119,14 @@ export default class WDIOReporter extends EventEmitter {
             this.onTestPass(testStat)
         })
 
+        this.on('test:skip', (test: Test) => {
+            const testStat = this.tests[test.uid]
+            currentTest.skip(test.pendingReason!)
+            this.counts.skipping++
+            this.counts.tests++
+            this.onTestSkip(testStat)
+        })
+
         this.on('test:fail',  /* istanbul ignore next */(test: Test) => {
             const testStat = this.tests[test.uid]
 

--- a/packages/wdio-reporter/src/stats/test.ts
+++ b/packages/wdio-reporter/src/stats/test.ts
@@ -10,7 +10,7 @@ import { types as nodeUtilTypes } from 'util'
 const maxStringLength = 2048
 
 export interface Test {
-    type: 'test:start' | 'test:pass' | 'test:fail' | 'test:retry' | 'test:pending' | 'test:end'
+    type: 'test:start' | 'test:pass' | 'test:fail' | 'test:retry' | 'test:pending' | 'test:end' | 'test:skip'
     title: string
     parent: string
     fullTitle: string

--- a/packages/wdio-reporter/tests/reporter.test.ts
+++ b/packages/wdio-reporter/tests/reporter.test.ts
@@ -25,6 +25,7 @@ describe('WDIOReporter', () => {
         expect(eventsOnSpy).toBeCalledWith('hook:end', expect.any(Function))
         expect(eventsOnSpy).toBeCalledWith('test:start', expect.any(Function))
         expect(eventsOnSpy).toBeCalledWith('test:pass', expect.any(Function))
+        expect(eventsOnSpy).toBeCalledWith('test:skip', expect.any(Function))
         expect(eventsOnSpy).toBeCalledWith('test:fail', expect.any(Function))
         expect(eventsOnSpy).toBeCalledWith('test:pending', expect.any(Function))
         expect(eventsOnSpy).toBeCalledWith('test:retry', expect.any(Function))


### PR DESCRIPTION
## Proposed changes
Fix for: https://github.com/webdriverio/webdriverio/issues/8007

After investigation it seems issue indeed was because of https://github.com/webdriverio/webdriverio/pull/7777/files#r805094553

On versions before changes was applied state was `state = 'pending'` and wdio-reporter on `pendind` state did `.skip(..)`

Checked locally using `example/wdio/cucumber` with adding allure reporter with and without service settings:

```
disableWebdriverStepsReporting: true,
useCucumberStepReporter: true,
```
<img width="1870" alt="Cucumber_steps_example" src="https://user-images.githubusercontent.com/85994438/164545366-131bacf3-fb48-4e07-88c5-80830a9430ce.png">

<img width="1442" alt="cucumber_steps_example_without_settings" src="https://user-images.githubusercontent.com/85994438/164545352-0aa541a9-64c4-48df-8398-493e122c0fc2.png">

Checked also that spec reporter works as expected and displays correct symbol:
```
 "spec" Reporter:
------------------------------------------------------------------
[Chrome 100.0.4896.127 darwin #0-0] Running: Chrome (v100.0.4896.127) on darwin
[Chrome 100.0.4896.127 darwin #0-0] Session ID: 35a6c672-3478-4155-9647-385255d4bdf3
[Chrome 100.0.4896.127 darwin #0-0]
[Chrome 100.0.4896.127 darwin #0-0] » /cucumber/features/my-feature.feature
[Chrome 100.0.4896.127 darwin #0-0] Example feature
[Chrome 100.0.4896.127 darwin #0-0] As a user of WebdriverIO
[Chrome 100.0.4896.127 darwin #0-0] I should be able to use different commands
[Chrome 100.0.4896.127 darwin #0-0] to get informations about elements on the page
[Chrome 100.0.4896.127 darwin #0-0]
[Chrome 100.0.4896.127 darwin #0-0] Get size of an element
[Chrome 100.0.4896.127 darwin #0-0]    ✓ Given I go on the website "https://github.com/"
[Chrome 100.0.4896.127 darwin #0-0]    ✖ Then should the element ".header-logged-out a" be 32px wide and 35px high
[Chrome 100.0.4896.127 darwin #0-0]    - * something else
[Chrome 100.0.4896.127 darwin #0-0]    - * something else
[Chrome 100.0.4896.127 darwin #0-0]    - * something else
[Chrome 100.0.4896.127 darwin #0-0]    - * something else
[Chrome 100.0.4896.127 darwin #0-0]    - * something else
[Chrome 100.0.4896.127 darwin #0-0]    - * something else
[Chrome 100.0.4896.127 darwin #0-0]
[Chrome 100.0.4896.127 darwin #0-0] Get title of website
[Chrome 100.0.4896.127 darwin #0-0] Business rule 1
[Chrome 100.0.4896.127 darwin #0-0]    ✓ Given I go on the website "https://github.com/"
[Chrome 100.0.4896.127 darwin #0-0]    ✓ Then should the title of the page be "GitHub: Where the world builds software · GitHub"
[Chrome 100.0.4896.127 darwin #0-0]
[Chrome 100.0.4896.127 darwin #0-0] Data Tables
[Chrome 100.0.4896.127 darwin #0-0] Business rule 2
[Chrome 100.0.4896.127 darwin #0-0]    ✓ Given I go on the website "http://todomvc.com/examples/react/#/"
[Chrome 100.0.4896.127 darwin #0-0]    ✓ When I add the following groceries
[Chrome 100.0.4896.127 darwin #0-0]      │ Item       │ Amount │
[Chrome 100.0.4896.127 darwin #0-0]      │ Milk       │ 2      │
[Chrome 100.0.4896.127 darwin #0-0]      │ Butter     │ 1      │
[Chrome 100.0.4896.127 darwin #0-0]      │ Noodles    │ 1      │
[Chrome 100.0.4896.127 darwin #0-0]      │ Schocolate │ 3      │
[Chrome 100.0.4896.127 darwin #0-0]    ✓ Then I should have a list of 4 items
[Chrome 100.0.4896.127 darwin #0-0]
[Chrome 100.0.4896.127 darwin #0-0] 6 passing (5.5s)
[Chrome 100.0.4896.127 darwin #0-0] 1 failing
[Chrome 100.0.4896.127 darwin #0-0] 6 skipped
```

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
