### PR TITLE
Provide mock primitives from `@vitest/spy`

### DIFF
--- a/examples/wdio/browser-runner/components/LitComponent.ts
+++ b/examples/wdio/browser-runner/components/LitComponent.ts
@@ -16,6 +16,10 @@ export class SimpleGreeting extends LitElement {
 
     // Render the UI as a function of component state
     render() {
-        return html`<p>Hello, ${this.name}!</p>`
+        return html`<p>Hello, ${this.name}! ${this.getQuestion()}</p>`
+    }
+
+    getQuestion () {
+        return 'How are you today?'
     }
 }

--- a/examples/wdio/browser-runner/lit.test.js
+++ b/examples/wdio/browser-runner/lit.test.js
@@ -1,6 +1,9 @@
 import { expect, $ } from '@wdio/globals'
+import { spyOn } from '@wdio/browser-runner'
 import { html, render } from 'lit'
-import './components/LitComponent.ts'
+import { SimpleGreeting } from './components/LitComponent.ts'
+
+const getQuestionFn = spyOn(SimpleGreeting.prototype, 'getQuestion')
 
 describe('Lit Component testing', () => {
     it('should render component', async () => {
@@ -10,6 +13,17 @@ describe('Lit Component testing', () => {
         )
 
         const innerElem = await $('simple-greeting').$('>>> p')
-        expect(await innerElem.getText()).toBe('Hello, WebdriverIO!')
+        expect(await innerElem.getText()).toBe('Hello, WebdriverIO! How are you today?')
+    })
+
+    it('should render with mocked component function', async () => {
+        getQuestionFn.mockReturnValue('Does this work?')
+        render(
+            html`<simple-greeting name="WebdriverIO" />`,
+            document.body
+        )
+
+        const innerElem = await $('simple-greeting').$('>>> p')
+        expect(await innerElem.getText()).toBe('Hello, WebdriverIO! Does this work?')
     })
 })

--- a/packages/wdio-browser-runner/package.json
+++ b/packages/wdio-browser-runner/package.json
@@ -31,6 +31,7 @@
     "@originjs/vite-plugin-commonjs": "^1.0.3",
     "@types/istanbul-lib-source-maps": "^4.0.1",
     "@types/node": "^18.11.18",
+    "@vitest/spy": "^0.28.4",
     "@wdio/globals": "8.3.2",
     "@wdio/local-runner": "8.3.2",
     "@wdio/logger": "8.1.0",

--- a/packages/wdio-browser-runner/src/browser/spy.ts
+++ b/packages/wdio-browser-runner/src/browser/spy.ts
@@ -1,0 +1,4 @@
+/**
+ * re-export mock module
+ */
+export * from '@vitest/spy'

--- a/packages/wdio-browser-runner/src/index.ts
+++ b/packages/wdio-browser-runner/src/index.ts
@@ -87,7 +87,7 @@ export default class BrowserRunner extends LocalRunner {
             return worker.postMessage('workerHookExecution', payload)
         })
 
-        worker.on('message', this._onWorkerMessage.bind(this))
+        worker.on('message', this.#onWorkerMessage.bind(this))
         return worker
     }
 
@@ -102,7 +102,7 @@ export default class BrowserRunner extends LocalRunner {
         return this._generateCoverageReports()
     }
 
