### PR TITLE
add: browserstack-service backwards compatibility

### DIFF
--- a/packages/wdio-browserstack-service/src/launcher.ts
+++ b/packages/wdio-browserstack-service/src/launcher.ts
@@ -24,6 +24,7 @@ export default class BrowserstackLauncherService implements Services.ServiceInst
         capabilities: Capabilities.RemoteCapability,
         private _config: Options.Testrunner
     ) {
+        // added to maintain backward compatibility with webdriverIO v5
         this._config || (this._config = _options)
         if (Array.isArray(capabilities)) {
             capabilities.forEach((capability: Capabilities.DesiredCapabilities) => {

--- a/packages/wdio-browserstack-service/src/launcher.ts
+++ b/packages/wdio-browserstack-service/src/launcher.ts
@@ -20,10 +20,11 @@ export default class BrowserstackLauncherService implements Services.ServiceInst
     browserstackLocal?: BrowserstackLocal
 
     constructor (
-        private _options: BrowserstackConfig,
+        private _options: BrowserstackConfig | any,
         capabilities: Capabilities.RemoteCapability,
-        private _config: Options.Testrunner
+        private _config: Options.Testrunner | any
     ) {
+        this._config || (this._config = _options)
         if (Array.isArray(capabilities)) {
             capabilities.forEach((capability: Capabilities.DesiredCapabilities) => {
                 if (!capability['bstack:options']) {

--- a/packages/wdio-browserstack-service/src/launcher.ts
+++ b/packages/wdio-browserstack-service/src/launcher.ts
@@ -20,9 +20,9 @@ export default class BrowserstackLauncherService implements Services.ServiceInst
     browserstackLocal?: BrowserstackLocal
 
     constructor (
-        private _options: BrowserstackConfig | any,
+        private _options: BrowserstackConfig & Options.Testrunner,
         capabilities: Capabilities.RemoteCapability,
-        private _config: Options.Testrunner | any
+        private _config: Options.Testrunner
     ) {
         this._config || (this._config = _options)
         if (Array.isArray(capabilities)) {

--- a/packages/wdio-browserstack-service/src/service.ts
+++ b/packages/wdio-browserstack-service/src/service.ts
@@ -21,6 +21,7 @@ export default class BrowserstackService implements Services.ServiceInstance {
         private _caps: Capabilities.RemoteCapability,
         private _config: Options.Testrunner
     ) {
+        // added to maintain backward compatibility with webdriverIO v5
         this._config || (this._config = _options)
         // Cucumber specific
         const strict = Boolean(this._config.cucumberOpts && this._config.cucumberOpts.strict)
@@ -58,6 +59,7 @@ export default class BrowserstackService implements Services.ServiceInstance {
     }
 
     before(caps: Capabilities.RemoteCapability, specs: string[], browser: Browser<'async'> | MultiRemoteBrowser<'async'>) {
+        // added to maintain backward compatibility with webdriverIO v5
         this._browser = browser ? browser : (global as any).browser
 
         // Ensure capabilities are not null in case of multiremote

--- a/packages/wdio-browserstack-service/src/service.ts
+++ b/packages/wdio-browserstack-service/src/service.ts
@@ -17,9 +17,9 @@ export default class BrowserstackService implements Services.ServiceInstance {
     private _fullTitle?: string
 
     constructor (
-        private _options: BrowserstackConfig | any,
+        private _options: BrowserstackConfig & Options.Testrunner,
         private _caps: Capabilities.RemoteCapability,
-        private _config: Options.Testrunner | any
+        private _config: Options.Testrunner
     ) {
         this._config || (this._config = _options)
         // Cucumber specific

--- a/packages/wdio-browserstack-service/src/service.ts
+++ b/packages/wdio-browserstack-service/src/service.ts
@@ -17,10 +17,11 @@ export default class BrowserstackService implements Services.ServiceInstance {
     private _fullTitle?: string
 
     constructor (
-        private _options: BrowserstackConfig,
+        private _options: BrowserstackConfig | any,
         private _caps: Capabilities.RemoteCapability,
-        private _config: Options.Testrunner
+        private _config: Options.Testrunner | any
     ) {
+        this._config || (this._config = _options)
         // Cucumber specific
         const strict = Boolean(this._config.cucumberOpts && this._config.cucumberOpts.strict)
         // See https://github.com/cucumber/cucumber-js/blob/master/src/runtime/index.ts#L136
@@ -57,7 +58,7 @@ export default class BrowserstackService implements Services.ServiceInstance {
     }
 
     before(caps: Capabilities.RemoteCapability, specs: string[], browser: Browser<'async'> | MultiRemoteBrowser<'async'>) {
-        this._browser = browser
+        this._browser = browser ? browser : (global as any).browser
 
         // Ensure capabilities are not null in case of multiremote
 


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)
Making the browserstack-service run with older webdriverIO versions. 
Assigning `_config  = options` in constructor as in webdriverIO v5 the config is being passed in options, with config being undefined. 

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers


<a href="https://gitpod.io/#https://github.com/webdriverio/webdriverio/pull/8374"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

