### PR TITLE
[Browserstack-service] Local App file upload to browserstack for Appium sessions

### DIFF
--- a/packages/wdio-browserstack-service/README.md
+++ b/packages/wdio-browserstack-service/README.md
@@ -58,6 +58,7 @@ Type: `Boolean`<br />
 Default: `false`
 
 ### app
+
 [Appium](https://appium.io/) set this with app file path available locally on your machine to use the app as [application under test](https://www.browserstack.com/docs/app-automate/appium/set-up-tests/specify-app) for Appium sessions.
 
 Type: `String` or `JsonObject`<br />

--- a/packages/wdio-browserstack-service/README.md
+++ b/packages/wdio-browserstack-service/README.md
@@ -57,6 +57,92 @@ Set this to true to kill the browserstack process on complete, without waiting f
 Type: `Boolean`<br />
 Default: `false`
 
+### app
+[Appium] set this with app file path available locally on your machine to use the app as application under test for appium sessions.
+[specify-application-under-test](https://www.browserstack.com/docs/app-automate/appium/set-up-tests/specify-app)
+
+Type: `String` or `JsonObject`<br />
+Default: `undefined`
+
+List of available app values:
+
+#### path
+
+Use local available app file path as application under test for appium.
+
+```js
+services: [
+  ['browserstack', {
+    app: '/path/to/local/app.apk'
+    // OR
+    app: {
+      path: '/path/to/local/app.apk'
+    }
+  }]
+]
+```
+
+Pass custom_id while app upload.
+
+```js
+services: [
+  ['browserstack', {
+    app: {
+      path: '/path/to/local/app.apk',
+      custom_id: 'custom_id'
+    }
+  }]
+]
+```
+
+#### id
+
+Use app url returned after uploading app to BrowserStack.
+
+```js
+services: [
+  ['browserstack', {
+    app: 'bs://<app-id>'
+    // OR
+    app: {
+      id: 'bs://<app-id>'
+    }
+  }]
+]
+```
+
+#### custom_id
+
+use custom_id of already uploaded apps
+
+```js
+services: [
+  ['browserstack', {
+    app: 'custom_id'
+    // OR
+    app: {
+      custom_id: 'custom_id'
+    }
+  }]
+]
+```
+
+#### shareable_id
+
+use shareable_id of already uploaded apps
+
+```js
+services: [
+  ['browserstack', {
+    app: 'username/custom_id'
+    // OR
+    app: {
+      shareable_id: 'username/custom_id'
+    }
+  }]
+]
+```
+
 ### opts
 Specified optional will be passed down to BrowserstackLocal.
 

--- a/packages/wdio-browserstack-service/README.md
+++ b/packages/wdio-browserstack-service/README.md
@@ -58,8 +58,7 @@ Type: `Boolean`<br />
 Default: `false`
 
 ### app
-[Appium] set this with app file path available locally on your machine to use the app as application under test for appium sessions.
-[specify-application-under-test](https://www.browserstack.com/docs/app-automate/appium/set-up-tests/specify-app)
+[Appium](https://appium.io/) set this with app file path available locally on your machine to use the app as [application under test](https://www.browserstack.com/docs/app-automate/appium/set-up-tests/specify-app) for Appium sessions.
 
 Type: `String` or `JsonObject`<br />
 Default: `undefined`

--- a/packages/wdio-browserstack-service/package.json
+++ b/packages/wdio-browserstack-service/package.json
@@ -36,8 +36,7 @@
     "webdriverio": "7.20.7"
   },
   "peerDependencies": {
-    "@wdio/cli": "^5.0.0 || ^6.0.0 || ^7.0.0",
-    "webdriverio": "7.20.7"
+    "@wdio/cli": "^5.0.0 || ^6.0.0 || ^7.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/wdio-browserstack-service/package.json
+++ b/packages/wdio-browserstack-service/package.json
@@ -32,6 +32,7 @@
     "@wdio/types": "7.20.7",
     "browserstack-local": "^1.5.1",
     "got": "^12.1.0",
+    "form-data": "^4.0.0",
     "webdriverio": "7.20.7"
   },
   "peerDependencies": {

--- a/packages/wdio-browserstack-service/package.json
+++ b/packages/wdio-browserstack-service/package.json
@@ -36,7 +36,8 @@
     "webdriverio": "7.20.7"
   },
   "peerDependencies": {
-    "@wdio/cli": "^5.0.0 || ^6.0.0 || ^7.0.0"
+    "@wdio/cli": "^5.0.0 || ^6.0.0 || ^7.0.0",
+    "webdriverio": "7.20.7"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/wdio-browserstack-service/src/constants.ts
+++ b/packages/wdio-browserstack-service/src/constants.ts
@@ -8,3 +8,9 @@ export const BROWSER_DESCRIPTION = [
     'browserVersion',
     'browser_version'
 ] as const
+
+export const VALID_APP_EXTENSION = [
+    '.apk',
+    '.aab',
+    '.ipa'
+]

--- a/packages/wdio-browserstack-service/src/launcher.ts
+++ b/packages/wdio-browserstack-service/src/launcher.ts
@@ -1,20 +1,19 @@
+import got from 'got'
+import FormData from 'form-data'
+import fs from 'node:fs'
+import path from 'node:path'
 import { createRequire } from 'node:module'
 import { promisify } from 'node:util'
 import { performance, PerformanceObserver } from 'node:perf_hooks'
 import { SevereServiceError } from 'webdriverio'
-import { VALID_APP_EXTENSION } from './constants.js'
 
 import * as BrowserstackLocalLauncher from 'browserstack-local'
 
 import logger from '@wdio/logger'
 import type { Capabilities, Services, Options } from '@wdio/types'
 
-import got, { Response } from 'got'
-import FormData from 'form-data'
-import fs from 'node:fs'
-import * as path from 'node:path'
-
 import type { BrowserstackConfig, App, AppConfig, AppUploadResponse } from './types'
+import { VALID_APP_EXTENSION } from './constants.js'
 
 const require = createRequire(import.meta.url)
 const { version: bstackServiceVersion } = require('../package.json')
@@ -85,17 +84,13 @@ export default class BrowserstackLauncherService implements Services.ServiceInst
             if (VALID_APP_EXTENSION.includes(path.extname(app.app!))){
                 if (fs.existsSync(app.app!)) {
                     let data: AppUploadResponse
-                    try {
-                        data = await this._uploadApp(app)
-                    } catch (error: any) {
-                        throw new SevereServiceError(error)
-                    }
+                    data = await this._uploadApp(app)
                     log.info(`app upload completed: ${JSON.stringify(data)}`)
                     app.app = data.app_url
                 } else if (app.customId){
                     app.app = app.customId
                 } else {
-                    throw new SevereServiceError('Invalid file path...')
+                    throw new SevereServiceError(`[Invalid app path] app path ${app.app} is not correct, Provide correct path to app under test`)
                 }
             }
 
@@ -192,7 +187,9 @@ export default class BrowserstackLauncherService implements Services.ServiceInst
             body: form,
             username : this._config.user,
             password : this._config.key
-        }).json().catch((err) => { this._uploadErrHandler(err) })
+        }).json().catch((err) => {
+            throw new SevereServiceError(`app upload failed ${(err as Error).message}`)
+        })
 
         return res as AppUploadResponse
     }
