### PR TITLE
backward compatibility for node 12,13

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,9 @@ updates:
     # Chalk v5 is ESM only
     - dependency-name: "chalk"
       update-types: ["version-update:semver-major"]
+    # fs-extra v11 >= is node14 >=
+    - dependency-name: "fs-extra"
+      update-types: ["version-update:semver-major"]
 - package-ecosystem: github-actions
   directory: "/"
   schedule:

--- a/packages/wdio-appium-service/package.json
+++ b/packages/wdio-appium-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wdio/appium-service",
-  "version": "7.28.0",
+  "version": "7.29.1",
   "description": "A WebdriverIO service to start & stop Appium Server",
   "author": "Morten Bjerg Gregersen <morten@mogee.dk>",
   "homepage": "https://github.com/webdriverio/webdriverio/tree/main/packages/wdio-appium-service",
@@ -30,7 +30,7 @@
     "@wdio/config": "7.26.0",
     "@wdio/logger": "7.26.0",
     "@wdio/types": "7.26.0",
-    "fs-extra": "^11.1.0",
+    "fs-extra": "^10.0.0",
     "param-case": "^3.0.0"
   },
   "peerDependencies": {

--- a/packages/wdio-appium-service/package.json
+++ b/packages/wdio-appium-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wdio/appium-service",
-  "version": "7.29.1",
+  "version": "7.28.0",
   "description": "A WebdriverIO service to start & stop Appium Server",
   "author": "Morten Bjerg Gregersen <morten@mogee.dk>",
   "homepage": "https://github.com/webdriverio/webdriverio/tree/main/packages/wdio-appium-service",

--- a/packages/wdio-cli/package.json
+++ b/packages/wdio-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wdio/cli",
-  "version": "7.29.1",
+  "version": "7.29.0",
   "description": "WebdriverIO testrunner command line interface",
   "author": "Christian Bromann <mail@bromann.dev>",
   "homepage": "https://github.com/webdriverio/webdriverio/tree/main/packages/wdio-cli",

--- a/packages/wdio-cli/package.json
+++ b/packages/wdio-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wdio/cli",
-  "version": "7.29.0",
+  "version": "7.29.1",
   "description": "WebdriverIO testrunner command line interface",
   "author": "Christian Bromann <mail@bromann.dev>",
   "homepage": "https://github.com/webdriverio/webdriverio/tree/main/packages/wdio-cli",
@@ -47,7 +47,7 @@
     "chokidar": "^3.0.0",
     "cli-spinners": "^2.1.0",
     "ejs": "^3.0.1",
-    "fs-extra": "^11.1.0",
+    "fs-extra": "^10.0.0",
     "inquirer": "8.2.4",
     "lodash.flattendeep": "^4.4.0",
     "lodash.pickby": "^4.6.0",

--- a/packages/wdio-reporter/package.json
+++ b/packages/wdio-reporter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wdio/reporter",
-  "version": "7.28.0",
+  "version": "7.29.1",
   "description": "A WebdriverIO utility to help reporting all events",
   "author": "Christian Bromann <mail@bromann.dev>",
   "homepage": "https://github.com/webdriverio/webdriverio/tree/main/packages/wdio-reporter",
@@ -36,7 +36,7 @@
     "@types/tmp": "^0.2.0",
     "@wdio/types": "7.26.0",
     "diff": "^5.0.0",
-    "fs-extra": "^11.1.0",
+    "fs-extra": "^10.0.0",
     "object-inspect": "^1.10.3",
     "supports-color": "8.1.1"
   },

--- a/packages/wdio-reporter/package.json
+++ b/packages/wdio-reporter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wdio/reporter",
-  "version": "7.29.1",
+  "version": "7.28.0",
   "description": "A WebdriverIO utility to help reporting all events",
   "author": "Christian Bromann <mail@bromann.dev>",
   "homepage": "https://github.com/webdriverio/webdriverio/tree/main/packages/wdio-reporter",

