### PR TITLE
Simplify special keys in add/set value commands

### DIFF
--- a/packages/wdio-cli/src/launcher.ts
+++ b/packages/wdio-cli/src/launcher.ts
@@ -415,7 +415,19 @@ class Launcher {
             cid: runnerId,
             command: 'run',
             configFile: this._configFilePath,
-            args: { ...this._args, ...(config?.autoCompileOpts ? { autoCompileOpts: config.autoCompileOpts } : {}) },
+            args: {
+                ...this._args,
+                ...(config?.autoCompileOpts
+                    ? { autoCompileOpts: config.autoCompileOpts }
+                    : {}
+                ),
+                /**
+                 * Pass on user and key values to ensure they are available in the worker process when using
+                 * environment variables that were locally exported but not part of the environment.
+                 */
+                user: config.user,
+                key: config.key
+            },
             caps,
             specs,
             execArgv,

--- a/packages/wdio-utils/src/constants.ts
+++ b/packages/wdio-utils/src/constants.ts
@@ -78,4 +78,4 @@ export const UNICODE_CHARACTERS = {
     'Meta': '\uE03D',
     'ZenkakuHankaku': '\uE040',
     'Zenkaku_Hankaku': '\uE040'
-}
+} as const

--- a/packages/webdriverio/src/commands/browser/keys.ts
+++ b/packages/webdriverio/src/commands/browser/keys.ts
@@ -1,25 +1,36 @@
 import { UNICODE_CHARACTERS } from '@wdio/utils'
