### PR TITLE
Throw err if getter's is used before server init

### DIFF
--- a/packages/wdio-shared-store-service/src/client.ts
+++ b/packages/wdio-shared-store-service/src/client.ts
@@ -26,6 +26,9 @@ export const setPort = (port: number) => {
  * @returns {*}
  */
 export const getValue = async (key: string): Promise<string | number | boolean | JsonObject | JsonArray | null | undefined> => {
+    if (!isBaseUrlReady) {
+        throw new Error('Attempting to use `getValue` before the server has been initialized.')
+    }
     const baseUrl = await baseUrlPromise
     const res = await got.get(`${baseUrl}/${key}`, { responseType: 'json' }).catch(errHandler)
     return res?.body ? (res.body as JsonObject).value : undefined
@@ -63,6 +66,9 @@ export const setResourcePool = async (key: string, value: JsonArray) => {
  * @param {*}       value
  */
 export const getValueFromPool = async (key: string, options?: GetValueOptions) => {
+    if (!isBaseUrlReady) {
+        throw new Error('Attempting to use `getValueFromPool` before the server has been initialized.')
+    }
     const baseUrl = await baseUrlPromise
     const res = await got.get(`${baseUrl}/pool/${key}${typeof options?.timeout === 'number' ? `?timeout=${options.timeout}` : '' }`, { responseType: 'json' }).catch(errHandler)
     return res?.body ? (res.body as JsonObject).value : undefined
@@ -74,6 +80,9 @@ export const getValueFromPool = async (key: string, options?: GetValueOptions) =
  * @param {*}       value
  */
 export const addValueToPool = async (key: string, value: JsonPrimitive | JsonCompatible) => {
+    if (!isBaseUrlReady) {
+        throw new Error('Attempting to use `addValueToPool` before the server has been initialized.')
+    }
     const baseUrl = await baseUrlPromise
     const res = await got.post(`${baseUrl}/pool/${key}`, { json: { value }, responseType: 'json' }).catch(errHandler)
     return res?.body ? (res.body as JsonObject).value : undefined

--- a/packages/wdio-shared-store-service/tests/client.test.ts
+++ b/packages/wdio-shared-store-service/tests/client.test.ts
@@ -41,6 +41,12 @@ describe('client', () => {
     })
 
     describe('when used in launcher process', () => {
+        it('should not return a value if the server has not been initialized', () => {
+            expect(getValue('*')).rejects.toThrowError('Attempting to use `getValue` before the server has been initialized.')
+            expect(getValueFromPool('*')).rejects.toThrowError('Attempting to use `getValueFromPool` before the server has been initialized.')
+            expect(addValueToPool('*', '')).rejects.toThrowError('Attempting to use `addValueToPool` before the server has been initialized.')
+        })
+
         it('should not post before server has started', async () => {
             const result1 = await setValue('foo', 'bar')
             const result2 = await setValue('bar', 'foo')

--- a/packages/wdio-shared-store-service/tests/client.test.ts
+++ b/packages/wdio-shared-store-service/tests/client.test.ts
@@ -41,7 +41,7 @@ describe('client', () => {
     })
 
     describe('when used in launcher process', () => {
-        it('should not return a value if the server has not been initialized', () => {
+        it('Error should be thrown when attempting to retrieve a value before server initialization', () => {
             expect(getValue('*')).rejects.toThrowError('Attempting to use `getValue` before the server has been initialized.')
             expect(getValueFromPool('*')).rejects.toThrowError('Attempting to use `getValueFromPool` before the server has been initialized.')
             expect(addValueToPool('*', '')).rejects.toThrowError('Attempting to use `addValueToPool` before the server has been initialized.')


### PR DESCRIPTION
## Proposed changes

Proposal for #11208 

Throw an error when attempting to call `getValue`, `getValueFromPool`, `addValueToPool` before the server is initialised.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
