### PR TITLE
fix: avoid script syntax to support IE11 again (#11711)

### DIFF
--- a/packages/webdriverio/src/scripts/isElementDisplayed.ts
+++ b/packages/webdriverio/src/scripts/isElementDisplayed.ts
@@ -205,7 +205,7 @@ export default function isElementDisplayed (element: Element): boolean {
     // This is a partial reimplementation of Selenium's "element is displayed" algorithm.
     // When the W3C specification's algorithm stabilizes, we should implement that.
     // If this command is misdirected to the wrong document (and is NOT inside a shadow root), treat it as not shown.
-    if (!isElementInsideShadowRoot(element) && !document.contains(element)) {
+    if (!isElementInsideShadowRoot(element) && !document.body.contains(element)) {
         return false
     }
 

--- a/packages/webdriverio/src/scripts/isElementDisplayed.ts
+++ b/packages/webdriverio/src/scripts/isElementDisplayed.ts
@@ -133,7 +133,7 @@ export default function isElementDisplayed (element: Element): boolean {
 
         // If the container's overflow is not hidden and it has zero size, consider the
         // container to have non-zero dimensions if a child node has non-zero dimensions.
-        return Array.from(element.childNodes).some((childNode: Element) => {
+        return Array.from(element.childNodes).some(function (childNode: Element) {
             if (childNode.nodeType === Node.TEXT_NODE) {
                 return true
             }
@@ -172,7 +172,7 @@ export default function isElementDisplayed (element: Element): boolean {
         }
 
         // This element's subtree is hidden by overflow if all child subtrees are as well.
-        return Array.from(element.childNodes).every((childNode: Element) => {
+        return Array.from(element.childNodes).every(function (childNode: Element) {
             // Returns true if the child node is overflowed or otherwise hidden.
             // Base case: not an element, has zero size, scrolled out, or doesn't overflow container.
             // Visibility of text nodes is controlled by parent
@@ -221,7 +221,9 @@ export default function isElementDisplayed (element: Element): boolean {
     case 'OPTGROUP':
     case 'OPTION': {
         // Option/optgroup are considered shown if the containing <select> is shown.
-        const enclosingSelectElement = enclosingNodeOrSelfMatchingPredicate(element, (e: Element) => e.tagName.toUpperCase() === 'SELECT')
+        const enclosingSelectElement = enclosingNodeOrSelfMatchingPredicate(element, function (e: Element) {
+            return e.tagName.toUpperCase() === 'SELECT'
+        })
         return isElementDisplayed(enclosingSelectElement as Element)
     }
     case 'INPUT':
@@ -241,10 +243,10 @@ export default function isElementDisplayed (element: Element): boolean {
         return false
     }
 
-    const hasAncestorWithZeroOpacity = !!enclosingElementOrSelfMatchingPredicate(element as HTMLElement, (e: Element) => {
+    const hasAncestorWithZeroOpacity = !!enclosingElementOrSelfMatchingPredicate(element as HTMLElement, function (e: Element) {
         return Number(cascadedStylePropertyForElement(e, 'opacity')) === 0
     })
-    const hasAncestorWithDisplayNone = !!enclosingElementOrSelfMatchingPredicate(element as HTMLElement, (e: Element) => {
+    const hasAncestorWithDisplayNone = !!enclosingElementOrSelfMatchingPredicate(element as HTMLElement, function (e: Element) {
         return cascadedStylePropertyForElement(e, 'display') === 'none'
     })
     if (hasAncestorWithZeroOpacity || hasAncestorWithDisplayNone) {

--- a/packages/webdriverio/src/scripts/resq.ts
+++ b/packages/webdriverio/src/scripts/resq.ts
@@ -69,7 +69,7 @@ export const react$$ = function react$$ (
     // [[div, div], [div, div]] => [div, div, div, div]
     let nodes: HTMLElement[] = []
 
-    elements.forEach(element => {
+    elements.forEach(function (element) {
         const { node, isFragment } = element
 
         if (isFragment) {

--- a/packages/webdriverio/src/scripts/resq.ts
+++ b/packages/webdriverio/src/scripts/resq.ts
@@ -70,12 +70,10 @@ export const react$$ = function react$$ (
     let nodes: HTMLElement[] = []
 
     elements.forEach(function (element) {
-        const { node, isFragment } = element
-
-        if (isFragment) {
-            nodes = nodes.concat(node || [])
-        } else if (node) {
-            nodes.push(node)
+        if (element.isFragment) {
+            nodes = nodes.concat(element.node || [])
+        } else if (element.node) {
+            nodes.push(element.node)
         }
     })
 


### PR DESCRIPTION
## Proposed changes

Attempts to fix https://github.com/webdriverio/webdriverio/issues/11711 so WebdriverIO v8 works with IE11

Avoids the following in browser scripts:

1. [Arrow functions](https://caniuse.com/arrow-functions) `=>`
2. [Destructuring assignment](https://caniuse.com/mdn-javascript_operators_destructuring) `const { that } = this`
3. Restricting [`.contains()`](https://caniuse.com/mdn-api_node_contains) to `HTMLElement` type

For 3) I've changed [`document` to `document.body`](https://github.com/webdriverio/webdriverio/pull/11712/commits/6cd6fee56939d17f87541bed3788fc61d245b1dc) which supports `.contains()` in IE11

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

It might help to lower TypeScript `"target": "es2022"` for **./packages/webdriverio/src/scripts** in future

Arrow functions can be downleveled automatically

### Reviewers: @webdriverio/project-committers
