### PR TITLE
fix: disable restored mocks

### DIFF
--- a/packages/webdriverio/src/commands/browser/mock.ts
+++ b/packages/webdriverio/src/commands/browser/mock.ts
@@ -4,8 +4,10 @@ import WebDriverNetworkInterception from '../../utils/interception/webdriver.js'
 import { getBrowserObject } from '../../utils/index.js'
 import type { Mock } from '../../types.js'
 import type { MockFilterOptions } from '../../utils/interception/types.js'
+import type { CDPSession } from 'puppeteer-core/lib/esm/puppeteer/common/Connection.js'
 
 export const SESSION_MOCKS: Record<string, Set<Interception>> = {}
+export const CDP_SESSIONS: Record<string, CDPSession> = {}
 
 /**
  * Mock the response of a request. You can define a mock based on a matching
@@ -158,7 +160,7 @@ export async function mock (
             page = pages[0]
         }
 
-        const client = await page.target().createCDPSession()
+        const client = CDP_SESSIONS[handle] = await page.target().createCDPSession()
         await client.send('Fetch.enable', {
             patterns: [{ requestStage: 'Request' }, { requestStage: 'Response' }]
         })

--- a/packages/webdriverio/src/commands/browser/mockRestoreAll.ts
+++ b/packages/webdriverio/src/commands/browser/mockRestoreAll.ts
@@ -32,7 +32,7 @@ export async function mockRestoreAll () {
     for (const [handle, mocks] of Object.entries(SESSION_MOCKS)) {
         log.trace(`Clearing mocks for ${handle}`)
         for (const mock of mocks) {
-            mock.restore()
+            await mock.restore()
         }
     }
 }

--- a/packages/webdriverio/src/commands/mock/restore.ts
+++ b/packages/webdriverio/src/commands/mock/restore.ts
@@ -1,5 +1,6 @@
 /**
  * Does everything that `mock.clear()` does, and also removes any mocked return values or implementations.
+ * Restored mock does not emit events and could not mock responses.
  *
  * <example>
     :addValue.js

--- a/packages/webdriverio/src/types.ts
+++ b/packages/webdriverio/src/types.ts
@@ -116,7 +116,7 @@ type MultiRemoteElementCommands = {
 }
 
 export type MultiRemoteBrowserCommandsType = {
-    [K in keyof Omit<BrowserCommandsType, ElementCommandNames | 'SESSION_MOCKS'>]: (...args: Parameters<BrowserCommandsType[K]>) => Promise<ThenArg<ReturnType<BrowserCommandsType[K]>>[]>
+    [K in keyof Omit<BrowserCommandsType, ElementCommandNames | 'SESSION_MOCKS' | 'CDP_SESSIONS'>]: (...args: Parameters<BrowserCommandsType[K]>) => Promise<ThenArg<ReturnType<BrowserCommandsType[K]>>[]>
 } & MultiRemoteElementCommands
 export type MultiRemoteElementCommandsType = {
     [K in keyof Omit<ElementCommandsType, ElementCommandNames>]: (...args: Parameters<ElementCommandsType[K]>) => Promise<ThenArg<ReturnType<ElementCommandsType[K]>>[]>

--- a/packages/webdriverio/src/utils/index.ts
+++ b/packages/webdriverio/src/utils/index.ts
@@ -23,7 +23,7 @@ import type { CustomStrategyReference } from '../types.js'
 
 const log = logger('webdriverio')
 const INVALID_SELECTOR_ERROR = 'selector needs to be typeof `string` or `function`'
-const IGNORED_COMMAND_FILE_EXPORTS = ['SESSION_MOCKS']
+const IGNORED_COMMAND_FILE_EXPORTS = ['SESSION_MOCKS', 'CDP_SESSIONS']
 
 declare global {
     interface Window { __wdio_element: Record<string, HTMLElement> }

--- a/packages/webdriverio/src/utils/interception/devtools.ts
+++ b/packages/webdriverio/src/utils/interception/devtools.ts
@@ -8,6 +8,7 @@ import Interception from './index.js'
 import type { Matches, MockOverwrite, MockResponseParams } from './types.js'
 import { containsHeaderObject } from '../index.js'
 import { ERROR_REASON } from '../../constants.js'
+import { CDP_SESSIONS, SESSION_MOCKS } from '../../commands/browser/mock.js'
 
 const log = logger('webdriverio')
 
@@ -31,6 +32,8 @@ type Event = {
 type ExpectParameter<T> = ((param: T) => boolean) | T;
 
 export default class DevtoolsInterception extends Interception {
+    private restored = false
+
     static handleRequestInterception (client: CDPSession, mocks: Set<Interception>): (event: Event) => Promise<void | ClientResponse> {
         return async (event) => {
             // responseHeaders and responseStatusCode are only present in Response stage
@@ -220,10 +223,27 @@ export default class DevtoolsInterception extends Interception {
     /**
      * Does everything that `mock.clear()` does, and also
      * removes any mocked return values or implementations.
+     * Restored mock does not emit events and could not mock responses
      */
