### PR TITLE
Allow selectors to further search for elements by text and tag name

### DIFF
--- a/e2e/browser-runner/lit.test.js
+++ b/e2e/browser-runner/lit.test.js
@@ -122,6 +122,27 @@ describe('Lit Component testing', () => {
             expect(await $('div*=me').getHTML(false)).toBe('Find me')
         })
 
+        it('fetches the parent element by content correctly', async () => {
+            render(
+                html`<button><span>Click Me!</span></button>`,
+                document.body
+            )
+            expect(await $('span=Click Me!').getHTML(false)).toBe('Click Me!')
+            expect(await $('button=Click Me!').getHTML(false)).toBe('<span>Click Me!</span>')
+            const elem = $('button=Click Me!')
+            await expect(elem).toHaveText('Click Me!')
+        })
+
+        it('fetches the element with multiple text nodes by the content', async () => {
+            render(
+                html`<p>
+                Find
+                me</p>`, document.body
+            )
+            const elem = await $('p=Find me')
+            await expect(elem).toHaveText('Find me')
+        })
+
         it('fetches element by JS function', async () => {
             expect((await $(() => document.body).getTagName()).toLowerCase()).toBe('body')
         })

--- a/e2e/browser-runner/lit.test.js
+++ b/e2e/browser-runner/lit.test.js
@@ -134,11 +134,10 @@ describe('Lit Component testing', () => {
         })
 
         it('fetches the element with multiple text nodes by the content', async () => {
-            render(
-                html`<p>
-                Find
-                me</p>`, document.body
-            )
+            const container = document.createElement('p')
+            container.appendChild(document.createTextNode('Find'))
+            container.appendChild(document.createTextNode(' me'))
+            render(container, document.body)
             const elem = await $('p=Find me')
             await expect(elem).toHaveText('Find me')
         })

--- a/packages/webdriverio/src/utils/findStrategy.ts
+++ b/packages/webdriverio/src/utils/findStrategy.ts
@@ -246,7 +246,7 @@ export const findStrategy = function (selector: SelectorStrategy, isW3C?: boolea
             throw new Error(`InvalidSelectorMatch: Strategy 'xpath extended' has failed to match '${stringSelector}'`)
         }
         const PREFIX_NAME: Record<string, string> = { '.': 'class', '#': 'id' }
