### PR TITLE
(webdriverio): clean up remaining ElementArray artifacts

### DIFF
--- a/packages/webdriverio/src/commands/browser/$$.ts
+++ b/packages/webdriverio/src/commands/browser/$$.ts
@@ -1,8 +1,8 @@
 import type { ElementReference } from '@wdio/protocols'
 
-import { findElements, enhanceElementsArray, isElement, findElement } from '../../utils/index.js'
+import { findElements, isElement, findElement } from '../../utils/index.js'
 import { getElements } from '../../utils/getElementObject.js'
-import type { Selector, ElementArray } from '../../types.js'
+import type { Selector } from '../../types.js'
 
 /**
  * The `$$` command is a short and handy way in order to fetch multiple elements on the page.
@@ -36,7 +36,7 @@ import type { Selector, ElementArray } from '../../types.js'
  *
  * @alias $$
  * @param {String|Function} selector  selector or JS Function to fetch multiple elements
- * @return {ElementArray}
+ * @return {WebdriverIO.Element[]}
  * @example https://github.com/webdriverio/example-recipes/blob/59c122c809d44d343c231bde2af7e8456c8f086c/queryElements/example.html
  * @example https://github.com/webdriverio/example-recipes/blob/59c122c809d44d343c231bde2af7e8456c8f086c/queryElements/multipleElements.js#L6-L7
  * @example https://github.com/webdriverio/example-recipes/blob/59c122c809d44d343c231bde2af7e8456c8f086c/queryElements/multipleElements.js#L15-L24
@@ -62,6 +62,5 @@ export async function $$ (
         }
     }
 
-    const elements = await getElements.call(this, selector as Selector, res)
-    return enhanceElementsArray(elements, this, selector as Selector) as ElementArray
+    return getElements.call(this, selector as Selector, res)
 }

--- a/packages/webdriverio/src/commands/browser/custom$$.ts
+++ b/packages/webdriverio/src/commands/browser/custom$$.ts
@@ -1,7 +1,6 @@
-import { enhanceElementsArray } from '../../utils/index.js'
 import { getElements } from '../../utils/getElementObject.js'
 import { ELEMENT_KEY } from '../../constants.js'
-import type { ElementArray, CustomStrategyFunction, CustomStrategyReference } from '../../types.js'
+import type { CustomStrategyFunction, CustomStrategyReference } from '../../types.js'
 
 /**
  *
@@ -25,13 +24,13 @@ import type { ElementArray, CustomStrategyFunction, CustomStrategyReference } fr
  * @alias custom$$
  * @param {string} strategyName
  * @param {*} strategyArguments
- * @return {ElementArray}
+ * @return {WebdriverIO.Element[]}
  */
 export async function custom$$ (
     this: WebdriverIO.Browser,
     strategyName: string,
     ...strategyArguments: any[]
-): Promise<ElementArray> {
+): Promise<WebdriverIO.Element[]> {
     const strategy = this.strategies.get(strategyName) as CustomStrategyFunction
 
     if (!strategy) {
@@ -52,6 +51,5 @@ export async function custom$$ (
 
     res = res.filter(el => !!el && typeof el[ELEMENT_KEY] === 'string')
 
-    const elements = res.length ? await getElements.call(this, strategyRef, res) : [] as any as ElementArray
-    return enhanceElementsArray(elements, this, strategyName, 'custom$$', strategyArguments)
+    return res.length ? await getElements.call(this, strategyRef, res) : []
 }

--- a/packages/webdriverio/src/commands/browser/react$$.ts
+++ b/packages/webdriverio/src/commands/browser/react$$.ts
@@ -4,10 +4,9 @@ import url from 'node:url'
 import { resolve } from 'import-meta-resolve'
 import type { ElementReference } from '@wdio/protocols'
 
-import { enhanceElementsArray } from '../../utils/index.js'
 import { getElements } from '../../utils/getElementObject.js'
 import { waitToLoadReact, react$$ as react$$Script } from '../../scripts/resq.js'
-import type { ReactSelectorOptions, ElementArray } from '../../types.js'
+import type { ReactSelectorOptions } from '../../types.js'
 
 let resqScript: string
 
@@ -41,7 +40,7 @@ let resqScript: string
  * @param {ReactSelectorOptions=}                    options         React selector options
  * @param {Object=}                                  options.props   React props the element should contain
  * @param {Array<any>|number|string|object|boolean=} options.state  React state the element should be in
- * @return {ElementArray}
+ * @return {WebdriverIO.Element[]}
  *
  */
 export async function react$$ (
@@ -60,6 +59,5 @@ export async function react$$ (
         react$$Script as any, selector, props, state
     ) as ElementReference[]
 
-    const elements: ElementArray = await getElements.call(this, selector, res, { isReactElement: true })
-    return enhanceElementsArray(elements, this, selector, 'react$$', [props, state])
+    return getElements.call(this, selector, res, { isReactElement: true })
 }

--- a/packages/webdriverio/src/commands/element/$$.ts
+++ b/packages/webdriverio/src/commands/element/$$.ts
@@ -33,7 +33,7 @@
  *
  * @alias $$
  * @param {String|Function|Matcher} selector  selector, JS Function, or Matcher object to fetch multiple elements
- * @return {ElementArray}
+ * @return {WebdriverIO.Element[]}
  * @example https://github.com/webdriverio/example-recipes/blob/59c122c809d44d343c231bde2af7e8456c8f086c/queryElements/example.html
  * @example https://github.com/webdriverio/example-recipes/blob/59c122c809d44d343c231bde2af7e8456c8f086c/queryElements/multipleElements.js#L6-L7
  * @example https://github.com/webdriverio/example-recipes/blob/59c122c809d44d343c231bde2af7e8456c8f086c/queryElements/multipleElements.js#L15-L24

--- a/packages/webdriverio/src/commands/element/custom$$.ts
+++ b/packages/webdriverio/src/commands/element/custom$$.ts
@@ -1,7 +1,7 @@
 import { getElements } from '../../utils/getElementObject.js'
-import { getBrowserObject, enhanceElementsArray } from '../../utils/index.js'
+import { getBrowserObject } from '../../utils/index.js'
 import { ELEMENT_KEY } from '../../constants.js'
-import type { ElementArray, CustomStrategyFunction } from '../../types.js'
+import type { CustomStrategyFunction } from '../../types.js'
 
 /**
  *
@@ -26,13 +26,13 @@ import type { ElementArray, CustomStrategyFunction } from '../../types.js'
  * @alias custom$$
  * @param {string} strategyName
  * @param {*} strategyArguments
- * @return {ElementArray}
+ * @return {WebdriverIO.Element[]}
  */
 export async function custom$$ (
     this: WebdriverIO.Element,
     strategyName: string,
     ...strategyArguments: any[]
-): Promise<ElementArray> {
+): Promise<WebdriverIO.Element[]> {
     const browserObject = getBrowserObject(this)
     const strategy = browserObject.strategies.get(strategyName) as CustomStrategyFunction
 
@@ -64,6 +64,5 @@ export async function custom$$ (
 
     res = res.filter((el) => !!el && typeof el[ELEMENT_KEY] === 'string')
 
-    const elements = res.length ? await getElements.call(this, strategyRef, res) : [] as any as ElementArray
-    return enhanceElementsArray(elements, this, strategyName, 'custom$$', strategyArguments)
+    return res.length ? await getElements.call(this, strategyRef, res) : []
 }

--- a/packages/webdriverio/src/commands/element/react$$.ts
+++ b/packages/webdriverio/src/commands/element/react$$.ts
@@ -4,7 +4,7 @@ import url from 'node:url'
 import { resolve } from 'import-meta-resolve'
 import type { ElementReference } from '@wdio/protocols'
 
-import { enhanceElementsArray, getBrowserObject } from '../../utils/index.js'
+import { getBrowserObject } from '../../utils/index.js'
 import { getElements } from '../../utils/getElementObject.js'
 import { waitToLoadReact, react$$ as react$$Script } from '../../scripts/resq.js'
 import type { ReactSelectorOptions } from '../../types.js'
@@ -41,14 +41,14 @@ let resqScript: string
  * @param {ReactSelectorOptions=}                    options         React selector options
  * @param {Object=}                                  options.props   React props the element should contain
  * @param {Array<any>|number|string|object|boolean=} options.state  React state the element should be in
- * @return {ElementArray}
+ * @return {WebdriverIO.Element[]}
  *
  */
 export async function react$$(
     this: WebdriverIO.Element,
     selector: string,
     { props = {}, state = {} }: ReactSelectorOptions = {}
-) {
+): Promise<WebdriverIO.Element[]> {
     if (!resqScript) {
         const resqScriptPath = url.fileURLToPath(await resolve('resq', import.meta.url))
         resqScript = (await fs.readFile(resqScriptPath)).toString()
@@ -61,6 +61,5 @@ export async function react$$(
         react$$Script as any, selector, props, state, this
     ) as ElementReference[]
 
-    const elements = await getElements.call(this, selector, res, { isReactElement: true })
-    return enhanceElementsArray(elements, this, selector, 'react$$', [props, state])
+    return getElements.call(this, selector, res, { isReactElement: true })
 }

--- a/packages/webdriverio/src/commands/element/shadow$$.ts
+++ b/packages/webdriverio/src/commands/element/shadow$$.ts
@@ -2,10 +2,10 @@ import logger from '@wdio/logger'
 
 import { shadowFnFactory } from '../../scripts/shadowFnFactory.js'
 import { getElements } from '../../utils/getElementObject.js'
-import { getBrowserObject, enhanceElementsArray } from '../../utils/index.js'
+import { getBrowserObject } from '../../utils/index.js'
 import { findStrategy } from '../../utils/findStrategy.js'
 import { SHADOW_ELEMENT_KEY } from '../../constants.js'
-import type { Selector, ElementArray } from '../../types.js'
+import type { Selector } from '../../types.js'
 
 const log = logger('webdriverio')
 
@@ -25,22 +25,21 @@ const log = logger('webdriverio')
  *
  * @alias element.shadow$$
  * @param {String|Function} selector  selector or JS Function to fetch a certain element
- * @return {ElementArray}
+ * @return {WebdriverIO.Element[]}
  * @type utility
  *
  */
 export async function shadow$$ (
     this: WebdriverIO.Element,
     selector: string
-) {
+): Promise<WebdriverIO.Element[]> {
     const browser = getBrowserObject(this)
 
     try {
         const shadowRoot = await browser.getElementShadowRoot(this.elementId)
         const { using, value } = findStrategy(selector as string, this.isW3C, this.isMobile)
         const res = await browser.findElementsFromShadowRoot(shadowRoot[SHADOW_ELEMENT_KEY], using, value)
-        const elements = await getElements.call(this, selector as Selector, res, { isShadowElement: true })
-        return enhanceElementsArray(elements, this, selector as Selector) as ElementArray
+        return await getElements.call(this, selector as Selector, res, { isShadowElement: true })
     } catch (err: unknown) {
         log.warn(
             `Failed to fetch element within shadow DOM using WebDriver command: ${(err as Error).message}!\n` +

--- a/packages/webdriverio/src/types.ts
+++ b/packages/webdriverio/src/types.ts
@@ -126,13 +126,6 @@ export type MultiRemoteProtocolCommandsType = {
     [K in keyof ProtocolCommands]: (...args: Parameters<ProtocolCommands[K]>) => Promise<ThenArg<ReturnType<ProtocolCommands[K]>>[]>
 }
 
-export interface ElementArray extends Array<WebdriverIO.Element> {
-    selector: Selector
-    parent: WebdriverIO.Element | WebdriverIO.Browser | WebdriverIO.MultiRemoteBrowser
-    foundWith: string
-    props: any[]
-}
-
 type AddCommandFnScoped<
     InstanceType = Browser,
     IsElement extends boolean = false

--- a/packages/webdriverio/src/utils/getElementObject.ts
+++ b/packages/webdriverio/src/utils/getElementObject.ts
@@ -6,7 +6,7 @@ import { getBrowserObject, getPrototype as getWDIOPrototype, getElementFromRespo
 import { elementErrorHandler } from '../middlewares.js'
 import { ELEMENT_KEY } from '../constants.js'
 import * as browserCommands from '../commands/browser.js'
-import type { Selector, ElementArray } from '../types.js'
+import type { Selector } from '../types.js'
 
 interface GetElementProps {
     isReactElement?: boolean
@@ -113,7 +113,7 @@ export const getElements = function getElements(
     selector: Selector | ElementReference[] | WebdriverIO.Element[],
     elemResponse: (ElementReference | Error | WebDriverError)[],
     props: GetElementProps = { isReactElement: false, isShadowElement: false }
-): ElementArray {
+): WebdriverIO.Element[] {
     const browser = getBrowserObject(this as WebdriverIO.Element)
     const browserCommandKeys = Object.keys(browserCommands)
     const propertiesObject = {
@@ -179,5 +179,5 @@ export const getElements = function getElements(
         return elementInstance
     })
 
-    return elements as ElementArray
+    return elements
 }

--- a/packages/webdriverio/src/utils/index.ts
+++ b/packages/webdriverio/src/utils/index.ts
@@ -15,7 +15,7 @@ import * as elementCommands from '../commands/element.js'
 import querySelectorAllDeep from './thirdParty/querySelectorShadowDom.js'
 import { ELEMENT_KEY, DEEP_SELECTOR, Key } from '../constants.js'
 import { findStrategy } from './findStrategy.js'
-import type { ElementArray, ElementFunction, Selector, ParsedCSSValue, CustomLocatorReturnValue } from '../types.js'
+import type { ElementFunction, Selector, ParsedCSSValue, CustomLocatorReturnValue } from '../types.js'
 import type { CustomStrategyReference } from '../types.js'
 
 const log = logger('webdriverio')
@@ -491,36 +491,6 @@ export function addLocatorStrategyHandler(scope: WebdriverIO.Browser | Webdriver
 
         scope.strategies.set(name, func)
     }
-}
-
-/**
- * Enhance elements array with data required to refetch it
- * @param   {object[]}          elements    elements
- * @param   {object}            parent      element or browser
- * @param   {string|Function}   selector    string or function, or strategy name for `custom$$`
- * @param   {string}            foundWith   name of the command elements were found with, ex `$$`, `react$$`, etc
- * @param   {Array}             props       additional properties required to fetch elements again
- * @returns {object[]}  elements
- */
-export const enhanceElementsArray = (
-    elements: ElementArray,
-    parent: WebdriverIO.Browser | WebdriverIO.Element,
-    selector: Selector | ElementReference[] | WebdriverIO.Element[],
-    foundWith = '$$',
-    props: any[] = []
-) => {
-    /**
-     * if we have an element collection, e.g. `const elems = $$([elemA, elemB])`
-     * we cna't assign a common selector to the element array
-     */
-    if (!Array.isArray(selector)) {
-        elements.selector = selector
-    }
-
-    elements.parent = parent
-    elements.foundWith = foundWith
-    elements.props = props
-    return elements
 }
 
 /**

--- a/packages/webdriverio/tests/commands/browser/$$.test.ts
+++ b/packages/webdriverio/tests/commands/browser/$$.test.ts
@@ -43,10 +43,6 @@ describe('elements', () => {
         expect(elems[2].selector).toBe('.foo')
         expect(elems[2].index).toBe(2)
         expect(elems[2].constructor.name).toBe('Element')
-
-        expect(elems.parent).toBe(browser)
-        expect(elems.selector).toBe('.foo')
-        expect(elems.foundWith).toBe('$$')
     })
 
     it('should fetch elements (no w3c)', async () => {

--- a/packages/webdriverio/tests/commands/browser/customSelectors.test.ts
+++ b/packages/webdriverio/tests/commands/browser/customSelectors.test.ts
@@ -27,7 +27,6 @@ describe('custom$', () => {
         const elems = await browser.custom$$('test', '.test')
 
         expect(elems).toHaveLength(2)
-        expect(typeof elems.selector).toBe('string')
         expect(typeof elems[0].selector).toBe('object')
         expect(typeof (elems[0].selector as any as CustomStrategyReference).strategy).toBe('function')
         expect((elems[0].selector as CustomStrategyReference).strategyName).toBe('test')
@@ -35,9 +34,6 @@ describe('custom$', () => {
         expect((elems[0].selector as CustomStrategyReference).strategyArguments[0]).toBe('.test')
         expect(elems[0].elementId).toBe('.test-foobar')
         expect(elems[1].elementId).toBe('.test-other-foobar')
-        expect(elems.foundWith).toBe('custom$$')
-        expect(elems.selector).toBe('test')
-        expect(elems.props).toEqual(['.test'])
     })
 
     it('should error if no strategy found', async () => {

--- a/packages/webdriverio/tests/commands/browser/reactElements.test.ts
+++ b/packages/webdriverio/tests/commands/browser/reactElements.test.ts
@@ -66,8 +66,6 @@ describe('react$', () => {
 
         const elems = await browser.react$$('myComp')
 
-        expect(elems.filter((elem: WebdriverIO.Element) => elem.isReactElement
-        ).length).toBe(3)
-        expect(elems.foundWith).toBe('react$$')
+        expect(elems.filter((elem: WebdriverIO.Element) => elem.isReactElement).length).toBe(3)
     })
 })

--- a/packages/webdriverio/tests/commands/element/customSelectors.test.ts
+++ b/packages/webdriverio/tests/commands/element/customSelectors.test.ts
@@ -28,7 +28,6 @@ describe('custom$', () => {
         const elems = await elem.custom$$('test', '.test')
 
         expect(elems).toHaveLength(2)
-        expect(typeof elems.selector).toBe('string')
         expect(typeof elems[0].selector).toBe('object')
         expect(typeof (elems[0].selector as CustomStrategyReference).strategy).toBe('function')
         expect((elems[0].selector as CustomStrategyReference).strategyName).toBe('test')
@@ -37,9 +36,6 @@ describe('custom$', () => {
         expect((elems[0].selector as CustomStrategyReference).strategyArguments[1]).toBe(elem)
         expect(elems[0].elementId).toBe('.test-some-elem-123')
         expect(elems[1].elementId).toBe('.test-other-some-elem-123')
-        expect(elems.foundWith).toBe('custom$$')
-        expect(elems.selector).toBe('test')
-        expect(elems.props).toEqual(['.test'])
     })
 
     it('should error if no strategy found', async () => {

--- a/packages/webdriverio/tests/commands/element/reactElements.test.ts
+++ b/packages/webdriverio/tests/commands/element/reactElements.test.ts
@@ -70,8 +70,6 @@ describe('elem.react$', () => {
         })
 
         const elems = await browser.react$$('myComp')
-
         expect(elems.filter(elem => elem.isReactElement).length).toBe(3)
-        expect(elems.foundWith).toBe('react$$')
     })
 })

--- a/packages/webdriverio/tests/utils/getElementObject.test.ts
+++ b/packages/webdriverio/tests/utils/getElementObject.test.ts
@@ -59,11 +59,9 @@ vi.mock('../../src/utils/getElementObject.js', async () => {
 })
 
 describe('getElements', () => {
-
     let browser: WebdriverIO.Browser
 
     beforeEach(async () => {
-
         browser = await remote({
             baseUrl: 'http://foobar.com',
             capabilities: {
@@ -73,7 +71,6 @@ describe('getElements', () => {
 
         vi.mocked(getElem.getElement).mockClear()
         vi.mocked(getElem.getElements).mockClear()
-
         vi.mocked(getElem.getElements).mockImplementation(
             (elem, _res, props) => origGetElem
                 .getElements
@@ -82,7 +79,6 @@ describe('getElements', () => {
     })
 
     it('should deal with a W3C spec error response', async () => {
-
         const error = new Error()
         Object.assign(error, {
             name: ErrorExamplesW3C.chrome.error,
@@ -91,13 +87,8 @@ describe('getElements', () => {
         })
 
         const elems = await browser.$$('#foo')
-        const [elem] = elems
-
-        expect(elems.foundWith).toBe('$$')
-
         expect(elems).toHaveLength(1)
-
-        expect(elem.error).toBeInstanceOf(Error)
-        expect(elem).toEqual(expect.objectContaining({ error }))
+        expect(elems[0].error).toBeInstanceOf(Error)
+        expect(elems[0]).toEqual(expect.objectContaining({ error }))
     })
 })

--- a/tests/typings/webdriverio/async.ts
+++ b/tests/typings/webdriverio/async.ts
@@ -324,13 +324,6 @@ async function bar() {
     const elem1 = await $('')
     elem1.setValue('Delete')
 
-    const selector$$: string | HTMLElement | Function | Record<'element-6066-11e4-a52e-4f735466cecf', string> | {strategy: Function; strategyName: string; strategyArguments: any[]} = elems.selector
-    ;(elems.parent as WebdriverIO.Element).click()
-    ;(elems.parent as WebdriverIO.Browser).url('')
-    ;(elems.parent as WebdriverIO.MultiRemoteBrowser).url('')
-    // @ts-expect-error
-    ;(elems.parent as WebdriverIO.Browser).click()
-
     // test access to base client properties
     expectType<string>(browser.sessionId)
     expectType<string>((browser.capabilities as WebdriverIO.Capabilities).browserName)

--- a/tests/typings/webdriverio/async.ts
+++ b/tests/typings/webdriverio/async.ts
@@ -67,10 +67,6 @@ async function bar() {
 
     // instances array
     expectType<string[]>(mr.instances)
-
-    const elements = await browser.$$('foo')
-    expectType<string>(elements.foundWith)
-
     ////////////////////////////////////////////////////////////////////////////////
 
     // remote

--- a/tests/typings/webdriverio/async.ts
+++ b/tests/typings/webdriverio/async.ts
@@ -4,7 +4,7 @@ import allure from '@wdio/allure-reporter'
 import { remote, multiremote, SevereServiceError } from 'webdriverio'
 import type { DetailedContext } from '@wdio/protocols'
 import type { MockOverwriteFunction } from '../../../packages/webdriverio/src/utils/interception/types.ts'
-import type { ClickOptions, TouchAction, Selector, Action, ElementArray } from '../../../packages/webdriverio/build/types'
+import type { ClickOptions, TouchAction, Selector, Action } from '../../../packages/webdriverio/build/types'
 import { Key } from 'webdriverio'
 
 declare global {
@@ -83,7 +83,7 @@ async function bar() {
     const elemA = await remoteBrowser.$('')
     const elemB = await remoteBrowser.$('')
     const multipleElems = await $$([elemA, elemB])
-    expectType<ElementArray>(multipleElems)
+    expectType<WebdriverIO.Element[]>(multipleElems)
 
     ////////////////////////////////////////////////////////////////////////////////
 
@@ -150,7 +150,7 @@ async function bar() {
         }
         return elems
     })
-    expectType<ElementArray>(waitUntilElems)
+    expectType<WebdriverIO.Element[]>(waitUntilElems)
 
     await browser.getCookies()
     await browser.getCookies('foobar')
@@ -506,10 +506,6 @@ async function bar() {
             return browser.call(async () => {}).then(() => acc)
         }, {} as Random)
     )
-
-    const elemArrayTest: ElementArray = {} as any
-    expectType<string>(elemArrayTest.foundWith)
-    expectType<WebdriverIO.Element>(elemArrayTest[123])
 }
 
 function testSevereServiceError_noParameters() {

--- a/tests/typings/webdriverio/globalImport.ts
+++ b/tests/typings/webdriverio/globalImport.ts
@@ -9,7 +9,7 @@ import { fn, spyOn, mock, unmock, mocked } from '@wdio/browser-runner'
     expectType<string>(label)
 
     const elems = await $$('foo')
-    expectType<string>(elems.foundWith)
+    expectType<WebdriverIO.Element[]>(elems)
     const tagNames = await $$('foo').map((el) => el.getTagName())
     expectType<string[]>(tagNames)
 


### PR DESCRIPTION
## Proposed changes

We recently cleaned up `WebdriverIO.ElementArray` from the public interface and should now also remove all internal usage of it. This type was never really useful at all.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
