### PR TITLE
(@wdio/browser-runner): allow to take screenshots and pdf when running component tests

### DIFF
--- a/e2e/browser-runner/lit.test.js
+++ b/e2e/browser-runner/lit.test.js
@@ -236,6 +236,12 @@ describe('Lit Component testing', () => {
         })
 
         it('can save a pdf', async () => {
+            /**
+             * Safari does not support 'POST /session/<sessionId>/print' command
+             */
+            if (browser.capabilities.browserName.toLowerCase() === 'safari') {
+                return
+            }
             expect((await browser.savePDF('./screenshot.pdf')).type)
                 .toBe('Buffer')
         })
@@ -250,7 +256,7 @@ describe('Lit Component testing', () => {
                 expect(await $('aria/Find me').getHTML(false)).toBe('Find me')
             })
 
-            it(' images with an alt tag', async () => {
+            it('images with an alt tag', async () => {
                 // https://www.w3.org/TR/accname-1.1/#step2D
                 render(
                     html`<img alt="foo" src="Find me">`,

--- a/e2e/browser-runner/lit.test.js
+++ b/e2e/browser-runner/lit.test.js
@@ -230,6 +230,16 @@ describe('Lit Component testing', () => {
             expect((await $(() => document.body).getTagName()).toLowerCase()).toBe('body')
         })
 
+        it('can save a screenshot', async () => {
+            expect((await browser.saveScreenshot('./screenshot.png')).type)
+                .toBe('Buffer')
+        })
+
+        it('can save a pdf', async () => {
+            expect((await browser.savePDF('./screenshot.pdf')).type)
+                .toBe('Buffer')
+        })
+
         describe('a11y selectors', () => {
             it('aria label is received from element content', async () => {
                 // https://www.w3.org/TR/accname-1.1/#step2B

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -21,7 +21,7 @@
     "test:browser:lit:wdio": "cross-env WDIO_PRESET=lit node ../packages/wdio-cli/bin/wdio.js ./browser-runner/wdio.conf.js --spec lit.test.js",
     "test:browser:lit:verifyCoverage": "run-s verifyCoverage",
     "test:browser:lit:verifyScreenshotFile": "test -f ./screenshot.png && rm ./screenshot.png",
-    "test:browser:lit:verifyPDFFile": "test -f ./screenshot.pdf && rm ./screenshot.pdf",
+    "test:browser:lit:verifyPDFFile": "if [ \"$(uname -s)\" == \"Darwin\" ]; then echo \"skip on mac\"; else test -f ./screenshot.pdf && rm ./screenshot.pdf; fi",
     "test:browser:stencil": "run-s test:browser:stencil:*",
     "test:browser:stencil:wdio": "cross-env WDIO_PRESET=stencil node ../packages/wdio-cli/bin/wdio.js ./browser-runner/wdio.conf.js --spec stencil.test.tsx",
     "test:browser:stencil:verifyCoverage": "run-s verifyCoverage",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -20,6 +20,8 @@
     "test:browser:lit": "run-s test:browser:lit:*",
     "test:browser:lit:wdio": "cross-env WDIO_PRESET=lit node ../packages/wdio-cli/bin/wdio.js ./browser-runner/wdio.conf.js --spec lit.test.js",
     "test:browser:lit:verifyCoverage": "run-s verifyCoverage",
+    "test:browser:lit:verifyScreenshotFile": "test -f ./screenshot.png && rm ./screenshot.png",
+    "test:browser:lit:verifyPDFFile": "test -f ./screenshot.pdf && rm ./screenshot.pdf",
     "test:browser:stencil": "run-s test:browser:stencil:*",
     "test:browser:stencil:wdio": "cross-env WDIO_PRESET=stencil node ../packages/wdio-cli/bin/wdio.js ./browser-runner/wdio.conf.js --spec stencil.test.tsx",
     "test:browser:stencil:verifyCoverage": "run-s verifyCoverage",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -21,7 +21,6 @@
     "test:browser:lit:wdio": "cross-env WDIO_PRESET=lit node ../packages/wdio-cli/bin/wdio.js ./browser-runner/wdio.conf.js --spec lit.test.js",
     "test:browser:lit:verifyCoverage": "run-s verifyCoverage",
     "test:browser:lit:verifyScreenshotFile": "test -f ./screenshot.png && rm ./screenshot.png",
-    "test:browser:lit:verifyPDFFile": "if [ \"$(uname -s)\" == \"Darwin\" ]; then echo \"skip on mac\"; else test -f ./screenshot.pdf && rm ./screenshot.pdf; fi",
     "test:browser:stencil": "run-s test:browser:stencil:*",
     "test:browser:stencil:wdio": "cross-env WDIO_PRESET=stencil node ../packages/wdio-cli/bin/wdio.js ./browser-runner/wdio.conf.js --spec stencil.test.tsx",
     "test:browser:stencil:verifyCoverage": "run-s verifyCoverage",


### PR DESCRIPTION
### Have you read the Contributing Guidelines on issues?

- [X] I have read the [Contributing Guidelines on issues](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md#reporting-new-issues).

### WebdriverIO Version

latest

### Node.js Version

latest`

### Mode

WDIO Testrunner

### Which capabilities are you using?

```typescript
n/a
```


### What happened?

calling `browser.saveScreenshot` raises the following error, when running component tests:

```
[chrome 116.0.5845.96 mac os x #0-0] callback must be a function
[chrome 116.0.5845.96 mac os x #0-0] TypeError: callback must be a function
[chrome 116.0.5845.96 mac os x #0-0]     at validateCallback (http://localhost:55104/node_modules/@jspm/core/nodelibs/browser/fs.js:1921:47)
```

### What is your expected behavior?

it should work.

### How to reproduce the bug.

n/a

### Relevant log output

```typescript
n/a
```


### Code of Conduct

- [X] I agree to follow this project's Code of Conduct

### Is there an existing issue for this?

- [X] I have searched the existing issues