### PR TITLE
Enhance prefs browser Options with expected types

### DIFF
--- a/packages/wdio-types/src/Capabilities.ts
+++ b/packages/wdio-types/src/Capabilities.ts
@@ -267,7 +267,7 @@ export interface ChromeOptions {
      * file in Chrome's user data directory for examples.
      */
     prefs?: {
-        [name: string]: string | number | boolean;
+        [name: string]: string[] | string | number | boolean;
     };
     /**
      * A list of window types that will appear in the list of window handles. For access
@@ -308,7 +308,7 @@ export interface FirefoxOptions {
     profile?: string
     log?: FirefoxLogObject
     prefs?: {
-        [name: string]: string | number | boolean
+        [name: string]: string[] | string | number | boolean
     }
 }
 


### PR DESCRIPTION
- hardware.audio_capture_allowed_urls is array of strings

## Proposed changes
We will need to set correct values into [goog:chromeOptions][prefs][hardware.audio_capture_allowed_urls]

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments
-

### Reviewers: @webdriverio/project-committers
