### PR TITLE
networkLogsOptions & interactiveDebugging

### DIFF
--- a/packages/wdio-types/src/Capabilities.ts
+++ b/packages/wdio-types/src/Capabilities.ts
@@ -1163,6 +1163,18 @@ export interface BrowserStackCapabilities {
      */
     debug?: boolean
     networkLogs?: boolean
+     /**
+     * https://www.browserstack.com/docs/app-automate/appium/debug-failed-tests/network-logs
+     * Enable viewing the response data in the Network Logs tab on your session
+     */
+    networkLogsOptions?: {
+        captureContent?: boolean
+    },
+    /**
+     * https://www.browserstack.com/docs/app-automate/appium/debug-failed-tests/interactive-session
+     * Enable an interactive debugging session while your test session is running
+     */
+    interactiveDebugging?: boolean,
     seleniumVersion?: string
     seleniumCdp?: boolean,
     ie?: {


### PR DESCRIPTION
## Proposed changes

[//]: # (Add support for 2 more of BrowserStack's capabilities.)

`networkLogsOptions` --> This lets you view the Response tab of the Network Logs tab inside the post-session details. Useful for analytics testing.

`interactiveDebugging` --> I noticed iOS has this enabled when I run tests but not Android. Figured this might help guarantee access to this feature during a run.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

If you want me to add a test for this, I can. I didn't see any outside of the `isBrowserStackCapability` unit test in `util.test.ts`.

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
