### PR TITLE
Transform CJS deps to ESM through Vite

### DIFF
--- a/packages/wdio-browser-runner/src/vite/constants.ts
+++ b/packages/wdio-browser-runner/src/vite/constants.ts
@@ -28,7 +28,10 @@ export const DEFAULT_VITE_CONFIG: Partial<InlineConfig> = {
     logLevel: 'silent',
     plugins: [topLevelAwait()],
     build: {
-        sourcemap: 'inline'
+        sourcemap: 'inline',
+        commonjsOptions: {
+            include: [/node_modules/],
+        }
     },
     optimizeDeps: {
         include: ['expect', 'jest-matcher-utils'],

--- a/packages/wdio-browser-runner/src/vite/plugins/testrunner.ts
+++ b/packages/wdio-browser-runner/src/vite/plugins/testrunner.ts
@@ -34,21 +34,13 @@ const WDIO_PACKAGES = ['webdriverio', 'expect-webdriverio']
 const virtualModuleId = 'virtual:wdio'
 const resolvedVirtualModuleId = '\0' + virtualModuleId
 
-const MODULES_TO_MOCK = [
-    'import-meta-resolve', 'puppeteer-core', 'archiver', 'glob', 'devtools', 'ws'
-]
+const MODULES_TO_MOCK = ['import-meta-resolve', 'puppeteer-core', 'archiver', 'glob', 'devtools', 'ws']
+const FETCH_FROM_ESM = ['mocha']
 
 const POLYFILLS = [
     ...builtinModules,
     ...builtinModules.map((m) => `node:${m}`)
 ].map((m) => m.replace('/promises', ''))
-
-const FETCH_FROM_ESM = [
-    'serialize-error', 'minimatch', 'css-shorthand-properties', 'lodash.merge', 'lodash.zip',
-    'lodash.clonedeep', 'lodash.pickby', 'lodash.flattendeep', 'aria-query', 'grapheme-splitter',
-    'css-value', 'rgb2hex', 'p-iteration', 'fast-safe-stringify', 'deepmerge-ts',
-    'mocha'
-]
 
 export function testrunner(options: WebdriverIO.BrowserRunnerOptions): Plugin[] {
     const automationProtocolPath = `/@fs${url.pathToFileURL(path.resolve(__dirname, '..', '..', 'browser', 'driver.js')).pathname}`

--- a/packages/wdio-browser-runner/src/vite/utils.ts
+++ b/packages/wdio-browser-runner/src/vite/utils.ts
@@ -40,6 +40,7 @@ export async function getTemplate(options: WebdriverIO.BrowserRunnerOptions, env
         (p) => path.join(url.fileURLToPath(path.dirname(p)), 'mocha.css'),
         () => 'https://unpkg.com/mocha@10.0.0/mocha.css'
     )
+    const processEnv = JSON.stringify(process.env)
 
     return /* html */`
     <!doctype html>
@@ -48,6 +49,11 @@ export async function getTemplate(options: WebdriverIO.BrowserRunnerOptions, env
             <title>WebdriverIO Browser Test</title>
             <link rel="icon" type="image/x-icon" href="https://webdriver.io/img/favicon.png">
             <link rel="stylesheet" href="${mochaCSSHref}">
+            <script type="module">
+                window.process = {
+                    env: ${processEnv}
+                }
+            </script>
             <script type="module">
                 /**
                  * Inject environment variables

--- a/packages/wdio-browser-runner/src/vite/utils.ts
+++ b/packages/wdio-browser-runner/src/vite/utils.ts
@@ -5,7 +5,7 @@ import { resolve } from 'import-meta-resolve'
 
 import type { Environment, FrameworkPreset } from '../types.js'
 
-export async function getTemplate(options: WebdriverIO.BrowserRunnerOptions, env: Environment, spec: string) {
+export async function getTemplate(options: WebdriverIO.BrowserRunnerOptions, env: Environment, spec: string, processEnv = process.env) {
     const root = options.rootDir || process.cwd()
     const rootFileUrl = url.pathToFileURL(root).href
 
@@ -40,7 +40,6 @@ export async function getTemplate(options: WebdriverIO.BrowserRunnerOptions, env
         (p) => path.join(url.fileURLToPath(path.dirname(p)), 'mocha.css'),
         () => 'https://unpkg.com/mocha@10.0.0/mocha.css'
     )
-    const processEnv = JSON.stringify(process.env)
 
     return /* html */`
     <!doctype html>
@@ -51,7 +50,7 @@ export async function getTemplate(options: WebdriverIO.BrowserRunnerOptions, env
             <link rel="stylesheet" href="${mochaCSSHref}">
             <script type="module">
                 window.process = {
-                    env: ${processEnv}
+                    env: ${JSON.stringify(processEnv)}
                 }
             </script>
             <script type="module">

--- a/packages/wdio-browser-runner/tests/vite/__snapshots__/utils.test.ts.snap
+++ b/packages/wdio-browser-runner/tests/vite/__snapshots__/utils.test.ts.snap
@@ -9,6 +9,11 @@ exports[`getTemplate > renders template correctly 1`] = `
             <link rel=\\"icon\\" type=\\"image/x-icon\\" href=\\"https://webdriver.io/img/favicon.png\\">
             <link rel=\\"stylesheet\\" href=\\"/foo/bar/mocha.css\\">
             <script type=\\"module\\">
+                window.process = {
+                    env: {\\"some\\":\\"env\\"}
+                }
+            </script>
+            <script type=\\"module\\">
                 /**
                  * Inject environment variables
                  */

--- a/packages/wdio-browser-runner/tests/vite/utils.test.ts
+++ b/packages/wdio-browser-runner/tests/vite/utils.test.ts
@@ -33,7 +33,7 @@ describe('getTemplate', () => {
             return
         }
         vi.mocked(resolve).mockResolvedValue('file:///foo/bar/vue')
-        expect(await getTemplate({ preset: 'vue' }, {} as any, '/spec.js')).toMatchSnapshot()
+        expect(await getTemplate({ preset: 'vue' }, {} as any, '/spec.js', { some: 'env' })).toMatchSnapshot()
         expect(fs.readFile).toBeCalledTimes(2)
     })
 })


### PR DESCRIPTION
## Proposed changes

A little tweak to the Vitejs config allows us to do the compile work from CJS to ESM for some dependencies via Vitejs rather than loading it from `https://esm.sh` .. this should improve performance a bit.

We have to load Mocha through this way still as it wouldn't allow to easily get integrated into the browser.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
