### PR TITLE
@wdio/browserstack-service: Add session naming options

### DIFF
--- a/packages/wdio-browserstack-service/README.md
+++ b/packages/wdio-browserstack-service/README.md
@@ -1,7 +1,7 @@
-WebdriverIO Browserstack Service
+WebdriverIO BrowserStack Service
 ==========
 
-> A WebdriverIO service that manages local tunnel and job metadata for Browserstack users.
+> A WebdriverIO service that manages local tunnel and job metadata for BrowserStack users.
 
 ## Installation
 
@@ -17,7 +17,7 @@ Instructions on how to install `WebdriverIO` can be found [here.](https://webdri
 
 ## Configuration
 
-WebdriverIO has Browserstack support out of the box. You should set `user` and `key` in your `wdio.conf.js` file. This service plugin provides support for [Browserstack](https://www.browserstack.com/automate/node#setting-local-tunnel) Tunnel](https://www.browserstack.com/automate/node#setting-local-tunnel). Set `browserstackLocal: true` also to activate this feature.
+WebdriverIO has BrowserStack support out of the box. You should set `user` and `key` in your `wdio.conf.js` file. This service plugin provides support for [BrowserStack](https://www.browserstack.com/automate/node#setting-local-tunnel) Tunnel](https://www.browserstack.com/automate/node#setting-local-tunnel). Set `browserstackLocal: true` also to activate this feature.
 Reporting of session status on BrowserStack will respect `strict` setting of Cucumber options.
 
 ```js
@@ -40,19 +40,13 @@ export const config = {
 In order to authorize to the BrowserStack service your config needs to contain a [`user`](https://webdriver.io/docs/options#user) and [`key`](https://webdriver.io/docs/options#key) option.
 
 ### browserstackLocal
-Set this to true to enable routing connections from Browserstack cloud through your computer.
-
-Type: `Boolean`<br />
-Default: `false`
-
-### preferScenarioName
-Cucumber only. Set this to true to enable updating the session name to the Scenario name if only a single Scenario was run. Useful when running in parallel with [wdio-cucumber-parallel-execution](https://github.com/SimitTomar/wdio-cucumber-parallel-execution).
+Set this to true to enable routing connections from BrowserStack cloud through your computer.
 
 Type: `Boolean`<br />
 Default: `false`
 
 ### forcedStop
-Set this to true to kill the Browserstack process on complete, without waiting for the browserstack stop callback to be called. This is experimental and should not be used by all. Mostly necessary as a workaraound for [this issue](https://github.com/browserstack/browserstack-local-nodejs/issues/41).
+Set this to true to kill the BrowserStack Local process on complete, without waiting for the BrowserStack Local stop callback to be called. This is experimental and should not be used by all. Mostly necessary as a workaraound for [this issue](https://github.com/browserstack/browserstack-local-nodejs/issues/41).
 
 Type: `Boolean`<br />
 Default: `false`
@@ -141,8 +135,53 @@ services: [
 ]
 ```
 
+### preferScenarioName
+
+Cucumber only. Set the BrowserStack Automate session name to the Scenario name if only a single Scenario ran.
+Useful when running in parallel with [wdio-cucumber-parallel-execution](https://github.com/SimitTomar/wdio-cucumber-parallel-execution).
+
+Type: `Boolean`<br />
+Default: `false`
+
+### sessionNameFormat
+
+Customize the BrowserStack Automate session name format.
+
+Type: `Function`<br />
+Default (Cucumber/Jasmine): `(config, capabilities, suiteTitle) => suiteTitle`<br />
+Default (Mocha): `(config, capabilities, suiteTitle, testTitle) => suiteTitle + ' - ' + testTitle`
+
+### sessionNameOmitTestTitle
+
+Mocha only. Do not append the test title to the BrowserStack Automate session name.
+
+Type: `Boolean`<br />
+Default: `false`
+
+### sessionNamePrependTopLevelSuiteTitle
+
+Mocha only. Prepend the top level suite title to the BrowserStack Automate session name.
+
+Type: `Boolean`<br />
+Default: `false`
+
+### setSessionName
+
+Automatically set the BrowserStack Automate session name.
+
+Type: `Boolean`<br />
+Default: `true`
+
+### setSessionStatus
+
+Automatically set the BrowserStack Automate session status (passed/failed).
+
+Type: `Boolean`<br />
+Default: `true`
+
 ### opts
-Specified optional will be passed down to BrowserstackLocal.
+
+BrowserStack Local options.
 
 Type: `Object`<br />
 Default: `{}`
@@ -185,7 +224,7 @@ opts = { f: "/my/awesome/folder" };
 
 #### Force Start
 
-To kill other running Browserstack Local instances -
+To kill other running BrowserStack Local instances -
 
 ```js
 opts = { force: "true" };

--- a/packages/wdio-browserstack-service/src/constants.ts
+++ b/packages/wdio-browserstack-service/src/constants.ts
@@ -1,3 +1,5 @@
+import type { BrowserstackConfig } from './types'
+
 export const BROWSER_DESCRIPTION = [
     'device',
     'os',
@@ -14,3 +16,8 @@ export const VALID_APP_EXTENSION = [
     '.aab',
     '.ipa'
 ]
+
+export const DEFAULT_OPTIONS: Partial<BrowserstackConfig> = {
+    setSessionName: true,
+    setSessionStatus: true
+}

--- a/packages/wdio-browserstack-service/src/service.ts
+++ b/packages/wdio-browserstack-service/src/service.ts
@@ -5,6 +5,7 @@ import type { Browser, MultiRemoteBrowser } from 'webdriverio'
 
 import { getBrowserDescription, getBrowserCapabilities, isBrowserstackCapability, getParentSuiteName } from './util.js'
 import type { BrowserstackConfig, MultiRemoteAction, SessionResponse } from './types'
+import { DEFAULT_OPTIONS } from './constants.js'
 
 const log = logger('@wdio/browserstack-service')
 
@@ -14,15 +15,18 @@ export default class BrowserstackService implements Services.ServiceInstance {
     private _scenariosThatRan: string[] = []
     private _failureStatuses: string[] = ['failed', 'ambiguous', 'undefined', 'unknown']
     private _browser?: Browser<'async'> | MultiRemoteBrowser<'async'>
+    private _suiteTitle?: string
     private _fullTitle?: string
+    private _options: BrowserstackConfig & Options.Testrunner
 
     constructor (
-        private _options: BrowserstackConfig & Options.Testrunner,
+        options: BrowserstackConfig & Options.Testrunner,
         private _caps: Capabilities.RemoteCapability,
         private _config: Options.Testrunner
     ) {
+        this._options = { ...DEFAULT_OPTIONS, ...options }
         // added to maintain backward compatibility with webdriverIO v5
-        this._config || (this._config = _options)
+        this._config || (this._config = this._options)
         // Cucumber specific
         const strict = Boolean(this._config.cucumberOpts && this._config.cucumberOpts.strict)
         // See https://github.com/cucumber/cucumber-js/blob/master/src/runtime/index.ts#L136
@@ -41,12 +45,10 @@ export default class BrowserstackService implements Services.ServiceInstance {
         return fn(this._caps as Capabilities.Capabilities)
     }
 
-    /**
-     * if no user and key is specified even though a browserstack service was
-     * provided set user and key with values so that the session request
-     * will fail
-     */
-    beforeSession (config: Options.Testrunner) {
+    beforeSession (config: Omit<Options.Testrunner, 'capabilities'>) {
+        // if no user and key is specified even though a browserstack service was
+        // provided set user and key with values so that the session request
+        // will fail
         if (!config.user) {
             config.user = 'NotSetUser'
         }
@@ -73,50 +75,69 @@ export default class BrowserstackService implements Services.ServiceInstance {
         return this._printSessionURL()
     }
 
-    beforeSuite (suite: Frameworks.Suite) {
-        this._fullTitle = suite.title
+    /**
+     * Set the default job name at the suite level to make sure we account
+     * for the cases where there is a long running `before` function for a
+     * suite or one that can fail.
+     * Don't do this for Jasmine because `suite.title` is `Jasmine__TopLevel__Suite`
+     * and `suite.fullTitle` is `undefined`, so no alternative to use for the job name.
+     */
+    async beforeSuite (suite: Frameworks.Suite) {
+        this._suiteTitle = suite.title
+
+        if (suite.title && suite.title !== 'Jasmine__TopLevel__Suite') {
+            await this._setSessionName(suite.title)
+        }
     }
 
+    async beforeTest (test: Frameworks.Test) {
+        let suiteTitle = this._suiteTitle
+
+        if (test.fullName) {
+            // For Jasmine, `suite.title` is `Jasmine__TopLevel__Suite`.
+            // This tweak allows us to set the real suite name.
+            const testSuiteName = test.fullName.slice(0, test.fullName.indexOf(test.description || '') - 1)
+            if (this._suiteTitle === 'Jasmine__TopLevel__Suite') {
+                suiteTitle = testSuiteName
+            } else if (this._suiteTitle) {
+                suiteTitle = getParentSuiteName(this._suiteTitle, testSuiteName)
+            }
+        }
+
+        await this._setSessionName(suiteTitle, test)
+    }
+
+    /**
+     * For CucumberJS
+     */
     beforeFeature(uri: unknown, feature: { name: string }) {
-        this._fullTitle = feature.name
-        return this._updateJob({ name: this._fullTitle })
+        this._suiteTitle = feature.name
+        return this._setSessionName(feature.name)
     }
 
     afterTest(test: Frameworks.Test, context: never, results: Frameworks.TestResult) {
         const { error, passed } = results
-
-        // Jasmine
-        if (test.fullName) {
-            const testSuiteName = test.fullName.slice(0, test.fullName.indexOf(test.description || '') - 1)
-            if (this._fullTitle === 'Jasmine__TopLevel__Suite') {
-                this._fullTitle = testSuiteName
-            } else if (this._fullTitle) {
-                this._fullTitle = getParentSuiteName(this._fullTitle, testSuiteName)
-            }
-        } else {
-            // Mocha
-            this._fullTitle = `${test.parent} - ${test.title}`
-        }
-
         if (!passed) {
             this._failReasons.push((error && error.message) || 'Unknown Error')
         }
     }
 
-    after (result: number) {
+    async after (result: number) {
+        const { preferScenarioName, setSessionName, setSessionStatus } = this._options
         // For Cucumber: Checks scenarios that ran (i.e. not skipped) on the session
         // Only 1 Scenario ran and option enabled => Redefine session name to Scenario's name
-        if (this._options.preferScenarioName && this._scenariosThatRan.length === 1){
+        if (preferScenarioName && this._scenariosThatRan.length === 1){
             this._fullTitle = this._scenariosThatRan.pop()
         }
 
-        const hasReasons = Boolean(this._failReasons.filter(Boolean).length)
-
-        return this._updateJob({
-            status: result === 0 ? 'passed' : 'failed',
-            name: this._fullTitle,
-            reason: hasReasons ? this._failReasons.join('\n') : undefined
-        })
+        if (setSessionStatus) {
+            const hasReasons = this._failReasons.length > 0
+            await this._updateJob({
+                status: result === 0 ? 'passed' : 'failed',
+                ...(setSessionName ? { name: this._fullTitle } : {}),
+                ...(hasReasons ? { reason: this._failReasons.join('\n') } : {})
+            })
+        }
     }
 
     /**
@@ -146,9 +167,10 @@ export default class BrowserstackService implements Services.ServiceInstance {
             return Promise.resolve()
         }
 
-        const hasReasons = Boolean(this._failReasons.filter(Boolean).length)
+        const { setSessionName, setSessionStatus } = this._options
+        const hasReasons = this._failReasons.length > 0
+        const status = hasReasons ? 'failed' : 'passed'
 
-        let status = hasReasons ? 'failed' : 'passed'
         if (!this._browser.isMultiremote) {
             log.info(`Update (reloaded) job with sessionId ${oldSessionId}, ${status}`)
         } else {
@@ -157,12 +179,16 @@ export default class BrowserstackService implements Services.ServiceInstance {
             log.info(`Update (reloaded) multiremote job for browser "${browserName}" and sessionId ${oldSessionId}, ${status}`)
         }
 
-        await this._update(oldSessionId, {
-            name: this._fullTitle,
-            status,
-            reason: hasReasons ? this._failReasons.join('\n') : undefined
-        })
+        if (setSessionStatus) {
+            await this._update(oldSessionId, {
+                status,
+                ...(setSessionName ? { name: this._fullTitle } : {}),
+                ...(hasReasons ? { reason: this._failReasons.join('\n') } : {})
+            })
+        }
+
         this._scenariosThatRan = []
+        delete this._suiteTitle
         delete this._fullTitle
         this._failReasons = []
         await this._printSessionURL()
@@ -237,5 +263,31 @@ export default class BrowserstackService implements Services.ServiceInstance {
             const browserString = getBrowserDescription(capabilities)
             log.info(`${browserString} session: ${response.body.automation_session.browser_url}`)
         })
+    }
+
+    private async _setSessionName(suiteTitle: string | undefined, test?: Frameworks.Test) {
+        if (!this._options.setSessionName || !suiteTitle) {
+            return
+        }
+
+        let name = suiteTitle
+        if (this._options.sessionNameFormat) {
+            name = this._options.sessionNameFormat(
+                this._config,
+                this._caps,
+                suiteTitle,
+                test?.title
+            )
+        } else if (test && !test.fullName) {
+            // Mocha
+            const pre = this._options.sessionNamePrependTopLevelSuiteTitle ? `${suiteTitle} - ` : ''
+            const post = !this._options.sessionNameOmitTestTitle ? ` - ${test.title}` : ''
+            name = `${pre}${test.parent}${post}`
+        }
+
+        if (name !== this._fullTitle) {
+            this._fullTitle = name
+            await this._updateJob({ name })
+        }
     }
 }

--- a/packages/wdio-browserstack-service/src/types.ts
+++ b/packages/wdio-browserstack-service/src/types.ts
@@ -1,3 +1,5 @@
+import type { Capabilities, Options } from '@wdio/types'
+
 export interface SessionResponse {
     // eslint-disable-next-line camelcase
     automation_session: {
@@ -28,29 +30,28 @@ export interface App {
 
 export interface BrowserstackConfig {
     /**
-     * Set this to true to enable routing connections from Browserstack cloud through your computer.
-     * You will also need to set `browserstack.local` to true in browser capabilities.
-     */
-    browserstackLocal?: boolean;
-    /**
      * Set this with app file path present locally on your device or
-     * app hashed id returned after uploading app to Browserstack or
+     * app hashed id returned after uploading app to BrowserStack or
      * custom_id, sharable_id of the uploaded app
+     * @default undefined
      */
     app?: string | AppConfig;
     /**
-     * Cucumber only. Set this to true to enable updating the session name to the Scenario name if only
-     * a single Scenario was ran. Useful when running in parallel
-     * with [wdio-cucumber-parallel-execution](https://github.com/SimitTomar/wdio-cucumber-parallel-execution).
+     * Enable routing connections from BrowserStack cloud through your computer.
+     * You will also need to set `browserstack.local` to true in browser capabilities.
+     * @default false
      */
-    preferScenarioName?: boolean;
+    browserstackLocal?: boolean;
     /**
-     * Set this to true to kill the browserstack process on complete, without waiting for the
-     * browserstack stop callback to be called. This is experimental and should not be used by all.
+     * Kill the BrowserStack Local process on complete, without waiting for the
+     * BrowserStack Local stop callback to be called.
+     *
+     * __This is experimental and should not be used by all.__
+     * @default false
      */
     forcedStop?: boolean;
     /**
-     * Specified optional will be passed down to BrowserstackLocal. For more details check out the
+     * BrowserStack Local options. For more details check out the
      * [`browserstack-local`](https://www.npmjs.com/package/browserstack-local#arguments) docs.
      *
      * @example
@@ -59,6 +60,43 @@ export interface BrowserstackConfig {
      *   localIdentifier: 'some-identifier'
      * }
      * ```
+     * @default {}
      */
     opts?: Partial<import('browserstack-local').Options>
+    /**
+     * Cucumber only. Set the BrowserStack Automate session name to the Scenario name if only a single Scenario ran.
+     * Useful when running in parallel with [wdio-cucumber-parallel-execution](https://github.com/SimitTomar/wdio-cucumber-parallel-execution).
+     * @default false
+     */
+    preferScenarioName?: boolean;
+    /**
+     * Customize the BrowserStack Automate session name format.
+     * @default undefined
+     */
+    sessionNameFormat?: (
+        config: Options.Testrunner,
+        capabilities: Capabilities.RemoteCapability,
+        suiteTitle: string,
+        testTitle?: string
+    ) => string
+    /**
+     * Mocha only. Do not append the test title to the BrowserStack Automate session name.
+     * @default false
+     */
+    sessionNameOmitTestTitle?: boolean;
+    /**
+     * Mocha only. Prepend the top level suite title to the BrowserStack Automate session name.
+     * @default false
+     */
+    sessionNamePrependTopLevelSuiteTitle?: boolean;
+    /**
+     * Automatically set the BrowserStack Automate session name.
+     * @default true
+     */
+    setSessionName?: boolean
+    /**
+     * Automatically set the BrowserStack Automate session status (passed/failed).
+     * @default true
+     */
+    setSessionStatus?: boolean
 }

--- a/packages/wdio-browserstack-service/tests/service.test.ts
+++ b/packages/wdio-browserstack-service/tests/service.test.ts
@@ -1,18 +1,23 @@
-/// <reference path="../../webdriverio/src/@types/async.d.ts" />
-
 import path from 'node:path'
+
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 import got from 'got'
 import logger from '@wdio/logger'
+import type { Browser, MultiRemoteBrowser } from 'webdriverio'
 
 import BrowserstackService from '../src/service.js'
+
+const jasmineSuiteTitle = 'Jasmine__TopLevel__Suite'
+const sessionBaseUrl = 'https://api.browserstack.com/automate/sessions'
+const sessionId = 'session123'
+const sessionIdA = 'session456'
 
 vi.mock('got')
 vi.mock('@wdio/logger', () => import(path.join(process.cwd(), '__mocks__', '@wdio/logger')))
 
 const log = logger('test')
 let service: BrowserstackService
-let browser: WebdriverIO.Browser
+let browser: Browser<'async'> | MultiRemoteBrowser<'async'>
 
 beforeEach(() => {
     vi.mocked(log.info).mockClear()
@@ -28,7 +33,7 @@ beforeEach(() => {
     vi.mocked(got.put).mockResolvedValue({})
 
     browser = {
-        sessionId: 'session123',
+        sessionId: sessionId,
         config: {},
         capabilities: {
             device: '',
@@ -39,16 +44,18 @@ beforeEach(() => {
         instances: ['browserA', 'browserB'],
         isMultiremote: false,
         browserA: {
-            sessionId: 'session456',
-            capabilities: { 'bstack:options': {
-                device: '',
-                os: 'Windows',
-                osVersion: 10,
-                browserName: 'chrome'
-            } }
+            sessionId: sessionIdA,
+            capabilities: {
+                'bstack:options': {
+                    device: '',
+                    os: 'Windows',
+                    osVersion: 10,
+                    browserName: 'chrome'
+                }
+            }
         },
         browserB: {}
-    } as any as WebdriverIO.Browser
+    } as unknown as Browser<'async'> | MultiRemoteBrowser<'async'>
     service = new BrowserstackService({} as any, [] as any, { user: 'foo', key: 'bar' } as any)
 })
 
@@ -115,7 +122,7 @@ describe('_printSessionURL', () => {
         const logInfoSpy = vi.spyOn(log, 'info').mockImplementation((string) => string)
         await service._printSessionURL()
         expect(got).toHaveBeenCalledWith(
-            'https://api.browserstack.com/automate/sessions/session123.json',
+            `${sessionBaseUrl}/${sessionId}.json`,
             { username: 'foo', password: 'bar', responseType: 'json' })
         expect(logInfoSpy).toHaveBeenCalled()
         expect(logInfoSpy).toHaveBeenCalledWith(
@@ -129,7 +136,7 @@ describe('_printSessionURL', () => {
         const logInfoSpy = vi.spyOn(log, 'info').mockImplementation((string) => string)
         await service._printSessionURL()
         expect(got).toHaveBeenCalledWith(
-            'https://api.browserstack.com/automate/sessions/session456.json',
+            `${sessionBaseUrl}/${sessionIdA}.json`,
             { username: 'foo', password: 'bar', responseType: 'json' })
         expect(logInfoSpy).toHaveBeenCalled()
         expect(logInfoSpy).toHaveBeenCalledWith(
@@ -180,7 +187,7 @@ describe('before', () => {
         let service = new BrowserstackService({} as any, [{}] as any, { capabilities: {} })
 
         await service.beforeSession({} as any as any)
-        await service.before(service['_config'] as any, [], browser as WebdriverIO.Browser)
+        await service.before(service['_config'] as any, [], browser)
 
         expect(service['_failReasons']).toEqual([])
         expect(service['_config'].user).toEqual('NotSetUser')
@@ -212,7 +219,7 @@ describe('before', () => {
         service.before(service['_config'] as any, [], browser)
 
         expect(service['_failReasons']).toEqual([])
-        expect(service['_sessionBaseUrl']).toEqual('https://api.browserstack.com/automate/sessions')
+        expect(service['_sessionBaseUrl']).toEqual(sessionBaseUrl)
     })
 
     it('should initialize correctly for multiremote', () => {
@@ -228,7 +235,7 @@ describe('before', () => {
         service.before(service['_config'] as any, [], browser)
 
         expect(service['_failReasons']).toEqual([])
-        expect(service['_sessionBaseUrl']).toEqual('https://api.browserstack.com/automate/sessions')
+        expect(service['_sessionBaseUrl']).toEqual(sessionBaseUrl)
     })
 
     it('should initialize correctly for appium', () => {
@@ -298,17 +305,226 @@ describe('before', () => {
     })
 })
 
+describe('beforeSuite', () => {
+    it('should send request to set the session name as suite name for Mocha tests', async () => {
+        await service.before(service['_config'] as any, [], browser)
+        expect(service['_suiteTitle']).toBeUndefined()
+        expect(service['_fullTitle']).toBeUndefined()
+        await service.beforeSuite({ title: 'foobar' } as any)
+        expect(service['_suiteTitle']).toBe('foobar')
+        expect(service['_fullTitle']).toBe('foobar')
+        expect(got.put).toBeCalledWith(
+            `${sessionBaseUrl}/${sessionId}.json`,
+            {
+                json: { name: 'foobar' },
+                username: 'foo',
+                password: 'bar'
+            }
+        )
+    })
+
+    it('should not send request to set the session name as suite name for Jasmine tests', async () => {
+        await service.before(service['_config'] as any, [], browser)
+        expect(service['_suiteTitle']).toBeUndefined()
+        expect(service['_fullTitle']).toBeUndefined()
+        await service.beforeSuite({ title: jasmineSuiteTitle } as any)
+        expect(service['_suiteTitle']).toBe(jasmineSuiteTitle)
+        expect(service['_fullTitle']).toBeUndefined()
+        expect(got.put).not.toBeCalled()
+    })
+
+    it('should not send request to set the session name if option setSessionName is false', async () => {
+        const service = new BrowserstackService({ setSessionName: false } as any, [] as any, { user: 'foo', key: 'bar' } as any)
+        await service.beforeSuite({ title: 'Project Title' } as any)
+        expect(got.put).not.toBeCalled()
+    })
+})
+
+describe('beforeTest', () => {
+    it('should not send request to set the session name if option setSessionName is false', async () => {
+        const service = new BrowserstackService({ setSessionName: false } as any, [] as any, { user: 'foo', key: 'bar' } as any)
+        await service.beforeSuite({ title: 'Project Title' } as any)
+        await service.beforeTest({ title: 'Test Title', parent: 'Suite Title' } as any)
+        expect(got.put).not.toBeCalled()
+    })
+
+    describe('sessionNamePrependTopLevelSuiteTitle is true', () => {
+        it('should set title for Mocha tests using concatenation of top level suite name, innermost suite name, and test title', async () => {
+            const service = new BrowserstackService({ sessionNamePrependTopLevelSuiteTitle: true } as any, [] as any, { user: 'foo', key: 'bar' } as any)
+            await service.before(service['_config'] as any, [], browser)
+            await service.beforeSuite({ title: 'Project Title' } as any)
+            expect(service['_fullTitle']).toBe('Project Title')
+            await service.beforeTest({ title: 'Test Title', parent: 'Suite Title' } as any)
+            expect(service['_fullTitle']).toBe('Project Title - Suite Title - Test Title')
+            expect(got.put).toBeCalledTimes(2)
+            expect(got.put).toBeCalledWith(
+                `${sessionBaseUrl}/${sessionId}.json`,
+                {
+                    json: { name: 'Project Title' },
+                    username: 'foo',
+                    password: 'bar'
+                }
+            )
+            expect(got.put).toBeCalledWith(
+                `${sessionBaseUrl}/${sessionId}.json`,
+                {
+                    json: { name: 'Project Title - Suite Title - Test Title' },
+                    username: 'foo',
+                    password: 'bar'
+                }
+            )
+        })
+    })
+
+    describe('sessionNameOmitTestTitle is true', () => {
+        beforeEach(() => {
+            service = new BrowserstackService({ sessionNameOmitTestTitle: true } as any, [] as any, { user: 'foo', key: 'bar' } as any)
+        })
+        it('should not set title for Mocha tests', async () => {
+            await service.before(service['_config'] as any, [], browser)
+            await service.beforeSuite({ title: 'Suite Title' } as any)
+            expect(service['_fullTitle']).toBe('Suite Title')
+            await service.beforeTest({ title: 'bar', parent: 'Suite Title' } as any)
+            expect(service['_fullTitle']).toBe('Suite Title')
+            await service.afterTest({ title: 'bar', parent: 'Suite Title' } as any, undefined as never, {} as any)
+            expect(service['_fullTitle']).toBe('Suite Title')
+            expect(got.put).toBeCalledTimes(1)
+            expect(got.put).toBeCalledWith(
+                `${sessionBaseUrl}/${sessionId}.json`,
+                {
+                    json: { name: 'Suite Title' },
+                    username: 'foo',
+                    password: 'bar'
+                }
+            )
+        })
+    })
+
+    describe('sessionNamePrependTopLevelSuiteTitle is true, sessionNameOmitTestTitle is true', () => {
+        beforeEach(() => {
+            service = new BrowserstackService({ sessionNameOmitTestTitle: true, sessionNamePrependTopLevelSuiteTitle: true } as any, [] as any, { user: 'foo', key: 'bar' } as any)
+        })
+        it('should set title for Mocha tests using concatenation of top level suite name and innermost suite name', async () => {
+            await service.before(service['_config'] as any, [], browser)
+            await service.beforeSuite({ title: 'Project Title' } as any)
+            expect(service['_fullTitle']).toBe('Project Title')
+            await service.beforeTest({ title: 'Test Title', parent: 'Suite Title' } as any)
+            expect(service['_fullTitle']).toBe('Project Title - Suite Title')
+            expect(got.put).toBeCalledTimes(2)
+            expect(got.put).toBeCalledWith(
+                `${sessionBaseUrl}/${sessionId}.json`,
+                {
+                    json: { name: 'Project Title' },
+                    username: 'foo',
+                    password: 'bar'
+                }
+            )
+            expect(got.put).toBeCalledWith(
+                `${sessionBaseUrl}/${sessionId}.json`,
+                {
+                    json: { name: 'Project Title - Suite Title' },
+                    username: 'foo',
+                    password: 'bar'
+                }
+            )
+        })
+    })
+
+    describe('sessionNameFormat is defined', () => {
+        beforeEach(() => {
+            service = new BrowserstackService({
+                sessionNameFormat: (config, caps, suiteTitle, testTitle) => {
+                    if (testTitle) {
+                        return `${config.region} - ${(caps as any).browserName} - ${suiteTitle} - ${testTitle}`
+                    }
+                    return `${config.region} - ${(caps as any).browserName} - ${suiteTitle}`
+                }
+            } as any, {
+                browserName: 'foobar'
+            }, {
+                user: 'foo',
+                key: 'bar',
+                region: 'barfoo'
+            } as any)
+        })
+        it('should set title via sessionNameFormat method', async () => {
+            await service.before(service['_config'] as any, [], browser)
+            service['_browser'] = browser
+            service['_suiteTitle'] = 'Suite Title'
+            await service.beforeSuite({ title: 'Suite Title' } as any)
+            expect(service['_fullTitle']).toBe('barfoo - foobar - Suite Title')
+            await service.beforeTest({ title: 'Test Title', parent: 'Suite Title' } as any)
+            expect(service['_fullTitle']).toBe('barfoo - foobar - Suite Title - Test Title')
+            expect(got.put).toBeCalledTimes(2)
+            expect(got.put).toBeCalledWith(
+                `${sessionBaseUrl}/${sessionId}.json`,
+                {
+                    json: { name: 'barfoo - foobar - Suite Title' },
+                    username: 'foo',
+                    password: 'bar'
+                }
+            )
+            expect(got.put).toBeCalledWith(
+                `${sessionBaseUrl}/${sessionId}.json`,
+                {
+                    json: { name: 'barfoo - foobar - Suite Title - Test Title' },
+                    username: 'foo',
+                    password: 'bar'
+                }
+            )
+        })
+    })
+
+    describe('Jasmine only', () => {
+        it('should set suite name of first test as title', async () => {
+            await service.before(service['_config'] as any, [], browser)
+            await service.beforeSuite({ title: jasmineSuiteTitle } as any)
+            await service.beforeTest({ fullName: 'foo bar baz', description: 'baz' } as any)
+            service.afterTest({ fullName: 'foo bar baz', description: 'baz' } as any, undefined as never, {} as any)
+            expect(service['_fullTitle']).toBe('foo bar')
+            expect(got.put).toBeCalledWith(
+                `${sessionBaseUrl}/${sessionId}.json`,
+                {
+                    json: { name: 'foo bar' },
+                    username: 'foo',
+                    password: 'bar'
+                }
+            )
+        })
+
+        it('should set parent suite name as title', async () => {
+            await service.before(service['_config'] as any, [], browser)
+            await service.beforeSuite({ title: jasmineSuiteTitle } as any)
+            await service.beforeTest({ fullName: 'foo bar baz', description: 'baz' } as any)
+            await service.beforeTest({ fullName: 'foo xyz', description: 'xyz' } as any)
+            service.afterTest({ fullName: 'foo bar baz', description: 'baz' } as any, undefined as never, {} as any)
+            service.afterTest({ fullName: 'foo xyz', description: 'xyz' } as any, undefined as never, {} as any)
+            expect(service['_fullTitle']).toBe('foo')
+            expect(got.put).toBeCalledWith(
+                `${sessionBaseUrl}/${sessionId}.json`,
+                {
+                    json: { name: 'foo' },
+                    username: 'foo',
+                    password: 'bar'
+                }
+            )
+        })
+    })
+})
+
 describe('afterTest', () => {
     it('should increment failure reasons on fails', () => {
         service.before(service['_config'] as any, [], browser)
         service['_fullTitle'] = ''
         service.beforeSuite({ title: 'foo' } as any)
+        service.beforeTest({ title: 'foo', parent: 'bar' } as any)
         service.afterTest(
             { title: 'foo', parent: 'bar' } as any,
             undefined as never,
             { error: { message: 'cool reason' }, result: 1, duration: 5, passed: false } as any)
         expect(service['_failReasons']).toContain('cool reason')
 
+        service.beforeTest({ title: 'foo2', parent: 'bar2' } as any)
         service.afterTest(
             { title: 'foo2', parent: 'bar2' } as any,
             undefined as never,
@@ -318,6 +534,7 @@ describe('afterTest', () => {
         expect(service['_failReasons']).toContain('cool reason')
         expect(service['_failReasons']).toContain('not so cool reason')
 
+        service.beforeTest({ title: 'foo3', parent: 'bar3' } as any)
         service.afterTest(
             { title: 'foo3', parent: 'bar3' } as any,
             undefined as never,
@@ -333,12 +550,14 @@ describe('afterTest', () => {
     it('should not increment failure reasons on passes', () => {
         service.before(service['_config'] as any, [], browser)
         service.beforeSuite({ title: 'foo' } as any)
+        service.beforeTest({ title: 'foo', parent: 'bar' } as any)
         service.afterTest(
             { title: 'foo', parent: 'bar' } as any,
             undefined as never,
             { error: { message: 'cool reason' }, result: 1, duration: 5, passed: true } as any)
         expect(service['_failReasons']).toEqual([])
 
+        service.beforeTest({ title: 'foo2', parent: 'bar2' } as any)
         service.afterTest(
             { title: 'foo2', parent: 'bar2' } as any,
             undefined as never,
@@ -346,30 +565,6 @@ describe('afterTest', () => {
 
         expect(service['_fullTitle']).toBe('bar2 - foo2')
         expect(service['_failReasons']).toEqual([])
-    })
-
-    it('should set title for Mocha tests', () => {
-        service.before(service['_config'] as any, [], browser)
-        service.beforeSuite({ title: 'foo' } as any)
-        service.afterTest({ title: 'bar', parent: 'foo' } as any, undefined as never, {} as any)
-        expect(service['_fullTitle']).toBe('foo - bar')
-    })
-
-    describe('Jasmine only', () => {
-        it('should set suite name of first test as title', () => {
-            service.before(service['_config'] as any, [], browser)
-            service.beforeSuite({ title: 'Jasmine__TopLevel__Suite' } as any)
-            service.afterTest({ fullName: 'foo bar baz', description: 'baz' } as any, undefined as never, {} as any)
-            expect(service['_fullTitle']).toBe('foo bar')
-        })
-
-        it('should set parent suite name as title', () => {
-            service.before(service['_config'] as any, [], browser)
-            service.beforeSuite({ title: 'Jasmine__TopLevel__Suite' } as any)
-            service.afterTest({ fullName: 'foo bar baz', description: 'baz' } as any, undefined as never, {} as any)
-            service.afterTest({ fullName: 'foo xyz', description: 'xyz' } as any, undefined as never, {} as any)
-            expect(service['_fullTitle']).toBe('foo')
-        })
     })
 })
 
@@ -476,15 +671,13 @@ describe('after', () => {
         expect(updateSpy).toHaveBeenCalledWith(service['_browser']?.sessionId,
             {
                 status: 'passed',
-                name: 'foo - bar',
-                reason: undefined
+                name: 'foo - bar'
             })
         expect(got.put).toHaveBeenCalledWith(
-            'https://api.browserstack.com/automate/sessions/session123.json',
+            `${sessionBaseUrl}/${sessionId}.json`,
             { json: {
                 status: 'passed',
-                name: 'foo - bar',
-                reason: undefined
+                name: 'foo - bar'
             }, username: 'foo', password: 'bar' })
     })
 
@@ -503,12 +696,41 @@ describe('after', () => {
                 reason: 'I am failure'
             })
         expect(got.put).toHaveBeenCalledWith(
-            'https://api.browserstack.com/automate/sessions/session123.json',
+            `${sessionBaseUrl}/${sessionId}.json`,
             { json: {
                 status: 'failed',
                 name: 'foo - bar',
                 reason: 'I am failure'
             }, username: 'foo', password: 'bar' })
+    })
+
+    it('should not set session status if option setSessionStatus is false', async () => {
+        const service = new BrowserstackService({ setSessionStatus: false } as any, [] as any, { user: 'foo', key: 'bar' } as any)
+        const updateSpy = vi.spyOn(service, '_update')
+        await service.before(service['_config'] as any, [], browser)
+
+        service['_fullTitle'] = 'foo - bar'
+        service['_failReasons'] = ['I am failure']
+        await service.after(1)
+
+        expect(updateSpy).not.toHaveBeenCalled()
+        expect(got.put).not.toHaveBeenCalled()
+    })
+
+    it('should not set session name if option setSessionName is false', async () => {
+        const service = new BrowserstackService({ setSessionName: false } as any, [] as any, { user: 'foo', key: 'bar' } as any)
+        const updateSpy = vi.spyOn(service, '_update')
+        await service.before(service['_config'] as any, [], browser)
+
+        service['_failReasons'] = []
+        service['_fullTitle'] = 'foo - bar'
+
+        await service.after(0)
+
+        expect(updateSpy).toHaveBeenCalledWith(service['_browser']?.sessionId, { status: 'passed' })
+        expect(got.put).toHaveBeenCalledWith(
+            `${sessionBaseUrl}/${sessionId}.json`,
+            { json: { status: 'passed' }, username: 'foo', password: 'bar' })
     })
 
     describe('Cucumber only', function () {
@@ -555,7 +777,6 @@ describe('after', () => {
             expect(updateSpy).toHaveBeenCalled()
             expect(updateSpy).toHaveBeenLastCalledWith(service['_browser']?.sessionId, {
                 name: 'Feature1',
-                reason: undefined,
                 status: 'passed',
             })
         })
@@ -597,7 +818,6 @@ describe('after', () => {
 
             expect(updateSpy).toHaveBeenCalledWith(service['_browser']?.sessionId, {
                 name: 'Feature1',
-                reason: undefined,
                 status: 'passed',
             })
         })
@@ -706,7 +926,6 @@ describe('after', () => {
 
                     expect(updateSpy).toHaveBeenLastCalledWith(service['_browser']?.sessionId, {
                         name: 'Can do something single',
-                        reason: undefined,
                         status: 'passed',
                     })
                 })
@@ -752,7 +971,6 @@ describe('after', () => {
 
                     expect(updateSpy).toHaveBeenLastCalledWith(service['_browser']?.sessionId, {
                         name: 'Feature1',
-                        reason: undefined,
                         status: 'passed',
                     })
                 })


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

- Set the session name in `beforeSuite` and/or `beforeTest` instead of `afterTest`
  - allow the user the option to update the name at any given point in time.
  - account for cases where there is a long running `before` function, or one that can fail.
- Add options `setSessionName` and `setSessionStatus` (both default to `true`)
- Add option `sessionNamePrependTopLevelSuiteTitle `
  - For nested suites, set session name to: `<outer suite title> - <inner suite title>`
- Add option `sessionNameOmitTestTitle `
  - Set session name to: `<suite title>`
- Add option `sessionNameFormat` to allow customizing the session name using configuration, capabilities, suite title, test title (Mocha only)

Setting `sessionNamePrependTopLevelSuiteTitle =true` and `sessionNameOmitTestTitle=true` will resolve #7876 using the consensus from the discussion in #6777.

Examples, `sessionNamePrependTopLevelSuiteTitle` and `sessionNameOmitTestTitle` set to `true`:
```javascript
describe('webdriver.io', () => {
    describe('header bar', () => {
        it('should have logo', () => {})
    })
    describe('body', () => {
        xit('font should be...', () => {})
    })
})

// Session name before the fix: "header bar - should have logo"
// Session name after the fix: "webdriver.io - header bar"
```

Deeply nested suites:
```javascript
describe('webdriver.io', () => {
    describe('v6', () => {
        describe('header bar', () => {
            it('should have inline search', () => {})
        })
    })
})

// Session name before the fix: "header bar - should have inline search"
// Session name after the fix: "webdriver.io - header bar"
```

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
