### PR TITLE
Fix name selector to allow other characters

### DIFF
--- a/packages/webdriverio/src/utils/findStrategy.ts
+++ b/packages/webdriverio/src/utils/findStrategy.ts
@@ -104,7 +104,7 @@ const defineStrategy = function (selector: SelectorStrategy) {
     // Use name strategy if selector queries elements with name attributes for JSONWP
     // or if isMobile is used even when w3c is used
     // e.g. "[name='myName']" or '[name="myName"]'
-    if (stringSelector.search(/^\[name=("|')([a-zA-z0-9\-_.@=[\] ']+)("|')]$/) >= 0) {
+    if (stringSelector.search(/^\[name=(?:"(.[^"]*)"|'(.[^']*)')]$/) >= 0) {
         return 'name'
     }
     // Allow to move up to the parent or select current element
@@ -232,12 +232,12 @@ export const findStrategy = function (selector: SelectorStrategy, isW3C?: boolea
     }
     case 'name': {
         if (isMobile || !isW3C) {
-            const match = stringSelector.match(/^\[name=("|')([a-zA-z0-9\-_.@=[\] ']+)("|')]$/)
+            const match = stringSelector.match(/^\[name=(?:"(.[^"]*)"|'(.[^']*)')]$/)
             if (!match) {
                 throw new Error(`InvalidSelectorMatch. Strategy 'name' has failed to match '${stringSelector}'`)
             }
             using = 'name'
-            value = match[2]
+            value = match[1] || match[2]
         }
         break
     }

--- a/packages/webdriverio/tests/findStrategy.test.ts
+++ b/packages/webdriverio/tests/findStrategy.test.ts
@@ -29,17 +29,36 @@ describe('selector strategies helper', () => {
         expect(element.value).toBe('[name="searchinput"]')
     })
 
-    it('should find an element using "name" method with a . in the name', () => {
-        const element = findStrategy('[name="search.input"]')
-        expect(element.using).toBe('name')
-        expect(element.value).toBe('search.input')
-    })
-
-    it('should find an element using "name" method with an attribute', () => {
-        const element = findStrategy('[name="searchinput[@isDisplayed=\'true\']"]')
-        expect(element.using).toBe('name')
-        expect(element.value).toBe('searchinput[@isDisplayed=\'true\']')
-    })
+    it.each([
+        {
+            selector: '[name="search.with.dot"]',
+            expectedValue: 'search.with.dot',
+        },
+        {
+            selector: '[name="search (with parentheses)"]',
+            expectedValue: 'search (with parentheses)',
+        },
+        {
+            selector: "[name='search with \"double quotes\"']",
+            expectedValue: 'search with "double quotes"',
+        },
+        {
+            selector: "[name=\"search with 'single quotes'\"]",
+            expectedValue: "search with 'single quotes'",
+        },
+        {
+            // Complex name selector example taken from Youi.tv selectors, see https://github.com/YOU-i-Labs/appium-youiengine-driver#selector-strategies
+            selector: "[name=\"searchinput[@isDisplayed='true']\"]",
+            expectedValue: "searchinput[@isDisplayed='true']",
+        },
+    ])(
+        'should find an element using "name" method with special characters in the name (using selector %s)',
+        ({ selector, expectedValue }) => {
+            const element = findStrategy(selector)
+            expect(element.using).toBe('name')
+            expect(element.value).toBe(expectedValue)
+        }
+    )
 
     it('should find an element using "name" method by "name" strategy if isMobile is used even when w3c is used', () => {
         const element = findStrategy('[name="searchinput"]', true, true)


### PR DESCRIPTION
Fix the `name` selector strategy to allow other characters, such as parentheses.
For example, using `$('[name="test (Test)"]')` will now correctly result in using the `name` selector strategy instead of using the `css selector` strategy.

Fixes #11553

## Proposed changes

Fix the `name` selector strategy to allow other characters, such as parentheses.
For example, using `$('[name="test (Test)"]')` will now correctly result in using the `name` selector strategy instead of using the `css selector` strategy.

Fixes #11553

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

### Reviewers: @webdriverio/project-committers