-    private async _onWorkerMessage (payload: SessionStartedMessage | SessionEndedMessage | WorkerHookResultMessage | WorkerCoverageMapMessage) {
+    async #onWorkerMessage (payload: SessionStartedMessage | SessionEndedMessage | WorkerHookResultMessage | WorkerCoverageMapMessage) {
         if (payload.name === 'sessionStarted' && !SESSIONS.has(payload.cid!)) {
             SESSIONS.set(payload.cid!, {
                 args: this.#config.mochaOpts || {},

--- a/packages/wdio-browser-runner/src/index.ts
+++ b/packages/wdio-browser-runner/src/index.ts
@@ -28,6 +28,8 @@ export default class BrowserRunner extends LocalRunner {
     #server: ViteServer
     #coverageOptions: CoverageOptions
     #reportsDirectory: string
+
+    #mapStore = libSourceMap.createSourceMapStore()
     private _coverageMaps: CoverageMap[] = []
 
     constructor(
@@ -85,47 +87,7 @@ export default class BrowserRunner extends LocalRunner {
             return worker.postMessage('workerHookExecution', payload)
         })
 
-        const mapStore = libSourceMap.createSourceMapStore()
-        worker.on('message', async (payload: SessionStartedMessage | SessionEndedMessage | WorkerHookResultMessage | WorkerCoverageMapMessage) => {
-            if (payload.name === 'sessionStarted' && !SESSIONS.has(payload.cid!)) {
-                SESSIONS.set(payload.cid!, {
-                    args: this.#config.mochaOpts || {},
-                    config: this.#config,
-                    capabilities: payload.content.capabilities,
-                    sessionId: payload.content.sessionId,
-                    injectGlobals: payload.content.injectGlobals
-                })
-                const browser = await attach({
-                    ...this.#config,
-                    ...payload.content,
-                    options: {
-                        ...this.#config,
-                        ...payload.content
-                    }
-                })
-                /**
-                 * propagate debug state to the worker
-                 */
-                BROWSER_POOL.set(payload.cid!, browser)
-            }
-
-            if (payload.name === 'sessionEnded') {
-                SESSIONS.delete(payload.cid)
-                BROWSER_POOL.delete(payload.cid)
-            }
-
-            if (payload.name === 'workerHookResult') {
-                this.#server.resolveHook(payload.args)
-            }
-
-            if (payload.name === 'coverageMap') {
-                const cmd = payload.content.coverageMap as CoverageMapData
-                this._coverageMaps.push(
-                    await mapStore.transformCoverage(libCoverage.createCoverageMap(cmd))
-                )
-            }
-        })
-
+        worker.on('message', this._onWorkerMessage.bind(this))
         return worker
     }
 
@@ -138,6 +100,46 @@ export default class BrowserRunner extends LocalRunner {
         await super.shutdown()
         await this.#server.close()
         return this._generateCoverageReports()
+    }
+
+    private async _onWorkerMessage (payload: SessionStartedMessage | SessionEndedMessage | WorkerHookResultMessage | WorkerCoverageMapMessage) {
+        if (payload.name === 'sessionStarted' && !SESSIONS.has(payload.cid!)) {
+            SESSIONS.set(payload.cid!, {
+                args: this.#config.mochaOpts || {},
+                config: this.#config,
+                capabilities: payload.content.capabilities,
+                sessionId: payload.content.sessionId,
+                injectGlobals: payload.content.injectGlobals
+            })
+            const browser = await attach({
+                ...this.#config,
+                ...payload.content,
+                options: {
+                    ...this.#config,
+                    ...payload.content
+                }
+            })
+            /**
+             * propagate debug state to the worker
+             */
+            BROWSER_POOL.set(payload.cid!, browser)
+        }
+
+        if (payload.name === 'sessionEnded') {
+            SESSIONS.delete(payload.cid)
+            BROWSER_POOL.delete(payload.cid)
+        }
+
+        if (payload.name === 'workerHookResult') {
+            this.#server.resolveHook(payload.args)
+        }
+
+        if (payload.name === 'coverageMap') {
+            const cmd = payload.content.coverageMap as CoverageMapData
+            this._coverageMaps.push(
+                await this.#mapStore.transformCoverage(libCoverage.createCoverageMap(cmd))
+            )
+        }
     }
 
     private async _generateCoverageReports () {
@@ -206,3 +208,8 @@ declare global {
         interface BrowserRunnerOptions extends BrowserRunnerOptionsImport {}
     }
 }
+
+/**
+ * re-export mock module
+ */
+export * from '@vitest/spy'

--- a/packages/wdio-browser-runner/src/index.ts
+++ b/packages/wdio-browser-runner/src/index.ts
@@ -208,3 +208,8 @@ declare global {
         interface BrowserRunnerOptions extends BrowserRunnerOptionsImport {}
     }
 }
+
+/**
+ * re-export mock types
+ */
+export * from '@vitest/spy'

--- a/packages/wdio-browser-runner/src/index.ts
+++ b/packages/wdio-browser-runner/src/index.ts
@@ -208,8 +208,3 @@ declare global {
         interface BrowserRunnerOptions extends BrowserRunnerOptionsImport {}
     }
 }
-
-/**
- * re-export mock module
- */
-export * from '@vitest/spy'

--- a/packages/wdio-browser-runner/src/vite/plugins/testrunner.ts
+++ b/packages/wdio-browser-runner/src/vite/plugins/testrunner.ts
@@ -48,12 +48,17 @@ export function testrunner (options: WebdriverIO.BrowserRunnerOptions): Plugin {
     const automationProtocolPath = `/@fs${url.pathToFileURL(path.resolve(__dirname, '..', '..', 'browser', 'driver.js')).pathname}`
     const mockModulePath = path.resolve(__dirname, '..', '..', 'browser', 'mock.js')
     const setupModulePath = path.resolve(__dirname, '..', '..', 'browser', 'setup.js')
+    const spyModulePath = path.resolve(__dirname, '..', '..', 'browser', 'spy.js')
     return {
         name: 'wdio:testrunner',
         enforce: 'pre',
         resolveId: async (id) => {
             if (id === virtualModuleId) {
                 return resolvedVirtualModuleId
+            }
+
+            if (id === '@wdio/browser-runner') {
+                return spyModulePath
             }
 
             if (id.endsWith('@wdio/browser-runner/setup')) {

--- a/packages/wdio-browser-runner/tests/runner.test.ts
+++ b/packages/wdio-browser-runner/tests/runner.test.ts
@@ -9,7 +9,7 @@ import libSourceMap from 'istanbul-lib-source-maps'
 import reports from 'istanbul-reports'
 
 import { SESSIONS, BROWSER_POOL } from '../src/constants.js'
-import BrowserRunner, { fn, spyOn } from '../src/index.js'
+import BrowserRunner from '../src/index.js'
 
 vi.mock('webdriverio', () => import(path.join(process.cwd(), '__mocks__', 'webdriverio')))
 vi.mock('@wdio/logger', () => import(path.join(process.cwd(), '__mocks__', '@wdio/logger')))
@@ -51,11 +51,6 @@ describe('BrowserRunner', () => {
     beforeEach(() => {
         delete process.env.CI
         vi.mocked(libSourceMap.createSourceMapStore).mockClear()
-    })
-
-    it('it should re-export @vitest/spy', () => {
-        expect(typeof fn).toBe('function')
-        expect(typeof spyOn).toBe('function')
     })
 
     it('should throw if framework is not Mocha', () => {

--- a/packages/wdio-browser-runner/tests/runner.test.ts
+++ b/packages/wdio-browser-runner/tests/runner.test.ts
@@ -9,7 +9,7 @@ import libSourceMap from 'istanbul-lib-source-maps'
 import reports from 'istanbul-reports'
 
 import { SESSIONS, BROWSER_POOL } from '../src/constants.js'
-import BrowserRunner from '../src/index.js'
+import BrowserRunner, { fn, spyOn } from '../src/index.js'
 
 vi.mock('webdriverio', () => import(path.join(process.cwd(), '__mocks__', 'webdriverio')))
 vi.mock('@wdio/logger', () => import(path.join(process.cwd(), '__mocks__', '@wdio/logger')))
@@ -50,6 +50,12 @@ vi.mock('node:fs/promises', async () => {
 describe('BrowserRunner', () => {
     beforeEach(() => {
         delete process.env.CI
+        vi.mocked(libSourceMap.createSourceMapStore).mockClear()
+    })
+
+    it('it should re-export @vitest/spy', () => {
+        expect(typeof fn).toBe('function')
+        expect(typeof spyOn).toBe('function')
     })
 
     it('should throw if framework is not Mocha', () => {

--- a/packages/wdio-browser-runner/tests/vite/plugins/testrunner.test.ts
+++ b/packages/wdio-browser-runner/tests/vite/plugins/testrunner.test.ts
@@ -40,6 +40,9 @@ test('resolveId', async () => {
     expect(await (plugin.resolveId as Function)('@wdio/browser-runner/setup'))
         .toContain(path.join('browser', 'setup.js'))
 
+    expect(await (plugin.resolveId as Function)('@wdio/browser-runner'))
+        .toContain(path.join('browser', 'spy.js'))
+
     vi.mocked(resolve).mockResolvedValue('file:///foo/bar')
     expect(await (plugin.resolveId as Function)('@wdio/config'))
         .toBe('/foo/bar')

--- a/tests/typings/setup.js
+++ b/tests/typings/setup.js
@@ -20,6 +20,7 @@ const packages = {
     'webdriver': 'packages/webdriver',
     'webdriverio': 'packages/webdriverio',
     '@wdio/globals': 'packages/wdio-globals',
+    '@wdio/browser-runner': 'packages/wdio-browser-runner',
     '@wdio/reporter': 'packages/wdio-reporter',
     '@wdio/allure-reporter': 'packages/wdio-allure-reporter',
     '@wdio/appium-service': 'packages/wdio-appium-service',

--- a/tests/typings/webdriverio/globalImport.ts
+++ b/tests/typings/webdriverio/globalImport.ts
@@ -1,5 +1,6 @@
 import { expectType } from 'tsd'
 import { $, $$, browser, driver, multiremotebrowser } from '@wdio/globals'
+import { fn, spyOn } from '@wdio/browser-runner'
 
 ;(async () => {
     const elem = await $('foo')
@@ -19,4 +20,7 @@ import { $, $$, browser, driver, multiremotebrowser } from '@wdio/globals'
 
     const multiTitle = await multiremotebrowser.getTitle()
     expectType<string[]>(multiTitle)
+
+    expectType<Function>(fn)
+    expectType<Function>(spyOn)
 })

--- a/website/_sidebars.json
+++ b/website/_sidebars.json
@@ -79,12 +79,19 @@
         "id": "component-testing"
       },
       "items": [
-        "component-testing/lit",
-        "component-testing/vue",
-        "component-testing/svelte",
-        "component-testing/solid",
-        "component-testing/react",
-        "component-testing/preact"
+        {
+          "type": "category",
+          "label": "Framework Setup",
+          "items": [
+            "component-testing/lit",
+            "component-testing/vue",
+            "component-testing/svelte",
+            "component-testing/solid",
+            "component-testing/react",
+            "component-testing/preact"
+          ]
+        },
+        "component-testing/mocks-and-spies"
       ]
     },
     {

--- a/website/docs/component-testing/MocksAndSpies.md
+++ b/website/docs/component-testing/MocksAndSpies.md
@@ -1,0 +1,44 @@
+---
+id: mocks-and-spies
+title: Mocks and Spies
+---
+
+In order to validate whether certain function handler are called as part of your component tests, the `@wdio/browser-runner` module exports mocking primitives you can use to test, if these functions have been called. By importing `fn` you can create a spy function (mock) to track its execution and with `spyOn` track a method on an already created object.
+
+```ts
+// see full example here: https://github.com/webdriverio/component-testing-examples/blob/main/react-typescript-vite/src/tests/LoginForm.test.tsx
+import React from 'react'
+import { $, expect } from '@wdio/globals'
+import { Key } from 'webdriverio'
+import { render } from '@testing-library/react'
+
+/**
+ * import mock capabilities
+ */
+import { fn, spyOn } from '@wdio/browser-runner'
+
+import LoginForm from '../components/LoginForm'
+
+describe('LoginForm', () => {
+    it('should call onLogin handler if username and password was provided', async () => {
+        const onLogin = fn()
+        render(<LoginForm onLogin={onLogin} />)
+        await $('input[name="username"]').setValue('testuser123')
+        await $('input[name="password"]').setValue('s3cret')
+        await browser.keys(Key.Enter)
+
+        /**
+         * verify the handler was called
+         */
+        expect(onLogin).toBeCalledTimes(1)
+        expect(onLogin).toBeCalledWith(expect.equal({
+            username: 'testuser123',
+            password: 's3cret'
+        }))
+    })
+})
+```
+
+WebdriverIO just re-exports [`@vitest/spy`](https://www.npmjs.com/package/@vitest/spy) here which is a lightweight Jest compatible spy implementation that can be used with WebdriverIOs [`expect`](/docs/api/expect-webdriverio) matchers. You can find more documentation on these mock functions on the [Vitest project page](https://vitest.dev/api/mock.html).
+
+Of course, you can also install and import any other spy framework, e.g. [SinonJS](https://sinonjs.org/), as long as it supports the browser environment.

--- a/website/docs/component-testing/MocksAndSpies.md
+++ b/website/docs/component-testing/MocksAndSpies.md
@@ -3,19 +3,34 @@ id: mocks-and-spies
 title: Mocks and Spies
 ---
 
-In order to validate whether certain function handler are called as part of your component tests, the `@wdio/browser-runner` module exports mocking primitives you can use to test, if these functions have been called. By importing `fn` you can create a spy function (mock) to track its execution and with `spyOn` track a method on an already created object.
+In order to validate whether certain function handler are called as part of your component tests, the `@wdio/browser-runner` module exports mocking primitives you can use to test, if these functions have been called. You can import these methods via:
+
+```js
+import { fn, spy } from '@wdio/browser-runner'
+```
+
+By importing `fn` you can create a spy function (mock) to track its execution and with `spyOn` track a method on an already created object.
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs
+  defaultValue="mocks"
+  values={[
+    {label: 'Mocks', value: 'mocks'},
+    {label: 'Spies', value: 'spies'}
+  ]
+}>
+<TabItem value="mocks">
+
+The full example can be found in the [Component Testing Example](https://github.com/webdriverio/component-testing-examples/blob/main/react-typescript-vite/src/tests/LoginForm.test.tsx) repository.
 
 ```ts
-// see full example here: https://github.com/webdriverio/component-testing-examples/blob/main/react-typescript-vite/src/tests/LoginForm.test.tsx
 import React from 'react'
 import { $, expect } from '@wdio/globals'
+import { fn } from '@wdio/browser-runner'
 import { Key } from 'webdriverio'
 import { render } from '@testing-library/react'
-
-/**
- * import mock capabilities
- */
-import { fn, spyOn } from '@wdio/browser-runner'
 
 import LoginForm from '../components/LoginForm'
 
@@ -38,6 +53,46 @@ describe('LoginForm', () => {
     })
 })
 ```
+
+</TabItem>
+<TabItem value="spies">
+
+The full example can be found in the [examples](https://github.com/webdriverio/webdriverio/blob/main/examples/wdio/browser-runner/lit.test.js) directory.
+
+```js
+import { expect, $ } from '@wdio/globals'
+import { spyOn } from '@wdio/browser-runner'
+import { html, render } from 'lit'
+import { SimpleGreeting } from './components/LitComponent.ts'
+
+const getQuestionFn = spyOn(SimpleGreeting.prototype, 'getQuestion')
+
+describe('Lit Component testing', () => {
+    it('should render component', async () => {
+        render(
+            html`<simple-greeting name="WebdriverIO" />`,
+            document.body
+        )
+
+        const innerElem = await $('simple-greeting').$('>>> p')
+        expect(await innerElem.getText()).toBe('Hello, WebdriverIO! How are you today?')
+    })
+
+    it('should render with mocked component function', async () => {
+        getQuestionFn.mockReturnValue('Does this work?')
+        render(
+            html`<simple-greeting name="WebdriverIO" />`,
+            document.body
+        )
+
+        const innerElem = await $('simple-greeting').$('>>> p')
+        expect(await innerElem.getText()).toBe('Hello, WebdriverIO! Does this work?')
+    })
+})
+```
+
+</TabItem>
+</Tabs>
 
 WebdriverIO just re-exports [`@vitest/spy`](https://www.npmjs.com/package/@vitest/spy) here which is a lightweight Jest compatible spy implementation that can be used with WebdriverIOs [`expect`](/docs/api/expect-webdriverio) matchers. You can find more documentation on these mock functions on the [Vitest project page](https://vitest.dev/api/mock.html).
 


### PR DESCRIPTION
## Proposed changes

In order to simplify accessing mock functions this patch allows to import them directly from the `@wdio/browser-runner` which just re-exports it from `@vitest/spy`. Users could import them from `@vitest/spy` directly but this way we simplify it as user don't need to maintain this dependency.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
