### PR TITLE
wdio-config: Add multi-run cli flag

### DIFF
--- a/packages/wdio-cli/src/commands/run.ts
+++ b/packages/wdio-cli/src/commands/run.ts
@@ -82,6 +82,10 @@ export const cmdArgs = {
         desc: 'exclude certain spec file from the test run - overrides exclude piped from stdin',
         type: 'array'
     },
+    'multi-run': {
+        desc: 'Run individual spec files x amount of times',
+        type: 'number'
+    },
     mochaOpts: {
         desc: 'Mocha options'
     },

--- a/packages/wdio-config/src/lib/ConfigParser.ts
+++ b/packages/wdio-config/src/lib/ConfigParser.ts
@@ -299,9 +299,10 @@ export default class ConfigParser {
 
         // If the --multi-run flag is set, duplicate the specs array
         // Ensure that when --multi-run is set that either --spec or --suite is also set
-        if (multiRun && (isSpecParamPassed || suites.length > 0)) {
+        const hasSubsetOfSpecsDefined = isSpecParamPassed || suites.length > 0
+        if (multiRun && hasSubsetOfSpecsDefined) {
             specs = specs.flatMap(i => Array.from({ length: multiRun }).fill(i)) as Spec[]
-        } else if (multiRun && !isSpecParamPassed && suites.length === 0) {
+        } else if (multiRun && !hasSubsetOfSpecsDefined) {
             throw new Error('The --multi-run flag requires that either the --spec or --suite flag is also set')
         }
 

--- a/packages/wdio-config/tests/configparser.test.ts
+++ b/packages/wdio-config/tests/configparser.test.ts
@@ -810,6 +810,34 @@ describe('ConfigParser', () => {
             expect(specs).toContain(path.join(__dirname, 'RequireLibrary.test.ts'))
         })
 
+        it('should include spec 3 times with mulit-run', async () => {
+            const configParser = await ConfigParserForTestWithAllFiles(FIXTURES_CONF)
+            await configParser.initialize({ spec: [INDEX_PATH], multiRun: 3 })
+
+            const specs = configParser.getSpecs()
+            expect(specs).toHaveLength(3)
+            expect(specs).toStrictEqual([
+                INDEX_PATH,
+                INDEX_PATH,
+                INDEX_PATH,
+            ])
+        })
+
+        it('should include specs from suite 3 times with mulit-run', async () => {
+            const configParser = await ConfigParserForTestWithAllFiles(FIXTURES_CONF)
+            await configParser.initialize({ suite: ['functional'], multiRun: 3 })
+
+            const specs = configParser.getSpecs()
+            expect(specs).toHaveLength(3)
+        })
+
+        it('should throw an error if multi-run is set but no spec or suite is specified', async () => {
+            const configParser = await ConfigParserForTestWithAllFiles(FIXTURES_CONF)
+            await configParser.initialize({ multiRun: 3 })
+
+            expect(() => configParser.getSpecs()).toThrow('The --multi-run flag requires that either the --spec or --suite flag is also set')
+        })
+
         it('should include spec when specifying a suite unless excluded', async () => {
             const configParser = ConfigParserBuilder
                 .withBaseDir(

--- a/website/docs/Retry.md
+++ b/website/docs/Retry.md
@@ -157,3 +157,16 @@ module.exports = function () {
     specFileRetriesDeferred: false
 }
 ```
+
+## Run a specific test multiple times
+
+This is to help prevent flaky tests from being introduced in a codebase. By adding the `--multi-run` cli option it will run the specified test(s) or suite(s) x number of times. When using this cli flag the `--spec` or `--suite` flag must also be specified.
+
+When adding new tests to a codebase, espically through a CI/CD process the tests could pass and get merged but become flakly later on. This flakiness could come from a number of things like network issues, server load, database size, etc. Using the `--multi-run` flag in your CD/CD process can help catch these flaky tests before they get merged to a main codebase. 
+
+One strategy to use is run your tests like regular in your CI/CD process but if you're introducing a new test you can then run another set of tests with the new spec specifed in `--spec` along with `--multi-run` so it runs the new test x number of times. If the test fails any of those times then the test will not get merged and will need to be looked at why it failed.
+
+```sh
+# This will run the example.e2e.js spec 5 times
+npx wdio run ./wdio.conf.js --spec example.e2e.js --multi-run 5
+```

--- a/website/docs/Testrunner.md
+++ b/website/docs/Testrunner.md
@@ -119,6 +119,7 @@ Options:
                         from stdin                                       [array]
 --exclude             exclude spec file(s) from a run - overrides specs piped
                         from stdin                                       [array]
+--multi-run           Run one or more specs x amount of times            [number]
 --mochaOpts           Mocha options
 --jasmineOpts         Jasmine options
 --cucumberOpts        Cucumber options


### PR DESCRIPTION
## Proposed changes

Implements [9926](https://github.com/webdriverio/webdriverio/issues/9926)

I noticed some of the other cli flags do camel case so we could change it from `--mulit-run` to `--multiRun` or a new name all together. 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

### Reviewers: @webdriverio/project-committers
