### PR TITLE
(@wdio/utils): fix error when promise rejected with error within test duration

### DIFF
--- a/packages/wdio-utils/src/shim.ts
+++ b/packages/wdio-utils/src/shim.ts
@@ -316,7 +316,7 @@ async function executeAsync(this: any, fn: Function, retries: Retries, args: any
         let done = false
         const result = await Promise.race([
             fn.apply(this, args),
-            new Promise((resolve, reject) => {
+            new Promise<void>((resolve, reject) => {
                 setTimeout(() => {
                     if (done) {
                         resolve()

--- a/packages/wdio-utils/src/shim.ts
+++ b/packages/wdio-utils/src/shim.ts
@@ -313,14 +313,20 @@ async function executeAsync(this: any, fn: Function, retries: Retries, args: any
         /**
          * Executes the function with specified timeout and returns the result, or throws an error if the timeout is exceeded.
          */
+        let done = false
         const result = await Promise.race([
             fn.apply(this, args),
             new Promise((resolve, reject) => {
                 setTimeout(() => {
-                    reject(new Error('Timeout'))
+                    if (done) {
+                        resolve()
+                    } else {
+                        reject(new Error('Timeout'))
+                    }
                 }, _timeout)
             })
         ])
+        done = true
 
         if (result && typeof result.finally === 'function') {
             result.catch((err: any) => err)


### PR DESCRIPTION
Promise.race takes the value of the first promise that resolves/rejects, however it does not cancel the other promises.
Say that your test is running for 10 seconds, the timeout for the executeAsync shim is 5 second and the executeAsync is resolved instantly. You would think that this does not throw an error but it does!
This is because when the 5 seconds are passed, it will throw the error, even though the first promise resolved.
This PR fixes this while keeping the previous functionality intact.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

### Reviewers: @webdriverio/project-committers
