### PR TITLE
update for scroll

### DIFF
--- a/packages/webdriverio/src/commands/element/scrollIntoView.ts
+++ b/packages/webdriverio/src/commands/element/scrollIntoView.ts
@@ -79,7 +79,7 @@ export async function scrollIntoView (
 
     try {
         return await browser.action('wheel')
-            .scroll({ origin: this, duration: 200, deltaY, deltaX })
+            .scroll({ origin: browser, duration: 200, deltaY, deltaX })
             .perform()
     } catch (err: any) {
         log.warn(

--- a/packages/webdriverio/src/utils/actions/wheel.ts
+++ b/packages/webdriverio/src/utils/actions/wheel.ts
@@ -1,6 +1,5 @@
 import type { BaseActionParams } from './base.js'
 import BaseAction from './base.js'
-import type { ChainablePromiseElement } from '../../types.js'
 
 export interface ScrollParams {
     /**
@@ -22,7 +21,7 @@ export interface ScrollParams {
     /**
      * element origin
      */
-    origin?: WebdriverIO.Element | ChainablePromiseElement<WebdriverIO.Element>
+    origin?: WebdriverIO.Browser
     /**
      * duration ratio be the ratio of time delta and duration
      */


### PR DESCRIPTION
## Proposed changes

Fix for https://github.com/webdriverio/webdriverio/issues/9805
Scrolling was ok as long as the element location hadn't changed before (that is, a previous scroll had taken place as part of the same test). The second (or subsequent) scrolls were getting correct distance to scroll but were starting from the location of the element that had already moved, so it was scrolling down more than necessary.

Changing the `origin` of the scroll to be `browser` rather than `this` corrects this issue.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
