### PR TITLE
Fix creation of reporter output directories if they don't exist.

### DIFF
--- a/packages/wdio-reporter/src/index.ts
+++ b/packages/wdio-reporter/src/index.ts
@@ -42,9 +42,11 @@ export default class WDIOReporter extends EventEmitter {
 
         // ensure the report directory exists
         if (this.options.outputDir) {
-            fs.mkdir(this.options.outputDir, { recursive: true }, (err) => {
-                err && log.error(`Couldn't create output dir: ${err.stack}`)
-            })
+            try {
+                fs.mkdirSync(this.options.outputDir, { recursive: true })
+            } catch (err: any) {
+                log.error(`Couldn't create output dir: ${err.stack}`)
+            }
         }
 
         this.outputStream = (this.options.stdout || !this.options.logFile) && this.options.writeStream

--- a/packages/wdio-reporter/tests/reporter.test.ts
+++ b/packages/wdio-reporter/tests/reporter.test.ts
@@ -12,7 +12,7 @@ vi.mock('node:fs', () => ({
             write: vi.fn(),
             end: vi.fn((cb) => cb())
         }),
-        mkdir: vi.fn()
+        mkdirSync: vi.fn()
     }
 }))
 
@@ -79,12 +79,12 @@ describe('WDIOReporter', () => {
             const options = { outputDir: './tempDir', logFile: '' }
             new WDIOReporter(options)
 
-            expect(fs.mkdir).toHaveBeenCalled()
-            expect(fs.mkdir).toHaveBeenCalledWith('./tempDir', { recursive: true }, expect.any(Function))
+            expect(fs.mkdirSync).toHaveBeenCalled()
+            expect(fs.mkdirSync).toHaveBeenCalledWith('./tempDir', { recursive: true })
         })
 
         afterEach(() => {
-            vi.mocked(fs.mkdir).mockClear()
+            vi.mocked(fs.mkdirSync).mockClear()
         })
     })
 


### PR DESCRIPTION
## Proposed changes

Creation of output directories for reporters, which are not existing is broken since v8. Eg. the allure reporter crashes with:

```
[0-0] node:events:491
[0-0]       throw er; // Unhandled 'error' event
[0-0]       ^
[0-0] 
[0-0] Error: ENOENT: no such file or directory, open '/home/michael/devel/reports/allure/wdio/wdio-0-0-allure-reporter.log'
[0-0] Emitted 'error' event on WriteStream instance at:
[0-0]     at emitErrorNT (node:internal/streams/destroy:157:8)
[0-0]     at emitErrorCloseNT (node:internal/streams/destroy:122:3)
[0-0]     at processTicksAndRejections (node:internal/process/task_queues:83:21) {
[0-0]   errno: -2,
[0-0]   code: 'ENOENT',
[0-0]   syscall: 'open',
[0-0]   path: '/home/michael/devel/reports/allure/wdio/wdio-0-0-allure-reporter.log'
```

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
