### PR TITLE
[V7 Backport] Integrating Windows-Specific Appium Capability

### DIFF
--- a/packages/wdio-types/src/Capabilities.ts
+++ b/packages/wdio-types/src/Capabilities.ts
@@ -468,6 +468,13 @@ export interface AppiumW3CCapabilities {
     'appium:directConnectHost'?: string;
     'appium:directConnectPort'?: number;
     'appium:directConnectPath'?: string;
+
+    /**
+     * Windows-specific capability: Please see https://github.com/appium/appium-windows-driver#usage
+     * This is a hexadecimal handle of an existing application top level window to attach to. Either this
+     * capability or 'appium:app' must be provided on session startup.
+     */
+     'appium:appTopLevelWindow'?: string;    
 }
 
 /**


### PR DESCRIPTION
In regards to issue #8894 

## Proposed changes

Appium's [window driver](https://github.com/appium/appium-windows-driver#usage) contains support for the following Capability:

<html>
<body>
<!--StartFragment-->

appTopLevelWindow | The hexadecimal handle of an existing application top level window to attach to, for example 0x12345 (should be of string type). Either this capability or app must be provided on session startup.
-- | --


<!--EndFragment-->
</body>
</html>

However, when I add it in my capabilities list like above, it returns the following error:
```
Type '{ maxInstances: number; platformName: string; 'appium:automationName': string; 'appium:deviceName': string; 'appium:appTopLevelWindow': string; }' is not assignable to type 'DesiredCapabilities | W3CCapabilities'.
  Object literal may only specify known properties, and ''appium:appTopLevelWindow'' does not exist in type 'DesiredCapabilities | W3CCapabilities'
```

To fix this error, I'm adding an entry for it in `interface AppiumW3CCapabilities`

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
I don't believe this needs a test, as there isn't a simple example I can just add to. However, I did confirm this fixes the issue locally.
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
