### PR TITLE
(@wdio/utils): have driver manager time out when trying to connect to driver

### DIFF
--- a/packages/wdio-utils/src/driver/index.ts
+++ b/packages/wdio-utils/src/driver/index.ts
@@ -32,6 +32,7 @@ declare global {
 }
 
 const log = logger('@wdio/utils')
+const DRIVER_WAIT_TIMEOUT = 10 * 1000 // 10s
 
 export async function startWebDriver (options: Options.WebDriver) {
     /**
@@ -153,7 +154,8 @@ export async function startWebDriver (options: Options.WebDriver) {
         driverProcess.stderr?.pipe(logStream)
     }
 
-    await waitPort({ port, output: 'silent' })
+    await waitPort({ port, output: 'silent', timeout: DRIVER_WAIT_TIMEOUT })
+        .catch((e) => { throw new Error(`Timed out to connect to ${driver}: ${e.message}`) })
 
     options.hostname = '0.0.0.0'
     options.port = port


### PR DESCRIPTION
## Proposed changes

A user reported that their test never started and just got stuck when setting up the driver. The reason why a driver might not boot up can be arbitrary but to avoid having stale processes around we should set a timeout.

fixes #11008

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Polish (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
