### PR TITLE
@wdio/types: fix return type of hooks

### DIFF
--- a/packages/wdio-types/src/Services.ts
+++ b/packages/wdio-types/src/Services.ts
@@ -87,7 +87,22 @@ export interface HookFunctions {
     onPrepare?(
         config: TestrunnerOptions,
         capabilities: RemoteCapabilities
-    ): void;
+    ): unknown | Promise<unknown>
+
+    /**
+     * Gets executed after all workers got shut down and the process is about to exit. An error
+     * thrown in the onComplete hook will result in the test run failing.
+     * @param exitCode      runner exit code: 0 - success, 1 - fail
+     * @param config        wdio configuration object
+     * @param capabilities  list of capabilities details
+     * @param results       test results
+     */
+    onComplete?(
+        exitCode: number,
+        config: Omit<TestrunnerOptions, 'capabilities'>,
+        capabilities: RemoteCapabilities,
+        results: any // Results
+    ): unknown | Promise<unknown>
 
     /**
      * Gets executed before a worker process is spawned and can be used to initialise specific service
@@ -104,7 +119,7 @@ export interface HookFunctions {
         specs: string[],
         args: TestrunnerOptions,
         execArgv: string[]
-    ): void;
+    ): unknown | Promise<unknown>
 
     /**
      * Gets executed just after a worker process has exited.
@@ -113,37 +128,12 @@ export interface HookFunctions {
      * @param  {[type]} specs    specs to be run in the worker process
      * @param  {Number} retries  number of retries used
      */
-     onWorkerEnd?(
+    onWorkerEnd?(
         cid: string,
         exitCode: number,
         specs: string[],
         retries: number,
-    ): void;
-
-    /**
-     * Gets executed after all workers got shut down and the process is about to exit. An error
-     * thrown in the onComplete hook will result in the test run failing.
-     * @param exitCode      runner exit code
-     * @param config        wdio configuration object
-     * @param capabilities  list of capabilities details
-     * @param results       test results
-     */
-    onComplete?(
-        exitCode: number,
-        config: Omit<TestrunnerOptions, 'capabilities'>,
-        capabilities: RemoteCapabilities,
-        results: any // Results
-    ): void;
-
-    /**
-     * Gets executed when a refresh happens.
-     * @param oldSessionId session id of old session
-     * @param newSessionId session id of new session
-     */
-    onReload?(
-        oldSessionId: string,
-        newSessionId: string
-    ): void;
+    ): unknown | Promise<unknown>
 
     /**
      * Gets executed before test execution begins. At this point you can access to all global
@@ -156,25 +146,20 @@ export interface HookFunctions {
         capabilities: RemoteCapability,
         specs: string[],
         browser: any // BrowserObject
-    ): void;
+    ): unknown | Promise<unknown>
 
     /**
-     * Runs before a WebdriverIO command gets executed.
-     * @param commandName command name
-     * @param args        arguments that command would receive
+     * Gets executed after all tests are done. You still have access to all global variables from
+     * the test.
+     * @param result        number of total failing tests
+     * @param capabilities  list of capabilities details
+     * @param specs         list of spec file paths that are to be run
      */
-    beforeCommand?(
-        commandName: string,
-        args: any[]
-    ): void;
-
-    /**
-     * Hook that gets executed _before_ a hook within the suite starts (e.g. runs before calling
-     * beforeEach in Mocha). `stepData` and `world` are Cucumber framework specific properties.
-     * @param test      details to current running test (represents step in Cucumber)
-     * @param context   context to current running test (represents World object in Cucumber)
-     */
-    beforeHook?(test: any, context: any): void;
+    after?(
+        result: number,
+        capabilities: RemoteCapability,
+        specs: string[]
+    ): unknown | Promise<unknown>
 
     /**
      * Gets executed just before initialising the webdriver session and test framework. It allows you
@@ -189,20 +174,48 @@ export interface HookFunctions {
         capabilities: RemoteCapability,
         specs: string[],
         cid: string
-    ): void;
+    ): unknown | Promise<unknown>
+
+    /**
+     * Gets executed right after terminating the webdriver session.
+     * @param config        wdio configuration object
+     * @param capabilities  list of capabilities details
+     * @param specs         list of spec file paths that are to be run
+     */
+    afterSession?(
+        config: TestrunnerOptions,
+        capabilities: RemoteCapability,
+        specs: string[]
+    ): unknown | Promise<unknown>
+
+    /**
+     * Gets executed when a refresh happens.
+     * @param oldSessionId session id of old session
+     * @param newSessionId session id of new session
+     */
+    onReload?(
+        oldSessionId: string,
+        newSessionId: string
+    ): unknown | Promise<unknown>
 
     /**
      * Hook that gets executed before the suite starts.
      * @param suite suite details
      */
