### PR TITLE
fix: duplicated suite

### DIFF
--- a/packages/wdio-config/src/lib/ConfigParser.ts
+++ b/packages/wdio-config/src/lib/ConfigParser.ts
@@ -178,6 +178,13 @@ export default class ConfigParser {
         }
 
         /**
+         * overwrite suite
+         */
+        if (object.suite && object.suite.length > 0) {
+            this._config.suite = object.suite as string[]
+        }
+
+        /**
          * overwrite capabilities
          */
         this._capabilities = validObjectOrArray(this._config.capabilities) ? this._config.capabilities : this._capabilities

--- a/packages/wdio-config/src/lib/ConfigParser.ts
+++ b/packages/wdio-config/src/lib/ConfigParser.ts
@@ -178,10 +178,10 @@ export default class ConfigParser {
         }
 
         /**
-         * overwrite suite
+         * cleanup duplicated "suite" if the same value was provided
          */
         if (object.suite && object.suite.length > 0) {
-            this._config.suite = object.suite as string[]
+            this._config.suite = this._config.suite?.filter((suite, idx, suites) => suites.indexOf(suite) === idx)
         }
 
         /**

--- a/packages/wdio-config/tests/configparser.test.ts
+++ b/packages/wdio-config/tests/configparser.test.ts
@@ -142,8 +142,8 @@ function ConfigParserForTest(config = FIXTURES_CONF) {
         ).build()
 }
 
-async function ConfigParserForTestWithAllFiles(configPath: string) {
-    return ConfigParserBuilder.withBaseDir(FIXTURES_PATH, configPath)
+async function ConfigParserForTestWithAllFiles(configPath: string, args = {}) {
+    return ConfigParserBuilder.withBaseDir(FIXTURES_PATH, configPath, args)
         .withFiles(
             await MockedFileSystem_LoadingAsMuchAsCanFromFileSystem()
         ).build()
@@ -477,10 +477,13 @@ describe('ConfigParser', () => {
         })
 
         it('should allow to specify a single suite', async () => {
-            const configParser = await ConfigParserForTestWithAllFiles(FIXTURES_CONF)
+            const configParser = await ConfigParserForTestWithAllFiles(FIXTURES_CONF, { suite: ['mobile'] })
             await configParser.initialize({ suite: ['mobile'] })
 
             const specs = configParser.getSpecs()
+            const suite = configParser.getConfig().suite
+
+            expect(suite).toHaveLength(1)
             expect(specs).toHaveLength(1)
             expect(specs).toContain(path.join(__dirname, 'RequireLibrary.test.ts'))
         })


### PR DESCRIPTION
## Proposed changes

Issue reported: https://github.com/webdriverio/webdriverio/issues/9439

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)


`packages/wdio-cli/src/launcher.ts` passes command line arguments `this._args`  to the `ConfigParser` **two times** [[1](https://github.com/webdriverio/webdriverio/blob/445f1c901e9bd08b2d17d35592ad7c3258937917/packages/wdio-cli/src/launcher.ts#L59), [2](https://github.com/webdriverio/webdriverio/blob/445f1c901e9bd08b2d17d35592ad7c3258937917/packages/wdio-cli/src/launcher.ts#L67
)] during its initialization which results in `configParser._config.suite` to contain provided suite name two times


Duplicated suite name on the config makes `wdio` to start 2x amount of workers for a grouped specs within a suite

For example, with given config

```js
module.exports.config = {
  specs: ['./specs/*.test.js'],
  suites: {
    mysuite: [
        // grouped spec ⬇️⬇️⬇️⬇️
        ['./specs/file-1.test.js', './specs/file-2.test.js']
    ]
  },
  capabilities: [{ browserName: 'chrome' }],
  framework: 'mocha',
};
```

trying to run a single suite `node ./node_modules/.bin/wdio ./config.js --suite mysuite`  will start 2 workers:

```
# ⬇️⬇️⬇️⬇️⬇️ two workers will start
Execution of 2 workers started at 2023-03-02T18:54:13.487Z

2023-03-02T18:54:13.497Z INFO @wdio/cli:launcher: Run onPrepare hook
2023-03-02T18:54:13.498Z INFO @wdio/cli:launcher: Run onWorkerStart hook
2023-03-02T18:54:13.498Z INFO @wdio/cli:launcher: Run onWorkerStart hook
2023-03-02T18:54:13.498Z INFO @wdio/local-runner: Start worker 0-0 with arg: ./config.js,--suite,mysuite
2023-03-02T18:54:13.501Z INFO @wdio/local-runner: Start worker 0-1 with arg: ./config.js,--suite,mysuite
[0-0] 2023-03-02T18:54:13.930Z INFO @wdio/local-runner: Run worker command: run
[0-1] 2023-03-02T18:54:13.930Z INFO @wdio/local-runner: Run worker command: run
[0-0] RUNNING in chrome - file:///specs/file-1.test.js, file:///specs/file-2.test.js
[0-1] RUNNING in chrome - file:///specs/file-1.test.js, file:///specs/file-2.test.js
```


This PR adds code that explicitly overwrites `suite` config if new value provided to `ConfigParser.initialize`


## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
