### PR TITLE
(@wdio/utils): don't setup a driver nor browser if using devtools protocol

### DIFF
--- a/packages/wdio-utils/src/driver/manager.ts
+++ b/packages/wdio-utils/src/driver/manager.ts
@@ -30,7 +30,12 @@ function mapCapabilities (
                 const isMultiremote = Boolean(multiremoteCaps[Object.keys(cap)[0]].capabilities)
 
                 if (isMultiremote) {
-                    return Object.values(multiremoteCaps).map((c) => c.capabilities)as Capabilities.Capabilities[]
+                    return Object.values(multiremoteCaps).map((c) => {
+                        if (c.automationProtocol === 'devtools') {
+                            return
+                        }
+                        return c.capabilities
+                    }) as Capabilities.Capabilities[]
                 } else if (w3cCaps.alwaysMatch) {
                     return w3cCaps.alwaysMatch
                 }
@@ -38,6 +43,9 @@ function mapCapabilities (
             }).flat()
             : Object.values(caps as Capabilities.MultiRemoteCapabilities).map((mrOpts) => {
                 const w3cCaps = mrOpts.capabilities as Capabilities.W3CCapabilities
+                if (mrOpts.automationProtocol === 'devtools') {
+                    return
+                }
                 if (w3cCaps.alwaysMatch) {
                     return w3cCaps.alwaysMatch
                 }
@@ -47,6 +55,8 @@ function mapCapabilities (
         /**
          * only set up driver if
          */
+        // - capabilities are defined and not empty because automationProtocol is set to `devtools`
+        cap &&
         // - browserName is defined so we know it is a browser session
         cap.browserName &&
         // - we are not about to run a cloud session
@@ -57,7 +67,7 @@ function mapCapabilities (
         !getDriverOptions(cap).binary &&
         // - user is not defining "devtools" as automation protocol
         (options as Options.WebdriverIO).automationProtocol !== 'devtools'
-    ))
+    )) as Capabilities.Capabilities[]
 
     /**
      * nothing to setup

--- a/packages/wdio-utils/src/driver/manager.ts
+++ b/packages/wdio-utils/src/driver/manager.ts
@@ -54,7 +54,9 @@ function mapCapabilities (
         // - we are not running Safari (driver already installed on macOS)
         !isSafari(cap.browserName) &&
         // - driver options don't define a binary path
-        !getDriverOptions(cap).binary
+        !getDriverOptions(cap).binary &&
+        // - user is not defining "devtools" as automation protocol
+        (options as Options.WebdriverIO).automationProtocol !== 'devtools'
     ))
 
     /**

--- a/packages/wdio-utils/tests/driver/manager.test.ts
+++ b/packages/wdio-utils/tests/driver/manager.test.ts
@@ -90,6 +90,24 @@ describe('setupDriver', () => {
         expect(setupGeckodriver).toBeCalledWith('/foo/bar', '6')
     })
 
+    test('don\'t setup driver if automation protocol is devtools', async () => {
+        await setupDriver({
+            automationProtocol: 'devtools'
+        } as any, [{
+            browserName: 'chrome',
+            browserVersion: '1'
+        }, {
+            browserName: 'firefox',
+            browserVersion: '5'
+        }, {
+            browserName: 'edge',
+            browserVersion: '4'
+        }])
+        expect(setupGeckodriver).toBeCalledTimes(0)
+        expect(setupChromedriver).toBeCalledTimes(0)
+        expect(setupEdgedriver).toBeCalledTimes(0)
+    })
+
     test('with multiremote capabilities', async () => {
         await setupDriver({}, {
             browserA: {

--- a/packages/wdio-utils/tests/driver/manager.test.ts
+++ b/packages/wdio-utils/tests/driver/manager.test.ts
@@ -90,7 +90,7 @@ describe('setupDriver', () => {
         expect(setupGeckodriver).toBeCalledWith('/foo/bar', '6')
     })
 
-    test('don\'t setup driver if automation protocol is devtools', async () => {
+    test('no setup with testrunner capabilities when automation protocol is set to devtools', async () => {
         await setupDriver({
             automationProtocol: 'devtools'
         } as any, [{
@@ -203,6 +203,26 @@ describe('setupDriver', () => {
         expect(setupGeckodriver).toBeCalledWith('/foo/bar', '7')
     })
 
+    test('no setup with multiremote capabilities when automation protocol is set to devtools', async () => {
+        await setupDriver({}, {
+            browserA: {
+                capabilities: {
+                    browserName: 'chrome',
+                    browserVersion: '1'
+                }
+            },
+            browserB: {
+                automationProtocol: 'devtools',
+                capabilities: {
+                    browserName: 'edge',
+                    browserVersion: '3'
+                }
+            }
+        })
+        expect(setupChromedriver).toBeCalledTimes(1)
+        expect(setupEdgedriver).toBeCalledTimes(0)
+    })
+
     test('with multiremote capabilities series', async () => {
         await setupDriver({}, [{
             browserA: {
@@ -292,6 +312,25 @@ describe('setupDriver', () => {
         expect(setupGeckodriver).toBeCalledTimes(2)
         expect(setupGeckodriver).toBeCalledWith('/foo/bar', '5')
         expect(setupGeckodriver).toBeCalledWith('/foo/bar', '6')
+    })
+
+    test('no setup with multiremote capabilities series when automation protocol is set to devtools', async () => {
+        await setupDriver({}, [{
+            browserA: {
+                capabilities: {
+                    browserName: 'chrome',
+                    browserVersion: '1'
+                }
+            },
+            browserB: {
+                automationProtocol: 'devtools',
+                capabilities: {
+                    browserName: 'chrome',
+                    browserVersion: '2'
+                }
+            }
+        }])
+        expect(setupChromedriver).toBeCalledTimes(1)
     })
 })
 


### PR DESCRIPTION
## Proposed changes

When a user defines `devtools` as automation protocol we should not set up any drivers.

fixes #11129

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
