### PR TITLE
Have same exports for webdriverio cjs and esm module

### DIFF
--- a/packages/webdriverio/src/cjs/index.ts
+++ b/packages/webdriverio/src/cjs/index.ts
@@ -2,6 +2,12 @@ import type { Options, Capabilities } from '@wdio/types'
 import type * as WebDriverTypes from 'webdriver'
 import type { AttachOptions } from '../types.js'
 
+import SevereServiceError from '../utils/SevereServiceError.js'
+import { Key } from '../constants.js'
+
+exports.SevereServiceError = SevereServiceError
+exports.Key = Key
+
 export type RemoteOptions = Options.WebdriverIO & Omit<Options.Testrunner, 'capabilities' | 'rootDir'>
 
 /**

--- a/packages/webdriverio/src/cjs/index.ts
+++ b/packages/webdriverio/src/cjs/index.ts
@@ -2,11 +2,72 @@ import type { Options, Capabilities } from '@wdio/types'
 import type * as WebDriverTypes from 'webdriver'
 import type { AttachOptions } from '../types.js'
 
-import SevereServiceError from '../utils/SevereServiceError.js'
-import { Key } from '../constants.js'
+exports.SevereServiceError = class SevereServiceError extends Error {
+    constructor(message = 'Severe Service Error occurred.') {
+        super(message)
+        this.name = 'SevereServiceError'
+    }
+}
 
-exports.SevereServiceError = SevereServiceError
-exports.Key = Key
+exports.Key = {
+    Ctrl: 'WDIO_CONTROL',
+    NULL: '\uE000',
+    Cancel: '\uE001',
+    Help: '\uE002',
+    Backspace: '\uE003',
+    Tab: '\uE004',
+    Clear: '\uE005',
+    Return: '\uE006',
+    Enter: '\uE007',
+    Shift: '\uE008',
+    Control: '\uE009',
+    Alt: '\uE00A',
+    Pause: '\uE00B',
+    Escape: '\uE00C',
+    Space: '\uE00D',
+    PageUp: '\uE00E',
+    PageDown: '\uE00F',
+    End: '\uE010',
+    Home: '\uE011',
+    ArrowLeft: '\uE012',
+    ArrowUp: '\uE013',
+    ArrowRight: '\uE014',
+    ArrowDown: '\uE015',
+    Insert: '\uE016',
+    Delete: '\uE017',
+    Semicolon: '\uE018',
+    Equals: '\uE019',
+    Numpad0: '\uE01A',
+    Numpad1: '\uE01B',
+    Numpad2: '\uE01C',
+    Numpad3: '\uE01D',
+    Numpad4: '\uE01E',
+    Numpad5: '\uE01F',
+    Numpad6: '\uE020',
+    Numpad7: '\uE021',
+    Numpad8: '\uE022',
+    Numpad9: '\uE023',
+    Multiply: '\uE024',
+    Add: '\uE025',
+    Separator: '\uE026',
+    Subtract: '\uE027',
+    Decimal: '\uE028',
+    Divide: '\uE029',
+    F1: '\uE031',
+    F2: '\uE032',
+    F3: '\uE033',
+    F4: '\uE034',
+    F5: '\uE035',
+    F6: '\uE036',
+    F7: '\uE037',
+    F8: '\uE038',
+    F9: '\uE039',
+    F10: '\uE03A',
+    F11: '\uE03B',
+    F12: '\uE03C',
+    Command: '\uE03D',
+    ZenkakuHankaku: '\uE040'
+}
 
 export type RemoteOptions = Options.WebdriverIO & Omit<Options.Testrunner, 'capabilities' | 'rootDir'>
 

--- a/packages/webdriverio/tests/module.test.ts
+++ b/packages/webdriverio/tests/module.test.ts
@@ -7,10 +7,10 @@ import { validateConfig } from '@wdio/config'
 
 import detectBackend from '../src/utils/detectBackend.js'
 import type { RemoteOptions } from '../src/index.js'
-import { remote, multiremote, attach } from '../src/index.js'
+import { remote, multiremote, attach, Key, SevereServiceError } from '../src/index.js'
+import * as cjsExport from '../src/cjs/index.js'
 
 vi.mock('../src/utils/detectBackend', () => ({ default: vi.fn() }))
-
 vi.mock('@wdio/logger', () => import(path.join(process.cwd(), '__mocks__', '@wdio/logger')))
 vi.mock('webdriver', () => {
     const client = {
@@ -92,10 +92,18 @@ describe('WebdriverIO module interface', () => {
         vi.mocked(detectBackend).mockClear()
     })
 
-    it('should provide remote and multiremote access', () => {
+    it('should provide all exports', () => {
         expect(typeof remote).toBe('function')
         expect(typeof attach).toBe('function')
         expect(typeof multiremote).toBe('function')
+        expect(typeof Key).toBe('object')
+        expect(typeof SevereServiceError).toBe('function')
+
+        expect(typeof (cjsExport as any).remote).toBe('function')
+        expect(typeof (cjsExport as any).attach).toBe('function')
+        expect(typeof (cjsExport as any).multiremote).toBe('function')
+        expect(typeof (cjsExport as any).Key).toBe('object')
+        expect(typeof (cjsExport as any).SevereServiceError).toBe('function')
     })
 
     describe('remote function', () => {


### PR DESCRIPTION
## Proposed changes

A user in our support chat has reported the problem that the WebdriverIO cjs module doesn't export `Key` and `SevereServiceError`. This patch fixes this.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
