### PR TITLE
(feature) wdio-cucumber-framework: support `@skip` annotation without `()` for skip tests

### DIFF
--- a/packages/wdio-cucumber-framework/src/utils.ts
+++ b/packages/wdio-cucumber-framework/src/utils.ts
@@ -150,7 +150,7 @@ export function setUserHookNames (options: typeof supportCodeLibraryBuilder) {
  * @param {*} testCase
  */
 export function filterPickles (capabilities: Capabilities.RemoteCapability, pickle?: Pickle) {
-    const skipTag = /^@skip\((.*)\)$/
+    const skipTag = /^@skip$|^@skip\((.*)\)$/
 
     const match = (value: string, expr: RegExp) => {
         if (Array.isArray(expr)) {

--- a/packages/wdio-cucumber-framework/tests/utils.test.ts
+++ b/packages/wdio-cucumber-framework/tests/utils.test.ts
@@ -161,6 +161,18 @@ describe('utils', () => {
             id: '123',
             tags: [{ name: '@skip(something=weird)' }]
         } as any)).toBe(false)
+        expect(filterPickles({
+            browserName: 'chrome'
+        }, {
+            id: '123',
+            tags: [{ name: '@skip(browserName="chrome")' }]
+        } as any)).toBe(false)
+        expect(filterPickles({
+            browserName: 'chrome'
+        }, {
+            id: '123',
+            tags: [{ name: '@skip_local' }]
+        } as any)).toBe(true)
     })
 
     it('addKeywordToStep should add keywords to the steps', () => {

--- a/website/docs/Frameworks.md
+++ b/website/docs/Frameworks.md
@@ -389,8 +389,10 @@ Note that if you want to skip a test using regular cucumber test filtering capab
 
 were condition is an optional combination of capabilities properties with their values that when **all** matched with cause the tagged scenario or feature to be skipped. Of course you can add several tags to scenarios and features to skip a tests under several different conditions.
 
+You can also use the '@skip' annotation to skip tests without changing `tagExpression'. In this case the skipped tests will be displayed in the test report.
+
 Here you have some examples of this syntax:
-- `@skip()`: will always skip the tagged item
+- `@skip` or `@skip()`: will always skip the tagged item
 - `@skip(browserName="chrome")`: the test will not be executed against chrome browsers.
 - `@skip(browserName="firefox";platformName="linux")`: will skip the test in firefox over linux executions.
 - `@skip(browserName=["chrome","firefox"])`: tagged items will be skipped for both chrome and firefox browsers.


### PR DESCRIPTION
## Proposed changes

The pull request I submitted adds the ability to use the tag `@skip` instead of `@skip()`, as sometimes in reports it is necessary to see the tests that were skipped without changing the test run filter.

The ability to use the skip tag was added here:
https://github.com/webdriverio/webdriverio/pull/5076
But using `@skip()` tag looks very strange next to other tags without `()` 

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
