### PR TITLE
Add missing noProxy typing for Capabilities ProxyObject

### DIFF
--- a/packages/wdio-types/src/Capabilities.ts
+++ b/packages/wdio-types/src/Capabilities.ts
@@ -34,6 +34,7 @@ export interface ProxyObject {
     socksVersion?: string;
     socksUsername?: string;
     socksPassword?: string;
+    noProxy?: string[];
 }
 
 export interface Capabilities extends VendorExtensions, ConnectionOptions {


### PR DESCRIPTION
## Proposed changes

Currently @wdi/types is missing typing definition for ProxyObject, which prevent to set proxy bypass rule when using typescript
Currently noProxy will only accept array of string, follow by [WebDriver specification](https://w3c.github.io/webdriver/#proxy)
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

### Reviewers: @webdriverio/project-committers
