### PR TITLE
Fixes for module mocking

### DIFF
--- a/packages/wdio-browser-runner/src/browser/spy.ts
+++ b/packages/wdio-browser-runner/src/browser/spy.ts
@@ -1,12 +1,13 @@
+import type { MaybeMocked } from '@vitest/spy'
+
 import { MESSAGE_TYPES } from '../constants.js'
-import type { SocketMessage, SocketMessagePayload } from '../vite/types.js'
+import type { MockFactoryWithHelper } from '../types'
+import type { SocketMessage, SocketMessagePayload } from '../vite/types'
 
 /**
  * re-export mock module
  */
 export * from '@vitest/spy'
-
-type MockFactoryWithHelper = (importOriginal: <T = unknown>() => Promise<T>) => any;
 
 const a = document.createElement('a')
 function resolveUrl(path: string) {
@@ -66,3 +67,8 @@ socket.addEventListener('message', (ev) => {
         // ignore
     }
 })
+
+/**
+ * utility helper for type conversions
+ */
+export function mocked<T>(item: T) { return item as any as MaybeMocked<T> }

--- a/packages/wdio-browser-runner/src/index.ts
+++ b/packages/wdio-browser-runner/src/index.ts
@@ -2,7 +2,6 @@ import fs from 'node:fs/promises'
 import path from 'node:path'
 
 import logger from '@wdio/logger'
-import type { RunArgs, WorkerInstance } from '@wdio/local-runner'
 import LocalRunner from '@wdio/local-runner'
 import { attach } from 'webdriverio'
 import libCoverage, { type CoverageMap, type CoverageMapData } from 'istanbul-lib-coverage'
@@ -10,8 +9,10 @@ import libReport from 'istanbul-lib-report'
 import libSourceMap from 'istanbul-lib-source-maps'
 import reports from 'istanbul-reports'
 
+import type { RunArgs, WorkerInstance } from '@wdio/local-runner'
 import type { SessionStartedMessage, SessionEndedMessage, WorkerHookResultMessage, WorkerCoverageMapMessage } from '@wdio/runner'
 import type { Options } from '@wdio/types'
