### PR TITLE
Fix invalid unicode escape error on Windows

### DIFF
--- a/packages/wdio-browser-runner/src/vite/utils.ts
+++ b/packages/wdio-browser-runner/src/vite/utils.ts
@@ -114,7 +114,7 @@ export async function getTemplate(options: WebdriverIO.BrowserRunnerOptions, env
                     env: ${JSON.stringify(p.env)},
                     stdout: {},
                     stderr: {},
-                    cwd: () => '${p.cwd()}',
+                    cwd: () => ${JSON.stringify(p.cwd())},
                 }
             </script>
             <script type="module" src="@wdio/browser-runner/setup"></script>


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

On Windows, file system paths are delimited with `\`, so by interpolating paths directly between quotation marks could potentially lead to invalid values in good cases or to an "Uncaught SyntaxError: Invalid Unicode escape sequence" in the worst case, causing tests not being able to run.

This can be reproduced when running wdio with the browser runner in a current working directory whose path includes a directory that starts with e.g. `ui` under Windows.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
