### PR TITLE
Fix ScrollIntoView - DeltaX and DeltaY should be rounded

### DIFF
--- a/packages/webdriverio/src/commands/element/scrollIntoView.ts
+++ b/packages/webdriverio/src/commands/element/scrollIntoView.ts
@@ -83,6 +83,9 @@ export async function scrollIntoView (
         }
     }
 
+    deltaX = Math.round(deltaX)
+    deltaY = Math.round(deltaY)
+
     try {
         return await browser.action('wheel')
             .scroll({ duration: 200, deltaX, deltaY })


### PR DESCRIPTION
## Proposed changes

```
ERROR webdriver: Request failed with status 400 due to invalid argument: invalid argument
[0-0] from invalid argument: 'delta x' must be an int
[0-0]   (Session info: chrome=111.0.5563.64)
```

deltaX and deltaY should be rounded values

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works

- Ran Tests locally. They were fine.

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
