### PR TITLE
webdriverio: Add missing specFileRetries* to WDIO_DEFAULTS

### DIFF
--- a/packages/webdriverio/src/constants.ts
+++ b/packages/webdriverio/src/constants.ts
@@ -296,6 +296,24 @@ export const WDIO_DEFAULTS: Options.Definition<Options.WebdriverIO & Options.Tes
         type: 'boolean'
     },
     /**
+     * The number of times to retry the entire specfile when it fails as a whole
+     */
+    specFileRetries: {
+        type: 'number'
+    },
+    /**
+     * Delay in seconds between the spec file retry attempts
+     */
+    specFileRetriesDelay: {
+        type: 'number'
+    },
+    /**
+     * Whether or not retried specfiles should be retried immediately or deferred to the end of the queue
+     */
+    specFileRetriesDeferred: {
+        type: 'boolean'
+    },
+    /**
      * list of strings to watch of `wdio` command is called with `--watch` flag
      */
     filesToWatch: {

--- a/packages/webdriverio/src/constants.ts
+++ b/packages/webdriverio/src/constants.ts
@@ -313,7 +313,8 @@ export const WDIO_DEFAULTS: Options.Definition<Options.WebdriverIO & Options.Tes
      * Whether or not retried specfiles should be retried immediately or deferred to the end of the queue
      */
     specFileRetriesDeferred: {
-        type: 'boolean'
+        type: 'boolean',
+        default: true
     },
     /**
      * list of strings to watch of `wdio` command is called with `--watch` flag

--- a/packages/webdriverio/src/constants.ts
+++ b/packages/webdriverio/src/constants.ts
@@ -299,7 +299,8 @@ export const WDIO_DEFAULTS: Options.Definition<Options.WebdriverIO & Options.Tes
      * The number of times to retry the entire specfile when it fails as a whole
      */
     specFileRetries: {
-        type: 'number'
+        type: 'number',
+        default: 0
     },
     /**
      * Delay in seconds between the spec file retry attempts

--- a/packages/webdriverio/src/constants.ts
+++ b/packages/webdriverio/src/constants.ts
@@ -306,7 +306,8 @@ export const WDIO_DEFAULTS: Options.Definition<Options.WebdriverIO & Options.Tes
      * Delay in seconds between the spec file retry attempts
      */
     specFileRetriesDelay: {
-        type: 'number'
+        type: 'number',
+        default: 0
     },
     /**
      * Whether or not retried specfiles should be retried immediately or deferred to the end of the queue


### PR DESCRIPTION
## Proposed changes

Fixes [10020](https://github.com/webdriverio/webdriverio/issues/10020)

I couldn't find a place to add tests for this change. Let me know if there is a place to add them.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

### Reviewers: @webdriverio/project-committers
