### PR TITLE
fix refetch elements with index > 0

### DIFF
--- a/packages/webdriverio/src/utils/index.ts
+++ b/packages/webdriverio/src/utils/index.ts
@@ -309,6 +309,16 @@ export async function findElements(
     }
 
     /**
+     * fetch elements using custom strategy function
+     */
+    if (isPlainObject(selector) && typeof (selector as CustomStrategyReference).strategy === 'function') {
+        const { strategy, strategyArguments } = selector as CustomStrategyReference
+        const elems = await this.execute(strategy, ...strategyArguments)
+        const elemArray = Array.isArray(elems) ? elems as ElementReference[] : [elems]
+        return elemArray.filter((elem) => elem && getElementFromResponse(elem))
+    }
+
+    /**
      * fetch element using regular protocol command
      */
     if (typeof selector === 'string' || isPlainObject(selector)) {

--- a/packages/webdriverio/src/utils/refetchElement.ts
+++ b/packages/webdriverio/src/utils/refetchElement.ts
@@ -26,7 +26,7 @@ export default async function refetchElement (
     // Beginning with the browser object, rechain
     return selectors.reduce(async (elementPromise, { selector, index }, currentIndex) => {
         const resolvedElement = await elementPromise
-        let nextElement = index > 0 ? await resolvedElement.$$(selector as string)[index] : null
+        let nextElement = index > 0 ? (await resolvedElement.$$(selector as string))[index] : null
         nextElement = nextElement || await resolvedElement.$(selector)
         /**
          *  For error purposes, changing command name to '$' if we aren't

--- a/packages/webdriverio/tests/__mocks__/got.ts
+++ b/packages/webdriverio/tests/__mocks__/got.ts
@@ -222,9 +222,9 @@ const requestMock: any = jest.fn().mockImplementation((uri, params) => {
         break
     } case `${path}/${sessionId}/element/${genericElementId}/elements`:
         value = [
-            { [ELEMENT_KEY]: genericSubElementId },
-            { [ELEMENT_KEY]: 'some-elem-456' },
-            { [ELEMENT_KEY]: 'some-elem-789' },
+            { [ELEMENT_KEY]: genericSubElementId, index: 0 },
+            { [ELEMENT_KEY]: 'some-elem-456', index: 1 },
+            { [ELEMENT_KEY]: 'some-elem-789', index: 2 },
         ]
         break
     case `${path}/${sessionId}/cookie`:

--- a/packages/webdriverio/tests/commands/element/selectByIndex.test.ts
+++ b/packages/webdriverio/tests/commands/element/selectByIndex.test.ts
@@ -35,7 +35,8 @@ describe('selectByIndex test', () => {
         expect(got.mock.calls[3][0].pathname)
             .toBe('/session/foobar-123/element/some-elem-456/click')
         expect(getElementFromResponseSpy).toBeCalledWith({
-            [ELEMENT_KEY]: 'some-elem-456'
+            [ELEMENT_KEY]: 'some-elem-456',
+            index: 1
         })
     })
 

--- a/packages/webdriverio/tests/utils/refetchElement.test.ts
+++ b/packages/webdriverio/tests/utils/refetchElement.test.ts
@@ -49,9 +49,12 @@ describe('refetchElement', () => {
     it('should not lose element index', async () => {
         const elem = await browser.$('#foo')
         const subElems = await elem.$$('#subfoo')
-        const subElem = subElems[0]
-        const refetchedElement = await refetchElement(subElem, '$')
-        expect(refetchedElement.elementId).toEqual(subElem.elementId)
+        const subElem1 = subElems[0]
+        const subElem2 = subElems[1]
+        const refetchedElement1 = await refetchElement(subElem1, '$')
+        const refetchedElement2 = await refetchElement(subElem2, '$')
+        expect(refetchedElement1.elementId).toEqual(subElem1.elementId)
+        expect(refetchedElement2.elementId).toEqual(subElem2.elementId)
     })
 
     it('should successfully refetch an element that isn\'t immediately present', async () => {
@@ -77,13 +80,19 @@ describe('refetchElement', () => {
 
     it('should successfully refetch an element from a list using custom locator', async () => {
         browser.addLocatorStrategy('myLocator2', (id: string) => (
-            [{ 'element-6066-11e4-a52e-4f735466cecf': id }]
+            [
+                { 'element-6066-11e4-a52e-4f735466cecf': id + '0', index: 0 },
+                { 'element-6066-11e4-a52e-4f735466cecf': id + '1', index: 1 }
+            ]
         ))
 
         const elems = await browser.custom$$('myLocator2', 'foo')
-        const refetchedElement = await refetchElement(elems[0], '$')
-        expect(elems[0].elementId).toEqual('foo')
-        expect(refetchedElement.elementId).toEqual(elems[0].elementId)
+        const refetchedElement1 = await refetchElement(elems[0], '$')
+        const refetchedElement2 = await refetchElement(elems[0], '$')
+        expect(elems[0].elementId).toEqual('foo0')
+        expect(elems[1].elementId).toEqual('foo1')
+        expect(refetchedElement1.elementId).toEqual(elems[0].elementId)
+        expect(refetchedElement2.elementId).toEqual(elems[0].elementId)
     })
 
     it('should successfully refetch a sub element using custom locator', async () => {
@@ -101,14 +110,20 @@ describe('refetchElement', () => {
 
     it('should successfully refetch a sub element from a list using custom locator', async () => {
         browser.addLocatorStrategy('myLocator4', (id: string, root: any) => (
-            [{ 'element-6066-11e4-a52e-4f735466cecf': root + id }]
+            [
+                { 'element-6066-11e4-a52e-4f735466cecf': root + id + '0', index: 0 },
+                { 'element-6066-11e4-a52e-4f735466cecf': root + id + '1', index: 1 }
+            ]
         ))
 
         const elem = await browser.$('#foo')
         expect(elem.elementId).toEqual('some-elem-123')
         const subElems = await elem.custom$$('myLocator4', 'bar')
-        const refetchedElement = await refetchElement(subElems[0], '$')
-        expect(subElems[0].elementId).toEqual('some-elem-123bar')
-        expect(refetchedElement.elementId).toEqual(subElems[0].elementId)
+        const refetchedElement1 = await refetchElement(subElems[0], '$')
+        const refetchedElement2 = await refetchElement(subElems[1], '$')
+        expect(subElems[0].elementId).toEqual('some-elem-123bar0')
+        expect(subElems[1].elementId).toEqual('some-elem-123bar1')
+        expect(refetchedElement1.elementId).toEqual(subElems[0].elementId)
+        expect(refetchedElement2.elementId).toEqual(subElems[1].elementId)
     })
 })


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

Fix refetch element with index > 0
1. For built-in selectors, fix the error caused by index is accessed before `await`
2. For custom selectors, added missing implementation in `findElements`.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers


<a href="https://gitpod.io/#https://github.com/webdriverio/webdriverio/pull/8434"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

