### PR TITLE
Allow preset and ViteConfig at the same time

### DIFF
--- a/packages/wdio-browser-runner/src/types.ts
+++ b/packages/wdio-browser-runner/src/types.ts
@@ -85,7 +85,7 @@ export interface BrowserRunnerOptions {
     /**
      * Vite configuration to overwrite the preset
      */
-    viteConfig?: InlineConfig
+    viteConfig?: string | InlineConfig
     /**
      * Run tests in headless mode
      * @default false // true in CI environment

--- a/packages/wdio-browser-runner/src/vite/server.ts
+++ b/packages/wdio-browser-runner/src/vite/server.ts
@@ -1,3 +1,4 @@
+import path from 'node:path'
 import { EventEmitter } from 'node:events'
 
 import getPort from 'get-port'
@@ -37,6 +38,7 @@ export class ViteServer extends EventEmitter {
     #pendingHooks = new Map<string, PendingHook>()
     #connections = new Set<WebSocket>()
     #options: WebdriverIO.BrowserRunnerOptions
+    #config: Options.Testrunner
     #viteConfig: Partial<InlineConfig>
     #wss?: WebSocketServer
     #server?: ViteDevServer
@@ -53,12 +55,8 @@ export class ViteServer extends EventEmitter {
     constructor (options: WebdriverIO.BrowserRunnerOptions, config: Options.Testrunner) {
         super()
         this.#options = options
+        this.#config = config
         this.#mockHandler = new MockHandler(options, config)
-
-        if (options.preset && options.viteConfig) {
-            throw new Error('Invalid runner configuration: "preset" and "viteConfig" options are defined but only one of each can be used at the same time')
-        }
-
         this.#viteConfig = deepmerge(DEFAULT_VITE_CONFIG, {
             root: options.rootDir || process.cwd(),
             plugins: [
@@ -77,14 +75,22 @@ export class ViteServer extends EventEmitter {
                 ...options.coverage
             }))
         }
-
-        if (options.viteConfig) {
-            this.#viteConfig = deepmerge(this.#viteConfig, options.viteConfig)
-        }
     }
 
     async start () {
         const [vitePort, wssPort] = await Promise.all([getPort(), getPort()])
+        this.#viteConfig = deepmerge(this.#viteConfig, <Partial<InlineConfig>>{
+            server: {
+                host: '0.0.0.0',
+                port: vitePort,
+                proxy: {
+                    '/ws': {
+                        target: `ws://localhost:${wssPort}`,
+                        ws: true
+                    }
+                }
+            }
+        })
 
         /**
          * load additional Vite plugins for framework
@@ -98,22 +104,22 @@ export class ViteServer extends EventEmitter {
         }
 
         /**
+         * merge custom `viteConfig` last into the object
+         */
+        if (this.#options.viteConfig) {
+            const configToMerge = typeof this.#options.viteConfig === 'string'
+                ? (
+                    await import(path.resolve(this.#config.rootDir || process.cwd(), this.#options.viteConfig))
+                ).default
+                : this.#options.viteConfig
+            this.#viteConfig = deepmerge(this.#viteConfig, configToMerge)
+        }
+
+        /**
          * initialize Socket server on top of vite server
          */
         this.#wss = new WebSocketServer({ port: wssPort })
         this.#wss.on('connection', this.#onConnect.bind(this))
-        this.#viteConfig = deepmerge(this.#viteConfig, <Partial<InlineConfig>>{
-            server: {
-                host: '0.0.0.0',
-                port: vitePort,
-                proxy: {
-                    '/ws': {
-                        target: `ws://localhost:${wssPort}`,
-                        ws: true
-                    }
-                }
-            }
-        })
 
         /**
          * initialize Vite

--- a/packages/wdio-browser-runner/tests/vite/__fixtures__/vite.conf.ts
+++ b/packages/wdio-browser-runner/tests/vite/__fixtures__/vite.conf.ts
@@ -1,0 +1,5 @@
+export default {
+    server: {
+        port: 3210
+    }
+}

--- a/website/docs/Runner.md
+++ b/website/docs/Runner.md
@@ -110,9 +110,9 @@ export const {
 
 #### `viteConfig`
 
-Define your own [Vite configuration](https://vitejs.dev/config/). You can either pass in a custom object or import an existing `vite.conf.ts` file if you use Vite.js for development. Note that WebdriverIO merges custom configurations to set up framework and runner objects. This option can't be used together with `preset`.
+Define your own [Vite configuration](https://vitejs.dev/config/). You can either pass in a custom object or import an existing `vite.conf.ts` file if you use Vite.js for development. Note that WebdriverIO keeps custom Vite configurations to set up the test harness.
 
-__Type:__ [`UserConfig`](https://github.com/vitejs/vite/blob/52e64eb43287d241f3fd547c332e16bd9e301e95/packages/vite/src/node/config.ts#L119-L272)<br />
+__Type:__ `string` or [`UserConfig`](https://github.com/vitejs/vite/blob/52e64eb43287d241f3fd547c332e16bd9e301e95/packages/vite/src/node/config.ts#L119-L272)<br />
 __Example:__
 
 ```js title="wdio.conf.ts"
@@ -121,6 +121,8 @@ import viteConfig from '../vite.config.ts'
 export const {
     // ...
     runner: ['browser', { viteConfig }],
+    // or just:
+    runner: ['browser', { viteConfig: '../vites.config.ts' }],
     // ...
 }
 ```


### PR DESCRIPTION
## Proposed changes

The current behavior was that `preset` and `viteConfig` could not be set at the same time. This turned out to be not practical in reality. So this patch changes that and allows to add a custom `viteConfig` at any time. It also includes the ability to just refer to a vite config as string reference.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
