### PR TITLE
Ignore path for browser tests

### DIFF
--- a/packages/wdio-browser-runner/src/browser/driver.ts
+++ b/packages/wdio-browser-runner/src/browser/driver.ts
@@ -24,7 +24,8 @@ export default class ProxyDriver {
         userPrototype: Record<string, PropertyDescriptor>,
         commandWrapper: any
     ) {
-        const [cid] = window.location.pathname.slice(1).split('/')
+        const urlParamString = new URLSearchParams(window.location.search)
+        const cid = urlParamString.get('cid')
         if (!cid) {
             throw new Error('"cid" query parameter is missing')
         }

--- a/packages/wdio-browser-runner/src/browser/frameworks/mocha.ts
+++ b/packages/wdio-browser-runner/src/browser/frameworks/mocha.ts
@@ -15,7 +15,8 @@ export class MochaFramework {
     constructor (socket: WebSocket) {
         this.#socket = socket
         socket.addEventListener('message', this.#handleSocketMessage.bind(this))
-        const [cid] = window.location.pathname.slice(1).split('/')
+        const urlParamString = new URLSearchParams(window.location.search)
+        const cid = urlParamString.get('cid')
         if (!cid) {
             throw new Error('"cid" query parameter is missing')
         }
@@ -90,7 +91,8 @@ export class MochaFramework {
     #getHook (name: string) {
         return (...args: any[]) => new Promise((resolve, reject) => {
             const id = (this.#hookResolver.size + 1).toString()
-            const [cid] = window.location.pathname.slice(1).split('/')
+            const urlParamString = new URLSearchParams(window.location.search)
+            const cid = urlParamString.get('cid')
             if (!cid) {
                 return reject(new Error('"cid" query parameter is missing'))
             }

--- a/packages/wdio-browser-runner/src/vite/plugins/mockHoisting.ts
+++ b/packages/wdio-browser-runner/src/vite/plugins/mockHoisting.ts
@@ -207,11 +207,11 @@ export function mockHoisting(mockHandler: MockHandler): Plugin[] {
         configureServer(server) {
             return () => {
                 server.middlewares.use('/', async (req, res, next) => {
-                    if (!req.url) {
+                    if (!req.originalUrl) {
                         return next()
                     }
 
-                    const urlParsed = url.parse(req.url)
+                    const urlParsed = url.parse(req.originalUrl)
                     const urlParamString = new URLSearchParams(urlParsed.query || '')
                     const specParam = urlParamString.get('spec')
 

--- a/packages/wdio-browser-runner/src/vite/plugins/testrunner.ts
+++ b/packages/wdio-browser-runner/src/vite/plugins/testrunner.ts
@@ -118,20 +118,15 @@ export function testrunner(options: WebdriverIO.BrowserRunnerOptions): Plugin[] 
         },
         configureServer(server) {
             return () => {
-                server.middlewares.use('/', async (req, res, next) => {
-                    log.info(`Received request for: ${req.url}`)
-                    if (!req.url) {
+                server.middlewares.use(async (req, res, next) => {
+                    log.info(`Received request for: ${req.originalUrl}`)
+                    if (!req.originalUrl) {
                         return next()
                     }
 
-                    const urlParsed = url.parse(req.url)
-                    // if request is not html , directly return next()
-                    if (!urlParsed.pathname || !urlParsed.path || !urlParsed.pathname.endsWith('test.html')) {
-                        return next()
-                    }
-
+                    const urlParsed = url.parse(req.originalUrl)
                     const urlParamString = new URLSearchParams(urlParsed.query || '')
-                    const [cid] = urlParsed.pathname.slice(1).split('/')
+                    const cid = urlParamString.get('cid')
                     const spec = urlParamString.get('spec')
                     if (!cid || !SESSIONS.has(cid)) {
                         log.error(`No environment found for ${cid || 'non determined environment'}`)
@@ -146,12 +141,12 @@ export function testrunner(options: WebdriverIO.BrowserRunnerOptions): Plugin[] 
                     const env = SESSIONS.get(cid)!
                     try {
                         const template = await getTemplate(options, env, spec)
-                        log.debug(`Render template for ${req.url}`)
-                        res.end(await server.transformIndexHtml(`${req.url}`, template))
+                        log.debug(`Render template for ${req.originalUrl}`)
+                        res.end(await server.transformIndexHtml(`${req.originalUrl}`, template))
                     } catch (err: any) {
-                        const template = getErrorTemplate(req.url, err)
+                        const template = getErrorTemplate(req.originalUrl, err)
                         log.error(`Failed to render template: ${err.message}`)
-                        res.end(await server.transformIndexHtml(`${req.url}`, template))
+                        res.end(await server.transformIndexHtml(`${req.originalUrl}`, template))
                     }
 
                     return next()

--- a/packages/wdio-browser-runner/tests/vite/plugins/mockHoisting.test.ts
+++ b/packages/wdio-browser-runner/tests/vite/plugins/mockHoisting.test.ts
@@ -54,9 +54,9 @@ test('does not transform if file is not within spec', () => {
 test('transforms test file properly for mocking', () => {
     const postPlugin = mockHoisting(mockHandler).pop()!
     const testfilePath = os.platform() === 'win32' ? '/C:/sometest.ts' : 'sometest.ts'
-    const url = `/foo?spec=/${testfilePath}`
+    const originalUrl = `/foo?spec=/${testfilePath}`
     const server = {
-        middlewares: { use: (_: never, cb: Function) => cb({ url }, {}, vi.fn()) }
+        middlewares: { use: (_: never, cb: Function) => cb({ originalUrl }, {}, vi.fn()) }
     }
     ;(postPlugin.configureServer as Function)(server)()
     const newCode = (postPlugin.transform as Function)(TESTFILE, os.platform() === 'win32' ? testfilePath : `/${testfilePath}`)

--- a/packages/wdio-runner/src/browser.ts
+++ b/packages/wdio-runner/src/browser.ts
@@ -96,7 +96,7 @@ export default class BrowserFramework implements Omit<TestFramework, 'init'> {
              * is no need to call the url command again
              */
             if (!this._config.sessionId) {
-                await browser.url(`/${this._cid}/test.html?spec=${url.parse(spec).pathname}`)
+                await browser.url(`/?cid=${this._cid}&spec=${url.parse(spec).pathname}`)
             }
             // await browser.debug()
 


### PR DESCRIPTION
## Proposed changes

The current url for running the browser tests was `/0-0/test.html?spec=...` which becomes problematic if components deal with routes. To allow more flexibility this patch removes any requirement for a specific url to be set, it returns the text runner page for all routes.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
