### PR TITLE
Fix missing capabilites in typescript definitions for windows application driver

### DIFF
--- a/packages/wdio-types/src/Capabilities.ts
+++ b/packages/wdio-types/src/Capabilities.ts
@@ -170,6 +170,10 @@ export interface VendorExtensions extends EdgeCapabilities, AppiumW3CCapabilitie
     'ms:edgeOptions'?: MicrosoftEdgeOptions;
     'ms:edgeChromium'?: MicrosoftEdgeOptions;
 
+    // Windows Application Driver
+    'ms:experimental-webdriver'?: boolean;
+    'ms:waitForAppLaunch'?: string;
+
     // Safari specific
     'safari.options'?: {
         [name: string]: any;
@@ -702,6 +706,10 @@ export interface AppiumXCUITestCapabilities {
     'appium:forceAppLaunch'?: boolean;
     'appium:useNativeCachingStrategy'?: boolean;
     'appium:appInstallStrategy'?: string;
+    /**
+     * Windows Application Driver capabilities
+     */
+    'appium:appArguments'?: string;
 }
 
 export interface AppiumXCUISafariGlobalPreferences {


### PR DESCRIPTION
## Proposed changes

This PR fixes some typescript errors in my config file when I define some specific capabilities for windows application .

My capabilites :
```
 {
    maxInstances: 7,
    platformName: 'WINDOWS',
    'appium:app': `C:\\Program Files\\Intescia\\DieManufacturing.${dieApplication}\\Fr.Intescia.DieManufacturing.Client.exe`,
    'appium:appArguments': '-noCloseConfirmationPopUp',
    'ms:experimental-webdriver': true,
    'ms:waitForAppLaunch': '10',
    browserName: `DieManufacturing.${dieApplication}`,
  },
```

This lines are in error:
```
    'appium:appArguments': '-noCloseConfirmationPopUp',
    'ms:experimental-webdriver': true,
    'ms:waitForAppLaunch': '10',
```

_Type '{ maxInstances: number; platformName: string; 'appium:app': string; 'appium:appArguments': string; 'ms:experimental-webdriver': true; 'ms:waitForAppLaunch': string; browserName: string; }' is not assignable to type 'W3CCapabilities | DesiredCapabilities'.
  Object literal may only specify known properties, and ''appium:appArguments'' does not exist in type 'W3CCapabilities | DesiredCapabilities'.ts(2322)_

The supported capabilites by windows application driver:
https://github.com/microsoft/WinAppDriver/blob/master/Docs/AuthoringTestScripts.md#supported-capabilities
https://github.com/microsoft/WinAppDriver/releases/tag/v1.2.1

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
