### PR TITLE
Fix URLs for webauthn extension capabilities

### DIFF
--- a/packages/wdio-protocols/protocols/webdriver.json
+++ b/packages/wdio-protocols/protocols/webdriver.json
@@ -1221,7 +1221,7 @@
       }]
     }
   },
-  "/session/:sessionId/authenticator/:authenticatorId": {
+  "/session/:sessionId/webauthn/authenticator/:authenticatorId": {
     "DELETE": {
       "command": "removeVirtualAuthenticator",
       "description": "Removes a previously created Virtual Authenticator.",
@@ -1233,7 +1233,7 @@
       "parameters": []
     }
   },
-  "/session/:sessionId/authenticator/:authenticatorId/credential": {
+  "/session/:sessionId/webauthn/authenticator/:authenticatorId/credential": {
     "POST": {
       "command": "addCredential",
       "description": "Injects a Public Key Credential Source into an existing Virtual Authenticator.",
@@ -1276,7 +1276,7 @@
       }]
     }
   },
-  "/session/:sessionId/authenticator/:authenticatorId/credentials": {
+  "/session/:sessionId/webauthn/authenticator/:authenticatorId/credentials": {
     "GET": {
       "command": "getCredentials",
       "description": "Returns one Credential Parameters object for every Public Key Credential Source stored in a Virtual Authenticator, regardless of whether they were stored using Add Credential or `navigator.credentials.create()`.",
@@ -1298,7 +1298,7 @@
       "parameters": []
     }
   },
-  "/session/:sessionId/authenticator/:authenticatorId/credentials/:credentialId": {
+  "/session/:sessionId/webauthn/authenticator/:authenticatorId/credentials/:credentialId": {
     "DELETE": {
       "command": "removeCredential",
       "description": "Removes a Public Key Credential Source stored on a Virtual Authenticator.",
@@ -1313,7 +1313,7 @@
       "parameters": []
     }
   },
-  "/session/:sessionId/authenticator/:authenticatorId/credentials/:credentialId/uv": {
+  "/session/:sessionId/webauthn/authenticator/:authenticatorId/credentials/:credentialId/uv": {
     "POST": {
       "command": "setUserVerified",
       "description": "The Set User Verified extension command sets the isUserVerified property on the Virtual Authenticator.",


### PR DESCRIPTION
## Proposed changes

(Ported #9161 to this branch at the request of @christian-bromann)

This is a follow on to issue #8354. The pull request for that issue fixed one of the endpoints used by the webauthn capabilities, but there were several more that still have incorrect URLs per the specification. The incorrect URLs appear to be causing a number of `unknown command` errors when we try to use the webauthn capabilities. 

I've set the URLs to the values defined in the specification.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

there are no tests in the Protocol Package so have not added any tests

### Reviewers: @webdriverio/project-committers
