### PR TITLE
(@wdio/globals): fix method calls on global objects so that they're correctly bound

### DIFF
--- a/packages/wdio-globals/src/index.ts
+++ b/packages/wdio-globals/src/index.ts
@@ -24,7 +24,12 @@ function proxyHandler (key: SupportedGlobals) {
                 throw new Error(GLOBALS_ERROR_MESSAGE)
             }
 
-            return globals.get(key)[prop]
+            const receiver = globals.get(key)
+            const field = receiver[prop]
+
+            return typeof field === 'function'
+                ? field.bind(receiver)
+                : field
         }
     }
 }


### PR DESCRIPTION
## Proposed changes

At the moment, `proxyHandler` from `@wdio/globals` returns fields from global objects without binding them to their receivers:
https://github.com/webdriverio/webdriverio/blob/bd86d6975458ad8bba3fd87f2af505e1537204db/packages/wdio-globals/src/index.ts#L20-L30

This means that when the field happens to be a method referencing `this` (like the `getPuppeteer` method), it loses the context of its receiver object and doesn't work:
https://github.com/webdriverio/webdriverio/blob/caa2302eb1123d5595a01f147374d5430ea451e7/packages/webdriverio/src/commands/browser/getPuppeteer.ts#L45-L68

For example, the following code sample DOESN'T WORK as `getPuppeteer()` is not bound to `browser` and returns an `undefined`.

```typescript
import { browser } from '@wdio/globals';

const puppeteer = await browser.getPuppeteer();
// returns undefined
```

## Types of changes

This pull request addresses the issue by binding method calls to their respective receiver objects.

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
