### PR TITLE
Have better internal API for shared store

### DIFF
--- a/packages/wdio-shared-store-service/src/client.ts
+++ b/packages/wdio-shared-store-service/src/client.ts
@@ -2,7 +2,7 @@ import type { RequestError } from 'got'
 import got from 'got'
 
 import type { JsonCompatible, JsonPrimitive, JsonObject, JsonArray } from '@wdio/types'
-import type { GetValueOptions } from 'src'
+import type { GetValueOptions } from './types'
 
 let baseUrlResolve: Parameters<ConstructorParameters<typeof Promise>[0]>[0]
 const baseUrlPromise = new Promise<string>((resolve) => {
@@ -27,7 +27,7 @@ export const setPort = (port: number) => {
  */
 export const getValue = async (key: string): Promise<string | number | boolean | JsonObject | JsonArray | null | undefined> => {
     const baseUrl = await baseUrlPromise
-    const res = await got.post(`${baseUrl}/get`, { json: { key }, responseType: 'json' }).catch(errHandler)
+    const res = await got.get(`${baseUrl}/${key}`).catch(errHandler)
     return res?.body ? (res.body as JsonObject).value : undefined
 }
 
@@ -38,7 +38,7 @@ export const getValue = async (key: string): Promise<string | number | boolean |
  */
 export const setValue = async (key: string, value: JsonCompatible | JsonPrimitive) => {
     const setPromise = baseUrlPromise.then((baseUrl) => {
-        return got.post(`${baseUrl}/set`, { json: { key, value } }).catch(errHandler)
+        return got.post(`${baseUrl}/`, { json: { key, value } }).catch(errHandler)
     })
 
     return isBaseUrlReady ? setPromise : Promise.resolve()
@@ -51,7 +51,7 @@ export const setValue = async (key: string, value: JsonCompatible | JsonPrimitiv
  */
 export const setResourcePool = async (key: string, value: JsonArray) => {
     const setPromise = baseUrlPromise.then((baseUrl) => {
-        return got.post(`${baseUrl}/pool/set`, { json: { key, value } }).catch(errHandler)
+        return got.post(`${baseUrl}/pool`, { json: { key, value } }).catch(errHandler)
     })
 
     return isBaseUrlReady ? setPromise : Promise.resolve()
@@ -64,7 +64,7 @@ export const setResourcePool = async (key: string, value: JsonArray) => {
  */
 export const getValueFromPool = async (key: string, options: GetValueOptions) => {
     const baseUrl = await baseUrlPromise
-    const res = await got.get(`${baseUrl}/pool/get/${key}${options?.timeout ? `?timeout=${options.timeout}` : '' }`, { responseType: 'json' }).catch(errHandler)
+    const res = await got.get(`${baseUrl}/pool/${key}${options?.timeout ? `?timeout=${options.timeout}` : '' }`, { responseType: 'json' }).catch(errHandler)
     return res?.body ? (res.body as JsonObject).value : undefined
 }
 
@@ -75,7 +75,7 @@ export const getValueFromPool = async (key: string, options: GetValueOptions) =>
  */
 export const addValueToPool = async (key: string, value: JsonPrimitive | JsonCompatible) => {
     const baseUrl = await baseUrlPromise
-    const res = await got.post(`${baseUrl}/pool/add`, { json: { key, value }, responseType: 'json' }).catch(errHandler)
+    const res = await got.post(`${baseUrl}/pool/${key}`, { json: { value }, responseType: 'json' }).catch(errHandler)
     return res?.body ? (res.body as JsonObject).value : undefined
 }
 

--- a/packages/wdio-shared-store-service/src/index.ts
+++ b/packages/wdio-shared-store-service/src/index.ts
@@ -2,11 +2,11 @@ import type { JsonPrimitive, JsonCompatible, JsonArray } from '@wdio/types'
 
 import SharedStoreLauncher from './launcher.js'
 import SharedStoreService from './service.js'
+import type { GetValueOptions } from './types'
 
 export { getValue, setValue, setResourcePool, getValueFromPool, addValueToPool } from './client.js'
 export default SharedStoreService
 export const launcher = SharedStoreLauncher
-export type GetValueOptions = { timeout: Number } | undefined;
 
 export interface BrowserExtension {
     sharedStore: {

--- a/packages/wdio-shared-store-service/src/server.ts
+++ b/packages/wdio-shared-store-service/src/server.ts
@@ -34,14 +34,7 @@ export const startServer = () => new Promise<{ port: number, app: PolkaInstance 
         .use(json(), validateBody)
 
         // routes
-        .post('/get', (req, res) => {
-            const key = req.body.key as string
-            const value = key === '*'
-                ? store
-                : store[key]
-            res.end(JSON.stringify({ value }))
-        })
-        .post('/set', (req, res) => {
+        .post('/', (req, res) => {
             const key = req.body.key as string
 
             if (key === '*') {
@@ -51,7 +44,14 @@ export const startServer = () => new Promise<{ port: number, app: PolkaInstance 
             store[key] = req.body.value as JsonCompatible | JsonPrimitive
             return res.end()
         })
-        .post('/pool/set', (req, res, next) => {
+        .get('/:key', (req, res) => {
+            const key = req.params.key as string
+            const value = key === '*'
+                ? store
+                : store[key]
+            res.end(JSON.stringify({ value }))
+        })
+        .post('/pool', (req, res, next) => {
             const key = req.body.key as string
             const value = req.body.value as JsonCompatible | JsonPrimitive
 
@@ -62,7 +62,7 @@ export const startServer = () => new Promise<{ port: number, app: PolkaInstance 
             resourcePoolStore.set(key, value)
             return res.end()
         })
-        .get('/pool/get/:key', async (req, res, next) => {
+        .get('/pool/:key', async (req, res, next) => {
             const key = req.params.key as string
 
             if (!resourcePoolStore.has(key)) {
@@ -93,8 +93,8 @@ export const startServer = () => new Promise<{ port: number, app: PolkaInstance 
                 return next(err)
             }
         })
-        .post('/pool/add', (req, res, next) => {
-            const key = req.body.key as string
+        .post('/pool/:key', (req, res, next) => {
+            const key = req.params.key as string
             const value = req.body.value as JsonCompatible | JsonPrimitive
             const pool = resourcePoolStore.get(key)
 

--- a/packages/wdio-shared-store-service/src/service.ts
+++ b/packages/wdio-shared-store-service/src/service.ts
@@ -2,7 +2,7 @@ import type { JsonCompatible, JsonPrimitive, Services, JsonArray } from '@wdio/t
 
 import { getValue, setValue, setPort, setResourcePool, getValueFromPool, addValueToPool } from './client.js'
 import type { SharedStoreServiceCapabilities } from './types.js'
-import type { GetValueOptions } from './index.js'
+import type { GetValueOptions } from './types'
 
 export default class SharedStoreService implements Services.ServiceInstance {
     private _browser?: WebdriverIO.Browser

--- a/packages/wdio-shared-store-service/src/types.ts
+++ b/packages/wdio-shared-store-service/src/types.ts
@@ -3,3 +3,4 @@ import type { Capabilities } from '@wdio/types'
 export interface SharedStoreServiceCapabilities extends Capabilities.Capabilities {
     'wdio:sharedStoreServicePort': number
 }
+export type GetValueOptions = { timeout: Number } | undefined


### PR DESCRIPTION
## Proposed changes

After https://github.com/webdriverio/webdriverio/pull/10029 was merged I realised it would be nice to have a better API interface for the shared store service. Even though it is an internal API that users don't interact with it will make code more and better to read if we stay compliant with common API design patterns.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Polish (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
