### PR TITLE
[📖 Docs]: Better Document `Key` import

### DIFF
--- a/packages/webdriverio/src/commands/browser/action.ts
+++ b/packages/webdriverio/src/commands/browser/action.ts
@@ -39,6 +39,18 @@ import { KeyAction, PointerAction, WheelAction, ActionType, BaseActionParams } f
  * - `up(value: string)`: generates a key up action
  * - `pause(ms: number)`: indicate that an input source does nothing during a particular tick
  *
+ * #### Special Characters
+ *
+ * If you like to use special characters like e.g. `Control`, `Page Up` or `Shift`, make sure to import the
+ * [`Key`](https://github.com/webdriverio/webdriverio/blob/main/packages/webdriverio/src/constants.ts#L352-L417) object
+ * from the `webdriverio` package like so:
+ *
+ * ```ts
+ * import { Key } from 'webdriverio'
+ * ```
+ *
+ * The object allows you to access the unicode representation of the desired special character.
+ *
  * ### Pointer input source
  *
  * A pointer input source is an input source that is associated with a pointer-type input device. The type can be
@@ -96,6 +108,8 @@ import { KeyAction, PointerAction, WheelAction, ActionType, BaseActionParams } f
             .perform()
     });
     :key-action.js
+    import { Key } from 'webdriverio'
+
     it('should emit key events using key action commands', async () => {
         const elem = await $('input')
         await elem.click() // make element active
@@ -110,6 +124,13 @@ import { KeyAction, PointerAction, WheelAction, ActionType, BaseActionParams } f
             .perform()
 
         console.log(await elem.getValue()) // returns "foo"
+
+        // copy value out of input element
+        await browser.action('key)
+            .down(Key.Ctrl).down('c')
+            .pause(10)
+            .up(Key.Ctrl).up('c')
+            .perform()
     })
     :wheel-action.js
     it('should scroll using wheel action commands', async () => {

--- a/packages/webdriverio/src/commands/browser/actions.ts
+++ b/packages/webdriverio/src/commands/browser/actions.ts
@@ -2,7 +2,7 @@ import { KeyAction, PointerAction, WheelAction } from '../../utils/actions/index
 
 /**
  * Allows to run multiple action interaction at once, e.g. to simulate a pinch zoom.
- * For more information on the `action` command, check out the [docs](./action).
+ * For more information on the `action` command, check out the [docs](/docs/api/browser/action).
  *
  * <example>
     :action.js


### PR DESCRIPTION
### Pre-check

- [X] I know I can edit the docs but prefer to file this issue

### Describe the improvement

Missing documentation

### Description of the improvement / report

WebdriverIO offers all special characters when interacting with key action, e.g.:

```ts
import { Key } from 'webdriverio'
```

We should make sure this is document properly in the action docs. So people use this object rather than creating/having to copy the keys from the protocol themselves.

### Code of Conduct

- [X] I agree to follow this project's Code of Conduct