### PR TITLE
webdriverio: remove @wdio/globals dependency

### DIFF
--- a/packages/webdriverio/package.json
+++ b/packages/webdriverio/package.json
@@ -67,7 +67,6 @@
     "@types/aria-query": "^5.0.0",
     "@types/node": "^18.0.0",
     "@wdio/config": "8.0.14",
-    "@wdio/globals": "8.0.15",
     "@wdio/logger": "8.0.14",
     "@wdio/protocols": "8.0.15",
     "@wdio/repl": "8.0.14",


### PR DESCRIPTION
## Proposed changes

@wdio/globals is not referenced in `webdriverio`

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
