### PR TITLE
filter spec by loadSources cucumber interface

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1093,11 +1093,6 @@
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.1.tgz",
       "integrity": "sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA=="
     },
-    "node_modules/@cucumber/tag-expressions": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/@cucumber/tag-expressions/-/tag-expressions-5.0.6.tgz",
-      "integrity": "sha512-IWeUm73mJCv+Wv35nD+OX37C2U7ljRaRUWj1mSbZLAY8Zwgc+bwbS667y88WpBNhznxWwXyBd+k5sZk8O+aXJQ=="
-    },
     "node_modules/@esbuild/android-arm": {
       "version": "0.18.19",
       "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.19.tgz",
@@ -28864,7 +28859,6 @@
         "@cucumber/cucumber": "9.5.1",
         "@cucumber/gherkin": "26.2.0",
         "@cucumber/messages": "22.0.0",
-        "@cucumber/tag-expressions": "5.0.6",
         "@types/node": "^20.1.0",
         "@wdio/logger": "8.11.0",
         "@wdio/types": "8.16.7",

--- a/packages/wdio-cucumber-framework/package.json
+++ b/packages/wdio-cucumber-framework/package.json
@@ -41,7 +41,6 @@
     "@cucumber/cucumber": "9.5.1",
     "@cucumber/gherkin": "26.2.0",
     "@cucumber/messages": "22.0.0",
-    "@cucumber/tag-expressions": "5.0.6",
     "@types/node": "^20.1.0",
     "@wdio/logger": "8.11.0",
     "@wdio/types": "8.16.7",

--- a/packages/wdio-cucumber-framework/src/index.ts
+++ b/packages/wdio-cucumber-framework/src/index.ts
@@ -12,10 +12,9 @@ import { executeHooksWithArgs } from '@wdio/utils'
 import * as Cucumber from '@cucumber/cucumber'
 import Gherkin from '@cucumber/gherkin'
 import { IdGenerator } from '@cucumber/messages'
-import TagExpressionParser from '@cucumber/tag-expressions'
 
 import { DEFAULT_OPTS } from './constants.js'
-import { generateSkipTagsFromCapabilities, shouldRun } from './utils.js'
+import { generateSkipTagsFromCapabilities } from './utils.js'
 
 import type {
     CucumberOptions,
@@ -30,6 +29,8 @@ import type {
     IRunEnvironment } from '@cucumber/cucumber/api'
 import {
     loadConfiguration,
+    loadSources,
+    loadSupport,
     runCucumber
 } from '@cucumber/cucumber/api'
 
@@ -190,40 +191,6 @@ class CucumberAdapter {
         })
     }
 
