### PR TITLE
chore: add `disableSuppressAccessibilityService` typing to Android capabilities

### DIFF
--- a/packages/wdio-types/src/Capabilities.ts
+++ b/packages/wdio-types/src/Capabilities.ts
@@ -555,6 +555,7 @@ export interface AppiumAndroidCapabilities {
     uiautomator2ServerInstallTimeout?: number;
     skipServerInstallation?: boolean;
     espressoServerLaunchTimeout?: number;
+    disableSuppressAccessibilityService?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Proposed changes

The `disableSuppressAccessibilityService` has been supported since Appium V.18.0 (see release notes https://github.com/appium/appium/releases/tag/v1.18.0). It is also documented in the UiAutomator2 docs: https://github.com/appium/appium-uiautomator2-driver#other.


The typings in wdio were missing this property in the `AppiumAndroidCapabilities`. As the `Capabilities` is a discriminated union, adding the `disableSuppressAccessibilityService` property arbitrarily would make the whole object be marked as an error by Typescript. See the picture below:


<img width="821" alt="image" src="https://user-images.githubusercontent.com/8704336/192625578-795ebccc-75fb-43b9-913e-6bff2dd9840e.png">


Adding this property to the `AppiumAndroidCapabilities` interface fixes this issue. 






[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
