### PR TITLE
(@wdio/utils): Add envDetector for browserstack

### DIFF
--- a/packages/wdio-types/src/Capabilities.ts
+++ b/packages/wdio-types/src/Capabilities.ts
@@ -1102,6 +1102,7 @@ export interface BrowserStackCapabilities {
     osVersion?: string
     desired?: DesiredCapabilities
     device?: string
+    platformName?: string
     /**
      * Specify a name for a logical group of builds.
      */

--- a/packages/wdio-utils/src/envDetector.ts
+++ b/packages/wdio-utils/src/envDetector.ts
@@ -88,7 +88,8 @@ function isFirefox(capabilities?: Capabilities.DesiredCapabilities) {
  */
 function isMobile(capabilities: WebdriverIO.Capabilities) {
     const browserName = (capabilities.browserName || '').toLowerCase()
-
+    const bsOptions = capabilities['bstack:options'] || {}
+    const browserstackBrowserName = (bsOptions.browserName || '').toLowerCase()
     /**
      * we have mobile capabilities if
      */
@@ -99,6 +100,9 @@ function isMobile(capabilities: WebdriverIO.Capabilities) {
         capabilities.platformName && capabilities.platformName.match(/ios/i) ||
         capabilities.platformName && capabilities.platformName.match(/tvos/i) ||
         capabilities.platformName && capabilities.platformName.match(/android/i) ||
+        /ios/i.test(bsOptions.platformName) ||
+        /tvos/i.test(bsOptions.platformName) ||
+        /android/i.test(bsOptions.platformName) ||
         /**
          * capabilities contain mobile only specific capabilities
          */
@@ -107,10 +111,12 @@ function isMobile(capabilities: WebdriverIO.Capabilities) {
          * browserName is empty (and eventually app is defined)
          */
         capabilities.browserName === '' ||
+        capabilities['bstack:options']?.browserName === '' ||
         /**
          * browserName is a mobile browser
          */
-        MOBILE_BROWSER_NAMES.includes(browserName)
+        MOBILE_BROWSER_NAMES.includes(browserName) ||
+        MOBILE_BROWSER_NAMES.includes(browserstackBrowserName)
     )
 }
 
@@ -120,13 +126,16 @@ function isMobile(capabilities: WebdriverIO.Capabilities) {
  * @return {Boolean}               true if run on iOS device
  */
 function isIOS(capabilities?: Capabilities.DesiredCapabilities) {
+    const bsOptions = capabilities['bstack:options'] || {}
     if (!capabilities) {
         return false
     }
 
     return Boolean(
         (capabilities.platformName && capabilities.platformName.match(/iOS/i)) ||
-        (capabilities.deviceName && capabilities.deviceName.match(/(iPad|iPhone)/i))
+        (capabilities.deviceName && capabilities.deviceName.match(/(iPad|iPhone)/i)) ||
+        (/iOS/i.test(bsOptions.platformName)) ||
+        (/(iPad|iPhone)/i.test(bsOptions.deviceName))
     )
 }
 
@@ -136,12 +145,15 @@ function isIOS(capabilities?: Capabilities.DesiredCapabilities) {
  * @return {Boolean}               true if run on Android device
  */
 function isAndroid(capabilities?: WebdriverIO.Capabilities) {
+    const bsOptions = capabilities['bstack:options'] || {}
     if (!capabilities) {
         return false
     }
 
     return Boolean(
         (capabilities.platformName && capabilities.platformName.match(/Android/i)) ||
+        (/Android/i.test(bsOptions.platformName)) ||
+        (/Android/i.test(bsOptions.browserName)) ||
         (capabilities.browserName && capabilities.browserName.match(/Android/i))
     )
 }

--- a/packages/wdio-utils/src/envDetector.ts
+++ b/packages/wdio-utils/src/envDetector.ts
@@ -100,7 +100,7 @@ function isMobile(capabilities: WebdriverIO.Capabilities) {
         capabilities.platformName && capabilities.platformName.match(/ios/i) ||
         capabilities.platformName && capabilities.platformName.match(/tvos/i) ||
         capabilities.platformName && capabilities.platformName.match(/android/i) ||
-        /ios/i.test(bsOptions.platformName) ||
+        /ios/i.test(bsOptions.platformName || '') ||
         /tvos/i.test(bsOptions.platformName) ||
         /android/i.test(bsOptions.platformName) ||
         /**

--- a/packages/wdio-utils/src/envDetector.ts
+++ b/packages/wdio-utils/src/envDetector.ts
@@ -145,7 +145,7 @@ function isIOS(capabilities?: Capabilities.DesiredCapabilities) {
  * @return {Boolean}               true if run on Android device
  */
 function isAndroid(capabilities?: WebdriverIO.Capabilities) {
-    const bsOptions = capabilities['bstack:options'] || {}
+    const bsOptions = capabilities?.['bstack:options'] || {}
     if (!capabilities) {
         return false
     }

--- a/packages/wdio-utils/src/envDetector.ts
+++ b/packages/wdio-utils/src/envDetector.ts
@@ -101,8 +101,8 @@ function isMobile(capabilities: WebdriverIO.Capabilities) {
         capabilities.platformName && capabilities.platformName.match(/tvos/i) ||
         capabilities.platformName && capabilities.platformName.match(/android/i) ||
         /ios/i.test(bsOptions.platformName || '') ||
-        /tvos/i.test(bsOptions.platformName) ||
-        /android/i.test(bsOptions.platformName) ||
+        /tvos/i.test(bsOptions.platformName || '') ||
+        /android/i.test(bsOptions.platformName || '') ||
         /**
          * capabilities contain mobile only specific capabilities
          */
@@ -134,8 +134,8 @@ function isIOS(capabilities?: Capabilities.DesiredCapabilities) {
     return Boolean(
         (capabilities.platformName && capabilities.platformName.match(/iOS/i)) ||
         (capabilities.deviceName && capabilities.deviceName.match(/(iPad|iPhone)/i)) ||
-        (/iOS/i.test(bsOptions.platformName)) ||
-        (/(iPad|iPhone)/i.test(bsOptions.deviceName))
+        (/iOS/i.test(bsOptions.platformName || '')) ||
+        (/(iPad|iPhone)/i.test(bsOptions.deviceName || ''))
     )
 }
 
@@ -152,8 +152,8 @@ function isAndroid(capabilities?: WebdriverIO.Capabilities) {
 
     return Boolean(
         (capabilities.platformName && capabilities.platformName.match(/Android/i)) ||
-        (/Android/i.test(bsOptions.platformName)) ||
-        (/Android/i.test(bsOptions.browserName)) ||
+        (/Android/i.test(bsOptions.platformName || '')) ||
+        (/Android/i.test(bsOptions.browserName || '')) ||
         (capabilities.browserName && capabilities.browserName.match(/Android/i))
     )
 }

--- a/packages/wdio-utils/src/envDetector.ts
+++ b/packages/wdio-utils/src/envDetector.ts
@@ -126,7 +126,7 @@ function isMobile(capabilities: WebdriverIO.Capabilities) {
  * @return {Boolean}               true if run on iOS device
  */
 function isIOS(capabilities?: Capabilities.DesiredCapabilities) {
-    const bsOptions = capabilities['bstack:options'] || {}
+    const bsOptions = capabilities?.['bstack:options'] || {}
     if (!capabilities) {
         return false
     }

--- a/packages/wdio-utils/tests/envDetector.test.ts
+++ b/packages/wdio-utils/tests/envDetector.test.ts
@@ -54,6 +54,12 @@ describe('sessionEnvironmentDetector', () => {
         expect(sessionEnvironmentDetector({ capabilities: tvOSCaps, requestedCapabilities }).isMobile).toBe(true)
         const androidCaps = { ...chromeCaps, 'platformName': 'Android' }
         expect(sessionEnvironmentDetector({ capabilities: androidCaps, requestedCapabilities }).isMobile).toBe(true)
+        const iosCapsBS = { 'bstack:options': { ...chromeCaps, 'platformName': 'ios' } }
+        expect(sessionEnvironmentDetector({ capabilities: iosCapsBS, requestedCapabilities }).isMobile).toBe(true)
+        const tvOSCapsBS = { 'bstack:options': { ...chromeCaps, 'platformName': 'tvOS' } }
+        expect(sessionEnvironmentDetector({ capabilities: tvOSCapsBS, requestedCapabilities }).isMobile).toBe(true)
+        const androidCapsBS = { 'bstack:options': { ...chromeCaps, 'platformName': 'Android' } }
+        expect(sessionEnvironmentDetector({ capabilities: androidCapsBS, requestedCapabilities }).isMobile).toBe(true)
     })
 
     it('isW3C', () => {
@@ -151,8 +157,26 @@ describe('sessionEnvironmentDetector', () => {
         expect(isAndroid).toEqual(false)
     })
 
+    it('should not detect mobile app for browserName===undefined with BrowserStack Service', function () {
+        const requestedCapabilities = { browserName: '' }
+        const capabilities = { 'bstack:options': {} }
+        const { isMobile, isIOS, isAndroid } = sessionEnvironmentDetector({ capabilities, requestedCapabilities })
+        expect(isMobile).toEqual(false)
+        expect(isIOS).toEqual(false)
+        expect(isAndroid).toEqual(false)
+    })
+
     it('should not detect mobile app for browserName==="firefox"', function () {
         const capabilities = { browserName: 'firefox' }
+        const requestedCapabilities = { browserName: '' }
+        const { isMobile, isIOS, isAndroid } = sessionEnvironmentDetector({ capabilities, requestedCapabilities })
+        expect(isMobile).toEqual(false)
+        expect(isIOS).toEqual(false)
+        expect(isAndroid).toEqual(false)
+    })
+
+    it('should not detect mobile app for browserName==="firefox" with BrowserStack Service', function () {
+        const capabilities = { 'bstack:options': { browserName: 'firefox' } }
         const requestedCapabilities = { browserName: '' }
         const { isMobile, isIOS, isAndroid } = sessionEnvironmentDetector({ capabilities, requestedCapabilities })
         expect(isMobile).toEqual(false)
@@ -169,8 +193,26 @@ describe('sessionEnvironmentDetector', () => {
         expect(isAndroid).toEqual(false)
     })
 
+    it('should not detect mobile app for browserName==="chrome" with BrowserStack Service', function () {
+        const capabilities = { 'bstack:options': { browserName: 'chrome' } }
+        const requestedCapabilities = { browserName: '' }
+        const { isMobile, isIOS, isAndroid } = sessionEnvironmentDetector({ capabilities, requestedCapabilities })
+        expect(isMobile).toEqual(false)
+        expect(isIOS).toEqual(false)
+        expect(isAndroid).toEqual(false)
+    })
+
     it('should detect mobile app for browserName===""', function () {
         const capabilities = { browserName: '' }
+        const requestedCapabilities = { browserName: '' }
+        const { isMobile, isIOS, isAndroid } = sessionEnvironmentDetector({ capabilities, requestedCapabilities })
+        expect(isMobile).toEqual(true)
+        expect(isIOS).toEqual(false)
+        expect(isAndroid).toEqual(false)
+    })
+
+    it('should detect mobile app for browserName==="" with BrowserStack Service', function () {
+        const capabilities =  { 'bstack:options': { browserName: '' } }
         const requestedCapabilities = { browserName: '' }
         const { isMobile, isIOS, isAndroid } = sessionEnvironmentDetector({ capabilities, requestedCapabilities })
         expect(isMobile).toEqual(true)
@@ -184,6 +226,26 @@ describe('sessionEnvironmentDetector', () => {
             platformVersion: '4.4',
             deviceName: 'LGVS450PP2a16334',
             app: 'foo.apk'
+        }
+        const requestedCapabilities = { browserName: '' }
+        const { isMobile, isIOS, isAndroid } = sessionEnvironmentDetector({ capabilities, requestedCapabilities })
+        expect(isMobile).toEqual(true)
+        expect(isIOS).toEqual(false)
+        expect(isAndroid).toEqual(true)
+    })
+
+    it('should detect Android mobile app without upload with BrowserStack Service', function () {
+        const capabilities = {
+            'bstack:options':
+            {
+                platformName: 'Android',
+                platformVersion: '4.4',
+                deviceName: 'LGVS450PP2a16334',
+                appPackage: 'com.example',
+                appActivity: 'com.example.gui.LauncherActivity',
+                noReset: true,
+                appWaitActivity: 'com.example.gui.LauncherActivity'
+            }
         }
         const requestedCapabilities = { browserName: '' }
         const { isMobile, isIOS, isAndroid } = sessionEnvironmentDetector({ capabilities, requestedCapabilities })


### PR DESCRIPTION
## Proposed changes

[//]: # I fix the bug that doesn't allow to check isMobile, isAndroid, isIOS command in browserstack

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
