### PR TITLE
(@wdio/cli): corrected TypeScript loading

### DIFF
--- a/e2e/wdio/headless/ts-node.e2e.ts
+++ b/e2e/wdio/headless/ts-node.e2e.ts
@@ -1,7 +1,7 @@
-import { describe, it } from 'mocha'
-
+// eslint-disable-next-line no-undef
 describe('WebdriverIO', () => {
 
+    // eslint-disable-next-line no-undef
     it('should support source maps when running TypeScript files', async () => {
         const location = getInvocationLocation()
 

--- a/e2e/wdio/headless/ts-node.e2e.ts
+++ b/e2e/wdio/headless/ts-node.e2e.ts
@@ -1,0 +1,16 @@
+import { describe, it } from 'mocha'
+
+describe('WebdriverIO', () => {
+
+    it('should support source maps when running TypeScript files', async () => {
+        const location = getInvocationLocation()
+
+        expect(location).toMatch(/ts-node.e2e.ts:6:26/)
+    })
+})
+
+function getInvocationLocation(): string {
+    const error = new Error('example error')
+    const lines = error.stack.split('\n')
+    return lines[2]
+}

--- a/packages/wdio-cli/src/commands/run.ts
+++ b/packages/wdio-cli/src/commands/run.ts
@@ -177,7 +177,7 @@ export async function handler(argv: RunCommandArguments) {
         NODE_OPTIONS?.includes('ts-node/esm')
     )
     if (isTSFile && !runsWithLoader && nodePath) {
-        NODE_OPTIONS += ' -r ts-node/register --loader ts-node/esm/transpile-only --no-warnings'
+        NODE_OPTIONS += ' --loader ts-node/esm/transpile-only --no-warnings'
         const localTSConfigPath = (
             (
                 params.autoCompileOpts?.tsNodeOpts?.project &&


### PR DESCRIPTION
## Proposed changes

Change https://github.com/webdriverio/webdriverio/commit/429273377b76628dff1a691061982041b13f5dd3 introduced a regression where TypeScript files get loaded using both `-r ts-node/register` AND `--loader ts-node/esm/transpile-only`, preventing source maps from working correctly:
https://github.com/webdriverio/webdriverio/blob/54cbada9d273982612181f2bfae21394e2cd8d6e/packages/wdio-cli/src/commands/run.ts#L180

Even though [one part of ts-node documentation](https://github.com/TypeStrong/ts-node#mocha-7-and-newer) seems to indicate that specifying both flags _should be_ supported, another part talks about specifying [only one of the flags at the time](https://github.com/TypeStrong/ts-node#other).  

Looking at the source code of [`ts-node/esm/transpile-only`](https://github.com/TypeStrong/ts-node/blob/47d4f45f35e824a2515e17383a563be7dba7d8ff/esm/transpile-only.mjs#L7), we can see that the method [`registerAndCreateEsmHooks`](
https://github.com/TypeStrong/ts-node/blob/47d4f45f35e824a2515e17383a563be7dba7d8ff/src/esm.ts#L102-L107) already calls `register(opts)`, which means specifying the flag `-r ts-node/register` is redundant.

From what I've observed, using both flags results in TS Node incorrectly mapping the resulting JavaScript to the original TypeScript, which means that stack traces point to incorrect lines.

I've modified `@wdio/cli` running locally on a CJS project to remove the `ts-node/register` flag and the stack traces started to work correctly again.  

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
