### PR TITLE
remove unnecessary await from example

### DIFF
--- a/packages/webdriverio/src/commands/browser/custom$.ts
+++ b/packages/webdriverio/src/commands/browser/custom$.ts
@@ -10,7 +10,7 @@ import type { CustomStrategyFunction } from '../../types'
     :example.js
     it('should fetch the project title', async () => {
         await browser.url('https://webdriver.io')
-        await browser.addLocatorStrategy('myStrat', (selector) => {
+        browser.addLocatorStrategy('myStrat', (selector) => {
             return document.querySelectorAll(selector)
         })
 


### PR DESCRIPTION
A minor fix for the docs - browser.addLocatorStrategy has a return type of `void` so it doesn't need to be awaited.