### PR TITLE
(@wdio/cli): support loading of config files with mjs or mts extension

### DIFF
--- a/packages/wdio-cli/src/commands/config.ts
+++ b/packages/wdio-cli/src/commands/config.ts
@@ -182,7 +182,14 @@ export async function canAccessConfigPath(configPath: string) {
     return await fs.access(`${configPath}.js`).then(
         () => true,
         () => fs.access(`${configPath}.ts`).then(
-            () => true, () => false
+            () => true,
+            () => fs.access(`${configPath}.mjs`).then(
+                () => true,
+                () => fs.access(`${configPath}.mts`).then(
+                    () => true,
+                    () => false
+                )
+            )
         )
     )
 }

--- a/packages/wdio-cli/src/commands/run.ts
+++ b/packages/wdio-cli/src/commands/run.ts
@@ -168,6 +168,7 @@ export async function handler(argv: RunCommandArguments) {
      */
     const nodePath = process.argv[0]
     let NODE_OPTIONS = process.env.NODE_OPTIONS || ''
+    const isTSFile = wdioConf.fullPath.endsWith('.ts') || wdioConf.fullPath.endsWith('.mts')
     const runsWithLoader = (
         Boolean(
             process.argv.find((arg) => arg.startsWith('--loader')) &&
@@ -175,7 +176,7 @@ export async function handler(argv: RunCommandArguments) {
         ) ||
         NODE_OPTIONS?.includes('ts-node/esm')
     )
-    if (wdioConf.fullPath.endsWith('.ts') && !runsWithLoader && nodePath) {
+    if (isTSFile && !runsWithLoader && nodePath) {
         NODE_OPTIONS += ' --loader ts-node/esm/transpile-only --no-warnings'
         const localTSConfigPath = (
             (

--- a/packages/wdio-cli/tests/commands/run.test.ts
+++ b/packages/wdio-cli/tests/commands/run.test.ts
@@ -62,7 +62,7 @@ describe('Command: run', () => {
 
     it('should use local conf if nothing defined', async () => {
         await runCmd.handler({ argv: {} } as any)
-        expect(fs.access).toBeCalledTimes(2)
+        expect(fs.access).toBeCalledTimes(4)
     })
 
     it('should use Watcher if "--watch" flag is passed', async () => {


### PR DESCRIPTION
## Proposed changes

In a CJS project one might want to use WebdriverIO in ESM. Therefor we should support loading `wdio.conf.mjs` and `wdio.conf.mts` files.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
