### PR TITLE
[💡 Feature]: Receive spec and cid properties from browser session

### DIFF
--- a/packages/wdio-browser-runner/src/browser/driver.ts
+++ b/packages/wdio-browser-runner/src/browser/driver.ts
@@ -4,6 +4,7 @@ import { commands } from 'virtual:wdio'
 import { webdriverMonad, sessionEnvironmentDetector } from '@wdio/utils'
 import { getEnvironmentVars } from 'webdriver'
 
+import { getCID } from './utils.js'
 import { MESSAGE_TYPES } from '../constants.js'
 import type { SocketMessage, SocketMessagePayload, ConsoleEvent, CommandRequestEvent } from '../vite/types.js'
 
@@ -24,8 +25,7 @@ export default class ProxyDriver {
         userPrototype: Record<string, PropertyDescriptor>,
         commandWrapper: any
     ) {
-        const urlParamString = new URLSearchParams(window.location.search)
-        const cid = urlParamString.get('cid')
+        const cid = getCID()
         if (!cid) {
             throw new Error('"cid" query parameter is missing')
         }

--- a/packages/wdio-browser-runner/src/browser/frameworks/mocha.ts
+++ b/packages/wdio-browser-runner/src/browser/frameworks/mocha.ts
@@ -2,6 +2,7 @@ import stringify from 'fast-safe-stringify'
 
 import { setupEnv, formatMessage } from '@wdio/mocha-framework/common'
 
+import { getCID } from '../utils.js'
 import { MESSAGE_TYPES, EVENTS } from '../../constants.js'
 import type { HookResultEvent, HookTriggerEvent, SocketMessage } from '../../vite/types.js'
 
@@ -15,8 +16,7 @@ export class MochaFramework {
     constructor (socket: WebSocket) {
         this.#socket = socket
         socket.addEventListener('message', this.#handleSocketMessage.bind(this))
-        const urlParamString = new URLSearchParams(window.location.search)
-        const cid = urlParamString.get('cid')
+        const cid = getCID()
         if (!cid) {
             throw new Error('"cid" query parameter is missing')
         }
@@ -91,8 +91,7 @@ export class MochaFramework {
     #getHook (name: string) {
         return (...args: any[]) => new Promise((resolve, reject) => {
             const id = (this.#hookResolver.size + 1).toString()
-            const urlParamString = new URLSearchParams(window.location.search)
-            const cid = urlParamString.get('cid')
+            const cid = getCID()
             if (!cid) {
                 return reject(new Error('"cid" query parameter is missing'))
             }

--- a/packages/wdio-browser-runner/src/browser/utils.ts
+++ b/packages/wdio-browser-runner/src/browser/utils.ts
@@ -1,0 +1,13 @@
+export function getCID () {
+    const urlParamString = new URLSearchParams(window.location.search)
+    return (
+        // initial request contains cid as query parameter
+        urlParamString.get('cid') ||
+        // if not provided check for document cookie, set by `@wdio/runner` package
+        (document.cookie.split(';') || [])
+            .find((c) => c.includes('WDIO_CID'))
+            ?.trim()
+            .split('=')
+            .pop()
+    )
+}

--- a/packages/wdio-browser-runner/src/vite/plugins/testrunner.ts
+++ b/packages/wdio-browser-runner/src/vite/plugins/testrunner.ts
@@ -124,10 +124,11 @@ export function testrunner(options: WebdriverIO.BrowserRunnerOptions): Plugin[] 
                         return next()
                     }
 
+                    const cookies = ((req.headers.cookie && req.headers.cookie.split(';')) || []).map((c) => c.trim())
                     const urlParsed = url.parse(req.originalUrl)
                     const urlParamString = new URLSearchParams(urlParsed.query || '')
-                    const cid = urlParamString.get('cid')
-                    const spec = urlParamString.get('spec')
+                    const cid = urlParamString.get('cid') || cookies.find((c) => c.includes('WDIO_CID'))?.split('=').pop()
+                    const spec = urlParamString.get('spec') || cookies.find((c) => c.includes('WDIO_SPEC'))?.split('=').pop()
                     if (!cid || !SESSIONS.has(cid)) {
                         log.error(`No environment found for ${cid || 'non determined environment'}`)
                         return next()

--- a/packages/wdio-browser-runner/tests/vite/plugins/testrunner.test.ts
+++ b/packages/wdio-browser-runner/tests/vite/plugins/testrunner.test.ts
@@ -75,6 +75,7 @@ test('transform', () => {
     expect((plugin[0].transform as Function)(expectJS, '.vite/deps/expect.js')).toMatchSnapshot()
 })
 
+const req = { headers: { cookie: '' } }
 test('configureServer continues if no url given', async () => {
     const plugin = testrunner({})
     const server = { middlewares: { use: vi.fn() }, transformIndexHtml: vi.fn((...args) => args) }
@@ -88,21 +89,21 @@ test('configureServer continues if no url given', async () => {
     expect(next).toBeCalledWith()
     next.mockClear()
 
-    middleware({ originalUrl: 'https://google.com' }, {}, next)
+    middleware({ ...req, originalUrl: 'https://google.com' }, {}, next)
     expect(next).toBeCalledWith()
     next.mockClear()
 
-    middleware({ originalUrl: 'http://localhost:1234/?cid=1-2&spec=foobar' }, {}, next)
+    middleware({ ...req, originalUrl: 'http://localhost:1234/?cid=1-2&spec=foobar' }, {}, next)
     expect(next).toBeCalledWith()
     next.mockClear()
 
     SESSIONS.set('1-2', {} as any)
-    middleware({ originalUrl: 'http://localhost:1234/?cid=1-2' }, {}, next)
+    middleware({ ...req, originalUrl: 'http://localhost:1234/?cid=1-2' }, {}, next)
     expect(next).toBeCalledWith()
     next.mockClear()
 
     vi.mocked(getTemplate).mockResolvedValue('some html')
-    await middleware({ originalUrl: 'http://localhost:1234/?cid=1-2&spec=foobar' }, res, next)
+    await middleware({ ...req, originalUrl: 'http://localhost:1234/?cid=1-2&spec=foobar' }, res, next)
     expect(getTemplate).toBeCalledTimes(1)
     expect(next).toBeCalledWith()
     expect(res.end).toBeCalledWith([
@@ -114,7 +115,7 @@ test('configureServer continues if no url given', async () => {
 
     vi.mocked(getTemplate).mockRejectedValue(new Error('ups'))
     vi.mocked(getErrorTemplate).mockReturnValue('some error html')
-    await middleware({ originalUrl: 'http://localhost:1234/?cid=1-2&spec=foobar' }, res, next)
+    await middleware({ ...req, originalUrl: 'http://localhost:1234/?cid=1-2&spec=foobar' }, res, next)
     expect(getTemplate).toBeCalledTimes(1)
     expect(getErrorTemplate).toBeCalledTimes(1)
     expect(next).toBeCalledWith()

--- a/packages/wdio-protocols/src/protocols/webdriver.ts
+++ b/packages/wdio-protocols/src/protocols/webdriver.ts
@@ -1043,7 +1043,7 @@ export default {
                 },
                 {
                     name: 'args',
-                    type: '(string|object|number|boolean|undefined)[]',
+                    type: '(string|object|number|boolean|null|undefined)[]',
                     description:
                         'an array of JSON values which will be deserialized and passed as arguments to your function',
                     required: true,
@@ -1075,7 +1075,7 @@ export default {
                 },
                 {
                     name: 'args',
-                    type: '(string|object|number|boolean|undefined)[]',
+                    type: '(string|object|number|boolean|null|undefined)[]',
                     description:
                         'an array of JSON values which will be deserialized and passed as arguments to your function',
                     required: true,

--- a/packages/wdio-runner/src/browser.ts
+++ b/packages/wdio-runner/src/browser.ts
@@ -101,6 +101,15 @@ export default class BrowserFramework implements Omit<TestFramework, 'init'> {
             // await browser.debug()
 
             /**
+             * set spec and cid as cookie so the Vite plugin can detect session even without
+             * query parameters
+             */
+            await browser.setCookies([
+                { name: 'WDIO_SPEC', value: url.fileURLToPath(spec) },
+                { name: 'WDIO_CID', value: this._cid }
+            ])
+
+            /**
              * wait for test results or page errors
              */
             let state: TestState = {}

--- a/packages/wdio-utils/src/test-framework/errorHandler.ts
+++ b/packages/wdio-utils/src/test-framework/errorHandler.ts
@@ -26,8 +26,8 @@ export const logHookError = (hookName: string, hookResults: any[] = [], cid: str
         state: 'fail'
     }
 
-    if (globalThis.process) {
-        process.send!({
+    if (globalThis.process && typeof globalThis.process.send === 'function') {
+        globalThis.process.send!({
             origin: 'reporter',
             name: 'printFailureMessage',
             content

--- a/packages/webdriverio/src/types.ts
+++ b/packages/webdriverio/src/types.ts
@@ -319,7 +319,7 @@ export interface MultiRemoteBrowser extends MultiRemoteBrowserType {}
 interface MultiRemoteElementType extends MultiRemoteElementBase, MultiRemoteProtocolCommandsType, Omit<MultiRemoteBrowserCommandsType, keyof MultiRemoteElementCommandsType>, MultiRemoteElementCommandsType {}
 export interface MultiRemoteElement extends MultiRemoteElementType {}
 
-export type ElementFunction = ((elem: HTMLElement) => HTMLElement) | ((elem: HTMLElement) => HTMLElement[])
+export type ElementFunction = ((elem: HTMLElement) => HTMLElement | undefined) | ((elem: HTMLElement) => (HTMLElement | undefined)[])
 export type CustomStrategyFunction = (...args: any) => ElementReference | ElementReference[]
 export type CustomStrategyReference = {
     strategy: CustomStrategyFunction


### PR DESCRIPTION
### Is your feature request related to a problem?

When debugging component tests it can happen that an application reloads and is loosing the query parameters. This currently prevents WebdriverIO from being able to inject the test harness.

### Describe the solution you'd like.

Store the spec and cid information as cookie so we can receive it and render the test harness even if not available in the query.

### Describe alternatives you've considered.

using local storage but this way the vite plugin would still not know which spec and cid is making the page request.

### Additional context

n/a

### Code of Conduct

- [X] I agree to follow this project's Code of Conduct