### PR TITLE
update: mark session as failed if no specs ran

### DIFF
--- a/packages/wdio-browserstack-service/src/service.ts
+++ b/packages/wdio-browserstack-service/src/service.ts
@@ -18,6 +18,7 @@ export default class BrowserstackService implements Services.ServiceInstance {
     private _suiteTitle?: string
     private _fullTitle?: string
     private _options: BrowserstackConfig & Options.Testrunner
+    private _specsRan: boolean = false
 
     constructor (
         options: BrowserstackConfig & Options.Testrunner,
@@ -135,6 +136,7 @@ export default class BrowserstackService implements Services.ServiceInstance {
     }
 
     afterTest(test: Frameworks.Test, context: never, results: Frameworks.TestResult) {
+        this._specsRan = true
         const { error, passed } = results
         if (!passed) {
             this._failReasons.push((error && error.message) || 'Unknown Error')
@@ -152,7 +154,7 @@ export default class BrowserstackService implements Services.ServiceInstance {
         if (setSessionStatus) {
             const hasReasons = this._failReasons.length > 0
             await this._updateJob({
-                status: result === 0 ? 'passed' : 'failed',
+                status: result === 0 && this._specsRan ? 'passed' : 'failed',
                 ...(setSessionName ? { name: this._fullTitle } : {}),
                 ...(hasReasons ? { reason: this._failReasons.join('\n') } : {})
             })

--- a/packages/wdio-browserstack-service/src/service.ts
+++ b/packages/wdio-browserstack-service/src/service.ts
@@ -165,6 +165,7 @@ export default class BrowserstackService implements Services.ServiceInstance {
      * For CucumberJS
      */
     afterScenario (world: Frameworks.World) {
+        this._specsRan = true
         const status = world.result?.status.toLowerCase()
         if (status !== 'skipped') {
             this._scenariosThatRan.push(world.pickle.name || 'unknown pickle name')

--- a/packages/wdio-browserstack-service/tests/service.test.ts
+++ b/packages/wdio-browserstack-service/tests/service.test.ts
@@ -666,6 +666,7 @@ describe('after', () => {
 
         service['_failReasons'] = []
         service['_fullTitle'] = 'foo - bar'
+        service['_specsRan'] = true
 
         await service.after(0)
 
@@ -705,6 +706,28 @@ describe('after', () => {
             }, username: 'foo', password: 'bar' })
     })
 
+    it('should call _update with failed when session has no errors (exit code 0) but no tests ran', async () => {
+        const updateSpy = vi.spyOn(service, '_update')
+        await service.before(service['_config'] as any, [], browser)
+
+        service['_failReasons'] = []
+        service['_fullTitle'] = 'foo - bar'
+
+        await service.after(0)
+
+        expect(updateSpy).toHaveBeenCalledWith(service['_browser']?.sessionId,
+            {
+                status: 'failed',
+                name: 'foo - bar'
+            })
+        expect(got.put).toHaveBeenCalledWith(
+            `${sessionBaseUrl}/${sessionId}.json`,
+            { json: {
+                status: 'failed',
+                name: 'foo - bar'
+            }, username: 'foo', password: 'bar' })
+    })
+
     it('should not set session status if option setSessionStatus is false', async () => {
         const service = new BrowserstackService({ setSessionStatus: false } as any, [] as any, { user: 'foo', key: 'bar' } as any)
         const updateSpy = vi.spyOn(service, '_update')
@@ -725,6 +748,7 @@ describe('after', () => {
 
         service['_failReasons'] = []
         service['_fullTitle'] = 'foo - bar'
+        service['_specsRan'] = true
 
         await service.after(0)
 


### PR DESCRIPTION
when there is an error in the test script on cli there would be a failure message but the session on browserstack would get marked as passed, addressing this

## Proposed changes
Mark session as failed in the above case.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
