### PR TITLE
wdio-browserstack-service: make failures to launch local tunnel halt execution.

### DIFF
--- a/packages/wdio-browserstack-service/src/launcher.ts
+++ b/packages/wdio-browserstack-service/src/launcher.ts
@@ -133,7 +133,14 @@ export default class BrowserstackLauncherService implements Services.ServiceInst
         if (!this._options.browserstackLocal) {
             return log.info('browserstackLocal is not enabled - skipping...')
         }
+        try {
+            return await this.launchLocal(capabilities)
+        } catch (error: any) {
+            throw new SevereServiceError(error)
+        }
+    }
 
+    private launchLocal (capabilities?: Capabilities.RemoteCapabilities) {
         const opts = {
             key: this._config.key,
             ...this._options.opts

--- a/packages/wdio-browserstack-service/tests/launcher.test.ts
+++ b/packages/wdio-browserstack-service/tests/launcher.test.ts
@@ -10,6 +10,7 @@ import BrowserstackLauncher from '../src/launcher.js'
 import type { BrowserstackConfig } from '../src/types.js'
 import * as utils from '../src/util.js'
 import { version as bstackServiceVersion } from '../package.json' assert { type: 'json' }
+import { SevereServiceError } from 'webdriverio'
 
 vi.mock('@wdio/logger', () => import(path.join(process.cwd(), '__mocks__', '@wdio/logger')))
 vi.mock('browserstack-local')
@@ -304,7 +305,7 @@ describe('onPrepare', () => {
         const service = new BrowserstackLauncher(options as any, caps, config)
         mockStart.mockImplementationOnce((_: never, cb: Function) => cb(error))
 
-        return expect(service.onPrepare(config, caps)).rejects.toThrow(error)
+        return expect(service.onPrepare(config, caps)).rejects.toThrow(new SevereServiceError(error as any))
             .then(() => expect(service.browserstackLocal?.start).toHaveBeenCalled())
     })
 


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

Currently, spec tests are executed even if the browserstack-local tunnel fails to launch. This results in spurious "element not found" errors in your spec because your browser.url call actually took you to a "page could not be loaded" page. You'll have to ignore those reports and scroll all the way back through the logs to find the underlying onPrepare hook error.

Here I've changed any failures to launch the tunnel into a `webdriverio.SevereServiceError` so that failures to launch the tunnel prevent execution of the spec tests.

## Types of changes

I've marked this as breaking change out of an abundance of caution. There could be users that have browserstack tunnel fallbacks that allow their tests to pass even when this step fails -- those would now start erroring with my proposed change. 

Perhaps we could only escalate to a `SevereServiceError` if the `baseUrl` contains bs-local.com/browserstack.com?

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate) -- :question: should I add some?
- [x] ~I have added proper type definitions for new commands (if appropriate)~

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
