### PR TITLE
[🐛 Bug]: grouping specs results in only a single test report

### DIFF
--- a/packages/wdio-runner/src/browser.ts
+++ b/packages/wdio-runner/src/browser.ts
@@ -60,6 +60,7 @@ export default class BrowserFramework implements Omit<TestFramework, 'init'> {
          */
         let failures = 0
 
+        let uid = 0
         for (const spec of this._specs) {
             log.info(`Run spec file ${spec} for cid ${this._cid}`)
 
@@ -92,13 +93,13 @@ export default class BrowserFramework implements Omit<TestFramework, 'init'> {
                 continue
             }
 
-            failures += await this.#fetchEvents(browser, spec)
+            failures += await this.#fetchEvents(browser, spec, ++uid)
         }
 
         return failures
     }
 
-    async #fetchEvents (browser: Browser<'async'>, spec: string): Promise<number> {
+    async #fetchEvents (browser: Browser<'async'>, spec: string, uid: number): Promise<number> {
         /**
          * wait until tests have finished and results are emitted to the window scope
          */
@@ -129,7 +130,7 @@ export default class BrowserFramework implements Omit<TestFramework, 'init'> {
             this._reporter.emit(ev.type, {
                 ...ev,
                 file: spec,
-                uid: this._cid,
+                uid: `${this._cid}-${uid}`,
                 cid: this._cid
             })
         }


### PR DESCRIPTION
### Have you read the Contributing Guidelines on issues?

- [X] I have read the [Contributing Guidelines on issues](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md#reporting-new-issues).

### WebdriverIO Version

v8

### Node.js Version

latest

### Mode

WDIO Testrunner

### Which capabilities are you using?

```typescript
n/a
```


### What happened?

If I group my component tests so that many run within a single browser session, only the last ran test is being reported.

### What is your expected behavior?

All tests should be reported correctly.

### How to reproduce the bug.

Setup the SolidJS example and run it:
https://github.com/webdriverio/component-testing-examples/tree/main/solidjs-typescript-vite

### Relevant log output

The number of tests seems fine but the details of other file results are missing

```log
 "spec" Reporter:
------------------------------------------------------------------
[chrome 107.0.5304.121 mac os x #0-0] Running: chrome (v107.0.5304.121) on mac os x
[chrome 107.0.5304.121 mac os x #0-0] Session ID: 8db114c464616ef9486a1f1b15acc158
[chrome 107.0.5304.121 mac os x #0-0]
[chrome 107.0.5304.121 mac os x #0-0] » file:///src/tests/modal.test.tsx
[chrome 107.0.5304.121 mac os x #0-0] my component tests
[chrome 107.0.5304.121 mac os x #0-0]    ✓ will trigger on click outside
[chrome 107.0.5304.121 mac os x #0-0]    ✓ will not trigger on click inside
[chrome 107.0.5304.121 mac os x #0-0]
[chrome 107.0.5304.121 mac os x #0-0] 5 passing (3.8s)
```

### Code of Conduct

- [X] I agree to follow this project's Code of Conduct

### Is there an existing issue for this?

- [X] I have searched the existing issues