### PR TITLE
handle timeout exceptions

### DIFF
--- a/packages/wdio-utils/tests/shim.test.ts
+++ b/packages/wdio-utils/tests/shim.test.ts
@@ -1,5 +1,5 @@
 import { vi, describe, it, expect } from 'vitest'
-import { wrapCommand } from '../src/shim.js'
+import { wrapCommand, executeAsync } from '../src/shim.js'
 
 describe('wrapCommand', () => {
     it('should run command with before and after hook', async () => {
@@ -41,5 +41,39 @@ describe('wrapCommand', () => {
 
         expect(afterHook).toBeCalledTimes(3)
         expect(afterHook).toBeCalledWith('someCommand', [123, 'barfoo'], undefined, error)
+    })
+})
+
+describe('executeAsync', () => {
+    it('should trigger a timeout exception if the function finishes within the specified timeframe', async () => {
+        const fn = () => new Promise((resolve) => setTimeout(resolve, 300))
+        const result = await executeAsync(fn, { attempts: 1, limit: 1 }, [], 200).catch((err) => err.message)
+        expect(result).toEqual('Timeout')
+    })
+
+    it('should not trigger a timeout exception if the function finishes within the specified timeframe', async () => {
+        const fn = () => new Promise((resolve) => setTimeout(() => resolve(true), 100))
+        const result = await executeAsync(fn, { attempts: 1, limit: 1 }, [], 300)
+        expect(result).toBe(true)
+    })
+
+    it('should retry', async () => {
+        let attempts = 0
+        const retryFunction = () => {
+            attempts++
+            if (attempts < 3) {
+                return Promise.reject(new Error('Failed'))
+            }
+            return Promise.resolve('Success')
+        }
+        const result = await executeAsync(retryFunction, { attempts: 1, limit: 3 }, [], 300)
+        expect(attempts).to.equal(3)
+        expect(result).to.equal('Success')
+    })
+
+    it('should handle errors during execution', async () => {
+        const fn = () => Promise.reject(new Error('Execution Error'))
+        const result = await executeAsync(fn, { attempts: 1, limit: 1 }, [], 200).catch((err) => err.message)
+        expect(result).toEqual('Execution Error')
     })
 })


### PR DESCRIPTION
## Proposed changes

Fix - #5545

When the framework library throws a timeout exception, it abruptly ends the function, which disrupts the retry process and prevents the subsequent `afterCommand` / `afterTest` from running.

![Screenshot 2023-09-15 at 7 33 25 AM](https://github.com/webdriverio/webdriverio/assets/49207189/693a73f7-e634-473d-b951-a787c72ae1b3)


## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