-        const conditions = []
+        const conditions: Array<string> = []
         const [
             tag,
             prefix, name,
@@ -267,7 +267,16 @@ export const findStrategy = function (selector: SelectorStrategy, isW3C?: boolea
         conditions.push(
             partial ? `contains(text(), "${query}")` : `normalize-space(text()) = "${query}"`
         )
-        value = `.//${tag || '*'}[${conditions.join(' and ')}]`
+        const getValue = () => `.//${tag || '*'}[${conditions.join(' and ')}]`
+        value = getValue()
+        if (!partial) {
+            conditions.pop()
+            conditions.push(
+                `not(${value})`,
+                `normalize-space() = "${query}"`
+            )
+            value = value + ' | ' + getValue()
+        }
         break
     }
     case '-image': {

--- a/packages/webdriverio/tests/findStrategy.test.ts
+++ b/packages/webdriverio/tests/findStrategy.test.ts
@@ -95,13 +95,13 @@ describe('selector strategies helper', () => {
     it('should find an element by tag name + content', () => {
         const element = findStrategy('div=some random text with "§$%&/()div=or others')
         expect(element.using).toBe('xpath')
-        expect(element.value).toBe('.//div[normalize-space(text()) = "some random text with "§$%&/()div=or others"]')
+        expect(element.value).toBe('.//div[normalize-space(text()) = "some random text with "§$%&/()div=or others"] | .//div[not(.//div[normalize-space(text()) = "some random text with "§$%&/()div=or others"]) and normalize-space() = "some random text with "§$%&/()div=or others"]')
     })
 
     it('should find an element by tag name + id + similar content', () => {
         const element = findStrategy('h1=Christian')
         expect(element.using).toBe('xpath')
-        expect(element.value).toBe('.//h1[normalize-space(text()) = "Christian"]')
+        expect(element.value).toBe('.//h1[normalize-space(text()) = "Christian"] | .//h1[not(.//h1[normalize-space(text()) = "Christian"]) and normalize-space() = "Christian"]')
     })
 
     it('should find an element by tag name + similar content', () => {
@@ -113,13 +113,13 @@ describe('selector strategies helper', () => {
     it('should find an element by tag name + class + content', () => {
         const element = findStrategy('div.some-class=some random text with "§$%&/()div=or others')
         expect(element.using).toBe('xpath')
-        expect(element.value).toBe('.//div[contains(@class, "some-class") and normalize-space(text()) = "some random text with "§$%&/()div=or others"]')
+        expect(element.value).toBe('.//div[contains(@class, "some-class") and normalize-space(text()) = "some random text with "§$%&/()div=or others"] | .//div[contains(@class, "some-class") and not(.//div[contains(@class, "some-class") and normalize-space(text()) = "some random text with "§$%&/()div=or others"]) and normalize-space() = "some random text with "§$%&/()div=or others"]')
     })
 
     it('should find an element class + content', () => {
         const element = findStrategy('.some-class=some random text with "§$%&/()div=or others')
         expect(element.using).toBe('xpath')
-        expect(element.value).toBe('.//*[contains(@class, "some-class") and normalize-space(text()) = "some random text with "§$%&/()div=or others"]')
+        expect(element.value).toBe('.//*[contains(@class, "some-class") and normalize-space(text()) = "some random text with "§$%&/()div=or others"] | .//*[contains(@class, "some-class") and not(.//*[contains(@class, "some-class") and normalize-space(text()) = "some random text with "§$%&/()div=or others"]) and normalize-space() = "some random text with "§$%&/()div=or others"]')
     })
 
     it('should find an element by tag name + class + similar content', () => {
@@ -137,13 +137,13 @@ describe('selector strategies helper', () => {
     it('should find an element by tag name + id + content', () => {
         const element = findStrategy('div#some-class=some random text with "§$%&/()div=or others')
         expect(element.using).toBe('xpath')
-        expect(element.value).toBe('.//div[contains(@id, "some-class") and normalize-space(text()) = "some random text with "§$%&/()div=or others"]')
+        expect(element.value).toBe('.//div[contains(@id, "some-class") and normalize-space(text()) = "some random text with "§$%&/()div=or others"] | .//div[contains(@id, "some-class") and not(.//div[contains(@id, "some-class") and normalize-space(text()) = "some random text with "§$%&/()div=or others"]) and normalize-space() = "some random text with "§$%&/()div=or others"]')
     })
 
     it('should find an element by id + content', () => {
         const element = findStrategy('#some-class=some random text with "§$%&/()div=or others')
         expect(element.using).toBe('xpath')
-        expect(element.value).toBe('.//*[contains(@id, "some-class") and normalize-space(text()) = "some random text with "§$%&/()div=or others"]')
+        expect(element.value).toBe('.//*[contains(@id, "some-class") and normalize-space(text()) = "some random text with "§$%&/()div=or others"] | .//*[contains(@id, "some-class") and not(.//*[contains(@id, "some-class") and normalize-space(text()) = "some random text with "§$%&/()div=or others"]) and normalize-space() = "some random text with "§$%&/()div=or others"]')
     })
 
     it('should find an element by tag name + id + similar content', () => {
@@ -167,19 +167,19 @@ describe('selector strategies helper', () => {
     it('should find an element by tag name + attribute + content', () => {
         const element = findStrategy('div[some-attribute="some-value"]=some random text with "§$%&/()div=or others')
         expect(element.using).toBe('xpath')
-        expect(element.value).toBe('.//div[contains(@some-attribute, "some-value") and normalize-space(text()) = "some random text with "§$%&/()div=or others"]')
+        expect(element.value).toBe('.//div[contains(@some-attribute, "some-value") and normalize-space(text()) = "some random text with "§$%&/()div=or others"] | .//div[contains(@some-attribute, "some-value") and not(.//div[contains(@some-attribute, "some-value") and normalize-space(text()) = "some random text with "§$%&/()div=or others"]) and normalize-space() = "some random text with "§$%&/()div=or others"]')
     })
 
     it('should find an element by attribute + content', () => {
         const element = findStrategy('[some-attribute="some-value"]=some random text with "§$%&/()div=or others')
         expect(element.using).toBe('xpath')
-        expect(element.value).toBe('.//*[contains(@some-attribute, "some-value") and normalize-space(text()) = "some random text with "§$%&/()div=or others"]')
+        expect(element.value).toBe('.//*[contains(@some-attribute, "some-value") and normalize-space(text()) = "some random text with "§$%&/()div=or others"] | .//*[contains(@some-attribute, "some-value") and not(.//*[contains(@some-attribute, "some-value") and normalize-space(text()) = "some random text with "§$%&/()div=or others"]) and normalize-space() = "some random text with "§$%&/()div=or others"]')
     })
 
     it('should find an element by attribute existence + content', () => {
         const element = findStrategy('[some-attribute]=some random text with "§$%&/()div=or others')
         expect(element.using).toBe('xpath')
-        expect(element.value).toBe('.//*[@some-attribute and normalize-space(text()) = "some random text with "§$%&/()div=or others"]')
+        expect(element.value).toBe('.//*[@some-attribute and normalize-space(text()) = "some random text with "§$%&/()div=or others"] | .//*[@some-attribute and not(.//*[@some-attribute and normalize-space(text()) = "some random text with "§$%&/()div=or others"]) and normalize-space() = "some random text with "§$%&/()div=or others"]')
     })
 
     it('should find an element by tag name + attribute + similar content', () => {
@@ -197,7 +197,7 @@ describe('selector strategies helper', () => {
     it('should find an custom element by tag name + content', () => {
         const element = findStrategy('custom-element-with-multiple-dashes=some random text with "§$%&/()div=or others')
         expect(element.using).toBe('xpath')
-        expect(element.value).toBe('.//custom-element-with-multiple-dashes[normalize-space(text()) = "some random text with "§$%&/()div=or others"]')
+        expect(element.value).toBe('.//custom-element-with-multiple-dashes[normalize-space(text()) = "some random text with "§$%&/()div=or others"] | .//custom-element-with-multiple-dashes[not(.//custom-element-with-multiple-dashes[normalize-space(text()) = "some random text with "§$%&/()div=or others"]) and normalize-space() = "some random text with "§$%&/()div=or others"]')
     })
 
     it('should allow to go up and down the DOM tree with xpath', () => {


### PR DESCRIPTION
## Proposed changes

Aims to solve Issue: #10040.

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [X] I have added proper type definitions for new commands (if appropriate)

## Further comments

Currently, for selecting an element by Tag Name and Content, we are following the XPath of the form: ``.//{'*' if not tag else tag}[normalize-space(text()) = "{text}"]``

Example: `.//span[normalize-space(text()) = "Sign in"]`

It fetches the text specific to that node and normalizes 
it.  but we would not be able to find the parent element as it might have some child nodes. 

```html
<button><span>Click Me!</span></button>
```

In order to select the element *Button*, we cannot have the selector: `$("button=Click Me!")` to select the button. but we can select *span* with a similar syntax: `$("span=Click Me!")`.

#### Suggestion: 

If we would have used the following XPath expression of the form: ``.//{'*' if not tag else tag}[normalize-space() = "{text}"]``

Example: `.//button[normalize-space() = "Click Me!"]`

we can select both button and span based on our request. as it is converting the text (inside of its child nodes if exists) and normalizes it.

But that had an edge case:

```html
<div class="not-me">
 <div class="sub">
  <div class="main">
   Deep
  </div>
 </div>
</div>
```

Selector: `$(div=Deep)` would select all the *div s* with "not-me' as the first found. Expected result is the *div* with class "main". But the Current Implementation would select the right selector.

So the Fix is to cater to both the type of scenarios. keeping the current implementation as stricter part and the suggestion as the looser part.

Suggested Selector is form: `.//tag[normalize-space(text()) = "text"] | .//tag[not(.//tag[normalize-space(text()) = "text"]) and normalize-space() = "text"]`

Explanation

1. Look for the expression: `.//tag[normalize-space(text()) = "text"]` and if it exists,
   * `not(.//tag[normalize-space(text()) = "text"]` becomes false so right side of union operator is null
   * we pick only the left side which is `.//tag[normalize-space(text()) = "text"]` _same as existing implemetation_
2. If `.//tag[normalize-space(text()) = "text"]` doesn't exist,
   * then right side of the union operator is `.//tag[true and normalize-space(text()) = "text"]`

### Reviewers: @webdriverio/project-committers
