### PR TITLE
(@wdio/browser-runner): automatically open in devtools when in watch mode

### DIFF
--- a/packages/wdio-browser-runner/src/index.ts
+++ b/packages/wdio-browser-runner/src/index.ts
@@ -20,7 +20,7 @@ import {
     FRAMEWORK_SUPPORT_ERROR, SESSIONS, BROWSER_POOL, DEFAULT_COVERAGE_REPORTS, SUMMARY_REPORTER,
     DEFAULT_REPORTS_DIRECTORY
 } from './constants.js'
-import { makeHeadless, getCoverageByFactor } from './utils.js'
+import { makeHeadless, getCoverageByFactor, adjustWindowInWatchMode } from './utils.js'
 import type { HookTriggerEvent } from './vite/types.js'
 import type { BrowserRunnerOptions as BrowserRunnerOptionsImport, CoverageOptions, MockFactoryWithHelper } from './types.js'
 
@@ -80,6 +80,8 @@ export default class BrowserRunner extends LocalRunner {
 
     async run (runArgs: RunArgs): Promise<WorkerInstance> {
         runArgs.caps = makeHeadless(this.options, runArgs.caps)
+        runArgs.caps = adjustWindowInWatchMode(this.#config, runArgs.caps)
+
         const server = new ViteServer(this.#options, this.#config)
 
         try {

--- a/packages/wdio-browser-runner/src/utils.ts
+++ b/packages/wdio-browser-runner/src/utils.ts
@@ -2,7 +2,7 @@ import util from 'node:util'
 
 import { deepmerge } from 'deepmerge-ts'
 import logger from '@wdio/logger'
-import type { Capabilities } from '@wdio/types'
+import type { Capabilities, Options } from '@wdio/types'
 import type { CoverageSummary } from 'istanbul-lib-coverage'
 
 import { COVERAGE_FACTORS, GLOBAL_TRESHOLD_REPORTING, FILE_TRESHOLD_REPORTING } from './constants.js'
@@ -51,6 +51,37 @@ export function makeHeadless (options: BrowserRunnerOptions, caps: Capabilities.
     }
 
     log.error(`Headless mode not supported for browser "${capability.browserName}"`)
+    return caps
+}
+
+/**
+ * Open with devtools open when in watch mode
+ */
+export function adjustWindowInWatchMode (config: Options.Testrunner, caps: Capabilities.RemoteCapability): Capabilities.RemoteCapability {
+    if (!config.watch) {
+        return caps
+    }
+
+    const capability = (caps as Capabilities.W3CCapabilities).alwaysMatch || caps
+    if (config.watch && capability.browserName === 'chrome') {
+        return deepmerge(capability, {
+            'goog:chromeOptions': {
+                args: ['auto-open-devtools-for-tabs', 'window-size=1600,1200'],
+                prefs: {
+                    devtools: {
+                        preferences: {
+                            'panel-selectedTab': '"console"'
+                        }
+                    }
+                }
+            }
+        })
+    }
+    /**
+     * TODO: add support for other browsers (if possible)
+     * } else if (...) { }
+     */
+
     return caps
 }
 

--- a/packages/wdio-browser-runner/tests/utils.test.ts
+++ b/packages/wdio-browser-runner/tests/utils.test.ts
@@ -3,7 +3,7 @@ import path from 'node:path'
 import { deepmerge } from 'deepmerge-ts'
 import { expect, describe, it, vi, beforeEach } from 'vitest'
 
-import { makeHeadless, getCoverageByFactor } from '../src/utils.js'
+import { makeHeadless, getCoverageByFactor, adjustWindowInWatchMode } from '../src/utils.js'
 
 vi.mock('@wdio/logger', () => import(path.join(process.cwd(), '__mocks__', '@wdio/logger')))
 
@@ -38,6 +38,18 @@ describe('makeHeadless', () => {
         expect(deepmerge).toBeCalledTimes(4)
         makeHeadless({}, { browserName: 'safari' })
         expect(deepmerge).toBeCalledTimes(4)
+    })
+})
+
+describe('adjustWindowInWatchMode', () => {
+    it('does not adjust window size if not in watch mode', () => {
+        const caps: any = { foo: 'bar' }
+        expect(adjustWindowInWatchMode({} as any, caps)).toEqual(caps)
+    })
+
+    it('adjusts window size if in watch mode', () => {
+        adjustWindowInWatchMode({ watch: true } as any, { browserName: 'chrome' })
+        expect(deepmerge).toBeCalledTimes(1)
     })
 })
 


### PR DESCRIPTION
## Proposed changes

@degrammer wants devtools to be open when in `--watch` mode.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
