### PR TITLE
DevX improvements for component testing

### DIFF
--- a/packages/wdio-cli/src/templates/exampleFiles/mocha/example.e2e.js.ejs
+++ b/packages/wdio-cli/src/templates/exampleFiles/mocha/example.e2e.js.ejs
@@ -32,36 +32,64 @@ const importStatement = preset
     ? `import Component from '/path/to/component.${componentSuffix}'`
     : `import '/path/to/component.${componentSuffix}'`
 const renderStatement = (preset
-    ? [
-        preset.includes('react')
-            ? 'render(<Component />)'
-            : 'render(Component, { prop: \'foobar\' })',
-        'const component = screen.getByText(/Click me!/i)'
-    ]
+    ? installTestingLibrary
+        ? [
+            preset.includes('react')
+                ? 'render(<Component />)'
+                : 'render(Component, { prop: \'foobar\' })',
+            'const component = screen.getByText(/Click me!/i)'
+        ]
+        : preset === 'solid'
+            ? [
+                'render(() => <Component />, ref)',
+                'const component = \'.someSelector\''
+            ]
+            : [
+                '// render component here...',
+                'const component = document.querySelector("my-component")'
+            ]
     : [
         `const component = document.createElement('example-component')`,
         `component.setAttribute('prop', 'foobar')`,
         `document.body.appendChild(component)`
     ]
 ).join('\n        ')
-const assertionStatement = preset
-    ? `expect(elem).toContainText('Click me!')`
+const assertionStatement = preset && installTestingLibrary
+    ? `expect(component).toContainText('Click me!')`
     : `await expect(elem).toHaveText('Click me!')`
 
 /**
  * Component Testing
  */
 %>import { expect, $ } from '@wdio/globals'
