### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,7 @@ on:
 env:
   NPM_TOKEN: ${{secrets.NPM_TOKEN}}
 
+permissions: {}
 jobs:
   authorize:
     runs-on: ubuntu-latest
@@ -32,6 +33,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
   release:
+    permissions:
+      contents: write
     needs: [authorize]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,9 @@ on:
       - v7
   pull_request:
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   linux:
     runs-on: ubuntu-latest

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -8,8 +8,13 @@ on:
         workflows:
             - 'Test'
 
+permissions: {}
 jobs:
     merge-me:
+        permissions:
+          pull-requests: write
+          contents: write
+
         name: Merge me!
 
         runs-on: ubuntu-latest


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.