### PR TITLE
add: service version to caps for browserstack

### DIFF
--- a/packages/wdio-browserstack-service/src/launcher.ts
+++ b/packages/wdio-browserstack-service/src/launcher.ts
@@ -5,11 +5,11 @@ import * as BrowserstackLocalLauncher from 'browserstack-local'
 import logger from '@wdio/logger'
 import type { Capabilities, Services, Options } from '@wdio/types'
 
+// @ts-ignore
+import { version as bstackServiceVersion } from '../package.json'
 import { BrowserstackConfig } from './types'
 
 const log = logger('@wdio/browserstack-service')
-// @ts-ignore
-import { version as bstackServiceVersion } from '../package.json'
 
 type BrowserstackLocal = BrowserstackLocalLauncher.Local & {
     pid?: number;

--- a/packages/wdio-browserstack-service/src/launcher.ts
+++ b/packages/wdio-browserstack-service/src/launcher.ts
@@ -9,7 +9,7 @@ import { BrowserstackConfig } from './types'
 
 const log = logger('@wdio/browserstack-service')
 // @ts-ignore
-import { bstackServiceVersion } from '../package.json'
+import { version as bstackServiceVersion } from '../package.json'
 
 type BrowserstackLocal = BrowserstackLocalLauncher.Local & {
     pid?: number;

--- a/packages/wdio-browserstack-service/tests/launcher.test.ts
+++ b/packages/wdio-browserstack-service/tests/launcher.test.ts
@@ -9,6 +9,8 @@ const expect = global.expect as unknown as jest.Expect
 const log = logger('test')
 const error = new Error('I\'m an error!')
 const sleep = (ms: number = 100) => new Promise((resolve) => setTimeout(resolve, ms))
+// @ts-ignore
+import { version as bstackServiceVersion } from '../package.json'
 
 beforeEach(() => {
     jest.clearAllMocks()
@@ -148,5 +150,24 @@ describe('onComplete', () => {
         service.browserstackLocal = new Browserstack.Local()
         return expect(service.onComplete()).resolves.toBe(undefined)
             .then(() => expect(service.browserstackLocal?.stop).toHaveBeenCalled())
+    })
+})
+
+describe('constructor', () => {
+    const options: BrowserstackConfig = { }
+    const config = {
+        user: 'foobaruser',
+        key: '12345',
+        capabilities: []
+    }
+
+    it('should add the wdioService property to an array of capabilities', async () => {
+        const caps: any = [{}, {}]
+        new BrowserstackLauncher(options, caps, config)
+
+        expect(caps).toEqual([
+            { 'bstack:options': { wdioService: bstackServiceVersion } },
+            { 'bstack:options': { wdioService: bstackServiceVersion } }
+        ])
     })
 })

--- a/packages/wdio-browserstack-service/tests/launcher.test.ts
+++ b/packages/wdio-browserstack-service/tests/launcher.test.ts
@@ -3,14 +3,14 @@ import logger from '@wdio/logger'
 
 import BrowserstackLauncher from '../src/launcher'
 import { BrowserstackConfig } from '../src/types'
+// @ts-ignore
+import { version as bstackServiceVersion } from '../package.json'
 
 const expect = global.expect as unknown as jest.Expect
 
 const log = logger('test')
 const error = new Error('I\'m an error!')
 const sleep = (ms: number = 100) => new Promise((resolve) => setTimeout(resolve, ms))
-// @ts-ignore
-import { version as bstackServiceVersion } from '../package.json'
 
 beforeEach(() => {
     jest.clearAllMocks()

--- a/packages/wdio-types/src/Capabilities.ts
+++ b/packages/wdio-types/src/Capabilities.ts
@@ -1074,7 +1074,6 @@ export interface BrowserStackCapabilities {
     safari?: {
         enablePopups?: boolean
         allowAllCookies?: boolean
-        driver?: string
     }
     firefox?: {
         driver?: string
@@ -1082,6 +1081,9 @@ export interface BrowserStackCapabilities {
     browserName?: string
     browserVersion?: string
     acceptSslCerts?: boolean
+    /**
+     * @private
+     */
     wdioService?: string
 }
 

--- a/packages/wdio-types/src/Capabilities.ts
+++ b/packages/wdio-types/src/Capabilities.ts
@@ -1082,6 +1082,7 @@ export interface BrowserStackCapabilities {
     browserName?: string
     browserVersion?: string
     acceptSslCerts?: boolean
+    wdioService?: string
 }
 
 export interface SauceLabsVisualCapabilities {


### PR DESCRIPTION
## Proposed changes
Adding a capability 'wdioService' in caps being sent to browserstack, to track the service being used.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers


<a href="https://gitpod.io/#https://github.com/webdriverio/webdriverio/pull/8350"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

