### PR TITLE
add parallel multiremote capability

### DIFF
--- a/e2e/testrunner.test.ts
+++ b/e2e/testrunner.test.ts
@@ -32,3 +32,29 @@ test('should allow to run multiple browser at once', async () => {
 
     expect(hasPassed).toBe(true)
 })
+
+test('should allow to run parallel multiremote', async () => {
+    const launcher = new Launcher(`${__dirname}/wdio/wdio-multiremote.conf.ts`)
+    const failures = await launcher.run()
+    const hasPassed = failures === 0
+
+    /**
+     * print log files for debugging if test fails
+     */
+    if (!hasPassed) {
+        const rootPath = path.join(__dirname, 'wdio')
+        const logFiles = fs.readdirSync(rootPath)
+            // only log files
+            .filter((file) => file.endsWith('.log'))
+
+        for (const fileName of logFiles) {
+            // eslint-disable-next-line no-console
+            console.log(`\n========== LOG OUTPUT ${fileName}`)
+            // eslint-disable-next-line no-console
+            console.log(fs.readFileSync(path.resolve(rootPath, fileName)).toString())
+        }
+    }
+
+    expect(hasPassed).toBe(true)
+    expect(launcher.isMultiremote && launcher.isParallelMultiremote).toBe(true)
+})

--- a/e2e/wdio/headless/multiremoteTest.e2e.ts
+++ b/e2e/wdio/headless/multiremoteTest.e2e.ts
@@ -1,0 +1,21 @@
+import { Key } from 'webdriverio'
+
+describe('main suite 1', () => {
+    it('should open chat application', async () => {
+        await browser.url('https://socketio-chat-h9jt.herokuapp.com/')
+    })
+
+    it('should login the browser A', async () => {
+        const nameInput = await browserA.$('.usernameInput')
+        await nameInput.addValue('Browser A')
+        await browserA.keys(Key.Enter)
+        await expect(browserA.$('.inputMessage')).toHaveAttribute('placeHolder', 'Type here...')
+    })
+
+    it('should login the browser B', async () => {
+        const nameInput = await browserB.$('.usernameInput')
+        await nameInput.addValue('Browser B')
+        await browserB.keys(Key.Enter)
+        await expect(browserB.$('.inputMessage')).toHaveAttribute('placeHolder', 'Type here...')
+    })
+})

--- a/e2e/wdio/wdio-multiremote.conf.ts
+++ b/e2e/wdio/wdio-multiremote.conf.ts
@@ -25,7 +25,7 @@ export const config = {
                 capabilities: {
                     browserName: 'chrome',
                     browserVersion: 'stable',
-                    'wdio:devtoolsOptions': { headless: true, dumpio: true }
+                    'goog:chromeOptions': { args: ['headless', 'disable-gpu'] }
                 }
             },
         },

--- a/e2e/wdio/wdio-multiremote.conf.ts
+++ b/e2e/wdio/wdio-multiremote.conf.ts
@@ -34,7 +34,7 @@ export const config = {
                 capabilities: {
                     browserName: 'chrome',
                     browserVersion: 'stable',
-                    'wdio:devtoolsOptions': { headless: true, dumpio: true }
+                    'goog:chromeOptions': { args: ['headless', 'disable-gpu'] }
                 }
             },
             browserB: {

--- a/e2e/wdio/wdio-multiremote.conf.ts
+++ b/e2e/wdio/wdio-multiremote.conf.ts
@@ -1,0 +1,49 @@
+import url from 'node:url'
+import path from 'node:path'
+import { config as baseConfig } from './wdio.conf.js'
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url))
+
+export const config = {
+    ...baseConfig,
+
+    /**
+     * Sauce specific config
+     */
+    specs: [path.resolve(__dirname, 'headless', 'multiremoteTest.e2e.ts')],
+    exclude: [],
+    capabilities: [
+        {
+            browserA: {
+                capabilities: {
+                    browserName: 'chrome',
+                    browserVersion: 'stable',
+                    'wdio:devtoolsOptions': { headless: true, dumpio: true }
+                }
+            },
+            browserB: {
+                capabilities: {
+                    browserName: 'chrome',
+                    browserVersion: 'stable',
+                    'wdio:devtoolsOptions': { headless: true, dumpio: true }
+                }
+            },
+        },
+        {
+            browserA: {
+                capabilities: {
+                    browserName: 'chrome',
+                    browserVersion: 'stable',
+                    'wdio:devtoolsOptions': { headless: true, dumpio: true }
+                }
+            },
+            browserB: {
+                capabilities: {
+                    browserName: 'chrome',
+                    browserVersion: 'stable',
+                    'wdio:devtoolsOptions': { headless: true, dumpio: true }
+                }
+            },
+        }
+    ]
+}

