### PR TITLE
handle local and wdioService capabilities when jsonwp format caps are passed

### DIFF
--- a/packages/wdio-browserstack-service/src/launcher.ts
+++ b/packages/wdio-browserstack-service/src/launcher.ts
@@ -29,16 +29,28 @@ export default class BrowserstackLauncherService implements Services.ServiceInst
         if (Array.isArray(capabilities)) {
             capabilities.forEach((capability: Capabilities.DesiredCapabilities) => {
                 if (!capability['bstack:options']) {
-                    capability['bstack:options'] = {}
+                    const extensionCaps = Object.keys(capability).filter((cap) => cap.includes(':'))
+                    if (extensionCaps.length) {
+                        capability['bstack:options'] = { wdioService: bstackServiceVersion }
+                    } else {
+                        capability['browserstack.wdioService'] = bstackServiceVersion
+                    }
+                } else {
+                    capability['bstack:options'].wdioService = bstackServiceVersion
                 }
-                capability['bstack:options'].wdioService = bstackServiceVersion
             })
         } else if (typeof capabilities === 'object') {
             Object.entries(capabilities as Capabilities.MultiRemoteCapabilities).forEach(([, caps]) => {
                 if (!(caps.capabilities as Capabilities.Capabilities)['bstack:options']) {
-                    (caps.capabilities as Capabilities.Capabilities)['bstack:options'] = {}
+                    const extensionCaps = Object.keys(caps.capabilities).filter((cap) => cap.includes(':'))
+                    if (extensionCaps.length) {
+                        (caps.capabilities as Capabilities.Capabilities)['bstack:options'] = { wdioService: bstackServiceVersion }
+                    } else {
+                        (caps.capabilities as Capabilities.Capabilities)['browserstack.wdioService'] = bstackServiceVersion
+                    }
+                } else {
+                    (caps.capabilities as Capabilities.Capabilities)['bstack:options']!.wdioService = bstackServiceVersion
                 }
-                (caps.capabilities as Capabilities.Capabilities)['bstack:options']!.wdioService = bstackServiceVersion
             })
         }
     }
