### PR TITLE
increasing the stability of the setCookies method

### DIFF
--- a/packages/webdriverio/src/commands/browser/setCookies.ts
+++ b/packages/webdriverio/src/commands/browser/setCookies.ts
@@ -64,7 +64,8 @@ export default async function setCookies(
         throw new Error('Invalid input (see https://webdriver.io/docs/api/browser/setCookies for documentation)')
     }
 
-    await Promise.all(cookieObjsList
-        .map(cookieObj => this.addCookie(cookieObj)))
+    for (const cookieObj of cookieObjsList) {
+        await this.addCookie(cookieObj)
+    }
     return
 }


### PR DESCRIPTION
## Proposed changes

Fix for issue https://github.com/webdriverio/webdriverio/issues/8866

Increased stability of the setCookies method. If you send requests via Promise.All with a lot of Coookies, you get ECONNRESET error.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments
I have not found where to add this test, which checks the stability:
```js
it('should add a lot of cookies', async () => {
        await browser.navigateTo('http://guinea-pig.webdriver.io')
        const cookies = Array.from({length: 60}).map((_, index) => ({
            name: 'foo' + index,
            value: 'bar' + index
        }))
        console.log(cookies)
        await browser.setCookies(cookies)
        expect(await browser.getAllCookies()).toHaveLength(60)
    })
```
Does it look like wdio e2e?
### Reviewers: @webdriverio/project-committers
