### PR TITLE
Watch mode improvements for browser runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
         run: npm run test
       - name: Interop Tests
         run: |
-          npm i chromedriver@109
+          npm i chromedriver@110
           npm run test:e2e:cjs
       - uses: actions/upload-artifact@v3
         if: failure()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
         run: npm run test
       - name: Interop Tests
         run: |
-          npm i chromedriver@110
+          npm i chromedriver --detect_chromedriver_version
           npm run test:e2e:cjs
       - uses: actions/upload-artifact@v3
         if: failure()

--- a/packages/wdio-browser-runner/src/browser/frameworks/mocha.ts
+++ b/packages/wdio-browser-runner/src/browser/frameworks/mocha.ts
@@ -79,12 +79,7 @@ export class MochaFramework extends HTMLElement {
         }
     }
 
-    async run () {
-        /**
-         * wait for socket to be connected
-         */
-        const socket = await window.__wdioConnectPromise__
-
+    async run (socket: WebSocket) {
         /**
          * import test case (order is important here)
          */
@@ -92,6 +87,8 @@ export class MochaFramework extends HTMLElement {
         await import(file)
 
         this.#socket = socket
+        console.log('SOO', socket)
+
         socket.addEventListener('message', this.#handleSocketMessage.bind(this))
         const cid = getCID()
         if (!cid) {

--- a/packages/wdio-browser-runner/src/browser/frameworks/mocha.ts
+++ b/packages/wdio-browser-runner/src/browser/frameworks/mocha.ts
@@ -87,8 +87,6 @@ export class MochaFramework extends HTMLElement {
         await import(file)
 
         this.#socket = socket
-        console.log('SOO', socket)
-
         socket.addEventListener('message', this.#handleSocketMessage.bind(this))
         const cid = getCID()
         if (!cid) {

--- a/packages/wdio-browser-runner/src/browser/frameworks/mocha.ts
+++ b/packages/wdio-browser-runner/src/browser/frameworks/mocha.ts
@@ -28,8 +28,6 @@ class HTMLReporter extends BaseReporter {
     addCodeToggle () {}
 }
 
-//examples/wdio/node_modules/uuid/dist/esm-browser/index.js
-
 export class MochaFramework extends HTMLElement {
     #root: ShadowRoot
     #spec: string
@@ -81,7 +79,12 @@ export class MochaFramework extends HTMLElement {
         }
     }
 
-    async run (socket: WebSocket) {
+    async run () {
+        /**
+         * wait for socket to be connected
+         */
+        const socket = await window.__wdioConnectPromise__
+
         /**
          * import test case (order is important here)
          */

--- a/packages/wdio-browser-runner/src/browser/setup.ts
+++ b/packages/wdio-browser-runner/src/browser/setup.ts
@@ -5,7 +5,6 @@ import { remote } from 'webdriverio'
 import { _setGlobal } from '@wdio/globals'
 
 import './frameworks/mocha.js'
-import type { MochaFramework } from './frameworks/mocha'
 
 type WDIOErrorEvent = Pick<ErrorEvent, 'filename' | 'message'>
 declare global {
@@ -44,9 +43,3 @@ _setGlobal('driver', browser, window.__wdioEnv__.injectGlobals)
 _setGlobal('expect', expect, window.__wdioEnv__.injectGlobals)
 _setGlobal('$', browser.$.bind(browser), window.__wdioEnv__.injectGlobals)
 _setGlobal('$$', browser.$$.bind(browser), window.__wdioEnv__.injectGlobals)
-
-const mochaFramework = document.querySelector('mocha-framework') as MochaFramework
-if (mochaFramework) {
-    await connectPromise
-    mochaFramework.run(socket)
-}

--- a/packages/wdio-browser-runner/src/browser/setup.ts
+++ b/packages/wdio-browser-runner/src/browser/setup.ts
@@ -5,6 +5,7 @@ import { remote } from 'webdriverio'
 import { _setGlobal } from '@wdio/globals'
 
 import './frameworks/mocha.js'
+import type { MochaFramework } from './frameworks/mocha'
 
 type WDIOErrorEvent = Pick<ErrorEvent, 'filename' | 'message'>
 declare global {
@@ -43,3 +44,12 @@ _setGlobal('driver', browser, window.__wdioEnv__.injectGlobals)
 _setGlobal('expect', expect, window.__wdioEnv__.injectGlobals)
 _setGlobal('$', browser.$.bind(browser), window.__wdioEnv__.injectGlobals)
 _setGlobal('$$', browser.$$.bind(browser), window.__wdioEnv__.injectGlobals)
+
+/**
+ * run framework immediatelly on page load
+ */
+const mochaFramework = document.querySelector('mocha-framework') as MochaFramework
+if (mochaFramework) {
+    const socket = await connectPromise
+    mochaFramework.run(socket)
+}

--- a/packages/wdio-cli/src/constants.ts
+++ b/packages/wdio-cli/src/constants.ts
@@ -214,7 +214,7 @@ export const QUESTIONNAIRE = [{
     type: 'confirm',
     name: 'installTestingLibrary',
     message: 'Do you like to use Testing Library (https://testing-library.com/) as test utility?',
-    default: false,
+    default: true,
     // only ask if there are more than 1 runner to pick from
     when: /* istanbul ignore next */ (answers: Questionnair) => (
         isBrowserRunner(answers) &&

--- a/packages/wdio-cli/src/interface.ts
+++ b/packages/wdio-cli/src/interface.ts
@@ -265,9 +265,6 @@ export default class WDIOCLInterface extends EventEmitter {
         }
 
         this._messages[event.origin][event.name].push(event.content)
-        if (this._isWatchMode) {
-            this.printReporters()
-        }
     }
 
     sigintTrigger() {
@@ -278,7 +275,7 @@ export default class WDIOCLInterface extends EventEmitter {
             return false
         }
 
-        const isRunning = this._jobs.size !== 0
+        const isRunning = this._jobs.size !== 0 || this._isWatchMode
         const shutdownMessage = isRunning
             ? 'Ending WebDriver sessions gracefully ...\n' +
             '(press ctrl+c again to hard kill the runner)'
@@ -312,10 +309,6 @@ export default class WDIOCLInterface extends EventEmitter {
     }
 
     finalise() {
-        if (this._isWatchMode) {
-            return
-        }
-
         this.printReporters()
         this.printSummary()
     }

--- a/packages/wdio-cli/src/launcher.ts
+++ b/packages/wdio-cli/src/launcher.ts
@@ -513,7 +513,15 @@ class Launcher {
          * - we are running watch mode
          */
         const shouldRunSpecs = this.runSpecs()
-        if (!shouldRunSpecs || (this._isWatchMode && !this._hasTriggeredExitRoutine)) {
+        const inWatchMode = this._isWatchMode && !this._hasTriggeredExitRoutine
+        if (!shouldRunSpecs || inWatchMode) {
+            /**
+             * print reporter results when in watch mode
+             */
+            if (inWatchMode) {
+                this.interface?.finalise()
+            }
+
             return
         }
 

--- a/packages/wdio-cli/src/templates/exampleFiles/mocha/example.e2e.js.ejs
+++ b/packages/wdio-cli/src/templates/exampleFiles/mocha/example.e2e.js.ejs
@@ -24,9 +24,9 @@ describe('My Login application', () => {
 <% } else if (runner === 'browser') {
 
 const componentSuffix = preset
-    ? preset.includes('react')
-        ? isUsingTypeScript ? 'tsx' : 'jsx'
-        : preset
+    ? ['svelte', 'vue'].includes(preset)
+        ? preset
+        : isUsingTypeScript ? 'tsx' : 'jsx'
     : isUsingTypeScript ? 'ts' : 'js'
 const importStatement = preset
     ? `import Component from '/path/to/component.${componentSuffix}'`

--- a/packages/wdio-cli/src/watcher.ts
+++ b/packages/wdio-cli/src/watcher.ts
@@ -173,7 +173,8 @@ export default class Watcher {
          */
         for (const [, worker] of Object.entries(workers)) {
             const { cid, capabilities, specs, sessionId } = worker
-            const args = Object.assign({ sessionId, baseUrl: worker.config.baseUrl }, params)
+            const { hostname, path, port, protocol, automationProtocol } = worker.config
+            const args = Object.assign({ sessionId, baseUrl: worker.config.baseUrl, hostname, path, port, protocol, automationProtocol }, params)
             worker.postMessage('run', args)
             this._launcher.interface.emit('job:start', { cid, caps: capabilities, specs })
         }

--- a/packages/wdio-cli/tests/__snapshots__/templates.test.ts.snap
+++ b/packages/wdio-cli/tests/__snapshots__/templates.test.ts.snap
@@ -116,7 +116,7 @@ exports[`template generation > solid 1`] = `
 import { render } from 'solid-js/web'
 
 // ToDo: fix me
-import Component from '/path/to/component.solid'
+import Component from '/path/to/component.tsx'
 
 describe('solid component tests', () => {
     const ref = document.createElement('div')

--- a/packages/wdio-cli/tests/interface.test.ts
+++ b/packages/wdio-cli/tests/interface.test.ts
@@ -123,23 +123,6 @@ describe('cli interface', () => {
         expect(wdioClInterface.emit).toBeCalledWith('job:start', 'content')
     })
 
-    it('should print reporter messages in watch mode', () => {
-        wdioClInterface['_isWatchMode'] = true
-        wdioClInterface.printReporters = vi.fn()
-
-        wdioClInterface.onMessage({
-            origin: 'reporter',
-            name: 'foo',
-            content: 'bar'
-        })
-
-        expect(wdioClInterface.printReporters).toBeCalledTimes(1)
-        expect(wdioClInterface['_messages']).toEqual({
-            ...EMPTY_INTERFACE_MESSAGE_OBJECT,
-            reporter: { foo: ['bar'] }
-        })
-    })
-
     it('should not store any other messages', () => {
         wdioClInterface.printReporters = vi.fn()
 
@@ -344,17 +327,26 @@ describe('cli interface', () => {
     })
 
     describe('sigintTrigger', () => {
+        const runningErrorMessage = 'Ending WebDriver sessions gracefully'
         it('should print message with jobs', () => {
             wdioClInterface['_jobs'].set('0-0', {
                 caps: { browserName: 'foo' },
                 specs: ['bar'],
                 hasTests: true
             })
-            expect(wdioClInterface.sigintTrigger()[0]).toContain('Ending WebDriver sessions gracefully')
+            expect((wdioClInterface.sigintTrigger() as any)[0])
+                .toContain(runningErrorMessage)
+        })
+
+        it('should print message when in watch mode', () => {
+            wdioClInterface['_isWatchMode'] = true
+            expect((wdioClInterface.sigintTrigger() as any)[0])
+                .toContain(runningErrorMessage)
         })
 
         it('should print message without jobs', () => {
-            expect(wdioClInterface.sigintTrigger()[0]).toContain('Ended WebDriver sessions gracefully')
+            expect((wdioClInterface.sigintTrigger() as any)[0])
+                .toContain('Ended WebDriver sessions gracefully')
         })
 
         it('should do nothing in debug mode', () => {
@@ -386,15 +378,6 @@ describe('cli interface', () => {
             wdioClInterface.finalise()
             expect(wdioClInterface.printReporters).toBeCalledTimes(1)
             expect(wdioClInterface.printSummary).toBeCalledTimes(1)
-        })
-
-        it('finalise should do nothing in watch mode', () => {
-            wdioClInterface['_isWatchMode'] = true
-            wdioClInterface.printReporters = vi.fn()
-            wdioClInterface.printSummary = vi.fn()
-            wdioClInterface.finalise()
-            expect(wdioClInterface.printReporters).toBeCalledTimes(0)
-            expect(wdioClInterface.printSummary).toBeCalledTimes(0)
         })
     })
 

--- a/packages/wdio-cli/tests/launcher.test.ts
+++ b/packages/wdio-cli/tests/launcher.test.ts
@@ -35,6 +35,7 @@ describe('launcher', () => {
         launcher = new Launcher('./')
         launcher.interface = {
             onMessage: vi.fn(),
+            finalise: vi.fn(),
             emit: vi.fn(),
             sigintTrigger: vi.fn()
         } as any
@@ -200,6 +201,7 @@ describe('launcher', () => {
             launcher['_resolve'] = vi.fn()
             await launcher.endHandler({ cid: '0-1', exitCode: 0 } as any)
             expect(launcher.interface!.emit).toBeCalledWith('job:end', { cid: '0-1', passed: true })
+            expect(launcher.interface?.finalise).toBeCalledTimes(0)
             expect(launcher['_resolve']).toBeCalledTimes(0)
         })
 
@@ -211,6 +213,7 @@ describe('launcher', () => {
             launcher['_resolve'] = vi.fn()
             await launcher.endHandler({ cid: '0-1', exitCode: 1 } as any)
             expect(launcher.interface!.emit).toBeCalledWith('job:end', { cid: '0-1', passed: false })
+            expect(launcher.interface?.finalise).toBeCalledTimes(1)
             expect(launcher['_resolve']).toBeCalledTimes(0)
         })
 

--- a/packages/wdio-local-runner/src/worker.ts
+++ b/packages/wdio-local-runner/src/worker.ts
@@ -168,6 +168,7 @@ export default class WorkerInstance extends EventEmitter implements Workers.Work
             } else {
                 this.sessionId = payload.content.sessionId
                 this.capabilities = payload.content.capabilities
+                Object.assign(this.config, payload.content)
             }
         }
 

--- a/packages/wdio-local-runner/src/worker.ts
+++ b/packages/wdio-local-runner/src/worker.ts
@@ -48,8 +48,11 @@ export default class WorkerInstance extends EventEmitter implements Workers.Work
     isMultiremote?: boolean
 
     isBusy = false
+    isKilled = false
     isReady: Promise<boolean>
+    isSetup: Promise<boolean>
     isReadyResolver: (value: boolean | PromiseLike<boolean>) => void = () => {}
+    isSetupResolver: (value: boolean | PromiseLike<boolean>) => void = () => {}
 
     /**
      * assigns paramters to scope of instance
@@ -79,9 +82,8 @@ export default class WorkerInstance extends EventEmitter implements Workers.Work
         this.stdout = stdout
         this.stderr = stderr
 
-        this.isReady = new Promise((resolve) => {
-            this.isReadyResolver = resolve
-        })
+        this.isReady = new Promise((resolve) => { this.isReadyResolver = resolve })
+        this.isSetup = new Promise((resolve) => { this.isSetupResolver = resolve })
     }
 
     /**
@@ -163,6 +165,7 @@ export default class WorkerInstance extends EventEmitter implements Workers.Work
          * store sessionId and connection data to worker instance
          */
         if (payload.name === 'sessionStarted') {
+            this.isSetupResolver(true)
             if (payload.content.isMultiremote) {
                 Object.assign(this, payload.content)
             } else {
@@ -208,6 +211,7 @@ export default class WorkerInstance extends EventEmitter implements Workers.Work
          */
         delete this.childProcess
         this.isBusy = false
+        this.isKilled = true
 
         log.debug(`Runner ${cid} finished with exit code ${exitCode}`)
         this.emit('exit', { cid, exitCode, specs, retries })
@@ -222,7 +226,7 @@ export default class WorkerInstance extends EventEmitter implements Workers.Work
      * @param  command  method to run in wdio-runner
      * @param  args     arguments for functions to call
      */
-    postMessage (command: string, args: Workers.WorkerMessageArgs): void {
+    postMessage (command: string, args: Workers.WorkerMessageArgs, requiresSetup = false): void {
         const { cid, configFile, capabilities, specs, retries, isBusy } = this
 
         if (isBusy && !ACCEPTABLE_BUSY_COMMANDS.includes(command)) {
@@ -239,7 +243,13 @@ export default class WorkerInstance extends EventEmitter implements Workers.Work
 
         const cmd: Workers.WorkerCommand = { cid, command, configFile, args, caps: capabilities, specs, retries }
         log.debug(`Send command ${command} to worker with cid "${cid}"`)
-        this.isReady.then(() => this.childProcess!.send(cmd))
+        this.isReady.then(async () => {
+            if (requiresSetup) {
+                await this.isSetup
+            }
+
+            this.childProcess!.send(cmd)
+        })
         this.isBusy = true
     }
 }

--- a/packages/wdio-runner/src/browser.ts
+++ b/packages/wdio-runner/src/browser.ts
@@ -110,6 +110,17 @@ export default class BrowserFramework implements Omit<TestFramework, 'init'> {
             ])
 
             /**
+             * start framework execution
+             */
+            await browser.execute(() => {
+                const mochaFramework: any = document.querySelector('mocha-framework')
+                if (!mochaFramework) {
+                    throw new Error('Mocha framework not set-up in the browser!')
+                }
+                mochaFramework.run()
+            })
+
+            /**
              * wait for test results or page errors
              */
             let state: TestState = {}

--- a/packages/wdio-runner/src/browser.ts
+++ b/packages/wdio-runner/src/browser.ts
@@ -110,17 +110,6 @@ export default class BrowserFramework implements Omit<TestFramework, 'init'> {
             ])
 
             /**
-             * start framework execution
-             */
-            await browser.execute(() => {
-                const mochaFramework: any = document.querySelector('mocha-framework')
-                if (!mochaFramework) {
-                    throw new Error('Mocha framework not set-up in the browser!')
-                }
-                mochaFramework.run()
-            })
-
-            /**
              * wait for test results or page errors
              */
             let state: TestState = {}

--- a/packages/wdio-runner/src/utils.ts
+++ b/packages/wdio-runner/src/utils.ts
@@ -64,8 +64,14 @@ export async function initialiseInstance (
         /**
          * propagate connection details defined by services or user in capabilities
          */
-        const { protocol, hostname, port, path } = capabilities as Capabilities.Capabilities
-        return attach({ ...config, ...{ protocol, hostname, port, path }, capabilities } as Required<ConfigWithSessionId>)
+        const caps = capabilities as Capabilities.Capabilities
+        const connectionProps = {
+            protocol: caps.protocol || config.protocol,
+            hostname: caps.hostname || config.hostname,
+            port: caps.port || config.port,
+            path: caps.path || config.path
+        }
+        return attach({ ...config, ...connectionProps, capabilities } as Required<ConfigWithSessionId>)
     }
 
     if (!isMultiremote) {


### PR DESCRIPTION
## Proposed changes

It turns out that there is a race condition when Mocha tries to start the test without the worker process being ready and initialised. This patch is an attempt to fix that.

fixes #9612
fixes #9608

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

Missing for this to land:

- ~find a better approach to auto trigger or wait for the browser runner: if we let the browser runner trigger the framework to start, we loose the ability to re-run tests through hot reload (e.g. due to changes to the component)~
- ~let's add smoke tests to ensure we test watch capabilities~ created new issue for it: https://github.com/webdriverio/webdriverio/issues/9974

### Reviewers: @webdriverio/project-committers
