### PR TITLE
[🐛 Bug]: Allow CJS services within v8 testrunner

### DIFF
--- a/packages/wdio-smoke-test-cjs-service/.npmignore
+++ b/packages/wdio-smoke-test-cjs-service/.npmignore
@@ -1,0 +1,4 @@
+src
+tests
+tsconfig.json
+tsconfig.prod.json

--- a/packages/wdio-smoke-test-cjs-service/LICENSE-MIT
+++ b/packages/wdio-smoke-test-cjs-service/LICENSE-MIT
@@ -1,0 +1,20 @@
+Copyright (c) OpenJS Foundation and other contributors
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/wdio-smoke-test-cjs-service/README.md
+++ b/packages/wdio-smoke-test-cjs-service/README.md
@@ -1,5 +1,5 @@
-WebdriverIO Smoke Test Service
-==============================
+WebdriverIO Smoke Test Service CJS
+==================================
 
 > A WebdriverIO utility to smoke test services for internal testing purposes.
 

--- a/packages/wdio-smoke-test-cjs-service/package.json
+++ b/packages/wdio-smoke-test-cjs-service/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@wdio/smoke-test-cjs-service",
+  "version": "7.19.0",
+  "description": "A WebdriverIO utility to smoke test services for internal testing purposes.",
+  "author": "Christian Bromann <mail@bromann.dev>",
+  "homepage": "https://github.com/webdriverio/webdriverio/tree/main/packages/wdio-smoke-test-service",
+  "license": "MIT",
+  "engines": {
+    "node": "^16.13 || >=18"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/webdriverio/webdriverio.git",
+    "directory": "packages/wdio-smoke-test-service"
+  },
+  "keywords": [],
+  "bugs": {
+    "url": "https://github.com/webdriverio/webdriverio/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "type": "commonjs",
+  "main": "./build/index.js",
+  "types": "./build/index.d.ts",
+  "typeScriptVersion": "3.8.3"
+}

--- a/packages/wdio-smoke-test-cjs-service/src/index.ts
+++ b/packages/wdio-smoke-test-cjs-service/src/index.ts
@@ -1,0 +1,5 @@
+import Launcher from './launcher.js'
+import Service from './service.js'
+
+export const launcher = Launcher
+export default Service

--- a/packages/wdio-smoke-test-cjs-service/src/launcher.ts
+++ b/packages/wdio-smoke-test-cjs-service/src/launcher.ts
@@ -1,0 +1,13 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+export default class SmokeServiceLauncher {
+    logFile: fs.WriteStream
+    constructor () {
+        this.logFile = fs.createWriteStream(path.join(process.cwd(), 'tests', 'helpers', 'launcher.log'))
+    }
+    onPrepare () { this.logFile.write('onPrepare called\n') } // eslint-disable-line no-console
+    onWorkerStart () { this.logFile.write('onWorkerStart called\n')} // eslint-disable-line no-console
+    onWorkerEnd () { this.logFile.write('onWorkerEnd called\n')} // eslint-disable-line no-console
+    onComplete () { this.logFile.write('onComplete called\n') } // eslint-disable-line no-console
+}

--- a/packages/wdio-smoke-test-cjs-service/src/service.ts
+++ b/packages/wdio-smoke-test-cjs-service/src/service.ts
@@ -1,0 +1,21 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+export default class SmokeService {
+    logFile: fs.WriteStream
+    constructor () {
+        this.logFile = fs.createWriteStream(path.join(process.cwd(), 'tests', 'helpers', 'service.log'))
+    }
+    beforeSession () { this.logFile.write('beforeSession called\n') } // eslint-disable-line no-console
+    before () { this.logFile.write('before called\n') } // eslint-disable-line no-console
+    beforeSuite () { this.logFile.write('beforeSuite called\n') } // eslint-disable-line no-console
+    beforeHook () { this.logFile.write('beforeHook called\n') } // eslint-disable-line no-console
+    afterHook () { this.logFile.write('afterHook called\n') } // eslint-disable-line no-console
+    beforeTest () { this.logFile.write('beforeTest called\n') } // eslint-disable-line no-console
+    beforeCommand () { this.logFile.write('beforeCommand called\n') } // eslint-disable-line no-console
+    afterCommand () { this.logFile.write('afterCommand called\n') } // eslint-disable-line no-console
+    afterTest () { this.logFile.write('afterTest called\n') } // eslint-disable-line no-console
+    afterSuite () { this.logFile.write('afterSuite called\n') } // eslint-disable-line no-console
+    after () { this.logFile.write('after called\n') } // eslint-disable-line no-console
+    afterSession () { this.logFile.write('afterSession called\n') } // eslint-disable-line no-console
+}

