### PR TITLE
fix: guard check for ShadowRoot using `'ShadowRoot' in window` (#11705)

### DIFF
--- a/packages/webdriverio/src/scripts/isElementDisplayed.ts
+++ b/packages/webdriverio/src/scripts/isElementDisplayed.ts
@@ -91,7 +91,7 @@ export default function isElementDisplayed (element: Element): boolean {
         // if document-fragment, skip it and use element.host instead. This happens
         // when the element is inside a shadow root.
         // window.getComputedStyle errors on document-fragment.
-        if (element instanceof window.ShadowRoot) {
+        if ('ShadowRoot' in window && element instanceof window.ShadowRoot) {
             element = element.host
         }
 


### PR DESCRIPTION
This PR appears to fix https://github.com/webdriverio/webdriverio/issues/11705

Although other issues affecting Firefox 55 and Internet Explorer 11 might still exist

## Proposed changes

In older browsers the right-hand operand `window.ShadowRoot` in `element instanceof window.ShadowRoot` isn’t callable and has no `prototype` so it throws the following error ([see MDN docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/invalid_right_hand_side_instanceof_operand))

```
TypeError: invalid 'instanceof' operand window.ShadowRoot
```

This tightens the fix from https://github.com/webdriverio/webdriverio/commit/410ea50258ebe1798ddb1d0a3bee1b26afe7dc1e added in:

* https://github.com/webdriverio/webdriverio/pull/9046

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
