### PR TITLE
fix: access ShadowRoot via window.ShadowRoot

### DIFF
--- a/packages/webdriverio/src/scripts/isElementDisplayed.ts
+++ b/packages/webdriverio/src/scripts/isElementDisplayed.ts
@@ -109,8 +109,7 @@ export default function isElementDisplayed (element: Element): boolean {
         // for our purposes here are specially resolved, so this may not be an issue.
         // Specification is here: https://drafts.csswg.org/cssom/#resolved-values
         let parentElement = parentElementForElement(element as Element) as ParentNode
-        return 
-            (parentElement, property)
+        return cascadedStylePropertyForElement(parentElement, property)
     }
 
     function elementSubtreeHasNonZeroDimensions(element: Element): boolean {

--- a/packages/webdriverio/src/scripts/isElementDisplayed.ts
+++ b/packages/webdriverio/src/scripts/isElementDisplayed.ts
@@ -89,7 +89,7 @@ export default function isElementDisplayed (element: Element): boolean {
         // if document-fragment, skip it and use element.host instead. This happens
         // when the element is inside a shadow root.
         // window.getComputedStyle errors on document-fragment.
-        if (element instanceof ShadowRoot) {
+        if (element instanceof window.ShadowRoot) {
             element = element.host
         }
 
@@ -109,7 +109,8 @@ export default function isElementDisplayed (element: Element): boolean {
         // for our purposes here are specially resolved, so this may not be an issue.
         // Specification is here: https://drafts.csswg.org/cssom/#resolved-values
         let parentElement = parentElementForElement(element as Element) as ParentNode
-        return cascadedStylePropertyForElement(parentElement, property)
+        return 
+            (parentElement, property)
     }
 
     function elementSubtreeHasNonZeroDimensions(element: Element): boolean {


### PR DESCRIPTION
## Proposed changes

fixes an issue in browsers where ShadowRoot is not available globally (e.g. Edge 18). Error message is "ShadowRoot is not defined".

A similar issue was reported here https://github.com/vuejs/test-utils/issues/293 and the fix was referencing ShadowRoot from window instead: https://github.com/vuejs/core/pull/2943/files

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
