### PR TITLE
(@wdio/cucumber-framework): disable parallel execution and warn user that this feature is not supported

### DIFF
--- a/packages/wdio-cucumber-framework/src/constants.ts
+++ b/packages/wdio-cucumber-framework/src/constants.ts
@@ -23,7 +23,6 @@ export const DEFAULT_OPTS: CucumberOptions = {
     language: 'en',
     name: [],
     order: 'defined',
-    parallel: 0,
     publish: false,
     require: [],
     requireModule: [],

--- a/packages/wdio-cucumber-framework/src/index.ts
+++ b/packages/wdio-cucumber-framework/src/index.ts
@@ -104,8 +104,16 @@ class CucumberAdapter {
         this._cucumberOpts = Object.assign(
             {},
             DEFAULT_OPTS,
-            this._config.cucumberOpts as Required<CucumberOptions>
+            this._config.cucumberOpts as Required<CucumberOptions>,
+            /**
+             * explicitly disable running in parallel as it is not supported
+             */
+            { parallel: 0 }
         )
+
+        if (this._config.cucumberOpts?.parallel) {
+            log.warn('The option "parallel" is not supported by WebdriverIO')
+        }
 
         this._cucumberOpts.formatOptions = {
             _reporter: this._reporter,

--- a/packages/wdio-cucumber-framework/src/index.ts
+++ b/packages/wdio-cucumber-framework/src/index.ts
@@ -104,15 +104,14 @@ class CucumberAdapter {
         this._cucumberOpts = Object.assign(
             {},
             DEFAULT_OPTS,
-            this._config.cucumberOpts as Required<CucumberOptions>,
-            /**
-             * explicitly disable running in parallel as it is not supported
-             */
-            { parallel: 0 }
+            this._config.cucumberOpts as Required<CucumberOptions>
         )
 
+        /**
+         * WebdriverIO doesn't support this Cucumber feature so we should let the user know
+         */
         if (this._config.cucumberOpts?.parallel) {
-            log.warn('The option "parallel" is not supported by WebdriverIO')
+            throw new Error('The option "parallel" is not supported by WebdriverIO')
         }
 
         this._cucumberOpts.formatOptions = {

--- a/packages/wdio-cucumber-framework/src/types.ts
+++ b/packages/wdio-cucumber-framework/src/types.ts
@@ -61,10 +61,6 @@ export interface CucumberOptions {
      */
     order?: string;
     /**
-     * Run tests in parallel with the given number of worker processes
-     */
-    parallel?: number;
-    /**
      * Publish a report of your test run to https://reports.cucumber.io/
      */
     publish?: boolean;

--- a/packages/wdio-cucumber-framework/tests/adapter.test.ts
+++ b/packages/wdio-cucumber-framework/tests/adapter.test.ts
@@ -1,7 +1,6 @@
 import path from 'node:path'
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 
-import logger from '@wdio/logger'
 import { executeHooksWithArgs } from '@wdio/utils'
 import * as Cucumber from '@cucumber/cucumber'
 import type * as Messages from '@cucumber/messages'
@@ -11,7 +10,6 @@ import * as packageExports from '../src/index.js'
 import CucumberAdapter from '../src/index.js'
 
 vi.mock('@wdio/utils')
-vi.mock('@wdio/logger', () => import(path.join(process.cwd(), '__mocks__', '@wdio/logger')))
 vi.mock('expect-webdriverio')
 vi.mock('@cucumber/cucumber')
 vi.mock('@cucumber/messages', async () => {
@@ -81,8 +79,11 @@ describe('CucumberAdapter', () => {
     })
 
     it('throws if parallel cucumber opts is set', async () => {
-        await CucumberAdapter.init!('0-0', { cucumberOpts: { parallel: 1 } }, [], {}, {}, {}, false)
-        expect(logger('').warn).toBeCalledWith('The option "parallel" is not supported by WebdriverIO')
+        await expect(
+            CucumberAdapter.init!('0-0', { cucumberOpts: { parallel: 1 } }, [], {}, {}, {}, false)
+        ).rejects.toEqual(expect.objectContaining({
+            message: 'The option "parallel" is not supported by WebdriverIO'
+        }))
     })
 
     it('should not initiated with no tests', async () => {

--- a/packages/wdio-cucumber-framework/tests/adapter.test.ts
+++ b/packages/wdio-cucumber-framework/tests/adapter.test.ts
@@ -1,6 +1,7 @@
 import path from 'node:path'
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 
+import logger from '@wdio/logger'
 import { executeHooksWithArgs } from '@wdio/utils'
 import * as Cucumber from '@cucumber/cucumber'
 import type * as Messages from '@cucumber/messages'
@@ -10,6 +11,7 @@ import * as packageExports from '../src/index.js'
 import CucumberAdapter from '../src/index.js'
 
 vi.mock('@wdio/utils')
+vi.mock('@wdio/logger', () => import(path.join(process.cwd(), '__mocks__', '@wdio/logger')))
 vi.mock('expect-webdriverio')
 vi.mock('@cucumber/cucumber')
 vi.mock('@cucumber/messages', async () => {
@@ -73,13 +75,18 @@ describe('CucumberAdapter', () => {
     })
 
     it('can be initiated with tests', async () => {
-        const adapter = await CucumberAdapter.init!!('0-0', {}, ['/foo/bar'], {}, {}, {}, false)
+        const adapter = await CucumberAdapter.init!('0-0', {}, ['/foo/bar'], {}, {}, {}, false)
         expect(executeHooksWithArgs).toBeCalledTimes(0)
         expect(adapter.hasTests()).toBe(true)
     })
 
+    it('throws if parallel cucumber opts is set', async () => {
+        await CucumberAdapter.init!('0-0', { cucumberOpts: { parallel: 1 } }, [], {}, {}, {}, false)
+        expect(logger('').warn).toBeCalledWith('The option "parallel" is not supported by WebdriverIO')
+    })
+
     it('should not initiated with no tests', async () => {
-        const adapter = await CucumberAdapter.init!!('0-0', {}, [], {}, {}, {}, false)
+        const adapter = await CucumberAdapter.init!('0-0', {}, [], {}, {}, {}, false)
         expect(executeHooksWithArgs).toBeCalledTimes(0)
         expect(adapter.hasTests()).toBe(false)
     })


### PR DESCRIPTION
## Proposed changes

Disable the parallel execution of Cucumber as it is currently not supported.

refs #11078

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

I wonder if we should rather fail the test run instead of just printing a warning in the logs that might could get overseen.

### Reviewers: @webdriverio/project-committers
