### PR TITLE
feat: ability to send headers when connect to browser using puppeteer

### DIFF
--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -43,7 +43,7 @@
     "chrome-launcher": "^0.15.0",
     "edge-paths": "^2.1.0",
     "import-meta-resolve": "^2.1.0",
-    "puppeteer-core": "19.3.0",
+    "puppeteer-core": "19.4.0",
     "query-selector-shadow-dom": "^1.0.0",
     "ua-parser-js": "^1.0.1",
     "uuid": "^9.0.0",

--- a/packages/wdio-devtools-service/package.json
+++ b/packages/wdio-devtools-service/package.json
@@ -44,7 +44,7 @@
     "istanbul-lib-report": "^3.0.0",
     "istanbul-reports": "^3.1.4",
     "lighthouse": "8.6.0",
-    "puppeteer-core": "19.3.0",
+    "puppeteer-core": "19.4.0",
     "speedline": "^1.4.3",
     "stable": "^0.1.8",
     "webdriverio": "8.0.2",

--- a/packages/webdriverio/package.json
+++ b/packages/webdriverio/package.json
@@ -85,7 +85,7 @@
     "lodash.clonedeep": "^4.5.0",
     "lodash.zip": "^4.2.0",
     "minimatch": "^5.0.0",
-    "puppeteer-core": "19.3.0",
+    "puppeteer-core": "19.4.0",
     "query-selector-shadow-dom": "^1.0.0",
     "resq": "^1.9.1",
     "rgb2hex": "0.2.5",

--- a/packages/webdriverio/src/commands/browser/getPuppeteer.ts
+++ b/packages/webdriverio/src/commands/browser/getPuppeteer.ts
@@ -52,6 +52,7 @@ export default async function getPuppeteer (this: WebdriverIO.Browser) {
         return this.puppeteer
     }
 
+    const { headers } = this.options
     const caps = (this.capabilities as Capabilities.W3CCapabilities).alwaysMatch || this.capabilities as Capabilities.DesiredCapabilities
     /**
      * attach to a Selenium 4 CDP Session if it's returned in the capabilities
@@ -60,7 +61,8 @@ export default async function getPuppeteer (this: WebdriverIO.Browser) {
     if (cdpEndpoint) {
         this.puppeteer = await puppeteer.connect({
             browserWSEndpoint: cdpEndpoint,
-            defaultViewport: null
+            defaultViewport: null,
+            headers
         }) as any as PuppeteerBrowser
         return this.puppeteer
     }
@@ -73,7 +75,8 @@ export default async function getPuppeteer (this: WebdriverIO.Browser) {
         const { hostname, port } = this.options
         this.puppeteer = await puppeteer.connect({
             browserWSEndpoint: `ws://${hostname}:${port}/devtools/${this.sessionId}`,
-            defaultViewport: null
+            defaultViewport: null,
+            headers
         }) as any as PuppeteerBrowser
         return this.puppeteer
     }

--- a/packages/webdriverio/tests/commands/browser/__snapshots__/getPuppeteer.test.ts.snap
+++ b/packages/webdriverio/tests/commands/browser/__snapshots__/getPuppeteer.test.ts.snap
@@ -6,6 +6,9 @@ exports[`attach Puppeteer > should pass for Aerokube Moon CDP 1`] = `
     {
       "browserWSEndpoint": "ws://my.grid:4444/devtools/foobar-123",
       "defaultViewport": null,
+      "headers": {
+        "Authorization": "OAuth token",
+      },
     },
   ],
 ]
@@ -17,6 +20,9 @@ exports[`attach Puppeteer > should pass for Aerokube Selenoid CDP 1`] = `
     {
       "browserWSEndpoint": "ws://my.grid:4444/devtools/foobar-123",
       "defaultViewport": null,
+      "headers": {
+        "Authorization": "OAuth token",
+      },
     },
   ],
 ]
@@ -83,6 +89,9 @@ exports[`attach Puppeteer > should pass for Selenium CDP 1`] = `
     {
       "browserWSEndpoint": "http://my.grid:1234/session/mytestsession/se/cdp",
       "defaultViewport": null,
+      "headers": {
+        "Authorization": "OAuth token",
+      },
     },
   ],
 ]

--- a/packages/webdriverio/tests/commands/browser/getPuppeteer.test.ts
+++ b/packages/webdriverio/tests/commands/browser/getPuppeteer.test.ts
@@ -23,6 +23,9 @@ describe('attach Puppeteer', () => {
             baseUrl: 'http://foobar.com',
             capabilities: {
                 browserName: 'foobar'
+            },
+            headers: {
+                Authorization: 'OAuth token'
             }
         })
     })
@@ -198,7 +201,10 @@ describe('attach Puppeteer', () => {
             options: {
                 hostname: 'my.grid',
                 port: 4444,
-                path: '/wd/hub'
+                path: '/wd/hub',
+                headers: {
+                    Authorization: 'OAuth token'
+                }
             } as any
         })
         expect(typeof pptr).toBe('object')
@@ -221,7 +227,10 @@ describe('attach Puppeteer', () => {
             options: {
                 hostname: 'my.grid',
                 port: 4444,
-                path: '/wd/hub'
+                path: '/wd/hub',
+                headers: {
+                    Authorization: 'OAuth token'
+                }
             } as any
         })
         expect(typeof pptr).toBe('object')

--- a/website/docs/Configuration.md
+++ b/website/docs/Configuration.md
@@ -135,7 +135,7 @@ Default:
 
 ### headers
 
-Specify custom `headers` to pass into every WebDriver request.
+Specify custom `headers` to pass into every WebDriver request and when connect to browser through Puppeteer using CDP protocol.
 
 :::caution
 


### PR DESCRIPTION
## Proposed changes

I have browsers pool in some cloud. I want that only users with access will be able to connect to them. So they must provide token through headers. But wdio does not send headers when connect to browser using puppeteer, because puppeteer didn't support it before. But from puppeteer-core@19.4.0 it became possible (PR in puppeteer - https://github.com/puppeteer/puppeteer/pull/9314).

Moreover I want to support it for webdriverio@7, but branch v7 - https://github.com/webdriverio/webdriverio/tree/v7 use puppeteer-core@13.1.3 - https://github.com/webdriverio/webdriverio/blob/v7/packages/webdriverio/package.json#L79. And I'm not sure that I can bump it to 19. What should I do with it?

### Reviewers: @webdriverio/project-committers
