### PR TITLE
chore(docs): fix broken anchor link pointing to localhost in runner doc

### DIFF
--- a/website/docs/Runner.md
+++ b/website/docs/Runner.md
@@ -14,7 +14,7 @@ The [Local Runner](https://www.npmjs.com/package/@wdio/local-runner) initiates y
 Given every test is run in its own isolated process, it is not possible to share data across test files. There are two ways to work around this:
 
 - use the [`@wdio/shared-store-service`](https://www.npmjs.com/package/@wdio/shared-store-service) to share data across all workers
-- group spec files (read more in [Organizing Test Suite](http://localhost:3000/docs/organizingsuites#grouping-test-specs-to-run-sequentially))
+- group spec files (read more in [Organizing Test Suite](https://webdriver.io/docs/organizingsuites#grouping-test-specs-to-run-sequentially))
 
 If nothing else is defined in the `wdio.conf.js` the Local Runner is the default runner in WebdriverIO.
 


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

Just stumbled onto a link that points to localhost while browser the public website documentation. This patch fixes it to uses the WDIO website hostname instead.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
