### PR TITLE
docs(mock): 'matches' -> 'calls' property

### DIFF
--- a/website/docs/api/Mock.md
+++ b/website/docs/api/Mock.md
@@ -25,7 +25,7 @@ A mock object contains the following properties:
 | `url` | `String` | The url passed into the mock command |
 | `filterOptions` | `Object` | The resource filter options passed into the mock command |
 | `browser` | `Object` | The [Browser Object](/docs/api/browser) used to get the mock object. |
-| `matches` | `Object[]` | Information about matching browser requests, containing properties such as `url`, `method`, `headers`, `initialPriority`, `referrerPolic`, `statusCode`, `responseHeaders` and `body` |
+| `calls` | `Object[]` | Information about matching browser requests, containing properties such as `url`, `method`, `headers`, `initialPriority`, `referrerPolic`, `statusCode`, `responseHeaders` and `body` |
 
 ## Methods
 


### PR DESCRIPTION
## Proposed changes

Change `Mock` interface in [docs](https://webdriver.io/docs/api/mock#properties)  (use `calls` property instead of `matches`)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

### Reviewers: @webdriverio/project-committers
