### PR TITLE
Fix glob types missing in production env (v7)

### DIFF
--- a/packages/wdio-config/package.json
+++ b/packages/wdio-config/package.json
@@ -23,6 +23,7 @@
   },
   "types": "./build/index.d.ts",
   "dependencies": {
+    "@types/glob": "^8.1.0",
     "@wdio/logger": "7.26.0",
     "@wdio/types": "7.30.2",
     "@wdio/utils": "7.30.2",
@@ -33,7 +34,6 @@
     "access": "public"
   },
   "devDependencies": {
-    "@types/glob": "^8.1.0",
     "minimatch": "^6.0.4",
     "tsconfig-paths": "^4.0.0"
   }

--- a/packages/wdio-cucumber-framework/package.json
+++ b/packages/wdio-cucumber-framework/package.json
@@ -26,6 +26,7 @@
     "@cucumber/gherkin": "26.0.3",
     "@cucumber/gherkin-streams": "^5.0.0",
     "@cucumber/messages": "21.0.1",
+    "@types/glob": "^8.1.0",
     "@types/is-glob": "^4.0.1",
     "@types/long": "^4.0.1",
     "@types/mockery": "^1.4.29",
@@ -45,8 +46,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "types": "./build/index.d.ts",
-  "devDependencies": {
-    "@types/glob": "^8.1.0"
-  }
+  "types": "./build/index.d.ts"
 }


### PR DESCRIPTION
## Proposed changes
Move @types/glob from dev dependencies to normal dependencies, as they are needed for build but not getting installed when trying to install in a production (NODE_ENV = production)

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
