### PR TITLE
(@wdio/jasmine-framework): fix matcher

### DIFF
--- a/packages/wdio-jasmine-framework/tests/adapter.test.ts
+++ b/packages/wdio-jasmine-framework/tests/adapter.test.ts
@@ -70,7 +70,22 @@ test('comes with a factory', async () => {
     )
     const result = await instance.run()
     expect(result).toBe(0)
-    expect(globalThis.jasmine.addMatchers).toBe(globalThis.jasmine.addAsyncMatchers)
+
+    globalThis.jasmine.addAsyncMatchers = vi.fn()
+    globalThis.jasmine.addMatchers({
+        testMatcher: function testMatcher(/*matcherUtils*/) {
+            return {
+                compare: function compare(/*actual, expected*/) {
+                    return { pass: true, message: 'Just good vibes.' }
+                }
+            }
+        }
+    })
+    expect(globalThis.jasmine.addAsyncMatchers).toBeCalledTimes(1)
+    const testMatcher = vi.mocked(globalThis.jasmine.addAsyncMatchers).mock.calls[0][0].testMatcher
+    const { compare, negativeCompare } = testMatcher({} as any)
+    expect(compare.constructor.name).toBe('AsyncFunction')
+    expect(negativeCompare?.constructor.name).toBe('AsyncFunction')
 })
 
 test('should properly set up jasmine', async () => {

--- a/tests/jasmine/test.js
+++ b/tests/jasmine/test.js
@@ -56,6 +56,7 @@ describe('Jasmine smoke test', () => {
             const customMatcher = expect(1).testMatcher
             expect(customMatcher).toBeDefined()
             expect(customMatcher).toBeInstanceOf(Function)
+            expect(1).testMatcher()
         })
     })
 })

--- a/tests/smoke.runner.js
+++ b/tests/smoke.runner.js
@@ -144,6 +144,7 @@ const jasmineTestrunner = async () => {
             'expect(number).toBe(number)',
             'expect(object).toBeDefined(function)',
             'expect(function).toBeInstanceOf(function)',
+            'expect(object).testMatcher(number)',
             ''
         ].join('\n')
     )


### PR DESCRIPTION
## Proposed changes

In #10686 we have done some fixes to allow adding sync matchers. However based on a [user comment](https://github.com/webdriverio/webdriverio/issues/10586#issuecomment-1628658389) this didn't seem to work. This patch fixes it.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

n/a

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
