### PR TITLE
(fix) wdio-cucumber-framework: fix error after #10134

### DIFF
--- a/packages/wdio-cucumber-framework/src/utils.ts
+++ b/packages/wdio-cucumber-framework/src/utils.ts
@@ -177,7 +177,7 @@ export function filterPickles (capabilities: Capabilities.RemoteCapability, pick
     return !(pickle && pickle.tags && pickle.tags
         .map(p => p.name?.match(skipTag))
         .filter(Boolean)
-        .map(m => parse(m![1]))
+        .map(m => parse(m![1] ?? ''))
         .find((filter: Capabilities.Capabilities) => Object.keys(filter)
             .every((key: keyof Capabilities.Capabilities) => match((capabilities as any)[key], filter[key] as RegExp))))
 }

--- a/packages/wdio-cucumber-framework/tests/utils.test.ts
+++ b/packages/wdio-cucumber-framework/tests/utils.test.ts
@@ -165,7 +165,13 @@ describe('utils', () => {
             browserName: 'chrome'
         }, {
             id: '123',
-            tags: [{ name: '@skip(browserName="chrome")' }]
+            tags: [{ name: '@skip()' }]
+        } as any)).toBe(false)
+        expect(filterPickles({
+            browserName: 'chrome'
+        }, {
+            id: '123',
+            tags: [{ name: '@skip' }]
         } as any)).toBe(false)
         expect(filterPickles({
             browserName: 'chrome'


### PR DESCRIPTION
## Proposed changes

The use of the `@skip` tag could lead to an error:
```
TypeError: Cannot read properties of undefined (reading 'split')
 ❯ parse packages/wdio-cucumber-framework/src/utils.ts:165:18
    163| 
    164|     const parse = (skipExpr: string) =>
    165|         skipExpr.split(';').reduce((acc: Record<string, string>, splitItem: string) => {
       |                  ^
    166|             const pos = splitItem.indexOf('=')
    167|             if (pos > 0) {
 ❯ packages/wdio-cucumber-framework/src/utils.ts:180:19

```

This pull request contains a fix for an error that was introduced in a previous pull request (#10134). The mistake has been identified and corrected in this PR. 

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
