### PR TITLE
Modified wdio-cli -> utils.test.ts -> getProjectRoot to handle alternate names of clone directory

### DIFF
--- a/packages/wdio-cli/tests/utils.test.ts
+++ b/packages/wdio-cli/tests/utils.test.ts
@@ -745,7 +745,8 @@ test('specifyVersionIfNeeded', () => {
 test('getProjectRoot', () => {
     expect(getProjectRoot({ projectRoot: '/foo/bar' } as any)).toBe('/foo/bar')
     expect(getProjectRoot({} as any, { path: '/bar/foo' } as any)).toBe('/bar/foo')
-    expect(getProjectRoot({} as any).includes(path.join('/webdriverio'))).toBe(true)
+    const projectDir = process.cwd().substring(process.cwd().lastIndexOf(path.sep) + 1)
+    expect(getProjectRoot({} as any).includes(path.join(projectDir))).toBe(true)
 })
 
 test('hasBabelConfig', async () => {


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)
When I clone my fork of the webdriverio repo I clone it into a directory called ```RossVertizan_webdriverio```, so that I know that this is the forked version.

When I then run the tests the ```packages/wdio-cli/tests/utils.test.ts -> getProjectRoot``` test fails because the third test expects the project root to contain ```/webdriverio```, which in my case it does not.   Of course, it could be corrected in this case by simply removing the ```/```, but to be more generic, I have added code to derive the expected string from ```process.cwd()```.

The only question I have is if the testing can be run from other directories. 

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
