### PR TITLE
[v7] @wdio/browserstack-service: Add session naming options

### DIFF
--- a/packages/wdio-browserstack-service/README.md
+++ b/packages/wdio-browserstack-service/README.md
@@ -1,7 +1,7 @@
-WebdriverIO Browserstack Service
+WebdriverIO BrowserStack Service
 ==========
 
-> A WebdriverIO service that manages local tunnel and job metadata for Browserstack users.
+> A WebdriverIO service that manages local tunnel and job metadata for BrowserStack users.
 
 ## Installation
 
@@ -16,7 +16,7 @@ Instructions on how to install `WebdriverIO` can be found [here.](https://webdri
 
 ## Configuration
 
-WebdriverIO has Browserstack support out of the box. You should simply set `user` and `key` in your `wdio.conf.js` file. This service plugin provides supports for [Browserstack Tunnel](https://www.browserstack.com/automate/node#setting-local-tunnel). Set `browserstackLocal: true` also to activate this feature.
+WebdriverIO has BrowserStack support out of the box. You should set `user` and `key` in your `wdio.conf.js` file. This service plugin provides support for [BrowserStack](https://www.browserstack.com/automate/node#setting-local-tunnel) Tunnel](https://www.browserstack.com/automate/node#setting-local-tunnel). Set `browserstackLocal: true` also to activate this feature.
 Reporting of session status on BrowserStack will respect `strict` setting of Cucumber options.
 
 ```js
@@ -39,19 +39,13 @@ exports.config
 In order to authorize to the BrowserStack service your config needs to contain a [`user`](https://webdriver.io/docs/options#user) and [`key`](https://webdriver.io/docs/options#key) option.
 
 ### browserstackLocal
-Set this to true to enable routing connections from Browserstack cloud through your computer.
-
-Type: `Boolean`<br />
-Default: `false`
-
-### preferScenarioName
-Cucumber only. Set this to true to enable updating the session name to the Scenario name if only a single Scenario was ran. Useful when running in parallel with [wdio-cucumber-parallel-execution](https://github.com/SimitTomar/wdio-cucumber-parallel-execution).
+Set this to true to enable routing connections from BrowserStack cloud through your computer.
 
 Type: `Boolean`<br />
 Default: `false`
 
 ### forcedStop
-Set this to true to kill the browserstack process on complete, without waiting for the browserstack stop callback to be called. This is experimental and should not be used by all. Mostly necessary as a workaraound for [this issue](https://github.com/browserstack/browserstack-local-nodejs/issues/41).
+Set this to true to kill the BrowserStack Local process on complete, without waiting for the BrowserStack Local stop callback to be called. This is experimental and should not be used by all. Mostly necessary as a workaraound for [this issue](https://github.com/browserstack/browserstack-local-nodejs/issues/41).
 
 Type: `Boolean`<br />
 Default: `false`
@@ -141,8 +135,53 @@ services: [
 ]
 ```
 
+### preferScenarioName
+
+Cucumber only. Set the BrowserStack Automate session name to the Scenario name if only a single Scenario ran.
+Useful when running in parallel with [wdio-cucumber-parallel-execution](https://github.com/SimitTomar/wdio-cucumber-parallel-execution).
+
+Type: `Boolean`<br />
+Default: `false`
+
+### sessionNameFormat
+
+Customize the BrowserStack Automate session name format.
+
+Type: `Function`<br />
+Default (Cucumber/Jasmine): `(config, capabilities, suiteTitle) => suiteTitle`<br />
+Default (Mocha): `(config, capabilities, suiteTitle, testTitle) => suiteTitle + ' - ' + testTitle`
+
+### sessionNameOmitTestTitle
+
+Mocha only. Do not append the test title to the BrowserStack Automate session name.
+
+Type: `Boolean`<br />
+Default: `false`
+
+### sessionNamePrependTopLevelSuiteTitle
+
+Mocha only. Prepend the top level suite title to the BrowserStack Automate session name.
+
+Type: `Boolean`<br />
+Default: `false`
+
+### setSessionName
+
+Automatically set the BrowserStack Automate session name.
+
+Type: `Boolean`<br />
+Default: `true`
+
+### setSessionStatus
+
+Automatically set the BrowserStack Automate session status (passed/failed).
+
+Type: `Boolean`<br />
+Default: `true`
+
 ### opts
-Specified optional will be passed down to BrowserstackLocal.
+
+BrowserStack Local options.
 
 Type: `Object`<br />
 Default: `{}`
@@ -185,7 +224,7 @@ opts = { f: "/my/awesome/folder" };
 
 #### Force Start
 
-To kill other running Browserstack Local instances -
+To kill other running BrowserStack Local instances -
 
 ```js
 opts = { force: "true" };

--- a/packages/wdio-browserstack-service/src/constants.ts
+++ b/packages/wdio-browserstack-service/src/constants.ts
@@ -1,3 +1,5 @@
+import type { BrowserstackConfig } from './types'
+
 export const BROWSER_DESCRIPTION = [
     'device',
     'os',
@@ -14,3 +16,8 @@ export const VALID_APP_EXTENSION = [
     '.aab',
     '.ipa'
 ]
+
+export const DEFAULT_OPTIONS: Partial<BrowserstackConfig> = {
+    setSessionName: true,
+    setSessionStatus: true
+}

--- a/packages/wdio-browserstack-service/src/types.ts
+++ b/packages/wdio-browserstack-service/src/types.ts
@@ -1,3 +1,5 @@
+import type { Capabilities, Options } from '@wdio/types'
+
 export interface SessionResponse {
     // eslint-disable-next-line camelcase
     automation_session: {
@@ -50,6 +52,16 @@ export interface BrowserstackConfig {
      */
     forcedStop?: boolean;
     /**
+     * Set this to true to only use the suite title(s) for setting the session name.
+     * @default false
+     */
+    omitTestTitle?: boolean;
+    /**
+     * Set this to true to prepend the top level suite title to the session name.
+     * @default false
+     */
+    prependTopLevelSuiteTitle?: boolean;
+    /**
      * Specified optional will be passed down to BrowserstackLocal. For more details check out the
      * [`browserstack-local`](https://www.npmjs.com/package/browserstack-local#arguments) docs.
      *
@@ -61,4 +73,13 @@ export interface BrowserstackConfig {
      * ```
      */
     opts?: Partial<import('browserstack-local').Options>
+    /**
+     * Dynamically control the name of the session in Browserstack.
+     */
+    setSessionName?: (
+        config: Options.Testrunner,
+        capabilities: Capabilities.RemoteCapability,
+        suiteTitle: string,
+        testTitle?: string
+    ) => string
 }

--- a/packages/wdio-browserstack-service/src/types.ts
+++ b/packages/wdio-browserstack-service/src/types.ts
@@ -30,39 +30,28 @@ export interface App {
 
 export interface BrowserstackConfig {
     /**
-     * Set this to true to enable routing connections from Browserstack cloud through your computer.
-     * You will also need to set `browserstack.local` to true in browser capabilities.
-     */
-    browserstackLocal?: boolean;
-    /**
      * Set this with app file path present locally on your device or
-     * app hashed id returned after uploading app to Browserstack or
+     * app hashed id returned after uploading app to BrowserStack or
      * custom_id, sharable_id of the uploaded app
+     * @default undefined
      */
     app?: string | AppConfig;
     /**
-     * Cucumber only. Set this to true to enable updating the session name to the Scenario name if only
-     * a single Scenario was ran. Useful when running in parallel
-     * with [wdio-cucumber-parallel-execution](https://github.com/SimitTomar/wdio-cucumber-parallel-execution).
+     * Enable routing connections from BrowserStack cloud through your computer.
+     * You will also need to set `browserstack.local` to true in browser capabilities.
+     * @default false
      */
-    preferScenarioName?: boolean;
+    browserstackLocal?: boolean;
     /**
-     * Set this to true to kill the browserstack process on complete, without waiting for the
-     * browserstack stop callback to be called. This is experimental and should not be used by all.
+     * Kill the BrowserStack Local process on complete, without waiting for the
+     * BrowserStack Local stop callback to be called.
+     *
+     * __This is experimental and should not be used by all.__
+     * @default false
      */
     forcedStop?: boolean;
     /**
-     * Set this to true to only use the suite title(s) for setting the session name.
-     * @default false
-     */
-    omitTestTitle?: boolean;
-    /**
-     * Set this to true to prepend the top level suite title to the session name.
-     * @default false
-     */
-    prependTopLevelSuiteTitle?: boolean;
-    /**
-     * Specified optional will be passed down to BrowserstackLocal. For more details check out the
+     * BrowserStack Local options. For more details check out the
      * [`browserstack-local`](https://www.npmjs.com/package/browserstack-local#arguments) docs.
      *
      * @example
@@ -71,15 +60,43 @@ export interface BrowserstackConfig {
      *   localIdentifier: 'some-identifier'
      * }
      * ```
+     * @default {}
      */
     opts?: Partial<import('browserstack-local').Options>
     /**
-     * Dynamically control the name of the session in Browserstack.
+     * Cucumber only. Set the BrowserStack Automate session name to the Scenario name if only a single Scenario ran.
+     * Useful when running in parallel with [wdio-cucumber-parallel-execution](https://github.com/SimitTomar/wdio-cucumber-parallel-execution).
+     * @default false
      */
-    setSessionName?: (
+    preferScenarioName?: boolean;
+    /**
+     * Customize the BrowserStack Automate session name format.
+     * @default undefined
+     */
+    sessionNameFormat?: (
         config: Options.Testrunner,
         capabilities: Capabilities.RemoteCapability,
         suiteTitle: string,
         testTitle?: string
     ) => string
+    /**
+     * Mocha only. Do not append the test title to the BrowserStack Automate session name.
+     * @default false
+     */
+    sessionNameOmitTestTitle?: boolean;
+    /**
+     * Mocha only. Prepend the top level suite title to the BrowserStack Automate session name.
+     * @default false
+     */
+    sessionNamePrependTopLevelSuiteTitle?: boolean;
+    /**
+     * Automatically set the BrowserStack Automate session name.
+     * @default true
+     */
+    setSessionName?: boolean
+    /**
+     * Automatically set the BrowserStack Automate session status (passed/failed).
+     * @default true
+     */
+    setSessionStatus?: boolean
 }

--- a/packages/wdio-browserstack-service/tests/service.test.ts
+++ b/packages/wdio-browserstack-service/tests/service.test.ts
@@ -1,6 +1,6 @@
 import gotMock from 'got'
 import logger from '@wdio/logger'
-import type { Browser } from 'webdriverio'
+import type { Browser, MultiRemoteBrowser } from 'webdriverio'
 
 import BrowserstackService from '../src/service'
 
@@ -11,9 +11,14 @@ interface GotMock extends jest.Mock {
 const got = gotMock as unknown as GotMock
 const expect = global.expect as unknown as jest.Expect
 
+const jasmineSuiteTitle = 'Jasmine__TopLevel__Suite'
+const sessionBaseUrl = 'https://api.browserstack.com/automate/sessions'
+const sessionId = 'session123'
+const sessionIdA = 'session456'
+
 const log = logger('test')
 let service: BrowserstackService
-let browser: Browser
+let browser: Browser<'async'> | MultiRemoteBrowser<'async'>
 
 beforeEach(() => {
     (log.info as jest.Mock).mockClear()
@@ -29,7 +34,7 @@ beforeEach(() => {
     got.put.mockReturnValue(Promise.resolve({}))
 
     browser = {
-        sessionId: 'session123',
+        sessionId: sessionId,
         config: {},
         capabilities: {
             device: '',
@@ -40,17 +45,19 @@ beforeEach(() => {
         instances: ['browserA', 'browserB'],
         isMultiremote: false,
         browserA: {
-            sessionId: 'session456',
-            capabilities: { 'bstack:options': {
-                device: '',
-                os: 'Windows',
-                osVersion: 10,
-                browserName: 'chrome'
-            } }
+            sessionId: sessionIdA,
+            capabilities: {
+                'bstack:options': {
+                    device: '',
+                    os: 'Windows',
+                    osVersion: 10,
+                    browserName: 'chrome'
+                }
+            }
         },
         browserB: {}
-    } as any as Browser
-    service = new BrowserstackService({}, [] as any, { user: 'foo', key: 'bar' } as any)
+    } as unknown as Browser<'async'> | MultiRemoteBrowser<'async'>
+    service = new BrowserstackService({} as any, [] as any, { user: 'foo', key: 'bar' } as any)
 })
 
 it('should initialize correctly', () => {
@@ -117,7 +124,7 @@ describe('_printSessionURL', () => {
         const logInfoSpy = jest.spyOn(log, 'info').mockImplementation((string) => string)
         await service._printSessionURL()
         expect(got).toHaveBeenCalledWith(
-            'https://api.browserstack.com/automate/sessions/session123.json',
+            `${sessionBaseUrl}/${sessionId}.json`,
             { username: 'foo', password: 'bar', responseType: 'json' })
         expect(logInfoSpy).toHaveBeenCalled()
         expect(logInfoSpy).toHaveBeenCalledWith(
@@ -132,7 +139,7 @@ describe('_printSessionURL', () => {
         const logInfoSpy = jest.spyOn(log, 'info').mockImplementation((string) => string)
         await service._printSessionURL()
         expect(got).toHaveBeenCalledWith(
-            'https://api.browserstack.com/automate/sessions/session456.json',
+            `${sessionBaseUrl}/${sessionIdA}.json`,
             { username: 'foo', password: 'bar', responseType: 'json' })
         expect(logInfoSpy).toHaveBeenCalled()
         expect(logInfoSpy).toHaveBeenCalledWith(
@@ -183,7 +190,7 @@ describe('before', () => {
         let service = new BrowserstackService({}, [{}] as any, { capabilities: {} })
 
         await service.beforeSession({} as any as any)
-        await service.before(service['_config'], [], browser as Browser)
+        await service.before(service['_config'] as any, [], browser)
 
         expect(service['_failReasons']).toEqual([])
         expect(service['_config'].user).toEqual('NotSetUser')
@@ -215,7 +222,7 @@ describe('before', () => {
         service.before(service['_config'], [], browser)
 
         expect(service['_failReasons']).toEqual([])
-        expect(service['_sessionBaseUrl']).toEqual('https://api.browserstack.com/automate/sessions')
+        expect(service['_sessionBaseUrl']).toEqual(sessionBaseUrl)
     })
 
     it('should initialize correctly for multiremote', () => {
@@ -231,7 +238,7 @@ describe('before', () => {
         service.before(service['_config'], [], browser)
 
         expect(service['_failReasons']).toEqual([])
-        expect(service['_sessionBaseUrl']).toEqual('https://api.browserstack.com/automate/sessions')
+        expect(service['_sessionBaseUrl']).toEqual(sessionBaseUrl)
     })
 
     it('should initialize correctly for appium', () => {
@@ -301,17 +308,213 @@ describe('before', () => {
     })
 })
 
+describe('beforeSuite', () => {
+    it('should send request to set the session name as suite name for Mocha tests', async () => {
+        await service.before(service['_config'] as any, [], browser)
+        expect(service['_suiteTitle']).toBeUndefined()
+        expect(service['_fullTitle']).toBeUndefined()
+        await service.beforeSuite({ title: 'foobar' } as any)
+        expect(service['_suiteTitle']).toBe('foobar')
+        expect(service['_fullTitle']).toBe('foobar')
+        expect(got.put).toBeCalledWith(
+            `${sessionBaseUrl}/${sessionId}.json`,
+            {
+                json: { name: 'foobar' },
+                username: 'foo',
+                password: 'bar'
+            }
+        )
+    })
+
+    it('should not send request to set the session name as suite name for Jasmine tests', async () => {
+        await service.before(service['_config'] as any, [], browser)
+        expect(service['_suiteTitle']).toBeUndefined()
+        expect(service['_fullTitle']).toBeUndefined()
+        await service.beforeSuite({ title: jasmineSuiteTitle } as any)
+        expect(service['_suiteTitle']).toBe(jasmineSuiteTitle)
+        expect(service['_fullTitle']).toBeUndefined()
+        expect(got.put).not.toBeCalled()
+    })
+})
+
+describe('beforeTest', () => {
+    describe('prependTopLevelSuiteTitle is true', () => {
+        it('should set title for Mocha tests using concatenation of top level suite name, innermost suite name, and test title', () => {
+            const service = new BrowserstackService({ prependTopLevelSuiteTitle: true } as any, [] as any, { user: 'foo', key: 'bar' } as any)
+            service.before(service['_config'] as any, [], browser)
+            service.beforeSuite({ title: 'Project Title' } as any)
+            expect(service['_fullTitle']).toBe('Project Title')
+            service.beforeTest({ title: 'Test Title', parent: 'Suite Title' } as any)
+            expect(service['_fullTitle']).toBe('Project Title - Suite Title - Test Title')
+            expect(got.put).toBeCalledTimes(2)
+            expect(got.put).toBeCalledWith(
+                `${sessionBaseUrl}/${sessionId}.json`,
+                {
+                    json: { name: 'Project Title' },
+                    username: 'foo',
+                    password: 'bar'
+                }
+            )
+            expect(got.put).toBeCalledWith(
+                `${sessionBaseUrl}/${sessionId}.json`,
+                {
+                    json: { name: 'Project Title - Suite Title - Test Title' },
+                    username: 'foo',
+                    password: 'bar'
+                }
+            )
+        })
+    })
+
+    describe('omitTestTitle is true', () => {
+        beforeEach(() => {
+            service = new BrowserstackService({ omitTestTitle: true } as any, [] as any, { user: 'foo', key: 'bar' } as any)
+        })
+        it('should not set title for Mocha tests', () => {
+            service.before(service['_config'] as any, [], browser)
+            service.beforeSuite({ title: 'Suite Title' } as any)
+            expect(service['_fullTitle']).toBe('Suite Title')
+            service.beforeTest({ title: 'bar', parent: 'Suite Title' } as any)
+            expect(service['_fullTitle']).toBe('Suite Title')
+            service.afterTest({ title: 'bar', parent: 'Suite Title' } as any, undefined as never, {} as any)
+            expect(service['_fullTitle']).toBe('Suite Title')
+            expect(got.put).toBeCalledTimes(1)
+            expect(got.put).toBeCalledWith(
+                `${sessionBaseUrl}/${sessionId}.json`,
+                {
+                    json: { name: 'Suite Title' },
+                    username: 'foo',
+                    password: 'bar'
+                }
+            )
+        })
+    })
+
+    describe('prependTopLevelSuiteTitle is true, omitTestTitle is true', () => {
+        beforeEach(() => {
+            service = new BrowserstackService({ omitTestTitle: true, prependTopLevelSuiteTitle: true } as any, [] as any, { user: 'foo', key: 'bar' } as any)
+        })
+        it('should set title for Mocha tests using concatenation of top level suite name and innermost suite name', () => {
+            service.before(service['_config'] as any, [], browser)
+            service.beforeSuite({ title: 'Project Title' } as any)
+            expect(service['_fullTitle']).toBe('Project Title')
+            service.beforeTest({ title: 'Test Title', parent: 'Suite Title' } as any)
+            expect(service['_fullTitle']).toBe('Project Title - Suite Title')
+            expect(got.put).toBeCalledTimes(2)
+            expect(got.put).toBeCalledWith(
+                `${sessionBaseUrl}/${sessionId}.json`,
+                {
+                    json: { name: 'Project Title' },
+                    username: 'foo',
+                    password: 'bar'
+                }
+            )
+            expect(got.put).toBeCalledWith(
+                `${sessionBaseUrl}/${sessionId}.json`,
+                {
+                    json: { name: 'Project Title - Suite Title' },
+                    username: 'foo',
+                    password: 'bar'
+                }
+            )
+        })
+    })
+
+    describe('setSessionName is defined', () => {
+        beforeEach(() => {
+            service = new BrowserstackService({
+                setSessionName: (config, caps, suiteTitle, testTitle) => {
+                    if (testTitle) {
+                        return `${config.region} - ${(caps as any).browserName} - ${suiteTitle} - ${testTitle}`
+                    }
+                    return `${config.region} - ${(caps as any).browserName} - ${suiteTitle}`
+                }
+            } as any, {
+                browserName: 'foobar'
+            }, {
+                user: 'foo',
+                key: 'bar',
+                region: 'barfoo'
+            } as any)
+        })
+        it('should set title via custom setSessionName method', async () => {
+            await service.before(service['_config'] as any, [], browser)
+            service['_browser'] = browser
+            service['_suiteTitle'] = 'Suite Title'
+            await service.beforeSuite({ title: 'Suite Title' } as any)
+            expect(service['_fullTitle']).toBe('barfoo - foobar - Suite Title')
+            await service.beforeTest({ title: 'Test Title', parent: 'Suite Title' } as any)
+            expect(service['_fullTitle']).toBe('barfoo - foobar - Suite Title - Test Title')
+            expect(got.put).toBeCalledTimes(2)
+            expect(got.put).toBeCalledWith(
+                `${sessionBaseUrl}/${sessionId}.json`,
+                {
+                    json: { name: 'barfoo - foobar - Suite Title' },
+                    username: 'foo',
+                    password: 'bar'
+                }
+            )
+            expect(got.put).toBeCalledWith(
+                `${sessionBaseUrl}/${sessionId}.json`,
+                {
+                    json: { name: 'barfoo - foobar - Suite Title - Test Title' },
+                    username: 'foo',
+                    password: 'bar'
+                }
+            )
+        })
+    })
+
+    describe('Jasmine only', () => {
+        it('should set suite name of first test as title', async () => {
+            await service.before(service['_config'] as any, [], browser)
+            await service.beforeSuite({ title: jasmineSuiteTitle } as any)
+            await service.beforeTest({ fullName: 'foo bar baz', description: 'baz' } as any)
+            service.afterTest({ fullName: 'foo bar baz', description: 'baz' } as any, undefined as never, {} as any)
+            expect(service['_fullTitle']).toBe('foo bar')
+            expect(got.put).toBeCalledWith(
+                `${sessionBaseUrl}/${sessionId}.json`,
+                {
+                    json: { name: 'foo bar' },
+                    username: 'foo',
+                    password: 'bar'
+                }
+            )
+        })
+
+        it('should set parent suite name as title', async () => {
+            await service.before(service['_config'] as any, [], browser)
+            await service.beforeSuite({ title: jasmineSuiteTitle } as any)
+            await service.beforeTest({ fullName: 'foo bar baz', description: 'baz' } as any)
+            await service.beforeTest({ fullName: 'foo xyz', description: 'xyz' } as any)
+            service.afterTest({ fullName: 'foo bar baz', description: 'baz' } as any, undefined as never, {} as any)
+            service.afterTest({ fullName: 'foo xyz', description: 'xyz' } as any, undefined as never, {} as any)
+            expect(service['_fullTitle']).toBe('foo')
+            expect(got.put).toBeCalledWith(
+                `${sessionBaseUrl}/${sessionId}.json`,
+                {
+                    json: { name: 'foo' },
+                    username: 'foo',
+                    password: 'bar'
+                }
+            )
+        })
+    })
+})
+
 describe('afterTest', () => {
     it('should increment failure reasons on fails', () => {
         service.before(service['_config'], [], browser)
         service['_fullTitle'] = ''
         service.beforeSuite({ title: 'foo' } as any)
+        service.beforeTest({ title: 'foo', parent: 'bar' } as any)
         service.afterTest(
             { title: 'foo', parent: 'bar' } as any,
             undefined as never,
             { error: { message: 'cool reason' }, result: 1, duration: 5, passed: false } as any)
         expect(service['_failReasons']).toContain('cool reason')
 
+        service.beforeTest({ title: 'foo2', parent: 'bar2' } as any)
         service.afterTest(
             { title: 'foo2', parent: 'bar2' } as any,
             undefined as never,
@@ -321,6 +524,7 @@ describe('afterTest', () => {
         expect(service['_failReasons']).toContain('cool reason')
         expect(service['_failReasons']).toContain('not so cool reason')
 
+        service.beforeTest({ title: 'foo3', parent: 'bar3' } as any)
         service.afterTest(
             { title: 'foo3', parent: 'bar3' } as any,
             undefined as never,
@@ -336,12 +540,14 @@ describe('afterTest', () => {
     it('should not increment failure reasons on passes', () => {
         service.before(service['_config'], [], browser)
         service.beforeSuite({ title: 'foo' } as any)
+        service.beforeTest({ title: 'foo', parent: 'bar' } as any)
         service.afterTest(
             { title: 'foo', parent: 'bar' } as any,
             undefined as never,
             { error: { message: 'cool reason' }, result: 1, duration: 5, passed: true } as any)
         expect(service['_failReasons']).toEqual([])
 
+        service.beforeTest({ title: 'foo2', parent: 'bar2' } as any)
         service.afterTest(
             { title: 'foo2', parent: 'bar2' } as any,
             undefined as never,
@@ -349,30 +555,6 @@ describe('afterTest', () => {
 
         expect(service['_fullTitle']).toBe('bar2 - foo2')
         expect(service['_failReasons']).toEqual([])
-    })
-
-    it('should set title for Mocha tests', () => {
-        service.before(service['_config'], [], browser)
-        service.beforeSuite({ title: 'foo' } as any)
-        service.afterTest({ title: 'bar', parent: 'foo' } as any, undefined as never, {} as any)
-        expect(service['_fullTitle']).toBe('foo - bar')
-    })
-
-    describe('Jasmine only', () => {
-        it('should set suite name of first test as title', () => {
-            service.before(service['_config'], [], browser)
-            service.beforeSuite({ title: 'Jasmine__TopLevel__Suite' } as any)
-            service.afterTest({ fullName: 'foo bar baz', description: 'baz' } as any, undefined as never, {} as any)
-            expect(service['_fullTitle']).toBe('foo bar')
-        })
-
-        it('should set parent suite name as title', () => {
-            service.before(service['_config'], [], browser)
-            service.beforeSuite({ title: 'Jasmine__TopLevel__Suite' } as any)
-            service.afterTest({ fullName: 'foo bar baz', description: 'baz' } as any, undefined as never, {} as any)
-            service.afterTest({ fullName: 'foo xyz', description: 'xyz' } as any, undefined as never, {} as any)
-            expect(service['_fullTitle']).toBe('foo')
-        })
     })
 })
 
@@ -483,7 +665,7 @@ describe('after', () => {
                 reason: undefined
             })
         expect(got.put).toHaveBeenCalledWith(
-            'https://api.browserstack.com/automate/sessions/session123.json',
+            `${sessionBaseUrl}/${sessionId}.json`,
             { json: {
                 status: 'passed',
                 name: 'foo - bar',
@@ -506,7 +688,7 @@ describe('after', () => {
                 reason: 'I am failure'
             })
         expect(got.put).toHaveBeenCalledWith(
-            'https://api.browserstack.com/automate/sessions/session123.json',
+            `${sessionBaseUrl}/${sessionId}.json`,
             { json: {
                 status: 'failed',
                 name: 'foo - bar',


### PR DESCRIPTION
## Proposed changes

Additionally,  set session name before suite/test instead of after.

See #9107

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
