### PR TITLE
Add wdio-azure-devops-service to official docs

### DIFF
--- a/packages/wdio-cli/src/constants.ts
+++ b/packages/wdio-cli/src/constants.ts
@@ -141,7 +141,8 @@ export const SUPPORTED_PACKAGES = {
         { name: 'aws-device-farm', value: 'wdio-aws-device-farm-service$--$aws-device-farm' },
         { name: 'ocr-native-apps', value: 'wdio-ocr-service$--$ocr-native-apps' },
         { name: 'ms-teams', value: 'wdio-ms-teams-service$--$ms-teams' },
-        { name: 'tesults', value: 'wdio-tesults-service$--$tesults' }
+        { name: 'tesults', value: 'wdio-tesults-service$--$tesults' },
+        { name: 'azure-devops', value: '@gmangiapelo/wdio-azure-devops-service$--$azure-devops' }
     ]
 } as const
 

--- a/scripts/docs-generation/3rd-party/services.json
+++ b/scripts/docs-generation/3rd-party/services.json
@@ -169,5 +169,11 @@
     "title": "Tesults",
     "githubUrl": "https://github.com/tesults/wdio-tesults-service",
     "npmUrl": "https://www.npmjs.com/package/wdio-tesults-service"
+  },
+  {
+    "packageName": "@gmangiapelo/wdio-azure-devops-service",
+    "title": "Azure DevOps Test Plans",
+    "githubUrl": "https://github.com/gianlucamangiapelo/wdio-azure-devops-service",
+    "npmUrl": "https://www.npmjs.com/package/@gmangiapelo/wdio-azure-devops-service"
   }
 ]


### PR DESCRIPTION
## Proposed changes
Add WDIO Azure DevOps Service to the official Webdriver.io page
This custom service allows to Publishes WebdriverIO results on Azure DevOps Test Plans.

>npm link: https://www.npmjs.com/package/@gmangiapelo/wdio-azure-devops-service

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers


<a href="https://gitpod.io/#https://github.com/webdriverio/webdriverio/pull/8414"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