--- a/packages/wdio-smoke-test-cjs-service/tsconfig.json
+++ b/packages/wdio-smoke-test-cjs-service/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "esModuleInterop": true,
+    "baseUrl": ".",
+    "outDir": "./build",
+    "rootDir": "./src"
+  },
+  "include": [
+    "src/**/*"
+  ]
+}

--- a/packages/wdio-smoke-test-cjs-service/tsconfig.prod.json
+++ b/packages/wdio-smoke-test-cjs-service/tsconfig.prod.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.prod",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "module": "CommonJS",
+    "outDir": "./build",
+    "rootDir": "./src"
+  },
+  "include": [
+    "src/**/*"
+  ]
+}

--- a/packages/wdio-smoke-test-reporter/README.md
+++ b/packages/wdio-smoke-test-reporter/README.md
@@ -3,4 +3,4 @@ WebdriverIO Smoke-Test Reporter
 
 > A WebdriverIO utility to smoke test reporters for internal testing purposes.
 
-__Note:__ This reporter is for internal use only and not recommended to use in production test suites. It is used by the WebbdriverIO project for testing purposes.
+__Note:__ This reporter is for internal use only and is not recommended to use in production test suites. It is used by the WebbdriverIO project for testing purposes.

--- a/packages/wdio-webdriver-mock-service/README.md
+++ b/packages/wdio-webdriver-mock-service/README.md
@@ -3,4 +3,4 @@ WebdriverIO WebDriver Mock Service
 
 > Internal mock service to stub all endpoints for testing purposes.
 
-__Note:__ This service is for internal use only and not recommended to use in production test suites. It is used by the WebbdriverIO project for testing purposes.
+__Note:__ This service is for internal use only and is not recommended to use in production test suites. It is used by the WebbdriverIO project for testing purposes.

--- a/tests/smoke.runner.js
+++ b/tests/smoke.runner.js
@@ -270,6 +270,22 @@ const customService = async () => {
 }
 
 /**
+ * wdio test run with custom service
+ */
+const customCJSService = async () => {
+    await launch('customCJSService', baseConfig, {
+        autoCompileOpts: { autoCompile: false },
+        specs: [path.resolve(__dirname, 'mocha', 'service.js')],
+        services: [['smoke-test-cjs', { foo: 'bar' }]]
+    })
+    await sleep(100)
+    const serviceLogs = await fs.readFile(path.join(__dirname, 'helpers', 'service.log'))
+    assert.equal(serviceLogs.toString(), SERVICE_LOGS)
+    const launcherLogs = await fs.readFile(path.join(__dirname, 'helpers', 'launcher.log'))
+    assert.equal(launcherLogs.toString(), LAUNCHER_LOGS)
+}
+
+/**
  * wdio test run with custom reporter as string
  */
 const customReporterString = async () => {
@@ -523,6 +539,7 @@ const nonGlobalTestrunner = async () => {
         standaloneTest,
         mochaAsyncTestrunner,
         customService,
+        customCJSService,
         mochaSpecFiltering,
         jasmineSpecFiltering,
         jasmineReporter,


### PR DESCRIPTION
### Have you read the Contributing Guidelines on issues?

- [X] I have read the [Contributing Guidelines on issues](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md#reporting-new-issues).

### WebdriverIO Version

v8

### Node.js Version

latest

### Mode

WDIO Testrunner

### Which capabilities are you using?

```typescript
any
```


### What happened?

It seems that there are some issues using `@next` and stable `wdio-vscode-service` due to CJS exports, the following fixes the issue:

```patch
/**
 * check if service has a default export
 */
+ const defaultImport = service.default.default || service.default
if (serviceName &&
-   typeof service.default !== 'function' &&
+   typeof defaultImport !== 'function' &&
    typeof service !== 'function') {
    ignoredWorkerServices.push(serviceName);
}
```
and
```patch
log.debug(`initialise service "${serviceName}" as NPM package`);
const service = await initialisePlugin(serviceName, 'service');
- initialisedServices.push([service, serviceConfig, serviceName]);
+ initialisedServices.push([service.default, serviceConfig, serviceName]);
```

Let's double check that CJS services can be loaded without problems.

### What is your expected behavior?

Let's double check that CJS services can be loaded without problems.

### How to reproduce the bug.

- Set up WebdriverIO v8 with VS Code service

### Relevant log output

```typescript
n/a
```


### Code of Conduct

- [X] I agree to follow this project's Code of Conduct

### Is there an existing issue for this?

- [X] I have searched the existing issues