+import type { Capabilities } from '@wdio/types'
 
 import { checkUnicode } from '../../utils/index.js'
 /**
  *
- * Send a sequence of key strokes to the active element. You can also use characters like
- * "Left arrow" or "Back space". WebdriverIO will take care of translating them into unicode
- * characters. You’ll find all supported characters [here](https://w3c.github.io/webdriver/webdriver-spec.html#keyboard-actions).
- * To do that, the value has to correspond to a key from the table.
+ * Send a sequence of key strokes to the "active" element. You can make an input element active by just clicking
+ * on it. To use characters like "Left arrow" or "Back space", import the `Key` object from the WebdriverIO package.
  *
- * Modifier like Ctrl, Shift, Alt and Meta will stay pressed so you need to trigger them again to release them.
- * Modifiying a click however requires you to use the WebDriver Actions API through the [performActions](https://webdriver.io/docs/api/webdriver#performactions) method.
+ * Modifier like `Control`, `Shift`, `Alt` and `Command` will stay pressed so you need to trigger them again to release
+ * them. Modifiying a click however requires you to use the WebDriver Actions API through the
+ * [performActions](https://webdriver.io/docs/api/webdriver#performactions) method.
+ *
+ * :::info
+ *
+ * Control keys differ based on the operating system the browser is running on, e.g. MacOS: `Command` and Windows: `Control`.
+ * WebdriverIO provides a cross browser modifier control key called `Ctrl` (see example below).
+ *
+ * :::
  *
  * <example>
     :keys.js
-    it('copies text out of active element', async () => {
-        // copies text from an input element
-        const input = await $('#username')
-        await input.setValue('anonymous')
+    import { Key } from 'webdriverio'
 
-        await browser.keys(['Meta', 'a'])
-        await browser.keys(['Meta', 'c'])
+    it('copies text out of active element', async () => {
+        await $('#username').setValue('anonymous')
+
+        // copies text from an input element
+        await browser.keys([Key.Ctrl, 'a', 'c])
+
+        // inserts text from clipboard into input element
+        await $('#username').click() // make input active element
+        await browser.keys([Key.Ctrl, 'v'])
     });
  * </example>
  *
@@ -32,16 +43,17 @@ export default function keys (
     value: string | string[]
 ) {
     let keySequence: string[] = []
+    const platformName = (this.capabilities as Capabilities.Capabilities).platformName
 
     /**
      * replace key with corresponding unicode character
      */
     if (typeof value === 'string') {
-        keySequence = checkUnicode(value as keyof typeof UNICODE_CHARACTERS, this.isDevTools)
+        keySequence = checkUnicode(value as keyof typeof UNICODE_CHARACTERS, this.isDevTools, platformName)
     } else if (Array.isArray(value)) {
         const charArray: (keyof typeof UNICODE_CHARACTERS)[] = value as any
         for (const charSet of charArray) {
-            keySequence = keySequence.concat(checkUnicode(charSet, this.isDevTools))
+            keySequence = keySequence.concat(checkUnicode(charSet, this.isDevTools, platformName))
         }
     } else {
         throw new Error('"keys" command requires a string or array of strings as parameter')

--- a/packages/webdriverio/src/commands/element/addValue.ts
+++ b/packages/webdriverio/src/commands/element/addValue.ts
@@ -1,29 +1,13 @@
-import logger from '@wdio/logger'
-import { transformToCharString } from '../../utils/index.js'
-
-const log = logger('addValue')
-
-export type CommandOptions = {
-    translateToUnicode?: boolean
-}
-
-export type Value = string | number
-
-const isNumberOrString = (input: unknown) => typeof input === 'string' || typeof input === 'number'
-
-const isValidType = (value: unknown) => (
-    isNumberOrString(value) ||
-    Array.isArray(value) && value.every((item) => isNumberOrString(item))
-)
-
 /**
  *
- * Add a value to an object found by given selector. You can also use unicode
- * characters like Left arrow or Back space. WebdriverIO will take care of
- * translating them into unicode characters. You’ll find all supported characters
- * [here](https://w3c.github.io/webdriver/webdriver-spec.html#keyboard-actions).
- * To do that, the value has to correspond to a key from the table. It can be disabled
- * by setting `translateToUnicode` optional parameter to false.
+ * Add a value to an input or textarea element found by given selector.
+ *
+ * :::info
+ *
+ * If you like to use special characters, e.g. to copy and paste a value from one input to another, use the
+ * [`keys`](/docs/api/browser/keys) command.
+ *
+ * :::
  *
  * <example>
     :addValue.js
@@ -38,23 +22,24 @@ const isValidType = (value: unknown) => (
  * </example>
  *
  * @alias element.addValue
- * @param {string | number | Array<string | number>}        value                       value to be added
- * @param {CommandOptions=}                                 options                     command options (optional)
- * @param {boolean}                                         options.translateToUnicode  enable translation string to unicode value automatically
+ * @param {string | number}  value  value to be added
  *
  */
 export default function addValue (
     this: WebdriverIO.Element,
-    value: Value | Value[],
-    { translateToUnicode = true }: CommandOptions = {}
+    value: string | number
 ) {
-    if (!isValidType(value)) {
-        log.warn('@deprecated: support for type "string", "number" or "Array<string | number>" is deprecated')
+    /**
+     * The JSONWireProtocol allowed array values and use of special characters when adding a value to an input.
+     * With the W3C protocol this was not possible anymore. This is a type check to ensure users are aware of
+     * this transition.
+     */
+    if (Array.isArray(value) || !value || typeof value === 'boolean') {
+        throw new Error(
+            'The setValue/addValue command only take string or number values. ' +
+            'If you like to use special characters, use the "keys" command.'
+        )
     }
 
-    if (!this.isW3C) {
-        return this.elementSendKeys(this.elementId, transformToCharString(value, translateToUnicode) as any as string)
-    }
-
-    return this.elementSendKeys(this.elementId, transformToCharString(value, translateToUnicode).join(''))
+    return this.elementSendKeys(this.elementId, value.toString())
 }

--- a/packages/webdriverio/src/commands/element/addValue.ts
+++ b/packages/webdriverio/src/commands/element/addValue.ts
@@ -1,3 +1,5 @@
+const VALID_TYPES = ['string', 'number']
+
 /**
  *
  * Add a value to an input or textarea element found by given selector.
@@ -34,12 +36,17 @@ export default function addValue (
      * With the W3C protocol this was not possible anymore. This is a type check to ensure users are aware of
      * this transition.
      */
-    if (Array.isArray(value) || !value || typeof value === 'boolean') {
+    if (!VALID_TYPES.includes(typeof value)) {
         throw new Error(
             'The setValue/addValue command only take string or number values. ' +
             'If you like to use special characters, use the "keys" command.'
         )
     }
 
-    return this.elementSendKeys(this.elementId, value.toString())
+    if (this.isW3C) {
+        return this.elementSendKeys(this.elementId, value.toString())
+    }
+
+    // @ts-expect-error command is not typed as JWP command
+    return this.elementSendKeys(this.elementId, [value.toString()])
 }

--- a/packages/webdriverio/src/commands/element/clearValue.ts
+++ b/packages/webdriverio/src/commands/element/clearValue.ts
@@ -1,6 +1,6 @@
 /**
  *
- * Clear a `<textarea>` or text `<input>` element’s value. Make sure you can interact with the
+ * Clear the value of an input or textarea element. Make sure you can interact with the
  * element before using this command. You can't clear an input element that is disabled or in
  * readonly mode.
  *

--- a/packages/webdriverio/src/commands/element/setValue.ts
+++ b/packages/webdriverio/src/commands/element/setValue.ts
@@ -1,36 +1,33 @@
-import type { CommandOptions, Value } from './addValue'
-
 /**
+ * Send a sequence of key strokes to an element after the input has been cleared before. If the element doesn't need
+ * to be cleared first then use [`addValue`](/docs/api/element/addValue).
  *
- * Send a sequence of key strokes to an element (clears value before). If the element
- * doesn't need to be cleared first then use addValue. You can also use
- * unicode characters like Left arrow or Back space. WebdriverIO will take care of
- * translating them into unicode characters. You’ll find all supported characters
- * [here](https://w3c.github.io/webdriver/webdriver-spec.html#keyboard-actions).
- * To do that, the value has to correspond to a key from the table. It can be disabled
- * by setting `translateToUnicode` optional parameter to false.
+ * :::info
+ *
+ * If you like to use special characters, e.g. to copy and paste a value from one input to another, use the
+ * [`keys`](/docs/api/browser/keys) command.
+ *
+ * :::
  *
  * <example>
     :setValue.js
     it('should set value for a certain element', async () => {
         const input = await $('.input');
-        await input.setValue('test123');
+        await input.setValue('test')
+        await input.setValue(123)
 
-        console.log(await input.getValue()); // outputs: 'test123'
+        console.log(await input.getValue()); // outputs: '123'
     });
  * </example>
  *
  * @alias element.setValue
- * @param {string | number | Array<string | number>}        value                       value to be added
- * @param {CommandOptions=}                                 options                     command options (optional)
- * @param {boolean}                                         options.translateToUnicode  enable translation string to unicode value automatically
+ * @param {string | number}  value  value to be added
  *
  */
 export default async function setValue (
     this: WebdriverIO.Element,
-    value: Value | Value[],
-    { translateToUnicode = true }: CommandOptions = {}
+    value: string | number
 ) {
     await this.clearValue()
-    return this.addValue(value, { translateToUnicode })
+    return this.addValue(value)
 }

--- a/packages/webdriverio/src/constants.ts
+++ b/packages/webdriverio/src/constants.ts
@@ -1,6 +1,7 @@
 import { fileURLToPath } from 'node:url'
 import { dirname, resolve } from 'node:path'
 import { createRequire } from 'node:module'
+import { UNICODE_CHARACTERS } from '@wdio/utils'
 import type { Options, Capabilities, Services, Reporters } from '@wdio/types'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
@@ -320,3 +321,70 @@ export const ERROR_REASON = [
     'ConnectionFailed', 'NameNotResolved', 'InternetDisconnected',
     'AddressUnreachable', 'BlockedByClient', 'BlockedByResponse'
 ]
+
+/**
+ * Special Characters
+ */
+export const Key = {
+    /**
+     * Special control key that works cross browser for Mac, where it's the command key, and for
+     * Windows or Linux, where it is the control key.
+     */
+    Ctrl: 'WDIO_CONTROL',
+    NULL: UNICODE_CHARACTERS.NULL,
+    Cancel: UNICODE_CHARACTERS.Cancel,
+    Help: UNICODE_CHARACTERS.Help,
+    Backspace: UNICODE_CHARACTERS.Backspace,
+    Tab: UNICODE_CHARACTERS.Tab,
+    Clear: UNICODE_CHARACTERS.Clear,
+    Return: UNICODE_CHARACTERS.Return,
+    Enter: UNICODE_CHARACTERS.Enter,
+    Shift: UNICODE_CHARACTERS.Shift,
+    Control: UNICODE_CHARACTERS.Control,
+    Alt: UNICODE_CHARACTERS.Alt,
+    Pause: UNICODE_CHARACTERS.Pause,
+    Escape: UNICODE_CHARACTERS.Escape,
+    Space: UNICODE_CHARACTERS.Space,
+    PageUp: UNICODE_CHARACTERS.PageUp,
+    PageDown: UNICODE_CHARACTERS.PageDown,
+    End: UNICODE_CHARACTERS.End,
+    Home: UNICODE_CHARACTERS.Home,
+    ArrowLeft: UNICODE_CHARACTERS.ArrowLeft,
+    ArrowUp: UNICODE_CHARACTERS.ArrowUp,
+    ArrowRight: UNICODE_CHARACTERS.ArrowRight,
+    ArrowDown: UNICODE_CHARACTERS.ArrowDown,
+    Insert: UNICODE_CHARACTERS.Insert,
+    Delete: UNICODE_CHARACTERS.Delete,
+    Semicolon: UNICODE_CHARACTERS.Semicolon,
+    Equals: UNICODE_CHARACTERS.Equals,
+    Numpad0: UNICODE_CHARACTERS['Numpad 0'],
+    Numpad1: UNICODE_CHARACTERS['Numpad 1'],
+    Numpad2: UNICODE_CHARACTERS['Numpad 2'],
+    Numpad3: UNICODE_CHARACTERS['Numpad 3'],
+    Numpad4: UNICODE_CHARACTERS['Numpad 4'],
+    Numpad5: UNICODE_CHARACTERS['Numpad 5'],
+    Numpad6: UNICODE_CHARACTERS['Numpad 6'],
+    Numpad7: UNICODE_CHARACTERS['Numpad 7'],
+    Numpad8: UNICODE_CHARACTERS['Numpad 8'],
+    Numpad9: UNICODE_CHARACTERS['Numpad 9'],
+    Multiply: UNICODE_CHARACTERS.Multiply,
+    Add: UNICODE_CHARACTERS.Add,
+    Separator: UNICODE_CHARACTERS.Separator,
+    Subtract: UNICODE_CHARACTERS.Subtract,
+    Decimal: UNICODE_CHARACTERS.Decimal,
+    Divide: UNICODE_CHARACTERS.Divide,
+    F1: UNICODE_CHARACTERS.F1,
+    F2: UNICODE_CHARACTERS.F2,
+    F3: UNICODE_CHARACTERS.F3,
+    F4: UNICODE_CHARACTERS.F4,
+    F5: UNICODE_CHARACTERS.F5,
+    F6: UNICODE_CHARACTERS.F6,
+    F7: UNICODE_CHARACTERS.F7,
+    F8: UNICODE_CHARACTERS.F8,
+    F9: UNICODE_CHARACTERS.F9,
+    F10: UNICODE_CHARACTERS.F10,
+    F11: UNICODE_CHARACTERS.F11,
+    F12: UNICODE_CHARACTERS.F12,
+    Command: UNICODE_CHARACTERS.Command,
+    ZenkakuHankaku: UNICODE_CHARACTERS.ZenkakuHankaku
+} as const

--- a/packages/webdriverio/src/index.ts
+++ b/packages/webdriverio/src/index.ts
@@ -10,7 +10,7 @@ import MultiRemote from './multiremote.js'
 import type ElementCommands from './commands/element.js'
 import SevereServiceErrorImport from './utils/SevereServiceError.js'
 import detectBackend from './utils/detectBackend.js'
-import { WDIO_DEFAULTS } from './constants.js'
+import { WDIO_DEFAULTS, Key as KeyConstant } from './constants.js'
 import {
     getPrototype, addLocatorStrategyHandler, isStub, getAutomationProtocol,
     updateCapabilities
@@ -18,6 +18,7 @@ import {
 import type { AttachOptions } from './types'
 
 export type RemoteOptions = Options.WebdriverIO & Omit<Options.Testrunner, 'capabilities'>
+export const Key = KeyConstant
 
 /**
  * A method to create a new session with WebdriverIO.

--- a/packages/webdriverio/tests/commands/element/addValue.test.ts
+++ b/packages/webdriverio/tests/commands/element/addValue.test.ts
@@ -3,12 +3,12 @@ import { expect, describe, it, beforeEach, afterEach, vi } from 'vitest'
 
 // @ts-ignore mocked (original defined in webdriver package)
 import got from 'got'
-import { remote } from '../../../src'
+import { remote, Key } from '../../../src'
 
 vi.mock('got')
 vi.mock('@wdio/logger', () => import(path.join(process.cwd(), '__mocks__', '@wdio/logger')))
 
-let browser: any
+let browser: WebdriverIO.Browser
 
 describe('addValue test', () => {
     afterEach(() => {
@@ -42,33 +42,6 @@ describe('addValue test', () => {
             expect(got.mock.calls[2][1].json.text).toEqual('42')
             expect(got.mock.calls[2][1].json.value).toEqual(undefined)
         })
-
-        it('add object', async () => {
-            const elem = await browser.$('#foo')
-            await elem.addValue({ a: 42 })
-            expect(got.mock.calls[2][0].pathname)
-                .toBe('/session/foobar-123/element/some-elem-123/value')
-            expect(got.mock.calls[2][1].json.text).toEqual('{"a":42}')
-            expect(got.mock.calls[2][1].json.value).toEqual(undefined)
-        })
-
-        it('add boolean', async () => {
-            const elem = await browser.$('#foo')
-            await elem.addValue(true)
-            expect(got.mock.calls[2][0].pathname)
-                .toBe('/session/foobar-123/element/some-elem-123/value')
-            expect(got.mock.calls[2][1].json.text).toEqual('true')
-            expect(got.mock.calls[2][1].json.value).toEqual(undefined)
-        })
-
-        it('add Array<any>', async () => {
-            const elem = await browser.$('#foo')
-            await elem.addValue([2, '3', true, [1, 2]])
-            expect(got.mock.calls[2][0].pathname)
-                .toBe('/session/foobar-123/element/some-elem-123/value')
-            expect(got.mock.calls[2][1].json.text).toEqual('23true[1,2]')
-            expect(got.mock.calls[2][1].json.value).toEqual(undefined)
-        })
     })
 
     describe('should allow to add value to an input element using jsonwp', () => {
@@ -88,7 +61,7 @@ describe('addValue test', () => {
             expect(got.mock.calls[2][0].pathname)
                 .toBe('/session/foobar-123/element/some-elem-123/value')
             expect(got.mock.calls[2][1].json.value)
-                .toEqual(['f', 'o', 'o', 'b', 'a', 'r'])
+                .toEqual(['foobar'])
             expect(got.mock.calls[2][1].json.text).toEqual(undefined)
         })
 
@@ -98,40 +71,7 @@ describe('addValue test', () => {
             await elem.addValue(42)
             expect(got.mock.calls[2][0].pathname)
                 .toBe('/session/foobar-123/element/some-elem-123/value')
-            expect(got.mock.calls[2][1].json.value).toEqual(['4', '2'])
-            expect(got.mock.calls[2][1].json.text).toEqual(undefined)
-        })
-
-        it('add object', async () => {
-            const elem = await browser.$('#foo')
-
-            await elem.addValue({ a: 42 })
-            expect(got.mock.calls[2][0].pathname)
-                .toBe('/session/foobar-123/element/some-elem-123/value')
-            expect(got.mock.calls[2][1].json.value)
-                .toEqual(['{', '"', 'a', '"', ':', '4', '2', '}'])
-            expect(got.mock.calls[2][1].json.text).toEqual(undefined)
-        })
-
-        it('add boolean', async () => {
-            const elem = await browser.$('#foo')
-
-            await elem.addValue(true)
-            expect(got.mock.calls[2][0].pathname)
-                .toBe('/session/foobar-123/element/some-elem-123/value')
-            expect(got.mock.calls[2][1].json.value)
-                .toEqual(['t', 'r', 'u', 'e'])
-            expect(got.mock.calls[2][1].json.text).toEqual(undefined)
-        })
-
-        it('add Array<any>', async () => {
-            const elem = await browser.$('#foo')
-
-            await elem.addValue([1, '2', true, [1, 2]])
-            expect(got.mock.calls[2][0].pathname)
-                .toBe('/session/foobar-123/element/some-elem-123/value')
-            expect(got.mock.calls[2][1].json.value)
-                .toEqual(['1', '2', 't', 'r', 'u', 'e', '[', '1', ',', '2', ']'])
+            expect(got.mock.calls[2][1].json.value).toEqual(['42'])
             expect(got.mock.calls[2][1].json.text).toEqual(undefined)
         })
     })
@@ -149,7 +89,7 @@ describe('addValue test', () => {
         it('add string', async () => {
             const elem = await browser.$('#foo')
 
-            await elem.addValue('Delete', { translateToUnicode: false })
+            await elem.addValue('Delete')
             expect(got.mock.calls[2][0].pathname).toBe('/session/foobar-123/element/some-elem-123/value')
             expect(got.mock.calls[2][1].json.text).toEqual('Delete')
         })
@@ -168,27 +108,16 @@ describe('addValue test', () => {
         it('should not translate to unicode', async () => {
             const elem = await browser.$('#foo')
 
-            await elem.setValue('Delete', { translateToUnicode: false })
-            expect(got.mock.calls[2][0].pathname).toBe('/session/foobar-123/element/some-elem-123/clear')
-            expect(got.mock.calls[3][0].pathname).toBe('/session/foobar-123/element/some-elem-123/value')
-            expect(got.mock.calls[3][1].json.text).toEqual('Delete')
+            await elem.addValue('Delete')
+            expect(got.mock.calls[2][0].pathname).toBe('/session/foobar-123/element/some-elem-123/value')
+            expect(got.mock.calls[2][1].json.text).toEqual('Delete')
         })
         it('should translate to unicode', async () => {
             const elem = await browser.$('#foo')
 
-            await elem.setValue('Delete', { translateToUnicode: true })
-            expect(got.mock.calls[2][0].pathname).toBe('/session/foobar-123/element/some-elem-123/clear')
-            expect(got.mock.calls[3][0].pathname).toBe('/session/foobar-123/element/some-elem-123/value')
-            expect(got.mock.calls[3][1].json.text).toEqual('\uE017')
-        })
-
-        it('should translate to unicode by default', async () => {
-            const elem = await browser.$('#foo')
-
-            await elem.setValue('Delete', { translateToUnicode: true })
-            expect(got.mock.calls[2][0].pathname).toBe('/session/foobar-123/element/some-elem-123/clear')
-            expect(got.mock.calls[3][0].pathname).toBe('/session/foobar-123/element/some-elem-123/value')
-            expect(got.mock.calls[3][1].json.text).toEqual('\uE017')
+            await elem.addValue(Key.Delete)
+            expect(got.mock.calls[2][0].pathname).toBe('/session/foobar-123/element/some-elem-123/value')
+            expect(got.mock.calls[2][1].json.text).toEqual('\uE017')
         })
     })
 })

--- a/packages/webdriverio/tests/index.test.ts
+++ b/packages/webdriverio/tests/index.test.ts
@@ -61,6 +61,10 @@ describe('index.js', () => {
         expect(webdriverio.SevereServiceError).toBeDefined()
     })
 
+    it('exports key constant', () => {
+        expect(webdriverio.Key).toBeDefined()
+    })
+
     describe('remote method', () => {
         it('should be possible to skip setting outputDir', async () => {
             setUpLogCheck(() => !('WDIO_LOG_PATH' in process.env))

--- a/packages/webdriverio/tests/utils.test.ts
+++ b/packages/webdriverio/tests/utils.test.ts
@@ -11,7 +11,6 @@ import { ELEMENT_KEY } from '../src/constants.js'
 import {
     getElementFromResponse,
     getBrowserObject,
-    transformToCharString,
     parseCSS,
     checkUnicode,
     findElement,
@@ -81,63 +80,6 @@ describe('utils', () => {
                     }
                 }
             } as any)).toEqual({ foo: 'bar' })
-        })
-    })
-
-    describe('transformToCharString', () => {
-        it('should allow to pass non arrays to it', () => {
-            expect(transformToCharString('foobar')).toEqual(['f', 'o', 'o', 'b', 'a', 'r'])
-        })
-
-        it('should do nothing if all is good', () => {
-            expect(transformToCharString(['f'])).toEqual(['f'])
-        })
-
-        it('should be able to transform objects', () => {
-            expect(transformToCharString({ a: 1 })).toEqual(['{', '"', 'a', '"', ':', '1', '}'])
-        })
-
-        it('should be able to transform numbers', () => {
-            expect(transformToCharString(42)).toEqual(['4', '2'])
-        })
-
-        it('should be able to transform booleans', () => {
-            expect(transformToCharString(true)).toEqual(['t', 'r', 'u', 'e'])
-        })
-
-        it('ignore undefined/null', () => {
-            expect(transformToCharString([null])).toEqual([])
-            expect(transformToCharString([undefined])).toEqual([])
-        })
-
-        it('can do all of this together', () => {
-            expect(transformToCharString(['foo', undefined, { b: 1 }, null, 42, false])).toEqual(
-                ['f', 'o', 'o', '{', '"', 'b', '"', ':', '1', '}', '4', '2', 'f', 'a', 'l', 's', 'e'])
-        })
-
-        it('should convert string to unicode', () => {
-            expect(transformToCharString('Enter')).toEqual(['\uE007'])
-            expect(transformToCharString('Back space')).toEqual(['\uE003'])
-            expect(transformToCharString('Backspace')).toEqual(['\uE003'])
-            expect(transformToCharString('Pageup')).toEqual(['\uE00E'])
-        })
-
-        it('should transform string without converting to unicode', () => {
-            expect(transformToCharString('Delete', false)).toEqual(
-                ['D', 'e', 'l', 'e', 't', 'e'])
-            expect(transformToCharString('Back space', false)).toEqual(
-                ['B', 'a', 'c', 'k', ' ', 's', 'p', 'a', 'c', 'e'])
-            expect(transformToCharString('Backspace', false)).toEqual(
-                ['B', 'a', 'c', 'k', 's', 'p', 'a', 'c', 'e'])
-            expect(transformToCharString('Pageup', false)).toEqual(
-                ['P', 'a', 'g', 'e', 'u', 'p'])
-        })
-
-        it('should transform string with converting to unicode', () => {
-            expect(transformToCharString('Delete', true)).toEqual(['\uE017'])
-            expect(transformToCharString('Back space', true)).toEqual(['\uE003'])
-            expect(transformToCharString('Backspace', true)).toEqual(['\uE003'])
-            expect(transformToCharString('Pageup', true)).toEqual(['\uE00E'])
         })
     })
 

--- a/tests/typings/sync/sync.ts
+++ b/tests/typings/sync/sync.ts
@@ -182,7 +182,6 @@ el5.scrollIntoView(false)
 // An examples of addValue command with enabled/disabled translation to Unicode
 const el = $('')
 el.addValue('Delete')
-el.addValue('Delete', { translateToUnicode: false })
 
 // scroll into view
 el.scrollIntoView(true)
@@ -195,7 +194,6 @@ el.scrollIntoView(scrollOptions)
 
 // An examples of setValue command with enabled/disabled translation to Unicode
 const elem1 = $('')
-elem1.setValue('Delete', { translateToUnicode: true })
 elem1.setValue('Delete')
 
 expectType<Selector>(elems.selector)

--- a/tests/typings/webdriverio/async.ts
+++ b/tests/typings/webdriverio/async.ts
@@ -268,8 +268,7 @@ async function bar() {
 
     // An examples of addValue command with enabled/disabled translation to Unicode
     const elem = await $('')
-    await elem.addValue('Delete', { translateToUnicode: true })
-    await elem.addValue('Delete', { translateToUnicode: false })
+    await elem.addValue('Delete')
 
     // scroll into view
     await elem.scrollIntoView(true)
@@ -282,8 +281,7 @@ async function bar() {
 
     // An examples of setValue command with enabled/disabled translation to Unicode
     const elem1 = await $('')
-    elem1.setValue('Delete', { translateToUnicode: true })
-    elem1.setValue('Delete', { translateToUnicode: false })
+    elem1.setValue('Delete')
 
     const selector$$: string | Function | Record<'element-6066-11e4-a52e-4f735466cecf', string> | {strategy: Function; strategyName: string; strategyArguments: any[]} = elems.selector
     ;(elems.parent as WebdriverIO.Element).click()


### PR DESCRIPTION
Currently to set some value and press enter the following is required:

```js
browser.addValue(["foobar", "Enter"])
```

How about simplifying this down to:

```js
browser.addValue("foobar {Enter}")
```

?

<a href="https://gitpod.io/#https://github.com/webdriverio/webdriverio/pull/4065"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

