### PR TITLE
browser-runner: support nesting suites

### DIFF
--- a/packages/wdio-runner/src/browser.ts
+++ b/packages/wdio-runner/src/browser.ts
@@ -86,7 +86,6 @@ export default class BrowserFramework implements Omit<TestFramework, 'init'> {
          * start tests
          */
         let failures = 0
-        let uid = 0
         for (const spec of this._specs) {
             log.info(`Run spec file ${spec} for cid ${this._cid}`)
 
@@ -188,14 +187,14 @@ export default class BrowserFramework implements Omit<TestFramework, 'init'> {
                 continue
             }
 
-            await this.#fetchEvents(browser, spec, ++uid)
+            await this.#fetchEvents(browser, spec)
             failures += state.failures || 0
         }
 
         return failures
     }
 
-    async #fetchEvents (browser: WebdriverIO.Browser, spec: string, uid: number) {
+    async #fetchEvents (browser: WebdriverIO.Browser, spec: string) {
         /**
          * populate events to the reporter
          */
@@ -207,7 +206,7 @@ export default class BrowserFramework implements Omit<TestFramework, 'init'> {
             this._reporter.emit(ev.type, {
                 ...ev,
                 file: spec,
-                uid: `${this._cid}-${uid}`,
+                uid: `${this._cid}-${Buffer.from(ev.fullTitle).toString('base64')}`,
                 cid: this._cid
             })
         }

--- a/packages/wdio-spec-reporter/src/index.ts
+++ b/packages/wdio-spec-reporter/src/index.ts
@@ -167,7 +167,7 @@ export default class SpecReporter extends WDIOReporter {
      */
     printReport(runner: RunnerStats) {
         // Don't print non failed tests
-        if (runner.failures === 0 && this._onlyFailures === true){
+        if (runner.failures === 0 && this._onlyFailures === true) {
             return
         }
 


### PR DESCRIPTION
## Proposed changes

Before, the browser runner would only report the most nested suite. This patch fixes that.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
