### PR TITLE
[v8] Support: Setting session status and name when using BrowserStack Automate TurboScale

### DIFF
--- a/packages/wdio-browserstack-service/src/service.ts
+++ b/packages/wdio-browserstack-service/src/service.ts
@@ -417,9 +417,9 @@ export default class BrowserstackService implements Services.ServiceInstance {
             const capabilities = getBrowserCapabilities(this._browser, this._caps, browserName)
             const browserString = getBrowserDescription(capabilities)
 
-            let browserUrl = response.body.automation_session?.browser_url;
+            let browserUrl = response.body.automation_session?.browser_url
             if (this._turboScale) {
-                browserUrl = response.body.url;
+                browserUrl = response.body.url
             }
             log.info(`${browserString} session: ${browserUrl}`)
         })

--- a/packages/wdio-browserstack-service/src/types.ts
+++ b/packages/wdio-browserstack-service/src/types.ts
@@ -3,11 +3,14 @@ import type { Options as BSOptions } from 'browserstack-local'
 
 export interface SessionResponse {
     // eslint-disable-next-line camelcase
-    automation_session?: {
+    automation_session: {
         // eslint-disable-next-line camelcase
         browser_url: string
-    },
-    url?: string
+    }
+}
+
+export interface TurboScaleSessionResponse {
+    url: string
 }
 
 export type MultiRemoteAction = (sessionId: string, browserName?: string) => Promise<any>;

--- a/packages/wdio-browserstack-service/src/types.ts
+++ b/packages/wdio-browserstack-service/src/types.ts
@@ -3,10 +3,11 @@ import type { Options as BSOptions } from 'browserstack-local'
 
 export interface SessionResponse {
     // eslint-disable-next-line camelcase
-    automation_session: {
+    automation_session?: {
         // eslint-disable-next-line camelcase
         browser_url: string
-    }
+    },
+    url?: string
 }
 
 export type MultiRemoteAction = (sessionId: string, browserName?: string) => Promise<any>;
@@ -139,6 +140,12 @@ export interface BrowserstackConfig {
      * @default true
      */
     setSessionStatus?: boolean
+    /**
+     * Set this to true while running tests on the automation grid created using BrowserStack Automate TurboScale
+     * to automatically set the session name and status for quick debugging.
+     * @default false
+    */
+    turboScale?: boolean;
 }
 
 /**

--- a/packages/wdio-browserstack-service/tests/service.test.ts
+++ b/packages/wdio-browserstack-service/tests/service.test.ts
@@ -304,6 +304,36 @@ describe('_printSessionURL Appium', () => {
     })
 })
 
+describe('_printSessionURL TurboScale', () => {
+    beforeEach(() => {
+        vi.mocked(got).mockResolvedValue({
+            body: {
+                name: 'Smoke Test',
+                duration: 65,
+                browser_version: '116',
+                browser: 'chrome',
+                status: 'failed',
+                reason: 'CLIENT_STOPPED_SESSION',
+                url: 'https://grid.browserstack.com/dashboard/builds/1/sessions/2'
+            }
+        })
+
+        browser.capabilities = {
+            browserName: 'chrome',
+            browserVersion: '116'
+        }
+    })
+
+    it('should get and log session details', async () => {
+        service['_browser'] = browser
+        service['_turboScale'] = true
+        await service._printSessionURL()
+        expect(log.info).toHaveBeenCalledWith(
+            'chrome 116 session: https://grid.browserstack.com/dashboard/builds/1/sessions/2'
+        )
+    })
+})
+
 describe('before', () => {
     it('should set auth to default values if not provided', async () => {
         let service = new BrowserstackService({} as any, [{}] as any, { capabilities: {} })
@@ -424,6 +454,34 @@ describe('before', () => {
         expect(log.info).toHaveBeenCalled()
         expect(log.info).toHaveBeenCalledWith(
             'OS X Sierra chrome session: https://www.browserstack.com/automate/builds/1/sessions/2')
+    })
+
+    it('should initialize correctly for turboScale when option passed', () => {
+        const service = new BrowserstackService({
+            turboScale: true
+        } as any, {}, {
+            user: 'foo',
+            key: 'bar',
+            capabilities: {}
+        })
+        service.before(service['_config'] as any, [], browser)
+
+        expect(service['_failReasons']).toEqual([])
+        expect(service['_sessionBaseUrl']).toEqual('https://api.browserstack.com/automate-turboscale/v1/sessions')
+    })
+
+    it('should initialize correctly for turboScale when env var is set', () => {
+        process.env.BROWSERSTACK_TURBOSCALE = 'true'
+        const service = new BrowserstackService({} as any, {}, {
+            user: 'foo',
+            key: 'bar',
+            capabilities: {}
+        })
+        service.before(service['_config'] as any, [], browser)
+        delete process.env.BROWSERSTACK_TURBOSCALE
+
+        expect(service['_failReasons']).toEqual([])
+        expect(service['_sessionBaseUrl']).toEqual('https://api.browserstack.com/automate-turboscale/v1/sessions')
     })
 })
 


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

Current behaviour - setting session status and name doesn't work if user is running a test on BrowserStack Automate TurboScale grid
The changes in PR adds that support

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
