### PR TITLE
(@wdio/browser-runner): improve Nuxt optimization process

### DIFF
--- a/packages/wdio-browser-runner/src/index.ts
+++ b/packages/wdio-browser-runner/src/index.ts
@@ -20,6 +20,7 @@ import {
     FRAMEWORK_SUPPORT_ERROR, SESSIONS, BROWSER_POOL, DEFAULT_COVERAGE_REPORTS, SUMMARY_REPORTER,
     DEFAULT_REPORTS_DIRECTORY
 } from './constants.js'
+import updateViteConfig from './vite/frameworks/index.js'
 import { makeHeadless, getCoverageByFactor, adjustWindowInWatchMode } from './utils.js'
 import type { HookTriggerEvent } from './vite/types.js'
 import type { BrowserRunnerOptions as BrowserRunnerOptionsImport, CoverageOptions, MockFactoryWithHelper } from './types.js'
@@ -73,6 +74,15 @@ export default class BrowserRunner extends LocalRunner {
             if (reportsDirectoryExist) {
                 await fs.rm(this.#reportsDirectory, { recursive: true })
             }
+        }
+
+        /**
+         * make adjustments based on detected frontend frameworks
+         */
+        try {
+            await updateViteConfig(this.#options, this.#config)
+        } catch (err) {
+            log.error(`Failed to optimize Vite config: ${(err as Error).stack}`)
         }
 
         await super.initialise()

--- a/packages/wdio-browser-runner/src/vite/frameworks/index.ts
+++ b/packages/wdio-browser-runner/src/vite/frameworks/index.ts
@@ -1,11 +1,10 @@
-import type { InlineConfig } from 'vite'
 import type { Options } from '@wdio/types'
 
 import { isNuxtFramework, optimizeForNuxt } from './nuxt.js'
 
-export default async function updateViteConfig (viteConfig: Partial<InlineConfig>, options: WebdriverIO.BrowserRunnerOptions, config: Options.Testrunner) {
+export default async function updateViteConfig (options: WebdriverIO.BrowserRunnerOptions, config: Options.Testrunner) {
     const isNuxt = await isNuxtFramework(config.rootDir || process.cwd())
     if (isNuxt) {
-        await optimizeForNuxt(viteConfig, options, config)
+        await optimizeForNuxt(options, config)
     }
 }

--- a/packages/wdio-browser-runner/src/vite/frameworks/types.d.ts
+++ b/packages/wdio-browser-runner/src/vite/frameworks/types.d.ts
@@ -1,3 +1,3 @@
 declare module 'unimport/unplugin'
 declare module 'unimport'
-declare module 'nuxt'
+declare module '@nuxt/kit'

--- a/packages/wdio-browser-runner/src/vite/server.ts
+++ b/packages/wdio-browser-runner/src/vite/server.ts
@@ -13,7 +13,6 @@ import { createServer } from 'vite'
 import istanbulPlugin from 'vite-plugin-istanbul'
 import type { Services, Options } from '@wdio/types'
 
-import updateViteConfig from './frameworks/index.js'
 import { testrunner } from './plugins/testrunner.js'
 import { mockHoisting } from './plugins/mockHoisting.js'
 import { userfriendlyImport } from './utils.js'
@@ -129,15 +128,6 @@ export class ViteServer extends EventEmitter {
          */
         this.#wss = new WebSocketServer({ port: wssPort })
         this.#wss.on('connection', this.#onConnect.bind(this))
-
-        /**
-         * make adjustments based on detected frontend frameworks
-         */
-        try {
-            await updateViteConfig(this.#viteConfig, this.#options, this.#config)
-        } catch (err) {
-            log.error(`Failed to optimize Vite config: ${(err as Error).stack}`)
-        }
 
         /**
          * initialize Vite

--- a/packages/wdio-browser-runner/tests/vite/frameworks/index.test.ts
+++ b/packages/wdio-browser-runner/tests/vite/frameworks/index.test.ts
@@ -8,10 +8,11 @@ vi.mock('../../../src/vite/frameworks/nuxt.js', () => ({
 }))
 
 test('should apply optimizations for frameworks correctly', async () => {
-    await updateViteConfig({}, {} as any, { rootDir: '/foo/bar' } as any)
+    const options: any = {}
+    await updateViteConfig(options, { rootDir: '/foo/bar' } as any)
     expect(optimizeForNuxt).toBeCalledTimes(0)
 
     vi.mocked(isNuxtFramework).mockResolvedValueOnce(true)
-    await updateViteConfig({}, {} as any, { rootDir: '/foo/bar' } as any)
+    await updateViteConfig(options, { rootDir: '/foo/bar' } as any)
     expect(optimizeForNuxt).toBeCalledTimes(1)
 })

--- a/packages/wdio-browser-runner/tests/vite/frameworks/nuxt.test.ts
+++ b/packages/wdio-browser-runner/tests/vite/frameworks/nuxt.test.ts
@@ -17,18 +17,16 @@ vi.mock('unimport', () => ({
     scanDirExports: vi.fn().mockResolvedValue(['some', 'imports'])
 }))
 
-vi.mock('nuxt', () => ({
-    loadNuxt: vi.fn().mockResolvedValue({
-        options: {
-            _layers: [{
-                config: {
-                    srcDir: '/foo/bar',
-                    imports: {
-                        dirs: ['foobar']
-                    }
+vi.mock('@nuxt/kit', () => ({
+    loadNuxtConfig: vi.fn().mockResolvedValue({
+        _layers: [{
+            config: {
+                srcDir: '/foo/bar',
+                imports: {
+                    dirs: ['foobar']
                 }
-            }]
-        }
+            }
+        }]
     })
 }))
 
@@ -46,10 +44,10 @@ test('isNuxtFramework', async () => {
 })
 
 test('optimizeForNuxt', async () => {
-    const viteConfig = { plugins: [] }
+    const options: any = {}
     vi.mocked(hasFile).mockResolvedValueOnce(true)
-    await optimizeForNuxt(viteConfig, {} as any, { rootDir } as any)
-    expect(viteConfig.plugins).toEqual(['the right plugin'])
+    await optimizeForNuxt(options, { rootDir } as any)
+    expect(options.viteConfig.plugins).toEqual(['the right plugin'])
     expect(unimport.vite).toBeCalledWith({
         imports: ['some', 'imports'],
         presets: ['vue']

--- a/scripts/depcheck.ts
+++ b/scripts/depcheck.ts
@@ -26,7 +26,7 @@ EventEmitter.defaultMaxListeners = packages.length + 3
 const ROOT_DIR = path.join(__dirname, '..')
 
 const IGNORE_PACKAGES: IgnoredPackages = {
-    'wdio-browser-runner': ['virtual:wdio', 'mocha', 'nuxt', 'unimport', 'unimport/unplugin']
+    'wdio-browser-runner': ['virtual:wdio', 'mocha', '@nuxt/kit', 'unimport', 'unimport/unplugin']
 }
 
 const brokenPackages = (await Promise.all(packages.map(async (pkg) => {


### PR DESCRIPTION
## Proposed changes

This patch:
- replacing loading Nuxt config via import and instead use `@nuxt/kit`
- moves the process into browser runner so it only runs once and allows parallelisations

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
