### PR TITLE
(@wdio/browser-runner): fix detection of mocked module

### DIFF
--- a/packages/wdio-browser-runner/src/vite/plugins/mockHoisting.ts
+++ b/packages/wdio-browser-runner/src/vite/plugins/mockHoisting.ts
@@ -187,8 +187,10 @@ export function mockHoisting(mockHandler: MockHandler): Plugin[] {
                             source.startsWith('.') &&
                             [...sessionMocks.values()].find((m) => {
                                 const fileImportPath = path.resolve(path.dirname(id), source)
+                                const fileImportPathSliced = fileImportPath.slice(0, path.extname(fileImportPath).length * -1)
                                 const testMockPath = path.resolve(path.dirname(spec || '/'), m)
-                                return fileImportPath.slice(0, path.extname(fileImportPath).length * -1) === testMockPath.slice(0, path.extname(testMockPath).length * -1)
+                                const testMockPathSliced = testMockPath.slice(0, path.extname(testMockPath).length * -1)
+                                return fileImportPathSliced === testMockPathSliced && fileImportPathSliced.length > 0
                             })
                         )
                     )


### PR DESCRIPTION
### Have you read the Contributing Guidelines on issues?

- [X] I have read the [Contributing Guidelines on issues](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md#reporting-new-issues).

### WebdriverIO Version

latest

### Node.js Version

latest

### Mode

WDIO Testrunner

### Which capabilities are you using?

```typescript
n/a
```


### What happened?

A module was detected as a mock because we compared their filepaths which all ended with a length 0, to fix here is a preliminary tweak:

```ts
// matches if a dependency is mocked
                        sessionMocks.has(source) ||
                            // matches if a relative file is mocked
                            (source.startsWith('.') &&
                                [...sessionMocks.values()].find((m) => {
                                    const fileImportPath = path.resolve(path.dirname(id), source);
                                    const testMockPath = path.resolve(path.dirname(spec || '/'), m);
                                    const fp = fileImportPath.slice(0, path.extname(fileImportPath).length * -1)
                                    return fp === testMockPath.slice(0, path.extname(testMockPath).length * -1) && fp.length > 0;
                                })));
```

### What is your expected behavior?

Module is correctly identified as mock or not.

### How to reproduce the bug.

Can't reproduce as I work on an internal project, will raise a PR myself for this.

### Relevant log output

```typescript
n/a
```


### Code of Conduct

- [X] I agree to follow this project's Code of Conduct

### Is there an existing issue for this?

- [X] I have searched the existing issues