### PR TITLE
(browser-runner): avoid responses on map requests

### DIFF
--- a/e2e/wdio/headless/test.e2e.ts
+++ b/e2e/wdio/headless/test.e2e.ts
@@ -1,7 +1,7 @@
 
 import type { Capabilities } from '../../../packages/wdio-types'
 
-const SCROLL_MARGIN_TRESHOLD = 20
+const SCROLL_MARGIN_TRESHOLD = 25
 
 describe('main suite 1', () => {
     it('foobar test', async () => {

--- a/packages/devtools/src/scripts/executeAsyncScript.ts
+++ b/packages/devtools/src/scripts/executeAsyncScript.ts
@@ -23,7 +23,7 @@ export default (
 ): Promise<any> => {
     return new Promise((_resolve, _reject) => {
         setTimeout(
-            () => _reject('script timeout'),
+            () => _reject(new Error('Evaluation failed: script timeout')),
             scriptTimeout
         )
 

--- a/packages/wdio-browser-runner/src/vite/plugins/testrunner.ts
+++ b/packages/wdio-browser-runner/src/vite/plugins/testrunner.ts
@@ -120,7 +120,10 @@ export function testrunner(options: WebdriverIO.BrowserRunnerOptions): Plugin[] 
             return () => {
                 server.middlewares.use(async (req, res, next) => {
                     log.info(`Received request for: ${req.originalUrl}`)
-                    if (!req.originalUrl) {
+                    /**
+                     * don't return test page when sourcemaps are requested
+                     */
+                    if (!req.originalUrl || req.url?.endsWith('.map')) {
                         return next()
                     }
 

--- a/packages/wdio-browser-runner/tests/vite/plugins/testrunner.test.ts
+++ b/packages/wdio-browser-runner/tests/vite/plugins/testrunner.test.ts
@@ -86,19 +86,28 @@ test('configureServer continues if no url given', async () => {
     const next = vi.fn()
     const res = { end: vi.fn() }
     middleware({}, {}, next)
+    expect(getTemplate).toBeCalledTimes(0)
     expect(next).toBeCalledWith()
     next.mockClear()
 
     middleware({ ...req, originalUrl: 'https://google.com' }, {}, next)
+    expect(getTemplate).toBeCalledTimes(0)
     expect(next).toBeCalledWith()
     next.mockClear()
 
     middleware({ ...req, originalUrl: 'http://localhost:1234/?cid=1-2&spec=foobar' }, {}, next)
+    expect(getTemplate).toBeCalledTimes(0)
     expect(next).toBeCalledWith()
     next.mockClear()
 
     SESSIONS.set('1-2', {} as any)
     middleware({ ...req, originalUrl: 'http://localhost:1234/?cid=1-2' }, {}, next)
+    expect(getTemplate).toBeCalledTimes(0)
+    expect(next).toBeCalledWith()
+    next.mockClear()
+
+    middleware({ ...req, originalUrl: 'http://localhost:1234/build/foobar.js.map', url: 'build/foobar.js.map' }, {}, next)
+    expect(getTemplate).toBeCalledTimes(0)
     expect(next).toBeCalledWith()
     next.mockClear()
 


### PR DESCRIPTION
## Proposed changes

Making requests to sourcemaps e.g. `/foo/bar.js.map` would currently cause the browser runner to return an HTML file while sourcemaps expects a JSON. This patch ignores these requests so they fail correctly with 404.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

Also this patch fixes some e2e test failures.

### Reviewers: @webdriverio/project-committers
