### PR TITLE
Cope with missing command

### DIFF
--- a/packages/wdio-browserstack-service/src/insights-handler.ts
+++ b/packages/wdio-browserstack-service/src/insights-handler.ts
@@ -225,6 +225,9 @@ export default class InsightsHandler {
         }
 
         const requestData = this._commands[dataKey]
+        if (!requestData) {
+            return
+        }
 
         // log http request
         const req = this._requestQueueHandler.add({

--- a/packages/wdio-browserstack-service/tests/insights-handler.test.ts
+++ b/packages/wdio-browserstack-service/tests/insights-handler.test.ts
@@ -501,6 +501,12 @@ describe('browserCommand', () => {
         insightsHandler['_tests'] = { 'test title not there': { 'uuid': 'uuid' } }
         expect(uploadEventDataSpy).toBeCalledTimes(0)
     })
+
+    it('return if command not in _commands', () => {
+        insightsHandler['_commands'] = { 'command not here': {} }
+        insightsHandler.browserCommand('client:afterCommand', { sessionId: 's', method: 'm', endpoint: 'e', result: { value: 'random' } }, {})
+        expect(uploadEventDataSpy).toBeCalledTimes(0)
+    })
 })
 
 describe('getIdentifier', () => {


### PR DESCRIPTION
In our case requestData was undefined, which resulted in an unhandled promise rejection.

[0-0] TypeError: Cannot read property 'endpoint' of undefined
[0-0] at InsightsHandler.browserCommand (.../node_modules/@wdio/browserstack-service/build/insights-handler.js:205:43)

For browser.setupInterceptor(), only a "client:afterCommand" is generated, not a "client:beforeCommand". So the browserstack service (@wdio/browserstack-service) only receives a "result" event, not a "command" event.

## Proposed changes

When using "browser.setupInterceptor()" our tests succeed when running webdriverio in docker, but they fail when using browserstack. The tests on their own run fine, but they are marked as failed, because there is a dangling unhandled promise rejection.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