--- a/packages/wdio-selenium-standalone-service/package.json
+++ b/packages/wdio-selenium-standalone-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wdio/selenium-standalone-service",
-  "version": "7.29.1",
+  "version": "7.28.0",
   "description": "A WebdriverIO service to start & stop Selenium Standalone",
   "author": "Christian Bromann <mail@bromann.dev>",
   "homepage": "https://github.com/webdriverio/webdriverio/tree/main/packages/wdio-selenium-standalone-service",

--- a/packages/wdio-selenium-standalone-service/package.json
+++ b/packages/wdio-selenium-standalone-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wdio/selenium-standalone-service",
-  "version": "7.28.0",
+  "version": "7.29.1",
   "description": "A WebdriverIO service to start & stop Selenium Standalone",
   "author": "Christian Bromann <mail@bromann.dev>",
   "homepage": "https://github.com/webdriverio/webdriverio/tree/main/packages/wdio-selenium-standalone-service",
@@ -33,7 +33,7 @@
     "@wdio/config": "7.26.0",
     "@wdio/logger": "7.26.0",
     "@wdio/types": "7.26.0",
-    "fs-extra": "^11.1.0",
+    "fs-extra": "^10.0.0",
     "selenium-standalone": "^8.0.3"
   },
   "peerDependencies": {

--- a/packages/wdio-static-server-service/package.json
+++ b/packages/wdio-static-server-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wdio/static-server-service",
-  "version": "7.28.0",
+  "version": "7.29.1",
   "description": "A WebdriverIO service that can serve your static websites",
   "author": "Christian Bromann <mail@bromann.dev>",
   "homepage": "https://github.com/webdriverio/webdriverio/tree/main/packages/wdio-static-server-service",
@@ -33,7 +33,7 @@
     "@wdio/logger": "7.26.0",
     "@wdio/types": "7.26.0",
     "express": "^4.14.0",
-    "fs-extra": "^11.1.0",
+    "fs-extra": "^10.0.0",
     "morgan": "^1.7.0"
   },
   "publishConfig": {

--- a/packages/wdio-static-server-service/package.json
+++ b/packages/wdio-static-server-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wdio/static-server-service",
-  "version": "7.29.1",
+  "version": "7.28.0",
   "description": "A WebdriverIO service that can serve your static websites",
   "author": "Christian Bromann <mail@bromann.dev>",
   "homepage": "https://github.com/webdriverio/webdriverio/tree/main/packages/wdio-static-server-service",

--- a/packages/webdriverio/package.json
+++ b/packages/webdriverio/package.json
@@ -1,7 +1,7 @@
 {
   "name": "webdriverio",
   "description": "Next-gen browser and mobile automation test framework for Node.js",
-  "version": "7.29.1",
+  "version": "7.29.0",
   "homepage": "https://webdriver.io",
   "author": "Christian Bromann <mail@bromann.dev>",
   "license": "MIT",

--- a/packages/webdriverio/package.json
+++ b/packages/webdriverio/package.json
@@ -1,7 +1,7 @@
 {
   "name": "webdriverio",
   "description": "Next-gen browser and mobile automation test framework for Node.js",
-  "version": "7.29.0",
+  "version": "7.29.1",
   "homepage": "https://webdriver.io",
   "author": "Christian Bromann <mail@bromann.dev>",
   "license": "MIT",
@@ -69,7 +69,7 @@
     "css-value": "^0.0.1",
     "devtools": "7.28.1",
     "devtools-protocol": "^0.0.1085790",
-    "fs-extra": "^11.1.0",
+    "fs-extra": "^10.0.0",
     "grapheme-splitter": "^1.0.2",
     "lodash.clonedeep": "^4.5.0",
     "lodash.isobject": "^3.0.2",


### PR DESCRIPTION
dependand bot had changed fs-extra from ^10.0.0 to ^11.1.0 for wdio7 but  fs-extra ^11.1.0 support only node>=14 the pull request change version fs-extra back to ^10.0.0 for backward compatibility with node 12,13

## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
