### PR TITLE
Fix incorrect browser auto-setup doc

### DIFF
--- a/website/docs/DriverBinaries.md
+++ b/website/docs/DriverBinaries.md
@@ -7,7 +7,7 @@ To run automation based on the WebDriver protocol you need to have browser drive
 
 ## Automated setup
 
-With WebdriverIO `v8.14` and above there is no need to manually download and setup any browser drivers anymore as this is handled by WebdriverIO. All you have to do is specify the browser you want to test and WebdriverIO will do the rest. For more information on this feature, see [here](capabilities#automate-different-browser-channels).
+With WebdriverIO `v8.14` and above there is no need to manually download and setup any browser drivers anymore as this is handled by WebdriverIO. All you have to do is specify the browser you want to test and WebdriverIO will do the rest.
 
 ### Customizing the level of automation
 
@@ -15,7 +15,7 @@ WebdriverIO's have three levels of automation:
 
 **1. Download and install the browser using [@puppeteer/browsers](https://www.npmjs.com/package/@puppeteer/browsers).**
 
-WebdriverIO will only do this if it cannot autodetect an installation of the browser with the `browserName`/`browserVersion` combination specified in the [capabilities](configuration#capabilities-1) configuration. If `browserVersion` is omitted, WebdriverIO will try to use the browser found with [locate-app](https://www.npmjs.com/package/locate-app), otherwise it will install the current stable browser release.
+If you specify a `browserName`/`browserVersion` combination in the [capabilities](configuration#capabilities-1) configuration, WebdriverIO will download and install the requested combination, regardless of whether there's an existing installation on the machine. If you omit `browserVersion`, WebdriverIO will first try to locate and use an existing installation with [locate-app](https://www.npmjs.com/package/locate-app), otherwise it will download and install the current stable browser release. For more details on `browserVersion`, see [here](capabilities#automate-different-browser-channels).
 
 :::caution
 


### PR DESCRIPTION
## Proposed changes

Fix an incorrect statement that says `browserVersion` is used to locate an existing installation of the browser, when in reality instead it always trigger a download.

When I contributed #11128, I misunderstood the `browserVersion` logic. This update corrects this misunderstanding.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
