### PR TITLE
fix devtools-service browser.cdp events (#9348 #9545)

### DIFF
--- a/packages/wdio-devtools-service/package.json
+++ b/packages/wdio-devtools-service/package.json
@@ -44,8 +44,7 @@
     "puppeteer-core": "19.5.0",
     "speedline": "^1.4.3",
     "stable": "^0.1.8",
-    "webdriverio": "8.1.3",
-    "ws": "^8.8.1"
+    "webdriverio": "8.1.3"
   },
   "publishConfig": {
     "access": "public"
@@ -53,7 +52,6 @@
   "devDependencies": {
     "@types/babel__core": "^7.1.19",
     "@types/istanbul-lib-report": "^3.0.0",
-    "@types/istanbul-reports": "^3.0.1",
-    "@types/ws": "^8.5.3"
+    "@types/istanbul-reports": "^3.0.1"
   }
 }

--- a/packages/wdio-devtools-service/tests/service.test.ts
+++ b/packages/wdio-devtools-service/tests/service.test.ts
@@ -159,7 +159,7 @@ test('if supported by browser', async () => {
         'checkPWA', expect.any(Function))
 
     service['_devtoolsGatherer'] = { onMessage: vi.fn() } as any
-    service['_propagateWSEvents']({ data: '{"method": "foo", "params": "bar"}' })
+    service['_propagateWSEvents']({ method: 'foo', params: 'bar' })
     expect(service['_devtoolsGatherer']?.onMessage).toBeCalledTimes(1)
     expect(service['_devtoolsGatherer']?.onMessage).toBeCalledWith({ method:'foo', params: 'bar' })
     expect((service['_browser'] as any).emit).toBeCalledTimes(1)


### PR DESCRIPTION
## Proposed changes

Fixes #9348 
Fixes #9545 

Puppeteer previously exposed a websocket to listen to CDP events. That code was replaced with `const cdpWS = new WebSocket(this._puppeteer.wsEndpoint())`, however, this does not seem to emit anything.

`this._session` has the underlying websocket but does not expose it, so I've used a trick in puppeteer's [EventEmitter.on](https://pptr.dev/api/puppeteer.eventemitter.on), which uses [mitt](https://github.com/developit/mitt), by using `on('*', ...)` and reusing `_propagateWSEvents`

However, since wdio now exposes the puppeteer instance, if we want this behaviour, it's best to use [tkmcmaster's recommendation](https://github.com/webdriverio/webdriverio/issues/9545#issuecomment-1377506091):

```javascript
const puppeteer = await browser.getPuppeteer();
const [page] = await puppeteer.pages();
const cdpSession = await page.target().createCDPSession();
await cdpSession.send("Network.enable");
cdpSession.on(...
```

 It may be best to fix this issue with this PR or just remove the feature all together so that the user docs aren't misleading.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

### Reviewers: @webdriverio/project-committers