-    restore () {
+    async restore (sessionMocks = SESSION_MOCKS, cdpSessions = CDP_SESSIONS) {
         this.clear()
         this.respondOverwrites = []
+        this.restored = true
+        const handle = await this.browser.getWindowHandle()
+
+        log.trace(`Restoring mock for ${handle}`)
+        sessionMocks[handle].delete(this)
+
+        if (sessionMocks[handle].size) {
+            return
+        }
+
+        log.trace(`Disabling fetch domain for ${handle}`)
+        return cdpSessions[handle].send('Fetch.disable')
+            .then(() => {
+                delete sessionMocks[handle]
+                delete cdpSessions[handle]
+            }).catch(/* istanbul ignore next */logFetchError)
     }
 
     /**
@@ -232,6 +252,7 @@ export default class DevtoolsInterception extends Interception {
      * @param {*} params      additional respond parameters to overwrite
      */
     respond (overwrite: MockOverwrite, params: MockResponseParams = {}) {
+        this.ensureNotRestored()
         this.respondOverwrites.push({ overwrite, params, sticky: true })
     }
 
@@ -241,6 +262,7 @@ export default class DevtoolsInterception extends Interception {
      * @param {*} params      additional respond parameters to overwrite
      */
     respondOnce (overwrite: MockOverwrite, params: MockResponseParams = {}) {
+        this.ensureNotRestored()
         this.respondOverwrites.push({ overwrite, params })
     }
 
@@ -249,6 +271,7 @@ export default class DevtoolsInterception extends Interception {
      * @param {string} errorCode  error code of the response
      */
     abort (errorReason: Protocol.Network.ErrorReason, sticky: boolean = true) {
+        this.ensureNotRestored()
         if (typeof errorReason !== 'string' || !ERROR_REASON.includes(errorReason)) {
             throw new Error(`Invalid value for errorReason, allowed are: ${ERROR_REASON.join(', ')}`)
         }
@@ -261,6 +284,12 @@ export default class DevtoolsInterception extends Interception {
      */
     abortOnce (errorReason: Protocol.Network.ErrorReason) {
         this.abort(errorReason, false)
+    }
+
+    private ensureNotRestored() {
+        if (this.restored) {
+            throw new Error('This can\'t be done on restored mock')
+        }
     }
 }
 

--- a/packages/webdriverio/src/utils/interception/devtools.ts
+++ b/packages/webdriverio/src/utils/interception/devtools.ts
@@ -27,6 +27,7 @@ type Event = {
     request: Matches & { mockedResponse: string | Buffer }
     responseStatusCode?: number
     responseHeaders: HeaderEntry[]
+    responseErrorReason?: string
 }
 
 type ExpectParameter<T> = ((param: T) => boolean) | T;
@@ -38,9 +39,9 @@ export default class DevtoolsInterception extends Interception {
         return async (event) => {
             // responseHeaders and responseStatusCode are only present in Response stage
             // https://chromedevtools.github.io/devtools-protocol/tot/Fetch/#event-requestPaused
-            const isRequest = !event.responseHeaders
+            const isRequest = !event.responseHeaders && !event.responseErrorReason
 
-            event.responseStatusCode ||= 200
+            event.responseStatusCode ||= event.responseErrorReason ? 0 : 200
             event.responseHeaders ||= []
 
             const responseHeaders = event.responseHeaders.reduce((headers, { name, value }) => {

--- a/packages/webdriverio/src/utils/interception/index.ts
+++ b/packages/webdriverio/src/utils/interception/index.ts
@@ -11,7 +11,7 @@ import type { Protocol } from 'devtools-protocol'
 export default abstract class Interception extends EventEmitter {
     abstract calls: Matches[] | Promise<Matches[]>
     abstract clear (): void
-    abstract restore (): void
+    abstract restore (): Promise<void>
     abstract respond (overwrite: MockOverwrite, params: MockResponseParams): void
     abstract respondOnce (overwrite: MockOverwrite, params: MockResponseParams): void
     abstract abort (errorReason: Protocol.Network.ErrorReason, sticky: boolean): void

--- a/packages/webdriverio/src/utils/interception/webdriver.ts
+++ b/packages/webdriverio/src/utils/interception/webdriver.ts
@@ -47,8 +47,8 @@ export default class WebDriverInterception extends Interception {
      * Does everything that `mock.clear()` does, and also
      * removes any mocked return values or implementations.
      */
-    restore () {
-        return this.browser.call(
+    async restore () {
+        await this.browser.call(
             async () => this.browser.clearMockCalls(this.mockId as string, true))
     }
 

--- a/packages/webdriverio/tests/utils/interception/devtools.test.ts
+++ b/packages/webdriverio/tests/utils/interception/devtools.test.ts
@@ -232,6 +232,18 @@ test('decodes base64 responses', async () => {
     expect(mock.calls[1].body).toBe('{"foo":"bar"}')
 })
 
+test('response error', async () => {
+    const mock = new NetworkInterception('**/foobar/**', undefined, browserMock)
+    cdpClient.send.mockReturnValueOnce(Promise.resolve({}))
+    cdpClient.send.mockReturnValueOnce(Promise.resolve({}))
+    await fetchListener(mock, {
+        request: { url: 'http://test.com/foobar/test.html' },
+        responseErrorReason: 'NameNotResolved'
+    })
+
+    expect(mock.calls[0].statusCode).toBe(0)
+})
+
 test('undefined response', async () => {
     const mock = new NetworkInterception('**/foobar/**', undefined, browserMock)
     cdpClient.send.mockReturnValueOnce(Promise.resolve({}))

--- a/packages/webdriverio/tests/utils/interception/webdriver.test.ts
+++ b/packages/webdriverio/tests/utils/interception/webdriver.test.ts
@@ -47,7 +47,7 @@ test('clear', async () => {
 test('restore', async () => {
     const mock = new NetworkInterception('**/foobar/**', {}, browserMock)
     await mock.init()
-    expect(await mock.restore()).toEqual({})
+    expect(await mock.restore()).toBeUndefined()
     expect(browserMock.clearMockCalls).toBeCalledWith(123, true)
 })
 


### PR DESCRIPTION
## Proposed changes

So `Mock` has `clear` and `restore`, but it does not stop requests/responses from being processed just like active mocks.

- `request` / `match` / `continue` / ... events will still be emitted, and now there is no way to prevent it.

Example:
```ts
    it('some test', async () => {
        const mock = await browser.mock('**', {
            headers: {
                'content-type': 'text/html'
            }
        })
        mock.on('request', () => console.log('opening wdio.io page'))
        await browser.url('https://webdriver.io')
        // logs 'opening wdio.io page' once
    })
    
    it('some other test', async () => {
        const mock = await browser.mock('**', {
            headers: {
                'content-type': 'text/html'
            }
        })
        mock.on('request', () => console.log('opening wdio.io page'))
        await browser.url('https://webdriver.io')
        // logs 'opening wdio.io page' twice
    })
```
- It affects memory usage.

Example: 

```ts
it('test 0', async () => {
    const mock = await browser.mock('**');
    mock.restore();
    setInterval(() => {
        console.log(mock.calls.length);
    }, 5000);
})
Array(100).fill(0).map((_, i) => {
    it(`test ${i + 1}`, async () => {
        await browser.url(`https://youtube.com`);
    })
})
``` 
produces this log (tail), where the number comes from `console.log(mock.calls.length)`:
```
3352
[16:48:06 GMT+3] ✓ test 94 [chrome:66454ccd-cb0d-45f2-9dcd-f30994a3e0f6] - 2331ms
[16:48:09 GMT+3] ✓ test 95 [chrome:66454ccd-cb0d-45f2-9dcd-f30994a3e0f6] - 2354ms
3421
[16:48:11 GMT+3] ✓ test 96 [chrome:66454ccd-cb0d-45f2-9dcd-f30994a3e0f6] - 2456ms
[16:48:14 GMT+3] ✓ test 97 [chrome:66454ccd-cb0d-45f2-9dcd-f30994a3e0f6] - 2796ms
3491
[16:48:17 GMT+3] ✓ test 98 [chrome:66454ccd-cb0d-45f2-9dcd-f30994a3e0f6] - 2592ms
[16:48:19 GMT+3] ✓ test 99 [chrome:66454ccd-cb0d-45f2-9dcd-f30994a3e0f6] - 2456ms
3555
[16:48:24 GMT+3] ✓ test 100 [chrome:c8ffdf93-165f-4377-9f09-16a9de8e9247] - 3174ms
```
so, it looks like those calls are being saved, and if each test has a mock, then 100-th test will be stored 100 times.

Example:

```ts
Array(100).fill(0).map((_, i) => {
    it(`test ${i + 1}`, async () => {
        const mock = await browser.mock('**');
        await browser.url(`https://youtube.com`);
        mock.restore(); // replace with mock.remove to fix exponential memory leak
    })
})
```
uses 3.5GB ram:
<img width="1072" alt="image" src="https://github.com/webdriverio/webdriverio/assets/54893992/d7729ff7-00b9-4482-9823-7e48ff390679">

- It affects performance (not much, really, but still): with just `mock.restore` at the end of test, 100-th test takes 1171 ms, and with `mock.remove` - 810ms (on simple test: `mock = browser.mock('**'); browser.url('localhost:3000'); mock.remove`, where localhost:3000 serves react app template, generated with create-react-app). `mock.remove` also disables fetch domain, if there are no other mocks. I assume, fetch domain has some effect on performance.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

### Reviewers: @webdriverio/project-committers
