### PR TITLE
[🐛 Bug]: browser runner - `alert` or `confirm` stales execution of runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,8 +7,6 @@ on:
     branches:
       - main
       - v7
-    branches-ignore:
-      - l10n_main
   pull_request:
     branches-ignore:
       - l10n_main

--- a/e2e/browser-runner/lit.test.js
+++ b/e2e/browser-runner/lit.test.js
@@ -8,7 +8,6 @@ import namespacedModule from '@namespace/module'
 import { someExport, namedExports } from '@testing-library/user-event'
 
 import { SimpleGreeting } from './components/LitComponent.ts'
-import { it } from 'node:test'
 
 const getQuestionFn = spyOn(SimpleGreeting.prototype, 'getQuestion')
 mock('./components/constants.ts', async (getOrigModule) => {

--- a/e2e/browser-runner/lit.test.js
+++ b/e2e/browser-runner/lit.test.js
@@ -8,6 +8,7 @@ import namespacedModule from '@namespace/module'
 import { someExport, namedExports } from '@testing-library/user-event'
 
 import { SimpleGreeting } from './components/LitComponent.ts'
+import { it } from 'node:test'
 
 const getQuestionFn = spyOn(SimpleGreeting.prototype, 'getQuestion')
 mock('./components/constants.ts', async (getOrigModule) => {
@@ -110,6 +111,13 @@ describe('Lit Component testing', () => {
             'I am within another shadow root element',
             'I am within another shadow root element as well'
         ])
+    })
+
+    it('should not stale process due to alert or prompt', async () => {
+        alert('test')
+        prompt('test')
+        confirm('test')
+        await expect(browser).toHaveTitle('WebdriverIO Browser Test')
     })
 
     describe('Selector Tests', () => {

--- a/packages/wdio-browser-runner/src/browser/setup.ts
+++ b/packages/wdio-browser-runner/src/browser/setup.ts
@@ -5,6 +5,7 @@ import { remote } from 'webdriverio'
 import { _setGlobal } from '@wdio/globals'
 
 import './frameworks/mocha.js'
+import { showPopupWarning } from './utils.js'
 import type { MochaFramework } from './frameworks/mocha'
 
 type WDIOErrorEvent = Pick<ErrorEvent, 'filename' | 'message'>
@@ -20,6 +21,10 @@ declare global {
         __wdioMockFactories__: Record<string, any>
     }
 }
+
+globalThis.alert = showPopupWarning('alert', undefined)
+globalThis.confirm = showPopupWarning('confirm', false, true)
+globalThis.prompt = showPopupWarning('prompt', null, 'your value')
 
 /**
  * create connection to Vite server

--- a/packages/wdio-browser-runner/src/browser/utils.ts
+++ b/packages/wdio-browser-runner/src/browser/utils.ts
@@ -1,4 +1,4 @@
-export function getCID () {
+export function getCID() {
     const urlParamString = new URLSearchParams(window.location.search)
     return (
         // initial request contains cid as query parameter
@@ -10,4 +10,18 @@ export function getCID () {
             .split('=')
             .pop()
     )
+}
+
+export const showPopupWarning = <T>(name: string, value: T, defaultValue?: T) => (...params: any[]) => {
+    const formatedParams = params.map(p => JSON.stringify(p)).join(', ')
+
+    console.warn(`WebdriverIO encountered a \`${name}(${formatedParams})\` call that it cannot handle by default, so it returned \`${value}\`. Read more in https://webdriver.io/docs/runner#limitations.
+  If needed, mock the \`${name}\` call manually like:
+  \`\`\`
+  import { spyOn } from "@wdio/browser-runner"
+  spyOn(window, "${name}")${defaultValue ? `.mockReturnValue(${JSON.stringify(defaultValue)})` : ''}
+  ${name}(${formatedParams})
+  expect(${name}).toHaveBeenCalledWith(${formatedParams})
+  \`\`\``)
+    return value
 }

--- a/packages/wdio-browser-runner/tests/browser/utils.test.ts
+++ b/packages/wdio-browser-runner/tests/browser/utils.test.ts
@@ -1,0 +1,23 @@
+import { vi, describe, it, beforeAll, afterAll, expect } from 'vitest'
+import { showPopupWarning } from '../../src/browser/utils.js'
+
+describe('browser utils', () => {
+    const consoleWarn = console.warn.bind(console)
+    beforeAll(() => {
+        console.warn = vi.fn()
+        globalThis.alert = showPopupWarning('alert', undefined)
+        globalThis.confirm = showPopupWarning('confirm', false, true)
+        globalThis.prompt = showPopupWarning('prompt', null, 'your value')
+    })
+
+    it('showPopupWarning', () => {
+        expect(alert('test')).toBeUndefined()
+        expect(prompt('test')).toBeNull()
+        expect(confirm('test')).toBe(false)
+        expect(console.warn).toBeCalledTimes(3)
+    })
+
+    afterAll(() => {
+        console.warn = consoleWarn
+    })
+})

--- a/website/docs/Runner.md
+++ b/website/docs/Runner.md
@@ -260,6 +260,12 @@ Threshold for statements.
 __Type:__ `number`<br />
 __Default:__ `undefined`
 
+### Limitations
+
+When using the WebdriverIO browser runner, it's important to note that thread blocking dialogs like `alert` or `confirm` cannot be used natively. This is because they block the web page, which means WebdriverIO cannot continue communicating with the page, causing the execution to hang.
+
+In such situations, WebdriverIO provides default mocks with default returned values for these APIs. This ensures that if the user accidentally uses synchronous popup web APIs, the execution would not hang. However, it's still recommended for the user to mock these web APIs for better experience. Read more in [Mocking](/docs/component-testing/mocking).
+
 ### Examples
 
 Make sure to check out the docs around [component testing](https://webdriver.io/docs/component-testing) and have a look into the [example repository](https://github.com/webdriverio/component-testing-examples) for examples using these and various other frameworks.


### PR DESCRIPTION
### Have you read the Contributing Guidelines on issues?

- [X] I have read the [Contributing Guidelines on issues](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md#reporting-new-issues).

### WebdriverIO Version

latest

### Node.js Version

latest

### Mode

WDIO Testrunner

### Which capabilities are you using?

```typescript
any
```


### What happened?

When an `alert` or `confirm` is triggered in the browser, all execution comes to an halt. This causes also the test to stop and it is impossible for the user to resume without manually interacting with the browser

### What is your expected behavior?

Have these methods mocked automatically to avoid this edge case.

### How to reproduce the bug.

n/a

### Relevant log output

```typescript
n/a
```


### Code of Conduct

- [X] I agree to follow this project's Code of Conduct

### Is there an existing issue for this?

- [X] I have searched the existing issues