### PR TITLE
Fix for issue 8376

### DIFF
--- a/packages/wdio-config/src/lib/ConfigParser.ts
+++ b/packages/wdio-config/src/lib/ConfigParser.ts
@@ -37,7 +37,8 @@ export default class ConfigParser {
     constructor(
         private _pathService: PathService = new FileSystemPathService(),
         private _moduleRequireService: ModuleRequireService = new RequireLibrary()
-    ) {}
+    ) {
+    }
 
     autoCompile() {
         /**
@@ -214,26 +215,33 @@ export default class ConfigParser {
             // Removing any duplicate tests that could be included
             let tmpSpecs = spec.length > 0 ? [...specs, ...suiteSpecs] : suiteSpecs
 
+            //Only merge capability specs if --spec is not defined
+            if (spec.length === 0) {
+                if (Array.isArray(capSpecs)) {
+                    tmpSpecs = ConfigParser.getFilePaths(capSpecs, undefined, this._pathService)
+                }
+
+                if (Array.isArray(capExclude)) {
+                    exclude = ConfigParser.getFilePaths(capExclude, undefined, this._pathService)
+                }
+            }
+
+            specs = [...new Set(tmpSpecs)]
+            return this.filterSpecs(specs, <string[]>exclude)
+        }
+
+        //Only merge capability specs if --spec is not defined
+        if (spec.length === 0) {
             if (Array.isArray(capSpecs)) {
-                tmpSpecs = ConfigParser.getFilePaths(capSpecs, undefined, this._pathService)
+                specs = ConfigParser.getFilePaths(capSpecs, undefined, this._pathService)
             }
 
             if (Array.isArray(capExclude)) {
                 exclude = ConfigParser.getFilePaths(capExclude, undefined, this._pathService)
             }
-
-            specs = [...new Set(tmpSpecs)]
-            return this.filterSpecs(specs, <string[]> exclude)
         }
 
-        if (Array.isArray(capSpecs)) {
-            specs = ConfigParser.getFilePaths(capSpecs, undefined, this._pathService)
-        }
-
-        if (Array.isArray(capExclude)) {
-            exclude = ConfigParser.getFilePaths(capExclude, undefined, this._pathService)
-        }
-        return this.filterSpecs(specs, <string[]> exclude)
+        return this.filterSpecs(specs, <string[]>exclude)
     }
 
     /**

--- a/packages/wdio-config/tests/configparser.test.ts
+++ b/packages/wdio-config/tests/configparser.test.ts
@@ -39,7 +39,7 @@ jest.mock('tsconfig-paths', () => ({
  * @constructor
  */
 // eslint-disable-next-line camelcase
-const TestWdioConfig_AllInMemory = () : MockFileContent => ({
+const TestWdioConfig_AllInMemory = (): MockFileContent => ({
     config: {
         user: 'foobar',
         key: '50fa142c-3121-4gb0-9p07-8q326vvbq7b0',
@@ -70,19 +70,19 @@ const TestWdioConfig_AllInMemory = () : MockFileContent => ({
  * @constructor
  */
 // eslint-disable-next-line camelcase
-function MockedFileSystem_LoadingAsMuchAsCanFromFileSystem() : FilePathsAndContents {
+function MockedFileSystem_LoadingAsMuchAsCanFromFileSystem(): FilePathsAndContents {
     return [
         realReadFilePair(path.resolve(FIXTURES_PATH, '../validateConfig.test.ts')),
         realReadFilePair(path.resolve(FIXTURES_PATH, '../configparser.test.ts')),
         realReadFilePair(path.resolve(FIXTURES_PATH, '../utils.test.ts')),
         realReadFilePair(path.resolve(FIXTURES_PATH, '../RequireLibrary.test.ts')),
         FileNamed(path.resolve(FIXTURES_PATH, 'test.cjs')).withContents('test file contents'),
-        FileNamed(path.resolve(FIXTURES_PATH, 'test.es6')).withContents( 'test file contents'),
-        FileNamed(path.resolve(FIXTURES_PATH, 'test.java')).withContents( 'test file contents'),
-        FileNamed(path.resolve(FIXTURES_PATH, 'test.mjs')).withContents( 'test file contents'),
-        FileNamed(path.resolve(FIXTURES_PATH, 'test-a.feature')).withContents( 'feature file contents'),
-        FileNamed(path.resolve(FIXTURES_PATH, 'test-b.feature')).withContents( 'feature file contents'),
-        FileNamed(path.resolve(FIXTURES_PATH, 'typescript.ts')).withContents( 'test file contents'),
+        FileNamed(path.resolve(FIXTURES_PATH, 'test.es6')).withContents('test file contents'),
+        FileNamed(path.resolve(FIXTURES_PATH, 'test.java')).withContents('test file contents'),
+        FileNamed(path.resolve(FIXTURES_PATH, 'test.mjs')).withContents('test file contents'),
+        FileNamed(path.resolve(FIXTURES_PATH, 'test-a.feature')).withContents('feature file contents'),
+        FileNamed(path.resolve(FIXTURES_PATH, 'test-b.feature')).withContents('feature file contents'),
+        FileNamed(path.resolve(FIXTURES_PATH, 'typescript.ts')).withContents('test file contents'),
         realRequiredFilePair(path.resolve(FIXTURES_PATH, 'wdio.array.conf.ts')),
         realRequiredFilePair(path.resolve(FIXTURES_PATH, 'wdio.conf.multiremote.rdc.ts')),
         realRequiredFilePair(path.resolve(FIXTURES_PATH, 'wdio.conf.rdc.ts')),
@@ -102,7 +102,7 @@ function MockedFileSystem_LoadingAsMuchAsCanFromFileSystem() : FilePathsAndConte
  * @constructor
  */
 // eslint-disable-next-line camelcase
-function MockedFileSystem_OnlyLoadingConfig(baseDir: MockSystemFolderPath, configFilepath: MockSystemFilePath) : FilePathsAndContents {
+function MockedFileSystem_OnlyLoadingConfig(baseDir: MockSystemFolderPath, configFilepath: MockSystemFilePath): FilePathsAndContents {
     return [
         FileNamed(configFilepath).withContents(TestWdioConfig_AllInMemory()),
         FileNamed(path.join(baseDir, '../validateConfig.test.ts')).withContents('test contents'),
@@ -190,9 +190,9 @@ describe('ConfigParser', () => {
                 configParser.addConfigFile('cool.conf')
                 configParser.autoCompile()
                 expect(tsNodeRegister).toBeCalledTimes(1)
-                expect(tsNodeRegister).toHaveBeenCalledWith( {
+                expect(tsNodeRegister).toHaveBeenCalledWith({
                     'transpileOnly': true
-                } )
+                })
             })
 
             it('when ts-node exists should initiate TypeScript compiler with defaults if autoCompiled before config is read', function () {
@@ -245,11 +245,11 @@ describe('ConfigParser', () => {
                 configParser.addConfigFile('tests/cool.conf')
                 configParser.autoCompile()
                 expect(tsNodeRegister).toBeCalledTimes(1)
-                expect(tsNodeRegister).toHaveBeenCalledWith( {
+                expect(tsNodeRegister).toHaveBeenCalledWith({
                     'transpileOnly': true,
                     'ts-node': 'do this',
                     'and': 'that'
-                } )
+                })
             })
 
             it('config can overwrite defaults', function () {
@@ -276,9 +276,9 @@ describe('ConfigParser', () => {
                 configParser.autoCompile()
                 expect(tsConfigPath.register).toBeCalledTimes(0)
                 expect(tsNodeRegister).toBeCalledTimes(1)
-                expect(tsNodeRegister).toHaveBeenCalledWith( {
+                expect(tsNodeRegister).toHaveBeenCalledWith({
                     'transpileOnly': false
-                } )
+                })
             })
 
             it('bootstraps tsconfig-paths if options are given', function () {
@@ -303,14 +303,16 @@ describe('ConfigParser', () => {
                     .withTsNodeModule(tsNodeRegister).build()
                 configParser.addConfigFile('tests/cool.conf')
                 configParser.autoCompile()
-                expect(tsConfigPath.register).toHaveBeenCalledWith( {
+                expect(tsConfigPath.register).toHaveBeenCalledWith({
                     base: '/foo/bar'
-                } )
+                })
             })
 
             it('should just continue without initiation when autoCompile:false', function () {
                 (tsNode.register as jest.Mock)
-                    .mockImplementation(() => { throw new Error('boom') })
+                    .mockImplementation(() => {
+                        throw new Error('boom')
+                    })
                 const tsNodeRegister = jest.fn()
                 const configParser = ConfigParserBuilder
                     .withBaseDir(FIXTURES_PATH)
@@ -329,7 +331,9 @@ describe('ConfigParser', () => {
 
             it('should just continue without initiation if ts-node does not exist', () => {
                 (tsNode.register as jest.Mock)
-                    .mockImplementation(() => { throw new Error('boom') })
+                    .mockImplementation(() => {
+                        throw new Error('boom')
+                    })
                 const configParser = ConfigParserBuilder
                     .withBaseDir(FIXTURES_PATH)
                     .withFiles(MockedFileSystem_LoadingAsMuchAsCanFromFileSystem())
@@ -415,10 +419,10 @@ describe('ConfigParser', () => {
                 configParser.addConfigFile(path.join(__dirname, '/tests/cool.conf'))
                 configParser.autoCompile()
                 expect(babelRegister).toBeCalledTimes(1)
-                expect(babelRegister).toHaveBeenCalledWith( {
+                expect(babelRegister).toHaveBeenCalledWith({
                     'babel': 'do this',
                     'and': 'that'
-                } )
+                })
             })
 
             it('should just continue without initiation when autoCompile:false', () => {
@@ -494,6 +498,20 @@ describe('ConfigParser', () => {
             expect(specs).toContain(INDEX_PATH)
         })
 
+        it('should overwrite capability defined specs if piped into cli command', () => {
+            const configParser = ConfigParserForTestWithAllFiles()
+            configParser.addConfigFile(FIXTURES_CONF)
+            configParser.merge({ capabilities: [{ specs: [INDEX_PATH] }] })
+            expect(configParser.getCapabilities()).toMatchObject([{ specs: [INDEX_PATH] }])
+
+            const capSpecs = configParser.getCapabilities()[0].specs
+            configParser.merge({ spec: [path.join(__dirname, '/utils.test.ts')] })
+
+            const specs = configParser.getSpecs(capSpecs)
+            expect(specs).toHaveLength(1)
+            expect(specs).toContain(path.join(__dirname, '/utils.test.ts'))
+        })
+
         it('should allow specifying a spec file', () => {
             const configParser = ConfigParserForTestWithAllFiles()
             configParser.addConfigFile(FIXTURES_CONF)
@@ -511,7 +529,7 @@ describe('ConfigParser', () => {
             const specs = configParser.getSpecs()
             expect(specs).toHaveLength(1)
             let featureFileWithoutLine = ''
-            if (isWindows){
+            if (isWindows) {
                 featureFileWithoutLine = FIXTURES_CUCUMBER_FEATURE_A_LINE_2.split(':')[0] + ':' + FIXTURES_CUCUMBER_FEATURE_A_LINE_2.split(':')[1]
             } else {
                 featureFileWithoutLine = FIXTURES_CUCUMBER_FEATURE_A_LINE_2.split(':')[0]
@@ -527,7 +545,7 @@ describe('ConfigParser', () => {
             const specs = configParser.getSpecs()
             expect(specs).toHaveLength(1)
             let featureFileWithoutLine = ''
-            if (isWindows){
+            if (isWindows) {
                 featureFileWithoutLine = FIXTURES_CUCUMBER_FEATURE_A_LINE_2_AND_12.split(':')[0] + ':' + FIXTURES_CUCUMBER_FEATURE_A_LINE_2_AND_12.split(':')[1]
             } else {
                 featureFileWithoutLine = FIXTURES_CUCUMBER_FEATURE_A_LINE_2_AND_12.split(':')[0]
@@ -544,7 +562,7 @@ describe('ConfigParser', () => {
             expect(specs).toHaveLength(2)
             let featureFileA = ''
             let featureFileB = ''
-            if (isWindows){
+            if (isWindows) {
                 featureFileA = FIXTURES_CUCUMBER_FEATURE_A_LINE_2.split(':')[0] + ':' + FIXTURES_CUCUMBER_FEATURE_A_LINE_2.split(':')[1]
                 featureFileB = FIXTURES_CUCUMBER_FEATURE_B_LINE_7.split(':')[0] + ':' + FIXTURES_CUCUMBER_FEATURE_B_LINE_7.split(':')[1]
             } else {
@@ -558,7 +576,7 @@ describe('ConfigParser', () => {
         it('should allow specifying mutliple single spec file', () => {
             const configParser = ConfigParserForTestWithAllFiles()
             configParser.addConfigFile(FIXTURES_CONF)
-            configParser.merge({ spec : [INDEX_PATH, FIXTURES_CONF] })
+            configParser.merge({ spec: [INDEX_PATH, FIXTURES_CONF] })
 
             const specs = configParser.getSpecs()
             expect(specs).toHaveLength(2)
@@ -569,7 +587,7 @@ describe('ConfigParser', () => {
         it('should allow to specify partial matching spec file', () => {
             const configParser = ConfigParserForTestWithAllFiles()
             configParser.addConfigFile(FIXTURES_CONF)
-            configParser.merge({ spec : ['Library'] })
+            configParser.merge({ spec: ['Library'] })
 
             const specs = configParser.getSpecs()
             expect(specs).toContain(path.join(__dirname, 'RequireLibrary.test.ts'))
@@ -578,7 +596,7 @@ describe('ConfigParser', () => {
         it('should handle an array in the config_specs', () => {
             const configParser = ConfigParserForTestWithAllFiles()
             configParser.addConfigFile(FIXTURES_CONF_ARRAY)
-            configParser.merge({ spec : ['Library'] })
+            configParser.merge({ spec: ['Library'] })
 
             const specs = configParser.getSpecs()
             expect(specs).toContain(path.join(__dirname, 'RequireLibrary.test.ts'))
@@ -587,7 +605,7 @@ describe('ConfigParser', () => {
         it('should exclude duplicate spec files', () => {
             const configParser = ConfigParserForTestWithAllFiles()
             configParser.addConfigFile(FIXTURES_CONF)
-            configParser.merge({ spec : [INDEX_PATH, INDEX_PATH] })
+            configParser.merge({ spec: [INDEX_PATH, INDEX_PATH] })
 
             const specs = configParser.getSpecs()
             expect(specs).toHaveLength(1)
@@ -956,7 +974,7 @@ describe('ConfigParser', () => {
             expect(specs).not.toContain(path.resolve(__dirname, 'zelda.test.ts'))
         })
 
-        it("should throw if suite doesn't exist or doesn't contain any files", () => {
+        it('should throw if suite doesn\'t exist or doesn\'t contain any files', () => {
             const configParser = ConfigParserBuilder
                 .withBaseDir(path.join(process.cwd(), '/workdir/'))
                 .withFiles(
@@ -990,7 +1008,10 @@ describe('ConfigParser', () => {
             configParser.addConfigFile('conf-under-test')
             // eslint-disable-next-line no-useless-escape
             expect(() => configParser.getSpecs()).toThrowError('The suite(s) \"something\" you specified don\'t exist in your config file or doesn\'t contain any files!')
-            configParser.merge({ suite: ['something-else'], spec: [path.join(__dirname, '/tests/only-this-test-one.test.ts')] })
+            configParser.merge({
+                suite: ['something-else'],
+                spec: [path.join(__dirname, '/tests/only-this-test-one.test.ts')]
+            })
             // eslint-disable-next-line no-useless-escape
             expect(() => configParser.getSpecs()).toThrowError('The suite(s) \"something\", \"something-else\" you specified don\'t exist in your config file or doesn\'t contain any files!')
         })

--- a/website/docs/OrganizingTestSuites.md
+++ b/website/docs/OrganizingTestSuites.md
@@ -1,19 +1,25 @@
 ---
-id: organizingsuites
-title: Organizing Test Suite
+id: organizingsuites title: Organizing Test Suite
 ---
 
-As projects grow, inevitably more and more integration tests are added. This increases build time and slows productivity.
+As projects grow, inevitably more and more integration tests are added. This increases build time and slows
+productivity.
 
-To prevent this, you should run your tests in parallel. WebdriverIO already tests each spec (or _feature file_ in Cucumber) in parallel within a single session. In general, try to test only a single feature per spec file. Try to not have too many or too few tests in one file. (However, there is no golden rule here.)
+To prevent this, you should run your tests in parallel. WebdriverIO already tests each spec (or _feature file_ in
+Cucumber) in parallel within a single session. In general, try to test only a single feature per spec file. Try to not
+have too many or too few tests in one file. (However, there is no golden rule here.)
 
-Once your tests have several spec files, you should start running your tests concurrently. To do so, adjust the `maxInstances` property in your config file. WebdriverIO allows you to run your tests with maximum concurrency—meaning that no matter how many files and tests you have, they can all run in parallel.  (This is still subject to certain limits, like your computer’s CPU, concurrency restrictions, etc.)
+Once your tests have several spec files, you should start running your tests concurrently. To do so, adjust
+the `maxInstances` property in your config file. WebdriverIO allows you to run your tests with maximum
+concurrency—meaning that no matter how many files and tests you have, they can all run in parallel.  (This is still
+subject to certain limits, like your computer’s CPU, concurrency restrictions, etc.)
 
 > Let's say you have 3 different capabilities (Chrome, Firefox, and Safari) and you have set `maxInstances` to `1`. The WDIO test runner will spawn 3 processes. Therefore, if you have 10 spec files and you set `maxInstances` to `10`, _all_ spec files will be tested simultaneously, and 30 processes will be spawned.
 
 You can define the `maxInstances` property globally to set the attribute for all browsers.
 
-If you run your own WebDriver grid, you may (for example) have more capacity for one browser than another. In that case, you can _limit_ the `maxInstances` in your capability object:
+If you run your own WebDriver grid, you may (for example) have more capacity for one browser than another. In that case,
+you can _limit_ the `maxInstances` in your capability object:
 
 ```js
 // wdio.conf.js
@@ -36,11 +42,14 @@ exports.config = {
 
 ## Inherit From Main Config File
 
-If you run your test suite in multiple environments (e.g., dev and integration) it may help to use multiple configuration files to keep things manageable.
+If you run your test suite in multiple environments (e.g., dev and integration) it may help to use multiple
+configuration files to keep things manageable.
 
-Similar to the [page object concept](PageObjects.md), the first thing you’ll need is a main config file. It contains all configurations you share across environments.
+Similar to the [page object concept](PageObjects.md), the first thing you’ll need is a main config file. It contains all
+configurations you share across environments.
 
-Then create another config file for each environment, and supplement the the main config with the environment-specific ones:
+Then create another config file for each environment, and supplement the the main config with the environment-specific
+ones:
 
 ```js
 // wdio.dev.config.js
@@ -104,37 +113,43 @@ wdio wdio.conf.js --suite login --suite otherFeature
 
 ## Grouping Test Specs To Run Sequentially
 
-As described above, there are benefits in running the tests concurrently.  However, there are cases where it would be beneficial to group tests together to run sequentially in a single instance.  Examples of this are mainly where there is a large setup cost e.g. transpiling code or provisioning cloud instances, but there are also advanced usage models that benefit from this capability.
+As described above, there are benefits in running the tests concurrently. However, there are cases where it would be
+beneficial to group tests together to run sequentially in a single instance. Examples of this are mainly where there is
+a large setup cost e.g. transpiling code or provisioning cloud instances, but there are also advanced usage models that
+benefit from this capability.
 
 To group tests to run in a single instance, simply define them as an array within the specs definition.
 
 ```json
     "specs": [
-        [
-            "./test/specs/test_login.js",
-            "./test/specs/test_product_order.js",
-            "./test/specs/test_checkout.js"
-        ],
-        "./test/specs/test_b*.js",
-    ],
+[
+"./test/specs/test_login.js",
+"./test/specs/test_product_order.js",
+"./test/specs/test_checkout.js"
+],
+"./test/specs/test_b*.js",
+],
 ```
-In the example above, the tests 'test_login.js', 'test_product_order.js' and 'test_checkout.js' will be run sequentially in a single instance and each of the "test_b*" tests will run concurrently in individual instances.
+
+In the example above, the tests 'test_login.js', 'test_product_order.js' and 'test_checkout.js' will be run sequentially
+in a single instance and each of the "test_b*" tests will run concurrently in individual instances.
 
 It is also possible to group specs defined in suites, so you can now also define suites like this:
+
 ```json
     "suites": {
-        end2end: [
-            [
-                "./test/specs/test_login.js",
-                "./test/specs/test_product_order.js",
-                "./test/specs/test_checkout.js"
-            ]
-        ],
-        allb: ["./test/specs/test_b*.js"]
+end2end: [
+[
+"./test/specs/test_login.js",
+"./test/specs/test_product_order.js",
+"./test/specs/test_checkout.js"
+]
+],
+allb: ["./test/specs/test_b*.js"]
 },
 ```
-and in this case all of the tests of the "end2end" suite would be run in a single instance.
 
+and in this case all of the tests of the "end2end" suite would be run in a single instance.
 
 ## Run Selected Tests
 
@@ -154,7 +169,8 @@ Or run multiple specs at once:
 wdio wdio.conf.js --spec ./test/specs/signup.js --spec ./test/specs/forgot-password.js
 ```
 
-If the `--spec` value does not point to a particular spec file, it is instead used to filter the spec filenames defined in your configuration.
+If the `--spec` value does not point to a particular spec file, it is instead used to filter the spec filenames defined
+in your configuration.
 
 To run all specs with the word “dialog” in the spec file names, you could use:
 
@@ -162,13 +178,19 @@ To run all specs with the word “dialog” in the spec file names, you could us
 wdio wdio.conf.js --spec dialog
 ```
 
-Note that each test file is running in a single test runner process. Since we don't scan files in advance (see the next section for information on piping filenames to `wdio`), you _can't_ use (for example) `describe.only` at the top of your spec file to instruct Mocha to run only that suite.
+When the `--spec` option is provided, it will override any patterns defined by the config or capability level's `specs`
+parameter.
+
+Note that each test file is running in a single test runner process. Since we don't scan files in advance (see the next
+section for information on piping filenames to `wdio`), you _can't_ use (for example) `describe.only` at the top of your
+spec file to instruct Mocha to run only that suite.
 
 This feature will help you to accomplish the same goal.
 
 ## Exclude Selected Tests
 
-When needed, if you need to exclude particular spec file(s) from a run, you can use the `--exclude` parameter (Mocha, Jasmine) or feature (Cucumber).
+When needed, if you need to exclude particular spec file(s) from a run, you can use the `--exclude` parameter (Mocha,
+Jasmine) or feature (Cucumber).
 
 For example, to exclude your login test from the test run:
 
@@ -188,6 +210,9 @@ Or, exclude a spec file when filtering using a suite:
 wdio wdio.conf.js --suite login --exclude ./test/specs/e2e/login.js
 ```
 
+When the `--exclude` option is provided, it will override any patterns defined by the config or capability
+level's `exclude` parameter.
+
 ## Run Suites and Test Specs
 
 Run an entire suite along with individual specs.
@@ -198,7 +223,8 @@ wdio wdio.conf.js --suite login --spec ./test/specs/signup.js
 
 ## Run Multiple, Specific Test Specs
 
-It is sometimes necessary&mdash;in the context of continuous integration and otherwise&mdash;to specify multiple sets of specs to run. WebdriverIO's `wdio` command line utility accepts piped-in filenames (from `find`, `grep`, or others).
+It is sometimes necessary&mdash;in the context of continuous integration and otherwise&mdash;to specify multiple sets of
+specs to run. WebdriverIO's `wdio` command line utility accepts piped-in filenames (from `find`, `grep`, or others).
 
 Piped-in filenames override the list of globs or filenames specified in the configuration's `spec` list.
 
@@ -210,21 +236,103 @@ _**Note:** This will_ not _override the `--spec` flag for running a single spec.
 
 ## Running Specific Tests with MochaOpts
 
-You can also filter which specific `suite|describe` and/or `it|test` you want to run by passing a mocha specific argument: `--mochaOpts.grep` to the wdio CLI.
+You can also filter which specific `suite|describe` and/or `it|test` you want to run by passing a mocha specific
+argument: `--mochaOpts.grep` to the wdio CLI.
 
 ```sh
 wdio wdio.conf.js --mochaOpts.grep myText
 wdio wdio.conf.js --mochaOpts.grep "Text with spaces"
 ```
 
-_**Note:** Mocha will filter the tests after the WDIO test runner creates the instances, so you might see several instances being spawned but not actually executed._
+_**Note:** Mocha will filter the tests after the WDIO test runner creates the instances, so you might see several
+instances being spawned but not actually executed._
 
 ## Stop testing after failure
 
 With the `bail` option, you can tell WebdriverIO to stop testing after any test fails.
 
-This is helpful with large test suites when you already know that your build will break, but you want to avoid the lengthy wait of a full testing run.
+This is helpful with large test suites when you already know that your build will break, but you want to avoid the
+lengthy wait of a full testing run.
 
-The `bail` option expects a number, which specifies how many test failures can occur before WebDriver stop the entire testing run. The default is `0`, meaning that it always runs all tests specs it can find.
+The `bail` option expects a number, which specifies how many test failures can occur before WebDriver stop the entire
+testing run. The default is `0`, meaning that it always runs all tests specs it can find.
 
 Please see [Options Page](Options.md) for additional information on the bail configuration.
+
+## Hierarchy of spec patterns
+
+When declaring what specs to run, there is a certain hierarchy defining what pattern will take precedence when defined.
+Currently, this is how it works, from highest priority to lowest:
+> CLI `--spec` argument > capability `specs` pattern > config `specs` pattern
+
+If only the config parameter is given, it will be used for all capabilities. However, if defining the pattern at the
+capability level, it will be used instead of the config pattern. Finally, any spec pattern defined on the command line
+will override all other patterns given.
+
+### Using capability-defined spec patterns
+
+When you define a spec pattern at the capability level, it will override any patterns defined at the config level. This
+is useful when needing to separate tests based on differentiating device capabilities. In cases like this, it is more
+useful to use a generic spec pattern at the config level, and more specific patterns at the capability level.
+
+For example, let's say you had two directories, with one for Android tests, and one for iOS tests.
+
+Your config file may define the pattern as such, for non-specific device tests:
+
+```js
+{
+    specs: ['tests/general/**/*.js']
+}
+```
+
+but then, you will have different capabilities for your Android and iOS devices, where the patterns could look like
+such:
+
+
+```json
+{
+    "platformName": "Android",
+    "specs": [
+        "tests/android/**/*.js"
+    ]
+}
+```
+
+```json
+{
+    "platformName": "iOS",
+    "specs": [
+        "tests/ios/**/*.js"
+    ]
+}
+```
+
+If you require both of these capabilities in your config file, then the Android device will only run the tests under
+the "android" namespace, and the iOS tests will run only tests under the "ios" namespace!
+
+```js
+//wdio.conf.js
+exports.config = {
+    "specs": [
+        "tests/general/**/*.js"
+    ],
+    "capabilities": [
+        {
+            platformName: "Android",
+            specs: ["tests/android/**/*.js"],
+            //...
+        },
+        {
+            platformName: "iOS",
+            specs: ["tests/ios/**/*.js"],
+            //...
+        },
+        {
+            platformName: "Chrome",
+            //config level specs will be used
+        }
+    ]
+}
+```
+
+

--- a/website/docs/OrganizingTestSuites.md
+++ b/website/docs/OrganizingTestSuites.md
@@ -244,9 +244,7 @@ If only the config parameter is given, it will be used for all capabilities. How
 
 ### Using capability-defined spec patterns
 
-When you define a spec pattern at the capability level, it will override any patterns defined at the config level. This
-is useful when needing to separate tests based on differentiating device capabilities. In cases like this, it is more
-useful to use a generic spec pattern at the config level, and more specific patterns at the capability level.
+When you define a spec pattern at the capability level, it will override any patterns defined at the config level. This is useful when needing to separate tests based on differentiating device capabilities. In cases like this, it is more useful to use a generic spec pattern at the config level, and more specific patterns at the capability level.
 
 For example, let's say you had two directories, with one for Android tests, and one for iOS tests.
 

--- a/website/docs/OrganizingTestSuites.md
+++ b/website/docs/OrganizingTestSuites.md
@@ -1,25 +1,19 @@
 ---
-id: organizingsuites title: Organizing Test Suite
+id: organizingsuites
+title: Organizing Test Suite
 ---
 
-As projects grow, inevitably more and more integration tests are added. This increases build time and slows
-productivity.
+As projects grow, inevitably more and more integration tests are added. This increases build time and slows productivity.
 
-To prevent this, you should run your tests in parallel. WebdriverIO already tests each spec (or _feature file_ in
-Cucumber) in parallel within a single session. In general, try to test only a single feature per spec file. Try to not
-have too many or too few tests in one file. (However, there is no golden rule here.)
+To prevent this, you should run your tests in parallel. WebdriverIO already tests each spec (or _feature file_ in Cucumber) in parallel within a single session. In general, try to test only a single feature per spec file. Try to not have too many or too few tests in one file. (However, there is no golden rule here.)
 
-Once your tests have several spec files, you should start running your tests concurrently. To do so, adjust
-the `maxInstances` property in your config file. WebdriverIO allows you to run your tests with maximum
-concurrency—meaning that no matter how many files and tests you have, they can all run in parallel.  (This is still
-subject to certain limits, like your computer’s CPU, concurrency restrictions, etc.)
+Once your tests have several spec files, you should start running your tests concurrently. To do so, adjust the `maxInstances` property in your config file. WebdriverIO allows you to run your tests with maximum concurrency—meaning that no matter how many files and tests you have, they can all run in parallel.  (This is still subject to certain limits, like your computer’s CPU, concurrency restrictions, etc.)
 
 > Let's say you have 3 different capabilities (Chrome, Firefox, and Safari) and you have set `maxInstances` to `1`. The WDIO test runner will spawn 3 processes. Therefore, if you have 10 spec files and you set `maxInstances` to `10`, _all_ spec files will be tested simultaneously, and 30 processes will be spawned.
 
 You can define the `maxInstances` property globally to set the attribute for all browsers.
 
-If you run your own WebDriver grid, you may (for example) have more capacity for one browser than another. In that case,
-you can _limit_ the `maxInstances` in your capability object:
+If you run your own WebDriver grid, you may (for example) have more capacity for one browser than another. In that case, you can _limit_ the `maxInstances` in your capability object:
 
 ```js
 // wdio.conf.js
@@ -42,14 +36,11 @@ exports.config = {
 
 ## Inherit From Main Config File
 
-If you run your test suite in multiple environments (e.g., dev and integration) it may help to use multiple
-configuration files to keep things manageable.
+If you run your test suite in multiple environments (e.g., dev and integration) it may help to use multiple configuration files to keep things manageable.
 
-Similar to the [page object concept](PageObjects.md), the first thing you’ll need is a main config file. It contains all
-configurations you share across environments.
+Similar to the [page object concept](PageObjects.md), the first thing you’ll need is a main config file. It contains all configurations you share across environments.
 
-Then create another config file for each environment, and supplement the the main config with the environment-specific
-ones:
+Then create another config file for each environment, and supplement the the main config with the environment-specific ones:
 
 ```js
 // wdio.dev.config.js
@@ -113,43 +104,37 @@ wdio wdio.conf.js --suite login --suite otherFeature
 
 ## Grouping Test Specs To Run Sequentially
 
-As described above, there are benefits in running the tests concurrently. However, there are cases where it would be
-beneficial to group tests together to run sequentially in a single instance. Examples of this are mainly where there is
-a large setup cost e.g. transpiling code or provisioning cloud instances, but there are also advanced usage models that
-benefit from this capability.
+As described above, there are benefits in running the tests concurrently.  However, there are cases where it would be beneficial to group tests together to run sequentially in a single instance.  Examples of this are mainly where there is a large setup cost e.g. transpiling code or provisioning cloud instances, but there are also advanced usage models that benefit from this capability.
 
 To group tests to run in a single instance, simply define them as an array within the specs definition.
 
 ```json
     "specs": [
-[
-"./test/specs/test_login.js",
-"./test/specs/test_product_order.js",
-"./test/specs/test_checkout.js"
-],
-"./test/specs/test_b*.js",
-],
+        [
+            "./test/specs/test_login.js",
+            "./test/specs/test_product_order.js",
+            "./test/specs/test_checkout.js"
+        ],
+        "./test/specs/test_b*.js",
+    ],
 ```
-
-In the example above, the tests 'test_login.js', 'test_product_order.js' and 'test_checkout.js' will be run sequentially
-in a single instance and each of the "test_b*" tests will run concurrently in individual instances.
+In the example above, the tests 'test_login.js', 'test_product_order.js' and 'test_checkout.js' will be run sequentially in a single instance and each of the "test_b*" tests will run concurrently in individual instances.
 
 It is also possible to group specs defined in suites, so you can now also define suites like this:
-
 ```json
     "suites": {
-end2end: [
-[
-"./test/specs/test_login.js",
-"./test/specs/test_product_order.js",
-"./test/specs/test_checkout.js"
-]
-],
-allb: ["./test/specs/test_b*.js"]
+        end2end: [
+            [
+                "./test/specs/test_login.js",
+                "./test/specs/test_product_order.js",
+                "./test/specs/test_checkout.js"
+            ]
+        ],
+        allb: ["./test/specs/test_b*.js"]
 },
 ```
-
 and in this case all of the tests of the "end2end" suite would be run in a single instance.
+
 
 ## Run Selected Tests
 
@@ -169,8 +154,7 @@ Or run multiple specs at once:
 wdio wdio.conf.js --spec ./test/specs/signup.js --spec ./test/specs/forgot-password.js
 ```
 
-If the `--spec` value does not point to a particular spec file, it is instead used to filter the spec filenames defined
-in your configuration.
+If the `--spec` value does not point to a particular spec file, it is instead used to filter the spec filenames defined in your configuration.
 
 To run all specs with the word “dialog” in the spec file names, you could use:
 
@@ -178,19 +162,13 @@ To run all specs with the word “dialog” in the spec file names, you could us
 wdio wdio.conf.js --spec dialog
 ```
 
-When the `--spec` option is provided, it will override any patterns defined by the config or capability level's `specs`
-parameter.
-
-Note that each test file is running in a single test runner process. Since we don't scan files in advance (see the next
-section for information on piping filenames to `wdio`), you _can't_ use (for example) `describe.only` at the top of your
-spec file to instruct Mocha to run only that suite.
+Note that each test file is running in a single test runner process. Since we don't scan files in advance (see the next section for information on piping filenames to `wdio`), you _can't_ use (for example) `describe.only` at the top of your spec file to instruct Mocha to run only that suite.
 
 This feature will help you to accomplish the same goal.
 
 ## Exclude Selected Tests
 
-When needed, if you need to exclude particular spec file(s) from a run, you can use the `--exclude` parameter (Mocha,
-Jasmine) or feature (Cucumber).
+When needed, if you need to exclude particular spec file(s) from a run, you can use the `--exclude` parameter (Mocha, Jasmine) or feature (Cucumber).
 
 For example, to exclude your login test from the test run:
 
@@ -210,9 +188,6 @@ Or, exclude a spec file when filtering using a suite:
 wdio wdio.conf.js --suite login --exclude ./test/specs/e2e/login.js
 ```
 
-When the `--exclude` option is provided, it will override any patterns defined by the config or capability
-level's `exclude` parameter.
-
 ## Run Suites and Test Specs
 
 Run an entire suite along with individual specs.
@@ -223,8 +198,7 @@ wdio wdio.conf.js --suite login --spec ./test/specs/signup.js
 
 ## Run Multiple, Specific Test Specs
 
-It is sometimes necessary&mdash;in the context of continuous integration and otherwise&mdash;to specify multiple sets of
-specs to run. WebdriverIO's `wdio` command line utility accepts piped-in filenames (from `find`, `grep`, or others).
+It is sometimes necessary&mdash;in the context of continuous integration and otherwise&mdash;to specify multiple sets of specs to run. WebdriverIO's `wdio` command line utility accepts piped-in filenames (from `find`, `grep`, or others).
 
 Piped-in filenames override the list of globs or filenames specified in the configuration's `spec` list.
 
@@ -236,103 +210,21 @@ _**Note:** This will_ not _override the `--spec` flag for running a single spec.
 
 ## Running Specific Tests with MochaOpts
 
-You can also filter which specific `suite|describe` and/or `it|test` you want to run by passing a mocha specific
-argument: `--mochaOpts.grep` to the wdio CLI.
+You can also filter which specific `suite|describe` and/or `it|test` you want to run by passing a mocha specific argument: `--mochaOpts.grep` to the wdio CLI.
 
 ```sh
 wdio wdio.conf.js --mochaOpts.grep myText
 wdio wdio.conf.js --mochaOpts.grep "Text with spaces"
 ```
 
-_**Note:** Mocha will filter the tests after the WDIO test runner creates the instances, so you might see several
-instances being spawned but not actually executed._
+_**Note:** Mocha will filter the tests after the WDIO test runner creates the instances, so you might see several instances being spawned but not actually executed._
 
 ## Stop testing after failure
 
 With the `bail` option, you can tell WebdriverIO to stop testing after any test fails.
 
-This is helpful with large test suites when you already know that your build will break, but you want to avoid the
-lengthy wait of a full testing run.
+This is helpful with large test suites when you already know that your build will break, but you want to avoid the lengthy wait of a full testing run.
 
-The `bail` option expects a number, which specifies how many test failures can occur before WebDriver stop the entire
-testing run. The default is `0`, meaning that it always runs all tests specs it can find.
+The `bail` option expects a number, which specifies how many test failures can occur before WebDriver stop the entire testing run. The default is `0`, meaning that it always runs all tests specs it can find.
 
 Please see [Options Page](Options.md) for additional information on the bail configuration.
-
-## Hierarchy of spec patterns
-
-When declaring what specs to run, there is a certain hierarchy defining what pattern will take precedence when defined.
-Currently, this is how it works, from highest priority to lowest:
-> CLI `--spec` argument > capability `specs` pattern > config `specs` pattern
-
-If only the config parameter is given, it will be used for all capabilities. However, if defining the pattern at the
-capability level, it will be used instead of the config pattern. Finally, any spec pattern defined on the command line
-will override all other patterns given.
-
-### Using capability-defined spec patterns
-
-When you define a spec pattern at the capability level, it will override any patterns defined at the config level. This
-is useful when needing to separate tests based on differentiating device capabilities. In cases like this, it is more
-useful to use a generic spec pattern at the config level, and more specific patterns at the capability level.
-
-For example, let's say you had two directories, with one for Android tests, and one for iOS tests.
-
-Your config file may define the pattern as such, for non-specific device tests:
-
-```js
-{
-    specs: ['tests/general/**/*.js']
-}
-```
-
-but then, you will have different capabilities for your Android and iOS devices, where the patterns could look like
-such:
-
-
-```json
-{
-    "platformName": "Android",
-    "specs": [
-        "tests/android/**/*.js"
-    ]
-}
-```
-
-```json
-{
-    "platformName": "iOS",
-    "specs": [
-        "tests/ios/**/*.js"
-    ]
-}
-```
-
-If you require both of these capabilities in your config file, then the Android device will only run the tests under
-the "android" namespace, and the iOS tests will run only tests under the "ios" namespace!
-
-```js
-//wdio.conf.js
-exports.config = {
-    "specs": [
-        "tests/general/**/*.js"
-    ],
-    "capabilities": [
-        {
-            platformName: "Android",
-            specs: ["tests/android/**/*.js"],
-            //...
-        },
-        {
-            platformName: "iOS",
-            specs: ["tests/ios/**/*.js"],
-            //...
-        },
-        {
-            platformName: "Chrome",
-            //config level specs will be used
-        }
-    ]
-}
-```
-
-

--- a/website/docs/OrganizingTestSuites.md
+++ b/website/docs/OrganizingTestSuites.md
@@ -190,8 +190,7 @@ Or, exclude a spec file when filtering using a suite:
 wdio wdio.conf.js --suite login --exclude ./test/specs/e2e/login.js
 ```
 
-When the `--exclude` option is provided, it will override any patterns defined by the config or capability
-level's `exclude` parameter.
+When the `--exclude` option is provided, it will override any patterns defined by the config or capability level's `exclude` parameter.
 
 ## Run Suites and Test Specs
 

--- a/website/docs/OrganizingTestSuites.md
+++ b/website/docs/OrganizingTestSuites.md
@@ -166,8 +166,7 @@ Note that each test file is running in a single test runner process. Since we do
 
 This feature will help you to accomplish the same goal.
 
-When the `--spec` option is provided, it will override any patterns defined by the config or capability level's `specs`
-parameter.
+When the `--spec` option is provided, it will override any patterns defined by the config or capability level's `specs` parameter.
 
 ## Exclude Selected Tests
 

--- a/website/docs/OrganizingTestSuites.md
+++ b/website/docs/OrganizingTestSuites.md
@@ -166,6 +166,9 @@ Note that each test file is running in a single test runner process. Since we do
 
 This feature will help you to accomplish the same goal.
 
+When the `--spec` option is provided, it will override any patterns defined by the config or capability level's `specs`
+parameter.
+
 ## Exclude Selected Tests
 
 When needed, if you need to exclude particular spec file(s) from a run, you can use the `--exclude` parameter (Mocha, Jasmine) or feature (Cucumber).
@@ -187,6 +190,9 @@ Or, exclude a spec file when filtering using a suite:
 ```sh
 wdio wdio.conf.js --suite login --exclude ./test/specs/e2e/login.js
 ```
+
+When the `--exclude` option is provided, it will override any patterns defined by the config or capability
+level's `exclude` parameter.
 
 ## Run Suites and Test Specs
 
@@ -228,3 +234,80 @@ This is helpful with large test suites when you already know that your build wil
 The `bail` option expects a number, which specifies how many test failures can occur before WebDriver stop the entire testing run. The default is `0`, meaning that it always runs all tests specs it can find.
 
 Please see [Options Page](Options.md) for additional information on the bail configuration.
+
+
+## Hierarchy of spec patterns
+
+When declaring what specs to run, there is a certain hierarchy defining what pattern will take precedence when defined.
+Currently, this is how it works, from highest priority to lowest:
+> CLI `--spec` argument > capability `specs` pattern > config `specs` pattern
+
+If only the config parameter is given, it will be used for all capabilities. However, if defining the pattern at the
+capability level, it will be used instead of the config pattern. Finally, any spec pattern defined on the command line
+will override all other patterns given.
+
+### Using capability-defined spec patterns
+
+When you define a spec pattern at the capability level, it will override any patterns defined at the config level. This
+is useful when needing to separate tests based on differentiating device capabilities. In cases like this, it is more
+useful to use a generic spec pattern at the config level, and more specific patterns at the capability level.
+
+For example, let's say you had two directories, with one for Android tests, and one for iOS tests.
+
+Your config file may define the pattern as such, for non-specific device tests:
+
+```js
+{
+    specs: ['tests/general/**/*.js']
+}
+```
+
+but then, you will have different capabilities for your Android and iOS devices, where the patterns could look like
+such:
+
+```json
+{
+  "platformName": "Android",
+  "specs": [
+    "tests/android/**/*.js"
+  ]
+}
+```
+
+```json
+{
+  "platformName": "iOS",
+  "specs": [
+    "tests/ios/**/*.js"
+  ]
+}
+```
+
+If you require both of these capabilities in your config file, then the Android device will only run the tests under
+the "android" namespace, and the iOS tests will run only tests under the "ios" namespace!
+
+```js
+//wdio.conf.js
+exports.config = {
+    "specs": [
+        "tests/general/**/*.js"
+    ],
+    "capabilities": [
+        {
+            platformName: "Android",
+            specs: ["tests/android/**/*.js"],
+            //...
+        },
+        {
+            platformName: "iOS",
+            specs: ["tests/ios/**/*.js"],
+            //...
+        },
+        {
+            platformName: "Chrome",
+            //config level specs will be used
+        }
+    ]
+}
+```
+

--- a/website/docs/OrganizingTestSuites.md
+++ b/website/docs/OrganizingTestSuites.md
@@ -256,8 +256,7 @@ Your config file may define the pattern as such, for non-specific device tests:
 }
 ```
 
-but then, you will have different capabilities for your Android and iOS devices, where the patterns could look like
-such:
+but then, you will have different capabilities for your Android and iOS devices, where the patterns could look like such:
 
 ```json
 {

--- a/website/docs/OrganizingTestSuites.md
+++ b/website/docs/OrganizingTestSuites.md
@@ -236,13 +236,11 @@ Please see [Options Page](Options.md) for additional information on the bail con
 
 ## Hierarchy of spec patterns
 
-When declaring what specs to run, there is a certain hierarchy defining what pattern will take precedence when defined.
-Currently, this is how it works, from highest priority to lowest:
+When declaring what specs to run, there is a certain hierarchy defining what pattern will take precedence when defined. Currently, this is how it works, from highest priority to lowest:
+
 > CLI `--spec` argument > capability `specs` pattern > config `specs` pattern
 
-If only the config parameter is given, it will be used for all capabilities. However, if defining the pattern at the
-capability level, it will be used instead of the config pattern. Finally, any spec pattern defined on the command line
-will override all other patterns given.
+If only the config parameter is given, it will be used for all capabilities. However, if defining the pattern at the capability level, it will be used instead of the config pattern. Finally, any spec pattern defined on the command line will override all other patterns given.
 
 ### Using capability-defined spec patterns
 

--- a/website/docs/OrganizingTestSuites.md
+++ b/website/docs/OrganizingTestSuites.md
@@ -232,8 +232,6 @@ This is helpful with large test suites when you already know that your build wil
 The `bail` option expects a number, which specifies how many test failures can occur before WebDriver stop the entire testing run. The default is `0`, meaning that it always runs all tests specs it can find.
 
 Please see [Options Page](Options.md) for additional information on the bail configuration.
-
-
 ## Hierarchy of spec patterns
 
 When declaring what specs to run, there is a certain hierarchy defining what pattern will take precedence when defined. Currently, this is how it works, from highest priority to lowest:

--- a/website/docs/OrganizingTestSuites.md
+++ b/website/docs/OrganizingTestSuites.md
@@ -276,8 +276,7 @@ but then, you will have different capabilities for your Android and iOS devices,
 }
 ```
 
-If you require both of these capabilities in your config file, then the Android device will only run the tests under
-the "android" namespace, and the iOS tests will run only tests under the "ios" namespace!
+If you require both of these capabilities in your config file, then the Android device will only run the tests under the "android" namespace, and the iOS tests will run only tests under the "ios" namespace!
 
 ```js
 //wdio.conf.js


### PR DESCRIPTION
## Proposed changes
If `--spec` is defined on the command line, it should overwrite and ignore any spec patterns defined in both the configuration file and additionally in the capabilities array.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)



## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

I can't say for sure if this is a breaking change, but if anyone has scripts pre-defined with `--spec` option, but they are anticipating that their capability-defined specs to run, this will affect them. However, we now have the option to define the hierarchy for spec priority as discussed in #8376:

> `--spec` > capability > config 

### Reviewers: @webdriverio/project-committers


<a href="https://gitpod.io/#https://github.com/webdriverio/webdriverio/pull/8432"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

