### PR TITLE
update expect-webdriverio and initiate it in @wdio/globals

### DIFF
--- a/__mocks__/expect-webdriverio.ts
+++ b/__mocks__/expect-webdriverio.ts
@@ -1,4 +1,5 @@
 import { vi } from 'vitest'
 process.env.WDIO_ASSERTION_LIB_ACTIVATED = '1'
 const setOptions = vi.fn()
-export { setOptions }
+const expect = vi.fn()
+export { setOptions, expect }

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/webdriverio/webdriverio/tree/main/packages/devtools",
   "license": "MIT",
   "engines": {
-     "node": "^16.13 || >=18"
+    "node": "^16.13 || >=18"
   },
   "repository": {
     "type": "git",

--- a/packages/eslint-plugin-wdio/package.json
+++ b/packages/eslint-plugin-wdio/package.json
@@ -10,7 +10,7 @@
   "types": "./build/index.d.ts",
   "typeScriptVersion": "3.8.3",
   "engines": {
-     "node": "^16.13 || >=18"
+    "node": "^16.13 || >=18"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-allure-reporter/package.json
+++ b/packages/wdio-allure-reporter/package.json
@@ -23,7 +23,7 @@
   "types": "./build/index.d.ts",
   "typeScriptVersion": "3.8.3",
   "engines": {
-     "node": "^16.13 || >=18"
+    "node": "^16.13 || >=18"
   },
   "dependencies": {
     "@wdio/reporter": "7.20.7",

--- a/packages/wdio-appium-service/package.json
+++ b/packages/wdio-appium-service/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/webdriverio/webdriverio/tree/main/packages/wdio-appium-service",
   "license": "MIT",
   "engines": {
-     "node": "^16.13 || >=18"
+    "node": "^16.13 || >=18"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-browserstack-service/package.json
+++ b/packages/wdio-browserstack-service/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/webdriverio/webdriverio/tree/main/packages/wdio-browserstack-service",
   "license": "MIT",
   "engines": {
-     "node": "^16.13 || >=18"
+    "node": "^16.13 || >=18"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-concise-reporter/package.json
+++ b/packages/wdio-concise-reporter/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/webdriverio/webdriverio/tree/main/packages/wdio-concise-reporter",
   "license": "MIT",
   "engines": {
-     "node": "^16.13 || >=18"
+    "node": "^16.13 || >=18"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-config/package.json
+++ b/packages/wdio-config/package.json
@@ -10,7 +10,7 @@
   "types": "./build/index.d.ts",
   "typeScriptVersion": "3.8.3",
   "engines": {
-     "node": "^16.13 || >=18"
+    "node": "^16.13 || >=18"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-crossbrowsertesting-service/package.json
+++ b/packages/wdio-crossbrowsertesting-service/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/webdriverio/webdriverio/tree/main/packages/wdio-crossbrowsertesting-service",
   "license": "MIT",
   "engines": {
-     "node": "^16.13 || >=18"
+    "node": "^16.13 || >=18"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-cucumber-framework/package.json
+++ b/packages/wdio-cucumber-framework/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/webdriverio/webdriverio/tree/main/packages/wdio-cucumber-framework",
   "license": "MIT",
   "engines": {
-     "node": "^16.13 || >=18"
+    "node": "^16.13 || >=18"
   },
   "repository": {
     "type": "git",
@@ -35,7 +35,6 @@
     "@wdio/logger": "7.19.0",
     "@wdio/types": "7.20.7",
     "@wdio/utils": "7.20.7",
-    "expect-webdriverio": "^3.0.0",
     "glob": "^8.0.3",
     "is-glob": "^4.0.0",
     "long": "^4.0.0",

--- a/packages/wdio-cucumber-framework/src/index.ts
+++ b/packages/wdio-cucumber-framework/src/index.ts
@@ -32,9 +32,7 @@ import { Long } from 'long'
 import { IdGenerator } from '@cucumber/messages'
 
 import { executeHooksWithArgs, testFnWrapper } from '@wdio/utils'
-import { setOptions } from 'expect-webdriverio'
 import type { Capabilities, Options, Frameworks } from '@wdio/types'
-import type ExpectWebdriverIO from 'expect-webdriverio'
 
 import CucumberReporter from './reporter.js'
 import { DEFAULT_OPTS } from './constants.js'
@@ -133,15 +131,6 @@ class CucumberAdapter {
             await executeHooksWithArgs('after', this._config.after, [runtimeError, this._capabilities, this._specs])
             throw runtimeError
         }
-
-        /**
-         * import and set options for `expect-webdriverio` assertion lib once
-         * the framework was initiated so that it can detect the environment
-         */
-        setOptions({
-            wait: this._config.waitforTimeout, // ms to wait for expectation to succeed
-            interval: this._config.waitforInterval, // interval between attempts
-        })
 
         return this
     }
@@ -429,10 +418,5 @@ declare global {
     namespace WebdriverIO {
         interface CucumberOpts extends CucumberOptions {}
         interface HookFunctionExtension extends HookFunctionExtensionImport {}
-    }
-    namespace NodeJS {
-        interface Global {
-            expect: ExpectWebdriverIO.Expect
-        }
     }
 }

--- a/packages/wdio-cucumber-framework/tests/adapter.test.ts
+++ b/packages/wdio-cucumber-framework/tests/adapter.test.ts
@@ -1,7 +1,6 @@
 import path from 'node:path'
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 
-import { setOptions } from 'expect-webdriverio'
 import { executeHooksWithArgs, testFnWrapper } from '@wdio/utils'
 import * as Cucumber from '@cucumber/cucumber'
 import mockery from 'mockery'
@@ -84,16 +83,9 @@ describe('CucumberAdapter', () => {
     })
 
     it('can be initiated with tests', async () => {
-        const adapter = await CucumberAdapter.init!!('0-0', {
-            waitforTimeout: 1,
-            waitforInterval: 2
-        }, ['/foo/bar'], {}, {})
+        const adapter = await CucumberAdapter.init!!('0-0', {}, ['/foo/bar'], {}, {})
 
         expect(executeHooksWithArgs).toBeCalledTimes(0)
-        expect(setOptions).toBeCalledWith({
-            wait: 1,
-            interval: 2
-        })
         expect(adapter.hasTests()).toBe(true)
         expect(Cucumber.PickleFilter).toBeCalledWith({
             cwd: expect.any(String),

--- a/packages/wdio-dot-reporter/package.json
+++ b/packages/wdio-dot-reporter/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/webdriverio/webdriverio/tree/main/packages/wdio-dot-reporter",
   "license": "MIT",
   "engines": {
-     "node": "^16.13 || >=18"
+    "node": "^16.13 || >=18"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-firefox-profile-service/package.json
+++ b/packages/wdio-firefox-profile-service/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/webdriverio/webdriverio/tree/main/packages/wdio-firefox-profile-service",
   "license": "MIT",
   "engines": {
-     "node": "^16.13 || >=18"
+    "node": "^16.13 || >=18"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-globals/package.json
+++ b/packages/wdio-globals/package.json
@@ -28,7 +28,7 @@
     "access": "public"
   },
   "dependencies": {
-    "expect-webdriverio": "^4.0.0-alpha.1",
+    "expect-webdriverio": "^4.0.0-alpha.2",
     "webdriverio": "7.20.7"
   }
 }

--- a/packages/wdio-globals/package.json
+++ b/packages/wdio-globals/package.json
@@ -10,7 +10,7 @@
   "types": "./build/index.d.ts",
   "typeScriptVersion": "3.8.3",
   "engines": {
-     "node": "^16.13 || >=18"
+    "node": "^16.13 || >=18"
   },
   "repository": {
     "type": "git",
@@ -28,6 +28,7 @@
     "access": "public"
   },
   "dependencies": {
+    "expect-webdriverio": "^4.0.0-alpha.1",
     "webdriverio": "7.20.7"
   }
 }

--- a/packages/wdio-globals/package.json
+++ b/packages/wdio-globals/package.json
@@ -28,7 +28,7 @@
     "access": "public"
   },
   "dependencies": {
-    "expect-webdriverio": "^4.0.0-alpha.2",
+    "expect-webdriverio": "^4.0.0-alpha.3",
     "webdriverio": "7.20.7"
   }
 }

--- a/packages/wdio-globals/src/index.ts
+++ b/packages/wdio-globals/src/index.ts
@@ -3,7 +3,7 @@
 type SupportedGlobals = 'browser' | 'driver' | 'multiremotebrowser' | '$' | '$$' | 'expect'
 
 const globals: Map<SupportedGlobals, any> = new Map()
-const GLOBALS_ERROR_MESSAGE = 'Don\'t import @wdio/globals outside of the WDIO testrunner context'
+const GLOBALS_ERROR_MESSAGE = 'No browser instance registered. Don\'t import @wdio/globals outside of the WDIO testrunner context. Or you have two two different "@wdio/globals" packages installed.'
 
 function proxyHandler (key: SupportedGlobals) {
     return {
@@ -41,6 +41,12 @@ export const $$: WebdriverIO.Browser['$$'] = (...args: any) => {
     }
     return globals.get('$$')(...args)
 }
+export const expect: ExpectWebdriverIO.Expect = ((...args: any) => {
+    if (!globals.has('expect')) {
+        throw new Error(GLOBALS_ERROR_MESSAGE)
+    }
+    return globals.get('expect')(...args)
+}) as ExpectWebdriverIO.Expect
 
 /**
  * allows to set global property to be imported and used later on

--- a/packages/wdio-globals/src/index.ts
+++ b/packages/wdio-globals/src/index.ts
@@ -1,6 +1,6 @@
 /// <reference path="../types.d.ts" />
 
-type SupportedGlobals = 'browser' | 'driver' | 'multiremotebrowser' | '$' | '$$'
+type SupportedGlobals = 'browser' | 'driver' | 'multiremotebrowser' | '$' | '$$' | 'expect'
 
 const globals: Map<SupportedGlobals, any> = new Map()
 const GLOBALS_ERROR_MESSAGE = 'Don\'t import @wdio/globals outside of the WDIO testrunner context'

--- a/packages/wdio-globals/types.d.ts
+++ b/packages/wdio-globals/types.d.ts
@@ -2,6 +2,7 @@ type BrowserType = import('webdriverio').Browser<'async'>
 type ElementType = import('webdriverio').Element<'async'>
 type ElementArrayType = import('webdriverio').ElementArray
 type MultiRemoteBrowserType = import('webdriverio').MultiRemoteBrowser<'async'>
+type ExpectWebdriverIO = import('expect-webdriverio')
 
 declare namespace WebdriverIOAsync {
     interface Browser {}
@@ -23,6 +24,7 @@ declare module NodeJS {
         browser: WebdriverIO.Browser
         driver: WebdriverIO.Browser
         multiremotebrowser: WebdriverIO.MultiRemoteBrowser
+        expect: ExpectWebdriverIO.Expect
     }
 }
 
@@ -31,3 +33,4 @@ declare function $$(...args: Parameters<WebdriverIO.Browser['$$']>): ReturnType<
 declare const browser: WebdriverIO.Browser
 declare const driver: WebdriverIO.Browser
 declare const multiremotebrowser: WebdriverIO.MultiRemoteBrowser
+declare const expect: ExpectWebdriverIO.Expect

--- a/packages/wdio-jasmine-framework/package.json
+++ b/packages/wdio-jasmine-framework/package.json
@@ -10,7 +10,7 @@
   "types": "./build/index.d.ts",
   "typeScriptVersion": "3.8.3",
   "engines": {
-     "node": "^16.13 || >=18"
+    "node": "^16.13 || >=18"
   },
   "repository": {
     "type": "git",
@@ -30,10 +30,11 @@
   "dependencies": {
     "@types/jasmine": "4.0.3",
     "@types/node": "^18.0.0",
+    "@wdio/globals": "^7.20.7",
     "@wdio/logger": "7.19.0",
     "@wdio/types": "7.20.7",
     "@wdio/utils": "7.20.7",
-    "expect-webdriverio": "^4.0.0-alpha.2",
+    "expect-webdriverio": "^4.0.0-alpha.3",
     "jasmine": "^4.2.1"
   },
   "peerDependencies": {

--- a/packages/wdio-jasmine-framework/package.json
+++ b/packages/wdio-jasmine-framework/package.json
@@ -33,7 +33,7 @@
     "@wdio/logger": "7.19.0",
     "@wdio/types": "7.20.7",
     "@wdio/utils": "7.20.7",
-    "expect-webdriverio": "next",
+    "expect-webdriverio": "^4.0.0-alpha.2",
     "jasmine": "^4.2.1"
   },
   "peerDependencies": {

--- a/packages/wdio-jasmine-framework/package.json
+++ b/packages/wdio-jasmine-framework/package.json
@@ -33,7 +33,7 @@
     "@wdio/logger": "7.19.0",
     "@wdio/types": "7.20.7",
     "@wdio/utils": "7.20.7",
-    "expect-webdriverio": "^3.4.0",
+    "expect-webdriverio": "next",
     "jasmine": "^4.2.1"
   },
   "peerDependencies": {

--- a/packages/wdio-jasmine-framework/src/index.ts
+++ b/packages/wdio-jasmine-framework/src/index.ts
@@ -3,6 +3,7 @@ import logger from '@wdio/logger'
 import { runTestInFiberContext, executeHooksWithArgs } from '@wdio/utils'
 import { EventEmitter } from 'node:events'
 import type { Options, Services, Capabilities } from '@wdio/types'
+import type ExpectWebdriverIO from 'expect-webdriverio'
 
 import JasmineReporter from './reporter.js'
 import type {
@@ -186,17 +187,6 @@ class JasmineAdapter {
         }
 
         await this._loadFiles()
-
-        /**
-         * expect-webdriverio needs to be dynamically imported here so that it can
-         * attach its matchers to the jasmine expect library
-         */
-        const { setOptions } = await import('expect-webdriverio')
-        setOptions({
-            wait: this._config.waitforTimeout, // ms to wait for expectation to succeed
-            interval: this._config.waitforInterval, // interval between attempts
-        })
-
         return this
     }
 
@@ -455,7 +445,6 @@ declare global {
     }
 
     namespace jasmine {
-        interface Matchers<T> extends ExpectWebdriverIO.Matchers<any, T> {}
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         interface AsyncMatchers<T, U> extends ExpectWebdriverIO.Matchers<Promise<void>, T> {}
     }

--- a/packages/wdio-jasmine-framework/src/index.ts
+++ b/packages/wdio-jasmine-framework/src/index.ts
@@ -5,7 +5,6 @@ import { EventEmitter } from 'node:events'
 import { expect } from 'expect-webdriverio'
 import { _setGlobal } from '@wdio/globals'
 import type { Options, Services, Capabilities } from '@wdio/types'
-import type ExpectWebdriverIO from 'expect-webdriverio'
 
 import JasmineReporter from './reporter.js'
 import type {

--- a/packages/wdio-jasmine-framework/src/index.ts
+++ b/packages/wdio-jasmine-framework/src/index.ts
@@ -451,9 +451,4 @@ declare global {
     namespace WebdriverIO {
         interface JasmineOpts extends jasmineNodeOpts {}
     }
-
-    namespace jasmine {
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        interface AsyncMatchers<T, U> extends ExpectWebdriverIO.Matchers<Promise<void>, T> {}
-    }
 }

--- a/packages/wdio-jasmine-framework/src/index.ts
+++ b/packages/wdio-jasmine-framework/src/index.ts
@@ -2,6 +2,8 @@ import Jasmine from 'jasmine'
 import logger from '@wdio/logger'
 import { runTestInFiberContext, executeHooksWithArgs } from '@wdio/utils'
 import { EventEmitter } from 'node:events'
+import { expect } from 'expect-webdriverio'
+import { _setGlobal } from '@wdio/globals'
 import type { Options, Services, Capabilities } from '@wdio/types'
 import type ExpectWebdriverIO from 'expect-webdriverio'
 
@@ -187,6 +189,12 @@ class JasmineAdapter {
         }
 
         await this._loadFiles()
+
+        /**
+         * overwrite Jasmine global expect with WebdriverIOs expect
+         */
+        _setGlobal('expect', expect, this._config.injectGlobals)
+
         return this
     }
 

--- a/packages/wdio-jasmine-framework/tests/adapter.test.ts
+++ b/packages/wdio-jasmine-framework/tests/adapter.test.ts
@@ -2,7 +2,6 @@ import path from 'node:path'
 import { expect, test, vi, it, describe, afterEach } from 'vitest'
 import logger from '@wdio/logger'
 import { runTestInFiberContext, executeHooksWithArgs } from '@wdio/utils'
-import { setOptions } from 'expect-webdriverio'
 import { EventEmitter } from 'node:events'
 
 import JasmineAdapterFactory, { JasmineAdapter } from '../src/index.js'
@@ -69,7 +68,6 @@ test('should properly set up jasmine', async () => {
     const result = await adapter.run()
 
     expect(result).toBe(0)
-    expect(setOptions).toBeCalledTimes(1)
     expect(vi.mocked(adapter['_jrunner']!.addSpecFile).mock.calls[0][0]).toEqual('/foo/bar.test.js')
     // @ts-ignore outdated types
     expect(vi.mocked(adapter['_jrunner']!.jasmine.addReporter).mock.calls).toHaveLength(1)
@@ -518,7 +516,6 @@ describe('hasTests', () => {
 })
 
 afterEach(() => {
-    vi.mocked(setOptions).mockClear()
     vi.mocked(runTestInFiberContext).mockClear()
     vi.mocked(executeHooksWithArgs).mockClear()
 })

--- a/packages/wdio-junit-reporter/package.json
+++ b/packages/wdio-junit-reporter/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/webdriverio/webdriverio/tree/main/packages/wdio-junit-reporter",
   "license": "MIT",
   "engines": {
-     "node": "^16.13 || >=18"
+    "node": "^16.13 || >=18"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-local-runner/package.json
+++ b/packages/wdio-local-runner/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/webdriverio/webdriverio/tree/main/packages/wdio-local-runner",
   "license": "MIT",
   "engines": {
-     "node": "^16.13 || >=18"
+    "node": "^16.13 || >=18"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-logger/package.json
+++ b/packages/wdio-logger/package.json
@@ -10,7 +10,7 @@
   "types": "./build/index.d.ts",
   "typeScriptVersion": "3.8.3",
   "engines": {
-     "node": "^16.13 || >=18"
+    "node": "^16.13 || >=18"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-mocha-framework/package.json
+++ b/packages/wdio-mocha-framework/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/webdriverio/webdriverio/tree/main/packages/wdio-mocha-framework",
   "license": "MIT",
   "engines": {
-     "node": "^16.13 || >=18"
+    "node": "^16.13 || >=18"
   },
   "repository": {
     "type": "git",
@@ -29,7 +29,6 @@
     "@wdio/logger": "7.19.0",
     "@wdio/types": "7.20.7",
     "@wdio/utils": "7.20.7",
-    "expect-webdriverio": "^3.4.0",
     "mocha": "^10.0.0"
   },
   "devDependencies": {

--- a/packages/wdio-mocha-framework/src/index.ts
+++ b/packages/wdio-mocha-framework/src/index.ts
@@ -4,14 +4,12 @@ import Mocha, { Runner } from 'mocha'
 
 import logger from '@wdio/logger'
 import { runTestInFiberContext, executeHooksWithArgs } from '@wdio/utils'
-import { setOptions } from 'expect-webdriverio'
 import type { Capabilities, Services } from '@wdio/types'
 
 import { loadModule } from './utils.js'
 import { INTERFACES, EVENTS, NOOP, MOCHA_TIMEOUT_MESSAGE, MOCHA_TIMEOUT_MESSAGE_REPLACEMENT } from './constants.js'
 import type { MochaConfig, MochaOpts as MochaOptsImport, FrameworkMessage, FormattedMessage, MochaError } from './types'
 import type { EventEmitter } from 'node:events'
-import type ExpectWebdriverIO from 'expect-webdriverio'
 
 const log = logger('@wdio/mocha-framework')
 
@@ -73,12 +71,6 @@ class MochaAdapter {
         ))
         mocha.suite.on('pre-require', this.preRequire.bind(this))
         await this._loadFiles(mochaOpts)
-
-        setOptions({
-            wait: this._config.waitforTimeout, // ms to wait for expectation to succeed
-            interval: this._config.waitforInterval, // interval between attempts
-        })
-
         return this
     }
 
@@ -394,10 +386,5 @@ export { MochaAdapter, adapterFactory }
 declare global {
     namespace WebdriverIO {
         interface MochaOpts extends MochaOptsImport {}
-    }
-    namespace NodeJS {
-        interface Global {
-            expect: ExpectWebdriverIO.Expect
-        }
     }
 }

--- a/packages/wdio-mocha-framework/tests/adapter.test.ts
+++ b/packages/wdio-mocha-framework/tests/adapter.test.ts
@@ -3,7 +3,6 @@ import path from 'node:path'
 import Mocha from 'mocha'
 import logger from '@wdio/logger'
 import { runTestInFiberContext, executeHooksWithArgs } from '@wdio/utils'
-import { setOptions } from 'expect-webdriverio'
 
 import MochaAdapterFactory, { MochaAdapter } from '../src/index.js'
 import { loadModule } from '../src/utils.js'
@@ -57,7 +56,6 @@ test('should properly set up mocha', async () => {
     const result = await adapter.run()
     expect(result).toBe(0)
 
-    expect(setOptions).toBeCalledTimes(1)
     expect(adapter['_mocha']!['loadFiles']).not.toBeCalled()
     expect(adapter['_mocha']!.loadFilesAsync).toBeCalled()
     expect(adapter['_mocha']!.reporter).toBeCalled()
@@ -528,5 +526,4 @@ afterEach(() => {
     vi.mocked(Mocha.Runner).mockClear()
     vi.mocked(runTestInFiberContext).mockReset()
     vi.mocked(executeHooksWithArgs).mockReset()
-    vi.mocked(setOptions).mockClear()
 })

--- a/packages/wdio-repl/package.json
+++ b/packages/wdio-repl/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/webdriverio/webdriverio/tree/main/packages/wdio-repl",
   "license": "MIT",
   "engines": {
-     "node": "^16.13 || >=18"
+    "node": "^16.13 || >=18"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-reporter/package.json
+++ b/packages/wdio-reporter/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/webdriverio/webdriverio/tree/main/packages/wdio-reporter",
   "license": "MIT",
   "engines": {
-     "node": "^16.13 || >=18"
+    "node": "^16.13 || >=18"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-runner/package.json
+++ b/packages/wdio-runner/package.json
@@ -31,7 +31,7 @@
     "@wdio/types": "7.20.7",
     "@wdio/utils": "7.20.7",
     "deepmerge": "^4.0.0",
-    "expect-webdriverio": "^4.0.0-alpha.2",
+    "expect-webdriverio": "^4.0.0-alpha.3",
     "gaze": "^1.1.2",
     "webdriver": "7.20.7",
     "webdriverio": "7.20.7"

--- a/packages/wdio-runner/package.json
+++ b/packages/wdio-runner/package.json
@@ -31,7 +31,7 @@
     "@wdio/types": "7.20.7",
     "@wdio/utils": "7.20.7",
     "deepmerge": "^4.0.0",
-    "expect-webdriverio": "^4.0.0-alpha.1",
+    "expect-webdriverio": "^4.0.0-alpha.2",
     "gaze": "^1.1.2",
     "webdriver": "7.20.7",
     "webdriverio": "7.20.7"

--- a/packages/wdio-runner/package.json
+++ b/packages/wdio-runner/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/webdriverio/webdriverio/tree/main/packages/wdio-runner",
   "license": "MIT",
   "engines": {
-     "node": "^16.13 || >=18"
+    "node": "^16.13 || >=18"
   },
   "repository": {
     "type": "git",
@@ -26,11 +26,12 @@
   "typeScriptVersion": "3.8.3",
   "dependencies": {
     "@wdio/config": "7.20.7",
+    "@wdio/globals": "7.20.7",
     "@wdio/logger": "7.19.0",
     "@wdio/types": "7.20.7",
-    "@wdio/globals": "7.20.7",
     "@wdio/utils": "7.20.7",
     "deepmerge": "^4.0.0",
+    "expect-webdriverio": "^4.0.0-alpha.1",
     "gaze": "^1.1.2",
     "webdriver": "7.20.7",
     "webdriverio": "7.20.7"

--- a/packages/wdio-runner/src/index.ts
+++ b/packages/wdio-runner/src/index.ts
@@ -6,6 +6,7 @@ import logger from '@wdio/logger'
 import { initialiseWorkerService, initialisePlugin, executeHooksWithArgs } from '@wdio/utils'
 import { ConfigParser } from '@wdio/config'
 import { _setGlobal } from '@wdio/globals'
+import { expect, setOptions } from 'expect-webdriverio'
 import type { Options, Capabilities, Services } from '@wdio/types'
 import type { Selector, Browser, MultiRemoteBrowser } from 'webdriverio'
 
@@ -296,6 +297,16 @@ export default class Runner extends EventEmitter {
             this._browser = await initialiseInstance(config, caps, this._isMultiremote)
             _setGlobal('browser', this._browser, config.injectGlobals)
             _setGlobal('driver', this._browser, config.injectGlobals)
+            _setGlobal('expect', expect, config.injectGlobals)
+
+            /**
+             * import and set options for `expect-webdriverio` assertion lib once
+             * the browser was initiated
+             */
+            setOptions({
+                wait: config.waitforTimeout, // ms to wait for expectation to succeed
+                interval: config.waitforInterval, // interval between attempts
+            })
 
             /**
              * attach browser to `multiremotebrowser` so user have better typing support

--- a/packages/wdio-sauce-service/package.json
+++ b/packages/wdio-sauce-service/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/webdriverio/webdriverio/tree/main/packages/wdio-sauce-service",
   "license": "MIT",
   "engines": {
-     "node": "^16.13 || >=18"
+    "node": "^16.13 || >=18"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-selenium-standalone-service/package.json
+++ b/packages/wdio-selenium-standalone-service/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/webdriverio/webdriverio/tree/main/packages/wdio-selenium-standalone-service",
   "license": "MIT",
   "engines": {
-     "node": "^16.13 || >=18"
+    "node": "^16.13 || >=18"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-shared-store-service/package.json
+++ b/packages/wdio-shared-store-service/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/webdriverio/webdriverio/tree/main/packages/wdio-shared-store-service",
   "license": "MIT",
   "engines": {
-     "node": "^16.13 || >=18"
+    "node": "^16.13 || >=18"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-smoke-test-reporter/package.json
+++ b/packages/wdio-smoke-test-reporter/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/webdriverio/webdriverio/tree/main/packages/wdio-smoke-test-reporter",
   "license": "MIT",
   "engines": {
-     "node": "^16.13 || >=18"
+    "node": "^16.13 || >=18"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-smoke-test-service/package.json
+++ b/packages/wdio-smoke-test-service/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/webdriverio/webdriverio/tree/main/packages/wdio-smoke-test-service",
   "license": "MIT",
   "engines": {
-     "node": "^16.13 || >=18"
+    "node": "^16.13 || >=18"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-spec-reporter/package.json
+++ b/packages/wdio-spec-reporter/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/webdriverio/webdriverio/tree/main/packages/wdio-spec-reporter",
   "license": "MIT",
   "engines": {
-     "node": "^16.13 || >=18"
+    "node": "^16.13 || >=18"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-static-server-service/package.json
+++ b/packages/wdio-static-server-service/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/webdriverio/webdriverio/tree/main/packages/wdio-static-server-service",
   "license": "MIT",
   "engines": {
-     "node": "^16.13 || >=18"
+    "node": "^16.13 || >=18"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-sumologic-reporter/package.json
+++ b/packages/wdio-sumologic-reporter/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/webdriverio/webdriverio/tree/main/packages/wdio-sumologic-reporter",
   "license": "MIT",
   "engines": {
-     "node": "^16.13 || >=18"
+    "node": "^16.13 || >=18"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-testingbot-service/package.json
+++ b/packages/wdio-testingbot-service/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/webdriverio/webdriverio/tree/main/packages/wdio-testingbot-service",
   "license": "MIT",
   "engines": {
-     "node": "^16.13 || >=18"
+    "node": "^16.13 || >=18"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-types/package.json
+++ b/packages/wdio-types/package.json
@@ -12,7 +12,7 @@
     "./package.json": "./package.json"
   },
   "engines": {
-     "node": "^16.13 || >=18"
+    "node": "^16.13 || >=18"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-utils/package.json
+++ b/packages/wdio-utils/package.json
@@ -10,7 +10,7 @@
   "types": "./build/index.d.ts",
   "typeScriptVersion": "3.8.3",
   "engines": {
-     "node": "^16.13 || >=18"
+    "node": "^16.13 || >=18"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-utils/tests/shim.test.ts
+++ b/packages/wdio-utils/tests/shim.test.ts
@@ -1,5 +1,5 @@
 import { vi, describe, it, expect } from 'vitest'
-import { wrapCommand, expectAsyncShim } from '../src/shim.js'
+import { wrapCommand } from '../src/shim.js'
 
 describe('wrapCommand', () => {
     it('should run command with before and after hook', async () => {
@@ -42,24 +42,4 @@ describe('wrapCommand', () => {
         expect(afterHook).toBeCalledTimes(3)
         expect(afterHook).toBeCalledWith('someCommand', [123, 'barfoo'], undefined, error)
     })
-})
-
-it('expectAsyncShim', () => {
-    global.expectAsync = vi.fn()
-    const expectSync = vi.fn()
-    expectAsyncShim(undefined, expectSync)
-    expect(expectSync).toBeCalledTimes(1)
-    expect(global.expectAsync).toBeCalledTimes(0)
-    expectAsyncShim(42, expectSync)
-    expect(expectSync).toBeCalledTimes(2)
-    expect(global.expectAsync).toBeCalledTimes(0)
-    expectAsyncShim(Promise.resolve({}), expectSync)
-    expect(expectSync).toBeCalledTimes(2)
-    expect(global.expectAsync).toBeCalledTimes(1)
-    expectAsyncShim({ elementId: 42 }, expectSync)
-    expect(expectSync).toBeCalledTimes(2)
-    expect(global.expectAsync).toBeCalledTimes(2)
-    expectAsyncShim({ sessionId: '42' }, expectSync)
-    expect(expectSync).toBeCalledTimes(2)
-    expect(global.expectAsync).toBeCalledTimes(3)
 })

--- a/packages/wdio-webdriver-mock-service/package.json
+++ b/packages/wdio-webdriver-mock-service/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/webdriverio/webdriverio/tree/main/packages/wdio-webdriver-mock-service",
   "license": "MIT",
   "engines": {
-     "node": "^16.13 || >=18"
+    "node": "^16.13 || >=18"
   },
   "repository": {
     "type": "git",

--- a/tests/jasmine/test-timeout.js
+++ b/tests/jasmine/test-timeout.js
@@ -11,8 +11,4 @@ describe('Jasmine timeout test', () => {
     it('should allow also async assertions afterwards', async () => {
         await expect(browser).toHaveTitle('Mock Page Title')
     })
-
-    it('should allow also sync assertions afterwards', () => {
-        expect(browser).toHaveTitle('Mock Page Title')
-    })
 })

--- a/tests/mocha/noGlobals.ts
+++ b/tests/mocha/noGlobals.ts
@@ -1,4 +1,4 @@
-import { browser, $, $$ } from '../../packages/wdio-globals/build/index.js'
+import { browser, $, $$, expect } from '../../packages/wdio-globals/build/index.js'
 
 describe('global usage', () => {
     it('has no globals registered', () => {

--- a/tests/mocha/test.ts
+++ b/tests/mocha/test.ts
@@ -10,11 +10,13 @@ describe('Mocha smoke test', () => {
         }
     })
 
-    it('has globals set up', () => {
+    it('has globals set up', async () => {
+        expect(1).toBe(1) // has non wdio matcher support
         expect(global.browser).toBeDefined()
         expect(global.driver).toBeDefined()
         expect(global.$).toBeDefined()
         expect(global.$$).toBeDefined()
+        expect(global.expect).toBeDefined()
     })
 
     it('should return sync value', async () => {

--- a/tests/smoke.runner.js
+++ b/tests/smoke.runner.js
@@ -154,7 +154,7 @@ const jasmineTimeout = async () => {
         'spec was not failing due to timeout error'
     )
     assert.ok(
-        specLogs.includes('Expected true to be false.'),
+        specLogs.includes('Error: expect(received).toBe(expected) // Object.is equality'),
         'spec was not failing a sync assertion error'
     )
     assert.ok(
@@ -164,10 +164,6 @@ const jasmineTimeout = async () => {
     assert.ok(
         specLogs.includes('✓ should allow also async assertions afterwards'),
         'spec should also allow async assertions afterwards'
-    )
-    assert.ok(
-        specLogs.includes('✓ should allow also sync assertions afterwards'),
-        'spec should also allow sync assertions afterwards'
     )
 }
 


### PR DESCRIPTION
I have updated `expect-webdriverio` to be ESM compatible. This patch moves the initiation into `@wdio/runner` and ensures that it is exported by `@wdio/globals`.