### PR TITLE
Update reporters.json to include BrowserStack Test Observability

### DIFF
--- a/scripts/docs-generation/3rd-party/reporters.json
+++ b/scripts/docs-generation/3rd-party/reporters.json
@@ -6,6 +6,12 @@
     "npmUrl": "https://www.npmjs.com/package/wdio-reportportal-reporter"
   },
   {
+    "packageName": "wdio-browserstack-test-observability",
+    "title": "BrowserStack Test Observability",
+    "githubUrl": "https://github.com/browserstack/wdio-browserstack-test-observability",
+    "npmUrl": "https://www.npmjs.com/package/@wdio/browserstack-service"
+  },
+  {
     "packageName": "wdio-video-reporter",
     "title": "Video",
     "githubUrl": "https://github.com/presidenten/wdio-video-reporter",


### PR DESCRIPTION
## Proposed changes

BrowserStack Test Observability is a standalone test reporter, a debugging tool, and also surfaces test suite health-related metrics. It works for everyone - regardless of where tests are run (even if they are not on the BrowserStack) platform similar to other reporters. It is free to use for an unlimited number of tests.

I am creating this pull request to list BrowserStack Test Observability in the Reporters section of the WebdriverIO documentation. We hope users will discover and start using it to debug and optimize their test suites!


## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
