### PR TITLE
(@wdio/utils): apply fix to the gecko and edge drivers

### DIFF
--- a/packages/wdio-utils/src/driver/index.ts
+++ b/packages/wdio-utils/src/driver/index.ts
@@ -128,7 +128,7 @@ export async function startWebDriver (options: Options.WebDriver) {
         }
 
         driver = 'GeckoDriver'
-        driverProcess = await startGeckodriver({ ...geckodriverOptions, cacheDir, port })
+        driverProcess = await startGeckodriver({ ...geckodriverOptions, cacheDir, port, allowHosts: ['0.0.0.0'] })
     } else if (isEdge(caps.browserName)) {
         /**
          * Microsoft Edge
@@ -139,7 +139,7 @@ export async function startWebDriver (options: Options.WebDriver) {
         }
 
         driver = 'EdgeDriver'
-        driverProcess = await startEdgedriver({ ...edgedriverOptions, cacheDir, port }).catch((err) => {
+        driverProcess = await startEdgedriver({ ...edgedriverOptions, cacheDir, port, allowedIps: ['0.0.0.0'] }).catch((err) => {
             log.warn(`Couldn't start EdgeDriver: ${err.message}, retry ...`)
             return startEdgedriver({ ...edgedriverOptions, cacheDir, port })
         })

--- a/packages/wdio-utils/tests/driver/index.test.ts
+++ b/packages/wdio-utils/tests/driver/index.test.ts
@@ -148,7 +148,8 @@ describe('startWebDriver', () => {
         expect(startGeckodriver).toBeCalledWith({
             port: 1234,
             foo: 'bar',
-            cacheDir: expect.any(String)
+            cacheDir: expect.any(String),
+            allowHosts: ['0.0.0.0'],
         })
     })
 
@@ -177,7 +178,8 @@ describe('startWebDriver', () => {
         expect(startEdgedriver).toBeCalledWith({
             foo: 'bar',
             port: 1234,
-            cacheDir: expect.any(String)
+            cacheDir: expect.any(String),
+            allowedIps: ['0.0.0.0'],
         })
         expect(options.capabilities.browserName).toBe('MicrosoftEdge')
     })
@@ -258,6 +260,7 @@ describe('startWebDriver', () => {
         expect(res).toBe('geckodriver')
         expect(startGeckodriver).toBeCalledWith({
             cacheDir: expect.any(String),
+            allowHosts: ['0.0.0.0'],
             customGeckoDriverPath: '/my/geckodriver',
             port: 1234
         })
@@ -275,6 +278,7 @@ describe('startWebDriver', () => {
         expect(res).toBe('edgedriver')
         expect(startEdgedriver).toBeCalledWith({
             cacheDir: expect.any(String),
+            allowedIps: ['0.0.0.0'],
             customEdgeDriverPath: '/my/edgedriver',
             port: 1234
         })


### PR DESCRIPTION
## Proposed changes

Apply the same fix we did for the chromedriver. to the gecko and edge drivers.

Sadly, it looks like this cannot be applied to the safaridriver :(

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

### Reviewers: @webdriverio/project-committers
