### PR TITLE
(webdriver): set lower retry timeout

### DIFF
--- a/packages/webdriver/src/request/index.ts
+++ b/packages/webdriver/src/request/index.ts
@@ -51,7 +51,7 @@ export interface WebDriverResponse {
     sessionId?: string
 }
 
-const ONE_SECOND = 1000 * 1
+const MAX_RETRY_TIMEOUT = 100 // 100ms
 const DEFAULT_HEADERS = {
     'Content-Type': 'application/json; charset=utf-8',
     'Connection': 'keep-alive',
@@ -113,7 +113,7 @@ export default abstract class WebDriverRequest extends EventEmitter {
             retry: {
                 limit: options.connectionRetryCount as number,
                 methods: RETRY_METHODS,
-                calculateDelay: ({ computedValue }) => Math.min(ONE_SECOND, computedValue / 10)
+                calculateDelay: ({ computedValue }) => Math.min(MAX_RETRY_TIMEOUT, computedValue / 10)
             },
             timeout: { response: options.connectionRetryTimeout as number }
         }


### PR DESCRIPTION
## Proposed changes

We experience timeouts in our build due to additional retries for `POST` requests. Let's lower that to 100ms.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
