### PR TITLE
@wdio/cucumber-framework: Add original coordinates when resetting Cucumber Support Library

### DIFF
--- a/packages/wdio-cucumber-framework/src/index.ts
+++ b/packages/wdio-cucumber-framework/src/index.ts
@@ -249,7 +249,11 @@ class CucumberAdapter {
 
         try {
             await this.registerRequiredModules()
-            supportCodeLibraryBuilder.reset(this._cwd, this._newId)
+            supportCodeLibraryBuilder.reset(this._cwd, this._newId, {
+                requireModules: this._cucumberOpts.requireModule,
+                requirePaths: this._cucumberOpts.require,
+                importPaths: this._cucumberOpts.import,
+            })
 
             this.addWdioHooksAndWrapSteps(this._config, supportCodeLibraryBuilder)
 


### PR DESCRIPTION
## Proposed changes

Adds [original coordinates](https://github.com/cucumber/cucumber-js/blob/ad7f17d86d8fcf99d323240946cd83095e0b3c59/src/api/types.ts#L86)
```ts
export interface ISupportCodeCoordinates {
    requireModules: string[];
    requirePaths: string[];
    importPaths: string[];
}
```
when resetting the Cucumber Support Library.
In some cases, when a user defines a custom World like so:

```ts

import type { ITestCaseHookParameter } from '@cucumber/cucumber';
import { Before, World, setWorldConstructor } from '@wdio/cucumber-framework';

export class Scenario extends World {
  /** My custom World prop */
  myProp!: { myKey: string };
}

setWorldConstructor(Scenario);

Before(async function doStuff(this: Scenario, scenario: ITestCaseHookParameter) {
  this.myProp = { myKey: 'Test!' }
});
```

Cucumber follows different logic for dealing with the support library, as [seen here](https://github.com/cucumber/cucumber-js/blob/ad7f17d86d8fcf99d323240946cd83095e0b3c59/src/api/run_cucumber.ts#L34-L37):
```ts
  const supportCoordinates =
    'World' in configuration.support
      ? configuration.support.originalCoordinates
      : configuration.support
```

**This only appears to be a problem when the `parallel` option is set to a non-zero value.**

This fix includes the third argument for the original coordinates in the `reset()` call of the `SuportCodeLibraryBuilder`.

Prevents errors such as 
```ts
TypeError: Cannot read properties of undefined (reading 'getInvocationParameters')
    at Object.run (/Users/user/repos/repo/node_modules/@cucumber/cucumber/lib/runtime/step_runner.js:39:47)
    at TestCaseRunner.invokeStep (/Users/user/repos/repo/node_modules/@cucumber/cucumber/lib/runtime/test_case_runner.js:95:44)
    at TestCaseRunner.runHook (/Users/user/repos/repo/node_modules/@cucumber/cucumber/lib/runtime/test_case_runner.js:200:27)
    at /Users/user/repos/repo/node_modules/@cucumber/cucumber/lib/runtime/test_case_runner.js:171:39
    at TestCaseRunner.aroundTestStep (/Users/user/repos/repo/node_modules/@cucumber/cucumber/lib/runtime/test_case_runner.js:120:38)
    at TestCaseRunner.runAttempt (/Users/user/repos/repo/node_modules/@cucumber/cucumber/lib/runtime/test_case_runner.js:158:24)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async TestCaseRunner.run (/Users/user/repos/repo/node_modules/@cucumber/cucumber/lib/runtime/test_case_runner.js:136:35)
    at async Worker.runTestCase (/Users/user/repos/repo/node_modules/@cucumber/cucumber/lib/runtime/parallel/worker.js:82:9)
    at async Worker.receiveMessage (/Users/user/repos/repo/node_modules/@cucumber/cucumber/lib/runtime/parallel/worker.js:64:13)
```

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
