### PR TITLE
#9993 Properly set allure history id

### DIFF
--- a/packages/wdio-allure-reporter/src/reporter.ts
+++ b/packages/wdio-allure-reporter/src/reporter.ts
@@ -8,7 +8,7 @@ import type { Capabilities, Options } from '@wdio/types'
 import type { Label, MetadataMessage, AllureStep } from 'allure-js-commons'
 import {
     AllureRuntime, AllureGroup, AllureTest, Status as AllureStatus, Stage, LabelName,
-    LinkType, ContentType, AllureCommandStepExecutable, md5
+    LinkType, ContentType, AllureCommandStepExecutable,
 } from 'allure-js-commons'
 import {
     addFeature, addLink, addOwner, addEpic, addSuite, addSubSuite, addParentSuite,
@@ -205,33 +205,30 @@ export default class AllureReporter extends WDIOReporter {
         this._state.push(newStep)
     }
 
-    _getParamNameAndValue(cid?: string) {
-        const caps = this._capabilities as Capabilities.DesiredCapabilities
-        const { browserName, deviceName, desired, device } = caps
-        let targetName = device || browserName || deviceName || cid
-        // custom mobile grids can have device information in a `desired` cap
-        if (desired && desired.deviceName && desired.platformVersion) {
-            targetName = `${device || desired.deviceName} ${desired.platformVersion}`
-        }
-        const browserstackVersion = caps.os_version || caps.osVersion
-        const version = browserstackVersion || caps.browserVersion || caps.version || caps.platformVersion || ''
-        const paramName = (deviceName || device) ? 'device' : 'browser'
-        const paramValue = version ? `${targetName}-${version}` : targetName
-        return { paramName, paramValue }
-    }
-
     setTestParameters(cid?: string) {
         if (!this._state.currentTest) {
             return
         }
 
         if (!this._isMultiremote) {
-            const paramObj = this._getParamNameAndValue(cid)
-            const paramName = paramObj.paramName
-            const paramValue = paramObj.paramValue
+            const caps = this._capabilities as Capabilities.DesiredCapabilities
+            const { browserName, deviceName, desired, device } = caps
+            let targetName = device || browserName || deviceName || cid
+
+            // custom mobile grids can have device information in a `desired` cap
+            if (desired && desired.deviceName && desired.platformVersion) {
+                targetName = `${device || desired.deviceName} ${desired.platformVersion}`
+            }
+
+            const browserstackVersion = caps.os_version || caps.osVersion
+            const version = browserstackVersion || caps.browserVersion || caps.version || caps.platformVersion || ''
+            const paramName = (deviceName || device) ? 'device' : 'browser'
+            const paramValue = version ? `${targetName}-${version}` : targetName
+
             if (!paramValue) {
                 return
             }
+
             this._state.currentTest.addParameter(paramName, paramValue)
         } else {
             this._state.currentTest.addParameter('isMultiremote', 'true')
@@ -244,13 +241,7 @@ export default class AllureReporter extends WDIOReporter {
         if (this._state.currentPackageLabel) {
             this._state.currentTest.addLabel(LabelName.PACKAGE, this._state.currentPackageLabel)
         }
-        if (this._state.currentSuite?.name && this._state.currentTest.wrappedItem?.name) {
-            const paramObj = this._getParamNameAndValue(cid)
-            const paramName = paramObj.paramName
-            const paramValue = paramObj.paramValue
-            const hash = md5(this._state.currentSuite.name + this._state.currentTest.wrappedItem.name + paramName + paramValue)
-            this._state.currentTest.historyId = hash
-        }
+
         if (cid) {
             this._state.currentTest.addLabel(LabelName.THREAD, cid)
         }

--- a/packages/wdio-allure-reporter/src/reporter.ts
+++ b/packages/wdio-allure-reporter/src/reporter.ts
@@ -18,7 +18,7 @@ import {
 import { AllureReporterState } from './state.js'
 import {
     getTestStatus, isEmpty, isMochaEachHooks, getErrorFromFailedTest,
-    isMochaAllHooks, getLinkByTemplate, isScreenshotCommand, getSuiteLabels,
+    isMochaAllHooks, getLinkByTemplate, isScreenshotCommand, getSuiteLabels, setHistoryId,
 } from './utils.js'
 import { events } from './constants.js'
 import type {
@@ -136,6 +136,7 @@ export default class AllureReporter extends WDIOReporter {
             const currentTest = this._state.pop() as AllureTest | AllureStep
 
             if (currentTest instanceof AllureTest) {
+                setHistoryId(currentTest, this._state.currentSuite)
                 currentTest.endTest()
             } else {
                 currentTest.endStep()
@@ -167,6 +168,7 @@ export default class AllureReporter extends WDIOReporter {
         currentTest.status = AllureStatus.SKIPPED
 
         if (currentTest instanceof AllureTest) {
+            setHistoryId(currentTest, this._state.currentSuite)
             currentTest.endTest()
         } else {
             currentTest.endStep()
@@ -189,6 +191,7 @@ export default class AllureReporter extends WDIOReporter {
         }
 
         if (currentSpec instanceof AllureTest) {
+            setHistoryId(currentSpec, this._state.currentSuite)
             currentSpec.endTest()
         } else {
             currentSpec.endStep()
@@ -354,6 +357,7 @@ export default class AllureReporter extends WDIOReporter {
 
                 currentTest.status = AllureStatus.SKIPPED
                 currentTest.stage = Stage.PENDING
+                setHistoryId(currentTest, this._state.currentSuite)
                 currentTest.endTest()
                 return
             }
@@ -372,6 +376,7 @@ export default class AllureReporter extends WDIOReporter {
                     currentTest.detailsTrace = error.stack
                 }
 
+                setHistoryId(currentTest, this._state.currentSuite)
                 currentTest.endTest()
                 return
             }
@@ -385,6 +390,7 @@ export default class AllureReporter extends WDIOReporter {
 
                 currentTest.status = AllureStatus.PASSED
                 currentTest.stage = Stage.FINISHED
+                setHistoryId(currentTest, this._state.currentSuite)
                 currentTest.endTest()
                 return
             }

--- a/packages/wdio-allure-reporter/src/utils.ts
+++ b/packages/wdio-allure-reporter/src/utils.ts
@@ -1,8 +1,8 @@
 import stripAnsi from 'strip-ansi'
 import type { HookStats, TestStats, SuiteStats, CommandArgs, Tag } from '@wdio/reporter'
 import type { Options } from '@wdio/types'
-import type { Label } from 'allure-js-commons'
-import { Status as AllureStatus } from 'allure-js-commons'
+import type { Label, AllureTest, AllureGroup  } from 'allure-js-commons'
+import { Status as AllureStatus, md5 } from 'allure-js-commons'
 import CompoundError from './compoundError.js'
 import { mochaEachHooks, mochaAllHooks, linkPlaceholder } from './constants.js'
 
@@ -166,4 +166,16 @@ export const getSuiteLabels = ({ tags }: SuiteStats): Label[] => {
 
         return acc
     }, [])
+}
+
+export const setHistoryId = (test: AllureTest | undefined, suite: AllureGroup | undefined) => {
+    if (!test) {
+        return
+    }
+    const params = test.wrappedItem.parameters.slice()
+    const paramsPart = params
+        .sort((a, b) => a.name?.localeCompare(b.name))
+        .map(it => it.name + it.value)
+        .join('')
+    test.historyId = md5(`${suite?.name}${test.wrappedItem.name}${paramsPart}`)
 }

--- a/packages/wdio-allure-reporter/tests/allureFeatures.test.ts
+++ b/packages/wdio-allure-reporter/tests/allureFeatures.test.ts
@@ -395,6 +395,7 @@ describe('reporter runtime implementation', () => {
         const osParameter = results[0].parameters.find((parameter: Parameter) => parameter.name === 'os')
 
         expect(results).toHaveLength(1)
+        expect(results[0].historyId).toEqual('3cffc3d1d78d183463efee4c042f156c')
         expect(osParameter.value).toEqual('osx')
     })
 

--- a/packages/wdio-allure-reporter/tests/suite.test.ts
+++ b/packages/wdio-allure-reporter/tests/suite.test.ts
@@ -230,6 +230,7 @@ describe('Failed tests', () => {
         expect(results[0].name).toEqual('should can do something')
         expect(results[0].status).toEqual(Status.FAILED)
         expect(results[0].parameters).toHaveLength(1)
+        expect(results[0].historyId).toEqual('607cb53d8a84b61120bbab44d5f01694')
         expect(browserParameter.value).toEqual(testStart().cid)
     })
 
@@ -247,6 +248,7 @@ describe('Failed tests', () => {
         expect(results).toHaveLength(1)
         expect(results[0].name).toEqual('should can do something')
         expect(results[0].status).toEqual(Status.FAILED)
+        expect(results[0].historyId).toEqual('2838a547ee87e372fadb8927d9efaad3')
     })
 
     it('should detect failed test case with multiple errors', () => {
@@ -333,6 +335,7 @@ describe('Pending tests', () => {
         expect(results[0].name).toEqual('should can do something')
         expect(results[0].status).toEqual(Status.SKIPPED)
         expect(results[0].stage).toEqual(Stage.PENDING)
+        expect(results[0].historyId).toEqual('2838a547ee87e372fadb8927d9efaad3')
     })
 
     it('should detect not started pending test case', () => {
@@ -352,6 +355,7 @@ describe('Pending tests', () => {
         expect(results[0].name).toEqual('should can do something')
         expect(results[0].status).toEqual(Status.SKIPPED)
         expect(results[0].stage).toEqual(Stage.PENDING)
+        expect(results[0].historyId).toEqual('2838a547ee87e372fadb8927d9efaad3')
     })
 
     it('should detect not started pending test case after completed test', () => {


### PR DESCRIPTION
## Proposed changes

Fixes #9993
The allure historyId should be set correctly by taking into account the suite, test name, and all user-given parameters for the
 calculation of the historyId

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
