### PR TITLE
feat(drivers): Enable automatic driver management for Firefox

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -67,6 +67,7 @@ const config = {
             files: ['*.test.ts'],
             rules: {
                 'dot-notation': 'off',
+                '@typescript-eslint/consistent-type-imports': 'warn',
             },
         },
     ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -28600,11 +28600,15 @@
         "decamelize": "^6.0.0",
         "deepmerge-ts": "^5.1.0",
         "edgedriver": "^5.3.5",
+        "extract-zip": "2.0.1",
         "geckodriver": "^4.2.0",
         "get-port": "^7.0.0",
         "got": "^13.0.0",
         "import-meta-resolve": "^3.0.0",
         "safaridriver": "^0.1.0",
+        "semver": "^7.5.4",
+        "tar-fs": "3.0.4",
+        "unbzip2-stream": "1.4.3",
         "wait-port": "^1.0.4"
       },
       "engines": {
@@ -28645,6 +28649,36 @@
       "funding": {
         "url": "https://github.com/sindresorhus/got?sponsor=1"
       }
+    },
+    "packages/wdio-utils/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "packages/wdio-utils/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "packages/wdio-utils/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "packages/wdio-webdriver-mock-service": {
       "name": "@wdio/webdriver-mock-service",

--- a/packages/wdio-appium-service/tests/launcher.test.ts
+++ b/packages/wdio-appium-service/tests/launcher.test.ts
@@ -10,21 +10,53 @@ import type { Capabilities, Options } from '@wdio/types'
 
 import AppiumLauncher from '../src/launcher.js'
 
