### PR TITLE
fix: Deal with new W3C spec Error response

### DIFF
--- a/packages/webdriverio/tests/utils/getElementObject.test.ts
+++ b/packages/webdriverio/tests/utils/getElementObject.test.ts
@@ -1,0 +1,103 @@
+import path from 'node:path'
+import { describe, it, beforeEach, expect, vi } from 'vitest'
+import { remote } from '../../src/index.js'
+
+import * as getElem from '../../src/utils/getElementObject.js'
+
+const origGetElem: typeof getElem = await vi.importActual('../../src/utils/getElementObject')
+
+const ErrorExamplesW3C = {
+    chrome: {
+        error: 'no such element',
+        message: 'no such element: No node with given id found\n  (Session info: headless chrome=116.0.5845.50)',
+        stacktrace: '0   chromedriver                        0x000000010dc72288 chromedriver + 5014152\n' +
+        '1   chromedriver                        0x000000010dc68fe3 chromedriver + 4976611\n' +
+        '2   chromedriver                        0x000000010d80ddd7 chromedriver + 409047\n' +
+        '3   chromedriver                        0x000000010d85cc19 chromedriver + 732185\n' +
+        '4   chromedriver                        0x000000010d85cdd1 chromedriver + 732625\n' +
+        '5   chromedriver                        0x000000010d8a2bd4 chromedriver + 1018836\n' +
+        '6   chromedriver                        0x000000010d883f7d chromedriver + 892797\n' +
+        '7   chromedriver                        0x000000010d89ffb1 chromedriver + 1007537\n' +
+        '8   chromedriver                        0x000000010d883d23 chromedriver + 892195\n' +
+        '9   chromedriver                        0x000000010d84e919 chromedriver + 674073\n' +
+        '10  chromedriver                        0x000000010d84fb4e chromedriver + 678734\n' +
+        '11  chromedriver                        0x000000010dc34669 chromedriver + 4761193\n' +
+        '12  chromedriver                        0x000000010dc396e3 chromedriver + 4781795\n' +
+        '13  chromedriver                        0x000000010dc404ae chromedriver + 4809902\n' +
+        '14  chromedriver                        0x000000010dc3a40d chromedriver + 4785165\n' +
+        '15  chromedriver                        0x000000010dc0cd9c chromedriver + 4599196\n' +
+        '16  chromedriver                        0x000000010dc57ed8 chromedriver + 4906712\n' +
+        '17  chromedriver                        0x000000010dc58090 chromedriver + 4907152\n' +
+        '18  chromedriver                        0x000000010dc68c1e chromedriver + 4975646\n' +
+        '19  libsystem_pthread.dylib             0x00007ff810a2b1d3 _pthread_start + 125\n' +
+        '20  libsystem_pthread.dylib             0x00007ff810a26bd3 thread_start + 15\n'
+    },
+    firefox: {
+        error: 'no such element',
+        message: 'Unable to locate element: [role="example"]',
+        stacktrace: 'RemoteError@chrome://remote/content/shared/RemoteError.sys.mjs:8:8\n' +
+          'WebDriverError@chrome://remote/content/shared/webdriver/Errors.sys.mjs:188:5\n' +
+          'NoSuchElementError@chrome://remote/content/shared/webdriver/Errors.sys.mjs:506:5\n' +
+          'dom.find/</<@chrome://remote/content/shared/DOM.sys.mjs:132:16\n'
+    }
+}
+
+vi.mock('got')
+vi.mock('@wdio/logger', () => import(path.join(process.cwd(), '__mocks__', '@wdio/logger')))
+vi.mock('../../src/commands/element/waitForExist', () => ({
+    __esModule: true,
+    waitForExist: vi.fn().mockImplementation(() => { return true })
+}))
+vi.mock('../../src/utils/getElementObject.js', async () => {
+
+    const mod = {
+        getElement: vi.fn(),
+        getElements: vi.fn()
+    }
+
+    return { __esModule: true, ...mod, default: { ...mod } }
+})
+
+describe('getElements', () => {
+
+    let browser: WebdriverIO.Browser
+
+    beforeEach(async () => {
+
+        browser = await remote({
+            baseUrl: 'http://foobar.com',
+            capabilities: {
+                browserName: 'foobar'
+            }
+        })
+
+        vi.mocked(getElem.getElement).mockClear()
+        vi.mocked(getElem.getElements).mockClear()
+
+        vi.mocked(getElem.getElements).mockImplementation(
+            (elem, _res, props) => origGetElem
+                .getElements
+                .call(browser, elem, ErrorExamplesW3C.chrome, props)
+        )
+    })
+
+    it('should deal with a W3C spec error response', async () => {
+
+        const error = new Error()
+        Object.assign(error, {
+            name: ErrorExamplesW3C.chrome.error,
+            message: ErrorExamplesW3C.chrome.message,
+            stack: ErrorExamplesW3C.chrome.stacktrace,
+        })
+
+        const elems = await browser.$$('#foo')
+        const [elem] = elems
+
+        expect(elems.foundWith).toBe('$$')
+
+        expect(elems).toHaveLength(1)
+
+        expect(elem.error).toBeInstanceOf(Error)
+        expect(elem).toEqual(expect.objectContaining({ error }))
+    })
+})


### PR DESCRIPTION
## Proposed changes

Fixes https://github.com/webdriverio/webdriverio/issues/10843
Deal with new Chrome error responses to find element request.
Sometimes Chrome response is an error object like 

```json
{
    "error": "no such element",
    "message": "no such element: No node with given id found\n  (Session info: headless chrome=116.0.5845.50)",
    "stacktrace": "#0 0x55ddf07ae623 <unknown>\n#1 0x55ddf04d0f67 <unknown>\n#2 0x55ddf04b8527 <unknown>\n#3 0x55ddf04b6a94 <unknown>\n#4 0x55ddf04b700f <unknown>\n#5 0x55ddf04b6f64 <unknown>\n#6 0x55ddf04ddf16 <unknown>\n#7 0x55ddf04d5a34 <unknown>\n#8 0x55ddf04d4643 <unknown>\n#9 0x55ddf04d6d40 <unknown>\n#10 0x55ddf04d6dfc <unknown>\n#11 0x55ddf0514de8 <unknown>\n#12 0x55ddf05151b1 <unknown>\n#13 0x55ddf050b1a3 <unknown>\n#14 0x55ddf0535f3d <unknown>\n#15 0x55ddf050acf6 <unknown>\n#16 0x55ddf05360de <unknown>\n#17 0x55ddf054e249 <unknown>\n#18 0x55ddf0535ce3 <unknown>\n#19 0x55ddf05097bb <unknown>\n#20 0x55ddf050a55e <unknown>\n#21 0x55ddf076f648 <unknown>\n#22 0x55ddf0773547 <unknown>\n#23 0x55ddf077ddbc <unknown>\n#24 0x55ddf0774176 <unknown>\n#25 0x55ddf074251f <unknown>\n#26 0x55ddf0798458 <unknown>\n#27 0x55ddf0798628 <unknown>\n#28 0x55ddf07a74f3 <unknown>\n#29 0x7f60e12a0044 <unknown>\n"
}
```
instead of an array of elements that we have expected so far.

This change warps the element response in an array but then flats it till depth 1, meaning it maintains previous logic for an element response array but also wraps this new error object in an array. It will then be handled normally as other errors are, instead of crashing the test-runner with 
```shell
elemResponse.map is not a function
```

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
- [X] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
