### PR TITLE
(webdriverio): remove type exports

### DIFF
--- a/packages/webdriverio/src/index.ts
+++ b/packages/webdriverio/src/index.ts
@@ -15,9 +15,7 @@ import { getPrototype, addLocatorStrategyHandler, isStub } from './utils/index.j
 import type { AttachOptions, RemoteOptions } from './types.js'
 import type * as elementCommands from './commands/element.js'
 
-export * from './types.js'
-export * from './utils/interception/types.js'
-
+export { Selector, CustomInstanceCommands } from './types.js'
 export const Key = KeyConstant
 export const SevereServiceError = SevereServiceErrorImport
 


### PR DESCRIPTION
## Proposed changes

We currently export all WebdriverIO types from the module, including the ones for `Browser` and `Element`. These are not meant to be used for public consumption, instead folks should use the `WebdriverIO` namespace, e.g. `WebdriverIO.Browser`.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

fixes #11055

### Reviewers: @webdriverio/project-committers
