### PR TITLE
mocha: skip test in custom hooks

### DIFF
--- a/tests/helpers/mocha-hooks.conf.js
+++ b/tests/helpers/mocha-hooks.conf.js
@@ -1,0 +1,7 @@
+import { config as baseConfig } from './config.js'
+
+export const config = Object.assign({}, baseConfig, {
+    beforeTest(test, context) {
+        context.skip()
+    }
+})

--- a/tests/mocha/test-skipped-hooks.ts
+++ b/tests/mocha/test-skipped-hooks.ts
@@ -1,0 +1,7 @@
+import assert from 'node:assert'
+
+describe('Mocha smoke test to be skipped via wdio hooks', () => {
+    it('should be skipped', async () => {
+        assert.strictEqual(1, 2)
+    })
+})

--- a/tests/smoke.runner.js
+++ b/tests/smoke.runner.js
@@ -663,6 +663,22 @@ const nonGlobalTestrunner = async () => {
     assert.strictEqual(hasFailed, false)
 }
 
+/**
+ * Mocha wdio testrunner skip tests via wdio hook
+ */
+const mochaHooksTestrunner = async () => {
+    const { skippedSpecs } = await launch(
+        'mochaHooksTestrunner',
+        path.resolve(__dirname, 'helpers', 'mocha-hooks.conf.js'),
+        {
+            specs: [
+                path.resolve(__dirname, 'mocha', 'test-skipped-hooks.ts'),
+            ]
+        }
+    )
+    assert.strictEqual(skippedSpecs, 0)
+}
+
 (async () => {
     const smokeTests = [
         mochaTestrunner,
@@ -692,7 +708,8 @@ const nonGlobalTestrunner = async () => {
         customReporterString,
         customReporterObject,
         severeErrorTest,
-        nonGlobalTestrunner
+        nonGlobalTestrunner,
+        mochaHooksTestrunner
     ]
 
     console.log('\nRunning smoke tests...\n')


### PR DESCRIPTION
## Proposed changes

Fix - #6645

Preventing the execution of hooks when an exception is thrown to skip a test case in Mocha.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
