### PR TITLE
[🐛 Bug]: Don't fetch for browser events if `debug` command is called

### DIFF
--- a/packages/wdio-browser-runner/src/browser/commands/index.ts
+++ b/packages/wdio-browser-runner/src/browser/commands/index.ts
@@ -1,7 +1,0 @@
-import debug from './debug.js'
-
-const browserCommands = [debug]
-export default browserCommands.reduce((commands, fn) => {
-    commands[fn.name] = { value: fn }
-    return commands
-}, {} as Record<string, PropertyDescriptor>)

--- a/packages/wdio-browser-runner/src/index.ts
+++ b/packages/wdio-browser-runner/src/index.ts
@@ -62,14 +62,19 @@ export default class BrowserRunner extends LocalRunner {
                     sessionId: payload.content.sessionId,
                     injectGlobals: payload.content.injectGlobals
                 })
-                BROWSER_POOL.set(payload.cid!, await attach({
+                const browser = await attach({
                     ...this.#config,
                     ...payload.content,
                     options: {
                         ...this.#config,
                         ...payload.content
                     }
-                }))
+                })
+                /**
+                 * propagate debug state to the worker
+                 */
+                browser.on('debugState', (state: boolean) => worker.postMessage('switchDebugState', state))
+                BROWSER_POOL.set(payload.cid!, browser)
             }
 
             if (payload.name === 'sessionEnded') {

--- a/packages/wdio-browser-runner/tests/runner.test.ts
+++ b/packages/wdio-browser-runner/tests/runner.test.ts
@@ -6,7 +6,7 @@ import LocalRunner from '@wdio/local-runner'
 import { SESSIONS, BROWSER_POOL } from '../src/constants.js'
 import BrowserRunner from '../src/index.js'
 
-vi.mock('webdriverio')
+vi.mock('webdriverio', () => import(path.join(process.cwd(), '__mocks__', 'webdriverio')))
 vi.mock('@wdio/logger', () => import(path.join(process.cwd(), '__mocks__', '@wdio/logger')))
 vi.mock('@wdio/local-runner')
 vi.mock('../src/vite/server.js', () => ({
@@ -61,6 +61,11 @@ describe('BrowserRunner', () => {
         await on.mock.calls[0][1]({ name: 'sessionStarted', cid: '0-0', content: {} })
         expect(BROWSER_POOL.size).toBe(1)
         expect(SESSIONS.size).toBe(1)
+
+        // listens on debug state changes
+        const browser = BROWSER_POOL.get('0-0')
+        expect(browser?.on).toBeCalledWith('debugState', expect.any(Function))
+
         await on.mock.calls[0][1]({ name: 'sessionEnded', cid: '0-1', content: {} })
         expect(BROWSER_POOL.size).toBe(1)
         expect(SESSIONS.size).toBe(1)

--- a/packages/wdio-local-runner/src/run.ts
+++ b/packages/wdio-local-runner/src/run.ts
@@ -25,7 +25,7 @@ runner.on('error', ({ name, message, stack }) => process.send!({
 }))
 
 process.on('message', (m: Workers.WorkerCommand) => {
-    if (!m || !m.command) {
+    if (!m || !m.command || !runner[m.command]) {
         return
     }
 

--- a/packages/wdio-local-runner/src/worker.ts
+++ b/packages/wdio-local-runner/src/worker.ts
@@ -15,6 +15,7 @@ import RunnerStream from './stdStream.js'
 const log = logger('@wdio/local-runner')
 const replQueue = new ReplQueue()
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url))
+const ACCEPTABLE_BUSY_COMMANDS = ['switchDebugState', 'endSession']
 
 const stdOutStream = new RunnerStream()
 const stdErrStream = new RunnerStream()
@@ -210,7 +211,7 @@ export default class WorkerInstance extends EventEmitter implements Workers.Work
     postMessage (command: string, args: Workers.WorkerMessageArgs): void {
         const { cid, configFile, capabilities, specs, retries, isBusy } = this
 
-        if (isBusy && command !== 'endSession') {
+        if (isBusy && !ACCEPTABLE_BUSY_COMMANDS.includes(command)) {
             return log.info(`worker with cid ${cid} already busy and can't take new commands`)
         }
 

--- a/website/docs/ComponentTesting.md
+++ b/website/docs/ComponentTesting.md
@@ -91,11 +91,17 @@ This will run through all tests initially and halt once all are run. You can the
 
 ## Debugging
 
-While it is not (yet) possible to set breakpoints in your IDE and have them being recognised by the remote browser, you can use the [`debug`](/docs/api/browser/debug) command to stop the test at any point. This allows you to open DevTools to then debug the test by setting breakpoints in the [sources tab](https://buddy.works/tutorials/debugging-javascript-efficiently-with-chrome-devtools). Within the Console Tab you will see a WebdriverIO message saying:
+While it is not (yet) possible to set breakpoints in your IDE and have them being recognised by the remote browser, you can use the [`debug`](/docs/api/browser/debug) command to stop the test at any point. This allows you to open DevTools to then debug the test by setting breakpoints in the [sources tab](https://buddy.works/tutorials/debugging-javascript-efficiently-with-chrome-devtools).
 
-> Debug Mode Enabled enter the command `wdioDebugContinue()` in the console to continue
+When the `debug` command is called, you will also get a Node.js repl interface in your terminal, saying:
 
-By calling `wdioDebugContinue()` in the Console you can continue the test.
+```
+The execution has stopped!
+You can now go into the browser or use the command line as REPL
+(To exit, press ^C again or type .exit)
+```
+
+Press `Ctrl` or `Command` + `c` or enter `.exit` to continue with the test.
 
 ## Examples
 


### PR DESCRIPTION
### Have you read the Contributing Guidelines on issues?

- [X] I have read the [Contributing Guidelines on issues](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md#reporting-new-issues).

### WebdriverIO Version

v8

### Node.js Version

latest

### Mode

WDIO Testrunner

### Which capabilities are you using?

```typescript
n/a
```


### What happened?

When calling `browser.debug()` in my component tests, the runner continues to fetch result events which is unnecessary. Furthermore it would exit the test if the component throws an error, making debugging impossible.

### What is your expected behavior?

Let's pause fetching when debug is called.

### How to reproduce the bug.

Run a test here: https://github.com/webdriverio/component-testing-examples and have a debug command in the test.

### Relevant log output

n/a

### Code of Conduct

- [X] I agree to follow this project's Code of Conduct

### Is there an existing issue for this?

- [X] I have searched the existing issues