### PR TITLE
(@wdio/spec-reporter): don't throw if multiremote instance name matches a capability like 'app'

### DIFF
--- a/packages/wdio-spec-reporter/src/index.ts
+++ b/packages/wdio-spec-reporter/src/index.ts
@@ -581,6 +581,11 @@ export default class SpecReporter extends WDIOReporter {
      * @return {String}          Enviroment string
      */
     getEnviromentCombo (capability: Capabilities.RemoteCapability, verbose = true, isMultiremote = false) {
+        if (isMultiremote) {
+            const browserNames = Object.values(capability).map((c) => c.browserName)
+            const browserName = `${browserNames.slice(0, -1).join(', ')} and ${browserNames.pop()}`
+            return `MultiremoteBrowser on ${browserName}`
+        }
         const caps = (
             ((capability as Capabilities.W3CCapabilities).alwaysMatch as Capabilities.DesiredCapabilities) ||
             (capability as Capabilities.DesiredCapabilities)
@@ -588,7 +593,7 @@ export default class SpecReporter extends WDIOReporter {
         const device = caps['appium:deviceName']
         const app = ((caps['appium:app'] || (caps as any).app) || '').replace('sauce-storage:', '')
         const appName = app || caps['appium:bundleId'] || (caps as any).bundleId
-        const browser = isMultiremote ? 'MultiremoteBrowser' : (caps.browserName || caps.browser || appName)
+        const browser = caps.browserName || caps.browser || appName
         /**
          * fallback to different capability types:
          * browserVersion: W3C format
@@ -603,9 +608,7 @@ export default class SpecReporter extends WDIOReporter {
          * platform: JSONWP format
          * os, os_version: invalid BS capability
          */
-        const platform = isMultiremote
-            ? ''
-            : caps.platformName || caps['appium:platformName'] || caps.platform || (caps.os ? caps.os + (caps.os_version ?  ` ${caps.os_version}` : '') : '(unknown)')
+        const platform = caps.platformName || caps['appium:platformName'] || caps.platform || (caps.os ? caps.os + (caps.os_version ?  ` ${caps.os_version}` : '') : '(unknown)')
 
         // Mobile capabilities
         if (device) {
@@ -619,10 +622,6 @@ export default class SpecReporter extends WDIOReporter {
 
         if (!verbose) {
             return (browser + (version ? ` ${version} ` : ' ') + (platform)).trim()
-        }
-
-        if (isMultiremote) {
-            return browser + (version ? ` (v${version})` : '') + ` on ${Object.values(capability).map((c) => c.browserName).join(', ')}`
         }
 
         return browser + (version ? ` (v${version})` : '') + (` on ${platform}`)

--- a/packages/wdio-spec-reporter/src/index.ts
+++ b/packages/wdio-spec-reporter/src/index.ts
@@ -583,7 +583,9 @@ export default class SpecReporter extends WDIOReporter {
     getEnviromentCombo (capability: Capabilities.RemoteCapability, verbose = true, isMultiremote = false) {
         if (isMultiremote) {
             const browserNames = Object.values(capability).map((c) => c.browserName)
-            const browserName = `${browserNames.slice(0, -1).join(', ')} and ${browserNames.pop()}`
+            const browserName = browserNames.length > 1
+                ? `${browserNames.slice(0, -1).join(', ')} and ${browserNames.pop()}`
+                : browserNames.pop()
             return `MultiremoteBrowser on ${browserName}`
         }
         const caps = (

--- a/packages/wdio-spec-reporter/tests/__snapshots__/index.test.ts.snap
+++ b/packages/wdio-spec-reporter/tests/__snapshots__/index.test.ts.snap
@@ -1,5 +1,279 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`SpecReporter > getHeaderDisplay > should list multiple specs 1`] = `
+[
+  "Running: loremipsum (v50) on Windows 10",
+  "Session ID: foobar",
+]
+`;
+
+exports[`SpecReporter > getHeaderDisplay > should validate header output 1`] = `
+[
+  "Running: loremipsum (v50) on Windows 10",
+  "Session ID: foobar",
+]
+`;
+
+exports[`SpecReporter > getHeaderDisplay > should validate header output in multiremote 1`] = `
+[
+  "Running: MultiremoteBrowser on chrome and firefox",
+]
+`;
+
+exports[`SpecReporter > getResultDisplay > should not print if argument is a single line doc string 1`] = `
+[
+  "» /foo/bar/loo.e2e.js",
+  "Foo test",
+  "grey Some important",
+  "grey description to read!",
+  "",
+  "grey Very important business rule",
+  "   green ✓ foo",
+  "     \\"\\"\\"",
+  "     some different format",
+  "     \\"\\"\\"",
+  "   green ✓ bar",
+  "",
+]
+`;
+
+exports[`SpecReporter > getResultDisplay > should not print if data table is empty 1`] = `
+[
+  "» /foo/bar/loo.e2e.js",
+  "Foo test",
+  "grey Some important",
+  "grey description to read!",
+  "",
+  "grey Very important business rule",
+  "   green ✓ foo",
+  "   green ✓ bar",
+  "",
+]
+`;
+
+exports[`SpecReporter > getResultDisplay > should not print if the argument is undefined 1`] = `
+[
+  "» /foo/bar/loo.e2e.js",
+  "Foo test",
+  "grey Some important",
+  "grey description to read!",
+  "",
+  "grey Very important business rule",
+  "   green ✓ foo",
+  "   green ✓ bar",
+  "",
+]
+`;
+
+exports[`SpecReporter > getResultDisplay > should print data tables 1`] = `
+[
+  "» /foo/bar/loo.e2e.js",
+  "Foo test",
+  "grey Some important",
+  "grey description to read!",
+  "",
+  "grey Very important business rule",
+  "   green ✓ foo",
+  "     │ Vegetable │ Rating │",
+  "     │ Apricot   │ 5      │",
+  "     │ Brocolli  │ 2      │",
+  "     │ Cucumber  │ 10     │",
+  "   green ✓ bar",
+  "",
+]
+`;
+
+exports[`SpecReporter > getResultDisplay > should print if the doc string is a blank string 1`] = `
+[
+  "» /foo/bar/loo.e2e.js",
+  "Foo test",
+  "grey Some important",
+  "grey description to read!",
+  "",
+  "grey Very important business rule",
+  "   green ✓ foo",
+  "     \\"\\"\\"",
+  "     \\"\\"\\"",
+  "   green ✓ bar",
+  "     \\"\\"\\"",
+  "     \\"\\"\\"",
+  "",
+]
+`;
+
+exports[`SpecReporter > getResultDisplay > should print multiple lines doc string 1`] = `
+[
+  "» /foo/bar/loo.e2e.js",
+  "Foo test",
+  "grey Some important",
+  "grey description to read!",
+  "",
+  "grey Very important business rule",
+  "   green ✓ foo",
+  "     \\"\\"\\"",
+  "     Docstring line 1",
+  "     Docstring line 2",
+  "     Docstring line 3",
+  "     \\"\\"\\"",
+  "   green ✓ bar",
+  "     \\"\\"\\"",
+  "     Docstring line 4",
+  "     Docstring line 5",
+  "     Docstring line 6",
+  "     \\"\\"\\"",
+  "",
+]
+`;
+
+exports[`SpecReporter > getResultDisplay > should validate the result output with tests 1`] = `
+[
+  "» /foo/bar/loo.e2e.js",
+  "Foo test",
+  "   green ✓ foo",
+  "   green ✓ bar",
+  "",
+  "» /bar/foo/loo.e2e.js",
+  "Bar test",
+  "   green ✓ some test",
+  "   red ✖ a failed test",
+  "   red ✖ a failed test with no stack",
+  "",
+  "» /bar/loo/foo.e2e.js",
+  "Baz test",
+  "   green ✓ foo bar baz",
+  "   cyan - a skipped test",
+  "",
+]
+`;
+
+exports[`SpecReporter > onRetry > should group retried test cases 1`] = `
+[
+  [
+    "------------------------------------------------------------------
+[loremipsum 50 Windows 10 #0-0] Running: loremipsum (v50) on Windows 10
+[loremipsum 50 Windows 10 #0-0] Session ID: foobar
+[loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] » /foo/bar/loo.e2e.js
+[loremipsum 50 Windows 10 #0-0] Foo test
+[loremipsum 50 Windows 10 #0-0]    green ✓ foo
+[loremipsum 50 Windows 10 #0-0]    green ✓ bar
+[loremipsum 50 Windows 10 #0-0]    green ✓ loo (1 retries)
+[loremipsum 50 Windows 10 #0-0]    cyan ? baz
+[loremipsum 50 Windows 10 #0-0]
+",
+  ],
+]
+`;
+
+exports[`SpecReporter > onlyFailures > false > 0 failures 1`] = `
+[
+  [
+    "------------------------------------------------------------------
+[loremipsum 50 Windows 10 #0-0] Running: loremipsum (v50) on Windows 10
+[loremipsum 50 Windows 10 #0-0] Session ID: foobar
+[loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] » /foo/bar/loo.e2e.js
+[loremipsum 50 Windows 10 #0-0] Foo test
+[loremipsum 50 Windows 10 #0-0]    green ✓ foo
+[loremipsum 50 Windows 10 #0-0]    green ✓ bar
+[loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] » /bar/foo/loo.e2e.js
+[loremipsum 50 Windows 10 #0-0] Bar test
+[loremipsum 50 Windows 10 #0-0]    green ✓ some test
+[loremipsum 50 Windows 10 #0-0]    red ✖ a failed test
+[loremipsum 50 Windows 10 #0-0]    red ✖ a failed test with no stack
+[loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] » /bar/loo/foo.e2e.js
+[loremipsum 50 Windows 10 #0-0] Baz test
+[loremipsum 50 Windows 10 #0-0]    green ✓ foo bar baz
+[loremipsum 50 Windows 10 #0-0]    cyan - a skipped test
+[loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] 1) Bar test a failed test
+[loremipsum 50 Windows 10 #0-0] red expected foo to equal bar
+[loremipsum 50 Windows 10 #0-0] gray Failed test stack trace
+[loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] 2) Bar test a failed test with no stack
+[loremipsum 50 Windows 10 #0-0] red expected foo to equal bar
+",
+  ],
+]
+`;
+
+exports[`SpecReporter > onlyFailures > false > 1 failure 1`] = `
+[
+  [
+    "------------------------------------------------------------------
+[loremipsum 50 Windows 10 #0-0] Running: loremipsum (v50) on Windows 10
+[loremipsum 50 Windows 10 #0-0] Session ID: foobar
+[loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] » /foo/bar/loo.e2e.js
+[loremipsum 50 Windows 10 #0-0] Foo test
+[loremipsum 50 Windows 10 #0-0]    green ✓ foo
+[loremipsum 50 Windows 10 #0-0]    green ✓ bar
+[loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] » /bar/foo/loo.e2e.js
+[loremipsum 50 Windows 10 #0-0] Bar test
+[loremipsum 50 Windows 10 #0-0]    green ✓ some test
+[loremipsum 50 Windows 10 #0-0]    red ✖ a failed test
+[loremipsum 50 Windows 10 #0-0]    red ✖ a failed test with no stack
+[loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] » /bar/loo/foo.e2e.js
+[loremipsum 50 Windows 10 #0-0] Baz test
+[loremipsum 50 Windows 10 #0-0]    green ✓ foo bar baz
+[loremipsum 50 Windows 10 #0-0]    cyan - a skipped test
+[loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] 1) Bar test a failed test
+[loremipsum 50 Windows 10 #0-0] red expected foo to equal bar
+[loremipsum 50 Windows 10 #0-0] gray Failed test stack trace
+[loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] 2) Bar test a failed test with no stack
+[loremipsum 50 Windows 10 #0-0] red expected foo to equal bar
+",
+  ],
+]
+`;
+
+exports[`SpecReporter > onlyFailures > true > 0 failures 1`] = `[]`;
+
+exports[`SpecReporter > onlyFailures > true > 1 failure 1`] = `
+[
+  [
+    "------------------------------------------------------------------
+[loremipsum 50 Windows 10 #0-0] Running: loremipsum (v50) on Windows 10
+[loremipsum 50 Windows 10 #0-0] Session ID: foobar
+[loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] » /foo/bar/loo.e2e.js
+[loremipsum 50 Windows 10 #0-0] Foo test
+[loremipsum 50 Windows 10 #0-0]    green ✓ foo
+[loremipsum 50 Windows 10 #0-0]    green ✓ bar
+[loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] » /bar/foo/loo.e2e.js
+[loremipsum 50 Windows 10 #0-0] Bar test
+[loremipsum 50 Windows 10 #0-0]    green ✓ some test
+[loremipsum 50 Windows 10 #0-0]    red ✖ a failed test
+[loremipsum 50 Windows 10 #0-0]    red ✖ a failed test with no stack
+[loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] » /bar/loo/foo.e2e.js
+[loremipsum 50 Windows 10 #0-0] Baz test
+[loremipsum 50 Windows 10 #0-0]    green ✓ foo bar baz
+[loremipsum 50 Windows 10 #0-0]    cyan - a skipped test
+[loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] 1) Bar test a failed test
+[loremipsum 50 Windows 10 #0-0] red expected foo to equal bar
+[loremipsum 50 Windows 10 #0-0] gray Failed test stack trace
+[loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] 2) Bar test a failed test with no stack
+[loremipsum 50 Windows 10 #0-0] red expected foo to equal bar
+",
+  ],
+]
+`;
+
+exports[`SpecReporter > printReport > with disabled sharable Sauce report links > should print the default Sauce Labs job details page link 1`] = `[]`;
+
 exports[`SpecReporter > printReport > with normal setup > should print jobs of all instance when run with multiremote 1`] = `
 [
   [
@@ -157,6 +431,85 @@ exports[`SpecReporter > printReport > with normal setup > should print link to S
 ]
 `;
 
+exports[`SpecReporter > printReport > with normal setup > should print link to Sauce Labs job details page for RDC 1`] = `
+[
+  [
+    "------------------------------------------------------------------
+[udid-serial-of-device iOS 14.3 #0-0] Running: udid-serial-of-device on iOS 14.3 executing safari
+[udid-serial-of-device iOS 14.3 #0-0]
+[udid-serial-of-device iOS 14.3 #0-0] » /foo/bar/loo.e2e.js
+[udid-serial-of-device iOS 14.3 #0-0] Foo test
+[udid-serial-of-device iOS 14.3 #0-0]    green ✓ foo
+[udid-serial-of-device iOS 14.3 #0-0]    green ✓ bar
+[udid-serial-of-device iOS 14.3 #0-0]
+[udid-serial-of-device iOS 14.3 #0-0] » /bar/foo/loo.e2e.js
+[udid-serial-of-device iOS 14.3 #0-0] Bar test
+[udid-serial-of-device iOS 14.3 #0-0]    green ✓ some test
+[udid-serial-of-device iOS 14.3 #0-0]    red ✖ a failed test
+[udid-serial-of-device iOS 14.3 #0-0]    red ✖ a failed test with no stack
+[udid-serial-of-device iOS 14.3 #0-0]
+[udid-serial-of-device iOS 14.3 #0-0] » /bar/loo/foo.e2e.js
+[udid-serial-of-device iOS 14.3 #0-0] Baz test
+[udid-serial-of-device iOS 14.3 #0-0]    green ✓ foo bar baz
+[udid-serial-of-device iOS 14.3 #0-0]    cyan - a skipped test
+[udid-serial-of-device iOS 14.3 #0-0]
+[udid-serial-of-device iOS 14.3 #0-0] green 4 passing (5s)
+[udid-serial-of-device iOS 14.3 #0-0] red 1 failing
+[udid-serial-of-device iOS 14.3 #0-0] cyan 1 skipped
+[udid-serial-of-device iOS 14.3 #0-0]
+[udid-serial-of-device iOS 14.3 #0-0] 1) Bar test a failed test
+[udid-serial-of-device iOS 14.3 #0-0] red expected foo to equal bar
+[udid-serial-of-device iOS 14.3 #0-0] gray Failed test stack trace
+[udid-serial-of-device iOS 14.3 #0-0]
+[udid-serial-of-device iOS 14.3 #0-0] 2) Bar test a failed test with no stack
+[udid-serial-of-device iOS 14.3 #0-0] red expected foo to equal bar
+[udid-serial-of-device iOS 14.3 #0-0]
+[udid-serial-of-device iOS 14.3 #0-0] Check out job at  https://app.eu-central-1.saucelabs.com/tests/c752c683e0874da4b1dad593ce6645b2
+",
+  ],
+]
+`;
+
+exports[`SpecReporter > printReport > with normal setup > should print link to Sauce Labs job details page for VDC 1`] = `
+[
+  [
+    "------------------------------------------------------------------
+[loremipsum 50 Windows 10 #0-0] Running: loremipsum (v50) on Windows 10
+[loremipsum 50 Windows 10 #0-0] Session ID: foobar
+[loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] » /foo/bar/loo.e2e.js
+[loremipsum 50 Windows 10 #0-0] Foo test
+[loremipsum 50 Windows 10 #0-0]    green ✓ foo
+[loremipsum 50 Windows 10 #0-0]    green ✓ bar
+[loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] » /bar/foo/loo.e2e.js
+[loremipsum 50 Windows 10 #0-0] Bar test
+[loremipsum 50 Windows 10 #0-0]    green ✓ some test
+[loremipsum 50 Windows 10 #0-0]    red ✖ a failed test
+[loremipsum 50 Windows 10 #0-0]    red ✖ a failed test with no stack
+[loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] » /bar/loo/foo.e2e.js
+[loremipsum 50 Windows 10 #0-0] Baz test
+[loremipsum 50 Windows 10 #0-0]    green ✓ foo bar baz
+[loremipsum 50 Windows 10 #0-0]    cyan - a skipped test
+[loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] green 4 passing (5s)
+[loremipsum 50 Windows 10 #0-0] red 1 failing
+[loremipsum 50 Windows 10 #0-0] cyan 1 skipped
+[loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] 1) Bar test a failed test
+[loremipsum 50 Windows 10 #0-0] red expected foo to equal bar
+[loremipsum 50 Windows 10 #0-0] gray Failed test stack trace
+[loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] 2) Bar test a failed test with no stack
+[loremipsum 50 Windows 10 #0-0] red expected foo to equal bar
+[loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] Check out job at https://app.saucelabs.com/tests/ba86cbcb70774ef8a0757c1702c3bdf9?auth=364414eae3ee11cb8b8bb3fc3e3b5e12
+",
+  ],
+]
+`;
+
 exports[`SpecReporter > printReport > with normal setup > should print link to Sauce Labs job details page if run with Sauce Connect (jsonwp) 1`] = `
 [
   [
@@ -236,3 +589,45 @@ exports[`SpecReporter > printReport > with normal setup > should print link to S
   ],
 ]
 `;
+
+exports[`SpecReporter > printReport > with normal setup > should print the report to the console 1`] = `
+[
+  [
+    "------------------------------------------------------------------
+[loremipsum 50 Windows 10 #0-0] Running: loremipsum (v50) on Windows 10
+[loremipsum 50 Windows 10 #0-0] Session ID: foobar
+[loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] » /foo/bar/loo.e2e.js
+[loremipsum 50 Windows 10 #0-0] Foo test
+[loremipsum 50 Windows 10 #0-0]    green ✓ foo
+[loremipsum 50 Windows 10 #0-0]    green ✓ bar
+[loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] » /bar/foo/loo.e2e.js
+[loremipsum 50 Windows 10 #0-0] Bar test
+[loremipsum 50 Windows 10 #0-0]    green ✓ some test
+[loremipsum 50 Windows 10 #0-0]    red ✖ a failed test
+[loremipsum 50 Windows 10 #0-0]    red ✖ a failed test with no stack
+[loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] » /bar/loo/foo.e2e.js
+[loremipsum 50 Windows 10 #0-0] Baz test
+[loremipsum 50 Windows 10 #0-0]    green ✓ foo bar baz
+[loremipsum 50 Windows 10 #0-0]    cyan - a skipped test
+[loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] green 4 passing (5s)
+[loremipsum 50 Windows 10 #0-0] red 1 failing
+[loremipsum 50 Windows 10 #0-0] cyan 1 skipped
+[loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] 1) Bar test a failed test
+[loremipsum 50 Windows 10 #0-0] red expected foo to equal bar
+[loremipsum 50 Windows 10 #0-0] gray Failed test stack trace
+[loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] 2) Bar test a failed test with no stack
+[loremipsum 50 Windows 10 #0-0] red expected foo to equal bar
+",
+  ],
+]
+`;
+
+exports[`SpecReporter > showPreface > false 1`] = `[]`;
+
+exports[`SpecReporter > showPreface > true 1`] = `[]`;

--- a/packages/wdio-spec-reporter/tests/__snapshots__/index.test.ts.snap
+++ b/packages/wdio-spec-reporter/tests/__snapshots__/index.test.ts.snap
@@ -1,314 +1,37 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`SpecReporter > getHeaderDisplay > should list multiple specs 1`] = `
-[
-  "Running: loremipsum (v50) on Windows 10",
-  "Session ID: foobar",
-]
-`;
-
-exports[`SpecReporter > getHeaderDisplay > should validate header output 1`] = `
-[
-  "Running: loremipsum (v50) on Windows 10",
-  "Session ID: foobar",
-]
-`;
-
-exports[`SpecReporter > getHeaderDisplay > should validate header output in multiremote 1`] = `
-[
-  "Running: MultiremoteBrowser on chrome, firefox",
-]
-`;
-
-exports[`SpecReporter > getResultDisplay > should not print if argument is a single line doc string 1`] = `
-[
-  "» /foo/bar/loo.e2e.js",
-  "Foo test",
-  "grey Some important",
-  "grey description to read!",
-  "",
-  "grey Very important business rule",
-  "   green ✓ foo",
-  "     \\"\\"\\"",
-  "     some different format",
-  "     \\"\\"\\"",
-  "   green ✓ bar",
-  "",
-]
-`;
-
-exports[`SpecReporter > getResultDisplay > should not print if data table is empty 1`] = `
-[
-  "» /foo/bar/loo.e2e.js",
-  "Foo test",
-  "grey Some important",
-  "grey description to read!",
-  "",
-  "grey Very important business rule",
-  "   green ✓ foo",
-  "   green ✓ bar",
-  "",
-]
-`;
-
-exports[`SpecReporter > getResultDisplay > should not print if the argument is undefined 1`] = `
-[
-  "» /foo/bar/loo.e2e.js",
-  "Foo test",
-  "grey Some important",
-  "grey description to read!",
-  "",
-  "grey Very important business rule",
-  "   green ✓ foo",
-  "   green ✓ bar",
-  "",
-]
-`;
-
-exports[`SpecReporter > getResultDisplay > should print data tables 1`] = `
-[
-  "» /foo/bar/loo.e2e.js",
-  "Foo test",
-  "grey Some important",
-  "grey description to read!",
-  "",
-  "grey Very important business rule",
-  "   green ✓ foo",
-  "     │ Vegetable │ Rating │",
-  "     │ Apricot   │ 5      │",
-  "     │ Brocolli  │ 2      │",
-  "     │ Cucumber  │ 10     │",
-  "   green ✓ bar",
-  "",
-]
-`;
-
-exports[`SpecReporter > getResultDisplay > should print if the doc string is a blank string 1`] = `
-[
-  "» /foo/bar/loo.e2e.js",
-  "Foo test",
-  "grey Some important",
-  "grey description to read!",
-  "",
-  "grey Very important business rule",
-  "   green ✓ foo",
-  "     \\"\\"\\"",
-  "     \\"\\"\\"",
-  "   green ✓ bar",
-  "     \\"\\"\\"",
-  "     \\"\\"\\"",
-  "",
-]
-`;
-
-exports[`SpecReporter > getResultDisplay > should print multiple lines doc string 1`] = `
-[
-  "» /foo/bar/loo.e2e.js",
-  "Foo test",
-  "grey Some important",
-  "grey description to read!",
-  "",
-  "grey Very important business rule",
-  "   green ✓ foo",
-  "     \\"\\"\\"",
-  "     Docstring line 1",
-  "     Docstring line 2",
-  "     Docstring line 3",
-  "     \\"\\"\\"",
-  "   green ✓ bar",
-  "     \\"\\"\\"",
-  "     Docstring line 4",
-  "     Docstring line 5",
-  "     Docstring line 6",
-  "     \\"\\"\\"",
-  "",
-]
-`;
-
-exports[`SpecReporter > getResultDisplay > should validate the result output with tests 1`] = `
-[
-  "» /foo/bar/loo.e2e.js",
-  "Foo test",
-  "   green ✓ foo",
-  "   green ✓ bar",
-  "",
-  "» /bar/foo/loo.e2e.js",
-  "Bar test",
-  "   green ✓ some test",
-  "   red ✖ a failed test",
-  "   red ✖ a failed test with no stack",
-  "",
-  "» /bar/loo/foo.e2e.js",
-  "Baz test",
-  "   green ✓ foo bar baz",
-  "   cyan - a skipped test",
-  "",
-]
-`;
-
-exports[`SpecReporter > onRetry > should group retried test cases 1`] = `
-[
-  [
-    "------------------------------------------------------------------
-[loremipsum 50 Windows 10 #0-0] Running: loremipsum (v50) on Windows 10
-[loremipsum 50 Windows 10 #0-0] Session ID: foobar
-[loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] » /foo/bar/loo.e2e.js
-[loremipsum 50 Windows 10 #0-0] Foo test
-[loremipsum 50 Windows 10 #0-0]    green ✓ foo
-[loremipsum 50 Windows 10 #0-0]    green ✓ bar
-[loremipsum 50 Windows 10 #0-0]    green ✓ loo (1 retries)
-[loremipsum 50 Windows 10 #0-0]    cyan ? baz
-[loremipsum 50 Windows 10 #0-0]
-",
-  ],
-]
-`;
-
-exports[`SpecReporter > onlyFailures > false > 0 failures 1`] = `
-[
-  [
-    "------------------------------------------------------------------
-[loremipsum 50 Windows 10 #0-0] Running: loremipsum (v50) on Windows 10
-[loremipsum 50 Windows 10 #0-0] Session ID: foobar
-[loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] » /foo/bar/loo.e2e.js
-[loremipsum 50 Windows 10 #0-0] Foo test
-[loremipsum 50 Windows 10 #0-0]    green ✓ foo
-[loremipsum 50 Windows 10 #0-0]    green ✓ bar
-[loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] » /bar/foo/loo.e2e.js
-[loremipsum 50 Windows 10 #0-0] Bar test
-[loremipsum 50 Windows 10 #0-0]    green ✓ some test
-[loremipsum 50 Windows 10 #0-0]    red ✖ a failed test
-[loremipsum 50 Windows 10 #0-0]    red ✖ a failed test with no stack
-[loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] » /bar/loo/foo.e2e.js
-[loremipsum 50 Windows 10 #0-0] Baz test
-[loremipsum 50 Windows 10 #0-0]    green ✓ foo bar baz
-[loremipsum 50 Windows 10 #0-0]    cyan - a skipped test
-[loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] 1) Bar test a failed test
-[loremipsum 50 Windows 10 #0-0] red expected foo to equal bar
-[loremipsum 50 Windows 10 #0-0] gray Failed test stack trace
-[loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] 2) Bar test a failed test with no stack
-[loremipsum 50 Windows 10 #0-0] red expected foo to equal bar
-",
-  ],
-]
-`;
-
-exports[`SpecReporter > onlyFailures > false > 1 failure 1`] = `
-[
-  [
-    "------------------------------------------------------------------
-[loremipsum 50 Windows 10 #0-0] Running: loremipsum (v50) on Windows 10
-[loremipsum 50 Windows 10 #0-0] Session ID: foobar
-[loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] » /foo/bar/loo.e2e.js
-[loremipsum 50 Windows 10 #0-0] Foo test
-[loremipsum 50 Windows 10 #0-0]    green ✓ foo
-[loremipsum 50 Windows 10 #0-0]    green ✓ bar
-[loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] » /bar/foo/loo.e2e.js
-[loremipsum 50 Windows 10 #0-0] Bar test
-[loremipsum 50 Windows 10 #0-0]    green ✓ some test
-[loremipsum 50 Windows 10 #0-0]    red ✖ a failed test
-[loremipsum 50 Windows 10 #0-0]    red ✖ a failed test with no stack
-[loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] » /bar/loo/foo.e2e.js
-[loremipsum 50 Windows 10 #0-0] Baz test
-[loremipsum 50 Windows 10 #0-0]    green ✓ foo bar baz
-[loremipsum 50 Windows 10 #0-0]    cyan - a skipped test
-[loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] 1) Bar test a failed test
-[loremipsum 50 Windows 10 #0-0] red expected foo to equal bar
-[loremipsum 50 Windows 10 #0-0] gray Failed test stack trace
-[loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] 2) Bar test a failed test with no stack
-[loremipsum 50 Windows 10 #0-0] red expected foo to equal bar
-",
-  ],
-]
-`;
-
-exports[`SpecReporter > onlyFailures > true > 0 failures 1`] = `[]`;
-
-exports[`SpecReporter > onlyFailures > true > 1 failure 1`] = `
-[
-  [
-    "------------------------------------------------------------------
-[loremipsum 50 Windows 10 #0-0] Running: loremipsum (v50) on Windows 10
-[loremipsum 50 Windows 10 #0-0] Session ID: foobar
-[loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] » /foo/bar/loo.e2e.js
-[loremipsum 50 Windows 10 #0-0] Foo test
-[loremipsum 50 Windows 10 #0-0]    green ✓ foo
-[loremipsum 50 Windows 10 #0-0]    green ✓ bar
-[loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] » /bar/foo/loo.e2e.js
-[loremipsum 50 Windows 10 #0-0] Bar test
-[loremipsum 50 Windows 10 #0-0]    green ✓ some test
-[loremipsum 50 Windows 10 #0-0]    red ✖ a failed test
-[loremipsum 50 Windows 10 #0-0]    red ✖ a failed test with no stack
-[loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] » /bar/loo/foo.e2e.js
-[loremipsum 50 Windows 10 #0-0] Baz test
-[loremipsum 50 Windows 10 #0-0]    green ✓ foo bar baz
-[loremipsum 50 Windows 10 #0-0]    cyan - a skipped test
-[loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] 1) Bar test a failed test
-[loremipsum 50 Windows 10 #0-0] red expected foo to equal bar
-[loremipsum 50 Windows 10 #0-0] gray Failed test stack trace
-[loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] 2) Bar test a failed test with no stack
-[loremipsum 50 Windows 10 #0-0] red expected foo to equal bar
-",
-  ],
-]
-`;
-
-exports[`SpecReporter > printReport > with disabled sharable Sauce report links > should print the default Sauce Labs job details page link 1`] = `[]`;
-
 exports[`SpecReporter > printReport > with normal setup > should print jobs of all instance when run with multiremote 1`] = `
 [
   [
     "------------------------------------------------------------------
-[MultiremoteBrowser #0-0] Running: MultiremoteBrowser on ,
-[MultiremoteBrowser #0-0]
-[MultiremoteBrowser #0-0] » /foo/bar/loo.e2e.js
-[MultiremoteBrowser #0-0] Foo test
-[MultiremoteBrowser #0-0]    green ✓ foo
-[MultiremoteBrowser #0-0]    green ✓ bar
-[MultiremoteBrowser #0-0]
-[MultiremoteBrowser #0-0] » /bar/foo/loo.e2e.js
-[MultiremoteBrowser #0-0] Bar test
-[MultiremoteBrowser #0-0]    green ✓ some test
-[MultiremoteBrowser #0-0]    red ✖ a failed test
-[MultiremoteBrowser #0-0]    red ✖ a failed test with no stack
-[MultiremoteBrowser #0-0]
-[MultiremoteBrowser #0-0] » /bar/loo/foo.e2e.js
-[MultiremoteBrowser #0-0] Baz test
-[MultiremoteBrowser #0-0]    green ✓ foo bar baz
-[MultiremoteBrowser #0-0]    cyan - a skipped test
-[MultiremoteBrowser #0-0]
-[MultiremoteBrowser #0-0] green 4 passing (5s)
-[MultiremoteBrowser #0-0] red 1 failing
-[MultiremoteBrowser #0-0] cyan 1 skipped
-[MultiremoteBrowser #0-0]
-[MultiremoteBrowser #0-0] 1) Bar test a failed test
-[MultiremoteBrowser #0-0] red expected foo to equal bar
-[MultiremoteBrowser #0-0] gray Failed test stack trace
-[MultiremoteBrowser #0-0]
-[MultiremoteBrowser #0-0] 2) Bar test a failed test with no stack
-[MultiremoteBrowser #0-0] red expected foo to equal bar
-[MultiremoteBrowser #0-0]
-[MultiremoteBrowser #0-0] Check out browserA job at https://app.saucelabs.com/tests/foobar?auth=2d3c4ca3cae505723f2fa903563fe019
-[MultiremoteBrowser #0-0] Check out browserB job at https://app.saucelabs.com/tests/barfoo?auth=64012ad809cda36d46c5c2175bc212b4
+[MultiremoteBrowser on chrome and firefox #0-0] Running: MultiremoteBrowser on chrome and firefox
+[MultiremoteBrowser on chrome and firefox #0-0]
+[MultiremoteBrowser on chrome and firefox #0-0] » /foo/bar/loo.e2e.js
+[MultiremoteBrowser on chrome and firefox #0-0] Foo test
+[MultiremoteBrowser on chrome and firefox #0-0]    green ✓ foo
+[MultiremoteBrowser on chrome and firefox #0-0]    green ✓ bar
+[MultiremoteBrowser on chrome and firefox #0-0]
+[MultiremoteBrowser on chrome and firefox #0-0] » /bar/foo/loo.e2e.js
+[MultiremoteBrowser on chrome and firefox #0-0] Bar test
+[MultiremoteBrowser on chrome and firefox #0-0]    green ✓ some test
+[MultiremoteBrowser on chrome and firefox #0-0]    red ✖ a failed test
+[MultiremoteBrowser on chrome and firefox #0-0]    red ✖ a failed test with no stack
+[MultiremoteBrowser on chrome and firefox #0-0]
+[MultiremoteBrowser on chrome and firefox #0-0] » /bar/loo/foo.e2e.js
+[MultiremoteBrowser on chrome and firefox #0-0] Baz test
+[MultiremoteBrowser on chrome and firefox #0-0]    green ✓ foo bar baz
+[MultiremoteBrowser on chrome and firefox #0-0]    cyan - a skipped test
+[MultiremoteBrowser on chrome and firefox #0-0]
+[MultiremoteBrowser on chrome and firefox #0-0] green 4 passing (5s)
+[MultiremoteBrowser on chrome and firefox #0-0] red 1 failing
+[MultiremoteBrowser on chrome and firefox #0-0] cyan 1 skipped
+[MultiremoteBrowser on chrome and firefox #0-0]
+[MultiremoteBrowser on chrome and firefox #0-0] 1) Bar test a failed test
+[MultiremoteBrowser on chrome and firefox #0-0] red expected foo to equal bar
+[MultiremoteBrowser on chrome and firefox #0-0] gray Failed test stack trace
+[MultiremoteBrowser on chrome and firefox #0-0]
+[MultiremoteBrowser on chrome and firefox #0-0] 2) Bar test a failed test with no stack
+[MultiremoteBrowser on chrome and firefox #0-0] red expected foo to equal bar
 ",
   ],
 ]
@@ -434,85 +157,6 @@ exports[`SpecReporter > printReport > with normal setup > should print link to S
 ]
 `;
 
-exports[`SpecReporter > printReport > with normal setup > should print link to Sauce Labs job details page for RDC 1`] = `
-[
-  [
-    "------------------------------------------------------------------
-[udid-serial-of-device iOS 14.3 #0-0] Running: udid-serial-of-device on iOS 14.3 executing safari
-[udid-serial-of-device iOS 14.3 #0-0]
-[udid-serial-of-device iOS 14.3 #0-0] » /foo/bar/loo.e2e.js
-[udid-serial-of-device iOS 14.3 #0-0] Foo test
-[udid-serial-of-device iOS 14.3 #0-0]    green ✓ foo
-[udid-serial-of-device iOS 14.3 #0-0]    green ✓ bar
-[udid-serial-of-device iOS 14.3 #0-0]
-[udid-serial-of-device iOS 14.3 #0-0] » /bar/foo/loo.e2e.js
-[udid-serial-of-device iOS 14.3 #0-0] Bar test
-[udid-serial-of-device iOS 14.3 #0-0]    green ✓ some test
-[udid-serial-of-device iOS 14.3 #0-0]    red ✖ a failed test
-[udid-serial-of-device iOS 14.3 #0-0]    red ✖ a failed test with no stack
-[udid-serial-of-device iOS 14.3 #0-0]
-[udid-serial-of-device iOS 14.3 #0-0] » /bar/loo/foo.e2e.js
-[udid-serial-of-device iOS 14.3 #0-0] Baz test
-[udid-serial-of-device iOS 14.3 #0-0]    green ✓ foo bar baz
-[udid-serial-of-device iOS 14.3 #0-0]    cyan - a skipped test
-[udid-serial-of-device iOS 14.3 #0-0]
-[udid-serial-of-device iOS 14.3 #0-0] green 4 passing (5s)
-[udid-serial-of-device iOS 14.3 #0-0] red 1 failing
-[udid-serial-of-device iOS 14.3 #0-0] cyan 1 skipped
-[udid-serial-of-device iOS 14.3 #0-0]
-[udid-serial-of-device iOS 14.3 #0-0] 1) Bar test a failed test
-[udid-serial-of-device iOS 14.3 #0-0] red expected foo to equal bar
-[udid-serial-of-device iOS 14.3 #0-0] gray Failed test stack trace
-[udid-serial-of-device iOS 14.3 #0-0]
-[udid-serial-of-device iOS 14.3 #0-0] 2) Bar test a failed test with no stack
-[udid-serial-of-device iOS 14.3 #0-0] red expected foo to equal bar
-[udid-serial-of-device iOS 14.3 #0-0]
-[udid-serial-of-device iOS 14.3 #0-0] Check out job at  https://app.eu-central-1.saucelabs.com/tests/c752c683e0874da4b1dad593ce6645b2
-",
-  ],
-]
-`;
-
-exports[`SpecReporter > printReport > with normal setup > should print link to Sauce Labs job details page for VDC 1`] = `
-[
-  [
-    "------------------------------------------------------------------
-[loremipsum 50 Windows 10 #0-0] Running: loremipsum (v50) on Windows 10
-[loremipsum 50 Windows 10 #0-0] Session ID: foobar
-[loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] » /foo/bar/loo.e2e.js
-[loremipsum 50 Windows 10 #0-0] Foo test
-[loremipsum 50 Windows 10 #0-0]    green ✓ foo
-[loremipsum 50 Windows 10 #0-0]    green ✓ bar
-[loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] » /bar/foo/loo.e2e.js
-[loremipsum 50 Windows 10 #0-0] Bar test
-[loremipsum 50 Windows 10 #0-0]    green ✓ some test
-[loremipsum 50 Windows 10 #0-0]    red ✖ a failed test
-[loremipsum 50 Windows 10 #0-0]    red ✖ a failed test with no stack
-[loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] » /bar/loo/foo.e2e.js
-[loremipsum 50 Windows 10 #0-0] Baz test
-[loremipsum 50 Windows 10 #0-0]    green ✓ foo bar baz
-[loremipsum 50 Windows 10 #0-0]    cyan - a skipped test
-[loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] green 4 passing (5s)
-[loremipsum 50 Windows 10 #0-0] red 1 failing
-[loremipsum 50 Windows 10 #0-0] cyan 1 skipped
-[loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] 1) Bar test a failed test
-[loremipsum 50 Windows 10 #0-0] red expected foo to equal bar
-[loremipsum 50 Windows 10 #0-0] gray Failed test stack trace
-[loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] 2) Bar test a failed test with no stack
-[loremipsum 50 Windows 10 #0-0] red expected foo to equal bar
-[loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] Check out job at https://app.saucelabs.com/tests/ba86cbcb70774ef8a0757c1702c3bdf9?auth=364414eae3ee11cb8b8bb3fc3e3b5e12
-",
-  ],
-]
-`;
-
 exports[`SpecReporter > printReport > with normal setup > should print link to Sauce Labs job details page if run with Sauce Connect (jsonwp) 1`] = `
 [
   [
@@ -592,45 +236,3 @@ exports[`SpecReporter > printReport > with normal setup > should print link to S
   ],
 ]
 `;
-
-exports[`SpecReporter > printReport > with normal setup > should print the report to the console 1`] = `
-[
-  [
-    "------------------------------------------------------------------
-[loremipsum 50 Windows 10 #0-0] Running: loremipsum (v50) on Windows 10
-[loremipsum 50 Windows 10 #0-0] Session ID: foobar
-[loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] » /foo/bar/loo.e2e.js
-[loremipsum 50 Windows 10 #0-0] Foo test
-[loremipsum 50 Windows 10 #0-0]    green ✓ foo
-[loremipsum 50 Windows 10 #0-0]    green ✓ bar
-[loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] » /bar/foo/loo.e2e.js
-[loremipsum 50 Windows 10 #0-0] Bar test
-[loremipsum 50 Windows 10 #0-0]    green ✓ some test
-[loremipsum 50 Windows 10 #0-0]    red ✖ a failed test
-[loremipsum 50 Windows 10 #0-0]    red ✖ a failed test with no stack
-[loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] » /bar/loo/foo.e2e.js
-[loremipsum 50 Windows 10 #0-0] Baz test
-[loremipsum 50 Windows 10 #0-0]    green ✓ foo bar baz
-[loremipsum 50 Windows 10 #0-0]    cyan - a skipped test
-[loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] green 4 passing (5s)
-[loremipsum 50 Windows 10 #0-0] red 1 failing
-[loremipsum 50 Windows 10 #0-0] cyan 1 skipped
-[loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] 1) Bar test a failed test
-[loremipsum 50 Windows 10 #0-0] red expected foo to equal bar
-[loremipsum 50 Windows 10 #0-0] gray Failed test stack trace
-[loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] 2) Bar test a failed test with no stack
-[loremipsum 50 Windows 10 #0-0] red expected foo to equal bar
-",
-  ],
-]
-`;
-
-exports[`SpecReporter > showPreface > false 1`] = `[]`;
-
-exports[`SpecReporter > showPreface > true 1`] = `[]`;

--- a/packages/wdio-spec-reporter/tests/index.test.ts
+++ b/packages/wdio-spec-reporter/tests/index.test.ts
@@ -217,7 +217,7 @@ describe('SpecReporter', () => {
                 expect(printReporter.write.mock.calls).toMatchSnapshot()
             })
 
-            it('should print jobs of all instance when run with multiremote', () => {
+            it.only('should print jobs of all instance when run with multiremote', () => {
                 const options = {
                     hostname: 'ondemand.saucelabs.com',
                     user: 'foobar',
@@ -225,8 +225,8 @@ describe('SpecReporter', () => {
                 }
                 const runner = getRunnerConfig({
                     capabilities: {
-                        browserA: { sessionId: 'foobar' },
-                        browserB: { sessionId: 'barfoo' }
+                        browserA: { browserName: 'chrome' },
+                        browserB: { browserName: 'firefox' }
                     },
                     isMultiremote: true
                 })
@@ -822,6 +822,15 @@ describe('SpecReporter', () => {
         it('should return Multibrowser as capability if multiremote is used', () => {
             expect(tmpReporter.getEnviromentCombo({
                 myBrowser: {
+                    browserName: 'chrome',
+                    platform: 'Windows 8.1'
+                }
+            } as any, true, true)).toBe('MultiremoteBrowser on chrome')
+        })
+
+        it('should not throw if mutliremote name is "app"', () => {
+            expect(tmpReporter.getEnviromentCombo({
+                app: {
                     browserName: 'chrome',
                     platform: 'Windows 8.1'
                 }

--- a/packages/wdio-spec-reporter/tests/index.test.ts
+++ b/packages/wdio-spec-reporter/tests/index.test.ts
@@ -217,7 +217,7 @@ describe('SpecReporter', () => {
                 expect(printReporter.write.mock.calls).toMatchSnapshot()
             })
 
-            it.only('should print jobs of all instance when run with multiremote', () => {
+            it('should print jobs of all instance when run with multiremote', () => {
                 const options = {
                     hostname: 'ondemand.saucelabs.com',
                     user: 'foobar',


### PR DESCRIPTION
## Proposed changes

Discovered this issue when playing around with Multiremote testing. If a browser instance name has the name "app" it would fail here. This PR patches that.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
