### PR TITLE
(@wdio/browser-runner): support Nuxt alias and ensure plugin is loaded before WDIO related ones

### DIFF
--- a/packages/wdio-browser-runner/src/vite/frameworks/nuxt.ts
+++ b/packages/wdio-browser-runner/src/vite/frameworks/nuxt.ts
@@ -44,7 +44,15 @@ export async function optimizeForNuxt (options: WebdriverIO.BrowserRunnerOptions
         }
     }
     const composableImports = await scanDirExports(composablesDirs)
-    options.viteConfig = options.viteConfig || {}
+    options.viteConfig = (options.viteConfig || {}) as InlineConfig
+
+    /**
+     * propagate "alias" config
+     */
+    options.viteConfig.resolve = Object.assign(options.viteConfig.resolve || {}, {
+        alias: nuxtOptions.alias || {}
+    })
+
     const viteConfig = (options.viteConfig || {}) as InlineConfig
     if (!Array.isArray(viteConfig.plugins)) {
         viteConfig.plugins = []

--- a/packages/wdio-browser-runner/src/vite/server.ts
+++ b/packages/wdio-browser-runner/src/vite/server.ts
@@ -113,14 +113,15 @@ export class ViteServer extends EventEmitter {
          * merge custom `viteConfig` last into the object
          */
         if (this.#options.viteConfig) {
-            const configToMerge = typeof this.#options.viteConfig === 'string'
+            const { plugins, ...configToMerge } = typeof this.#options.viteConfig === 'string'
                 ? (
                     await import(path.resolve(this.#config.rootDir || process.cwd(), this.#options.viteConfig))
-                ).default
+                ).default as InlineConfig
                 : typeof this.#options.viteConfig === 'function'
                     ? await this.#options.viteConfig(DEFAULT_CONFIG_ENV)
                     : this.#options.viteConfig
             this.#viteConfig = deepmerge(this.#viteConfig, configToMerge)
+            this.#viteConfig.plugins = [...(plugins || []), ...this.#viteConfig.plugins!]
         }
 
         /**

--- a/packages/wdio-browser-runner/tests/vite/frameworks/nuxt.test.ts
+++ b/packages/wdio-browser-runner/tests/vite/frameworks/nuxt.test.ts
@@ -26,7 +26,10 @@ vi.mock('@nuxt/kit', () => ({
                     dirs: ['foobar']
                 }
             }
-        }]
+        }],
+        alias: {
+            '~': '/foo/bar'
+        }
     })
 }))
 
@@ -52,4 +55,5 @@ test('optimizeForNuxt', async () => {
         imports: ['some', 'imports'],
         presets: ['vue']
     })
+    expect(options.viteConfig.resolve.alias).toEqual({ '~': '/foo/bar' })
 })

--- a/website/docs/component-testing/Vue.md
+++ b/website/docs/component-testing/Vue.md
@@ -26,12 +26,6 @@ If you are already using [Vite](https://vitejs.dev/) as development server you c
 
 :::
 
-:::info
-
-If you are using [Nuxt](https://nuxt.com/), WebdriverIO will automatically enable the [auto-import](https://nuxt.com/docs/guide/concepts/auto-imports) feature.
-
-:::
-
 The Vue preset requires `@vitejs/plugin-vue` to be installed. Also we recommend using [Testing Library](https://testing-library.com/) for rendering the component into the test page. Therefor you'll need to install the following additional dependencies:
 
 ```sh npm2yarn
@@ -100,3 +94,48 @@ describe('Vue Component Testing', () => {
 ```
 
 You can find a full example of a WebdriverIO component test suite for Vue.js in our [example repository](https://github.com/webdriverio/component-testing-examples/tree/main/vue-typescript-vite).
+
+## Testing Vue Components in Nuxt
+
+If you are using the web framework [Nuxt](https://nuxt.com/), WebdriverIO will automatically enable the [auto-import](https://nuxt.com/docs/guide/concepts/auto-imports) feature and makes testing your Vue components and Nuxt pages easy. However any [Nuxt modules](https://nuxt.com/modules) that you might define in your config and requires context to the Nuxt application can not be supported.
+
+__Reasons for that are:__
+- WebdriverIO can't initiate a Nuxt application soley in a browser environment
+- Having component tests depend too much on the Nuxt environment creates complexity and we recommend to run these tests as e2e tests
+
+:::info
+
+WebdriverIO also provides a service for running e2e tests on Nuxt applications, see [`webdriverio-community/wdio-nuxt-service`](https://github.com/webdriverio-community/wdio-nuxt-service) for information.
+
+:::
+
+For example, given my application uses the [Supabase](https://nuxt.com/modules/supabase) module plugin:
+
+```js title=""
+export default defineNuxtConfig({
+  modules: [
+    "@nuxtjs/supabase",
+    // ...
+  ],
+  // ...
+});
+```
+
+and you create an instance of Supabase somewhere in your composables, e.g.:
+
+```ts
+const superbase = useSupabaseClient()
+```
+
+the test will fail due to:
+
+```
+ReferenceError: useSupabaseClient is not defined
+```
+
+Here, we recommend to either mock out the whole module that uses the `useSupabaseClient` function or create a global variable that mocks this function, e.g.:
+
+```ts
+import { fn } from '@wdio/browser-runner'
+globalThis.useSupabaseClient = fn().mockReturnValue({})
+```

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -140,7 +140,7 @@ function Home() {
                                 <h4><Translate>Easy setup for web component testing with:</Translate></h4>
                                 <a href="/docs/component-testing/react" className={styles.frameworkLogos}><img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9Ii0xMS41IC0xMC4yMzE3NCAyMyAyMC40NjM0OCI+CiAgPHRpdGxlPlJlYWN0IExvZ288L3RpdGxlPgogIDxjaXJjbGUgY3g9IjAiIGN5PSIwIiByPSIyLjA1IiBmaWxsPSIjNjFkYWZiIi8+CiAgPGcgc3Ryb2tlPSIjNjFkYWZiIiBzdHJva2Utd2lkdGg9IjEiIGZpbGw9Im5vbmUiPgogICAgPGVsbGlwc2Ugcng9IjExIiByeT0iNC4yIi8+CiAgICA8ZWxsaXBzZSByeD0iMTEiIHJ5PSI0LjIiIHRyYW5zZm9ybT0icm90YXRlKDYwKSIvPgogICAgPGVsbGlwc2Ugcng9IjExIiByeT0iNC4yIiB0cmFuc2Zvcm09InJvdGF0ZSgxMjApIi8+CiAgPC9nPgo8L3N2Zz4K" alt="" /></a>
                                 <a href="/docs/component-testing/vue" className={styles.frameworkLogos}><img src="/img/icons/vue.png" alt="Vue.js" /></a>
-                                <a href="/docs/component-testing/vue" className={styles.frameworkLogos}><img src="/img/icons/nuxt.svg" alt="Nuxt" /></a>
+                                <a href="/docs/component-testing/vue#testing-vue-components-in-nuxt" className={styles.frameworkLogos}><img src="/img/icons/nuxt.svg" alt="Nuxt" /></a>
                                 <a href="/docs/component-testing/svelte" className={styles.frameworkLogos}><img src="/img/icons/svelte.png" alt="Svelte" /></a>
                                 <a href="/docs/component-testing/preact" className={styles.frameworkLogos}><img src="/img/icons/preact.png" alt="Preact" /></a>
                                 <a href="/docs/component-testing/solid" className={styles.frameworkLogos}><img src="/img/icons/solidjs.svg" alt="SolidJS" /></a>


### PR DESCRIPTION
## Proposed changes

This patch enables support for Nuxt alias to allow imports as following:

```
import { useProjects } from "~/composables/useProjects";
```

Furthermore it moves the Nuxt plugin to the beginning of the plugin chain so that mocking can be applied to it.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
