### PR TITLE
Add property logLevel in moon:options

### DIFF
--- a/packages/wdio-types/src/Capabilities.ts
+++ b/packages/wdio-types/src/Capabilities.ts
@@ -378,7 +378,8 @@ export type MoonMobileDeviceOrientation =
     'portait' | 'vertical' | 'landscape' | 'horizontal'
 
 export interface MoonOptions extends SelenoidOptions {
-    mobileDevice?: { deviceName: string, orientation: MoonMobileDeviceOrientation }
+    mobileDevice?: { deviceName: string, orientation: MoonMobileDeviceOrientation },
+    logLevel?: string
 }
 
 // Selenium Grid specific

--- a/packages/wdio-types/src/index.ts
+++ b/packages/wdio-types/src/index.ts
@@ -26,6 +26,10 @@ interface DriverOptions {
      * path to custom driver binary
      */
     binary?: string
+    /**
+    * path to the log file
+    */
+    logPath?: string
 }
 
 declare global {

--- a/tests/typings/webdriverio/config.ts
+++ b/tests/typings/webdriverio/config.ts
@@ -144,6 +144,14 @@ const config: WebdriverIO.Config = {
             videoName: 'test.mp4'
         }
     }, {
+        'moon:options': {
+            logLevel: 'INFO',
+            mobileDevice: {
+                deviceName: 'Apple iPhone XR',
+                orientation: 'portrait'
+            }
+        }
+    },{
         'wdio:devtoolsOptions': {
             ignoreDefaultArgs: false
         }


### PR DESCRIPTION
## Proposed changes

This PR adds a missing property in the MoonOptions interface, this property is supported by vendor in the capabilities using `moon:options`. TypeScript was showing an error if I wanted to use this property in my capability configuration

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
