### PR TITLE
@wdio/config: Fix cucumberOpts.names command line parsing (#9229)

### DIFF
--- a/packages/wdio-config/src/lib/ConfigParser.ts
+++ b/packages/wdio-config/src/lib/ConfigParser.ts
@@ -142,6 +142,13 @@ export default class ConfigParser {
         if (exclude.length > 0) {
             this._config.exclude = this.setFilePathToFilterOptions(exclude, this._config.exclude!)
         }
+
+        /**
+         * Parse cucumberOpts.names into an array, if defined
+         */
+        if (this._config.cucumberOpts?.names != null && typeof this._config.cucumberOpts.names == 'string') {
+            this._config.cucumberOpts.names = this._config.cucumberOpts?.names.split(',')
+        }
     }
 
     /**

--- a/website/docs/Frameworks.md
+++ b/website/docs/Frameworks.md
@@ -314,7 +314,7 @@ Treat undefined definitions as warnings. Please note that this is a @wdio/cucumb
 Type: `boolean`<br />
 Default: `false`
 
-#### name
+#### names
 Only execute the scenarios with name matching the expression (repeatable).
 
 Type: `RegExp[]`<br />


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)
The PR fixes the bug described here: https://github.com/webdriverio/webdriverio/issues/9229. We check if the `cucumberOpts.names` attribute was defined and, if it is a string, we split it into an array.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
