### PR TITLE
[Browserstack-service] Support for BuildIdentifier and Fix for LocalIdentifier not adding in BrowserStack Capabilities

### DIFF
--- a/packages/wdio-browserstack-service/README.md
+++ b/packages/wdio-browserstack-service/README.md
@@ -181,9 +181,7 @@ Default: `true`
 
 ### buildIdentifier
 
-**buildIdentifier** is a unique id to differentiate every execution that gets appended to
-buildName. Choose your buildIdentifier format from the available expressions:
-
+**buildIdentifier** is a unique id to differentiate every execution that gets appended to buildName. Choose your buildIdentifier format from the available expressions:
 * ${BUILD_NUMBER}: Generates an incremental counter with every execution
 * ${DATE_TIME}: Generates a Timestamp with every execution. Eg. 05-Nov-19:30
 
@@ -194,6 +192,7 @@ services: [
   }]
 ]
 ```
+Build Identifier supports usage of either or both expressions along with any other characters enabling custom formatting options.
 
 ### opts
 

--- a/packages/wdio-browserstack-service/README.md
+++ b/packages/wdio-browserstack-service/README.md
@@ -179,6 +179,22 @@ Automatically set the BrowserStack Automate session status (passed/failed).
 Type: `Boolean`<br />
 Default: `true`
 
+### buildIdentifier
+
+**buildIdentifier** is a unique id to differentiate every execution that gets appended to
+buildName. Choose your buildIdentifier format from the available expressions:
+
+* ${BUILD_NUMBER}: Generates an incremental counter with every execution
+* ${DATE_TIME}: Generates a Timestamp with every execution. Eg. 05-Nov-19:30
+
+```js
+services: [
+  ['browserstack', {
+    buildIdentifier: '#${BUILD_NUMBER}'
+  }]
+]
+```
+
 ### opts
 
 BrowserStack Local options.

--- a/packages/wdio-browserstack-service/src/launcher.ts
+++ b/packages/wdio-browserstack-service/src/launcher.ts
@@ -161,11 +161,8 @@ export default class BrowserstackLauncherService implements Services.ServiceInst
 
         this.browserstackLocal = new BrowserstackLocalLauncher.Local()
 
-        if (opts.localIdentifier) {
-            this._updateCaps(capabilities, 'local', 'true', opts.localIdentifier)
-        } else {
-            this._updateCaps(capabilities, 'local')
-        }
+        this._updateCaps(capabilities, 'local')
+        this._updateCaps(capabilities, 'localIdentifier', opts.localIdentifier)
 
         /**
          * measure BrowserStack tunnel boot time
@@ -292,24 +289,23 @@ export default class BrowserstackLauncherService implements Services.ServiceInst
         return app
     }
 
-    _updateCaps(capabilities?: Capabilities.RemoteCapabilities, capType?: string, value?:string, localId?:string) {
+    _updateCaps(capabilities?: Capabilities.RemoteCapabilities, capType?: string, value?:string) {
         if (Array.isArray(capabilities)) {
             capabilities.forEach((capability: Capabilities.DesiredCapabilities) => {
                 if (!capability['bstack:options']) {
                     const extensionCaps = Object.keys(capability).filter((cap) => cap.includes(':'))
                     if (extensionCaps.length) {
                         if (capType === 'local') {
-                            capability['bstack:options'] = localId ? { local: true } : { local: true, localIdentifier : localId }
+                            capability['bstack:options'] = { local: true }
                         } else if (capType === 'app') {
                             capability['appium:app'] = value
                         } else if (capType === 'buildIdentifier' && value) {
                             capability['bstack:options'] = { buildIdentifier: value }
+                        } else if (capType === 'localIdentifier') {
+                            capability['bstack:options'] = { local: true, localIdentifier: value }
                         }
                     } else if (capType === 'local'){
                         capability['browserstack.local'] = true
-                        if (localId) {
-                            capability['browserstack.localIdentifier'] = localId
-                        }
                     } else if (capType === 'app') {
                         capability.app = value
                     } else if (capType === 'buildIdentifier') {
@@ -318,12 +314,11 @@ export default class BrowserstackLauncherService implements Services.ServiceInst
                         } else {
                             delete capability['browserstack.buildIdentifier']
                         }
+                    } else if (capType === 'localIdentifier') {
+                        capability['browserstack.localIdentifier'] = value
                     }
                 } else if (capType === 'local') {
                     capability['bstack:options'].local = true
-                    if (localId) {
-                        capability['bstack:options'].localIdentifier = localId
-                    }
                 } else if (capType === 'app') {
                     capability['appium:app'] = value
                 } else if (capType === 'buildIdentifier') {
@@ -332,6 +327,8 @@ export default class BrowserstackLauncherService implements Services.ServiceInst
                     } else {
                         delete capability['bstack:options'].buildIdentifier
                     }
+                } else if (capType === 'localIdentifier') {
+                    capability['bstack:options'].localIdentifier = value
                 }
             })
         } else if (typeof capabilities === 'object') {
@@ -340,17 +337,16 @@ export default class BrowserstackLauncherService implements Services.ServiceInst
                     const extensionCaps = Object.keys(caps.capabilities).filter((cap) => cap.includes(':'))
                     if (extensionCaps.length) {
                         if (capType === 'local') {
-                            (caps.capabilities as Capabilities.Capabilities)['bstack:options'] = localId ? { local: true } : { local: true, localIdentifier : localId }
+                            (caps.capabilities as Capabilities.Capabilities)['bstack:options'] = { local: true }
                         } else if (capType === 'app') {
                             (caps.capabilities as Capabilities.Capabilities)['appium:app'] = value
                         } else if (capType === 'buildIdentifier' && value) {
                             (caps.capabilities as Capabilities.Capabilities)['bstack:options'] = { buildIdentifier: value }
+                        } else if (capType === 'localIdentifier') {
+                            (caps.capabilities as Capabilities.Capabilities)['bstack:options'] = { local: true, localIdentifier : value }
                         }
                     } else if (capType === 'local'){
                         (caps.capabilities as Capabilities.Capabilities)['browserstack.local'] = true
-                        if (localId) {
-                            (caps.capabilities as Capabilities.Capabilities)['browserstack.localIdentifier'] = localId
-                        }
                     } else if (capType === 'app') {
                         (caps.capabilities as Capabilities.AppiumCapabilities).app = value
                     } else if (capType === 'buildIdentifier') {
@@ -359,12 +355,11 @@ export default class BrowserstackLauncherService implements Services.ServiceInst
                         } else {
                             delete (caps.capabilities as Capabilities.Capabilities)['browserstack.buildIdentifier']
                         }
+                    } else if (capType === 'localIdentifier') {
+                        (caps.capabilities as Capabilities.Capabilities)['browserstack.localIdentifier'] = value
                     }
                 } else if (capType === 'local'){
                     (caps.capabilities as Capabilities.Capabilities)['bstack:options']!.local = true
-                    if (localId) {
-                        (caps.capabilities as Capabilities.Capabilities)['bstack:options']!.localIdentifier = localId
-                    }
                 } else if (capType === 'app') {
                     (caps.capabilities as Capabilities.Capabilities)['appium:app'] = value
                 } else if (capType === 'buildIdentifier') {
@@ -373,6 +368,8 @@ export default class BrowserstackLauncherService implements Services.ServiceInst
                     } else {
                         delete (caps.capabilities as Capabilities.Capabilities)['bstack:options']!.buildIdentifier
                     }
+                } else if (capType === 'localIdentifier') {
+                    (caps.capabilities as Capabilities.Capabilities)['bstack:options']!.localIdentifier = value
                 }
             })
         } else {
@@ -394,12 +391,14 @@ export default class BrowserstackLauncherService implements Services.ServiceInst
         }
 
         if (this._buildIdentifier && this._buildIdentifier.includes('${DATE_TIME}')){
-            const dateObj = new Date()
-            const date = ('0' + dateObj.getDate()).slice(-2)
-            const month = dateObj.toLocaleString('default', { month: 'short' })
-            const hours = ('0' + dateObj.getHours()).slice(-2)
-            const minutes = ('0' + dateObj.getMinutes()).slice(-2)
-            const formattedDate = date + '-' + month + '-' + hours + ':' + minutes
+            const formattedDate = new Intl.DateTimeFormat('en-GB', {
+                month: 'short',
+                day: '2-digit',
+                hour: '2-digit',
+                minute: '2-digit',
+                hour12: false })
+                .format(new Date())
+                .replace(/ |, /g, '-')
             this._buildIdentifier = this._buildIdentifier.replace('${DATE_TIME}', formattedDate)
             this._updateCaps(capabilities, 'buildIdentifier', this._buildIdentifier)
         }

--- a/packages/wdio-browserstack-service/src/launcher.ts
+++ b/packages/wdio-browserstack-service/src/launcher.ts
@@ -89,6 +89,10 @@ export default class BrowserstackLauncherService implements Services.ServiceInst
         ) {
             this._config.specs = process.env.BROWSERSTACK_RERUN_TESTS.split(',')
         }
+
+        if (this._options.buildIdentifier) {
+            this._buildIdentifier = this._options.buildIdentifier
+        }
     }
 
     async onPrepare (config?: Options.Testrunner, capabilities?: Capabilities.RemoteCapabilities) {

--- a/packages/wdio-browserstack-service/src/launcher.ts
+++ b/packages/wdio-browserstack-service/src/launcher.ts
@@ -386,6 +386,7 @@ export default class BrowserstackLauncherService implements Services.ServiceInst
         if (!this._buildName || process.env.BROWSERSTACK_BUILD_NAME) {
             if (this._buildIdentifier) {
                 this._updateCaps(capabilities, 'buildIdentifier')
+                log.warn('Skipping buildIdentifier as buildName is not passed.')
                 return
             }
         }

--- a/packages/wdio-browserstack-service/src/launcher.ts
+++ b/packages/wdio-browserstack-service/src/launcher.ts
@@ -46,12 +46,10 @@ export default class BrowserstackLauncherService implements Services.ServiceInst
                     const extensionCaps = Object.keys(capability).filter((cap) => cap.includes(':'))
                     if (extensionCaps.length) {
                         capability['bstack:options'] = { wdioService: bstackServiceVersion }
-                    } else {
-                        if (shouldAddServiceVersion(this._config, this._options.testObservability)) {
-                            capability['browserstack.wdioService'] = bstackServiceVersion
-                        }
-                        this._buildIdentifier = capability['browserstack.buildIdentifier']
+                    } else if (shouldAddServiceVersion(this._config, this._options.testObservability)) {
+                        capability['browserstack.wdioService'] = bstackServiceVersion
                     }
+                    this._buildIdentifier = capability['browserstack.buildIdentifier']
                 } else {
                     capability['bstack:options'].wdioService = bstackServiceVersion
                     this._buildName = capability['bstack:options'].buildName
@@ -66,12 +64,10 @@ export default class BrowserstackLauncherService implements Services.ServiceInst
                     const extensionCaps = Object.keys(caps.capabilities).filter((cap) => cap.includes(':'))
                     if (extensionCaps.length) {
                         (caps.capabilities as Capabilities.Capabilities)['bstack:options'] = { wdioService: bstackServiceVersion }
-                    } else {
-                        if (shouldAddServiceVersion(this._config, this._options.testObservability)) {
-                            (caps.capabilities as Capabilities.Capabilities)['browserstack.wdioService'] = bstackServiceVersion
-                        }
-                        this._buildIdentifier = (caps.capabilities as Capabilities.Capabilities)['browserstack.buildIdentifier']
+                    } else if (shouldAddServiceVersion(this._config, this._options.testObservability)) {
+                        (caps.capabilities as Capabilities.Capabilities)['browserstack.wdioService'] = bstackServiceVersion
                     }
+                    this._buildIdentifier = (caps.capabilities as Capabilities.Capabilities)['browserstack.buildIdentifier']
                 } else {
                     const bstackOptions = (caps.capabilities as Capabilities.Capabilities)['bstack:options']
                     bstackOptions!.wdioService = bstackServiceVersion

--- a/packages/wdio-browserstack-service/src/launcher.ts
+++ b/packages/wdio-browserstack-service/src/launcher.ts
@@ -442,17 +442,17 @@ export default class BrowserstackLauncherService implements Services.ServiceInst
             if (this._buildName && this._buildName in parsedBuildCacheFileData) {
                 const prevIdentifier = parseInt((parsedBuildCacheFileData[this._buildName].identifier))
                 const newIdentifier = prevIdentifier + 1
-                this._updateLocalBuildCache(filePath, this._buildName, newIdentifier.toString())
+                this._updateLocalBuildCache(filePath, this._buildName, newIdentifier)
                 return newIdentifier.toString()
             }
-            this._updateLocalBuildCache(filePath, this._buildName, '1')
+            this._updateLocalBuildCache(filePath, this._buildName, 1)
             return '1'
         } catch (error: any) {
             return '-1'
         }
     }
 
-    _updateLocalBuildCache(filePath?:string, buildName?:string, buildIdentifier?:string) {
+    _updateLocalBuildCache(filePath?:string, buildName?:string, buildIdentifier?:number) {
         const newIdentifier = { 'identifier': buildIdentifier }
         if (buildName && filePath) {
             const jsonContent = JSON.parse(fs.readFileSync(filePath).toString())

--- a/packages/wdio-browserstack-service/src/types.ts
+++ b/packages/wdio-browserstack-service/src/types.ts
@@ -175,7 +175,8 @@ export interface UserConfig {
     buildName?: string,
     projectName?: string,
     buildTag?: string,
-    bstackServiceVersion?: string
+    bstackServiceVersion?: string,
+    buildIdentifier?: string
 }
 
 export interface UploadType {

--- a/packages/wdio-browserstack-service/src/types.ts
+++ b/packages/wdio-browserstack-service/src/types.ts
@@ -39,6 +39,13 @@ export interface TestObservabilityOptions {
 
 export interface BrowserstackConfig {
     /**
+     *`buildIdentifier` is a unique id to differentiate every execution that gets appended to
+     * buildName. Choose your buildIdentifier format from the available expressions:
+     * ${BUILD_NUMBER} (Default): Generates an incremental counter with every execution
+     * ${DATE_TIME}: Generates a Timestamp with every execution. Eg. 05-Nov-19:30
+     */
+     buildIdentifier?: string;
+    /**
      * Set this to true to enable BrowserStack Test Observability which will collect test related data
      * (name, hierarchy, status, error stack trace, file name and hierarchy), test commands, etc.
      * and show all the data in a meaningful manner in BrowserStack Test Observability dashboards for faster test debugging and better insights.

--- a/packages/wdio-browserstack-service/src/util.ts
+++ b/packages/wdio-browserstack-service/src/util.ts
@@ -102,6 +102,7 @@ export async function launchTestSession (options: BrowserstackConfig & Options.T
         format: 'json',
         project_name: getObservabilityProject(options, bsConfig.projectName),
         name: getObservabilityBuild(options, bsConfig.buildName),
+        build_identifier: bsConfig.buildIdentifier,
         start_time: (new Date()).toISOString(),
         tags: getObservabilityBuildTags(options, bsConfig.buildTag),
         host_info: {

--- a/packages/wdio-browserstack-service/tests/launcher.test.ts
+++ b/packages/wdio-browserstack-service/tests/launcher.test.ts
@@ -248,12 +248,42 @@ describe('onPrepare', () => {
         expect(capabilities.chromeBrowser.capabilities).toEqual({ 'browserstack.local': true })
     })
 
+    it('should add the "browserstack.localIdentifier" property to a multiremote capability if no "bstack:options"', async () => {
+        const service = new BrowserstackLauncher({
+            browserstackLocal: true,
+            opts: { localIdentifier: 'wdio1' }
+        }, caps, {
+            user: 'foobaruser',
+            key: '12345',
+            capabilities: []
+        })
+        const capabilities = { chromeBrowser: { capabilities: {} } }
+
+        await service.onPrepare(config, capabilities)
+        expect(capabilities.chromeBrowser.capabilities).toEqual({ 'browserstack.local': true, 'browserstack.localIdentifier': 'wdio1' })
+    })
+
     it('should add the "local" property to a multiremote capability inside "bstack:options" if "bstack:options" present', async () => {
         const service = new BrowserstackLauncher(options as any, caps, config)
         const capabilities = { chromeBrowser: { capabilities: { 'bstack:options': {} } } }
 
         await service.onPrepare(config, capabilities)
         expect(capabilities.chromeBrowser.capabilities).toEqual({ 'bstack:options': { local: true } })
+    })
+
+    it('should add the "localIdentifier" property to a multiremote capability inside "bstack:options" if "bstack:options" present', async () => {
+        const service = new BrowserstackLauncher({
+            browserstackLocal: true,
+            opts: { localIdentifier: 'wdio1' }
+        }, caps, {
+            user: 'foobaruser',
+            key: '12345',
+            capabilities: []
+        })
+        const capabilities = { chromeBrowser: { capabilities: { 'bstack:options': {} } } }
+
+        await service.onPrepare(config, capabilities)
+        expect(capabilities.chromeBrowser.capabilities).toEqual({ 'bstack:options': { local: true, localIdentifier: 'wdio1' } })
     })
 
     it('should add the "local" property to a multiremote capability inside "bstack:options" if any extension cap present', async () => {
@@ -273,6 +303,25 @@ describe('onPrepare', () => {
             { 'browserstack.local': true },
             { 'browserstack.local': true },
             { 'browserstack.local': true }
+        ])
+    })
+
+    it('should add the "browserstack.localIdentifier" property to an array of capabilities if no "bstack:options"', async () => {
+        const service = new BrowserstackLauncher({
+            browserstackLocal: true,
+            opts: { localIdentifier: 'wdio1' }
+        }, caps, {
+            user: 'foobaruser',
+            key: '12345',
+            capabilities: []
+        })
+        const capabilities = [{}, {}, {}]
+
+        await service.onPrepare(config, capabilities)
+        expect(capabilities).toEqual([
+            { 'browserstack.local': true, 'browserstack.localIdentifier': 'wdio1' },
+            { 'browserstack.local': true, 'browserstack.localIdentifier': 'wdio1' },
+            { 'browserstack.local': true, 'browserstack.localIdentifier': 'wdio1' }
         ])
     })
 
@@ -298,6 +347,48 @@ describe('onPrepare', () => {
             { 'bstack:options': { local: true }, 'goog:chromeOptions': {} },
             { 'bstack:options': { local: true }, 'moz:firefoxOptions': {} }
         ])
+    })
+
+    it('should add the "buildIdentifier" property to a multiremote capability inside "bstack:options" if "bstack:options" present', async () => {
+        const caps: any = { chromeBrowser: { capabilities: { 'bstack:options': { buildName: 'browserstack wdio build', buildIdentifier: '#${BUILD_NUMBER}' } } } }
+        const service = new BrowserstackLauncher({} as any, caps, config)
+        const capabilities = { chromeBrowser: { capabilities: { 'bstack:options': { buildName: 'browserstack wdio build', buildIdentifier: '#${BUILD_NUMBER}' } } } }
+        vi.spyOn(service, '_getLocalBuildNumber').mockImplementation(() => { return '1' })
+
+        await service.onPrepare(config, capabilities)
+        expect(capabilities.chromeBrowser.capabilities).toEqual({ 'bstack:options': { buildName: 'browserstack wdio build', buildIdentifier: '#1' } })
+    })
+
+    it('should add the "buildIdentifier" property to an array of capabilities inside "bstack:options" if "bstack:options" present', async () => {
+        const caps: any = [{ 'bstack:options': {
+            buildName: 'browserstack wdio build',
+            buildIdentifier: '#${BUILD_NUMBER}'
+        } },
+        { 'bstack:options': {
+            buildName: 'browserstack wdio build',
+            buildIdentifier: '#${BUILD_NUMBER}'
+        } }]
+        const service = new BrowserstackLauncher(options as any, caps, config)
+        const capabilities = [{ 'bstack:options': { buildName: 'browserstack wdio build', buildIdentifier: '#${BUILD_NUMBER}' } }, { 'bstack:options': { buildName: 'browserstack wdio build', buildIdentifier: '#${BUILD_NUMBER}' } }]
+        vi.spyOn(service, '_getLocalBuildNumber').mockImplementation(() => { return '1' })
+
+        await service.onPrepare(config, capabilities)
+        expect(capabilities).toEqual([
+            { 'bstack:options': { buildName: 'browserstack wdio build', buildIdentifier: '#1', local: true } },
+            { 'bstack:options': { buildName: 'browserstack wdio build', buildIdentifier: '#1', local: true } },
+        ])
+    })
+
+    it('should delete the "buildIdentifier" property from Capabilities object', async () => {
+        const caps: any = [{ 'bstack:options': {
+            buildIdentifier: '#${BUILD_NUMBER}'
+        } }]
+        const service = new BrowserstackLauncher({} as any, caps, config)
+        const capabilities = [{ 'bstack:options': { buildIdentifier: '#${BUILD_NUMBER}' } }]
+        vi.spyOn(service, '_getLocalBuildNumber').mockImplementation(() => { return '1' })
+
+        await service.onPrepare(config, capabilities as any)
+        expect(capabilities[0]).toEqual({ 'bstack:options': {} })
     })
 
     it('should reject if local.start throws an error', () => {
@@ -456,6 +547,57 @@ describe('_updateCaps', () => {
         expect(() => service._updateCaps(capabilities as any, 'local'))
             .toThrow(TypeError('Capabilities should be an object or Array!'))
     })
+
+    it('should update the local cap in capabilities', () => {
+        const options: BrowserstackConfig = { browserstackLocal: true }
+        const service = new BrowserstackLauncher(options as any, caps, config)
+
+        service._updateCaps(caps, 'local')
+        expect(caps[0]['browserstack.local']).toEqual(true)
+    })
+
+    it('should update the localIdentifier cap in capabilities if present in opts', () => {
+        const options: BrowserstackConfig = { browserstackLocal: true, opts: { localIdentifier: 'wdio1' } }
+        const service = new BrowserstackLauncher(options as any, caps, config)
+
+        service._updateCaps(caps, 'local', 'true', 'wdio1')
+        expect(caps[0]['browserstack.localIdentifier']).toContain('wdio1')
+    })
+
+    it('should update the buildIdentifier cap in capabilities', () => {
+        const options: BrowserstackConfig = { browserstackLocal: true }
+        const service = new BrowserstackLauncher(options as any, caps, config)
+
+        service._updateCaps(caps, 'buildIdentifier', '#1')
+        expect(caps[0]['browserstack.buildIdentifier']).toEqual('#1')
+    })
+
+    it('should update the buildIdentifier cap if bstack:options is not present in caps array', () => {
+        const options: BrowserstackConfig = { browserstackLocal: true }
+        const caps = [{ 'ms:edgeOptions': {} }]
+        const service = new BrowserstackLauncher(options as any, caps, config)
+
+        service._updateCaps(caps, 'buildIdentifier', '#1')
+        expect(caps[0]['bstack:options']['buildIdentifier']).toEqual('#1')
+    })
+
+    it('should delete buildidentifier in caps array if value not passed in _updateCaps', () => {
+        const options: BrowserstackConfig = { browserstackLocal: true }
+        const caps = [{ 'bstack:options': { buildIdentifier: '1234' } }]
+        const service = new BrowserstackLauncher(options as any, caps as any, config)
+
+        service._updateCaps(caps as any, 'buildIdentifier')
+        expect(caps[0]['bstack:options']).toEqual({ 'wdioService': bstackServiceVersion })
+    })
+
+    it('should delete buildidentifier in caps object if value not passed in _updateCaps', () => {
+        const options: BrowserstackConfig = { browserstackLocal: true }
+        const caps = { chromeBrowser: { capabilities: { 'bstack:options': { buildIdentifier: '123' } } } }
+        const service = new BrowserstackLauncher(options as any, caps as any, config)
+
+        service._updateCaps(caps as any, 'buildIdentifier')
+        expect(caps.chromeBrowser.capabilities['bstack:options']).toEqual({ 'wdioService': bstackServiceVersion })
+    })
 })
 
 describe('_validateApp', () => {
@@ -560,5 +702,210 @@ describe('_uploadApp', () => {
             expect(got.post).toHaveBeenCalled()
             expect(e.name).toEqual('SevereServiceError')
         }
+    })
+})
+
+describe('_handleBuildIdentifier', () => {
+    const options: BrowserstackConfig = { browserstackLocal: true }
+    const config = {
+        user: 'foobaruser',
+        key: '12345',
+        capabilities: []
+    }
+
+    it('should update ${BUILD_NUMBER}', async() => {
+        const caps: any = [{
+            'bstack:options': {
+                buildName: 'browserstack wdio build',
+                buildIdentifier: '#${BUILD_NUMBER}'
+            }
+        }]
+        const service = new BrowserstackLauncher(options as any, caps, config)
+
+        vi.spyOn(service, '_getLocalBuildNumber').mockReturnValueOnce('1')
+        vi.spyOn(service, '_updateLocalBuildCache').mockImplementation(() => {})
+        service._handleBuildIdentifier(caps)
+        expect(caps[0]['bstack:options']?.buildIdentifier).toEqual('#1')
+    })
+
+    it('should update ${DATE_TIME}', async() => {
+        const caps: any = [{
+            'bstack:options': {
+                buildName: 'browserstack wdio build',
+                buildIdentifier: '${DATE_TIME}'
+            }
+        }]
+        const service = new BrowserstackLauncher(options as any, caps, config)
+
+        vi.spyOn(service, '_getLocalBuildNumber').mockReturnValueOnce('-1')
+        vi.spyOn(service, '_updateLocalBuildCache').mockImplementation(() => {})
+        service._handleBuildIdentifier(caps)
+
+        expect(caps[0]['bstack:options']?.buildIdentifier).not.toEqual('${DATE_TIME}')
+    })
+
+    it('should update ${DATE_TIME} and ${BUILD_NUMBER}', async() => {
+        const caps: any = [{
+            'bstack:options': {
+                buildName: 'browserstack wdio build',
+                buildIdentifier: '#${BUILD_NUMBER} ${DATE_TIME}'
+            }
+        }]
+        const service = new BrowserstackLauncher(options as any, caps, config)
+
+        vi.spyOn(service, '_getLocalBuildNumber').mockReturnValueOnce('1')
+        vi.spyOn(service, '_updateLocalBuildCache').mockImplementation(() => {})
+        service._handleBuildIdentifier(caps)
+
+        expect(caps[0]['bstack:options']?.buildIdentifier).not.toEqual('${DATE_TIME}')
+        expect(caps[0]['bstack:options']?.buildIdentifier).toContain('#1')
+    })
+
+    it('should update ${BUILD_NUMBER} in case of CI', async() => {
+        process.env.JENKINS_URL = 'https://jenkins-url'
+        process.env.JENKINS_HOME = '~/.jenkins'
+        process.env.BUILD_NUMBER = '121'
+        const caps: any = [{
+            'bstack:options': {
+                buildName: 'browserstack wdio build',
+                buildIdentifier: '${BUILD_NUMBER}'
+            }
+        }]
+        const service = new BrowserstackLauncher(options as any, caps, config)
+
+        service._handleBuildIdentifier(caps)
+        expect(caps[0]['bstack:options']?.buildIdentifier).toContain('CI 121')
+
+        delete process.env.JENKINS_URL
+        delete process.env.JENKINS_HOME
+        delete process.env.BUILD_NUMBER
+    })
+
+    it('should delete buildIdentifier if buildName is not present in caps', async() => {
+        const caps: any = [{
+            'bstack:options': {
+                buildIdentifier: '#${BUILD_NUMBER}'
+            }
+        }]
+        const updatedcaps: any = [{
+            'bstack:options': {
+                wdioService: bstackServiceVersion
+            }
+        }]
+        const service = new BrowserstackLauncher(options as any, caps, config)
+
+        service._handleBuildIdentifier(caps)
+        expect(caps[0]).toMatchObject(updatedcaps[0])
+    })
+
+    it('should delete buildIdentifier if BROWSERSTACK_BUILD_NAME is defined as env var', async() => {
+        process.env.BROWSERSTACK_BUILD_NAME = 'browserstack wdio build'
+        const caps: any = [{
+            'bstack:options': {
+                buildIdentifier: '#${BUILD_NUMBER}'
+            }
+        }]
+        const updatedcaps: any = [{
+            'bstack:options': {
+                wdioService: bstackServiceVersion
+            }
+        }]
+        const service = new BrowserstackLauncher(options as any, caps, config)
+
+        service._handleBuildIdentifier(caps)
+        expect(caps[0]).toMatchObject(updatedcaps[0])
+        delete process.env.BROWSERSTACK_BUILD_NAME
+    })
+
+    it('should not evaluate buildIdentifier if buildIdentifier is not present in the caps', async() => {
+        const caps: any = [{}]
+        const updatedcaps: any = [{ 'browserstack.wdioService': bstackServiceVersion }]
+        const service = new BrowserstackLauncher(options as any, caps, config)
+
+        service._handleBuildIdentifier(caps)
+        expect(caps[0]).toMatchObject(updatedcaps[0])
+    })
+
+    it('should return if localBuildNumber is -1', async() => {
+        const caps: any = [{
+            'bstack:options': {
+                buildName: 'browserstack wdio build',
+                buildIdentifier: '#${BUILD_NUMBER}'
+            }
+        }]
+        const service = new BrowserstackLauncher(options as any, caps, config)
+        vi.spyOn(service, '_getLocalBuildNumber').mockReturnValueOnce('-1')
+
+        service._handleBuildIdentifier(caps)
+        expect(caps[0]['bstack:options']?.buildIdentifier).toEqual('#${BUILD_NUMBER}')
+    })
+})
+
+describe('_getLocalBuildNumber', () => {
+    const options: BrowserstackConfig = { browserstackLocal: true }
+    const config = {
+        user: 'foobaruser',
+        key: '12345',
+        capabilities: []
+    }
+    const caps: any = [{
+        'bstack:options': {
+            buildName: 'browserstack wdio build',
+            buildIdentifier: '#${BUILD_NUMBER}'
+        }
+    }]
+    const service = new BrowserstackLauncher(options as any, caps, config)
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true)
+
+    it('returns 1 in case of buildName key not present in json file', async() => {
+        vi.spyOn(fs, 'existsSync').mockReturnValue(true)
+        vi.spyOn(fs, 'readFileSync').mockReset().mockReturnValue(JSON.stringify({ 'browserstack wdio build test': { 'identifier':'2' } }))
+        vi.spyOn(service, '_updateLocalBuildCache').mockImplementation(() => {})
+        const buildNumber = service._getLocalBuildNumber()
+        expect(buildNumber).toEqual('1')
+    })
+
+    it('returns new identifier in case of buildName key is present in json file', async() => {
+        vi.spyOn(fs, 'existsSync').mockReturnValue(true)
+        vi.spyOn(fs, 'readFileSync').mockReset().mockReturnValue(JSON.stringify({ 'browserstack wdio build': { 'identifier':'2' } }))
+        vi.spyOn(service, '_updateLocalBuildCache').mockImplementation(() => {})
+        const buildNumber = service._getLocalBuildNumber()
+        expect(buildNumber).toEqual('3')
+    })
+
+    it('returns -1 in case of caught exception', async() => {
+        vi.spyOn(fs, 'existsSync').mockReturnValue(true)
+        vi.spyOn(service, '_updateLocalBuildCache').mockImplementation(() => { throw new Error('Unable to parse JSON file') })
+        const buildNumber = service._getLocalBuildNumber()
+        expect(buildNumber).toEqual('-1')
+    })
+})
+
+describe('_updateLocalBuildCache', () => {
+    const options: BrowserstackConfig = { browserstackLocal: true }
+    const config = {
+        user: 'foobaruser',
+        key: '12345',
+        capabilities: []
+    }
+    const caps: any = [{
+        'bstack:options': {
+            buildName: 'browserstack wdio build test',
+            buildIdentifier: '#${BUILD_NUMBER}'
+        }
+    }]
+    const service = new BrowserstackLauncher(options as any, caps, config)
+
+    it('updates buildIdentifier in json file', async() => {
+        vi.spyOn(fs, 'writeFileSync').mockImplementation(() => {})
+        vi.spyOn(fs, 'readFileSync').mockReset().mockReturnValue(JSON.stringify({ 'browserstack wdio build test' : { 'identifier' : '3' } }))
+        const browserstackFolderPath = path.join(require('node:os').homedir(), '.browserstack')
+        const filePath = path.join(browserstackFolderPath, '.build-name-cache.json')
+
+        service._updateLocalBuildCache(filePath, 'browserstack wdio build test', '3')
+        const buildCacheFileData = fs.readFileSync(filePath)
+
+        const parsedBuildCacheFileData = JSON.parse(buildCacheFileData.toString())
+        expect(parsedBuildCacheFileData['browserstack wdio build test']['identifier']).toEqual('3')
     })
 })

--- a/packages/wdio-browserstack-service/tests/launcher.test.ts
+++ b/packages/wdio-browserstack-service/tests/launcher.test.ts
@@ -294,6 +294,17 @@ describe('onPrepare', () => {
         expect(capabilities.chromeBrowser.capabilities).toEqual({ 'bstack:options': { local: true }, 'goog:chromeOptions': {} })
     })
 
+    it('should add the "localIdentifier" property to a multiremote capability inside "bstack:options" if any extension cap present', async () => {
+        const service = new BrowserstackLauncher({
+            browserstackLocal: true,
+            opts: { localIdentifier: 'wdio1' }
+        }, caps, config)
+        const capabilities = { chromeBrowser: { capabilities: { 'goog:chromeOptions': {} } } }
+
+        await service.onPrepare(config, capabilities)
+        expect(capabilities.chromeBrowser.capabilities).toEqual({ 'bstack:options': { local: true, localIdentifier: 'wdio1' }, 'goog:chromeOptions': {} })
+    })
+
     it('should add the "browserstack.local" property to an array of capabilities if no "bstack:options"', async () => {
         const service = new BrowserstackLauncher(options as any, caps, config)
         const capabilities = [{}, {}, {}]
@@ -560,7 +571,7 @@ describe('_updateCaps', () => {
         const options: BrowserstackConfig = { browserstackLocal: true, opts: { localIdentifier: 'wdio1' } }
         const service = new BrowserstackLauncher(options as any, caps, config)
 
-        service._updateCaps(caps, 'local', 'true', 'wdio1')
+        service._updateCaps(caps, 'localIdentifier', 'wdio1')
         expect(caps[0]['browserstack.localIdentifier']).toContain('wdio1')
     })
 

--- a/packages/wdio-browserstack-service/tests/launcher.test.ts
+++ b/packages/wdio-browserstack-service/tests/launcher.test.ts
@@ -592,6 +592,24 @@ describe('_updateCaps', () => {
         expect(caps[0]['bstack:options']['buildIdentifier']).toEqual('#1')
     })
 
+    it('should update buildidentifier in caps object if bstack:options is present', () => {
+        const options: BrowserstackConfig = { browserstackLocal: true }
+        const caps = { chromeBrowser: { capabilities: { 'goog:chromeOptions': {}, 'bstack:options': { buildIdentifier: '123' } } } }
+        const service = new BrowserstackLauncher(options, caps, config)
+
+        service._updateCaps(caps, 'buildIdentifier', '#1')
+        expect(caps.chromeBrowser.capabilities['bstack:options']).toEqual({ 'wdioService': bstackServiceVersion, buildIdentifier: '#1' })
+    })
+
+    it('should update buildidentifier in caps object if bstack:options is not present', () => {
+        const options: BrowserstackConfig = { browserstackLocal: true }
+        const caps = { chromeBrowser: { capabilities: {} } }
+        const service = new BrowserstackLauncher(options, caps, config)
+
+        service._updateCaps(caps, 'buildIdentifier', '#1')
+        expect(caps.chromeBrowser.capabilities).toEqual({ 'browserstack.wdioService': bstackServiceVersion, 'browserstack.buildIdentifier': '#1' })
+    })
+
     it('should delete buildidentifier in caps array if value not passed in _updateCaps', () => {
         const options: BrowserstackConfig = { browserstackLocal: true }
         const caps = [{ 'bstack:options': { buildIdentifier: '1234' } }]

--- a/packages/wdio-browserstack-service/tests/launcher.test.ts
+++ b/packages/wdio-browserstack-service/tests/launcher.test.ts
@@ -402,6 +402,16 @@ describe('onPrepare', () => {
         expect(capabilities[0]).toEqual({ 'bstack:options': {} })
     })
 
+    it('should evaluate and set buildIdentifier from service options', async () => {
+        const caps: any = { chromeBrowser: { capabilities: { 'bstack:options': { buildName: 'browserstack wdio build', buildIdentifier: 'test ${BUILD_NUMBER}' } } } }
+        const service = new BrowserstackLauncher({ buildIdentifier: '#${BUILD_NUMBER}' }, caps, config)
+        const capabilities = { chromeBrowser: { capabilities: { 'bstack:options': { buildName: 'browserstack wdio build', buildIdentifier: 'test ${BUILD_NUMBER}' } } } }
+        vi.spyOn(service, '_getLocalBuildNumber').mockImplementation(() => { return '1' })
+
+        await service.onPrepare(config, capabilities)
+        expect(capabilities.chromeBrowser.capabilities).toEqual({ 'bstack:options': { buildName: 'browserstack wdio build', buildIdentifier: '#1' } })
+    })
+
     it('should reject if local.start throws an error', () => {
         const service = new BrowserstackLauncher(options as any, caps, config)
         mockStart.mockImplementationOnce((_: never, cb: Function) => cb(error))

--- a/packages/wdio-types/src/Capabilities.ts
+++ b/packages/wdio-types/src/Capabilities.ts
@@ -164,6 +164,8 @@ export interface VendorExtensions extends EdgeCapabilities, AppiumW3CCapabilitie
      * @private
      */
     'browserstack.wdioService'?: string
+    'browserstack.buildIdentifier'?: string
+    'browserstack.localIdentifier'?: string
 
     'goog:chromeOptions'?: ChromeOptions
     'moz:firefoxOptions'?: FirefoxOptions
@@ -1293,6 +1295,12 @@ export interface BrowserStackCapabilities {
      * @private
      */
     wdioService?: string
+    /**
+     * Specify an identifier for a build consists group of tests.
+     */
+    buildIdentifier?: string
+    'browserstack.buildIdentifier'?: string
+    'browserstack.localIdentifier'?: string
 }
 
 export interface SauceLabsVisualCapabilities {


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

This PR:

- Add support for `buildIdentifier` browserstack capability to the browserstack-service and generate unique identifiers corresponding to placeholders (For instance, `${BUILD_NUMBER}` and `${DATE_TIME}`)
- Fix for localIdentifier, when adding localIdentifier in `opts` does not add it to browserstack capabilities which leads to session failure. Currently, user needs to add localIdentifier explicitly in the capabilities. With this PR changes, adding localIdentifier in capabilities out of the box.


## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
