### PR TITLE
Improve DX when using TypeScript

### DIFF
--- a/packages/wdio-cli/tests/commands/run.test.ts
+++ b/packages/wdio-cli/tests/commands/run.test.ts
@@ -1,12 +1,23 @@
 import { vi, describe, it, expect, afterEach, beforeEach } from 'vitest'
 // @ts-expect-error mock
 import { yargs } from 'yargs'
-import fs from 'fs-extra'
+import fs from 'node:fs/promises'
+import cp from 'node:child_process'
 import * as runCmd from '../../src/commands/run.js'
 import * as configCmd from '../../src/commands/config.js'
 
 vi.mock('yargs')
-vi.mock('fs-extra')
+vi.mock('node:child_process', () => ({
+    default: {
+        spawn: vi.fn()
+    }
+}))
+vi.mock('node:fs/promises', () => ({
+    default: {
+        access: vi.fn().mockResolvedValue(true),
+        readFile: vi.fn()
+    }
+}))
 vi.mock('./../../src/launcher', () => ({
     default: class {
         run() {
@@ -31,8 +42,7 @@ describe('Command: run', () => {
     const onMock = vi.fn((s, c) => c())
 
     beforeEach(() => {
-        vi.mocked(fs.existsSync).mockImplementation(() => true)
-        vi.mocked(fs.existsSync).mockClear()
+        vi.mocked(fs.access).mockClear()
         vi.spyOn(configCmd, 'missingConfigurationPrompt').mockImplementation((): Promise<never> => {
             return undefined as never
         })
@@ -42,19 +52,16 @@ describe('Command: run', () => {
     })
 
     it('should call missingConfigurationPrompt if no config found', async () => {
-        vi.mocked(fs.existsSync).mockImplementation(() => false)
+        vi.mocked(fs.access).mockRejectedValueOnce('not found')
         await runCmd.handler({ configPath: 'sample.conf.js' } as any)
         expect(configCmd.missingConfigurationPrompt).toHaveBeenCalledTimes(1)
         expect(vi.mocked(configCmd.missingConfigurationPrompt).mock.calls[0][1])
             .toContain('sample.conf.js')
-
-        vi.mocked(fs.existsSync).mockClear()
     })
 
     it('should use local conf if nothing defined', async () => {
-        vi.mocked(fs.existsSync).mockImplementation(() => true)
         await runCmd.handler({ argv: {} } as any)
-        expect(fs.existsSync).toBeCalledTimes(2)
+        expect(fs.access).toBeCalledTimes(2)
     })
 
     it('should use Watcher if "--watch" flag is passed', async () => {
@@ -93,10 +100,20 @@ describe('Command: run', () => {
         expect(yargs.help).toHaveBeenCalled()
     })
 
+    describe('launch', () => {
+        it('should restart process if esm loader if needed', async () => {
+            expect(cp.spawn).toBeCalledTimes(0)
+            await runCmd.launch('/wdio.conf.ts', {})
+            expect(cp.spawn).toBeCalledTimes(1)
+            expect(vi.mocked(cp.spawn).mock.calls[0][2].env?.NODE_OPTIONS)
+                .toContain('--loader ts-node/esm/transpile-only')
+        })
+    })
+
     afterEach(() => {
         vi.mocked(process.openStdin).mockReset()
         vi.mocked(console.error).mockReset()
-        vi.mocked(fs.existsSync).mockClear()
+        vi.mocked(fs.access).mockClear()
         vi.mocked(configCmd.missingConfigurationPrompt).mockClear()
     })
 })

--- a/packages/wdio-cli/tests/commands/run.test.ts
+++ b/packages/wdio-cli/tests/commands/run.test.ts
@@ -101,12 +101,24 @@ describe('Command: run', () => {
     })
 
     describe('launch', () => {
+        afterEach(() => {
+            vi.mocked(cp.spawn).mockClear()
+            delete process.env.NODE_OPTIONS
+        })
+
         it('should restart process if esm loader if needed', async () => {
             expect(cp.spawn).toBeCalledTimes(0)
             await runCmd.launch('/wdio.conf.ts', {})
             expect(cp.spawn).toBeCalledTimes(1)
             expect(vi.mocked(cp.spawn).mock.calls[0][2].env?.NODE_OPTIONS)
                 .toContain('--loader ts-node/esm/transpile-only')
+        })
+
+        it('should not restart if loader is already provided', async () => {
+            expect(cp.spawn).toBeCalledTimes(0)
+            process.env.NODE_OPTIONS = '--loader ts-node/esm'
+            await runCmd.launch('/wdio.conf.ts', {})
+            expect(cp.spawn).toBeCalledTimes(0)
         })
     })
 

--- a/packages/wdio-config/src/constants.ts
+++ b/packages/wdio-config/src/constants.ts
@@ -97,3 +97,9 @@ export const SUPPORTED_HOOKS: (keyof Services.Hooks)[] = [
 export const SUPPORTED_FILE_EXTENSIONS = [
     '.js', '.mjs', '.es6', '.ts', '.feature', '.coffee', '.cjs'
 ]
+
+export const NO_NAMED_CONFIG_EXPORT = (
+    'No named export object called "config" found. Make sure you export the config object ' +
+    'via `exports.config = { ... }` when using CommonJS or `export config = { ... }` when ' +
+    'using ESM. Read more on this on https://webdriver.io/docs/configurationfile !'
+)

--- a/packages/wdio-config/tests/__fixtures__/wdio.default.conf.ts
+++ b/packages/wdio-config/tests/__fixtures__/wdio.default.conf.ts
@@ -1,0 +1,5 @@
+export default {
+    config: {
+        foo: 'bar'
+    }
+}

--- a/packages/wdio-config/tests/configparser.test.ts
+++ b/packages/wdio-config/tests/configparser.test.ts
@@ -20,6 +20,7 @@ const FIXTURES_CONF = path.resolve(FIXTURES_PATH, 'wdio.conf.ts')
 const FIXTURES_CONF_RDC = path.resolve(FIXTURES_PATH, 'wdio.conf.rdc.ts')
 const FIXTURES_CONF_ARRAY = path.resolve(FIXTURES_PATH, 'wdio.array.conf.ts')
 const FIXTURES_LOCAL_CONF = path.resolve(FIXTURES_PATH, 'wdio.local.conf.ts')
+const FIXTURES_DEFAULT_CONF = path.resolve(FIXTURES_PATH, 'wdio.default.conf.ts')
 const FIXTURES_CUCUMBER_FEATURE_A_LINE_2 = path.resolve(FIXTURES_PATH, 'test-a.feature:2')
 const FIXTURES_CUCUMBER_FEATURE_A_LINE_2_AND_12 = path.resolve(FIXTURES_PATH, 'test-a.feature:2:12')
 const FIXTURES_CUCUMBER_FEATURE_B_LINE_7 = path.resolve(FIXTURES_PATH, 'test-b.feature:7')
@@ -683,6 +684,19 @@ describe('ConfigParser', () => {
             const config = configParser.getConfig()
             expect(config.hostname).toBe('127.0.0.1')
             expect(config.port).toBe(4444)
+        })
+
+        it('should be able to read config file if object is attached to default', async () => {
+            const configParser = ConfigParserBuilder.withBaseDir(FIXTURES_PATH).withFiles([
+                FileNamed(FIXTURES_DEFAULT_CONF).withContents({
+                    default: {
+                        config: { foo: 'bar' }
+                    }
+                })
+            ]).build()
+            await configParser.addConfigFile(FIXTURES_DEFAULT_CONF)
+            const config = configParser.getConfig()
+            expect(config['foo']).toBe('bar')
         })
 
         it('should allow specifying a exclude file', async () => {


### PR DESCRIPTION
## Proposed changes

Currently when using TypeScript in order to read the config one would need to pass in `ts-node/esm` as a loader which can be confusing for folks upgrading from v7 to v8. This patch simplifies this by:

- restarting the CLI `run` command with `ts-node/esm` loader in case WDIO config is a TS file
- be more flexible with the export format - with wrong TS configurations named exports can be attached to the `default` object, this patch makes the configParser a bit more flexible in regards to that

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

This is basically just a bit DX improvements.

### Reviewers: @webdriverio/project-committers
