### PR TITLE
Update ConfigurationFile.md

### DIFF
--- a/website/docs/ConfigurationFile.md
+++ b/website/docs/ConfigurationFile.md
@@ -57,7 +57,7 @@ export const config = {
     // Specify Test Files
     // ==================
     // Define which test specs should run. The pattern is relative to the directory
-    // from which `wdio` was called.
+    // of the configuration file being run.
     //
     // The specs are defined as an array of spec files (optionally using wildcards
     // that will be expanded). The test for each spec file will be run in a separate


### PR DESCRIPTION

## Proposed changes

Updated to reflect change from v8 announcement and the behavior we see locally in v8. The 'specs' option now refers to a relative path from the configuration file running instead of the previous behavior where it was relative to where 'wdio' was ran out of.

## Types of changes

- [x] Documentation update

## Checklist

- [x ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc

### Reviewers: @webdriverio/project-committers
