### PR TITLE
Transform CJS deps to ESM through Vite

### DIFF
--- a/examples/wdio/browser-runner/node_modules
+++ b/examples/wdio/browser-runner/node_modules
@@ -1,1 +1,0 @@
-../node_modules/

--- a/examples/wdio/browser-runner/node_modules
+++ b/examples/wdio/browser-runner/node_modules
@@ -1,0 +1,1 @@
+../node_modules/

--- a/packages/wdio-browser-runner/src/vite/constants.ts
+++ b/packages/wdio-browser-runner/src/vite/constants.ts
@@ -28,7 +28,10 @@ export const DEFAULT_VITE_CONFIG: Partial<InlineConfig> = {
     logLevel: 'silent',
     plugins: [topLevelAwait()],
     build: {
-        sourcemap: 'inline'
+        sourcemap: 'inline',
+        commonjsOptions: {
+            include: [/node_modules/],
+        }
     },
     optimizeDeps: {
         include: ['expect', 'jest-matcher-utils'],

--- a/packages/wdio-browser-runner/src/vite/constants.ts
+++ b/packages/wdio-browser-runner/src/vite/constants.ts
@@ -34,7 +34,15 @@ export const DEFAULT_VITE_CONFIG: Partial<InlineConfig> = {
         }
     },
     optimizeDeps: {
-        include: ['expect', 'jest-matcher-utils'],
+        /**
+         * the following deps are CJS packages and need to be optimized (compiled to ESM) by Vite
+         */
+        include: [
+            'expect', 'jest-matcher-utils', 'serialize-error', 'minimatch', 'css-shorthand-properties',
+            'lodash.merge', 'lodash.zip', 'lodash.clonedeep', 'lodash.pickby', 'lodash.flattendeep',
+            'aria-query', 'grapheme-splitter', 'css-value', 'rgb2hex', 'p-iteration', 'fast-safe-stringify',
+            'deepmerge-ts'
+        ],
         esbuildOptions: {
             logLevel: 'silent',
             // Node.js global to browser globalThis

--- a/packages/wdio-browser-runner/src/vite/plugins/testrunner.ts
+++ b/packages/wdio-browser-runner/src/vite/plugins/testrunner.ts
@@ -34,8 +34,15 @@ const WDIO_PACKAGES = ['webdriverio', 'expect-webdriverio']
 const virtualModuleId = 'virtual:wdio'
 const resolvedVirtualModuleId = '\0' + virtualModuleId
 
-const MODULES_TO_MOCK = ['import-meta-resolve', 'puppeteer-core', 'archiver', 'glob', 'devtools', 'ws']
-const FETCH_FROM_ESM = ['mocha']
+/**
+ * these modules are used in Node.js environments only and
+ * don't need to be compiled, we just have them point to a
+ * mocked module that returns a matching interface without
+ * functionality
+ */
+const MODULES_TO_MOCK = [
+    'import-meta-resolve', 'puppeteer-core', 'archiver', 'glob', 'devtools', 'ws'
+]
 
 const POLYFILLS = [
     ...builtinModules,
@@ -79,14 +86,6 @@ export function testrunner(options: WebdriverIO.BrowserRunnerOptions): Plugin[] 
              */
             if (MODULES_TO_MOCK.includes(id)) {
                 return mockModulePath
-            }
-
-            /**
-             * some dependencies used by WebdriverIO packages are still using CJS
-             * so we need to pull them from esm.sh to have them run in the browser
-             */
-            if (FETCH_FROM_ESM.includes(id)) {
-                return `https://esm.sh/${id}`
             }
         },
         load(id) {

--- a/packages/wdio-browser-runner/src/vite/plugins/testrunner.ts
+++ b/packages/wdio-browser-runner/src/vite/plugins/testrunner.ts
@@ -34,20 +34,13 @@ const WDIO_PACKAGES = ['webdriverio', 'expect-webdriverio']
 const virtualModuleId = 'virtual:wdio'
 const resolvedVirtualModuleId = '\0' + virtualModuleId
 
-const MODULES_TO_MOCK = [
-    'import-meta-resolve', 'puppeteer-core', 'archiver', 'glob', 'devtools', 'ws'
-]
+const MODULES_TO_MOCK = ['import-meta-resolve', 'puppeteer-core', 'archiver', 'glob', 'devtools', 'ws']
+const FETCH_FROM_ESM = ['mocha']
 
 const POLYFILLS = [
     ...builtinModules,
     ...builtinModules.map((m) => `node:${m}`)
 ].map((m) => m.replace('/promises', ''))
-
-const FETCH_FROM_ESM = [
-    'serialize-error', 'minimatch', 'css-shorthand-properties', 'lodash.merge', 'lodash.zip',
-    'lodash.clonedeep', 'lodash.pickby', 'lodash.flattendeep', 'aria-query', 'grapheme-splitter',
-    'css-value', 'rgb2hex', 'p-iteration', 'fast-safe-stringify', 'deepmerge-ts'
-]
 
 export function testrunner(options: WebdriverIO.BrowserRunnerOptions): Plugin[] {
     const automationProtocolPath = `/@fs${url.pathToFileURL(path.resolve(__dirname, '..', '..', 'browser', 'driver.js')).pathname}`

--- a/packages/wdio-browser-runner/src/vite/utils.ts
+++ b/packages/wdio-browser-runner/src/vite/utils.ts
@@ -53,7 +53,8 @@ export async function getTemplate(options: WebdriverIO.BrowserRunnerOptions, env
         <head>
             <title>WebdriverIO Browser Test</title>
             <link rel="icon" type="image/x-icon" href="https://webdriver.io/img/favicon.png">
-            <link rel="stylesheet" href="${mochaCSSHref}"><script type="module" src="${mochaJSSrc}"></script>
+            <link rel="stylesheet" href="${mochaCSSHref}">
+            <script type="module" src="${mochaJSSrc}"></script>
             <script src="/@fs/${sourceMapSupportDir}/browser-source-map-support.js"></script>
             <script type="module">
                 sourceMapSupport.install()

--- a/packages/wdio-browser-runner/tests/vite/__snapshots__/utils.test.ts.snap
+++ b/packages/wdio-browser-runner/tests/vite/__snapshots__/utils.test.ts.snap
@@ -7,7 +7,8 @@ exports[`getTemplate > renders template correctly 1`] = `
         <head>
             <title>WebdriverIO Browser Test</title>
             <link rel=\\"icon\\" type=\\"image/x-icon\\" href=\\"https://webdriver.io/img/favicon.png\\">
-            <link rel=\\"stylesheet\\" href=\\"/foo/bar/mocha.css\\"><script type=\\"module\\" src=\\"/foo/bar/mocha.js\\"></script>
+            <link rel=\\"stylesheet\\" href=\\"/foo/bar/mocha.css\\">
+            <script type=\\"module\\" src=\\"/foo/bar/mocha.js\\"></script>
             <script src=\\"/@fs//foo/bar/browser-source-map-support.js\\"></script>
             <script type=\\"module\\">
                 sourceMapSupport.install()

--- a/packages/wdio-runner/src/browser.ts
+++ b/packages/wdio-runner/src/browser.ts
@@ -133,7 +133,7 @@ export default class BrowserFramework implements Omit<TestFramework, 'init'> {
                             }
                         }
                         const loadError = typeof window.__wdioErrors__ === 'undefined'
-                            ?  [{ message: 'Failed to load test page' }]
+                            ?  [{ message: `Failed to load test page (title = ${document.title})` }]
                             : null
                         const errors = viteError || window.__wdioErrors__ || loadError
                         return { failures, errors, hasViteError: Boolean(viteError) }

--- a/packages/wdio-runner/src/browser.ts
+++ b/packages/wdio-runner/src/browser.ts
@@ -98,7 +98,7 @@ export default class BrowserFramework implements Omit<TestFramework, 'init'> {
             if (!this._config.sessionId) {
                 await browser.url(`/${this._cid}/test.html?spec=${url.parse(spec).pathname}`)
             }
-            await browser.debug()
+            // await browser.debug()
 
             /**
              * wait for test results or page errors

--- a/packages/wdio-runner/src/browser.ts
+++ b/packages/wdio-runner/src/browser.ts
@@ -98,7 +98,7 @@ export default class BrowserFramework implements Omit<TestFramework, 'init'> {
             if (!this._config.sessionId) {
                 await browser.url(`/${this._cid}/test.html?spec=${url.parse(spec).pathname}`)
             }
-            // await browser.debug()
+            await browser.debug()
 
             /**
              * wait for test results or page errors


### PR DESCRIPTION
The original PR #9735 looked fine in our pipeline here but broke all example tests. This needs more work.