### PR TITLE
Update wdio-browserstack-service logging for http status codes

### DIFF
--- a/packages/wdio-browserstack-service/src/util.ts
+++ b/packages/wdio-browserstack-service/src/util.ts
@@ -141,8 +141,17 @@ export async function launchTestSession (options: BrowserstackConfig & Options.T
             process.env.BS_TESTOPS_ALLOW_SCREENSHOTS = response.allow_screenshots.toString()
         }
     } catch (error) {
-        if (error instanceof HTTPError && error.response && error.response.statusCode === 401) {
-            log.debug('Data upload to BrowserStack Test Observability failed either due to incorrect credentials or an unsupported SDK version or because you do not have access to the product.')
+        if (error instanceof HTTPError && error.response) {
+            const errorMessageJson = error.response.body ? JSON.parse(error.response.body.toString()).message : null
+            if (error.response.statusCode === 401) {
+                log.error(errorMessageJson)
+            } else if (error.response.statusCode === 403) {
+                log.trace(errorMessageJson)
+            } else if (error.response.statusCode === 400) {
+                log.error(errorMessageJson)
+            } else {
+                log.debug('Data upload to BrowserStack Test Observability failed either due to incorrect credentials or an unsupported SDK version or because you do not have access to the product.')
+            }
         } else {
             log.debug(`[Start_Build] Failed. Error: ${error}`)
         }

--- a/packages/wdio-browserstack-service/src/util.ts
+++ b/packages/wdio-browserstack-service/src/util.ts
@@ -146,7 +146,7 @@ export async function launchTestSession (options: BrowserstackConfig & Options.T
             if (error.response.statusCode === 401) {
                 log.error(errorMessageJson)
             } else if (error.response.statusCode === 403) {
-                log.trace(errorMessageJson)
+                log.info(errorMessageJson)
             } else if (error.response.statusCode === 400) {
                 log.error(errorMessageJson)
             } else {


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)
We want to update logging in cases of authorization or access errors users face. The error messages in such cases would be simply logged based on http response status code & the messages are being sent from a Browserstack server.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
