### PR TITLE
@wdio/sauce-service: apply setJobName in beforeSuite

### DIFF
--- a/packages/wdio-sauce-service/tests/service.test.ts
+++ b/packages/wdio-sauce-service/tests/service.test.ts
@@ -107,6 +107,26 @@ test('beforeSuite should not send request to set the job name as suite name for 
     expect(service.setAnnotation).not.toBeCalled()
 })
 
+test('beforeSuite should set job-name via custom setJobName method', async () => {
+    const service = new SauceService({
+        setJobName: (config, caps, title) => {
+            return `${config.region} - ${(caps as any).browserName} - ${title}`
+        }
+    }, {
+        browserName: 'foobar'
+    }, {
+        user: 'foobar',
+        key: '123',
+        region: 'barfoo' as any
+    } as any)
+    service['_browser'] = browser
+    service.setAnnotation = vi.fn()
+    expect(service['_isJobNameSet']).toBe(false)
+    await service.beforeSuite({ title: 'Suite Title' } as any)
+    expect(service['_isJobNameSet']).toBe(true)
+    expect(service.setAnnotation).toBeCalledWith('sauce:job-name=barfoo - foobar - Suite Title')
+})
+
 test('beforeTest should send the job-name as suite name by default', async () => {
     const service = new SauceService({}, {}, { user: 'foobar', key: '123', capabilities: {} })
     service['_browser'] = browser
@@ -139,7 +159,7 @@ test('beforeTest should mark job-name as set', async () => {
 test('beforeTest should set job-name via custom setJobName method', async () => {
     const service = new SauceService({
         setJobName: (config, caps, title) => {
-            return `${config.region}-${(caps as any).browserName}-${title}`
+            return `${config.region} - ${(caps as any).browserName} - ${title}`
         }
     }, {
         browserName: 'foobar'
@@ -157,10 +177,10 @@ test('beforeTest should set job-name via custom setJobName method', async () => 
         description: 'foobar'
     } as any)
     expect(service['_isJobNameSet']).toBe(true)
-    expect(service.setAnnotation).toBeCalledWith('sauce:job-name=barfoo-foobar-Suite Title')
+    expect(service.setAnnotation).toBeCalledWith('sauce:job-name=barfoo - foobar - Suite Title')
 })
 
-test('beforeTest not should set job-name when it has already been set', async () => {
+test('beforeTest should not set job-name when it has already been set', async () => {
     const service = new SauceService({}, {}, { user: 'foobar', key: '123', capabilities: {} })
     service['_browser'] = browser
     service['_suiteTitle'] = 'Suite Title'


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)
Currently it appears that `setJobName` is only in effect in `beforeTest`. This PR applies it in all locations where the job name is set.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
