### PR TITLE
fix workaround for Safari 12.0.3

### DIFF
--- a/packages/webdriverio/src/utils/index.ts
+++ b/packages/webdriverio/src/utils/index.ts
@@ -381,7 +381,7 @@ export async function getElementRect(scope: WebdriverIO.Element) {
      * getElementRect workaround for Safari 12.0.3
      * if one of [x, y, height, width] is undefined get rect with javascript
      */
-    if (Object.keys(defaults).some((key: keyof typeof defaults) => !rect[key])) {
+    if (Object.keys(defaults).some((key: keyof typeof defaults) => rect[key] === undefined)) {
         /* istanbul ignore next */
         const rectJs = await getBrowserObject(scope).execute(function (this: Window, el: HTMLElement) {
             if (!el || !el.getBoundingClientRect) {

--- a/packages/webdriverio/tests/utils.test.ts
+++ b/packages/webdriverio/tests/utils.test.ts
@@ -469,6 +469,17 @@ describe('utils', () => {
             expect(fakeScope.getElementRect).toHaveBeenCalled()
             expect(fakeScope.execute).toHaveBeenCalled()
         })
+
+        it('does not use getBoundingClientRect if a value is 0', async () => {
+            const fakeScope = {
+                elementId: 123,
+                getElementRect: vi.fn(() => Promise.resolve({ x: 10, y: 0, width: 300, height: 400 })),
+                execute: vi.fn(() => Promise.reject(new Error('Method is not implemented')))
+            } as any as Element<'async'>
+            expect(await getElementRect(fakeScope as any)).toEqual({ x: 10, y: 0, width: 300, height: 400 })
+            expect(fakeScope.getElementRect).toHaveBeenCalled()
+            expect(fakeScope.execute).not.toHaveBeenCalled()
+        })
     })
 
     describe('getAbsoluteFilepath', () => {


### PR DESCRIPTION
## Proposed changes

The issue is that when the element's `getRect` command is executed there is a Safari workaround to extract a rect from the browser executing js snippet. The workaround applied when one of the properties (x, y, width, or height) is a falsy (`!`) value, previously (in wdio 7) it was applied only if one of the properties were equal to null (`== null`). The problem happens when on appium you extract a region that has one of those properties `0`, it is a valid value, but js snippet execution fails everything on appium.

## Types of changes

I am replacing `!` with `=== undefined`.

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

I didn't find any tests in this area which is why I don't know how you guys usually test things like that. Feel free to add a test or instruct me on what I should add.

### Reviewers: @webdriverio/project-committers