@@ -58,16 +70,28 @@ export default class BrowserstackLauncherService implements Services.ServiceInst
         if (Array.isArray(capabilities)) {
             capabilities.forEach((capability: Capabilities.DesiredCapabilities) => {
                 if (!capability['bstack:options']) {
-                    capability['bstack:options'] = {}
+                    const extensionCaps = Object.keys(capability).filter((cap) => cap.includes(':'))
+                    if (extensionCaps.length) {
+                        capability['bstack:options'] = { local: true }
+                    } else {
+                        capability['browserstack.local'] = true
+                    }
+                } else {
+                    capability['bstack:options'].local = true
                 }
-                capability['bstack:options'].local = true
             })
         } else if (typeof capabilities === 'object') {
             Object.entries(capabilities as Capabilities.MultiRemoteCapabilities).forEach(([, caps]) => {
                 if (!(caps.capabilities as Capabilities.Capabilities)['bstack:options']) {
-                    (caps.capabilities as Capabilities.Capabilities)['bstack:options'] = {}
+                    const extensionCaps = Object.keys(caps.capabilities).filter((cap) => cap.includes(':'))
+                    if (extensionCaps.length) {
+                        (caps.capabilities as Capabilities.Capabilities)['bstack:options'] = { local: true }
+                    } else {
+                        (caps.capabilities as Capabilities.Capabilities)['browserstack.local'] = true
+                    }
+                } else {
+                    (caps.capabilities as Capabilities.Capabilities)['bstack:options']!.local = true
                 }
-                (caps.capabilities as Capabilities.Capabilities)['bstack:options']!.local = true
             })
         } else {
             throw TypeError('Capabilities should be an object or Array!')

--- a/packages/wdio-browserstack-service/tests/launcher.test.ts
+++ b/packages/wdio-browserstack-service/tests/launcher.test.ts
@@ -58,23 +58,63 @@ describe('onPrepare', () => {
         expect(service.browserstackLocal).toBeDefined()
     })
 
-    it('should add the "browserstack.local" property to a multiremote capability', async () => {
+    it('should add the "browserstack.local" property to a multiremote capability if no "bstack:options"', async () => {
         const service = new BrowserstackLauncher(options, caps, config)
         const capabilities = { chromeBrowser: { capabilities: {} } }
+
+        await service.onPrepare(config, capabilities)
+        expect(capabilities.chromeBrowser.capabilities).toEqual({ 'browserstack.local': true })
+    })
+
+    it('should add the "local" property to a multiremote capability inside "bstack:options" if "bstack:options" present', async () => {
+        const service = new BrowserstackLauncher(options, caps, config)
+        const capabilities = { chromeBrowser: { capabilities: { 'bstack:options': {} } } }
 
         await service.onPrepare(config, capabilities)
         expect(capabilities.chromeBrowser.capabilities).toEqual({ 'bstack:options': { local: true } })
     })
 
-    it('should add the "browserstack.local" property to an array of capabilities', async () => {
+    it('should add the "local" property to a multiremote capability inside "bstack:options" if any extension cap present', async () => {
+        const service = new BrowserstackLauncher(options, caps, config)
+        const capabilities = { chromeBrowser: { capabilities: { 'goog:chromeOptions': {} } } }
+
+        await service.onPrepare(config, capabilities)
+        expect(capabilities.chromeBrowser.capabilities).toEqual({ 'bstack:options': { local: true }, 'goog:chromeOptions': {} })
+    })
+
+    it('should add the "browserstack.local" property to an array of capabilities if no "bstack:options"', async () => {
         const service = new BrowserstackLauncher(options, caps, config)
         const capabilities = [{}, {}, {}]
+
+        await service.onPrepare(config, capabilities)
+        expect(capabilities).toEqual([
+            { 'browserstack.local': true },
+            { 'browserstack.local': true },
+            { 'browserstack.local': true }
+        ])
+    })
+
+    it('should add the "local" property to an array of capabilities inside "bstack:options" if "bstack:options" present', async () => {
+        const service = new BrowserstackLauncher(options, caps, config)
+        const capabilities = [{ 'bstack:options': {} }, { 'bstack:options': {} }, { 'bstack:options': {} }]
 
         await service.onPrepare(config, capabilities)
         expect(capabilities).toEqual([
             { 'bstack:options': { local: true } },
             { 'bstack:options': { local: true } },
             { 'bstack:options': { local: true } }
+        ])
+    })
+
+    it('should add the "local" property to an array of capabilities inside "bstack:options" if any extension cap present', async () => {
+        const service = new BrowserstackLauncher(options, caps, config)
+        const capabilities = [{ 'ms:edgeOptions': {} }, { 'goog:chromeOptions': {} }, { 'moz:firefoxOptions': {} }]
+
+        await service.onPrepare(config, capabilities)
+        expect(capabilities).toEqual([
+            { 'bstack:options': { local: true }, 'ms:edgeOptions': {} },
+            { 'bstack:options': { local: true }, 'goog:chromeOptions': {} },
+            { 'bstack:options': { local: true }, 'moz:firefoxOptions': {} }
         ])
     })
 
@@ -161,13 +201,33 @@ describe('constructor', () => {
         capabilities: []
     }
 
-    it('should add the wdioService property to an array of capabilities', async () => {
+    it('should add the "browserstack.wdioService" property to an array of capabilities if no "bstack:options"', async () => {
         const caps: any = [{}, {}]
+        new BrowserstackLauncher(options, caps, config)
+
+        expect(caps).toEqual([
+            { 'browserstack.wdioService': bstackServiceVersion },
+            { 'browserstack.wdioService': bstackServiceVersion }
+        ])
+    })
+
+    it('should add the "wdioService" property to an array of capabilities inside "bstack:options" if "bstack:options" present', async () => {
+        const caps: any = [{ 'bstack:options': {} }, { 'bstack:options': {} }]
         new BrowserstackLauncher(options, caps, config)
 
         expect(caps).toEqual([
             { 'bstack:options': { wdioService: bstackServiceVersion } },
             { 'bstack:options': { wdioService: bstackServiceVersion } }
+        ])
+    })
+
+    it('should add the "wdioService" property to an array of capabilities inside "bstack:options" if any extension cap present', async () => {
+        const caps: any = [{ 'moz:firefoxOptions': {} }, { 'goog:chromeOptions': {} }]
+        new BrowserstackLauncher(options, caps, config)
+
+        expect(caps).toEqual([
+            { 'bstack:options': { wdioService: bstackServiceVersion }, 'moz:firefoxOptions': {} },
+            { 'bstack:options': { wdioService: bstackServiceVersion }, 'goog:chromeOptions': {} }
         ])
     })
 })

--- a/packages/wdio-types/src/Capabilities.ts
+++ b/packages/wdio-types/src/Capabilities.ts
@@ -1091,10 +1091,6 @@ export interface BrowserStackCapabilities {
      * @private
      */
     wdioService?: string
-    /**
-     * @private
-     */
-    'browserstack.wdioService'?: string
 }
 
 export interface SauceLabsVisualCapabilities {

--- a/packages/wdio-types/src/Capabilities.ts
+++ b/packages/wdio-types/src/Capabilities.ts
@@ -155,6 +155,10 @@ export interface VendorExtensions extends EdgeCapabilities, AppiumW3CCapabilitie
     // Browserstack w3c specific
     'bstack:options'?: BrowserStackCapabilities
     'browserstack.local'?: boolean
+    /**
+     * @private
+     */
+    'browserstack.wdioService'?: string
 
     'goog:chromeOptions'?: ChromeOptions;
     'moz:firefoxOptions'?: FirefoxOptions;
@@ -1087,6 +1091,10 @@ export interface BrowserStackCapabilities {
      * @private
      */
     wdioService?: string
+    /**
+     * @private
+     */
+    'browserstack.wdioService'?: string
 }
 
 export interface SauceLabsVisualCapabilities {


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

Introduce `bstack:options` only when necessary, so as not to break sessions for users running v7 webdriverio but with `jsonwp` formatted caps. Currently we are adding `bstack:options` into user caps for adding `local` and `wdioSerivce` - now will add them as `browserstack.local` / `browserstack.wdioService` in cases where introducing `bstack:options` would have triggered the check [here](https://github.com/webdriverio/webdriverio/blob/main/packages/webdriver/src/utils.ts#L45).

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers


<a href="https://gitpod.io/#https://github.com/webdriverio/webdriverio/pull/8524"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

