### PR TITLE
docs: Fix a few typos

### DIFF
--- a/examples/standalone/sample.js
+++ b/examples/standalone/sample.js
@@ -4,7 +4,7 @@ let browser
 
 ;(async () => {
     /**
-     * intiate browser
+     * initiate browser
      * As we use this script in our dev environments which has no
      * browser driver nor xfvb set up we have to make sure to set
      * the headless flag for running with devtools

--- a/website/docs/ComponentTesting.md
+++ b/website/docs/ComponentTesting.md
@@ -7,7 +7,7 @@ With WebdriverIOs [Browser Runner](/docs/runner#browser-runner) you can run test
 
 ## How does it Work?
 
-The Browser Runner uses [Vite](https://vitejs.dev/) to render a test page and intialize a test framework to run your tests in the browser. Currently it only supports Mocha but Jasmine and Cucumber are [on the roadmap](https://github.com/orgs/webdriverio/projects/1). This allows to test any kind of components even for projects that don't use Vite.
+The Browser Runner uses [Vite](https://vitejs.dev/) to render a test page and initialize a test framework to run your tests in the browser. Currently it only supports Mocha but Jasmine and Cucumber are [on the roadmap](https://github.com/orgs/webdriverio/projects/1). This allows to test any kind of components even for projects that don't use Vite.
 
 The Vite server is started by the WebdriverIO testrunner and configured so that you can use all reporter and services as you used to for normal e2e tests. Furthermore initialises the runner a [`browser`](/docs/api/browser) instance within the global scope that allows you to access a subset of the [WebdriverIO API](/docs/api).
 


### PR DESCRIPTION
There are small typos in:
- examples/standalone/sample.js
- website/docs/ComponentTesting.md

Fixes:
- Should read `initiate` rather than `intiate`.
- Should read `initialize` rather than `intialize`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md