### PR TITLE
(wdio) Adding addLocatorStrategy to attach returning object #7724

### DIFF
--- a/packages/webdriverio/src/index.ts
+++ b/packages/webdriverio/src/index.ts
@@ -91,7 +91,16 @@ export const attach = async function (attachOptions: AttachOptions): Promise<Web
     }
     const prototype = getPrototype('browser')
     const { Driver } = await getProtocolDriver(params as Options.WebdriverIO)
-    return (Driver as typeof WebDriver).attachToSession(params, undefined, prototype, wrapCommand) as WebdriverIO.Browser
+
+    const driver = Driver.attachToSession(
+        params,
+        undefined,
+        prototype,
+        wrapCommand
+    ) as WebdriverIO.Browser
+
+    driver.addLocatorStrategy = addLocatorStrategyHandler(driver)
+    return driver
 }
 
 /**

--- a/packages/webdriverio/tests/__snapshots__/module.test.ts.snap
+++ b/packages/webdriverio/tests/__snapshots__/module.test.ts.snap
@@ -1,0 +1,15 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`WebdriverIO module interface > attach > attaches 1`] = `
+{
+  "automationProtocol": "webdriver",
+  "capabilities": {
+    "browserName": "chrome",
+    "platformName": "MacOS",
+  },
+  "requestedCapabilities": {
+    "browserName": "chrome",
+  },
+  "sessionId": "foobar",
+}
+`;

--- a/packages/webdriverio/tests/module.test.ts
+++ b/packages/webdriverio/tests/module.test.ts
@@ -256,11 +256,7 @@ describe('WebdriverIO module interface', () => {
         })
     })
 
-    /**
-     * fails due to vitest bug
-     * https://github.com/vitest-dev/vitest/issues/1563
-     */
-    describe.skip('attach', () => {
+    describe('attach', () => {
         it('attaches', async () => {
             const browser = {
                 sessionId: 'foobar',
@@ -275,6 +271,21 @@ describe('WebdriverIO module interface', () => {
             await attach(browser)
             expect(WebDriver.attachToSession).toBeCalledTimes(1)
             expect(vi.mocked(WebDriver.attachToSession).mock.calls[0][0]).toMatchSnapshot()
+        })
+
+        it('should have defined locatorStrategy', async () => {
+            const browser = {
+                sessionId: 'foobar',
+                capabilities: {
+                    browserName: 'chrome',
+                    platformName: 'MacOS'
+                },
+                requestedCapabilities: {
+                    browserName: 'chrome'
+                }
+            }
+            const newBrowser = await attach(browser)
+            expect(newBrowser).toHaveProperty('addLocatorStrategy')
         })
     })
 


### PR DESCRIPTION
## Proposed changes

Add missing `locatorStrategy ` to returning browser object of `attach ` function. IT was described in [7724 ](https://github.com/webdriverio/webdriverio/issues/7724)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

I tested this outcome using standalone example and worked fine. Idk if I should add unit test for this? I saw there is some issues with vitest and attach function test.

### Reviewers: @webdriverio/project-committers