-    filterSpecsByTagExpression(
-        specs: Options.Testrunner['specs'] = [],
-        tagExpression = this._cucumberOpts.tags ?? ''
-    ): typeof specs {
-        if (!tagExpression) {
-            return specs
-        }
-
-        const tagParser = TagExpressionParser(tagExpression)
-
-        const filteredSpecs: Options.Testrunner['specs'] =
-            this.getGherkinDocuments([this._specs])
-                .map((specDoc: GherkinDocument | GherkinDocument[]) => {
-                    const [doc, ...etc] = [specDoc]
-                        .flat(1)
-                        .filter((doc) => shouldRun(doc, tagParser))
-
-                    const ret = Array.isArray(specDoc)
-                        ? // Return group only if its not empty
-                        doc && [doc, ...etc]
-                        : doc
-
-                    return ret as GherkinDocument | GherkinDocument[]
-                })
-                .filter((doc: GherkinDocument) => !!doc)
-                .map((doc) => {
-                    // Get URIs from Gherkin documents to run
-                    const [uri, ...etc] = [doc].flat(1).map((doc) => doc.uri!)
-                    return Array.isArray(doc) ? [uri, ...etc] : uri
-                })
-
-        return filteredSpecs
-    }
-
     generateDynamicSkipTags() {
         return this.getGherkinDocuments([this._specs])
             .map((specDoc: GherkinDocument | GherkinDocument[]) => {
@@ -243,13 +210,22 @@ class CucumberAdapter {
         // Filter the specs according to the tag expression
         // Some workers would only spawn to then skip the spec (Feature) file
         // Filtering at this stage can prevent the spawning of a massive number of workers
-        if (this._cucumberOpts.tags) {
-            this._specs = this.filterSpecsByTagExpression([this._specs]).flat(1)
-        }
+        const { plan } = await loadSources({
+            paths: this._specs,
+            defaultDialect: this._cucumberOpts.language,
+            order: this._cucumberOpts.order,
+            names: this._cucumberOpts.name,
+            tagExpression: this._cucumberOpts.tags,
+        })
+        this._specs = plan?.map((pl) => path.resolve(pl.uri))
+
         // Filter the specs according to line numbers
         if (this._config.cucumberFeaturesWithLineNumbers?.length! > 0) {
             this._specs = this._config.cucumberFeaturesWithLineNumbers!
         }
+
+        this._specs = [...new Set(this._specs)]
+
         this._cucumberOpts.paths = this._specs
         this._hasTests = this._specs.length > 0
         return this
@@ -302,10 +278,14 @@ class CucumberAdapter {
                 environment
             )
 
+            const support = await loadSupport(runConfiguration, environment)
+
+            const _support = { ...supportCodeLibrary, originalCoordinates: support.originalCoordinates }
+
             const { success } = await runCucumber(
                 {
                     ...runConfiguration,
-                    support: supportCodeLibrary || runConfiguration.support,
+                    support: supportCodeLibrary ? _support : runConfiguration.support,
                 },
                 environment
             )

--- a/packages/wdio-cucumber-framework/src/index.ts
+++ b/packages/wdio-cucumber-framework/src/index.ts
@@ -30,7 +30,6 @@ import type {
 import {
     loadConfiguration,
     loadSources,
-    loadSupport,
     runCucumber
 } from '@cucumber/cucumber/api'
 
@@ -278,14 +277,10 @@ class CucumberAdapter {
                 environment
             )
 
-            const support = await loadSupport(runConfiguration, environment)
-
-            const _support = { ...supportCodeLibrary, originalCoordinates: support.originalCoordinates }
-
             const { success } = await runCucumber(
                 {
                     ...runConfiguration,
-                    support: supportCodeLibrary ? _support : runConfiguration.support,
+                    support: supportCodeLibrary || runConfiguration.support,
                 },
                 environment
             )

--- a/packages/wdio-cucumber-framework/src/utils.ts
+++ b/packages/wdio-cucumber-framework/src/utils.ts
@@ -1,8 +1,5 @@
 import path from 'node:path'
 import logger from '@wdio/logger'
-import type TagExpressionParser from '@cucumber/tag-expressions'
-import { compile } from '@cucumber/gherkin'
-import { IdGenerator } from '@cucumber/messages'
 
 import type {
     TableRow,
@@ -11,8 +8,7 @@ import type {
     TestStep,
     Feature,
     Pickle,
-    TestStepResultStatus,
-    GherkinDocument
+    TestStepResultStatus
 } from '@cucumber/messages'
 import type { Capabilities } from '@wdio/types'
 import type { ReporterStep } from './types.js'
@@ -175,15 +171,6 @@ export function addKeywordToStep(steps: ReporterStep[], feature: Feature){
         }
         return step
     })
-}
-
-export function shouldRun(doc: GherkinDocument, tagParser: ReturnType<typeof TagExpressionParser>) {
-    if (!doc.feature) {
-        return false
-    }
-    const pickles = compile(doc, '', IdGenerator.uuid())
-    const tags = pickles.map((pickle) => pickle.tags.map((tag) => tag.name))
-    return tags.some((tag) => tagParser.evaluate(tag))
 }
 
 /**

--- a/packages/wdio-cucumber-framework/tests/adapter.test.ts
+++ b/packages/wdio-cucumber-framework/tests/adapter.test.ts
@@ -542,4 +542,31 @@ describe('CucumberAdapter', () => {
         expect(result).toBe(0)
         expect(executeHooksWithArgs).toBeCalledTimes(1)
     })
+
+    it('should skip test if `skip` tag condition is matched', async () => {
+        const adapter = await CucumberAdapter.init!(
+            '0-0',
+            { cucumberOpts: { format: [], dryRun: true } },
+            [
+                'packages/wdio-cucumber-framework/tests/fixtures/test_skip.feature',
+            ],
+            { browserName: 'chrome' },
+            {},
+            {},
+            true,
+            ['progress']
+        )
+
+        expect(adapter._specs).toHaveLength(0)
+        expect(adapter.hasTests()).toBe(false)
+
+        adapter.registerRequiredModules = vi.fn()
+        adapter.addWdioHooksAndWrapSteps = vi.fn()
+        adapter.loadFiles = vi.fn()
+
+        const result = await adapter.run()
+
+        expect(result).toBe(0)
+        expect(executeHooksWithArgs).toBeCalledTimes(1)
+    })
 })

--- a/packages/wdio-cucumber-framework/tests/adapter.test.ts
+++ b/packages/wdio-cucumber-framework/tests/adapter.test.ts
@@ -73,7 +73,7 @@ describe('CucumberAdapter', () => {
     })
 
     it('can be initiated with tests', async () => {
-        const adapter = await CucumberAdapter.init!('0-0', {}, ['/foo/bar'], {}, {}, {}, false, ['progress'])
+        const adapter = await CucumberAdapter.init!('0-0', {}, ['packages/wdio-cucumber-framework/tests/fixtures/test_no_tags.feature'], {}, {}, {}, false, ['progress'])
         expect(executeHooksWithArgs).toBeCalledTimes(0)
         expect(adapter.hasTests()).toBe(true)
     })
@@ -485,5 +485,61 @@ describe('CucumberAdapter', () => {
         )
 
         expect(adapter.gherkinParser.tokenMatcher.dialect.name).toBe('Danish')
+    })
+
+    it('can run when filtering by name', async () => {
+        const adapter = await CucumberAdapter.init!(
+            '0-0',
+            { cucumberOpts: { name: ['Scenario #2'], format: [], dryRun: true } },
+            [
+                'packages/wdio-cucumber-framework/tests/fixtures/test_tags.feature',
+                'packages/wdio-cucumber-framework/tests/fixtures/test_no_tags.feature',
+            ],
+            {},
+            {},
+            {},
+            false,
+            ['progress']
+        )
+
+        expect(adapter._specs).toHaveLength(2)
+        expect(adapter._hasTests).toBe(true)
+
+        adapter.registerRequiredModules = vi.fn()
+        adapter.addWdioHooksAndWrapSteps = vi.fn()
+        adapter.loadFiles = vi.fn()
+
+        const result = await adapter.run()
+
+        expect(result).toBe(0)
+        expect(executeHooksWithArgs).toBeCalledTimes(1)
+    })
+
+    it('can run when filtering by name & tags', async () => {
+        const adapter = await CucumberAdapter.init!(
+            '0-0',
+            { cucumberOpts: { name: ['Scenario #2'], tags: '@runall', format: [], dryRun: true } },
+            [
+                'packages/wdio-cucumber-framework/tests/fixtures/test_tags.feature',
+                'packages/wdio-cucumber-framework/tests/fixtures/test_no_tags.feature',
+            ],
+            {},
+            {},
+            {},
+            false,
+            ['progress']
+        )
+
+        expect(adapter._specs).toHaveLength(1)
+        expect(adapter._hasTests).toBe(true)
+
+        adapter.registerRequiredModules = vi.fn()
+        adapter.addWdioHooksAndWrapSteps = vi.fn()
+        adapter.loadFiles = vi.fn()
+
+        const result = await adapter.run()
+
+        expect(result).toBe(0)
+        expect(executeHooksWithArgs).toBeCalledTimes(1)
     })
 })

--- a/packages/wdio-cucumber-framework/tests/fixtures/test_skip.feature
+++ b/packages/wdio-cucumber-framework/tests/fixtures/test_skip.feature
@@ -1,0 +1,17 @@
+Feature: Test Feature
+
+  Background: Background #1
+    Given a step passes
+    When a step passes
+
+  @skip(browserName="chrome") 
+  Scenario: Scenario #1
+    Given a step passes
+    When a step passes
+    Then a step passes
+
+  @skip()
+  Scenario: Scenario #2
+    Given a step passes
+    When a step passes
+    Then a step passes


### PR DESCRIPTION
## Proposed changes

Fix - #11204 

- Improving the method of filtering specs based on tags and names by utilising the loadSource Cucumber interface. This addresses the problem of feature files spinning when the scenario name doesn't match.
- Adding unit test for "skipping test in cucumber"

**Output of use-case mentioned in Bug:**

![Screenshot 2023-09-20 at 8 33 44 AM](https://github.com/webdriverio/webdriverio/assets/49207189/6c318d14-2a50-40b4-b04d-f941a8fd8397)


## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