-    beforeSuite?(suite: Suite): void;
+    beforeSuite?(suite: Suite): unknown | Promise<unknown>
+
+    /**
+     * Hook that gets executed after the suite has ended
+     * @param suite suite details
+     */
+    afterSuite?(suite: Suite): unknown | Promise<unknown>
 
     /**
      * Function to be executed before a test (in Mocha/Jasmine only)
      * @param {Object} test    test object
      * @param {Object} context scope object the test was executed with
      */
-    beforeTest?(test: Test, context: any): void;
+    beforeTest?(test: Test, context: any): unknown | Promise<unknown>
 
     /**
      * Function to be executed after a test (in Mocha/Jasmine only)
@@ -214,13 +227,15 @@ export interface HookFunctions {
      * @param {Boolean} result.passed    true if test has passed, otherwise false
      * @param {Object}  result.retries   informations to spec related retries, e.g. `{ attempts: 0, limit: 0 }`
      */
-    afterTest?(test: Test, context: any, result: TestResult): void;
+    afterTest?(test: Test, context: any, result: TestResult): unknown | Promise<unknown>
 
     /**
-     * Hook that gets executed after the suite has ended
-     * @param suite suite details
+     * Hook that gets executed _before_ a hook within the suite starts (e.g. runs before calling
+     * beforeEach in Mocha). `stepData` and `world` are Cucumber framework specific properties.
+     * @param test      details to current running test (represents step in Cucumber)
+     * @param context   context to current running test (represents World object in Cucumber)
      */
-    afterSuite?(suite: Suite): void;
+    beforeHook?(test: any, context: any): unknown | Promise<unknown>
 
     /**
      * Hook that gets executed _after_ a hook within the suite ends (e.g. runs after calling
@@ -229,20 +244,17 @@ export interface HookFunctions {
      * @param context   context to current running test (represents World object in Cucumber)
      * @param result    test result
      */
-    afterHook?(test: Test, context: any, result: TestResult): void;
+    afterHook?(test: Test, context: any, result: TestResult): unknown | Promise<unknown>
 
     /**
-     * Gets executed after all tests are done. You still have access to all global variables from
-     * the test.
-     * @param result        number of total failing tests
-     * @param capabilities  list of capabilities details
-     * @param specs         list of spec file paths that are to be run
+     * Runs before a WebdriverIO command gets executed.
+     * @param commandName command name
+     * @param args        arguments that command would receive
      */
-    after?(
-        result: number,
-        capabilities: RemoteCapability,
-        specs: string[]
-    ): void;
+    beforeCommand?(
+        commandName: string,
+        args: any[]
+    ): unknown | Promise<unknown>
 
     /**
      * Runs after a WebdriverIO command gets executed
@@ -256,17 +268,5 @@ export interface HookFunctions {
         args: any[],
         result: any,
         error?: Error
-    ): void;
-
-    /**
-     * Gets executed right after terminating the webdriver session.
-     * @param config        wdio configuration object
-     * @param capabilities  list of capabilities details
-     * @param specs         list of spec file paths that are to be run
-     */
-    afterSession?(
-        config: TestrunnerOptions,
-        capabilities: RemoteCapability,
-        specs: string[]
-    ): void;
+    ): unknown | Promise<unknown>
 }


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)
Issue:
Currently, if a hook returns a Promise and typescript-eslint's `no-misused-promises` rule is enabled (which is enabled in the recommended set of rules), there's an eslint error: `Promise returned in function argument where a void return was expected`:
<img width="951" alt="Screen Shot 2022-12-06 at 5 02 29 PM" src="https://user-images.githubusercontent.com/29472529/206062216-5eb7770f-faac-4b00-bc37-29e5976a636e.png">

Note: I re-ordered the hooks, pairing each "start" & "end" hook, and sorting from outermost to innermost:
- onPrepare/onComplete
- onWorkerStart/onWorkerEnd
- before/after
- beforeSession/afterSession
- onReload
- beforeSuite/afterSuite
- beforeTest/afterTest
- beforeHook/afterHook
- beforeCommand/afterCommand

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
