### PR TITLE
Issue 9082 - beforeTest afterTest hooks not working with specify test interface in Mocha BDD

### DIFF
--- a/packages/wdio-mocha-framework/src/constants.ts
+++ b/packages/wdio-mocha-framework/src/constants.ts
@@ -1,8 +1,14 @@
 export const INTERFACES = {
-    bdd: ['it', 'before', 'beforeEach', 'after', 'afterEach'],
+    bdd: ['it', 'specify', 'before', 'beforeEach', 'after', 'afterEach'],
     tdd: ['test', 'suiteSetup', 'setup', 'suiteTeardown', 'teardown'],
     qunit: ['test', 'before', 'beforeEach', 'after', 'afterEach']
 } as const
+
+export const TEST_INTERFACES = {
+     bdd: ['it', 'specify'],
+     tdd: ['test'],
+     qunit: ['test']
+ } as const
 
 /**
  * to map Mocha events to WDIO events

--- a/packages/wdio-mocha-framework/src/constants.ts
+++ b/packages/wdio-mocha-framework/src/constants.ts
@@ -5,10 +5,10 @@ export const INTERFACES = {
 } as const
 
 export const TEST_INTERFACES = {
-     bdd: ['it', 'specify'],
-     tdd: ['test'],
-     qunit: ['test']
- } as const
+    bdd: ['it', 'specify'],
+    tdd: ['test'],
+    qunit: ['test']
+} as const
 
 /**
  * to map Mocha events to WDIO events

--- a/packages/wdio-mocha-framework/src/index.ts
+++ b/packages/wdio-mocha-framework/src/index.ts
@@ -8,7 +8,7 @@ import { runTestInFiberContext, executeHooksWithArgs } from '@wdio/utils'
 import type { Capabilities, Services } from '@wdio/types'
 
 import { loadModule } from './utils.js'
-import { INTERFACES, EVENTS, NOOP, MOCHA_TIMEOUT_MESSAGE, MOCHA_TIMEOUT_MESSAGE_REPLACEMENT } from './constants.js'
+import { INTERFACES, TEST_INTERFACES, EVENTS, NOOP, MOCHA_TIMEOUT_MESSAGE, MOCHA_TIMEOUT_MESSAGE_REPLACEMENT } from './constants.js'
 import type { MochaConfig, MochaOpts as MochaOptsImport, FrameworkMessage, FormattedMessage, MochaError } from './types'
 import type { EventEmitter } from 'node:events'
 
@@ -159,8 +159,7 @@ class MochaAdapter {
         }
 
         INTERFACES[type].forEach((fnName: string) => {
-            let testCommand = INTERFACES[type][0]
-            const isTest = [testCommand, testCommand + '.only'].includes(fnName)
+            const isTest = TEST_INTERFACES[type].flatMap((testCommand: string) => [testCommand, testCommand + '.only']).includes(fnName)
 
             runTestInFiberContext(
                 isTest,

--- a/packages/wdio-mocha-framework/tests/adapter.test.ts
+++ b/packages/wdio-mocha-framework/tests/adapter.test.ts
@@ -107,24 +107,48 @@ test('options', () => {
     expect(adapter.requireExternalModules).toBeCalledWith(['the/compiler.js', 'foo/bar.js'])
 })
 
-test('preRequire', () => {
-    const mochaOpts = { foo: 'bar', ui: 'tdd' }
-    const adapter = adapterFactory({ mochaOpts, beforeHook: 'beforeHook123', afterHook: 'afterHook123', beforeTest: 'beforeTest234', afterTest: 'afterTest234' })
-    adapter.preRequire()
-    expect(runTestInFiberContext).toBeCalledWith(
-        false, 'beforeHook123', expect.any(Function), 'afterHook123', expect.any(Function), 'suiteSetup', '0-2')
-    expect(runTestInFiberContext).toBeCalledWith(
-        false, 'beforeHook123', expect.any(Function), 'afterHook123', expect.any(Function), 'setup', '0-2')
-    expect(runTestInFiberContext).toBeCalledWith(
-        true, 'beforeTest234', expect.any(Function), 'afterTest234', expect.any(Function), 'test', '0-2')
-    expect(runTestInFiberContext).toBeCalledWith(
-        false, 'beforeHook123', expect.any(Function), 'afterHook123', expect.any(Function), 'suiteTeardown', '0-2')
-    expect(runTestInFiberContext).toBeCalledWith(
-        false, 'beforeHook123', expect.any(Function), 'afterHook123', expect.any(Function), 'teardown', '0-2')
+describe('preRequire', () => {
+    test('preRequire - TDD', () => {
+        const mochaOpts = { foo: 'bar', ui: 'tdd' }
+        const adapter = adapterFactory({ mochaOpts, beforeHook: 'beforeHook123', afterHook: 'afterHook123', beforeTest: 'beforeTest234', afterTest: 'afterTest234' })
+        adapter.preRequire()
+        expect(runTestInFiberContext).toBeCalledWith(
+            false, 'beforeHook123', expect.any(Function), 'afterHook123', expect.any(Function), 'suiteSetup', '0-2')
+        expect(runTestInFiberContext).toBeCalledWith(
+            false, 'beforeHook123', expect.any(Function), 'afterHook123', expect.any(Function), 'setup', '0-2')
+        expect(runTestInFiberContext).toBeCalledWith(
+            true, 'beforeTest234', expect.any(Function), 'afterTest234', expect.any(Function), 'test', '0-2')
+        expect(runTestInFiberContext).toBeCalledWith(
+            false, 'beforeHook123', expect.any(Function), 'afterHook123', expect.any(Function), 'suiteTeardown', '0-2')
+        expect(runTestInFiberContext).toBeCalledWith(
+            false, 'beforeHook123', expect.any(Function), 'afterHook123', expect.any(Function), 'teardown', '0-2')
 
-    const hookArgsFn = vi.mocked(runTestInFiberContext).mock.calls[0][2]
-    expect(hookArgsFn({ test: { foo: 'bar', parent: { title: 'parent' } } }))
-        .toEqual([{ foo: 'bar', parent: 'parent' }, { test: { foo: 'bar', parent: { title: 'parent' } } }])
+        const hookArgsFn = vi.mocked(runTestInFiberContext).mock.calls[0][2]
+        expect(hookArgsFn({ test: { foo: 'bar', parent: { title: 'parent' } } }))
+            .toEqual([{ foo: 'bar', parent: 'parent' }, { test: { foo: 'bar', parent: { title: 'parent' } } }])
+    })
+
+    test('preRequire - BDD', () => {
+        const mochaOpts = { foo: 'bar', ui: 'bdd' }
+        const adapter = adapterFactory({ mochaOpts, beforeHook: 'beforeHook123', afterHook: 'afterHook123', beforeTest: 'beforeTest234', afterTest: 'afterTest234' })
+        adapter.preRequire()
+        expect(runTestInFiberContext).toBeCalledWith(
+            false, 'beforeHook123', expect.any(Function), 'afterHook123', expect.any(Function), 'before', '0-2')
+        expect(runTestInFiberContext).toBeCalledWith(
+            false, 'beforeHook123', expect.any(Function), 'afterHook123', expect.any(Function), 'beforeEach', '0-2')
+        expect(runTestInFiberContext).toBeCalledWith(
+            true, 'beforeTest234', expect.any(Function), 'afterTest234', expect.any(Function), 'it', '0-2')
+        expect(runTestInFiberContext).toBeCalledWith(
+            true, 'beforeTest234', expect.any(Function), 'afterTest234', expect.any(Function), 'specify', '0-2')
+        expect(runTestInFiberContext).toBeCalledWith(
+            false, 'beforeHook123', expect.any(Function), 'afterHook123', expect.any(Function), 'after', '0-2')
+        expect(runTestInFiberContext).toBeCalledWith(
+            false, 'beforeHook123', expect.any(Function), 'afterHook123', expect.any(Function), 'afterEach', '0-2')
+
+        const hookArgsFn = vi.mocked(runTestInFiberContext).mock.calls[0][2]
+        expect(hookArgsFn({ test: { foo: 'bar', parent: { title: 'parent' } } }))
+            .toEqual([{ foo: 'bar', parent: 'parent' }, { test: { foo: 'bar', parent: { title: 'parent' } } }])
+    })
 })
 
 test('custom ui', () => {


### PR DESCRIPTION
## Proposed changes
beforeTest & afterTest hooks in any service aren't working for `mocha` when test interface being used is `specify` instead of `it`. As per mocha [documentation](https://mochajs.org/#interfaces) for BDD, mocha allows usage of `it` and `specify` which is an alias for `it`.

Issue link: https://github.com/webdriverio/webdriverio/issues/9082
WebdriverIO v7 PR: https://github.com/webdriverio/webdriverio/pull/9083

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
