### PR TITLE
Modified globalSetup.ts to make reason and origin of throwBetterErrorMessage more clear

### DIFF
--- a/scripts/test/globalSetup.ts
+++ b/scripts/test/globalSetup.ts
@@ -33,7 +33,7 @@ function throwBetterErrorMessageSetup (err: Error) {
 function throwBetterErrorMessageTearDown (err: Error) {
     throw new Error(
         util.format(ERROR_MESSAGE, 'Tear-down') +
-        err.stack +
+        err.stack
         '\n\nTo correct this error please check you have the file: "packages/webdriver/node_modules/got"\n'
     )
 }

--- a/scripts/test/globalSetup.ts
+++ b/scripts/test/globalSetup.ts
@@ -21,7 +21,7 @@ function throwBetterErrorMessageSetup (err: Error) {
     throw new Error(
         util.format(ERROR_MESSAGE, 'Setup') +
         err.stack +
-        '\n\nTo correct this error please run:\n   mv packages/webdriver/node_modules/tmp_got packages/webdriver/node_modules/got\n'
+        '\n\nTo correct this error please run:\n\tmv packages/webdriver/node_modules/tmp_got packages/webdriver/node_modules/got\n'
     )
 }
 

--- a/scripts/test/globalSetup.ts
+++ b/scripts/test/globalSetup.ts
@@ -8,10 +8,15 @@ const nodeModulesPath = path.join(__dirname, '..', '..', 'packages', 'webdriver'
 const gotPath = path.join(nodeModulesPath, 'got')
 const tmpGotPath = path.join(nodeModulesPath, 'tmp_got')
 const ERROR_MESSAGE = `Renaming "got" dependency failed!
-'WebdriverIO needs to hide the "got" dependency (at "packages/webdriver/node_modules/got")
-'during the test to force Vitest to use our mocked version. WebdriverIO does this by
-'renaming "packages/webdriver/node_modules/got" to "packages/webdriver/node_modules/tmp_got"
-'during test setup and back again during test tear-down.
+
+WebdriverIO needs to hide the "got" dependency (at "packages/webdriver/node_modules/got")
+during the test to force Vitest to use our mocked version. WebdriverIO does this by renaming: 
+
+"packages/webdriver/node_modules/got"
+to
+"packages/webdriver/node_modules/tmp_got"
+
+during test setup and back again during test tear-down.
 
 '%s has failed.  Maybe because you are already running unit tests in a different
 'terminal.

--- a/scripts/test/globalSetup.ts
+++ b/scripts/test/globalSetup.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs/promises'
+import util from 'node:util'
 import url from 'node:url'
 import path from 'node:path'
 
@@ -6,16 +7,17 @@ const __dirname = path.dirname(url.fileURLToPath(import.meta.url))
 const nodeModulesPath = path.join(__dirname, '..', '..', 'packages', 'webdriver', 'node_modules')
 const gotPath = path.join(nodeModulesPath, 'got')
 const tmpGotPath = path.join(nodeModulesPath, 'tmp_got')
+const ERROR_MESSAGE = 'Renaming "got" dependency failed!\n' +
+'WebdriverIO needs to hide the "got" dependency (at "packages/webdriver/node_modules/got")\n' +
+'during the test to force Vitest to use our mocked version. WebdriverIO does this by\n' +
+'renaming "packages/webdriver/node_modules/got" to "packages/webdriver/node_modules/tmp_got"\n' +
+'during test setup and back again during test tear-down. \n\n' +
+'%s has failed.  Maybe because you are already running unit tests in a different\n' +
+'terminal.\n\n'
 
 function throwBetterErrorMessageSetup (err: Error) {
     throw new Error(
-        'Renaming "got" dependency failed!\n' +
-        'WebdriverIO needs to hide the "got" dependency (at "packages/webdriver/node_modules/got")\n' +
-        'during the test to force Vitest to use our mocked version. WebdriverIO does this by\n' +
-        'renaming "packages/webdriver/node_modules/got" to "packages/webdriver/node_modules/tmp_got"\n' +
-        'during test setup and back again during test tear-down. \n\n' +
-        'Setup has failed.  Maybe because you are already running unit tests in a different\n' +
-        'terminal.\n\n' +
+        util.format(ERROR_MESSAGE, 'Setup') +
         err.stack +
         '\n\nTo correct this error please run:\n   mv packages/webdriver/node_modules/tmp_got packages/webdriver/node_modules/got\n'
     )
@@ -23,13 +25,7 @@ function throwBetterErrorMessageSetup (err: Error) {
 
 function throwBetterErrorMessageTearDown (err: Error) {
     throw new Error(
-        'Renaming "got" dependency failed!\n' +
-        'WebdriverIO needs to hide the "got" dependency (at "packages/webdriver/node_modules/got")\n' +
-        'during the test to force Vitest to use our mocked version. WebdriverIO does this by\n' +
-        'renaming "packages/webdriver/node_modules/got" to "packages/webdriver/node_modules/tmp_got"\n' +
-        'during test setup and back again during test tear-down. \n\n' +
-        'Tear-down has failed.  Maybe because you are already running unit tests in a different\n' +
-        'terminal.\n\n' +
+        util.format(ERROR_MESSAGE, 'Tear-down') +
         err.stack +
         '\n\nTo correct this error please check you have the file: "packages/webdriver/node_modules/got"\n'
     )

--- a/scripts/test/globalSetup.ts
+++ b/scripts/test/globalSetup.ts
@@ -7,14 +7,31 @@ const nodeModulesPath = path.join(__dirname, '..', '..', 'packages', 'webdriver'
 const gotPath = path.join(nodeModulesPath, 'got')
 const tmpGotPath = path.join(nodeModulesPath, 'tmp_got')
 
-function throwBetterErrorMessage (err: Error) {
+function throwBetterErrorMessageSetup (err: Error) {
     throw new Error(
         'Renaming "got" dependency failed!\n' +
-        'We need to remove rename the got dependency (at "packages/webdriver/node_modules/got") ' +
-        'during the test to force Vitest to use our mocked version. You might already run unit ' +
-        'tests in a different terminal.\n\n' +
+        'WebdriverIO needs to hide the "got" dependency (at "packages/webdriver/node_modules/got")\n' +
+        'during the test to force Vitest to use our mocked version. WebdriverIO does this by\n' +
+        'renaming "packages/webdriver/node_modules/got" to "packages/webdriver/node_modules/tmp_got"\n' +
+        'during test setup and back again during test tear-down. \n\n' +
+        'Setup has failed.  Maybe because you are already running unit tests in a different\n' +
+        'terminal.\n\n' +
         err.stack +
-        '\n\nPlease run:\n   mv packages/webdriver/node_modules/tmp_got packages/webdriver/node_modules/got'
+        '\n\nTo correct this error please run:\n   mv packages/webdriver/node_modules/tmp_got packages/webdriver/node_modules/got\n'
+    )
+}
+
+function throwBetterErrorMessageTearDown (err: Error) {
+    throw new Error(
+        'Renaming "got" dependency failed!\n' +
+        'WebdriverIO needs to hide the "got" dependency (at "packages/webdriver/node_modules/got")\n' +
+        'during the test to force Vitest to use our mocked version. WebdriverIO does this by\n' +
+        'renaming "packages/webdriver/node_modules/got" to "packages/webdriver/node_modules/tmp_got"\n' +
+        'during test setup and back again during test tear-down. \n\n' +
+        'Tear-down has failed.  Maybe because you are already running unit tests in a different\n' +
+        'terminal.\n\n' +
+        err.stack +
+        '\n\nTo correct this error please check you have the file: "packages/webdriver/node_modules/got"\n'
     )
 }
 
@@ -25,9 +42,9 @@ function throwBetterErrorMessage (err: Error) {
  * the deps.inline option. This is a workaround for this.
  */
 export const setup = async () => {
-    await fs.rename(gotPath, tmpGotPath).catch(throwBetterErrorMessage)
+    await fs.rename(gotPath, tmpGotPath).catch(throwBetterErrorMessageSetup)
 }
 
 export const teardown = async () => {
-    await fs.rename(tmpGotPath, gotPath).catch(throwBetterErrorMessage)
+    await fs.rename(tmpGotPath, gotPath).catch(throwBetterErrorMessageTearDown)
 }

--- a/scripts/test/globalSetup.ts
+++ b/scripts/test/globalSetup.ts
@@ -7,13 +7,15 @@ const __dirname = path.dirname(url.fileURLToPath(import.meta.url))
 const nodeModulesPath = path.join(__dirname, '..', '..', 'packages', 'webdriver', 'node_modules')
 const gotPath = path.join(nodeModulesPath, 'got')
 const tmpGotPath = path.join(nodeModulesPath, 'tmp_got')
-const ERROR_MESSAGE = 'Renaming "got" dependency failed!\n' +
-'WebdriverIO needs to hide the "got" dependency (at "packages/webdriver/node_modules/got")\n' +
-'during the test to force Vitest to use our mocked version. WebdriverIO does this by\n' +
-'renaming "packages/webdriver/node_modules/got" to "packages/webdriver/node_modules/tmp_got"\n' +
-'during test setup and back again during test tear-down. \n\n' +
-'%s has failed.  Maybe because you are already running unit tests in a different\n' +
-'terminal.\n\n'
+const ERROR_MESSAGE = `Renaming "got" dependency failed!
+'WebdriverIO needs to hide the "got" dependency (at "packages/webdriver/node_modules/got")
+'during the test to force Vitest to use our mocked version. WebdriverIO does this by
+'renaming "packages/webdriver/node_modules/got" to "packages/webdriver/node_modules/tmp_got"
+'during test setup and back again during test tear-down.
+
+'%s has failed.  Maybe because you are already running unit tests in a different
+'terminal.
+`
 
 function throwBetterErrorMessageSetup (err: Error) {
     throw new Error(

--- a/scripts/test/globalSetup.ts
+++ b/scripts/test/globalSetup.ts
@@ -34,7 +34,6 @@ function throwBetterErrorMessageTearDown (err: Error) {
     throw new Error(
         util.format(ERROR_MESSAGE, 'Tear-down') +
         err.stack
-        '\n\nTo correct this error please check you have the file: "packages/webdriver/node_modules/got"\n'
     )
 }
 


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

In working with the WebdriverIO testing, I tried to use the ViTest extension to VSCode and when I ran it I got the error message about having to rename "got".  I wasn't really sure where it was coming from and because I had successfully run the tests in a terminal decided that it must being caused by the ViTest plugin or VS Code.  Then I realised that the tests would not run in my terminal any more and I got the same error.

The key change is to change "We" to "WebdriverIO", which hopefully makes it clearer where the source of the error is.  I have also created a separate message for Setup and TearDown and made them slightly more descriptive of what is happening.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
