### PR TITLE
Don't have users extend `ChainablePromiseElement`

### DIFF
--- a/packages/webdriverio/src/types.ts
+++ b/packages/webdriverio/src/types.ts
@@ -24,7 +24,7 @@ type AsyncElementProto = {
     [K in keyof Omit<$ElementCommands, keyof ChainablePrototype>]: OmitThisParameter<$ElementCommands[K]>
 } & ChainablePrototype
 
-export interface ChainablePromiseElement<T> extends AsyncElementProto, Promise<T> {
+interface ChainablePromiseBaseElement {
     /**
      * WebDriver element reference
      */
@@ -49,6 +49,11 @@ export interface ChainablePromiseElement<T> extends AsyncElementProto, Promise<T
      */
     index?: Promise<number>
 }
+export interface ChainablePromiseElement<T> extends
+    ChainablePromiseBaseElement,
+    AsyncElementProto,
+    Promise<T>,
+    Omit<WebdriverIO.Element, keyof ChainablePromiseBaseElement | keyof AsyncElementProto> {}
 
 export interface ChainablePromiseArray<T> extends Promise<T> {
     [Symbol.asyncIterator](): AsyncIterableIterator<WebdriverIO.Element>

--- a/tests/typings/webdriverio/async.ts
+++ b/tests/typings/webdriverio/async.ts
@@ -286,6 +286,10 @@ async function bar() {
     const el2result = await el3.elementCustomCommand(4)
     expectType<number>(el2result)
 
+    // chainable promise element custom command
+    const elcResult = await $('foo').$('bar').elementCustomCommand(4)
+    expectType<number>(elcResult)
+
     // $$
     const elems = await $$('')
     const el4 = elems[0]


### PR DESCRIPTION
## Proposed changes

fixes #7767

This patch allows users to just need to extend the `WebdriverIO.Element` namespace and have access to the command on the `ChainablePromiseElement` type.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
