### PR TITLE
(@wdio/spec-reporter): propagate root suite hook errors

### DIFF
--- a/packages/wdio-spec-reporter/src/index.ts
+++ b/packages/wdio-spec-reporter/src/index.ts
@@ -321,7 +321,7 @@ export default class SpecReporter extends WDIOReporter {
             const suiteIndent = this.indent(suite.uid)
 
             // Display file path of spec
-            if (!specFileReferences.includes(suite.file)) {
+            if (suite.file && !specFileReferences.includes(suite.file)) {
                 output.push(`${suiteIndent}» ${suite.file.replace(process.cwd(), '')}`)
                 specFileReferences.push(suite.file)
             }
@@ -485,6 +485,30 @@ export default class SpecReporter extends WDIOReporter {
 
                 this._orderedSuites.push(suite)
             }
+        }
+
+        /**
+         * ensure we include root suite hook errors
+         */
+        const rootSuite = this.currentSuites[0]
+        if (rootSuite) {
+            const baseRootSuite = {
+                ...rootSuite,
+                type: 'suite',
+                title: '(root)',
+                fullTitle: '(root)',
+                suites: []
+            }
+            const beforeAllHooks = rootSuite.hooks.filter((hook) => hook.state && hook.title.startsWith('"before') && hook.title.endsWith('"{root}"'))
+            const afterAllHooks = rootSuite.hooks.filter((hook) => hook.state && hook.title.startsWith('"after') && hook.title.endsWith('"{root}"'))
+            this._orderedSuites.unshift(Object.assign({} as SuiteStats, baseRootSuite, {
+                hooks: beforeAllHooks,
+                hooksAndTests: beforeAllHooks
+            }))
+            this._orderedSuites.push(Object.assign({} as SuiteStats, baseRootSuite, {
+                hooks: afterAllHooks,
+                hooksAndTests: afterAllHooks
+            }))
         }
 
         return this._orderedSuites

--- a/packages/wdio-spec-reporter/tests/index.test.ts
+++ b/packages/wdio-spec-reporter/tests/index.test.ts
@@ -546,6 +546,30 @@ describe('SpecReporter', () => {
         it('should return no suites', () => {
             expect(tmpReporter.getOrderedSuites().length).toBe(0)
         })
+
+        it('should propagate root suite hook errors', () => {
+            tmpReporter['_suiteUids'] = new Set(['5', '3', '8'])
+            tmpReporter.suites = { '3': { uid: 3 }, '5': { uid: 5 } } as any
+            tmpReporter.currentSuites = [{
+                hooks: [{
+                    type: 'hook',
+                    title: '"before all" hook in "{root}"',
+                    state: 'failed'
+                }, {
+                    type: 'hook',
+                    title: '"after all" hook in "{root}"',
+                    state: undefined
+                }, {
+                    type: 'hook',
+                    title: '"after all" hook in "{root}"',
+                    state: 'failed'
+                }]
+            }] as any
+            const result = tmpReporter.getOrderedSuites()
+            expect(result.length).toBe(4)
+            expect(result[0].hooks.length).toBe(1)
+            expect(result[3].hooks.length).toBe(1)
+        })
     })
 
     describe('indent', () => {


### PR DESCRIPTION
### Have you read the Contributing Guidelines on issues?

- [X] I have read the [Contributing Guidelines on issues](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md#reporting-new-issues).

### WebdriverIO Version

latest

### Node.js Version

latest

### Mode

WDIO Testrunner

### Which capabilities are you using?

```typescript
any
```


### What happened?

Given I have a Mocha test file as following:

```ts
import { expect, $, $$, browser } from '@wdio/globals'
import { Key } from 'webdriverio'

describe('Trello Application', () => {
  it('can find links with partial or full text selector', async () => {
    // ...
  })

  // ...
})

after(() => {
  throw new Error('FAIL')
})
```

The test fails as expected but the error in the root hook is not reported in the spec reporter:

```
 "spec" Reporter:
------------------------------------------------------------------
[chrome 110.0.5481.177 mac os x #0-0] Running: chrome (v110.0.5481.177) on mac os x
[chrome 110.0.5481.177 mac os x #0-0] Session ID: 7f57bd6942b2948627a4b8627bffefa2
[chrome 110.0.5481.177 mac os x #0-0]
[chrome 110.0.5481.177 mac os x #0-0] » /test/e2e/applitools.e2e.ts
[chrome 110.0.5481.177 mac os x #0-0] Trello Application
[chrome 110.0.5481.177 mac os x #0-0]    ✓ can create an initial board
[chrome 110.0.5481.177 mac os x #0-0]    ✓ can add a list on the board
[chrome 110.0.5481.177 mac os x #0-0]    ✓ can add a card to the list
[chrome 110.0.5481.177 mac os x #0-0]    ✓ can close adding more cards
[chrome 110.0.5481.177 mac os x #0-0]    ✓ can star the board
[chrome 110.0.5481.177 mac os x #0-0]    ✓ can delete a board
[chrome 110.0.5481.177 mac os x #0-0]    ✓ can find links with partial or full text selector
[chrome 110.0.5481.177 mac os x #0-0]
[chrome 110.0.5481.177 mac os x #0-0] 7 passing (53.2s)
[chrome 110.0.5481.177 mac os x #0-0] 1 failing


Spec Files:      0 passed, 1 failed, 1 total (100% completed) in 00:00:56
```

### What is your expected behavior?

I suggest the following reporting:

```
 "spec" Reporter:
------------------------------------------------------------------
[chrome 110.0.5481.177 mac os x #0-0] Running: chrome (v110.0.5481.177) on mac os x
[chrome 110.0.5481.177 mac os x #0-0] Session ID: 7f57bd6942b2948627a4b8627bffefa2
[chrome 110.0.5481.177 mac os x #0-0]
[chrome 110.0.5481.177 mac os x #0-0] » /test/e2e/applitools.e2e.ts
[chrome 110.0.5481.177 mac os x #0-0] Trello Application
[chrome 110.0.5481.177 mac os x #0-0]    ✓ can create an initial board
[chrome 110.0.5481.177 mac os x #0-0]    ✓ can add a list on the board
[chrome 110.0.5481.177 mac os x #0-0]    ✓ can add a card to the list
[chrome 110.0.5481.177 mac os x #0-0]    ✓ can close adding more cards
[chrome 110.0.5481.177 mac os x #0-0]    ✓ can star the board
[chrome 110.0.5481.177 mac os x #0-0]    ✓ can delete a board
[chrome 110.0.5481.177 mac os x #0-0]    ✓ can find links with partial or full text selector
[chrome 110.0.5481.177 mac os x #0-0]
[chrome 110.0.5481.177 mac os x #0-0] <ROOT HOOK>
[chrome 110.0.5481.177 mac os x #0-0]    ❌ Error: FAIL
[chrome 110.0.5481.177 mac os x #0-0]
[chrome 110.0.5481.177 mac os x #0-0] 7 passing (53.2s)
[chrome 110.0.5481.177 mac os x #0-0] 1 failing


Spec Files:      0 passed, 1 failed, 1 total (100% completed) in 00:00:56
```

or alternatively whatever is the behavior for a similar Mocha test.

### How to reproduce the bug.

n/a

### Relevant log output

```typescript
n/a
```


### Code of Conduct

- [X] I agree to follow this project's Code of Conduct

### Is there an existing issue for this?

- [X] I have searched the existing issues