### PR TITLE
Fix example to check wdio options with TypeScript

### DIFF
--- a/website/docs/TypeScript.md
+++ b/website/docs/TypeScript.md
@@ -169,9 +169,9 @@ Adding services and reporters to your TypeScript config also strengthen the type
 When running WebdriverIO commands all properties are usually typed so that you don't have to deal with importing additional types. However there are cases where you want to define variables upfront. To ensure that these are type safe you can use all types defined in the [`@wdio/types`](https://www.npmjs.com/package/@wdio/types) package. For example if you like to define the remote option for `webdriverio` you can do:
 
 ```ts
-import type { Capabilities } from '@wdio/types'
+import type { Options } from '@wdio/types'
 
-const config: Capabilities.WebdriverIO = {
+const config: Options.WebdriverIO = {
     hostname: 'http://localhost',
     port: '4444' // Error: Type 'string' is not assignable to type 'number'.ts(2322)
     capabilities: {


### PR DESCRIPTION
## Proposed changes

Fix a small mistake in document for TypeScript + webdriverio.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[`Capabilities` in `@wdio/types` package](https://github.com/webdriverio/webdriverio/blob/main/packages/wdio-types/src/Capabilities.ts) does not have the `WebdriverIO` type. Instead I found [`Options.WebdriverIO`](https://github.com/webdriverio/webdriverio/blob/a5d47b14d9c08c05579fec09d7ba9067d83f21b1/packages/wdio-types/src/Options.ts#L215) was the correct type to check wdio config object. This PR fixes the example.

### Reviewers: @webdriverio/project-committers
