### PR TITLE
(@wdio/types): allow to extend capability interface

### DIFF
--- a/e2e/wdio/headless/secondTest.e2e.ts
+++ b/e2e/wdio/headless/secondTest.e2e.ts
@@ -1,9 +1,8 @@
 import { browser, $, expect } from '@wdio/globals'
-import type { Capabilities } from '@wdio/types'
 
 describe('main suite 1', () => {
     it('foobar test', async () => {
-        const caps = browser.capabilities as Capabilities.Capabilities
+        const caps = browser.capabilities as WebdriverIO.Capabilities
         const assertionValue = caps.browserName === 'msedge'
             ? 'headlessedg'
             : caps.browserName!.toLowerCase()

--- a/e2e/wdio/headless/test.e2e.ts
+++ b/e2e/wdio/headless/test.e2e.ts
@@ -1,9 +1,8 @@
 import os from 'node:os'
-import type { Capabilities } from '../../../packages/wdio-types'
 
 describe('main suite 1', () => {
     it('foobar test', async () => {
-        const browserName = (browser.capabilities as Capabilities.Capabilities).browserName
+        const browserName = (browser.capabilities as WebdriverIO.Capabilities).browserName
         await browser.url('http://guinea-pig.webdriver.io/')
         await expect((await $('#useragent').getText()).toLowerCase()).toContain(browserName)
     })

--- a/e2e/wdio/wdio.local.conf.ts
+++ b/e2e/wdio/wdio.local.conf.ts
@@ -1,7 +1,7 @@
 import os from 'node:os'
 import url from 'node:url'
 import path from 'node:path'
-import type { Capabilities, Options } from '@wdio/types'
+import type { Options } from '@wdio/types'
 
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url))
 
@@ -62,7 +62,7 @@ export const config: Options.Testrunner = {
 }
 
 if (os.platform() === 'darwin') {
-    (config.capabilities as Capabilities.Capabilities[]).push({
+    (config.capabilities as WebdriverIO.Capabilities[]).push({
         browserName: 'safari'
     })
 }

--- a/packages/devtools/src/commands/newSession.ts
+++ b/packages/devtools/src/commands/newSession.ts
@@ -3,7 +3,6 @@ import { v4 as uuidv4 } from 'uuid'
 
 import launch from '../launcher.js'
 import { sessionMap } from '../index.js'
-import type { ExtendedCapabilities } from '../types.js'
 import type DevToolsDriver from '../devtoolsdriver.js'
 
 /**
@@ -17,7 +16,7 @@ import type DevToolsDriver from '../devtoolsdriver.js'
  */
 export default async function newSession (
     this: DevToolsDriver,
-    { capabilities }: { capabilities: ExtendedCapabilities }
+    { capabilities }: { capabilities: WebdriverIO.Capabilities }
 ) {
     const browser = await launch(capabilities)
     const sessionId = uuidv4()

--- a/packages/devtools/src/index.ts
+++ b/packages/devtools/src/index.ts
@@ -67,10 +67,10 @@ export default class DevTools {
          */
         type ValueOf<T> = T[keyof T]
         const availableVendorPrefixes = Object.values(VENDOR_PREFIX)
-        const vendorCapPrefix = Object.keys(params.capabilities as Capabilities.Capabilities)
+        const vendorCapPrefix = Object.keys(params.capabilities as WebdriverIO.Capabilities)
             .find(
                 (capKey: ValueOf<typeof VENDOR_PREFIX>) => availableVendorPrefixes.includes(capKey)
-            ) as keyof Capabilities.Capabilities
+            ) as keyof WebdriverIO.Capabilities
             ||
             VENDOR_PREFIX[userAgent.browser.name?.toLocaleLowerCase() as keyof typeof VENDOR_PREFIX]
 

--- a/packages/devtools/src/index.ts
+++ b/packages/devtools/src/index.ts
@@ -14,12 +14,7 @@ import DevToolsDriver from './devtoolsdriver.js'
 import launch from './launcher.js'
 import { DEFAULTS, SUPPORTED_BROWSER, VENDOR_PREFIX } from './constants.js'
 import { getPrototype, patchDebug } from './utils.js'
-import type {
-    Client,
-    AttachOptions,
-    ExtendedCapabilities,
-    WDIODevtoolsOptions as WDIODevtoolsOptionsExtension
-} from './types.js'
+import type { Client, AttachOptions, DevToolsOptions as WDIODevtoolsOptionsExtension } from './types.js'
 
 const log = logger('devtools:puppeteer')
 
@@ -55,7 +50,7 @@ export default class DevTools {
         log.info('Initiate new session using the DevTools protocol')
 
         const requestedCapabilities = { ...params.capabilities }
-        const browser = await launch(params.capabilities as ExtendedCapabilities)
+        const browser = await launch(params.capabilities as WebdriverIO.Capabilities)
         const pages = await browser.pages()
         const driver = new DevToolsDriver(browser, pages)
         const sessionId = uuidv4()
@@ -144,7 +139,7 @@ export default class DevTools {
         userPrototype = {},
         customCommandWrapper?: Function
     ): Promise<Client> {
-        const browser = await launch(options.capabilities as ExtendedCapabilities)
+        const browser = await launch(options.capabilities)
         const pages = await browser.pages()
         const driver = new DevToolsDriver(browser, pages)
         const sessionId = uuidv4()

--- a/packages/devtools/src/launcher.ts
+++ b/packages/devtools/src/launcher.ts
@@ -21,7 +21,6 @@ import {
     DEFAULT_Y_POSITION,
     VENDOR_PREFIX
 } from './constants.js'
-import type { ExtendedCapabilities, DevToolsOptions } from './types.js'
 
 const log = logger('devtools')
 
@@ -32,10 +31,10 @@ const DEVICE_NAMES = Object.keys(KnownDevices)
  * @param  {object} capabilities  session capabilities
  * @return {object}               puppeteer browser instance
  */
-async function launchChrome (capabilities: ExtendedCapabilities) {
+async function launchChrome (capabilities: WebdriverIO.Capabilities) {
     const chromeOptions: Capabilities.ChromeOptions = capabilities[VENDOR_PREFIX.chrome] || {}
     const mobileEmulation = chromeOptions.mobileEmulation || {}
-    const devtoolsOptions: DevToolsOptions = capabilities['wdio:devtoolsOptions'] || {}
+    const devtoolsOptions = capabilities['wdio:devtoolsOptions'] || {}
     const chromeOptionsArgs = (chromeOptions.args || []).map((arg) => (
         arg.startsWith('--') ? arg : `--${arg}`
     ))
@@ -147,10 +146,10 @@ async function launchChrome (capabilities: ExtendedCapabilities) {
     return browser
 }
 
-function launchBrowser (capabilities: ExtendedCapabilities, browserType: 'edge' | 'firefox') {
+function launchBrowser (capabilities: WebdriverIO.Capabilities, browserType: 'edge' | 'firefox') {
     const product = browserType === BROWSER_TYPE.firefox ? BROWSER_TYPE.firefox : BROWSER_TYPE.chrome
     const vendorCapKey = VENDOR_PREFIX[browserType]
-    const devtoolsOptions: DevToolsOptions = capabilities['wdio:devtoolsOptions'] || {}
+    const devtoolsOptions = capabilities['wdio:devtoolsOptions'] || {}
 
     /**
      * `ignoreDefaultArgs` and `headless` are currently expected to be part of the capabilities
@@ -205,7 +204,7 @@ function launchBrowser (capabilities: ExtendedCapabilities, browserType: 'edge' 
     return puppeteer.launch(puppeteerOptions) as unknown as Promise<Browser>
 }
 
-function connectBrowser (connectionUrl: string, capabilities: ExtendedCapabilities) {
+function connectBrowser (connectionUrl: string, capabilities: WebdriverIO.Capabilities) {
     const connectionProp = connectionUrl.startsWith('http') ? 'browserURL' : 'browserWSEndpoint'
     const devtoolsOptions = capabilities['wdio:devtoolsOptions']
     const options: ConnectOptions = {
@@ -215,7 +214,7 @@ function connectBrowser (connectionUrl: string, capabilities: ExtendedCapabiliti
     return puppeteer.connect(options) as unknown as Promise<Browser>
 }
 
-export default async function launch (capabilities: ExtendedCapabilities) {
+export default async function launch (capabilities: WebdriverIO.Capabilities) {
     try {
         Puppeteer.unregisterCustomQueryHandler('shadow')
     } catch {

--- a/packages/devtools/src/types.ts
+++ b/packages/devtools/src/types.ts
@@ -4,10 +4,13 @@ import type { Options, Capabilities } from '@wdio/types'
 import type { ProtocolCommands } from '@wdio/protocols'
 import type { LaunchOptions, BrowserLaunchArgumentOptions, BrowserConnectOptions, ConnectOptions } from 'puppeteer-core'
 import type { EventEmitter as PuppeteerEventEmitter } from 'puppeteer-core/lib/esm/puppeteer/common/EventEmitter.js'
-export interface ExtendedCapabilities extends WebdriverIO.Capabilities, WDIODevtoolsOptions {}
 
-export interface WDIODevtoolsOptions {
-    'wdio:devtoolsOptions'?: DevToolsOptions
+declare global {
+    namespace WebdriverIO {
+        interface Capabilities {
+            'wdio:devtoolsOptions'?: Partial<DevToolsOptions>
+        }
+    }
 }
 
 export interface DevToolsOptions extends LaunchOptions, BrowserLaunchArgumentOptions, BrowserConnectOptions, ConnectOptions {

--- a/packages/devtools/src/types.ts
+++ b/packages/devtools/src/types.ts
@@ -4,7 +4,7 @@ import type { Options, Capabilities } from '@wdio/types'
 import type { ProtocolCommands } from '@wdio/protocols'
 import type { LaunchOptions, BrowserLaunchArgumentOptions, BrowserConnectOptions, ConnectOptions } from 'puppeteer-core'
 import type { EventEmitter as PuppeteerEventEmitter } from 'puppeteer-core/lib/esm/puppeteer/common/EventEmitter.js'
-export interface ExtendedCapabilities extends Capabilities.Capabilities, WDIODevtoolsOptions {}
+export interface ExtendedCapabilities extends WebdriverIO.Capabilities, WDIODevtoolsOptions {}
 
 export interface WDIODevtoolsOptions {
     'wdio:devtoolsOptions'?: DevToolsOptions

--- a/packages/wdio-browserstack-service/src/accessibility-handler.ts
+++ b/packages/wdio-browserstack-service/src/accessibility-handler.ts
@@ -35,7 +35,7 @@ class _AccessibilityHandler {
         private _accessibilityAutomation?: boolean | string,
         private _accessibilityOpts?: { [key: string]: any; }
     ) {
-        const caps = (this._browser as WebdriverIO.Browser).capabilities as Capabilities.Capabilities
+        const caps = (this._browser as WebdriverIO.Browser).capabilities as WebdriverIO.Capabilities
 
         this._platformA11yMeta = {
             browser_name: caps.browserName,
@@ -56,27 +56,27 @@ class _AccessibilityHandler {
     _getCapabilityValue(caps: Capabilities.RemoteCapability, capType: string, legacyCapType: string) {
         if (caps) {
             if (capType === 'accessibility') {
-                if ((caps as Capabilities.Capabilities)['bstack:options'] && (isTrue((caps as Capabilities.Capabilities)['bstack:options']?.accessibility))) {
-                    return (caps as Capabilities.Capabilities)['bstack:options']?.accessibility
-                } else if (isTrue((caps as Capabilities.Capabilities)['browserstack.accessibility'])) {
-                    return (caps as Capabilities.Capabilities)['browserstack.accessibility']
+                if ((caps as WebdriverIO.Capabilities)['bstack:options'] && (isTrue((caps as WebdriverIO.Capabilities)['bstack:options']?.accessibility))) {
+                    return (caps as WebdriverIO.Capabilities)['bstack:options']?.accessibility
+                } else if (isTrue((caps as WebdriverIO.Capabilities)['browserstack.accessibility'])) {
+                    return (caps as WebdriverIO.Capabilities)['browserstack.accessibility']
                 }
             } else if (capType === 'deviceName') {
-                if ((caps as Capabilities.Capabilities)['bstack:options'] && (caps as Capabilities.Capabilities)['bstack:options']?.deviceName) {
-                    return (caps as Capabilities.Capabilities)['bstack:options']?.deviceName
-                } else if ((caps as Capabilities.Capabilities)['bstack:options'] && (caps as Capabilities.Capabilities)['bstack:options']?.device) {
-                    return (caps as Capabilities.Capabilities)['bstack:options']?.device
-                } else if ((caps as Capabilities.Capabilities)['appium:deviceName']) {
-                    return (caps as Capabilities.Capabilities)['appium:deviceName']
+                if ((caps as WebdriverIO.Capabilities)['bstack:options'] && (caps as WebdriverIO.Capabilities)['bstack:options']?.deviceName) {
+                    return (caps as WebdriverIO.Capabilities)['bstack:options']?.deviceName
+                } else if ((caps as WebdriverIO.Capabilities)['bstack:options'] && (caps as WebdriverIO.Capabilities)['bstack:options']?.device) {
+                    return (caps as WebdriverIO.Capabilities)['bstack:options']?.device
+                } else if ((caps as WebdriverIO.Capabilities)['appium:deviceName']) {
+                    return (caps as WebdriverIO.Capabilities)['appium:deviceName']
                 }
-            } else if (capType === 'goog:chromeOptions' && (caps as Capabilities.Capabilities)['goog:chromeOptions']) {
-                return (caps as Capabilities.Capabilities)['goog:chromeOptions']
+            } else if (capType === 'goog:chromeOptions' && (caps as WebdriverIO.Capabilities)['goog:chromeOptions']) {
+                return (caps as WebdriverIO.Capabilities)['goog:chromeOptions']
             } else {
-                const bstackOptions = (caps as Capabilities.Capabilities)['bstack:options']
+                const bstackOptions = (caps as WebdriverIO.Capabilities)['bstack:options']
                 if ( bstackOptions && bstackOptions?.[capType as keyof Capabilities.BrowserStackCapabilities]) {
                     return bstackOptions?.[capType as keyof Capabilities.BrowserStackCapabilities]
-                } else if ((caps as Capabilities.Capabilities)[legacyCapType as keyof Capabilities.Capabilities]) {
-                    return (caps as Capabilities.Capabilities)[legacyCapType as keyof Capabilities.Capabilities]
+                } else if ((caps as WebdriverIO.Capabilities)[legacyCapType as keyof WebdriverIO.Capabilities]) {
+                    return (caps as WebdriverIO.Capabilities)[legacyCapType as keyof WebdriverIO.Capabilities]
                 }
             }
         }

--- a/packages/wdio-browserstack-service/src/insights-handler.ts
+++ b/packages/wdio-browserstack-service/src/insights-handler.ts
@@ -1,6 +1,6 @@
 import path from 'node:path'
 
-import type { Capabilities, Frameworks } from '@wdio/types'
+import type { Frameworks } from '@wdio/types'
 import type { BeforeCommandArgs, AfterCommandArgs } from '@wdio/reporter'
 import logger from '@wdio/logger'
 
@@ -54,7 +54,7 @@ class _InsightsHandler {
 
     constructor (private _browser: WebdriverIO.Browser | WebdriverIO.MultiRemoteBrowser, isAppAutomate?: boolean, private _framework?: string) {
         this._requestQueueHandler.start()
-        const caps = (this._browser as WebdriverIO.Browser).capabilities as Capabilities.Capabilities
+        const caps = (this._browser as WebdriverIO.Browser).capabilities as WebdriverIO.Capabilities
         const sessionId = (this._browser as WebdriverIO.Browser).sessionId
 
         this._platformMeta = {

--- a/packages/wdio-browserstack-service/src/launcher.ts
+++ b/packages/wdio-browserstack-service/src/launcher.ts
@@ -95,23 +95,23 @@ export default class BrowserstackLauncherService implements Services.ServiceInst
                 })
         } else if (typeof capabilities === 'object') {
             Object.entries(capabilities as Capabilities.MultiRemoteCapabilities).forEach(([, caps]) => {
-                if (!(caps.capabilities as Capabilities.Capabilities)['bstack:options']) {
+                if (!(caps.capabilities as WebdriverIO.Capabilities)['bstack:options']) {
                     if (isBStackSession(this._config)) {
                         const extensionCaps = Object.keys(caps.capabilities).filter((cap) => cap.includes(':'))
                         if (extensionCaps.length) {
-                            (caps.capabilities as Capabilities.Capabilities)['bstack:options'] = { wdioService: BSTACK_SERVICE_VERSION }
-                            if (!isUndefined((caps.capabilities as Capabilities.Capabilities)['browserstack.accessibility'])) {
-                                this._accessibilityAutomation ||= isTrue((caps.capabilities as Capabilities.Capabilities)['browserstack.accessibility'])
+                            (caps.capabilities as WebdriverIO.Capabilities)['bstack:options'] = { wdioService: BSTACK_SERVICE_VERSION }
+                            if (!isUndefined((caps.capabilities as WebdriverIO.Capabilities)['browserstack.accessibility'])) {
+                                this._accessibilityAutomation ||= isTrue((caps.capabilities as WebdriverIO.Capabilities)['browserstack.accessibility'])
                             } else if (isTrue(this._options.accessibility)) {
-                                (caps.capabilities as Capabilities.Capabilities)['bstack:options'] = { wdioService: BSTACK_SERVICE_VERSION, accessibility: (isTrue(this._options.accessibility)) }
+                                (caps.capabilities as WebdriverIO.Capabilities)['bstack:options'] = { wdioService: BSTACK_SERVICE_VERSION, accessibility: (isTrue(this._options.accessibility)) }
                             }
                         } else if (shouldAddServiceVersion(this._config, this._options.testObservability)) {
-                            (caps.capabilities as Capabilities.Capabilities)['browserstack.wdioService'] = BSTACK_SERVICE_VERSION
+                            (caps.capabilities as WebdriverIO.Capabilities)['browserstack.wdioService'] = BSTACK_SERVICE_VERSION
                         }
                     }
-                    this._buildIdentifier = (caps.capabilities as Capabilities.Capabilities)['browserstack.buildIdentifier']
+                    this._buildIdentifier = (caps.capabilities as WebdriverIO.Capabilities)['browserstack.buildIdentifier']
                 } else {
-                    const bstackOptions = (caps.capabilities as Capabilities.Capabilities)['bstack:options']
+                    const bstackOptions = (caps.capabilities as WebdriverIO.Capabilities)['bstack:options']
                     bstackOptions!.wdioService = BSTACK_SERVICE_VERSION
                     this._buildName = bstackOptions!.buildName
                     this._projectName = bstackOptions!.projectName
@@ -446,34 +446,34 @@ export default class BrowserstackLauncherService implements Services.ServiceInst
                     })
             } else if (typeof capabilities === 'object') {
                 Object.entries(capabilities as Capabilities.MultiRemoteCapabilities).forEach(([, caps]) => {
-                    if (!(caps.capabilities as Capabilities.Capabilities)['bstack:options']) {
+                    if (!(caps.capabilities as WebdriverIO.Capabilities)['bstack:options']) {
                         const extensionCaps = Object.keys(caps.capabilities).filter((cap) => cap.includes(':'))
                         if (extensionCaps.length) {
                             if (capType === 'accessibilityOptions' && value) {
-                                (caps.capabilities as Capabilities.Capabilities)['bstack:options'] = { accessibilityOptions: value }
+                                (caps.capabilities as WebdriverIO.Capabilities)['bstack:options'] = { accessibilityOptions: value }
                             }
                         } else if (capType === 'accessibilityOptions') {
                             if (value) {
                                 const accessibilityOpts = { ...value }
-                                if ((caps.capabilities as Capabilities.Capabilities)['browserstack.accessibility']) {
+                                if ((caps.capabilities as WebdriverIO.Capabilities)['browserstack.accessibility']) {
                                     accessibilityOpts.authToken = process.env.BSTACK_A11Y_JWT
                                     accessibilityOpts.scannerVersion = process.env.BSTACK_A11Y_SCANNER_VERSION
                                 }
-                                (caps.capabilities as Capabilities.Capabilities)['browserstack.accessibilityOptions'] = accessibilityOpts
+                                (caps.capabilities as WebdriverIO.Capabilities)['browserstack.accessibilityOptions'] = accessibilityOpts
                             } else {
-                                delete (caps.capabilities as Capabilities.Capabilities)['browserstack.accessibilityOptions']
+                                delete (caps.capabilities as WebdriverIO.Capabilities)['browserstack.accessibilityOptions']
                             }
                         }
                     } else if (capType === 'accessibilityOptions') {
                         if (value) {
                             const accessibilityOpts = { ...value }
-                            if ((caps.capabilities as Capabilities.Capabilities)['bstack:options']!.accessibility) {
+                            if ((caps.capabilities as WebdriverIO.Capabilities)['bstack:options']!.accessibility) {
                                 accessibilityOpts.authToken = process.env.BSTACK_A11Y_JWT
                                 accessibilityOpts.scannerVersion = process.env.BSTACK_A11Y_SCANNER_VERSION
                             }
-                            (caps.capabilities as Capabilities.Capabilities)['bstack:options']!.accessibilityOptions = accessibilityOpts
+                            (caps.capabilities as WebdriverIO.Capabilities)['bstack:options']!.accessibilityOptions = accessibilityOpts
                         } else {
-                            delete (caps.capabilities as Capabilities.Capabilities)['bstack:options']!.accessibilityOptions
+                            delete (caps.capabilities as WebdriverIO.Capabilities)['bstack:options']!.accessibilityOptions
                         }
                     }
                 })
@@ -533,41 +533,41 @@ export default class BrowserstackLauncherService implements Services.ServiceInst
                 })
         } else if (typeof capabilities === 'object') {
             Object.entries(capabilities as Capabilities.MultiRemoteCapabilities).forEach(([, caps]) => {
-                if (!(caps.capabilities as Capabilities.Capabilities)['bstack:options']) {
+                if (!(caps.capabilities as WebdriverIO.Capabilities)['bstack:options']) {
                     const extensionCaps = Object.keys(caps.capabilities).filter((cap) => cap.includes(':'))
                     if (extensionCaps.length) {
                         if (capType === 'local') {
-                            (caps.capabilities as Capabilities.Capabilities)['bstack:options'] = { local: true }
+                            (caps.capabilities as WebdriverIO.Capabilities)['bstack:options'] = { local: true }
                         } else if (capType === 'app') {
-                            (caps.capabilities as Capabilities.Capabilities)['appium:app'] = value
+                            (caps.capabilities as WebdriverIO.Capabilities)['appium:app'] = value
                         } else if (capType === 'buildIdentifier' && value) {
-                            (caps.capabilities as Capabilities.Capabilities)['bstack:options'] = { buildIdentifier: value }
+                            (caps.capabilities as WebdriverIO.Capabilities)['bstack:options'] = { buildIdentifier: value }
                         }
                     } else if (capType === 'local'){
-                        (caps.capabilities as Capabilities.Capabilities)['browserstack.local'] = true
+                        (caps.capabilities as WebdriverIO.Capabilities)['browserstack.local'] = true
                     } else if (capType === 'app') {
-                        (caps.capabilities as Capabilities.Capabilities)['appium:app'] = value
+                        (caps.capabilities as WebdriverIO.Capabilities)['appium:app'] = value
                     } else if (capType === 'buildIdentifier') {
                         if (value) {
-                            (caps.capabilities as Capabilities.Capabilities)['browserstack.buildIdentifier'] = value
+                            (caps.capabilities as WebdriverIO.Capabilities)['browserstack.buildIdentifier'] = value
                         } else {
-                            delete (caps.capabilities as Capabilities.Capabilities)['browserstack.buildIdentifier']
+                            delete (caps.capabilities as WebdriverIO.Capabilities)['browserstack.buildIdentifier']
                         }
                     } else if (capType === 'localIdentifier') {
-                        (caps.capabilities as Capabilities.Capabilities)['browserstack.localIdentifier'] = value
+                        (caps.capabilities as WebdriverIO.Capabilities)['browserstack.localIdentifier'] = value
                     }
                 } else if (capType === 'local'){
-                    (caps.capabilities as Capabilities.Capabilities)['bstack:options']!.local = true
+                    (caps.capabilities as WebdriverIO.Capabilities)['bstack:options']!.local = true
                 } else if (capType === 'app') {
-                    (caps.capabilities as Capabilities.Capabilities)['appium:app'] = value
+                    (caps.capabilities as WebdriverIO.Capabilities)['appium:app'] = value
                 } else if (capType === 'buildIdentifier') {
                     if (value) {
-                        (caps.capabilities as Capabilities.Capabilities)['bstack:options']!.buildIdentifier = value
+                        (caps.capabilities as WebdriverIO.Capabilities)['bstack:options']!.buildIdentifier = value
                     } else {
-                        delete (caps.capabilities as Capabilities.Capabilities)['bstack:options']!.buildIdentifier
+                        delete (caps.capabilities as WebdriverIO.Capabilities)['bstack:options']!.buildIdentifier
                     }
                 } else if (capType === 'localIdentifier') {
-                    (caps.capabilities as Capabilities.Capabilities)['bstack:options']!.localIdentifier = value
+                    (caps.capabilities as WebdriverIO.Capabilities)['bstack:options']!.localIdentifier = value
                 }
             })
         } else {

--- a/packages/wdio-browserstack-service/src/reporter.ts
+++ b/packages/wdio-browserstack-service/src/reporter.ts
@@ -3,7 +3,7 @@ import path from 'node:path'
 import logger from '@wdio/logger'
 import type { SuiteStats, TestStats, RunnerStats, HookStats } from '@wdio/reporter'
 import WDIOReporter from '@wdio/reporter'
-import type { Capabilities, Options } from '@wdio/types'
+import type { Options } from '@wdio/types'
 import * as url from 'node:url'
 
 import { v4 as uuidv4 } from 'uuid'
@@ -24,7 +24,7 @@ import RequestQueueHandler from './request-handler.js'
 const log = logger('@wdio/browserstack-service')
 
 class _TestReporter extends WDIOReporter {
-    private _capabilities: Capabilities.Capabilities = {}
+    private _capabilities: WebdriverIO.Capabilities = {}
     private _config?: BrowserstackConfig & Options.Testrunner
     private _observability = true
     private _sessionId?: string
@@ -38,7 +38,7 @@ class _TestReporter extends WDIOReporter {
     private _currentTest: CurrentRunInfo = {}
 
     async onRunnerStart (runnerStats: RunnerStats) {
-        this._capabilities = runnerStats.capabilities as Capabilities.Capabilities
+        this._capabilities = runnerStats.capabilities as WebdriverIO.Capabilities
         this._config = runnerStats.config as BrowserstackConfig & Options.Testrunner
         this._sessionId = runnerStats.sessionId
         if (typeof this._config.testObservability !== 'undefined') {

--- a/packages/wdio-browserstack-service/src/service.ts
+++ b/packages/wdio-browserstack-service/src/service.ts
@@ -63,14 +63,14 @@ export default class BrowserstackService implements Services.ServiceInstance {
         }
     }
 
-    _updateCaps (fn: (caps: Capabilities.Capabilities | Capabilities.DesiredCapabilities) => void) {
+    _updateCaps (fn: (caps: WebdriverIO.Capabilities | Capabilities.DesiredCapabilities) => void) {
         const multiRemoteCap = this._caps as Capabilities.MultiRemoteCapabilities
 
         if (multiRemoteCap.capabilities) {
-            return Object.entries(multiRemoteCap).forEach(([, caps]) => fn(caps.capabilities as Capabilities.Capabilities))
+            return Object.entries(multiRemoteCap).forEach(([, caps]) => fn(caps.capabilities as WebdriverIO.Capabilities))
         }
 
-        return fn(this._caps as Capabilities.Capabilities)
+        return fn(this._caps as WebdriverIO.Capabilities)
     }
 
     beforeSession (config: Omit<Options.Testrunner, 'capabilities'>) {

--- a/packages/wdio-browserstack-service/src/types.ts
+++ b/packages/wdio-browserstack-service/src/types.ts
@@ -149,7 +149,7 @@ export interface PlatformMeta {
     browserName?: string,
     browserVersion?: string,
     platformName?: string,
-    caps?: Capabilities.Capabilities,
+    caps?: WebdriverIO.Capabilities,
     product?: string
 }
 
@@ -248,7 +248,7 @@ export interface CredentialsForCrashReportUpload {
 }
 
 interface IntegrationObject {
-    capabilities?: Capabilities.Capabilities,
+    capabilities?: WebdriverIO.Capabilities,
     session_id?: string
     browser?: string
     browser_version?: string

--- a/packages/wdio-browserstack-service/src/util.ts
+++ b/packages/wdio-browserstack-service/src/util.ts
@@ -65,20 +65,20 @@ export function getBrowserDescription(cap: Capabilities.DesiredCapabilities) {
  */
 export function getBrowserCapabilities(browser: WebdriverIO.Browser | WebdriverIO.MultiRemoteBrowser, caps?: Capabilities.RemoteCapability, browserName?: string) {
     if (!browser.isMultiremote) {
-        return { ...browser.capabilities, ...caps } as Capabilities.Capabilities
+        return { ...browser.capabilities, ...caps } as WebdriverIO.Capabilities
     }
 
     const multiCaps = caps as Capabilities.MultiRemoteCapabilities
     const globalCap = browserName && browser.getInstance(browserName) ? browser.getInstance(browserName).capabilities : {}
     const cap = browserName && multiCaps[browserName] ? multiCaps[browserName].capabilities : {}
-    return { ...globalCap, ...cap } as Capabilities.Capabilities
+    return { ...globalCap, ...cap } as WebdriverIO.Capabilities
 }
 
 /**
  * check for browserstack W3C capabilities. Does not support legacy capabilities
  * @param cap browser capabilities
  */
-export function isBrowserstackCapability(cap?: Capabilities.Capabilities) {
+export function isBrowserstackCapability(cap?: WebdriverIO.Capabilities) {
     return Boolean(
         cap &&
             cap['bstack:options'] &&

--- a/packages/wdio-cli/src/launcher.ts
+++ b/packages/wdio-cli/src/launcher.ts
@@ -16,7 +16,7 @@ const log = logger('@wdio/cli:launcher')
 
 interface Schedule {
     cid: number
-    caps: Capabilities.Capabilities
+    caps: WebdriverIO.Capabilities
     specs: WorkerSpecs[]
     availableInstances: number
     runningInstances: number
@@ -74,7 +74,7 @@ class Launcher {
          */
         this._args.autoCompileOpts = config.autoCompileOpts
 
-        const capabilities = this.configParser.getCapabilities() as (Capabilities.Capabilities | Capabilities.W3CCapabilities | Capabilities.MultiRemoteCapabilities)
+        const capabilities = this.configParser.getCapabilities() as Capabilities.RemoteCapability
         this.isParallelMultiremote = Array.isArray(capabilities) &&
             capabilities.every(cap => Object.values(cap).length > 0 && Object.values(cap).every(c => typeof c === 'object' && (c as any).capabilities))
         this.isMultiremote = this.isParallelMultiremote || !Array.isArray(capabilities)
@@ -229,7 +229,7 @@ class Launcher {
 
                 this._schedule.push({
                     cid: cid++,
-                    caps: capabilities as (Capabilities.Capabilities | Capabilities.MultiRemoteCapabilities),
+                    caps: capabilities as (WebdriverIO.Capabilities | Capabilities.MultiRemoteCapabilities),
                     specs: this._formatSpecs(capabilities, specFileRetries),
                     availableInstances,
                     runningInstances: 0

--- a/packages/wdio-config/src/utils.ts
+++ b/packages/wdio-config/src/utils.ts
@@ -3,7 +3,7 @@ import path from 'node:path'
 import logger from '@wdio/logger'
 import decamelize from 'decamelize'
 import { resolve } from 'import-meta-resolve'
-import type { Capabilities, Options } from '@wdio/types'
+import type { Options } from '@wdio/types'
 
 import type { ModuleImportService } from './types.js'
 
@@ -36,11 +36,11 @@ export function isCucumberFeatureWithLineNumber(spec: string | string[]) {
     return specs.some((s) => s.match(/:\d+(:\d+$|$)/))
 }
 
-export function isCloudCapability(caps: Capabilities.Capabilities) {
+export function isCloudCapability(caps: WebdriverIO.Capabilities) {
     return Boolean(caps && (caps['bstack:options'] || caps['sauce:options'] || caps['tb:options']))
 }
 
-export function isAppiumCapability(caps: Capabilities.Capabilities) {
+export function isAppiumCapability(caps: WebdriverIO.Capabilities) {
     return Boolean(
         caps &&
         // @ts-expect-error outdated jsonwp cap

--- a/packages/wdio-crossbrowsertesting-service/src/launcher.ts
+++ b/packages/wdio-crossbrowsertesting-service/src/launcher.ts
@@ -1,6 +1,6 @@
 import { promisify } from 'node:util'
 import { performance, PerformanceObserver } from 'node:perf_hooks'
-import type { Capabilities, Services, Options } from '@wdio/types'
+import type { Services, Options } from '@wdio/types'
 
 import cbt from 'cbt_tunnels'
 import logger from '@wdio/logger'
@@ -15,7 +15,7 @@ export default class CrossBrowserTestingLauncher implements Services.ServiceInst
 
     constructor (
         private _options: CrossBrowserTestingConfig,
-        private _caps: Capabilities.Capabilities,
+        private _caps: WebdriverIO.Capabilities,
         private _config: Options.Testrunner
     ) {
         this._cbtTunnelOpts = Object.assign({

--- a/packages/wdio-crossbrowsertesting-service/src/service.ts
+++ b/packages/wdio-crossbrowsertesting-service/src/service.ts
@@ -1,6 +1,6 @@
 import got from 'got'
 import logger from '@wdio/logger'
-import type { Capabilities, Services, Options, Frameworks } from '@wdio/types'
+import type { Services, Options, Frameworks } from '@wdio/types'
 
 const log = logger('@wdio/crossbrowsertesting-service')
 const jobDataProperties = ['name', 'tags', 'public', 'build', 'extra']
@@ -16,7 +16,7 @@ export default class CrossBrowserTestingService implements Services.ServiceInsta
 
     constructor(
         private _config: Options.Testrunner,
-        private _capabilities: Capabilities.Capabilities
+        private _capabilities: WebdriverIO.Capabilities
     ) {
         this._cbtUsername = this._config.user as string
         this._cbtAuthkey = this._config.key as string
@@ -24,7 +24,7 @@ export default class CrossBrowserTestingService implements Services.ServiceInsta
     }
 
     before (
-        caps: Capabilities.Capabilities,
+        caps: WebdriverIO.Capabilities,
         specs: string[],
         browser: WebdriverIO.Browser | WebdriverIO.MultiRemoteBrowser
     ) {

--- a/packages/wdio-cucumber-framework/src/utils.ts
+++ b/packages/wdio-cucumber-framework/src/utils.ts
@@ -216,8 +216,8 @@ export function generateSkipTagsFromCapabilities(capabilities: Capabilities.Remo
         const matched = tag.match(skipTag)
         if (matched) {
             const isSkip = [parse(matched[1] ?? '')]
-                .find((filter: Capabilities.Capabilities) => Object.keys(filter)
-                    .every((key: keyof Capabilities.Capabilities) => match((capabilities as any)[key], filter[key] as RegExp)))
+                .find((filter: WebdriverIO.Capabilities) => Object.keys(filter)
+                    .every((key: keyof WebdriverIO.Capabilities) => match((capabilities as any)[key], filter[key] as RegExp)))
             if (isSkip) {
                 generatedTags.push(`(not ${tag.replace(/(\(|\))/g, '\\$1')})`)
             }

--- a/packages/wdio-firefox-profile-service/src/launcher.ts
+++ b/packages/wdio-firefox-profile-service/src/launcher.ts
@@ -93,7 +93,7 @@ export default class FirefoxProfileLauncher {
         }
     }
 
-    _setProfile(capability: Capabilities.Capabilities, zippedProfile: string) {
+    _setProfile(capability: WebdriverIO.Capabilities, zippedProfile: string) {
         if (this._options.legacy) {
             // for older firefox and geckodriver versions
             capability.firefox_profile = zippedProfile

--- a/packages/wdio-runner/src/index.ts
+++ b/packages/wdio-runner/src/index.ts
@@ -65,7 +65,7 @@ export default class Runner extends EventEmitter {
         this._config = this._configParser.getConfig()
         this._specFileRetryAttempts = (this._config.specFileRetries || 0) - (retries || 0)
         logger.setLogLevelsConfig(this._config.logLevels, this._config.logLevel)
-        const capabilities = this._configParser.getCapabilities() as (Capabilities.Capabilities | Capabilities.W3CCapabilities | Capabilities.MultiRemoteCapabilities)
+        const capabilities = this._configParser.getCapabilities() as Capabilities.RemoteCapability
         const isMultiremote = this._isMultiremote = !Array.isArray(capabilities) ||
             (Object.values(caps).length > 0 && Object.values(caps).every(c => typeof c === 'object' && c.capabilities))
 
@@ -84,7 +84,7 @@ export default class Runner extends EventEmitter {
          */
         ;(await initialiseWorkerService(
             this._config as Options.Testrunner,
-            caps as Capabilities.Capabilities,
+            caps as WebdriverIO.Capabilities,
             args.ignoredWorkerServices
         )).map(this._configParser.addService.bind(this._configParser))
 
@@ -478,7 +478,7 @@ export default class Runner extends EventEmitter {
         /**
          * store capabilities for afterSession hook
          */
-        const capabilities: Capabilities.Capabilities | Capabilities.W3CCapabilities | MultiRemoteCaps = this._browser?.capabilities || {}
+        const capabilities: Capabilities.RemoteCapability = this._browser?.capabilities || {}
         if (this._isMultiremote) {
             multiremoteBrowser.instances.forEach((browserName: string) => {
                 (capabilities as MultiRemoteCaps)[browserName] = multiremoteBrowser.getInstance(browserName).capabilities

--- a/packages/wdio-runner/src/types.ts
+++ b/packages/wdio-runner/src/types.ts
@@ -49,7 +49,7 @@ export interface SessionStartedMessage {
         headers: Record<string, string>
         isMultiremote: boolean
         injectGlobals: boolean
-        capabilities: Capabilities.Capabilities
+        capabilities: WebdriverIO.Capabilities
     },
     cid?: string
 }

--- a/packages/wdio-runner/src/utils.ts
+++ b/packages/wdio-runner/src/utils.ts
@@ -64,7 +64,7 @@ export async function initialiseInstance (
         /**
          * propagate connection details defined by services or user in capabilities
          */
-        const caps = capabilities as Capabilities.Capabilities
+        const caps = capabilities as WebdriverIO.Capabilities
         const connectionProps = {
             protocol: caps.protocol || config.protocol,
             hostname: caps.hostname || config.hostname,

--- a/packages/wdio-runner/tests/index-initSession.test.ts
+++ b/packages/wdio-runner/tests/index-initSession.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi, beforeEach } from 'vitest'
 
 import WDIORunner from '../src/index.js'
 import type BaseReporter from '../src/reporter.js'
-import type { Options, Capabilities } from '@wdio/types'
+import type { Options } from '@wdio/types'
 
 vi.mock('../src/utils', () => ({
     __esModule: true,
@@ -22,7 +22,7 @@ vi.mock('../src/utils', () => ({
 }))
 
 const config: Options.WebdriverIO = { capabilities: {} }
-const capability: Capabilities.Capabilities = { browserName: 'foo' }
+const capability: WebdriverIO.Capabilities = { browserName: 'foo' }
 
 describe('wdio-runner', () => {
     describe('_initSession', () => {

--- a/packages/wdio-runner/tests/reporter.test.ts
+++ b/packages/wdio-runner/tests/reporter.test.ts
@@ -20,7 +20,7 @@ class CustomReporter {
     }
 }
 
-const capability: Capabilities.Capabilities = { browserName: 'foo' }
+const capability: Capabilities.WebdriverIO = { browserName: 'foo' }
 
 process.send = vi.fn()
 

--- a/packages/wdio-sauce-service/src/service.ts
+++ b/packages/wdio-sauce-service/src/service.ts
@@ -70,7 +70,7 @@ export default class SauceService implements Services.ServiceInstance {
         // `this._browser.capabilities` returns the process data from Sauce which is without
         // the postfix
         const capabilities = (this._browser as WebdriverIO.Browser).requestedCapabilities || {}
-        this._isRDC = isRDC(capabilities as Capabilities.Capabilities)
+        this._isRDC = isRDC(capabilities as WebdriverIO.Capabilities)
     }
 
     async beforeSuite (suite: Frameworks.Suite) {
@@ -266,7 +266,7 @@ export default class SauceService implements Services.ServiceInstance {
 
         return Promise.all(Object.keys(this._capabilities).map(async (browserName) => {
             const multiRemoteBrowser = (this._browser as WebdriverIO.MultiRemoteBrowser).getInstance(browserName)
-            const isMultiRemoteRDC = isRDC(multiRemoteBrowser.capabilities as Capabilities.Capabilities)
+            const isMultiRemoteRDC = isRDC(multiRemoteBrowser.capabilities as WebdriverIO.Capabilities)
             log.info(`Update multiRemote job for browser "${browserName}" and sessionId ${multiRemoteBrowser.sessionId}, ${status}`)
             await this._uploadLogs(multiRemoteBrowser.sessionId)
             // Sauce Unified Platform (RDC) can not be updated with an API.
@@ -351,7 +351,7 @@ export default class SauceService implements Services.ServiceInstance {
             body.name += ` (${testCnt})`
         }
 
-        const caps = (this._capabilities as Capabilities.Capabilities)['sauce:options'] || this._capabilities as Capabilities.SauceLabsCapabilities
+        const caps = (this._capabilities as WebdriverIO.Capabilities)['sauce:options'] || this._capabilities as Capabilities.SauceLabsCapabilities
 
         for (const prop of jobDataProperties) {
             if (!caps[prop]) {

--- a/packages/wdio-sauce-service/tests/service.test.ts
+++ b/packages/wdio-sauce-service/tests/service.test.ts
@@ -773,7 +773,7 @@ test('getBody', () => {
         passed: true
     })
 
-    service['_capabilities'] = {} as Capabilities.Capabilities
+    service['_capabilities'] = {} as WebdriverIO.Capabilities
     expect(service.getBody(1)).toEqual({
         passed: false
     })

--- a/packages/wdio-shared-store-service/src/launcher.ts
+++ b/packages/wdio-shared-store-service/src/launcher.ts
@@ -30,12 +30,12 @@ export default class SharedStoreLauncher implements Services.HookFunctions {
             if (!multiremote.browserName && multiremote[Object.keys(multiremote)[0]].capabilities) {
                 return Object.values(multiremote).map((options) =>
                     (options.capabilities as Capabilities.W3CCapabilities)?.alwaysMatch ||
-                    (options.capabilities as Capabilities.Capabilities)
+                    (options.capabilities as WebdriverIO.Capabilities)
                 )
             }
 
             const w3cCaps = c as Capabilities.W3CCapabilities
-            return w3cCaps.alwaysMatch || c as Capabilities.Capabilities
+            return w3cCaps.alwaysMatch || c as WebdriverIO.Capabilities
         })
         caps.forEach((c) => { c[CUSTOM_CAP] = port })
         log.info(`Started shared server on port ${port}`)

--- a/packages/wdio-shared-store-service/src/types.ts
+++ b/packages/wdio-shared-store-service/src/types.ts
@@ -1,6 +1,4 @@
-import type { Capabilities } from '@wdio/types'
-
-export interface SharedStoreServiceCapabilities extends Capabilities.Capabilities {
+export interface SharedStoreServiceCapabilities extends WebdriverIO.Capabilities {
     'wdio:sharedStoreServicePort': number
 }
 export type GetValueOptions = { timeout: Number } | undefined

--- a/packages/wdio-spec-reporter/src/index.ts
+++ b/packages/wdio-spec-reporter/src/index.ts
@@ -10,7 +10,7 @@ import type { StateCount, Symbols, SpecReporterOptions, TestLink } from './types
 
 const DEFAULT_INDENT = '   '
 
-interface CapabilitiesWithSessionId extends Capabilities.Capabilities {
+interface CapabilitiesWithSessionId extends WebdriverIO.Capabilities {
     sessionId: string
 }
 

--- a/packages/wdio-types/src/Capabilities.ts
+++ b/packages/wdio-types/src/Capabilities.ts
@@ -39,56 +39,60 @@ export interface ProxyObject {
     noProxy?: string[];
 }
 
-export interface Capabilities extends VendorExtensions, ConnectionOptions {
-    /**
-     * Identifies the user agent.
-     */
-    browserName?: string;
-    /**
-     * Identifies the version of the user agent.
-     */
-    browserVersion?: string;
-    /**
-     * Identifies the operating system of the endpoint node.
-     */
-    platformName?: string;
-    /**
-     * Indicates whether untrusted and self-signed TLS certificates are implicitly trusted on navigation for the duration of the session.
-     */
-    acceptInsecureCerts?: boolean;
-    /**
-     * Defines the current session’s page load strategy.
-     */
-    pageLoadStrategy?: PageLoadingStrategy;
-    /**
-     * Defines the current session’s proxy configuration.
-     */
-    proxy?: ProxyObject;
-    /**
-     * Indicates whether the remote end supports all of the resizing and repositioning commands.
-     */
-    setWindowRect?: boolean;
-    /**
-     * Describes the timeouts imposed on certain session operations.
-     */
-    timeouts?: Timeouts;
-    /**
-     * Defines the current session’s strict file interactability.
-     */
-    strictFileInteractability?: boolean,
-    /**
-     * Describes the current session’s user prompt handler. Defaults to the dismiss and notify state.
-     */
-    unhandledPromptBehavior?: string;
-    /**
-     * WebDriver clients opt in to a bidirectional connection by requesting a capability with the name "webSocketUrl" and value true.
-     */
-    webSocketUrl?: boolean
+declare global {
+    namespace WebdriverIO {
+        interface Capabilities extends VendorExtensions, ConnectionOptions {
+            /**
+             * Identifies the user agent.
+             */
+            browserName?: string;
+            /**
+             * Identifies the version of the user agent.
+             */
+            browserVersion?: string;
+            /**
+             * Identifies the operating system of the endpoint node.
+             */
+            platformName?: string;
+            /**
+             * Indicates whether untrusted and self-signed TLS certificates are implicitly trusted on navigation for the duration of the session.
+             */
+            acceptInsecureCerts?: boolean;
+            /**
+             * Defines the current session’s page load strategy.
+             */
+            pageLoadStrategy?: PageLoadingStrategy;
+            /**
+             * Defines the current session’s proxy configuration.
+             */
+            proxy?: ProxyObject;
+            /**
+             * Indicates whether the remote end supports all of the resizing and repositioning commands.
+             */
+            setWindowRect?: boolean;
+            /**
+             * Describes the timeouts imposed on certain session operations.
+             */
+            timeouts?: Timeouts;
+            /**
+             * Defines the current session’s strict file interactability.
+             */
+            strictFileInteractability?: boolean,
+            /**
+             * Describes the current session’s user prompt handler. Defaults to the dismiss and notify state.
+             */
+            unhandledPromptBehavior?: string;
+            /**
+             * WebDriver clients opt in to a bidirectional connection by requesting a capability with the name "webSocketUrl" and value true.
+             */
+            webSocketUrl?: boolean
+        }
+    }
 }
 
 export interface W3CCapabilities {
-    alwaysMatch: Capabilities;
-    firstMatch: Capabilities[];
+    alwaysMatch: WebdriverIO.Capabilities;
+    firstMatch: WebdriverIO.Capabilities[];
 }
 
 export type RemoteCapabilities = (DesiredCapabilities | W3CCapabilities)[] | MultiRemoteCapabilities | MultiRemoteCapabilities[];
@@ -99,7 +103,10 @@ export interface MultiRemoteCapabilities {
 
 export type RemoteCapability = DesiredCapabilities | W3CCapabilities | MultiRemoteCapabilities;
 
-export interface DesiredCapabilities extends Capabilities, SauceLabsCapabilities, SauceLabsVisualCapabilities,
+/**
+ * @deprecated use `WebdriverIO.Capabilities` instead
+ */
+export interface DesiredCapabilities extends WebdriverIO.Capabilities, SauceLabsCapabilities, SauceLabsVisualCapabilities,
     TestingbotCapabilities, SeleniumRCCapabilities, GeckodriverCapabilities, IECapabilities,
     AppiumAndroidCapabilities, AppiumCapabilities, VendorExtensions, GridCapabilities,
     ChromeCapabilities, BrowserStackCapabilities, AppiumXCUITestCapabilities, LambdaTestCapabilities {
@@ -378,7 +385,10 @@ export type MoonMobileDeviceOrientation =
     'portait' | 'vertical' | 'landscape' | 'horizontal'
 
 export interface MoonOptions extends SelenoidOptions {
-    mobileDevice?: { deviceName: string, orientation: MoonMobileDeviceOrientation },
+    mobileDevice?: {
+        deviceName: string
+        orientation: MoonMobileDeviceOrientation
+    }
     logLevel?: string
 }
 

--- a/packages/wdio-types/src/Options.ts
+++ b/packages/wdio-types/src/Options.ts
@@ -300,7 +300,7 @@ export interface Testrunner extends Hooks, Omit<WebdriverIO, 'capabilities'>, We
      * ```js
      * // wdio.conf.js
      * export const config = {
-     *   // ...
+     *   // define parallel running capabilities
      *   capabilities: [{
      *     browserName: 'safari',
      *     platformName: 'MacOS 10.13',
@@ -317,7 +317,7 @@ export interface Testrunner extends Hooks, Omit<WebdriverIO, 'capabilities'>, We
      * ```
      * // wdio.conf.js
      * export const config = {
-     *   // ...
+     *   // multiremote example
      *   capabilities: {
      *     browserA: {
      *       browserName: 'chrome',

--- a/packages/wdio-types/src/Options.ts
+++ b/packages/wdio-types/src/Options.ts
@@ -2,7 +2,7 @@ import type http from 'node:http'
 import type https from 'node:https'
 import type { URL } from 'node:url'
 
-import type { W3CCapabilities, DesiredCapabilities, RemoteCapabilities, RemoteCapability, MultiRemoteCapabilities, Capabilities } from './Capabilities.js'
+import type { W3CCapabilities, DesiredCapabilities, RemoteCapabilities, RemoteCapability, MultiRemoteCapabilities } from './Capabilities.js'
 import type { Hooks, ServiceEntry } from './Services.js'
 import type { ReporterEntry } from './Reporters.js'
 
@@ -575,7 +575,7 @@ export interface RunnerStart {
     isMultiremote: boolean
     instanceOptions: Record<string, WebdriverIO>
     sessionId: string
-    capabilities: Capabilities
+    capabilities: WebdriverIO.Capabilities
     retry?: number
     failures?: number
     retries?: number

--- a/packages/wdio-types/src/index.ts
+++ b/packages/wdio-types/src/index.ts
@@ -49,9 +49,4 @@ declare global {
         interface EdgedriverOptions extends DriverOptions {}
         interface SafaridriverOptions {}
     }
-
-    namespace WebDriver {
-        interface Capabilities extends Capabilities.Capabilities, Capabilities.WebdriverIOCapabilities {}
-        interface DesiredCapabilities extends Capabilities.DesiredCapabilities, Capabilities.WebdriverIOCapabilities {}
-    }
 }

--- a/packages/wdio-utils/src/driver/index.ts
+++ b/packages/wdio-utils/src/driver/index.ts
@@ -56,7 +56,7 @@ export async function startWebDriver (options: Options.WebDriver) {
     let driverProcess: ChildProcess
     let driver = ''
     const start = Date.now()
-    const caps = (options.capabilities as Capabilities.W3CCapabilities).alwaysMatch || options.capabilities as Capabilities.Capabilities
+    const caps = (options.capabilities as Capabilities.W3CCapabilities).alwaysMatch || options.capabilities as WebdriverIO.Capabilities
 
     /**
      * session might be a mobile session so don't do anything

--- a/packages/wdio-utils/src/driver/manager.ts
+++ b/packages/wdio-utils/src/driver/manager.ts
@@ -10,7 +10,7 @@ import {
 const log = logger('@wdio/utils')
 const UNDEFINED_BROWSER_VERSION = null
 
-type SetupTaskFunction = (cap: Capabilities.Capabilities) => Promise<unknown>
+type SetupTaskFunction = (cap: WebdriverIO.Capabilities) => Promise<unknown>
 
 enum BrowserDriverTaskLabel {
     BROWSER = 'browser binaries',
@@ -35,11 +35,11 @@ function mapCapabilities (
                             return
                         }
                         return c.capabilities
-                    }) as Capabilities.Capabilities[]
+                    }) as WebdriverIO.Capabilities[]
                 } else if (w3cCaps.alwaysMatch) {
                     return w3cCaps.alwaysMatch
                 }
-                return cap as Capabilities.Capabilities
+                return cap as WebdriverIO.Capabilities
             }).flat()
             : Object.values(caps as Capabilities.MultiRemoteCapabilities).map((mrOpts) => {
                 const w3cCaps = mrOpts.capabilities as Capabilities.W3CCapabilities
@@ -49,7 +49,7 @@ function mapCapabilities (
                 if (w3cCaps.alwaysMatch) {
                     return w3cCaps.alwaysMatch
                 }
-                return mrOpts.capabilities as Capabilities.Capabilities
+                return mrOpts.capabilities as WebdriverIO.Capabilities
             })
     ).flat().filter((cap) => (
         /**
@@ -67,7 +67,7 @@ function mapCapabilities (
         !getDriverOptions(cap).binary &&
         // - user is not defining "devtools" as automation protocol
         options.automationProtocol !== 'devtools'
-    )) as Capabilities.Capabilities[]
+    )) as WebdriverIO.Capabilities[]
 
     /**
      * nothing to setup
@@ -84,7 +84,7 @@ function mapCapabilities (
             return queue
         }
         if (!queue.has(cap.browserName)) {
-            queue.set(cap.browserName, new Map<string, Capabilities.Capabilities>())
+            queue.set(cap.browserName, new Map<string, WebdriverIO.Capabilities>())
         }
         const browserVersion = cap.browserVersion || UNDEFINED_BROWSER_VERSION
         queue.get(cap.browserName)!.set(browserVersion, cap)
@@ -108,7 +108,7 @@ function mapCapabilities (
 }
 
 export async function setupDriver (options: Omit<Options.WebDriver, 'capabilities'>, caps: Capabilities.RemoteCapabilities) {
-    return mapCapabilities(options, caps, async (cap: Capabilities.Capabilities) => {
+    return mapCapabilities(options, caps, async (cap: WebdriverIO.Capabilities) => {
         const cacheDir = getCacheDir(options, cap)
         if (isEdge(cap.browserName)) {
             return setupEdgedriver(cacheDir, cap.browserVersion)
@@ -125,7 +125,7 @@ export async function setupDriver (options: Omit<Options.WebDriver, 'capabilitie
 }
 
 export function setupBrowser (options: Omit<Options.WebDriver, 'capabilities'>, caps: Capabilities.RemoteCapabilities) {
-    return mapCapabilities(options, caps, async (cap: Capabilities.Capabilities) => {
+    return mapCapabilities(options, caps, async (cap: WebdriverIO.Capabilities) => {
         const cacheDir = getCacheDir(options, cap)
         if (isEdge(cap.browserName)) {
             // not yet implemented

--- a/packages/wdio-utils/src/driver/utils.ts
+++ b/packages/wdio-utils/src/driver/utils.ts
@@ -15,7 +15,7 @@ import { download as downloadGeckodriver } from 'geckodriver'
 import { download as downloadEdgedriver } from 'edgedriver'
 import { locateChrome, locateFirefox } from 'locate-app'
 import type { EdgedriverParameters } from 'edgedriver'
-import type { Options, Capabilities } from '@wdio/types'
+import type { Options } from '@wdio/types'
 
 import { DEFAULT_HOSTNAME, DEFAULT_PROTOCOL, DEFAULT_PATH, SUPPORTED_BROWSERNAMES } from '../constants.js'
 
@@ -106,7 +106,7 @@ const _install = async (args: InstallOptions & { unpack?: true | undefined }): P
     log.progress('')
 }
 
-export async function setupPuppeteerBrowser(cacheDir: string, caps: Capabilities.Capabilities) {
+export async function setupPuppeteerBrowser(cacheDir: string, caps: WebdriverIO.Capabilities) {
     caps.browserName = caps.browserName?.toLowerCase()
 
     const browserName = caps.browserName === Browser.FIREFOX ? Browser.FIREFOX : Browser.CHROME
@@ -185,7 +185,7 @@ export async function setupPuppeteerBrowser(cacheDir: string, caps: Capabilities
     return { executablePath, browserVersion: buildId }
 }
 
-export function getDriverOptions (caps: Capabilities.Capabilities) {
+export function getDriverOptions (caps: WebdriverIO.Capabilities) {
     return (
         caps['wdio:chromedriverOptions'] ||
         caps['wdio:geckodriverOptions'] ||
@@ -196,7 +196,7 @@ export function getDriverOptions (caps: Capabilities.Capabilities) {
     )
 }
 
-export function getCacheDir (options: Pick<Options.WebDriver, 'cacheDir'>, caps: Capabilities.Capabilities) {
+export function getCacheDir (options: Pick<Options.WebDriver, 'cacheDir'>, caps: WebdriverIO.Capabilities) {
     const driverOptions = getDriverOptions(caps)
     return driverOptions.cacheDir || options.cacheDir || os.tmpdir()
 }

--- a/packages/wdio-utils/src/envDetector.ts
+++ b/packages/wdio-utils/src/envDetector.ts
@@ -86,7 +86,7 @@ function isFirefox(capabilities?: Capabilities.DesiredCapabilities) {
  * @param  {Object}  caps  capabilities
  * @return {Boolean}       true if platform is mobile device
  */
-function isMobile(capabilities: Capabilities.Capabilities) {
+function isMobile(capabilities: WebdriverIO.Capabilities) {
     const browserName = (capabilities.browserName || '').toLowerCase()
 
     /**
@@ -135,7 +135,7 @@ function isIOS(capabilities?: Capabilities.DesiredCapabilities) {
  * @param  {Object}  capabilities  caps of session response
  * @return {Boolean}               true if run on Android device
  */
-function isAndroid(capabilities?: Capabilities.Capabilities) {
+function isAndroid(capabilities?: WebdriverIO.Capabilities) {
     if (!capabilities) {
         return false
     }
@@ -213,7 +213,7 @@ function isSeleniumStandalone(capabilities?: Capabilities.DesiredCapabilities) {
  * @param  {string=} automationProtocol     `devtools`
  * @return {Object}                         object with environment flags
  */
-export function capabilitiesEnvironmentDetector(capabilities: Capabilities.Capabilities, automationProtocol: string) {
+export function capabilitiesEnvironmentDetector(capabilities: WebdriverIO.Capabilities, automationProtocol: string) {
     return automationProtocol === 'devtools'
         ? devtoolsEnvironmentDetector(capabilities)
         : webdriverEnvironmentDetector(capabilities)
@@ -227,7 +227,7 @@ export function capabilitiesEnvironmentDetector(capabilities: Capabilities.Capab
  */
 export function sessionEnvironmentDetector({ capabilities, requestedCapabilities }:
     { capabilities: Capabilities.RemoteCapability, requestedCapabilities: Capabilities.RemoteCapability }) {
-    const cap: Capabilities.Capabilities = 'alwaysMatch' in capabilities
+    const cap: WebdriverIO.Capabilities = 'alwaysMatch' in capabilities
         ? capabilities.alwaysMatch
         : capabilities
     return {
@@ -248,7 +248,7 @@ export function sessionEnvironmentDetector({ capabilities, requestedCapabilities
  * @param  {Object}  capabilities           caps of session response
  * @return {Object}                         object with environment flags
  */
-export function devtoolsEnvironmentDetector({ browserName }: Capabilities.Capabilities) {
+export function devtoolsEnvironmentDetector({ browserName }: WebdriverIO.Capabilities) {
     return {
         isDevTools: true,
         isW3C: true,
@@ -269,7 +269,7 @@ export function devtoolsEnvironmentDetector({ browserName }: Capabilities.Capabi
  * @param  {Object}  capabilities           caps provided by user
  * @return {Object}                         object with environment flags
  */
-export function webdriverEnvironmentDetector(capabilities: Capabilities.Capabilities) {
+export function webdriverEnvironmentDetector(capabilities: WebdriverIO.Capabilities) {
     return {
         isChrome: isChrome(capabilities),
         isFirefox: isFirefox(capabilities),

--- a/packages/wdio-utils/tests/envDetector.test.ts
+++ b/packages/wdio-utils/tests/envDetector.test.ts
@@ -18,18 +18,18 @@ import seleniumstandalone4Response from './__fixtures__/standaloneserver4.respon
 import bidiResponse from './__fixtures__/bidi.response.json' assert { type: 'json' }
 
 describe('sessionEnvironmentDetector', () => {
-    const chromeCaps = chromedriverResponse.value as WebDriver.Capabilities
-    const appiumCaps = appiumResponse.value.capabilities as WebDriver.Capabilities
-    const experitestAppiumCaps = experitestResponse.appium.capabilities as WebDriver.Capabilities
-    const geckoCaps = geckodriverResponse.value.capabilities as WebDriver.Capabilities
-    const edgeCaps = edgedriverResponse.value.capabilities as WebDriver.Capabilities
-    const phantomCaps = ghostdriverResponse.value as WebDriver.Capabilities
-    const safariCaps = safaridriverResponse.value.capabilities as WebDriver.Capabilities
-    const safariDockerNpNCaps = safaridriverdockerNpNResponse.value.capabilities as WebDriver.Capabilities // absent capability.platformName
-    const safariDockerNbVCaps = safaridriverdockerNbVResponse.value.capabilities as WebDriver.Capabilities // absent capability.browserVersion
-    const safariLegacyCaps = safaridriverLegacyResponse.value as WebDriver.Capabilities
-    const standaloneCaps = seleniumstandaloneResponse.value as WebDriver.DesiredCapabilities
-    const standalonev4Caps = seleniumstandalone4Response.value as WebDriver.DesiredCapabilities
+    const chromeCaps = chromedriverResponse.value as WebdriverIO.Capabilities
+    const appiumCaps = appiumResponse.value.capabilities as WebdriverIO.Capabilities
+    const experitestAppiumCaps = experitestResponse.appium.capabilities as WebdriverIO.Capabilities
+    const geckoCaps = geckodriverResponse.value.capabilities as WebdriverIO.Capabilities
+    const edgeCaps = edgedriverResponse.value.capabilities as WebdriverIO.Capabilities
+    const phantomCaps = ghostdriverResponse.value as WebdriverIO.Capabilities
+    const safariCaps = safaridriverResponse.value.capabilities as WebdriverIO.Capabilities
+    const safariDockerNpNCaps = safaridriverdockerNpNResponse.value.capabilities as WebdriverIO.Capabilities // absent capability.platformName
+    const safariDockerNbVCaps = safaridriverdockerNbVResponse.value.capabilities as WebdriverIO.Capabilities // absent capability.browserVersion
+    const safariLegacyCaps = safaridriverLegacyResponse.value as WebdriverIO.Capabilities
+    const standaloneCaps = seleniumstandaloneResponse.value as Capabilities.DesiredCapabilities
+    const standalonev4Caps = seleniumstandalone4Response.value as Capabilities.DesiredCapabilities
 
     it('isMobile', () => {
         const requestedCapabilities = { browserName: '' }

--- a/packages/wdio-utils/tests/initialiseServices.test.ts
+++ b/packages/wdio-utils/tests/initialiseServices.test.ts
@@ -3,7 +3,7 @@ import type { MockedFunction } from 'vitest'
 import { vi, describe, it, expect, beforeEach } from 'vitest'
 
 import logger from '@wdio/logger'
-import type { Capabilities, Options, Services } from '@wdio/types'
+import type { Options, Services } from '@wdio/types'
 
 import { initialiseLauncherService, initialiseWorkerService } from '../src/initialiseServices.js'
 import { safeImport } from '../src/utils.js'
@@ -21,8 +21,8 @@ interface TestLauncherService extends Services.ServiceInstance {
 class CustomService {
     options: Record<string, any>
     config: Options.Testrunner
-    caps: Capabilities.Capabilities
-    constructor (options: Record<string, any>, caps: Capabilities.Capabilities, config: Options.Testrunner) {
+    caps: WebdriverIO.Capabilities
+    constructor (options: Record<string, any>, caps: WebdriverIO.Capabilities, config: Options.Testrunner) {
         this.options = options
         this.config = config
         this.caps = caps

--- a/packages/webdriverio/src/commands/browser/uploadFile.ts
+++ b/packages/webdriverio/src/commands/browser/uploadFile.ts
@@ -1,7 +1,6 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import archiver from 'archiver'
-import type { Capabilities } from '@wdio/types'
 
 /**
  * Uploads a file to the Selenium Standalone server or other browser driver
@@ -48,7 +47,7 @@ export async function uploadFile (
      * check if command is available
      */
     if (typeof this.file !== 'function') {
-        throw new Error(`The uploadFile command is not available in ${(this.capabilities as Capabilities.Capabilities).browserName}`)
+        throw new Error(`The uploadFile command is not available in ${(this.capabilities as WebdriverIO.Capabilities).browserName}`)
     }
 
     const zipData: Uint8Array[] = []

--- a/packages/webdriverio/src/commands/element/isDisplayed.ts
+++ b/packages/webdriverio/src/commands/element/isDisplayed.ts
@@ -1,5 +1,3 @@
-import type { Capabilities } from '@wdio/types'
-
 import { ELEMENT_KEY } from '../../constants.js'
 import { getBrowserObject, hasElementId } from '../../utils/index.js'
 import isElementDisplayedScript from '../../scripts/isElementDisplayed.js'
@@ -76,7 +74,7 @@ export async function isDisplayed (this: WebdriverIO.Element) {
         (
             await browser.isW3C &&
             !browser.isMobile &&
-            noW3CEndpoint.includes((browser.capabilities as Capabilities.Capabilities).browserName?.toLowerCase()!)
+            noW3CEndpoint.includes((browser.capabilities as WebdriverIO.Capabilities).browserName?.toLowerCase()!)
         )
     )
 

--- a/packages/webdriverio/src/middlewares.ts
+++ b/packages/webdriverio/src/middlewares.ts
@@ -1,5 +1,3 @@
-import type { Capabilities } from '@wdio/types'
-
 import refetchElement from './utils/refetchElement.js'
 import implicitWait from './utils/implicitWait.js'
 import { getBrowserObject } from './utils/index.js'
@@ -25,7 +23,7 @@ export const elementErrorHandler = (fn: Function) => (commandName: string, comma
                  * assume Safari responses like { error: 'no such element', message: '', stacktrace: '' }
                  * as `stale element reference`
                  */
-                const caps = getBrowserObject(this).capabilities as Capabilities.Capabilities
+                const caps = getBrowserObject(this).capabilities as WebdriverIO.Capabilities
                 if (
                     caps && caps.browserName === 'safari' &&
                     result && result.error === 'no such element'

--- a/packages/webdriverio/src/utils/actions/key.ts
+++ b/packages/webdriverio/src/utils/actions/key.ts
@@ -1,5 +1,4 @@
 import os from 'node:os'
-import type { Capabilities } from '@wdio/types'
 
 import type { BaseActionParams } from './base.js'
 import BaseAction from './base.js'
@@ -15,7 +14,7 @@ export default class KeyAction extends BaseAction {
             throw new Error(`Invalid type for key input: "${typeof value}", expected a string!`)
         }
 
-        const platformName = (this.instance.capabilities as Capabilities.Capabilities).platformName
+        const platformName = (this.instance.capabilities as WebdriverIO.Capabilities).platformName
         const isMac = (
             // check capabilities first
             platformName && platformName.match(/mac(\s)*os/i) ||

--- a/packages/webdriverio/src/utils/detectBackend.ts
+++ b/packages/webdriverio/src/utils/detectBackend.ts
@@ -80,8 +80,8 @@ export default function detectBackend(options: BackendConfigurations = {}) {
      * For Sauce Labs Legacy RDC we only need to determine if the sauce option has a `testobject_api_key`.
      * Same for Sauce Visual where an apiKey can be passed in through the capabilities (soon to be legacy too).
      */
-    const isRDC = Boolean(!Array.isArray(capabilities) && (capabilities as WebDriver.DesiredCapabilities)?.testobject_api_key)
-    const isVisual = Boolean(!Array.isArray(capabilities) && capabilities && (capabilities as WebDriver.DesiredCapabilities)['sauce:visual']?.apiKey)
+    const isRDC = Boolean(!Array.isArray(capabilities) && (capabilities as Capabilities.DesiredCapabilities)?.testobject_api_key)
+    const isVisual = Boolean(!Array.isArray(capabilities) && capabilities && (capabilities as WebdriverIO.Capabilities)['sauce:visual']?.apiKey)
     if ((typeof user === 'string' && typeof key === 'string' && key.length === 36) ||
         // Or only RDC or visual
         (isRDC || isVisual)

--- a/tests/typings/webdriverio/async.ts
+++ b/tests/typings/webdriverio/async.ts
@@ -333,8 +333,8 @@ async function bar() {
 
     // test access to base client properties
     expectType<string>(browser.sessionId)
-    expectType<string>((browser.capabilities as WebDriver.Capabilities).browserName)
-    expectType<string>((browser.requestedCapabilities as WebDriver.Capabilities).browserName)
+    expectType<string>((browser.capabilities as WebdriverIO.Capabilities).browserName)
+    expectType<string>((browser.requestedCapabilities as WebdriverIO.Capabilities).browserName)
     expectType<boolean>(browser.isMobile)
     expectType<boolean>(browser.isAndroid)
     expectType<boolean>(browser.isIOS)

--- a/tests/typings/webdriverio/config.ts
+++ b/tests/typings/webdriverio/config.ts
@@ -1,4 +1,5 @@
 import { expectType } from 'tsd'
+import type { Capabilities } from '@wdio/types'
 
 class CustomService {
     onPrepare() {
@@ -161,18 +162,17 @@ const config: WebdriverIO.Config = {
             logLevel: 'INFO',
             mobileDevice: {
                 deviceName: 'Apple iPhone XR',
-                orientation: 'portrait'
+                orientation: 'portrait' as Capabilities.MoonMobileDeviceOrientation
             }
         }
-    },{
+    }, {
         'wdio:devtoolsOptions': {
             ignoreDefaultArgs: false
         }
     }, {
         'wdio:customCaps': {
             foo: 'bar',
-            // @ts-expect-error
-            bar: 'foo'
+            bar: 123
         }
     }],
 

--- a/tests/typings/webdriverio/config.ts
+++ b/tests/typings/webdriverio/config.ts
@@ -6,6 +6,19 @@ class CustomService {
     }
 }
 
+declare global {
+    namespace WebdriverIO {
+        interface Capabilities {
+            'wdio:customCaps'?: {
+                // a foo cap
+                foo: string
+                // a bar cap
+                bar: number
+            }
+        }
+    }
+}
+
 const configA: WebdriverIO.Config = {
     // @ts-expect-error should not be available
     beforeFeature () {
@@ -155,7 +168,13 @@ const config: WebdriverIO.Config = {
         'wdio:devtoolsOptions': {
             ignoreDefaultArgs: false
         }
-    }] as WebDriver.DesiredCapabilities[],
+    }, {
+        'wdio:customCaps': {
+            foo: 'bar',
+            // @ts-expect-error
+            bar: 'foo'
+        }
+    }],
 
     filesToWatch: [
         '/foo/page-objects/**/*.page.js',

--- a/tests/typings/webdriverio/tsconfig.json
+++ b/tests/typings/webdriverio/tsconfig.json
@@ -4,6 +4,7 @@
     "noImplicitAny": true,
     "lib": ["es2018", "dom"],
     "types": [
+      "devtools",
       "@wdio/utils",
       "@wdio/globals/types",
       "@wdio/allure-reporter",

--- a/website/docs/Capabilities.md
+++ b/website/docs/Capabilities.md
@@ -353,3 +353,39 @@ When testing on Safari, make sure you have the [Safari Technology Preview](https
 
 </TabItem>
 </Tabs>
+
+## Extend Custom Capabilities
+
+If you like to define your own set of capabilities in order to e.g. store arbitrary data to be used within the tests for that specific capability, you can do so by e.g. setting:
+
+```js title=wdio.conf.ts
+export const config = {
+    // ...
+    capabilities: [{
+        browserName: 'chrome',
+        'custom:caps': {
+            // custom configurations
+        }
+    }]
+}
+```
+
+It is advised to follow the [W3C protocol](https://w3c.github.io/webdriver/#dfn-extension-capability) when it comes to capability naming which requires a `:` (colon) character, denoting an implementation specific namespace. Within your tests you can access your custom capability through, e.g.:
+
+```ts
+browser.capabilities['custom:caps']
+```
+
+In order to ensure type safety you can extend WebdriverIOs capability interface via:
+
+```ts
+declare global {
+    namespace WebdriverIO {
+        interface Capabilities {
+            'custom:caps': {
+                // ...
+            }
+        }
+    }
+}
+```

--- a/website/docs/extension-testing/WebExtension.md
+++ b/website/docs/extension-testing/WebExtension.md
@@ -79,7 +79,7 @@ const extensionPath = path.resolve(__dirname, `web-extension.xpi`)
 export const config = {
     // ...
     before: async (capabilities) => {
-        const browserName = (capabilities as Capabilities.Capabilities).browserName
+        const browserName = (capabilities as WebdriverIO.Capabilities).browserName
         if (browserName === 'firefox') {
             const extension = await fs.readFile(extensionPath)
             await browser.installAddOn(extension.toString('base64'), true)
@@ -106,7 +106,7 @@ In Chrome this works by retrieving the extension ID and opening the popup page t
 
 ```ts customCommand.ts
 export async function openExtensionPopup (this: WebdriverIO.Browser, extensionName: string, popupUrl = 'index.html') {
-  if ((this.capabilities as Capabilities.Capabilities).browserName !== 'chrome') {
+  if ((this.capabilities as WebdriverIO.Capabilities).browserName !== 'chrome') {
     throw new Error('This command only works with Chrome')
   }
   await this.url('chrome://extensions/')

--- a/website/i18n/ar/docusaurus-plugin-content-docs/current/WebExtensionTesting.md
+++ b/website/i18n/ar/docusaurus-plugin-content-docs/current/WebExtensionTesting.md
@@ -79,7 +79,7 @@ const extensionPath = path.resolve(__dirname, `web-extension.xpi`)
 export const config = {
     // ...
     before: async (capabilities) => {
-        const browserName = (capabilities as Capabilities.Capabilities).browserName
+        const browserName = (capabilities as WebdriverIO.Capabilities).browserName
         if (browserName === 'firefox') {
             const extension = await fs.readFile(extensionPath)
             await browser.installAddOn(extension.toString('base64'), true)

--- a/website/i18n/ar/docusaurus-plugin-content-docs/current/extension-testing/WebExtension.md
+++ b/website/i18n/ar/docusaurus-plugin-content-docs/current/extension-testing/WebExtension.md
@@ -79,7 +79,7 @@ const extensionPath = path.resolve(__dirname, `web-extension.xpi`)
 export const config = {
     // ...
     before: async (capabilities) => {
-        const browserName = (capabilities as Capabilities.Capabilities).browserName
+        const browserName = (capabilities as WebdriverIO.Capabilities).browserName
         if (browserName === 'firefox') {
             const extension = await fs.readFile(extensionPath)
             await browser.installAddOn(extension.toString('base64'), true)
@@ -106,7 +106,7 @@ In Chrome this works by retrieving the extension ID and opening the popup page t
 
 ```ts customCommand.ts
 export async function openExtensionPopup (this: WebdriverIO.Browser, extensionName: string, popupUrl = 'index.html') {
-  if ((this.capabilities as Capabilities.Capabilities).browserName !== 'chrome') {
+  if ((this.capabilities as WebdriverIO.Capabilities).browserName !== 'chrome') {
     throw new Error('This command only works with Chrome')
   }
   await this.url('chrome://extensions/')

--- a/website/i18n/ar/docusaurus-plugin-content-docs/current/web-extension-testing/TipsAndTricks.md
+++ b/website/i18n/ar/docusaurus-plugin-content-docs/current/web-extension-testing/TipsAndTricks.md
@@ -13,7 +13,7 @@ In Chrome this works by retrieving the extension ID and opening the popup page t
 
 ```ts customCommand.ts
 export async function openExtensionPopup (this: WebdriverIO.Browser, extensionName: string, popupUrl = 'index.html') {
-  if ((this.capabilities as Capabilities.Capabilities).browserName !== 'chrome') {
+  if ((this.capabilities as WebdriverIO.Capabilities).browserName !== 'chrome') {
     throw new Error('This command only works with Chrome')
   }
   await this.url('chrome://extensions/')

--- a/website/i18n/bg/docusaurus-plugin-content-docs/current/WebExtensionTesting.md
+++ b/website/i18n/bg/docusaurus-plugin-content-docs/current/WebExtensionTesting.md
@@ -79,7 +79,7 @@ const extensionPath = path.resolve(__dirname, `web-extension.xpi`)
 export const config = {
     // ...
     before: async (capabilities) => {
-        const browserName = (capabilities as Capabilities.Capabilities).browserName
+        const browserName = (capabilities as WebdriverIO.Capabilities).browserName
         if (browserName === 'firefox') {
             const extension = await fs.readFile(extensionPath)
             await browser.installAddOn(extension.toString('base64'), true)

--- a/website/i18n/bg/docusaurus-plugin-content-docs/current/extension-testing/WebExtension.md
+++ b/website/i18n/bg/docusaurus-plugin-content-docs/current/extension-testing/WebExtension.md
@@ -79,7 +79,7 @@ const extensionPath = path.resolve(__dirname, `web-extension.xpi`)
 export const config = {
     // ...
     before: async (capabilities) => {
-        const browserName = (capabilities as Capabilities.Capabilities).browserName
+        const browserName = (capabilities as WebdriverIO.Capabilities).browserName
         if (browserName === 'firefox') {
             const extension = await fs.readFile(extensionPath)
             await browser.installAddOn(extension.toString('base64'), true)
@@ -106,7 +106,7 @@ In Chrome this works by retrieving the extension ID and opening the popup page t
 
 ```ts customCommand.ts
 export async function openExtensionPopup (this: WebdriverIO.Browser, extensionName: string, popupUrl = 'index.html') {
-  if ((this.capabilities as Capabilities.Capabilities).browserName !== 'chrome') {
+  if ((this.capabilities as WebdriverIO.Capabilities).browserName !== 'chrome') {
     throw new Error('This command only works with Chrome')
   }
   await this.url('chrome://extensions/')

--- a/website/i18n/bg/docusaurus-plugin-content-docs/current/web-extension-testing/TipsAndTricks.md
+++ b/website/i18n/bg/docusaurus-plugin-content-docs/current/web-extension-testing/TipsAndTricks.md
@@ -13,7 +13,7 @@ In Chrome this works by retrieving the extension ID and opening the popup page t
 
 ```ts customCommand.ts
 export async function openExtensionPopup (this: WebdriverIO.Browser, extensionName: string, popupUrl = 'index.html') {
-  if ((this.capabilities as Capabilities.Capabilities).browserName !== 'chrome') {
+  if ((this.capabilities as WebdriverIO.Capabilities).browserName !== 'chrome') {
     throw new Error('This command only works with Chrome')
   }
   await this.url('chrome://extensions/')

--- a/website/i18n/de/docusaurus-plugin-content-docs/current/WebExtensionTesting.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/current/WebExtensionTesting.md
@@ -79,7 +79,7 @@ const extensionPath = path.resolve(__dirname, `web-extension.xpi`)
 export const config = {
     // ...
     before: async (capabilities) => {
-        const browserName = (capabilities as Capabilities.Capabilities).browserName
+        const browserName = (capabilities as WebdriverIO.Capabilities).browserName
         if (browserName === 'firefox') {
             const extension = await fs.readFile(extensionPath)
             await browser.installAddOn(extension.toString('base64'), true)

--- a/website/i18n/de/docusaurus-plugin-content-docs/current/extension-testing/WebExtension.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/current/extension-testing/WebExtension.md
@@ -79,7 +79,7 @@ const extensionPath = path.resolve(__dirname, `web-extension.xpi`)
 export const config = {
     // ...
     before: async (capabilities) => {
-        const browserName = (capabilities as Capabilities.Capabilities).browserName
+        const browserName = (capabilities as WebdriverIO.Capabilities).browserName
         if (browserName === 'firefox') {
             const extension = await fs.readFile(extensionPath)
             await browser.installAddOn(extension.toString('base64'), true)
@@ -106,7 +106,7 @@ In Chrome this works by retrieving the extension ID and opening the popup page t
 
 ```ts customCommand.ts
 export async function openExtensionPopup (this: WebdriverIO.Browser, extensionName: string, popupUrl = 'index.html') {
-  if ((this.capabilities as Capabilities.Capabilities).browserName !== 'chrome') {
+  if ((this.capabilities as WebdriverIO.Capabilities).browserName !== 'chrome') {
     throw new Error('This command only works with Chrome')
   }
   await this.url('chrome://extensions/')

--- a/website/i18n/de/docusaurus-plugin-content-docs/current/web-extension-testing/TipsAndTricks.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/current/web-extension-testing/TipsAndTricks.md
@@ -13,7 +13,7 @@ In Chrome funktioniert dies, indem die Erweiterungs-ID abgerufen und die Popup-S
 
 ```ts customCommand.ts
 export async function openExtensionPopup (this: WebdriverIO.Browser, extensionName: string, popupUrl = 'index.html') {
-  if ((this.capabilities as Capabilities.Capabilities).browserName !== 'chrome') {
+  if ((this.capabilities as WebdriverIO.Capabilities).browserName !== 'chrome') {
     throw new Error('This command only works with Chrome')
   }
   await this.url('chrome://extensions/')

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/WebExtensionTesting.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/WebExtensionTesting.md
@@ -79,7 +79,7 @@ const extensionPath = path.resolve(__dirname, `web-extension.xpi`)
 export const config = {
     // ...
     before: async (capabilities) => {
-        const browserName = (capabilities as Capabilities.Capabilities).browserName
+        const browserName = (capabilities as WebdriverIO.Capabilities).browserName
         if (browserName === 'firefox') {
             const extension = await fs.readFile(extensionPath)
             await browser.installAddOn(extension.toString('base64'), true)

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/extension-testing/WebExtension.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/extension-testing/WebExtension.md
@@ -79,7 +79,7 @@ const extensionPath = path.resolve(__dirname, `web-extension.xpi`)
 export const config = {
     // ...
     before: async (capabilities) => {
-        const browserName = (capabilities as Capabilities.Capabilities).browserName
+        const browserName = (capabilities as WebdriverIO.Capabilities).browserName
         if (browserName === 'firefox') {
             const extension = await fs.readFile(extensionPath)
             await browser.installAddOn(extension.toString('base64'), true)
@@ -106,7 +106,7 @@ In Chrome this works by retrieving the extension ID and opening the popup page t
 
 ```ts customCommand.ts
 export async function openExtensionPopup (this: WebdriverIO.Browser, extensionName: string, popupUrl = 'index.html') {
-  if ((this.capabilities as Capabilities.Capabilities).browserName !== 'chrome') {
+  if ((this.capabilities as WebdriverIO.Capabilities).browserName !== 'chrome') {
     throw new Error('This command only works with Chrome')
   }
   await this.url('chrome://extensions/')

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/web-extension-testing/TipsAndTricks.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/web-extension-testing/TipsAndTricks.md
@@ -13,7 +13,7 @@ En Chrome esto funciona recuperando el ID de extensión y abriendo la página em
 
 ```ts customCommand.ts
 export async function openExtensionPopup (this: WebdriverIO.Browser, extensionName: string, popupUrl = 'index.html') {
-  if ((this.capabilities as Capabilities.Capabilities).browserName !== 'chrome') {
+  if ((this.capabilities as WebdriverIO.Capabilities).browserName !== 'chrome') {
     throw new Error('This command only works with Chrome')
   }
   await this.url('chrome://extensions/')

--- a/website/i18n/fa/docusaurus-plugin-content-docs/current/WebExtensionTesting.md
+++ b/website/i18n/fa/docusaurus-plugin-content-docs/current/WebExtensionTesting.md
@@ -79,7 +79,7 @@ const extensionPath = path.resolve(__dirname, `web-extension.xpi`)
 export const config = {
     // ...
     before: async (capabilities) => {
-        const browserName = (capabilities as Capabilities.Capabilities).browserName
+        const browserName = (capabilities as WebdriverIO.Capabilities).browserName
         if (browserName === 'firefox') {
             const extension = await fs.readFile(extensionPath)
             await browser.installAddOn(extension.toString('base64'), true)

--- a/website/i18n/fa/docusaurus-plugin-content-docs/current/extension-testing/WebExtension.md
+++ b/website/i18n/fa/docusaurus-plugin-content-docs/current/extension-testing/WebExtension.md
@@ -79,7 +79,7 @@ const extensionPath = path.resolve(__dirname, `web-extension.xpi`)
 export const config = {
     // ...
     before: async (capabilities) => {
-        const browserName = (capabilities as Capabilities.Capabilities).browserName
+        const browserName = (capabilities as WebdriverIO.Capabilities).browserName
         if (browserName === 'firefox') {
             const extension = await fs.readFile(extensionPath)
             await browser.installAddOn(extension.toString('base64'), true)
@@ -106,7 +106,7 @@ In Chrome this works by retrieving the extension ID and opening the popup page t
 
 ```ts customCommand.ts
 export async function openExtensionPopup (this: WebdriverIO.Browser, extensionName: string, popupUrl = 'index.html') {
-  if ((this.capabilities as Capabilities.Capabilities).browserName !== 'chrome') {
+  if ((this.capabilities as WebdriverIO.Capabilities).browserName !== 'chrome') {
     throw new Error('This command only works with Chrome')
   }
   await this.url('chrome://extensions/')

--- a/website/i18n/fa/docusaurus-plugin-content-docs/current/web-extension-testing/TipsAndTricks.md
+++ b/website/i18n/fa/docusaurus-plugin-content-docs/current/web-extension-testing/TipsAndTricks.md
@@ -13,7 +13,7 @@ title: نکات و ترفندها
 
 ```ts customCommand.ts
 export async function openExtensionPopup (this: WebdriverIO.Browser, extensionName: string, popupUrl = 'index.html') {
-  if ((this.capabilities as Capabilities.Capabilities).browserName !== 'chrome') {
+  if ((this.capabilities as WebdriverIO.Capabilities).browserName !== 'chrome') {
     throw new Error('This command only works with Chrome')
   }
   await this.url('chrome://extensions/')

--- a/website/i18n/fr/docusaurus-plugin-content-docs/current/WebExtensionTesting.md
+++ b/website/i18n/fr/docusaurus-plugin-content-docs/current/WebExtensionTesting.md
@@ -79,7 +79,7 @@ const extensionPath = path.resolve(__dirname, `web-extension.xpi`)
 export const config = {
     // ...
     before: async (capabilities) => {
-        const browserName = (capabilities as Capabilities.Capabilities).browserName
+        const browserName = (capabilities as WebdriverIO.Capabilities).browserName
         if (browserName === 'firefox') {
             const extension = await fs.readFile(extensionPath)
             await browser.installAddOn(extension.toString('base64'), true)

--- a/website/i18n/fr/docusaurus-plugin-content-docs/current/extension-testing/WebExtension.md
+++ b/website/i18n/fr/docusaurus-plugin-content-docs/current/extension-testing/WebExtension.md
@@ -79,7 +79,7 @@ const extensionPath = path.resolve(__dirname, `web-extension.xpi`)
 export const config = {
     // ...
     before: async (capabilities) => {
-        const browserName = (capabilities as Capabilities.Capabilities).browserName
+        const browserName = (capabilities as WebdriverIO.Capabilities).browserName
         if (browserName === 'firefox') {
             const extension = await fs.readFile(extensionPath)
             await browser.installAddOn(extension.toString('base64'), true)
@@ -106,7 +106,7 @@ In Chrome this works by retrieving the extension ID and opening the popup page t
 
 ```ts customCommand.ts
 export async function openExtensionPopup (this: WebdriverIO.Browser, extensionName: string, popupUrl = 'index.html') {
-  if ((this.capabilities as Capabilities.Capabilities).browserName !== 'chrome') {
+  if ((this.capabilities as WebdriverIO.Capabilities).browserName !== 'chrome') {
     throw new Error('This command only works with Chrome')
   }
   await this.url('chrome://extensions/')

--- a/website/i18n/fr/docusaurus-plugin-content-docs/current/web-extension-testing/TipsAndTricks.md
+++ b/website/i18n/fr/docusaurus-plugin-content-docs/current/web-extension-testing/TipsAndTricks.md
@@ -13,7 +13,7 @@ Dans Chrome, cela fonctionne en récupérant l'ID de l'extension et en ouvrant l
 
 ```ts customCommand.ts
 export async function openExtensionPopup (this: WebdriverIO.Browser, extensionName: string, popupUrl = 'index.html') {
-  if ((this.capabilities as Capabilities.Capabilities).browserName !== 'chrome') {
+  if ((this.capabilities as WebdriverIO.Capabilities).browserName !== 'chrome') {
     throw new Error('This command only works with Chrome')
   }
   await this.url('chrome://extensions/')

--- a/website/i18n/hi/docusaurus-plugin-content-docs/current/WebExtensionTesting.md
+++ b/website/i18n/hi/docusaurus-plugin-content-docs/current/WebExtensionTesting.md
@@ -79,7 +79,7 @@ const extensionPath = path.resolve(__dirname, `web-extension.xpi`)
 export const config = {
     // ...
     before: async (capabilities) => {
-        const browserName = (capabilities as Capabilities.Capabilities).browserName
+        const browserName = (capabilities as WebdriverIO.Capabilities).browserName
         if (browserName === 'firefox') {
             const extension = await fs.readFile(extensionPath)
             await browser.installAddOn(extension.toString('base64'), true)

--- a/website/i18n/hi/docusaurus-plugin-content-docs/current/extension-testing/WebExtension.md
+++ b/website/i18n/hi/docusaurus-plugin-content-docs/current/extension-testing/WebExtension.md
@@ -79,7 +79,7 @@ const extensionPath = path.resolve(__dirname, `web-extension.xpi`)
 export const config = {
     // ...
     before: async (capabilities) => {
-        const browserName = (capabilities as Capabilities.Capabilities).browserName
+        const browserName = (capabilities as WebdriverIO.Capabilities).browserName
         if (browserName === 'firefox') {
             const extension = await fs.readFile(extensionPath)
             await browser.installAddOn(extension.toString('base64'), true)
@@ -106,7 +106,7 @@ In Chrome this works by retrieving the extension ID and opening the popup page t
 
 ```ts customCommand.ts
 export async function openExtensionPopup (this: WebdriverIO.Browser, extensionName: string, popupUrl = 'index.html') {
-  if ((this.capabilities as Capabilities.Capabilities).browserName !== 'chrome') {
+  if ((this.capabilities as WebdriverIO.Capabilities).browserName !== 'chrome') {
     throw new Error('This command only works with Chrome')
   }
   await this.url('chrome://extensions/')

--- a/website/i18n/hi/docusaurus-plugin-content-docs/current/web-extension-testing/TipsAndTricks.md
+++ b/website/i18n/hi/docusaurus-plugin-content-docs/current/web-extension-testing/TipsAndTricks.md
@@ -15,7 +15,7 @@ title: सलाह व सुझाव
 
 ```ts customCommand.ts
 export async function openExtensionPopup (this: WebdriverIO.Browser, extensionName: string, popupUrl = 'index.html') {
-  if ((this.capabilities as Capabilities.Capabilities).browserName !== 'chrome') {
+  if ((this.capabilities as WebdriverIO.Capabilities).browserName !== 'chrome') {
     throw new Error('This command only works with Chrome')
   }
   await this.url('chrome://extensions/')

--- a/website/i18n/it/docusaurus-plugin-content-docs/current/WebExtensionTesting.md
+++ b/website/i18n/it/docusaurus-plugin-content-docs/current/WebExtensionTesting.md
@@ -79,7 +79,7 @@ const extensionPath = path.resolve(__dirname, `web-extension.xpi`)
 export const config = {
     // ...
     before: async (capabilities) => {
-        const browserName = (capabilities as Capabilities.Capabilities).browserName
+        const browserName = (capabilities as WebdriverIO.Capabilities).browserName
         if (browserName === 'firefox') {
             const extension = await fs.readFile(extensionPath)
             await browser.installAddOn(extension.toString('base64'), true)

--- a/website/i18n/it/docusaurus-plugin-content-docs/current/extension-testing/WebExtension.md
+++ b/website/i18n/it/docusaurus-plugin-content-docs/current/extension-testing/WebExtension.md
@@ -79,7 +79,7 @@ const extensionPath = path.resolve(__dirname, `web-extension.xpi`)
 export const config = {
     // ...
     before: async (capabilities) => {
-        const browserName = (capabilities as Capabilities.Capabilities).browserName
+        const browserName = (capabilities as WebdriverIO.Capabilities).browserName
         if (browserName === 'firefox') {
             const extension = await fs.readFile(extensionPath)
             await browser.installAddOn(extension.toString('base64'), true)
@@ -106,7 +106,7 @@ In Chrome this works by retrieving the extension ID and opening the popup page t
 
 ```ts customCommand.ts
 export async function openExtensionPopup (this: WebdriverIO.Browser, extensionName: string, popupUrl = 'index.html') {
-  if ((this.capabilities as Capabilities.Capabilities).browserName !== 'chrome') {
+  if ((this.capabilities as WebdriverIO.Capabilities).browserName !== 'chrome') {
     throw new Error('This command only works with Chrome')
   }
   await this.url('chrome://extensions/')

--- a/website/i18n/it/docusaurus-plugin-content-docs/current/web-extension-testing/TipsAndTricks.md
+++ b/website/i18n/it/docusaurus-plugin-content-docs/current/web-extension-testing/TipsAndTricks.md
@@ -13,7 +13,7 @@ In Chrome this works by retrieving the extension ID and opening the popup page t
 
 ```ts customCommand.ts
 export async function openExtensionPopup (this: WebdriverIO.Browser, extensionName: string, popupUrl = 'index.html') {
-  if ((this.capabilities as Capabilities.Capabilities).browserName !== 'chrome') {
+  if ((this.capabilities as WebdriverIO.Capabilities).browserName !== 'chrome') {
     throw new Error('This command only works with Chrome')
   }
   await this.url('chrome://extensions/')

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/extension-testing/WebExtension.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/extension-testing/WebExtension.md
@@ -79,7 +79,7 @@ const extensionPath = path.resolve(__dirname, `web-extension.xpi`)
 export const config = {
     // ...
     before: async (capabilities) => {
-        const browserName = (capabilities as Capabilities.Capabilities).browserName
+        const browserName = (capabilities as WebdriverIO.Capabilities).browserName
         if (browserName === 'firefox') {
             const extension = await fs.readFile(extensionPath)
             await browser.installAddOn(extension.toString('base64'), true)
@@ -106,7 +106,7 @@ In Chrome this works by retrieving the extension ID and opening the popup page t
 
 ```ts customCommand.ts
 export async function openExtensionPopup (this: WebdriverIO.Browser, extensionName: string, popupUrl = 'index.html') {
-  if ((this.capabilities as Capabilities.Capabilities).browserName !== 'chrome') {
+  if ((this.capabilities as WebdriverIO.Capabilities).browserName !== 'chrome') {
     throw new Error('This command only works with Chrome')
   }
   await this.url('chrome://extensions/')

--- a/website/i18n/pl/docusaurus-plugin-content-docs/current/WebExtensionTesting.md
+++ b/website/i18n/pl/docusaurus-plugin-content-docs/current/WebExtensionTesting.md
@@ -79,7 +79,7 @@ const extensionPath = path.resolve(__dirname, `web-extension.xpi`)
 export const config = {
     // ...
     before: async (capabilities) => {
-        const browserName = (capabilities as Capabilities.Capabilities).browserName
+        const browserName = (capabilities as WebdriverIO.Capabilities).browserName
         if (browserName === 'firefox') {
             const extension = await fs.readFile(extensionPath)
             await browser.installAddOn(extension.toString('base64'), true)

--- a/website/i18n/pl/docusaurus-plugin-content-docs/current/extension-testing/WebExtension.md
+++ b/website/i18n/pl/docusaurus-plugin-content-docs/current/extension-testing/WebExtension.md
@@ -79,7 +79,7 @@ const extensionPath = path.resolve(__dirname, `web-extension.xpi`)
 export const config = {
     // ...
     before: async (capabilities) => {
-        const browserName = (capabilities as Capabilities.Capabilities).browserName
+        const browserName = (capabilities as WebdriverIO.Capabilities).browserName
         if (browserName === 'firefox') {
             const extension = await fs.readFile(extensionPath)
             await browser.installAddOn(extension.toString('base64'), true)
@@ -106,7 +106,7 @@ In Chrome this works by retrieving the extension ID and opening the popup page t
 
 ```ts customCommand.ts
 export async function openExtensionPopup (this: WebdriverIO.Browser, extensionName: string, popupUrl = 'index.html') {
-  if ((this.capabilities as Capabilities.Capabilities).browserName !== 'chrome') {
+  if ((this.capabilities as WebdriverIO.Capabilities).browserName !== 'chrome') {
     throw new Error('This command only works with Chrome')
   }
   await this.url('chrome://extensions/')

--- a/website/i18n/pl/docusaurus-plugin-content-docs/current/web-extension-testing/TipsAndTricks.md
+++ b/website/i18n/pl/docusaurus-plugin-content-docs/current/web-extension-testing/TipsAndTricks.md
@@ -13,7 +13,7 @@ In Chrome this works by retrieving the extension ID and opening the popup page t
 
 ```ts customCommand.ts
 export async function openExtensionPopup (this: WebdriverIO.Browser, extensionName: string, popupUrl = 'index.html') {
-  if ((this.capabilities as Capabilities.Capabilities).browserName !== 'chrome') {
+  if ((this.capabilities as WebdriverIO.Capabilities).browserName !== 'chrome') {
     throw new Error('This command only works with Chrome')
   }
   await this.url('chrome://extensions/')

--- a/website/i18n/ru/docusaurus-plugin-content-docs/current/WebExtensionTesting.md
+++ b/website/i18n/ru/docusaurus-plugin-content-docs/current/WebExtensionTesting.md
@@ -79,7 +79,7 @@ const extensionPath = path.resolve(__dirname, `web-extension.xpi`)
 export const config = {
     // ...
     before: async (capabilities) => {
-        const browserName = (capabilities as Capabilities.Capabilities).browserName
+        const browserName = (capabilities as WebdriverIO.Capabilities).browserName
         if (browserName === 'firefox') {
             const extension = await fs.readFile(extensionPath)
             await browser.installAddOn(extension.toString('base64'), true)

--- a/website/i18n/ru/docusaurus-plugin-content-docs/current/extension-testing/WebExtension.md
+++ b/website/i18n/ru/docusaurus-plugin-content-docs/current/extension-testing/WebExtension.md
@@ -79,7 +79,7 @@ const extensionPath = path.resolve(__dirname, `web-extension.xpi`)
 export const config = {
     // ...
     before: async (capabilities) => {
-        const browserName = (capabilities as Capabilities.Capabilities).browserName
+        const browserName = (capabilities as WebdriverIO.Capabilities).browserName
         if (browserName === 'firefox') {
             const extension = await fs.readFile(extensionPath)
             await browser.installAddOn(extension.toString('base64'), true)
@@ -106,7 +106,7 @@ In Chrome this works by retrieving the extension ID and opening the popup page t
 
 ```ts customCommand.ts
 export async function openExtensionPopup (this: WebdriverIO.Browser, extensionName: string, popupUrl = 'index.html') {
-  if ((this.capabilities as Capabilities.Capabilities).browserName !== 'chrome') {
+  if ((this.capabilities as WebdriverIO.Capabilities).browserName !== 'chrome') {
     throw new Error('This command only works with Chrome')
   }
   await this.url('chrome://extensions/')

--- a/website/i18n/ru/docusaurus-plugin-content-docs/current/web-extension-testing/TipsAndTricks.md
+++ b/website/i18n/ru/docusaurus-plugin-content-docs/current/web-extension-testing/TipsAndTricks.md
@@ -13,7 +13,7 @@ title: Советы
 
 ```ts customCommand.ts
 export async function openExtensionPopup (this: WebdriverIO.Browser, extensionName: string, popupUrl = 'index.html') {
-  if ((this.capabilities as Capabilities.Capabilities).browserName !== 'chrome') {
+  if ((this.capabilities as WebdriverIO.Capabilities).browserName !== 'chrome') {
     throw new Error('This command only works with Chrome')
   }
   await this.url('chrome://extensions/')

--- a/website/i18n/ta/docusaurus-plugin-content-docs/current/WebExtensionTesting.md
+++ b/website/i18n/ta/docusaurus-plugin-content-docs/current/WebExtensionTesting.md
@@ -79,7 +79,7 @@ const extensionPath = path.resolve(__dirname, `web-extension.xpi`)
 export const config = {
     // ...
     before: async (capabilities) => {
-        const browserName = (capabilities as Capabilities.Capabilities).browserName
+        const browserName = (capabilities as WebdriverIO.Capabilities).browserName
         if (browserName === 'firefox') {
             const extension = await fs.readFile(extensionPath)
             await browser.installAddOn(extension.toString('base64'), true)

--- a/website/i18n/ta/docusaurus-plugin-content-docs/current/extension-testing/WebExtension.md
+++ b/website/i18n/ta/docusaurus-plugin-content-docs/current/extension-testing/WebExtension.md
@@ -79,7 +79,7 @@ const extensionPath = path.resolve(__dirname, `web-extension.xpi`)
 export const config = {
     // ...
     before: async (capabilities) => {
-        const browserName = (capabilities as Capabilities.Capabilities).browserName
+        const browserName = (capabilities as WebdriverIO.Capabilities).browserName
         if (browserName === 'firefox') {
             const extension = await fs.readFile(extensionPath)
             await browser.installAddOn(extension.toString('base64'), true)
@@ -106,7 +106,7 @@ In Chrome this works by retrieving the extension ID and opening the popup page t
 
 ```ts customCommand.ts
 export async function openExtensionPopup (this: WebdriverIO.Browser, extensionName: string, popupUrl = 'index.html') {
-  if ((this.capabilities as Capabilities.Capabilities).browserName !== 'chrome') {
+  if ((this.capabilities as WebdriverIO.Capabilities).browserName !== 'chrome') {
     throw new Error('This command only works with Chrome')
   }
   await this.url('chrome://extensions/')

--- a/website/i18n/ta/docusaurus-plugin-content-docs/current/web-extension-testing/TipsAndTricks.md
+++ b/website/i18n/ta/docusaurus-plugin-content-docs/current/web-extension-testing/TipsAndTricks.md
@@ -13,7 +13,7 @@ Chrome இல், extension ஐடியை மீட்டெடுத்து
 
 ```ts customCommand.ts
 export async function openExtensionPopup (this: WebdriverIO.Browser, extensionName: string, popupUrl = 'index.html') {
-  if ((this.capabilities as Capabilities.Capabilities).browserName !== 'chrome') {
+  if ((this.capabilities as WebdriverIO.Capabilities).browserName !== 'chrome') {
     throw new Error('This command only works with Chrome')
   }
   await this.url('chrome://extensions/')

--- a/website/i18n/uk/docusaurus-plugin-content-docs/current/WebExtensionTesting.md
+++ b/website/i18n/uk/docusaurus-plugin-content-docs/current/WebExtensionTesting.md
@@ -79,7 +79,7 @@ const extensionPath = path.resolve(__dirname, `web-extension.xpi`)
 export const config = {
     // ...
     before: async (capabilities) => {
-        const browserName = (capabilities as Capabilities.Capabilities).browserName
+        const browserName = (capabilities as WebdriverIO.Capabilities).browserName
         if (browserName === 'firefox') {
             const extension = await fs.readFile(extensionPath)
             await browser.installAddOn(extension.toString('base64'), true)

--- a/website/i18n/uk/docusaurus-plugin-content-docs/current/extension-testing/WebExtension.md
+++ b/website/i18n/uk/docusaurus-plugin-content-docs/current/extension-testing/WebExtension.md
@@ -79,7 +79,7 @@ const extensionPath = path.resolve(__dirname, `web-extension.xpi`)
 export const config = {
     // ...
     before: async (capabilities) => {
-        const browserName = (capabilities as Capabilities.Capabilities).browserName
+        const browserName = (capabilities as WebdriverIO.Capabilities).browserName
         if (browserName === 'firefox') {
             const extension = await fs.readFile(extensionPath)
             await browser.installAddOn(extension.toString('base64'), true)
@@ -106,7 +106,7 @@ In Chrome this works by retrieving the extension ID and opening the popup page t
 
 ```ts customCommand.ts
 export async function openExtensionPopup (this: WebdriverIO.Browser, extensionName: string, popupUrl = 'index.html') {
-  if ((this.capabilities as Capabilities.Capabilities).browserName !== 'chrome') {
+  if ((this.capabilities as WebdriverIO.Capabilities).browserName !== 'chrome') {
     throw new Error('This command only works with Chrome')
   }
   await this.url('chrome://extensions/')

--- a/website/i18n/uk/docusaurus-plugin-content-docs/current/web-extension-testing/TipsAndTricks.md
+++ b/website/i18n/uk/docusaurus-plugin-content-docs/current/web-extension-testing/TipsAndTricks.md
@@ -13,7 +13,7 @@ title: Поради та хитрощі
 
 ```ts customCommand.ts
 export async function openExtensionPopup (this: WebdriverIO.Browser, extensionName: string, popupUrl = 'index.html') {
-  if ((this.capabilities as Capabilities.Capabilities).browserName !== 'chrome') {
+  if ((this.capabilities as WebdriverIO.Capabilities).browserName !== 'chrome') {
     throw new Error('This command only works with Chrome')
   }
   await this.url('chrome://extensions/')

--- a/website/i18n/zh/docusaurus-plugin-content-docs/current/WebExtensionTesting.md
+++ b/website/i18n/zh/docusaurus-plugin-content-docs/current/WebExtensionTesting.md
@@ -79,7 +79,7 @@ const extensionPath = path.resolve(__dirname, `web-extension.xpi`)
 export const config = {
     // ...
     before: async (capabilities) => {
-        const browserName = (capabilities as Capabilities.Capabilities).browserName
+        const browserName = (capabilities as WebdriverIO.Capabilities).browserName
         if (browserName === 'firefox') {
             const extension = await fs.readFile(extensionPath)
             await browser.installAddOn(extension.toString('base64'), true)

--- a/website/i18n/zh/docusaurus-plugin-content-docs/current/extension-testing/WebExtension.md
+++ b/website/i18n/zh/docusaurus-plugin-content-docs/current/extension-testing/WebExtension.md
@@ -79,7 +79,7 @@ const extensionPath = path.resolve(__dirname, `web-extension.xpi`)
 export const config = {
     // ...
     before: async (capabilities) => {
-        const browserName = (capabilities as Capabilities.Capabilities).browserName
+        const browserName = (capabilities as WebdriverIO.Capabilities).browserName
         if (browserName === 'firefox') {
             const extension = await fs.readFile(extensionPath)
             await browser.installAddOn(extension.toString('base64'), true)
@@ -106,7 +106,7 @@ In Chrome this works by retrieving the extension ID and opening the popup page t
 
 ```ts customCommand.ts
 export async function openExtensionPopup (this: WebdriverIO.Browser, extensionName: string, popupUrl = 'index.html') {
-  if ((this.capabilities as Capabilities.Capabilities).browserName !== 'chrome') {
+  if ((this.capabilities as WebdriverIO.Capabilities).browserName !== 'chrome') {
     throw new Error('This command only works with Chrome')
   }
   await this.url('chrome://extensions/')

--- a/website/i18n/zh/docusaurus-plugin-content-docs/current/web-extension-testing/TipsAndTricks.md
+++ b/website/i18n/zh/docusaurus-plugin-content-docs/current/web-extension-testing/TipsAndTricks.md
@@ -13,7 +13,7 @@ In Chrome this works by retrieving the extension ID and opening the popup page t
 
 ```ts customCommand.ts
 export async function openExtensionPopup (this: WebdriverIO.Browser, extensionName: string, popupUrl = 'index.html') {
-  if ((this.capabilities as Capabilities.Capabilities).browserName !== 'chrome') {
+  if ((this.capabilities as WebdriverIO.Capabilities).browserName !== 'chrome') {
     throw new Error('This command only works with Chrome')
   }
   await this.url('chrome://extensions/')


### PR DESCRIPTION
## Proposed changes

There are several services that use custom capabilities , e.g. `wdio:electronServiceOptions` to allow to configure the service behavior for a specific capability. It was currently not possible to extend the capability object. This PR introduces a new `WebdriverIO.Capabilities` interface that allows to extend the capabilities.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
