### PR TITLE
fix footer wrapping

### DIFF
--- a/website/src/theme/Footer/index.js
+++ b/website/src/theme/Footer/index.js
@@ -1,8 +1,9 @@
 import React from 'react'
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext'
+import Footer from '@theme-original/Footer'
 import { MendableFloatingButton } from '@mendable/search'
 
-export default function FooterWrapper() {
+export default function FooterWrapper(props) {
     const {
         siteConfig: { customFields },
     } = useDocusaurusContext()
@@ -30,6 +31,7 @@ export default function FooterWrapper() {
                 dialogPlaceholder='Why Webdriver.IO?'
                 welcomeMessage='Welcome! How can I help?'
             />
+            <Footer {...props} />
         </>
     )
 }


### PR DESCRIPTION
## Proposed changes

With the adjustments made in this change (#11017), the footer component has been overwritten. To address this, the footer is now been wrapped with the default properties placed in the config file. This internally fixes the `e2e` tests running against mac.

Live Version:
![Screenshot 2023-08-29 at 10 12 37 AM](https://github.com/webdriverio/webdriverio/assets/49207189/019891c5-a19d-44f1-9811-6d975d86d4e4)

Proposed Version:
![Screenshot 2023-08-29 at 10 13 23 AM](https://github.com/webdriverio/webdriverio/assets/49207189/d1a488bd-1c0d-4f69-a5b4-438bb840a574)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