@@ -208,26 +205,22 @@ export default class BrowserstackLauncherService implements Services.ServiceInst
             app.app = appConfig
         } else if (typeof appConfig === 'object' && Object.keys(appConfig).length) {
             if (Object.keys(appConfig).length > 2 || (Object.keys(appConfig).length === 2 && (!appConfig.path || !appConfig.custom_id))) {
-                throw new Error(`keys ${Object.keys(appConfig)} can't co-exist as app values, use any one property from
+                throw new SevereServiceError(`keys ${Object.keys(appConfig)} can't co-exist as app values, use any one property from
                             {id<string>, path<string>, custom_id<string>, shareable_id<string>}, only "path" and "custom_id" can co-exist.`)
             }
 
             app.app = appConfig.id || appConfig.path || appConfig.custom_id || appConfig.shareable_id
             app.customId = appConfig.custom_id
         } else {
-            throw new Error('[Invalid format] app should be string or an object')
+            throw new SevereServiceError('[Invalid format] app should be string or an object')
         }
 
         if (!app.app) {
-            throw new Error(`[Invalid app property] supported properties are {id<string>, path<string>, custom_id<string>, shareable_id<string>}.
+            throw new SevereServiceError(`[Invalid app property] supported properties are {id<string>, path<string>, custom_id<string>, shareable_id<string>}.
                         For more details please visit https://www.browserstack.com/docs/app-automate/appium/set-up-tests/specify-app ')`)
         }
 
         return app
-    }
-
-    _uploadErrHandler(err: Response<Error>) {
-        throw new Error(`app upload failed, ${err}`)
     }
 
     _updateCaps(capabilities?: Capabilities.RemoteCapabilities, capType?: string, value?:string) {

--- a/packages/wdio-browserstack-service/src/launcher.ts
+++ b/packages/wdio-browserstack-service/src/launcher.ts
@@ -7,7 +7,12 @@ import * as BrowserstackLocalLauncher from 'browserstack-local'
 import logger from '@wdio/logger'
 import type { Capabilities, Services, Options } from '@wdio/types'
 
-import type { BrowserstackConfig } from './types'
+import got, { Response } from 'got'
+import FormData from 'form-data'
+import fs from 'node:fs'
+import * as path from 'node:path'
+
+import type { BrowserstackConfig, App, AppConfig, AppUploadResponse } from './types'
 
 const require = createRequire(import.meta.url)
 const { version: bstackServiceVersion } = require('../package.json')
@@ -58,7 +63,47 @@ export default class BrowserstackLauncherService implements Services.ServiceInst
         }
     }
 
