### PR TITLE
re-register devtools when switching windows

### DIFF
--- a/packages/wdio-devtools-service/tests/service.test.ts
+++ b/packages/wdio-devtools-service/tests/service.test.ts
@@ -72,7 +72,8 @@ beforeEach(() => {
         sessionId: vi.fn(),
         getPuppeteer: vi.fn(() => puppeteer.connect({})),
         addCommand: vi.fn(),
-        emit: vi.fn()
+        emit: vi.fn(),
+        getUrl: vi.fn()
     } as any
 
     multiBrowser = {
@@ -82,7 +83,8 @@ beforeEach(() => {
                 sessionId: vi.fn(),
                 getPuppeteer: vi.fn(() => puppeteer.connect({})),
                 addCommand: vi.fn(),
-                emit: vi.fn()
+                emit: vi.fn(),
+                getUrl: vi.fn()
             }
         },
         addCommand: vi.fn(),
@@ -141,6 +143,17 @@ test('afterCommand', async () => {
 
     // @ts-ignore test without paramater
     service.afterCommand()
+    expect(service['_command'][0]._afterCmd).toBeCalledTimes(1)
+})
+
+test('afterCommand: switchToWindow', async () => {
+    const service = new DevToolsService({})
+    service['_browser'] = browser
+    await service._setupHandler()
+
+    service._setupHandler = vi.fn()
+    await service.afterCommand('switchToWindow')
+    expect(service._setupHandler).toBeCalledTimes(1)
     expect(service['_command'][0]._afterCmd).toBeCalledTimes(1)
 })
 


### PR DESCRIPTION
## Proposed changes

Reset devtools service when a user switches windows. This is done by comparing the url.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

This is a fix for [6627](https://github.com/webdriverio/webdriverio/issues/6627), except done with webdriver protocol (in the issue, it is using devtools protocol). 

I also see [7683](https://github.com/webdriverio/webdriverio/issues/7683) being linked in [6627](https://github.com/webdriverio/webdriverio/issues/6627) thread. The fix for this one is different from this PR and has to be done inside the devtools package. I decide not to do it because I see that devtools package will be removed in the near future.

### Reviewers: @webdriverio/project-committers
