### PR TITLE
Assign empty object if options are undefined

### DIFF
--- a/packages/webdriverio/src/commands/element/click.ts
+++ b/packages/webdriverio/src/commands/element/click.ts
@@ -147,7 +147,7 @@ export default async function click(
             () => null,
             (err) => log.warn(`Failed to call "releaseAction" command due to: ${err.message}, ignoring!`))
 
-        return
+        return null
     }
 
     const { width, height } = await this.getElementSize(this.elementId)

--- a/packages/webdriverio/src/commands/element/click.ts
+++ b/packages/webdriverio/src/commands/element/click.ts
@@ -88,7 +88,7 @@ export default async function click(
     options?: ClickOptions
 ) {
     if (typeof options === 'undefined') {
-        return this.elementClick(this.elementId)
+        options = {}
     }
 
     if (typeof options !== 'object' || Array.isArray(options)) {

--- a/packages/webdriverio/tests/commands/element/click.test.ts
+++ b/packages/webdriverio/tests/commands/element/click.test.ts
@@ -21,7 +21,7 @@ describe('click test', () => {
         await elem.click()
 
         expect(got.mock.calls[2][0].pathname)
-            .toBe('/session/foobar-123/element/some-elem-123/click')
+            .toBe('/session/foobar-123/actions')
     })
 
     it('should allow to left click on an element by passing a button type', async () => {


### PR DESCRIPTION
## Proposed changes

If the click command is called with no options, the click action on the element is executed, but when passing empty options or just a button left option, then the code first scrolls the button into view and then clicking.
By just setting the options to an empty object if it is not passed in, the code follows the same pattern for all options.
Resolves bug: [8628](https://github.com/webdriverio/webdriverio/issues/8628)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

By setting options to an empty object, it can follow the current code flow.
I also looked into setting a scroll into view just before the elementClick command, but that introduces another place where you scroll and click, adding more complexity to the code. So I rather chose a simple fix that follows the existing code paths.

### Reviewers: @webdriverio/project-committers


<a href="https://gitpod.io/#https://github.com/webdriverio/webdriverio/pull/8658"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

