### PR TITLE
Wait for 1 second on startProcess() (#9288)

### DIFF
--- a/__mocks__/@wdio/local-runner.ts
+++ b/__mocks__/@wdio/local-runner.ts
@@ -12,9 +12,9 @@ export default class LocalRunnerMock {
         this.config = config
     }
 
-    run ({ command, args, ...options }: any) {
+    async run ({ command, args, ...options }: any) {
         this.workerPool[options.cid as string] = { postMessage: vi.fn() } as unknown as WorkerInstance
-        this.workerPool[options.cid].postMessage(command, args)
+        await this.workerPool[options.cid].postMessage(command, args)
         return this.workerPool[options.cid]
     }
 }

--- a/packages/wdio-browser-runner/tests/runner.test.ts
+++ b/packages/wdio-browser-runner/tests/runner.test.ts
@@ -49,7 +49,7 @@ describe('BrowserRunner', () => {
 
         const on = vi.fn()
         vi.mocked(LocalRunner.prototype.run).mockReturnValue({ on } as any)
-        const worker = runner.run({ caps: { browserName: 'chrome' }, command: 'run', args: {} } as any)
+        const worker = await runner.run({ caps: { browserName: 'chrome' }, command: 'run', args: {} } as any)
         expect(worker).toBeDefined()
         expect(LocalRunner.prototype.run).toBeCalledWith({
             args: { baseUrl: 'http://localhost:1234' },

--- a/packages/wdio-cli/src/launcher.ts
+++ b/packages/wdio-cli/src/launcher.ts
@@ -411,7 +411,7 @@ class Launcher {
             .catch((error) => this._workerHookError(error))
 
         // prefer launcher settings in capabilities over general launcher
-        const worker = this.runner.run({
+        const worker = await this.runner.run({
             cid: runnerId,
             command: 'run',
             configFile: this._configFilePath,

--- a/packages/wdio-cli/src/watcher.ts
+++ b/packages/wdio-cli/src/watcher.ts
@@ -143,7 +143,7 @@ export default class Watcher {
      * run workers with params
      * @param  params parameters to run the worker with
      */
-    run (params: Partial<RunCommandArguments> = {}) {
+    async run (params: Partial<RunCommandArguments> = {}) {
         const workers = this.getWorkers(
             (params.spec
                 ? (worker) => Boolean(worker.specs.find((s) => params.spec?.includes(s)))
@@ -174,7 +174,7 @@ export default class Watcher {
         for (const [, worker] of Object.entries(workers)) {
             const { cid, capabilities, specs, sessionId } = worker
             const args = Object.assign({ sessionId, baseUrl: worker.config.baseUrl }, params)
-            worker.postMessage('run', args)
+            await worker.postMessage('run', args)
             this._launcher.interface.emit('job:start', { cid, caps: capabilities, specs })
         }
     }

--- a/packages/wdio-cli/tests/watcher.test.ts
+++ b/packages/wdio-cli/tests/watcher.test.ts
@@ -246,7 +246,7 @@ describe('watcher', () => {
         ).toEqual({ '1-0': workerPool['1-0'] })
     })
 
-    it('should run workers on existing session', () => {
+    it('should run workers on existing session', async () => {
         // skip for Windows
         if (os.platform() === 'win32') {
             return
@@ -261,7 +261,7 @@ describe('watcher', () => {
             '1-0': new WorkerMock({ cid: '1-0', specs: ['/bar/foo.js'] })
         }
         watcher['_launcher'].interface!.emit = vi.fn()
-        watcher.run({ spec: 'file:///foo/bar.js' } as any)
+        await watcher.run({ spec: 'file:///foo/bar.js' } as any)
         expect(watcher['_launcher'].interface!.emit).toHaveBeenCalledWith('job:start', {
             cid: '0-0',
             caps: { browserName: 'chrome' },
@@ -277,7 +277,7 @@ describe('watcher', () => {
         expect(watcher['_launcher'].interface!.totalWorkerCnt).toBe(1)
     })
 
-    it('should not clean if no watcher is running', () => {
+    it('should not clean if no watcher is running', async () => {
         const wdioConf = path.join(__dirname, '__fixtures__', 'wdio.conf')
         const watcher = new Watcher(wdioConf, {})
         watcher['_launcher'].runner!.workerPool = {
@@ -288,11 +288,11 @@ describe('watcher', () => {
             '1-0': new WorkerMock({ cid: '1-0', specs: ['/bar/foo.js'] })
         }
         watcher['_launcher'].interface!.emit = vi.fn()
-        watcher.run({ spec: '/foo/bar2.js' } as any)
+        await watcher.run({ spec: '/foo/bar2.js' } as any)
         expect(watcher['_launcher'].interface!.emit).toHaveBeenCalledTimes(0)
     })
 
-    it('should run all tests if `filesToWatch` entry was changed', () => {
+    it('should run all tests if `filesToWatch` entry was changed', async () => {
         // skip for Windows
         if (os.platform() === 'win32') {
             return
@@ -309,7 +309,7 @@ describe('watcher', () => {
             // @ts-ignore mock feature
             '1-0': new WorkerMock({ cid: '1-0', specs: ['/bar/foo.js'] })
         }
-        watcher.run()
+        await watcher.run()
 
         expect(watcher['_launcher'].interface!.totalWorkerCnt).toBe(2)
 

--- a/packages/wdio-local-runner/package.json
+++ b/packages/wdio-local-runner/package.json
@@ -32,6 +32,7 @@
     "@wdio/repl": "8.0.0",
     "@wdio/runner": "8.0.9",
     "@wdio/types": "8.0.8",
+    "@wdio/utils": "8.0.2",
     "async-exit-hook": "^2.0.1",
     "split2": "^4.1.0",
     "stream-buffers": "^3.0.2"

--- a/packages/wdio-local-runner/src/index.ts
+++ b/packages/wdio-local-runner/src/index.ts
@@ -32,7 +32,7 @@ export default class LocalRunner {
         return Object.keys(this.workerPool).length
     }
 
-    run ({ command, args, ...workerOptions }: RunArgs) {
+    async run ({ command, args, ...workerOptions }: RunArgs) {
         /**
          * adjust max listeners on stdout/stderr when creating listeners
          */
@@ -44,7 +44,7 @@ export default class LocalRunner {
 
         const worker = new WorkerInstance(this._config, workerOptions, this.stdout, this.stderr)
         this.workerPool[workerOptions.cid] = worker
-        worker.postMessage(command, args)
+        await worker.postMessage(command, args)
         return worker
     }
 
@@ -54,7 +54,7 @@ export default class LocalRunner {
      * @return {Promise}  resolves when all worker have been shutdown or
      *                    a timeout was reached
      */
-    shutdown () {
+    async shutdown () {
         log.info('Shutting down spawned worker')
 
         for (const [cid, worker] of Object.entries(this.workerPool)) {
@@ -78,7 +78,7 @@ export default class LocalRunner {
                 continue
             }
 
-            worker.postMessage('endSession', payload)
+            await worker.postMessage('endSession', payload)
         }
 
         return new Promise<void>((resolve) => {

--- a/packages/wdio-local-runner/tests/localRunner.test.ts
+++ b/packages/wdio-local-runner/tests/localRunner.test.ts
@@ -18,12 +18,12 @@ vi.mock('child_process', () => {
     }
 })
 
-test('should fork a new process', () => {
+test('should fork a new process', async () => {
     const runner = new LocalRunner(undefined as never, {
         outputDir: '/foo/bar',
         runnerEnv: { FORCE_COLOR: 1 }
     } as any)
-    const worker = runner.run({
+    const worker = await runner.run({
         cid: '0-5',
         command: 'run',
         configFile: '/path/to/wdio.conf.js',
@@ -54,7 +54,7 @@ test('should fork a new process', () => {
         specs: ['/foo/bar.test.js']
     })
 
-    worker.postMessage('runAgain', { foo: 'bar' })
+    await worker.postMessage('runAgain', { foo: 'bar' })
 })
 
 test('should shut down worker processes', async () => {
@@ -62,7 +62,7 @@ test('should shut down worker processes', async () => {
         outputDir: '/foo/bar',
         runnerEnv: { FORCE_COLOR: 1 }
     } as any)
-    const worker1 = runner.run({
+    const worker1 = await runner.run({
         cid: '0-4',
         command: 'run',
         configFile: '/path/to/wdio.conf.js',
@@ -72,7 +72,7 @@ test('should shut down worker processes', async () => {
         execArgv: [],
         retries: 0
     })
-    const worker2 = runner.run({
+    const worker2 = await runner.run({
         cid: '0-5',
         command: 'run',
         configFile: '/path/to/wdio.conf.js',
@@ -108,7 +108,7 @@ test('should avoid shutting down if worker is not busy', async () => {
         runnerEnv: { FORCE_COLOR: 1 }
     } as any)
 
-    runner.run({
+    await runner.run({
         cid: '0-8',
         command: 'run',
         configFile: '/path/to/wdio.conf.js',
@@ -132,7 +132,7 @@ test('should shut down worker processes in watch mode - regular', async () => {
         watch: true,
     } as any)
 
-    const worker = runner.run({
+    const worker = await runner.run({
         cid: '0-6',
         command: 'run',
         configFile: '/path/to/wdio.conf.js',
@@ -156,7 +156,7 @@ test('should shut down worker processes in watch mode - regular', async () => {
 
     expect(after - before).toBeGreaterThanOrEqual(300)
 
-    const call: any = vi.mocked(worker.childProcess?.send)!.mock.calls.pop()![0]
+    const call: any = vi.mocked(await worker.childProcess?.send)!.mock.calls.pop()![0]
     expect(call.cid).toBe('0-6')
     expect(call.command).toBe('endSession')
     expect(call.args.watch).toBe(true)
@@ -172,7 +172,7 @@ test('should shut down worker processes in watch mode - mutliremote', async () =
         watch: true,
     } as any)
 
-    const worker = runner.run({
+    const worker = await runner.run({
         cid: '0-7',
         command: 'run',
         configFile: '/path/to/wdio.conf.js',

--- a/packages/wdio-local-runner/tests/worker.test.ts
+++ b/packages/wdio-local-runner/tests/worker.test.ts
@@ -120,26 +120,26 @@ describe('handleExit', () => {
 })
 
 describe('postMessage', () => {
-    it('should log if the cid is busy and exit', () => {
+    it('should log if the cid is busy and exit', async () => {
         const worker = new Worker({} as any, workerConfig, new WritableStreamBuffer(), new WritableStreamBuffer())
         const log = logger('webdriver')
         vi.spyOn(log, 'info').mockImplementation((string) => string)
 
         worker.isBusy = true
-        worker.postMessage('test-message', {})
+        await worker.postMessage('test-message', {})
 
         expect(log.info)
             .toHaveBeenCalledWith('worker with cid 0-3 already busy and can\'t take new commands')
     })
 
-    it('should create a process if it does not have one', () => {
+    it('should create a process if it does not have one', async () => {
         const worker = new Worker({} as any, workerConfig, new WritableStreamBuffer(), new WritableStreamBuffer())
         worker.childProcess = undefined
         vi.spyOn(worker, 'startProcess').mockImplementation(
-            () => ({ send: vi.fn() }) as unknown as ChildProcess)
-        worker.postMessage('test-message', {})
+            () => ({ send: vi.fn() }) as unknown as Promise<ChildProcess>)
+        await worker.postMessage('test-message', {})
 
-        expect(worker.startProcess).toHaveBeenCalled()
+        expect(await worker.startProcess).toHaveBeenCalled()
         expect(worker.isBusy).toBeTruthy()
 
         vi.mocked(worker.startProcess).mockRestore()

--- a/packages/wdio-types/src/Services.ts
+++ b/packages/wdio-types/src/Services.ts
@@ -7,7 +7,7 @@ export interface RunnerInstance {
     shutdown(): Promise<void>
     closeSession?: (cid: number) => Promise<void>
     getWorkerCount(): number
-    run(args: any): NodeJS.EventEmitter
+    run(args: any): Promise<NodeJS.EventEmitter>
     workerPool: any
     browserPool: any
 }

--- a/packages/wdio-types/src/Workers.ts
+++ b/packages/wdio-types/src/Workers.ts
@@ -48,7 +48,7 @@ export interface Worker
     caps: RemoteCapability;
     cid: string;
     isBusy?: boolean;
-    postMessage: (command: string, args: WorkerMessageArgs) => void;
+    postMessage: (command: string, args: WorkerMessageArgs) => Promise<void>;
     specs: string[];
     sessionId?: string;
 }


### PR DESCRIPTION
## Proposed changes

Wait for 1 second on `startProcess()` in order to give the child process a chance to initialise.

I think this is the easiest, albeit not the nicest approach - i'm waiting for @christian-bromann to tell me I can't do this.

I believe the _correct_ way to do this would be to make the local-runner send "ready" and make the worker listen for this before sending any commands, but I think that approach would take awhile to implement.

Closes #9288

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

### Reviewers: @webdriverio/project-committers
