### PR TITLE
@wdio/browserstack-service: Add annotations for Automate text logs

### DIFF
--- a/packages/wdio-browserstack-service/tests/service.test.ts
+++ b/packages/wdio-browserstack-service/tests/service.test.ts
@@ -33,6 +33,7 @@ beforeEach(() => {
     vi.mocked(got.put).mockResolvedValue({})
 
     browser = {
+        execute: vi.fn(),
         sessionId: sessionId,
         config: {},
         capabilities: {
@@ -975,6 +976,47 @@ describe('after', () => {
                     })
                 })
             })
+        })
+    })
+})
+
+describe('setAnnotation', () => {
+    describe('Cucumber', () => {
+        it('should correctly annotate Features, Scenarios, and Steps', async () => {
+            await service.before(service['_config'] as any, [], browser)
+            await service.beforeFeature(null, { name: 'Feature1' })
+            await service.beforeScenario({ pickle: { name: 'foobar' } })
+            const step = {
+                id: '5',
+                text: 'I am a step',
+                astNodeIds: ['0'],
+                keyword: 'Given ',
+            }
+            await service.beforeStep(step)
+            expect(browser.execute).toBeCalledTimes(3)
+            expect(browser.execute).toBeCalledWith('browserstack_executor: {"action":"annotate","arguments":{"data":"Feature: Feature1","level":"info"}}')
+            expect(browser.execute).toBeCalledWith('browserstack_executor: {"action":"annotate","arguments":{"data":"Scenario: foobar","level":"info"}}')
+            expect(browser.execute).toBeCalledWith('browserstack_executor: {"action":"annotate","arguments":{"data":"Step: Given I am a step","level":"info"}}')
+        })
+    })
+
+    describe('Jasmine', () => {
+        it('should correctly annotate Tests', async () => {
+            await service.before(service['_config'] as any, [], browser)
+            await service.beforeSuite({ title: jasmineSuiteTitle } as any)
+            await service.beforeTest({ fullName: 'foo bar baz', description: 'baz' } as any)
+            expect(browser.execute).toBeCalledTimes(1)
+            expect(browser.execute).toBeCalledWith('browserstack_executor: {"action":"annotate","arguments":{"data":"Test: foo bar baz","level":"info"}}')
+        })
+    })
+
+    describe('Mocha', () => {
+        it('should correctly annotate Tests', async () => {
+            await service.before(service['_config'] as any, [], browser)
+            await service.beforeSuite({ title: 'My Feature' } as any)
+            await service.beforeTest({ title: 'Test Title', parent: 'Suite Title' } as any)
+            expect(browser.execute).toBeCalledTimes(1)
+            expect(browser.execute).toBeCalledWith('browserstack_executor: {"action":"annotate","arguments":{"data":"Test: Test Title","level":"info"}}')
         })
     })
 })


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

Adds a JS executor to add annotations in the logs to better distinguish the different describes/its being executed in the same session - as right now the session name gets updated with each it block and the final name is the last it block - having the annotations will put the different describes/its as visually different blocks in the logs, making logs more meaningful and debugging easier.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
