### PR TITLE
Remove 'module: ESNext' from config wizard's tsconfig.json template

### DIFF
--- a/packages/wdio-cli/src/utils.ts
+++ b/packages/wdio-cli/src/utils.ts
@@ -711,7 +711,6 @@ export async function setupTypeScript (parsedAnswers: ParsedAnswers) {
     const config = {
         compilerOptions: {
             moduleResolution: 'node',
-            module: 'ESNext',
             types,
             target: 'es2022',
         }

--- a/packages/wdio-cli/tests/__snapshots__/utils.test.ts.snap
+++ b/packages/wdio-cli/tests/__snapshots__/utils.test.ts.snap
@@ -134,7 +134,6 @@ exports[`setupTypeScript 1`] = `
 "{
     \\"compilerOptions\\": {
         \\"moduleResolution\\": \\"node\\",
-        \\"module\\": \\"ESNext\\",
         \\"types\\": [
             \\"node\\",
             \\"@wdio/globals/types\\",


### PR DESCRIPTION
## Proposed changes

Was discovered that the generated `tsconfig.json` file from the configuration wizard includes a property that breaks proper TypeScript transpiling, so I removed it. (fixes #9539)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

### Reviewers: @webdriverio/project-committers
