### PR TITLE
fix cucumber junit report

### DIFF
--- a/packages/wdio-cucumber-framework/src/cucumberFormatter.ts
+++ b/packages/wdio-cucumber-framework/src/cucumberFormatter.ts
@@ -69,11 +69,11 @@ export default class CucumberFormatter extends Formatter {
         let results: TestStepResult[] = []
         options.eventBroadcaster.on('envelope', (envelope: Envelope) => {
             if (envelope.gherkinDocument) {
-                this.onGherkinDocument({ ...envelope.gherkinDocument, uri: this.normalizeURI(envelope.gherkinDocument.uri) })
+                this.onGherkinDocument({ ...envelope.gherkinDocument, ...(envelope.gherkinDocument.uri ? { uri: this.normalizeURI(envelope.gherkinDocument.uri) } : {}) })
             } else if (envelope.testRunStarted) {
                 this.onTestRunStarted()
             } else if (envelope.pickle) {
-                this.onPickleAccepted({ ...envelope.pickle, uri: this.normalizeURI(envelope.pickle.uri)!! })
+                this.onPickleAccepted({ ...envelope.pickle, uri: this.normalizeURI(envelope.pickle.uri) })
             } else if (envelope.testCase) {
                 this.onTestCasePrepared(envelope.testCase)
             } else if (envelope.testCaseStarted) {
@@ -113,8 +113,8 @@ export default class CucumberFormatter extends Formatter {
         this.failAmbiguousDefinitions = options.parsedArgvOptions._failAmbiguousDefinitions
     }
 
-    normalizeURI(uri?: string) {
-        return uri ? (path.isAbsolute(uri) ? uri : path.resolve(uri)) : undefined
+    normalizeURI(uri: string) {
+        return path.isAbsolute(uri) ? uri : path.resolve(uri)
     }
 
     emit(event: string, payload: any) {

--- a/packages/wdio-cucumber-framework/src/cucumberFormatter.ts
+++ b/packages/wdio-cucumber-framework/src/cucumberFormatter.ts
@@ -1,6 +1,7 @@
 import type { IFormatterOptions } from '@cucumber/cucumber'
 import { Formatter, Status } from '@cucumber/cucumber'
 import type { EventEmitter } from 'node:events'
+import path from 'node:path'
 
 import logger from '@wdio/logger'
 
@@ -68,11 +69,11 @@ export default class CucumberFormatter extends Formatter {
         let results: TestStepResult[] = []
         options.eventBroadcaster.on('envelope', (envelope: Envelope) => {
             if (envelope.gherkinDocument) {
-                this.onGherkinDocument(envelope.gherkinDocument)
+                this.onGherkinDocument({ ...envelope.gherkinDocument, uri: this.normalizeURI(envelope.gherkinDocument.uri) })
             } else if (envelope.testRunStarted) {
                 this.onTestRunStarted()
             } else if (envelope.pickle) {
-                this.onPickleAccepted(envelope.pickle)
+                this.onPickleAccepted({ ...envelope.pickle, uri: this.normalizeURI(envelope.pickle.uri)!! })
             } else if (envelope.testCase) {
                 this.onTestCasePrepared(envelope.testCase)
             } else if (envelope.testCaseStarted) {
@@ -110,6 +111,10 @@ export default class CucumberFormatter extends Formatter {
         this.tagsInTitle = options.parsedArgvOptions._tagsInTitle
         this.ignoreUndefinedDefinitions = options.parsedArgvOptions._ignoreUndefinedDefinitions
         this.failAmbiguousDefinitions = options.parsedArgvOptions._failAmbiguousDefinitions
+    }
+
+    normalizeURI(uri?: string) {
+        return uri ? (path.isAbsolute(uri) ? uri : path.resolve(uri)) : undefined
     }
 
     emit(event: string, payload: any) {


### PR DESCRIPTION
## Proposed changes

Fix - #11125 

It looks at the URI that comes from the cucumber event broadcaster to see if it's an absolute path. If it's absolute, it just uses that URI. If not then it figures out the full path and uses it.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
