### PR TITLE
fix: Clear executeScript timeout in case of promise rejection

### DIFF
--- a/e2e/protocol.test.ts
+++ b/e2e/protocol.test.ts
@@ -332,6 +332,21 @@ describe('executeScript', () => {
         ).toBe('WebdriverJS Testpage Test!')
     })
 
+    it('sync error', async () => {
+        const spy = jest.spyOn(global, 'clearTimeout')
+
+        await expect(async () => {
+            await browser.executeScript(
+                'throw new Error(\'sync error\')',
+                []
+            )
+        }).rejects.toThrow('sync error');
+
+        expect(spy).toHaveBeenCalledTimes(1);
+
+        spy.mockClear()
+    })
+
     it('async', async () => {
         expect(await browser.executeAsyncScript(
             'return setTimeout(() => arguments[2](document.title + \' \' + arguments[0] + arguments[1]), 500)',

--- a/packages/devtools/src/commands/executeScript.ts
+++ b/packages/devtools/src/commands/executeScript.ts
@@ -38,7 +38,7 @@ export default async function executeScript (
         ...(await transformExecuteArgs.call(this, args))
     )
 
-    let executeTimeout
+    let executeTimeout: undefined | ReturnType<typeof setTimeout>
     const timeoutPromise = new Promise((_, reject) => {
         executeTimeout = setTimeout(() => {
             const timeoutError = `script timeout${
@@ -51,7 +51,9 @@ export default async function executeScript (
         }, scriptTimeout)
     })
 
-    const result = await Promise.race([executePromise, timeoutPromise])
-    clearTimeout(executeTimeout)
+    const result = await Promise.race([executePromise, timeoutPromise]).finally(() => {
+        clearTimeout(executeTimeout)
+    })
+
     return transformExecuteResult.call(this, page, result)
 }


### PR DESCRIPTION
## Proposed changes

If an exception is thrown in `executeScript` the script timeout timer wasn't cleared preventing NodeJS process from exiting. This PR simply make sure that the timer is always cleared

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

I've split the test and fix in two different commit so it's easy to check that the test fails before the fix and works after it.

### Reviewers: @webdriverio/project-committers


<a href="https://gitpod.io/#https://github.com/webdriverio/webdriverio/pull/8420"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

