### PR TITLE
changed order for preventing some errors

### DIFF
--- a/packages/wdio-utils/src/driver/utils.ts
+++ b/packages/wdio-utils/src/driver/utils.ts
@@ -267,8 +267,8 @@ export async function setupChromedriver (cacheDir: string, driverVersion?: strin
             try{
                 await _install({ ...chromedriverInstallOpts, buildId })
                 log.info(`Download of Chromedriver v${buildId} was successful`)
-            } catch {
-                throw new Error(`Couldn't have founded known good version for Chromedriver v${buildId}`);
+            } catch (err: any) {
+                throw new Error(`Couldn't download Chromedriver v${buildId}: ${err.message}`);
             }
         }         
         executablePath = computeExecutablePath({

--- a/packages/wdio-utils/src/driver/utils.ts
+++ b/packages/wdio-utils/src/driver/utils.ts
@@ -202,35 +202,30 @@ export function getCacheDir (options: Pick<Options.WebDriver, 'cacheDir'>, caps:
 }
 
 export function getMajorVersionFromString(fullVersion:string) {
-    let prefix;
-  
+    let prefix
     if (fullVersion) {
-      prefix = fullVersion.match(/^[+-]?([0-9]+)/);
+        prefix = fullVersion.match(/^[+-]?([0-9]+)/)
     }
-    return prefix && prefix.length > 0 ? prefix[0] : '';
-  }
+    return prefix && prefix.length > 0 ? prefix[0] : ''
+}
 
 export async function checkKnownBuild (build: string) {
     try {
         const knownGoodVersions: any = await got('https://googlechromelabs.github.io/chrome-for-testing/known-good-versions.json').json()
-
-        const versionMatch = knownGoodVersions.versions.filter(({ version }: { version: string }) => version === build).pop();
-    
-        if(versionMatch && versionMatch.version) {
+        const versionMatch = knownGoodVersions.versions.filter(({ version }: { version: string }) => version === build).pop()
+        if (versionMatch && versionMatch.version) {
             return versionMatch.version as string
         } else {
-            log.warn(`Chromedriver v${build} don't exist, trying to find known good version...`);
-            const majorVersion = getMajorVersionFromString(build);
+            log.warn(`Chromedriver v${build} don't exist, trying to find known good version...`)
+            const majorVersion = getMajorVersionFromString(build)
             const versionMatchMajor = knownGoodVersions.versions.filter(({ version }: { version: string }) => version.startsWith(majorVersion)).pop()
-    
             if(versionMatchMajor && versionMatchMajor.version) {
                 return versionMatchMajor.version as string;
-            } else {
-                return '';
             }
+            return ''
         }
     } catch {
-        return '';
+        return ''
     }
 }
 
@@ -239,7 +234,6 @@ export async function setupChromedriver (cacheDir: string, driverVersion?: strin
     if (!platform) {
         throw new Error('The current platform is not supported.')
     }
-
     const version = driverVersion || getBuildIdByChromePath(await locateChrome()) || ChromeReleaseChannel.STABLE
     const buildId = await resolveBuildId(Browser.CHROMEDRIVER, platform, version)
     let executablePath = computeExecutablePath({
@@ -260,7 +254,7 @@ export async function setupChromedriver (cacheDir: string, driverVersion?: strin
             downloadProgressCallback: (downloadedBytes, totalBytes) => downloadProgressCallback('Chromedriver', downloadedBytes, totalBytes)
         }
         const knownBuild = await checkKnownBuild(buildId);
-        if(knownBuild && getMajorVersionFromString(knownBuild)) {
+        if (knownBuild && getMajorVersionFromString(knownBuild)) {
             await _install({ ...chromedriverInstallOpts, buildId: knownBuild })
             log.info(`Download of Chromedriver v${knownBuild} was successful`)
         } else {
@@ -268,7 +262,7 @@ export async function setupChromedriver (cacheDir: string, driverVersion?: strin
                 await _install({ ...chromedriverInstallOpts, buildId })
                 log.info(`Download of Chromedriver v${buildId} was successful`)
             } catch (err: any) {
-                throw new Error(`Couldn't download Chromedriver v${buildId}: ${err.message}`);
+                throw new Error(`Couldn't download Chromedriver v${buildId}: ${err.message}`)
             }
         }         
         executablePath = computeExecutablePath({
@@ -280,7 +274,6 @@ export async function setupChromedriver (cacheDir: string, driverVersion?: strin
     } else {
         log.info(`Using Chromedriver v${buildId} from cache directory ${cacheDir}`)
     }
-
     return { executablePath }
 }
 

--- a/packages/wdio-utils/src/driver/utils.ts
+++ b/packages/wdio-utils/src/driver/utils.ts
@@ -244,7 +244,7 @@ export async function setupChromedriver (cacheDir: string, driverVersion?: strin
             unpack: true,
             downloadProgressCallback: (downloadedBytes, totalBytes) => downloadProgressCallback('Chromedriver', downloadedBytes, totalBytes)
         }
-        let knownBuild = buildId;
+        let knownBuild = buildId
         if (await canDownload(chromedriverInstallOpts)) {
             await _install({ ...chromedriverInstallOpts, buildId })
             log.info(`Download of Chromedriver v${buildId} was successful`)

--- a/packages/wdio-utils/src/driver/utils.ts
+++ b/packages/wdio-utils/src/driver/utils.ts
@@ -215,15 +215,14 @@ export async function checkKnownBuild (build: string) {
         const versionMatch = knownGoodVersions.versions.filter(({ version }: { version: string }) => version === build).pop()
         if (versionMatch && versionMatch.version) {
             return versionMatch.version as string
-        } else {
-            log.warn(`Chromedriver v${build} don't exist, trying to find known good version...`)
-            const majorVersion = getMajorVersionFromString(build)
-            const versionMatchMajor = knownGoodVersions.versions.filter(({ version }: { version: string }) => version.startsWith(majorVersion)).pop()
-            if(versionMatchMajor && versionMatchMajor.version) {
-                return versionMatchMajor.version as string;
-            }
-            return ''
         }
+        log.warn(`Chromedriver v${build} don't exist, trying to find known good version...`)
+        const majorVersion = getMajorVersionFromString(build)
+        const versionMatchMajor = knownGoodVersions.versions.filter(({ version }: { version: string }) => version.startsWith(majorVersion)).pop()
+        if (versionMatchMajor && versionMatchMajor.version) {
+            return versionMatchMajor.version as string
+        }
+        return ''
     } catch {
         return ''
     }
@@ -253,18 +252,18 @@ export async function setupChromedriver (cacheDir: string, driverVersion?: strin
             unpack: true,
             downloadProgressCallback: (downloadedBytes, totalBytes) => downloadProgressCallback('Chromedriver', downloadedBytes, totalBytes)
         }
-        const knownBuild = await checkKnownBuild(buildId);
+        const knownBuild = await checkKnownBuild(buildId)
         if (knownBuild && getMajorVersionFromString(knownBuild)) {
             await _install({ ...chromedriverInstallOpts, buildId: knownBuild })
             log.info(`Download of Chromedriver v${knownBuild} was successful`)
         } else {
-            try{
+            try {
                 await _install({ ...chromedriverInstallOpts, buildId })
                 log.info(`Download of Chromedriver v${buildId} was successful`)
             } catch (err: any) {
                 throw new Error(`Couldn't download Chromedriver v${buildId}: ${err.message}`)
             }
-        }         
+        }
         executablePath = computeExecutablePath({
             browser: Browser.CHROMEDRIVER,
             buildId: knownBuild,

--- a/packages/wdio-utils/tests/driver/index.test.ts
+++ b/packages/wdio-utils/tests/driver/index.test.ts
@@ -318,7 +318,6 @@ describe('startWebDriver', () => {
         }
         vi.mocked(install)
             .mockResolvedValueOnce({} as any)
-            .mockRejectedValueOnce(new Error('boom'))
             .mockResolvedValue({} as any)
         await startWebDriver(options)
         expect(install).toBeCalledTimes(1)


### PR DESCRIPTION
## Proposed changes

I just would like to suggest to check existence of chromedriver version before downloading and prevent the error when version of browser don't match with driver version each time when we're starting test execution.

2023-10-10T18:14:01.637Z WARN webdriver: Couldn't download Chromedriver v117.0.5938.150: Download failed: server returned code 404. URL: https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/117.0.5938.150/win64/chromedriver-win64.zip, trying to find known good version...
2023-10-10T18:14:02.270Z INFO webdriver: Download of Chromedriver v117.0.5938.149 was successful


