### PR TITLE
wdio-cucumber-framework: Don't attempt to filter empty specs

### DIFF
--- a/packages/wdio-cucumber-framework/tests/adapter.test.ts
+++ b/packages/wdio-cucumber-framework/tests/adapter.test.ts
@@ -118,9 +118,9 @@ describe('CucumberAdapter', () => {
     })
 
     it('should trigger after hook if initiation fails', async () => {
+
         vi.mocked(Cucumber.parseGherkinMessageStream)
             .mockRejectedValueOnce(new Error('boom'))
-
         const err = await CucumberAdapter.init!('0-0', {
             cucumberFeaturesWithLineNumbers: ['/bar/foo', '/foo/bar']
         }, ['/foo/bar'], {}, {})
@@ -350,6 +350,7 @@ describe('CucumberAdapter', () => {
         )
 
         expect(adapter._specs).toHaveLength(1)
+        expect(adapter._hasTests).toBe(true)
 
         const result = await adapter.run()
 
@@ -370,6 +371,7 @@ describe('CucumberAdapter', () => {
         )
 
         expect(adapter._specs).toHaveLength(1)
+        expect(adapter._hasTests).toBe(true)
 
         const result = await adapter.run()
 
@@ -390,6 +392,7 @@ describe('CucumberAdapter', () => {
         )
 
         expect(adapter._specs).toHaveLength(1)
+        expect(adapter._hasTests).toBe(true)
 
         const result = await adapter.run()
 
@@ -410,6 +413,7 @@ describe('CucumberAdapter', () => {
         )
 
         expect(adapter._specs).toHaveLength(1)
+        expect(adapter._hasTests).toBe(true)
 
         const result = await adapter.run()
 
@@ -430,6 +434,7 @@ describe('CucumberAdapter', () => {
         )
 
         expect(adapter._specs).toHaveLength(0)
+        expect(adapter._hasTests).toBe(false)
 
         const result = await adapter.run()
 


### PR DESCRIPTION
## Proposed changes

fixes #10367 #10366

Adds a safe guard to the work done in #10330
Further filtering might be done after filtering all the specs that match the tag expression. 
But it shouldn't be attempted when there are no specs to run.
Prevents cases where it was listening for events forever.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
