### PR TITLE
fix(webdriverio): updated devtools peer dependency to 8.14.0

### DIFF
--- a/packages/webdriverio/package.json
+++ b/packages/webdriverio/package.json
@@ -93,7 +93,7 @@
     "webdriver": "8.14.0"
   },
   "peerDependencies": {
-    "devtools": "8.13.13"
+    "devtools": "^8.14.0"
   },
   "peerDependenciesMeta": {
     "devtools": {


### PR DESCRIPTION
## Proposed changes

Now that `devtools` is an optional peer dependency, its version should match the major/minor version of the main `webdriverio` package

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
