### PR TITLE
[💡 Feature]: Make `ChainablePromiseArray` and `ElementArray` iterable

### DIFF
--- a/packages/webdriverio/src/commands/browser/$$.ts
+++ b/packages/webdriverio/src/commands/browser/$$.ts
@@ -5,14 +5,28 @@ import { getElements } from '../../utils/getElementObject.js'
 import type { Selector, ElementArray } from '../../types.js'
 
 /**
- * The `$$` command is a short way to call the [`findElements`](/docs/api/webdriver#findelements) command in order
- * to fetch multiple elements on the page. It returns an array with element results that will have an
- * extended prototype to call action commands without passing in a selector. However if you still pass
- * in a selector it will look for that element first and call the action on that element.
+ * The `$$` command is a short and handy way in order to fetch multiple elements on the page.
+ * It returns a `ChainablePromiseArray` containing a set of WebdriverIO elements.
  *
- * Using the wdio testrunner this command is a global variable else it will be located on the browser object instead.
+ * Using the wdio testrunner this command is a global variable, see [Globals](https://webdriver.io/docs/api/globals)
+ * for more information. Using WebdriverIO within a [standalone](https://webdriver.io/docs/setuptypes#standalone-mode)
+ * script it will be located on the browser object instead (e.g. `browser.$$`).
  *
- * You can chain `$` or `$$` together in order to walk down the DOM tree.
+ * You can chain `$` or `$$` together without wrapping individual commands into `await` in order
+ * to walk down the DOM tree, e.g.:
+ *
+ * ```js
+ * const imageSrc = await $$('div')[1].nextElement().$$('img')[2].getAttribute('src)
+ * ```
+ *
+ * It is also possible to use async iterators to loop over the result of the query, e.g.:
+ *
+ * ```js
+ * // print all image sources
+ * for await (const img of $$('img')) {
+ *   console.log(await img.getAttribute('src))
+ * }
+ * ```
  *
  * :::info
  *

--- a/packages/webdriverio/src/commands/browser/$.ts
+++ b/packages/webdriverio/src/commands/browser/$.ts
@@ -5,21 +5,29 @@ import type { Selector } from '../../types.js'
 import type { ElementReference } from '@wdio/protocols'
 
 /**
- * The `$` command is a short way to call the [`findElement`](/docs/api/webdriver#findelement) command in order
- * to fetch a single element on the page. It returns an object that with an extended prototype to call
- * action commands without passing in a selector. However if you still pass in a selector it will look
- * for that element first and call the action on that element.
+ * The `$` command is a short and handy way in order to fetch a single element on the page.
  *
- * You can also pass in an object as selector where the object contains a property
- * `element-6066-11e4-a52e-4f735466cecf` with the value of a reference to an element.
- * The command will then transform the reference to an extended WebdriverIO element.
+ * You can also pass in an object as selector where the object contains a property `element-6066-11e4-a52e-4f735466cecf`
+ * with the value of a reference to an element. The command will then transform the reference to an extended WebdriverIO element.
+ *
+ * Note: chaining `$` and `$$` commands only make sense when you use multiple selector strategies. You will otherwise
+ * make unnecessary requests that slow down the test (e.g. `$('body').$('div')` will trigger two request whereas
+ * `$('body div')` does literally the same with just one request)
+ *
  * __Note:__ only use these element objects if you are certain they still exist on the
  * page, e.g. using the `isExisting` command. WebdriverIO is unable to refetch them given
  * that there are no selector information available.
  *
- * Using the wdio testrunner this command is a global variable else it will be located on the browser object instead.
+ * Using the wdio testrunner this command is a global variable, see [Globals](https://webdriver.io/docs/api/globals)
+ * for more information. Using WebdriverIO within a [standalone](https://webdriver.io/docs/setuptypes#standalone-mode)
+ * script it will be located on the browser object instead (e.g. `browser.$$`).
  *
- * You can chain `$` or `$$` together in order to walk down the DOM tree.
+ * You can chain `$` or `$$` together without wrapping individual commands into `await` in order
+ * to walk down the DOM tree, e.g.:
+ *
+ * ```js
+ * const imageSrc = await $$('div')[1].nextElement().$$('img')[2].getAttribute('src)
+ * ```
  *
  * :::info
  *

--- a/packages/webdriverio/src/commands/element/$$.ts
+++ b/packages/webdriverio/src/commands/element/$$.ts
@@ -1,7 +1,29 @@
 /**
- * The `$$` command is a short way to call the [`findElements`](/docs/api/webdriver#findelements) command in order
- * to fetch multiple elements on the page similar to the `$$` command from the browser scope. The difference when calling
- * it from an element scope is that the driver will look within the children of that element.
+ * The `$$` command is a short and handy way in order to fetch multiple elements on the page.
+ * It returns a `ChainablePromiseArray` containing a set of WebdriverIO elements.
+ *
+ * :::info
+ *
+ * As opposed to the [`$$`](/docs/api/browser/$$) attached to the [browser object](/docs/api/browser)
+ * this command queries elements based on a root element.
+ *
+ * :::
+ *
+ * You can chain `$` or `$$` together without wrapping individual commands into `await` in order
+ * to walk down the DOM tree, e.g.:
+ *
+ * ```js
+ * const imageSrc = await $$('div')[1].nextElement().$$('img')[2].getAttribute('src)
+ * ```
+ *
+ * It is also possible to use async iterators to loop over the result of the query, e.g.:
+ *
+ * ```js
+ * // print all image sources
+ * for await (const img of $$('img')) {
+ *   console.log(await img.getAttribute('src))
+ * }
+ * ```
  *
  * :::info
  *

--- a/packages/webdriverio/src/commands/element/$.ts
+++ b/packages/webdriverio/src/commands/element/$.ts
@@ -1,13 +1,26 @@
 /**
- * The `$` command is a short way to call the [`findElement`](/docs/api/webdriver#findelement) command in order
- * to fetch a single element on the page similar to the `$` command from the browser scope. The difference when calling
- * it from an element scope is that the driver will look within the children of that element. You can also pass in an object as selector
- * where the object contains a property `element-6066-11e4-a52e-4f735466cecf` with the value of a reference
- * to an element. The command will then transform the reference to an extended WebdriverIO element.
+ * The `$` command is a short and handy way in order to fetch a single element on the page.
+ *
+ * :::info
+ *
+ * As opposed to the [`$`](/docs/api/browser/$) attached to the [browser object](/docs/api/browser)
+ * this command queries an element based on a root element.
+ *
+ * :::
+ *
+ * You can also pass in an object as selector where the object contains a property `element-6066-11e4-a52e-4f735466cecf`
+ * with the value of a reference to an element. The command will then transform the reference to an extended WebdriverIO element.
  *
  * Note: chaining `$` and `$$` commands only make sense when you use multiple selector strategies. You will otherwise
  * make unnecessary requests that slow down the test (e.g. `$('body').$('div')` will trigger two request whereas
  * `$('body div')` does literally the same with just one request)
+ *
+ * You can chain `$` or `$$` together without wrapping individual commands into `await` in order
+ * to walk down the DOM tree, e.g.:
+ *
+ * ```js
+ * const imageSrc = await $$('div')[1].nextElement().$$('img')[2].getAttribute('src)
+ * ```
  *
  * :::info
  *


### PR DESCRIPTION
### Is your feature request related to a problem?

It is currently not easy to iterate over a set of elements found using `$$` command.

### Describe the solution you'd like.

Something like:

```ts
await for (const elem of $$('someElem')) {
    // ...
}
```

would be nice.

### Describe alternatives you've considered.

n/a

### Additional context

n/a

### Code of Conduct

- [X] I agree to follow this project's Code of Conduct