### PR TITLE
Ignore file extension of mocked files

### DIFF
--- a/packages/wdio-browser-runner/src/browser/spy.ts
+++ b/packages/wdio-browser-runner/src/browser/spy.ts
@@ -29,7 +29,7 @@ export async function mock (path: string, factory?: MockFactoryWithHelper) {
         return
     }
 
-    const mockLocalFile = path.startsWith('/') || path.startsWith('./')
+    const mockLocalFile = path.startsWith('/') || path.startsWith('./') || path.startsWith('../')
     const mockPath = mockLocalFile
         ? (new URL(resolveUrl(window.__wdioSpec__.split('/').slice(0, -1).join('/') + '/' + path))).pathname
         : path

--- a/packages/wdio-browser-runner/src/vite/plugins/mockHoisting.ts
+++ b/packages/wdio-browser-runner/src/vite/plugins/mockHoisting.ts
@@ -32,6 +32,7 @@ export function mockHoisting(mockHandler: MockHandler): Plugin[] {
                 }
             }
 
+            const mocks = [...mockHandler.mocks.values()]
             const preBundledDepName = path.basename(id).split('?')[0]
             const mockedMod = (
                 // mocked file
@@ -39,7 +40,15 @@ export function mockHoisting(mockHandler: MockHandler): Plugin[] {
                 // mocked dependency
                 mockHandler.mocks.get(path.basename(id, path.extname(id))) ||
                 // pre-bundled deps e.g. /node_modules/.vite/deps/algoliasearch_lite.js?v=e31c24e
-                [...mockHandler.mocks.values()].find((mock) => `${mock.path.replace('/', '_')}.js` === preBundledDepName)
+                mocks.find((mock) => `${mock.path.replace('/', '_')}.js` === preBundledDepName) ||
+                // relative file imports, e.g. `mock('../../constants.ts', () => { ... })`
+                mocks.filter((m) => m.path.startsWith('.')).find((mock) => {
+                    const fileToMock = path.resolve(mock.origin, mock.path)
+                    const mockFileExtLength = path.extname(fileToMock).length
+                    const toCompare = mockFileExtLength > 0 ? fileToMock.slice(0, -mockFileExtLength) : fileToMock
+                    // compare without file extension as we don't know if users use them or not
+                    return toCompare === id.slice(0, -path.extname(id).length)
+                })
             )
             if (mockedMod) {
                 const newCode = mockedMod.namedExports.map((ne) => {

--- a/packages/wdio-browser-runner/src/vite/plugins/mockHoisting.ts
+++ b/packages/wdio-browser-runner/src/vite/plugins/mockHoisting.ts
@@ -41,11 +41,10 @@ export function mockHoisting(mockHandler: MockHandler): Plugin[] {
                 mockHandler.mocks.get(path.basename(id, path.extname(id))) ||
                 // pre-bundled deps e.g. /node_modules/.vite/deps/algoliasearch_lite.js?v=e31c24e
                 mocks.find((mock) => `${mock.path.replace('/', '_')}.js` === preBundledDepName) ||
-                // relative file imports, e.g. `mock('../../constants.ts', () => { ... })`
-                mocks.filter((m) => m.path.startsWith('.')).find((mock) => {
-                    const fileToMock = path.resolve(mock.origin, mock.path)
-                    const mockFileExtLength = path.extname(fileToMock).length
-                    const toCompare = mockFileExtLength > 0 ? fileToMock.slice(0, -mockFileExtLength) : fileToMock
+                // relative file imports ignoring file extension, e.g. `mock('../../constants.ts', () => { ... })`
+                mocks.find((mock) => {
+                    const mockFileExtLength = path.extname(mock.path).length
+                    const toCompare = mockFileExtLength > 0 ? mock.path.slice(0, -mockFileExtLength) : mock.path
                     // compare without file extension as we don't know if users use them or not
                     return toCompare === id.slice(0, -path.extname(id).length)
                 })

--- a/packages/wdio-browser-runner/tests/vite/plugins/__snapshots__/mockHoisting.test.ts.snap
+++ b/packages/wdio-browser-runner/tests/vite/plugins/__snapshots__/mockHoisting.test.ts.snap
@@ -8,6 +8,11 @@ export default window.__wdioMockFactories__['mocked'].default;"
 
 exports[`returns mock for prebundled dep 1`] = `"export default window.__wdioMockFactories__['algoliasearch/lite'].default;"`;
 
+exports[`returns mock for relative file import 1`] = `
+"export const HEADING = window.__wdioMockFactories__['../../constants']['HEADING'];
+export default window.__wdioMockFactories__['../../constants'];"
+`;
+
 exports[`transforms test file properly for mocking 1`] = `
 PrintResult {
   "code": "import { spyOn, mock, unmock as foobar, fn } from '@wdio/browser-runner'

--- a/packages/wdio-browser-runner/tests/vite/plugins/__snapshots__/mockHoisting.test.ts.snap
+++ b/packages/wdio-browser-runner/tests/vite/plugins/__snapshots__/mockHoisting.test.ts.snap
@@ -9,8 +9,8 @@ export default window.__wdioMockFactories__['mocked'].default;"
 exports[`returns mock for prebundled dep 1`] = `"export default window.__wdioMockFactories__['algoliasearch/lite'].default;"`;
 
 exports[`returns mock for relative file import 1`] = `
-"export const HEADING = window.__wdioMockFactories__['../../constants']['HEADING'];
-export default window.__wdioMockFactories__['../../constants'];"
+"export const HEADING = window.__wdioMockFactories__['/path/to/project/constants']['HEADING'];
+export default window.__wdioMockFactories__['/path/to/project/constants'];"
 `;
 
 exports[`transforms test file properly for mocking 1`] = `

--- a/packages/wdio-browser-runner/tests/vite/plugins/mockHoisting.test.ts
+++ b/packages/wdio-browser-runner/tests/vite/plugins/mockHoisting.test.ts
@@ -24,6 +24,10 @@ const mockHandler: any = {
             path: 'algoliasearch/lite',
             origin: '/some/path',
             namedExports: ['default']
+        }, {
+            path: '../../constants',
+            origin: '/path/to/project/src/components',
+            namedExports: ['HEADING']
         }])
     }
 }
@@ -79,6 +83,13 @@ test('returns mock file', async () => {
 test('returns mock for prebundled dep', async () => {
     vi.mocked(mockHandler.mocks.get).mockReturnValue()
     const id = '/path/to/project/node_modules/.vite/deps/algoliasearch_lite.js?v=e31c24e7'
+    const prePlugin = mockHoisting(mockHandler).shift()!
+    expect(await (prePlugin.load as Function)(id)).toMatchSnapshot()
+})
+
+test('returns mock for relative file import', async () => {
+    vi.mocked(mockHandler.mocks.get).mockReturnValue()
+    const id = '/path/to/project/constants.ts'
     const prePlugin = mockHoisting(mockHandler).shift()!
     expect(await (prePlugin.load as Function)(id)).toMatchSnapshot()
 })

--- a/packages/wdio-browser-runner/tests/vite/plugins/mockHoisting.test.ts
+++ b/packages/wdio-browser-runner/tests/vite/plugins/mockHoisting.test.ts
@@ -25,7 +25,7 @@ const mockHandler: any = {
             origin: '/some/path',
             namedExports: ['default']
         }, {
-            path: '../../constants',
+            path: '/path/to/project/constants',
             origin: '/path/to/project/src/components',
             namedExports: ['HEADING']
         }])


### PR DESCRIPTION
## Proposed changes

We never know whether some people still import without file extensions. This patch makes the behavior same to Vitest or Jest where the file extension is ignored.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
