### PR TITLE
devtools: Attempt to rerun command before waiting for a page load (that might timeout)

### DIFF
--- a/packages/devtools/tests/__snapshots__/devtoolsdriver.test.ts.snap
+++ b/packages/devtools/tests/__snapshots__/devtoolsdriver.test.ts.snap
@@ -24,6 +24,53 @@ Map {
 }
 `;
 
+exports[`should rerun command 3 times before attempting to wait for page load 1`] = `
+[
+  [
+    "command",
+    {
+      "command": "elementClick",
+      "params": {
+        "elementId": "123",
+        "text": "some text",
+        "value": [
+          "some value",
+        ],
+      },
+      "retries": 0,
+    },
+  ],
+  [
+    "command",
+    {
+      "command": "elementClick",
+      "params": {
+        "elementId": "123",
+        "text": "some text",
+        "value": [
+          "some value",
+        ],
+      },
+      "retries": 1,
+    },
+  ],
+  [
+    "command",
+    {
+      "command": "elementClick",
+      "params": {
+        "elementId": "123",
+        "text": "some text",
+        "value": [
+          "some value",
+        ],
+      },
+      "retries": 2,
+    },
+  ],
+]
+`;
+
 exports[`should rerun command if it was executed within navigation 1`] = `
 [
   [


### PR DESCRIPTION
## Proposed changes

When using `automationProtocol` `devtools` sometimes the Pupeteer execution context is destroyed.
Currently, when that happens, we attempt to wait for a page loaded event to be emitted, after it is emitted, we retry the command. I recently discovered a case where the page load is never emitted, therefore the tests would hang for a long time and then finally error with
```ts
Error: page load timeout
    at Timeout._onTimeout (file:///opt/atlassian/pipelines/agent/build/e2e/node_modules/devtools/build/devtoolsdriver.js:141:73)
    at listOnTimeout (node:internal/timers:568:17)
    at processTimers (node:internal/timers:511:7)
```

This same use case also benefits from an immediate retry of the command.
When rerun (without first waiting for the page load that is never emitted) the command successfully executes and returns the desired result.

I've implemented a 3 retry limit for a command, therefore the previous behavior is maintained but only after attempting the command again a couple of times.

You can see a demo for this with the actual use case in question.

https://user-images.githubusercontent.com/3788982/228007306-e09bbdf0-d662-4b81-80b7-0d04c0b39430.mov

Nothing was mocked for this demo, a real test executes a command with a destroyed context and then recovers after rerunning the command. This same demo would hang eventually with `Error: page load timeout` if these changes were not implemented, as the page load is never completed.

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
