### PR TITLE
Fix request retries by using `got` retry feature

### DIFF
--- a/packages/wdio-types/src/Options.ts
+++ b/packages/wdio-types/src/Options.ts
@@ -1,5 +1,5 @@
-import type * as http from 'node:http'
-import type * as https from 'node:https'
+import type http from 'node:http'
+import type https from 'node:https'
 import type { URL } from 'node:url'
 
 import type { W3CCapabilities, DesiredCapabilities, RemoteCapabilities, RemoteCapability, MultiRemoteCapabilities, Capabilities } from './Capabilities.js'
@@ -8,18 +8,18 @@ import type { ReporterEntry } from './Reporters.js'
 
 export type WebDriverLogTypes = 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'silent'
 export type SupportedProtocols = 'webdriver' | 'devtools' | './protocol-stub.js'
-export type Agents = {http?: any, https?: any}
+export type Agents = { http?: any, https?: any }
 
 export interface RequestLibOptions {
-    agent?: Agents | null
+    agent?: Agents
     followRedirect?: boolean
-    headers?: Record<string, unknown>
+    headers?: Record<string, string | string[] | undefined>
     https?: Record<string, unknown>
     json?: Record<string, unknown>
-    method?: string
-    responseType?: string
+    method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'HEAD' | 'DELETE' | 'OPTIONS' | 'TRACE' | 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete' | 'options' | 'trace'
+    responseType?: 'json' | 'buffer' | 'text'
     retry?: { limit: number }
-    searchParams?: Record<string, unknown>
+    searchParams?: Record<string, string | number | boolean | null | undefined> | URLSearchParams
     throwHttpErrors?: boolean
     timeout?: { response: number }
     url?: URL

--- a/packages/webdriver/src/request/index.ts
+++ b/packages/webdriver/src/request/index.ts
@@ -58,7 +58,6 @@ export default abstract class WebDriverRequest extends EventEmitter {
     requiresSessionId: boolean
     defaultAgents?: Agents
     defaultOptions: RequestLibOptions = {
-        retry: { limit: 3 },
         followRedirect: true,
         responseType: 'json',
         throwHttpErrors: false
@@ -100,6 +99,7 @@ export default abstract class WebDriverRequest extends EventEmitter {
                 ...(typeof options.headers === 'object' ? options.headers : {})
             },
             searchParams,
+            retry: { limit: options.connectionRetryCount! },
             timeout: { response: options.connectionRetryTimeout as number }
         }
 

--- a/packages/webdriver/src/request/index.ts
+++ b/packages/webdriver/src/request/index.ts
@@ -56,9 +56,9 @@ export default abstract class WebDriverRequest extends EventEmitter {
     endpoint: string
     isHubCommand: boolean
     requiresSessionId: boolean
-    defaultAgents: Agents | null
+    defaultAgents?: Agents
     defaultOptions: RequestLibOptions = {
-        retry: { limit: 0 }, // we have our own retry mechanism
+        retry: { limit: 3 },
         followRedirect: true,
         responseType: 'json',
         throwHttpErrors: false
@@ -70,7 +70,6 @@ export default abstract class WebDriverRequest extends EventEmitter {
         this.method = method
         this.endpoint = endpoint
         this.isHubCommand = isHubCommand
-        this.defaultAgents = null
         this.requiresSessionId = Boolean(this.endpoint.match(/:sessionId/))
     }
 
@@ -176,10 +175,7 @@ export default abstract class WebDriverRequest extends EventEmitter {
         const { url, ...requestLibOptions } = fullRequestOptions
         const startTime = this._libPerformanceNow()
         let response = await this._libRequest(url!, requestLibOptions)
-            // @ts-ignore
-            .catch((err: RequestLibError) => {
-                return err
-            })
+            .catch((err: RequestLibError) => err)
         const durationMillisecond = this._libPerformanceNow() - startTime
 
         /**

--- a/packages/webdriver/src/request/node.ts
+++ b/packages/webdriver/src/request/node.ts
@@ -3,7 +3,6 @@ import https from 'node:https'
 import { performance } from 'node:perf_hooks'
 import type { URL } from 'node:url'
 
-import type { Options as GotOptions } from 'got'
 import got from 'got'
 import type { Options } from '@wdio/types'
 
@@ -22,7 +21,7 @@ export default class NodeJSRequest extends WebDriverRequest {
 
     protected async _libRequest (url: URL, opts: Options.RequestLibOptions) {
         try {
-            return (await got(url, opts as any as GotOptions)) as Options.RequestLibResponse
+            return (await got(url, opts)) as Options.RequestLibResponse
         } catch (err: any) {
             if (!(err instanceof Error)) {
                 throw new RequestLibError(err.message || err)


### PR DESCRIPTION
## Proposed changes

fixes #9520

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

It seems that something in got has changed or how ChromeDriver handles multiple requests these days. I found that using `got` retry feature seems like a straight forward solution to this.

### Reviewers: @webdriverio/project-committers
