### PR TITLE
[Browserstack-service] Support for BuildIdentifier and Fix for LocalIdentifier not adding in BrowserStack Capabilities

### DIFF
--- a/packages/wdio-browserstack-service/README.md
+++ b/packages/wdio-browserstack-service/README.md
@@ -179,6 +179,22 @@ Automatically set the BrowserStack Automate session status (passed/failed).
 Type: `Boolean`<br />
 Default: `true`
 
+### buildIdentifier
+
+**buildIdentifier** is a unique id to differentiate every execution that gets appended to
+buildName. Choose your buildIdentifier format from the available expressions:
+
+* ${BUILD_NUMBER} (Default): Generates an incremental counter with every execution
+* ${DATE_TIME}: Generates a Timestamp with every execution. Eg. 05-Nov-19:30
+
+```js
+services: [
+  ['browserstack', {
+    buildIdentifier: '#${BUILD_NUMBER}'
+  }]
+]
+```
+
 ### opts
 
 BrowserStack Local options.

--- a/packages/wdio-browserstack-service/README.md
+++ b/packages/wdio-browserstack-service/README.md
@@ -183,9 +183,8 @@ Default: `true`
 
 **buildIdentifier** is a unique id to differentiate every execution that gets appended to
 buildName. Choose your buildIdentifier format from the available expressions:
-
-* ${BUILD_NUMBER}: Generates an incremental counter with every execution
-* ${DATE_TIME}: Generates a Timestamp with every execution. Eg. 05-Nov-19:30
+* `${BUILD_NUMBER}`: Generates an incremental counter with every execution
+* `${DATE_TIME}`: Generates a Timestamp with every execution. Eg. 05-Nov-19:30
 
 ```js
 services: [
@@ -194,6 +193,7 @@ services: [
   }]
 ]
 ```
+Build Identifier supports usage of either or both expressions along with any other characters enabling custom formatting options.
 
 ### opts
 

--- a/packages/wdio-browserstack-service/README.md
+++ b/packages/wdio-browserstack-service/README.md
@@ -184,7 +184,7 @@ Default: `true`
 **buildIdentifier** is a unique id to differentiate every execution that gets appended to
 buildName. Choose your buildIdentifier format from the available expressions:
 
