### PR TITLE
fix: tune isMobile for Appium situation

### DIFF
--- a/packages/wdio-utils/src/envDetector.ts
+++ b/packages/wdio-utils/src/envDetector.ts
@@ -96,9 +96,9 @@ function isMobile(capabilities: Capabilities.Capabilities) {
         /**
          * If the device is ios, tvos or android, the device might be mobile.
          */
-        capabilities.platformName && capabilities.platformName.toLowerCase().match(/ios/i) ||
-        capabilities.platformName && capabilities.platformName.toLowerCase().match(/tvos/i) ||
-        capabilities.platformName && capabilities.platformName.toLowerCase().match(/android/i) ||
+        capabilities.platformName && capabilities.platformName.match(/ios/i) ||
+        capabilities.platformName && capabilities.platformName.match(/tvos/i) ||
+        capabilities.platformName && capabilities.platformName.match(/android/i) ||
         /**
          * capabilities contain mobile only specific capabilities
          */

--- a/packages/wdio-utils/src/envDetector.ts
+++ b/packages/wdio-utils/src/envDetector.ts
@@ -94,9 +94,11 @@ function isMobile(capabilities: Capabilities.Capabilities) {
      */
     return Boolean(
         /**
-         * there are any Appium vendor capabilties
+         * If the device is ios, tvos or android, the device might be mobile.
          */
-        Object.keys(capabilities).find((cap) => cap.startsWith('appium:')) ||
+        capabilities.platformName && capabilities.platformName.toLowerCase().match(/ios/i) ||
+        capabilities.platformName && capabilities.platformName.toLowerCase().match(/tvos/i) ||
+        capabilities.platformName && capabilities.platformName.toLowerCase().match(/android/i) ||
         /**
          * capabilities contain mobile only specific capabilities
          */

--- a/packages/wdio-utils/tests/envDetector.test.ts
+++ b/packages/wdio-utils/tests/envDetector.test.ts
@@ -43,6 +43,11 @@ describe('sessionEnvironmentDetector', () => {
         expect(sessionEnvironmentDetector({ capabilities: chromeCaps, requestedCapabilities: appiumW3CCaps }).isMobile).toBe(false)
         const newCaps = { ...chromeCaps, 'appium:options': {} }
         expect(sessionEnvironmentDetector({ capabilities: newCaps, requestedCapabilities }).isMobile).toBe(true)
+
+        // match with Appium if it had
+        expect(sessionEnvironmentDetector({ capabilities: chromeCaps, requestedCapabilities: { platformName: 'ios' } }).isMobile).toBe(true)
+        expect(sessionEnvironmentDetector({ capabilities: chromeCaps, requestedCapabilities: { platformName: 'tvos' } }).isMobile).toBe(true)
+        expect(sessionEnvironmentDetector({ capabilities: chromeCaps, requestedCapabilities: { platformName: 'android' } }).isMobile).toBe(true)
     })
 
     it('isW3C', () => {

--- a/packages/wdio-utils/tests/envDetector.test.ts
+++ b/packages/wdio-utils/tests/envDetector.test.ts
@@ -47,9 +47,12 @@ describe('sessionEnvironmentDetector', () => {
         expect(sessionEnvironmentDetector({ capabilities: newCaps, requestedCapabilities }).isMobile).toBe(false)
 
         // match with Appium if it had
-        expect(sessionEnvironmentDetector({ capabilities: chromeCaps, requestedCapabilities: { platformName: 'ios' } }).isMobile).toBe(true)
-        expect(sessionEnvironmentDetector({ capabilities: chromeCaps, requestedCapabilities: { platformName: 'tvos' } }).isMobile).toBe(true)
-        expect(sessionEnvironmentDetector({ capabilities: chromeCaps, requestedCapabilities: { platformName: 'android' } }).isMobile).toBe(true)
+        const iosCaps = { ...chromeCaps, 'platformName': 'ios' }
+        expect(sessionEnvironmentDetector({ capabilities: iosCaps, requestedCapabilities }).isMobile).toBe(true)
+        const tvOSCaps = { ...chromeCaps, 'platformName': 'tvOS' }
+        expect(sessionEnvironmentDetector({ capabilities: tvOSCaps, requestedCapabilities }).isMobile).toBe(true)
+        const androidCaps = { ...chromeCaps, 'platformName': 'Android' }
+        expect(sessionEnvironmentDetector({ capabilities: androidCaps, requestedCapabilities }).isMobile).toBe(true)
     })
 
     it('isW3C', () => {

--- a/packages/wdio-utils/tests/envDetector.test.ts
+++ b/packages/wdio-utils/tests/envDetector.test.ts
@@ -41,8 +41,10 @@ describe('sessionEnvironmentDetector', () => {
         // doesn't matter if there are Appium capabilities if returned session details don't show signs of Appium
         expect(sessionEnvironmentDetector({ capabilities: chromeCaps, requestedCapabilities: appiumReqCaps }).isMobile).toBe(false)
         expect(sessionEnvironmentDetector({ capabilities: chromeCaps, requestedCapabilities: appiumW3CCaps }).isMobile).toBe(false)
+
+        // expected to be false since it has apppium: but no mobile related platform name info
         const newCaps = { ...chromeCaps, 'appium:options': {} }
-        expect(sessionEnvironmentDetector({ capabilities: newCaps, requestedCapabilities }).isMobile).toBe(true)
+        expect(sessionEnvironmentDetector({ capabilities: newCaps, requestedCapabilities }).isMobile).toBe(false)
 
         // match with Appium if it had
         expect(sessionEnvironmentDetector({ capabilities: chromeCaps, requestedCapabilities: { platformName: 'ios' } }).isMobile).toBe(true)

--- a/packages/webdriver/tests/index.test.ts
+++ b/packages/webdriver/tests/index.test.ts
@@ -317,7 +317,7 @@ describe('WebDriver', () => {
                 ...sessionOptions,
                 capabilities: {
                     'appium:automationName': 'foo',
-                    'appium:platformName': 'ios',
+                    'platformName': 'ios',
                 }
             }) as any as TestClient
             expect(client.isMobile).toBe(true)

--- a/packages/webdriver/tests/index.test.ts
+++ b/packages/webdriver/tests/index.test.ts
@@ -317,6 +317,7 @@ describe('WebDriver', () => {
                 ...sessionOptions,
                 capabilities: {
                     'appium:automationName': 'foo',
+                    'appium:platformName': 'ios',
                 }
             }) as any as TestClient
             expect(client.isMobile).toBe(true)


### PR DESCRIPTION
## Proposed changes


Current `isMobile` detection returns `true` if the session was appium by checking the caps has `appium:`. In this case, for example. the displayed check method call calls `/displayed` endpoint, although Appium would like to expect to get JS one for chrome/msedge (desktop browser) for https://github.com/appium/appium-chromium-driver . It could cause unexpected W3C/MJSONWP endpoint call. So this PR's idea is to make the isMobile true only when the platformName is ios, tvos and android. For Appium's case, probably the platformName is more accurate in detecting whether the target device is mobile, or not.


Btw, when I tried to run `npm run test:unit` to check the test code, I got an error below. Thus I haven't completed the test case yet. `npx vitest ./packages/wdio-utils/tests` also returned the same result.

Let me kick this repository's CI how the test case will be... (since it did not work on my local...)

```
⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Error during global setup ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
Error: Renaming "got" dependency failed!

WebdriverIO needs to hide the "got" dependency (at "packages/webdriver/node_modules/got")
during the test to force Vitest to use our mocked version. WebdriverIO does this by renaming:

"packages/webdriver/node_modules/got"
to
"packages/webdriver/node_modules/tmp_got"

during test setup and back again during test tear-down.

'Setup has failed.  Maybe because you are already running unit tests in a different
'terminal.
Error: ENOENT: no such file or directory, rename '/Users/kazu/GitHub/webdriverio/packages/webdriver/node_modules/got' -> '/Users/kazu/GitHub/webdriverio/packages/webdriver/node_modules/tmp_got'

To correct this error please run:
        mv packages/webdriver/node_modules/tmp_got packages/webdriver/node_modules/got

 ❯ throwBetterErrorMessageSetup scripts/test/globalSetup.ts:28:9
     26|     throw new Error(
     27|         util.format(ERROR_MESSAGE, 'Setup') +
     28|         err.stack +
       |         ^
     29|         '\n\nTo correct this error please run:\n\tmv packages/webdriver/node_modules/tmp_got packages/webdriver/node_modules/got\n'
     30|     )
 ❯ Object.setup scripts/test/globalSetup.ts:38:3
 ❯ hookParallel node_modules/vite/dist/node/chunks/dep-e8f070e8.js:42512:9
 ❯ Object.buildStart node_modules/vite/dist/node/chunks/dep-e8f070e8.js:42824:13
```

In my brief testing on my local, iOS session was handled as isMobile as true but false for chrome desktop. This is expected behavior.


## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
