### PR TITLE
devtools commands for multiremote

### DIFF
--- a/e2e/wdio/headless/multiremoteTest.e2e.ts
+++ b/e2e/wdio/headless/multiremoteTest.e2e.ts
@@ -18,4 +18,22 @@ describe('main suite 1', () => {
         await browserB.keys(Key.Enter)
         await expect(browserB.$('.inputMessage')).toHaveAttribute('placeHolder', 'Type here...')
     })
+
+    it('should return devtools result', async () => {
+        await browserA.url('https://webdriver.io')
+        await browserB.url('https://google.com')
+
+        const cookiesA = await browserA.cdp('Network', 'getCookies')
+        const cookiesB = await browserB.cdp('Network', 'getCookies')
+        const cookies = await browser.cdp('Network', 'getCookies')
+
+        expect(Object.keys(cookiesA).length).toBe(1)
+        expect(Object.keys(cookiesA)).toEqual(['cookies'])
+        expect(Object.keys(cookiesB).length).toBe(1)
+        expect(Object.keys(cookiesB)).toEqual(['cookies'])
+        expect(Object.keys(cookies).length).toBe(2)
+
+        const score = await browser.checkPWA()
+        expect(Object.keys(score).length).toBe(2)
+    })
 })

--- a/packages/wdio-devtools-service/src/commands.ts
+++ b/packages/wdio-devtools-service/src/commands.ts
@@ -8,32 +8,85 @@ import type { TracingOptions } from 'puppeteer-core/lib/esm/puppeteer/common/Tra
 import type { RequestPayload } from './handler/network.js'
 import NetworkHandler from './handler/network.js'
 
-import { DEFAULT_TRACING_CATEGORIES } from './constants.js'
+import { CLICK_TRANSITION, DEFAULT_THROTTLE_STATE, DEFAULT_TRACING_CATEGORIES, NETWORK_STATES } from './constants.js'
 import { sumByKey } from './utils.js'
+import type {
+    Device,
+    DeviceDescription, DevtoolsConfig,
+    EnablePerformanceAuditsOptions,
+    FormFactor,
+    GathererDriver,
+    PWAAudits
+} from './types'
+import { KnownDevices } from 'puppeteer-core'
+import type { CDPSessionOnMessageObject } from './gatherer/devtools.js'
+import DevtoolsGatherer from './gatherer/devtools.js'
+import Auditor from './auditor.js'
+import PWAGatherer from './gatherer/pwa.js'
+import TraceGatherer from './gatherer/trace.js'
+import CoverageGatherer from './gatherer/coverage.js'
 
 const log = logger('@wdio/devtools-service:CommandHandler')
