### PR TITLE
(@wdio/browser-runner): support Nuxt auto-import

### DIFF
--- a/packages/wdio-browser-runner/src/vite/frameworks/index.ts
+++ b/packages/wdio-browser-runner/src/vite/frameworks/index.ts
@@ -1,0 +1,11 @@
+import type { InlineConfig } from 'vite'
+import type { Options } from '@wdio/types'
+
+import { isNuxtFramework, optimizeForNuxt } from './nuxt.js'
+
+export default async function updateViteConfig (viteConfig: Partial<InlineConfig>, options: WebdriverIO.BrowserRunnerOptions, config: Options.Testrunner) {
+    const isNuxt = await isNuxtFramework(config.rootDir || process.cwd())
+    if (isNuxt) {
+        optimizeForNuxt(viteConfig, options, config)
+    }
+}

--- a/packages/wdio-browser-runner/src/vite/frameworks/index.ts
+++ b/packages/wdio-browser-runner/src/vite/frameworks/index.ts
@@ -6,6 +6,6 @@ import { isNuxtFramework, optimizeForNuxt } from './nuxt.js'
 export default async function updateViteConfig (viteConfig: Partial<InlineConfig>, options: WebdriverIO.BrowserRunnerOptions, config: Options.Testrunner) {
     const isNuxt = await isNuxtFramework(config.rootDir || process.cwd())
     if (isNuxt) {
-        optimizeForNuxt(viteConfig, options, config)
+        await optimizeForNuxt(viteConfig, options, config)
     }
 }

--- a/packages/wdio-browser-runner/src/vite/frameworks/nuxt.ts
+++ b/packages/wdio-browser-runner/src/vite/frameworks/nuxt.ts
@@ -1,0 +1,79 @@
+import type { InlineConfig } from 'vite'
+import path from 'node:path'
+import logger from '@wdio/logger'
+import type { Options } from '@wdio/types'
+
+import { hasFile } from './utils.js'
+
+declare global {
+    // eslint-disable-next-line no-var
+    var defineNuxtConfig: Function
+}
+
+const log = logger('@wdio/browser-runner:NuxtOptimization')
+
+export async function isNuxtFramework (rootDir: string) {
+    return (
+        await Promise.all([
+            getNuxtConfig(rootDir),
+            hasFile(path.join(rootDir, '.nuxt'))
+        ])
+    ).filter(Boolean).length > 0
+}
+
+export async function optimizeForNuxt (viteConfig: Partial<InlineConfig>, options: WebdriverIO.BrowserRunnerOptions, config: Options.Testrunner) {
+    const rootDir = config.rootDir || process.cwd()
+    const nuxtConfigPath = await getNuxtConfig(rootDir)
+
+    if (!nuxtConfigPath) {
+        throw new Error('No Nuxt project found!')
+    }
+
+    globalThis.defineNuxtConfig = (opts: unknown) => opts
+    try {
+        const nuxtConfig = (await import(nuxtConfigPath)).default
+        const Unimport = (await import('unimport/unplugin')).default
+        const { scanDirExports } = await import('unimport')
+        const { loadNuxt } = await import('nuxt')
+        const nuxt = await loadNuxt(nuxtConfig)
+        const composablesDirs: string[] = []
+
+        for (const layer of nuxt._layers) {
+            composablesDirs.push(path.resolve(layer.config.srcDir, 'composables'))
+            composablesDirs.push(path.resolve(layer.config.srcDir, 'utils'))
+            for (const dir of (layer.config.imports?.dirs ?? [])) {
+                if (!dir) {
+                    continue
+                }
+                composablesDirs.push(path.resolve(layer.config.srcDir, dir))
+            }
+
+            const composableImports = await scanDirExports(composablesDirs)
+            viteConfig.plugins?.push(Unimport.vite({
+                presets: ['vue'],
+                imports: composableImports
+            }))
+        }
+
+    } catch (err) {
+        log.error(`Failed to optimize Vite config for Nuxt: ${(err as Error).stack}`)
+    }
+}
+
+async function getNuxtConfig (rootDir: string) {
+    const pathOptions = [
+        path.join(rootDir, 'nuxt.config.js'),
+        path.join(rootDir, 'nuxt.config.ts'),
+        path.join(rootDir, 'nuxt.config.mjs'),
+        path.join(rootDir, 'nuxt.config.mts')
+    ]
+    return (
+        await Promise.all(
+            pathOptions.map(
+                async (o) => (await hasFile(o)) && o
+            )
+        ).then(
+            (res) => res.filter(Boolean)
+        )
+    )[0] as string | undefined
+}

