### PR TITLE
Allow `moz:debuggerAddress` in DesiredCapabilities

### DIFF
--- a/packages/wdio-types/src/Capabilities.ts
+++ b/packages/wdio-types/src/Capabilities.ts
@@ -158,6 +158,7 @@ export interface VendorExtensions extends EdgeCapabilities, AppiumW3CCapabilitie
 
     'goog:chromeOptions'?: ChromeOptions;
     'moz:firefoxOptions'?: FirefoxOptions;
+    'moz:debuggerAddress'?: boolean;
     // eslint-disable-next-line
     firefox_profile?: string;
     'ms:edgeOptions'?: MicrosoftEdgeOptions;


### PR DESCRIPTION
## Proposed changes

Allow `moz:debuggerAddress` capability which is described here: https://firefox-source-docs.mozilla.org/testing/geckodriver/Capabilities.html

Ironically, the webdriverio documentation [also mentions this feature](https://webdriver.io/docs/devtools-service), but it is missing in types.

Tested the change locally, works well with Geckodriver v0.31.0

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
