### PR TITLE
Updated worker.ts to implement #7992

### DIFF
--- a/packages/wdio-local-runner/src/worker.ts
+++ b/packages/wdio-local-runner/src/worker.ts
@@ -81,7 +81,8 @@ export default class WorkerInstance extends EventEmitter implements Workers.Work
         const argv = process.argv.slice(2)
 
         const runnerEnv = Object.assign({}, process.env, this.config.runnerEnv, {
-            WDIO_WORKER: true
+            WDIO_WORKER: true,
+            WDIO_CID: cid
         })
 
         if (this.config.outputDir) {


### PR DESCRIPTION
Implemented #7992 for local runner by adding cid as an environment variable to the worker process, so it can accessed in hooks

## Proposed changes

[//]: # Adding cid as an env variable allows us to access worker cid in hooks such as beforeSession etc

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers


<a href="https://gitpod.io/#https://github.com/webdriverio/webdriverio/pull/8481"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

