### PR TITLE
Map Cucumber tags with special names to Allure links

### DIFF
--- a/packages/wdio-allure-reporter/README.md
+++ b/packages/wdio-allure-reporter/README.md
@@ -40,8 +40,14 @@ export const config = {
 ```
 - `outputDir` defaults to `./allure-results`. After a test run is complete, you will find that this directory has been populated with an `.xml` file for each spec, plus a number of `.txt` and `.png` files and other attachments.
 - `disableWebdriverStepsReporting` - optional parameter(`false` by default), in order to log only custom steps to the reporter.
-- `issueLinkTemplate` - optional parameter, in order to specify the issue link pattern. Reporter will replace `{}` placeholder with value specified in `addIssue(value)` call parameter. Example `https://example.org/issue/{}`
-- `tmsLinkTemplate` - optional parameter, in order to specify the tms link pattern. Reporter will replace `{}` placeholder with value specified in `addTestId(value)` call parameter. Example `https://example.org/tms/{}`
+- `issueLinkTemplate` - optional parameter, in order to specify the issue link pattern. Reporter will replace `{}` placeholder with value specified in `addIssue(value)` call parameter. The same logic is applied if Cucumber is used and tag `issue` is set at any level, it will be converted to the link in the report. The parameter value example:
+  ```
+  https://example.org/issue/{}
+  ```
+- `tmsLinkTemplate` - optional parameter, in order to specify TMS (Test Management System) link pattern. Reporter will replace `{}` placeholder with value specified in `addTestId(value)` call parameter. The same logic is applied if Cucumber is used and tag `testId` is set at any level, it will be converted to the link in the report. The parameter value example:
+  ```
+  https://example.org/tms/{}
+  ```
 - `disableWebdriverScreenshotsReporting` - optional parameter(`false` by default), in order to not attach screenshots to the reporter.
 - `useCucumberStepReporter` - optional parameter (`false` by default), set it to true in order to change the report hierarchy when using cucumber. Try it for yourself and see how it looks.
 - `disableMochaHooks` - optional parameter (`false` by default), set it to true in order to not fetch the `before/after` stacktrace/screenshot/result hooks into the Allure Reporter.
@@ -105,6 +111,18 @@ Given('I include feature and story name', () => {
     allureReporter.addFeature('Feature_name');
     allureReporter.addStory('Story_name');
 })
+```
+
+Cucumber tags converted to the links example (the corresponding link templates must be configured):
+```gherkin
+@issue=BUG-1
+@testId=TST-2
+Feature: This is a feature with global tags that will be converted to Allure links
+
+  @issue=BUG-3
+  @testId=TST-4
+  Scenario: This is a scenario with tags that will be converted to Allure links
+    Given I do something
 ```
 
 ## Displaying the report

--- a/packages/wdio-allure-reporter/src/reporter.ts
+++ b/packages/wdio-allure-reporter/src/reporter.ts
@@ -119,7 +119,13 @@ export default class AllureReporter extends WDIOReporter {
         const currentTest = this._allure.getCurrentTest()
 
         this.getLabels(suite).forEach(({ name, value }) => {
-            currentTest.addLabel(name, value)
+            if (name === 'issue') {
+                this.addIssue({ issue: value })
+            } else if (name === 'testId') {
+                this.addTestId({ testId: value })
+            } else {
+                currentTest.addLabel(name, value)
+            }
         })
 
         if (suite.description) {

--- a/packages/wdio-allure-reporter/tests/__fixtures__/cucumber.ts
+++ b/packages/wdio-allure-reporter/tests/__fixtures__/cucumber.ts
@@ -12,6 +12,12 @@ const suite = (type = 'feature') => ({
         type: 'Tag',
         location: { line: 5, column: 3 },
         name: '@severity=critical'
+    }, {
+        type: 'Tag',
+        name: '@issue=BUG-987'
+    }, {
+        type: 'Tag',
+        name: '@testId=TST-123'
     }],
     tests: [],
     parent: type === 'feature' ? undefined : 'MyFeature1',

--- a/packages/wdio-allure-reporter/tests/cucumber.suite.test.ts
+++ b/packages/wdio-allure-reporter/tests/cucumber.suite.test.ts
@@ -11,6 +11,7 @@ import { temporaryDirectory } from 'tempy'
 import { clean, getResults } from './helpers/wdio-allure-helper'
 
 import AllureReporter from '../src/reporter.js'
+import { linkPlaceholder } from '../src/constants.js'
 import { runnerEnd, runnerStart } from './__fixtures__/runner.js'
 import * as cucumberHelper from './__fixtures__/cucumber.js'
 import * as attachmentHelper from './__fixtures__/attachment.js'
@@ -36,7 +37,13 @@ describe('reporter option "useCucumberStepReporter" set to true', () => {
             let allureXml: any
 
             beforeAll(() => {
-                const reporter = new AllureReporter({ outputDir, useCucumberStepReporter: true, disableWebdriverStepsReporting: true })
+                const reporter = new AllureReporter({
+                    outputDir,
+                    useCucumberStepReporter: true,
+                    disableWebdriverStepsReporting: true,
+                    issueLinkTemplate: `https://github.com/webdriverio/webdriverio/issues/${linkPlaceholder}`,
+                    tmsLinkTemplate: `https://webdriver.io/${linkPlaceholder}`
+                })
 
                 reporter.onRunnerStart(runnerStart())
                 reporter.onSuiteStart(cucumberHelper.featureStart())
@@ -99,6 +106,14 @@ describe('reporter option "useCucumberStepReporter" set to true', () => {
 
             it('should detect tags labels on top in test case', () => {
                 expect(allureXml('test-case label[name="severity"]').eq(0).attr('value')).toEqual('critical')
+            })
+
+            it('should convert tag label "issue" to allure link', () => {
+                expect(allureXml('test-case label[name="issue"]').eq(0).attr('value')).toEqual('https://github.com/webdriverio/webdriverio/issues/BUG-987')
+            })
+
+            it('should convert tag label "testId" to allure link', () => {
+                expect(allureXml('test-case label[name="testId"]').eq(0).attr('value')).toEqual('https://webdriver.io/TST-123')
             })
 
             it('should detect description on top in test case', () => {
@@ -200,6 +215,14 @@ describe('reporter option "useCucumberStepReporter" set to true', () => {
 
         it('should detect tags labels on top in test case', () => {
             expect(allureXml('test-case label[name="severity"]').eq(0).attr('value')).toEqual('critical')
+        })
+
+        it('should keep tag label "issue" as is if issue link template is not configured', () => {
+            expect(allureXml('test-case label[name="issue"]').eq(0).attr('value')).toEqual('BUG-987')
+        })
+
+        it('should keep tag label "testId" as is if tms link template is not configured', () => {
+            expect(allureXml('test-case label[name="testId"]').eq(0).attr('value')).toEqual('TST-123')
         })
 
         it('should detect description on top in test case', () => {


### PR DESCRIPTION
## Proposed changes

Cucumber tags are converted to Allure labels. In turn Allure labels with special names (like `issue`, `testId`) are converted to Allure links. But there is a gap here: Cucumber tags converted to Allure labels are not resulted in links. The goal of this PR is to eliminate this gap.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
