### PR TITLE
Fix ScrollIntoView - correct position for the focus

### DIFF
--- a/__mocks__/got.ts
+++ b/__mocks__/got.ts
@@ -241,6 +241,8 @@ const requestMock: any = vi.fn().mockImplementation((uri, params) => {
             result = params.json.args[0][ELEMENT_KEY] === genericElementId
                 ? { [ELEMENT_KEY]: 'some-next-elem' }
                 : {}
+        } else if (params.json.script.includes('scrollX')) {
+            result = [0, 0]
         } else if (params.json.script.includes('function isFocused')) {
             result = true
         } else {

--- a/e2e/wdio/headless/test.e2e.ts
+++ b/e2e/wdio/headless/test.e2e.ts
@@ -100,14 +100,25 @@ describe('main suite 1', () => {
     it('should be able to handle successive scrollIntoView', async () => {
         await browser.url('http://guinea-pig.webdriver.io')
         await browser.setWindowSize(500, 500)
-        const searchInput = await $('.searchinput')
+        let searchInput = await $('.searchinput')
 
+        await browser.newWindow('http://guinea-pig.webdriver.io')
+        await browser.setWindowSize(500, 500)
+        const handles = await browser.getWindowHandles()
         const scrollAndCheck = async (params?: ScrollIntoViewOptions | boolean) => {
+
+            await browser.switchToWindow(handles[0])
+            await browser.pause(500)
+            searchInput = await $('.searchinput')
             await searchInput.scrollIntoView(params)
             await browser.pause(500)
             const [wdioX, wdioY] = await browser.execute(() => [
                 window.scrollX, window.scrollY
             ])
+
+            await browser.switchToWindow(handles[1])
+            await browser.pause(500)
+            searchInput = await $('.searchinput')
 
             await browser.execute((elem, _params) => elem.scrollIntoView(_params), searchInput, params)
             await browser.pause(500)
@@ -123,6 +134,7 @@ describe('main suite 1', () => {
         await scrollAndCheck({ block: 'nearest', inline: 'nearest' })
         await scrollAndCheck()
         await scrollAndCheck({ block: 'center', inline: 'center' })
+        await scrollAndCheck({ block: 'start', inline: 'start' })
         await scrollAndCheck({ block: 'end', inline: 'end' })
         await scrollAndCheck(true)
         await scrollAndCheck({ block: 'nearest', inline: 'nearest' })

--- a/e2e/wdio/headless/test.e2e.ts
+++ b/e2e/wdio/headless/test.e2e.ts
@@ -100,22 +100,15 @@ describe('main suite 1', () => {
     it('should be able to handle successive scrollIntoView', async () => {
         await browser.url('http://guinea-pig.webdriver.io')
         await browser.setWindowSize(500, 500)
-        let searchInput = await $('.searchinput')
+        const searchInput = await $('.searchinput')
 
         const scrollAndCheck = async (params?: ScrollIntoViewOptions | boolean) => {
-
-            await browser.refresh()
-            searchInput = await $('.searchinput')
-            await browser.pause(500)
             await searchInput.scrollIntoView(params)
             await browser.pause(500)
             const [wdioX, wdioY] = await browser.execute(() => [
                 window.scrollX, window.scrollY
             ])
 
-            await browser.refresh()
-            searchInput = await $('.searchinput')
-            await browser.pause(500)
             await browser.execute((elem, _params) => elem.scrollIntoView(_params), searchInput, params)
             await browser.pause(500)
             const [windowX, windowY] = await browser.execute(() => [

--- a/e2e/wdio/headless/test.e2e.ts
+++ b/e2e/wdio/headless/test.e2e.ts
@@ -102,24 +102,20 @@ describe('main suite 1', () => {
         await browser.setWindowSize(500, 500)
         let searchInput = await $('.searchinput')
 
-        await browser.newWindow('http://guinea-pig.webdriver.io')
-        await browser.setWindowSize(500, 500)
-        const handles = await browser.getWindowHandles()
         const scrollAndCheck = async (params?: ScrollIntoViewOptions | boolean) => {
 
-            await browser.switchToWindow(handles[0])
-            await browser.pause(500)
+            await browser.refresh()
             searchInput = await $('.searchinput')
+            await browser.pause(500)
             await searchInput.scrollIntoView(params)
             await browser.pause(500)
             const [wdioX, wdioY] = await browser.execute(() => [
                 window.scrollX, window.scrollY
             ])
 
-            await browser.switchToWindow(handles[1])
-            await browser.pause(500)
+            await browser.refresh()
             searchInput = await $('.searchinput')
-
+            await browser.pause(500)
             await browser.execute((elem, _params) => elem.scrollIntoView(_params), searchInput, params)
             await browser.pause(500)
             const [windowX, windowY] = await browser.execute(() => [

--- a/packages/webdriverio/src/commands/element/scrollIntoView.ts
+++ b/packages/webdriverio/src/commands/element/scrollIntoView.ts
@@ -61,10 +61,19 @@ export async function scrollIntoView (
      */
     const elemRect = await browser.getElementRect(this.elementId)
     const viewport = await browser.getWindowSize()
+    let [windowX, windowY] = await browser.execute(() => [
+        window.scrollX, window.scrollY
+    ])
+
+    const origin = windowX === 0 && windowY === 0 ? this : undefined
+
+    windowX = elemRect.x <= viewport.width ? elemRect.x - 10 : viewport.width / 2
+    windowY = elemRect.y <= viewport.height ? elemRect.y - 10 : viewport.height / 2
+
     const deltaByOption = {
         start: { y: elemRect.y, x: elemRect.x },
         center: { y: elemRect.y - Math.round((viewport.height - elemRect.height) / 2), x: elemRect.x - Math.round((viewport.width - elemRect.width) / 2) },
-        end: { y: elemRect.y - (viewport.height - elemRect.height), x: elemRect.x - (viewport.width - elemRect.width) }
+        end: { y: elemRect.y - (viewport.height - elemRect.height - 20), x: elemRect.x - (viewport.width - elemRect.width) }
     }
     let [deltaX, deltaY] = [deltaByOption.start.x, deltaByOption.start.y]
     if (options && typeof options !== 'boolean') {
@@ -83,12 +92,23 @@ export async function scrollIntoView (
         }
     }
 
-    deltaX = Math.round(deltaX)
-    deltaY = Math.round(deltaY)
+    if (origin) {
+        deltaX = Math.round(deltaX - elemRect.x)
+        deltaY = Math.round(deltaY - (elemRect.y - viewport.height))
+
+        windowX = 0
+        windowY = 0
+    } else {
+        deltaX = Math.round(deltaX - windowX)
+        deltaY = Math.round(deltaY - windowY)
+
+        windowX = Math.round(windowX)
+        windowY = Math.round(windowY)
+    }
 
     try {
         return await browser.action('wheel')
-            .scroll({ duration: 200, deltaX, deltaY, origin: this })
+            .scroll({ duration: 200, x: windowX, y: windowY, deltaX, deltaY, origin })
             .perform()
     } catch (err: any) {
         log.warn(

--- a/packages/webdriverio/src/commands/element/scrollIntoView.ts
+++ b/packages/webdriverio/src/commands/element/scrollIntoView.ts
@@ -88,7 +88,7 @@ export async function scrollIntoView (
 
     try {
         return await browser.action('wheel')
-            .scroll({ duration: 200, deltaX, deltaY })
+            .scroll({ duration: 200, deltaX, deltaY, origin: this })
             .perform()
     } catch (err: any) {
         log.warn(

--- a/packages/webdriverio/tests/commands/element/__snapshots__/scrollIntoView.test.ts.snap
+++ b/packages/webdriverio/tests/commands/element/__snapshots__/scrollIntoView.test.ts.snap
@@ -9,6 +9,9 @@ exports[`scrollIntoView test > desktop > scrolls by default the element to the t
           "deltaX": 15,
           "deltaY": 20,
           "duration": 200,
+          "origin": {
+            "element-6066-11e4-a52e-4f735466cecf": "some-elem-123",
+          },
           "type": "scroll",
           "x": 0,
           "y": 0,
@@ -31,6 +34,9 @@ exports[`scrollIntoView test > desktop > scrolls element using scroll into view 
           "deltaX": -260,
           "deltaY": -365,
           "duration": 200,
+          "origin": {
+            "element-6066-11e4-a52e-4f735466cecf": "some-elem-123",
+          },
           "type": "scroll",
           "x": 0,
           "y": 0,
@@ -53,6 +59,9 @@ exports[`scrollIntoView test > desktop > scrolls element when using boolean scro
           "deltaX": 15,
           "deltaY": 20,
           "duration": 200,
+          "origin": {
+            "element-6066-11e4-a52e-4f735466cecf": "some-elem-123",
+          },
           "type": "scroll",
           "x": 0,
           "y": 0,
@@ -75,6 +84,9 @@ exports[`scrollIntoView test > desktop > scrolls element when using boolean scro
           "deltaX": 15,
           "deltaY": 20,
           "duration": 200,
+          "origin": {
+            "element-6066-11e4-a52e-4f735466cecf": "some-elem-123",
+          },
           "type": "scroll",
           "x": 0,
           "y": 0,

--- a/packages/webdriverio/tests/commands/element/__snapshots__/scrollIntoView.test.ts.snap
+++ b/packages/webdriverio/tests/commands/element/__snapshots__/scrollIntoView.test.ts.snap
@@ -1,13 +1,67 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`scrollIntoView test > desktop > scrolls by default the element after a previous scr 1`] = `
+{
+  "actions": [
+    {
+      "actions": [
+        {
+          "deltaX": 0,
+          "deltaY": 800,
+          "duration": 200,
+          "origin": {
+            "element-6066-11e4-a52e-4f735466cecf": {
+              "scrollIntoView": [MockFunction spy],
+            },
+          },
+          "type": "scroll",
+          "x": 0,
+          "y": 0,
+        },
+      ],
+      "id": "action7",
+      "parameters": {},
+      "type": "wheel",
+    },
+  ],
+}
+`;
+
+exports[`scrollIntoView test > desktop > scrolls by default the element after a previous scroll 1`] = `
+{
+  "actions": [
+    {
+      "actions": [
+        {
+          "deltaX": 0,
+          "deltaY": 800,
+          "duration": 200,
+          "origin": {
+            "element-6066-11e4-a52e-4f735466cecf": {
+              "scrollIntoView": [MockFunction spy],
+            },
+          },
+          "type": "scroll",
+          "x": 0,
+          "y": 0,
+        },
+      ],
+      "id": "action7",
+      "parameters": {},
+      "type": "wheel",
+    },
+  ],
+}
+`;
+
 exports[`scrollIntoView test > desktop > scrolls by default the element to the top 1`] = `
 {
   "actions": [
     {
       "actions": [
         {
-          "deltaX": 15,
-          "deltaY": 20,
+          "deltaX": 0,
+          "deltaY": 800,
           "duration": 200,
           "origin": {
             "element-6066-11e4-a52e-4f735466cecf": "some-elem-123",
@@ -31,8 +85,8 @@ exports[`scrollIntoView test > desktop > scrolls element using scroll into view 
     {
       "actions": [
         {
-          "deltaX": -260,
-          "deltaY": -365,
+          "deltaX": -275,
+          "deltaY": 415,
           "duration": 200,
           "origin": {
             "element-6066-11e4-a52e-4f735466cecf": "some-elem-123",
@@ -56,8 +110,8 @@ exports[`scrollIntoView test > desktop > scrolls element when using boolean scro
     {
       "actions": [
         {
-          "deltaX": 15,
-          "deltaY": 20,
+          "deltaX": 0,
+          "deltaY": 800,
           "duration": 200,
           "origin": {
             "element-6066-11e4-a52e-4f735466cecf": "some-elem-123",
@@ -81,8 +135,8 @@ exports[`scrollIntoView test > desktop > scrolls element when using boolean scro
     {
       "actions": [
         {
-          "deltaX": 15,
-          "deltaY": 20,
+          "deltaX": 0,
+          "deltaY": 800,
           "duration": 200,
           "origin": {
             "element-6066-11e4-a52e-4f735466cecf": "some-elem-123",

--- a/packages/webdriverio/tests/commands/element/scrollIntoView.test.ts
+++ b/packages/webdriverio/tests/commands/element/scrollIntoView.test.ts
@@ -72,9 +72,10 @@ describe('scrollIntoView test', () => {
                 ({ x: 15.34, y: 20.23, height: 30.2344, width: 50.543 }))
             await elem.scrollIntoView({ block: 'center', inline: 'center' })
             const optionsCenter = vi.mocked(got).mock.calls.slice(-2, -1)[0][1] as any
-            expect(optionsCenter.json.actions[0].actions[0].deltaX).toBe(-260)
-            expect(optionsCenter.json.actions[0].actions[0].deltaY).toBe(-365)
+            expect(optionsCenter.json.actions[0].actions[0].deltaX).toBe(-275)
+            expect(optionsCenter.json.actions[0].actions[0].deltaY).toBe(415)
         })
+
     })
 
     describe('mobile', () => {


### PR DESCRIPTION
## Proposed changes

In case where there are several possible scrolls in the page(example: a page with a left menu), the scroll doesn't work on the other parts of the page because the focus by default is positioned at x:0 , y:0.
To fix it, I just added the origin element in argument.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # 

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
