### PR TITLE
(@wdio/utils): support setup of Firefox browser through @puppeteer/browser

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -134,8 +134,8 @@ jobs:
             e2e/wdio/*.log
             e2e/*.log
             e2e/browser-runner/logs
-      # - name: 🐛 Debug Build
-      #   uses: stateful/vscode-server-action@v1
-      #   if: failure()
-      #   with:
-      #     timeout: '30000'
+      - name: 🐛 Debug Build
+        uses: stateful/vscode-server-action@v1
+        if: failure()
+        with:
+          timeout: '30000'

--- a/e2e/wdio/wdio.local.conf.ts
+++ b/e2e/wdio/wdio.local.conf.ts
@@ -24,7 +24,19 @@ export const config: Options.Testrunner = {
             args: ['headless', 'disable-gpu']
         }
     }, {
+        browserName: 'chrome',
+        browserVersion: 'canary',
+        'goog:chromeOptions': {
+            args: ['headless', 'disable-gpu']
+        }
+    }, {
         browserName: 'firefox',
+        'moz:firefoxOptions': {
+            args: ['-headless']
+        }
+    }, {
+        browserName: 'firefox',
+        browserVersion: 'latest',
         'moz:firefoxOptions': {
             args: ['-headless']
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16999,6 +16999,27 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/locate-app": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/locate-app/-/locate-app-2.1.0.tgz",
+      "integrity": "sha512-rcVo/iLUxrd9d0lrmregK/Z5Y5NCpSwf9KlMbPpOHmKmdxdQY1Fj8NDQ5QymJTryCsBLqwmniFv2f3JKbk9Bvg==",
+      "dependencies": {
+        "n12": "0.4.0",
+        "type-fest": "2.13.0",
+        "userhome": "1.0.0"
+      }
+    },
+    "node_modules/locate-app/node_modules/type-fest": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.13.0.tgz",
+      "integrity": "sha512-lPfAm42MxE4/456+QyIaaVBAwgpJb6xZ8PRu09utnhPdWwcyj9vgy6Sq0Z5yNbJ21EdxB5dRU/Qg8bsyAMtlcw==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/locate-character": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
@@ -18412,6 +18433,11 @@
         "object-assign": "^4.0.1",
         "thenify-all": "^1.0.0"
       }
+    },
+    "node_modules/n12": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/n12/-/n12-0.4.0.tgz",
+      "integrity": "sha512-p/hj4zQ8d3pbbFLQuN1K9honUxiDDhueOWyFLw/XgBv+wZCE44bcLH4CIcsolOceJQduh4Jf7m/LfaTxyGmGtQ=="
     },
     "node_modules/nanoclone": {
       "version": "0.2.1",
@@ -26637,6 +26663,14 @@
       "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==",
       "dev": true
     },
+    "node_modules/userhome": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/userhome/-/userhome-1.0.0.tgz",
+      "integrity": "sha512-ayFKY3H+Pwfy4W98yPdtH1VqH4psDeyW8lYYFzfecR9d6hqLpqhecktvYR3SEEXt7vG0S1JEpciI3g94pMErig==",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/util": {
       "version": "0.12.5",
       "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
@@ -28819,6 +28853,7 @@
         "get-port": "^7.0.0",
         "got": "^13.0.0",
         "import-meta-resolve": "^3.0.0",
+        "locate-app": "^2.1.0",
         "safaridriver": "^0.1.0",
         "wait-port": "^1.0.4"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -28845,7 +28845,6 @@
         "@puppeteer/browsers": "^1.6.0",
         "@wdio/logger": "8.11.0",
         "@wdio/types": "8.15.7",
-        "chrome-launcher": "^1.0.0",
         "decamelize": "^6.0.0",
         "deepmerge-ts": "^5.1.0",
         "edgedriver": "^5.3.5",

--- a/packages/wdio-browser-runner/src/browser/mock.ts
+++ b/packages/wdio-browser-runner/src/browser/mock.ts
@@ -29,5 +29,6 @@ export const ChromeReleaseChannel = () => {}
 export const detectBrowserPlatform = () => {}
 export const type = 'browser'
 export const sync = () => {}
-export const getChromePath = () => {}
+export const locateChrome = () => {}
+export const locateFirefox = () => {}
 export default () => {}

--- a/packages/wdio-browser-runner/src/vite/plugins/testrunner.ts
+++ b/packages/wdio-browser-runner/src/vite/plugins/testrunner.ts
@@ -42,7 +42,7 @@ const resolvedVirtualModuleId = '\0' + virtualModuleId
  */
 const MODULES_TO_MOCK = [
     'import-meta-resolve', 'puppeteer-core', 'archiver', 'glob', 'devtools', 'ws', 'decamelize', 'got',
-    'geckodriver', 'safaridriver', 'edgedriver', '@puppeteer/browsers', 'chrome-launcher', 'wait-port'
+    'geckodriver', 'safaridriver', 'edgedriver', '@puppeteer/browsers', 'locate-app', 'wait-port'
 ]
 
 const POLYFILLS = [

--- a/packages/wdio-utils/package.json
+++ b/packages/wdio-utils/package.json
@@ -33,7 +33,6 @@
     "@puppeteer/browsers": "^1.6.0",
     "@wdio/logger": "8.11.0",
     "@wdio/types": "8.15.7",
-    "chrome-launcher": "^1.0.0",
     "decamelize": "^6.0.0",
     "deepmerge-ts": "^5.1.0",
     "edgedriver": "^5.3.5",
@@ -41,6 +40,7 @@
     "get-port": "^7.0.0",
     "got": "^13.0.0",
     "import-meta-resolve": "^3.0.0",
+    "locate-app": "^2.1.0",
     "safaridriver": "^0.1.0",
     "wait-port": "^1.0.4"
   },

--- a/packages/wdio-utils/src/driver/index.ts
+++ b/packages/wdio-utils/src/driver/index.ts
@@ -21,7 +21,7 @@ import {
 } from './utils.js'
 import { SUPPORTED_BROWSERNAMES } from '../constants.js'
 
