### PR TITLE
[v7] Adds title when updating job in onReload

### DIFF
--- a/packages/wdio-browserstack-service/src/service.ts
+++ b/packages/wdio-browserstack-service/src/service.ts
@@ -146,6 +146,10 @@ export default class BrowserstackService implements Services.ServiceInstance {
             return Promise.resolve()
         }
 
+        if (this._options.preferScenarioName && this._scenariosThatRan.length === 1){
+            this._fullTitle = this._scenariosThatRan.pop()
+        }
+
         const hasReasons = Boolean(this._failReasons.filter(Boolean).length)
 
         let status = hasReasons ? 'failed' : 'passed'


### PR DESCRIPTION
## Proposed changes
When calling `reloadSession` command, the BrowserStack service is updating the old session status as passed/failed.
But the title is not updated correctly (with Cucumber).

There is a service option called `preferScenarioName` that configures the service to use the title of the (only) scenario that ran. This option is working for regular session, but when reloading the session, the option was not being considered.

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

This is the back-port for v7.
[v8 PR](https://github.com/webdriverio/webdriverio/pull/9095)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

### Reviewers: @webdriverio/project-committers
