### PR TITLE
(@wdio/globals): support asymmetric matchers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13659,9 +13659,9 @@
       }
     },
     "node_modules/expect-webdriverio": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/expect-webdriverio/-/expect-webdriverio-4.4.1.tgz",
-      "integrity": "sha512-RnFYy2ocC7x7GPX98GhaueoBZlcpqP0InCKvsjZFTSDNcdHR3jODTBko3Kftivm+tRkAduNvYmBL7NjhhKW4pw==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/expect-webdriverio/-/expect-webdriverio-4.5.1.tgz",
+      "integrity": "sha512-fwcMpPV/+e0bS+F7+bC1UoQsZYjJTcbA1XhU4VVB2pEZDhNmeuaPrCanA0tLVP8nDya75oegXK7LgPzP3zZR9w==",
       "dependencies": {
         "expect": "^29.7.0",
         "jest-matcher-utils": "^29.7.0",
@@ -13671,8 +13671,8 @@
         "node": ">=16 || >=18 || >=20"
       },
       "optionalDependencies": {
-        "@wdio/globals": "^8.16.7",
-        "webdriverio": "^8.16.7"
+        "@wdio/globals": "^8.22.1",
+        "webdriverio": "^8.22.1"
       }
     },
     "node_modules/exponential-backoff": {
@@ -29589,7 +29589,7 @@
         "@wdio/utils": "8.22.0",
         "ast-types": "^0.14.2",
         "deepmerge-ts": "^5.0.0",
-        "expect-webdriverio": "^4.2.5",
+        "expect-webdriverio": "^4.5.1",
         "fast-safe-stringify": "^2.1.1",
         "get-port": "^7.0.0",
         "import-meta-resolve": "^3.0.0",
@@ -29888,7 +29888,7 @@
         "node": "^16.13 || >=18"
       },
       "optionalDependencies": {
-        "expect-webdriverio": "^4.2.5",
+        "expect-webdriverio": "^4.5.1",
         "webdriverio": "8.22.1"
       }
     },
@@ -29902,7 +29902,7 @@
         "@wdio/logger": "8.16.17",
         "@wdio/types": "8.21.0",
         "@wdio/utils": "8.22.0",
-        "expect-webdriverio": "^4.2.5",
+        "expect-webdriverio": "^4.5.1",
         "jasmine": "^5.0.0"
       },
       "devDependencies": {
@@ -30076,7 +30076,7 @@
         "@wdio/types": "8.21.0",
         "@wdio/utils": "8.22.0",
         "deepmerge-ts": "^5.0.0",
-        "expect-webdriverio": "^4.2.5",
+        "expect-webdriverio": "^4.5.1",
         "gaze": "^1.1.2",
         "webdriver": "8.22.1",
         "webdriverio": "8.22.1"

--- a/packages/wdio-browser-runner/package.json
+++ b/packages/wdio-browser-runner/package.json
@@ -44,7 +44,7 @@
     "@wdio/utils": "8.22.0",
     "ast-types": "^0.14.2",
     "deepmerge-ts": "^5.0.0",
-    "expect-webdriverio": "^4.2.5",
+    "expect-webdriverio": "^4.5.1",
     "fast-safe-stringify": "^2.1.1",
     "get-port": "^7.0.0",
     "import-meta-resolve": "^3.0.0",

--- a/packages/wdio-globals/package.json
+++ b/packages/wdio-globals/package.json
@@ -42,7 +42,7 @@
     "access": "public"
   },
   "optionalDependencies": {
-    "expect-webdriverio": "^4.2.5",
+    "expect-webdriverio": "^4.5.1",
     "webdriverio": "8.22.1"
   }
 }

--- a/packages/wdio-globals/src/index.ts
+++ b/packages/wdio-globals/src/index.ts
@@ -65,6 +65,34 @@ export const expect: ExpectWebdriverIO.Expect = ((...args: any) => {
     return globals.get('expect')(...args)
 }) as ExpectWebdriverIO.Expect
 
+const ASYNC_MATCHERS = [
+    'any',
+    'anything',
+    'arrayContaining',
+    'objectContaining',
+    'stringContaining',
+    'stringMatching',
+] as const
+
+for (const matcher of ASYNC_MATCHERS) {
+    expect[matcher] = (...args: any) => {
+        if (!globals.has('expect')) {
+            throw new Error(GLOBALS_ERROR_MESSAGE)
+        }
+        return globals.get('expect')[matcher](...args)
+    }
+}
+
+expect.not = ASYNC_MATCHERS.reduce((acc, matcher) => {
+    acc[matcher] = (...args: any) => {
+        if (!globals.has('expect')) {
+            throw new Error(GLOBALS_ERROR_MESSAGE)
+        }
+        return globals.get('expect').not[matcher](...args)
+    }
+    return acc
+}, {} as ExpectWebdriverIO.AsymmetricMatchers)
+
 expect.extend = (...args: unknown[]) => {
     if (!globals.has('expect')) {
         throw new Error(GLOBALS_ERROR_MESSAGE)

--- a/packages/wdio-jasmine-framework/package.json
+++ b/packages/wdio-jasmine-framework/package.json
@@ -37,7 +37,7 @@
     "@wdio/logger": "8.16.17",
     "@wdio/types": "8.21.0",
     "@wdio/utils": "8.22.0",
-    "expect-webdriverio": "^4.2.5",
+    "expect-webdriverio": "^4.5.1",
     "jasmine": "^5.0.0"
   },
   "devDependencies": {

--- a/packages/wdio-runner/package.json
+++ b/packages/wdio-runner/package.json
@@ -36,7 +36,7 @@
     "@wdio/types": "8.21.0",
     "@wdio/utils": "8.22.0",
     "deepmerge-ts": "^5.0.0",
-    "expect-webdriverio": "^4.2.5",
+    "expect-webdriverio": "^4.5.1",
     "gaze": "^1.1.2",
     "webdriver": "8.22.1",
     "webdriverio": "8.22.1"

--- a/tests/mocha/test.ts
+++ b/tests/mocha/test.ts
@@ -17,6 +17,17 @@ describe('Mocha smoke test', () => {
         await expect(browser).toHaveTitle('Mock Page Title')
     })
 
+    it('should allow to use asymmetric matchers', async () => {
+        await expect(browser).toHaveTitle(
+            expect.stringContaining('Page'))
+        await expect(browser).toHaveTitle(
+            expect.not.stringContaining('foobar'))
+        await expect(browser).toHaveUrl(
+            expect.stringContaining('mymockpage'))
+        await expect(browser).toHaveUrl(
+            expect.not.stringContaining('mymock_page.'))
+    })
+
     it('has a testrunner config object', () => {
         const opts = browser.options as Options.Testrunner
         expect(Array.isArray(opts.services)).toBe(true)


### PR DESCRIPTION
## Proposed changes

This patch updates to latest `expect-webdriverio` which comes with support for asymmetric matchers like:

```ts
await expect(browser).toHaveTitle(
  expect.stringContaining('foobar'))
```

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