-export type ChromedriverParameters = InstallOptions & Omit<EdgedriverParameters, 'port' | 'edgeDriverVersion' | 'customEdgeDriverPath'>
+export type ChromedriverParameters = Partial<InstallOptions> & Omit<EdgedriverParameters, 'port' | 'edgeDriverVersion' | 'customEdgeDriverPath'>
 declare global {
     namespace WebdriverIO {
         interface ChromedriverOptions extends ChromedriverParameters {}
@@ -116,15 +116,23 @@ export async function startWebDriver (options: Options.WebDriver) {
             { binary: executablePath },
             caps['moz:firefoxOptions'] || {}
         )
+
+        /**
+         * the "binary" parameter refers to the driver binary in the WebdriverIO.GeckodriverOptions and
+         * to the Firefox binary in the driver option
+         */
         delete caps.browserVersion
-        const geckodriverOptions = caps['wdio:geckodriverOptions'] || ({} as GeckodriverParameters)
+        const { binary, ...geckodriverOptions } = caps['wdio:geckodriverOptions'] || ({} as WebdriverIO.GeckodriverOptions)
+        geckodriverOptions.customGeckoDriverPath = binary
+
         driver = 'GeckoDriver'
         driverProcess = await startGeckodriver({ ...geckodriverOptions, cacheDir, port })
     } else if (isEdge(caps.browserName)) {
         /**
          * Microsoft Edge
          */
-        const edgedriverOptions = caps['wdio:edgedriverOptions'] || ({} as EdgedriverParameters)
+        const { binary, ...edgedriverOptions } = caps['wdio:edgedriverOptions'] || ({} as WebdriverIO.EdgedriverOptions)
+        edgedriverOptions.customEdgeDriverPath = binary
         driver = 'EdgeDriver'
         driverProcess = await startEdgedriver({ ...edgedriverOptions, cacheDir, port }).catch((err) => {
             log.warn(`Couldn't start EdgeDriver: ${err.message}, retry ...`)

--- a/packages/wdio-utils/src/driver/index.ts
+++ b/packages/wdio-utils/src/driver/index.ts
@@ -16,7 +16,7 @@ import type { InstallOptions } from '@puppeteer/browsers'
 import type { Capabilities, Options } from '@wdio/types'
 
 import {
-    parseParams, setupChrome, definesRemoteDriver, setupChromedriver,
+    parseParams, setupPuppeteerBrowser, definesRemoteDriver, setupChromedriver,
     isChrome, isFirefox, isEdge, isSafari, getCacheDir
 } from './utils.js'
 import { SUPPORTED_BROWSERNAMES } from '../constants.js'
@@ -76,7 +76,8 @@ export async function startWebDriver (options: Options.WebDriver) {
          * Chrome
          */
         const chromedriverOptions = caps['wdio:chromedriverOptions'] || ({} as WebdriverIO.ChromedriverOptions)
-        const { executablePath: chromeExecuteablePath, browserVersion } = await setupChrome(cacheDir, caps)
+
+        const { executablePath: chromeExecuteablePath, browserVersion } = await setupPuppeteerBrowser(cacheDir, caps)
         const { executablePath: chromedriverExcecuteablePath } = chromedriverOptions.binary
             ? { executablePath: chromedriverOptions.binary }
             : await setupChromedriver(cacheDir, browserVersion)
@@ -110,6 +111,12 @@ export async function startWebDriver (options: Options.WebDriver) {
         /**
          * Firefox
          */
+        const { executablePath } = await setupPuppeteerBrowser(cacheDir, caps)
+        caps['moz:firefoxOptions'] = deepmerge(
+            { binary: executablePath },
+            caps['moz:firefoxOptions'] || {}
+        )
+        delete caps.browserVersion
         const geckodriverOptions = caps['wdio:geckodriverOptions'] || ({} as GeckodriverParameters)
         driver = 'GeckoDriver'
         driverProcess = await startGeckodriver({ ...geckodriverOptions, cacheDir, port })

--- a/packages/wdio-utils/src/driver/index.ts
+++ b/packages/wdio-utils/src/driver/index.ts
@@ -123,7 +123,9 @@ export async function startWebDriver (options: Options.WebDriver) {
          */
         delete caps.browserVersion
         const { binary, ...geckodriverOptions } = caps['wdio:geckodriverOptions'] || ({} as WebdriverIO.GeckodriverOptions)
-        geckodriverOptions.customGeckoDriverPath = binary
+        if (binary) {
+            geckodriverOptions.customGeckoDriverPath = binary
+        }
 
         driver = 'GeckoDriver'
         driverProcess = await startGeckodriver({ ...geckodriverOptions, cacheDir, port })

--- a/packages/wdio-utils/src/driver/index.ts
+++ b/packages/wdio-utils/src/driver/index.ts
@@ -134,7 +134,10 @@ export async function startWebDriver (options: Options.WebDriver) {
          * Microsoft Edge
          */
         const { binary, ...edgedriverOptions } = caps['wdio:edgedriverOptions'] || ({} as WebdriverIO.EdgedriverOptions)
-        edgedriverOptions.customEdgeDriverPath = binary
+        if (binary) {
+            edgedriverOptions.customEdgeDriverPath = binary
+        }
+
         driver = 'EdgeDriver'
         driverProcess = await startEdgedriver({ ...edgedriverOptions, cacheDir, port }).catch((err) => {
             log.warn(`Couldn't start EdgeDriver: ${err.message}, retry ...`)

--- a/packages/wdio-utils/src/driver/manager.ts
+++ b/packages/wdio-utils/src/driver/manager.ts
@@ -4,7 +4,7 @@ import type { Options, Capabilities } from '@wdio/types'
 import {
     getCacheDir, definesRemoteDriver,
     isSafari, isEdge, isFirefox, isChrome,
-    setupChromedriver, setupEdgedriver, setupGeckodriver, setupChrome
+    setupChromedriver, setupEdgedriver, setupGeckodriver, setupPuppeteerBrowser
 } from './utils.js'
 
 const log = logger('@wdio/utils')
@@ -109,11 +109,8 @@ export function setupBrowser (options: Omit<Options.WebDriver, 'capabilities'>, 
         if (isEdge(cap.browserName)) {
             // not yet implemented
             return Promise.resolve()
-        } else if (isFirefox(cap.browserName)) {
-            // not yet implemented
-            return Promise.resolve()
-        } else if (isChrome(cap.browserName)) {
-            return setupChrome(cacheDir, cap)
+        } else if (isChrome(cap.browserName) || isFirefox(cap.browserName)) {
+            return setupPuppeteerBrowser(cacheDir, cap)
         }
 
         return Promise.resolve()

--- a/packages/wdio-utils/src/driver/manager.ts
+++ b/packages/wdio-utils/src/driver/manager.ts
@@ -94,7 +94,9 @@ export async function setupDriver (options: Omit<Options.WebDriver, 'capabilitie
         if (isEdge(cap.browserName)) {
             return setupEdgedriver(cacheDir, cap.browserVersion)
         } else if (isFirefox(cap.browserName)) {
-            return setupGeckodriver(cacheDir, cap.browserVersion)
+            // "latest" works for setting up browser only but not geckodriver
+            const version = cap.browserVersion === 'latest' ? undefined : cap.browserVersion
+            return setupGeckodriver(cacheDir, version)
         } else if (isChrome(cap.browserName)) {
             return setupChromedriver(cacheDir, cap.browserVersion)
         }

--- a/packages/wdio-utils/src/driver/utils.ts
+++ b/packages/wdio-utils/src/driver/utils.ts
@@ -66,7 +66,7 @@ export async function getBuildIdByFirefoxPath(firefoxPath?: string) {
         return contents
             .split('\n')
             .filter((line) => line.startsWith('Version='))
-            .map((line) => line.replace('Version=', ''))
+            .map((line) => line.replace('Version=', '').replace(/\r/, ''))
             .pop()
     }
 
@@ -140,8 +140,6 @@ export async function setupPuppeteerBrowser(cacheDir: string, caps: Capabilities
         browser: browserName,
         downloadProgressCallback: (downloadedBytes, totalBytes) => downloadProgressCallback(browserName, downloadedBytes, totalBytes)
     }
-    console.log('CHECK', buildId, browserName, platform, tag)
-
     const isCombinationAvailable = await canDownload(installOptions)
     if (!isCombinationAvailable) {
         throw new Error(`Couldn't find a matching Chrome browser for tag "${buildId}" on platform "${platform}"`)

--- a/packages/wdio-utils/src/driver/utils.ts
+++ b/packages/wdio-utils/src/driver/utils.ts
@@ -135,7 +135,9 @@ export async function setupPuppeteerBrowser(cacheDir: string, caps: Capabilities
     /**
      * otherwise download provided Chrome browser version or "stable"
      */
-    const tag = caps.browserVersion || ChromeReleaseChannel.STABLE
+    const tag = browserName === Browser.CHROME
+        ? caps.browserVersion || ChromeReleaseChannel.STABLE
+        : caps.browserVersion || 'latest'
     const buildId = await resolveBuildId(browserName, platform, tag)
     const installOptions: InstallOptions & { unpack?: true } = {
         unpack: true,
@@ -143,7 +145,7 @@ export async function setupPuppeteerBrowser(cacheDir: string, caps: Capabilities
         platform,
         buildId,
         browser: browserName,
-        downloadProgressCallback: (downloadedBytes, totalBytes) => downloadProgressCallback(browserName, downloadedBytes, totalBytes)
+        downloadProgressCallback: (downloadedBytes, totalBytes) => downloadProgressCallback(`${browserName} (${buildId})`, downloadedBytes, totalBytes)
     }
     const isCombinationAvailable = await canDownload(installOptions)
     if (!isCombinationAvailable) {

--- a/packages/wdio-utils/src/driver/utils.ts
+++ b/packages/wdio-utils/src/driver/utils.ts
@@ -156,7 +156,7 @@ export async function setupPuppeteerBrowser(cacheDir: string, caps: Capabilities
     return { executablePath, browserVersion: buildId }
 }
 
-function getDriverOptions (caps: Capabilities.Capabilities) {
+export function getDriverOptions (caps: Capabilities.Capabilities) {
     return (
         caps['wdio:chromedriverOptions'] ||
         caps['wdio:geckodriverOptions'] ||

--- a/packages/wdio-utils/src/driver/utils.ts
+++ b/packages/wdio-utils/src/driver/utils.ts
@@ -7,13 +7,13 @@ import cp from 'node:child_process'
 import got from 'got'
 import decamelize from 'decamelize'
 import logger from '@wdio/logger'
-import { getChromePath } from 'chrome-launcher'
 import {
     install, canDownload, resolveBuildId, detectBrowserPlatform, Browser, ChromeReleaseChannel,
     computeExecutablePath, type InstallOptions
 } from '@puppeteer/browsers'
 import { download as downloadGeckodriver } from 'geckodriver'
 import { download as downloadEdgedriver } from 'edgedriver'
+import { locateChrome, locateFirefox } from 'locate-app'
 import type { EdgedriverParameters } from 'edgedriver'
 import type { Options, Capabilities } from '@wdio/types'
 
@@ -36,16 +36,7 @@ export function parseParams(params: EdgedriverParameters) {
         .filter(Boolean)
 }
 
-export function getLocalChromePath() {
-    try {
-        const chromePath = getChromePath()
-        return chromePath
-    } catch (err: unknown) {
-        return
-    }
-}
-
-export function getBuildIdByPath(chromePath?: string) {
+export function getBuildIdByChromePath(chromePath?: string) {
     if (!chromePath) {
         return
     }
@@ -64,6 +55,25 @@ export function getBuildIdByPath(chromePath?: string) {
     return versionString.trim().split(' ').pop()?.trim()
 }
 
+export async function getBuildIdByFirefoxPath(firefoxPath?: string) {
+    if (!firefoxPath) {
+        return
+    }
+
+    if (os.platform() === 'win32') {
+        const appPath = path.dirname(firefoxPath)
+        const contents = (await fsp.readFile(path.join(appPath, 'application.ini'))).toString('utf-8')
+        return contents
+            .split('\n')
+            .filter((line) => line.startsWith('Version='))
+            .map((line) => line.replace('Version=', ''))
+            .pop()
+    }
+
+    const versionString = cp.execSync(`"${firefoxPath}" --version`).toString()
+    return versionString.split(' ').pop()?.trim()
+}
+
 let lastTimeCalled = Date.now()
 export const downloadProgressCallback = (artifact: string, downloadedBytes: number, totalBytes: number) => {
     if (Date.now() - lastTimeCalled < 1000) {
@@ -74,8 +84,10 @@ export const downloadProgressCallback = (artifact: string, downloadedBytes: numb
     lastTimeCalled = Date.now()
 }
 
-export async function setupChrome(cacheDir: string, caps: Capabilities.Capabilities) {
+export async function setupPuppeteerBrowser(cacheDir: string, caps: Capabilities.Capabilities) {
     caps.browserName = caps.browserName?.toLowerCase()
+
+    const browserName = caps.browserName === Browser.FIREFOX ? Browser.FIREFOX : Browser.CHROME
     const exist = await fsp.access(cacheDir).then(() => true, () => false)
     if (!exist) {
         await fsp.mkdir(cacheDir, { recursive: true })
@@ -98,16 +110,19 @@ export async function setupChrome(cacheDir: string, caps: Capabilities.Capabilit
     }
 
     if (!caps.browserVersion) {
-        const executablePath = getLocalChromePath()!
-        const tag = getBuildIdByPath(executablePath)
-
+        const executablePath = browserName === Browser.CHROME
+            ? await locateChrome().catch(() => undefined)
+            : await locateFirefox().catch(() => undefined)
+        const tag = browserName === Browser.CHROME
+            ? getBuildIdByChromePath(executablePath)
+            : await getBuildIdByFirefoxPath(executablePath)
         /**
          * verify that we have a valid Chrome browser installed
          */
         if (tag) {
             return {
                 executablePath,
-                browserVersion: await resolveBuildId(Browser.CHROME, platform, tag)
+                browserVersion: await resolveBuildId(browserName, platform, tag)
             }
         }
     }
@@ -116,21 +131,21 @@ export async function setupChrome(cacheDir: string, caps: Capabilities.Capabilit
      * otherwise download provided Chrome browser version or "stable"
      */
     const tag = caps.browserVersion || ChromeReleaseChannel.STABLE
-    const buildId = await resolveBuildId(Browser.CHROME, platform, tag)
+    const buildId = await resolveBuildId(browserName, platform, tag)
     const installOptions: InstallOptions & { unpack?: true } = {
         unpack: true,
         cacheDir,
         platform,
         buildId,
-        browser: Browser.CHROME,
-        downloadProgressCallback: (downloadedBytes, totalBytes) => downloadProgressCallback('Chrome', downloadedBytes, totalBytes)
+        browser: browserName,
+        downloadProgressCallback: (downloadedBytes, totalBytes) => downloadProgressCallback(browserName, downloadedBytes, totalBytes)
     }
     const isCombinationAvailable = await canDownload(installOptions)
     if (!isCombinationAvailable) {
         throw new Error(`Couldn't find a matching Chrome browser for tag "${buildId}" on platform "${platform}"`)
     }
 
-    log.info(`Setting up Chrome v${buildId}`)
+    log.info(`Setting up ${browserName} v${buildId}`)
     await install(installOptions)
     const executablePath = computeExecutablePath(installOptions)
     return { executablePath, browserVersion: buildId }
@@ -158,7 +173,7 @@ export async function setupChromedriver (cacheDir: string, driverVersion?: strin
         throw new Error('The current platform is not supported.')
     }
 
-    const version = driverVersion || getBuildIdByPath(getLocalChromePath()) || ChromeReleaseChannel.STABLE
+    const version = driverVersion || getBuildIdByChromePath(await locateChrome()) || ChromeReleaseChannel.STABLE
     const buildId = await resolveBuildId(Browser.CHROMEDRIVER, platform, version)
     let executablePath = computeExecutablePath({
         browser: Browser.CHROMEDRIVER,

--- a/packages/wdio-utils/src/driver/utils.ts
+++ b/packages/wdio-utils/src/driver/utils.ts
@@ -140,6 +140,8 @@ export async function setupPuppeteerBrowser(cacheDir: string, caps: Capabilities
         browser: browserName,
         downloadProgressCallback: (downloadedBytes, totalBytes) => downloadProgressCallback(browserName, downloadedBytes, totalBytes)
     }
+    console.log('CHECK', buildId, browserName, platform, tag)
+
     const isCombinationAvailable = await canDownload(installOptions)
     if (!isCombinationAvailable) {
         throw new Error(`Couldn't find a matching Chrome browser for tag "${buildId}" on platform "${platform}"`)

--- a/packages/wdio-utils/tests/driver/__fixtures__/application.ini
+++ b/packages/wdio-utils/tests/driver/__fixtures__/application.ini
@@ -1,0 +1,26 @@
+; This file is not used. If you modify it and want the application to use
+; your modifications, move it under the browser/ subdirectory and start with
+; the "-app /path/to/browser/application.ini" argument.
+[App]
+Vendor=Mozilla
+Name=Firefox
+RemotingName=firefox
+Version=116.0.3
+BuildID=20230815173142
+SourceRepository=https://hg.mozilla.org/releases/mozilla-release
+SourceStamp=183063cc6efa429f4f184aff169e1f9dad68cbfc
+ID={ec8030f7-c20a-464f-9b0e-13a3a9e97384}
+
+[Gecko]
+MinVersion=116.0.3
+MaxVersion=116.0.3
+
+[XRE]
+EnableProfileMigrator=1
+
+[Crash Reporter]
+Enabled=1
+ServerURL=https://crash-reports.mozilla.com/submit?id={ec8030f7-c20a-464f-9b0e-13a3a9e97384}&version=116.0.3&buildid=20230815173142
+
+[AppUpdate]
+URL=https://aus5.mozilla.org/update/6/%PRODUCT%/%VERSION%/%BUILD_ID%/%BUILD_TARGET%/%LOCALE%/%CHANNEL%/%OS_VERSION%/%SYSTEM_CAPABILITIES%/%DISTRIBUTION%/%DISTRIBUTION_VERSION%/update.xml

--- a/packages/wdio-utils/tests/driver/index.test.ts
+++ b/packages/wdio-utils/tests/driver/index.test.ts
@@ -238,8 +238,6 @@ describe('startWebDriver', () => {
                 },
             }
         })
-        expect(fsp.access).toBeCalledTimes(1)
-        expect(fsp.mkdir).toBeCalledTimes(1)
         expect(cp.spawn).toBeCalledTimes(1)
         expect(cp.spawn).toBeCalledWith(
             '/my/chromedriver',
@@ -272,17 +270,9 @@ describe('startWebDriver', () => {
             .mockRejectedValueOnce(new Error('boom'))
             .mockResolvedValue({} as any)
         await startWebDriver(options)
-        expect(install).toBeCalledTimes(3)
+        expect(install).toBeCalledTimes(1)
         expect(install).toBeCalledWith(expect.objectContaining({
             buildId: '115.0.5790.171',
-            browser: 'chrome'
-        }))
-        expect(install).toBeCalledWith(expect.objectContaining({
-            buildId: '115.0.5790.171',
-            browser: 'chromedriver'
-        }))
-        expect(install).toBeCalledWith(expect.objectContaining({
-            buildId: '115.0.5790.170',
             browser: 'chromedriver'
         }))
     })

--- a/packages/wdio-utils/tests/driver/index.test.ts
+++ b/packages/wdio-utils/tests/driver/index.test.ts
@@ -87,6 +87,7 @@ describe('startWebDriver', () => {
         vi.mocked(fsp.access).mockClear()
         vi.mocked(fsp.mkdir).mockClear()
         vi.mocked(cp.spawn).mockClear()
+        vi.mocked(startGeckodriver).mockClear()
     })
 
     afterEach(() => {
@@ -243,6 +244,40 @@ describe('startWebDriver', () => {
             '/my/chromedriver',
             ['--port=1234', '--binary=/my/chromedriver', '--allowed-origins=*', '--allowed-ips=']
         )
+    })
+
+    it('should start no driver or download geckodriver if binaries are defined', async () => {
+        const options = {
+            capabilities: {
+                browserName: 'firefox',
+                'wdio:geckodriverOptions': { binary: '/my/geckodriver' },
+                'moz:firefoxOptions': { binary: '/my/firefox' }
+            } as any
+        }
+        const res = await startWebDriver(options)
+        expect(res).toBe('geckodriver')
+        expect(startGeckodriver).toBeCalledWith({
+            cacheDir: expect.any(String),
+            customGeckoDriverPath: '/my/geckodriver',
+            port: 1234
+        })
+    })
+
+    it('should start no driver or download edgedriver if binaries are defined', async () => {
+        const options = {
+            capabilities: {
+                browserName: 'edge',
+                'wdio:edgedriverOptions': { binary: '/my/edgedriver' },
+                'ms:edgeOptions': { binary: '/my/edge' }
+            } as any
+        }
+        const res = await startWebDriver(options)
+        expect(res).toBe('edgedriver')
+        expect(startEdgedriver).toBeCalledWith({
+            cacheDir: expect.any(String),
+            customEdgeDriverPath: '/my/edgedriver',
+            port: 1234
+        })
     })
 
     it('should fail on timeout', async () => {

--- a/packages/wdio-utils/tests/driver/index.test.ts
+++ b/packages/wdio-utils/tests/driver/index.test.ts
@@ -71,6 +71,14 @@ vi.mock('../../src/driver/detectBackend.js', () => ({
     })
 }))
 
+vi.mock('../../src/driver/utils.js', async (actualMod) => ({
+    ...(await actualMod() as any),
+    setupPuppeteerBrowser: vi.fn().mockResolvedValue({
+        executablePath: '/path/to/browser',
+        browserVersion: '1.2.3'
+    })
+}))
+
 describe('startWebDriver', () => {
     const WDIO_SKIP_DRIVER_SETUP = process.env.WDIO_SKIP_DRIVER_SETUP
     beforeEach(() => {
@@ -127,6 +135,9 @@ describe('startWebDriver', () => {
             port: 1234,
             capabilities: {
                 browserName: 'firefox',
+                'moz:firefoxOptions': {
+                    binary: '/path/to/browser'
+                },
                 'wdio:geckodriverOptions': {
                     foo: 'bar'
                 },
@@ -194,8 +205,7 @@ describe('startWebDriver', () => {
                 },
             }
         })
-        expect(fsp.access).toBeCalledTimes(2)
-        expect(fsp.mkdir).toBeCalledTimes(1)
+        expect(fsp.access).toBeCalledTimes(1)
         expect(cp.spawn).toBeCalledTimes(1)
         expect(cp.spawn).toBeCalledWith(
             '/foo/bar/executable',

--- a/packages/wdio-utils/tests/driver/manager.test.ts
+++ b/packages/wdio-utils/tests/driver/manager.test.ts
@@ -2,7 +2,7 @@ import path from 'node:path'
 import { describe, test, expect, vi, beforeEach } from 'vitest'
 
 import type * as utils from '../../src/driver/utils.js'
-import { setupChromedriver, setupEdgedriver, setupGeckodriver, setupChrome } from '../../src/driver/utils.js'
+import { setupChromedriver, setupEdgedriver, setupGeckodriver, setupPuppeteerBrowser } from '../../src/driver/utils.js'
 import { setupDriver, setupBrowser } from '../../src/driver/manager.js'
 
 vi.mock('../../src/driver/utils.js', async (orig) => {
@@ -13,7 +13,7 @@ vi.mock('../../src/driver/utils.js', async (orig) => {
         setupChromedriver: vi.fn(),
         setupEdgedriver: vi.fn(),
         setupGeckodriver: vi.fn(),
-        setupChrome: vi.fn()
+        setupPuppeteerBrowser: vi.fn()
     }
 })
 vi.mock('@wdio/logger', () => import(path.join(process.cwd(), '__mocks__', '@wdio/logger')))
@@ -196,7 +196,7 @@ describe('setupDriver', () => {
 
 describe('setupBrowser', () => {
     beforeEach(() => {
-        vi.mocked(setupChrome).mockClear()
+        vi.mocked(setupPuppeteerBrowser).mockClear()
     })
 
     test('with testrunner capabilities', async () => {
@@ -219,14 +219,22 @@ describe('setupBrowser', () => {
             browserName: 'firefox',
             browserVersion: '6'
         }])
-        expect(setupChrome).toBeCalledTimes(2)
-        expect(setupChrome).toBeCalledWith('/foo/bar', {
+        expect(setupPuppeteerBrowser).toBeCalledTimes(4)
+        expect(setupPuppeteerBrowser).toBeCalledWith('/foo/bar', {
             browserName: 'chrome',
             browserVersion: '1'
         })
-        expect(setupChrome).toBeCalledWith('/foo/bar', {
+        expect(setupPuppeteerBrowser).toBeCalledWith('/foo/bar', {
             browserName: 'chrome',
             browserVersion: '2'
+        })
+        expect(setupPuppeteerBrowser).toBeCalledWith('/foo/bar', {
+            browserName: 'firefox',
+            browserVersion: '5'
+        })
+        expect(setupPuppeteerBrowser).toBeCalledWith('/foo/bar', {
+            browserName: 'firefox',
+            browserVersion: '6'
         })
     })
 
@@ -269,14 +277,22 @@ describe('setupBrowser', () => {
                 }
             }
         })
-        expect(setupChrome).toBeCalledTimes(2)
-        expect(setupChrome).toBeCalledWith('/foo/bar', {
+        expect(setupPuppeteerBrowser).toBeCalledTimes(4)
+        expect(setupPuppeteerBrowser).toBeCalledWith('/foo/bar', {
             browserName: 'chrome',
             browserVersion: '1'
         })
-        expect(setupChrome).toBeCalledWith('/foo/bar', {
+        expect(setupPuppeteerBrowser).toBeCalledWith('/foo/bar', {
             browserName: 'chrome',
             browserVersion: '2'
+        })
+        expect(setupPuppeteerBrowser).toBeCalledWith('/foo/bar', {
+            browserName: 'firefox',
+            browserVersion: '5'
+        })
+        expect(setupPuppeteerBrowser).toBeCalledWith('/foo/bar', {
+            browserName: 'firefox',
+            browserVersion: '6'
         })
     })
 
@@ -321,14 +337,22 @@ describe('setupBrowser', () => {
                 }
             }
         }])
-        expect(setupChrome).toBeCalledTimes(2)
-        expect(setupChrome).toBeCalledWith('/foo/bar', {
+        expect(setupPuppeteerBrowser).toBeCalledTimes(4)
+        expect(setupPuppeteerBrowser).toBeCalledWith('/foo/bar', {
             browserName: 'chrome',
             browserVersion: '1'
         })
-        expect(setupChrome).toBeCalledWith('/foo/bar', {
+        expect(setupPuppeteerBrowser).toBeCalledWith('/foo/bar', {
             browserName: 'chrome',
             browserVersion: '2'
+        })
+        expect(setupPuppeteerBrowser).toBeCalledWith('/foo/bar', {
+            browserName: 'firefox',
+            browserVersion: '5'
+        })
+        expect(setupPuppeteerBrowser).toBeCalledWith('/foo/bar', {
+            browserName: 'firefox',
+            browserVersion: '6'
         })
     })
 })

--- a/packages/wdio-utils/tests/driver/manager.test.ts
+++ b/packages/wdio-utils/tests/driver/manager.test.ts
@@ -33,6 +33,18 @@ describe('setupDriver', () => {
             browserName: 'chrome',
             browserVersion: '2'
         }, {
+            browserName: 'chrome',
+            browserVersion: '2',
+            'wdio:chromedriverOptions': {
+                binary: 'foo'
+            }
+        }, {
+            browserName: 'chrome',
+            browserVersion: '3',
+            'wdio:chromedriverOptions': {
+                binary: 'foo'
+            }
+        }, {
             browserName: 'edge',
             browserVersion: '3'
         }, {
@@ -44,10 +56,21 @@ describe('setupDriver', () => {
         }, {
             browserName: 'edge'
         }, {
+            browserName: 'edge',
+            'wdio:edgedriverOptions': {
+                binary: 'foo'
+            }
+        }, {
             browserName: 'edge'
         }, {
             browserName: 'firefox',
             browserVersion: '5'
+        }, {
+            browserName: 'firefox',
+            browserVersion: '5',
+            'wdio:geckodriverOptions': {
+                binary: 'foo'
+            }
         }, {
             browserName: 'firefox',
             browserVersion: '5'
@@ -81,6 +104,15 @@ describe('setupDriver', () => {
                     browserVersion: '2'
                 }
             },
+            browserBWithDriverBinary: {
+                capabilities: {
+                    browserName: 'chrome',
+                    browserVersion: '3',
+                    'wdio:chromedriverOptions': {
+                        binary: 'foo'
+                    }
+                }
+            },
             browserBRepeat: {
                 capabilities: {
                     browserName: 'chrome',
@@ -99,6 +131,21 @@ describe('setupDriver', () => {
                     browserVersion: '4'
                 }
             },
+            browserDRepeat: {
+                capabilities: {
+                    browserName: 'edge',
+                    browserVersion: '4'
+                }
+            },
+            browserDWithDriverBinary: {
+                capabilities: {
+                    browserName: 'edge',
+                    browserVersion: '5',
+                    'wdio:edgedriverOptions': {
+                        binary: 'foo'
+                    }
+                }
+            },
             browserE: {
                 capabilities: {
                     browserName: 'firefox',
@@ -111,10 +158,19 @@ describe('setupDriver', () => {
                     browserVersion: '5'
                 }
             },
+            browserEWithDriverBinary: {
+                capabilities: {
+                    browserName: 'firefox',
+                    browserVersion: '6',
+                    'wdio:geckodriverOptions': {
+                        binary: 'foo'
+                    }
+                }
+            },
             browserF: {
                 capabilities: {
                     browserName: 'firefox',
-                    browserVersion: '6'
+                    browserVersion: '7'
                 }
             }
         })
@@ -126,7 +182,7 @@ describe('setupDriver', () => {
         expect(setupEdgedriver).toBeCalledWith('/foo/bar', '4')
         expect(setupGeckodriver).toBeCalledTimes(2)
         expect(setupGeckodriver).toBeCalledWith('/foo/bar', '5')
-        expect(setupGeckodriver).toBeCalledWith('/foo/bar', '6')
+        expect(setupGeckodriver).toBeCalledWith('/foo/bar', '7')
     })
 
     test('with multiremote capabilities series', async () => {
@@ -141,6 +197,15 @@ describe('setupDriver', () => {
                 capabilities: {
                     browserName: 'chrome',
                     browserVersion: '2'
+                }
+            },
+            browserBWithDriverBinary: {
+                capabilities: {
+                    browserName: 'chrome',
+                    browserVersion: '3',
+                    'wdio:chromedriverOptions': {
+                        binary: 'foo'
+                    }
                 }
             },
         }, {
@@ -162,6 +227,15 @@ describe('setupDriver', () => {
                     browserVersion: '4'
                 }
             },
+            browserDWithDriverBinary: {
+                capabilities: {
+                    browserName: 'edge',
+                    browserVersion: '5',
+                    'wdio:edgedriverOptions': {
+                        binary: 'foo'
+                    }
+                }
+            },
         }, {
             browserA: {
                 capabilities: {
@@ -179,6 +253,15 @@ describe('setupDriver', () => {
                 capabilities: {
                     browserName: 'firefox',
                     browserVersion: '6'
+                }
+            },
+            browserFWithDriverBinary: {
+                capabilities: {
+                    browserName: 'firefox',
+                    browserVersion: '7',
+                    'wdio:geckodriverOptions': {
+                        binary: 'foo'
+                    }
                 }
             }
         }])

--- a/packages/wdio-utils/tests/driver/utils.test.ts
+++ b/packages/wdio-utils/tests/driver/utils.test.ts
@@ -1,19 +1,25 @@
 import os from 'node:os'
+import path from 'node:path'
+import url from 'node:url'
+import type fs from 'node:fs'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { getChromePath } from 'chrome-launcher'
 import { canDownload, resolveBuildId, detectBrowserPlatform } from '@puppeteer/browsers'
+import { locateChrome } from 'locate-app'
 
-import { parseParams, getLocalChromePath, getBuildIdByPath, setupChrome, definesRemoteDriver } from '../../src/driver/utils.js'
+import { parseParams, getBuildIdByChromePath, getBuildIdByFirefoxPath, setupPuppeteerBrowser, definesRemoteDriver } from '../../src/driver/utils.js'
 
-vi.mock('chrome-launcher', () => ({
-    getChromePath: vi.fn().mockReturnValue('/foo/bar')
-}))
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url))
 
 vi.mock('node:os', () => ({
     default: {
         tmpdir: vi.fn().mockReturnValue('/tmp'),
         platform: vi.fn().mockReturnValue('darwin')
     }
+}))
+
+vi.mock('locate-app', () => ({
+    locateChrome: vi.fn().mockResolvedValue('/path/to/chrome'),
+    locateFirefox: vi.fn().mockResolvedValue('/path/to/firefox')
 }))
 
 vi.mock('node:fs', () => ({
@@ -35,7 +41,11 @@ vi.mock('node:fs', () => ({
 vi.mock('node:fs/promises', () => ({
     default: {
         mkdir: vi.fn().mockResolvedValue({}),
-        access: vi.fn().mockResolvedValue({})
+        access: vi.fn().mockResolvedValue({}),
+        readFile: vi.fn(async () => {
+            const { readFileSync } = await vi.importActual<typeof fs>('node:fs')
+            return readFileSync(path.resolve(__dirname, '__fixtures__', 'application.ini'))
+        })
     }
 }))
 
@@ -46,7 +56,7 @@ vi.mock('node:child_process', () => ({
 }))
 
 vi.mock('@puppeteer/browsers', () => ({
-    Browser: { CHROME: 'chrome' },
+    Browser: { CHROME: 'chrome', FIREFOX: 'firefox' },
     ChromeReleaseChannel: { STABLE: 'stable' },
     detectBrowserPlatform: vi.fn(),
     resolveBuildId: vi.fn().mockReturnValue('116.0.5845.110'),
@@ -61,33 +71,35 @@ describe('driver utils', () => {
             .toMatchSnapshot()
     })
 
-    it('getLocalChromePath', () => {
-        expect(getLocalChromePath()).toBe('/foo/bar')
-        vi.mocked(getChromePath).mockImplementationOnce(() => { throw new Error('boom') })
-        expect(getLocalChromePath()).toBe(undefined)
-    })
-
-    it('getBuildIdByPath', () => {
-        expect(getBuildIdByPath()).toBe(undefined)
-        expect(getBuildIdByPath('/foo/bar')).toBe('116.0.5845.110')
+    it('getBuildIdByChromePath', () => {
+        expect(getBuildIdByChromePath()).toBe(undefined)
+        expect(getBuildIdByChromePath('/foo/bar')).toBe('115.0.5790.98')
 
         vi.mocked(os.platform).mockReturnValueOnce('win32')
-        expect(getBuildIdByPath('/foo/bar')).toBe('115.0.5790.110')
+        expect(getBuildIdByChromePath('/foo/bar')).toBe('115.0.5790.110')
     })
 
-    describe('setupChrome', () => {
+    it('getBuildIdByFirefoxPath', async () => {
+        expect(await getBuildIdByFirefoxPath()).toBe(undefined)
+        expect(await getBuildIdByFirefoxPath('/foo/bar')).toBe('115.0.5790.98')
+
+        vi.mocked(os.platform).mockReturnValueOnce('win32')
+        expect(await getBuildIdByFirefoxPath('/foo/bar')).toBe('116.0.3')
+    })
+
+    describe('setupPuppeteerBrowser', () => {
         beforeEach(() => {
             vi.mocked(resolveBuildId).mockClear()
         })
 
         it('should throw if platform is not supported', async () => {
             vi.mocked(detectBrowserPlatform).mockReturnValueOnce(undefined)
-            await expect(setupChrome('/foo/bar', {})).rejects.toThrow('The current platform is not supported.')
+            await expect(setupPuppeteerBrowser('/foo/bar', { browserName: 'chrome' })).rejects.toThrow('The current platform is not supported.')
         })
 
         it('should run setup for local chrome if browser version is omitted', async () => {
             vi.mocked(detectBrowserPlatform).mockReturnValueOnce('mac' as any)
-            await expect(setupChrome('/foo/bar', {})).resolves.toEqual({
+            await expect(setupPuppeteerBrowser('/foo/bar', {})).resolves.toEqual({
                 browserVersion: '116.0.5845.110',
                 executablePath: '/foo/bar'
             })
@@ -95,7 +107,7 @@ describe('driver utils', () => {
 
         it('should do nothing if browser binary is defined within caps', async () => {
             vi.mocked(detectBrowserPlatform).mockReturnValueOnce('mac' as any)
-            await expect(setupChrome('/foo/bar', {
+            await expect(setupPuppeteerBrowser('/foo/bar', {
                 'goog:chromeOptions': { binary: '/my/chrome' }
             })).resolves.toEqual({
                 browserVersion: '116.0.5845.110',
@@ -105,8 +117,8 @@ describe('driver utils', () => {
 
         it('should install chrome stable if browser is not found', async () => {
             vi.mocked(detectBrowserPlatform).mockReturnValueOnce('windows' as any)
-            vi.mocked(getChromePath).mockReturnValue('/path/to/stable')
-            await expect(setupChrome('/foo/bar', {})).resolves.toEqual( {
+            vi.mocked(locateChrome).mockReturnValue('/path/to/stable')
+            await expect(setupPuppeteerBrowser('/foo/bar', {})).resolves.toEqual( {
                 browserVersion: '116.0.5845.110',
                 executablePath: '/path/to/stable'
             })
@@ -115,13 +127,14 @@ describe('driver utils', () => {
         it('should throw if browser version is not found', async () => {
             vi.mocked(detectBrowserPlatform).mockReturnValueOnce('windows' as any)
             vi.mocked(canDownload).mockResolvedValueOnce(false)
-            vi.mocked(getChromePath).mockImplementationOnce(() => { throw new Error('boom') })
-            await expect(setupChrome('/foo/bar', {})).rejects.toThrow(/Couldn't find a matching Chrome browser /)
+            vi.mocked(locateChrome).mockRejectedValueOnce(new Error('not found'))
+            await expect(setupPuppeteerBrowser('/foo/bar', { browserName: 'chrome' }))
+                .rejects.toThrow(/Couldn't find a matching Chrome browser/)
         })
 
         it('should install chrome browser with specific version provided', async () => {
             vi.mocked(detectBrowserPlatform).mockReturnValueOnce('windows' as any)
-            await expect(setupChrome('/foo/bar', { browserVersion: '1.2.3' })).resolves.toEqual({
+            await expect(setupPuppeteerBrowser('/foo/bar', { browserVersion: '1.2.3' })).resolves.toEqual({
                 browserVersion: '116.0.5845.110',
                 executablePath: '/foo/bar/executable',
             })

--- a/packages/wdio-utils/tests/driver/utils.test.ts
+++ b/packages/wdio-utils/tests/driver/utils.test.ts
@@ -73,7 +73,7 @@ describe('driver utils', () => {
 
     it('getBuildIdByChromePath', () => {
         expect(getBuildIdByChromePath()).toBe(undefined)
-        expect(getBuildIdByChromePath('/foo/bar')).toBe('115.0.5790.98')
+        expect(getBuildIdByChromePath('/foo/bar')).toBe('116.0.5845.110')
 
         vi.mocked(os.platform).mockReturnValueOnce('win32')
         expect(getBuildIdByChromePath('/foo/bar')).toBe('115.0.5790.110')
@@ -81,7 +81,7 @@ describe('driver utils', () => {
 
     it('getBuildIdByFirefoxPath', async () => {
         expect(await getBuildIdByFirefoxPath()).toBe(undefined)
-        expect(await getBuildIdByFirefoxPath('/foo/bar')).toBe('115.0.5790.98')
+        expect(await getBuildIdByFirefoxPath('/foo/bar')).toBe('116.0.5845.110')
 
         vi.mocked(os.platform).mockReturnValueOnce('win32')
         expect(await getBuildIdByFirefoxPath('/foo/bar')).toBe('116.0.3')
@@ -101,7 +101,7 @@ describe('driver utils', () => {
             vi.mocked(detectBrowserPlatform).mockReturnValueOnce('mac' as any)
             await expect(setupPuppeteerBrowser('/foo/bar', {})).resolves.toEqual({
                 browserVersion: '116.0.5845.110',
-                executablePath: '/foo/bar'
+                executablePath: '/path/to/chrome'
             })
         })
 
@@ -117,7 +117,7 @@ describe('driver utils', () => {
 
         it('should install chrome stable if browser is not found', async () => {
             vi.mocked(detectBrowserPlatform).mockReturnValueOnce('windows' as any)
-            vi.mocked(locateChrome).mockReturnValue('/path/to/stable')
+            vi.mocked(locateChrome).mockResolvedValue('/path/to/stable')
             await expect(setupPuppeteerBrowser('/foo/bar', {})).resolves.toEqual( {
                 browserVersion: '116.0.5845.110',
                 executablePath: '/path/to/stable'
@@ -129,7 +129,7 @@ describe('driver utils', () => {
             vi.mocked(canDownload).mockResolvedValueOnce(false)
             vi.mocked(locateChrome).mockRejectedValueOnce(new Error('not found'))
             await expect(setupPuppeteerBrowser('/foo/bar', { browserName: 'chrome' }))
-                .rejects.toThrow(/Couldn't find a matching Chrome browser/)
+                .rejects.toThrow(/Couldn't find a matching chrome browser/)
         })
 
         it('should install chrome browser with specific version provided', async () => {

--- a/website/docs/Capabilities.md
+++ b/website/docs/Capabilities.md
@@ -247,7 +247,14 @@ When testing on Chrome, WebdriverIO will automatically download the desired brow
 </TabItem>
 <TabItem value="firefox">
 
-When testing on Firefox, make sure you have the desired browser version installed on your machine. You can point WebdriverIO to the browser to execute via:
+When testing on Firefox, you can let WebdriverIO setup Firefox Nightly for you by providing `latest` as `browserVersion`:
+
+```ts
+    browserName: 'firefox',
+    browserVersion: 'latest'
+```
+
+If you like to test a manually downloaded version you can provide a binary path to the browser via:
 
 ```ts
     browserName: 'firefox',


### PR DESCRIPTION
## Proposed changes

This patch enables downloading and setting up Firefox Nightly if `browserVersion` is set to `latest`.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Polish (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