--- a/e2e/wdio/wdio-multiremote.conf.ts
+++ b/e2e/wdio/wdio-multiremote.conf.ts
@@ -41,7 +41,7 @@ export const config = {
                 capabilities: {
                     browserName: 'chrome',
                     browserVersion: 'stable',
-                    'wdio:devtoolsOptions': { headless: true, dumpio: true }
+                    'goog:chromeOptions': { args: ['headless', 'disable-gpu'] }
                 }
             },
         }

--- a/e2e/wdio/wdio-multiremote.conf.ts
+++ b/e2e/wdio/wdio-multiremote.conf.ts
@@ -18,7 +18,7 @@ export const config = {
                 capabilities: {
                     browserName: 'chrome',
                     browserVersion: 'stable',
-                    'wdio:devtoolsOptions': { headless: true, dumpio: true }
+                    'goog:chromeOptions': { args: ['headless', 'disable-gpu'] }
                 }
             },
             browserB: {

--- a/e2e/wdio/wdio.conf.ts
+++ b/e2e/wdio/wdio.conf.ts
@@ -10,6 +10,7 @@ export const config = {
      * specify test files
      */
     specs: [path.join(__dirname, 'headless', '*.e2e.ts')],
+    exclude: [path.join(__dirname, 'headless', 'multiremoteTest.e2e.ts')],
 
     /**
      * capabilities

--- a/packages/wdio-appium-service/src/launcher.ts
+++ b/packages/wdio-appium-service/src/launcher.ts
@@ -89,13 +89,32 @@ export default class AppiumLauncher implements Services.ServiceInstance {
         }
 
         this._capabilities.forEach(
-            (cap) => !isCloudCapability((cap as Capabilities.W3CCapabilities).alwaysMatch || cap) && Object.assign(
-                cap,
-                DEFAULT_CONNECTION,
-                'port' in this._args ? { port: this._args.port } : {},
-                { path: this._args.basePath },
-                { ...cap }
-            ))
+            (cap) => {
+                /**
+                 * Parallel Multiremote
+                 */
+                if (Object.values(cap).length > 0 && Object.values(cap).every(c => typeof c === 'object' && c.capabilities)) {
+                    Object.values(cap).forEach(c => {
+                        const capa = (c.capabilities as Capabilities.W3CCapabilities).alwaysMatch || (c.capabilities as Capabilities.W3CCapabilities) || c
+                        !isCloudCapability(capa) && Object.assign(
+                            c,
+                            DEFAULT_CONNECTION,
+                            'port' in this._args ? { port: this._args.port } : {},
+                            { path: this._args.basePath },
+                            { ...c }
+                        )
+                    }
+                    )
+                } else {
+                    !isCloudCapability((cap as Capabilities.W3CCapabilities).alwaysMatch || cap) && Object.assign(
+                        cap,
+                        DEFAULT_CONNECTION,
+                        'port' in this._args ? { port: this._args.port } : {},
+                        { path: this._args.basePath },
+                        { ...cap }
+                    )
+                }
+            })
     }
 
     async onPrepare() {

--- a/packages/wdio-appium-service/tests/launcher.test.ts
+++ b/packages/wdio-appium-service/tests/launcher.test.ts
@@ -150,6 +150,39 @@ describe('Appium launcher', () => {
             expect(capabilities.browserB.path).toBe('/')
         })
 
+        test('should set correct config properties using parallel multiremote', async () => {
+            const options = {
+                logPath: './',
+                command: 'path/to/my_custom_appium',
+                args: { foo: 'bar' }
+            }
+            const capabilities: Capabilities.MultiRemoteCapabilities[] = [{
+                browserA: { port: 1234, capabilities: {} },
+                browserB: { capabilities: {} }
+            }, {
+                browserC: { port: 5678, capabilities: {} },
+                browserD: { capabilities: {} }
+            }]
+            const launcher = new AppiumLauncher(options, capabilities, {} as any)
+            await launcher.onPrepare()
+            expect(capabilities[0].browserA.protocol).toBe('http')
+            expect(capabilities[0].browserA.hostname).toBe('127.0.0.1')
+            expect(capabilities[0].browserA.port).toBe(1234)
+            expect(capabilities[0].browserA.path).toBe('/')
+            expect(capabilities[0].browserB.protocol).toBe('http')
+            expect(capabilities[0].browserB.hostname).toBe('127.0.0.1')
+            expect(capabilities[0].browserB.port).toBe(4723)
+            expect(capabilities[0].browserB.path).toBe('/')
+            expect(capabilities[1].browserC.protocol).toBe('http')
+            expect(capabilities[1].browserC.hostname).toBe('127.0.0.1')
+            expect(capabilities[1].browserC.port).toBe(5678)
+            expect(capabilities[1].browserC.path).toBe('/')
+            expect(capabilities[1].browserD.protocol).toBe('http')
+            expect(capabilities[1].browserD.hostname).toBe('127.0.0.1')
+            expect(capabilities[1].browserD.port).toBe(4723)
+            expect(capabilities[1].browserD.path).toBe('/')
+        })
+
         test('should not override cloud config using multiremote', async () => {
             const options = {
                 logPath : './',

--- a/packages/wdio-cli/src/launcher.ts
+++ b/packages/wdio-cli/src/launcher.ts
@@ -38,6 +38,7 @@ export interface EndMessage {
 class Launcher {
     public configParser: ConfigParser
     public isMultiremote = false
+    public isParallelMultiremote = false
     public runner?: Services.RunnerInstance
     public interface?: CLInterface
 
@@ -74,7 +75,9 @@ class Launcher {
         this._args.autoCompileOpts = config.autoCompileOpts
 
         const capabilities = this.configParser.getCapabilities() as (Capabilities.Capabilities | Capabilities.W3CCapabilities | Capabilities.MultiRemoteCapabilities)
-        this.isMultiremote = !Array.isArray(capabilities)
+        this.isParallelMultiremote = Array.isArray(capabilities) &&
+            capabilities.every(cap => Object.values(cap).length > 0 && Object.values(cap).every(c => typeof c === 'object' && (c as any).capabilities))
+        this.isMultiremote = this.isParallelMultiremote || !Array.isArray(capabilities)
 
         if (config.outputDir) {
             await fs.mkdir(path.join(config.outputDir), { recursive: true })
@@ -83,9 +86,19 @@ class Launcher {
 
         logger.setLogLevelsConfig(config.logLevels, config.logLevel)
 
+        /**
+         * For Parallel-Multiremote, only get the specs and excludes from the first object
+         */
         const totalWorkerCnt = Array.isArray(capabilities)
             ? capabilities
-                .map((c: Capabilities.DesiredCapabilities) => this.configParser.getSpecs(c.specs, c.exclude).length)
+                .map((c: Capabilities.DesiredCapabilities | Capabilities.MultiRemoteCapabilities) => {
+                    if (this.isParallelMultiremote) {
+                        const keys = Object.keys(c as Capabilities.MultiRemoteCapabilities)
+                        return this.configParser.getSpecs(((c as Capabilities.MultiRemoteCapabilities)[keys[0]].capabilities as Capabilities.DesiredCapabilities).specs,
+                            ((c as Capabilities.MultiRemoteCapabilities)[keys[0]].capabilities as Capabilities.DesiredCapabilities).exclude).length
+                    }
+                    return this.configParser.getSpecs((c as Capabilities.DesiredCapabilities).specs, (c as Capabilities.DesiredCapabilities).exclude).length
+                })
                 .reduce((a, b) => a + b, 0)
             : 1
 
@@ -183,7 +196,7 @@ class Launcher {
          * schedule test runs
          */
         let cid = 0
-        if (this.isMultiremote) {
+        if (this.isMultiremote && !this.isParallelMultiremote) {
             /**
              * Multiremote mode
              */
@@ -196,19 +209,19 @@ class Launcher {
             })
         } else {
             /**
-             * Regular mode
+             * Regular mode & Parallel Multiremote
              */
-            for (const capabilities of caps as (Capabilities.DesiredCapabilities | Capabilities.W3CCapabilities)[]) {
+            for (const capabilities of caps as (Capabilities.DesiredCapabilities | Capabilities.W3CCapabilities | Capabilities.MultiRemoteCapabilities)[]) {
                 /**
                  * when using browser runner we only allow one session per browser
                  */
-                const availableInstances = config.runner === 'browser'
+                const availableInstances = this.isParallelMultiremote ? config.maxInstances || 1 : config.runner === 'browser'
                     ? 1
                     : (capabilities as Capabilities.DesiredCapabilities).maxInstances || config.maxInstancesPerCapability
 
                 this._schedule.push({
                     cid: cid++,
-                    caps: capabilities as Capabilities.Capabilities,
+                    caps: capabilities as (Capabilities.Capabilities | Capabilities.MultiRemoteCapabilities),
                     specs: this._formatSpecs(capabilities, specFileRetries),
                     availableInstances,
                     runningInstances: 0

--- a/packages/wdio-cli/tests/launcher.test.ts
+++ b/packages/wdio-cli/tests/launcher.test.ts
@@ -98,6 +98,26 @@ describe('launcher', () => {
             expect(launcher['_runSpecs']).toBeCalledTimes(1)
         })
 
+        it('should start instances with parallel multiremote', () => {
+            launcher['_runSpecs'] = vi.fn()
+            launcher.isMultiremote = true
+            launcher.isParallelMultiremote = true
+            launcher['_runMode'](
+                { specs: ['./'], specFileRetries: 2 } as any,
+                [
+                    { foo: { capabilities: { browserName: 'chrome' } } },
+                    { foo: { capabilities: { browserName: 'chrome' } } }
+                ]
+            )
+
+            expect(launcher['_schedule']).toHaveLength(2)
+            expect(launcher['_schedule'][0].specs[0].retries).toBe(2)
+            expect(launcher['_schedule'][1].specs[0].retries).toBe(2)
+
+            expect(typeof launcher['_resolve']).toBe('function')
+            expect(launcher['_runSpecs']).toBeCalledTimes(1)
+        })
+
         it('should start instance with grouped specs', () => {
             launcher['_runSpecs'] = vi.fn()
             launcher.isMultiremote = false

--- a/packages/wdio-firefox-profile-service/src/launcher.ts
+++ b/packages/wdio-firefox-profile-service/src/launcher.ts
@@ -67,7 +67,13 @@ export default class FirefoxProfileLauncher {
         const zippedProfile = await promisify(this._profile.encoded.bind(this._profile))()
 
         if (Array.isArray(capabilities)) {
-            (capabilities as Capabilities.DesiredCapabilities[])
+            (capabilities as Capabilities.DesiredCapabilities[] | Capabilities.MultiRemoteCapabilities[])
+                .flatMap((c: Capabilities.DesiredCapabilities | Capabilities.MultiRemoteCapabilities) => {
+                    if (Object.values(c).length > 0 && Object.values(c).every(c => typeof c === 'object' && c.capabilities)) {
+                        return Object.values(c).map((o) => o.capabilities)
+                    }
+                    return c as (Capabilities.DesiredCapabilities)
+                })
                 .filter((capability) => capability.browserName === 'firefox')
                 .forEach((capability) => {
                     this._setProfile(capability, zippedProfile)

--- a/packages/wdio-firefox-profile-service/tests/launcher.test.ts
+++ b/packages/wdio-firefox-profile-service/tests/launcher.test.ts
@@ -129,6 +129,32 @@ describe('Firefox profile service', () => {
             expect(capabilities.firefox.capabilities['moz:firefoxOptions']).toEqual({ profile : 'foobar' })
         })
 
+        test('should set capabilities when in parallel multiremote', async () => {
+            const options = {
+                'browser.startup.homepage': 'https://webdriver.io',
+            }
+
+            const capabilities: WebdriverIO.MultiRemoteCapabilities[] = [{
+                firefox0 : {
+                    capabilities : {
+                        browserName : 'firefox',
+                    }
+                }
+            }, {
+                firefox1 : {
+                    capabilities : {
+                        browserName : 'firefox',
+                    }
+                }
+            }]
+
+            const service = new Launcher(options)
+            await service.onPrepare({} as never, capabilities)
+
+            expect(capabilities[0].firefox0.capabilities['moz:firefoxOptions']).toEqual({ profile : 'foobar' })
+            expect(capabilities[1].firefox1.capabilities['moz:firefoxOptions']).toEqual({ profile : 'foobar' })
+        })
+
         test('should not set capabilities when an object and not firefox', async () => {
             const options = {
                 'browser.startup.homepage': 'https://webdriver.io',

--- a/packages/wdio-runner/src/index.ts
+++ b/packages/wdio-runner/src/index.ts
@@ -65,7 +65,9 @@ export default class Runner extends EventEmitter {
         this._config = this._configParser.getConfig()
         this._specFileRetryAttempts = (this._config.specFileRetries || 0) - (retries || 0)
         logger.setLogLevelsConfig(this._config.logLevels, this._config.logLevel)
-        const isMultiremote = this._isMultiremote = !Array.isArray(this._configParser.getCapabilities())
+        const capabilities = this._configParser.getCapabilities() as (Capabilities.Capabilities | Capabilities.W3CCapabilities | Capabilities.MultiRemoteCapabilities)
+        const isMultiremote = this._isMultiremote = !Array.isArray(capabilities) ||
+            (Object.values(caps).length > 0 && Object.values(caps).every(c => typeof c === 'object' && c.capabilities))
 
         /**
          * create `browser` stub only if `specFiltering` feature is enabled

--- a/packages/wdio-sauce-service/src/launcher.ts
+++ b/packages/wdio-sauce-service/src/launcher.ts
@@ -62,7 +62,17 @@ export default class SauceLauncher implements Services.ServiceInstance {
         const prepareCapability = makeCapabilityFactory(sauceConnectTunnelIdentifier)
         if (Array.isArray(capabilities)) {
             for (const capability of capabilities) {
-                prepareCapability(capability as Capabilities.DesiredCapabilities)
+                /**
+                 * Parallel Multiremote
+                 */
+                if (Object.values(capability).length > 0 && Object.values(capability).every(c => typeof c === 'object' && c.capabilities)) {
+                    for (const browserName of Object.keys(capability)) {
+                        const caps = (capability as Capabilities.MultiRemoteCapabilities)[browserName].capabilities
+                        prepareCapability((caps as Capabilities.W3CCapabilities).alwaysMatch || caps)
+                    }
+                } else {
+                    prepareCapability(capability as Capabilities.DesiredCapabilities)
+                }
             }
         } else {
             for (const browserName of Object.keys(capabilities)) {

--- a/packages/wdio-sauce-service/tests/launcher.test.ts
+++ b/packages/wdio-sauce-service/tests/launcher.test.ts
@@ -242,6 +242,74 @@ test('onPrepare multiremote', async () => {
     expect(service['_sauceConnectProcess']).not.toBeUndefined()
 })
 
+test('onPrepare parallel multiremote', async () => {
+    const options: SauceServiceConfig = {
+        sauceConnect: true,
+        scRelay: true,
+        sauceConnectOpts: {
+            sePort: 4446,
+            tunnelIdentifier: 'my-tunnel'
+        }
+    }
+    const caps: Capabilities.MultiRemoteCapabilities[] = [{
+        browserA: {
+            capabilities: { browserName: 'chrome' }
+        },
+        browserB: {
+            capabilities: {
+                browserName: 'firefox',
+                'sauce:options': { tunnelIdentifier: 'fish' }
+            }
+        }
+    }, {
+        browserC: {
+            capabilities: { browserName: 'chrome' }
+        },
+        browserD: {
+            capabilities: {
+                browserName: 'firefox',
+                'sauce:options': { tunnelIdentifier: 'fish' }
+            }
+        }
+    }]
+    const config = {
+        user: 'foobaruser',
+        key: '12345'
+    } as Options.Testrunner
+    const service = new SauceServiceLauncher(options, caps, config)
+    expect(service['_sauceConnectProcess']).toBeUndefined()
+    await service.onPrepare(config, caps)
+
+    expect(caps).toEqual([{
+        browserA: {
+            capabilities: {
+                browserName: 'chrome',
+                'sauce:options': { tunnelIdentifier: 'my-tunnel' }
+            }
+        },
+        browserB: {
+            capabilities: {
+                browserName: 'firefox',
+                'sauce:options': { tunnelIdentifier: 'fish' }
+            },
+        }
+    }, {
+        browserC: {
+            capabilities: {
+                browserName: 'chrome',
+                'sauce:options': { tunnelIdentifier: 'my-tunnel' }
+            }
+        },
+        browserD: {
+            capabilities: {
+                browserName: 'firefox',
+                'sauce:options': { tunnelIdentifier: 'fish' }
+            },
+        }
+    }])
+    expect(service['_sauceConnectProcess']).not.toBeUndefined()
+})
+
 test('onPrepare if sauceTunnel is not set', async () => {
     const options: SauceServiceConfig = {
         sauceConnectOpts: {

--- a/packages/wdio-testingbot-service/src/launcher.ts
+++ b/packages/wdio-testingbot-service/src/launcher.ts
@@ -33,7 +33,11 @@ export default class TestingBotLauncher implements Services.ServiceInstance {
             'tunnel-identifier': tbTunnelIdentifier,
         }, this.options.tbTunnelOpts)
 
-        const capabilitiesEntries = Array.isArray(capabilities) ? capabilities : Object.values(capabilities)
+        const capabilitiesEntries = Array.isArray(capabilities) ?
+            (capabilities as []).every(cap => Object.values(cap).length > 0 && Object.values(cap).every(c => typeof c === 'object' && (c as any).capabilities)) ?
+                capabilities.flatMap((cap: Capabilities.MultiRemoteCapabilities ) => Object.values(cap))
+                : capabilities
+            : Object.values(capabilities)
         for (const capability of capabilitiesEntries) {
             const caps = (capability as Options.WebDriver).capabilities || capability
             const c = (caps as Capabilities.W3CCapabilities).alwaysMatch || caps

--- a/packages/wdio-testingbot-service/tests/launcher.test.ts
+++ b/packages/wdio-testingbot-service/tests/launcher.test.ts
@@ -138,6 +138,90 @@ describe('wdio-testingbot-service', () => {
         })
     })
 
+    it('should merge tunnelIdentifier in tb:options in parallel multiremote', async () => {
+        const options: TestingbotOptions = {
+            tbTunnel: true,
+            tbTunnelOpts: {
+                apiKey: 'user',
+                apiSecret: 'key',
+                tunnelIdentifier: 'my-tunnel'
+            }
+        }
+        const config: any = {
+            user: 'user',
+            key: 'key'
+        }
+        const caps: Capabilities.MultiRemoteCapabilities[] = [{
+            browserA: {
+                capabilities: {
+                    'tb:options': {
+                        build: 'unit-test',
+                    }
+                }
+            } as any,
+            browserB: {
+                capabilities: {
+                    'tb:options': {
+                        build: 'other-unit-test',
+                    }
+                }
+            } as any
+        }, {
+            browserC: {
+                capabilities: {
+                    'tb:options': {
+                        build: 'unit-test',
+                    }
+                }
+            } as any,
+            browserD: {
+                capabilities: {
+                    'tb:options': {
+                        build: 'other-unit-test',
+                    }
+                }
+            } as any
+        }]
+        const tbLauncher = new TestingBotLauncher(options)
+
+        await tbLauncher.onPrepare(config, caps as any)
+        expect(caps).toEqual([{
+            browserA: {
+                capabilities: {
+                    'tb:options': {
+                        'tunnel-identifier': 'my-tunnel',
+                        build: 'unit-test',
+                    }
+                }
+            },
+            browserB: {
+                capabilities: {
+                    'tb:options': {
+                        'tunnel-identifier': 'my-tunnel',
+                        build: 'other-unit-test',
+                    }
+                }
+            }
+        }, {
+            browserC: {
+                capabilities: {
+                    'tb:options': {
+                        'tunnel-identifier': 'my-tunnel',
+                        build: 'unit-test',
+                    }
+                }
+            },
+            browserD: {
+                capabilities: {
+                    'tb:options': {
+                        'tunnel-identifier': 'my-tunnel',
+                        build: 'other-unit-test',
+                    }
+                }
+            }
+        }])
+    })
+
     it('should add tunnelIdentifier in tb:options', async () => {
         const options: TestingbotOptions = {
             tbTunnel: true,

--- a/packages/wdio-types/src/Capabilities.ts
+++ b/packages/wdio-types/src/Capabilities.ts
@@ -91,7 +91,7 @@ export interface W3CCapabilities {
     firstMatch: Capabilities[];
 }
 
-export type RemoteCapabilities = (DesiredCapabilities | W3CCapabilities)[] | MultiRemoteCapabilities;
+export type RemoteCapabilities = (DesiredCapabilities | W3CCapabilities)[] | MultiRemoteCapabilities | MultiRemoteCapabilities[];
 
 export interface MultiRemoteCapabilities {
     [instanceName: string]: WebDriverIOOptions;

--- a/tests/helpers/parallel-multiremote-config.js
+++ b/tests/helpers/parallel-multiremote-config.js
@@ -1,0 +1,37 @@
+import path from 'node:path'
+import url from 'node:url'
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url))
+
+export const config = {
+    /**
+     * capabilities
+     */
+    capabilities: [{
+        browserA: {
+            capabilities: { browserName: 'chrome' }
+        },
+        browserB: {
+            capabilities: { browserName: 'chrome' }
+        }
+    },
+    {
+        browserC: {
+            capabilities: { browserName: 'chrome' }
+        },
+        browserD: {
+            capabilities: { browserName: 'chrome' }
+        }
+    }
+    ],
+
+    /**
+     * test configurations
+     */
+    logLevel: 'trace',
+    framework: 'mocha',
+    outputDir: __dirname,
+
+    reporters: ['spec'],
+    services: ['webdriver-mock'],
+}

--- a/tests/multiremote/test.js
+++ b/tests/multiremote/test.js
@@ -5,8 +5,14 @@ describe('smoke test multiremote', () => {
         assert.equal(
             JSON.stringify(await browser.getTitle()),
             JSON.stringify(['Mock Page Title', 'Mock Page Title']))
-        assert.equal(await browser.browserB.getTitle(), 'Mock Page Title')
-        assert.equal(await browser.browserA.getTitle(), 'Mock Page Title')
+
+        if (browser.browserA) {
+            assert.equal(await browser.browserB.getTitle(), 'Mock Page Title')
+            assert.equal(await browser.browserA.getTitle(), 'Mock Page Title')
+        } else {
+            assert.equal(await browser.browserC.getTitle(), 'Mock Page Title')
+            assert.equal(await browser.browserD.getTitle(), 'Mock Page Title')
+        }
     })
 
     it('should allow to chain element calls', async () => {
@@ -33,12 +39,19 @@ describe('smoke test multiremote', () => {
 
         it('should respect promises if command was added to single browser', async () => {
             await browser.customCommandScenario(Object.keys(browser.instances).length)
-            global.browserA.addCommand('foobar', async () => {
-                const title = await global.browserA.getTitle()
+            let browserObj = global.browserA,
+                anotherBrowserObj  = global.browserB
+            if (browser.browserC) {
+                browserObj = global.browserC
+                anotherBrowserObj  = global.browserD
+            }
+
+            browserObj.addCommand('foobar', async () => {
+                const title = await browserObj.getTitle()
                 return `Title: ${title}`
             })
-            assert.strictEqual(await global.browserA.foobar(), 'Title: Mock Page Title')
-            assert.equal(typeof global.browserB.foobar, 'undefined')
+            assert.strictEqual(await browserObj.foobar(), 'Title: Mock Page Title')
+            assert.equal(typeof anotherBrowserObj.foobar, 'undefined')
         })
 
         it('should throw if promise rejects', async () => {
@@ -81,11 +94,18 @@ describe('smoke test multiremote', () => {
 
         it('should allow to overwrite element commands of a single browser', async () => {
             await browser.customCommandScenario(Object.keys(browser.instances).length)
-            global.browserA.overwriteCommand('getTitle', async function (origCommand) {
+            let browserObj = global.browserA,
+                anotherBrowserObj  = global.browserB
+            if (browser.browserC) {
+                browserObj = global.browserC
+                anotherBrowserObj  = global.browserD
+            }
+
+            browserObj.overwriteCommand('getTitle', async function (origCommand) {
                 return `Title: ${await origCommand()}`
             })
-            assert.equal(await global.browserA.getTitle(), 'Title: Mock Page Title')
-            assert.equal(await global.browserB.getTitle(), 'Mock Page Title')
+            assert.equal(await browserObj.getTitle(), 'Title: Mock Page Title')
+            assert.equal(await anotherBrowserObj.getTitle(), 'Mock Page Title')
         })
 
         it('should allow to overwrite element commands', async () => {

--- a/tests/smoke.runner.js
+++ b/tests/smoke.runner.js
@@ -8,6 +8,7 @@ import { SevereServiceError } from '../packages/node_modules/webdriverio/build/i
 
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url))
 const baseConfig = path.resolve(__dirname, 'helpers', 'config.js')
+const parallelMultiRemoteBaseConfig = path.resolve(__dirname, 'helpers', 'parallel-multiremote-config.js')
 const jasmineConfig = path.resolve(__dirname, 'helpers', 'configJasmine.js')
 
 import launch from './helpers/launch.js'
@@ -477,6 +478,17 @@ const multiremote = async () => {
 }
 
 /**
+ * parallel multiremote wdio testrunner tests
+ */
+const parallelMultiremote = async () => {
+    console.log(parallelMultiRemoteBaseConfig)
+    await launch('parallelMultiremote', parallelMultiRemoteBaseConfig, {
+        autoCompileOpts: { autoCompile: false },
+        specs: [path.resolve(__dirname, 'multiremote', 'test.js')],
+    })
+}
+
+/**
  * specfile-level retries (fail)
  */
 const retryFail = async () => {
@@ -656,6 +668,7 @@ const nonGlobalTestrunner = async () => {
         mochaTestrunner,
         jasmineTestrunner,
         multiremote,
+        parallelMultiremote,
         wdioHooks,
         cjsTestrunner,
         sharedStoreServiceTest,

--- a/website/docs/Multiremote.md
+++ b/website/docs/Multiremote.md
@@ -80,6 +80,38 @@ export const config = {
 
 This will create two WebDriver sessions with Chrome and Firefox. Instead of just Chrome and Firefox you can also boot up two mobile devices using [Appium](http://appium.io) or one mobile device and one browser.
 
+You can also run multiremote in parallel by putting the browser capabilities object in an array. Please make sure to have `capabilities` field included in each browser, as this is how we tell each mode apart.
+
+```js
+export const config = {
+    // ...
+    capabilities: [{
+        myChromeBrowser0: {
+            capabilities: {
+                browserName: 'chrome'
+            }
+        },
+        myFirefoxBrowser0: {
+            capabilities: {
+                browserName: 'firefox'
+            }
+        }
+    }, {
+        myChromeBrowser1: {
+            capabilities: {
+                browserName: 'chrome'
+            }
+        },
+        myFirefoxBrowser1: {
+            capabilities: {
+                browserName: 'firefox'
+            }
+        }
+    }]
+    // ...
+}
+```
+
 You can even boot up one of the [cloud services backend](https://webdriver.io/docs/cloudservices.html) together with local Webdriver/Appium, or Selenium Standalone instances. WebdriverIO automatically detect cloud backend capabilities if you specified either of `bstack:options` ([Browserstack](https://webdriver.io/docs/browserstack-service.html)), `sauce:options` ([SauceLabs](https://webdriver.io/docs/sauce-service.html)), or `tb:options` ([TestingBot](https://webdriver.io/docs/testingbot-service.html)) in browser capabilities.
 
 ```js


### PR DESCRIPTION
## Proposed changes

Continuation of [5458](https://github.com/webdriverio/webdriverio/pull/5458) and [5445](https://github.com/webdriverio/webdriverio/issues/5445), this feature allows running Multiremote in parallel by passing an array of multiremote capabilities.

```
capabilities: [
        {
            browser1: { capabilities: { browserName: 'chrome' } },
            browser2: { capabilities: { browserName: 'chrome' } }
        },
        {
            browser1: { capabilities: { browserName: 'firefox' } },
            browser2: { capabilities: { browserName: 'firefox' } }
        },
        {
            browser1: { capabilities: { browserName: 'chrome' } },
            browser2: { capabilities: { browserName: 'firefox' } }
        }
    ],
```

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

I try to do this by not adding any new configuration, but instead adding logic to determine if the objects inside capabilities array are of multiremote type by checking for the 'capabilities' field. To use it, a user just have to put multiremote object in an array.

```
capabilities: [
        {
            browser1: { capabilities: { browserName: 'chrome' } },
            browser2: { capabilities: { browserName: 'chrome' } }
        },
        {
            browser1: { capabilities: { browserName: 'firefox' } },
            browser2: { capabilities: { browserName: 'firefox' } }
        },
    ],
```

 I have run some test locally using devtools and selenium service and it went well. 

I also try to make changes to other services that require it. However, I can only test non-cloud services locally. If there is any other place that I miss applying the changes, please let me know.

### Reviewers: @webdriverio/project-committers