+const TRACE_COMMANDS = ['click', 'navigateTo', 'url']
+
+function isCDPSessionOnMessageObject(
+    data: any
+): data is CDPSessionOnMessageObject {
+    return (
+        data !== null &&
+        typeof data === 'object' &&
+        Object.prototype.hasOwnProperty.call(data, 'params') &&
+        Object.prototype.hasOwnProperty.call(data, 'method')
+    )
+}
 
 export default class CommandHandler {
     private _isTracing = false
     private _networkHandler: NetworkHandler
     private _traceEvents?: TraceEvent[]
 
+    private _shouldRunPerformanceAudits = false
+
+    private _cacheEnabled?: boolean
+    private _cpuThrottling?: number
+    private _networkThrottling?: keyof typeof NETWORK_STATES
+    private _formFactor?: FormFactor
+
+    private _traceGatherer?: TraceGatherer
+    private _devtoolsGatherer?: DevtoolsGatherer
+    private _coverageGatherer?: CoverageGatherer
+    private _pwaGatherer?: PWAGatherer
+
     constructor (
         private _session: CDPSession,
         private _page: Page,
-        browser: WebdriverIO.Browser | WebdriverIO.MultiRemoteBrowser
+        private _driver: GathererDriver,
+        private _options: DevtoolsConfig,
+        private _browser: WebdriverIO.Browser | WebdriverIO.MultiRemoteBrowser
     ) {
         this._networkHandler = new NetworkHandler(_session)
+        this._traceGatherer = new TraceGatherer(_session, _page, _driver)
+        this._pwaGatherer = new PWAGatherer(_session, _page, _driver)
+
+        _session.on('Page.loadEventFired', this._traceGatherer.onLoadEventFired.bind(this._traceGatherer))
+        _session.on('Page.frameNavigated', this._traceGatherer.onFrameNavigated.bind(this._traceGatherer))
+
+        _page.on('requestfailed', this._traceGatherer.onFrameLoadFail.bind(this._traceGatherer))
+
+        this._pwaGatherer = new PWAGatherer(_session, _page, _driver)
 
         /**
          * register browser commands
          */
         const commands = Object.getOwnPropertyNames(Object.getPrototypeOf(this)).filter(
             fnName => fnName !== 'constructor' && !fnName.startsWith('_'))
-        commands.forEach(fnName => browser.addCommand(
+        commands.forEach(fnName => _browser.addCommand(
             fnName,
             this[fnName as keyof CommandHandler].bind(this)
         ))
+
+        this._devtoolsGatherer = new DevtoolsGatherer()
+        _session.on('*', this._propagateWSEvents.bind(this))
     }
 
     /**
@@ -131,5 +184,179 @@ export default class CommandHandler {
         const transferred = sumByKey(requestTypes, 'encoded')
         const requestCount = sumByKey(requestTypes, 'count')
         return { pageWeight, transferred, requestCount, details: this._networkHandler.requestTypes }
+    }
+
+    /**
+     * set flag to run performance audits for page transitions
+     */
+    enablePerformanceAudits ({ networkThrottling, cpuThrottling, cacheEnabled, formFactor }: EnablePerformanceAuditsOptions = DEFAULT_THROTTLE_STATE) {
+        if (!NETWORK_STATES[networkThrottling]) {
+            throw new Error(`Network throttling profile "${networkThrottling}" is unknown, choose between ${Object.keys(NETWORK_STATES).join(', ')}`)
+        }
+
+        if (typeof cpuThrottling !== 'number') {
+            throw new Error(`CPU throttling rate needs to be typeof number but was "${typeof cpuThrottling}"`)
+        }
+
+        this._networkThrottling = networkThrottling
+        this._cpuThrottling = cpuThrottling
+        this._cacheEnabled = Boolean(cacheEnabled)
+        this._formFactor = formFactor
+        this._shouldRunPerformanceAudits = true
+    }
+
+    /**
+     * custom command to disable performance audits
+     */
+    disablePerformanceAudits () {
+        this._shouldRunPerformanceAudits = false
+    }
+
+    /**
+     * set device emulation
+     */
+    async emulateDevice (device: string | DeviceDescription, inLandscape?: boolean) {
+        if (!this._page) {
+            throw new Error('No page has been captured yet')
+        }
+
+        if (typeof device === 'string') {
+            const deviceName = device + (inLandscape ? ' landscape' : '') as keyof typeof KnownDevices
+            const deviceCapabilities = KnownDevices[deviceName]
+            if (!deviceCapabilities) {
+                const deviceNames = Object.values(KnownDevices)
+                    .map((device: Device) => device.name)
+                    .filter((device: string) => !device.endsWith('landscape'))
+                throw new Error(`Unknown device, available options: ${deviceNames.join(', ')}`)
+            }
+
+            return this._page.emulate(deviceCapabilities)
+        }
+
+        return this._page.emulate(device)
+    }
+
+    /**
+     * helper method to set throttling profile
+     */
+    async setThrottlingProfile(
+        networkThrottling = DEFAULT_THROTTLE_STATE.networkThrottling,
+        cpuThrottling: number = DEFAULT_THROTTLE_STATE.cpuThrottling,
+        cacheEnabled: boolean = DEFAULT_THROTTLE_STATE.cacheEnabled
+    ) {
+        if (!this._page || !this._session) {
+            throw new Error('No page or session has been captured yet')
+        }
+
+        await this._page.setCacheEnabled(Boolean(cacheEnabled))
+        await this._session.send('Emulation.setCPUThrottlingRate', { rate: cpuThrottling })
+        await this._session.send('Network.emulateNetworkConditions', NETWORK_STATES[networkThrottling])
+    }
+
+    async checkPWA (auditsToBeRun?: PWAAudits[]) {
+        const auditor = new Auditor()
+        const artifacts = await this._pwaGatherer!.gatherData()
+        return auditor._auditPWA(artifacts, auditsToBeRun)
+    }
+
+    getCoverageReport () {
+        return this._coverageGatherer!.getCoverageReport()
+    }
+
+    async _logCoverage() {
+        if (this._coverageGatherer) {
+            await this._coverageGatherer.logCoverage()
+        }
+    }
+
+    private _propagateWSEvents (data: any) {
+        if (!isCDPSessionOnMessageObject(data)) {
+            return
+        }
+
+        this._devtoolsGatherer?.onMessage(data)
+        const method = data.method || 'event'
+        try {
+            // can fail due to "Cannot convert a Symbol value to a string"
+            log.debug(`cdp event: ${method} with params ${JSON.stringify(data.params)}`)
+        } catch {
+            // ignore
+        }
+        if (this._browser) {
+            this._browser.emit(method, data.params)
+        }
+    }
+
+    async _initCommand () {
+        /**
+         * register coverage gatherer if options is set by user
+         */
+        if (this._options.coverageReporter?.enable) {
+            this._coverageGatherer = new CoverageGatherer(this._page, this._options.coverageReporter)
+            this._browser.addCommand('getCoverageReport', this.getCoverageReport.bind(this))
+            await this._coverageGatherer.init()
+        }
+
+        /**
+         * enable domains for client
+         */
+        await Promise.all(['Page', 'Network', 'Runtime'].map(
+            (domain) => Promise.all([
+                this._session?.send(`${domain}.enable` as any)
+            ])
+        ))
+    }
+
+    _beforeCmd (commandName: string, params: any[]) {
+        const isCommandNavigation = ['url', 'navigateTo'].some(cmdName => cmdName === commandName)
+        if (!this._shouldRunPerformanceAudits || !this._traceGatherer || this._traceGatherer.isTracing || !TRACE_COMMANDS.includes(commandName)) {
+            return
+        }
+
+        /**
+         * set browser profile
+         */
+        this.setThrottlingProfile(this._networkThrottling, this._cpuThrottling, this._cacheEnabled)
+
+        const url = isCommandNavigation
+            ? params[0]
+            : CLICK_TRANSITION
+        return this._traceGatherer.startTracing(url)
+    }
+
+    _afterCmd (commandName: string) {
+        if (!this._traceGatherer || !this._traceGatherer.isTracing || !TRACE_COMMANDS.includes(commandName)) {
+            return
+        }
+
+        /**
+         * update custom commands once tracing finishes
+         */
+        this._traceGatherer.once('tracingComplete', (traceEvents) => {
+            const auditor = new Auditor(traceEvents, this._devtoolsGatherer?.getLogs(), this._formFactor)
+            auditor.updateCommands(this._browser as WebdriverIO.Browser)
+        })
+
+        this._traceGatherer.once('tracingError', (err: Error) => {
+            const auditor = new Auditor()
+            auditor.updateCommands(this._browser as WebdriverIO.Browser, /* istanbul ignore next */() => {
+                throw new Error(`Couldn't capture performance due to: ${err.message}`)
+            })
+        })
+
+        return new Promise<void>((resolve) => {
+            log.info(`Wait until tracing for command ${commandName} finishes`)
+
+            /**
+             * wait until tracing stops
+             */
+            this._traceGatherer?.once('tracingFinished', async () => {
+                log.info('Disable throttling')
+                await this.setThrottlingProfile('online', 0, true)
+
+                log.info('continuing with next WebDriver command')
+                resolve()
+            })
+        })
     }
 }

--- a/packages/wdio-devtools-service/src/index.ts
+++ b/packages/wdio-devtools-service/src/index.ts
@@ -1,69 +1,29 @@
-import logger from '@wdio/logger'
-import { KnownDevices } from 'puppeteer-core'
-
 import type { Capabilities, Services, FunctionProperties, ThenArg } from '@wdio/types'
-import type { Page } from 'puppeteer-core/lib/esm/puppeteer/api/Page.js'
-import type { CDPSession } from 'puppeteer-core/lib/esm/puppeteer/common/Connection.js'
 import type { Browser as PuppeteerBrowser } from 'puppeteer-core/lib/esm/puppeteer/api/Browser.js'
-import type { Target } from 'puppeteer-core/lib/esm/puppeteer/common/Target.js'
 
 import CommandHandler from './commands.js'
-import Auditor from './auditor.js'
-import PWAGatherer from './gatherer/pwa.js'
-import TraceGatherer from './gatherer/trace.js'
-import CoverageGatherer from './gatherer/coverage.js'
-import type { CDPSessionOnMessageObject } from './gatherer/devtools.js'
-import DevtoolsGatherer from './gatherer/devtools.js'
+import type Auditor from './auditor.js'
 import { setUnsupportedCommand, getLighthouseDriver } from './utils.js'
-import { NETWORK_STATES, CLICK_TRANSITION, DEFAULT_THROTTLE_STATE } from './constants.js'
+import { DEFAULT_THROTTLE_STATE, NETWORK_STATES } from './constants.js'
 import type {
-    DevtoolsConfig, FormFactor, EnablePerformanceAuditsOptions,
-    DeviceDescription, Device, PWAAudits, GathererDriver
+    DevtoolsConfig, EnablePerformanceAuditsOptions,
+    DeviceDescription, PWAAudits
 } from './types.js'
 
-const log = logger('@wdio/devtools-service')
-const TRACE_COMMANDS = ['click', 'navigateTo', 'url']
-
-function isCDPSessionOnMessageObject(
-    data: any
-): data is CDPSessionOnMessageObject {
-    return (
-        data !== null &&
-        typeof data === 'object' &&
-        Object.prototype.hasOwnProperty.call(data, 'params') &&
-        Object.prototype.hasOwnProperty.call(data, 'method')
-    )
-}
-
 export default class DevToolsService implements Services.ServiceInstance {
-    private _shouldRunPerformanceAudits = false
+    private _command: CommandHandler[] = []
 
-    private _puppeteer?: PuppeteerBrowser
-    private _target?: Target
-    private _page: Page | null = null
-    private _session?: CDPSession
-    private _driver?: GathererDriver
-
-    private _cacheEnabled?: boolean
-    private _cpuThrottling?: number
-    private _networkThrottling?: keyof typeof NETWORK_STATES
-    private _formFactor?: FormFactor
-
-    private _traceGatherer?: TraceGatherer
-    private _devtoolsGatherer?: DevtoolsGatherer
-    private _coverageGatherer?: CoverageGatherer
-    private _pwaGatherer?: PWAGatherer
     private _browser?: WebdriverIO.Browser | WebdriverIO.MultiRemoteBrowser
 
     constructor (private _options: DevtoolsConfig) {}
 
-    before (
+    async before (
         caps: Capabilities.RemoteCapability,
         specs: string[],
         browser: WebdriverIO.Browser | WebdriverIO.MultiRemoteBrowser
     ) {
         this._browser = browser
-        return this._setupHandler()
+        return await this._setupHandler()
     }
 
     async onReload () {
@@ -75,61 +35,16 @@ export default class DevToolsService implements Services.ServiceInstance {
     }
 
     async beforeCommand (commandName: string, params: any[]) {
-        const isCommandNavigation = ['url', 'navigateTo'].some(cmdName => cmdName === commandName)
-        if (!this._shouldRunPerformanceAudits || !this._traceGatherer || this._traceGatherer.isTracing || !TRACE_COMMANDS.includes(commandName)) {
-            return
-        }
-
-        /**
-         * set browser profile
-         */
-        this._setThrottlingProfile(this._networkThrottling, this._cpuThrottling, this._cacheEnabled)
-
-        const url = isCommandNavigation
-            ? params[0]
-            : CLICK_TRANSITION
-        return this._traceGatherer.startTracing(url)
+        return Promise.all(this._command.map(async c => await c._beforeCmd(commandName, params)))
     }
 
     async afterCommand (commandName: string) {
-        if (!this._traceGatherer || !this._traceGatherer.isTracing || !TRACE_COMMANDS.includes(commandName)) {
-            return
-        }
-
-        /**
-         * update custom commands once tracing finishes
-         */
-        this._traceGatherer.once('tracingComplete', (traceEvents) => {
-            const auditor = new Auditor(traceEvents, this._devtoolsGatherer?.getLogs(), this._formFactor)
-            auditor.updateCommands(this._browser as WebdriverIO.Browser)
-        })
-
-        this._traceGatherer.once('tracingError', (err: Error) => {
-            const auditor = new Auditor()
-            auditor.updateCommands(this._browser as WebdriverIO.Browser, /* istanbul ignore next */() => {
-                throw new Error(`Couldn't capture performance due to: ${err.message}`)
-            })
-        })
-
-        return new Promise<void>((resolve) => {
-            log.info(`Wait until tracing for command ${commandName} finishes`)
-
-            /**
-             * wait until tracing stops
-             */
-            this._traceGatherer?.once('tracingFinished', async () => {
-                log.info('Disable throttling')
-                await this._setThrottlingProfile('online', 0, true)
-
-                log.info('continuing with next WebDriver command')
-                resolve()
-            })
-        })
+        return Promise.all(this._command.map(async c => await c._afterCmd(commandName)))
     }
 
     async after () {
-        if (this._coverageGatherer) {
-            await this._coverageGatherer.logCoverage()
+        for (const c of this._command) {
+            await c._logCoverage()
         }
     }
 
@@ -145,69 +60,74 @@ export default class DevToolsService implements Services.ServiceInstance {
             throw new Error(`CPU throttling rate needs to be typeof number but was "${typeof cpuThrottling}"`)
         }
 
-        this._networkThrottling = networkThrottling
-        this._cpuThrottling = cpuThrottling
-        this._cacheEnabled = Boolean(cacheEnabled)
-        this._formFactor = formFactor
-        this._shouldRunPerformanceAudits = true
+        if (this._command.length === 1) {
+            this._command[0].enablePerformanceAudits({ networkThrottling, cpuThrottling, cacheEnabled, formFactor })
+        } else {
+            for (const c of this._command) {
+                c.enablePerformanceAudits({ networkThrottling, cpuThrottling, cacheEnabled, formFactor })
+            }
+        }
     }
 
     /**
      * custom command to disable performance audits
      */
     _disablePerformanceAudits () {
-        this._shouldRunPerformanceAudits = false
+        if (this._command.length === 1) {
+            this._command[0].disablePerformanceAudits()
+        } else {
+            for (const c of this._command) {
+                c.disablePerformanceAudits()
+            }
+        }
     }
 
     /**
      * set device emulation
      */
     async _emulateDevice (device: string | DeviceDescription, inLandscape?: boolean) {
-        if (!this._page) {
-            throw new Error('No page has been captured yet')
+        if (this._command.length === 1) {
+            return await this._command[0].emulateDevice(device, inLandscape)
         }
 
-        if (typeof device === 'string') {
-            const deviceName = device + (inLandscape ? ' landscape' : '') as keyof typeof KnownDevices
-            const deviceCapabilities = KnownDevices[deviceName]
-            if (!deviceCapabilities) {
-                const deviceNames = Object.values(KnownDevices)
-                    .map((device: Device) => device.name)
-                    .filter((device: string) => !device.endsWith('landscape'))
-                throw new Error(`Unknown device, available options: ${deviceNames.join(', ')}`)
-            }
-
-            return this._page.emulate(deviceCapabilities)
-        }
-
-        return this._page.emulate(device)
+        return Promise.all(this._command.map(async c => await c.emulateDevice(device, inLandscape)))
     }
 
-    /**
-     * helper method to set throttling profile
-     */
     async _setThrottlingProfile(
         networkThrottling = DEFAULT_THROTTLE_STATE.networkThrottling,
         cpuThrottling: number = DEFAULT_THROTTLE_STATE.cpuThrottling,
         cacheEnabled: boolean = DEFAULT_THROTTLE_STATE.cacheEnabled
     ) {
-        if (!this._page || !this._session) {
-            throw new Error('No page or session has been captured yet')
+        if (this._command.length === 1) {
+            this._command[0].setThrottlingProfile(networkThrottling, cpuThrottling, cacheEnabled)
+        } else {
+            for (const c of this._command) {
+                c.setThrottlingProfile(networkThrottling, cpuThrottling, cacheEnabled)
+            }
         }
-
-        await this._page.setCacheEnabled(Boolean(cacheEnabled))
-        await this._session.send('Emulation.setCPUThrottlingRate', { rate: cpuThrottling })
-        await this._session.send('Network.emulateNetworkConditions', NETWORK_STATES[networkThrottling])
     }
 
     async _checkPWA (auditsToBeRun?: PWAAudits[]) {
-        const auditor = new Auditor()
-        const artifacts = await this._pwaGatherer!.gatherData()
-        return auditor._auditPWA(artifacts, auditsToBeRun)
+        if (this._command.length === 1) {
+            return await this._command[0].checkPWA(auditsToBeRun)
+        }
+        return Promise.all(this._command.map(async c => await c.checkPWA(auditsToBeRun)))
     }
 
-    _getCoverageReport () {
-        return this._coverageGatherer!.getCoverageReport()
+    async _getCoverageReport () {
+        if (this._command.length === 1) {
+            return this._command[0].getCoverageReport()
+        }
+
+        return await Promise.all(this._command.map(c => c.getCoverageReport()))
+    }
+
+    _cdp (domain: string, command: string, args = {}) {
+        if (this._command.length === 1) {
+            return this._command[0].cdp(domain, command, args)
+        }
+
+        return Promise.all(this._command.map(async c => await c.cdp(domain, command, args)))
     }
 
     async _setupHandler () {
@@ -216,95 +136,57 @@ export default class DevToolsService implements Services.ServiceInstance {
         }
 
         /**
-         * casting is required as types differ between core and definitely typed types
+         * To avoid if-else, gather all browser instances into an array
          */
-        this._puppeteer = await (this._browser as WebdriverIO.Browser).getPuppeteer().catch(() => undefined) as any as PuppeteerBrowser
-        if (!this._puppeteer) {
-            return setUnsupportedCommand(this._browser as WebdriverIO.Browser)
-        }
+        const browsers = Object.keys(this._browser).includes('sessionId') ?
+            [this._browser] :
+            (this._browser as WebdriverIO.MultiRemoteBrowser).instances.map(i => (this._browser as WebdriverIO.MultiRemoteBrowser).getInstance(i))
 
-        /* istanbul ignore next */
-        if (!this._puppeteer) {
-            throw new Error('Could not initiate Puppeteer instance')
-        }
+        for (const browser of browsers) {
+            const puppeteer = await (browser as WebdriverIO.Browser).getPuppeteer().catch(() => undefined) as any as PuppeteerBrowser
+            if (!puppeteer) {
+                return setUnsupportedCommand(browser as WebdriverIO.Browser)
+            }
 
-        this._target = await this._puppeteer.waitForTarget(
             /* istanbul ignore next */
-            (t) => t.type() === 'page' || Boolean(t._getTargetInfo().browserContextId))
+            if (!puppeteer) {
+                throw new Error('Could not initiate Puppeteer instance')
+            }
 
-        /* istanbul ignore next */
-        if (!this._target) {
-            throw new Error('No page target found')
+            const target = await puppeteer.waitForTarget(
+                /* istanbul ignore next */
+                (t) => t.type() === 'page' || Boolean(t._getTargetInfo().browserContextId))
+
+            /* istanbul ignore next */
+            if (!target) {
+                throw new Error('No page target found')
+            }
+
+            const page = await target.page() || null
+            /* istanbul ignore next */
+            if (!page) {
+                throw new Error('No page found')
+            }
+
+            const session = await target.createCDPSession()
+            const driver = await getLighthouseDriver(session, target)
+
+            const cmd = new CommandHandler(session, page, driver, this._options, browser)
+            await cmd._initCommand()
+            this._command.push(cmd)
         }
-
-        this._page = await this._target.page() || null
-        /* istanbul ignore next */
-        if (!this._page) {
-            throw new Error('No page found')
-        }
-
-        this._session = await this._target.createCDPSession()
-        this._driver = await getLighthouseDriver(this._session, this._target)
-
-        new CommandHandler(this._session, this._page, this._browser)
-        this._traceGatherer = new TraceGatherer(this._session, this._page, this._driver)
-
-        this._session.on('Page.loadEventFired', this._traceGatherer.onLoadEventFired.bind(this._traceGatherer))
-        this._session.on('Page.frameNavigated', this._traceGatherer.onFrameNavigated.bind(this._traceGatherer))
-
-        this._page.on('requestfailed', this._traceGatherer.onFrameLoadFail.bind(this._traceGatherer))
-
-        /**
-         * enable domains for client
-         */
-        await Promise.all(['Page', 'Network', 'Runtime'].map(
-            (domain) => Promise.all([
-                this._session?.send(`${domain}.enable` as any)
-            ])
-        ))
-
-        /**
-         * register coverage gatherer if options is set by user
-         */
-        if (this._options.coverageReporter?.enable) {
-            this._coverageGatherer = new CoverageGatherer(this._page, this._options.coverageReporter)
-            this._browser.addCommand('getCoverageReport', this._getCoverageReport.bind(this))
-            await this._coverageGatherer.init()
-        }
-
-        this._devtoolsGatherer = new DevtoolsGatherer()
-        this._session.on('*', this._propagateWSEvents.bind(this))
 
         this._browser.addCommand('enablePerformanceAudits', this._enablePerformanceAudits.bind(this))
         this._browser.addCommand('disablePerformanceAudits', this._disablePerformanceAudits.bind(this))
         this._browser.addCommand('emulateDevice', this._emulateDevice.bind(this))
-
-        this._pwaGatherer = new PWAGatherer(this._session, this._page, this._driver)
         this._browser.addCommand('checkPWA', this._checkPWA.bind(this))
-    }
-
-    private _propagateWSEvents (data: any) {
-        if (!isCDPSessionOnMessageObject(data)) {
-            return
-        }
-
-        this._devtoolsGatherer?.onMessage(data)
-        const method = data.method || 'event'
-        try {
-            // can fail due to "Cannot convert a Symbol value to a string"
-            log.debug(`cdp event: ${method} with params ${JSON.stringify(data.params)}`)
-        } catch {
-            // ignore
-        }
-        if (this._browser) {
-            this._browser.emit(method, data.params)
-        }
+        this._browser.addCommand('getCoverageReport', this._getCoverageReport.bind(this))
+        this._browser.addCommand('cdp', this._cdp.bind(this))
     }
 }
 
 export * from './types.js'
 
-type ServiceCommands = Omit<FunctionProperties<DevToolsService>, keyof Services.HookFunctions | '_setupHandler'>
 type CommandHandlerCommands = FunctionProperties<CommandHandler>
 type AuditorCommands = Omit<FunctionProperties<Auditor>, '_audit' | '_auditPWA' | 'updateCommands'>
 
@@ -312,36 +194,7 @@ type AuditorCommands = Omit<FunctionProperties<Auditor>, '_audit' | '_auditPWA' 
  * ToDo(Christian): use key remapping with TS 4.1
  * https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-1.html#key-remapping-in-mapped-types
  */
-interface BrowserExtension extends CommandHandlerCommands, AuditorCommands {
-    /**
-     * Enables auto performance audits for all page loads that are cause by calling the url command or clicking on a link or anything that causes a page load.
-     * You can pass in a config object to determine some throttling options. The default throttling profile is Good 3G network with a 4x CPU trottling.
-     */
-    enablePerformanceAudits: ServiceCommands['_enablePerformanceAudits']
-    /**
-     * Disable the performance audits
-     */
-    disablePerformanceAudits: ServiceCommands['_disablePerformanceAudits']
-    /**
-     * The service allows you to emulate a specific device type.
-     * If set, the browser viewport will be modified to fit the device capabilities as well as the user agent will set according to the device user agent.
-     * Note: This only works if you don't use mobileEmulation within capabilities['goog:chromeOptions']. If mobileEmulation is present the call to browser.emulateDevice() won't do anything.
-     */
-    emulateDevice: ServiceCommands['_emulateDevice']
-    /**
-     * Throttle network speed of the browser.
-     */
-    setThrottlingProfile: ServiceCommands['_setThrottlingProfile']
-    /**
-     * Runs various PWA Lighthouse audits on the current opened page.
-     * Read more about Lighthouse PWA audits at https://web.dev/lighthouse-pwa/.
-     */
-    checkPWA: ServiceCommands['_checkPWA']
-    /**
-     * Returns the coverage report for the current opened page.
-     */
-    getCoverageReport: ServiceCommands['_getCoverageReport']
-}
+interface BrowserExtension extends CommandHandlerCommands, AuditorCommands {}
 
 export type BrowserExtensionSync = {
     [K in keyof BrowserExtension]: (...args: Parameters<BrowserExtension[K]>) => ThenArg<ReturnType<BrowserExtension[K]>>

--- a/packages/wdio-devtools-service/tests/__snapshots__/commands.test.ts.snap
+++ b/packages/wdio-devtools-service/tests/__snapshots__/commands.test.ts.snap
@@ -1,0 +1,20 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`emulateDevice 1`] = `
+[
+  [
+    {
+      "name": "Nexus 6P",
+      "userAgent": "Mozilla/5.0 (Linux; Android 8.0.0; Nexus 6P Build/OPP3.170518.006) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Mobile Safari/537.36",
+      "viewport": {
+        "deviceScaleFactor": 3.5,
+        "hasTouch": true,
+        "height": 732,
+        "isLandscape": false,
+        "isMobile": true,
+        "width": 412,
+      },
+    },
+  ],
+]
+`;

--- a/packages/wdio-devtools-service/tests/commands.test.ts
+++ b/packages/wdio-devtools-service/tests/commands.test.ts
@@ -1,7 +1,9 @@
 import path from 'node:path'
+import { EventEmitter } from 'node:events'
 import { expect, test, vi, beforeEach } from 'vitest'
 import type { CDPSession } from 'puppeteer-core/lib/esm/puppeteer/common/Connection.js'
 import type { Page } from 'puppeteer-core/lib/esm/puppeteer/api/Page.js'
+import Auditor from '../src/auditor.js'
 
 import CommandHandler from '../src/commands.js'
 
@@ -12,7 +14,40 @@ vi.mock('../src/utils', () => ({
     sumByKey: vi.fn().mockReturnValue('foobar')
 }))
 
+vi.mock('../src/auditor', () => {
+    const updateCommandsMock = vi.fn()
+    return {
+        default: class {
+            traceEvents: any
+            logs: any
+            updateCommands = updateCommandsMock
+
+            constructor (traceEvents: any, logs: any) {
+                this.traceEvents = traceEvents
+                this.logs = logs
+            }
+        }
+    }
+})
+
+vi.mock('../src/gatherer/coverage', () => {
+    const instances: any[] = []
+    return {
+        default: class {
+            getCoverageReport = vi.fn()
+            init = vi.fn()
+
+            constructor () {
+                instances.push(this)
+            }
+        }
+    }
+})
+
 const pageMock = {
+    setCacheEnabled: vi.fn(),
+    emulate: vi.fn(),
+    on: vi.fn(),
     tracing: {
         start: vi.fn(),
         stop: vi.fn()
@@ -25,33 +60,62 @@ const sessionMock = {
     send: vi.fn()
 }
 
+const driverMock = {}
+
+const options = {}
+
 const browser: any = {
-    addCommand: vi.fn()
+    addCommand: vi.fn(),
+    emit: vi.fn()
 }
 
 beforeEach(() => {
+    pageMock.on.mockClear()
     pageMock.tracing.start.mockClear()
     pageMock.tracing.stop.mockClear()
     sessionMock.on.mockClear()
-    sessionMock.emit.mockClear()
+    // sessionMock.emit.mockClear()
     sessionMock.send.mockClear()
     browser.addCommand.mockReset()
 })
 
-test('initialization', () => {
-    new CommandHandler(
+test('initialization', async () => {
+    const handler = new CommandHandler(
         sessionMock as any,
         pageMock as any,
+        driverMock as any,
+        {
+            coverageReporter: {
+                enable: true
+            }
+        },
         browser as any
     )
-    expect(browser.addCommand.mock.calls).toHaveLength(7)
+    await handler._initCommand()
+
+    expect(browser.addCommand.mock.calls).toHaveLength(14)
     expect(sessionMock.on).toBeCalled()
+    expect(pageMock.on).toBeCalled()
+
+    expect(handler['_session']?.send).toBeCalledWith('Network.enable')
+    expect(handler['_session']?.send).toBeCalledWith('Runtime.enable')
+    expect(handler['_session']?.send).toBeCalledWith('Page.enable')
+
+    handler['_devtoolsGatherer'] = { onMessage: vi.fn() } as any
+    handler['_propagateWSEvents']({ method: 'foo', params: 'bar' })
+    expect(handler['_devtoolsGatherer']?.onMessage).toBeCalledTimes(1)
+    expect(handler['_devtoolsGatherer']?.onMessage).toBeCalledWith({ method:'foo', params: 'bar' })
+    expect((handler['_browser'] as any).emit).toBeCalledTimes(1)
+    expect((handler['_browser'] as any).emit).toBeCalledWith('foo', 'bar')
+    expect(handler['_coverageGatherer']!.init).toBeCalledTimes(1)
 })
 
 test('getTraceLogs', () => {
     const commander = new CommandHandler(
         sessionMock as unknown as CDPSession,
         pageMock as unknown as Page,
+        driverMock as any,
+        options as any,
         browser
     )
     commander['_traceEvents'] = [{ foo: 'bar' }] as any
@@ -63,6 +127,8 @@ test('cdp', async () => {
     const handler = new CommandHandler(
         sessionMock as any,
         pageMock as any,
+        driverMock as any,
+        options as any,
         browser as any
     )
     expect(await handler.cdp('Network', 'enable')).toBe('foobar')
@@ -75,6 +141,8 @@ test('getNodeId', async () => {
     const handler = new CommandHandler(
         sessionMock as any,
         pageMock as any,
+        driverMock as any,
+        options as any,
         browser as any
     )
 
@@ -91,6 +159,8 @@ test('getNodeIds', async () => {
     const handler = new CommandHandler(
         sessionMock as any,
         pageMock as any,
+        driverMock as any,
+        options as any,
         browser as any
     )
 
@@ -105,6 +175,8 @@ test('startTracing', () => {
     const handler = new CommandHandler(
         sessionMock as any,
         pageMock as any,
+        driverMock as any,
+        options as any,
         browser as any
     )
     handler.startTracing()
@@ -119,6 +191,8 @@ test('endTracing', async () => {
     const handler = new CommandHandler(
         sessionMock as any,
         pageMock as any,
+        driverMock as any,
+        options as any,
         browser as any
     )
     handler['_isTracing'] = true
@@ -133,6 +207,8 @@ test('endTracing throws if not tracing', async () => {
     const handler = new CommandHandler(
         sessionMock as any,
         pageMock as any,
+        driverMock as any,
+        options as any,
         browser as any
     )
     const err = await handler.endTracing().catch((err) => err)
@@ -144,6 +220,8 @@ test('endTracing throws if parsing of trace events fails', async () => {
     const handler = new CommandHandler(
         sessionMock as any,
         pageMock as any,
+        driverMock as any,
+        options as any,
         browser as any
     )
     handler['_isTracing'] = true
@@ -155,6 +233,8 @@ test('getPageWeight', () => {
     const handler = new CommandHandler(
         sessionMock as any,
         pageMock as any,
+        driverMock as any,
+        options as any,
         browser as any
     )
     handler['_networkHandler'].requestTypes = {
@@ -168,4 +248,255 @@ test('getPageWeight', () => {
     expect(transferred).toBe('foobar')
     expect(requestCount).toBe('foobar')
     expect(details).toEqual(handler['_networkHandler'].requestTypes)
+})
+
+test('beforeCmd', () => {
+    const handler = new CommandHandler(
+        sessionMock as any,
+        pageMock as any,
+        driverMock as any,
+        options as any,
+        browser as any
+    )
+    handler['_traceGatherer'] = { startTracing: vi.fn() } as any
+    handler.setThrottlingProfile = vi.fn()
+
+    handler['_networkThrottling'] = 'offline'
+    handler['_cpuThrottling'] = 2
+    handler['_cacheEnabled'] = true
+
+    // @ts-ignore test without paramater
+    handler._beforeCmd()
+    expect(handler['_traceGatherer']?.startTracing).toBeCalledTimes(0)
+
+    handler['_shouldRunPerformanceAudits'] = true
+    // @ts-ignore test without paramater
+    handler._beforeCmd()
+    expect(handler['_traceGatherer']?.startTracing).toBeCalledTimes(0)
+
+    // @ts-ignore test with only one paramater
+    handler._beforeCmd('foobar')
+    expect(handler['_traceGatherer']?.startTracing).toBeCalledTimes(0)
+
+    handler._beforeCmd('navigateTo', ['some page'])
+    expect(handler['_traceGatherer']?.startTracing).toBeCalledTimes(1)
+    expect(handler['_traceGatherer']?.startTracing).toBeCalledWith('some page')
+    expect(handler.setThrottlingProfile).toBeCalledWith('offline', 2, true)
+
+    handler._beforeCmd('url', ['next page'])
+    expect(handler['_traceGatherer']?.startTracing).toBeCalledTimes(2)
+    expect(handler['_traceGatherer']?.startTracing).toBeCalledWith('next page')
+    expect(handler.setThrottlingProfile).toBeCalledWith('offline', 2, true)
+
+    handler._beforeCmd('click', ['some other page'])
+    expect(handler['_traceGatherer']?.startTracing).toBeCalledTimes(3)
+    expect(handler['_traceGatherer']?.startTracing).toBeCalledWith('click transition')
+})
+
+test('afterCmd', () => {
+    const handler = new CommandHandler(
+        sessionMock as any,
+        pageMock as any,
+        driverMock as any,
+        options as any,
+        browser as any
+    )
+    handler['_traceGatherer'] = { once: vi.fn() } as any
+
+    // @ts-ignore test without paramater
+    handler._afterCmd()
+    expect(handler['_traceGatherer']?.once).toBeCalledTimes(0)
+
+    // @ts-ignore access mock
+    handler['_traceGatherer']['isTracing'] = true
+    // @ts-ignore test without paramater
+    handler._afterCmd()
+    expect(handler['_traceGatherer']?.once).toBeCalledTimes(0)
+
+    handler._afterCmd('foobar')
+    expect(handler['_traceGatherer']?.once).toBeCalledTimes(0)
+
+    handler._afterCmd('navigateTo')
+    expect(handler['_traceGatherer']?.once).toBeCalledTimes(3)
+
+    handler._afterCmd('url')
+    expect(handler['_traceGatherer']?.once).toBeCalledTimes(6)
+
+    handler._afterCmd('click')
+    expect(handler['_traceGatherer']?.once).toBeCalledTimes(9)
+})
+
+test('afterCmd: should create a new auditor instance and should update the browser commands', () => {
+    const handler = new CommandHandler(
+        sessionMock as any,
+        pageMock as any,
+        driverMock as any,
+        options as any,
+        browser as any
+    )
+    handler['_traceGatherer'] = new EventEmitter() as any
+
+    // @ts-ignore access mock
+    handler['_traceGatherer']['isTracing'] = true
+    handler['_devtoolsGatherer'] = { getLogs: vi.fn() } as any
+    handler['_browser'] = 'some browser' as any
+    handler._afterCmd('url')
+    handler['_traceGatherer']?.emit('tracingComplete', { some: 'events' })
+
+    const auditor = new Auditor()
+    expect(auditor.updateCommands).toBeCalledWith('some browser')
+})
+
+test('afterCmd: should update browser commands even if failed', () => {
+    const handler = new CommandHandler(
+        sessionMock as any,
+        pageMock as any,
+        driverMock as any,
+        options as any,
+        browser as any
+    )
+    handler['_traceGatherer'] = new EventEmitter() as any
+
+    // @ts-ignore access mock
+    handler['_traceGatherer']['isTracing'] = true
+    handler['_devtoolsGatherer'] = { getLogs: vi.fn() } as any
+    handler['_browser'] = 'some browser' as any
+    handler._afterCmd('url')
+    handler['_traceGatherer']?.emit('tracingError', new Error('boom'))
+
+    const auditor = new Auditor()
+    expect(auditor.updateCommands).toBeCalledWith('some browser', expect.any(Function))
+})
+
+test('afterCmd: should continue with command after tracingFinished was emitted', async () => {
+    const handler = new CommandHandler(
+        sessionMock as any,
+        pageMock as any,
+        driverMock as any,
+        options as any,
+        browser as any
+    )
+    handler['_traceGatherer'] = new EventEmitter() as any
+
+    // @ts-ignore access mock
+    handler['_traceGatherer']['isTracing'] = true
+    handler.setThrottlingProfile = vi.fn()
+
+    const start = Date.now()
+    setTimeout(() => handler['_traceGatherer']?.emit('tracingFinished'), 100)
+    await handler._afterCmd('navigateTo')
+
+    expect(Date.now() - start).toBeGreaterThan(98)
+    expect(handler.setThrottlingProfile).toBeCalledWith('online', 0, true)
+})
+
+test('enablePerformanceAudits: applies some default values', () => {
+    const handler = new CommandHandler(
+        sessionMock as any,
+        pageMock as any,
+        driverMock as any,
+        options as any,
+        browser as any
+    )
+    handler.enablePerformanceAudits()
+
+    expect(handler['_networkThrottling']).toBe('online')
+    expect(handler['_cpuThrottling']).toBe(0)
+    expect(handler['_cacheEnabled']).toBe(false)
+    expect(handler['_formFactor']).toBe('desktop')
+})
+
+test('enablePerformanceAudits: applies some custom values', () => {
+    const handler = new CommandHandler(
+        sessionMock as any,
+        pageMock as any,
+        driverMock as any,
+        options as any,
+        browser as any
+    )
+    handler.enablePerformanceAudits({
+        networkThrottling: 'Regular 2G',
+        cpuThrottling: 42,
+        cacheEnabled: true,
+        formFactor: 'mobile'
+    })
+
+    expect(handler['_networkThrottling']).toBe('Regular 2G')
+    expect(handler['_cpuThrottling']).toBe(42)
+    expect(handler['_cacheEnabled']).toBe(true)
+    expect(handler['_formFactor']).toBe('mobile')
+})
+
+test('disablePerformanceAudits', () => {
+    const handler = new CommandHandler(
+        sessionMock as any,
+        pageMock as any,
+        driverMock as any,
+        options as any,
+        browser as any
+    )
+    handler.enablePerformanceAudits({
+        networkThrottling: 'Regular 2G',
+        cpuThrottling: 42,
+        cacheEnabled: true,
+        formFactor: 'mobile'
+    })
+    handler.disablePerformanceAudits()
+    expect(handler['_shouldRunPerformanceAudits']).toBe(false)
+})
+
+test('setThrottlingProfile', async () => {
+    const handler = new CommandHandler(
+        sessionMock as any,
+        pageMock as any,
+        driverMock as any,
+        options as any,
+        browser as any
+    )
+
+    await handler.setThrottlingProfile('GPRS', 42, true)
+    expect(pageMock.setCacheEnabled).toBeCalledWith(true)
+    expect(sessionMock.send).toBeCalledWith('Emulation.setCPUThrottlingRate', { rate: 42 })
+    expect(sessionMock.send).toBeCalledWith('Network.emulateNetworkConditions', {
+        downloadThroughput: 6400,
+        latency: 500,
+        offline: false,
+        uploadThroughput: 2560
+    })
+
+    pageMock.setCacheEnabled.mockClear()
+    sessionMock.send.mockClear()
+    await handler.setThrottlingProfile()
+    expect(pageMock.setCacheEnabled).toBeCalledWith(false)
+    expect(sessionMock.send).toBeCalledWith('Emulation.setCPUThrottlingRate', { rate: 0 })
+    expect(sessionMock.send).toBeCalledWith('Network.emulateNetworkConditions', {
+        downloadThroughput: -1,
+        latency: 0,
+        offline: false,
+        uploadThroughput: -1
+    })
+})
+
+test('emulateDevice', async () => {
+    const handler = new CommandHandler(
+        sessionMock as any,
+        pageMock as any,
+        driverMock as any,
+        options as any,
+        browser as any
+    )
+
+    handler['_page'] = pageMock as any
+    handler['_session'] = sessionMock as any
+    await handler.emulateDevice('Nexus 6P')
+
+    expect(pageMock.emulate.mock.calls).toMatchSnapshot()
+    pageMock.emulate.mockClear()
+    await handler.emulateDevice({ foo: 'bar' } as any)
+    expect(pageMock.emulate.mock.calls).toEqual([[{ foo: 'bar' }]])
+
+    const isSuccessful = await handler.emulateDevice('not existing').then(
+        () => true,
+        () => false)
+    expect(isSuccessful).toBe(false)
 })

--- a/packages/wdio-devtools-service/tests/service.test.ts
+++ b/packages/wdio-devtools-service/tests/service.test.ts
@@ -1,10 +1,8 @@
 import path from 'node:path'
-import { EventEmitter } from 'node:events'
 import { expect, test, vi, beforeEach } from 'vitest'
 import puppeteer from 'puppeteer-core'
 
 import DevToolsService from '../src/index.js'
-import Auditor from '../src/auditor.js'
 import { setUnsupportedCommand } from '../src/utils.js'
 
 import logger from '@wdio/logger'
@@ -17,6 +15,16 @@ vi.mock('@wdio/logger', () => import(path.join(process.cwd(), '__mocks__', '@wdi
 vi.mock('../src/commands', () => {
     class CommandHandlerMock {
         cdp = vi.fn()
+        _initCommand = vi.fn()
+        _beforeCmd = vi.fn()
+        _afterCmd = vi.fn()
+        enablePerformanceAudits = vi.fn()
+        disablePerformanceAudits = vi.fn()
+        setThrottlingProfile = vi.fn()
+        emulateDevice = vi.fn()
+        checkPWA = vi.fn()
+        getCoverageReport = vi.fn()
+        _logCoverage = vi.fn()
     }
 
     return { default: CommandHandlerMock }
@@ -54,33 +62,30 @@ vi.mock('../src/utils', async () => {
     }
 })
 
-vi.mock('../src/gatherer/coverage', () => {
-    const instances: any[] = []
-    return {
-        default: class {
-            getCoverageReport = vi.fn()
-            init = vi.fn()
-
-            constructor () {
-                instances.push(this)
-            }
-        }
-    }
-})
-
-const pageMock = {
-    setCacheEnabled: vi.fn(),
-    emulate: vi.fn()
-}
 const sessionMock = { send: vi.fn() }
 const log = logger('')
 
 let browser: WebdriverIO.Browser
+let multiBrowser: WebdriverIO.MultiRemoteBrowser
 beforeEach(() => {
     browser = {
+        sessionId: vi.fn(),
         getPuppeteer: vi.fn(() => puppeteer.connect({})),
         addCommand: vi.fn(),
         emit: vi.fn()
+    } as any
+
+    multiBrowser = {
+        instances: ['1', '2'],
+        getInstance: () => {
+            return {
+                sessionId: vi.fn(),
+                getPuppeteer: vi.fn(() => puppeteer.connect({})),
+                addCommand: vi.fn(),
+                emit: vi.fn()
+            }
+        },
+        addCommand: vi.fn(),
     } as any
 
     sessionMock.send.mockClear()
@@ -90,6 +95,7 @@ beforeEach(() => {
 test('if not supported by browser', async () => {
     const service = new DevToolsService({})
     service['_browser'] = {
+        sessionId: vi.fn(),
         addCommand: vi.fn(),
         getPuppeteer: vi.fn(() => Promise.reject(new Error('ups')))
     } as any
@@ -107,9 +113,7 @@ test('if supported by browser', async () => {
     })
     service['_browser'] = browser
     await service._setupHandler()
-    expect(service['_session']?.send).toBeCalledWith('Network.enable')
-    expect(service['_session']?.send).toBeCalledWith('Runtime.enable')
-    expect(service['_session']?.send).toBeCalledWith('Page.enable')
+
     expect(service['_browser']?.addCommand).toBeCalledWith(
         'enablePerformanceAudits', expect.any(Function))
     expect(service['_browser']?.addCommand).toBeCalledWith(
@@ -118,129 +122,26 @@ test('if supported by browser', async () => {
         'emulateDevice', expect.any(Function))
     expect(service['_browser']?.addCommand).toBeCalledWith(
         'checkPWA', expect.any(Function))
-
-    service['_devtoolsGatherer'] = { onMessage: vi.fn() } as any
-    service['_propagateWSEvents']({ method: 'foo', params: 'bar' })
-    expect(service['_devtoolsGatherer']?.onMessage).toBeCalledTimes(1)
-    expect(service['_devtoolsGatherer']?.onMessage).toBeCalledWith({ method:'foo', params: 'bar' })
-    expect((service['_browser'] as any).emit).toBeCalledTimes(1)
-    expect((service['_browser'] as any).emit).toBeCalledWith('foo', 'bar')
-    expect(service['_coverageGatherer']!.init).toBeCalledTimes(1)
 })
 
-test('beforeCommand', () => {
+test('beforeCommand', async () => {
     const service = new DevToolsService({})
     service['_browser'] = browser
-    service['_traceGatherer'] = { startTracing: vi.fn() } as any
-    service._setThrottlingProfile = vi.fn()
-
-    service['_networkThrottling'] = 'offline'
-    service['_cpuThrottling'] = 2
-    service['_cacheEnabled'] = true
+    await service._setupHandler()
 
     // @ts-ignore test without paramater
     service.beforeCommand()
-    expect(service['_traceGatherer']?.startTracing).toBeCalledTimes(0)
-
-    service['_shouldRunPerformanceAudits'] = true
-    // @ts-ignore test without paramater
-    service.beforeCommand()
-    expect(service['_traceGatherer']?.startTracing).toBeCalledTimes(0)
-
-    // @ts-ignore test with only one paramater
-    service.beforeCommand('foobar')
-    expect(service['_traceGatherer']?.startTracing).toBeCalledTimes(0)
-
-    service.beforeCommand('navigateTo', ['some page'])
-    expect(service['_traceGatherer']?.startTracing).toBeCalledTimes(1)
-    expect(service['_traceGatherer']?.startTracing).toBeCalledWith('some page')
-    expect(service._setThrottlingProfile).toBeCalledWith('offline', 2, true)
-
-    service.beforeCommand('url', ['next page'])
-    expect(service['_traceGatherer']?.startTracing).toBeCalledTimes(2)
-    expect(service['_traceGatherer']?.startTracing).toBeCalledWith('next page')
-    expect(service._setThrottlingProfile).toBeCalledWith('offline', 2, true)
-
-    service.beforeCommand('click', ['some other page'])
-    expect(service['_traceGatherer']?.startTracing).toBeCalledTimes(3)
-    expect(service['_traceGatherer']?.startTracing).toBeCalledWith('click transition')
+    expect(service['_command'][0]._beforeCmd).toBeCalledTimes(1)
 })
 
-test('afterCommand', () => {
+test('afterCommand', async () => {
     const service = new DevToolsService({})
     service['_browser'] = browser
-    service['_traceGatherer'] = { once: vi.fn() } as any
+    await service._setupHandler()
 
     // @ts-ignore test without paramater
     service.afterCommand()
-    expect(service['_traceGatherer']?.once).toBeCalledTimes(0)
-
-    // @ts-ignore access mock
-    service['_traceGatherer']['isTracing'] = true
-    // @ts-ignore test without paramater
-    service.afterCommand()
-    expect(service['_traceGatherer']?.once).toBeCalledTimes(0)
-
-    service.afterCommand('foobar')
-    expect(service['_traceGatherer']?.once).toBeCalledTimes(0)
-
-    service.afterCommand('navigateTo')
-    expect(service['_traceGatherer']?.once).toBeCalledTimes(3)
-
-    service.afterCommand('url')
-    expect(service['_traceGatherer']?.once).toBeCalledTimes(6)
-
-    service.afterCommand('click')
-    expect(service['_traceGatherer']?.once).toBeCalledTimes(9)
-})
-
-test('afterCommand: should create a new auditor instance and should update the browser commands', () => {
-    const service = new DevToolsService({})
-    service['_browser'] = browser
-    service['_traceGatherer'] = new EventEmitter() as any
-
-    // @ts-ignore access mock
-    service['_traceGatherer']['isTracing'] = true
-    service['_devtoolsGatherer'] = { getLogs: vi.fn() } as any
-    service['_browser'] = 'some browser' as any
-    service.afterCommand('url')
-    service['_traceGatherer']?.emit('tracingComplete', { some: 'events' })
-
-    const auditor = new Auditor()
-    expect(auditor.updateCommands).toBeCalledWith('some browser')
-})
-
-test('afterCommand: should update browser commands even if failed', () => {
-    const service = new DevToolsService({})
-    service['_browser'] = browser
-    service['_traceGatherer'] = new EventEmitter() as any
-
-    // @ts-ignore access mock
-    service['_traceGatherer']['isTracing'] = true
-    service['_devtoolsGatherer'] = { getLogs: vi.fn() } as any
-    service['_browser'] = 'some browser' as any
-    service.afterCommand('url')
-    service['_traceGatherer']?.emit('tracingError', new Error('boom'))
-
-    const auditor = new Auditor()
-    expect(auditor.updateCommands).toBeCalledWith('some browser', expect.any(Function))
-})
-
-test('afterCommand: should continue with command after tracingFinished was emitted', async () => {
-    const service = new DevToolsService({})
-    service['_browser'] = browser
-    service['_traceGatherer'] = new EventEmitter() as any
-
-    // @ts-ignore access mock
-    service['_traceGatherer']['isTracing'] = true
-    service._setThrottlingProfile = vi.fn()
-
-    const start = Date.now()
-    setTimeout(() => service['_traceGatherer']?.emit('tracingFinished'), 100)
-    await service.afterCommand('navigateTo')
-
-    expect(Date.now() - start).toBeGreaterThan(98)
-    expect(service._setThrottlingProfile).toBeCalledWith('online', 0, true)
+    expect(service['_command'][0]._afterCmd).toBeCalledTimes(1)
 })
 
 test('_enablePerformanceAudits: throws if network or cpu properties have wrong types', () => {
@@ -254,36 +155,30 @@ test('_enablePerformanceAudits: throws if network or cpu properties have wrong t
     ).toThrow(/CPU throttling rate needs to be typeof number/)
 })
 
-test('_enablePerformanceAudits: applies some default values', () => {
+test('_enablePerformanceAudits', async () => {
     const service = new DevToolsService({})
     service['_browser'] = browser
+    await service._setupHandler()
     service._enablePerformanceAudits()
 
-    expect(service['_networkThrottling']).toBe('online')
-    expect(service['_cpuThrottling']).toBe(0)
-    expect(service['_cacheEnabled']).toBe(false)
-    expect(service['_formFactor']).toBe('desktop')
+    expect(service['_command'][0].enablePerformanceAudits).toBeCalledTimes(1)
 })
 
-test('_enablePerformanceAudits: applies some custom values', () => {
+test('_enablePerformanceAudits for multiremote', async () => {
     const service = new DevToolsService({})
-    service['_browser'] = browser
-    service._enablePerformanceAudits({
-        networkThrottling: 'Regular 2G',
-        cpuThrottling: 42,
-        cacheEnabled: true,
-        formFactor: 'mobile'
-    })
+    service['_browser'] = multiBrowser
+    await service._setupHandler()
+    service._enablePerformanceAudits()
 
-    expect(service['_networkThrottling']).toBe('Regular 2G')
-    expect(service['_cpuThrottling']).toBe(42)
-    expect(service['_cacheEnabled']).toBe(true)
-    expect(service['_formFactor']).toBe('mobile')
+    expect(service['_command'].length).toBe(2)
+    expect(service['_command'][0].enablePerformanceAudits).toBeCalledTimes(1)
+    expect(service['_command'][1].enablePerformanceAudits).toBeCalledTimes(1)
 })
 
-test('_disablePerformanceAudits', () => {
+test('_disablePerformanceAudits', async () => {
     const service = new DevToolsService({})
     service['_browser'] = browser
+    await service._setupHandler()
     service._enablePerformanceAudits({
         networkThrottling: 'Regular 2G',
         cpuThrottling: 42,
@@ -291,62 +186,120 @@ test('_disablePerformanceAudits', () => {
         formFactor: 'mobile'
     })
     service._disablePerformanceAudits()
-    expect(service['_shouldRunPerformanceAudits']).toBe(false)
+    expect(service['_command'][0].disablePerformanceAudits).toBeCalledTimes(1)
+})
+
+test('_disablePerformanceAudits for multiremote', async () => {
+    const service = new DevToolsService({})
+    service['_browser'] = multiBrowser
+    await service._setupHandler()
+    service._enablePerformanceAudits({
+        networkThrottling: 'Regular 2G',
+        cpuThrottling: 42,
+        cacheEnabled: true,
+        formFactor: 'mobile'
+    })
+    service._disablePerformanceAudits()
+
+    expect(service['_command'][0].disablePerformanceAudits).toBeCalledTimes(1)
+    expect(service['_command'][1].disablePerformanceAudits).toBeCalledTimes(1)
 })
 
 test('_setThrottlingProfile', async () => {
     const service = new DevToolsService({})
     service['_browser'] = browser
-    const err = await service._setThrottlingProfile('Good 3G', 4, true)
-        .catch((err: Error) => err) as Error
-    expect(err.message).toContain('No page')
+    await service._setupHandler()
 
-    service['_page'] = pageMock as any
-    service['_session'] = sessionMock as any
+    await service._setThrottlingProfile('Good 3G', 4, true)
+    expect(service['_command'][0].setThrottlingProfile).toBeCalledTimes(1)
+})
 
-    await service._setThrottlingProfile('GPRS', 42, true)
-    expect(pageMock.setCacheEnabled).toBeCalledWith(true)
-    expect(sessionMock.send).toBeCalledWith('Emulation.setCPUThrottlingRate', { rate: 42 })
-    expect(sessionMock.send).toBeCalledWith('Network.emulateNetworkConditions', {
-        downloadThroughput: 6400,
-        latency: 500,
-        offline: false,
-        uploadThroughput: 2560
-    })
+test('_setThrottlingProfile for multiremote', async () => {
+    const service = new DevToolsService({})
+    service['_browser'] = multiBrowser
+    await service._setupHandler()
+    await service._setThrottlingProfile('Good 3G', 4, true)
 
-    pageMock.setCacheEnabled.mockClear()
-    sessionMock.send.mockClear()
-    await service._setThrottlingProfile()
-    expect(pageMock.setCacheEnabled).toBeCalledWith(false)
-    expect(sessionMock.send).toBeCalledWith('Emulation.setCPUThrottlingRate', { rate: 0 })
-    expect(sessionMock.send).toBeCalledWith('Network.emulateNetworkConditions', {
-        downloadThroughput: -1,
-        latency: 0,
-        offline: false,
-        uploadThroughput: -1
-    })
+    expect(service['_command'][0].setThrottlingProfile).toBeCalledTimes(1)
+    expect(service['_command'][1].setThrottlingProfile).toBeCalledTimes(1)
 })
 
 test('_emulateDevice', async () => {
     const service = new DevToolsService({})
     service['_browser'] = browser
-    const err = await service._emulateDevice('Nexus 6P')
-        .catch((err: Error) => err) as Error
-    expect(err.message).toContain('No page')
+    await service._setupHandler()
 
-    service['_page'] = pageMock as any
-    service['_session'] = sessionMock as any
+    await service._emulateDevice('Nexus 6P')
+    expect(service['_command'][0].emulateDevice).toBeCalledTimes(1)
+})
+
+test('_emulateDevice for multiremote', async () => {
+    const service = new DevToolsService({})
+    service['_browser'] = multiBrowser
+    await service._setupHandler()
     await service._emulateDevice('Nexus 6P')
 
-    expect(pageMock.emulate.mock.calls).toMatchSnapshot()
-    pageMock.emulate.mockClear()
-    await service._emulateDevice({ foo: 'bar' } as any)
-    expect(pageMock.emulate.mock.calls).toEqual([[{ foo: 'bar' }]])
+    expect(service['_command'][0].emulateDevice).toBeCalledTimes(1)
+    expect(service['_command'][1].emulateDevice).toBeCalledTimes(1)
+})
 
-    const isSuccessful = await service._emulateDevice('not existing').then(
-        () => true,
-        () => false)
-    expect(isSuccessful).toBe(false)
+test('_checkPWA', async () => {
+    const service = new DevToolsService({})
+    service['_browser'] = browser
+    await service._setupHandler()
+
+    await service._checkPWA()
+    expect(service['_command'][0].checkPWA).toBeCalledTimes(1)
+})
+
+test('_checkPWA for multiremote', async () => {
+    const service = new DevToolsService({})
+    service['_browser'] = multiBrowser
+    await service._setupHandler()
+    await service._checkPWA()
+
+    expect(service['_command'][0].checkPWA).toBeCalledTimes(1)
+    expect(service['_command'][1].checkPWA).toBeCalledTimes(1)
+})
+
+test('_getCoverageReport', async () => {
+    const service = new DevToolsService({})
+    service['_browser'] = browser
+    await service._setupHandler()
+
+    await service._getCoverageReport()
+    expect(service['_command'][0].getCoverageReport).toBeCalledTimes(1)
+})
+
+test('_getCoverageReport for multiremote', async () => {
+    const service = new DevToolsService({})
+    service['_browser'] = multiBrowser
+    await service._setupHandler()
+    await service._getCoverageReport()
+
+    expect(service['_command'][0].getCoverageReport).toBeCalledTimes(1)
+    expect(service['_command'][1].getCoverageReport).toBeCalledTimes(1)
+})
+
+test('_cdp', async () => {
+    const service = new DevToolsService({})
+    service['_browser'] = browser
+    await service._setupHandler()
+
+    // @ts-ignore test without paramater
+    await service._cdp()
+    expect(service['_command'][0].cdp).toBeCalledTimes(1)
+})
+
+test('_cdp for multiremote', async () => {
+    const service = new DevToolsService({})
+    service['_browser'] = multiBrowser
+    await service._setupHandler()
+
+    // @ts-ignore test without paramater
+    await service._cdp()
+    expect(service['_command'][0].cdp).toBeCalledTimes(1)
+    expect(service['_command'][1].cdp).toBeCalledTimes(1)
 })
 
 test('before hook', async () => {
@@ -367,9 +320,9 @@ test('onReload hook', async () => {
 
 test('after hook', async () => {
     const service = new DevToolsService({})
-    await service.after()
+    service['_browser'] = browser
+    await service._setupHandler()
 
-    service['_coverageGatherer'] = { logCoverage: vi.fn() } as any
     await service.after()
-    expect(service['_coverageGatherer']!.logCoverage).toHaveBeenCalledTimes(1)
+    expect(service['_command'][0]._logCoverage).toBeCalledTimes(1)
 })


### PR DESCRIPTION
## Proposed changes

Continuation from [#5505](https://github.com/webdriverio/webdriverio/issues/5505), this feature allows devtools commands to be used for multiremote. The commands can be used with `browser` object itself, which produces array result for all instances, or with an individual instance.

```js
// example cap
cap = 
{
  chrome1: {
    capabilities: {
      browserName: 'chrome'
    }
  },
 chrome2: {
    capabilities: {
      browserName: 'chrome'
    }
  },
}

await browser.cdp('Network', 'getCookies') // returns an array containing result for both instance
await chrome1.cdp('Network', 'getCookies')  // returns only result for chrome1
```

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

This change is pretty much done by moving the code from devtools/index.ts to devtools/commands.ts and having a separate command object for each browser instance. All commands can be used by an individual instance. However, because I try to do this while wanting to make as little changes as possible, not all commands can be used by `browser` and those command are: `getNodeId` , `getNodeIds`, `startTracing`, `endTracing`, `getTraceLogs`, and `getPageWeight` (the commands that originally exist in commands.ts file). If needed, I can make more change to allow those commands to be used by `browser`.

Also, performance testing with lighthouse is a little bit tricky to use. Because of the way `beforeCommand` work, I don't have a way to determine which instance the command is coming from, and this can cause the code to hang because `onLoadEventFired` and `onFrameNavigated` are not triggered.

```js
// This works
await chrome1.enablePerformanceAudits()
await chrome1.url('https://webdriver.io')
await chrome1.disablePerformanceAudits()

// This will cause timeout
await chrome1.enablePerformanceAudits()
await chrome1.url('https://webdriver.io')
await chrome2.url('https://webdriver.io') // <---this line will causes chrome1 to hang because beforeCommand triggers 
                                       //  for both instances and chrome1 will get stuck waiting for onLoadEventFired to finish

```

So for performance testing, a user will have to do one instance at a time while having `enablePerformanceAudits` and `disablePerformanceAudits` before and after it.

Nothing change if a user is using normal mode.

### Reviewers: @webdriverio/project-committers
