### PR TITLE
(webdriver): retry on post requests

### DIFF
--- a/e2e/vitest.config.ts
+++ b/e2e/vitest.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'vite'
 
 export default defineConfig({
     test: {
-        testTimeout: 1000 * 60 * 3,
+        testTimeout: 1000 * 60 * 5,
         include: ['./e2e/**/*.test.ts'],
         hookTimeout: 60 * 1000,
         threads: false

--- a/packages/wdio-types/src/Options.ts
+++ b/packages/wdio-types/src/Options.ts
@@ -10,15 +10,17 @@ export type WebDriverLogTypes = 'trace' | 'debug' | 'info' | 'warn' | 'error' | 
 export type SupportedProtocols = 'webdriver' | 'devtools' | './protocol-stub.js'
 export type Agents = { http?: any, https?: any }
 
+export type Method = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'HEAD' | 'DELETE' | 'OPTIONS' | 'TRACE' | 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete' | 'options' | 'trace'
+
 export interface RequestLibOptions {
     agent?: Agents
     followRedirect?: boolean
     headers?: Record<string, string | string[] | undefined>
     https?: Record<string, unknown>
     json?: Record<string, unknown>
-    method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'HEAD' | 'DELETE' | 'OPTIONS' | 'TRACE' | 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete' | 'options' | 'trace'
+    method?: Method
     responseType?: 'json' | 'buffer' | 'text'
-    retry?: { limit: number }
+    retry?: { limit: number, methods: Method[] }
     searchParams?: Record<string, string | number | boolean | null | undefined> | URLSearchParams
     throwHttpErrors?: boolean
     timeout?: { response: number }

--- a/packages/wdio-types/src/Options.ts
+++ b/packages/wdio-types/src/Options.ts
@@ -20,7 +20,7 @@ export interface RequestLibOptions {
     json?: Record<string, unknown>
     method?: Method
     responseType?: 'json' | 'buffer' | 'text'
-    retry?: { limit: number, methods: Method[] }
+    retry?: { limit: number, methods: Method[], calculateDelay: (retryOptions: { computedValue: number }) => number }
     searchParams?: Record<string, string | number | boolean | null | undefined> | URLSearchParams
     throwHttpErrors?: boolean
     timeout?: { response: number }

--- a/packages/wdio-webdriver-mock-service/src/index.ts
+++ b/packages/wdio-webdriver-mock-service/src/index.ts
@@ -128,28 +128,28 @@ export default class WebdriverMockService implements Services.ServiceInstance {
         const elemResponse = { [ELEM_PROP]: ELEMENT_ID }
         const elem2Response = { [ELEM_PROP]: ELEMENT_REFETCHED }
 
-        //Found initially
+        // Found initially
         this._mock.command.findElement().once().reply(200, { value: elemResponse })
-        //Initiate refetch, but its not ready
+        // Initiate refetch, but its not ready
         this._mock.command.findElement().once().reply(404, NO_SUCH_ELEMENT)
-        //Always return the new element after
+        // Always return the new element after
         this._mock.command.findElement().times(4).reply(200, { value: elem2Response })
 
-        //First click works
+        // First click works
         this._mock.command.elementClick(ELEMENT_ID).once().reply(200, { value: null })
-        //Additional clicks won't for the original element
-        this._mock.command.elementClick(ELEMENT_ID).times(4).reply(500, {
+        // Additional clicks won't for the original element
+        this._mock.command.elementClick(ELEMENT_ID).times(8).reply(500, {
             value: {
                 error: 'stale element reference',
                 message: 'element is not attached to the page document'
             }
         })
-        //Clicks on the new element are successful
+        // Clicks on the new element are successful
         this._mock.command.elementClick(ELEMENT_REFETCHED).times(4).reply(200, { value: null })
 
-        //Wait for it to exist - but 2 failed iterations
+        // Wait for it to exist - but 2 failed iterations
         this._mock.command.findElements().times(2).reply(200, { value: [] })
-        //Always appears thereafter
+        // Always appears thereafter
         this._mock.command.findElements().times(4).reply(200, { value: [elem2Response] })
     }
 

--- a/packages/webdriver/src/request/index.ts
+++ b/packages/webdriver/src/request/index.ts
@@ -18,6 +18,16 @@ type RequestLibOptions = Options.RequestLibOptions
 type RequestLibResponse = Options.RequestLibResponse
 type RequestOptions = Omit<Options.WebDriver, 'capabilities'>
 
+const RETRY_METHODS = [
+    'GET',
+    'POST',
+    'PUT',
+    'HEAD',
+    'DELETE',
+    'OPTIONS',
+    'TRACE'
+] as Options.Method[]
+
 export class RequestLibError extends Error {
     statusCode?: number
     body?: any
@@ -99,7 +109,10 @@ export default abstract class WebDriverRequest extends EventEmitter {
                 ...(typeof options.headers === 'object' ? options.headers : {})
             },
             searchParams,
-            retry: { limit: options.connectionRetryCount! },
+            retry: {
+                limit: options.connectionRetryCount as number,
+                methods: RETRY_METHODS
+            },
             timeout: { response: options.connectionRetryTimeout as number }
         }
 

--- a/packages/webdriver/src/request/index.ts
+++ b/packages/webdriver/src/request/index.ts
@@ -51,6 +51,7 @@ export interface WebDriverResponse {
     sessionId?: string
 }
 
+const ONE_SECOND = 1000 * 1
 const DEFAULT_HEADERS = {
     'Content-Type': 'application/json; charset=utf-8',
     'Connection': 'keep-alive',
@@ -111,7 +112,8 @@ export default abstract class WebDriverRequest extends EventEmitter {
             searchParams,
             retry: {
                 limit: options.connectionRetryCount as number,
-                methods: RETRY_METHODS
+                methods: RETRY_METHODS,
+                calculateDelay: ({ computedValue }) => Math.min(ONE_SECOND, computedValue / 10)
             },
             timeout: { response: options.connectionRetryTimeout as number }
         }

--- a/tests/helpers/config.js
+++ b/tests/helpers/config.js
@@ -23,7 +23,7 @@ export const config = {
 
     mochaOpts: {
         ui: 'bdd',
-        timeout: 10000,
+        timeout: 60000,
         grep: 'SKIPPED_GREP',
         invert: true
     },


### PR DESCRIPTION
## Proposed changes

We have experienced a lot of errors in our test pipeline from our e2e Windows tests where establishing an Edge session failed due to `ECONNREFUSED`. This could be caused by Edgedriver not being ready for requests at the point of calling `newSession`. I looked into our retry mechanism which should catch this and turns out we don't do retries on `POST` requests since `got` doesn't do this by default.

I updated the `methods` option for retries to include post requests since they are used a lot in the WebDriver protocol.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
