### PR TITLE
Fix tests in v7 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,12 +17,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [14.x, 16.x]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Upgrade npm
+        run: npm install -g npm@7
       - name: Install Dependencies
         run: npm ci
       - name: Bootstrap Packages

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [16.x]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 </p>
 
 <p align="center">
-    Next-gen browser and mobile automation test work for Node.js.
+    Next-gen browser and mobile automation test framework for Node.js.
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 </p>
 
 <p align="center">
-    Next-gen browser and mobile automation test framework for Node.js.
+    Next-gen browser and mobile automation test work for Node.js.
 </p>
 
 <p align="center">

--- a/packages/webdriverio/package.json
+++ b/packages/webdriverio/package.json
@@ -64,7 +64,7 @@
     "@wdio/types": "7.30.2",
     "@wdio/utils": "7.30.2",
     "archiver": "^5.0.0",
-    "aria-query": "^5.0.0",
+    "aria-query": "^5.2.1",
     "css-shorthand-properties": "^1.1.1",
     "css-value": "^0.0.1",
     "devtools": "7.31.1",

--- a/packages/webdriverio/tests/findStrategy.test.ts
+++ b/packages/webdriverio/tests/findStrategy.test.ts
@@ -418,7 +418,7 @@ describe('selector strategies helper', () => {
     it('should find an element using "css selector" method with implicit & explicit ARIA roles of button in case of role selector', () => {
         const element = findStrategy('[role=button]')
         expect(element.using).toBe('css selector')
-        expect(element.value).toBe('[role="button"],input[type="checkbox"],summary[aria-expanded="false"],summary[aria-expanded="true"],input[type="button"],input[type="image"],input[type="reset"],input[type="submit"],button')
+        expect(element.value).toBe('[role="button"],input[type="button"],input[type="image"],input[type="reset"],input[type="submit"],button')
     })
 
     it('should find an element using "css selector" method with implicit & explicit ARIA roles of checkbox in case of role selector', () => {
@@ -430,7 +430,7 @@ describe('selector strategies helper', () => {
     it('should find an element using "css selector" method with implicit & explicit ARIA roles of listbox in case of role selector', () => {
         const element = findStrategy('[role=listbox]')
         expect(element.using).toBe('css selector')
-        expect(element.value).toBe('[role="listbox"],select[multiple],select[size],select[multiple],datalist')
+        expect(element.value).toBe('[role="listbox"],select[multiple],select[size],select[multiple],datalist[aria-multiselectable="true"],datalist[aria-multiselectable="false"]')
     })
 
     it('should find an element using "css selector" method with implicit & explicit ARIA roles of rowgroup in case of role selector', () => {


### PR DESCRIPTION
## Proposed changes

1.  linux with node 14.x
    - This was failing due to conflicting `@types/node` versions installed in different packages
    - One solution was to upgrade npm 6 to npm 7
    - The current `package-lock.json` has of version of v2, but npm 6 only supports v1. So maybe that's why upgrading it solved the issue. Also tried deleting the existing package-lock.json and running `npm install` with npm 6, but that didn't solve the issue.
    - `setup-node` doesn't offer any way to specify npm version, so had to upgrade it using command - [related issue](https://github.com/actions/setup-node/issues/213)
2. find element tests
    - These were failing on Linux and Windows.
    - Made the same changes as [you made for v8](https://github.com/webdriverio/webdriverio/commit/33aa5aade1047b1a7876c576a44fe30f1a236ae5). But after this changes Mac tests were failing
    - On debugging found out that, the version of `aria-query` was getting installed as 5.1.3 on linux and windows as 5.2.1 on Mac (mac be due to caching or something). The output of [roleElements](https://github.com/webdriverio/webdriverio/blob/08067cc7d4dd957c892185ad6fed90c4f527944a/packages/webdriverio/src/utils/findStrategy.ts#LL291C9-L291C9) was different in different versions, thereby causing the tests to fail.
    - So had upgraded this package version to 5.2.1 to be consisitent

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
