### PR TITLE
(@wdio/utils): use --no-sandbox flag when detecting Chrome version

### DIFF
--- a/packages/wdio-utils/src/driver/utils.ts
+++ b/packages/wdio-utils/src/driver/utils.ts
@@ -51,7 +51,7 @@ export function getBuildIdByChromePath(chromePath?: string) {
         return oldest
     }
 
-    const versionString = cp.execSync(`"${chromePath}" --version`).toString()
+    const versionString = cp.execSync(`"${chromePath}" --version --no-sandbox`).toString()
     return versionString.trim().split(' ').pop()?.trim()
 }
 

--- a/packages/wdio-utils/tests/driver/utils.test.ts
+++ b/packages/wdio-utils/tests/driver/utils.test.ts
@@ -1,6 +1,7 @@
 import os from 'node:os'
 import path from 'node:path'
 import url from 'node:url'
+import cp from 'node:child_process'
 import type fs from 'node:fs'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { canDownload, resolveBuildId, detectBrowserPlatform } from '@puppeteer/browsers'
@@ -74,6 +75,7 @@ describe('driver utils', () => {
     it('getBuildIdByChromePath', () => {
         expect(getBuildIdByChromePath()).toBe(undefined)
         expect(getBuildIdByChromePath('/foo/bar')).toBe('116.0.5845.110')
+        expect(cp.execSync).toBeCalledWith('"/foo/bar" --version --no-sandbox')
 
         vi.mocked(os.platform).mockReturnValueOnce('win32')
         expect(getBuildIdByChromePath('/foo/bar')).toBe('115.0.5790.110')


### PR DESCRIPTION
## Proposed changes

fixes #11113

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
