### PR TITLE
Remove `browser.config` as it is a duplicate of `browser.options`

### DIFF
--- a/packages/wdio-runner/src/index.ts
+++ b/packages/wdio-runner/src/index.ts
@@ -308,7 +308,6 @@ export default class Runner extends EventEmitter {
             return
         }
 
-        this._browser.config = config as Options.Testrunner
         return this._browser
     }
 

--- a/tests/mocha/retry_and_pass.js
+++ b/tests/mocha/retry_and_pass.js
@@ -1,5 +1,5 @@
 import fs from 'node:fs'
-const filename = browser.config.retryFilename
+const filename = browser.options.retryFilename
 
 describe('fail on first run and succeed on second', function () {
     it(`pass if ${filename} exists, otherwise create it and fail`, function () {

--- a/website/docs/BrowserObject.md
+++ b/website/docs/BrowserObject.md
@@ -88,7 +88,7 @@ exports.config = {
 And access it in your tests:
 
 ```js
-console.log(browser.config)
+console.log(browser.options)
 /**
  * outputs:
  * {
@@ -106,43 +106,10 @@ console.log(browser.config)
         // ...
  */
 
-console.log(browser.config.fakeUser) // outputs: "maxmustermann"
+console.log(browser.options.fakeUser) // outputs: "maxmustermann"
 ```
 
-### Configurations versus Options
 
-Custom configurations should not be confused with [Options](Options.md), which are accessed separately.
-
-```js
-console.log(browser.options)
-/**
- * outputs:
- * {
-        protocol: 'http',
-        port: 4444,
-        hostname: 'localhost',
-        baseUrl: 'example.com',
-        // ...
- */
-```
-
-When using the WDIO testrunner, if any configuration and option keys conflict in name (e.g. `baseUrl` in the following code snippets) the option value will take precedence and overwrite the config value.
-
-```js
-// wdio.conf.js
-exports.config = {
-    baseUrl: 'example.com'
-}
-```
-
-```sh
-# testrunner invocation
-$ npm wdio wdio.conf.js --baseUrl foobar.com
-```
-
-```js
-console.log(browser.config.baseUrl) // 'foobar.com', despite being set as 'example.com'
-console.log(browser.options.baseUrl) // 'foobar.com'
 ```
 
 ## Mobile Flags


### PR DESCRIPTION
## Proposed changes

see #7005

There was nothing useful keeping `browser.config` around, so with `v8` we can finally remove it.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers


<a href="https://gitpod.io/#https://github.com/webdriverio/webdriverio/pull/8649"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

