### PR TITLE
Adding ability to get pseudo-elements css value via getCSSProperty #7709

### DIFF
--- a/packages/webdriverio/src/commands/element/getCSSProperty.ts
+++ b/packages/webdriverio/src/commands/element/getCSSProperty.ts
@@ -77,19 +77,11 @@ export async function getCSSProperty (
     cssProperty: string,
     pseudoElement?: PseudoElement,
 ) {
-    if (cssShorthandProps.isShorthand(cssProperty)) {
-        const cssValue = await getShorthandPropertyCSSValue.call(
-            this,
-            {
-                cssProperty,
-                pseudoElement,
-            }
-        )
+    const getCSSProperty = cssShorthandProps.isShorthand(cssProperty)
+        ? getShorthandPropertyCSSValue
+        : getPropertyCSSValue
 
-        return parseCSS(cssValue, cssProperty)
-    }
-
-    const cssValue = await getPropertyCSSValue.call(
+    const cssValue = await getCSSProperty.call(
         this,
         {
             cssProperty,

--- a/packages/webdriverio/src/commands/element/getCSSProperty.ts
+++ b/packages/webdriverio/src/commands/element/getCSSProperty.ts
@@ -1,6 +1,11 @@
 import cssShorthandProps from 'css-shorthand-properties'
 import { parseCSS } from '../../utils/index.js'
 
+type PseudoElement = {
+    target: '::before'|'::after',
+    browser: WebdriverIO.Browser | WebdriverIO.MultiRemoteBrowser
+ }
+
 /**
  *
  * Get a css property from a DOM-element selected by given selector. The return value
@@ -49,7 +54,10 @@ import { parseCSS } from '../../utils/index.js'
         //      }
         // }
 
-        var width = await elem.getCSSProperty('width')
+        var width = await elem.getCSSProperty('width', {
+            target: '::before',
+            browser
+        })
         console.log(width)
         // outputs the following:
         // {
@@ -64,41 +72,103 @@ import { parseCSS } from '../../utils/index.js'
         // }
     })
  * </example>
- *
  * @alias element.getCSSProperty
- * @param  {string}      cssProperty css property name
- * @return {CSSProperty}             The specified css of the element
+ * @param  {string}        cssProperty   css property name
+ * @param  {PseudoElement} pseudoElement css pseudo element
+ * @return {CSSProperty}                 The specified css of the element
  *
  */
 export async function getCSSProperty (
     this: WebdriverIO.Element,
-    cssProperty: string
+    cssProperty: string,
+    pseudoElement?: PseudoElement,
 ) {
+    if (cssShorthandProps.isShorthand(cssProperty)) {
+        const cssValue = await getShorthandPropertyCSSValue.call(
+            this,
+            cssProperty,
+            pseudoElement,
+        )
+
+        return parseCSS(cssValue, cssProperty)
+    }
+
+    const cssValue = await getPropertyCSSValue.call(
+        this,
+        cssProperty,
+        pseudoElement,
+    )
+
+    return parseCSS(cssValue, cssProperty)
+}
+
+async function getShorthandPropertyCSSValue(
+    this: WebdriverIO.Element,
+    cssProperty: string,
+    pseudoElement?: PseudoElement,
+) {
+    let cssValues: string[]
+    const properties = getShorthandProperties(cssProperty)
+
+    if (pseudoElement) {
+        const { browser, target } = pseudoElement
+
+        cssValues = await Promise.all(
+            properties.map((prop) => getPseudoElementCSSValue(
+                browser,
+                this,
+                prop,
+                target
+            ))
+        )
+    } else {
+        cssValues = await Promise.all(
+            properties.map((prop) => this.getElementCSSValue(this.elementId, prop))
+        )
+    }
+
+    return mergeEqualSymmetricalValue(cssValues)
+}
+
+async function getPropertyCSSValue(
+    this: WebdriverIO.Element,
+    cssProperty: string,
+    pseudoElement?: PseudoElement,
+) {
+    if (pseudoElement) {
+        const { browser, target } = pseudoElement
+
+        return await getPseudoElementCSSValue(
+            browser,
+            this,
+            cssProperty,
+            target
+        )
+    }
+    return await this.getElementCSSValue(this.elementId, cssProperty)
+}
+
+function getShorthandProperties(cssProperty: string) {
     /**
      * Getting the css value of a shorthand property results in different results
      * given that the behavior of `getComputedStyle` is not defined in this case.
      * Therefore if we don't deal with a shorthand property run `getElementCSSValue`
      * otherwise expand it and run the command for each longhand property.
      */
-    if (!cssShorthandProps.isShorthand(cssProperty)) {
-        const cssValue = await this.getElementCSSValue(this.elementId, cssProperty)
-        return parseCSS(cssValue, cssProperty)
-    }
+    return cssShorthandProps.expand(cssProperty)
+}
 
-    const properties = cssShorthandProps.expand(cssProperty)
-    let cssValues = await Promise.all(
-        properties.map((prop) => this.getElementCSSValue(this.elementId, prop))
-    )
-
+function mergeEqualSymmetricalValue(cssValues: string[]) {
     /**
      * merge equal symmetrical values
      * - e.g. `36px 10px 36px 10px` to `36px 10px`
      * - or `0px 0px 0px 0px` to `0px`
-     */
-    while ((cssValues.length % 2) === 0) {
+    */
+    let newCssValues = [...cssValues]
+    while ((newCssValues.length % 2) === 0) {
         const mergedValues = [
-            cssValues.slice(0, cssValues.length / 2).join(' '),
-            cssValues.slice(cssValues.length / 2).join(' ')
+            newCssValues.slice(0, newCssValues.length / 2).join(' '),
+            newCssValues.slice(newCssValues.length / 2).join(' ')
         ]
 
         const hasEqualProperties = mergedValues.every((v) => v === mergedValues[0])
@@ -106,8 +176,24 @@ export async function getCSSProperty (
             break
         }
 
-        cssValues = cssValues.slice(0, cssValues.length / 2)
+        newCssValues = newCssValues.slice(0, newCssValues.length / 2)
     }
 
-    return parseCSS(cssValues.join(' '), cssProperty)
+    return newCssValues.join(' ')
+}
+
+async function getPseudoElementCSSValue (
+    browser: WebdriverIO.Browser | WebdriverIO.MultiRemoteBrowser,
+    elem: WebdriverIO.Element,
+    cssProperty: string,
+    pseudoElement: string
+): Promise<string> {
+    const cssValue = await browser.execute(
+        (elem: Element, pseudoElement: string, cssProperty: string) => (window.getComputedStyle(elem, pseudoElement) as any)[cssProperty],
+        elem,
+        pseudoElement,
+        cssProperty
+    )
+
+    return cssValue
 }


### PR DESCRIPTION
## Proposed changes
Added possibility to select pseudo-element css value. It is not defined in Webdriver spec so I did it via browser execute and did not modify protocols.

I didn't found a way to get browser element other than passing it as argument. I also did split `getCSSProperty` to smaller functions because it was hard to understand with all the comments and pseudoElement ifs.

Example usage:
```js
element.getCSSProperty('width', {
   target: '::before',
   browser
})
```

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

I don't know how to mock window object with `got.ts` to be able to add tests for it in `getCSSProperty.test.ts`. I tried to use vitest spyOn to mock window object but it does not work.

### Reviewers: @webdriverio/project-committers
