### PR TITLE
(@wdio/globals): fix type reference annotation

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -141,6 +141,25 @@ if (!HAS_WATCH_FLAG) {
         const fileContent = await readFile(filePath, 'utf8')
         await writeFile(filePath, fileContent.toString().replace('export {};', ''), 'utf8')
     }
+
+    /**
+     * Fix type annotation in `@wdio/globals` package.
+     *
+     * For some reason TypeScript doesn't keep the type annotation comment in
+     * `packages/wdio-globals/src/index.ts` in the first line. After compiling
+     * the package it becomes:
+     *
+     * ```ts
+     * /// <reference types="./standalone.js" />
+     * /// <reference types="types.js" />
+     * ```
+     *
+     * Which can't get resolved by TypeScript. Instead we want the original annotation
+     * comment to be kept.
+     */
+    const filePath = path.join(__dirname, '..', 'packages', 'wdio-globals', 'build', 'index.d.ts')
+    const fileContent = (await readFile(filePath, 'utf8')).toString().replace(/\/\/\/ <reference (types|path)(.*)/g, '')
+    await writeFile(filePath, `/// <reference path="../types.d.ts" />${fileContent}`, 'utf8')
 }
 
 if (esmCode || cjsCode) {


### PR DESCRIPTION
## Proposed changes

For some reason TypeScript doesn't keep the type annotation comment in `packages/wdio-globals/src/index.ts` in the first line. After compiling the package it becomes:

```ts
/// <reference types="./standalone.js" />
/// <reference types="types.js" />
```

Which can't get resolved by TypeScript. Instead we want the original annotation comment to be kept.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
