### PR TITLE
(webdriverio): fix - scrollIntoView calls scroll action with a wrong …

### DIFF
--- a/packages/webdriverio/src/commands/element/scrollIntoView.ts
+++ b/packages/webdriverio/src/commands/element/scrollIntoView.ts
@@ -104,7 +104,7 @@ export async function scrollIntoView (
         deltaY = Math.round(deltaY - scrollY)
 
         await browser.action('wheel')
-            .scroll({ duration: 0, x: deltaX, deltaY, origin: this })
+            .scroll({ duration: 0, x: deltaX, y: deltaY, origin: this })
             .perform()
     } catch (err: any) {
         log.warn(

--- a/packages/webdriverio/tests/commands/element/__snapshots__/scrollIntoView.test.ts.snap
+++ b/packages/webdriverio/tests/commands/element/__snapshots__/scrollIntoView.test.ts.snap
@@ -7,14 +7,14 @@ exports[`scrollIntoView test > desktop > scrolls by default the element to the t
       "actions": [
         {
           "deltaX": 0,
-          "deltaY": -30,
+          "deltaY": 0,
           "duration": 0,
           "origin": {
             "element-6066-11e4-a52e-4f735466cecf": "some-elem-123",
           },
           "type": "scroll",
           "x": -550,
-          "y": 0,
+          "y": -30,
         },
       ],
       "id": "action1",
@@ -32,14 +32,14 @@ exports[`scrollIntoView test > desktop > scrolls element using scroll into view 
       "actions": [
         {
           "deltaX": 0,
-          "deltaY": -385,
+          "deltaY": 0,
           "duration": 0,
           "origin": {
             "element-6066-11e4-a52e-4f735466cecf": "some-elem-123",
           },
           "type": "scroll",
           "x": -275,
-          "y": 0,
+          "y": -385,
         },
       ],
       "id": "action4",
@@ -57,14 +57,14 @@ exports[`scrollIntoView test > desktop > scrolls element when using boolean scro
       "actions": [
         {
           "deltaX": 0,
-          "deltaY": -30,
+          "deltaY": 0,
           "duration": 0,
           "origin": {
             "element-6066-11e4-a52e-4f735466cecf": "some-elem-123",
           },
           "type": "scroll",
           "x": -550,
-          "y": 0,
+          "y": -30,
         },
       ],
       "id": "action2",
@@ -82,14 +82,14 @@ exports[`scrollIntoView test > desktop > scrolls element when using boolean scro
       "actions": [
         {
           "deltaX": 0,
-          "deltaY": -770,
+          "deltaY": 0,
           "duration": 0,
           "origin": {
             "element-6066-11e4-a52e-4f735466cecf": "some-elem-123",
           },
           "type": "scroll",
           "x": -550,
-          "y": 0,
+          "y": -770,
         },
       ],
       "id": "action3",

--- a/packages/webdriverio/tests/commands/element/scrollIntoView.test.ts
+++ b/packages/webdriverio/tests/commands/element/scrollIntoView.test.ts
@@ -73,7 +73,8 @@ describe('scrollIntoView test', () => {
             await elem.scrollIntoView({ block: 'center', inline: 'center' })
             const optionsCenter = vi.mocked(got).mock.calls.slice(-2, -1)[0][1] as any
             expect(optionsCenter.json.actions[0].actions[0].deltaX).toBe(0)
-            expect(optionsCenter.json.actions[0].actions[0].deltaY).toBe(-385)
+            expect(optionsCenter.json.actions[0].actions[0].deltaY).toBe(0)
+            expect(optionsCenter.json.actions[0].actions[0].y).toBe(-385)
         })
 
     })


### PR DESCRIPTION
## Proposed changes

From the last improvement in the function, a bad argument is sent to the `scroll` action. We should not use `deltaX` value into `x` argument.

This fixes https://github.com/webdriverio/webdriverio/issues/11272

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

I tested in a local project but I wasn't sure how to add or update existing tests inside webdriverio project. I was not able to reproduce the issue with existing tests but with my own.
[Here](https://github.com/qaflorent/wdio-examples) is the test I used to see the log disappeared.

The fix should be also testable using example provided in the initial ticket description by Lara.

### Reviewers: @webdriverio/project-committers

@erwinheitzman since you worked in it recently