-* ${BUILD_NUMBER} (Default): Generates an incremental counter with every execution
+* ${BUILD_NUMBER}: Generates an incremental counter with every execution
 * ${DATE_TIME}: Generates a Timestamp with every execution. Eg. 05-Nov-19:30
 
 ```js

--- a/packages/wdio-browserstack-service/README.md
+++ b/packages/wdio-browserstack-service/README.md
@@ -181,8 +181,7 @@ Default: `true`
 
 ### buildIdentifier
 
-**buildIdentifier** is a unique id to differentiate every execution that gets appended to
-buildName. Choose your buildIdentifier format from the available expressions:
+**buildIdentifier** is a unique id to differentiate every execution that gets appended to buildName. Choose your buildIdentifier format from the available expressions:
 * `${BUILD_NUMBER}`: Generates an incremental counter with every execution
 * `${DATE_TIME}`: Generates a Timestamp with every execution. Eg. 05-Nov-19:30
 

--- a/packages/wdio-browserstack-service/src/launcher.ts
+++ b/packages/wdio-browserstack-service/src/launcher.ts
@@ -14,7 +14,7 @@ import type { Capabilities, Services, Options } from '@wdio/types'
 import { version as bstackServiceVersion } from '../package.json'
 import type { App, AppConfig, AppUploadResponse, BrowserstackConfig } from './types'
 import { VALID_APP_EXTENSION } from './constants'
-import { launchTestSession, shouldAddServiceVersion, stopBuildUpstream } from './util'
+import { launchTestSession, shouldAddServiceVersion, stopBuildUpstream, getCiInfo } from './util'
 
 const log = logger('@wdio/browserstack-service')
 
@@ -28,6 +28,7 @@ export default class BrowserstackLauncherService implements Services.ServiceInst
     private _buildName?: string
     private _projectName?: string
     private _buildTag?: string
+    private _buildIdentifier?: string
 
     constructor (
         private _options: BrowserstackConfig & Options.Testrunner,
@@ -42,14 +43,18 @@ export default class BrowserstackLauncherService implements Services.ServiceInst
                     const extensionCaps = Object.keys(capability).filter((cap) => cap.includes(':'))
                     if (extensionCaps.length) {
                         capability['bstack:options'] = { wdioService: bstackServiceVersion }
-                    } else if (shouldAddServiceVersion(this._config, this._options.testObservability)) {
-                        capability['browserstack.wdioService'] = bstackServiceVersion
+                    } else {
+                        if (shouldAddServiceVersion(this._config, this._options.testObservability)) {
+                            capability['browserstack.wdioService'] = bstackServiceVersion
+                        }
+                        this._buildIdentifier = capability['browserstack.buildIdentifier']
                     }
                 } else {
                     capability['bstack:options'].wdioService = bstackServiceVersion
                     this._buildName = capability['bstack:options'].buildName
                     this._projectName = capability['bstack:options'].projectName
                     this._buildTag = capability['bstack:options'].buildTag
+                    this._buildIdentifier = capability['bstack:options'].buildIdentifier
                 }
             })
         } else if (typeof capabilities === 'object') {
@@ -58,8 +63,11 @@ export default class BrowserstackLauncherService implements Services.ServiceInst
                     const extensionCaps = Object.keys(caps.capabilities).filter((cap) => cap.includes(':'))
                     if (extensionCaps.length) {
                         (caps.capabilities as Capabilities.Capabilities)['bstack:options'] = { wdioService: bstackServiceVersion }
-                    } else if (shouldAddServiceVersion(this._config, this._options.testObservability)) {
-                        (caps.capabilities as Capabilities.Capabilities)['browserstack.wdioService'] = bstackServiceVersion
+                    } else { 
+                        if (shouldAddServiceVersion(this._config, this._options.testObservability)) {
+                            (caps.capabilities as Capabilities.Capabilities)['browserstack.wdioService'] = bstackServiceVersion
+                        }
+                        this._buildIdentifier = (caps.capabilities as Capabilities.Capabilities)['browserstack.buildIdentifier']
                     }
                 } else {
                     const bstackOptions = (caps.capabilities as Capabilities.Capabilities)['bstack:options']
@@ -67,6 +75,7 @@ export default class BrowserstackLauncherService implements Services.ServiceInst
                     this._buildName = bstackOptions!.buildName
                     this._projectName = bstackOptions!.projectName
                     this._buildTag = bstackOptions!.buildTag
+                    this._buildIdentifier = bstackOptions!.buildIdentifier
                 }
             })
         }
@@ -116,6 +125,16 @@ export default class BrowserstackLauncherService implements Services.ServiceInst
             this._updateCaps(capabilities, 'app', app.app)
         }
 
+        /**
+         * evaluate buildIdentifier in case unique execution identifiers are present
+         * e.g., ${BUILD_NUMBER} and ${DATE_TIME}
+        */
+        try {
+            this._handleBuildIdentifier(capabilities)
+        } catch (error: any) {
+            log.error(`Error while processing buildIdentifier, stacktrace: ${error}`)
+        }
+
         if (this._options.testObservability) {
             log.debug('Sending launch start event')
 
@@ -123,7 +142,8 @@ export default class BrowserstackLauncherService implements Services.ServiceInst
                 projectName: this._projectName,
                 buildName: this._buildName,
                 buildTag: this._buildTag,
-                bstackServiceVersion: bstackServiceVersion
+                bstackServiceVersion: bstackServiceVersion,
+                buildIdentifier: this._buildIdentifier
             })
         }
 
@@ -137,7 +157,12 @@ export default class BrowserstackLauncherService implements Services.ServiceInst
         }
 
         this.browserstackLocal = new BrowserstackLocalLauncher.Local()
-        this._updateCaps(capabilities, 'local')
+
+        if (opts.localIdentifier) {
+            this._updateCaps(capabilities, 'local', 'true', opts.localIdentifier)
+        } else {
+            this._updateCaps(capabilities, 'local')
+        }
 
         /**
          * measure BrowserStack tunnel boot time
@@ -260,26 +285,46 @@ export default class BrowserstackLauncherService implements Services.ServiceInst
         return app
     }
 
-    _updateCaps(capabilities?: Capabilities.RemoteCapabilities, capType?: string, value?:string) {
+    _updateCaps(capabilities?: Capabilities.RemoteCapabilities, capType?: string, value?:string, localId?:string) {
         if (Array.isArray(capabilities)) {
             capabilities.forEach((capability: Capabilities.DesiredCapabilities) => {
                 if (!capability['bstack:options']) {
                     const extensionCaps = Object.keys(capability).filter((cap) => cap.includes(':'))
                     if (extensionCaps.length) {
                         if (capType === 'local') {
-                            capability['bstack:options'] = { local: true }
+                            capability['bstack:options'] = localId ? { local: true } : { local: true, localIdentifier : localId }
                         } else if (capType === 'app') {
                             capability['appium:app'] = value
+                        } else if (capType === 'buildIdentifier' && value) {
+                            capability['bstack:options'] = { buildIdentifier: value }
                         }
                     } else if (capType === 'local'){
                         capability['browserstack.local'] = true
+                        if (localId) {
+                            capability['browserstack.localIdentifier'] = localId
+                        }
                     } else if (capType === 'app') {
                         capability['app'] = value
+                    } else if (capType === 'buildIdentifier') {
+                        if (value) {
+                            capability['browserstack.buildIdentifier'] = value
+                        } else {
+                            delete capability['browserstack.buildIdentifier']
+                        }
                     }
                 } else if (capType === 'local') {
                     capability['bstack:options'].local = true
+                    if (localId) {
+                        capability['bstack:options'].localIdentifier = localId
+                    }
                 } else if (capType === 'app') {
                     capability['appium:app'] = value
+                } else if (capType === 'buildIdentifier') {
+                    if (value) {
+                        capability['bstack:options'].buildIdentifier = value
+                    } else {
+                        delete capability['bstack:options'].buildIdentifier
+                    }
                 }
             })
         } else if (typeof capabilities === 'object') {
@@ -288,23 +333,124 @@ export default class BrowserstackLauncherService implements Services.ServiceInst
                     const extensionCaps = Object.keys(caps.capabilities).filter((cap) => cap.includes(':'))
                     if (extensionCaps.length) {
                         if (capType === 'local') {
-                            (caps.capabilities as Capabilities.Capabilities)['bstack:options'] = { local: true }
+                            (caps.capabilities as Capabilities.Capabilities)['bstack:options'] = localId ? { local: true } : { local: true, localIdentifier : localId }
                         } else if (capType === 'app') {
                             (caps.capabilities as Capabilities.Capabilities)['appium:app'] = value
+                        } else if (capType === 'buildIdentifier' && value) {
+                            (caps.capabilities as Capabilities.Capabilities)['bstack:options'] = { buildIdentifier: value }
                         }
                     } else if (capType === 'local'){
                         (caps.capabilities as Capabilities.Capabilities)['browserstack.local'] = true
+                        if (localId) {
+                            (caps.capabilities as Capabilities.Capabilities)['browserstack.localIdentifier'] = localId
+                        }
                     } else if (capType === 'app') {
                         (caps.capabilities as Capabilities.AppiumCapabilities)['app'] = value
+                    } else if (capType === 'buildIdentifier') {
+                        if (value) {
+                            (caps.capabilities as Capabilities.Capabilities)['browserstack.buildIdentifier'] = value
+                        } else {
+                            delete (caps.capabilities as Capabilities.Capabilities)['browserstack.buildIdentifier']
+                        }
                     }
                 } else if (capType === 'local'){
                     (caps.capabilities as Capabilities.Capabilities)['bstack:options']!.local = true
+                    if (localId) {
+                        (caps.capabilities as Capabilities.Capabilities)['bstack:options']!.localIdentifier = localId
+                    }
                 } else if (capType === 'app') {
                     (caps.capabilities as Capabilities.Capabilities)['appium:app'] = value
+                } else if (capType === 'buildIdentifier') {
+                    if (value) {
+                        (caps.capabilities as Capabilities.Capabilities)['bstack:options']!.buildIdentifier = value
+                    } else {
+                        delete (caps.capabilities as Capabilities.Capabilities)['bstack:options']!.buildIdentifier
+                    }
                 }
             })
         } else {
             throw new SevereServiceError('Capabilities should be an object or Array!')
+        }
+    }
+
+    _handleBuildIdentifier(capabilities?: Capabilities.RemoteCapabilities) {
+        if (!this._buildIdentifier) {
+            this._updateCaps(capabilities, 'buildIdentifier')
+            return
+        }
+
+        if (!this._buildName || process.env.BROWSERSTACK_BUILD_NAME) {
+            if (this._buildIdentifier) {
+                this._updateCaps(capabilities, 'buildIdentifier')
+                return
+            }
+        }
+
+        if (this._buildIdentifier && this._buildIdentifier.includes('${DATE_TIME}')){
+            const dateObj = new Date()
+            const date = ('0' + dateObj.getDate()).slice(-2)
+            const month = dateObj.toLocaleString('default', { month: 'short' })
+            const hours = ('0' + dateObj.getHours()).slice(-2)
+            const minutes = ('0' + dateObj.getMinutes()).slice(-2)
+            const formattedDate = date + '-' + month + '-' + hours + ':' + minutes
+            this._buildIdentifier = this._buildIdentifier.replace('${DATE_TIME}', formattedDate)
+            this._updateCaps(capabilities, 'buildIdentifier', this._buildIdentifier)
+        }
+
+        if (!this._buildIdentifier.includes('${BUILD_NUMBER}')) return
+
+        const ciInfo = getCiInfo()
+        if (ciInfo != null) {
+            const ciBuildNumber = ciInfo.build_number
+            if (ciBuildNumber != null) {
+                this._buildIdentifier = this._buildIdentifier.replace('${BUILD_NUMBER}', 'CI '+ ciBuildNumber)
+                this._updateCaps(capabilities, 'buildIdentifier', this._buildIdentifier)
+            }
+        } else {
+            const localBuildNumber = this._getLocalBuildNumber()
+            if (localBuildNumber != '-1') {
+                this._buildIdentifier = this._buildIdentifier.replace('${BUILD_NUMBER}', localBuildNumber)
+                this._updateCaps(capabilities, 'buildIdentifier', this._buildIdentifier)
+            } else {
+                return
+            }
+        }
+    }
+
+    _getLocalBuildNumber() {
+        let browserstackFolderPath = path.join(require('os').homedir(), '.browserstack')
+        try {
+            if (!fs.existsSync(browserstackFolderPath)){
+                fs.mkdirSync(browserstackFolderPath)
+            }
+
+            let filePath = path.join(browserstackFolderPath, '.build-name-cache.json')
+            if (!fs.existsSync(filePath)) {
+                fs.appendFileSync(filePath, JSON.stringify({}))
+            }
+
+            const buildCacheFileData = fs.readFileSync(filePath)
+            const parsedBuildCacheFileData = JSON.parse(buildCacheFileData.toString())
+
+            if (this._buildName && this._buildName in parsedBuildCacheFileData) {
+                let prevIdentifier = parseInt((parsedBuildCacheFileData[this._buildName]['identifier']))
+                let newIdentifier = prevIdentifier + 1
+                this._updateLocalBuildCache(filePath, this._buildName, newIdentifier.toString())
+                return newIdentifier.toString()
+            }
+            this._updateLocalBuildCache(filePath, this._buildName, '1')
+            return '1'
+        } catch (error: any) {
+            return '-1'
+        }
+    }
+
+    _updateLocalBuildCache(filePath?:string, buildName?:string, buildIdentifier?:string) {
+        let newIdentifier = { 'identifier': buildIdentifier }
+        if (buildName && filePath) {
+            let jsonContent = JSON.parse(fs.readFileSync(filePath).toString())
+            jsonContent[buildName] = newIdentifier
+            fs.writeFileSync(filePath, JSON.stringify(jsonContent))
         }
     }
 }

--- a/packages/wdio-browserstack-service/src/launcher.ts
+++ b/packages/wdio-browserstack-service/src/launcher.ts
@@ -423,13 +423,14 @@ export default class BrowserstackLauncherService implements Services.ServiceInst
             const parsedBuildCacheFileData = JSON.parse(buildCacheFileData.toString())
 
             if (this._buildName && this._buildName in parsedBuildCacheFileData) {
-                let prevIdentifier = parseInt((parsedBuildCacheFileData[this._buildName]['identifier']))
-                let newIdentifier = prevIdentifier + 1
+                const prevIdentifier = parseInt((parsedBuildCacheFileData[this._buildName]['identifier']))
+                const newIdentifier = prevIdentifier + 1
                 this._updateLocalBuildCache(filePath, this._buildName, newIdentifier)
                 return newIdentifier.toString()
             }
+            const newIdentifier = 1
             this._updateLocalBuildCache(filePath, this._buildName, 1)
-            return '1'
+            return newIdentifier.toString()
         } catch (error: any) {
             return '-1'
         }

--- a/packages/wdio-browserstack-service/src/launcher.ts
+++ b/packages/wdio-browserstack-service/src/launcher.ts
@@ -85,6 +85,10 @@ export default class BrowserstackLauncherService implements Services.ServiceInst
         ) {
             this._config.specs = process.env.BROWSERSTACK_RERUN_TESTS.split(',')
         }
+
+        if (this._options.buildIdentifier) {
+            this._buildIdentifier = this._options.buildIdentifier
+        }
     }
 
     async onPrepare (config?: Options.Testrunner, capabilities?: Capabilities.RemoteCapabilities) {

--- a/packages/wdio-browserstack-service/src/launcher.ts
+++ b/packages/wdio-browserstack-service/src/launcher.ts
@@ -43,12 +43,10 @@ export default class BrowserstackLauncherService implements Services.ServiceInst
                     const extensionCaps = Object.keys(capability).filter((cap) => cap.includes(':'))
                     if (extensionCaps.length) {
                         capability['bstack:options'] = { wdioService: bstackServiceVersion }
-                    } else {
-                        if (shouldAddServiceVersion(this._config, this._options.testObservability)) {
-                            capability['browserstack.wdioService'] = bstackServiceVersion
-                        }
-                        this._buildIdentifier = capability['browserstack.buildIdentifier']
+                    } else if (shouldAddServiceVersion(this._config, this._options.testObservability)) {
+                        capability['browserstack.wdioService'] = bstackServiceVersion
                     }
+                    this._buildIdentifier = capability['browserstack.buildIdentifier']
                 } else {
                     capability['bstack:options'].wdioService = bstackServiceVersion
                     this._buildName = capability['bstack:options'].buildName
@@ -63,12 +61,10 @@ export default class BrowserstackLauncherService implements Services.ServiceInst
                     const extensionCaps = Object.keys(caps.capabilities).filter((cap) => cap.includes(':'))
                     if (extensionCaps.length) {
                         (caps.capabilities as Capabilities.Capabilities)['bstack:options'] = { wdioService: bstackServiceVersion }
-                    } else {
-                        if (shouldAddServiceVersion(this._config, this._options.testObservability)) {
-                            (caps.capabilities as Capabilities.Capabilities)['browserstack.wdioService'] = bstackServiceVersion
-                        }
-                        this._buildIdentifier = (caps.capabilities as Capabilities.Capabilities)['browserstack.buildIdentifier']
+                    } else if (shouldAddServiceVersion(this._config, this._options.testObservability)) {
+                        (caps.capabilities as Capabilities.Capabilities)['browserstack.wdioService'] = bstackServiceVersion
                     }
+                    this._buildIdentifier = (caps.capabilities as Capabilities.Capabilities)['browserstack.buildIdentifier']
                 } else {
                     const bstackOptions = (caps.capabilities as Capabilities.Capabilities)['bstack:options']
                     bstackOptions!.wdioService = bstackServiceVersion

--- a/packages/wdio-browserstack-service/src/launcher.ts
+++ b/packages/wdio-browserstack-service/src/launcher.ts
@@ -379,6 +379,7 @@ export default class BrowserstackLauncherService implements Services.ServiceInst
         if (!this._buildName || process.env.BROWSERSTACK_BUILD_NAME) {
             if (this._buildIdentifier) {
                 this._updateCaps(capabilities, 'buildIdentifier')
+                log.warn('Skipping buildIdentifier as buildName is not passed.')
                 return
             }
         }

--- a/packages/wdio-browserstack-service/src/launcher.ts
+++ b/packages/wdio-browserstack-service/src/launcher.ts
@@ -87,10 +87,6 @@ export default class BrowserstackLauncherService implements Services.ServiceInst
         ) {
             this._config.specs = process.env.BROWSERSTACK_RERUN_TESTS.split(',')
         }
-
-        if (this._options.buildIdentifier) {
-            this._buildIdentifier = this._options.buildIdentifier
-        }
     }
 
     async onPrepare (config?: Options.Testrunner, capabilities?: Capabilities.RemoteCapabilities) {
@@ -125,6 +121,14 @@ export default class BrowserstackLauncherService implements Services.ServiceInst
 
             log.info(`Using app: ${app.app}`)
             this._updateCaps(capabilities, 'app', app.app)
+        }
+
+        /**
+         * buildIdentifier in service options will take precedence over specified in capabilities
+        */
+        if (this._options.buildIdentifier) {
+            this._buildIdentifier = this._options.buildIdentifier
+            this._updateCaps(capabilities, 'buildIdentifier', this._buildIdentifier)
         }
 
         /**

--- a/packages/wdio-browserstack-service/src/launcher.ts
+++ b/packages/wdio-browserstack-service/src/launcher.ts
@@ -435,17 +435,17 @@ export default class BrowserstackLauncherService implements Services.ServiceInst
             if (this._buildName && this._buildName in parsedBuildCacheFileData) {
                 let prevIdentifier = parseInt((parsedBuildCacheFileData[this._buildName]['identifier']))
                 let newIdentifier = prevIdentifier + 1
-                this._updateLocalBuildCache(filePath, this._buildName, newIdentifier.toString())
+                this._updateLocalBuildCache(filePath, this._buildName, newIdentifier)
                 return newIdentifier.toString()
             }
-            this._updateLocalBuildCache(filePath, this._buildName, '1')
+            this._updateLocalBuildCache(filePath, this._buildName, 1)
             return '1'
         } catch (error: any) {
             return '-1'
         }
     }
 
-    _updateLocalBuildCache(filePath?:string, buildName?:string, buildIdentifier?:string) {
+    _updateLocalBuildCache(filePath?:string, buildName?:string, buildIdentifier?:number) {
         let newIdentifier = { 'identifier': buildIdentifier }
         if (buildName && filePath) {
             let jsonContent = JSON.parse(fs.readFileSync(filePath).toString())

--- a/packages/wdio-browserstack-service/src/launcher.ts
+++ b/packages/wdio-browserstack-service/src/launcher.ts
@@ -400,13 +400,17 @@ export default class BrowserstackLauncherService implements Services.ServiceInst
             this._updateCaps(capabilities, 'buildIdentifier', this._buildIdentifier)
         } else {
             const localBuildNumber = this._getLocalBuildNumber()
-            if (localBuildNumber != '-1') {
+            if (localBuildNumber) {
                 this._buildIdentifier = this._buildIdentifier.replace('${BUILD_NUMBER}', localBuildNumber)
                 this._updateCaps(capabilities, 'buildIdentifier', this._buildIdentifier)
             }
         }
     }
 
+    /**
+     * @return {string} if buildName doesn't exist in json file, it will return 1
+     *                  else returns corresponding value in json file (e.g. { "wdio-build": { "identifier" : 2 } } => 2 in this case)
+     */
     _getLocalBuildNumber() {
         let browserstackFolderPath = path.join(os.homedir(), '.browserstack')
         try {
@@ -432,7 +436,7 @@ export default class BrowserstackLauncherService implements Services.ServiceInst
             this._updateLocalBuildCache(filePath, this._buildName, 1)
             return newIdentifier.toString()
         } catch (error: any) {
-            return '-1'
+            return null
         }
     }
 

--- a/packages/wdio-browserstack-service/src/launcher.ts
+++ b/packages/wdio-browserstack-service/src/launcher.ts
@@ -63,7 +63,7 @@ export default class BrowserstackLauncherService implements Services.ServiceInst
                     const extensionCaps = Object.keys(caps.capabilities).filter((cap) => cap.includes(':'))
                     if (extensionCaps.length) {
                         (caps.capabilities as Capabilities.Capabilities)['bstack:options'] = { wdioService: bstackServiceVersion }
-                    } else { 
+                    } else {
                         if (shouldAddServiceVersion(this._config, this._options.testObservability)) {
                             (caps.capabilities as Capabilities.Capabilities)['browserstack.wdioService'] = bstackServiceVersion
                         }

--- a/packages/wdio-browserstack-service/src/types.ts
+++ b/packages/wdio-browserstack-service/src/types.ts
@@ -173,7 +173,8 @@ export interface UserConfig {
     buildName?: string,
     projectName?: string,
     buildTag?: string,
-    bstackServiceVersion?: string
+    bstackServiceVersion?: string,
+    buildIdentifier?: string
 }
 
 export interface UploadType {

--- a/packages/wdio-browserstack-service/src/types.ts
+++ b/packages/wdio-browserstack-service/src/types.ts
@@ -38,6 +38,13 @@ export interface TestObservabilityOptions {
 
 export interface BrowserstackConfig {
     /**
+     *`buildIdentifier` is a unique id to differentiate every execution that gets appended to
+     * buildName. Choose your buildIdentifier format from the available expressions:
+     * ${BUILD_NUMBER} (Default): Generates an incremental counter with every execution
+     * ${DATE_TIME}: Generates a Timestamp with every execution. Eg. 05-Nov-19:30
+     */
+    buildIdentifier?: string;
+    /**
      * Set this to true to enable BrowserStack Test Observability which will collect test related data
      * (name, hierarchy, status, error stack trace, file name and hierarchy), test commands, etc.
      * and show all the data in a meaningful manner in BrowserStack Test Observability dashboards for faster test debugging and better insights.

--- a/packages/wdio-browserstack-service/src/util.ts
+++ b/packages/wdio-browserstack-service/src/util.ts
@@ -102,6 +102,7 @@ export async function launchTestSession (options: BrowserstackConfig & Options.T
         format: 'json',
         project_name: getObservabilityProject(options, bsConfig.projectName),
         name: getObservabilityBuild(options, bsConfig.buildName),
+        build_identifier: bsConfig.buildIdentifier,
         start_time: (new Date()).toISOString(),
         tags: getObservabilityBuildTags(options, bsConfig.buildTag),
         host_info: {

--- a/packages/wdio-browserstack-service/tests/launcher.test.ts
+++ b/packages/wdio-browserstack-service/tests/launcher.test.ts
@@ -403,6 +403,16 @@ describe('onPrepare', () => {
         expect(capabilities[0]).toEqual({ 'bstack:options': {} })
     })
 
+    it('should evaluate and set buildIdentifier from service options', async () => {
+        const caps: any = { chromeBrowser: { capabilities: { 'bstack:options': { buildName: 'browserstack wdio build', buildIdentifier: 'test ${BUILD_NUMBER}' } } } }
+        const service = new BrowserstackLauncher({ buildIdentifier: '#${BUILD_NUMBER}' }, caps, config)
+        const capabilities = { chromeBrowser: { capabilities: { 'bstack:options': { buildName: 'browserstack wdio build', buildIdentifier: 'test ${BUILD_NUMBER}' } } } }
+        jest.spyOn(service, '_getLocalBuildNumber').mockImplementation(() => { return '1' })
+
+        await service.onPrepare(config, capabilities)
+        expect(capabilities.chromeBrowser.capabilities).toEqual({ 'bstack:options': { buildName: 'browserstack wdio build', buildIdentifier: '#1' } })
+    })
+
     it('should reject if local.start throws an error', () => {
         const service = new BrowserstackLauncher(options, caps, config)
         const BrowserstackLocalStartSpy = jest.spyOn(new Browserstack.Local(), 'start')

--- a/packages/wdio-browserstack-service/tests/launcher.test.ts
+++ b/packages/wdio-browserstack-service/tests/launcher.test.ts
@@ -595,6 +595,24 @@ describe('_updateCaps', () => {
         expect(caps[0]['bstack:options']['buildIdentifier']).toEqual('#1')
     })
 
+    it('should update buildidentifier in caps object if bstack:options is present', () => {
+        const options: BrowserstackConfig = { browserstackLocal: true }
+        const caps = { chromeBrowser: { capabilities: { 'goog:chromeOptions': {}, 'bstack:options': { buildIdentifier: '123' } } } }
+        const service = new BrowserstackLauncher(options, caps, config)
+
+        service._updateCaps(caps, 'buildIdentifier', '#1')
+        expect(caps.chromeBrowser.capabilities['bstack:options']).toEqual({ 'wdioService': bstackServiceVersion, buildIdentifier: '#1' })
+    })
+
+    it('should update buildidentifier in caps object if bstack:options is not present', () => {
+        const options: BrowserstackConfig = { browserstackLocal: true }
+        const caps = { chromeBrowser: { capabilities: {} } }
+        const service = new BrowserstackLauncher(options, caps, config)
+
+        service._updateCaps(caps, 'buildIdentifier', '#1')
+        expect(caps.chromeBrowser.capabilities).toEqual({ 'browserstack.wdioService': bstackServiceVersion, 'browserstack.buildIdentifier': '#1' })
+    })
+
     it('should delete buildidentifier in caps array if value not passed in _updateCaps', () => {
         const options: BrowserstackConfig = { browserstackLocal: true }
         const caps = [{ 'bstack:options': { buildIdentifier: '1234' } }]

--- a/packages/wdio-browserstack-service/tests/launcher.test.ts
+++ b/packages/wdio-browserstack-service/tests/launcher.test.ts
@@ -823,7 +823,7 @@ describe('_handleBuildIdentifier', () => {
         }]
         const service = new BrowserstackLauncher(options, caps, config)
 
-        jest.spyOn(service, '_getLocalBuildNumber').mockReturnValueOnce('-1')
+        jest.spyOn(service, '_getLocalBuildNumber').mockReturnValueOnce(null)
         jest.spyOn(service, '_updateLocalBuildCache').mockImplementation(() => {})
         service._handleBuildIdentifier(caps)
 
@@ -912,7 +912,7 @@ describe('_handleBuildIdentifier', () => {
         expect(caps[0]).toMatchObject(updatedcaps[0])
     })
 
-    it('should return if localBuildNumber is -1', async() => {
+    it('should return if localBuildNumber is null', async() => {
         const caps: any = [{
             'bstack:options': {
                 buildName: 'browserstack wdio build',
@@ -920,7 +920,7 @@ describe('_handleBuildIdentifier', () => {
             }
         }]
         const service = new BrowserstackLauncher(options, caps, config)
-        jest.spyOn(service, '_getLocalBuildNumber').mockReturnValueOnce('-1')
+        jest.spyOn(service, '_getLocalBuildNumber').mockReturnValueOnce(null)
 
         service._handleBuildIdentifier(caps)
         expect(caps[0]['bstack:options']?.buildIdentifier).toEqual('#${BUILD_NUMBER}')
@@ -959,11 +959,11 @@ describe('_getLocalBuildNumber', () => {
         expect(buildNumber).toEqual('3')
     })
 
-    it('returns -1 in case of caught exception', async() => {
+    it('returns null in case of caught exception', async() => {
         jest.spyOn(fs, 'existsSync').mockReturnValue(true)
         jest.spyOn(service, '_updateLocalBuildCache').mockImplementation(() => { throw new Error('Unable to parse JSON file') })
         const buildNumber = service._getLocalBuildNumber()
-        expect(buildNumber).toEqual('-1')
+        expect(buildNumber).toEqual(null)
     })
 })
 

--- a/packages/wdio-browserstack-service/tests/launcher.test.ts
+++ b/packages/wdio-browserstack-service/tests/launcher.test.ts
@@ -429,6 +429,72 @@ describe('onPrepare', () => {
         expect(capabilities.chromeBrowser.capabilities).toEqual({ 'bstack:options': { buildName: 'browserstack wdio build', buildIdentifier: '#1' } })
     })
 
+    it('should add "browserstack.buildIdentifier" property in capabilities if no "bstack:options" and buildIdentifier present in capabilities', async () => {
+        const capabilities = [{ build: 'browserstack wdio build', 'browserstack.buildIdentifier': '#${BUILD_NUMBER}' }]
+        const service = new BrowserstackLauncher(options, capabilities, {
+            user: 'foobaruser',
+            key: '12345',
+            capabilities: []
+        })
+        jest.spyOn(service, '_getLocalBuildNumber').mockImplementation(() => { return '1' })
+
+        await service.onPrepare(config, capabilities)
+        expect(capabilities).toEqual([
+            { build: 'browserstack wdio build', 'browserstack.buildIdentifier': '#1', 'browserstack.local': true, 'browserstack.wdioService': bstackServiceVersion }
+        ])
+    })
+
+    it('should add the "browserstack.buildIdentifier" property in capabilities if no "bstack:options" and passing buildIdentifier in service options', async () => {
+        const capabilities = [{ build: 'browserstack wdio build' }]
+        const service = new BrowserstackLauncher({
+            buildIdentifier: '#${BUILD_NUMBER}',
+        }, capabilities, {
+            user: 'foobaruser',
+            key: '12345',
+            capabilities: []
+        })
+        jest.spyOn(service, '_getLocalBuildNumber').mockImplementation(() => { return '1' })
+
+        await service.onPrepare(config, capabilities)
+        expect(capabilities).toEqual([
+            { build: 'browserstack wdio build', 'browserstack.buildIdentifier': '#1', 'browserstack.wdioService': bstackServiceVersion }
+        ])
+    })
+
+    it('should not add "browserstack.buildIdentifier" property in capabilities if no "bstack:options" and "build" not present', async () => {
+        const capabilities = [{}]
+        const service = new BrowserstackLauncher({
+            buildIdentifier: '#${BUILD_NUMBER}',
+        }, capabilities, {
+            user: 'foobaruser',
+            key: '12345',
+            capabilities: []
+        })
+        jest.spyOn(service, '_getLocalBuildNumber').mockImplementation(() => { return '1' })
+
+        await service.onPrepare(config, capabilities)
+        expect(capabilities).toEqual([
+            { 'browserstack.wdioService': bstackServiceVersion }
+        ])
+    })
+
+    it('should delete "browserstack.buildIdentifier" property from capabilities if no "bstack:options" and "build" not present', async () => {
+        const capabilities = [{ 'browserstack.buildIdentifier': '#${BUILD_NUMBER}' }]
+        const service = new BrowserstackLauncher({
+            buildIdentifier: '#${BUILD_NUMBER}',
+        }, capabilities, {
+            user: 'foobaruser',
+            key: '12345',
+            capabilities: []
+        })
+        jest.spyOn(service, '_getLocalBuildNumber').mockImplementation(() => { return '1' })
+
+        await service.onPrepare(config, capabilities)
+        expect(capabilities).toEqual([
+            { 'browserstack.wdioService': bstackServiceVersion }
+        ])
+    })
+
     it('should reject if local.start throws an error', () => {
         const service = new BrowserstackLauncher(options, caps, config)
         const BrowserstackLocalStartSpy = jest.spyOn(new Browserstack.Local(), 'start')

--- a/packages/wdio-browserstack-service/tests/launcher.test.ts
+++ b/packages/wdio-browserstack-service/tests/launcher.test.ts
@@ -350,6 +350,17 @@ describe('onPrepare', () => {
         ])
     })
 
+    it('should add the "localIdentifier" property to a multiremote capability inside "bstack:options" if any extension cap present', async () => {
+        const service = new BrowserstackLauncher({
+            browserstackLocal: true,
+            opts: { localIdentifier: 'wdio1' }
+        }, caps, config)
+        const capabilities = { chromeBrowser: { capabilities: { 'goog:chromeOptions': {} } } }
+
+        await service.onPrepare(config, capabilities)
+        expect(capabilities.chromeBrowser.capabilities).toEqual({ 'bstack:options': { local: true, localIdentifier: 'wdio1' }, 'goog:chromeOptions': {} })
+    })
+
     it('should add the "buildIdentifier" property to a multiremote capability inside "bstack:options" if "bstack:options" present', async () => {
         const caps: any = { chromeBrowser: { capabilities: { 'bstack:options': { buildName: 'browserstack wdio build', buildIdentifier: '#${BUILD_NUMBER}' } } } }
         const service = new BrowserstackLauncher({}, caps, config)
@@ -563,7 +574,7 @@ describe('_updateCaps', () => {
         const options: BrowserstackConfig = { browserstackLocal: true, opts: { localIdentifier: 'wdio1' } }
         const service = new BrowserstackLauncher(options, caps, config)
 
-        service._updateCaps(caps, 'local', 'true', 'wdio1')
+        service._updateCaps(caps, 'localIdentifier', 'wdio1')
         expect(caps[0]['browserstack.localIdentifier']).toContain('wdio1')
     })
 

--- a/packages/wdio-types/src/Capabilities.ts
+++ b/packages/wdio-types/src/Capabilities.ts
@@ -161,6 +161,8 @@ export interface VendorExtensions extends EdgeCapabilities, AppiumW3CCapabilitie
      * @private
      */
     'browserstack.wdioService'?: string
+    'browserstack.buildIdentifier'?: string
+    'browserstack.localIdentifier'?: string
 
     'goog:chromeOptions'?: ChromeOptions;
     'moz:firefoxOptions'?: FirefoxOptions;
@@ -1227,6 +1229,12 @@ export interface BrowserStackCapabilities {
      * @private
      */
     wdioService?: string
+    /**
+     * Specify an identifier for a build consists group of tests.
+     */
+    buildIdentifier?: string
+    'browserstack.buildIdentifier'?: string
+    'browserstack.localIdentifier'?: string
 }
 
 export interface SauceLabsVisualCapabilities {


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)
This PR:

- Add support for `buildIdentifier` browserstack capability to the browserstack-service and generate unique identifiers corresponding to placeholders (For instance, `${BUILD_NUMBER}` and `${DATE_TIME}`)
- Fix for localIdentifier, when adding localIdentifier in `opts` does not add it to browserstack capabilities which leads to session failure. Currently, user needs to add localIdentifier explicitly in the capabilities. With this PR changes, adding localIdentifier in capabilities out of the box.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
