### PR TITLE
(@wdio/jasmine-framework): support sync negative matchers

### DIFF
--- a/packages/wdio-jasmine-framework/src/index.ts
+++ b/packages/wdio-jasmine-framework/src/index.ts
@@ -395,7 +395,13 @@ class JasmineAdapter {
         const syncMatchers: jasmine.CustomAsyncMatcherFactories = Object.entries(jasmineMatchers).reduce((prev, [name, fn]) => {
             prev[name] = (util) => ({
                 compare: async <T>(actual: T, expected: T, ...args: any[]) => fn(util).compare(actual, expected, ...args),
-                negativeCompare: async <T>(actual: T, expected: T, ...args: unknown[]) => fn(util).negativeCompare!(actual, expected, ...args)
+                negativeCompare: async <T>(actual: T, expected: T, ...args: unknown[]) => {
+                    const { pass, message } = fn(util).compare(actual, expected, ...args)
+                    return {
+                        pass: !pass,
+                        message
+                    }
+                }
             })
             return prev
         }, {} as jasmine.CustomAsyncMatcherFactories)

--- a/tests/jasmine/test.js
+++ b/tests/jasmine/test.js
@@ -4,6 +4,7 @@ describe('Jasmine smoke test', () => {
     it('should allow sync matchers', () => {
         const test = 123
         expect(test).toBe(123)
+        expect(test).not.toBe(124)
     })
 
     it('should support sync Jest and Jasmine matchers', () => {

--- a/tests/smoke.runner.js
+++ b/tests/smoke.runner.js
@@ -134,6 +134,7 @@ const jasmineTestrunner = async () => {
         [
             'expect(number).toBe(number)',
             'expect(number).toBe(number)',
+            'expect(number).toBe(number)',
             'expect(object).toEqual(object)',
             'expect(object).toBeFalse(boolean)',
             'expect(string).toHaveTitle(object)',


### PR DESCRIPTION
## Proposed changes

fixes #10606

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
