### PR TITLE
Export dataTabels, world & status from cucumber

### DIFF
--- a/packages/wdio-cucumber-framework/src/index.ts
+++ b/packages/wdio-cucumber-framework/src/index.ts
@@ -37,6 +37,8 @@ import {
 
 import type { SupportCodeLibraryBuilder } from '@cucumber/cucumber/lib/support_code_library_builder/index.js'
 
+import { DataTable, World, Status } from '@cucumber/cucumber'
+
 export const FILE_PROTOCOL = 'file://'
 
 const log = logger('@wdio/cucumber-framework')
@@ -53,12 +55,6 @@ const {
     Given,
     When,
     Then,
-
-    DataTable,
-
-    World,
-
-    Status,
 
     setDefaultTimeout,
     setDefinitionFunctionWrapper,


### PR DESCRIPTION
## Proposed changes

Fixes - #11355 

Moving the import of `dataTabels, world & status` to be made from library directly.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