--- a/packages/wdio-browser-runner/src/vite/frameworks/types.d.ts
+++ b/packages/wdio-browser-runner/src/vite/frameworks/types.d.ts
@@ -1,0 +1,3 @@
+declare module 'unimport/unplugin'
+declare module 'unimport'
+declare module 'nuxt'

--- a/packages/wdio-browser-runner/src/vite/frameworks/utils.ts
+++ b/packages/wdio-browser-runner/src/vite/frameworks/utils.ts
@@ -1,0 +1,5 @@
+import fs from 'node:fs/promises'
+
+export function hasFile (p: string) {
+    return fs.access(p).then(() => true, () => false)
+}

--- a/packages/wdio-browser-runner/src/vite/server.ts
+++ b/packages/wdio-browser-runner/src/vite/server.ts
@@ -13,6 +13,7 @@ import { createServer } from 'vite'
 import istanbulPlugin from 'vite-plugin-istanbul'
 import type { Services, Options } from '@wdio/types'
 
+import updateViteConfig from './frameworks/index.js'
 import { testrunner } from './plugins/testrunner.js'
 import { mockHoisting } from './plugins/mockHoisting.js'
 import { userfriendlyImport } from './utils.js'
@@ -128,6 +129,11 @@ export class ViteServer extends EventEmitter {
          */
         this.#wss = new WebSocketServer({ port: wssPort })
         this.#wss.on('connection', this.#onConnect.bind(this))
+
+        /**
+         * make adjustments based on detected frontend frameworks
+         */
+        updateViteConfig(this.#viteConfig, this.#options, this.#config)
 
         /**
          * initialize Vite

--- a/packages/wdio-browser-runner/tests/vite/frameworks/__fixtures__/composables/test.ts
+++ b/packages/wdio-browser-runner/tests/vite/frameworks/__fixtures__/composables/test.ts
@@ -1,0 +1,1 @@
+export const foo = 'bar'

--- a/packages/wdio-browser-runner/tests/vite/frameworks/__fixtures__/nuxt.config.ts
+++ b/packages/wdio-browser-runner/tests/vite/frameworks/__fixtures__/nuxt.config.ts
@@ -1,0 +1,23 @@
+// https://nuxt.com/docs/api/configuration/nuxt-config
+export default defineNuxtConfig({
+    devtools: { enabled: true },
+    modules: [
+        '@nuxtjs/tailwindcss',
+        '@nuxtjs/color-mode',
+        '@nuxtjs/supabase',
+        '@vueuse/nuxt',
+        '@vee-validate/nuxt',
+        'nuxt-proxy',
+    ],
+    colorMode: {
+        preference: 'cupcake', // default theme
+        dataValue: 'theme', // activate data-theme in <html> tag
+    },
+    proxy: {
+        options: {
+            target: 'http://localhost:55321',
+            changeOrigin: true,
+            pathFilter: ['/rest/**', '/auth/**', '/storage/**'],
+        },
+    },
+})

--- a/packages/wdio-browser-runner/tests/vite/frameworks/index.test.ts
+++ b/packages/wdio-browser-runner/tests/vite/frameworks/index.test.ts
@@ -1,0 +1,17 @@
+import { expect, vi, test } from 'vitest'
+import updateViteConfig from '../../../src/vite/frameworks/index.js'
+import { isNuxtFramework, optimizeForNuxt } from '../../../src/vite/frameworks/nuxt.js'
+
+vi.mock('../../../src/vite/frameworks/nuxt.js', () => ({
+    isNuxtFramework: vi.fn(),
+    optimizeForNuxt: vi.fn()
+}))
+
+test('should apply optimizations for frameworks correctly', async () => {
+    await updateViteConfig({}, {} as any, { rootDir: '/foo/bar' } as any)
+    expect(optimizeForNuxt).toBeCalledTimes(0)
+
+    vi.mocked(isNuxtFramework).mockResolvedValueOnce(true)
+    await updateViteConfig({}, {} as any, { rootDir: '/foo/bar' } as any)
+    expect(optimizeForNuxt).toBeCalledTimes(1)
+})

--- a/packages/wdio-browser-runner/tests/vite/frameworks/nuxt.test.ts
+++ b/packages/wdio-browser-runner/tests/vite/frameworks/nuxt.test.ts
@@ -1,0 +1,55 @@
+import path from 'node:path'
+import url from 'node:url'
+
+import unimport from 'unimport/unplugin'
+import { expect, vi, test } from 'vitest'
+import { isNuxtFramework, optimizeForNuxt } from '../../../src/vite/frameworks/nuxt.js'
+import { hasFile } from '../../../src/vite/frameworks/utils.js'
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url))
+const rootDir = path.resolve(__dirname, '__fixtures__')
+
+vi.mock('unimport/unplugin', () => ({
+    default: { vite: vi.fn().mockReturnValue('the right plugin') }
+}))
+
+vi.mock('unimport', () => ({
+    scanDirExports: vi.fn().mockResolvedValue(['some', 'imports'])
+}))
+
+vi.mock('nuxt', () => ({
+    loadNuxt: vi.fn().mockResolvedValue({
+        _layers: [{
+            config: {
+                srcDir: '/foo/bar',
+                imports: {
+                    dirs: ['foobar']
+                }
+            }
+        }]
+    })
+}))
+
+vi.mock('../../../src/vite/frameworks/utils.js', () => ({
+    hasFile: vi.fn()
+}))
+
+vi.mock('/foo/bar/nuxt.config.js', () => ({}))
+
+test('isNuxtFramework', async () => {
+    expect(await isNuxtFramework('/foo/bar')).toBe(false)
+    vi.mocked(hasFile).mockResolvedValueOnce(false)
+    vi.mocked(hasFile).mockResolvedValueOnce(true)
+    expect(await isNuxtFramework('/foo/bar')).toBe(true)
+})
+
+test('optimizeForNuxt', async () => {
+    const viteConfig = { plugins: [] }
+    vi.mocked(hasFile).mockResolvedValueOnce(true)
+    await optimizeForNuxt(viteConfig, {} as any, { rootDir } as any)
+    expect(viteConfig.plugins).toEqual(['the right plugin'])
+    expect(unimport.vite).toBeCalledWith({
+        imports: ['some', 'imports'],
+        presets: ['vue']
+    })
+})

--- a/scripts/depcheck.ts
+++ b/scripts/depcheck.ts
@@ -26,7 +26,7 @@ EventEmitter.defaultMaxListeners = packages.length + 3
 const ROOT_DIR = path.join(__dirname, '..')
 
 const IGNORE_PACKAGES: IgnoredPackages = {
-    'wdio-browser-runner': ['virtual:wdio', 'mocha'],
+    'wdio-browser-runner': ['virtual:wdio', 'mocha', 'nuxt', 'unimport', 'unimport/unplugin']
 }
 
 const brokenPackages = (await Promise.all(packages.map(async (pkg) => {

--- a/website/docs/component-testing/Vue.md
+++ b/website/docs/component-testing/Vue.md
@@ -26,6 +26,12 @@ If you are already using [Vite](https://vitejs.dev/) as development server you c
 
 :::
 
+:::info
+
+If you are using [Nuxt](https://nuxt.com/) WebdriverIO will automatically enable the [auto-import](https://nuxt.com/docs/guide/concepts/auto-imports) feature.
+
+:::
+
 The Vue preset requires `@vitejs/plugin-vue` to be installed. Also we recommend using [Testing Library](https://testing-library.com/) for rendering the component into the test page. Therefor you'll need to install the following additional dependencies:
 
 ```sh npm2yarn


### PR DESCRIPTION
## Proposed changes

Nuxt has an [auto import](https://nuxt.com/docs/guide/concepts/auto-imports) feature and in order to make component testing with Nuxt projects feasible we need to enable this in WebdriverIO.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
