### PR TITLE
[🐛 Bug]: Selecting Lit as framework when selecting browser runner does not create example files for Lit

### DIFF
--- a/packages/wdio-cli/src/constants.ts
+++ b/packages/wdio-cli/src/constants.ts
@@ -156,7 +156,7 @@ export const SUPPORTED_PACKAGES = {
 } as const
 
 export const SUPPORTED_BROWSER_RUNNER_PRESETS = [
-    { name: 'Lit (https://lit.dev/)', value: '' },
+    { name: 'Lit (https://lit.dev/)', value: '$--$' },
     { name: 'Vue.js (https://vuejs.org/)', value: '@vitejs/plugin-vue$--$vue' },
     { name: 'Svelte (https://svelte.dev/)', value: '@sveltejs/vite-plugin-svelte$--$svelte' },
     { name: 'SolidJS (https://www.solidjs.com/)', value: 'vite-plugin-solid$--$solid' },


### PR DESCRIPTION
### Have you read the Contributing Guidelines on issues?

- [X] I have read the [Contributing Guidelines on issues](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md#reporting-new-issues).

### WebdriverIO Version

latest

### Node.js Version

latest

### Mode

WDIO Testrunner

### Which capabilities are you using?

```typescript
n/a
```


### What happened?

The browser runner generates example files for every framework if the user desires that. However when selecting Lit, no Lit component is generated. This is a bug in the `@wdio/cli` package as we use the `SUPPORTED_BROWSER_RUNNER_PRESETS` constant to determine if an example component for a framework should be generated and something goes wrong here given lit has the same value as `Other`.

### What is your expected behavior?

Proper example component is created for Lit.

### How to reproduce the bug.

Just run `npm init wdio@latest ./` and select browser runner, Lit as framework and press yes when the wizard asks for generating example files.

### Relevant log output

```typescript
n/a
```


### Code of Conduct

- [X] I agree to follow this project's Code of Conduct

### Is there an existing issue for this?

- [X] I have searched the existing issues