### PR TITLE
docs: change function based on explanation in previous paragraph

### DIFF
--- a/website/docs/SyncAsyncMigration.md
+++ b/website/docs/SyncAsyncMigration.md
@@ -64,7 +64,7 @@ The function we pass into `forEach` is an iterator function. In a synchronous wo
 
 ```js
 const elems = await $$('div')
-await elems.forEach((elem) => {
+await elems.map((elem) => {
     return elem.click()
 })
 ```


### PR DESCRIPTION
Previous paragraph says:

> Therefore we need to replace `forEach` with `map` which returns that promise