### PR TITLE
(@wdio/browser-runner): elevate errors happening during test setup

### DIFF
--- a/packages/wdio-browser-runner/src/browser/frameworks/mocha.ts
+++ b/packages/wdio-browser-runner/src/browser/frameworks/mocha.ts
@@ -58,6 +58,10 @@ export class MochaFramework extends HTMLElement {
         return ['minified']
     }
 
+    get spec () {
+        return this.#spec
+    }
+
     connectedCallback() {
         this.#root.appendChild(template.content.cloneNode(true))
         this.#root.querySelector('.btnCollapseExpand')?.addEventListener('click', () => {

--- a/packages/wdio-browser-runner/src/browser/setup.ts
+++ b/packages/wdio-browser-runner/src/browser/setup.ts
@@ -56,5 +56,10 @@ _setGlobal('$$', browser.$$.bind(browser), window.__wdioEnv__.injectGlobals)
 const mochaFramework = document.querySelector('mocha-framework') as MochaFramework
 if (mochaFramework) {
     const socket = await connectPromise
-    mochaFramework.run(socket)
+    mochaFramework.run(socket).catch((err) => (
+        window.__wdioErrors__.push({
+            message: err.stack,
+            filename: mochaFramework.spec
+        })
+    ))
 }

--- a/packages/wdio-concise-reporter/src/index.ts
+++ b/packages/wdio-concise-reporter/src/index.ts
@@ -53,10 +53,11 @@ export default class ConciseReporter extends WDIOReporter {
      */
     getCountDisplay () {
         const failedTestsCount = this._stateCounts.failed
-
         return failedTestsCount > 0
-            ? `Test${failedTestsCount > 1 ? 's' : ''} failed (${failedTestsCount}):`
-            : 'All went well !!'
+            ? `❌ Test${failedTestsCount > 1 ? 's' : ''} failed (${failedTestsCount}):`
+            : this.counts.tests === 0
+                ? '❌ Failed to setup tests, no tests found'
+                : '✅ All went well!'
     }
 
     /**

--- a/packages/wdio-concise-reporter/tests/fixtures.ts
+++ b/packages/wdio-concise-reporter/tests/fixtures.ts
@@ -79,7 +79,7 @@ export const SUITES_NO_TESTS = [
 
 export const REPORT = `yellow ========= Your concise report ==========
 chrome
-Test failed (1):
+❌ Test failed (1):
   Fail : red a failed test
     AssertionError [ERR_ASSERTION] : yellow 'Google' == 'Google2'
 `

--- a/packages/wdio-concise-reporter/tests/index.test.ts
+++ b/packages/wdio-concise-reporter/tests/index.test.ts
@@ -108,15 +108,19 @@ describe('ConciseReporter', () => {
         it('should return failing count', () => {
             tmpReporter['_stateCounts'].failed = 0
             let result = tmpReporter.getCountDisplay()
-            expect(result).toBe('All went well !!')
+            expect(result).toBe('❌ Failed to setup tests, no tests found')
+
+            tmpReporter.counts.tests = 1
+            result = tmpReporter.getCountDisplay()
+            expect(result).toBe('✅ All went well!')
 
             tmpReporter['_stateCounts'].failed = 1
             result = tmpReporter.getCountDisplay()
-            expect(result).toBe('Test failed (1):')
+            expect(result).toBe('❌ Test failed (1):')
 
             tmpReporter['_stateCounts'].failed = 2
             result = tmpReporter.getCountDisplay()
-            expect(result).toBe('Tests failed (2):')
+            expect(result).toBe('❌ Tests failed (2):')
         })
     })
 


### PR DESCRIPTION
## Proposed changes

When the test fails to run due to a JS error or anything, the test would just timeout eventually without error messages. This patch elevates the error when loading the spec as well as when executing the setup and teardown scripts.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
