### PR TITLE
fix cucumber report issue - windows

### DIFF
--- a/packages/wdio-cucumber-framework/src/constants.ts
+++ b/packages/wdio-cucumber-framework/src/constants.ts
@@ -1,13 +1,6 @@
-import url from 'node:url'
-import path from 'node:path'
-
 import type { CucumberOptions } from './types.js'
 
 export const DEFAULT_TIMEOUT = 60000
-
-export const FILE_PROTOCOL = 'file://'
-
-const cucumberFormatter = path.resolve(url.fileURLToPath(import.meta.url), '../cucumberFormatter.js')
 
 export const DEFAULT_OPTS: CucumberOptions = {
     paths: [],
@@ -15,7 +8,7 @@ export const DEFAULT_OPTS: CucumberOptions = {
     dryRun: false,
     forceExit: false,
     failFast: false,
-    format: [cucumberFormatter],
+    format: [],
     formatOptions: {},
     import: [],
     language: 'en',

--- a/packages/wdio-cucumber-framework/src/index.ts
+++ b/packages/wdio-cucumber-framework/src/index.ts
@@ -14,7 +14,7 @@ import Gherkin from '@cucumber/gherkin'
 import { IdGenerator } from '@cucumber/messages'
 import TagExpressionParser from '@cucumber/tag-expressions'
 
-import { DEFAULT_OPTS, FILE_PROTOCOL } from './constants.js'
+import { DEFAULT_OPTS } from './constants.js'
 import { generateSkipTagsFromCapabilities, shouldRun } from './utils.js'
 
 import type {
@@ -34,6 +34,10 @@ import {
 } from '@cucumber/cucumber/api'
 
 import type { SupportCodeLibraryBuilder } from '@cucumber/cucumber/lib/support_code_library_builder/index.js'
+
+export const FILE_PROTOCOL = 'file://'
+
+const cucumberFormatter = url.pathToFileURL(path.resolve(url.fileURLToPath(import.meta.url), '../cucumberFormatter.js')).href
 
 const log = logger('@wdio/cucumber-framework')
 
@@ -114,6 +118,14 @@ class CucumberAdapter {
             throw new Error('The option "parallel" is not supported by WebdriverIO')
         }
 
+        /**
+         * Including the `cucumberFormatter` here allows you to use cucumber formatting in addition to other formatting options.
+         */
+        this._cucumberOpts.format.push([cucumberFormatter])
+
+        /**
+         * formatting options used by custom cucumberFormatter
+         */
         this._cucumberOpts.formatOptions = {
             _reporter: this._reporter,
             _cid: this._cid,

--- a/packages/wdio-cucumber-framework/src/index.ts
+++ b/packages/wdio-cucumber-framework/src/index.ts
@@ -120,8 +120,13 @@ class CucumberAdapter {
 
         /**
          * Including the `cucumberFormatter` here allows you to use cucumber formatting in addition to other formatting options.
+         *
+         * It's essential to validate `this._reporter` for unit testing purposes. In real-time scenarios, an instance of an event emitter is typically passed,
+         * whereas during unit testing, we pass the reporter as an empty object `{}`.
          */
-        this._cucumberOpts.format.push([cucumberFormatter])
+        if (Object.keys(this._reporter).length > 0) {
+            this._cucumberOpts.format.push([cucumberFormatter])
+        }
 
         /**
          * formatting options used by custom cucumberFormatter

--- a/packages/wdio-cucumber-framework/src/index.ts
+++ b/packages/wdio-cucumber-framework/src/index.ts
@@ -37,8 +37,6 @@ import type { SupportCodeLibraryBuilder } from '@cucumber/cucumber/lib/support_c
 
 export const FILE_PROTOCOL = 'file://'
 
-const cucumberFormatter = url.pathToFileURL(path.resolve(url.fileURLToPath(import.meta.url), '../cucumberFormatter.js')).href
-
 const log = logger('@wdio/cucumber-framework')
 
 const {
@@ -102,7 +100,8 @@ class CucumberAdapter {
         private _capabilities: Capabilities.RemoteCapability,
         private _reporter: EventEmitter,
         private _eventEmitter: EventEmitter,
-        private _generateSkipTags: boolean = true
+        private _generateSkipTags: boolean = true,
+        private _cucumberFormatter: string = url.pathToFileURL(path.resolve(url.fileURLToPath(import.meta.url), '..', 'cucumberFormatter.js')).href
     ) {
         this._eventEmitter = new EventEmitter()
         this._cucumberOpts = Object.assign(
@@ -120,13 +119,8 @@ class CucumberAdapter {
 
         /**
          * Including the `cucumberFormatter` here allows you to use cucumber formatting in addition to other formatting options.
-         *
-         * It's essential to validate `this._reporter` for unit testing purposes. In real-time scenarios, an instance of an event emitter is typically passed,
-         * whereas during unit testing, we pass the reporter as an empty object `{}`.
          */
-        if (Object.keys(this._reporter).length > 0) {
-            this._cucumberOpts.format.push([cucumberFormatter])
-        }
+        this._cucumberOpts.format.push([this._cucumberFormatter])
 
         /**
          * formatting options used by custom cucumberFormatter

--- a/packages/wdio-cucumber-framework/src/types.ts
+++ b/packages/wdio-cucumber-framework/src/types.ts
@@ -32,7 +32,7 @@ export interface CucumberOptions {
     /**
      * Name/path of formatter to use
      */
-    format?: string[];
+    format?: Array<string | [string, string?]>;
     /**
      * Options to be provided to formatters
      */

--- a/packages/wdio-cucumber-framework/tests/adapter.test.ts
+++ b/packages/wdio-cucumber-framework/tests/adapter.test.ts
@@ -73,21 +73,21 @@ describe('CucumberAdapter', () => {
     })
 
     it('can be initiated with tests', async () => {
-        const adapter = await CucumberAdapter.init!('0-0', {}, ['/foo/bar'], {}, {}, {}, false)
+        const adapter = await CucumberAdapter.init!('0-0', {}, ['/foo/bar'], {}, {}, {}, false, ['progress'])
         expect(executeHooksWithArgs).toBeCalledTimes(0)
         expect(adapter.hasTests()).toBe(true)
     })
 
     it('throws if parallel cucumber opts is set', async () => {
         await expect(
-            CucumberAdapter.init!('0-0', { cucumberOpts: { parallel: 1 } }, [], {}, {}, {}, false)
+            CucumberAdapter.init!('0-0', { cucumberOpts: { parallel: 1 } }, [], {}, {}, {}, false, ['progress'])
         ).rejects.toEqual(expect.objectContaining({
             message: 'The option "parallel" is not supported by WebdriverIO'
         }))
     })
 
     it('should not initiated with no tests', async () => {
-        const adapter = await CucumberAdapter.init!('0-0', {}, [], {}, {}, {}, false)
+        const adapter = await CucumberAdapter.init!('0-0', {}, [], {}, {}, {}, false, ['progress'])
         expect(executeHooksWithArgs).toBeCalledTimes(0)
         expect(adapter.hasTests()).toBe(false)
     })
@@ -95,7 +95,7 @@ describe('CucumberAdapter', () => {
     it('can run without errors', async () => {
         const adapter = await CucumberAdapter.init!('0-0', {
             cucumberOpts: { format: [] }
-        }, ['/foo/bar'], {}, {}, {}, false)
+        }, ['/foo/bar'], {}, {}, {}, false, ['progress'])
         adapter.registerRequiredModules = vi.fn()
         adapter.addWdioHooksAndWrapSteps = vi.fn()
         adapter.loadFiles = vi.fn()
@@ -120,7 +120,7 @@ describe('CucumberAdapter', () => {
                     }
                 ]
             }
-        }, ['/foo/bar'], {}, {}, {}, false)
+        }, ['/foo/bar'], {}, {}, {}, false, ['progress'])
         expect(global.MODULE_A_WAS_LOADED).toBe(undefined)
         expect(global.MODULE_A_WAS_LOADED).toBe(undefined)
         expect(global.MODULE_INLINE_WAS_LOADED).toBe(undefined)
@@ -146,13 +146,13 @@ describe('CucumberAdapter', () => {
                     path.join(process.cwd(), '__mocks__', 'module*.ts')
                 ]
             }
-        }, ['/foo/bar'], {}, {}, {}, false)
+        }, ['/foo/bar'], {}, {}, {}, false, ['progress'])
 
         expect(await adapter.loadFilesWithType(adapter._cucumberOpts.require)).toHaveLength(4)
     })
 
     it('loadSpecFiles', async () => {
-        const adapter = await CucumberAdapter.init!('0-0', {}, ['/foo/bar'], {}, {}, {}, false)
+        const adapter = await CucumberAdapter.init!('0-0', {}, ['/foo/bar'], {}, {}, {}, false, ['progress'])
         adapter.loadFilesWithType = vi.fn().mockReturnValue([process.cwd() + '/__mocks__/moduleC.ts'])
 
         expect(global.MODULE_C_WAS_LOADED).toBe(undefined)
@@ -175,7 +175,8 @@ describe('CucumberAdapter', () => {
             {},
             {},
             {},
-            false
+            false,
+            ['progress']
         )
         adapter.addWdioHooksAndWrapSteps(
             {
@@ -284,7 +285,8 @@ describe('CucumberAdapter', () => {
             {},
             {},
             {},
-            false
+            false,
+            ['progress']
         )
 
         expect(adapter._specs).toHaveLength(1)
@@ -311,7 +313,8 @@ describe('CucumberAdapter', () => {
             {},
             {},
             {},
-            false
+            false,
+            ['progress']
         )
 
         expect(adapter._specs).toHaveLength(1)
@@ -338,7 +341,8 @@ describe('CucumberAdapter', () => {
             {},
             {},
             {},
-            false
+            false,
+            ['progress']
         )
 
         expect(adapter._specs).toHaveLength(1)
@@ -365,7 +369,8 @@ describe('CucumberAdapter', () => {
             {},
             {},
             {},
-            false
+            false,
+            ['progress']
         )
 
         expect(adapter._specs).toHaveLength(1)
@@ -392,7 +397,8 @@ describe('CucumberAdapter', () => {
             {},
             {},
             {},
-            false
+            false,
+            ['progress']
         )
 
         expect(adapter._specs).toHaveLength(0)
@@ -419,7 +425,8 @@ describe('CucumberAdapter', () => {
             {},
             {},
             {},
-            false
+            false,
+            ['progress']
         )
 
         expect(adapter._specs).toHaveLength(1)
@@ -446,7 +453,8 @@ describe('CucumberAdapter', () => {
             {},
             {},
             {},
-            false
+            false,
+            ['progress']
         )
 
         expect(adapter._specs).toHaveLength(1)
@@ -472,7 +480,8 @@ describe('CucumberAdapter', () => {
             {},
             {},
             {},
-            false
+            false,
+            ['progress']
         )
 
         expect(adapter.gherkinParser.tokenMatcher.dialect.name).toBe('Danish')


### PR DESCRIPTION
## Proposed changes

- Fixing report path for windows
- Keeping custom reporter as default, allows to use cucumber formatting in addition to other formatting options

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
