### PR TITLE
generate report when suite filenames are relative paths fixes #11477

### DIFF
--- a/packages/wdio-junit-reporter/src/index.ts
+++ b/packages/wdio-junit-reporter/src/index.ts
@@ -1,4 +1,5 @@
 import url from 'node:url'
+import path from 'node:path'
 
 import junit from 'junit-report-builder'
 import type { SuiteStats, RunnerStats, TestStats } from '@wdio/reporter'
@@ -306,10 +307,20 @@ class JunitReporter extends WDIOReporter {
     }
 
     private _sameFileName(file1?: string, file2?: string) {
+        // if either file is undefined, return false
+        if (!file1 || !file2) {
+            return false;
+        }
+
         // ensure both files are not a file URL
-        file1 = file1?.startsWith('file://') ? url.fileURLToPath(file1) : file1
-        file2 = file2?.startsWith('file://') ? url.fileURLToPath(file2) : file2
-        return file1 === file2
+        file1 = file1?.startsWith('file://') ? url.fileURLToPath(file1) : file1;
+        file2 = file2?.startsWith('file://') ? url.fileURLToPath(file2) : file2;
+
+        // ensure both paths are absolute before comparing
+        file1 = !path.isAbsolute(file1) ? path.resolve(file1) : file1;
+        file2 = !path.isAbsolute(file2) ? path.resolve(file2) : file2;
+
+        return file1 === file2;
     }
 }
 

--- a/packages/wdio-junit-reporter/tests/reporter.test.ts
+++ b/packages/wdio-junit-reporter/tests/reporter.test.ts
@@ -365,4 +365,18 @@ describe('wdio-junit-reporter', () => {
         expect(reporter['_sameFileName'](file1Path, undefined)).toBeFalsy()
         expect(reporter['_sameFileName'](undefined, undefined)).toBeTruthy()
     })
+
+    it('_sameFileName when one path relative', () => {
+        reporter = new WDIOJunitReporter({ stdout: true });
+
+        const relativeFilePath = 'features/dir/mysuite.feature';
+        const absoluteFilePath = '/home/path/dev/features/dir/mysuite.feature';
+
+        expect(
+            reporter['_sameFileName'](relativeFilePath, absoluteFilePath)
+        ).toBeTruthy();
+        expect(
+            reporter['_sameFileName'](absoluteFilePath, relativeFilePath)
+        ).toBeTruthy();
+    });
 })


### PR DESCRIPTION
fixes #11477

## Proposed changes

Updating _sameFileName in JunitReporter to ensure files match when one path is absolute and the other is relative

## Types of changes

- [x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x ] I have added tests that prove my fix is effective or that my feature works
- [x ] I have added necessary documentation (if appropriate)
- [x ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