-<%- preset && installTestingLibrary ? `import { render, screen } from '@testing-library/${preset}'` : '' %>
-<% if (installTestingLibrary) { %>
+<%- installTestingLibrary
+    ? `import { render, screen } from '@testing-library/${preset}'`
+    : preset === 'solid'
+        ? 'import { render } from \'solid-js/web\'\n'
+        : ''
+%><% if (installTestingLibrary) { %>
+
 import * as matchers from '@testing-library/jest-dom/matchers'
 expect.extend(matchers)
+<% } else if (preset === 'preact') { %>
+import {h} from 'preact'
 <% } %>
 // ToDo: fix me
 <%- importStatement %>
 
-describe('<%- (preset || 'my') %> component tests', () => {
-    it('should do something cool', async () => {
+describe('<%- (preset || 'my') %> component tests', () => {<%
+    if (preset === 'solid') { %>
+    const ref = document.createElement('div')
+
+    before(() => {
+        document.body.appendChild(ref);
+    })
+
+    after(() => {
+        document.body.removeChild(ref);
+    })
+    <% } %>
+    it('should test my component', async () => {
         <%- renderStatement %>
 
         const elem = await $(component)

--- a/packages/wdio-cli/src/utils.ts
+++ b/packages/wdio-cli/src/utils.ts
@@ -399,13 +399,15 @@ export async function generateTestFiles (answers: ParsedAnswers) {
 
     for (const file of files) {
         const renderedTpl = await renderFile(file, answers)
+        const isJSX = answers.preset && ['preact', 'react'].includes(answers.preset)
+        const fileEnding = (answers.isUsingTypeScript ? '.ts' : '.js') + (isJSX ? 'x' : '')
         let destPath = (
             file.endsWith('page.js.ejs')
                 ? `${answers.destPageObjectRootPath}/${path.basename(file)}`
                 : file.includes('step_definition')
                     ? `${answers.stepDefinitions}`
                     : `${answers.destSpecRootPath}/${path.basename(file)}`
-        ).replace(/\.ejs$/, '').replace(/\.js$/, answers.isUsingTypeScript ? '.ts' : '.js')
+        ).replace(/\.ejs$/, '').replace(/\.js$/, fileEnding)
 
         await fs.mkdir(path.dirname(destPath), { recursive: true })
         await fs.writeFile(destPath, renderedTpl)
@@ -632,6 +634,13 @@ export function npmInstall (parsedAnswers: ParsedAnswers, useYarn: boolean, npmT
             TESTING_LIBRARY_PACKAGES[presetPackage.short],
             '@testing-library/jest-dom'
         )
+    }
+
+    /**
+     * add helper package for Solidjs testing
+     */
+    if (parsedAnswers.preset === 'solid') {
+        parsedAnswers.packagesToInstall.push('solid-js/web')
     }
 
     /**

--- a/packages/wdio-cli/tests/__snapshots__/templates.test.ts.snap
+++ b/packages/wdio-cli/tests/__snapshots__/templates.test.ts.snap
@@ -1,0 +1,187 @@
+// Vitest Snapshot v1
+
+exports[`template generation > lit 1`] = `
+"import { expect, $ } from '@wdio/globals'
+
+// ToDo: fix me
+import '/path/to/component.ts'
+
+describe('my component tests', () => {
+    it('should test my component', async () => {
+        const component = document.createElement('example-component')
+        component.setAttribute('prop', 'foobar')
+        document.body.appendChild(component)
+
+        const elem = await $(component)
+        await elem.click()
+        await expect(elem).toHaveText('Click me!')
+    })
+})
+
+"
+`;
+
+exports[`template generation > preact 1`] = `
+"import { expect, $ } from '@wdio/globals'
+import { render, screen } from '@testing-library/preact'
+
+import * as matchers from '@testing-library/jest-dom/matchers'
+expect.extend(matchers)
+
+// ToDo: fix me
+import Component from '/path/to/component.tsx'
+
+describe('preact component tests', () => {
+    it('should test my component', async () => {
+        render(<Component />)
+        const component = screen.getByText(/Click me!/i)
+
+        const elem = await $(component)
+        await elem.click()
+        expect(component).toContainText('Click me!')
+    })
+})
+
+"
+`;
+
+exports[`template generation > preact w/o testing library 1`] = `
+"import { expect, $ } from '@wdio/globals'
+
+import {h} from 'preact'
+
+// ToDo: fix me
+import Component from '/path/to/component.jsx'
+
+describe('preact component tests', () => {
+    it('should test my component', async () => {
+        // render component here...
+        const component = document.querySelector(\\"my-component\\")
+
+        const elem = await $(component)
+        await elem.click()
+        await expect(elem).toHaveText('Click me!')
+    })
+})
+
+"
+`;
+
+exports[`template generation > react 1`] = `
+"import { expect, $ } from '@wdio/globals'
+import { render, screen } from '@testing-library/react'
+
+import * as matchers from '@testing-library/jest-dom/matchers'
+expect.extend(matchers)
+
+// ToDo: fix me
+import Component from '/path/to/component.tsx'
+
+describe('react component tests', () => {
+    it('should test my component', async () => {
+        render(<Component />)
+        const component = screen.getByText(/Click me!/i)
+
+        const elem = await $(component)
+        await elem.click()
+        expect(component).toContainText('Click me!')
+    })
+})
+
+"
+`;
+
+exports[`template generation > react w/o testing library 1`] = `
+"import { expect, $ } from '@wdio/globals'
+
+// ToDo: fix me
+import Component from '/path/to/component.jsx'
+
+describe('react component tests', () => {
+    it('should test my component', async () => {
+        // render component here...
+        const component = document.querySelector(\\"my-component\\")
+
+        const elem = await $(component)
+        await elem.click()
+        await expect(elem).toHaveText('Click me!')
+    })
+})
+
+"
+`;
+
+exports[`template generation > solid 1`] = `
+"import { expect, $ } from '@wdio/globals'
+import { render } from 'solid-js/web'
+
+// ToDo: fix me
+import Component from '/path/to/component.solid'
+
+describe('solid component tests', () => {
+    const ref = document.createElement('div')
+
+    before(() => {
+        document.body.appendChild(ref);
+    })
+
+    after(() => {
+        document.body.removeChild(ref);
+    })
+    
+    it('should test my component', async () => {
+        render(() => <Component />, ref)
+        const component = '.someSelector'
+
+        const elem = await $(component)
+        await elem.click()
+        await expect(elem).toHaveText('Click me!')
+    })
+})
+
+"
+`;
+
+exports[`template generation > svelte 1`] = `
+"import { expect, $ } from '@wdio/globals'
+import { render, screen } from '@testing-library/svelte'
+
+import * as matchers from '@testing-library/jest-dom/matchers'
+expect.extend(matchers)
+
+// ToDo: fix me
+import Component from '/path/to/component.svelte'
+
+describe('svelte component tests', () => {
+    it('should test my component', async () => {
+        render(Component, { prop: 'foobar' })
+        const component = screen.getByText(/Click me!/i)
+
+        const elem = await $(component)
+        await elem.click()
+        expect(component).toContainText('Click me!')
+    })
+})
+
+"
+`;
+
+exports[`template generation > vue 1`] = `
+"import { expect, $ } from '@wdio/globals'
+
+// ToDo: fix me
+import Component from '/path/to/component.vue'
+
+describe('vue component tests', () => {
+    it('should test my component', async () => {
+        // render component here...
+        const component = document.querySelector(\\"my-component\\")
+
+        const elem = await $(component)
+        await elem.click()
+        await expect(elem).toHaveText('Click me!')
+    })
+})
+
+"
+`;

--- a/packages/wdio-cli/tests/templates.test.ts
+++ b/packages/wdio-cli/tests/templates.test.ts
@@ -1,0 +1,127 @@
+import fs from 'node:fs/promises'
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+
+import { generateTestFiles } from '../src/utils.js'
+
+vi.mock('node:fs/promises', () => ({
+    default: {
+        access: vi.fn().mockResolvedValue({}),
+        mkdir: vi.fn(),
+        writeFile: vi.fn().mockReturnValue(Promise.resolve())
+    }
+}))
+vi.mock('webdriverio')
+vi.mock('devtools')
+
+describe('template generation', () => {
+    beforeEach(() => {
+        vi.mocked(fs.writeFile).mockClear()
+    })
+
+    it('react', async () => {
+        await generateTestFiles({
+            framework: 'mocha',
+            preset: 'react',
+            usePageObjects: false,
+            runner: 'browser',
+            isUsingTypeScript: true,
+            installTestingLibrary: true
+        } as any)
+        expect(fs.writeFile).toBeCalledTimes(1)
+        expect(vi.mocked(fs.writeFile).mock.calls[0][1]).toMatchSnapshot()
+    })
+
+    it('react w/o testing library', async () => {
+        await generateTestFiles({
+            framework: 'mocha',
+            preset: 'react',
+            usePageObjects: false,
+            runner: 'browser',
+            esmSupport: false,
+            isUsingTypeScript: false,
+            installTestingLibrary: false
+        } as any)
+        expect(fs.writeFile).toBeCalledTimes(1)
+        expect(vi.mocked(fs.writeFile).mock.calls[0][1]).toMatchSnapshot()
+    })
+
+    it('preact', async () => {
+        await generateTestFiles({
+            framework: 'mocha',
+            preset: 'preact',
+            usePageObjects: false,
+            runner: 'browser',
+            isUsingTypeScript: true,
+            installTestingLibrary: true
+        } as any)
+        expect(fs.writeFile).toBeCalledTimes(1)
+        expect(vi.mocked(fs.writeFile).mock.calls[0][1]).toMatchSnapshot()
+    })
+
+    it('preact w/o testing library', async () => {
+        await generateTestFiles({
+            framework: 'mocha',
+            preset: 'preact',
+            usePageObjects: false,
+            runner: 'browser',
+            esmSupport: false,
+            isUsingTypeScript: false,
+            installTestingLibrary: false
+        } as any)
+        expect(fs.writeFile).toBeCalledTimes(1)
+        expect(vi.mocked(fs.writeFile).mock.calls[0][1]).toMatchSnapshot()
+    })
+
+    it('svelte', async () => {
+        await generateTestFiles({
+            framework: 'mocha',
+            preset: 'svelte',
+            usePageObjects: false,
+            runner: 'browser',
+            isUsingTypeScript: true,
+            installTestingLibrary: true
+        } as any)
+        expect(fs.writeFile).toBeCalledTimes(1)
+        expect(vi.mocked(fs.writeFile).mock.calls[0][1]).toMatchSnapshot()
+    })
+
+    it('vue', async () => {
+        await generateTestFiles({
+            framework: 'mocha',
+            preset: 'vue',
+            usePageObjects: false,
+            runner: 'browser',
+            isUsingTypeScript: true,
+            installTestingLibrary: false
+        } as any)
+        expect(fs.writeFile).toBeCalledTimes(1)
+        expect(vi.mocked(fs.writeFile).mock.calls[0][1]).toMatchSnapshot()
+    })
+
+    it('solid', async () => {
+        await generateTestFiles({
+            framework: 'mocha',
+            preset: 'solid',
+            usePageObjects: false,
+            runner: 'browser',
+            isUsingTypeScript: true,
+            installTestingLibrary: false
+        } as any)
+        expect(fs.writeFile).toBeCalledTimes(1)
+        expect(vi.mocked(fs.writeFile).mock.calls[0][1]).toMatchSnapshot()
+    })
+
+    it('lit', async () => {
+        await generateTestFiles({
+            framework: 'mocha',
+            preset: null,
+            usePageObjects: false,
+            runner: 'browser',
+            isUsingTypeScript: true,
+            installTestingLibrary: false
+        } as any)
+        expect(fs.writeFile).toBeCalledTimes(1)
+        expect(vi.mocked(fs.writeFile).mock.calls[0][1]).toMatchSnapshot()
+    })
+})
+


### PR DESCRIPTION
## Proposed changes

This patches improves DevX for component testing in the following way:

- errors our early if Vite shows error page (e.g. due to wrong import) and elevates error properly
- improved example file generation + snapshot testing of these
- add `solid-js/web` when solid is picked as preset
- set file ending to /(ts|js)x/ when react or preact is used

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