-vi.mock('node:fs', () => ({
-    default: {
-        createWriteStream: vi.fn()
-    }
-}))
+vi.mock('node:fs', async () => {
 
-vi.mock('node:fs/promises', () => ({
-    default: {
+    const origFS = await vi.importActual<typeof import('node:fs')>('node:fs')
+
+    const mod = {
+        createWriteStream: vi.fn(),
+    }
+
+    return {
+        ...origFS,
+        ...mod,
+        default: {
+            ...origFS,
+            ...mod,
+        }
+    }
+})
+
+vi.mock('node:fs/promises', async () => {
+
+    const origFS = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises')
+
+    const mod = {
         mkdir: vi.fn(),
         access: vi.fn().mockResolvedValue(true),
     }
-}))
+
+    return {
+        ...origFS,
+        ...mod,
+        default: {
+            ...origFS,
+            ...mod,
+        }
+    }
+})
 
 vi.mock('@wdio/logger', () => import(path.join(process.cwd(), '__mocks__', '@wdio/logger')))
-vi.mock('child_process', () => ({ spawn: vi.fn() }))
+vi.mock('child_process', async () => {
+
+    const origCP = await vi.importActual<typeof import('child_process')>('child_process')
+
+    return {
+        ...origCP,
+        spawn: vi.fn()
+    }
+})
 vi.mock('import-meta-resolve', () => ({ resolve: vi.fn().mockResolvedValue(
     url.pathToFileURL(path.resolve(process.cwd(), '/', 'foo', 'bar', 'appium')))
 }))
@@ -66,10 +98,10 @@ class MockCustomFailingProcess extends MockFailingProcess {
 }
 
 vi.mock('../src/utils', async () => {
-    const { formatCliArgs } = await vi.importActual('../src/utils.js') as any
+    const origUtils = await vi.importActual('../src/utils.js') as any
     return {
+        ...origUtils,
         getFilePath: vi.fn().mockReturnValue('/some/file/path'),
-        formatCliArgs
     }
 })
 

--- a/packages/wdio-browserstack-service/tests/service.test.ts
+++ b/packages/wdio-browserstack-service/tests/service.test.ts
@@ -179,11 +179,16 @@ describe('beforeSession', () => {
 })
 
 describe('_multiRemoteAction', () => {
-    it('resolve if no browser object', () => {
+    it('resolve if no browser object', async () => {
         const tmpService = new BrowserstackService({ testObservability: false }, [] as any,
             { user: 'foo', key: 'bar', cucumberOpts: { strict: false } } as any)
         tmpService['_browser'] = undefined
-        expect(tmpService._multiRemoteAction({} as any)).toEqual(Promise.resolve())
+
+        const action = tmpService._multiRemoteAction({} as any)
+
+        expect(action instanceof Promise).toEqual(true)
+        expect(await action).toEqual(undefined)
+        expect(action).resolves
     })
 })
 

--- a/packages/wdio-cli/tests/commands/run.test.ts
+++ b/packages/wdio-cli/tests/commands/run.test.ts
@@ -8,17 +8,43 @@ import * as configCmd from '../../src/commands/config.js'
 
 vi.mock('yargs')
 vi.mock('execa')
-vi.mock('node:child_process', () => ({
-    default: {
+vi.mock('node:child_process', async () => {
+
+    const origCP = await vi.importActual<typeof import('node:child_process')>('node:child_process')
+
+    const mod = {
         spawn: vi.fn()
     }
-}))
-vi.mock('node:fs/promises', () => ({
-    default: {
+
+    return {
+        ...origCP,
+        ...mod,
+        default: {
+            ...origCP,
+            ...mod,
+        }
+    }
+
+})
+
+vi.mock('node:fs/promises', async () => {
+
+    const origFS = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises')
+
+    const mod = {
         access: vi.fn().mockResolvedValue(true),
         readFile: vi.fn()
     }
-}))
+
+    return {
+        ...origFS,
+        ...mod,
+        default: {
+            ...origFS,
+            ...mod,
+        }
+    }
+})
 vi.mock('./../../src/launcher', () => ({
     default: class {
         run() {

--- a/packages/wdio-cli/tests/utils.test.ts
+++ b/packages/wdio-cli/tests/utils.test.ts
@@ -48,13 +48,17 @@ vi.mock('ejs')
 vi.mock('inquirer')
 vi.mock('recursive-readdir')
 vi.mock('@wdio/logger', () => import(path.join(process.cwd(), '__mocks__', '@wdio/logger')))
-vi.mock('child_process', () => {
+vi.mock('child_process', (origCP) => {
     const m = {
+        ...origCP,
         execSyncRes: 'APPIUM_MISSING',
         execSync: () => m.execSyncRes,
         spawn: vi.fn().mockReturnValue({ on: vi.fn().mockImplementation((ev, fn) => fn(0)) })
     }
-    return m
+    return {
+        default: m,
+        ...m,
+    }
 })
 
 vi.mock('read-pkg-up', () => ({
@@ -69,8 +73,9 @@ vi.mock('read-pkg-up', () => ({
 
 vi.mock('yarn-install', () => ({ default: vi.fn().mockReturnValue({ status: 0 }) }))
 
-vi.mock('node:fs/promises', () => ({
+vi.mock('node:fs/promises', (origFS) => ({
     default: {
+        ...origFS,
         access: vi.fn().mockRejectedValue(new Error('ENOENT')),
         mkdir: vi.fn(),
         writeFile: vi.fn().mockReturnValue(Promise.resolve())

--- a/packages/wdio-utils/package.json
+++ b/packages/wdio-utils/package.json
@@ -37,11 +37,15 @@
     "decamelize": "^6.0.0",
     "deepmerge-ts": "^5.1.0",
     "edgedriver": "^5.3.5",
+    "extract-zip": "2.0.1",
     "geckodriver": "^4.2.0",
     "get-port": "^7.0.0",
     "got": "^13.0.0",
     "import-meta-resolve": "^3.0.0",
     "safaridriver": "^0.1.0",
+    "semver": "^7.5.4",
+    "tar-fs": "3.0.4",
+    "unbzip2-stream": "1.4.3",
     "wait-port": "^1.0.4"
   },
   "publishConfig": {

--- a/packages/wdio-utils/src/driver/chrome.ts
+++ b/packages/wdio-utils/src/driver/chrome.ts
@@ -1,0 +1,171 @@
+import os from 'node:os'
+import fs from 'node:fs'
+import fsp from 'node:fs/promises'
+import path from 'node:path'
+import cp from 'node:child_process'
+
+import got from 'got'
+import logger from '@wdio/logger'
+
+import { getChromePath } from 'chrome-launcher'
+import {
+    install, canDownload, resolveBuildId, detectBrowserPlatform, Browser, ChromeReleaseChannel,
+    computeExecutablePath, type InstallOptions
+} from '@puppeteer/browsers'
+
+import { logDownload } from './utils.js'
+
+const log = logger('@wdio/utils')
+
+import type { Options, Capabilities } from '@wdio/types'
+import type { EdgedriverParameters } from './edge'
+export type ChromedriverParameters = InstallOptions & Omit<EdgedriverParameters, 'port' | 'edgeDriverVersion' | 'customEdgeDriverPath'>
+
+export function getLocalChromePath() {
+    try {
+        const chromePath = getChromePath()
+        return chromePath
+    } catch (err: unknown) {
+        return
+    }
+}
+
+export function getBuildIdByPath(chromePath?: string) {
+    if (!chromePath) {
+        return
+    } else if (os.platform() === 'win32') {
+        const versionPath = path.dirname(chromePath)
+        const contents = fs.readdirSync(versionPath)
+        const versions = contents.filter(a => /^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$/g.test(a))
+
+        // returning oldest in case there is an updated version and chrome still hasn't relaunched
+        const oldest = versions.sort((a: string, b: string) => a > b ? -1 : 1)[0]
+        return oldest
+    }
+
+    const versionString = cp.execSync(`"${chromePath}" --version`).toString()
+    return versionString.split(' ').pop()?.trim()
+}
+
+export function getCacheDir(options: Pick<Options.WebDriver, 'cacheDir'>, caps: Capabilities.Capabilities) {
+    const driverOptions: { cacheDir?: string } = caps['wdio:chromedriverOptions'] || {}
+    return driverOptions.cacheDir || options.cacheDir || os.tmpdir()
+}
+
+export async function setupChromedriver(cacheDir: string, driverVersion?: string) {
+    const platform = detectBrowserPlatform()
+    if (!platform) {
+        throw new Error('The current platform is not supported.')
+    }
+
+    const version = driverVersion || getBuildIdByPath(getLocalChromePath()) || ChromeReleaseChannel.STABLE
+    const buildId = await resolveBuildId(Browser.CHROMEDRIVER, platform, version)
+    let executablePath = computeExecutablePath({
+        browser: Browser.CHROMEDRIVER,
+        buildId,
+        platform,
+        cacheDir
+    })
+    let loggedBuildId = buildId
+    const hasChromedriverInstalled = await fsp.access(executablePath).then(() => true, () => false)
+    if (!hasChromedriverInstalled) {
+        log.info(`Downloading Chromedriver v${buildId}`)
+        const chromedriverInstallOpts: InstallOptions & { unpack?: true } = {
+            cacheDir,
+            buildId,
+            platform,
+            browser: Browser.CHROMEDRIVER,
+            unpack: true,
+            downloadProgressCallback: (downloadedBytes, totalBytes) => logDownload('Chromedriver', downloadedBytes, totalBytes)
+        }
+
+        try {
+            await install({ ...chromedriverInstallOpts, buildId })
+        } catch (err) {
+            /**
+             * in case we detect a Chrome browser installed for which there is no Chromedriver available
+             * we are falling back to the latest known good version
+             */
+            log.warn(`Couldn't download Chromedriver v${buildId}: ${(err as Error).message}, trying to find known good version...`)
+            let knownGoodVersion: string
+            if (buildId.includes('.')) {
+                const majorVersion = buildId.split('.')[0]
+                const knownGoodVersions: any = await got('https://googlechromelabs.github.io/chrome-for-testing/known-good-versions.json').json()
+                const versionMatch = knownGoodVersions.versions.filter(({ version }: { version: string }) => version.startsWith(majorVersion)).pop()
+                if (!versionMatch) {
+                    throw new Error(`Couldn't find known good version for Chromedriver v${majorVersion}`)
+                }
+                knownGoodVersion = versionMatch.version
+            } else {
+                knownGoodVersion = await resolveBuildId(Browser.CHROMEDRIVER, platform, buildId)
+            }
+
+            loggedBuildId = knownGoodVersion
+            await install({ ...chromedriverInstallOpts, buildId: loggedBuildId })
+            executablePath = computeExecutablePath({
+                browser: Browser.CHROMEDRIVER,
+                buildId: loggedBuildId,
+                platform,
+                cacheDir
+            })
+        }
+    } else {
+        log.info(`Using Chromedriver v${buildId} from cache directory ${cacheDir}`)
+    }
+
+    return { executablePath }
+}
+
+export async function setupChrome(cacheDir: string, caps: Capabilities.Capabilities) {
+    caps.browserName = caps.browserName?.toLowerCase()
+    const exist = await fsp.access(cacheDir).then(() => true, () => false)
+    if (!exist) {
+        await fsp.mkdir(cacheDir, { recursive: true })
+    }
+
+    const platform = detectBrowserPlatform()
+    if (!platform) {
+        throw new Error('The current platform is not supported.')
+    }
+
+    if (!caps.browserVersion) {
+        const executablePath = getLocalChromePath()!
+        const tag = getBuildIdByPath(executablePath)
+
+        /**
+         * verify that we have a valid Chrome browser installed
+         */
+        if (tag) {
+            return {
+                cacheDir,
+                platform,
+                executablePath,
+                buildId: await resolveBuildId(Browser.CHROME, platform, tag)
+            }
+        }
+    }
+
+    /**
+     * otherwise download provided Chrome browser version or "stable"
+     */
+    const tag = caps.browserVersion || ChromeReleaseChannel.STABLE
+    const buildId = await resolveBuildId(Browser.CHROME, platform, tag)
+    const installOptions: InstallOptions & { unpack?: true } = {
+        unpack: true,
+        cacheDir,
+        platform,
+        buildId,
+        browser: Browser.CHROME,
+        downloadProgressCallback: (downloadedBytes, totalBytes) => logDownload('Chrome', downloadedBytes, totalBytes)
+    }
+    const isCombinationAvailable = await canDownload(installOptions)
+    if (!isCombinationAvailable) {
+        throw new Error(`Couldn't find a matching Chrome browser for tag "${buildId}" on platform "${platform}"`)
+    }
+
+    log.info(`Setting up Chrome v${buildId}`)
+    await install(installOptions)
+    const executablePath = computeExecutablePath(installOptions)
+    return { executablePath, browserVersion: buildId }
+}
+

--- a/packages/wdio-utils/src/driver/edge.ts
+++ b/packages/wdio-utils/src/driver/edge.ts
@@ -1,0 +1,6 @@
+import { download as downloadEdgedriver } from 'edgedriver'
+export type { EdgedriverParameters } from 'edgedriver'
+
+export function setupEdgedriver(cacheDir: string, driverVersion?: string) {
+    return downloadEdgedriver(driverVersion, cacheDir)
+}

--- a/packages/wdio-utils/src/driver/firefox.ts
+++ b/packages/wdio-utils/src/driver/firefox.ts
@@ -1,0 +1,314 @@
+import fs from 'node:fs'
+import fsp from 'node:fs/promises'
+import path from 'node:path'
+
+import { Cache, Browser } from '@puppeteer/browsers'
+import got from 'got'
+import logger from '@wdio/logger'
+import { coerce } from 'semver'
+import { download as downloadGeckodriver } from 'geckodriver'
+
+import { logDownload, downloadFile, unpackArchive } from './utils.js'
+
+import type { BrowserPlatform } from '@puppeteer/browsers'
+import type { Capabilities } from '@wdio/types'
+
+const log = logger('@wdio/utils')
+
+export type FF_CHANNELS = 'LATEST_FIREFOX_VERSION'
+    | 'LATEST_FIREFOX_DEVEL_VERSION'
+    | 'LATEST_FIREFOX_RELEASED_DEVEL_VERSION'
+    | 'FIREFOX_DEVEDITION'
+    | 'FIREFOX_ESR'
+    | 'FIREFOX_ESR_NEXT'
+    | 'FIREFOX_NIGHTLY';
+
+async function getLatestVersions() {
+    return got
+        .get('https://product-details.mozilla.org/1.0/firefox_versions.json')
+        .json<Record<FF_CHANNELS, string>>()
+        .then(versions => versions)
+        .catch(err => {
+            throw new Error('Could not retrieve versions: ' + err)
+        })
+}
+
+async function getFirefoxInfo() {
+    return got
+        .get('https://product-details.mozilla.org/1.0/firefox.json', { resolveBodyOnly: true })
+        .json<{ releases: Record<`firefox-${string}`, FirefoxReleaseInfo> }>()
+        .then(data => data.releases)
+        .catch(err => { throw new Error(`Could not get Firefox releases information: ${err}`) }
+        )
+}
+
+async function getLatestVersion(channel: FF_CHANNELS = 'LATEST_FIREFOX_VERSION') {
+    const versions = await getLatestVersions()
+    const version = versions[channel]
+    if (!version) {
+        throw new Error(`Channel ${channel} is not found.`)
+    }
+    return version
+}
+
+export type FirefoxReleaseInfo = {
+    build_number: number,
+    category: string,
+    date: string,
+    description: string | null,
+    is_security_driven: boolean,
+    product: 'firefox',
+    version: string
+};
+
+export function setupGeckodriver(cacheDir: string, driverVersion?: string) {
+    return downloadGeckodriver(driverVersion, cacheDir)
+}
+
+export async function setupFirefox(cacheDir: string, caps: Capabilities.Capabilities) {
+
+    const { browserVersion } = caps ?? {}
+
+    if (!browserVersion) {
+        // Let Geckodriver deal with it
+        return {}
+    }
+
+    const OS = ({
+        win32: 'win',
+        darwin: 'osx'
+    }[process.platform as string] ?? 'linux') as 'win' | 'osx' | 'linux'
+
+    const arch = (({
+        arm: { osx: 'mac' },
+        arm64: { win: 'win64-aarch64', osx: 'mac' },
+        ia32: { win: 'win32', linux: 'linux-i686' },
+        x64: { win: 'win64', osx: 'mac', linux: 'linux-x86_64' },
+    }[process.arch as string]) ?? {})[OS]
+
+    if (!arch) {
+        throw new Error(`Cannot download Firefox for OS ${OS} and ${process.arch}!`)
+    }
+
+    const labelChannelMap: Record<string, FF_CHANNELS> = {
+        dev: 'FIREFOX_DEVEDITION',
+        esr: 'FIREFOX_ESR',
+        nightly: 'FIREFOX_NIGHTLY',
+        beta: 'LATEST_FIREFOX_RELEASED_DEVEL_VERSION',
+        stable: 'LATEST_FIREFOX_VERSION',
+        latest: 'LATEST_FIREFOX_VERSION'
+    }
+
+    let channel: FF_CHANNELS | undefined = labelChannelMap[browserVersion.toLowerCase()]
+
+    let nonSemanticVersion = channel
+        ? await getLatestVersion(channel)
+        : browserVersion
+
+    const parseVersion = (token: string) => {
+
+        const label = Object
+            .keys(labelChannelMap)
+            .find(label => token.endsWith(label))
+
+        if (label) {
+            token = token.substring(0, token.length - label.length)
+        }
+
+        const [alpha, beta] = ['a', 'b']
+            .map(t => token.split(t).length === 2
+                ? token.split(t).pop()
+                : undefined)
+
+        // semver removes anything extra of major, minor and patch
+        // Safeguards for when versions are specified without minor and patch
+        const semanticVersion = coerce(
+            `${(alpha || beta)
+                ? token
+                : token.replace(/[^.\d]/g, '')
+            }.0.0`,
+            { loose: true }
+        )
+
+        return { ...semanticVersion ?? {}, alpha, beta, label }
+    }
+
+    let semver = parseVersion(nonSemanticVersion)
+
+    channel = semver.label === 'dev' ? 'FIREFOX_DEVEDITION' : channel
+    channel = semver.label === 'esr' ? 'FIREFOX_ESR' : channel
+    channel = semver.alpha ? 'FIREFOX_NIGHTLY' : channel
+
+    if (!channel) {
+
+        type VersionAndInfo = [string?, FirefoxReleaseInfo?];
+        const versions = await getFirefoxInfo()
+
+        const [oficialVersion]: VersionAndInfo = Object
+            .entries(versions)
+            .map(([version, info]) => [version.substring('firefox-'.length), info] as VersionAndInfo)
+            .find(([oficialVersion]) => oficialVersion && oficialVersion === nonSemanticVersion) as VersionAndInfo
+            ?? []
+
+        if (!oficialVersion) {
+            log.error(`No Firefox version could be found from "${browserVersion}"`)
+            return {}
+        }
+
+        nonSemanticVersion = oficialVersion
+    }
+
+    semver = parseVersion(nonSemanticVersion)
+
+    const { major, minor, patch, alpha, beta } = semver
+
+    if (!major) {
+        log.error(`No Firefox version could be found from "${browserVersion}"`)
+        return {}
+    }
+
+    const locale = 'en-US'
+
+    const suffix = alpha
+        ? `a${alpha}`
+        : beta ? `b${beta}` : undefined
+
+    let mozVersion = `${major}.${minor}${suffix ?? `.${patch}`}`
+    channel === 'FIREFOX_ESR' && (mozVersion += 'esr')
+
+    // Set proper version in capabilities
+    // Geckodriver does not like 0-based patch versions
+    caps.browserVersion = `${major}.${minor}${patch ? `.${patch}` : ''}`
+
+    const dlURL = {
+
+        baseUrl: {
+            'FIREFOX_NIGHTLY': 'https://download.cdn.mozilla.net/pub',
+        }[channel as string] ?? 'https://ftp.mozilla.org/pub',
+
+        path: {
+            'FIREFOX_NIGHTLY': 'firefox/nightly/latest-mozilla-central',
+            'FIREFOX_DEVEDITION': `devedition/releases/${mozVersion}/${arch}/${locale}`,
+        }[channel as string] ?? `firefox/releases/${mozVersion}/${arch}/${locale}`,
+
+        filename: {
+            'FIREFOX_NIGHTLY': `firefox-${mozVersion}.${locale}.${arch}`,
+        }[channel as string] ?? {
+            osx: `Firefox ${mozVersion}`,
+            win: `Firefox Setup ${mozVersion}`,
+            linux: `firefox-${mozVersion}`
+        }[OS],
+
+        ext: {
+            osx: '.dmg',
+            win: channel === 'FIREFOX_NIGHTLY'
+                ? '.installer.exe'
+                : '.msi',
+            linux: '.tar.bz2'
+        }[OS],
+
+        get build() {
+            return [dlURL.baseUrl, dlURL.path, dlURL.filename].join('/') + dlURL.ext
+        }
+    }
+
+    const url = dlURL.build
+
+    log.info(`Setting up Firefox v${mozVersion}`)
+
+    const fileName: string = url.toString().split('/').pop() ?? ''
+
+    const cache = new Cache(cacheDir)
+    const browserRoot = cache.browserRoot(Browser.FIREFOX)
+    const archivePath = path.join(
+        browserRoot,
+        `${mozVersion}${path.extname(fileName)}`
+    )
+    if (!fs.existsSync(browserRoot)) {
+        fs.mkdirSync(browserRoot, { recursive: true })
+    }
+
+    const outputPath = cache.installationDir(
+        Browser.FIREFOX,
+        arch as BrowserPlatform,
+        channel === 'FIREFOX_DEVEDITION'
+            ? `${mozVersion}dev`
+            : mozVersion
+    )
+    fs.mkdirSync(outputPath, { recursive: true })
+
+    const getExecPath = (OS: 'win' | 'linux' | 'osx', outputPath: string, channel: string = '') => {
+
+        const fileName = OS !== 'osx'
+            ? { win: 'firefox.exe', linux: 'firefox' }[OS]
+            : fs
+                .readdirSync(outputPath)
+                .find(f => f.endsWith('.app')) ?? {
+
+                FIREFOX_DEVEDITION: 'Firefox Developer Edition.app',
+                FIREFOX_NIGHTLY: 'Firefox Nightly.app'
+
+            }[channel] ?? 'Firefox.app'
+
+        if (!fileName) {
+            return undefined
+        }
+
+        return {
+            'osx': path.join(
+                outputPath,
+                fileName,
+                'Contents', 'MacOS', 'firefox-bin'
+            ),
+        }[OS as string] ?? path.join(outputPath, fileName)
+    }
+
+    if (fs.existsSync(outputPath)) {
+
+        const executablePath = getExecPath(OS, outputPath)
+        const execFound = executablePath && fs.existsSync(executablePath)
+
+        !execFound && log.info(`Could not find Firefox executable in "${outputPath}"`)
+
+        if (execFound) {
+            const props = { executablePath, buildId: channel, platform: arch }
+
+            let shouldDownload = false
+
+            if (channel === 'FIREFOX_NIGHTLY') {
+
+                // Check latest nightly, updates often
+                shouldDownload = await got.head(url)
+                    .then(async res => {
+
+                        const header = res.headers['last-modified']
+                        const lastModified: number = new Date(header ?? NaN).valueOf()
+
+                        return (!!header && !Number.isNaN(lastModified)) && await fsp
+                            .lstat(executablePath)
+                            .then(exec => exec.birthtimeMs < lastModified)
+                    })
+                    .catch(err => { log.error(err); return false })
+            }
+
+            if (!shouldDownload) {
+                return props
+            }
+        }
+    }
+
+    await downloadFile(
+        url, archivePath,
+        ({ transferred, total }) => logDownload('Firefox', transferred, total)
+    )
+
+    await unpackArchive(archivePath, outputPath)
+
+    if (fs.existsSync(archivePath)) {
+        await fsp.unlink(archivePath).catch(err => log.error(err))
+    }
+
+    const executablePath = getExecPath(OS, outputPath)
+
+    return { executablePath, buildId: channel, platform: arch }
+}

--- a/packages/wdio-utils/src/driver/manager.ts
+++ b/packages/wdio-utils/src/driver/manager.ts
@@ -1,11 +1,11 @@
 import logger from '@wdio/logger'
 import type { Options, Capabilities } from '@wdio/types'
 
-import {
-    getCacheDir, definesRemoteDriver,
-    isSafari, isEdge, isFirefox, isChrome,
-    setupChromedriver, setupEdgedriver, setupGeckodriver, setupChrome
-} from './utils.js'
+import { definesRemoteDriver, getCacheDir, isSafari, isEdge, isFirefox, isChrome } from './utils.js'
+
+import { setupChrome, setupChromedriver } from './chrome.js'
+import { setupEdgedriver } from './edge.js'
+import { setupFirefox, setupGeckodriver } from './firefox.js'
 
 const log = logger('@wdio/utils')
 const UNDEFINED_BROWSER_VERSION = null
@@ -90,12 +90,14 @@ function mapCapabilities (
 
 export async function setupDriver (options: Omit<Options.WebDriver, 'capabilities'>, caps: Capabilities.RemoteCapabilities) {
     return mapCapabilities(options, caps, async (cap: Capabilities.Capabilities) => {
-        const cacheDir = getCacheDir(options, cap)
         if (isEdge(cap.browserName)) {
+            const cacheDir = getCacheDir(options, cap['wdio:edgedriverOptions'])
             return setupEdgedriver(cacheDir, cap.browserVersion)
         } else if (isFirefox(cap.browserName)) {
+            const cacheDir = getCacheDir(options, cap['wdio:geckodriverOptions'])
             return setupGeckodriver(cacheDir, cap.browserVersion)
         } else if (isChrome(cap.browserName)) {
+            const cacheDir = getCacheDir(options, cap['wdio:chromedriverOptions'])
             return setupChromedriver(cacheDir, cap.browserVersion)
         }
 
@@ -105,14 +107,14 @@ export async function setupDriver (options: Omit<Options.WebDriver, 'capabilitie
 
 export function setupBrowser (options: Omit<Options.WebDriver, 'capabilities'>, caps: Capabilities.RemoteCapabilities) {
     return mapCapabilities(options, caps, async (cap: Capabilities.Capabilities) => {
-        const cacheDir = getCacheDir(options, cap)
         if (isEdge(cap.browserName)) {
             // not yet implemented
             return Promise.resolve()
         } else if (isFirefox(cap.browserName)) {
-            // not yet implemented
-            return Promise.resolve()
+            const cacheDir = getCacheDir(options, cap['wdio:geckodriverOptions'])
+            return setupFirefox(cacheDir, cap)
         } else if (isChrome(cap.browserName)) {
+            const cacheDir = getCacheDir(options, cap['wdio:chromedriverOptions'])
             return setupChrome(cacheDir, cap)
         }
 

--- a/packages/wdio-utils/src/driver/utils.ts
+++ b/packages/wdio-utils/src/driver/utils.ts
@@ -1,29 +1,15 @@
-import os, { platform } from 'node:os'
+import os from 'node:os'
 import fs from 'node:fs'
 import fsp from 'node:fs/promises'
-import { mkdir, readdir, unlink } from 'node:fs/promises'
 import path from 'node:path'
 import cp from 'node:child_process'
 import { promisify } from 'node:util'
 import stream from 'node:stream'
 
+import type { Progress } from 'got'
 import got from 'got'
 import decamelize from 'decamelize'
 import logger from '@wdio/logger'
-import { getChromePath } from 'chrome-launcher'
-import type { BrowserPlatform } from '@puppeteer/browsers'
-import { coerce } from 'semver'
-
-import {
-    install, canDownload, resolveBuildId, detectBrowserPlatform, Browser, ChromeReleaseChannel, Cache,
-    computeExecutablePath, type InstallOptions
-} from '@puppeteer/browsers'
-import { download as downloadGeckodriver } from 'geckodriver'
-import { download as downloadEdgedriver } from 'edgedriver'
-import type { EdgedriverParameters } from 'edgedriver'
-import type { Options, Capabilities } from '@wdio/types'
-
-import { DEFAULT_HOSTNAME, DEFAULT_PROTOCOL, DEFAULT_PATH, SUPPORTED_BROWSERNAMES } from '../constants.js'
 
 import extractZip from 'extract-zip'
 // @ts-ignore
@@ -31,48 +17,83 @@ import tar from 'tar-fs'
 // @ts-ignore
 import bzip from 'unbzip2-stream'
 
-const log = logger('webdriver')
+import { DEFAULT_HOSTNAME, DEFAULT_PROTOCOL, DEFAULT_PATH, SUPPORTED_BROWSERNAMES } from '../constants.js'
+
+import type { Capabilities, Options } from '@wdio/types'
+import type { ChromedriverParameters } from './chrome.js'
+import type { EdgedriverParameters } from './edge.js'
+
+const log = logger('@wdio/utils')
 const EXCLUDED_PARAMS = ['version', 'help']
 
 const pipeline = promisify(stream.pipeline)
 const exec = promisify(cp.exec)
 
-export async function downloadFile(url: string, destinationPath: string, progressCallback: (downloadedBytes: number, totalBytes: number) => void
+export function getCacheDir(
+    options: Pick<Options.WebDriver, 'cacheDir'>,
+    driverOpts: Capabilities.WebdriverIOCapabilities[keyof Omit<Capabilities.WebdriverIOCapabilities, 'wdio:safaridriverOptions'>] = {},
+) {
+    const driverOptions: { cacheDir?: string } = driverOpts
+    return driverOptions.cacheDir || options.cacheDir || os.tmpdir()
+}
+
+export async function downloadFile(
+    url: string,
+    destinationPath: string,
+    progressCb: (p: Progress) => any
 ) {
     const downloadStream = got.stream(url)
     const fileWriterStream = fs.createWriteStream(destinationPath)
 
-    progressCallback && downloadStream
-        .on('downloadProgress', ({ transferred, total }) =>
-            progressCallback(transferred, total))
+    progressCb && downloadStream.on('downloadProgress', progressCb)
 
     return pipeline(downloadStream, fileWriterStream)
 }
 
 export async function unpackArchive(archivePath: string, folderPath: string) {
 
-    await mkdir(folderPath, { recursive: true })
+    const ext = path.extname(archivePath)
 
-    if (archivePath.endsWith('.zip')) {
-        await extractZip(archivePath, { dir: folderPath })
-    } else if (archivePath.endsWith('.tar.bz2')) {
-        await extractTar(archivePath, folderPath)
-    } else if (archivePath.endsWith('.dmg')) {
-        await installDMG(archivePath, folderPath)
-    } else if (archivePath.endsWith('.msi')) {
-        await exec(`msiexec /quiet /i "${archivePath}" INSTALL_DIRECTORY_PATH="${folderPath}" TASKBAR_SHORTCUT=false DESKTOP_SHORTCUT=false INSTALL_MAINTENANCE_SERVICE=false`)
-    } else if (archivePath.endsWith('.exe')) {
-        await exec(`"${archivePath}" /S /InstallDirectoryPath="${folderPath}" /TaskbarShortcut=false /DesktopShortcut=false /StartMenuShortcut=false /PrivateBrowsingShortcut=false /MaintenanceService=false`)
-            .catch((err) => {
-                console.log(err)
-            })
-    } else {
-        throw new Error(`Unsupported archive format: ${archivePath}`)
-    }
+    await fsp.mkdir(folderPath, { recursive: true })
+
+    let unpack = {
+        get zip(){ return extractZip(archivePath, { dir: folderPath }) },
+        get tar(){ return extractTar(archivePath, folderPath) },
+        get bz2(){ return this.tar },
+        get dmg(){ return installDMG(archivePath, folderPath) },
+        get msi(){
+            return exec([
+                'msiexec',
+                '/quiet',
+                '/i',
+                `"${archivePath}"`,
+                `INSTALL_DIRECTORY_PATH="${folderPath}"`,
+                'TASKBAR_SHORTCUT=false',
+                'DESKTOP_SHORTCUT=false',
+                'INSTALL_MAINTENANCE_SERVICE=false'
+            ].join(' '))
+        },
+        get exe(){
+            return exec([
+                `"${archivePath}"`,
+                '/S',
+                `/InstallDirectoryPath="${folderPath}"`,
+                '/TaskbarShortcut=false',
+                '/DesktopShortcut=false',
+                '/StartMenuShortcut=false',
+                '/PrivateBrowsingShortcut=false',
+                '/MaintenanceService=false'
+            ].join(' '))
+        }
+    }[ext]
+
+    unpack ??= Promise.reject<void>(`Unsupported archive format: ${archivePath}`)
+
+    return unpack.catch((err) => log.error(err))
 }
 
 export function extractTar(tarPath: string, folderPath: string) {
-    return new Promise((fulfill, reject) => {
+    return new Promise<void>((fulfill, reject) => {
         const tarStream = tar.extract(folderPath)
         tarStream.on('error', reject)
         tarStream.on('finish', fulfill)
@@ -92,7 +113,7 @@ export async function installDMG(dmgPath: string, folderPath: string) {
     let appName
 
     try {
-        const fileNames = await readdir(mountPath)
+        const fileNames = await fsp.readdir(mountPath)
         appName = fileNames.find(item => {
             return typeof item === 'string' && item.endsWith('.app')
         })
@@ -109,7 +130,7 @@ export async function installDMG(dmgPath: string, folderPath: string) {
     return appName
 }
 
-export function parseParams(params: EdgedriverParameters) {
+export function parseParams(params: ChromedriverParameters | EdgedriverParameters) {
     return Object.entries(params)
         .filter(([key,]) => !EXCLUDED_PARAMS.includes(key))
         .map(([key, val]) => {
@@ -123,458 +144,14 @@ export function parseParams(params: EdgedriverParameters) {
         .filter(Boolean)
 }
 
-export function getLocalChromePath() {
-    try {
-        const chromePath = getChromePath()
-        return chromePath
-    } catch (err: unknown) {
-        return
-    }
-}
-
-export function getBuildIdByPath(chromePath?: string) {
-    if (!chromePath) {
-        return
-    } else if (os.platform() === 'win32') {
-        const versionPath = path.dirname(chromePath)
-        const contents = fs.readdirSync(versionPath)
-        const versions = contents.filter(a => /^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$/g.test(a))
-
-        // returning oldest in case there is an updated version and chrome still hasn't relaunched
-        const oldest = versions.sort((a: string, b: string) => a > b ? -1 : 1)[0]
-        return oldest
-    }
-
-    const versionString = cp.execSync(`"${chromePath}" --version`).toString()
-    return versionString.split(' ').pop()?.trim()
-}
-
 let lastTimeCalled = Date.now()
-export const downloadProgressCallback = (artifact: string, downloadedBytes: number, totalBytes: number) => {
+export const logDownload = (artifact: string, downloadedBytes: number, totalBytes: number = downloadedBytes) => {
     if (Date.now() - lastTimeCalled < 1000) {
         return
     }
     const percentage = ((downloadedBytes / totalBytes) * 100).toFixed(2)
     log.info(`Downloading ${artifact} ${percentage}%`)
     lastTimeCalled = Date.now()
-}
-
-export async function setupChrome(cacheDir: string, caps: Capabilities.Capabilities) {
-    caps.browserName = caps.browserName?.toLowerCase()
-    const exist = await fsp.access(cacheDir).then(() => true, () => false)
-    if (!exist) {
-        await fsp.mkdir(cacheDir, { recursive: true })
-    }
-
-    const platform = detectBrowserPlatform()
-    if (!platform) {
-        throw new Error('The current platform is not supported.')
-    }
-
-    if (!caps.browserVersion) {
-        const executablePath = getLocalChromePath()!
-        const tag = getBuildIdByPath(executablePath)
-
-        /**
-         * verify that we have a valid Chrome browser installed
-         */
-        if (tag) {
-            return {
-                cacheDir,
-                platform,
-                executablePath,
-                buildId: await resolveBuildId(Browser.CHROME, platform, tag)
-            }
-        }
-    }
-
-    /**
-     * otherwise download provided Chrome browser version or "stable"
-     */
-    const tag = caps.browserVersion || ChromeReleaseChannel.STABLE
-    const buildId = await resolveBuildId(Browser.CHROME, platform, tag)
-    const installOptions: InstallOptions & { unpack?: true } = {
-        unpack: true,
-        cacheDir,
-        platform,
-        buildId,
-        browser: Browser.CHROME,
-        downloadProgressCallback: (downloadedBytes, totalBytes) => downloadProgressCallback('Chrome', downloadedBytes, totalBytes)
-    }
-    const isCombinationAvailable = await canDownload(installOptions)
-    if (!isCombinationAvailable) {
-        throw new Error(`Couldn't find a matching Chrome browser for tag "${buildId}" on platform "${platform}"`)
-    }
-
-    log.info(`Setting up Chrome v${buildId}`)
-    await install(installOptions)
-    const executablePath = computeExecutablePath(installOptions)
-    return { executablePath, browserVersion: buildId }
-}
-
-type FF_CHANNELS = 'LATEST_FIREFOX_VERSION'
-    | 'LATEST_FIREFOX_DEVEL_VERSION'
-    | 'LATEST_FIREFOX_RELEASED_DEVEL_VERSION'
-    | 'FIREFOX_DEVEDITION'
-    | 'FIREFOX_ESR'
-    | 'FIREFOX_ESR_NEXT'
-    | 'FIREFOX_NIGHTLY';
-
-async function getLatestVersionsFF() {
-    return got
-        .get('https://product-details.mozilla.org/1.0/firefox_versions.json')
-        .json<Record<FF_CHANNELS, string>>()
-        .then(versions => versions)
-        .catch(err => {
-            throw new Error('Could not retrieve versions: ' + err)
-        })
-}
-
-async function getFirefoxInfo() {
-    return got
-        .get('https://product-details.mozilla.org/1.0/firefox.json', { resolveBodyOnly: true })
-        .json<{ releases: Record<`firefox-${string}`, FirefoxReleaseInfo> }>()
-        .then(data => data.releases)
-        .catch(err => { throw new Error(`Could not get Firefox releases information: ${err}`) }
-        )
-}
-
-async function getLatestVersionFromChannelFF(channel: FF_CHANNELS = 'LATEST_FIREFOX_VERSION') {
-    const versions = await getLatestVersionsFF()
-    const version = versions[channel]
-    if (!version) {
-        throw new Error(`Channel ${channel} is not found.`)
-    }
-    return version
-}
-
-export type FirefoxReleaseInfo = {
-    build_number: number,
-    category: string,
-    date: string,
-    description: string | null,
-    is_security_driven: boolean,
-    product: 'firefox',
-    version: string
-};
-
-export async function setupFirefox(cacheDir: string, caps: Capabilities.Capabilities) {
-
-    const { browserVersion } = caps ?? {}
-
-    if (!browserVersion) {
-        // Let Geckodriver deal with it
-        return {}
-    }
-
-    const cbProgressFirefox = (downloadedBytes: number, totalBytes: number) =>
-        downloadProgressCallback('Firefox', downloadedBytes, totalBytes)
-
-    const OS: string = ({ 'win32': 'win', 'darwin': 'osx' }[platform() as string] ?? 'linux')
-
-    const arch = {
-        'arm': { 'osx': 'mac' }[OS],
-        'arm64': { 'win': 'win64-aarch64', 'osx': 'mac' }[OS],
-        'ia32': { 'win': 'win32', 'linux': 'linux-i686' }[OS],
-        'x64': { 'win': 'win64', 'osx': 'mac', 'linux': 'linux-x86_64' }[OS]
-    }[process.arch as string]
-
-    if (!arch) {
-        throw new Error(`Cannot download Firefox for OS ${OS} and ${process.arch}!`)
-    }
-
-    const labelChannelMap: Record<string, FF_CHANNELS> = {
-        'dev': 'FIREFOX_DEVEDITION',
-        'esr': 'FIREFOX_ESR',
-        'nightly': 'FIREFOX_NIGHTLY',
-        'beta': 'LATEST_FIREFOX_RELEASED_DEVEL_VERSION',
-        'stable': 'LATEST_FIREFOX_VERSION',
-        'latest': 'LATEST_FIREFOX_VERSION'
-    }
-
-    let channel: FF_CHANNELS | undefined = labelChannelMap[browserVersion.toLowerCase()]
-
-    let nonSemanticVersion = channel
-        ? await getLatestVersionFromChannelFF(channel)
-        : browserVersion
-
-    const parseVersion = (token: string) => {
-
-        const label = Object
-            .keys(labelChannelMap)
-            .find(label => token.endsWith(label))
-
-        if (label) {
-            token = token.substring(0, token.length - label.length)
-        }
-
-        const [alpha, beta] = ['a', 'b']
-            .map(t => token.split(t).length === 2
-                ? token.split(t).pop()
-                : undefined)
-
-        // semver removes anything extra of major, minor and patch
-        // Safeguards for when versions are specified without minor and patch
-        const semanticVersion = coerce(
-            `${(alpha || beta)
-                ? token
-                : token.replace(/[^.\d]/g, '')
-            }.0.0`,
-            { loose: true }
-        )
-
-        return { ...semanticVersion ?? {}, alpha, beta, label }
-    }
-
-    let semver = parseVersion(nonSemanticVersion)
-
-    channel = semver.label === 'dev' ? 'FIREFOX_DEVEDITION' : channel
-    channel = semver.label === 'esr' ? 'FIREFOX_ESR' : channel
-    channel = semver.alpha ? 'FIREFOX_NIGHTLY' : channel
-
-    if (!channel) {
-
-        type VersionAndInfo = [string?, FirefoxReleaseInfo?];
-        const versions = await getFirefoxInfo()
-
-        const [oficialVersion]: VersionAndInfo = Object
-            .entries(versions)
-            .map(([version, info]) => [version.substring('firefox-'.length), info] as VersionAndInfo)
-            .find(([oficialVersion]) => oficialVersion === nonSemanticVersion) as VersionAndInfo
-
-        if (!oficialVersion) {
-            throw new Error(`No Firefox version could be found from "${browserVersion}"`)
-        }
-
-        nonSemanticVersion = oficialVersion
-    }
-
-    semver = parseVersion(nonSemanticVersion)
-
-    const { major, minor, patch, alpha, beta } = semver
-
-    if (!major) {
-        throw new Error(`No Firefox version could be processed from "${browserVersion}"`)
-    }
-
-    const locale = 'en-US'
-
-    const suffix = alpha
-        ? `a${alpha}`
-        : beta ? `b${beta}` : undefined
-
-    let mozVersion = `${major}.${minor}${suffix ?? `.${patch}`}`
-    channel === 'FIREFOX_ESR' && (mozVersion += 'esr')
-
-    // Set proper version in capabilities
-    // Geckodriver does not like 0-based patch versions
-    caps.browserVersion = `${major}.${minor}${patch ? `.${patch}` : ''}`
-
-    const dlURL = {
-
-        baseUrl: {
-            'FIREFOX_NIGHTLY': 'https://download.cdn.mozilla.net/pub',
-        }[channel as string] ?? 'https://ftp.mozilla.org/pub',
-
-        path: {
-            'FIREFOX_NIGHTLY': 'firefox/nightly/latest-mozilla-central',
-            'FIREFOX_DEVEDITION': `devedition/releases/${mozVersion}/${arch}/${locale}`,
-        }[channel as string] ?? `firefox/releases/${mozVersion}/${arch}/${locale}`,
-
-        filename: {
-            'FIREFOX_NIGHTLY': `firefox-${mozVersion}.${locale}.${arch}`,
-        }[channel as string] ?? {
-            'osx': `Firefox ${mozVersion}`,
-            'win': `Firefox Setup ${mozVersion}`,
-            'linux': `firefox-${mozVersion}`
-        }[OS],
-
-        ext: {
-            'osx': '.dmg',
-            'win': channel === 'FIREFOX_NIGHTLY'
-                ? '.installer.exe'
-                : '.msi',
-            'linux': '.tar.bz2'
-        }[OS],
-
-        get build() {
-            return [dlURL.baseUrl, dlURL.path, dlURL.filename].join('/') + dlURL.ext
-        }
-    }
-
-    const url = dlURL.build
-
-    log.info(`Setting up Firefox v${mozVersion}`)
-
-    const fileName: string = url.toString().split('/').pop() ?? ''
-
-    const cache = new Cache(cacheDir)
-    const browserRoot = cache.browserRoot(Browser.FIREFOX)
-    const archivePath = path.join(
-        browserRoot,
-        `${mozVersion}${path.extname(fileName)}`
-    )
-    if (!fs.existsSync(browserRoot)) {
-        fs.mkdirSync(browserRoot, { recursive: true })
-    }
-
-    const outputPath = cache.installationDir(
-        Browser.FIREFOX,
-        arch as BrowserPlatform,
-        channel === 'FIREFOX_DEVEDITION'
-            ? `${mozVersion}dev`
-            : mozVersion
-    )
-    fs.mkdirSync(outputPath, { recursive: true })
-
-    const getExecPath = (OS: string, outputPath: string) => {
-
-        let fileName = {
-            'win': 'firefox.exe',
-            'linux': 'firefox',
-        }[OS]
-
-        if (OS === 'osx') {
-            fileName = fs.readdirSync(outputPath).find(f => f.endsWith('.app'))
-        }
-
-        if (!fileName) {
-            return undefined
-        }
-
-        return {
-            'osx': path.join(outputPath, fileName, 'Contents', 'MacOS', 'firefox-bin'),
-        }[OS] ?? path.join(outputPath, fileName)
-    }
-
-    if (fs.existsSync(outputPath)) {
-
-        const executablePath = getExecPath(OS, outputPath)
-        const execFound = executablePath && fs.existsSync(executablePath)
-
-        !execFound && log.info(`Could not find Firefox executable in "${outputPath}"`)
-
-        if (execFound) {
-            const props = { executablePath, buildId: channel, platform }
-
-            let shouldDownload = false
-
-            if (channel === 'FIREFOX_NIGHTLY') {
-
-                // Check latest nightly, updates often
-                shouldDownload = await got.head(url)
-                    .then(async res => {
-
-                        const header = res.headers['last-modified']
-                        const lastModified: number = new Date(header ?? NaN).valueOf()
-
-                        return (!!header && !Number.isNaN(lastModified)) && await fsp
-                            .lstat(executablePath)
-                            .then(exec => exec.birthtimeMs < lastModified)
-                    })
-                    .catch(err => { log.error(err); return false })
-            }
-
-            if (!shouldDownload){
-                return props
-            }
-        }
-    }
-
-    await downloadFile(url, archivePath, cbProgressFirefox)
-
-    await unpackArchive(archivePath, outputPath)
-
-    if (fs.existsSync(archivePath)) {
-        await unlink(archivePath).catch(err => log.error(err))
-    }
-
-    const executablePath = getExecPath(OS, outputPath)
-
-    return { executablePath, buildId: channel, platform: arch }
-}
-
-export function getCacheDir(options: Pick<Options.WebDriver, 'cacheDir'>, caps: Capabilities.Capabilities) {
-    const driverOptions: { cacheDir?: string } = (
-        caps['wdio:chromedriverOptions'] ||
-        caps['wdio:chromedriverOptions'] ||
-        caps['wdio:chromedriverOptions'] ||
-        caps['wdio:chromedriverOptions'] ||
-        {}
-    )
-    return driverOptions.cacheDir || options.cacheDir || os.tmpdir()
-}
-
-export async function setupChromedriver(cacheDir: string, driverVersion?: string) {
-    const platform = detectBrowserPlatform()
-    if (!platform) {
-        throw new Error('The current platform is not supported.')
-    }
-
-    const version = driverVersion || getBuildIdByPath(getLocalChromePath()) || ChromeReleaseChannel.STABLE
-    const buildId = await resolveBuildId(Browser.CHROMEDRIVER, platform, version)
-    let executablePath = computeExecutablePath({
-        browser: Browser.CHROMEDRIVER,
-        buildId,
-        platform,
-        cacheDir
-    })
-    let loggedBuildId = buildId
-    const hasChromedriverInstalled = await fsp.access(executablePath).then(() => true, () => false)
-    if (!hasChromedriverInstalled) {
-        log.info(`Downloading Chromedriver v${buildId}`)
-        const chromedriverInstallOpts: InstallOptions & { unpack?: true } = {
-            cacheDir,
-            buildId,
-            platform,
-            browser: Browser.CHROMEDRIVER,
-            unpack: true,
-            downloadProgressCallback: (downloadedBytes, totalBytes) => downloadProgressCallback('Chromedriver', downloadedBytes, totalBytes)
-        }
-
-        try {
-            await install({ ...chromedriverInstallOpts, buildId })
-        } catch (err) {
-            /**
-             * in case we detect a Chrome browser installed for which there is no Chromedriver available
-             * we are falling back to the latest known good version
-             */
-            log.warn(`Couldn't download Chromedriver v${buildId}: ${(err as Error).message}, trying to find known good version...`)
-            let knownGoodVersion: string
-            if (buildId.includes('.')) {
-                const majorVersion = buildId.split('.')[0]
-                const knownGoodVersions: any = await got('https://googlechromelabs.github.io/chrome-for-testing/known-good-versions.json').json()
-                const versionMatch = knownGoodVersions.versions.filter(({ version }: { version: string }) => version.startsWith(majorVersion)).pop()
-                if (!versionMatch) {
-                    throw new Error(`Couldn't find known good version for Chromedriver v${majorVersion}`)
-                }
-                knownGoodVersion = versionMatch.version
-            } else {
-                knownGoodVersion = await resolveBuildId(Browser.CHROMEDRIVER, platform, buildId)
-            }
-
-            loggedBuildId = knownGoodVersion
-            await install({ ...chromedriverInstallOpts, buildId: loggedBuildId })
-            executablePath = computeExecutablePath({
-                browser: Browser.CHROMEDRIVER,
-                buildId: loggedBuildId,
-                platform,
-                cacheDir
-            })
-        }
-    } else {
-        log.info(`Using Chromedriver v${buildId} from cache directory ${cacheDir}`)
-    }
-
-    return { executablePath }
-}
-
-export function setupGeckodriver(cacheDir: string, driverVersion?: string) {
-    return downloadGeckodriver(driverVersion, cacheDir)
-}
-
-export function setupEdgedriver(cacheDir: string, driverVersion?: string) {
-    return downloadEdgedriver(driverVersion, cacheDir)
 }
 
 /**

--- a/packages/wdio-utils/src/driver/utils.ts
+++ b/packages/wdio-utils/src/driver/utils.ts
@@ -26,7 +26,9 @@ import type { Options, Capabilities } from '@wdio/types'
 import { DEFAULT_HOSTNAME, DEFAULT_PROTOCOL, DEFAULT_PATH, SUPPORTED_BROWSERNAMES } from '../constants.js'
 
 import extractZip from 'extract-zip'
+// @ts-ignore
 import tar from 'tar-fs'
+// @ts-ignore
 import bzip from 'unbzip2-stream'
 
 const log = logger('webdriver')

--- a/packages/wdio-utils/src/driver/utils.ts
+++ b/packages/wdio-utils/src/driver/utils.ts
@@ -11,8 +11,9 @@ import got from 'got'
 import decamelize from 'decamelize'
 import logger from '@wdio/logger'
 import { getChromePath } from 'chrome-launcher'
-import type { BrowserPlatform
-} from '@puppeteer/browsers'
+import type { BrowserPlatform } from '@puppeteer/browsers'
+import { coerce } from 'semver'
+
 import {
     install, canDownload, resolveBuildId, detectBrowserPlatform, Browser, ChromeReleaseChannel, Cache,
     computeExecutablePath, type InstallOptions
@@ -24,16 +25,12 @@ import type { Options, Capabilities } from '@wdio/types'
 
 import { DEFAULT_HOSTNAME, DEFAULT_PROTOCOL, DEFAULT_PATH, SUPPORTED_BROWSERNAMES } from '../constants.js'
 
-const log = logger('webdriver')
-const EXCLUDED_PARAMS = ['version', 'help']
-
 import extractZip from 'extract-zip'
-// @ts-expect-error: This dependency comes from @puppeteer/browsers
 import tar from 'tar-fs'
-// @ts-expect-error: This dependency comes from @puppeteer/browsers
 import bzip from 'unbzip2-stream'
 
-import { coerce } from 'semver'
+const log = logger('webdriver')
+const EXCLUDED_PARAMS = ['version', 'help']
 
 const pipeline = promisify(stream.pipeline)
 const exec = promisify(cp.exec)
@@ -50,9 +47,6 @@ export async function downloadFile(url: string, destinationPath: string, progres
     return pipeline(downloadStream, fileWriterStream)
 }
 
-/**
- * @internal
- */
 export async function unpackArchive(archivePath: string, folderPath: string) {
     if (archivePath.endsWith('.zip')) {
         await extractZip(archivePath, { dir: folderPath })
@@ -73,9 +67,6 @@ export async function unpackArchive(archivePath: string, folderPath: string) {
     }
 }
 
-/**
- * @internal
- */
 function extractTar(tarPath: string, folderPath: string) {
     return new Promise((fulfill, reject) => {
         const tarStream = tar.extract(folderPath)
@@ -86,9 +77,6 @@ function extractTar(tarPath: string, folderPath: string) {
     })
 }
 
-/**
- * @internal
- */
 async function installDMG(dmgPath: string, folderPath: string) {
     const { stdout } = await exec(`hdiutil attach -nobrowse -noautoopen "${dmgPath}"`)
 

--- a/packages/wdio-utils/tests/driver/index.test.ts
+++ b/packages/wdio-utils/tests/driver/index.test.ts
@@ -2,6 +2,7 @@ import fsp from 'node:fs/promises'
 import cp from 'node:child_process'
 import fs from 'node:fs'
 import path from 'node:path'
+import os from 'node:os'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 import { start as startSafaridriver } from 'safaridriver'
@@ -9,7 +10,97 @@ import { start as startGeckodriver } from 'geckodriver'
 import { start as startEdgedriver } from 'edgedriver'
 import { install } from '@puppeteer/browsers'
 
-import { startWebDriver } from '../../src/driver/index.js'
+import * as drivers from '../../src/driver/index.js'
+
+const startWebDriver = drivers.startWebDriver
+
+vi.mock('../../src/driver/utils', async () => {
+    const origUtils = await vi.importActual('../../src/driver/utils.js') as any
+
+    const mod = {
+        installDMG: vi.fn().mockResolvedValue(void 0),
+        extractTar: vi.fn().mockResolvedValue(void 0),
+        downloadFile: vi.fn().mockResolvedValue(void 0),
+        unpackArchive: vi.fn().mockImplementation((archivePath: string, folderPath: string) => {
+            fs.mkdirSync(folderPath, { recursive: true })
+        }),
+
+        getLatestVersionsFF: vi.fn().mockResolvedValue({
+            'FIREFOX_AURORA': '',
+            'FIREFOX_DEVEDITION': '117.0b9',
+            'FIREFOX_ESR': '102.14.0esr',
+            'FIREFOX_ESR_NEXT': '115.1.0esr',
+            'FIREFOX_NIGHTLY': '118.0a1',
+            'LATEST_FIREFOX_DEVEL_VERSION': '117.0b9',
+            'LATEST_FIREFOX_OLDER_VERSION': '3.6.28',
+            'LATEST_FIREFOX_RELEASED_DEVEL_VERSION': '117.0b9',
+            'LATEST_FIREFOX_VERSION': '116.0.3',
+        }),
+
+        getFirefoxInfo: vi.fn().mockResolvedValue({
+            'firefox-102.14.0esr': {
+                'build_number': 1,
+                'category': 'stability',
+                'date': '2023-08-01',
+                'description': null,
+                'is_security_driven': false,
+                'product': 'firefox',
+                'version': '102.14.0'
+            },
+            'firefox-114.0b9': {
+                'build_number': 1,
+                'category': 'dev',
+                'date': '2023-05-26',
+                'description': null,
+                'is_security_driven': false,
+                'product': 'firefox',
+                'version': '114.0b9'
+            },
+            'firefox-115.1.0esr': {
+                'build_number': 1,
+                'category': 'esr',
+                'date': '2023-08-01',
+                'description': null,
+                'is_security_driven': false,
+                'product': 'firefox',
+                'version': '115.1.0'
+            },
+            'firefox-114.0.1': {
+                'build_number': 1,
+                'category': 'stability',
+                'date': '2023-06-09',
+                'description': null,
+                'is_security_driven': false,
+                'product': 'firefox',
+                'version': '114.0.1'
+            },
+            'firefox-116.0.3': {
+                'build_number': 2,
+                'category': 'stability',
+                'date': '2023-08-16',
+                'description': null,
+                'is_security_driven': false,
+                'product': 'firefox',
+                'version': '116.0.3'
+            },
+            'firefox-117.0b9': {
+                'build_number': 1,
+                'category': 'dev',
+                'date': '2023-08-18',
+                'description': null,
+                'is_security_driven': false,
+                'product': 'firefox',
+                'version': '117.0b9'
+            },
+        }),
+    }
+
+    return {
+        __esModule: true,
+        ...origUtils,
+        ...mod
+    }
+})
 
 vi.mock('node:fs/promises', async () => {
 
@@ -79,16 +170,29 @@ vi.mock('geckodriver', () => ({ start: vi.fn().mockResolvedValue('geckodriver') 
 vi.mock('wait-port', () => ({ default: vi.fn() }))
 vi.mock('get-port', () => ({ default: vi.fn().mockResolvedValue(1234) }))
 
-vi.mock('@puppeteer/browsers', () => ({
-    Browser: { CHROME: 'chrome', CHROMEDRIVER: 'chromedriver' },
-    ChromeReleaseChannel: { STABLE: 'stable' },
-    detectBrowserPlatform: vi.fn().mockReturnValue('mac_arm'),
-    resolveBuildId: vi.fn().mockReturnValue('115.0.5790.171'),
-    canDownload: vi.fn().mockResolvedValue(true),
-    computeExecutablePath: vi.fn().mockReturnValue('/foo/bar/executable'),
-    getInstalledBrowsers: vi.fn().mockResolvedValue([]),
-    install: vi.fn().mockResolvedValue({})
-}))
+vi.mock('@puppeteer/browsers', async () => {
+
+    const origPB = await vi.importActual<typeof import('@puppeteer/browsers')>('@puppeteer/browsers')
+
+    const mod = {
+        ChromeReleaseChannel: { STABLE: 'stable' },
+        detectBrowserPlatform: vi.fn().mockReturnValue('mac_arm'),
+        resolveBuildId: vi.fn().mockReturnValue('115.0.5790.171'),
+        canDownload: vi.fn().mockResolvedValue(true),
+        computeExecutablePath: vi.fn().mockReturnValue('/foo/bar/executable'),
+        getInstalledBrowsers: vi.fn().mockResolvedValue([]),
+        install: vi.fn().mockResolvedValue({}),
+    }
+
+    return {
+        ...origPB,
+        ...mod,
+        default: {
+            ...origPB,
+            ...mod,
+        }
+    }
+})
 
 vi.mock('../../src/driver/detectBackend.js', () => ({
     default: vi.fn().mockReturnValue({
@@ -103,6 +207,8 @@ describe('startWebDriver', () => {
         vi.mocked(install).mockClear()
         vi.mocked(fsp.access).mockClear()
         vi.mocked(fsp.mkdir).mockClear()
+        vi.mocked(startGeckodriver).mockClear()
+        vi.mocked(fs.createWriteStream).mockClear()
     })
 
     afterEach(() => {
@@ -159,6 +265,417 @@ describe('startWebDriver', () => {
                 }
             }
         })
+        expect(startGeckodriver).toBeCalledTimes(1)
+        expect(startGeckodriver).toBeCalledWith({
+            port: 1234,
+            foo: 'bar',
+            cacheDir: expect.any(String)
+        })
+    })
+
+    it('should start firefox driver with latest nightly', async () => {
+        const params = {
+            capabilities: {
+                browserName: 'firefox',
+                browserVersion: 'nightly',
+                'wdio:geckodriverOptions': { foo: 'bar' }
+            } as any
+        }
+        await expect(startWebDriver(params)).resolves.toBe('geckodriver')
+
+        const OS: 'win32' | 'darwin' | 'linux' = ['win32', 'darwin', 'linux'].includes(os.platform())
+            ? os.platform() as 'win32' | 'darwin' | 'linux'
+            : 'linux'
+
+        expect(params).toEqual({
+            hostname: '0.0.0.0',
+            port: 1234,
+            capabilities: {
+                browserName: 'firefox',
+                'browserVersion': '118.0',
+                'wdio:geckodriverOptions': {
+                    foo: 'bar'
+                },
+                'moz:firefoxOptions': expect.objectContaining({
+                    binary: expect.stringMatching({
+                        darwin: /[-]118[.]0a1[/]Firefox.*[.]app[/]Contents[/]MacOS[/]firefox-bin$/,
+                        linux: /[-]118[.]0a1[/]firefox$/,
+                        win32: /[-]118[.]0a1[/]firefox[.]exe$/
+                    }[OS])
+                })
+            }
+        })
+
+        expect(startGeckodriver).toBeCalledTimes(1)
+        expect(startGeckodriver).toBeCalledWith({
+            port: 1234,
+            foo: 'bar',
+            cacheDir: expect.any(String)
+        })
+    })
+
+    it('should start firefox driver with latest esr', async () => {
+        const params = {
+            capabilities: {
+                browserName: 'firefox',
+                browserVersion: 'esr',
+                'wdio:geckodriverOptions': { foo: 'bar' }
+            } as any
+        }
+        await expect(startWebDriver(params)).resolves.toBe('geckodriver')
+
+        const OS: 'win32' | 'darwin' | 'linux' = ['win32', 'darwin', 'linux'].includes(os.platform())
+            ? os.platform() as 'win32' | 'darwin' | 'linux'
+            : 'linux'
+
+        expect(params).toEqual({
+            hostname: '0.0.0.0',
+            port: 1234,
+            capabilities: {
+                browserName: 'firefox',
+                'browserVersion': '102.14',
+                'wdio:geckodriverOptions': {
+                    foo: 'bar'
+                },
+                'moz:firefoxOptions': expect.objectContaining({
+                    binary: expect.stringMatching({
+                        darwin: /[-]102[.]14[.]0esr[/]Firefox.*[.]app[/]Contents[/]MacOS[/]firefox-bin$/,
+                        linux: /[-]102[.]14[.]0esr[/]firefox$/,
+                        win32: /[-]102[.]14[.]0esr[/]firefox[.]exe$/
+                    }[OS])
+                })
+            }
+        })
+
+        expect(startGeckodriver).toBeCalledTimes(1)
+        expect(startGeckodriver).toBeCalledWith({
+            port: 1234,
+            foo: 'bar',
+            cacheDir: expect.any(String)
+        })
+    })
+
+    it('should start firefox driver with latest dev', async () => {
+
+        const params = {
+            capabilities: {
+                browserName: 'firefox',
+                browserVersion: 'dev',
+                'wdio:geckodriverOptions': { foo: 'bar' }
+            } as any
+        }
+        await expect(startWebDriver(params)).resolves.toBe('geckodriver')
+
+        const OS: 'win32' | 'darwin' | 'linux' = ['win32', 'darwin', 'linux'].includes(os.platform())
+            ? os.platform() as 'win32' | 'darwin' | 'linux'
+            : 'linux'
+
+        expect(params).toEqual({
+            hostname: '0.0.0.0',
+            port: 1234,
+            capabilities: {
+                browserName: 'firefox',
+                'browserVersion': '117.0',
+                'wdio:geckodriverOptions': {
+                    foo: 'bar'
+                },
+                'moz:firefoxOptions': expect.objectContaining({
+                    binary: expect.stringMatching({
+                        darwin: /[-]117[.]0b9dev[/]Firefox.*[.]app[/]Contents[/]MacOS[/]firefox-bin$/,
+                        linux: /[-]117[.]0b9dev[/]firefox$/,
+                        win32: /[-]117[.]0b9dev[/]firefox[.]exe$/
+                    }[OS])
+                })
+            }
+        })
+
+        expect(startGeckodriver).toBeCalledTimes(1)
+        expect(startGeckodriver).toBeCalledWith({
+            port: 1234,
+            foo: 'bar',
+            cacheDir: expect.any(String)
+        })
+    })
+
+    it('should start firefox driver with latest beta', async () => {
+        const params = {
+            capabilities: {
+                browserName: 'firefox',
+                browserVersion: 'beta',
+                'wdio:geckodriverOptions': { foo: 'bar' }
+            } as any
+        }
+        await expect(startWebDriver(params)).resolves.toBe('geckodriver')
+
+        const OS: 'win32' | 'darwin' | 'linux' = ['win32', 'darwin', 'linux'].includes(os.platform())
+            ? os.platform() as 'win32' | 'darwin' | 'linux'
+            : 'linux'
+
+        expect(params).toEqual({
+            hostname: '0.0.0.0',
+            port: 1234,
+            capabilities: {
+                browserName: 'firefox',
+                'browserVersion': '117.0',
+                'wdio:geckodriverOptions': {
+                    foo: 'bar'
+                },
+                'moz:firefoxOptions': expect.objectContaining({
+                    binary: expect.stringMatching({
+                        darwin: /[-]117[.]0b9[/]Firefox.*[.]app[/]Contents[/]MacOS[/]firefox-bin$/,
+                        linux: /[-]117[.]0b9[/]firefox$/,
+                        win32: /[-]117[.]0b9[/]firefox[.]exe$/
+                    }[OS])
+                })
+            }
+        })
+
+        expect(startGeckodriver).toBeCalledTimes(1)
+        expect(startGeckodriver).toBeCalledWith({
+            port: 1234,
+            foo: 'bar',
+            cacheDir: expect.any(String)
+        })
+    })
+
+    it('should start firefox driver with latest stable', async () => {
+        const params = {
+            capabilities: {
+                browserName: 'firefox',
+                browserVersion: 'stable',
+                'wdio:geckodriverOptions': { foo: 'bar' }
+            } as any
+        }
+        await expect(startWebDriver(params)).resolves.toBe('geckodriver')
+
+        const OS: 'win32' | 'darwin' | 'linux' = ['win32', 'darwin', 'linux'].includes(os.platform())
+            ? os.platform() as 'win32' | 'darwin' | 'linux'
+            : 'linux'
+
+        expect(params).toEqual({
+            hostname: '0.0.0.0',
+            port: 1234,
+            capabilities: {
+                browserName: 'firefox',
+                'browserVersion': '116.0.3',
+                'wdio:geckodriverOptions': {
+                    foo: 'bar'
+                },
+                'moz:firefoxOptions': expect.objectContaining({
+                    binary: expect.stringMatching({
+                        darwin: /[-]116[.]0[.]3[/]Firefox.*[.]app[/]Contents[/]MacOS[/]firefox-bin$/,
+                        linux: /[-]116[.]0[.]3[/]firefox$/,
+                        win32: /[-]116[.]0[.]3[/]firefox[.]exe$/
+                    }[OS])
+                })
+            }
+        })
+
+        expect(startGeckodriver).toBeCalledTimes(1)
+        expect(startGeckodriver).toBeCalledWith({
+            port: 1234,
+            foo: 'bar',
+            cacheDir: expect.any(String)
+        })
+    })
+
+    it('should start firefox driver with specific nightly', async () => {
+        const params = {
+            capabilities: {
+                browserName: 'firefox',
+                browserVersion: '118.0a1',
+                'wdio:geckodriverOptions': { foo: 'bar' }
+            } as any
+        }
+        await expect(startWebDriver(params)).resolves.toBe('geckodriver')
+
+        const OS: 'win32' | 'darwin' | 'linux' = ['win32', 'darwin', 'linux'].includes(os.platform())
+            ? os.platform() as 'win32' | 'darwin' | 'linux'
+            : 'linux'
+
+        expect(params).toEqual({
+            hostname: '0.0.0.0',
+            port: 1234,
+            capabilities: {
+                browserName: 'firefox',
+                'browserVersion': '118.0',
+                'wdio:geckodriverOptions': {
+                    foo: 'bar'
+                },
+                'moz:firefoxOptions': expect.objectContaining({
+                    binary: expect.stringMatching({
+                        darwin: /[-]118[.]0a1[/]Firefox.*[.]app[/]Contents[/]MacOS[/]firefox-bin$/,
+                        linux: /[-]118[.]0a1[/]firefox$/,
+                        win32: /[-]118[.]0a1[/]firefox[.]exe$/
+                    }[OS])
+                })
+            }
+        })
+
+        expect(startGeckodriver).toBeCalledTimes(1)
+        expect(startGeckodriver).toBeCalledWith({
+            port: 1234,
+            foo: 'bar',
+            cacheDir: expect.any(String)
+        })
+    })
+
+    it('should start firefox driver with specific esr', async () => {
+        const params = {
+            capabilities: {
+                browserName: 'firefox',
+                browserVersion: '115.1.0esr',
+                'wdio:geckodriverOptions': { foo: 'bar' }
+            } as any
+        }
+        await expect(startWebDriver(params)).resolves.toBe('geckodriver')
+
+        const OS: 'win32' | 'darwin' | 'linux' = ['win32', 'darwin', 'linux'].includes(os.platform())
+            ? os.platform() as 'win32' | 'darwin' | 'linux'
+            : 'linux'
+
+        expect(params).toEqual({
+            hostname: '0.0.0.0',
+            port: 1234,
+            capabilities: {
+                browserName: 'firefox',
+                'browserVersion': '115.1.0',
+                'wdio:geckodriverOptions': {
+                    foo: 'bar'
+                },
+                'moz:firefoxOptions': expect.objectContaining({
+                    binary: expect.stringMatching({
+                        darwin: /[-]115[.]1[.]0esr[/]Firefox.*[.]app[/]Contents[/]MacOS[/]firefox-bin$/,
+                        linux: /[-]115[.]1[.]0esr[/]firefox$/,
+                        win32: /[-]115[.]1[.]0esr[/]firefox[.]exe$/
+                    }[OS])
+                })
+            }
+        })
+
+        expect(startGeckodriver).toBeCalledTimes(1)
+        expect(startGeckodriver).toBeCalledWith({
+            port: 1234,
+            foo: 'bar',
+            cacheDir: expect.any(String)
+        })
+    })
+
+    it('should start firefox driver with specific dev', async () => {
+        const params = {
+            capabilities: {
+                browserName: 'firefox',
+                browserVersion: '117.0b2dev',
+                'wdio:geckodriverOptions': { foo: 'bar' }
+            } as any
+        }
+        await expect(startWebDriver(params)).resolves.toBe('geckodriver')
+
+        const OS: 'win32' | 'darwin' | 'linux' = ['win32', 'darwin', 'linux'].includes(os.platform())
+            ? os.platform() as 'win32' | 'darwin' | 'linux'
+            : 'linux'
+
+        expect(params).toEqual({
+            hostname: '0.0.0.0',
+            port: 1234,
+            capabilities: {
+                browserName: 'firefox',
+                'browserVersion': '117.0',
+                'wdio:geckodriverOptions': {
+                    foo: 'bar'
+                },
+                'moz:firefoxOptions': expect.objectContaining({
+                    binary: expect.stringMatching({
+                        darwin: /[-]117[.]0b2dev[/]Firefox.*[.]app[/]Contents[/]MacOS[/]firefox-bin$/,
+                        linux: /[-]117[.]0b2dev[/]firefox$/,
+                        win32: /[-]117[.]0b2dev[/]firefox[.]exe$/
+                    }[OS])
+                })
+            }
+        })
+
+        expect(startGeckodriver).toBeCalledTimes(1)
+        expect(startGeckodriver).toBeCalledWith({
+            port: 1234,
+            foo: 'bar',
+            cacheDir: expect.any(String)
+        })
+    })
+
+    it('should start firefox driver with specific beta', async () => {
+        const params = {
+            capabilities: {
+                browserName: 'firefox',
+                browserVersion: '117.0b2',
+                'wdio:geckodriverOptions': { foo: 'bar' }
+            } as any
+        }
+        await expect(startWebDriver(params)).resolves.toBe('geckodriver')
+
+        const OS: 'win32' | 'darwin' | 'linux' = ['win32', 'darwin', 'linux'].includes(os.platform())
+            ? os.platform() as 'win32' | 'darwin' | 'linux'
+            : 'linux'
+
+        expect(params).toEqual({
+            hostname: '0.0.0.0',
+            port: 1234,
+            capabilities: {
+                browserName: 'firefox',
+                'browserVersion': '117.0',
+                'wdio:geckodriverOptions': {
+                    foo: 'bar'
+                },
+                'moz:firefoxOptions': expect.objectContaining({
+                    binary: expect.stringMatching({
+                        darwin: /[-]117[.]0b2[/]Firefox.*[.]app[/]Contents[/]MacOS[/]firefox-bin$/,
+                        linux: /[-]117[.]0b2[/]firefox$/,
+                        win32: /[-]117[.]0b2[/]firefox[.]exe$/
+                    }[OS])
+                })
+            }
+        })
+
+        expect(startGeckodriver).toBeCalledTimes(1)
+        expect(startGeckodriver).toBeCalledWith({
+            port: 1234,
+            foo: 'bar',
+            cacheDir: expect.any(String)
+        })
+    })
+
+    it('should start firefox driver with specific stable', async () => {
+        const params = {
+            capabilities: {
+                browserName: 'firefox',
+                browserVersion: '114.0.1',
+                'wdio:geckodriverOptions': { foo: 'bar' }
+            } as any
+        }
+        await expect(startWebDriver(params)).resolves.toBe('geckodriver')
+
+        const OS: 'win32' | 'darwin' | 'linux' = ['win32', 'darwin', 'linux'].includes(os.platform())
+            ? os.platform() as 'win32' | 'darwin' | 'linux'
+            : 'linux'
+
+        expect(params).toEqual({
+            hostname: '0.0.0.0',
+            port: 1234,
+            capabilities: {
+                browserName: 'firefox',
+                'browserVersion': '114.0.1',
+                'wdio:geckodriverOptions': {
+                    foo: 'bar'
+                },
+                'moz:firefoxOptions': expect.objectContaining({
+                    binary: expect.stringMatching({
+                        darwin: /[-]114[.]0[.]1[/]Firefox.*[.]app[/]Contents[/]MacOS[/]firefox-bin$/,
+                        linux: /[-]114[.]0[.]1[/]firefox$/,
+                        win32: /[-]114[.]0[.]1[/]firefox[.]exe$/
+                    }[OS])
+                })
+            }
+        })
+
         expect(startGeckodriver).toBeCalledTimes(1)
         expect(startGeckodriver).toBeCalledWith({
             port: 1234,

--- a/packages/wdio-utils/tests/driver/index.test.ts
+++ b/packages/wdio-utils/tests/driver/index.test.ts
@@ -11,15 +11,17 @@ import { install } from '@puppeteer/browsers'
 
 import { startWebDriver } from '../../src/driver/index.js'
 
-vi.mock('node:fs/promises', () => ({
+vi.mock('node:fs/promises', (origFS) => ({
     default: {
+        ...origFS,
         access: vi.fn().mockRejectedValue(new Error('boom')),
         mkdir: vi.fn()
     }
 }))
 
-vi.mock('node:fs', () => ({
+vi.mock('node:fs', (origFS) => ({
     default: {
+        ...origFS,
         createWriteStream: vi.fn()
     }
 }))
@@ -31,8 +33,9 @@ vi.mock('node:os', async (origMod) => ({
     }
 }))
 
-vi.mock('node:child_process', () => ({
+vi.mock('node:child_process', (origCP) => ({
     default: {
+        ...origCP,
         spawn: vi.fn().mockReturnValue({
             stdout: { pipe: vi.fn() },
             stderr: { pipe: vi.fn() }

--- a/packages/wdio-utils/tests/driver/index.test.ts
+++ b/packages/wdio-utils/tests/driver/index.test.ts
@@ -1,8 +1,8 @@
 import fsp from 'node:fs/promises'
 import cp from 'node:child_process'
 import fs from 'node:fs'
-import path from 'node:path'
 import os from 'node:os'
+import * as path from 'node:path'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 import { start as startSafaridriver } from 'safaridriver'
@@ -14,6 +14,30 @@ import * as drivers from '../../src/driver/index.js'
 
 const startWebDriver = drivers.startWebDriver
 
+vi.mock('node:path', async (orig) => {
+
+    const origPath: typeof import('node:path') = await orig()
+
+    type PathEntries = [keyof typeof origPath, typeof origPath[keyof typeof origPath]]
+
+    const pathSUT = Object.fromEntries(
+        Object
+            .entries(origPath)
+            .map(([name, prop]: PathEntries) => {
+                return [name, vi.fn().mockImplementation((...args: any[]) => {
+                    const sutPath = origPath[process.platform as 'win32'] ?? origPath.posix
+                    return typeof prop === 'function'
+                        ? (sutPath[name] as Function)(...args)
+                        : sutPath[name]
+                })]
+            })
+    )
+
+    const mod = { ...origPath, ...pathSUT }
+
+    return { ...mod, default: { ...mod } }
+})
+
 vi.mock('../../src/driver/utils', async () => {
     const origUtils = await vi.importActual('../../src/driver/utils.js') as any
 
@@ -24,7 +48,23 @@ vi.mock('../../src/driver/utils', async () => {
         unpackArchive: vi.fn().mockImplementation((archivePath: string, folderPath: string) => {
             fs.mkdirSync(folderPath, { recursive: true })
         }),
+    }
 
+    return {
+        __esModule: true,
+        ...origUtils,
+        ...mod,
+        default: {
+            ...origUtils,
+            ...mod
+        }
+    }
+})
+
+vi.mock('../../src/driver/firefox', async (orig) => {
+    const origFF: typeof import('../../src/driver/firefox.js') = await orig()
+    const mod = {
+        ...origFF,
         getLatestVersionsFF: vi.fn().mockResolvedValue({
             'FIREFOX_AURORA': '',
             'FIREFOX_DEVEDITION': '117.0b9',
@@ -37,125 +77,59 @@ vi.mock('../../src/driver/utils', async () => {
             'LATEST_FIREFOX_VERSION': '116.0.3',
         }),
 
-        getFirefoxInfo: vi.fn().mockResolvedValue({
-            'firefox-102.14.0esr': {
-                'build_number': 1,
-                'category': 'stability',
-                'date': '2023-08-01',
-                'description': null,
-                'is_security_driven': false,
-                'product': 'firefox',
-                'version': '102.14.0'
-            },
-            'firefox-114.0b9': {
-                'build_number': 1,
-                'category': 'dev',
-                'date': '2023-05-26',
-                'description': null,
-                'is_security_driven': false,
-                'product': 'firefox',
-                'version': '114.0b9'
-            },
-            'firefox-115.1.0esr': {
-                'build_number': 1,
-                'category': 'esr',
-                'date': '2023-08-01',
-                'description': null,
-                'is_security_driven': false,
-                'product': 'firefox',
-                'version': '115.1.0'
-            },
-            'firefox-114.0.1': {
-                'build_number': 1,
-                'category': 'stability',
-                'date': '2023-06-09',
-                'description': null,
-                'is_security_driven': false,
-                'product': 'firefox',
-                'version': '114.0.1'
-            },
-            'firefox-116.0.3': {
-                'build_number': 2,
-                'category': 'stability',
-                'date': '2023-08-16',
-                'description': null,
-                'is_security_driven': false,
-                'product': 'firefox',
-                'version': '116.0.3'
-            },
-            'firefox-117.0b9': {
-                'build_number': 1,
-                'category': 'dev',
-                'date': '2023-08-18',
-                'description': null,
-                'is_security_driven': false,
-                'product': 'firefox',
-                'version': '117.0b9'
-            },
-        }),
+        getFirefoxInfo: vi.fn().mockResolvedValue(
+            Object.fromEntries(
+                [
+                    'firefox-102.14.0esr',
+                    'firefox-114.0b9',
+                    'firefox-115.1.0esr',
+                    'firefox-114.0.1',
+                    'firefox-116.0.3'
+                ].map(version => [version, {}])
+            )),
     }
 
     return {
         __esModule: true,
-        ...origUtils,
-        ...mod
-    }
-})
-
-vi.mock('node:fs/promises', async () => {
-
-    const origFS = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises')
-
-    const mod = {
-        access: vi.fn().mockRejectedValue(new Error('boom')),
-        mkdir: vi.fn()
-    }
-
-    return {
-        ...origFS,
+        ...origFF,
         ...mod,
         default: {
-            ...origFS,
+            ...origFF,
             ...mod,
         }
     }
 })
 
-vi.mock('node:fs', async () => {
-
-    const origFS = await vi.importActual<typeof import('node:fs')>('node:fs')
-
+vi.mock('node:fs/promises', async (orig) => {
+    const origFS: typeof import('node:fs/promises') = await orig()
     const mod = {
+        ...origFS,
+        access: vi.fn().mockRejectedValue(new Error('boom')),
+        mkdir: vi.fn(),
+    }
+    return { ...mod, default: { ...mod } }
+})
+
+vi.mock('node:fs', async (orig) => {
+    const origFS: typeof import('node:fs') = await orig()
+    const mod = {
+        ...origFS,
         createWriteStream: vi.fn()
     }
+    return { ...mod, default: { ...mod, } }
+})
 
-vi.mock('node:os', async (origMod) => ({
-    default: {
-        ...(await origMod<any>()),
-        platform: vi.fn().mockReturnValue('linux')
-    }
-}))
-
-vi.mock('node:child_process', async () => {
-
-    const origCP = await vi.importActual<typeof import('node:child_process')>('node:child_process')
-
+vi.mock('node:child_process', async (orig) => {
+    const origFS: typeof import('node:child_process') = await orig()
     const mod = {
+        ...origFS,
         spawn: vi.fn().mockReturnValue({
             stdout: { pipe: vi.fn() },
             stderr: { pipe: vi.fn() }
         }),
         execSync: vi.fn().mockReturnValue(Buffer.from('115.0.5790.171'))
     }
-
-    return {
-        ...origCP,
-        ...mod,
-        default: {
-            ...origCP,
-            ...mod,
-        }
-    }
+    return { ...mod, default: { ...mod, } }
 })
 
 vi.mock('@wdio/logger', () => import(path.join(process.cwd(), '__mocks__', '@wdio/logger')))
@@ -170,11 +144,10 @@ vi.mock('geckodriver', () => ({ start: vi.fn().mockResolvedValue('geckodriver') 
 vi.mock('wait-port', () => ({ default: vi.fn() }))
 vi.mock('get-port', () => ({ default: vi.fn().mockResolvedValue(1234) }))
 
-vi.mock('@puppeteer/browsers', async () => {
-
-    const origPB = await vi.importActual<typeof import('@puppeteer/browsers')>('@puppeteer/browsers')
-
+vi.mock('@puppeteer/browsers', async (orig) => {
+    const origPB: typeof import('@puppeteer/browsers') = await orig()
     const mod = {
+        ...origPB,
         ChromeReleaseChannel: { STABLE: 'stable' },
         detectBrowserPlatform: vi.fn().mockReturnValue('mac_arm'),
         resolveBuildId: vi.fn().mockReturnValue('115.0.5790.171'),
@@ -183,622 +156,624 @@ vi.mock('@puppeteer/browsers', async () => {
         getInstalledBrowsers: vi.fn().mockResolvedValue([]),
         install: vi.fn().mockResolvedValue({}),
     }
+    return { ...mod, default: { ...mod, } }
+})
 
-    return {
-        ...origPB,
-        ...mod,
-        default: {
-            ...origPB,
-            ...mod,
-        }
+vi.mock('node:os', async (orig) => {
+    const origOS: typeof import('node:os') = await orig()
+    const mod = {
+        ...origOS,
+        arch: vi.fn(),
+        platform: vi.fn(),
     }
+    return { ...mod, default: { ...mod } }
 })
 
-vi.mock('../../src/driver/detectBackend.js', () => ({
-    default: vi.fn().mockReturnValue({
-        hostname: 'cloudprovider.com'
-    })
-}))
+type PossibleArch = 'arm64' | 'arm64' | 'ia32' | 'x64'
+type PossibleOS = 'win32' | 'darwin' | 'linux'
 
-describe('startWebDriver', () => {
-    const WDIO_SKIP_DRIVER_SETUP = process.env.WDIO_SKIP_DRIVER_SETUP
-    beforeEach(() => {
-        delete process.env.WDIO_SKIP_DRIVER_SETUP
-        vi.mocked(install).mockClear()
-        vi.mocked(fsp.access).mockClear()
-        vi.mocked(fsp.mkdir).mockClear()
-        vi.mocked(startGeckodriver).mockClear()
-        vi.mocked(fs.createWriteStream).mockClear()
-    })
+const systemsUnderTest: { OS: PossibleOS, ARCH: PossibleArch }[] = process.env.CI
+    ? [{
+        OS: process.platform as PossibleOS,
+        ARCH: process.arch as PossibleArch
+    }]
+    : [
+        { OS: 'win32', ARCH: 'x64' },
+        { OS: 'win32', ARCH: 'arm64' },
+        { OS: 'win32', ARCH: 'ia32' },
+        { OS: 'darwin', ARCH: 'x64' },
+        { OS: 'darwin', ARCH: 'arm64' },
+        { OS: 'linux', ARCH: 'x64' },
+    ]
 
-    afterEach(() => {
-        process.env.WDIO_SKIP_DRIVER_SETUP = WDIO_SKIP_DRIVER_SETUP
-    })
+systemsUnderTest.forEach(({ OS, ARCH }) =>
 
-    it('should start safari driver', async () => {
-        const params = {
-            capabilities: {
-                browserName: 'safari',
-                'wdio:safaridriverOptions': { foo: 'bar' }
-            } as any
-        }
-        await expect(startWebDriver(params)).resolves.toBe('safaridriver')
-        await expect(params).toEqual({
-            hostname: '0.0.0.0',
-            port: 1234,
-            capabilities: {
-                browserName: 'safari',
-                'wdio:safaridriverOptions': {
-                    foo: 'bar'
-                },
-            },
-            headers: {
-                Host: 'localhost',
-            },
+    describe(`startWebDriver on ${OS} ${ARCH}`, () => {
+
+        const WDIO_SKIP_DRIVER_SETUP = process.env.WDIO_SKIP_DRIVER_SETUP
+
+        beforeEach(() => {
+            delete process.env.WDIO_SKIP_DRIVER_SETUP
+            vi.mocked(install).mockClear()
+            vi.mocked(fsp.access).mockClear()
+            vi.mocked(fsp.mkdir).mockClear()
+            vi.mocked(fs.createWriteStream).mockClear()
+            vi.mocked(cp.spawn).mockClear()
+
+            vi.mocked(startEdgedriver).mockClear()
+            vi.mocked(startGeckodriver).mockClear()
+            vi.mocked(startSafaridriver).mockClear()
+
+            // Mock system config
+            vi.stubGlobal('process', {
+                ...process,
+                arch: ARCH,
+                platform: OS
+            })
+            vi.spyOn(os, 'platform').mockImplementation(() => OS)
+            vi.spyOn(os, 'arch').mockImplementation(() => ARCH)
+        }),
+
+        afterEach(() => {
+
+            vi.unstubAllGlobals()
+
+            process.env.WDIO_SKIP_DRIVER_SETUP = WDIO_SKIP_DRIVER_SETUP
         })
-        expect(startSafaridriver).toBeCalledTimes(1)
-        expect(startSafaridriver).toBeCalledWith({
-            port: 1234,
-            foo: 'bar',
-            useTechnologyPreview: false
-        })
-    })
 
-    it('should start firefox driver', async () => {
-        const params = {
-            capabilities: {
-                browserName: 'firefox',
-                'wdio:geckodriverOptions': { foo: 'bar' }
-            } as any
-        }
-        await expect(startWebDriver(params)).resolves.toBe('geckodriver')
-        expect(params).toEqual({
-            hostname: '0.0.0.0',
-            port: 1234,
-            capabilities: {
-                browserName: 'firefox',
-                'wdio:geckodriverOptions': {
-                    foo: 'bar'
+        it('should start safari driver', async () => {
+            const params = {
+                capabilities: {
+                    browserName: 'safari',
+                    'wdio:safaridriverOptions': { foo: 'bar' }
+                } as any
+            }
+            await expect(startWebDriver(params)).resolves.toBe('safaridriver')
+            await expect(params).toEqual({
+                hostname: '0.0.0.0',
+                port: 1234,
+                capabilities: {
+                    browserName: 'safari',
+                    'wdio:safaridriverOptions': {
+                        foo: 'bar'
+                    },
                 },
-                'moz:firefoxOptions': {
-                    'binary': undefined,
+                headers: {
+                    Host: 'localhost',
+                },
+            })
+            expect(startSafaridriver).toBeCalledTimes(1)
+            expect(startSafaridriver).toBeCalledWith({
+                port: 1234,
+                foo: 'bar',
+                useTechnologyPreview: false
+            })
+        })
+
+        it('should start firefox driver', async () => {
+            const params = {
+                capabilities: {
+                    browserName: 'firefox',
+                    'wdio:geckodriverOptions': { foo: 'bar' }
+                } as any
+            }
+            await expect(startWebDriver(params)).resolves.toBe('geckodriver')
+            expect(params).toEqual({
+                hostname: '0.0.0.0',
+                port: 1234,
+                capabilities: {
+                    browserName: 'firefox',
+                    'wdio:geckodriverOptions': {
+                        foo: 'bar'
+                    },
+                    'moz:firefoxOptions': {
+                        'binary': undefined,
+                    }
                 }
+            })
+            expect(startGeckodriver).toBeCalledTimes(1)
+            expect(startGeckodriver).toBeCalledWith({
+                port: 1234,
+                foo: 'bar',
+                cacheDir: expect.any(String)
+            })
+        })
+
+        it('should start firefox driver with latest nightly', async () => {
+            const params = {
+                capabilities: {
+                    browserName: 'firefox',
+                    browserVersion: 'nightly',
+                    'wdio:geckodriverOptions': { foo: 'bar' }
+                } as any
             }
-        })
-        expect(startGeckodriver).toBeCalledTimes(1)
-        expect(startGeckodriver).toBeCalledWith({
-            port: 1234,
-            foo: 'bar',
-            cacheDir: expect.any(String)
-        })
-    })
+            await expect(startWebDriver(params)).resolves.toBe('geckodriver')
 
-    it('should start firefox driver with latest nightly', async () => {
-        const params = {
-            capabilities: {
-                browserName: 'firefox',
-                browserVersion: 'nightly',
-                'wdio:geckodriverOptions': { foo: 'bar' }
-            } as any
-        }
-        await expect(startWebDriver(params)).resolves.toBe('geckodriver')
-
-        const OS: 'win32' | 'darwin' | 'linux' = ['win32', 'darwin', 'linux'].includes(os.platform())
-            ? os.platform() as 'win32' | 'darwin' | 'linux'
-            : 'linux'
-
-        expect(params).toEqual({
-            hostname: '0.0.0.0',
-            port: 1234,
-            capabilities: {
-                browserName: 'firefox',
-                'browserVersion': '118.0',
-                'wdio:geckodriverOptions': {
-                    foo: 'bar'
-                },
-                'moz:firefoxOptions': expect.objectContaining({
-                    binary: expect.stringMatching({
-                        darwin: /[-]118[.]0a1[/]Firefox.*[.]app[/]Contents[/]MacOS[/]firefox-bin$/,
-                        linux: /[-]118[.]0a1[/]firefox$/,
-                        win32: /[-]118[.]0a1[/]firefox[.]exe$/
-                    }[OS])
-                })
-            }
-        })
-
-        expect(startGeckodriver).toBeCalledTimes(1)
-        expect(startGeckodriver).toBeCalledWith({
-            port: 1234,
-            foo: 'bar',
-            cacheDir: expect.any(String)
-        })
-    })
-
-    it('should start firefox driver with latest esr', async () => {
-        const params = {
-            capabilities: {
-                browserName: 'firefox',
-                browserVersion: 'esr',
-                'wdio:geckodriverOptions': { foo: 'bar' }
-            } as any
-        }
-        await expect(startWebDriver(params)).resolves.toBe('geckodriver')
-
-        const OS: 'win32' | 'darwin' | 'linux' = ['win32', 'darwin', 'linux'].includes(os.platform())
-            ? os.platform() as 'win32' | 'darwin' | 'linux'
-            : 'linux'
-
-        expect(params).toEqual({
-            hostname: '0.0.0.0',
-            port: 1234,
-            capabilities: {
-                browserName: 'firefox',
-                'browserVersion': '102.14',
-                'wdio:geckodriverOptions': {
-                    foo: 'bar'
-                },
-                'moz:firefoxOptions': expect.objectContaining({
-                    binary: expect.stringMatching({
-                        darwin: /[-]102[.]14[.]0esr[/]Firefox.*[.]app[/]Contents[/]MacOS[/]firefox-bin$/,
-                        linux: /[-]102[.]14[.]0esr[/]firefox$/,
-                        win32: /[-]102[.]14[.]0esr[/]firefox[.]exe$/
-                    }[OS])
-                })
-            }
-        })
-
-        expect(startGeckodriver).toBeCalledTimes(1)
-        expect(startGeckodriver).toBeCalledWith({
-            port: 1234,
-            foo: 'bar',
-            cacheDir: expect.any(String)
-        })
-    })
-
-    it('should start firefox driver with latest dev', async () => {
-
-        const params = {
-            capabilities: {
-                browserName: 'firefox',
-                browserVersion: 'dev',
-                'wdio:geckodriverOptions': { foo: 'bar' }
-            } as any
-        }
-        await expect(startWebDriver(params)).resolves.toBe('geckodriver')
-
-        const OS: 'win32' | 'darwin' | 'linux' = ['win32', 'darwin', 'linux'].includes(os.platform())
-            ? os.platform() as 'win32' | 'darwin' | 'linux'
-            : 'linux'
-
-        expect(params).toEqual({
-            hostname: '0.0.0.0',
-            port: 1234,
-            capabilities: {
-                browserName: 'firefox',
-                'browserVersion': '117.0',
-                'wdio:geckodriverOptions': {
-                    foo: 'bar'
-                },
-                'moz:firefoxOptions': expect.objectContaining({
-                    binary: expect.stringMatching({
-                        darwin: /[-]117[.]0b9dev[/]Firefox.*[.]app[/]Contents[/]MacOS[/]firefox-bin$/,
-                        linux: /[-]117[.]0b9dev[/]firefox$/,
-                        win32: /[-]117[.]0b9dev[/]firefox[.]exe$/
-                    }[OS])
-                })
-            }
-        })
-
-        expect(startGeckodriver).toBeCalledTimes(1)
-        expect(startGeckodriver).toBeCalledWith({
-            port: 1234,
-            foo: 'bar',
-            cacheDir: expect.any(String)
-        })
-    })
-
-    it('should start firefox driver with latest beta', async () => {
-        const params = {
-            capabilities: {
-                browserName: 'firefox',
-                browserVersion: 'beta',
-                'wdio:geckodriverOptions': { foo: 'bar' }
-            } as any
-        }
-        await expect(startWebDriver(params)).resolves.toBe('geckodriver')
-
-        const OS: 'win32' | 'darwin' | 'linux' = ['win32', 'darwin', 'linux'].includes(os.platform())
-            ? os.platform() as 'win32' | 'darwin' | 'linux'
-            : 'linux'
-
-        expect(params).toEqual({
-            hostname: '0.0.0.0',
-            port: 1234,
-            capabilities: {
-                browserName: 'firefox',
-                'browserVersion': '117.0',
-                'wdio:geckodriverOptions': {
-                    foo: 'bar'
-                },
-                'moz:firefoxOptions': expect.objectContaining({
-                    binary: expect.stringMatching({
-                        darwin: /[-]117[.]0b9[/]Firefox.*[.]app[/]Contents[/]MacOS[/]firefox-bin$/,
-                        linux: /[-]117[.]0b9[/]firefox$/,
-                        win32: /[-]117[.]0b9[/]firefox[.]exe$/
-                    }[OS])
-                })
-            }
-        })
-
-        expect(startGeckodriver).toBeCalledTimes(1)
-        expect(startGeckodriver).toBeCalledWith({
-            port: 1234,
-            foo: 'bar',
-            cacheDir: expect.any(String)
-        })
-    })
-
-    it('should start firefox driver with latest stable', async () => {
-        const params = {
-            capabilities: {
-                browserName: 'firefox',
-                browserVersion: 'stable',
-                'wdio:geckodriverOptions': { foo: 'bar' }
-            } as any
-        }
-        await expect(startWebDriver(params)).resolves.toBe('geckodriver')
-
-        const OS: 'win32' | 'darwin' | 'linux' = ['win32', 'darwin', 'linux'].includes(os.platform())
-            ? os.platform() as 'win32' | 'darwin' | 'linux'
-            : 'linux'
-
-        expect(params).toEqual({
-            hostname: '0.0.0.0',
-            port: 1234,
-            capabilities: {
-                browserName: 'firefox',
-                'browserVersion': '116.0.3',
-                'wdio:geckodriverOptions': {
-                    foo: 'bar'
-                },
-                'moz:firefoxOptions': expect.objectContaining({
-                    binary: expect.stringMatching({
-                        darwin: /[-]116[.]0[.]3[/]Firefox.*[.]app[/]Contents[/]MacOS[/]firefox-bin$/,
-                        linux: /[-]116[.]0[.]3[/]firefox$/,
-                        win32: /[-]116[.]0[.]3[/]firefox[.]exe$/
-                    }[OS])
-                })
-            }
-        })
-
-        expect(startGeckodriver).toBeCalledTimes(1)
-        expect(startGeckodriver).toBeCalledWith({
-            port: 1234,
-            foo: 'bar',
-            cacheDir: expect.any(String)
-        })
-    })
-
-    it('should start firefox driver with specific nightly', async () => {
-        const params = {
-            capabilities: {
-                browserName: 'firefox',
-                browserVersion: '118.0a1',
-                'wdio:geckodriverOptions': { foo: 'bar' }
-            } as any
-        }
-        await expect(startWebDriver(params)).resolves.toBe('geckodriver')
-
-        const OS: 'win32' | 'darwin' | 'linux' = ['win32', 'darwin', 'linux'].includes(os.platform())
-            ? os.platform() as 'win32' | 'darwin' | 'linux'
-            : 'linux'
-
-        expect(params).toEqual({
-            hostname: '0.0.0.0',
-            port: 1234,
-            capabilities: {
-                browserName: 'firefox',
-                'browserVersion': '118.0',
-                'wdio:geckodriverOptions': {
-                    foo: 'bar'
-                },
-                'moz:firefoxOptions': expect.objectContaining({
-                    binary: expect.stringMatching({
-                        darwin: /[-]118[.]0a1[/]Firefox.*[.]app[/]Contents[/]MacOS[/]firefox-bin$/,
-                        linux: /[-]118[.]0a1[/]firefox$/,
-                        win32: /[-]118[.]0a1[/]firefox[.]exe$/
-                    }[OS])
-                })
-            }
-        })
-
-        expect(startGeckodriver).toBeCalledTimes(1)
-        expect(startGeckodriver).toBeCalledWith({
-            port: 1234,
-            foo: 'bar',
-            cacheDir: expect.any(String)
-        })
-    })
-
-    it('should start firefox driver with specific esr', async () => {
-        const params = {
-            capabilities: {
-                browserName: 'firefox',
-                browserVersion: '115.1.0esr',
-                'wdio:geckodriverOptions': { foo: 'bar' }
-            } as any
-        }
-        await expect(startWebDriver(params)).resolves.toBe('geckodriver')
-
-        const OS: 'win32' | 'darwin' | 'linux' = ['win32', 'darwin', 'linux'].includes(os.platform())
-            ? os.platform() as 'win32' | 'darwin' | 'linux'
-            : 'linux'
-
-        expect(params).toEqual({
-            hostname: '0.0.0.0',
-            port: 1234,
-            capabilities: {
-                browserName: 'firefox',
-                'browserVersion': '115.1.0',
-                'wdio:geckodriverOptions': {
-                    foo: 'bar'
-                },
-                'moz:firefoxOptions': expect.objectContaining({
-                    binary: expect.stringMatching({
-                        darwin: /[-]115[.]1[.]0esr[/]Firefox.*[.]app[/]Contents[/]MacOS[/]firefox-bin$/,
-                        linux: /[-]115[.]1[.]0esr[/]firefox$/,
-                        win32: /[-]115[.]1[.]0esr[/]firefox[.]exe$/
-                    }[OS])
-                })
-            }
-        })
-
-        expect(startGeckodriver).toBeCalledTimes(1)
-        expect(startGeckodriver).toBeCalledWith({
-            port: 1234,
-            foo: 'bar',
-            cacheDir: expect.any(String)
-        })
-    })
-
-    it('should start firefox driver with specific dev', async () => {
-        const params = {
-            capabilities: {
-                browserName: 'firefox',
-                browserVersion: '117.0b2dev',
-                'wdio:geckodriverOptions': { foo: 'bar' }
-            } as any
-        }
-        await expect(startWebDriver(params)).resolves.toBe('geckodriver')
-
-        const OS: 'win32' | 'darwin' | 'linux' = ['win32', 'darwin', 'linux'].includes(os.platform())
-            ? os.platform() as 'win32' | 'darwin' | 'linux'
-            : 'linux'
-
-        expect(params).toEqual({
-            hostname: '0.0.0.0',
-            port: 1234,
-            capabilities: {
-                browserName: 'firefox',
-                'browserVersion': '117.0',
-                'wdio:geckodriverOptions': {
-                    foo: 'bar'
-                },
-                'moz:firefoxOptions': expect.objectContaining({
-                    binary: expect.stringMatching({
-                        darwin: /[-]117[.]0b2dev[/]Firefox.*[.]app[/]Contents[/]MacOS[/]firefox-bin$/,
-                        linux: /[-]117[.]0b2dev[/]firefox$/,
-                        win32: /[-]117[.]0b2dev[/]firefox[.]exe$/
-                    }[OS])
-                })
-            }
-        })
-
-        expect(startGeckodriver).toBeCalledTimes(1)
-        expect(startGeckodriver).toBeCalledWith({
-            port: 1234,
-            foo: 'bar',
-            cacheDir: expect.any(String)
-        })
-    })
-
-    it('should start firefox driver with specific beta', async () => {
-        const params = {
-            capabilities: {
-                browserName: 'firefox',
-                browserVersion: '117.0b2',
-                'wdio:geckodriverOptions': { foo: 'bar' }
-            } as any
-        }
-        await expect(startWebDriver(params)).resolves.toBe('geckodriver')
-
-        const OS: 'win32' | 'darwin' | 'linux' = ['win32', 'darwin', 'linux'].includes(os.platform())
-            ? os.platform() as 'win32' | 'darwin' | 'linux'
-            : 'linux'
-
-        expect(params).toEqual({
-            hostname: '0.0.0.0',
-            port: 1234,
-            capabilities: {
-                browserName: 'firefox',
-                'browserVersion': '117.0',
-                'wdio:geckodriverOptions': {
-                    foo: 'bar'
-                },
-                'moz:firefoxOptions': expect.objectContaining({
-                    binary: expect.stringMatching({
-                        darwin: /[-]117[.]0b2[/]Firefox.*[.]app[/]Contents[/]MacOS[/]firefox-bin$/,
-                        linux: /[-]117[.]0b2[/]firefox$/,
-                        win32: /[-]117[.]0b2[/]firefox[.]exe$/
-                    }[OS])
-                })
-            }
-        })
-
-        expect(startGeckodriver).toBeCalledTimes(1)
-        expect(startGeckodriver).toBeCalledWith({
-            port: 1234,
-            foo: 'bar',
-            cacheDir: expect.any(String)
-        })
-    })
-
-    it('should start firefox driver with specific stable', async () => {
-        const params = {
-            capabilities: {
-                browserName: 'firefox',
-                browserVersion: '114.0.1',
-                'wdio:geckodriverOptions': { foo: 'bar' }
-            } as any
-        }
-        await expect(startWebDriver(params)).resolves.toBe('geckodriver')
-
-        const OS: 'win32' | 'darwin' | 'linux' = ['win32', 'darwin', 'linux'].includes(os.platform())
-            ? os.platform() as 'win32' | 'darwin' | 'linux'
-            : 'linux'
-
-        expect(params).toEqual({
-            hostname: '0.0.0.0',
-            port: 1234,
-            capabilities: {
-                browserName: 'firefox',
-                'browserVersion': '114.0.1',
-                'wdio:geckodriverOptions': {
-                    foo: 'bar'
-                },
-                'moz:firefoxOptions': expect.objectContaining({
-                    binary: expect.stringMatching({
-                        darwin: /[-]114[.]0[.]1[/]Firefox.*[.]app[/]Contents[/]MacOS[/]firefox-bin$/,
-                        linux: /[-]114[.]0[.]1[/]firefox$/,
-                        win32: /[-]114[.]0[.]1[/]firefox[.]exe$/
-                    }[OS])
-                })
-            }
-        })
-
-        expect(startGeckodriver).toBeCalledTimes(1)
-        expect(startGeckodriver).toBeCalledWith({
-            port: 1234,
-            foo: 'bar',
-            cacheDir: expect.any(String)
-        })
-    })
-
-    it('should start edge driver', async () => {
-        const options = {
-            capabilities: {
-                browserName: 'edge',
-                'wdio:edgedriverOptions': { foo: 'bar' }
-            } as any
-        }
-        await expect(startWebDriver(options)).resolves.toBe('edgedriver')
-        expect(options).toEqual({
-            hostname: '0.0.0.0',
-            port: 1234,
-            capabilities: {
-                browserName: 'MicrosoftEdge',
-                'wdio:edgedriverOptions': {
-                    foo: 'bar'
-                },
-                'ms:edgeOptions': {
-                    binary: '/foo/bar/executable'
+            expect(params).toEqual({
+                hostname: '0.0.0.0',
+                port: 1234,
+                capabilities: {
+                    browserName: 'firefox',
+                    'browserVersion': '118.0',
+                    'wdio:geckodriverOptions': {
+                        foo: 'bar'
+                    },
+                    'moz:firefoxOptions': expect.objectContaining({
+                        binary: expect.stringMatching({
+                            darwin: /^.*[-]118[.]0a1[/]Firefox.*[.]app[/]Contents[/]MacOS[/]firefox-bin$/,
+                            linux: /^.*[-]118[.]0a1[/]firefox$/,
+                            win32: /^.*[-]118[.]0a1[\\]firefox[.]exe$/
+                        }[OS])
+                    })
                 }
+            })
+
+            expect(startGeckodriver).toBeCalledTimes(1)
+            expect(startGeckodriver).toBeCalledWith({
+                port: 1234,
+                foo: 'bar',
+                cacheDir: expect.any(String)
+            })
+        })
+
+        it('should start firefox driver with latest esr', async () => {
+            const params = {
+                capabilities: {
+                    browserName: 'firefox',
+                    browserVersion: 'esr',
+                    'wdio:geckodriverOptions': { foo: 'bar' }
+                } as any
             }
-        })
-        expect(startEdgedriver).toBeCalledTimes(1)
-        expect(startEdgedriver).toBeCalledWith({
-            foo: 'bar',
-            port: 1234,
-            cacheDir: expect.any(String)
-        })
-        expect(options.capabilities.browserName).toBe('MicrosoftEdge')
-    })
+            await expect(startWebDriver(params)).resolves.toBe('geckodriver')
 
-    it('should start chrome driver', async () => {
-        const options = {
-            capabilities: {
-                browserName: 'chrome',
-                'wdio:chromedriverOptions': { foo: 'bar' }
-            } as any
-        }
-        const res = await startWebDriver(options)
-        expect(Boolean(res?.stdout)).toBe(true)
-        expect(options).toEqual({
-            hostname: '0.0.0.0',
-            port: 1234,
-            capabilities: {
-                browserName: 'chrome',
-                'goog:chromeOptions': {
-                    binary: expect.any(String)
-                },
-                'wdio:chromedriverOptions': {
-                    allowedIps: [''],
-                    allowedOrigins: ['*'],
-                    'foo': 'bar',
-                },
+            expect(params).toEqual({
+                hostname: '0.0.0.0',
+                port: 1234,
+                capabilities: {
+                    browserName: 'firefox',
+                    'browserVersion': '102.14',
+                    'wdio:geckodriverOptions': {
+                        foo: 'bar'
+                    },
+                    'moz:firefoxOptions': expect.objectContaining({
+                        binary: expect.stringMatching({
+                            darwin: /^.*[-]102[.]14[.]0esr[/]Firefox.*[.]app[/]Contents[/]MacOS[/]firefox-bin$/,
+                            linux: /^.*[-]102[.]14[.]0esr[/]firefox$/,
+                            win32: /^.*[-]102[.]14[.]0esr[\\]firefox[.]exe$/
+                        }[OS])
+                    })
+                }
+            })
+
+            expect(startGeckodriver).toBeCalledTimes(1)
+            expect(startGeckodriver).toBeCalledWith({
+                port: 1234,
+                foo: 'bar',
+                cacheDir: expect.any(String)
+            })
+        })
+
+        it('should start firefox driver with latest dev', async () => {
+
+            const params = {
+                capabilities: {
+                    browserName: 'firefox',
+                    browserVersion: 'dev',
+                    'wdio:geckodriverOptions': { foo: 'bar' }
+                } as any
             }
+            await expect(startWebDriver(params)).resolves.toBe('geckodriver')
+
+            expect(params).toEqual({
+                hostname: '0.0.0.0',
+                port: 1234,
+                capabilities: {
+                    browserName: 'firefox',
+                    'browserVersion': '117.0',
+                    'wdio:geckodriverOptions': {
+                        foo: 'bar'
+                    },
+                    'moz:firefoxOptions': expect.objectContaining({
+                        binary: expect.stringMatching({
+                            darwin: /^.*[-]117[.]0b9dev[/]Firefox.*[.]app[/]Contents[/]MacOS[/]firefox-bin$/,
+                            linux: /^.*[-]117[.]0b9dev[/]firefox$/,
+                            win32: /^.*[-]117[.]0b9dev[\\]firefox[.]exe$/
+                        }[OS])
+                    })
+                }
+            })
+
+            expect(startGeckodriver).toBeCalledTimes(1)
+            expect(startGeckodriver).toBeCalledWith({
+                port: 1234,
+                foo: 'bar',
+                cacheDir: expect.any(String)
+            })
         })
-        expect(fsp.access).toBeCalledTimes(2)
-        expect(fsp.mkdir).toBeCalledTimes(1)
-        expect(cp.spawn).toBeCalledTimes(1)
-        expect(cp.spawn).toBeCalledWith(
-            '/foo/bar/executable',
-            ['--port=1234', '--foo=bar', '--allowed-origins=*', '--allowed-ips=']
-        )
+
+        it('should start firefox driver with latest beta', async () => {
+            const params = {
+                capabilities: {
+                    browserName: 'firefox',
+                    browserVersion: 'beta',
+                    'wdio:geckodriverOptions': { foo: 'bar' }
+                } as any
+            }
+            await expect(startWebDriver(params)).resolves.toBe('geckodriver')
+
+            expect(params).toEqual({
+                hostname: '0.0.0.0',
+                port: 1234,
+                capabilities: {
+                    browserName: 'firefox',
+                    'browserVersion': '117.0',
+                    'wdio:geckodriverOptions': {
+                        foo: 'bar'
+                    },
+                    'moz:firefoxOptions': expect.objectContaining({
+                        binary: expect.stringMatching({
+                            darwin: /^.*[-]117[.]0b9[/]Firefox.*[.]app[/]Contents[/]MacOS[/]firefox-bin$/,
+                            linux: /^.*[-]117[.]0b9[/]firefox$/,
+                            win32: /^.*[-]117[.]0b9[\\]firefox[.]exe$/
+                        }[OS])
+                    })
+                }
+            })
+
+            expect(startGeckodriver).toBeCalledTimes(1)
+            expect(startGeckodriver).toBeCalledWith({
+                port: 1234,
+                foo: 'bar',
+                cacheDir: expect.any(String)
+            })
+        })
+
+        it('should start firefox driver with latest stable', async () => {
+            const params = {
+                capabilities: {
+                    browserName: 'firefox',
+                    browserVersion: 'stable',
+                    'wdio:geckodriverOptions': { foo: 'bar' }
+                } as any
+            }
+            await expect(startWebDriver(params)).resolves.toBe('geckodriver')
+
+            expect(params).toEqual({
+                hostname: '0.0.0.0',
+                port: 1234,
+                capabilities: {
+                    browserName: 'firefox',
+                    'browserVersion': '116.0.3',
+                    'wdio:geckodriverOptions': {
+                        foo: 'bar'
+                    },
+                    'moz:firefoxOptions': expect.objectContaining({
+                        binary: expect.stringMatching({
+                            darwin: /^.*[-]116[.]0[.]3[/]Firefox.*[.]app[/]Contents[/]MacOS[/]firefox-bin$/,
+                            linux: /^.*[-]116[.]0[.]3[/]firefox$/,
+                            win32: /^.*[-]116[.]0[.]3[\\]firefox[.]exe$/
+                        }[OS])
+                    })
+                }
+            })
+
+            expect(startGeckodriver).toBeCalledTimes(1)
+            expect(startGeckodriver).toBeCalledWith({
+                port: 1234,
+                foo: 'bar',
+                cacheDir: expect.any(String)
+            })
+        })
+
+        it('should start firefox driver with specific nightly', async () => {
+            const params = {
+                capabilities: {
+                    browserName: 'firefox',
+                    browserVersion: '118.0a1',
+                    'wdio:geckodriverOptions': { foo: 'bar' }
+                } as any
+            }
+            await expect(startWebDriver(params)).resolves.toBe('geckodriver')
+
+            expect(params).toEqual({
+                hostname: '0.0.0.0',
+                port: 1234,
+                capabilities: {
+                    browserName: 'firefox',
+                    'browserVersion': '118.0',
+                    'wdio:geckodriverOptions': {
+                        foo: 'bar'
+                    },
+                    'moz:firefoxOptions': expect.objectContaining({
+                        binary: expect.stringMatching({
+                            darwin: /^.*[-]118[.]0a1[/]Firefox.*[.]app[/]Contents[/]MacOS[/]firefox-bin$/,
+                            linux: /^.*[-]118[.]0a1[/]firefox$/,
+                            win32: /^.*[-]118[.]0a1[\\]firefox[.]exe$/
+                        }[OS])
+                    })
+                }
+            })
+
+            expect(startGeckodriver).toBeCalledTimes(1)
+            expect(startGeckodriver).toBeCalledWith({
+                port: 1234,
+                foo: 'bar',
+                cacheDir: expect.any(String)
+            })
+        })
+
+        it('should start firefox driver with specific esr', async () => {
+            const params = {
+                capabilities: {
+                    browserName: 'firefox',
+                    browserVersion: '115.1.0esr',
+                    'wdio:geckodriverOptions': { foo: 'bar' }
+                } as any
+            }
+            await expect(startWebDriver(params)).resolves.toBe('geckodriver')
+
+            expect(params).toEqual({
+                hostname: '0.0.0.0',
+                port: 1234,
+                capabilities: {
+                    browserName: 'firefox',
+                    'browserVersion': '115.1',
+                    'wdio:geckodriverOptions': {
+                        foo: 'bar'
+                    },
+                    'moz:firefoxOptions': expect.objectContaining({
+                        binary: expect.stringMatching({
+                            darwin: /^.*[-]115[.]1[.]0esr[/]Firefox.*[.]app[/]Contents[/]MacOS[/]firefox-bin$/,
+                            linux: /^.*[-]115[.]1[.]0esr[/]firefox$/,
+                            win32: /^.*[-]115[.]1[.]0esr[\\]firefox[.]exe$/
+                        }[OS])
+                    })
+                }
+            })
+
+            expect(startGeckodriver).toBeCalledTimes(1)
+            expect(startGeckodriver).toBeCalledWith({
+                port: 1234,
+                foo: 'bar',
+                cacheDir: expect.any(String)
+            })
+        })
+
+        it('should start firefox driver with specific dev', async () => {
+            const params = {
+                capabilities: {
+                    browserName: 'firefox',
+                    browserVersion: '117.0b2dev',
+                    'wdio:geckodriverOptions': { foo: 'bar' }
+                } as any
+            }
+            await expect(startWebDriver(params)).resolves.toBe('geckodriver')
+
+            expect(params).toEqual({
+                hostname: '0.0.0.0',
+                port: 1234,
+                capabilities: {
+                    browserName: 'firefox',
+                    'browserVersion': '117.0',
+                    'wdio:geckodriverOptions': {
+                        foo: 'bar'
+                    },
+                    'moz:firefoxOptions': expect.objectContaining({
+                        binary: expect.stringMatching({
+                            darwin: /^.*[-]117[.]0b2dev[/]Firefox.*[.]app[/]Contents[/]MacOS[/]firefox-bin$/,
+                            linux: /^.*[-]117[.]0b2dev[/]firefox$/,
+                            win32: /^.*[-]117[.]0b2dev[\\]firefox[.]exe$/
+                        }[OS])
+                    })
+                }
+            })
+
+            expect(startGeckodriver).toBeCalledTimes(1)
+            expect(startGeckodriver).toBeCalledWith({
+                port: 1234,
+                foo: 'bar',
+                cacheDir: expect.any(String)
+            })
+        })
+
+        it('should start firefox driver with specific beta', async () => {
+            const params = {
+                capabilities: {
+                    browserName: 'firefox',
+                    browserVersion: '117.0b2',
+                    'wdio:geckodriverOptions': { foo: 'bar' }
+                } as any
+            }
+            await expect(startWebDriver(params)).resolves.toBe('geckodriver')
+
+            expect(params).toEqual({
+                hostname: '0.0.0.0',
+                port: 1234,
+                capabilities: {
+                    browserName: 'firefox',
+                    'browserVersion': '117.0',
+                    'wdio:geckodriverOptions': {
+                        foo: 'bar'
+                    },
+                    'moz:firefoxOptions': expect.objectContaining({
+                        binary: expect.stringMatching({
+                            darwin: /^.*[-]117[.]0b2[/]Firefox.*[.]app[/]Contents[/]MacOS[/]firefox-bin$/,
+                            linux: /^.*[-]117[.]0b2[/]firefox$/,
+                            win32: /^.*[-]117[.]0b2[\\]firefox[.]exe$/
+                        }[OS])
+                    })
+                }
+            })
+
+            expect(startGeckodriver).toBeCalledTimes(1)
+            expect(startGeckodriver).toBeCalledWith({
+                port: 1234,
+                foo: 'bar',
+                cacheDir: expect.any(String)
+            })
+        })
+
+        it('should start firefox driver with specific stable', async () => {
+            const params = {
+                capabilities: {
+                    browserName: 'firefox',
+                    browserVersion: '114.0.1',
+                    'wdio:geckodriverOptions': { foo: 'bar' }
+                } as any
+            }
+            await expect(startWebDriver(params)).resolves.toBe('geckodriver')
+
+            expect(params).toEqual({
+                hostname: '0.0.0.0',
+                port: 1234,
+                capabilities: {
+                    browserName: 'firefox',
+                    'browserVersion': '114.0.1',
+                    'wdio:geckodriverOptions': {
+                        foo: 'bar'
+                    },
+                    'moz:firefoxOptions': expect.objectContaining({
+                        binary: expect.stringMatching({
+                            darwin: /^.*[-]114[.]0[.]1[/]Firefox.*[.]app[/]Contents[/]MacOS[/]firefox-bin$/,
+                            linux: /^.*[-]114[.]0[.]1[/]firefox$/,
+                            win32: /^.*[-]114[.]0[.]1[\\]firefox[.]exe$/
+                        }[OS])
+                    })
+                }
+            })
+
+            expect(startGeckodriver).toBeCalledTimes(1)
+            expect(startGeckodriver).toBeCalledWith({
+                port: 1234,
+                foo: 'bar',
+                cacheDir: expect.any(String)
+            })
+        })
+
+        it('should start edge driver', async () => {
+
+            const options = {
+                capabilities: {
+                    browserName: 'edge',
+                    'wdio:edgedriverOptions': { foo: 'bar' }
+                } as any
+            }
+            await expect(startWebDriver(options)).resolves.toBe('edgedriver')
+            expect(options).toEqual({
+                hostname: '0.0.0.0',
+                port: 1234,
+                capabilities: {
+                    browserName: 'MicrosoftEdge',
+                    'wdio:edgedriverOptions': {
+                        foo: 'bar'
+                    },
+                    ...({
+                        linux: {
+                            'ms:edgeOptions': {
+                                binary: '/foo/bar/executable'
+                            }
+                        }
+                    }[OS as string] ?? {})
+                }
+            })
+            expect(startEdgedriver).toBeCalledTimes(1)
+            expect(startEdgedriver).toBeCalledWith({
+                foo: 'bar',
+                port: 1234,
+                cacheDir: expect.any(String)
+            })
+            expect(options.capabilities.browserName).toBe('MicrosoftEdge')
+        })
+
+        it('should start chrome driver', async () => {
+            const options = {
+                capabilities: {
+                    browserName: 'chrome',
+                    'wdio:chromedriverOptions': { foo: 'bar' }
+                } as any
+            }
+            const res = await startWebDriver(options)
+            expect(Boolean(res?.stdout)).toBe(true)
+            expect(options).toEqual({
+                hostname: '0.0.0.0',
+                port: 1234,
+                capabilities: {
+                    browserName: 'chrome',
+                    'goog:chromeOptions': {
+                        binary: expect.any(String)
+                    },
+                    'wdio:chromedriverOptions': {
+                        allowedIps: [''],
+                        allowedOrigins: ['*'],
+                        'foo': 'bar',
+                    },
+                }
+            })
+            expect(fsp.access).toBeCalledTimes(2)
+            expect(fsp.mkdir).toBeCalledTimes(1)
+            expect(cp.spawn).toBeCalledTimes(1)
+            expect(cp.spawn).toBeCalledWith(
+                '/foo/bar/executable',
+                ['--port=1234', '--foo=bar', '--allowed-origins=*', '--allowed-ips=']
+            )
+        })
+
+        it('should find last known good version for chromedriver', async () => {
+            const options = {
+                capabilities: {
+                    browserName: 'chrome',
+                    browserVersion: '115.0.5790.171',
+                    'wdio:chromedriverOptions': { foo: 'bar' }
+                } as any
+            }
+            vi.mocked(install)
+                .mockResolvedValueOnce({} as any)
+                .mockRejectedValueOnce(new Error('boom'))
+                .mockResolvedValue({} as any)
+            await startWebDriver(options)
+            expect(install).toBeCalledTimes(3)
+            expect(install).toBeCalledWith(expect.objectContaining({
+                buildId: '115.0.5790.171',
+                browser: 'chrome'
+            }))
+            expect(install).toBeCalledWith(expect.objectContaining({
+                buildId: '115.0.5790.171',
+                browser: 'chromedriver'
+            }))
+            expect(install).toBeCalledWith(expect.objectContaining({
+                buildId: '115.0.5790.170',
+                browser: 'chromedriver'
+            }))
+        })
+
+        it('should pipe logs into a file', async () => {
+            const options: any = {
+                outputDir: '/foo/bar',
+                capabilities: {
+                    browserName: 'chrome',
+                    'wdio:chromedriverOptions': { foo: 'bar' }
+                } as any
+            }
+
+            delete process.env.WDIO_WORKER_ID
+
+            await startWebDriver(options)
+            expect(fs.createWriteStream).toBeCalledTimes(1)
+            expect(fs.createWriteStream).toBeCalledWith(
+                expect.stringContaining('wdio-chromedriver-1234.log'),
+                { flags: 'w' }
+            )
+
+            process.env.WDIO_WORKER_ID = '1-2'
+            delete options.hostname
+            delete options.port
+            await startWebDriver(options)
+            expect(fs.createWriteStream).toBeCalledTimes(2)
+            expect(fs.createWriteStream).toBeCalledWith(
+                expect.stringContaining('wdio-1-2-chromedriver.log'),
+                { flags: 'w' }
+            )
+        })
     })
+)
 
-    it('should find last known good version for chromedriver', async () => {
-        const options = {
-            capabilities: {
-                browserName: 'chrome',
-                browserVersion: '115.0.5790.171',
-                'wdio:chromedriverOptions': { foo: 'bar' }
-            } as any
-        }
-        vi.mocked(install)
-            .mockResolvedValueOnce({} as any)
-            .mockRejectedValueOnce(new Error('boom'))
-            .mockResolvedValue({} as any)
-        await startWebDriver(options)
-        expect(install).toBeCalledTimes(3)
-        expect(install).toBeCalledWith(expect.objectContaining({
-            buildId: '115.0.5790.171',
-            browser: 'chrome'
-        }))
-        expect(install).toBeCalledWith(expect.objectContaining({
-            buildId: '115.0.5790.171',
-            browser: 'chromedriver'
-        }))
-        expect(install).toBeCalledWith(expect.objectContaining({
-            buildId: '115.0.5790.170',
-            browser: 'chromedriver'
-        }))
-    })
-
-    it('should pipe logs into a file', async () => {
-        const options: any = {
-            outputDir: '/foo/bar',
-            capabilities: {
-                browserName: 'chrome',
-                'wdio:chromedriverOptions': { foo: 'bar' }
-            } as any
-        }
-
-        await startWebDriver(options)
-        expect(fs.createWriteStream).toBeCalledTimes(1)
-        expect(fs.createWriteStream).toBeCalledWith(
-            expect.stringContaining('wdio-chromedriver-1234.log'),
-            { flags: 'w' }
-        )
-
-        process.env.WDIO_WORKER_ID = '1-2'
-        delete options.hostname
-        delete options.port
-        await startWebDriver(options)
-        expect(fs.createWriteStream).toBeCalledTimes(2)
-        expect(fs.createWriteStream).toBeCalledWith(
-            expect.stringContaining('wdio-1-2-chromedriver.log'),
-            { flags: 'w' }
-        )
-    })
-})

--- a/packages/wdio-utils/tests/driver/manager.test.ts
+++ b/packages/wdio-utils/tests/driver/manager.test.ts
@@ -13,7 +13,8 @@ vi.mock('../../src/driver/utils.js', async (orig) => {
         setupChromedriver: vi.fn(),
         setupEdgedriver: vi.fn(),
         setupGeckodriver: vi.fn(),
-        setupChrome: vi.fn()
+        setupChrome: vi.fn(),
+        setupFirefox: vi.fn()
     }
 })
 vi.mock('@wdio/logger', () => import(path.join(process.cwd(), '__mocks__', '@wdio/logger')))

--- a/packages/wdio-utils/tests/driver/manager.test.ts
+++ b/packages/wdio-utils/tests/driver/manager.test.ts
@@ -1,22 +1,44 @@
 import path from 'node:path'
 import { describe, test, expect, vi, beforeEach } from 'vitest'
 
-import type * as utils from '../../src/driver/utils.js'
-import { setupChromedriver, setupEdgedriver, setupGeckodriver, setupChrome } from '../../src/driver/utils.js'
+import { setupEdgedriver } from '../../src/driver/edge.js'
+import { setupChromedriver, setupChrome } from '../../src/driver/chrome.js'
+import { setupGeckodriver } from '../../src/driver/firefox.js'
 import { setupDriver, setupBrowser } from '../../src/driver/manager.js'
 
+vi.mock('../../src/driver/edge.js', async (orig) => {
+    const origMod = await orig() as any
+    return {
+        ...origMod,
+        setupEdgedriver: vi.fn(),
+    }
+})
+
+vi.mock('../../src/driver/firefox.js', async (orig) => {
+    const origMod = await orig() as any
+    return {
+        ...origMod,
+        setupGeckodriver: vi.fn(),
+    }
+})
+
+vi.mock('../../src/driver/chrome.js', async (orig) => {
+    const origMod = await orig() as any
+    return {
+        ...origMod,
+        setupChromedriver: vi.fn(),
+        setupChrome: vi.fn(),
+    }
+})
+
 vi.mock('../../src/driver/utils.js', async (orig) => {
-    const origMod = await orig<typeof utils>()
+    const origMod = await orig() as any
     return {
         ...origMod,
         getCacheDir: vi.fn().mockReturnValue('/foo/bar'),
-        setupChromedriver: vi.fn(),
-        setupEdgedriver: vi.fn(),
-        setupGeckodriver: vi.fn(),
-        setupChrome: vi.fn(),
-        setupFirefox: vi.fn()
     }
 })
+
 vi.mock('@wdio/logger', () => import(path.join(process.cwd(), '__mocks__', '@wdio/logger')))
 
 describe('setupDriver', () => {

--- a/packages/wdio-utils/tests/driver/utils.test.ts
+++ b/packages/wdio-utils/tests/driver/utils.test.ts
@@ -3,7 +3,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { getChromePath } from 'chrome-launcher'
 import { canDownload, resolveBuildId, detectBrowserPlatform } from '@puppeteer/browsers'
 
-import { parseParams, getLocalChromePath, getBuildIdByPath, setupChrome, definesRemoteDriver } from '../../src/driver/utils.js'
+import { parseParams, definesRemoteDriver } from '../../src/driver/utils.js'
+import { getLocalChromePath, getBuildIdByPath, setupChrome } from '../../src/driver/chrome.js'
 
 vi.mock('chrome-launcher', () => ({
     getChromePath: vi.fn().mockReturnValue('/foo/bar')

--- a/packages/wdio-utils/tests/driver/utils.test.ts
+++ b/packages/wdio-utils/tests/driver/utils.test.ts
@@ -94,15 +94,28 @@ vi.mock('node:child_process', async () => {
     }
 })
 
-vi.mock('@puppeteer/browsers', () => ({
-    Browser: { CHROME: 'chrome' },
-    ChromeReleaseChannel: { STABLE: 'stable' },
-    detectBrowserPlatform: vi.fn(),
-    resolveBuildId: vi.fn().mockReturnValue('115.0.5790.98'),
-    canDownload: vi.fn().mockResolvedValue(true),
-    computeExecutablePath: vi.fn().mockReturnValue('/foo/bar/executable'),
-    install: vi.fn()
-}))
+vi.mock('@puppeteer/browsers', async () => {
+
+    const mod = {
+        ChromeReleaseChannel: { STABLE: 'stable' },
+        detectBrowserPlatform: vi.fn(),
+        resolveBuildId: vi.fn().mockReturnValue('115.0.5790.98'),
+        canDownload: vi.fn().mockResolvedValue(true),
+        computeExecutablePath: vi.fn().mockReturnValue('/foo/bar/executable'),
+        install: vi.fn()
+    }
+
+    const origPB = await vi.importActual<typeof import('@puppeteer/browsers')>('@puppeteer/browsers')
+
+    return {
+        ...origPB,
+        ...mod,
+        default: {
+            ...origPB,
+            ...mod
+        }
+    }
+})
 
 describe('driver utils', () => {
     it('should parse params', () => {

--- a/packages/wdio-utils/tests/driver/utils.test.ts
+++ b/packages/wdio-utils/tests/driver/utils.test.ts
@@ -9,15 +9,17 @@ vi.mock('chrome-launcher', () => ({
     getChromePath: vi.fn().mockReturnValue('/foo/bar')
 }))
 
-vi.mock('node:os', () => ({
+vi.mock('node:os', (origOS) => ({
     default: {
+        ...origOS,
         tmpdir: vi.fn().mockReturnValue('/tmp'),
         platform: vi.fn().mockReturnValue('darwin')
     }
 }))
 
-vi.mock('node:fs', () => ({
+vi.mock('node:fs', (origFS) => ({
     default: {
+        ...origFS,
         readdirSync: vi.fn().mockReturnValue([
             '114.0.5735.199',
             '115.0.5790.110',
@@ -32,15 +34,17 @@ vi.mock('node:fs', () => ({
     }
 }))
 
-vi.mock('node:fs/promises', () => ({
+vi.mock('node:fs/promises', (origFS) => ({
     default: {
+        ...origFS,
         mkdir: vi.fn().mockResolvedValue({}),
         access: vi.fn().mockResolvedValue({})
     }
 }))
 
-vi.mock('node:child_process', () => ({
+vi.mock('node:child_process', (origCP) => ({
     default: {
+        ...origCP,
         execSync: vi.fn().mockReturnValue(Buffer.from('Google Chrome 115.0.5790.98\n'))
     }
 }))


### PR DESCRIPTION
## Proposed changes
Enables automatic driver management for Firefox and its channels.

Fixes https://github.com/webdriverio/webdriverio/issues/10924

Allows `browserVersion` capability to be set to a Firefox release channel:

i.e. `'stable' | 'latest' | 'beta' | 'dev' | 'esr'`

As well as any published version.

Example capabilities:
```js
{
	browserName: 'firefox',
	browserVersion: 'nightly' // Latest Nightly
},
{
	browserName: 'firefox',
	browserVersion: '118.0a1' // Specific Nightly
},
{
	browserName: 'firefox',
	browserVersion: 'esr' // Latest Extended Support Release
},
{
	browserName: 'firefox',
	browserVersion: '115.1.0esr' // Specifc Extended Support Release
},
{
	browserName: 'firefox',
	browserVersion: 'beta' // Latest Beta
},
{
	browserName: 'firefox',
	browserVersion: '117.0b2' // Specific Beta (non Developer Edition)
},
{
	browserName: 'firefox',
	browserVersion: 'latest' // sames as stable, latest released
},
{
	browserName: 'firefox',
	browserVersion: '114.0.1' // Specific past stable version
},
{
	browserName: 'firefox',
	browserVersion: 'dev' // Latest Developer Edition
},
{
	browserName: 'firefox',
	browserVersion: '117.0b2dev' // Specific Developer Edition
}
```

Please test more thoroughly on Windows and Linux.

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [X] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
