### PR TITLE
browserstack-service: fix reporter

### DIFF
--- a/packages/wdio-browserstack-service/src/service.ts
+++ b/packages/wdio-browserstack-service/src/service.ts
@@ -1,6 +1,3 @@
-import path from 'node:path'
-import { fileURLToPath } from 'node:url'
-
 import logger from '@wdio/logger'
 import got from 'got'
 import type { Services, Capabilities, Options, Frameworks } from '@wdio/types'
@@ -10,10 +7,8 @@ import { getBrowserDescription, getBrowserCapabilities, isBrowserstackCapability
 import type { BrowserstackConfig, MultiRemoteAction, SessionResponse } from './types.js'
 import type { Pickle, Feature, ITestCaseHookParameter } from './cucumber-types.js'
 import InsightsHandler from './insights-handler.js'
+import TestReporter from './reporter.js'
 import { DEFAULT_OPTIONS } from './constants.js'
-
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = path.dirname(__filename)
 
 const log = logger('@wdio/browserstack-service')
 
@@ -42,7 +37,7 @@ export default class BrowserstackService implements Services.ServiceInstance {
         this._observability = this._options.testObservability
 
         if (this._observability) {
-            this._config.reporters?.push(path.join(__dirname, 'reporter.js'))
+            this._config.reporters?.push(TestReporter)
         }
         // Cucumber specific
         const strict = Boolean(this._config.cucumberOpts && this._config.cucumberOpts.strict)


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

Receiving the following error when using browserstack-service v8.1.0:

```
[0-0] [Error: ENOENT: no such file or directory, open 'logs/wdio-0-0-/home/scg82/dev/my-project/node_modules/@wdio/browserstack-service/build/reporter.js-reporter.log'] {
[0-0]   errno: -2,
[0-0]   code: 'ENOENT',
[0-0]   syscall: 'open',
[0-0]   path: 'logs/wdio-0-0-/home/scg82/dev/my-project/node_modules/@wdio/browserstack-service/build/reporter.js-reporter.log'
[0-0] }
[0-0] FAILED
```

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
