### PR TITLE
(docs): update TypeScript documentation for missing types

### DIFF
--- a/website/docs/TypeScript.md
+++ b/website/docs/TypeScript.md
@@ -123,6 +123,27 @@ const config: Options.WebdriverIO = {
 }
 ```
 
+## Missing Types
+
+When using Node 20 or above, wdio runs ts-node with different settings as this is required in order to keep things running.
+These settings can cause your custom types not to be loaded, if this happens there are a few ways you can fix this, of which the easiest I will show below.
+
+Using ts-node's environment variables
+```
+TS_NODE_FILES=true wdio run ./wdio.conf.ts
+```
+
+Using tsconfig
+```
+{
+  "ts-node": {
+    "files": true
+  },
+}
+```
+
+For more information checkout the (ts-node documentation)[https://typestrong.org/ts-node/docs/troubleshooting#missing-types].
+
 ## Tips and Hints
 
 ### Compile & Lint


### PR DESCRIPTION
## Proposed changes

Update the TypeScript docs on how to deal with missing types due to the added `-r ts-node/register` for ts-node.

This fixes missing types (custom `wdio.d.ts` for example).

Resolves #11219 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

### Reviewers: @webdriverio/project-committers
