### PR TITLE
Expand type of otherApps capability 

### DIFF
--- a/packages/wdio-types/src/Capabilities.ts
+++ b/packages/wdio-types/src/Capabilities.ts
@@ -578,7 +578,7 @@ export interface AppiumAndroidCapabilities {
     skipLogcatCapture?: boolean;
     uninstallOtherPackages?: string;
     disableWindowAnimation?: boolean;
-    otherApps?: string;
+    otherApps?: string | string[];
     uiautomator2ServerLaunchTimeout?: number;
     uiautomator2ServerInstallTimeout?: number;
     skipServerInstallation?: boolean;
@@ -722,7 +722,7 @@ export interface AppiumXCUITestCapabilities {
     'appium:permissions'?: string;
     'appium:screenshotQuality'?: number;
     'appium:wdaEventloopIdleDelay'?: number;
-    'appium:otherApps'?: string;
+    'appium:otherApps'?: string | string[];
     'appium:includeSafariInWebviews'?: boolean;
     'appium:additionalWebviewBundleIds'?: Array<string>;
     'appium:webviewConnectTimeout'?: number;


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)
Appium allows `otherApps` to be either a string or an array of strings. When running tests on Browserstack, `otherApps` has to be passed as an array.

Currently this causes a type error:
```js
wdio.remote({ capabilities: {'appium:otherApps': ["/path/to/app"]} })`
```

but passing a string with Browserstack results in an error:

https://www.browserstack.com/question/39479


## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
