### PR TITLE
[🐛 Bug]: Improve typing for `switchToFrame` command

### DIFF
--- a/packages/devtools/src/commands/switchToFrame.ts
+++ b/packages/devtools/src/commands/switchToFrame.ts
@@ -6,6 +6,8 @@ import { ELEMENT_KEY } from '../constants.js'
 import { getStaleElementError } from '../utils.js'
 import type DevToolsDriver from '../devtoolsdriver.js'
 
+type FrameIdParameter = { id: null | number | ElementReference }
+
 /**
  * The Switch To Frame command is used to select the current top-level browsing context
  * or a child browsing context of the current browsing context to use as the current
@@ -17,7 +19,7 @@ import type DevToolsDriver from '../devtoolsdriver.js'
  */
 export default async function switchToFrame (
     this: DevToolsDriver,
-    { id }: { id: string }
+    { id }: FrameIdParameter
 ) {
     const page = this.getPageHandle(true) as unknown as Frame
 
@@ -43,12 +45,11 @@ export default async function switchToFrame (
     /**
      * switch frame by element ID
      */
-    const idAsElementReference = id as unknown as ElementReference
-    if (typeof idAsElementReference[ELEMENT_KEY] === 'string') {
-        const elementHandle = await this.elementStore.get(idAsElementReference[ELEMENT_KEY])
+    if (typeof id === 'object' && typeof (id as ElementReference)[ELEMENT_KEY] === 'string') {
+        const elementHandle = await this.elementStore.get(id[ELEMENT_KEY])
 
         if (!elementHandle) {
-            throw getStaleElementError(id)
+            throw getStaleElementError(id[ELEMENT_KEY])
         }
 
         const contentFrame = await elementHandle.contentFrame()
@@ -58,7 +59,7 @@ export default async function switchToFrame (
         }
 
         this.currentFrame = contentFrame as unknown as Page
-        return { id: idAsElementReference[ELEMENT_KEY] }
+        return { id: id[ELEMENT_KEY] }
     }
 
     /**


### PR DESCRIPTION
### Have you read the Contributing Guidelines on issues?

- [X] I have read the [Contributing Guidelines on issues](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md#reporting-new-issues).

### WebdriverIO Version

latest

### Node.js Version

latest

### Mode

Standalone Mode

### Which capabilities are you using?

```typescript
n/a
```


### What happened?

The command describes the `id` parameter to be

> one of three possible types: null: this represents the top-level browsing context (i.e., not an iframe), a Number, representing the index of the window object corresponding to a frame, an Element object received using `findElement`.

But the types are defined as:

```
{ id }: { id: string }
```

We should fix that and ensure it follows the reality and also allow passing chained webdriverio elements, e.g.

```ts
await browser.switchToFrame($('iframe'))`
```


### What is your expected behavior?

Make it work as described above.

### How to reproduce the bug.

n/a

### Relevant log output

```typescript
n/a
```


### Code of Conduct

- [X] I agree to follow this project's Code of Conduct

### Is there an existing issue for this?

- [X] I have searched the existing issues