### PR TITLE
(@wdio/utils): respect custom binary paths in caps

### DIFF
--- a/packages/wdio-types/src/index.ts
+++ b/packages/wdio-types/src/index.ts
@@ -22,6 +22,10 @@ interface DriverOptions {
      * directory where browser and driver should be stored
      */
     cacheDir?: string
+    /**
+     * path to custom driver binary
+     */
+    binary?: string
 }
 
 declare global {

--- a/packages/wdio-utils/src/driver/index.ts
+++ b/packages/wdio-utils/src/driver/index.ts
@@ -76,7 +76,9 @@ export async function startWebDriver (options: Options.WebDriver) {
          */
         const chromedriverOptions = caps['wdio:chromedriverOptions'] || ({} as WebdriverIO.ChromedriverOptions)
         const { executablePath: chromeExecuteablePath, browserVersion } = await setupChrome(cacheDir, caps)
-        const { executablePath: chromedriverExcecuteablePath } = await setupChromedriver(cacheDir, browserVersion)
+        const { executablePath: chromedriverExcecuteablePath } = chromedriverOptions.binary
+            ? { executablePath: chromedriverOptions.binary }
+            : await setupChromedriver(cacheDir, browserVersion)
 
         caps['goog:chromeOptions'] = deepmerge(
             { binary: chromeExecuteablePath },

--- a/packages/wdio-utils/src/driver/utils.ts
+++ b/packages/wdio-utils/src/driver/utils.ts
@@ -134,8 +134,8 @@ export async function setupChrome(cacheDir: string, caps: Capabilities.Capabilit
     return { executablePath, browserVersion: buildId }
 }
 
-export function getCacheDir (options: Pick<Options.WebDriver, 'cacheDir'>, caps: Capabilities.Capabilities) {
-    const driverOptions: { cacheDir?: string } = (
+function getDriverOptions (caps: Capabilities.Capabilities) {
+    return (
         caps['wdio:chromedriverOptions'] ||
         caps['wdio:geckodriverOptions'] ||
         caps['wdio:edgedriverOptions'] ||
@@ -143,6 +143,10 @@ export function getCacheDir (options: Pick<Options.WebDriver, 'cacheDir'>, caps:
         // is installed on macOS
         {}
     )
+}
+
+export function getCacheDir (options: Pick<Options.WebDriver, 'cacheDir'>, caps: Capabilities.Capabilities) {
+    const driverOptions = getDriverOptions(caps)
     return driverOptions.cacheDir || options.cacheDir || os.tmpdir()
 }
 

--- a/packages/wdio-utils/tests/driver/utils.test.ts
+++ b/packages/wdio-utils/tests/driver/utils.test.ts
@@ -88,10 +88,18 @@ describe('driver utils', () => {
         it('should run setup for local chrome if browser version is omitted', async () => {
             vi.mocked(detectBrowserPlatform).mockReturnValueOnce('mac' as any)
             await expect(setupChrome('/foo/bar', {})).resolves.toEqual({
-                buildId: '115.0.5790.98',
-                cacheDir: '/foo/bar',
-                executablePath: '/foo/bar',
-                platform: 'mac'
+                browserVersion: '115.0.5790.98',
+                executablePath: '/foo/bar'
+            })
+        })
+
+        it('should do nothing if browser binary is defined within caps', async () => {
+            vi.mocked(detectBrowserPlatform).mockReturnValueOnce('mac' as any)
+            await expect(setupChrome('/foo/bar', {
+                'goog:chromeOptions': { binary: '/my/chrome' }
+            })).resolves.toEqual({
+                browserVersion: '115.0.5790.98',
+                executablePath: '/my/chrome'
             })
         })
 
@@ -99,10 +107,8 @@ describe('driver utils', () => {
             vi.mocked(detectBrowserPlatform).mockReturnValueOnce('windows' as any)
             vi.mocked(getChromePath).mockReturnValue('/path/to/stable')
             await expect(setupChrome('/foo/bar', {})).resolves.toEqual( {
-                buildId: '115.0.5790.98',
-                cacheDir: '/foo/bar',
-                executablePath: '/path/to/stable',
-                platform: 'windows'
+                browserVersion: '115.0.5790.98',
+                executablePath: '/path/to/stable'
             })
         })
 


### PR DESCRIPTION
## Proposed changes

This patch ensures that we don't set up Chrome or Chromedriver if a binary property is set in the configurations.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
