### PR TITLE
Replace addMatchers with addAsyncMatchers to get matchers returned …

### DIFF
--- a/__mocks__/jasmine.ts
+++ b/__mocks__/jasmine.ts
@@ -25,6 +25,7 @@ export const jasmine = {
         })
     },
     addAsyncMatchers: vi.fn(),
+    addMatchers: vi.fn(),
     beforeAll: vi.fn((cb) => cb())
 }
 export default class JasmineMock {

--- a/packages/wdio-jasmine-framework/src/index.ts
+++ b/packages/wdio-jasmine-framework/src/index.ts
@@ -200,6 +200,11 @@ class JasmineAdapter {
          */
         const expect = jasmineEnv.expectAsync
         const matchers = this.#setupMatchers(jasmine)
+        /**
+         * Monkey patch addMatchers to actually call addAsyncMatchers.
+         * This wires the overridden expect (witch is actually expectAsync) with matchers added via addMatchers.
+         */
+        jasmineEnv.addMatchers = jasmineEnv.addAsyncMatchers
         jasmineEnv.beforeAll(() => jasmineEnv.addAsyncMatchers(matchers))
         _setGlobal('expect', expect, this._config.injectGlobals)
 

--- a/packages/wdio-jasmine-framework/tests/adapter.test.ts
+++ b/packages/wdio-jasmine-framework/tests/adapter.test.ts
@@ -98,6 +98,7 @@ test('should properly set up jasmine', async () => {
         toBe: expect.any(Function),
         toHaveTitle: expect.any(Function)
     })
+    expect(jasmine.addMatchers).toBe(jasmine.addAsyncMatchers)
 })
 
 test('should propery wrap interfaces', async () => {


### PR DESCRIPTION
…when calling expect(...).

Note: expect is actually expectAsync in wdio environment.

## Proposed changes

Assigne `addAsyncMatchers` to `addMatchers` when setting up jasmine environment.
This allows users to to use `addMatchers` as described in [the documentation of jasmine](https://jasmine.github.io/api/edge/jasmine.html).

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments
### Reviewers: @webdriverio/project-committers
