### PR TITLE
Spec repoter - add docstring to the final report

### DIFF
--- a/packages/wdio-spec-reporter/src/index.ts
+++ b/packages/wdio-spec-reporter/src/index.ts
@@ -352,13 +352,24 @@ export default class SpecReporter extends WDIOReporter {
                 // Output for a single test
                 output.push(`${testIndent}${chalk[this.getColor(state)](this.getSymbol(state))} ${testTitle}`)
 
-                // print cucumber data table cells
-                const args = (test as TestStats).argument as Argument
-                if (args && args.rows && args.rows.length) {
-                    const data = buildTableData(args.rows)
-                    const rawTable = printTable(data)
-                    const table = getFormattedRows(rawTable, testIndent)
-                    output.push(...table)
+                // print cucumber data table cells and docstring
+                const arg = (test as TestStats).argument
+                if (typeof(arg) === 'string'){
+                    // Doc string is the same with the indent on the output for a single test
+                    const docstringIndent = '  '
+                    const docstringMark = `${testIndent}${docstringIndent}"""`
+                    const docstring = String(arg)
+                    const formattedDocstringLines = docstring.split('\n')
+                        .map((line: string) => `${testIndent}${docstringIndent}${line}`)
+                    output.push(...[docstringMark, ...formattedDocstringLines, docstringMark])
+                } else {
+                    const dataTable = arg as Argument
+                    if (dataTable && dataTable.rows && dataTable.rows.length) {
+                        const data = buildTableData(dataTable.rows)
+                        const rawTable = printTable(data)
+                        const table = getFormattedRows(rawTable, testIndent)
+                        output.push(...table)
+                    }
                 }
 
                 // print pending reasons

--- a/packages/wdio-spec-reporter/tests/__fixtures__/testdata.ts
+++ b/packages/wdio-spec-reporter/tests/__fixtures__/testdata.ts
@@ -221,3 +221,31 @@ Object.values(SUITES_NO_TESTS_WITH_HOOK_ERROR).forEach(suite => {
     // @ts-expect-error
     suite.hooksAndTests = [...suite.hooks]
 })
+
+export const SUITES_WITH_DOC_STRING = {
+    [suiteIds[0]]: {
+        uid: suiteIds[0],
+        title: suiteIds[0].slice(0, -1),
+        rule: '\tVery important business rule',
+        description: '\tSome important\ndescription to read!',
+        file: '/foo/bar/loo.e2e.js',
+        hooks: [],
+        tests: [{
+            uid: 'foo1',
+            title: 'foo',
+            state: 'passed',
+            type: 'test',
+            argument: 'Docstring line 1\nDocstring line 2\nDocstring line 3'
+        }, {
+            uid: 'bar1',
+            title: 'bar',
+            state: 'passed',
+            type: 'test',
+            argument: 'Docstring line 4\nDocstring line 5\nDocstring line 6'
+        }]
+    }
+}
+Object.values(SUITES_WITH_DOC_STRING).forEach(suite => {
+    // @ts-expect-error
+    suite.hooksAndTests = [...suite.tests]
+})

--- a/packages/wdio-spec-reporter/tests/__snapshots__/index.test.ts.snap
+++ b/packages/wdio-spec-reporter/tests/__snapshots__/index.test.ts.snap
@@ -66,6 +66,30 @@ exports[`SpecReporter > getResultDisplay > should print data tables 1`] = `
 ]
 `;
 
+exports[`SpecReporter > getResultDisplay > should print doc string 1`] = `
+[
+  "» /foo/bar/loo.e2e.js",
+  "Foo test",
+  "grey Some important",
+  "grey description to read!",
+  "",
+  "grey Very important business rule",
+  "   green ✓ foo",
+  "     \\"\\"\\"",
+  "     Docstring line 1",
+  "     Docstring line 2",
+  "     Docstring line 3",
+  "     \\"\\"\\"",
+  "   green ✓ bar",
+  "     \\"\\"\\"",
+  "     Docstring line 4",
+  "     Docstring line 5",
+  "     Docstring line 6",
+  "     \\"\\"\\"",
+  "",
+]
+`;
+
 exports[`SpecReporter > getResultDisplay > should validate the result output with tests 1`] = `
 [
   "» /foo/bar/loo.e2e.js",

--- a/packages/wdio-spec-reporter/tests/index.test.ts
+++ b/packages/wdio-spec-reporter/tests/index.test.ts
@@ -9,7 +9,8 @@ import {
     SUITES_NO_TESTS,
     SUITES_WITH_DATA_TABLE,
     SUITES_NO_TESTS_WITH_HOOK_ERROR,
-    SUITES_MULTIPLE_ERRORS
+    SUITES_MULTIPLE_ERRORS,
+    SUITES_WITH_DOC_STRING
 } from './__fixtures__/testdata.js'
 
 vi.mock('chalk')
@@ -395,10 +396,9 @@ describe('SpecReporter', () => {
             expect(result).toMatchSnapshot()
         })
 
-        it('should not print if data table format is not given', () => {
+        it('should print doc string', () => {
             tmpReporter.getOrderedSuites = vi.fn(() => {
-                const suites = Object.values(JSON.parse(JSON.stringify(SUITES_WITH_DATA_TABLE))) as any[]
-                suites[0].hooksAndTests[0].argument = 'some different format'
+                const suites = Object.values(JSON.parse(JSON.stringify(SUITES_WITH_DOC_STRING))) as any[]
                 return suites
             })
             const result = tmpReporter.getResultDisplay()


### PR DESCRIPTION
## Proposed changes

Add docstring to the final report for cucumber tests generated by spec-reporter. This PR is created to solve this bug #10394.

The `argument` property of each `eventsToReports` has `string | Argument` type, but current logic only handles the Argument case. So the datatable of executed cucumber tests which has `Argument` type will display correctly on the report but the `docstring` will be missed.

This fix adds the logic to handle when the `argument` property is a string.

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

### Reviewers: @webdriverio/project-committers