-    onPrepare (config?: Options.Testrunner, capabilities?: Capabilities.RemoteCapabilities) {
+    async onPrepare (config?: Options.Testrunner, capabilities?: Capabilities.RemoteCapabilities) {
+        /**
+         * Upload app to BrowserStack if valid file path to app is given.
+         * Update app value of capability directly if app_url, custom_id, shareable_id is given
+         */
+        if (!this._options.app) {
+            log.info('app is not defined in browserstack-service config, skipping ...')
+        } else {
+            let app: App = {}
+            let appConfig: AppConfig | string = this._options.app
+
+            try {
+                app = await this._validateApp(appConfig)
+            } catch (error: unknown){
+                log.error(error)
+                return process.emit('SIGTERM')
+            }
+
+            if (['.apk', '.aab', '.ipa'].includes(path.extname(app.app!))){
+                if (fs.existsSync(app.app!)) {
+                    let data: AppUploadResponse
+                    try {
+                        data = await this._uploadApp(app)
+                    } catch (error: unknown) {
+                        log.error(error)
+                        return process.emit('SIGTERM')
+                    }
+                    log.info(`app upload completed: ${JSON.stringify(data)}`)
+                    app.app = data.app_url
+                } else if (app.customId){
+                    app.app = app.customId
+                } else {
+                    log.error('Invalid file path...')
+                    return process.emit('SIGTERM')
+                }
+            }
+
+            log.info(`Using app: ${app.app}`)
+            this._updateCaps(capabilities, 'app', app.app)
+        }
+
         if (!this._options.browserstackLocal) {
             return log.info('browserstackLocal is not enabled - skipping...')
         }
@@ -69,39 +114,10 @@ export default class BrowserstackLauncherService implements Services.ServiceInst
         }
 
         this.browserstackLocal = new BrowserstackLocalLauncher.Local()
-
-        if (Array.isArray(capabilities)) {
-            capabilities.forEach((capability: Capabilities.DesiredCapabilities) => {
-                if (!capability['bstack:options']) {
-                    const extensionCaps = Object.keys(capability).filter((cap) => cap.includes(':'))
-                    if (extensionCaps.length) {
-                        capability['bstack:options'] = { local: true }
-                    } else {
-                        capability['browserstack.local'] = true
-                    }
-                } else {
-                    capability['bstack:options'].local = true
-                }
-            })
-        } else if (typeof capabilities === 'object') {
-            Object.entries(capabilities as Capabilities.MultiRemoteCapabilities).forEach(([, caps]) => {
-                if (!(caps.capabilities as Capabilities.Capabilities)['bstack:options']) {
-                    const extensionCaps = Object.keys(caps.capabilities).filter((cap) => cap.includes(':'))
-                    if (extensionCaps.length) {
-                        (caps.capabilities as Capabilities.Capabilities)['bstack:options'] = { local: true }
-                    } else {
-                        (caps.capabilities as Capabilities.Capabilities)['browserstack.local'] = true
-                    }
-                } else {
-                    (caps.capabilities as Capabilities.Capabilities)['bstack:options']!.local = true
-                }
-            })
-        } else {
-            throw TypeError('Capabilities should be an object or Array!')
-        }
+        this._updateCaps(capabilities, 'local')
 
         /**
-         * measure TestingBot tunnel boot time
+         * measure BrowserStack tunnel boot time
          */
         const obs = new PerformanceObserver((list) => {
             const entry = list.getEntries()[0]
@@ -164,5 +180,104 @@ export default class BrowserstackLauncherService implements Services.ServiceInst
             clearTimeout(timer)
             return Promise.reject(err)
         })
+    }
+
+    async _uploadApp(app:App): Promise<AppUploadResponse> {
+        log.info(`uploading app ${app.app} ${app.customId? `and custom_id: ${app.customId}` : ''} to browserstack`)
+
+        const form = new FormData()
+        if (app.app) form.append('file', fs.createReadStream(app.app))
+        if (app.customId) form.append('custom_id', app.customId)
+
+        const res = await got.post('https://api-cloud.browserstack.com/app-automate/upload', {
+            body: form,
+            username : this._config.user,
+            password : this._config.key
+        }).json().catch((err) => { this._uploadErrHandler(err) })
+
+        return res as AppUploadResponse
+    }
+
+    /**
+     * @param  {String | AppConfig}  appConfig    <string>: should be "app file path" or "app_url" or "custom_id" or "shareable_id".
+     *                                            <object>: only "path" and "custom_id" should coexist as multiple properties.
+     */
+    _validateApp (appConfig: AppConfig | string): Promise<App> {
+        return new Promise((resolve, reject) => {
+            let app: App = {}
+
+            if (typeof appConfig === 'string'){
+                app.app = appConfig
+            } else if (typeof appConfig === 'object' && Object.keys(appConfig).length) {
+                if (Object.keys(appConfig).length > 2 || (Object.keys(appConfig).length === 2 && (!appConfig.path || !appConfig.custom_id))) {
+                    return reject(`keys ${Object.keys(appConfig)} can't co-exist as app values, use any one property from
+                                {id<string>, path<string>, custom_id<string>, shareable_id<string>}, only "path" and "custom_id" can co-exist.`)
+                }
+
+                app.app = appConfig.id || appConfig.path || appConfig.custom_id || appConfig.shareable_id
+                app.customId = appConfig.custom_id
+            } else {
+                return reject('[Invalid format] app should be string or an object')
+            }
+
+            if (!app.app) {
+                return reject(`[Invalid app property] supported properties are {id<string>, path<string>, custom_id<string>, shareable_id<string>}.
+                            For more details please visit https://www.browserstack.com/docs/app-automate/appium/set-up-tests/specify-app ')`)
+            }
+
+            resolve(app)
+        })
+    }
+
+    _uploadErrHandler(err: Response<Error>) {
+        throw new Error(`app upload failed, ${err}`)
+    }
+
+    _updateCaps(capabilities?: Capabilities.RemoteCapabilities, capType?: string, value?:string) {
+        if (Array.isArray(capabilities)) {
+            capabilities.forEach((capability: Capabilities.DesiredCapabilities) => {
+                if (!capability['bstack:options']) {
+                    const extensionCaps = Object.keys(capability).filter((cap) => cap.includes(':'))
+                    if (extensionCaps.length) {
+                        if (capType === 'local') {
+                            capability['bstack:options'] = { local: true }
+                        } else if (capType === 'app') {
+                            capability['appium:app'] = value
+                        }
+                    } else if (capType === 'local'){
+                        capability['browserstack.local'] = true
+                    } else if (capType === 'app') {
+                        capability['app'] = value
+                    }
+                } else if (capType === 'local') {
+                    capability['bstack:options'].local = true
+                } else if (capType === 'app') {
+                    capability['appium:app'] = value
+                }
+            })
+        } else if (typeof capabilities === 'object') {
+            Object.entries(capabilities as Capabilities.MultiRemoteCapabilities).forEach(([, caps]) => {
+                if (!(caps.capabilities as Capabilities.Capabilities)['bstack:options']) {
+                    const extensionCaps = Object.keys(caps.capabilities).filter((cap) => cap.includes(':'))
+                    if (extensionCaps.length) {
+                        if (capType === 'local') {
+                            (caps.capabilities as Capabilities.Capabilities)['bstack:options'] = { local: true }
+                        } else if (capType === 'app') {
+                            (caps.capabilities as Capabilities.Capabilities)['appium:app'] = value
+                        }
+                    } else if (capType === 'local'){
+                        (caps.capabilities as Capabilities.Capabilities)['browserstack.local'] = true
+                    } else if (capType === 'app') {
+                        (caps.capabilities as Capabilities.AppiumCapabilities)['app'] = value
+                    }
+                } else if (capType === 'local'){
+                    (caps.capabilities as Capabilities.Capabilities)['bstack:options']!.local = true
+                } else if (capType === 'app') {
+                    (caps.capabilities as Capabilities.Capabilities)['appium:app'] = value
+                }
+            })
+        } else {
+            throw TypeError('Capabilities should be an object or Array!')
+        }
     }
 }

