### PR TITLE
fix(jasmine-frame): Switch to addMatchingHelperFiles

### DIFF
--- a/packages/wdio-jasmine-framework/src/index.ts
+++ b/packages/wdio-jasmine-framework/src/index.ts
@@ -223,8 +223,7 @@ class JasmineAdapter {
                 this._jrunner.addRequires(this._jasmineOpts.requires)
             }
             if (Array.isArray(this._jasmineOpts.helpers)) {
-                // @ts-ignore outdated types
-                this._jrunner.addHelperFiles(this._jasmineOpts.helpers)
+                this._jrunner.addMatchingHelperFiles(this._jasmineOpts.helpers)
             }
             // @ts-ignore outdated types
             await this._jrunner.loadRequires()


### PR DESCRIPTION
## Proposed changes

`jasmine` [removed `addHelperFiles`](https://github.com/jasmine/jasmine-npm/commit/28f949554402280d13aab8608a11feb2f00bcf98) in its v4 release, but `@wdio/jasmine-framework` is [still calling it](https://github.com/webdriverio/webdriverio/blob/27b98700cd092b68df57849056783d5ae6b6980e/packages/wdio-jasmine-framework/src/index.ts#L227). `@wdio/jasmine-framework` is [using v5 of `jasmine`](https://github.com/webdriverio/webdriverio/blob/27b98700cd092b68df57849056783d5ae6b6980e/packages/wdio-jasmine-framework/package.json#L41) now. This method was deprecated in favor of [`addMatchingSpecFiles`](https://github.com/jasmine/jasmine-npm/commit/28f949554402280d13aab8608a11feb2f00bcf98#diff-9869551abc7867c844ec977e13e427247fb408dfde5e486b97c058c932510984L370).

I have some projects that are failing with an error stack pointing to this line. I have others that pass, however. I'm not sure why some projects work and others don't, but when I manually changed the method in `node_modules`, everything succeeded.

An example error:

```log
console.log
    [0-0] 2023-07-13T21:10:26.737Z WARN @wdio/jasmine-framework: Unable to load spec files quite likely because they rely on `browser` object that is not fully initialised.
    [0-0] `browser` object has only `capabilities` and some flags like `isMobile`.
    [0-0] Helper files that use other `browser` commands have to be moved to `before` hook.
    [0-0] Spec file(s): file:///tmp/tmp-5251AfIFKtpqHtwm/test.e2e.ts
    [0-0]  Error:  TypeError: this._jrunner.addHelperFiles is not a function
    [0-0]     at JasmineAdapter._loadFiles (file:///tmp/tmp-5251AfIFKtpqHtwm/auth-i18n/node_modules/@wdio/jasmine-framework/build/index.js:170:31)
    [0-0]     at JasmineAdapter.init (file:///tmp/tmp-5251AfIFKtpqHtwm/auth-i18n/node_modules/@wdio/jasmine-framework/build/index.js:155:20)
    [0-0]     at Object.adapterFactory.init (file:///tmp/tmp-5251AfIFKtpqHtwm/auth-i18n/node_modules/@wdio/jasmine-framework/build/index.js:350:36)
    [0-0]     at Runner.#initFramework (file:///tmp/tmp-5251AfIFKtpqHtwm/auth-i18n/node_modules/@wdio/runner/build/index.js:168:30)
    [0-0]     at async Runner.run (file:///tmp/tmp-5251AfIFKtpqHtwm/auth-i18n/node_modules/@wdio/runner/build/index.js:72:27)
    [0-0] TypeError: elem[prop] is not a function
    [0-0]     at file:///tmp/tmp-5251AfIFKtpqHtwm/auth-i18n/node_modules/@wdio/utils/build/shim.js:188:38
```

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

I don't know how to add a test for this. I'm assuming there weren't any before.

### Reviewers: @webdriverio/project-committers
