### PR TITLE
Explicitly fail if service initialisation fails

### DIFF
--- a/__mocks__/@wdio/scoped-service.ts
+++ b/__mocks__/@wdio/scoped-service.ts
@@ -1,3 +1,0 @@
-export default class MyService {
-    public isScoped = true
-}

--- a/__mocks__/wdio-borked-framework.js
+++ b/__mocks__/wdio-borked-framework.js
@@ -1,1 +1,0 @@
-throw new Error('foobar')

--- a/__mocks__/wdio-launcher-only-service.js
+++ b/__mocks__/wdio-launcher-only-service.js
@@ -1,5 +1,0 @@
-class Launcher {
-    isLauncher = true
-}
-
-exports.launcher = Launcher

--- a/__mocks__/wdio-scoped-service.js
+++ b/__mocks__/wdio-scoped-service.js
@@ -1,3 +1,0 @@
-export default class MyService {
-    isScoped = false
-}

--- a/packages/wdio-utils/src/utils.ts
+++ b/packages/wdio-utils/src/utils.ts
@@ -163,6 +163,8 @@ export function getArgumentType (arg: any) {
  * @return {object}       package content
  */
 export async function safeImport (name: string): Promise<Services.ServicePlugin | null> {
+    console.info('AHHH', name)
+
     let importPath = name
     try {
         /**


### PR DESCRIPTION
## Proposed changes

So far we ignored errors happening when a service fails to initialise e.g. through an error in the constructor. The original idea of this was to ensure test continue to run even if a third party service fails. These days I am more of the conviction that this behavior should be reverted as user want to know when they test fail due to a failing service.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

fixes #9051

### Reviewers: @webdriverio/project-committers
