### PR TITLE
(webdriverio): keep testrunner options

### DIFF
--- a/packages/wdio-runner/src/utils.ts
+++ b/packages/wdio-runner/src/utils.ts
@@ -88,6 +88,9 @@ export async function initialiseInstance (
         log.debug('init remote session')
         const sessionConfig: Options.WebdriverIO = {
             ...config,
+            /**
+             * allow to overwrite connection details by user through capabilities
+             */
             ...sanitizeCaps(capabilities, true),
             capabilities: sanitizeCaps(capabilities)
         }

--- a/packages/webdriverio/src/index.ts
+++ b/packages/webdriverio/src/index.ts
@@ -39,8 +39,8 @@ export const remote = async function(
     remoteModifier?: (client: WebDriverTypes.Client, options: Options.WebdriverIO) => WebDriverTypes.Client
 ): Promise<WebdriverIO.Browser> {
     logger.setLogLevelsConfig(params.logLevels as any, params.logLevel)
-
-    const config = validateConfig<RemoteOptions>(WDIO_DEFAULTS, params, Object.keys(DEFAULTS) as any)
+    const keysToKeep = Object.keys(process.env.WDIO_WORKER_ID ? params : DEFAULTS) as (keyof RemoteOptions)[]
+    const config = validateConfig<RemoteOptions>(WDIO_DEFAULTS, params, keysToKeep)
     const modifier = (client: WebDriverTypes.Client, options: Options.WebdriverIO) => {
         /**
          * overwrite instance options with default values of the protocol

--- a/tests/mocha/standalone.js
+++ b/tests/mocha/standalone.js
@@ -5,6 +5,8 @@ function sleep (ms) {
     return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
+delete process.env.WDIO_WORKER_ID
+
 describe('scripts run in standalone mode', () => {
     describe('remote', () => {
         let remoteBrowser
@@ -37,6 +39,22 @@ describe('scripts run in standalone mode', () => {
             assert.equal(beforeCmdCounter, 1)
             assert.equal(afterCmdCounter, 1)
             assert.ok((Date.now() - start) > 200)
+        })
+
+        it('should not have testrunner options since we initiating it as standalone instance', async () => {
+            const browser = await remote({
+                hostname: 'localhost',
+                port: 4444,
+                path: '/',
+                custom: 'foobar',
+                capabilities: {
+                    browserName: 'chrome'
+                },
+            })
+            expect(browser.options).toHaveProperty('hostname')
+            expect(browser.options).not.toHaveProperty('framework')
+            expect(browser.options).not.toHaveProperty('custom')
+            expect(browser.options).not.toHaveProperty('services')
         })
     })
 

--- a/tests/mocha/test.ts
+++ b/tests/mocha/test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert'
+import type { Options } from '@wdio/types'
 
 describe('Mocha smoke test', () => {
     const testJs = 'tests/mocha/test.ts'
@@ -12,8 +13,17 @@ describe('Mocha smoke test', () => {
         expect(global.expect).toBeDefined()
     })
 
-    it('should return sync value', async () => {
+    it('should allow to use WebdriverIO assertions', async () => {
         await expect(browser).toHaveTitle('Mock Page Title')
+    })
+
+    it('has a testrunner config object', () => {
+        const opts = browser.options as Options.Testrunner
+        expect(Array.isArray(opts.services)).toBe(true)
+        expect(opts).toHaveProperty('mochaOpts')
+        expect(opts).toHaveProperty('jasmineOpts')
+        expect(opts).toHaveProperty('cucumberOpts')
+        expect(opts).toHaveProperty('specs')
     })
 
     let hasRun = false


### PR DESCRIPTION
## Proposed changes

In https://github.com/webdriverio/webdriverio/pull/11441 we moved the location for WebdriverIOs testrunner defaults into the `@wdio/cli` package. This has caused regressions since users have relied on accessing testrunner options through `browser.options`. However since they got stripped out through the `validateConfig` method they weren't available anymore

This patch makes sure that all options people put in their `wdio.conf.js` are propagated to the `browser` object.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

fixes https://github.com/webdriverio/webdriverio/issues/11578

### Reviewers: @webdriverio/project-committers
