### PR TITLE
Throw error if select element/option is disabled 

### DIFF
--- a/packages/webdriverio/src/commands/element/selectByAttribute.ts
+++ b/packages/webdriverio/src/commands/element/selectByAttribute.ts
@@ -40,6 +40,14 @@ export default async function selectByAttribute (
     attribute: string,
     value: string | number
 ) {
+
+    /**
+     * Throw error if Select element is disabled
+     */
+    if (!(await this.isElementEnabled(this.elementId))) {
+        throw new Error(`Select element is disabled and may not be used.`)
+    }
+
     /**
      * convert value into string
      */
@@ -48,7 +56,7 @@ export default async function selectByAttribute (
         : value
 
     /**
-    * find option elememnt using xpath
+    * find option element using xpath
     */
     const normalized = `[normalize-space(@${attribute.trim()}) = "${value.trim()}"]`
     const optionElement = await this.findElementFromElement(
@@ -61,8 +69,17 @@ export default async function selectByAttribute (
         throw new Error(`Option with attribute "${attribute}=${value}" not found.`)
     }
 
+    const elementId = getElementFromResponse(optionElement) as string
+
+    /**
+     * Throw error if Select option is disabled
+     */
+    if (!(await this.isElementEnabled(elementId))) {
+        throw new Error(`Option with attribute "${attribute}=${value}" is disabled.`)
+    }
+
     /**
     * select option
     */
-    return this.elementClick(getElementFromResponse(optionElement) as string)
+    return this.elementClick(elementId)
 }

--- a/packages/webdriverio/src/commands/element/selectByAttribute.ts
+++ b/packages/webdriverio/src/commands/element/selectByAttribute.ts
@@ -45,7 +45,7 @@ export default async function selectByAttribute (
      * Throw error if Select element is disabled
      */
     if (!(await this.isElementEnabled(this.elementId))) {
-        throw new Error(`Select element is disabled and may not be used.`)
+        throw new Error('Select element is disabled and may not be used.')
     }
 
     /**

--- a/packages/webdriverio/src/commands/element/selectByIndex.ts
+++ b/packages/webdriverio/src/commands/element/selectByIndex.ts
@@ -38,7 +38,7 @@ export default async function selectByIndex (
      * Throw error if Select element is disabled
      */
     if (!(await this.isElementEnabled(this.elementId))) {
-        throw new Error(`Select element is disabled and may not be used.`)
+        throw new Error('Select element is disabled and may not be used.')
     }
 
     /**

--- a/packages/webdriverio/src/commands/element/selectByIndex.ts
+++ b/packages/webdriverio/src/commands/element/selectByIndex.ts
@@ -23,7 +23,7 @@ import { getElementFromResponse } from '../../utils/index.js'
     });
  * </example>
  *
- * @alias element.selectByIndexs
+ * @alias element.selectByIndex
  * @param {Number} index      option index
  * @uses protocol/findElementsFromElement, protocol/elementClick
  * @type action
@@ -33,6 +33,14 @@ export default async function selectByIndex (
     this: WebdriverIO.Element,
     index: number
 ) {
+
+    /**
+     * Throw error if Select element is disabled
+     */
+    if (!(await this.isElementEnabled(this.elementId))) {
+        throw new Error(`Select element is disabled and may not be used.`)
+    }
+
     /**
      * negative index check
      */
@@ -41,7 +49,7 @@ export default async function selectByIndex (
     }
 
     /**
-    * get option elememnts using css
+    * get option elements using css
     */
     const optionElements = await this.findElementsFromElement(this.elementId, 'css selector',  'option')
 
@@ -53,8 +61,17 @@ export default async function selectByIndex (
         throw new Error(`Option with index "${index}" not found. Select element only contains ${optionElements.length} option elements`)
     }
 
+    const elementId = getElementFromResponse(optionElements[index]) as string
+
+    /**
+     * Throw error if Select option is disabled
+     */
+    if (!(await this.isElementEnabled(elementId))) {
+        throw new Error(`Option with index "${index}" is disabled.`)
+    }
+
     /**
     * select option
     */
-    return this.elementClick(getElementFromResponse(optionElements[index]) as string)
+    return this.elementClick(elementId)
 }

--- a/packages/webdriverio/src/commands/element/selectByVisibleText.ts
+++ b/packages/webdriverio/src/commands/element/selectByVisibleText.ts
@@ -38,7 +38,7 @@ export default async function selectByVisibleText (
      * Throw error if Select element is disabled
      */
     if (!(await this.isElementEnabled(this.elementId))) {
-        throw new Error(`Select element is disabled and may not be used.`)
+        throw new Error('Select element is disabled and may not be used.')
     }
 
     /**

--- a/packages/webdriverio/src/commands/element/selectByVisibleText.ts
+++ b/packages/webdriverio/src/commands/element/selectByVisibleText.ts
@@ -33,6 +33,14 @@ export default async function selectByVisibleText (
     this: WebdriverIO.Element,
     text: string | number
 ) {
+
+    /**
+     * Throw error if Select element is disabled
+     */
+    if (!(await this.isElementEnabled(this.elementId))) {
+        throw new Error(`Select element is disabled and may not be used.`)
+    }
+
     /**
      * convert value into string
      */
@@ -64,6 +72,15 @@ export default async function selectByVisibleText (
 
     if (optionElement && (optionElement as any).error === 'no such element') {
         throw new Error(`Option with text "${text}" not found.`)
+    }
+
+    const elementId = getElementFromResponse(optionElement) as string
+
+    /**
+     * Throw error if Select option is disabled
+     */
+    if (!(await this.isElementEnabled(elementId))) {
+        throw new Error(`Option with text "${text}" is disabled.`)
     }
 
     /**

--- a/packages/webdriverio/tests/commands/element/selectByAttribute.test.ts
+++ b/packages/webdriverio/tests/commands/element/selectByAttribute.test.ts
@@ -36,10 +36,14 @@ describe('selectByAttribute test', () => {
         expect(got.mock.calls[1][0].pathname)
             .toBe('/session/foobar-123/element')
         expect(got.mock.calls[2][0].pathname)
-            .toBe('/session/foobar-123/element/some-elem-123/element')
-        expect(got.mock.calls[2][1].json.value)
-            .toBe('./option[normalize-space(@value) = "someValue1"]|./optgroup/option[normalize-space(@value) = "someValue1"]')
+            .toBe('/session/foobar-123/element/some-elem-123/enabled')
         expect(got.mock.calls[3][0].pathname)
+            .toBe('/session/foobar-123/element/some-elem-123/element')
+        expect(got.mock.calls[3][1].json.value)
+            .toBe('./option[normalize-space(@value) = "someValue1"]|./optgroup/option[normalize-space(@value) = "someValue1"]')
+        expect(got.mock.calls[4][0].pathname)
+            .toBe('/session/foobar-123/element/some-sub-elem-321/enabled')
+        expect(got.mock.calls[5][0].pathname)
             .toBe('/session/foobar-123/element/some-sub-elem-321/click')
         expect(getElementFromResponseSpy).toBeCalledWith({
             [ELEMENT_KEY]: 'some-sub-elem-321'
@@ -52,10 +56,14 @@ describe('selectByAttribute test', () => {
         expect(got.mock.calls[1][0].pathname)
             .toBe('/session/foobar-123/element')
         expect(got.mock.calls[2][0].pathname)
-            .toBe('/session/foobar-123/element/some-elem-123/element')
-        expect(got.mock.calls[2][1].json.value)
-            .toBe('./option[normalize-space(@value) = "123"]|./optgroup/option[normalize-space(@value) = "123"]')
+            .toBe('/session/foobar-123/element/some-elem-123/enabled')
         expect(got.mock.calls[3][0].pathname)
+            .toBe('/session/foobar-123/element/some-elem-123/element')
+        expect(got.mock.calls[3][1].json.value)
+            .toBe('./option[normalize-space(@value) = "123"]|./optgroup/option[normalize-space(@value) = "123"]')
+        expect(got.mock.calls[4][0].pathname)
+            .toBe('/session/foobar-123/element/some-sub-elem-321/enabled')
+        expect(got.mock.calls[5][0].pathname)
             .toBe('/session/foobar-123/element/some-sub-elem-321/click')
         expect(getElementFromResponseSpy).toBeCalledWith({
             [ELEMENT_KEY]: 'some-sub-elem-321'
@@ -71,6 +79,7 @@ describe('selectByAttribute test', () => {
             selector: 'foobar2',
             elementId: 'some-elem-123',
             'element-6066-11e4-a52e-4f735466cecf': 'some-elem-123',
+            isElementEnabled: vi.fn().mockReturnValue(Promise.resolve(true)),
             findElementFromElement: vi.fn().mockReturnValue(Promise.resolve({ error: 'no such element' }))
         }
         // @ts-ignore mock feature

--- a/packages/webdriverio/tests/commands/element/selectByIndex.test.ts
+++ b/packages/webdriverio/tests/commands/element/selectByIndex.test.ts
@@ -35,8 +35,12 @@ describe('selectByIndex test', () => {
         expect(got.mock.calls[1][0].pathname)
             .toBe('/session/foobar-123/element')
         expect(got.mock.calls[2][0].pathname)
-            .toBe('/session/foobar-123/element/some-elem-123/elements')
+            .toBe('/session/foobar-123/element/some-elem-123/enabled')
         expect(got.mock.calls[3][0].pathname)
+            .toBe('/session/foobar-123/element/some-elem-123/elements')
+        expect(got.mock.calls[4][0].pathname)
+            .toBe('/session/foobar-123/element/some-elem-456/enabled')
+        expect(got.mock.calls[5][0].pathname)
             .toBe('/session/foobar-123/element/some-elem-456/click')
         expect(getElementFromResponseSpy).toBeCalledWith({
             [ELEMENT_KEY]: 'some-elem-456',
@@ -62,7 +66,8 @@ describe('selectByIndex test', () => {
             selector: 'foobar2',
             elementId: 'some-elem-123',
             'element-6066-11e4-a52e-4f735466cecf': 'some-elem-123',
-            findElementsFromElement: vi.fn().mockReturnValue(Promise.resolve([]))
+            findElementsFromElement: vi.fn().mockReturnValue(Promise.resolve([])),
+            isElementEnabled: vi.fn().mockReturnValue(Promise.resolve(true))
         }
         // @ts-ignore mock feature
         mockElem.selectByIndex = elem.selectByIndex.bind(mockElem)
@@ -80,7 +85,8 @@ describe('selectByIndex test', () => {
         const mockElem = {
             options: {},
             selector: 'foobar',
-            findElementsFromElement: vi.fn().mockReturnValue(Promise.resolve([{ elem: 1 }]))
+            findElementsFromElement: vi.fn().mockReturnValue(Promise.resolve([{ elem: 1 }])),
+            isElementEnabled: vi.fn().mockReturnValue(Promise.resolve(true)),
         }
         // @ts-ignore mock feature
         mockElem.selectByIndex = elem.selectByIndex.bind(mockElem)

--- a/packages/webdriverio/tests/commands/element/selectByVisibleText.test.ts
+++ b/packages/webdriverio/tests/commands/element/selectByVisibleText.test.ts
@@ -38,10 +38,14 @@ describe('selectByVisibleText test', () => {
         expect(got.mock.calls[1][0].pathname)
             .toBe('/session/foobar-123/element')
         expect(got.mock.calls[2][0].pathname)
-            .toBe('/session/foobar-123/element/some-elem-123/element')
-        expect(got.mock.calls[2][1].json.value)
-            .toBe(`${optionSelection}|${optgroupSelection}`)
+            .toBe('/session/foobar-123/element/some-elem-123/enabled')
         expect(got.mock.calls[3][0].pathname)
+            .toBe('/session/foobar-123/element/some-elem-123/element')
+        expect(got.mock.calls[3][1].json.value)
+            .toBe(`${optionSelection}|${optgroupSelection}`)
+        expect(got.mock.calls[4][0].pathname)
+            .toBe('/session/foobar-123/element/some-sub-elem-321/enabled')
+        expect(got.mock.calls[5][0].pathname)
             .toBe('/session/foobar-123/element/some-sub-elem-321/click')
         expect(getElementFromResponseSpy).toBeCalledWith({
             [ELEMENT_KEY]: 'some-sub-elem-321'
@@ -56,10 +60,14 @@ describe('selectByVisibleText test', () => {
         expect(got.mock.calls[1][0].pathname)
             .toBe('/session/foobar-123/element')
         expect(got.mock.calls[2][0].pathname)
-            .toBe('/session/foobar-123/element/some-elem-123/element')
-        expect(got.mock.calls[2][1].json.value)
-            .toBe(`${optionSelection}|${optgroupSelection}`)
+            .toBe('/session/foobar-123/element/some-elem-123/enabled')
         expect(got.mock.calls[3][0].pathname)
+            .toBe('/session/foobar-123/element/some-elem-123/element')
+        expect(got.mock.calls[3][1].json.value)
+            .toBe(`${optionSelection}|${optgroupSelection}`)
+        expect(got.mock.calls[4][0].pathname)
+            .toBe('/session/foobar-123/element/some-sub-elem-321/enabled')
+        expect(got.mock.calls[5][0].pathname)
             .toBe('/session/foobar-123/element/some-sub-elem-321/click')
         expect(getElementFromResponseSpy).toBeCalledWith({
             [ELEMENT_KEY]: 'some-sub-elem-321'
@@ -74,10 +82,14 @@ describe('selectByVisibleText test', () => {
         expect(got.mock.calls[1][0].pathname)
             .toBe('/session/foobar-123/element')
         expect(got.mock.calls[2][0].pathname)
-            .toBe('/session/foobar-123/element/some-elem-123/element')
-        expect(got.mock.calls[2][1].json.value)
-            .toBe(`${optionSelection}|${optgroupSelection}`)
+            .toBe('/session/foobar-123/element/some-elem-123/enabled')
         expect(got.mock.calls[3][0].pathname)
+            .toBe('/session/foobar-123/element/some-elem-123/element')
+        expect(got.mock.calls[3][1].json.value)
+            .toBe(`${optionSelection}|${optgroupSelection}`)
+        expect(got.mock.calls[4][0].pathname)
+            .toBe('/session/foobar-123/element/some-sub-elem-321/enabled')
+        expect(got.mock.calls[5][0].pathname)
             .toBe('/session/foobar-123/element/some-sub-elem-321/click')
         expect(getElementFromResponseSpy).toBeCalledWith({
             [ELEMENT_KEY]: 'some-sub-elem-321'
@@ -92,10 +104,14 @@ describe('selectByVisibleText test', () => {
         expect(got.mock.calls[1][0].pathname)
             .toBe('/session/foobar-123/element')
         expect(got.mock.calls[2][0].pathname)
-            .toBe('/session/foobar-123/element/some-elem-123/element')
-        expect(got.mock.calls[2][1].json.value)
-            .toBe(`${optionSelection}|${optgroupSelection}`)
+            .toBe('/session/foobar-123/element/some-elem-123/enabled')
         expect(got.mock.calls[3][0].pathname)
+            .toBe('/session/foobar-123/element/some-elem-123/element')
+        expect(got.mock.calls[3][1].json.value)
+            .toBe(`${optionSelection}|${optgroupSelection}`)
+        expect(got.mock.calls[4][0].pathname)
+            .toBe('/session/foobar-123/element/some-sub-elem-321/enabled')
+        expect(got.mock.calls[5][0].pathname)
             .toBe('/session/foobar-123/element/some-sub-elem-321/click')
         expect(getElementFromResponseSpy).toBeCalledWith({
             [ELEMENT_KEY]: 'some-sub-elem-321'
@@ -110,10 +126,14 @@ describe('selectByVisibleText test', () => {
         expect(got.mock.calls[1][0].pathname)
             .toBe('/session/foobar-123/element')
         expect(got.mock.calls[2][0].pathname)
-            .toBe('/session/foobar-123/element/some-elem-123/element')
-        expect(got.mock.calls[2][1].json.value)
-            .toBe(`${optionSelection}|${optgroupSelection}`)
+            .toBe('/session/foobar-123/element/some-elem-123/enabled')
         expect(got.mock.calls[3][0].pathname)
+            .toBe('/session/foobar-123/element/some-elem-123/element')
+        expect(got.mock.calls[3][1].json.value)
+            .toBe(`${optionSelection}|${optgroupSelection}`)
+        expect(got.mock.calls[4][0].pathname)
+            .toBe('/session/foobar-123/element/some-sub-elem-321/enabled')
+        expect(got.mock.calls[5][0].pathname)
             .toBe('/session/foobar-123/element/some-sub-elem-321/click')
         expect(getElementFromResponseSpy).toBeCalledWith({
             [ELEMENT_KEY]: 'some-sub-elem-321'
@@ -128,10 +148,14 @@ describe('selectByVisibleText test', () => {
         expect(got.mock.calls[1][0].pathname)
             .toBe('/session/foobar-123/element')
         expect(got.mock.calls[2][0].pathname)
-            .toBe('/session/foobar-123/element/some-elem-123/element')
-        expect(got.mock.calls[2][1].json.value)
-            .toBe(`${optionSelection}|${optgroupSelection}`)
+            .toBe('/session/foobar-123/element/some-elem-123/enabled')
         expect(got.mock.calls[3][0].pathname)
+            .toBe('/session/foobar-123/element/some-elem-123/element')
+        expect(got.mock.calls[3][1].json.value)
+            .toBe(`${optionSelection}|${optgroupSelection}`)
+        expect(got.mock.calls[4][0].pathname)
+            .toBe('/session/foobar-123/element/some-sub-elem-321/enabled')
+        expect(got.mock.calls[5][0].pathname)
             .toBe('/session/foobar-123/element/some-sub-elem-321/click')
         expect(getElementFromResponseSpy).toBeCalledWith({
             [ELEMENT_KEY]: 'some-sub-elem-321'
@@ -147,7 +171,8 @@ describe('selectByVisibleText test', () => {
             selector: 'foobar2',
             elementId: 'some-elem-123',
             'element-6066-11e4-a52e-4f735466cecf': 'some-elem-123',
-            findElementFromElement: vi.fn().mockReturnValue(Promise.resolve({ error: 'no such element' }))
+            findElementFromElement: vi.fn().mockReturnValue(Promise.resolve({ error: 'no such element' })),
+            isElementEnabled: vi.fn().mockReturnValue(Promise.resolve(true)),
         }
         // @ts-ignore mock feature
         mockElem.selectByVisibleText = elem.selectByVisibleText.bind(mockElem)


### PR DESCRIPTION
## Proposed changes

* Currently WDIo select, selects the option even if the Select tag/ option is disabled for selection. We need to throw an error is Select tag/option is disabled for selection

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
