### PR TITLE
Use available Cucumber tag `feature` for Allure label instead of Feature name

### DIFF
--- a/packages/wdio-allure-reporter/README.md
+++ b/packages/wdio-allure-reporter/README.md
@@ -104,7 +104,9 @@ describe('Suite', () => {
 })
 ```
 
-Cucumber example:
+#### Cucumber
+
+Basic Cucumber example:
 
 ```js
 Given('I include feature and story name', () => {
@@ -113,7 +115,9 @@ Given('I include feature and story name', () => {
 })
 ```
 
-Cucumber tags converted to the links example (the corresponding link templates must be configured):
+##### Cucumber Tags
+
+Cucumber tags with special names (`issue` and `testId`) are converted to the links (the corresponding link templates must be configured before):
 ```gherkin
 @issue=BUG-1
 @testId=TST-2
@@ -122,6 +126,15 @@ Feature: This is a feature with global tags that will be converted to Allure lin
   @testId=TST-4
   Scenario: This is a scenario with tags that will be converted to Allure links
     Given I do something
+```
+
+Cucumber tags with special names (`feature`) are mapped to Allure labels:
+
+```gherkin
+Feature: Test user role
+  @feature=login
+  Scenario: Login
+    Given I test login
 ```
 
 ## Displaying the report

--- a/packages/wdio-allure-reporter/src/index.ts
+++ b/packages/wdio-allure-reporter/src/index.ts
@@ -110,12 +110,17 @@ class AllureReporter extends WDIOReporter {
 
         const currentTest = this._allure.getCurrentTest()
 
+        let featureLabelPresent = false
+
         this.getLabels(suite).forEach(({ name, value }) => {
             if (name === 'issue') {
                 this.addIssue({ issue: value })
             } else if (name === 'testId') {
                 this.addTestId({ testId: value })
             } else {
+                if (name === 'feature') {
+                    featureLabelPresent = true
+                }
                 currentTest.addLabel(name, value)
             }
         })
@@ -124,7 +129,7 @@ class AllureReporter extends WDIOReporter {
             this.addDescription(suite)
         }
 
-        this.setCaseParameters(suite.cid, suite.parent)
+        this.setCaseParameters(suite.cid, suite.parent, !featureLabelPresent)
     }
 
     onSuiteEnd(suite: SuiteStats) {
@@ -194,7 +199,7 @@ class AllureReporter extends WDIOReporter {
         this.setCaseParameters(test.cid, test.parent)
     }
 
-    setCaseParameters(cid: string | undefined, parentUid: string | undefined) {
+    setCaseParameters(cid: string | undefined, parentUid: string | undefined, addFeatureLabel: boolean = true) {
         const parentSuite = this.getParentSuite(parentUid)
         const currentTest = this._allure.getCurrentTest()
 
@@ -220,8 +225,11 @@ class AllureReporter extends WDIOReporter {
         currentTest.addLabel('framework', 'wdio')
         currentTest.addLabel('thread', cid)
 
-        if (parentSuite?.title) {
-            currentTest.addLabel('feature', parentSuite?.title)
+        if (addFeatureLabel && parentSuite) {
+            const labelValue = this.getLabels(parentSuite).find(label => label.name === 'feature')?.value ?? parentSuite.title
+            if (labelValue) {
+                currentTest.addLabel('feature', labelValue)
+            }
         }
     }
 

--- a/packages/wdio-allure-reporter/tests/__fixtures__/cucumber.ts
+++ b/packages/wdio-allure-reporter/tests/__fixtures__/cucumber.ts
@@ -35,8 +35,15 @@ const error = {
     actual: 'bar'
 }
 
-export function featureStart() {
-    return Object.assign(suite('feature'))
+export function featureStart(featureLabel?: string) {
+    const feature = Object.assign(suite('feature'))
+    if (featureLabel) {
+        feature.tags.push({
+            type: 'Tag',
+            name: '@feature=' + featureLabel
+        })
+    }
+    return feature
 }
 
 export function featureEnd(results = { tests: [], hooks: [] }) {
@@ -47,8 +54,15 @@ export function featureEnd(results = { tests: [], hooks: [] }) {
     })
 }
 
-export function scenarioStart() {
-    return Object.assign(suite('scenario'))
+export function scenarioStart(featureLabel?: string) {
+    const scenario = Object.assign(suite('scenario'))
+    if (featureLabel) {
+        scenario.tags.push({
+            type: 'Tag',
+            name: '@feature=' + featureLabel
+        })
+    }
+    return scenario
 }
 
 export function scenarioEnd({ tests = [], hooks = [] }): SuiteStats {

--- a/packages/wdio-allure-reporter/tests/cucumber.suite.test.ts
+++ b/packages/wdio-allure-reporter/tests/cucumber.suite.test.ts
@@ -132,7 +132,7 @@ describe('reporter option "useCucumberStepReporter" set to true', () => {
 
             reporter.onRunnerStart(runnerStart())
             reporter.onSuiteStart(cucumberHelper.featureStart())
-            reporter.onSuiteStart(cucumberHelper.scenarioStart())
+            reporter.onSuiteStart(cucumberHelper.scenarioStart('my-awesome-feature-at-scenario-level'))
             reporter.onHookStart(cucumberHelper.hookStart())
             reporter.onHookEnd(cucumberHelper.hookEnd())
             reporter.onTestStart(cucumberHelper.testStart())
@@ -199,6 +199,7 @@ describe('reporter option "useCucumberStepReporter" set to true', () => {
         })
 
         it('should detect analytics labels in test case', () => {
+            expect(allureXml('test-case label[name="feature"]').eq(0).attr('value')).toEqual('my-awesome-feature-at-scenario-level')
             expect(allureXml('test-case label[name="language"]').eq(0).attr('value')).toEqual('javascript')
             expect(allureXml('test-case label[name="framework"]').eq(0).attr('value')).toEqual('wdio')
         })
@@ -250,7 +251,7 @@ describe('reporter option "useCucumberStepReporter" set to true', () => {
             reporter = new AllureReporter({ outputDir, useCucumberStepReporter: true })
 
             reporter.onRunnerStart(runnerStart())
-            reporter.onSuiteStart(cucumberHelper.featureStart())
+            reporter.onSuiteStart(cucumberHelper.featureStart('my-awesome-feature-at-feature-level'))
             reporter.onSuiteStart(cucumberHelper.scenarioStart())
             reporter.onTestStart(cucumberHelper.testStart())
             reporter._consoleOutput = 'some console output'
@@ -268,6 +269,12 @@ describe('reporter option "useCucumberStepReporter" set to true', () => {
         afterAll(() => {
             clean(outputDir)
             jest.resetAllMocks()
+        })
+
+        it('should detect analytics labels in test case', () => {
+            expect(allureXml('test-case label[name="feature"]').eq(0).attr('value')).toEqual('my-awesome-feature-at-feature-level')
+            expect(allureXml('test-case label[name="language"]').eq(0).attr('value')).toEqual('javascript')
+            expect(allureXml('test-case label[name="framework"]').eq(0).attr('value')).toEqual('wdio')
         })
 
         it('should report one suite', () => {
@@ -308,8 +315,8 @@ describe('reporter option "useCucumberStepReporter" set to true', () => {
             const reporter = new AllureReporter({ outputDir, useCucumberStepReporter: true })
 
             reporter.onRunnerStart(runnerStart())
-            reporter.onSuiteStart(cucumberHelper.featureStart())
-            reporter.onSuiteStart(cucumberHelper.scenarioStart())
+            reporter.onSuiteStart(cucumberHelper.featureStart('my-awesome-feature-at-feature-level'))
+            reporter.onSuiteStart(cucumberHelper.scenarioStart('my-awesome-feature-at-scenario-level'))
             reporter.onTestStart(cucumberHelper.testStart())
             reporter.onTestPass()
             reporter.onTestStart(cucumberHelper.test2start())
@@ -326,6 +333,12 @@ describe('reporter option "useCucumberStepReporter" set to true', () => {
 
         afterAll(() => {
             clean(outputDir)
+        })
+
+        it('should detect analytics labels in test case', () => {
+            expect(allureXml('test-case label[name="feature"]').eq(0).attr('value')).toEqual('my-awesome-feature-at-scenario-level')
+            expect(allureXml('test-case label[name="language"]').eq(0).attr('value')).toEqual('javascript')
+            expect(allureXml('test-case label[name="framework"]').eq(0).attr('value')).toEqual('wdio')
         })
 
         it('should report one suite', () => {


### PR DESCRIPTION
Backport of #9721.

## Proposed changes

When Cucumber tag `feature` is presented at scenario or feature level it should be used as Allure label `feature` value for Allure test case (now it's always equal to Cucumber `Feature` name)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
