### PR TITLE
(webdriverio): deprecate touchAction command

### DIFF
--- a/packages/webdriverio/src/commands/browser/touchAction.ts
+++ b/packages/webdriverio/src/commands/browser/touchAction.ts
@@ -2,6 +2,19 @@ import { touchAction as touchActionCommand } from '../constant.js'
 import type { TouchActions } from '../../types.js'
 
 /**
+ * :::caution Deprecation Warning
+ *
+ * The `touchAction` command is __deprecated__ and will be removed in a future version.
+ * We recommend to use the [`action`](/docs/api/browser/action) command instead with
+ * pointer type `touch`, e.g.:
+ *
+ * ```ts
+ * await browser.action('pointer', {
+ *   parameters: { pointerType: 'touch' }
+ * })
+ * ```
+ *
+ * :::
  *
  * The Touch Action API provides the basis of all gestures that can be automated in Appium.
  * It is currently only available to native apps and can not be used to interact with webapps.

--- a/packages/webdriverio/src/commands/element/touchAction.ts
+++ b/packages/webdriverio/src/commands/element/touchAction.ts
@@ -2,6 +2,19 @@ import { touchAction as touchActionCommand } from '../constant.js'
 import type { TouchActions } from '../../types.js'
 
 /**
+ * :::caution Deprecation Warning
+ *
+ * The `touchAction` command is __deprecated__ and will be removed in a future version.
+ * We recommend to use the [`action`](/docs/api/browser/action) command instead with
+ * pointer type `touch`, e.g.:
+ *
+ * ```ts
+ * await browser.action('pointer', {
+ *   parameters: { pointerType: 'touch' }
+ * })
+ * ```
+ *
+ * :::
  *
  * The Touch Action API provides the basis of all gestures that can be automated in Appium.
  * It is currently only available to native apps and can not be used to interact with webapps.


### PR DESCRIPTION
## Proposed changes

The Appium team has confirmed that the `touchAction` command will be deprecated. Adding a notice now so we can remove it in v9.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
