### PR TITLE
Mark old allure step methods as deprecated

### DIFF
--- a/packages/wdio-allure-reporter/README.md
+++ b/packages/wdio-allure-reporter/README.md
@@ -77,15 +77,6 @@ export const config = {
 * `addDescription(description, [type])` – add description to test.
     * `description` (*String*) - description of the test.
     * `type` (*String*, optional) – description type, `text` by default. Values ['text', 'html','markdown']
-* `addStep(title, [{content, name = 'attachment'}], [status])` - add step to test.
-    * `title` (*String*) - name of the step.
-    * `content` (*String*, optional) - step attachment
-    * `name` (*String*, optional) - step attachment name, `attachment` by default.
-    * `status` (*String*, optional) - step status, `passed` by default. Must be "failed", "passed" or "broken"
-* `startStep(title)` - start with a step
-    * `title` (*String*) - name of the step.
-* `endStep(status)` - end with a step
-    * `status` (*String*, optional) - step status, `passed` by default. Must be "failed", "passed" or "broken"
 * `step(name, body)` - starts step with content function inside. Allows to create steps with infinite hierarchy
     * `body` (*Function*) - the step body async function
 

--- a/packages/wdio-allure-reporter/src/common/api.ts
+++ b/packages/wdio-allure-reporter/src/common/api.ts
@@ -177,6 +177,7 @@ export function addAttachment (name: string, content: string | Buffer | object, 
 
 /**
  * Start allure step
+ * @deprecated use `step` method instead
  * @name startStep
  * @param {string} title - step name in report
  */
@@ -186,6 +187,7 @@ export function startStep (title: string) {
 
 /**
  * End current allure step
+ * @deprecated use `step` method instead
  * @name endStep
  * @param {StepStatus} [status='passed'] - step status
  */
@@ -198,6 +200,7 @@ export function endStep (status: Status = Status.PASSED) {
 
 /**
  * Create allure step
+ * @deprecated use `step` method instead
  * @name addStep
  * @param {string} title - step name in report
  * @param {object} [attachmentObject={}] - attachment for step


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

The PR marks `addStep`, `startStep` and `endStep` as deprecated. I also removed them from the documentation and left only `step` recommend method. The method `step` allows adding allure steps in a better way, so there is no need to use another ones.

I marked the PR containing breaking changes, but actually it doesn't remove the methods, just marks them as deprecated.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
