### PR TITLE
add publishCucumberReport functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28964,6 +28964,7 @@
         "@wdio/types": "8.16.12",
         "@wdio/utils": "8.16.17",
         "glob": "^10.2.2",
+        "got": "^13.0.0",
         "is-glob": "^4.0.0"
       },
       "devDependencies": {
@@ -28971,6 +28972,30 @@
       },
       "engines": {
         "node": "^16.13 || >=18"
+      }
+    },
+    "packages/wdio-cucumber-framework/node_modules/got": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/got/-/got-13.0.0.tgz",
+      "integrity": "sha512-XfBk1CxOOScDcMr9O1yKkNaQyy865NbYs+F7dr4H0LZMVgCj2Le59k6PqbNHoL5ToeaEQUYh6c6yMfVcc6SJxA==",
+      "dependencies": {
+        "@sindresorhus/is": "^5.2.0",
+        "@szmarczak/http-timer": "^5.0.1",
+        "cacheable-lookup": "^7.0.0",
+        "cacheable-request": "^10.2.8",
+        "decompress-response": "^6.0.0",
+        "form-data-encoder": "^2.1.2",
+        "get-stream": "^6.0.1",
+        "http2-wrapper": "^2.1.10",
+        "lowercase-keys": "^3.0.0",
+        "p-cancelable": "^3.0.0",
+        "responselike": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/got?sponsor=1"
       }
     },
     "packages/wdio-devtools-service": {

--- a/packages/wdio-cucumber-framework/README.md
+++ b/packages/wdio-cucumber-framework/README.md
@@ -141,13 +141,46 @@ Default: ``
 
 ***Please note that this option would be deprecated in future. Use [`tags`](#tags) config property instead***
 
-#### profile
+### profile
 Specify the profile to use.
 
 Type: `string[]`<br />
 Default: `[]`
 
 ***Kindly take note that only specific values (worldParameters, name, retryTagFilter) are supported within profiles, as `cucumberOpts` takes precedence. Additionally, when using a profile, make sure that the mentioned values are not declared within `cucumberOpts`.***
+
+## Publishing Report
+
+Cucumber provides a feature to publish your test run reports to `https://reports.cucumber.io/`, which can be controlled either by setting the `publish` flag in `cucumberOpts` or by configuring the `CUCUMBER_PUBLISH_TOKEN` environment variable. However, when you use `WebdriverIO` for test execution, there's a limitation with this approach. It updates the reports separately for each feature file, making it difficult to view a consolidated report.
+
+To overcome this limitation, we've introduced a promise-based method called `publishCucumberReport` within `@wdio/cucumber-framework`. This method should be called in the `onComplete` hook, which is the optimal place to invoke it. `publishCucumberReport` requires the input of the report directory where cucumber message reports are stored.
+
+You can generate `cucumber message` reports by configuring the `format` option in your `cucumberOpts`. It's highly recommended to provide a dynamic file name within the `cucumber message` format option to prevent overwriting reports and ensure that each test run is accurately recorded.
+
+Before using this function, make sure to set the following environment variables:
+- CUCUMBER_PUBLISH_REPORT_URL: The URL where you want to publish the Cucumber report. If not provided, the default URL 'https://messages.cucumber.io/api/reports' will be used.
+- CUCUMBER_PUBLISH_REPORT_TOKEN: The authorization token required to publish the report. If this token is not set, the function will exit without publishing the report.
+
+Here's an example of the necessary configurations and code samples for implementation:
+
+```javascript
+import { v4 as uuidv4 } from 'uuid'
+import { publishCucumberReport } from '@wdio/cucumber-framework';
+
+export const config = {
+    // ... Other Configuration Options
+    cucumberOpts: {
+        // ... Cucumber Options Configuration
+        format: [['message', `./reports/${uuidv4()}.ndjson`]]
+    },
+    async onComplete() {
+        await publishCucumberReport('./reports');
+    }
+}
+```
+
+Please note that `./reports/` is the directory where `cucumber message` reports will be stored.
+
 ----
 
 For more information on WebdriverIO see the [homepage](http://webdriver.io).

--- a/packages/wdio-cucumber-framework/README.md
+++ b/packages/wdio-cucumber-framework/README.md
@@ -104,6 +104,29 @@ Only retries the features or scenarios with tags matching the expression (repeat
 
 Type: `RegExp`
 
+### language
+Default language for your feature files
+
+Type: `String`<br />
+Default: `en`
+
+### order
+Run tests in defined / random order
+
+Type: `String`<br />
+Default: `defined`
+
+### format
+Name and output file path of formatter to use.
+WebdriverIO primarily supports only the [Formatters](https://github.com/cucumber/cucumber-js/blob/main/docs/formatters.md) that writes output to a file.
+
+Type: `string[]`<br />
+
+### formatOptions
+Options to be provided to formatters
+
+Type: `object`<br />
+
 ### tagsInTitle
 Add cucumber tags to feature or scenario name
 
@@ -171,7 +194,10 @@ export const config = {
     // ... Other Configuration Options
     cucumberOpts: {
         // ... Cucumber Options Configuration
-        format: [['message', `./reports/${uuidv4()}.ndjson`]]
+        format: [
+            ['message', `./reports/${uuidv4()}.ndjson`],
+            ['json', './reports/test-report.json']
+        ]
     },
     async onComplete() {
         await publishCucumberReport('./reports');

--- a/packages/wdio-cucumber-framework/package.json
+++ b/packages/wdio-cucumber-framework/package.json
@@ -46,6 +46,7 @@
     "@wdio/types": "8.16.12",
     "@wdio/utils": "8.16.17",
     "glob": "^10.2.2",
+    "got": "^13.0.0",
     "is-glob": "^4.0.0"
   },
   "devDependencies": {

--- a/packages/wdio-cucumber-framework/src/cjs/index.ts
+++ b/packages/wdio-cucumber-framework/src/cjs/index.ts
@@ -51,7 +51,12 @@ const adapterFactory = {
     setDefinitionFunctionWrapper,
     setWorldConstructor,
     defineParameterType,
-    defineStep
+    defineStep,
+
+    publishCucumberReport: async function (cucumberMessageDir: string) {
+        const { publishCucumberReport } = await import('../index.js')
+        await publishCucumberReport(cucumberMessageDir)
+    }
 }
 
 module.exports = adapterFactory

--- a/packages/wdio-cucumber-framework/src/index.ts
+++ b/packages/wdio-cucumber-framework/src/index.ts
@@ -8,6 +8,8 @@ import logger from '@wdio/logger'
 import isGlob from 'is-glob'
 import { sync as globSync } from 'glob'
 import { executeHooksWithArgs } from '@wdio/utils'
+import got from 'got'
+import { readdir, readFile } from 'node:fs/promises'
 
 import * as Cucumber from '@cucumber/cucumber'
 import Gherkin from '@cucumber/gherkin'
@@ -481,6 +483,39 @@ class CucumberAdapter {
         })
     }
 }
+/**
+ * Publishes a Cucumber report to a specified URL using NDJSON files from a directory.
+ * @async
+ * @param {string} cucumberMessageDir - The directory path that holds Cucumber NDJSON files.
+ * @returns {Promise<void>} - A Promise that resolves when the report is successfully published.
+ * @throws {Error} - Throws an error if there are issues with file reading or the publishing process.
+ */
+const publishCucumberReport = async (cucumberMessageDir: string): Promise<void> => {
+    const url = process.env.CUCUMBER_PUBLISH_REPORT_URL || 'https://messages.cucumber.io/api/reports'
+    const token = process.env.CUCUMBER_PUBLISH_REPORT_TOKEN
+    if (!token) {
+        return
+    }
+
+    const { headers } = await got(url, {
+        headers: {
+            Authorization: `Bearer ${token}`,
+        }
+    })
+
+    const { location } = headers
+
+    const files = (await readdir(path.resolve(cucumberMessageDir))).filter((file) => path.extname(file) === '.ndjson')
+
+    const cucumberMessage = (await Promise.all(files.map((file) => readFile(path.resolve(`${cucumberMessageDir}/${file}`), 'utf8')))).join('')
+
+    await got.put(location as string, {
+        headers: {
+            'Content-Type': 'application/json'
+        },
+        body: `${cucumberMessage}`
+    })
+}
 
 const _CucumberAdapter = CucumberAdapter
 const adapterFactory: { init?: Function } = {}
@@ -521,7 +556,9 @@ export {
     setDefinitionFunctionWrapper,
     setWorldConstructor,
     defineParameterType,
-    defineStep
+    defineStep,
+
+    publishCucumberReport
 }
 
 declare global {

--- a/packages/wdio-cucumber-framework/tests/adapter.test.ts
+++ b/packages/wdio-cucumber-framework/tests/adapter.test.ts
@@ -1,5 +1,6 @@
 import path from 'node:path'
-import { describe, expect, it, vi, beforeEach } from 'vitest'
+import got from 'got'
+import { describe, expect, it, vi, beforeEach, beforeAll } from 'vitest'
 
 import { executeHooksWithArgs } from '@wdio/utils'
 import * as Cucumber from '@cucumber/cucumber'
@@ -7,7 +8,7 @@ import type * as Messages from '@cucumber/messages'
 
 import * as packageExports from '../src/index.js'
 
-import CucumberAdapter from '../src/index.js'
+import CucumberAdapter, { publishCucumberReport } from '../src/index.js'
 
 vi.mock('@wdio/utils')
 vi.mock('expect-webdriverio')
@@ -577,5 +578,47 @@ describe('CucumberAdapter', () => {
 
         expect(result).toBe(0)
         expect(executeHooksWithArgs).toBeCalledTimes(1)
+    })
+})
+
+describe('publishCucumberReport', () => {
+    beforeAll(() => {
+        vi.mock('fs/promises', () => ({
+            readdir: vi.fn().mockResolvedValue(['file1.ndjson', 'file2.ndjson']),
+            readFile: vi.fn().mockResolvedValueOnce('{"message": "Test 1"}').mockResolvedValueOnce('{"message": "Test 2"}')
+        }))
+        vi.mock('got')
+    })
+
+    it('should not publish report if CUCUMBER_PUBLISH_REPORT_TOKEN is not set', async () => {
+        await publishCucumberReport('/some/directory')
+        expect(got).not.toHaveBeenCalled()
+    })
+
+    it('should publish report successfully', async () => {
+        process.env.CUCUMBER_PUBLISH_REPORT_TOKEN = 'some-token'
+        process.env.CUCUMBER_PUBLISH_REPORT_URL = 'https://example.com/api/reports'
+
+        // @ts-expect-error mock feature
+        got.customResponseFor(/\/api\/reports/, {
+            headers: {
+                location: 'https://example.com/reports/12345'
+            }
+        })
+
+        await publishCucumberReport('./')
+
+        expect(got).toHaveBeenCalledWith('https://example.com/api/reports', {
+            headers: {
+                Authorization: 'Bearer some-token'
+            }
+        })
+
+        expect(got.put).toHaveBeenCalledWith('https://example.com/reports/12345', {
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: '{"message": "Test 1"}{"message": "Test 2"}'
+        })
     })
 })

--- a/website/docs/Frameworks.md
+++ b/website/docs/Frameworks.md
@@ -369,6 +369,29 @@ Only retries the features or scenarios with tags matching the expression (repeat
 
 Type: `RegExp`
 
+#### language
+Default language for your feature files
+
+Type: `String`<br />
+Default: `en`
+
+#### order
+Run tests in defined / random order
+
+Type: `String`<br />
+Default: `defined`
+
+#### format
+Name and output file path of formatter to use.
+WebdriverIO primarily supports only the [Formatters](https://github.com/cucumber/cucumber-js/blob/main/docs/formatters.md) that writes output to a file.
+
+Type: `string[]`<br />
+
+#### formatOptions
+Options to be provided to formatters
+
+Type: `object`<br />
+
 #### tagsInTitle
 Add cucumber tags to feature or scenario name
 
@@ -465,7 +488,10 @@ export const config = {
     // ... Other Configuration Options
     cucumberOpts: {
         // ... Cucumber Options Configuration
-        format: [['message', `./reports/${uuidv4()}.ndjson`]]
+        format: [
+            ['message', `./reports/${uuidv4()}.ndjson`],
+            ['json', './reports/test-report.json']
+        ]
     },
     async onComplete() {
         await publishCucumberReport('./reports');

--- a/website/docs/Frameworks.md
+++ b/website/docs/Frameworks.md
@@ -443,6 +443,38 @@ import { Given, When, Then } from '@wdio/cucumber-framework'
 
 This ensures that you use the right helpers within the WebdriverIO framework and allows you to use an independent Cucumber version for other types of testing.
 
+### Publishing Report
+
+Cucumber provides a feature to publish your test run reports to `https://reports.cucumber.io/`, which can be controlled either by setting the `publish` flag in `cucumberOpts` or by configuring the `CUCUMBER_PUBLISH_TOKEN` environment variable. However, when you use `WebdriverIO` for test execution, there's a limitation with this approach. It updates the reports separately for each feature file, making it difficult to view a consolidated report.
+
+To overcome this limitation, we've introduced a promise-based method called `publishCucumberReport` within `@wdio/cucumber-framework`. This method should be called in the `onComplete` hook, which is the optimal place to invoke it. `publishCucumberReport` requires the input of the report directory where cucumber message reports are stored.
+
+You can generate `cucumber message` reports by configuring the `format` option in your `cucumberOpts`. It's highly recommended to provide a dynamic file name within the `cucumber message` format option to prevent overwriting reports and ensure that each test run is accurately recorded.
+
+Before using this function, make sure to set the following environment variables:
+- CUCUMBER_PUBLISH_REPORT_URL: The URL where you want to publish the Cucumber report. If not provided, the default URL 'https://messages.cucumber.io/api/reports' will be used.
+- CUCUMBER_PUBLISH_REPORT_TOKEN: The authorization token required to publish the report. If this token is not set, the function will exit without publishing the report.
+
+Here's an example of the necessary configurations and code samples for implementation:
+
+```javascript
+import { v4 as uuidv4 } from 'uuid'
+import { publishCucumberReport } from '@wdio/cucumber-framework';
+
+export const config = {
+    // ... Other Configuration Options
+    cucumberOpts: {
+        // ... Cucumber Options Configuration
+        format: [['message', `./reports/${uuidv4()}.ndjson`]]
+    },
+    async onComplete() {
+        await publishCucumberReport('./reports');
+    }
+}
+```
+
+Please note that `./reports/` is the directory where `cucumber message` reports will be stored.
+
 ## Using Serenity/JS
 
 [Serenity/JS](https://serenity-js.org?pk_campaign=wdio8&pk_source=webdriver.io) is an open-source framework designed to make acceptance and regression testing of complex software systems faster, more collaborative, and easier to scale.


### PR DESCRIPTION
## Proposed changes

Incorporate the `publishCucumberReport` functionality to consolidate and upload results from all workers.

Fixes #7300 

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
