### PR TITLE
Don't fail wizard if npm pkg set scripts.wdio fails

### DIFF
--- a/packages/wdio-cli/src/utils.ts
+++ b/packages/wdio-cli/src/utils.ts
@@ -795,12 +795,18 @@ export async function createWDIOConfig (parsedAnswers: ParsedAnswers) {
 export async function createWDIOScript (parsedAnswers: ParsedAnswers) {
     const projectProps = await getProjectProps(process.cwd())
 
+    const script = `wdio run ./${path.join('.', parsedAnswers.wdioConfigPath.replace(projectProps?.path || process.cwd(), ''))}`
+    const args = ['pkg', 'set', `scripts.wdio=${script}`]
     try {
         console.log(`Adding ${chalk.bold('"wdio"')} script to package.json.`)
-        const script = `wdio run ./${path.join('.', parsedAnswers.wdioConfigPath.replace(projectProps?.path || process.cwd(), ''))}`
-        await runProgram(NPM_COMMAND, ['pkg', 'set', `scripts.wdio=${script}`], { cwd: parsedAnswers.projectRootDir })
+        await runProgram(NPM_COMMAND, args, { cwd: parsedAnswers.projectRootDir })
         console.log(chalk.green.bold('✔ Success!'))
+        return true
     } catch (err: any) {
-        throw new Error(`⚠️ Couldn't add script to package.json: ${err.stack}`)
+        console.error(
+            `⚠️ Couldn't add script to package.json: "${err.message}", you can add it manually ` +
+            `by running:\n\n\t${NPM_COMMAND} ${args.join(' ')}`
+        )
+        return false
     }
 }

--- a/packages/wdio-cli/src/utils.ts
+++ b/packages/wdio-cli/src/utils.ts
@@ -803,9 +803,10 @@ export async function createWDIOScript (parsedAnswers: ParsedAnswers) {
         console.log(chalk.green.bold('✔ Success!'))
         return true
     } catch (err: any) {
+        const [preArgs, scriptPath] = args.join(' ').split('=')
         console.error(
-            `⚠️ Couldn't add script to package.json: "${err.message}", you can add it manually ` +
-            `by running:\n\n\t${NPM_COMMAND} ${args.join(' ')}`
+            `⚠️  Couldn't add script to package.json: "${err.message}", you can add it manually ` +
+            `by running:\n\n\t${NPM_COMMAND} ${preArgs}="${scriptPath}"`
         )
         return false
     }


### PR DESCRIPTION
## Proposed changes

refs #9529

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

Seems like setting the script can fail in certain setups. Since setting the script is not really important we can just output what the user would need to do to add it. It's a better experience of having throwing an error.

### Reviewers: @webdriverio/project-committers
