### PR TITLE
fix: set sessionName in case of browser.reloadSession

### DIFF
--- a/packages/wdio-browserstack-service/src/service.ts
+++ b/packages/wdio-browserstack-service/src/service.ts
@@ -275,7 +275,6 @@ export default class BrowserstackService implements Services.ServiceInstance {
         }
 
         this._scenariosThatRan = []
-        delete this._suiteTitle
         delete this._fullTitle
         this._failReasons = []
         await this._printSessionURL()

--- a/packages/wdio-browserstack-service/tests/service.test.ts
+++ b/packages/wdio-browserstack-service/tests/service.test.ts
@@ -117,6 +117,18 @@ describe('onReload()', () => {
         await service.onReload('1', '2')
         expect(updateSpy).toBeCalledTimes(0)
     })
+
+    it('should not reset suiteTitle', async () => {
+        const updateSpy = jest.spyOn(service, '_update')
+        service['_browser'] = browser
+        service['_failReasons'] = []
+        service['_suiteTitle'] = 'my suite title'
+        await service.onReload('1', '2')
+        expect(updateSpy).toHaveBeenCalledWith('1', {
+            status: 'passed',
+        })
+        expect(service['_suiteTitle']).toEqual('my suite title')
+    })
 })
 
 describe('beforeSession', () => {


### PR DESCRIPTION
## Proposed changes

Fix: In the following scenario, the name of the second session would not marked on browserstack, this change fixes that.

```
describe('first describe', () => {
  it('session 1 on browserstack', async () => {

  });
});

describe('second describe ', () => {
  before('relaod session', async () => {
    await browser.reloadSession();
  });

  it('session 2 on browserstack', async () => {

  });
});
```
[Current behaviour](https://automate.browserstack.com/dashboard/v2/public-build/aHlhc1RjYWIwTXBpMGtMTXVQdnFGS2ZWVVBsb2daMjlDYnZFNEl2bHNZcnNOY1NOTUd3RmRxVmdvK0Z5MGRwMnN4TFVhYUhEYnlEUXV2ME5yclhWK2c9PS0taWRDRXdhYWM1cFM3ZnBMcEFkdEpUUT09--de2881c2d027e045c3e0644739b4e35a1d1c901e)
[After this change](https://automate.browserstack.com/dashboard/v2/public-build/TkpVdDd3S3FleHB4eHAwd0FCd0NwRTdjYWlTb0dWdjN6eFVWdUtNZGxKc0JMN2xueWtaWmthRitnTm00Y3JQYWZTZXBHUEpKallpaVpQcHdIK2VWdmc9PS0tVW4vR0grVjFkUENXa1Nxc2VNQ0prdz09--ef831d7408785e25507e034677aa177517490e90)

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
