### PR TITLE
fix refetch elements error in wdio expect

### DIFF
--- a/packages/webdriverio/src/commands/browser/custom$$.ts
+++ b/packages/webdriverio/src/commands/browser/custom$$.ts
@@ -52,5 +52,5 @@ export default async function custom$$ (
     res = res.filter(el => !!el && typeof el[ELEMENT_KEY] === 'string')
 
     const elements = res.length ? await getElements.call(this, strategyRef, res) : [] as any as ElementArray
-    return enhanceElementsArray(elements, this, strategy as any, 'custom$$', [strategyArguments])
+    return enhanceElementsArray(elements, this, strategyName, 'custom$$', strategyArguments)
 }

--- a/packages/webdriverio/src/commands/element/custom$$.ts
+++ b/packages/webdriverio/src/commands/element/custom$$.ts
@@ -64,7 +64,7 @@ async function custom$$ (
     res = res.filter((el) => !!el && typeof el[ELEMENT_KEY] === 'string')
 
     const elements = res.length ? await getElements.call(this, strategyRef, res) : [] as any as ElementArray
-    return enhanceElementsArray(elements, this, strategy as any, 'custom$$', [strategyArguments])
+    return enhanceElementsArray(elements, this, strategyName, 'custom$$', strategyArguments)
 }
 
 export default custom$$

--- a/packages/webdriverio/tests/commands/browser/customSelectors.test.ts
+++ b/packages/webdriverio/tests/commands/browser/customSelectors.test.ts
@@ -21,7 +21,7 @@ describe('custom$', () => {
         const elems = await browser.custom$$('test', '.test')
 
         expect(elems).toHaveLength(2)
-        expect(typeof elems.selector).toBe('function')
+        expect(typeof elems.selector).toBe('string')
         expect(typeof elems[0].selector).toBe('object')
         expect(typeof elems[0].selector.strategy).toBe('function')
         expect(elems[0].selector.strategyName).toBe('test')
@@ -30,6 +30,8 @@ describe('custom$', () => {
         expect(elems[0].elementId).toBe('.test-foobar')
         expect(elems[1].elementId).toBe('.test-other-foobar')
         expect(elems.foundWith).toBe('custom$$')
+        expect(elems.selector).toBe('test')
+        expect(elems.props).toEqual(['.test'])
     })
 
     it('should error if no strategy found', async () => {

--- a/packages/webdriverio/tests/commands/element/customSelectors.test.ts
+++ b/packages/webdriverio/tests/commands/element/customSelectors.test.ts
@@ -22,7 +22,7 @@ describe('custom$', () => {
         const elems = await elem.custom$$('test', '.test')
 
         expect(elems).toHaveLength(2)
-        expect(typeof elems.selector).toBe('function')
+        expect(typeof elems.selector).toBe('string')
         expect(typeof elems[0].selector).toBe('object')
         expect(typeof elems[0].selector.strategy).toBe('function')
         expect(elems[0].selector.strategyName).toBe('test')
@@ -32,6 +32,8 @@ describe('custom$', () => {
         expect(elems[0].elementId).toBe('.test-some-elem-123')
         expect(elems[1].elementId).toBe('.test-other-some-elem-123')
         expect(elems.foundWith).toBe('custom$$')
+        expect(elems.selector).toBe('test')
+        expect(elems.props).toEqual(['.test'])
     })
 
     it('should error if no strategy found', async () => {


### PR DESCRIPTION
## Proposed changes

In expect-webdriverio:
https://github.com/webdriverio/expect-webdriverio/blob/700d3fa95d7595b6e313b37a7fe23dcf05d85578/src/util/refetchElements.ts#L10-L14
```js
elements = (await elements.parent[elements.foundWith](elements.selector, ...elements.props) as WebdriverIO.ElementArray)
```
When refetching elements with custom locator it will become
```js
parent['custom$$'](fn, [arguments])
```
it should be
```js
parent['custom$$'](stategyName, arguments)
```


[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers


<a href="https://gitpod.io/#https://github.com/webdriverio/webdriverio/pull/8464"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

