### PR TITLE
wdio-config: Filter specs /w Cucumber Tag Expression before spawning workers

### DIFF
--- a/packages/wdio-config/package.json
+++ b/packages/wdio-config/package.json
@@ -29,6 +29,9 @@
     "url": "https://github.com/webdriverio/webdriverio/issues"
   },
   "dependencies": {
+    "@cucumber/messages": "22.0.0",
+    "@cucumber/gherkin": "26.2.0",
+    "@cucumber/tag-expressions": "5.0.1",
     "@wdio/logger": "8.6.6",
     "@wdio/types": "8.10.0",
     "@wdio/utils": "8.10.0",

--- a/packages/wdio-config/tests/__fixtures__/test-c.feature
+++ b/packages/wdio-config/tests/__fixtures__/test-c.feature
@@ -1,0 +1,86 @@
+@runall
+Feature: Test Feature C
+
+  Background: Background #1
+    Given a step passes
+    When a step passes
+
+  @run @tagAtLine
+  Scenario: Scenario #1
+    Given a step passes
+    When a step passes
+    Then a step passes
+
+  Scenario: Scenario #2
+    Given a step passes
+    When a step passes
+    Then a step passes
+
+  @tagAtLine
+  Scenario: Scenario #3
+    Given a step passes
+    When a step passes
+    Then a step passes
+
+  @runoutline
+  Scenario Outline: Scenario #4: <param>
+    Given a step passes
+    When a step passes
+    Then a step passes
+
+    Examples: 
+      | param |
+      | input |
+
+  @runrule
+  Rule: Rule #1
+
+    Background: Background #2
+      Given a step passes
+      When a step passes
+
+    @runinrule
+    Scenario: Scenario #5
+      Given a step passes
+      When a step passes
+      Then a step passes
+
+    Scenario: Scenario #6
+      Given a step passes
+      When a step passes
+      Then a step passes
+
+    @runinruleoutline
+    Scenario Outline: Scenario #7: <param>
+      Given a step passes
+      When a step passes
+      Then a step passes
+
+      Examples: 
+        | param |
+        | input |
+
+  Rule: Rule #2
+
+    Background: Background #3
+      Given a step passes
+      When a step passes
+
+    Scenario: Scenario #8
+      Given a step passes
+      When a step passes
+      Then a step passes
+
+    Scenario: Scenario #9
+      Given a step passes
+      When a step passes
+      Then a step passes
+
+    Scenario Outline: Scenario #10: <param>
+      Given a step passes
+      When a step passes
+      Then a step passes
+
+      Examples: 
+        | param |
+        | input |


### PR DESCRIPTION
fixes #8253 

## Proposed changes
Makes use of CucumberJS API to read the content of the Feature files used by the Cucumber framework to then filter the specs based on the provided Tag Expression.

We do this before spawning any workers, optimizing heavily the filtering process for less optimal hardware and from even moderate amounts of specs.

Before this change, a worker was spawned for each spec file, the worker would skip the file and then terminate, impacting performance heavily.

The filtering implementation is compatible with latest changes to the Gherkin spec (like the addition of the Rule).

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
