### PR TITLE
chore(docs): use -- for selenium args in Selenium Standalone Service

### DIFF
--- a/packages/wdio-selenium-standalone-service/README.md
+++ b/packages/wdio-selenium-standalone-service/README.md
@@ -71,7 +71,7 @@ export const config = {
             logPath: './temp',
             args: {
                 version: "3.141.59",
-                seleniumArgs: ['-host', '127.0.0.1','-port', '5555']
+                seleniumArgs: ['--host', '127.0.0.1','--port', '5555']
             },
         }]
     ],


### PR DESCRIPTION
## Proposed changes
After Selenium4, "--" is used to specify selenium args instead of "-"
If you use just "-", no parse args error is thrown but args are not taken into account, so I think is better to use "--" to match latest Selenium versions

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
