### PR TITLE
[💡 Feature]: Make WebdriverIO load `.env` environments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27679,6 +27679,17 @@
         "node": "*"
       }
     },
+    "packages/node_modules/dotenv": {
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
+      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/motdotla/dotenv?sponsor=1"
+      }
+    },
     "packages/node_modules/ip": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.8.tgz",
@@ -27905,6 +27916,7 @@
         "chalk": "^5.2.0",
         "chokidar": "^3.5.3",
         "cli-spinners": "^2.9.0",
+        "dotenv": "^16.3.1",
         "ejs": "^3.1.9",
         "execa": "^7.1.1",
         "import-meta-resolve": "^3.0.0",

--- a/packages/wdio-cli/package.json
+++ b/packages/wdio-cli/package.json
@@ -56,6 +56,7 @@
     "chalk": "^5.2.0",
     "chokidar": "^3.5.3",
     "cli-spinners": "^2.9.0",
+    "dotenv": "^16.3.1",
     "ejs": "^3.1.9",
     "execa": "^7.1.1",
     "import-meta-resolve": "^3.0.0",

--- a/packages/wdio-cli/src/index.ts
+++ b/packages/wdio-cli/src/index.ts
@@ -1,3 +1,5 @@
+import 'dotenv/config'
+
 export { default as Launcher } from './launcher.js'
 export { default as run } from './run.js'
 export * from './types.js'

--- a/packages/wdio-cli/tests/index.test.ts
+++ b/packages/wdio-cli/tests/index.test.ts
@@ -7,6 +7,10 @@ import { run } from '../src/index.js'
 import { run as cjsRun } from '../src/cjs/index.js'
 import { handler } from '../src/commands/run.js'
 
+vi.mock('dotenv/config', () => {
+    process.env = { ...process.env, ...{ foo: 'bar' } }
+    return {}
+})
 vi.mock('yargs')
 vi.mock('yargs/helpers', () => ({ hideBin: vi.fn() }))
 vi.mock('./../src/commands/run', async () => ({
@@ -21,6 +25,10 @@ describe('index', () => {
         vi.mocked(handler).mockClear()
         vi.mocked(yargsMock.parse).mockClear()
         console.error = vi.fn()
+    })
+
+    it('should populate environment using dotenv/conifg', () => {
+        expect(process.env.foo).toBe('bar')
     })
 
     it('should call config if no known command is used', async () => {


### PR DESCRIPTION
### Is your feature request related to a problem?

Make it easier to store environment variables into a `.env` file and read it from the testrunner via https://www.npmjs.com/package/dotenv

### Describe the solution you'd like.

Use https://www.npmjs.com/package/dotenv in the testrunner.

### Describe alternatives you've considered.

n/a

### Additional context

Request from Vue Forge workshop.

### Code of Conduct

- [X] I agree to follow this project's Code of Conduct