### PR TITLE
changed moveTo to like it's been implemented in click

### DIFF
--- a/e2e/wdio/headless/secondTest.e2e.ts
+++ b/e2e/wdio/headless/secondTest.e2e.ts
@@ -7,6 +7,6 @@ describe('main suite 1', () => {
             ? 'headlessedg'
             : caps.browserName!.toLowerCase()
         await browser.url('http://guinea-pig.webdriver.io/')
-        await expect((await $('#useragent').getText()).toLowerCase()).toContain(assertionValue)
+        await expect((await $('#useragent').getText()).toLowerCase()).toContain(assertionValue.replace(' ', ''))
     })
 })

--- a/e2e/wdio/headless/test.e2e.ts
+++ b/e2e/wdio/headless/test.e2e.ts
@@ -4,7 +4,7 @@ describe('main suite 1', () => {
     it('foobar test', async () => {
         const browserName = (browser.capabilities as WebdriverIO.Capabilities).browserName
         await browser.url('http://guinea-pig.webdriver.io/')
-        await expect((await $('#useragent').getText()).toLowerCase()).toContain(browserName)
+        await expect((await $('#useragent').getText()).toLowerCase()).toContain(browserName ? browserName.replace(' ', '') : browserName)
     })
 
     it('should allow to check for PWA', async () => {

--- a/e2e/wdio/headless/test.e2e.ts
+++ b/e2e/wdio/headless/test.e2e.ts
@@ -99,6 +99,13 @@ describe('main suite 1', () => {
     })
 
     describe('moveTo tests', () => {
+        const inputs = [
+            undefined,
+            { xOffset: 10 },
+            { yOffset: 10 },
+            { xOffset: 25, yOffset: 25 },
+        ]
+
         before(async () => {
             await browser.url('http://guinea-pig.webdriver.io/')
             await (await browser.$('a[href="pointer.html"]')).click()
@@ -117,18 +124,26 @@ describe('main suite 1', () => {
             expect(value.endsWith('center\n')).toBe(true)
         })
 
-        it('moveTo without iframe with xOffset and yOffset regarding center', async () => {
-            const elmRectChild = await browser.getElementRect(await browser.$('#child').elementId)
-            const elmRectParent = await browser.getElementRect(await browser.$('#parent').elementId)
-            await (await browser.$('#parent')).moveTo({ xOffset: elmRectParent.width/2 - elmRectChild.width/2 + 1, yOffset: elmRectParent.height - elmRectChild.height + 1 })
-            const value = await (await browser.$('#text')).getValue()
-            expect(value.endsWith('out\n')).toBe(true)
+        inputs.forEach((input) => {
+            it(`moves to position x,y outside of iframe when passing the arguments ${JSON.stringify(input)}`, async () => {
+                await browser.execute(() => {
+                    const mouse = { x:0, y:0 }
+                    document.onmousemove = function(e){ mouse.x = e.clientX, mouse.y = e.clientY }
+                    //@ts-ignore
+                    document.mouseMoveTo = mouse
+                })
+                await (await browser.$('#parent')).moveTo()
+                const rectBefore = await browser.execute('return document.mouseMoveTo') as {x: number, y: number}
+                await (await browser.$('#parent')).moveTo(input)
+                const rectAfter = await browser.execute('return document.mouseMoveTo') as {x: number, y: number}
+                expect(rectBefore.x + (input && input?.xOffset ? input?.xOffset : 0)).toEqual(rectAfter.x)
+                expect(rectBefore.y + (input && input?.yOffset ? input?.yOffset : 0)).toEqual(rectAfter.y)
+            })
         })
 
         it('moveTo in iframe', async () => {
             const iframe = await browser.$('iframe.code-tabs__result')
             await browser.switchToFrame(iframe)
-            await (await browser.$('#parent')).scrollIntoView()
             await (await browser.$('#parent')).moveTo()
             const value = await (await browser.$('#text')).getValue()
             expect(value.endsWith('center\n')).toBe(true)
@@ -140,12 +155,21 @@ describe('main suite 1', () => {
             expect(value.endsWith('center\n')).toBe(true)
         })
 
-        it('moveTo in iframe with xOffset and yOffset regarding center', async () => {
-            const elmRectChild = await browser.getElementRect(await browser.$('#child').elementId)
-            const elmRectParent = await browser.getElementRect(await browser.$('#parent').elementId)
-            await (await browser.$('#parent')).moveTo({ xOffset: elmRectParent.width/2 - elmRectChild.width/2 + 1, yOffset: elmRectParent.height - elmRectChild.height + 1 })
-            const value = await (await browser.$('#text')).getValue()
-            expect(value.endsWith('out\n')).toBe(true)
+        inputs.forEach((input) => {
+            it(`moves to position x,y inside of iframe when passing the arguments ${JSON.stringify(input)}`, async () => {
+                await browser.execute(() => {
+                    const mouse = { x:0, y:0 }
+                    document.onmousemove = function(e){ mouse.x = e.clientX, mouse.y = e.clientY }
+                    //@ts-ignore
+                    document.mouseMoveTo = mouse
+                })
+                await (await browser.$('#parent')).moveTo()
+                const rectBefore = await browser.execute('return document.mouseMoveTo') as {x: number, y: number}
+                await (await browser.$('#parent')).moveTo(input)
+                const rectAfter = await browser.execute('return document.mouseMoveTo') as {x: number, y: number}
+                expect(rectBefore.x + (input && input?.xOffset ? input?.xOffset : 0)).toEqual(rectAfter.x)
+                expect(rectBefore.y + (input && input?.yOffset ? input?.yOffset : 0)).toEqual(rectAfter.y)
+            })
         })
     })
 

--- a/e2e/wdio/headless/test.e2e.ts
+++ b/e2e/wdio/headless/test.e2e.ts
@@ -118,8 +118,9 @@ describe('main suite 1', () => {
         })
 
         it('moveTo without iframe with xOffset and yOffset regarding center', async () => {
-            const elmRect = await browser.getElementRect(await browser.$('#parent').elementId)
-            await (await browser.$('#parent')).moveTo({ xOffset: elmRect.width -  1, yOffset: elmRect.height - 1 })
+            const elmRectChild = await browser.getElementRect(await browser.$('#child').elementId)
+            const elmRectParent = await browser.getElementRect(await browser.$('#parent').elementId)
+            await (await browser.$('#parent')).moveTo({ xOffset: elmRectParent.width/2 - elmRectChild.width/2 + 1, yOffset: elmRectParent.height - elmRectChild.height + 1 })
             const value = await (await browser.$('#text')).getValue()
             expect(value.endsWith('out\n')).toBe(true)
         })
@@ -139,8 +140,9 @@ describe('main suite 1', () => {
         })
 
         it('moveTo in iframe with xOffset and yOffset regarding center', async () => {
-            const elmRect = await browser.getElementRect(await browser.$('#parent').elementId)
-            await (await browser.$('#parent')).moveTo({ xOffset: elmRect.width - 1, yOffset: elmRect.height - 1 })
+            const elmRectChild = await browser.getElementRect(await browser.$('#child').elementId)
+            const elmRectParent = await browser.getElementRect(await browser.$('#parent').elementId)
+            await (await browser.$('#parent')).moveTo({ xOffset: elmRectParent.width/2 - elmRectChild.width/2 + 1, yOffset: elmRectParent.height - elmRectChild.height + 1 })
             const value = await (await browser.$('#text')).getValue()
             expect(value.endsWith('out\n')).toBe(true)
         })

--- a/e2e/wdio/headless/test.e2e.ts
+++ b/e2e/wdio/headless/test.e2e.ts
@@ -128,6 +128,7 @@ describe('main suite 1', () => {
         it('moveTo in iframe', async () => {
             const iframe = await browser.$('iframe.code-tabs__result')
             await browser.switchToFrame(iframe)
+            await (await browser.$('#parent')).scrollIntoView()
             await (await browser.$('#parent')).moveTo()
             const value = await (await browser.$('#text')).getValue()
             expect(value.endsWith('center\n')).toBe(true)

--- a/e2e/wdio/headless/test.e2e.ts
+++ b/e2e/wdio/headless/test.e2e.ts
@@ -98,6 +98,54 @@ describe('main suite 1', () => {
         expect(oldScrollPosition).toEqual([x, y])
     })
 
+    describe('moveTo tests', () => {
+        before(async () => {
+            await browser.url('http://guinea-pig.webdriver.io/')
+            await (await browser.$('a[href="pointer.html"]')).click()
+            await (await browser.$('#parent')).waitForExist()
+        })
+
+        it('moveTo without iframe', async () => {
+            await (await browser.$('#parent')).moveTo()
+            const value = await (await browser.$('#text')).getValue()
+            expect(value.endsWith('center\n')).toBe(true)
+        })
+
+        it('moveTo without iframe with 0 offsets', async () => {
+            await (await browser.$('#parent')).moveTo({ xOffset: 0, yOffset: 0 })
+            const value = await (await browser.$('#text')).getValue()
+            expect(value.endsWith('center\n')).toBe(true)
+        })
+
+        it('moveTo without iframe with xOffset and yOffset regarding center', async () => {
+            const elmRect = await browser.getElementRect(await browser.$('#parent').elementId)
+            await (await browser.$('#parent')).moveTo({ xOffset: elmRect.width -  1, yOffset: elmRect.height - 1 })
+            const value = await (await browser.$('#text')).getValue()
+            expect(value.endsWith('out\n')).toBe(true)
+        })
+
+        it('moveTo in iframe', async () => {
+            const iframe = await browser.$('iframe.code-tabs__result')
+            await browser.switchToFrame(iframe)
+            await (await browser.$('#parent')).moveTo()
+            const value = await (await browser.$('#text')).getValue()
+            expect(value.endsWith('center\n')).toBe(true)
+        })
+
+        it('moveTo in iframe with 0 offsets', async () => {
+            await (await browser.$('#parent')).moveTo({ xOffset: 0, yOffset: 0 })
+            const value = await (await browser.$('#text')).getValue()
+            expect(value.endsWith('center\n')).toBe(true)
+        })
+
+        it('moveTo in iframe with xOffset and yOffset regarding center', async () => {
+            const elmRect = await browser.getElementRect(await browser.$('#parent').elementId)
+            await (await browser.$('#parent')).moveTo({ xOffset: elmRect.width - 1, yOffset: elmRect.height - 1 })
+            const value = await (await browser.$('#text')).getValue()
+            expect(value.endsWith('out\n')).toBe(true)
+        })
+    })
+
     const inputs: (ScrollIntoViewOptions | boolean | undefined)[] = [
         undefined,
         true,

--- a/e2e/wdio/headless/test.e2e.ts
+++ b/e2e/wdio/headless/test.e2e.ts
@@ -108,19 +108,19 @@ describe('main suite 1', () => {
 
         before(async () => {
             await browser.url('http://guinea-pig.webdriver.io/')
-            await (await browser.$('a[href="pointer.html"]')).click()
-            await (await browser.$('#parent')).waitForExist()
+            await browser.$('a[href="pointer.html"]').click()
+            await browser.$('#parent').waitForExist()
         })
 
         it('moveTo without iframe', async () => {
-            await (await browser.$('#parent')).moveTo()
-            const value = await (await browser.$('#text')).getValue()
+            await browser.$('#parent').moveTo()
+            const value = await browser.$('#text').getValue()
             expect(value.endsWith('center\n')).toBe(true)
         })
 
         it('moveTo without iframe with 0 offsets', async () => {
-            await (await browser.$('#parent')).moveTo({ xOffset: 0, yOffset: 0 })
-            const value = await (await browser.$('#text')).getValue()
+            await browser.$('#parent').moveTo({ xOffset: 0, yOffset: 0 })
+            const value = await browser.$('#text').getValue()
             expect(value.endsWith('center\n')).toBe(true)
         })
 
@@ -132,9 +132,9 @@ describe('main suite 1', () => {
                     //@ts-ignore
                     document.mouseMoveTo = mouse
                 })
-                await (await browser.$('#parent')).moveTo()
+                await browser.$('#parent').moveTo()
                 const rectBefore = await browser.execute('return document.mouseMoveTo') as {x: number, y: number}
-                await (await browser.$('#parent')).moveTo(input)
+                await browser.$('#parent').moveTo(input)
                 const rectAfter = await browser.execute('return document.mouseMoveTo') as {x: number, y: number}
                 expect(rectBefore.x + (input && input?.xOffset ? input?.xOffset : 0)).toEqual(rectAfter.x)
                 expect(rectBefore.y + (input && input?.yOffset ? input?.yOffset : 0)).toEqual(rectAfter.y)
@@ -144,14 +144,14 @@ describe('main suite 1', () => {
         it('moveTo in iframe', async () => {
             const iframe = await browser.$('iframe.code-tabs__result')
             await browser.switchToFrame(iframe)
-            await (await browser.$('#parent')).moveTo()
-            const value = await (await browser.$('#text')).getValue()
+            await browser.$('#parent').moveTo()
+            const value = await browser.$('#text').getValue()
             expect(value.endsWith('center\n')).toBe(true)
         })
 
         it('moveTo in iframe with 0 offsets', async () => {
-            await (await browser.$('#parent')).moveTo({ xOffset: 0, yOffset: 0 })
-            const value = await (await browser.$('#text')).getValue()
+            await browser.$('#parent').moveTo({ xOffset: 0, yOffset: 0 })
+            const value = await browser.$('#text').getValue()
             expect(value.endsWith('center\n')).toBe(true)
         })
 
@@ -163,9 +163,9 @@ describe('main suite 1', () => {
                     //@ts-ignore
                     document.mouseMoveTo = mouse
                 })
-                await (await browser.$('#parent')).moveTo()
+                await browser.$('#parent').moveTo()
                 const rectBefore = await browser.execute('return document.mouseMoveTo') as {x: number, y: number}
-                await (await browser.$('#parent')).moveTo(input)
+                await browser.$('#parent').moveTo(input)
                 const rectAfter = await browser.execute('return document.mouseMoveTo') as {x: number, y: number}
                 expect(rectBefore.x + (input && input?.xOffset ? input?.xOffset : 0)).toEqual(rectAfter.x)
                 expect(rectBefore.y + (input && input?.yOffset ? input?.yOffset : 0)).toEqual(rectAfter.y)

--- a/packages/webdriverio/src/commands/element/moveTo.ts
+++ b/packages/webdriverio/src/commands/element/moveTo.ts
@@ -1,4 +1,4 @@
-import { getElementRect, getScrollPosition, getBrowserObject } from '../../utils/index.js'
+import { getElementRect, getBrowserObject } from '../../utils/index.js'
 
 type MoveToOptions = {
     xOffset?: number,

--- a/packages/webdriverio/src/commands/element/moveTo.ts
+++ b/packages/webdriverio/src/commands/element/moveTo.ts
@@ -1,4 +1,4 @@
-import { getElementRect, getBrowserObject } from '../../utils/index.js'
+import { getBrowserObject } from '../../utils/index.js'
 
 type MoveToOptions = {
     xOffset?: number,
@@ -26,19 +26,11 @@ export async function moveTo (
     if (!this.isW3C) {
         return this.moveToElement(this.elementId, xOffset, yOffset)
     }
-
-    /**
-     * get rect of element
-     */
-    const { width, height } = await getElementRect(this)
-    const newXOffset = Math.floor(typeof xOffset === 'number' ? xOffset : (width / 2))
-    const newYOffset = Math.floor(typeof yOffset === 'number' ? yOffset : (height / 2))
-
     /**
      * W3C way of handle the mouse move actions
      */
     const browser = getBrowserObject(this)
     return browser.action('pointer', { parameters: { pointerType: 'mouse' } })
-        .move({ origin: this, x: newXOffset, y: newYOffset })
+        .move({ origin: this, x: xOffset ? xOffset : 0, y: yOffset ? yOffset : 0 })
         .perform()
 }

--- a/packages/webdriverio/src/commands/element/moveTo.ts
+++ b/packages/webdriverio/src/commands/element/moveTo.ts
@@ -30,16 +30,15 @@ export async function moveTo (
     /**
      * get rect of element
      */
-    const { x, y, width, height } = await getElementRect(this)
-    const { scrollX, scrollY } = await getScrollPosition(this)
-    const newXOffset = Math.floor(x - scrollX + (typeof xOffset === 'number' ? xOffset : (width / 2)))
-    const newYOffset = Math.floor(y - scrollY + (typeof yOffset === 'number' ? yOffset : (height / 2)))
+    const { width, height } = await getElementRect(this)
+    const newXOffset = Math.floor(typeof xOffset === 'number' ? xOffset : (width / 2))
+    const newYOffset = Math.floor(typeof yOffset === 'number' ? yOffset : (height / 2))
 
     /**
      * W3C way of handle the mouse move actions
      */
     const browser = getBrowserObject(this)
     return browser.action('pointer', { parameters: { pointerType: 'mouse' } })
-        .move({ x: newXOffset, y: newYOffset })
+        .move({ origin: this, x: newXOffset, y: newYOffset })
         .perform()
 }

--- a/packages/webdriverio/src/utils/index.ts
+++ b/packages/webdriverio/src/utils/index.ts
@@ -461,17 +461,6 @@ export function validateUrl (url: string, origError?: Error): string {
     }
 }
 
-/**
- * get window's scrollX and scrollY
- * @param {object} scope
- */
-export function getScrollPosition (scope: WebdriverIO.Element) {
-    return getBrowserObject(scope)
-        .execute(/* istanbul ignore next */function (this: Window) {
-            return { scrollX: this.pageXOffset, scrollY: this.pageYOffset }
-        })
-}
-
 export async function hasElementId (element: WebdriverIO.Element) {
     /*
      * This is only necessary as isDisplayed is on the exclusion list for the middleware

--- a/packages/webdriverio/tests/commands/element/__snapshots__/moveTo.test.ts.snap
+++ b/packages/webdriverio/tests/commands/element/__snapshots__/moveTo.test.ts.snap
@@ -22,28 +22,6 @@ exports[`moveTo > should do a moveTo with params 1`] = `
 }
 `;
 
-exports[`moveTo > should do a moveTo with params if getElementRect returned empty object 1`] = `
-{
-  "altitudeAngle": 0,
-  "azimuthAngle": 0,
-  "button": 0,
-  "duration": 100,
-  "height": 0,
-  "origin": {
-    "element-6066-11e4-a52e-4f735466cecf": "some-elem-123",
-  },
-  "pressure": 0,
-  "tangentialPressure": 0,
-  "tiltX": 0,
-  "tiltY": 0,
-  "twist": 0,
-  "type": "pointerMove",
-  "width": 0,
-  "x": 5,
-  "y": 10,
-}
-`;
-
 exports[`moveTo > should do a moveTo without params 1`] = `
 {
   "altitudeAngle": 0,
@@ -61,8 +39,7 @@ exports[`moveTo > should do a moveTo without params 1`] = `
   "twist": 0,
   "type": "pointerMove",
   "width": 0,
-  "x": 25,
-  "y": 15,
+  "x": 0,
+  "y": 0,
 }
 `;
-

--- a/packages/webdriverio/tests/commands/element/__snapshots__/moveTo.test.ts.snap
+++ b/packages/webdriverio/tests/commands/element/__snapshots__/moveTo.test.ts.snap
@@ -7,7 +7,9 @@ exports[`moveTo > should do a moveTo with params 1`] = `
   "button": 0,
   "duration": 100,
   "height": 0,
-  "origin": "viewport",
+  "origin": {
+    "element-6066-11e4-a52e-4f735466cecf": "some-elem-123",
+  },
   "pressure": 0,
   "tangentialPressure": 0,
   "tiltX": 0,
@@ -15,8 +17,8 @@ exports[`moveTo > should do a moveTo with params 1`] = `
   "twist": 0,
   "type": "pointerMove",
   "width": 0,
-  "x": 1,
-  "y": 30,
+  "x": 5,
+  "y": 10,
 }
 `;
 
@@ -27,7 +29,9 @@ exports[`moveTo > should do a moveTo with params if getElementRect returned empt
   "button": 0,
   "duration": 100,
   "height": 0,
-  "origin": "viewport",
+  "origin": {
+    "element-6066-11e4-a52e-4f735466cecf": "some-elem-123",
+  },
   "pressure": 0,
   "tangentialPressure": 0,
   "tiltX": 0,
@@ -35,8 +39,8 @@ exports[`moveTo > should do a moveTo with params if getElementRect returned empt
   "twist": 0,
   "type": "pointerMove",
   "width": 0,
-  "x": 10,
-  "y": 20,
+  "x": 5,
+  "y": 10,
 }
 `;
 
@@ -47,7 +51,9 @@ exports[`moveTo > should do a moveTo without params 1`] = `
   "button": 0,
   "duration": 100,
   "height": 0,
-  "origin": "viewport",
+  "origin": {
+    "element-6066-11e4-a52e-4f735466cecf": "some-elem-123",
+  },
   "pressure": 0,
   "tangentialPressure": 0,
   "tiltX": 0,
@@ -55,27 +61,8 @@ exports[`moveTo > should do a moveTo without params 1`] = `
   "twist": 0,
   "type": "pointerMove",
   "width": 0,
-  "x": 40,
+  "x": 25,
   "y": 15,
 }
 `;
 
-exports[`moveTo > should return integer values when provided float getScrollPosition params 1`] = `
-{
-  "altitudeAngle": 0,
-  "azimuthAngle": 0,
-  "button": 0,
-  "duration": 100,
-  "height": 0,
-  "origin": "viewport",
-  "pressure": 0,
-  "tangentialPressure": 0,
-  "tiltX": 0,
-  "tiltY": 0,
-  "twist": 0,
-  "type": "pointerMove",
-  "width": 0,
-  "x": 6,
-  "y": 15,
-}
-`;

--- a/packages/webdriverio/tests/commands/element/moveTo.test.ts
+++ b/packages/webdriverio/tests/commands/element/moveTo.test.ts
@@ -22,11 +22,11 @@ describe('moveTo', () => {
         got.setMockResponse([undefined])
         await elem.moveTo()
 
-        expect(vi.mocked(got).mock.calls[3][0]!.pathname).toContain('/foobar-123/actions')
-        expect(vi.mocked(got).mock.calls[3][1]!.json.actions).toHaveLength(1)
-        expect(vi.mocked(got).mock.calls[3][1]!.json.actions[0].type).toBe('pointer')
-        expect(vi.mocked(got).mock.calls[3][1]!.json.actions[0].actions).toHaveLength(1)
-        expect(vi.mocked(got).mock.calls[3][1]!.json.actions[0].actions[0])
+        expect(vi.mocked(got).mock.calls[2][0]!.pathname).toContain('/foobar-123/actions')
+        expect(vi.mocked(got).mock.calls[2][1]!.json.actions).toHaveLength(1)
+        expect(vi.mocked(got).mock.calls[2][1]!.json.actions[0].type).toBe('pointer')
+        expect(vi.mocked(got).mock.calls[2][1]!.json.actions[0].actions).toHaveLength(1)
+        expect(vi.mocked(got).mock.calls[2][1]!.json.actions[0].actions[0])
             .toMatchSnapshot()
     })
 
@@ -42,39 +42,8 @@ describe('moveTo', () => {
         // @ts-ignore mock feature
         got.setMockResponse([undefined])
         await elem.moveTo({ xOffset: 5, yOffset: 10 })
-        expect(vi.mocked(got).mock.calls[3][1]!.json.actions[0].actions[0])
+        expect(vi.mocked(got).mock.calls[2][1]!.json.actions[0].actions[0])
             .toMatchSnapshot()
-    })
-
-    it('should do a moveTo with params if getElementRect returned empty object', async () => {
-        const browser = await remote({
-            baseUrl: 'http://foobar.com',
-            capabilities: {
-                browserName: 'foobar'
-            }
-        })
-
-        const elem = await browser.$('#elem')
-        // @ts-ignore mock feature
-        got.setMockResponse([{}, { x: 5, y: 10, height: 33, width: 44 }])
-        await elem.moveTo({ xOffset: 5, yOffset: 10 })
-        expect(vi.mocked(got).mock.calls[4][1]!.json.actions[0].actions[0])
-            .toMatchSnapshot()
-    })
-
-    it('should do a moveTo with params if getElementRect and getBoundingClientRect returned empty object', async () => {
-        const browser = await remote({
-            baseUrl: 'http://foobar.com',
-            capabilities: {
-                browserName: 'foobar'
-            }
-        })
-
-        const elem = await browser.$('#elem')
-        // @ts-ignore mock feature
-        got.setMockResponse([{}, {}])
-        await expect(elem.moveTo({ xOffset: 5, yOffset: 10 }))
-            .rejects.toThrow('Failed to receive element rects via execute command')
     })
 
     it('should do a moveTo without params (no-w3c)', async () => {

--- a/packages/webdriverio/tests/commands/element/moveTo.test.ts
+++ b/packages/webdriverio/tests/commands/element/moveTo.test.ts
@@ -19,14 +19,14 @@ describe('moveTo', () => {
 
         const elem = await browser.$('#elem')
         // @ts-ignore mock feature
-        got.setMockResponse([undefined, { scrollX: 0, scrollY: 20 }])
+        got.setMockResponse([undefined])
         await elem.moveTo()
 
-        expect(vi.mocked(got).mock.calls[4][0]!.pathname).toContain('/foobar-123/actions')
-        expect(vi.mocked(got).mock.calls[4][1]!.json.actions).toHaveLength(1)
-        expect(vi.mocked(got).mock.calls[4][1]!.json.actions[0].type).toBe('pointer')
-        expect(vi.mocked(got).mock.calls[4][1]!.json.actions[0].actions).toHaveLength(1)
-        expect(vi.mocked(got).mock.calls[4][1]!.json.actions[0].actions[0])
+        expect(vi.mocked(got).mock.calls[3][0]!.pathname).toContain('/foobar-123/actions')
+        expect(vi.mocked(got).mock.calls[3][1]!.json.actions).toHaveLength(1)
+        expect(vi.mocked(got).mock.calls[3][1]!.json.actions[0].type).toBe('pointer')
+        expect(vi.mocked(got).mock.calls[3][1]!.json.actions[0].actions).toHaveLength(1)
+        expect(vi.mocked(got).mock.calls[3][1]!.json.actions[0].actions[0])
             .toMatchSnapshot()
     })
 
@@ -40,9 +40,9 @@ describe('moveTo', () => {
 
         const elem = await browser.$('#elem')
         // @ts-ignore mock feature
-        got.setMockResponse([undefined, { scrollX: 19, scrollY: 0 }])
+        got.setMockResponse([undefined])
         await elem.moveTo({ xOffset: 5, yOffset: 10 })
-        expect(vi.mocked(got).mock.calls[4][1]!.json.actions[0].actions[0])
+        expect(vi.mocked(got).mock.calls[3][1]!.json.actions[0].actions[0])
             .toMatchSnapshot()
     })
 
@@ -56,9 +56,9 @@ describe('moveTo', () => {
 
         const elem = await browser.$('#elem')
         // @ts-ignore mock feature
-        got.setMockResponse([{}, { x: 5, y: 10, height: 33, width: 44 }, { scrollX: 0, scrollY: 0 }])
+        got.setMockResponse([{}, { x: 5, y: 10, height: 33, width: 44 }])
         await elem.moveTo({ xOffset: 5, yOffset: 10 })
-        expect(vi.mocked(got).mock.calls[5][1]!.json.actions[0].actions[0])
+        expect(vi.mocked(got).mock.calls[4][1]!.json.actions[0].actions[0])
             .toMatchSnapshot()
     })
 
@@ -97,22 +97,6 @@ describe('moveTo', () => {
             .toContain('/foobar-123/moveto')
         expect(vi.mocked(got).mock.calls[3][1]!.json)
             .toEqual({ element: 'some-elem-123', xoffset: 5, yoffset: 10 })
-    })
-
-    it('should return integer values when provided float getScrollPosition params', async () => {
-        const browser = await remote({
-            baseUrl: 'http://foobar.com',
-            capabilities: {
-                browserName: 'foobar'
-            }
-        })
-
-        const elem = await browser.$('#elem')
-        // @ts-ignore mock feature
-        got.setMockResponse([{}, { x: 4, y: 9, height: 35, width: 42 }, { scrollX: 2.1, scrollY: 3.3 }])
-        await elem.moveTo({ xOffset: 5, yOffset: 10 })
-        expect(vi.mocked(got).mock.calls[5][1]!.json.actions[0].actions[0])
-            .toMatchSnapshot()
     })
 
     afterEach(() => {


### PR DESCRIPTION
## Proposed changes

change moveTo to click similarity, because of flaky moveTo

## Types of changes

I'd like to suggest to change it to a way like it's been implemented in click method with 'origin: this' instead of calculation full offset. Even more i don't understand why we should calculate it instead of using 'origin: this' as click method perform particularly the same, with stable behavior in each cases, just with some additional actions like 'down' and 'up'. 