--- a/packages/wdio-browserstack-service/src/types.ts
+++ b/packages/wdio-browserstack-service/src/types.ts
@@ -8,12 +8,36 @@ export interface SessionResponse {
 
 export type MultiRemoteAction = (sessionId: string, browserName?: string) => Promise<any>;
 
+export type AppConfig = {
+    id?: string,
+    path?: string,
+    custom_id?: string,
+    shareable_id?: string
+}
+
+export interface AppUploadResponse {
+    app_url?: string,
+    custom_id?: string,
+    shareable_id?: string
+}
+
+export interface App {
+    app?: string,
+    customId?: string
+}
+
 export interface BrowserstackConfig {
     /**
      * Set this to true to enable routing connections from Browserstack cloud through your computer.
      * You will also need to set `browserstack.local` to true in browser capabilities.
      */
     browserstackLocal?: boolean;
+    /**
+     * Set this with app file path present locally on your device or
+     * app hashed id returned after uploading app to Browserstack or
+     * custom_id, sharable_id of the uploaded app
+     */
+    app?: string | AppConfig;
     /**
      * Cucumber only. Set this to true to enable updating the session name to the Scenario name if only
      * a single Scenario was ran. Useful when running in parallel

--- a/packages/wdio-browserstack-service/tests/launcher.test.ts
+++ b/packages/wdio-browserstack-service/tests/launcher.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it, vi, beforeEach } from 'vitest'
 // @ts-expect-error mock feature
 import Browserstack, { mockStart } from 'browserstack-local'
 import logger from '@wdio/logger'
+import got from 'got'
+import fs from 'node:fs'
 
 import BrowserstackLauncher from '../src/launcher.js'
 import type { BrowserstackConfig } from '../src/types'
@@ -29,6 +31,13 @@ describe('onPrepare', () => {
     }
     const logInfoSpy = vi.spyOn(log, 'info').mockImplementation((string) => string)
 
+    it('should not try to upload app is app is undefined', () => {
+        const service = new BrowserstackLauncher({} as any, caps, config)
+        service.onPrepare()
+
+        expect(logInfoSpy).toHaveBeenCalledWith('app is not defined in browserstack-service config, skipping ...')
+    })
+
     it('should not call local if browserstackLocal is undefined', () => {
         const service = new BrowserstackLauncher({} as any, caps, {
             user: 'foobaruser',
@@ -53,6 +62,143 @@ describe('onPrepare', () => {
 
         expect(logInfoSpy).toHaveBeenCalledWith('browserstackLocal is not enabled - skipping...')
         expect(service.browserstackLocal).toBeUndefined()
+    })
+
+    it('should add the "app" property to a multiremote capability if no "bstack:options"', async () => {
+        const options: BrowserstackConfig = { app: 'bs://<app-id>' }
+        const service = new BrowserstackLauncher(options as any, caps, config)
+        const capabilities = { samsungGalaxy: { capabilities: {} } }
+
+        await service.onPrepare(config, capabilities)
+        expect(capabilities.samsungGalaxy.capabilities).toEqual({ 'app': 'bs://<app-id>' })
+    })
+
+    it('should add the "appium:app" property to a multiremote capability if "bstack:options" present', async () => {
+        const options: BrowserstackConfig = { app: 'bs://<app-id>' }
+        const service = new BrowserstackLauncher(options as any, caps, config)
+        const capabilities = { samsungGalaxy: { capabilities: { 'bstack:options': {} } } }
+
+        await service.onPrepare(config, capabilities)
+        expect(capabilities.samsungGalaxy.capabilities).toEqual({ 'bstack:options': {}, 'appium:app': 'bs://<app-id>' })
+    })
+
+    it('should add the "appium:app" property to a multiremote capability if any extension cap present', async () => {
+        const options: BrowserstackConfig = { app: 'bs://<app-id>' }
+        const service = new BrowserstackLauncher(options as any, caps, config)
+        const capabilities = { samsungGalaxy: { capabilities: { 'appium:chromeOptions': {} } } }
+
+        await service.onPrepare(config, capabilities as any)
+        expect(capabilities.samsungGalaxy.capabilities).toEqual({ 'appium:app': 'bs://<app-id>', 'appium:chromeOptions': {} })
+    })
+
+    it('should add the "app" property to an array of capabilities if no "bstack:options"', async () => {
+        const options: BrowserstackConfig = { app: 'bs://<app-id>' }
+        const service = new BrowserstackLauncher(options as any, caps, config)
+        const capabilities = [{}, {}, {}]
+
+        await service.onPrepare(config, capabilities)
+        expect(capabilities).toEqual([
+            { 'app': 'bs://<app-id>' },
+            { 'app': 'bs://<app-id>' },
+            { 'app': 'bs://<app-id>' }
+        ])
+    })
+
+    it('should add the "appium:app" property to an array of capabilities if "bstack:options" present', async () => {
+        const options: BrowserstackConfig = { app: 'bs://<app-id>' }
+        const service = new BrowserstackLauncher(options as any, caps, config)
+        const capabilities = [{ 'bstack:options': {} }, { 'bstack:options': {} }, { 'bstack:options': {} }]
+
+        await service.onPrepare(config, capabilities)
+        expect(capabilities).toEqual([
+            { 'bstack:options': {}, 'appium:app': 'bs://<app-id>' },
+            { 'bstack:options': {}, 'appium:app': 'bs://<app-id>' },
+            { 'bstack:options': {}, 'appium:app': 'bs://<app-id>' }
+        ])
+    })
+
+    it('should add the "appium:app" property to an array of capabilities if any extension cap present', async () => {
+        const options: BrowserstackConfig = { app: 'bs://<app-id>' }
+        const service = new BrowserstackLauncher(options as any, caps, config)
+        const capabilities = [{ 'appium:chromeOptions': {} }, { 'appium:chromeOptions': {} }]
+
+        await service.onPrepare(config, capabilities as any)
+        expect(capabilities).toEqual([
+            { 'appium:app': 'bs://<app-id>', 'appium:chromeOptions': {} },
+            { 'appium:app': 'bs://<app-id>', 'appium:chromeOptions': {} }
+        ])
+    })
+
+    it('should add the "appium:app" as custom_id of app to capability object', async () => {
+        const options: BrowserstackConfig = { app: 'custom_id' }
+        const service = new BrowserstackLauncher(options as any, caps, config)
+        const capabilities = [{ 'appium:chromeOptions': {} }, { 'appium:chromeOptions': {} }]
+
+        await service.onPrepare(config, capabilities as any)
+        expect(capabilities).toEqual([
+            { 'appium:app': 'custom_id', 'appium:chromeOptions': {} },
+            { 'appium:app': 'custom_id', 'appium:chromeOptions': {} }
+        ])
+    })
+
+    it('should add the "appium:app" as shareable_id of app to capability object', async () => {
+        const options: BrowserstackConfig = { app: 'user/custom_id' }
+        const service = new BrowserstackLauncher(options as any, caps, config)
+        const capabilities = [{ 'appium:chromeOptions': {} }, { 'appium:chromeOptions': {} }]
+
+        await service.onPrepare(config, capabilities as any)
+        expect(capabilities).toEqual([
+            { 'appium:app': 'user/custom_id', 'appium:chromeOptions': {} },
+            { 'appium:app': 'user/custom_id', 'appium:chromeOptions': {} }
+        ])
+    })
+
+    it('should add "appium:app" property with value returned from app upload to capabilities', async () => {
+        const options: BrowserstackConfig = { app: '/some/dummy/file.apk' }
+        const service = new BrowserstackLauncher(options as any, caps, config)
+        const capabilities = [{ 'bstack:options': {} }, { 'bstack:options': {} }, { 'bstack:options': {} }]
+
+        vi.spyOn(fs, 'existsSync').mockReturnValueOnce(true)
+        vi.spyOn(service, '_uploadApp').mockImplementation(() => Promise.resolve({ app_url: 'bs://<app-id>' }))
+
+        await service.onPrepare(config, capabilities)
+        expect(capabilities).toEqual([
+            { 'bstack:options': {}, 'appium:app': 'bs://<app-id>' },
+            { 'bstack:options': {}, 'appium:app': 'bs://<app-id>' },
+            { 'bstack:options': {}, 'appium:app': 'bs://<app-id>' }
+        ])
+    })
+
+    it('should upload app if path property present in appConfig', async() => {
+        const options: BrowserstackConfig = { app: { path: '/path/to/app.apk' } }
+        const service = new BrowserstackLauncher(options as any, caps, config)
+        const capabilities = [{ 'bstack:options': {} }, { 'bstack:options': {} }, { 'bstack:options': {} }]
+
+        vi.spyOn(fs, 'existsSync').mockReturnValueOnce(true)
+        vi.spyOn(service, '_uploadApp').mockImplementation(() => Promise.resolve({ app_url: 'bs://<app-id>' }))
+
+        await service.onPrepare(config, capabilities)
+        expect(capabilities).toEqual([
+            { 'bstack:options': {}, 'appium:app': 'bs://<app-id>' },
+            { 'bstack:options': {}, 'appium:app': 'bs://<app-id>' },
+            { 'bstack:options': {}, 'appium:app': 'bs://<app-id>' }
+        ])
+    })
+
+    it('should upload app along with custom_id if path and custom_id property present in appConfig', async() => {
+        const options: BrowserstackConfig = { app: { path: '/path/to/app.apk', custom_id: 'custom_id' } }
+        const service = new BrowserstackLauncher(options as any, caps, config)
+        const capabilities = [{ 'bstack:options': {} }, { 'bstack:options': {} }, { 'bstack:options': {} }]
+
+        vi.spyOn(fs, 'existsSync').mockReturnValueOnce(true)
+        vi.spyOn(service, '_uploadApp').mockImplementation(() => Promise.resolve({ app_url: 'bs://<app-id>', custom_id: 'custom_id', shareable_id: 'foobaruser/custom_id' }))
+
+        await service.onPrepare(config, capabilities)
+        expect(capabilities).toEqual([
+            { 'bstack:options': {}, 'appium:app': 'bs://<app-id>' },
+            { 'bstack:options': {}, 'appium:app': 'bs://<app-id>' },
+            { 'bstack:options': {}, 'appium:app': 'bs://<app-id>' }
+        ])
     })
 
     it('should initialize the opts object, and spawn a new Local instance', async () => {
@@ -121,14 +267,6 @@ describe('onPrepare', () => {
         ])
     })
 
-    it('should throw an error if "capabilities" is not an object/array', () => {
-        const service = new BrowserstackLauncher(options as any, caps, config)
-        const capabilities = 1
-
-        expect(() => service.onPrepare(config, capabilities as any))
-            .toThrow(TypeError('Capabilities should be an object or Array!'))
-    })
-
     it('should reject if local.start throws an error', () => {
         const service = new BrowserstackLauncher(options as any, caps, config)
         mockStart.mockImplementationOnce((_: never, cb: Function) => cb(error))
@@ -144,7 +282,7 @@ describe('onPrepare', () => {
         await service.onPrepare(config, caps)
         expect(service.browserstackLocal?.start).toHaveBeenCalled()
         await sleep(100)
-        expect(logInfoMock.mock.calls[0][0])
+        expect(logInfoMock.mock.calls[1][0])
             .toContain('Browserstack Local successfully started after')
     })
 
@@ -230,5 +368,85 @@ describe('constructor', () => {
             { 'bstack:options': { wdioService: bstackServiceVersion }, 'moz:firefoxOptions': {} },
             { 'bstack:options': { wdioService: bstackServiceVersion }, 'goog:chromeOptions': {} }
         ])
+    })
+})
+
+describe('_updateCaps', () => {
+    const options: BrowserstackConfig = { browserstackLocal: true }
+    const caps: any = [{}]
+    const config = {
+        user: 'foobaruser',
+        key: '12345',
+        capabilities: []
+    }
+
+    it('should throw an error if "capabilities" is not an object/array', () => {
+        const service = new BrowserstackLauncher(options as any, caps, config)
+        const capabilities = 1
+
+        expect(() => service._updateCaps(capabilities as any, 'local'))
+            .toThrow(TypeError('Capabilities should be an object or Array!'))
+    })
+})
+
+describe('_validateApp', () => {
+    const caps: any = [{}]
+    const config = {
+        user: 'foobaruser',
+        key: '12345',
+        capabilities: []
+    }
+
+    it('should use id as app value', async() => {
+        const options: BrowserstackConfig = { app: { id: 'bs://<app-id>' } }
+        const service = new BrowserstackLauncher(options as any, caps, config)
+
+        const app:any = await service._validateApp(options.app as any)
+        expect(app).toEqual({ app: 'bs://<app-id>', custom_id: undefined })
+    })
+
+    it('should throw error if more than two property passed in appConfig', async() => {
+        const options: BrowserstackConfig = { app: { custom_id: 'custom_id', id: 'bs://<app-id>' } }
+        const service = new BrowserstackLauncher(options as any, caps, config)
+
+        try {
+            await service._validateApp(options.app as any)
+        } catch (e){
+            expect(e).toEqual(`keys ${Object.keys(options.app as any)} can't co-exist as app values, use any one property from
+                                {id<string>, path<string>, custom_id<string>, shareable_id<string>}, only "path" and "custom_id" can co-exist.`)
+        }
+    })
+
+    it('should throw error if property not matches path and custom_id in appConfig', async() => {
+        const options: BrowserstackConfig = { app: { custom_id: 'custom_id', id: 'bs://<app-id>' } }
+        const service = new BrowserstackLauncher(options as any, caps, config)
+
+        try {
+            await service._validateApp(options.app as any)
+        } catch (e){
+            expect(e).toEqual(`keys ${Object.keys(options.app as any)} can't co-exist as app values, use any one property from
+                                {id<string>, path<string>, custom_id<string>, shareable_id<string>}, only "path" and "custom_id" can co-exist.`)
+        }
+    })
+})
+
+describe('_uploadApp', () => {
+    const options: BrowserstackConfig = { app: '/path/to/app.apk' }
+    const caps: any = [{}]
+    const config = {
+        user: 'foobaruser',
+        key: '12345',
+        capabilities: []
+    }
+    vi.mock('got')
+
+    got.post = vi.fn().mockReturnValue({
+        json: () => Promise.resolve({ app_url: 'bs://<app-id>' })
+    })
+
+    it('should upload the app and return app_url', async() => {
+        const service = new BrowserstackLauncher(options as any, caps, config)
+        const res = await service._uploadApp(options.app as any)
+        expect(res).toEqual({ app_url: 'bs://<app-id>' })
     })
 })

--- a/packages/wdio-browserstack-service/tests/launcher.test.ts
+++ b/packages/wdio-browserstack-service/tests/launcher.test.ts
@@ -412,8 +412,8 @@ describe('_validateApp', () => {
         try {
             await service._validateApp(options.app as any)
         } catch (e){
-            expect(e).toEqual(`keys ${Object.keys(options.app as any)} can't co-exist as app values, use any one property from
-                                {id<string>, path<string>, custom_id<string>, shareable_id<string>}, only "path" and "custom_id" can co-exist.`)
+            expect(e.message).toEqual(`keys ${Object.keys(options.app as any)} can't co-exist as app values, use any one property from
+                            {id<string>, path<string>, custom_id<string>, shareable_id<string>}, only "path" and "custom_id" can co-exist.`)
         }
     })
 
@@ -424,8 +424,8 @@ describe('_validateApp', () => {
         try {
             await service._validateApp(options.app as any)
         } catch (e){
-            expect(e).toEqual(`keys ${Object.keys(options.app as any)} can't co-exist as app values, use any one property from
-                                {id<string>, path<string>, custom_id<string>, shareable_id<string>}, only "path" and "custom_id" can co-exist.`)
+            expect(e.message).toEqual(`keys ${Object.keys(options.app as any)} can't co-exist as app values, use any one property from
+                            {id<string>, path<string>, custom_id<string>, shareable_id<string>}, only "path" and "custom_id" can co-exist.`)
         }
     })
 })


### PR DESCRIPTION
## Proposed changes

This PR:

- Add support for app upload using the local app file path to browserstack
  - app upload used in appium sessions
  - the value of the app can be a file path, app_url, custom_id, shareable_id. [ref](https://www.browserstack.com/docs/app-automate/appium/set-up-tests/specify-app)
  - custom_id can also be provided while uploading the app

`v7` PR: https://github.com/webdriverio/webdriverio/pull/8856

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
