### PR TITLE
fix: skipped tests not showing jasmine pending() reason in spec repor… [MAIN] branch

### DIFF
--- a/packages/wdio-spec-reporter/src/index.ts
+++ b/packages/wdio-spec-reporter/src/index.ts
@@ -22,6 +22,7 @@ export default class SpecReporter extends WDIOReporter {
     private _suiteIndent = ''
     private _preface = ''
     private _consoleLogs: string[] = []
+    private _pendingReasons: string[] = []
     private _originalStdoutWrite = process.stdout.write.bind(process.stdout)
 
     private _addConsoleLogs = false
@@ -115,6 +116,7 @@ export default class SpecReporter extends WDIOReporter {
 
     onTestSkip (testStat: TestStats) {
         this.printCurrentStats(testStat)
+        this._pendingReasons.push(testStat.pendingReason as string)
         this._consoleLogs.push(this._consoleOutput)
         this._stateCounts.skipped++
     }
@@ -356,6 +358,14 @@ export default class SpecReporter extends WDIOReporter {
                     const rawTable = printTable(data)
                     const table = getFormattedRows(rawTable, testIndent)
                     output.push(...table)
+                }
+
+                // print pending reasons
+                const pendingItem = this._pendingReasons.shift()
+                if (pendingItem) {
+                    output.push('')
+                    output.push(testIndent.repeat(2) + '.........Pending Reasons.........')
+                    output.push(testIndent.repeat(3) + pendingItem?.replace(/\n/g, '\n'.concat(preface + ' ', testIndent.repeat(3))))
                 }
 
                 // print console output

--- a/packages/wdio-spec-reporter/tests/index.test.ts
+++ b/packages/wdio-spec-reporter/tests/index.test.ts
@@ -118,8 +118,13 @@ describe('SpecReporter', () => {
         beforeAll(() => {
             reporter.onTestSkip({
                 title:'test1',
-                state:'skipped'
+                state:'skipped',
+                pendingReason: 'some random reason'
             } as any)
+        })
+
+        it('should have a pending reason', () => {
+            expect(reporter['_pendingReasons'][0]).toBe('some random reason')
         })
 
         it('should increase stateCounts.skipped by 1', () => {
@@ -615,6 +620,21 @@ describe('SpecReporter', () => {
             tmpReporter.onRunnerEnd(runnerEnd())
         })
 
+        it('should add pending reason to report for skipped tests', () => {
+            tmpReporter = new SpecReporter(options)
+            tmpReporter.onSuiteStart(Object.values(SUITES)[2] as any)
+            tmpReporter.onTestStart()
+            tmpReporter['_orderedSuites'] = Object.values(SUITES) as any
+            tmpReporter.onTestSkip({
+                title:'test1',
+                state:'skipped',
+                pendingReason:'some random Reasons'
+            } as any)
+            expect(tmpReporter.getResultDisplay().toString()).toContain('Pending Reasons')
+            tmpReporter.onSuiteEnd()
+            tmpReporter.onRunnerEnd(runnerEnd())
+        })
+        
         it('should not add webdriver logs to report', () => {
             tmpReporter = new SpecReporter(options)
             tmpReporter.onSuiteStart(Object.values(SUITES)[0] as any)

--- a/packages/wdio-spec-reporter/tests/index.test.ts
+++ b/packages/wdio-spec-reporter/tests/index.test.ts
@@ -634,7 +634,7 @@ describe('SpecReporter', () => {
             tmpReporter.onSuiteEnd()
             tmpReporter.onRunnerEnd(runnerEnd())
         })
-        
+
         it('should not add webdriver logs to report', () => {
             tmpReporter = new SpecReporter(options)
             tmpReporter.onSuiteStart(Object.values(SUITES)[0] as any)


### PR DESCRIPTION
…ter #8686

## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)
This adds jasmine pending() output to the test results from spec reporter, if a skipped test has pending reason. Fixes this issue : https://github.com/webdriverio/webdriverio/issues/8170 ,
## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers


<a href="https://gitpod.io/#https://github.com/webdriverio/webdriverio/pull/8688"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>



<a href="https://gitpod.io/#https://github.com/webdriverio/webdriverio/pull/8694"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

