### PR TITLE
(@wdio/browser-runner): ignore null error

### DIFF
--- a/packages/wdio-browser-runner/src/browser/setup.ts
+++ b/packages/wdio-browser-runner/src/browser/setup.ts
@@ -56,10 +56,18 @@ _setGlobal('$$', browser.$$.bind(browser), window.__wdioEnv__.injectGlobals)
 const mochaFramework = document.querySelector('mocha-framework') as MochaFramework
 if (mochaFramework) {
     const socket = await connectPromise
-    mochaFramework.run(socket).catch((err) => (
-        window.__wdioErrors__.push({
-            message: err.stack,
+    mochaFramework.run(socket).catch((err) => {
+        /**
+         * On MacOS importing the spec file might fail with a null error object.
+         * This is Vite doing a hot reload and the error is not relevant for us.
+         */
+        if (!err.stack) {
+            return
+        }
+
+        return window.__wdioErrors__.push({
+            message: `${err.message}: ${err.stack}`,
             filename: mochaFramework.spec
         })
-    ))
+    })
 }

--- a/packages/wdio-browser-runner/src/browser/spy.ts
+++ b/packages/wdio-browser-runner/src/browser/spy.ts
@@ -45,7 +45,8 @@ export async function mock (path: string, factory?: MockFactoryWithHelper) {
         window.__wdioMockCache__.set(mockPath, resolvedMock)
         return new Promise((resolve) => mockResolver.set(mockPath, resolve))
     } catch (err: unknown) {
-        throw new Error(ERROR_MESSAGE + '\n' + (err as Error).stack)
+        const error = err as Error
+        throw new Error(`${ERROR_MESSAGE}\n${error.message}: ${error.stack}`)
     }
 }
 


### PR DESCRIPTION
## Proposed changes

We have discovered some issues running component tests in Safari. This patch should help resolve them.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
