### PR TITLE
fix: Respect user-provided Cucumber formatter options

### DIFF
--- a/packages/wdio-cucumber-framework/src/index.ts
+++ b/packages/wdio-cucumber-framework/src/index.ts
@@ -124,8 +124,17 @@ class CucumberAdapter {
 
         /**
          * formatting options used by custom cucumberFormatter
+         * https://github.com/cucumber/cucumber-js/blob/3a945b1077d4539f8a363c955a0506e088ff4271/docs/formatters.md#options
          */
         this._cucumberOpts.formatOptions = {
+
+            // We need to pass the user provided Formatter options
+            // Example: JUnit formatter https://github.com/cucumber/cucumber-js/blob/3a945b1077d4539f8a363c955a0506e088ff4271/docs/formatters.md#junit
+            // { junit: { suiteName: "MySuite" } }
+            ...(this._cucumberOpts.formatOptions ?? {}),
+
+            // Our Cucumber Formatter options
+            // Put last so that user does not override them
             _reporter: this._reporter,
             _cid: this._cid,
             _specs: this._specs,

--- a/packages/wdio-cucumber-framework/tests/adapter.test.ts
+++ b/packages/wdio-cucumber-framework/tests/adapter.test.ts
@@ -78,6 +78,15 @@ describe('CucumberAdapter', () => {
         expect(adapter.hasTests()).toBe(true)
     })
 
+    it('respects user-defined formatOptions', async () => {
+
+        const formatOptions =  { myFormatter: { MyOption: 'MyValue' } }
+
+        const adapter = await CucumberAdapter.init!('0-0', { cucumberOpts: { formatOptions } }, [], {}, {}, {}, false)
+
+        expect(adapter._cucumberOpts.formatOptions).toEqual(expect.objectContaining(formatOptions))
+    })
+
     it('throws if parallel cucumber opts is set', async () => {
         await expect(
             CucumberAdapter.init!('0-0', { cucumberOpts: { parallel: 1 } }, [], {}, {}, {}, false, ['progress'])


### PR DESCRIPTION
## Proposed changes

Cucumber users can provide their own Cucumber formatter options.
Currently, webdriverIO is not respecting them.
Seems we are not passing these options along to Cucumber.
This fixes that.

To test, set a formatter (for example [JUnit](https://github.com/cucumber/cucumber-js/blob/main/docs/formatters.md#junit)) in the WDIO config, for example:
```json
{
  "cucumberOpts": {
    "format": [
      ["junit", `/path/to/results/junit-${process.env.WDIO_WORKER_ID}.xml`]
    ],
    "formatOptions": {
      "junit": {
        "suiteName": "My Custom Suite"
      }
    }
  }
}

```

and check that after running the tests, the JUnit XML files generated have a `name` property with value "My Custom Suite".
For example:
```xml
<?xml version="1.0"?>
<testsuite failures="0" skipped="0" name="My Custom Suite" time="18.300956380000002" tests="1">
  <testcase classname="Stuff" name="User does stuff" time="18.300956380000002">
    <system-out><![CDATA[Given I do stuff............................................passed
When I do stuff............................................passed
Then I do stuff............................................passed]]></system-out>
  </testcase>
</testsuite>
```

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
