### PR TITLE
Add coerce to framework cli args

### DIFF
--- a/packages/wdio-cli/src/commands/run.ts
+++ b/packages/wdio-cli/src/commands/run.ts
@@ -13,6 +13,17 @@ export const command = 'run <configPath>'
 
 export const desc = 'Run your WDIO configuration file to initialize your tests. (default)'
 
+const coerceOpts = (opts: { [x: string]: boolean | string }) => {
+    for (const key in opts) {
+        if (opts[key] === 'true') {
+            opts[key] = true
+        } else if (opts[key] === 'false') {
+            opts[key] = false
+        }
+    }
+    return opts
+}
+
 export const cmdArgs = {
     watch: {
         desc: 'Run WebdriverIO in watch mode',
@@ -87,13 +98,16 @@ export const cmdArgs = {
         type: 'number'
     },
     mochaOpts: {
-        desc: 'Mocha options'
+        desc: 'Mocha options',
+        coerce: coerceOpts
     },
     jasmineOpts: {
-        desc: 'Jasmine options'
+        desc: 'Jasmine options',
+        coerce: coerceOpts
     },
     cucumberOpts: {
-        desc: 'Cucumber options'
+        desc: 'Cucumber options',
+        coerce: coerceOpts
     },
     autoCompileOpts: {
         desc: 'Auto compilation options'

--- a/packages/wdio-cli/src/commands/run.ts
+++ b/packages/wdio-cli/src/commands/run.ts
@@ -13,7 +13,7 @@ export const command = 'run <configPath>'
 
 export const desc = 'Run your WDIO configuration file to initialize your tests. (default)'
 
-const coerceOpts = (opts: { [x: string]: boolean | string }) => {
+const coerceOpts = (opts: { [x: string]: boolean | string | number }) => {
     for (const key in opts) {
         if (opts[key] === 'true') {
             opts[key] = true

--- a/packages/wdio-cli/tests/coerce.test.ts
+++ b/packages/wdio-cli/tests/coerce.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+import yargs from 'yargs'
+
+import { builder } from '../src/commands/run.js'
+
+const args = ['$0', 'run', 'wdio.conf.js']
+
+describe('Coercion Tests', () => {
+
+    const runTest = (
+        argName: string,
+        argValue: string,
+        expectedResult: boolean | string | number
+    ) => {
+        it(`coerce ${argName} to ${typeof expectedResult} values`, async () => {
+            const argv = builder(yargs([...args, `--${argName}`, argValue]))
+            const expected: any = {}
+            const [key1, key2] = argName.split('.')
+            expected[key1] = { [key2]: expectedResult }
+
+            expect(argv.parse()).toMatchObject(expected)
+        })
+    }
+
+    runTest('mochaOpts.bail', 'true', true)
+    runTest('mochaOpts.fgrep', 'foo.', 'foo.')
+    runTest('cucumberOpts.bail', 'false', false)
+    runTest('jasmineOpts.defaultTimeoutInterval', '60000', 60000)
+})


### PR DESCRIPTION
## Proposed changes

Fixes #11266

When booleans are provided in CLI, they are converted into strings for all framework options. This conversion result in false failures. To address this issue, a "coerce" method has been implemented to convert stringed booleans into actionable booleans.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
