### PR TITLE
reloadSession with DevTools breaks switchWindow command v7

### DIFF
--- a/packages/devtools/src/devtoolsdriver.ts
+++ b/packages/devtools/src/devtoolsdriver.ts
@@ -106,7 +106,7 @@ export default class DevToolsDriver {
         this.activeListeners.push({ emitter, eventName, boundHandler })
     }
 
-    private offActiverListeners() {
+    private offAllListeners() {
         this.activeListeners.forEach(({ emitter, eventName, boundHandler }) => {
             emitter.off(eventName, boundHandler)
         })
@@ -115,12 +115,12 @@ export default class DevToolsDriver {
 
     /**
      * Inits browser listeners and sets initial handlers for given pages.
-     * Function is intended to be used while reloading DevTools session.
-     * @param browser pupeteer Browser
-     * @param pages pupeteer page array
+     * Function is also intended to be used while reloading DevTools session.
+     * @param browser Puppeteer Browser
+     * @param pages Puppeteer page array
      */
     initBrowser(browser: Browser, pages: Page[]) {
-        this.offActiverListeners()
+        this.offAllListeners()
         this.elementStore = new ElementStore()
         this.windows = new Map()
         this.activeDialog = undefined

--- a/packages/devtools/src/devtoolsdriver.ts
+++ b/packages/devtools/src/devtoolsdriver.ts
@@ -106,7 +106,7 @@ export default class DevToolsDriver {
         this.activeListeners.push({ emitter, eventName, boundHandler })
     }
 
-    private offAllListeners() {
+    private cleanupListeners() {
         this.activeListeners.forEach(({ emitter, eventName, boundHandler }) => {
             emitter.off(eventName, boundHandler)
         })
@@ -120,7 +120,7 @@ export default class DevToolsDriver {
      * @param pages Puppeteer page array
      */
     initBrowser(browser: Browser, pages: Page[]) {
-        this.offAllListeners()
+        this.cleanupListeners()
         this.elementStore = new ElementStore()
         this.windows = new Map()
         this.activeDialog = undefined

--- a/packages/devtools/src/devtoolsdriver.ts
+++ b/packages/devtools/src/devtoolsdriver.ts
@@ -13,7 +13,7 @@ import type { Frame } from 'puppeteer-core/lib/cjs/puppeteer/common/FrameManager
 import ElementStore from './elementstore'
 import { validate, sanitizeError } from './utils'
 import { DEFAULT_IMPLICIT_TIMEOUT, DEFAULT_PAGELOAD_TIMEOUT, DEFAULT_SCRIPT_TIMEOUT } from './constants'
-import { EventEmitter } from 'puppeteer-core/lib/cjs/puppeteer/common/EventEmitter'
+import { ActiveListener } from './types.js'
 
 const log = logger('devtools')
 
@@ -28,7 +28,7 @@ export default class DevToolsDriver {
     currentFrame?: Page
     currentWindowHandle?: string
     currentFrameUrl?: string
-    activeListeners: {emitter: EventEmitter, eventName: string, boundHandler: any}[] = []
+    activeListeners: ActiveListener[] = []
     constructor(browser: Browser, pages: Page[]) {
         this.browser = browser
 
@@ -100,7 +100,7 @@ export default class DevToolsDriver {
         return require(filePath).default
     }
 
-    private addListener(emitter: EventEmitter, eventName: string, handler: any) {
+    private addListener(emitter: ActiveListener['emitter'], eventName: string, handler: any) {
         const boundHandler = handler.bind(this)
         emitter.on(eventName, boundHandler)
         this.activeListeners.push({ emitter, eventName, boundHandler })

--- a/packages/devtools/src/devtoolsdriver.ts
+++ b/packages/devtools/src/devtoolsdriver.ts
@@ -13,6 +13,7 @@ import type { Frame } from 'puppeteer-core/lib/cjs/puppeteer/common/FrameManager
 import ElementStore from './elementstore'
 import { validate, sanitizeError } from './utils'
 import { DEFAULT_IMPLICIT_TIMEOUT, DEFAULT_PAGELOAD_TIMEOUT, DEFAULT_SCRIPT_TIMEOUT } from './constants'
+import { EventEmitter } from 'puppeteer-core/lib/cjs/puppeteer/common/EventEmitter'
 
 const log = logger('devtools')
 
@@ -27,11 +28,9 @@ export default class DevToolsDriver {
     currentFrame?: Page
     currentWindowHandle?: string
     currentFrameUrl?: string
-
+    activeListeners: {emitter: EventEmitter, eventName: string, boundHandler: any}[] = []
     constructor(browser: Browser, pages: Page[]) {
         this.browser = browser
-        this.browser.on('targetcreated', this._targetCreatedHandler.bind(this))
-        this.browser.on('targetdestroyed', this._targetDestroyedHandler.bind(this))
 
         const dir = path.resolve(__dirname, 'commands')
         const files = fs.readdirSync(dir).filter(
@@ -55,20 +54,7 @@ export default class DevToolsDriver {
             )
         }
 
-        for (const page of pages) {
-            this._createWindowHandle(page)
-        }
-
-        /**
-         * set default timeouts
-         */
-        this.setTimeouts(DEFAULT_IMPLICIT_TIMEOUT, DEFAULT_PAGELOAD_TIMEOUT, DEFAULT_SCRIPT_TIMEOUT)
-
-        const page = this.getPageHandle()
-        if (page) {
-            page.on('dialog', this.dialogHandler.bind(this))
-            page.on('framenavigated', this.framenavigatedHandler.bind(this))
-        }
+        this.initBrowser(browser, pages)
     }
 
     private _createWindowHandle (page: Page) {
@@ -112,6 +98,51 @@ export default class DevToolsDriver {
     /* istanbul ignore next */
     static requireCommand(filePath: string) {
         return require(filePath).default
+    }
+
+    private addListener(emitter: EventEmitter, eventName: string, handler: any) {
+        const boundHandler = handler.bind(this)
+        emitter.on(eventName, boundHandler)
+        this.activeListeners.push({ emitter, eventName, boundHandler })
+    }
+
+    private offActiverListeners() {
+        this.activeListeners.forEach(({ emitter, eventName, boundHandler }) => {
+            emitter.off(eventName, boundHandler)
+        })
+        this.activeListeners = []
+    }
+
+    /**
+     * Inits browser listeners and sets initial handlers for given pages.
+     * Function is intended to be used while reloading DevTools session.
+     * @param browser pupeteer Browser
+     * @param pages pupeteer page array
+     */
+    initBrowser(browser: Browser, pages: Page[]) {
+        this.offActiverListeners()
+        this.elementStore = new ElementStore()
+        this.windows = new Map()
+        this.activeDialog = undefined
+        this.browser = browser
+
+        this.addListener(this.browser, 'targetcreated', this._targetCreatedHandler)
+        this.addListener(this.browser, 'targetdestroyed', this._targetDestroyedHandler)
+
+        for (const page of pages) {
+            this._createWindowHandle(page)
+        }
+
+        /**
+         * set default timeouts
+         */
+        this.setTimeouts(DEFAULT_IMPLICIT_TIMEOUT, DEFAULT_PAGELOAD_TIMEOUT, DEFAULT_SCRIPT_TIMEOUT)
+
+        const page = this.getPageHandle()
+        if (page) {
+            this.addListener(page, 'dialog', this.dialogHandler)
+            this.addListener(page, 'framenavigated', this.framenavigatedHandler)
+        }
     }
 
     register(commandInfo: CommandEndpoint) {

--- a/packages/devtools/src/index.ts
+++ b/packages/devtools/src/index.ts
@@ -119,18 +119,8 @@ export default class DevTools {
         const { session } = sessionMap.get(instance.sessionId)
         const browser = await launch(instance.requestedCapabilities)
         const pages = await browser.pages()
-
-        session.elementStore.clear()
-        session.windows = new Map()
-        session.browser = browser
+        session.initBrowser.call(session, browser, pages)
         instance.puppeteer = browser
-
-        for (const page of pages) {
-            const pageId = uuidv4()
-            session.windows.set(pageId, page)
-            session.currentWindowHandle = pageId
-        }
-
         sessionMap.set(instance.sessionId, { browser, session })
         return instance.sessionId
     }

--- a/packages/devtools/src/types.ts
+++ b/packages/devtools/src/types.ts
@@ -3,7 +3,7 @@ import { EventEmitter } from 'events'
 import type { Options, Capabilities } from '@wdio/types'
 import type { ProtocolCommandsAsync } from '@wdio/protocols'
 import { LaunchOptions, BrowserLaunchArgumentOptions, BrowserConnectOptions, ConnectOptions } from 'puppeteer-core'
-
+import { EventEmitter as PuppeteerEventEmitter } from 'puppeteer-core/lib/cjs/puppeteer/common/EventEmitter.js'
 export interface ExtendedCapabilities extends Capabilities.Capabilities, WDIODevtoolsOptions {}
 
 export interface WDIODevtoolsOptions {
@@ -41,3 +41,15 @@ export interface BaseClient extends EventEmitter {
 }
 
 export interface Client extends BaseClient, ProtocolCommandsAsync {}
+
+/**
+ * Interface keeping together information allowing to remove active listener from emitter.
+ */
+export interface ActiveListener {
+    /** Event Emitter object emitting to the handler. */
+    emitter: PuppeteerEventEmitter
+    /** Name of the event the handler is attached to. */
+    eventName: string
+    /** Event function handler, bound to the context of its class instance. */
+    boundHandler: (...args: any[]) => any
+}

--- a/packages/devtools/tests/__mocks__/puppeteer-core.ts
+++ b/packages/devtools/tests/__mocks__/puppeteer-core.ts
@@ -46,6 +46,7 @@ const target = new TargetMock()
 
 class PageMock {
     on = jest.fn()
+    off = jest.fn()
     close = jest.fn()
     url = jest.fn().mockReturnValue('about:blank')
     emulate = jest.fn()
@@ -62,6 +63,7 @@ const page2 = new PageMock2()
 
 class PuppeteerMock {
     on = jest.fn()
+    off = jest.fn()
     waitForTarget = jest.fn().mockImplementation(() => target)
     getActivePage = jest.fn().mockImplementation(() => page)
     pages = jest.fn().mockReturnValue(Promise.resolve([page, page2]))

--- a/packages/devtools/tests/devtools.test.ts
+++ b/packages/devtools/tests/devtools.test.ts
@@ -8,6 +8,7 @@ jest.mock('../src/launcher', () => jest.fn().mockImplementation((capabilities) =
         off: jest.fn(),
         pages: jest.fn().mockReturnValue(Promise.resolve([{
             on: jest.fn(),
+            off: jest.fn(),
             setDefaultTimeout: jest.fn()
         }])),
         _connection: {

--- a/packages/devtools/tests/devtools.test.ts
+++ b/packages/devtools/tests/devtools.test.ts
@@ -5,6 +5,7 @@ jest.mock('../src/launcher', () => jest.fn().mockImplementation((capabilities) =
     capabilities['goog:chromeOptions'] = capabilities['goog:chromeOptions'] || {}
     return {
         on: jest.fn(),
+        off: jest.fn(),
         pages: jest.fn().mockReturnValue(Promise.resolve([{
             on: jest.fn(),
             setDefaultTimeout: jest.fn()


### PR DESCRIPTION
## Proposed changes

Note: this is PR for v7 version based on [previous v8 one](https://github.com/webdriverio/webdriverio/pull/8657)

This is a fix for reloadSession method, which was braking possibility to switchWindow for new windows opened after session was reloaded.
The problem was debugged/diagnosed and it turned out that Puppeteer browser in devToolsDriver stops listen on
targetcreated and targetdestroyed events after the session is reloaded. Proposed fix initialises the same listeners in devToolsDriver constructor as well as after session is reloaded and new Browser object is created. It unloads also listeners old handlers to prevent memory leaks and undesired behaviour.

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers


<a href="https://gitpod.io/#https://github.com/webdriverio/webdriverio/pull/8687"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

