### PR TITLE
(@wdio/utils): better transform function command arguments

### DIFF
--- a/packages/wdio-utils/src/utils.ts
+++ b/packages/wdio-utils/src/utils.ts
@@ -7,7 +7,7 @@ import type { Services, Clients } from '@wdio/types'
 
 const SCREENSHOT_REPLACEMENT = '"<Screenshot[base64]>"'
 const SCRIPT_PLACEHOLDER = '"<Script[base64]>"'
-const REGEX_SCRIPT_NAME = /return \((async )*function (\w+)/
+const REGEX_SCRIPT_NAME = /return \((async )?function (\w+)/
 
 /**
  * overwrite native element commands with user defined

--- a/packages/wdio-utils/src/utils.ts
+++ b/packages/wdio-utils/src/utils.ts
@@ -7,7 +7,7 @@ import type { Services, Clients } from '@wdio/types'
 
 const SCREENSHOT_REPLACEMENT = '"<Screenshot[base64]>"'
 const SCRIPT_PLACEHOLDER = '"<Script[base64]>"'
-const REGEX_SCRIPT_NAME = /return \(function (\w+)/
+const REGEX_SCRIPT_NAME = /return \((async )*function (\w+)/
 
 /**
  * overwrite native element commands with user defined
@@ -61,7 +61,7 @@ export function overwriteElementCommands(propertiesObject: { '__elementOverrides
  */
 export function commandCallStructure (commandName: string, args: any[], unfurl = false) {
     const callArgs = args.map((arg) => {
-        if (typeof arg === 'string' && (arg.startsWith('!function(') || arg.startsWith('return (function'))) {
+        if (typeof arg === 'string' && (arg.startsWith('!function(') || arg.startsWith('return (function') || arg.startsWith('return (async function'))) {
             arg = '<fn>'
         } else if (
             typeof arg === 'string' &&
@@ -103,7 +103,7 @@ export function transformCommandLogResult (result: { file?: string, script?: str
     } else if (typeof result.script === 'string' && isBase64(result.script)) {
         return SCRIPT_PLACEHOLDER
     } else if (typeof result.script === 'string' && result.script.match(REGEX_SCRIPT_NAME)) {
-        const newScript = result.script.match(REGEX_SCRIPT_NAME)![1]
+        const newScript = result.script.match(REGEX_SCRIPT_NAME)![2]
         return { ...result, script: `${newScript}(...) [${Buffer.byteLength(result.script, 'utf-8')} bytes]` }
     } else if (typeof result.script === 'string' && result.script.startsWith('!function(')) {
         return { ...result, script: `<minified function> [${Buffer.byteLength(result.script, 'utf-8')} bytes]` }

--- a/packages/wdio-utils/tests/utils.test.ts
+++ b/packages/wdio-utils/tests/utils.test.ts
@@ -13,6 +13,7 @@ vi.mock('fs', () => import(path.join(process.cwd(), '__mocks__', 'fs')))
 describe('utils', () => {
     it('commandCallStructure', () => {
         const stringFunction = 'return (function () => { })()'
+        const asyncStringFunction = 'return (async function () => { })()'
         const anotherStringFunction = '!function(t,e){}'
         expect(commandCallStructure(
             'foobar',
@@ -23,12 +24,13 @@ describe('utils', () => {
                 { a: 123 },
                 () => true,
                 stringFunction,
+                asyncStringFunction,
                 anotherStringFunction,
                 null,
                 undefined,
                 (Buffer.from('some screenshot')).toString('base64')
             ]
-        )).toBe('foobar("param", 1, true, <object>, <fn>, <fn>, <fn>, null, undefined, "<Screenshot[base64]>")')
+        )).toBe('foobar("param", 1, true, <object>, <fn>, <fn>, <fn>, <fn>, null, undefined, "<Screenshot[base64]>")')
         expect(commandCallStructure('foobar', ['/html/body/a']))
             .toBe('foobar("<Screenshot[base64]>")')
         expect(commandCallStructure('findElement', ['/html/body/a']))
@@ -53,6 +55,8 @@ describe('utils', () => {
         expect(transformCommandLogResult({ script: 'return foobar' })).toEqual({ script: 'return foobar' })
         expect(transformCommandLogResult({ script: 'return (function isElementDisplayed(element) {\n...' }))
             .toEqual({ script: 'isElementDisplayed(...) [50 bytes]' })
+        expect(transformCommandLogResult({ script: 'return (async function isElementDisplayed(element) {\n...' }))
+            .toEqual({ script: 'isElementDisplayed(...) [56 bytes]' })
 
         expect(transformCommandLogResult({ script: '!function(t,e){"object"==typeof exports&&"object"==typeof mod...' }))
             .toEqual({ script: '<minified function> [64 bytes]' })


### PR DESCRIPTION
## Proposed changes

Transforming wdio logs from:

```
[0-0] 2023-10-11T16:58:28.712Z INFO webdriver: COMMAND executeAsyncScript(<fn>, <object>)
[0-0] 2023-10-11T16:58:28.712Z INFO webdriver: [POST] http://0.0.0.0:64805/session/1ffbe34ea246724a15b2970af1de2447/execute/async
[0-0] 2023-10-11T16:58:28.713Z INFO webdriver: DATA {
[0-0]   script: 'return (async function callApi(bridgePropName, args, done) {\n' +
[0-0]     '    if (window.wdioElectron === undefined) {\n' +
[0-0]     '        throw new Error(`ContextBridge not available for invocation of "${bridgePropName}" API`);\n' +
[0-0]     '    }\n' +
[0-0]     '    if (window.wdioElectron[bridgePropName] === undefined) {\n' +
[0-0]     '        throw new Error(`"${bridgePropName}" API not found on ContextBridge`);\n' +
[0-0]     '    }\n' +
[0-0]     '    return done(await window.wdioElectron[bridgePropName].invoke(...args));\n' +
[0-0]     '}).apply(null, arguments)',
[0-0]   args: [ 'app', [ 'getName' ] ]
[0-0] }
[0-0] 2023-10-11T16:58:28.718Z INFO webdriver: RESULT electron-boilerplate
[0-0] 2023-10-11T16:58:28.718Z INFO webdriver: COMMAND executeAsyncScript(<fn>, <object>)
[0-0] 2023-10-11T16:58:28.719Z INFO webdriver: [POST] http://0.0.0.0:64805/session/1ffbe34ea246724a15b2970af1de2447/execute/async
[0-0] 2023-10-11T16:58:28.719Z INFO webdriver: DATA {
[0-0]   script: 'return (async function callApi(bridgePropName, args, done) {\n' +
[0-0]     '    if (window.wdioElectron === undefined) {\n' +
[0-0]     '        throw new Error(`ContextBridge not available for invocation of "${bridgePropName}" API`);\n' +
[0-0]     '    }\n' +
[0-0]     '    if (window.wdioElectron[bridgePropName] === undefined) {\n' +
[0-0]     '        throw new Error(`"${bridgePropName}" API not found on ContextBridge`);\n' +
[0-0]     '    }\n' +
[0-0]     '    return done(await window.wdioElectron[bridgePropName].invoke(...args));\n' +
[0-0]     '}).apply(null, arguments)',
[0-0]   args: [ 'app', [ 'getVersion' ] ]
[0-0] }
[0-0] 2023-10-11T16:58:28.739Z INFO webdriver: RESULT 1.0.0
[0-0] 2023-10-11T16:58:28.740Z INFO webdriver: COMMAND deleteSession()
```

to:

```
[0-0] 2023-10-11T17:00:29.825Z INFO webdriver: COMMAND executeAsyncScript(<fn>, <object>)
[0-0] 2023-10-11T17:00:29.826Z INFO webdriver: [POST] http://0.0.0.0:64849/session/d1adf37b0ade572f98161fce1347cac4/execute/async
[0-0] 2023-10-11T17:00:29.826Z INFO webdriver: DATA { script: 'callApi(...) [457 bytes]', args: [ 'app', [ 'getName' ] ] }
[0-0] 2023-10-11T17:00:29.830Z INFO webdriver: RESULT electron-boilerplate
[0-0] 2023-10-11T17:00:29.831Z INFO webdriver: COMMAND executeAsyncScript(<fn>, <object>)
[0-0] 2023-10-11T17:00:29.831Z INFO webdriver: [POST] http://0.0.0.0:64849/session/d1adf37b0ade572f98161fce1347cac4/execute/async
[0-0] 2023-10-11T17:00:29.831Z INFO webdriver: DATA {
[0-0]   script: 'callApi(...) [457 bytes]',
[0-0]   args: [ 'app', [ 'getVersion' ] ]
[0-0] }
[0-0] 2023-10-11T17:00:29.850Z INFO webdriver: RESULT 1.0.0
[0-0] 2023-10-11T17:00:29.851Z INFO webdriver: COMMAND deleteSession()
```

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