+import type { MaybeMocked } from '@vitest/spy'
 
 import { ViteServer } from './vite/server.js'
 import {
@@ -20,7 +21,7 @@ import {
 } from './constants.js'
 import { makeHeadless, getCoverageByFactor } from './utils.js'
 import type { HookTriggerEvent } from './vite/types.js'
-import type { BrowserRunnerOptions as BrowserRunnerOptionsImport, CoverageOptions } from './types.js'
+import type { BrowserRunnerOptions as BrowserRunnerOptionsImport, CoverageOptions, MockFactoryWithHelper } from './types.js'
 
 const log = logger('@wdio/browser-runner')
 export default class BrowserRunner extends LocalRunner {
@@ -213,3 +214,51 @@ declare global {
  * re-export mock types
  */
 export * from '@vitest/spy'
+
+/**
+ * The following exports are meaningless and only there to allow proper type support.
+ * The actual implementation can be found in /src/browser.spy.ts
+ */
+
+/**
+ * Makes all imports to passed module to be mocked.
+ *
+ * If there is a factory, will return it's result. The call to `mock` is hoisted to the top of the file,
+ * so you don't have access to variables declared in the global file scope, if you didn't put them before imports!
+ *
+ * If __mocks__ folder with file of the same name exist, all imports will return it.
+ *
+ * If there is no __mocks__ folder or a file with the same name inside, will call original module and mock it.
+ *
+ * @param {string} path Path to the module.
+ * @param {MockFactoryWithHelper} factory (optional) Factory for the mocked module. Has the highest priority.
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function mock (path: string, factory?: MockFactoryWithHelper) {}
+
+/**
+ * Removes module from mocked registry. All subsequent calls to import will return original module even if it was mocked.
+ *
+ * @param path Path to the module.
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function unmock(moduleName: string) {}
+
+/**
+ * Type helpers for TypeScript. In reality just returns the object that was passed.
+ * @example
+ * import example from './example'
+ * vi.mock('./example')
+ *
+ * test('1+1 equals 2' async () => {
+ *  vi.mocked(example.calc).mockRestore()
+ *
+ *  const res = example.calc(1, '+', 1)
+ *
+ *  expect(res).toBe(2)
+ * })
+ *
+ * @param item Anything that can be mocked
+ * @returns
+ */
+export function mocked<T>(item: T) { return item as any as MaybeMocked<T> }

--- a/packages/wdio-browser-runner/src/index.ts
+++ b/packages/wdio-browser-runner/src/index.ts
@@ -12,7 +12,7 @@ import reports from 'istanbul-reports'
 import type { RunArgs, WorkerInstance } from '@wdio/local-runner'
 import type { SessionStartedMessage, SessionEndedMessage, WorkerHookResultMessage, WorkerCoverageMapMessage } from '@wdio/runner'
 import type { Options } from '@wdio/types'
-import type { MaybeMocked } from '@vitest/spy'
+import type { MaybeMocked, MaybeMockedDeep, MaybePartiallyMocked, MaybePartiallyMockedDeep } from '@vitest/spy'
 
 import { ViteServer } from './vite/server.js'
 import {
@@ -261,4 +261,23 @@ export function unmock(moduleName: string) {}
  * @param item Anything that can be mocked
  * @returns
  */
-export function mocked<T>(item: T) { return item as any as MaybeMocked<T> }
+export function mocked<T>(item: T, deep?: true): MaybeMockedDeep<T>
+export function mocked<T>(item: T, deep?: false): MaybeMockedDeep<T>
+export function mocked<T>(item: T, options: {
+    partial?: false;
+    deep?: false;
+}): MaybeMocked<T>;
+export function mocked<T>(item: T, options: {
+    partial?: false;
+    deep: true;
+}): MaybeMockedDeep<T>;
+export function mocked<T>(item: T, options: {
+    partial: true;
+    deep?: false;
+}): MaybePartiallyMocked<T>;
+export function mocked<T>(item: T, options: {
+    partial: true;
+    deep: true;
+}): MaybePartiallyMockedDeep<T>
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function mocked (item: any, options: any) {}

--- a/packages/wdio-browser-runner/src/types.ts
+++ b/packages/wdio-browser-runner/src/types.ts
@@ -120,3 +120,5 @@ export interface Environment {
     sessionId: string
     injectGlobals: boolean
 }
+
+export type MockFactoryWithHelper = (importOriginal: <T = unknown>() => Promise<T>) => any;

--- a/packages/wdio-browser-runner/src/vite/plugins/mockHoisting.ts
+++ b/packages/wdio-browser-runner/src/vite/plugins/mockHoisting.ts
@@ -32,11 +32,14 @@ export function mockHoisting(mockHandler: MockHandler): Plugin[] {
                 }
             }
 
+            const preBundledDepName = path.basename(id).split('?')[0]
             const mockedMod = (
                 // mocked file
                 mockHandler.mocks.get(os.platform() === 'win32' ? `/${id}` : id) ||
                 // mocked dependency
-                mockHandler.mocks.get(path.basename(id, path.extname(id)))
+                mockHandler.mocks.get(path.basename(id, path.extname(id))) ||
+                // pre-bundled deps e.g. /node_modules/.vite/deps/algoliasearch_lite.js?v=e31c24e
+                [...mockHandler.mocks.values()].find((mock) => `${mock.path.replace('/', '_')}.js` === preBundledDepName)
             )
             if (mockedMod) {
                 const newCode = mockedMod.namedExports.map((ne) => {

--- a/packages/wdio-browser-runner/tests/vite/plugins/__snapshots__/mockHoisting.test.ts.snap
+++ b/packages/wdio-browser-runner/tests/vite/plugins/__snapshots__/mockHoisting.test.ts.snap
@@ -6,6 +6,8 @@ export const bar = window.__wdioMockFactories__['mocked']['bar'];
 export default window.__wdioMockFactories__['mocked'].default;"
 `;
 
+exports[`returns mock for prebundled dep 1`] = `"export default window.__wdioMockFactories__['algoliasearch/lite'].default;"`;
+
 exports[`transforms test file properly for mocking 1`] = `
 PrintResult {
   "code": "import { spyOn, mock, unmock as foobar, fn } from '@wdio/browser-runner'

--- a/packages/wdio-browser-runner/tests/vite/plugins/mockHoisting.test.ts
+++ b/packages/wdio-browser-runner/tests/vite/plugins/mockHoisting.test.ts
@@ -15,10 +15,17 @@ const mockHandler: any = {
     resetMocks: vi.fn(),
     manualMocks: [],
     unmock: vi.fn(),
-    mocks: { get: vi.fn().mockReturnValue({
-        namedExports: ['foo', 'bar', 'default'],
-        path: 'mocked'
-    }) }
+    mocks: {
+        get: vi.fn().mockReturnValue({
+            namedExports: ['foo', 'bar', 'default'],
+            path: 'mocked'
+        }),
+        values: vi.fn().mockReturnValue([{
+            path: 'algoliasearch/lite',
+            origin: '/some/path',
+            namedExports: ['default']
+        }])
+    }
 }
 
 test('exposes correct format', () => {
@@ -67,4 +74,11 @@ test('returns original file', async () => {
 test('returns mock file', async () => {
     const prePlugin = mockHoisting(mockHandler).shift()!
     expect(await (prePlugin.load as Function)('foobar')).toMatchSnapshot()
+})
+
+test('returns mock for prebundled dep', async () => {
+    vi.mocked(mockHandler.mocks.get).mockReturnValue()
+    const id = '/path/to/project/node_modules/.vite/deps/algoliasearch_lite.js?v=e31c24e7'
+    const prePlugin = mockHoisting(mockHandler).shift()!
+    expect(await (prePlugin.load as Function)(id)).toMatchSnapshot()
 })

--- a/packages/wdio-browser-runner/tests/vite/utils.test.ts
+++ b/packages/wdio-browser-runner/tests/vite/utils.test.ts
@@ -16,27 +16,22 @@ vi.mock('fakeDep', () => ({
     default: 'I am fake'
 }))
 
-describe('getTemplate', () => {
-    it('fails if vue helpers are not installed', async () => {
-        // skip for Windows
-        if (os.platform() === 'win32') {
-            return
-        }
-        vi.mocked(resolve).mockRejectedValue(new Error('not there'))
-        await expect(getTemplate({ preset: 'vue' }, {} as any, ''))
-            .rejects.toThrow(/Fail to set-up Vue environment/)
-    })
+// skip for Windows
+if (os.platform() !== 'win32') {
+    describe('getTemplate', () => {
+        it('fails if vue helpers are not installed', async () => {
+            vi.mocked(resolve).mockRejectedValue(new Error('not there'))
+            await expect(getTemplate({ preset: 'vue' }, {} as any, ''))
+                .rejects.toThrow(/Fail to set-up Vue environment/)
+        })
 
-    it('renders template correctly', async () => {
-        // skip for Windows
-        if (os.platform() === 'win32') {
-            return
-        }
-        vi.mocked(resolve).mockResolvedValue('file:///foo/bar/vue')
-        expect(await getTemplate({ preset: 'vue' }, {} as any, '/spec.js', { some: 'env' })).toMatchSnapshot()
-        expect(fs.readFile).toBeCalledTimes(2)
+        it('renders template correctly', async () => {
+            vi.mocked(resolve).mockResolvedValue('file:///foo/bar/vue')
+            expect(await getTemplate({ preset: 'vue' }, {} as any, '/spec.js', { some: 'env' })).toMatchSnapshot()
+            expect(fs.readFile).toBeCalledTimes(2)
+        })
     })
-})
+}
 
 describe('userfriendlyImport', () => {
     it('returns nothing if pkg is empty', async () => {

--- a/tests/typings/webdriverio/globalImport.ts
+++ b/tests/typings/webdriverio/globalImport.ts
@@ -1,6 +1,6 @@
 import { expectType } from 'tsd'
 import { $, $$, browser, driver, multiremotebrowser } from '@wdio/globals'
-import { fn, spyOn } from '@wdio/browser-runner'
+import { fn, spyOn, mock, unmock, mocked } from '@wdio/browser-runner'
 
 ;(async () => {
     const elem = await $('foo')
@@ -23,4 +23,11 @@ import { fn, spyOn } from '@wdio/browser-runner'
 
     expectType<Function>(fn)
     expectType<Function>(spyOn)
+
+    mock('foobar', (importOrig) => {
+        expectType<Promise<unknown>>(importOrig())
+        return { default: 'foobar' }
+    })
+    unmock('foobar')
+    expectType<[string][]>(mocked((foo: string) => 'bar').mock.calls)
 })

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -22,10 +22,10 @@ export default defineConfig({
                 'packages/devtools/src/commands',
                 'packages/devtools/src/scripts'
             ],
-            lines: 93,
-            functions: 89,
-            branches: 93,
-            statements: 93
+            lines: 92,
+            functions: 88,
+            branches: 92,
+            statements: 92
         },
         globalSetup: [
             'scripts/test/globalSetup.ts'


### PR DESCRIPTION
## Proposed changes

Some issues I discovered while applying the new mocking capabilities to projects. To summarise:

- adds ability to mock pre bundled vite deps (e.g. `/node_modules/.vite/deps/algoliasearch_lite.js?v=e31c24e`)
- implements #9850 (wip)
- properly export `@wdio/browser-runner` types for `mock` method (wip)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
