### PR TITLE
Add type definition for reporter outputFileFormat

### DIFF
--- a/packages/wdio-concise-reporter/src/index.ts
+++ b/packages/wdio-concise-reporter/src/index.ts
@@ -10,10 +10,8 @@ export default class ConciseReporter extends WDIOReporter {
     private _stateCounts = { failed: 0 }
 
     constructor(options: Reporters.Options) {
-        /**
-        * make Concise reporter to write to output stream by default
-        */
-        super(Object.assign(options, { stdout: true }))
+        // write to output stream by default
+        super(Object.assign({ stdout: true }, options))
     }
 
     onSuiteStart (suite: SuiteStats): void {
@@ -33,9 +31,9 @@ export default class ConciseReporter extends WDIOReporter {
     }
 
     /**
-    * Print the Concise report to the screen
-    * @param  {Object} runner Wdio runner
-    */
+     * Print the Concise report to the screen
+     * @param  {Object} runner Wdio runner
+     */
     printReport(runner: RunnerStats): void {
         const header = chalk.yellow('========= Your concise report ==========')
 
@@ -49,9 +47,9 @@ export default class ConciseReporter extends WDIOReporter {
     }
 
     /**
-    * Get the display for failing tests
-    * @return {String} Count display
-    */
+     * Get the display for failing tests
+     * @return {String} Count display
+     */
     getCountDisplay () {
         const failedTestsCount = this._stateCounts.failed
 
@@ -61,9 +59,9 @@ export default class ConciseReporter extends WDIOReporter {
     }
 
     /**
-    * Get display for failed tests, e.g. stack trace
-    * @return {Array} Stack trace output
-    */
+     * Get display for failed tests, e.g. stack trace
+     * @return {Array} Stack trace output
+     */
     getFailureDisplay () {
         const output: string[] = []
 

--- a/packages/wdio-junit-reporter/src/types.ts
+++ b/packages/wdio-junit-reporter/src/types.ts
@@ -25,23 +25,6 @@ interface TestSuiteNameFormatOptions {
 
 export interface JUnitReporterOptions extends Reporters.Options {
     /**
-     * Define the xml files created after the test execution.
-     *
-     * > Note: `options.capabilities` is your capabilities object for that runner, so specifying
-     * `${options.capabilities}` in your string will return [Object object]. You must specify which
-     * properties of capabilities you want in your filename.
-     *
-     * @example
-     * outputFileFormat: function (options) {
-     *     return 'mycustomfilename.xml'
-     * }
-     * @default
-     * outputFileFormat: function (options) {
-     *     return `wdio-${this.cid}-${opts.name}-reporter.log`
-     * }
-     */
-    outputFileFormat?: (opts: any) => string
-    /**
      * Gives the ability to provide custom regex for formatting test suite name (e.g. in output xml ) or
      * override the generated name of a test suite.
      *

--- a/packages/wdio-runner/src/reporter.ts
+++ b/packages/wdio-runner/src/reporter.ts
@@ -62,7 +62,10 @@ export default class BaseReporter {
 
     getLogFile (name: string) {
         // clone the config to avoid changing original properties
-        let options = Object.assign({}, this._config) as any
+        let options = Object.assign({}, this._config) as Omit<Options.Testrunner, 'capabilities'> & {
+            cid: string
+            capabilities: Capabilities.RemoteCapability
+        }
         let filename = `wdio-${this._cid}-${name}-reporter.log`
 
         const reporterOptions = this._config.reporters!.find((reporter) => (
@@ -71,9 +74,9 @@ export default class BaseReporter {
                 reporter[0] === name ||
                 typeof reporter[0] === 'function' && reporter[0].name === name
             )
-        )) as { outputFileFormat?: Function }[]
+        ))
 
-        if (reporterOptions) {
+        if (reporterOptions && Array.isArray(reporterOptions)) {
             const fileformat = reporterOptions[1].outputFileFormat
 
             options.cid = this._cid

--- a/packages/wdio-runner/tests/reporter.test.ts
+++ b/packages/wdio-runner/tests/reporter.test.ts
@@ -87,23 +87,28 @@ describe('BaseReporter', () => {
             .toMatch(/(\\|\/)foo(\\|\/)bar(\\|\/)baz(\\|\/)wdio-0-0-dot-reporter.log/)
     })
 
-    it('should return custom log file name', async () => {
+    it('should return custom log file name using cid and capabilities', async () => {
         const reporter = new BaseReporter({
             outputDir: '/foo/bar',
             reporters: [
                 'dot',
                 ['dot', {
                     foo: 'bar',
-                    outputFileFormat: (options: any) => {
-                        return `wdio-results-${options.cid}.xml`
+                    outputFileFormat: (options) => {
+                        const { cid, capabilities } = options
+                        expect(cid).toBe('0-0')
+                        expect(capabilities).toBe(capability)
+                        if ('browserName' in capabilities) {
+                            const { browserName } = capabilities
+                            return `wdio-results-${cid}-${browserName}.log`
+                        }
                     }
                 }]
             ]
         } as Options.Testrunner, '0-0', capability)
         await reporter.initReporters()
-
         expect(reporter.getLogFile('dot'))
-            .toMatch(/(\\|\/)foo(\\|\/)bar(\\|\/)wdio-results-0-0.xml/)
+            .toMatch(/(\\|\/)foo(\\|\/)bar(\\|\/)wdio-results-0-0-foo.log/)
     })
 
     it('should throw error if outputFileFormat is not a function', async () => {

--- a/packages/wdio-types/src/Reporters.ts
+++ b/packages/wdio-types/src/Reporters.ts
@@ -1,15 +1,55 @@
 import type { WriteStream } from 'node:fs'
 import type { EventEmitter } from 'node:events'
+import type { RemoteCapability } from './Capabilities'
+
+interface OutputFileFormatOptions {
+    cid: string
+    capabilities: RemoteCapability
+}
 
 export interface Options {
     outputDir?: string
+    /**
+     * Complete path of the reporter log file. If `setLogFile` is defined, it will
+     * be used instead of this option.
+     */
+    logFile?: string
+    /**
+     * Define the filename format for the reporter log files, using the `cid` and
+     * `capabilities`. `setLogFile` and `logFile` take precedence over this
+     * option, if defined (in that order).
+     *
+     * > Note: `options.capabilities` is your capabilities object for that runner, so specifying
+     * `${options.capabilities}` in your string will return [Object object]. You must specify which
+     * properties of capabilities you want in your filename.
+     *
+     * @default `wdio-${cid}-${name}-reporter.log`
+     *
+     * @example
+     * outputFileFormat: function (options) {
+     *     const { cid, capabilities } = options
+     *     const { browserName } = capabilities
+     *     return `wdio-${cid}-${browserName}-reporter.log`
+     * }
+     */
+    outputFileFormat?: (options: OutputFileFormatOptions) => string
+    /**
+     * Set the complete path for the reporter's log output, using `cid` and
+     * the reporter's `name`.
+     */
     setLogFile?: (cid: string, name: string) => string
+    /**
+     * No log file will be created if this option is set to `true`.
+     */
+    stdout?: boolean
+    /**
+     * Write to `writeStream` instead of a file.
+     *
+     * Note: `logFile` must not be set, unless `stdout` is set to `true`.
+     */
     writeStream?: WriteStream | {
         write: (content: any) => boolean
     }
-    stdout?: boolean
-    logFile?: string
-
     /**
      * allow random typings from 3rd party reporters
      */


### PR DESCRIPTION
## Proposed changes

I almost didn't open this PR due to a few potential issues:
- Third-party reporters that incorrectly extended `Reporters.Options` may face type errors
- in `wdio-types/src/Reporters`: importing `RemoteCapability` from `Capabilities`  creates a circular dependency (although no errors observed):
  - `Capabilities --> Options --> Reporters --> Capabilities ...`

Please feel free to close if any of these pitfalls outweigh the benefit of providing type information for this option.

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
