### PR TITLE
(@wdio/runner): support assertion hooks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13655,9 +13655,9 @@
       }
     },
     "node_modules/expect-webdriverio": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/expect-webdriverio/-/expect-webdriverio-4.5.1.tgz",
-      "integrity": "sha512-fwcMpPV/+e0bS+F7+bC1UoQsZYjJTcbA1XhU4VVB2pEZDhNmeuaPrCanA0tLVP8nDya75oegXK7LgPzP3zZR9w==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/expect-webdriverio/-/expect-webdriverio-4.6.1.tgz",
+      "integrity": "sha512-w6ee91kN3BoxNGVKQheAqFpRGMehdDg7kDiErEk/oM7tbd/WUT4R4v9KYOUtjiaUFHWWCRW2FtcOOjcd0+1pvQ==",
       "dependencies": {
         "expect": "^29.7.0",
         "jest-matcher-utils": "^29.7.0",
@@ -13667,8 +13667,9 @@
         "node": ">=16 || >=18 || >=20"
       },
       "optionalDependencies": {
-        "@wdio/globals": "^8.22.1",
-        "webdriverio": "^8.22.1"
+        "@wdio/globals": "^8.23.1",
+        "@wdio/logger": "^8.16.17",
+        "webdriverio": "^8.23.1"
       }
     },
     "node_modules/exponential-backoff": {
@@ -29599,7 +29600,7 @@
         "@wdio/utils": "8.23.1",
         "ast-types": "^0.14.2",
         "deepmerge-ts": "^5.0.0",
-        "expect-webdriverio": "^4.5.1",
+        "expect-webdriverio": "^4.6.1",
         "fast-safe-stringify": "^2.1.1",
         "get-port": "^7.0.0",
         "import-meta-resolve": "^3.0.0",
@@ -29898,7 +29899,7 @@
         "node": "^16.13 || >=18"
       },
       "optionalDependencies": {
-        "expect-webdriverio": "^4.5.1",
+        "expect-webdriverio": "^4.6.1",
         "webdriverio": "8.23.5"
       }
     },
@@ -29912,7 +29913,7 @@
         "@wdio/logger": "8.16.17",
         "@wdio/types": "8.23.1",
         "@wdio/utils": "8.23.1",
-        "expect-webdriverio": "^4.5.1",
+        "expect-webdriverio": "^4.6.1",
         "jasmine": "^5.0.0"
       },
       "devDependencies": {
@@ -30086,7 +30087,7 @@
         "@wdio/types": "8.23.1",
         "@wdio/utils": "8.23.1",
         "deepmerge-ts": "^5.0.0",
-        "expect-webdriverio": "^4.5.1",
+        "expect-webdriverio": "^4.6.1",
         "gaze": "^1.1.2",
         "webdriver": "8.23.1",
         "webdriverio": "8.23.5"

--- a/packages/wdio-browser-runner/package.json
+++ b/packages/wdio-browser-runner/package.json
@@ -44,7 +44,7 @@
     "@wdio/utils": "8.23.1",
     "ast-types": "^0.14.2",
     "deepmerge-ts": "^5.0.0",
-    "expect-webdriverio": "^4.5.1",
+    "expect-webdriverio": "^4.6.1",
     "fast-safe-stringify": "^2.1.1",
     "get-port": "^7.0.0",
     "import-meta-resolve": "^3.0.0",

--- a/packages/wdio-cli/src/constants.ts
+++ b/packages/wdio-cli/src/constants.ts
@@ -948,5 +948,7 @@ export const TESTRUNNER_DEFAULTS: Options.Definition<Options.Testrunner> = {
     afterSession: HOOK_DEFINITION,
     after: HOOK_DEFINITION,
     onComplete: HOOK_DEFINITION,
-    onReload: HOOK_DEFINITION
+    onReload: HOOK_DEFINITION,
+    beforeAssertion: HOOK_DEFINITION,
+    afterAssertion: HOOK_DEFINITION
 }

--- a/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
+++ b/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
@@ -408,4 +408,16 @@ if (answers.isUsingTypeScript) {
     */
     // onReload: function(oldSessionId, newSessionId) {
     // }
+    /**
+    * Hook that gets executed before a WebdriverIO assertion happens.
+    * @param {object} params information about the assertion to be executed
+    */
+    // beforeAssertion: function(params) {
+    // }
+    /**
+    * Hook that gets executed after a WebdriverIO assertion happened.
+    * @param {object} params information about the assertion that was executed, including its results
+    */
+    // afterAssertion: function(params) {
+    // }
 }

--- a/packages/wdio-config/src/constants.ts
+++ b/packages/wdio-config/src/constants.ts
@@ -77,6 +77,8 @@ export const DEFAULT_CONFIGS: () => Omit<Options.Testrunner, 'capabilities'> = (
     after: [],
     onComplete: [],
     onReload: [],
+    beforeAssertion: [],
+    afterAssertion: [],
 
     /**
      * cucumber specific hooks
@@ -92,6 +94,7 @@ export const DEFAULT_CONFIGS: () => Omit<Options.Testrunner, 'capabilities'> = (
 export const SUPPORTED_HOOKS: (keyof Services.Hooks)[] = [
     'before', 'beforeSession', 'beforeSuite', 'beforeHook', 'beforeTest', 'beforeCommand',
     'afterCommand', 'afterTest', 'afterHook', 'afterSuite', 'afterSession', 'after',
+    'beforeAssertion', 'afterAssertion',
     // @ts-ignore not defined in core hooks but added with cucumber
     'beforeFeature', 'beforeScenario', 'beforeStep', 'afterStep', 'afterScenario', 'afterFeature',
     'onReload', 'onPrepare', 'onWorkerStart', 'onWorkerEnd', 'onComplete'

--- a/packages/wdio-globals/package.json
+++ b/packages/wdio-globals/package.json
@@ -42,7 +42,7 @@
     "access": "public"
   },
   "optionalDependencies": {
-    "expect-webdriverio": "^4.5.1",
+    "expect-webdriverio": "^4.6.1",
     "webdriverio": "8.23.5"
   }
 }

--- a/packages/wdio-jasmine-framework/package.json
+++ b/packages/wdio-jasmine-framework/package.json
@@ -37,7 +37,7 @@
     "@wdio/logger": "8.16.17",
     "@wdio/types": "8.23.1",
     "@wdio/utils": "8.23.1",
-    "expect-webdriverio": "^4.5.1",
+    "expect-webdriverio": "^4.6.1",
     "jasmine": "^5.0.0"
   },
   "devDependencies": {

--- a/packages/wdio-reporter/src/index.ts
+++ b/packages/wdio-reporter/src/index.ts
@@ -62,6 +62,8 @@ export default class WDIOReporter extends EventEmitter {
 
         this.on('client:beforeCommand', this.onBeforeCommand.bind(this))
         this.on('client:afterCommand', this.onAfterCommand.bind(this))
+        this.on('client:beforeAssertion', this.onBeforeAssertion.bind(this))
+        this.on('client:afterAssertion', this.onAfterAssertion.bind(this))
 
         this.on('runner:start', /* istanbul ignore next */ (runner: Options.RunnerStart) => {
             rootSuite.cid = runner.cid
@@ -249,6 +251,12 @@ export default class WDIOReporter extends EventEmitter {
     /* istanbul ignore next */
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     onAfterCommand(commandArgs: AfterCommandArgs) { }
+    /* istanbul ignore next */
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    onBeforeAssertion(assertionArgs: unknown) { }
+    /* istanbul ignore next */
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    onAfterAssertion(assertionArgs: unknown) { }
     /* istanbul ignore next */
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     onSuiteStart(suiteStats: SuiteStats) { }

--- a/packages/wdio-runner/package.json
+++ b/packages/wdio-runner/package.json
@@ -36,7 +36,7 @@
     "@wdio/types": "8.23.1",
     "@wdio/utils": "8.23.1",
     "deepmerge-ts": "^5.0.0",
-    "expect-webdriverio": "^4.5.1",
+    "expect-webdriverio": "^4.6.1",
     "gaze": "^1.1.2",
     "webdriver": "8.23.1",
     "webdriverio": "8.23.5"

--- a/packages/wdio-runner/src/index.ts
+++ b/packages/wdio-runner/src/index.ts
@@ -313,6 +313,18 @@ export default class Runner extends EventEmitter {
             setOptions({
                 wait: config.waitforTimeout, // ms to wait for expectation to succeed
                 interval: config.waitforInterval, // interval between attempts
+                beforeAssertion: async (params) => {
+                    await Promise.all([
+                        this._reporter?.emit('client:beforeAssertion', { ...params, sessionId: (this._browser as WebdriverIO.Browser)?.sessionId }),
+                        executeHooksWithArgs('beforeAssertion', config.beforeAssertion, [params])
+                    ])
+                },
+                afterAssertion: async (params) => {
+                    await Promise.all([
+                        this._reporter?.emit('client:afterAssertion', { ...params, sessionId: (this._browser as WebdriverIO.Browser)?.sessionId }),
+                        executeHooksWithArgs('afterAssertion', config.afterAssertion, [params])
+                    ])
+                }
             })
 
             /**

--- a/packages/wdio-runner/tests/index.test.ts
+++ b/packages/wdio-runner/tests/index.test.ts
@@ -447,6 +447,8 @@ describe('wdio-runner', () => {
 
             expect(setOptions).toBeCalledTimes(1)
             expect(setOptions).toBeCalledWith({
+                afterAssertion: expect.any(Function),
+                beforeAssertion: expect.any(Function),
                 wait: 1,
                 interval: 2
             })

--- a/packages/wdio-smoke-test-cjs-service/src/service.ts
+++ b/packages/wdio-smoke-test-cjs-service/src/service.ts
@@ -18,4 +18,6 @@ export default class SmokeService {
     afterSuite () { this.logFile.write('afterSuite called\n') } // eslint-disable-line no-console
     after () { this.logFile.write('after called\n') } // eslint-disable-line no-console
     afterSession () { this.logFile.write('afterSession called\n') } // eslint-disable-line no-console
+    beforeAssertion () { this.logFile.write('beforeAssertion called\n') } // eslint-disable-line no-console
+    afterAssertion () { this.logFile.write('afterAssertion called\n') } // eslint-disable-line no-console
 }

--- a/packages/wdio-smoke-test-reporter/src/index.ts
+++ b/packages/wdio-smoke-test-reporter/src/index.ts
@@ -40,4 +40,10 @@ export default class CustomSmokeTestReporter extends WDIOReporter {
     onRunnerEnd () {
         this.write('onRunnerEnd\n')
     }
+    onAfterAssertion () {
+        this.write('onAfterAssertion\n')
+    }
+    onBeforeAssertion () {
+        this.write('onBeforeAssertion\n')
+    }
 }

--- a/packages/wdio-smoke-test-service/src/index.ts
+++ b/packages/wdio-smoke-test-service/src/index.ts
@@ -18,6 +18,8 @@ export default class SmokeService {
     afterSuite () { this.logFile.write('afterSuite called\n') } // eslint-disable-line no-console
     after () { this.logFile.write('after called\n') } // eslint-disable-line no-console
     afterSession () { this.logFile.write('afterSession called\n') } // eslint-disable-line no-console
+    beforeAssertion () { this.logFile.write('beforeAssertion called\n') } // eslint-disable-line no-console
+    afterAssertion () { this.logFile.write('afterAssertion called\n') } // eslint-disable-line no-console
 }
 
 class SmokeServiceLauncher {

--- a/packages/wdio-types/src/Services.ts
+++ b/packages/wdio-types/src/Services.ts
@@ -43,6 +43,34 @@ export interface ServiceInstance extends HookFunctions {
     config?: TestrunnerOptions
 }
 
+interface AssertionHookParams {
+    /**
+     * name of the matcher, e.g. `toHaveText` or `toBeClickable`
+     */
+    matcherName: string
+    /**
+     * Value that the user has passed in
+     *
+     * @example
+     * ```
+     * expect(el).toBeClickable() // expectedValue is undefined
+     * expect(el).toHaveText('foo') // expectedValue is `'foo'`
+     * expect(el).toHaveAttribute('attr', 'value', { ... }) // expectedValue is `['attr', 'value]`
+     * ```
+     */
+    expectedValue?: any
+    /**
+     * Options that the user has passed in, e.g. `expect(el).toHaveText('foo', { ignoreCase: true })` -> `{ ignoreCase: true }`
+     */
+    options: object
+}
+interface AfterAssertionHookParams extends AssertionHookParams {
+    result: {
+        message: () => string
+        result: boolean
+    }
+}
+
 export type ServiceEntry = (
     /**
      * e.g. `services: ['@wdio/sauce-service']`
@@ -271,4 +299,20 @@ export interface HookFunctions {
         result: any,
         error?: Error
     ): unknown | Promise<unknown>
+
+    /**
+     * Runs before a WebdriverIO assertion library makes an assertion.
+     * @param commandName command name
+     * @param args        arguments that command would receive
+     */
+    beforeAssertion?(params: AssertionHookParams): unknown | Promise<unknown>
+
+    /**
+     * Runs after a WebdriverIO command gets executed
+     * @param commandName  command name
+     * @param args         arguments that command would receive
+     * @param result       result of the command
+     * @param error        error in case something went wrong
+     */
+    afterAssertion?(params: AfterAssertionHookParams): unknown | Promise<unknown>
 }

--- a/tests/cucumber/reporter/reporter.given.js
+++ b/tests/cucumber/reporter/reporter.given.js
@@ -5,4 +5,6 @@ Before(function () {})
 After(function () {})
 AfterAll(() => {})
 
-Given('Foo', () => {})
+Given('Foo', async () => {
+    await expect(browser).toHaveTitle('Mock Page Title')
+})

--- a/tests/helpers/fixtures.js
+++ b/tests/helpers/fixtures.js
@@ -4,6 +4,10 @@ beforeSuite called
 beforeTest called
 beforeCommand called
 afterCommand called
+beforeAssertion called
+beforeCommand called
+afterCommand called
+afterAssertion called
 afterTest called
 afterSuite called
 after called
@@ -27,6 +31,10 @@ onHookStart
 onHookEnd
 onBeforeCommand
 onAfterCommand
+onBeforeAssertion
+onBeforeCommand
+onAfterCommand
+onAfterAssertion
 onTestPass
 onTestEnd
 onHookStart
@@ -51,6 +59,10 @@ onHookEnd
 onTestStart
 onBeforeCommand
 onAfterCommand
+onBeforeAssertion
+onBeforeCommand
+onAfterCommand
+onAfterAssertion
 onTestPass
 onTestEnd
 onTestStart
@@ -81,6 +93,10 @@ onHookEnd
 onHookStart
 onHookEnd
 onTestStart
+onBeforeAssertion
+onBeforeCommand
+onAfterCommand
+onAfterAssertion
 onTestPass
 onHookStart
 onHookEnd

--- a/tests/jasmine/reporter.js
+++ b/tests/jasmine/reporter.js
@@ -15,6 +15,7 @@ describe('Jasmine reporter', () => {
 
     it('should pass', async () => {
         expect(await browser.getTitle()).toBe('Mock Page Title')
+        await expect(browser).toHaveTitle('Mock Page Title')
     })
 
     it('should fail', async () => {

--- a/tests/mocha/reporter.js
+++ b/tests/mocha/reporter.js
@@ -6,5 +6,6 @@ describe('my feature', () => {
 
     it('should do stuff', async () => {
         assert.equal(await browser.getTitle(), 'Mock Page Title')
+        await expect(browser).toHaveTitle('Mock Page Title')
     })
 })

--- a/tests/mocha/service.js
+++ b/tests/mocha/service.js
@@ -1,5 +1,6 @@
 describe('my feature', () => {
     it('should do stuff', async () => {
         expect(await browser.getTitle()).toBe('Mock Page Title')
+        await expect(browser).toHaveTitle('Mock Page Title')
     })
 })

--- a/website/docs/Configuration.md
+++ b/website/docs/Configuration.md
@@ -676,3 +676,26 @@ Parameters:
 - `result.error` (`string`): error stack if scenario failed
 - `result.duration` (`number`): duration of scenario in milliseconds
 - `context` (`object`): Cucumber World object
+
+### beforeAssertion
+
+Hook that gets executed before a WebdriverIO assertion happens.
+
+Parameters:
+
+- `params`: assertion information
+- `params.matcherName` (`string`): name of the matcher (e.g. `toHaveTitle`)
+- `params.expectedValue`: value that is passed into the matcher
+- `params.options`: assertion options
+
+### afterAssertion
+
+Hook that gets executed after a WebdriverIO assertion happened.
+
+Parameters:
+
+- `params`: assertion information
+- `params.matcherName` (`string`): name of the matcher (e.g. `toHaveTitle`)
+- `params.expectedValue`: value that is passed into the matcher
+- `params.options`: assertion options
+- `params.result`: assertion results

--- a/website/docs/ConfigurationFile.md
+++ b/website/docs/ConfigurationFile.md
@@ -491,6 +491,22 @@ export const config = {
      * @param {GherkinDocument.IFeature} feature  Cucumber feature object
      */
     afterFeature: function (uri, feature) {
+    },
+    /**
+     * Runs before a WebdriverIO assertion library makes an assertion.
+     * @param commandName command name
+     * @param args        arguments that command would receive
+     */
+    beforeAssertion: function (params) {
+    },
+    /**
+     * Runs after a WebdriverIO command gets executed
+     * @param commandName  command name
+     * @param args         arguments that command would receive
+     * @param result       result of the command
+     * @param error        error in case something went wrong
+     */
+    afterAssertion: function (params) {
     }
 }
 ```

--- a/website/i18n/ar/docusaurus-plugin-content-docs/current/Configuration.md
+++ b/website/i18n/ar/docusaurus-plugin-content-docs/current/Configuration.md
@@ -621,3 +621,27 @@ Parameters:
 - `result.error` (`string`): error stack if scenario failed
 - `result.duration` (`number`): duration of scenario in milliseconds
 - `context` (`object`): Cucumber World object
+
+### beforeAssertion
+
+Hook that gets executed before a WebdriverIO assertion happens.
+
+Parameters:
+
+- `params`: assertion information
+- `params.matcherName` (`string`): name of the matcher (e.g. `toHaveTitle`)
+- `params.expectedValue`: value that is passed into the matcher
+- `params.options`: assertion options
+
+### afterAssertion
+
+Hook that gets executed after a WebdriverIO assertion happened.
+
+Parameters:
+
+- `params`: assertion information
+- `params.matcherName` (`string`): name of the matcher (e.g. `toHaveTitle`)
+- `params.expectedValue`: value that is passed into the matcher
+- `params.options`: assertion options
+- `params.result`: assertion results
+

--- a/website/i18n/ar/docusaurus-plugin-content-docs/current/ConfigurationFile.md
+++ b/website/i18n/ar/docusaurus-plugin-content-docs/current/ConfigurationFile.md
@@ -491,6 +491,22 @@ export const config = {
      * @param {GherkinDocument.IFeature} feature  Cucumber feature object
      */
     afterFeature: function (uri, feature) {
+    },
+    /**
+     * Runs before a WebdriverIO assertion library makes an assertion.
+     * @param commandName command name
+     * @param args        arguments that command would receive
+     */
+    beforeAssertion: function (params) {
+    },
+    /**
+     * Runs after a WebdriverIO command gets executed
+     * @param commandName  command name
+     * @param args         arguments that command would receive
+     * @param result       result of the command
+     * @param error        error in case something went wrong
+     */
+    afterAssertion: function (params) {
     }
 }
 ```

--- a/website/i18n/bg/docusaurus-plugin-content-docs/current/Configuration.md
+++ b/website/i18n/bg/docusaurus-plugin-content-docs/current/Configuration.md
@@ -623,3 +623,27 @@ Parameters:
 - `result.error` (`string`): error stack if scenario failed
 - `result.duration` (`number`): duration of scenario in milliseconds
 - `context` (`object`): Cucumber World object
+
+### beforeAssertion
+
+Hook that gets executed before a WebdriverIO assertion happens.
+
+Parameters:
+
+- `params`: assertion information
+- `params.matcherName` (`string`): name of the matcher (e.g. `toHaveTitle`)
+- `params.expectedValue`: value that is passed into the matcher
+- `params.options`: assertion options
+
+### afterAssertion
+
+Hook that gets executed after a WebdriverIO assertion happened.
+
+Parameters:
+
+- `params`: assertion information
+- `params.matcherName` (`string`): name of the matcher (e.g. `toHaveTitle`)
+- `params.expectedValue`: value that is passed into the matcher
+- `params.options`: assertion options
+- `params.result`: assertion results
+

--- a/website/i18n/bg/docusaurus-plugin-content-docs/current/ConfigurationFile.md
+++ b/website/i18n/bg/docusaurus-plugin-content-docs/current/ConfigurationFile.md
@@ -491,6 +491,22 @@ export const config = {
      * @param {GherkinDocument.IFeature} feature  Cucumber feature object
      */
     afterFeature: function (uri, feature) {
+    },
+    /**
+     * Runs before a WebdriverIO assertion library makes an assertion.
+     * @param commandName command name
+     * @param args        arguments that command would receive
+     */
+    beforeAssertion: function (params) {
+    },
+    /**
+     * Runs after a WebdriverIO command gets executed
+     * @param commandName  command name
+     * @param args         arguments that command would receive
+     * @param result       result of the command
+     * @param error        error in case something went wrong
+     */
+    afterAssertion: function (params) {
     }
 }
 ```

--- a/website/i18n/de/docusaurus-plugin-content-docs/current/Configuration.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/current/Configuration.md
@@ -621,3 +621,27 @@ Parameter:
 - `result.error` (`string`): Fehler, wenn Szenario fehlgeschlagen ist
 - `result.duration` (`ziffer`): Testdauer
 - `context` (`Objekt`): Cucumber World-Objekt
+
+### beforeAssertion
+
+Hook that gets executed before a WebdriverIO assertion happens.
+
+Parameters:
+
+- `params`: assertion information
+- `params.matcherName` (`string`): name of the matcher (e.g. `toHaveTitle`)
+- `params.expectedValue`: value that is passed into the matcher
+- `params.options`: assertion options
+
+### afterAssertion
+
+Hook that gets executed after a WebdriverIO assertion happened.
+
+Parameters:
+
+- `params`: assertion information
+- `params.matcherName` (`string`): name of the matcher (e.g. `toHaveTitle`)
+- `params.expectedValue`: value that is passed into the matcher
+- `params.options`: assertion options
+- `params.result`: assertion results
+

--- a/website/i18n/de/docusaurus-plugin-content-docs/current/ConfigurationFile.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/current/ConfigurationFile.md
@@ -485,6 +485,22 @@ export const config = {
      * @param {GherkinDocument.IFeature} feature  Cucumber feature object
      */
     afterFeature: function (uri, feature) {
+    },
+    /**
+     * Runs before a WebdriverIO assertion library makes an assertion.
+     * @param commandName command name
+     * @param args        arguments that command would receive
+     */
+    beforeAssertion: function (params) {
+    },
+    /**
+     * Runs after a WebdriverIO command gets executed
+     * @param commandName  command name
+     * @param args         arguments that command would receive
+     * @param result       result of the command
+     * @param error        error in case something went wrong
+     */
+    afterAssertion: function (params) {
     }
 }
 ```

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/Configuration.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/Configuration.md
@@ -621,3 +621,26 @@ Parámetros:
 - `result.error` (`string`): pila de errores si el escenario falló
 - `result.duration` (`number`): duración del escenario en milisegundos
 - `contexto` (`objeto`): objeto Cucumber World
+
+### beforeAssertion
+
+Hook that gets executed before a WebdriverIO assertion happens.
+
+Parameters:
+
+- `params`: assertion information
+- `params.matcherName` (`string`): name of the matcher (e.g. `toHaveTitle`)
+- `params.expectedValue`: value that is passed into the matcher
+- `params.options`: assertion options
+
+### afterAssertion
+
+Hook that gets executed after a WebdriverIO assertion happened.
+
+Parameters:
+
+- `params`: assertion information
+- `params.matcherName` (`string`): name of the matcher (e.g. `toHaveTitle`)
+- `params.expectedValue`: value that is passed into the matcher
+- `params.options`: assertion options
+- `params.result`: assertion results

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/ConfigurationFile.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/ConfigurationFile.md
@@ -491,6 +491,22 @@ export const config = {
      * @param {GherkinDocument.IFeature} feature  Cucumber feature object
      */
     afterFeature: function (uri, feature) {
+    },
+    /**
+     * Runs before a WebdriverIO assertion library makes an assertion.
+     * @param commandName command name
+     * @param args        arguments that command would receive
+     */
+    beforeAssertion: function (params) {
+    },
+    /**
+     * Runs after a WebdriverIO command gets executed
+     * @param commandName  command name
+     * @param args         arguments that command would receive
+     * @param result       result of the command
+     * @param error        error in case something went wrong
+     */
+    afterAssertion: function (params) {
     }
 }
 ```

--- a/website/i18n/fa/docusaurus-plugin-content-docs/current/Configuration.md
+++ b/website/i18n/fa/docusaurus-plugin-content-docs/current/Configuration.md
@@ -621,3 +621,27 @@ Parameters:
 - `result.error` (`string`): error stack if scenario failed
 - `result.duration` (`number`): duration of scenario in milliseconds
 - `context` (`object`): Cucumber World object
+
+### beforeAssertion
+
+Hook that gets executed before a WebdriverIO assertion happens.
+
+Parameters:
+
+- `params`: assertion information
+- `params.matcherName` (`string`): name of the matcher (e.g. `toHaveTitle`)
+- `params.expectedValue`: value that is passed into the matcher
+- `params.options`: assertion options
+
+### afterAssertion
+
+Hook that gets executed after a WebdriverIO assertion happened.
+
+Parameters:
+
+- `params`: assertion information
+- `params.matcherName` (`string`): name of the matcher (e.g. `toHaveTitle`)
+- `params.expectedValue`: value that is passed into the matcher
+- `params.options`: assertion options
+- `params.result`: assertion results
+

--- a/website/i18n/fa/docusaurus-plugin-content-docs/current/ConfigurationFile.md
+++ b/website/i18n/fa/docusaurus-plugin-content-docs/current/ConfigurationFile.md
@@ -491,6 +491,22 @@ export const config = {
      * @param {GherkinDocument.IFeature} feature  Cucumber feature object
      */
     afterFeature: function (uri, feature) {
+    },
+    /**
+     * Runs before a WebdriverIO assertion library makes an assertion.
+     * @param commandName command name
+     * @param args        arguments that command would receive
+     */
+    beforeAssertion: function (params) {
+    },
+    /**
+     * Runs after a WebdriverIO command gets executed
+     * @param commandName  command name
+     * @param args         arguments that command would receive
+     * @param result       result of the command
+     * @param error        error in case something went wrong
+     */
+    afterAssertion: function (params) {
     }
 }
 ```

--- a/website/i18n/fr/docusaurus-plugin-content-docs/current/Configuration.md
+++ b/website/i18n/fr/docusaurus-plugin-content-docs/current/Configuration.md
@@ -621,3 +621,27 @@ Parameters:
 - `result.error` (`string`): error stack if scenario failed
 - `result.duration` (`number`): duration of scenario in milliseconds
 - `context` (`object`): Cucumber World object
+
+### beforeAssertion
+
+Hook that gets executed before a WebdriverIO assertion happens.
+
+Parameters:
+
+- `params`: assertion information
+- `params.matcherName` (`string`): name of the matcher (e.g. `toHaveTitle`)
+- `params.expectedValue`: value that is passed into the matcher
+- `params.options`: assertion options
+
+### afterAssertion
+
+Hook that gets executed after a WebdriverIO assertion happened.
+
+Parameters:
+
+- `params`: assertion information
+- `params.matcherName` (`string`): name of the matcher (e.g. `toHaveTitle`)
+- `params.expectedValue`: value that is passed into the matcher
+- `params.options`: assertion options
+- `params.result`: assertion results
+

--- a/website/i18n/fr/docusaurus-plugin-content-docs/current/ConfigurationFile.md
+++ b/website/i18n/fr/docusaurus-plugin-content-docs/current/ConfigurationFile.md
@@ -491,6 +491,22 @@ export const config = {
      * @param {GherkinDocument.IFeature} feature  Cucumber feature object
      */
     afterFeature: function (uri, feature) {
+    },
+    /**
+     * Runs before a WebdriverIO assertion library makes an assertion.
+     * @param commandName command name
+     * @param args        arguments that command would receive
+     */
+    beforeAssertion: function (params) {
+    },
+    /**
+     * Runs after a WebdriverIO command gets executed
+     * @param commandName  command name
+     * @param args         arguments that command would receive
+     * @param result       result of the command
+     * @param error        error in case something went wrong
+     */
+    afterAssertion: function (params) {
     }
 }
 ```

--- a/website/i18n/hi/docusaurus-plugin-content-docs/current/Configuration.md
+++ b/website/i18n/hi/docusaurus-plugin-content-docs/current/Configuration.md
@@ -621,3 +621,27 @@ Hook that gets executed after the suite has ended (in Mocha/Jasmine only)
 - `esult.error` (`string`): परिदृश्य विफल होने पर त्रुटि स्टेक
 - `result.duration` (`number`): मिलीसेकंड में परिदृश्य की अवधि
 - `context` (`object`): कुकुम्बर विश्व ऑब्जेक्ट
+
+### beforeAssertion
+
+Hook that gets executed before a WebdriverIO assertion happens.
+
+Parameters:
+
+- `params`: assertion information
+- `params.matcherName` (`string`): name of the matcher (e.g. `toHaveTitle`)
+- `params.expectedValue`: value that is passed into the matcher
+- `params.options`: assertion options
+
+### afterAssertion
+
+Hook that gets executed after a WebdriverIO assertion happened.
+
+Parameters:
+
+- `params`: assertion information
+- `params.matcherName` (`string`): name of the matcher (e.g. `toHaveTitle`)
+- `params.expectedValue`: value that is passed into the matcher
+- `params.options`: assertion options
+- `params.result`: assertion results
+

--- a/website/i18n/it/docusaurus-plugin-content-docs/current/Configuration.md
+++ b/website/i18n/it/docusaurus-plugin-content-docs/current/Configuration.md
@@ -621,3 +621,27 @@ Parameters:
 - `result.error` (`string`): error stack if scenario failed
 - `result.duration` (`number`): duration of scenario in milliseconds
 - `context` (`object`): Cucumber World object
+
+### beforeAssertion
+
+Hook that gets executed before a WebdriverIO assertion happens.
+
+Parameters:
+
+- `params`: assertion information
+- `params.matcherName` (`string`): name of the matcher (e.g. `toHaveTitle`)
+- `params.expectedValue`: value that is passed into the matcher
+- `params.options`: assertion options
+
+### afterAssertion
+
+Hook that gets executed after a WebdriverIO assertion happened.
+
+Parameters:
+
+- `params`: assertion information
+- `params.matcherName` (`string`): name of the matcher (e.g. `toHaveTitle`)
+- `params.expectedValue`: value that is passed into the matcher
+- `params.options`: assertion options
+- `params.result`: assertion results
+

--- a/website/i18n/it/docusaurus-plugin-content-docs/current/ConfigurationFile.md
+++ b/website/i18n/it/docusaurus-plugin-content-docs/current/ConfigurationFile.md
@@ -491,6 +491,22 @@ export const config = {
      * @param {GherkinDocument.IFeature} feature  Cucumber feature object
      */
     afterFeature: function (uri, feature) {
+    },
+    /**
+     * Runs before a WebdriverIO assertion library makes an assertion.
+     * @param commandName command name
+     * @param args        arguments that command would receive
+     */
+    beforeAssertion: function (params) {
+    },
+    /**
+     * Runs after a WebdriverIO command gets executed
+     * @param commandName  command name
+     * @param args         arguments that command would receive
+     * @param result       result of the command
+     * @param error        error in case something went wrong
+     */
+    afterAssertion: function (params) {
     }
 }
 ```

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/Configuration.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/Configuration.md
@@ -621,3 +621,27 @@ Parameters:
 - `result.error` (`string`): error stack if scenario failed
 - `result.duration` (`number`): duration of scenario in milliseconds
 - `context` (`object`): Cucumber World object
+
+### beforeAssertion
+
+Hook that gets executed before a WebdriverIO assertion happens.
+
+Parameters:
+
+- `params`: assertion information
+- `params.matcherName` (`string`): name of the matcher (e.g. `toHaveTitle`)
+- `params.expectedValue`: value that is passed into the matcher
+- `params.options`: assertion options
+
+### afterAssertion
+
+Hook that gets executed after a WebdriverIO assertion happened.
+
+Parameters:
+
+- `params`: assertion information
+- `params.matcherName` (`string`): name of the matcher (e.g. `toHaveTitle`)
+- `params.expectedValue`: value that is passed into the matcher
+- `params.options`: assertion options
+- `params.result`: assertion results
+

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/ConfigurationFile.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/ConfigurationFile.md
@@ -491,6 +491,22 @@ export const config = {
      * @param {GherkinDocument.IFeature} feature  Cucumber feature object
      */
     afterFeature: function (uri, feature) {
+    },
+    /**
+     * Runs before a WebdriverIO assertion library makes an assertion.
+     * @param commandName command name
+     * @param args        arguments that command would receive
+     */
+    beforeAssertion: function (params) {
+    },
+    /**
+     * Runs after a WebdriverIO command gets executed
+     * @param commandName  command name
+     * @param args         arguments that command would receive
+     * @param result       result of the command
+     * @param error        error in case something went wrong
+     */
+    afterAssertion: function (params) {
     }
 }
 ```

--- a/website/i18n/pl/docusaurus-plugin-content-docs/current/Configuration.md
+++ b/website/i18n/pl/docusaurus-plugin-content-docs/current/Configuration.md
@@ -621,3 +621,27 @@ Parameters:
 - `result.error` (`string`): error stack if scenario failed
 - `result.duration` (`number`): duration of scenario in milliseconds
 - `context` (`object`): Cucumber World object
+
+### beforeAssertion
+
+Hook that gets executed before a WebdriverIO assertion happens.
+
+Parameters:
+
+- `params`: assertion information
+- `params.matcherName` (`string`): name of the matcher (e.g. `toHaveTitle`)
+- `params.expectedValue`: value that is passed into the matcher
+- `params.options`: assertion options
+
+### afterAssertion
+
+Hook that gets executed after a WebdriverIO assertion happened.
+
+Parameters:
+
+- `params`: assertion information
+- `params.matcherName` (`string`): name of the matcher (e.g. `toHaveTitle`)
+- `params.expectedValue`: value that is passed into the matcher
+- `params.options`: assertion options
+- `params.result`: assertion results
+

--- a/website/i18n/pl/docusaurus-plugin-content-docs/current/ConfigurationFile.md
+++ b/website/i18n/pl/docusaurus-plugin-content-docs/current/ConfigurationFile.md
@@ -491,6 +491,22 @@ export const config = {
      * @param {GherkinDocument.IFeature} feature  Cucumber feature object
      */
     afterFeature: function (uri, feature) {
+    },
+    /**
+     * Runs before a WebdriverIO assertion library makes an assertion.
+     * @param commandName command name
+     * @param args        arguments that command would receive
+     */
+    beforeAssertion: function (params) {
+    },
+    /**
+     * Runs after a WebdriverIO command gets executed
+     * @param commandName  command name
+     * @param args         arguments that command would receive
+     * @param result       result of the command
+     * @param error        error in case something went wrong
+     */
+    afterAssertion: function (params) {
     }
 }
 ```

--- a/website/i18n/ru/docusaurus-plugin-content-docs/current/Configuration.md
+++ b/website/i18n/ru/docusaurus-plugin-content-docs/current/Configuration.md
@@ -621,3 +621,27 @@ Parameters:
 - `result.error` (`string`): error stack if scenario failed
 - `result.duration` (`number`): duration of scenario in milliseconds
 - `context` (`object`): Cucumber World object
+
+### beforeAssertion
+
+Hook that gets executed before a WebdriverIO assertion happens.
+
+Parameters:
+
+- `params`: assertion information
+- `params.matcherName` (`string`): name of the matcher (e.g. `toHaveTitle`)
+- `params.expectedValue`: value that is passed into the matcher
+- `params.options`: assertion options
+
+### afterAssertion
+
+Hook that gets executed after a WebdriverIO assertion happened.
+
+Parameters:
+
+- `params`: assertion information
+- `params.matcherName` (`string`): name of the matcher (e.g. `toHaveTitle`)
+- `params.expectedValue`: value that is passed into the matcher
+- `params.options`: assertion options
+- `params.result`: assertion results
+

--- a/website/i18n/ru/docusaurus-plugin-content-docs/current/ConfigurationFile.md
+++ b/website/i18n/ru/docusaurus-plugin-content-docs/current/ConfigurationFile.md
@@ -491,6 +491,22 @@ export const config = {
      * @param {GherkinDocument.IFeature} feature  Cucumber feature object
      */
     afterFeature: function (uri, feature) {
+    },
+    /**
+     * Runs before a WebdriverIO assertion library makes an assertion.
+     * @param commandName command name
+     * @param args        arguments that command would receive
+     */
+    beforeAssertion: function (params) {
+    },
+    /**
+     * Runs after a WebdriverIO command gets executed
+     * @param commandName  command name
+     * @param args         arguments that command would receive
+     * @param result       result of the command
+     * @param error        error in case something went wrong
+     */
+    afterAssertion: function (params) {
     }
 }
 ```

--- a/website/i18n/ta/docusaurus-plugin-content-docs/current/Configuration.md
+++ b/website/i18n/ta/docusaurus-plugin-content-docs/current/Configuration.md
@@ -621,3 +621,27 @@ Parameters:
 - `result.error` (`string`): error stack if scenario failed
 - `result.duration` (`number`): duration of scenario in milliseconds
 - `context` (`object`): Cucumber World object
+
+### beforeAssertion
+
+Hook that gets executed before a WebdriverIO assertion happens.
+
+Parameters:
+
+- `params`: assertion information
+- `params.matcherName` (`string`): name of the matcher (e.g. `toHaveTitle`)
+- `params.expectedValue`: value that is passed into the matcher
+- `params.options`: assertion options
+
+### afterAssertion
+
+Hook that gets executed after a WebdriverIO assertion happened.
+
+Parameters:
+
+- `params`: assertion information
+- `params.matcherName` (`string`): name of the matcher (e.g. `toHaveTitle`)
+- `params.expectedValue`: value that is passed into the matcher
+- `params.options`: assertion options
+- `params.result`: assertion results
+

--- a/website/i18n/ta/docusaurus-plugin-content-docs/current/ConfigurationFile.md
+++ b/website/i18n/ta/docusaurus-plugin-content-docs/current/ConfigurationFile.md
@@ -491,6 +491,22 @@ export const config = {
      * @param {GherkinDocument.IFeature} feature  Cucumber feature object
      */
     afterFeature: function (uri, feature) {
+    },
+    /**
+     * Runs before a WebdriverIO assertion library makes an assertion.
+     * @param commandName command name
+     * @param args        arguments that command would receive
+     */
+    beforeAssertion: function (params) {
+    },
+    /**
+     * Runs after a WebdriverIO command gets executed
+     * @param commandName  command name
+     * @param args         arguments that command would receive
+     * @param result       result of the command
+     * @param error        error in case something went wrong
+     */
+    afterAssertion: function (params) {
     }
 }
 ```

--- a/website/i18n/uk/docusaurus-plugin-content-docs/current/Configuration.md
+++ b/website/i18n/uk/docusaurus-plugin-content-docs/current/Configuration.md
@@ -621,3 +621,27 @@ Parameters:
 - `result.error` (`string`): error stack if scenario failed
 - `result.duration` (`number`): duration of scenario in milliseconds
 - `context` (`object`): Cucumber World object
+
+### beforeAssertion
+
+Hook that gets executed before a WebdriverIO assertion happens.
+
+Parameters:
+
+- `params`: assertion information
+- `params.matcherName` (`string`): name of the matcher (e.g. `toHaveTitle`)
+- `params.expectedValue`: value that is passed into the matcher
+- `params.options`: assertion options
+
+### afterAssertion
+
+Hook that gets executed after a WebdriverIO assertion happened.
+
+Parameters:
+
+- `params`: assertion information
+- `params.matcherName` (`string`): name of the matcher (e.g. `toHaveTitle`)
+- `params.expectedValue`: value that is passed into the matcher
+- `params.options`: assertion options
+- `params.result`: assertion results
+

--- a/website/i18n/uk/docusaurus-plugin-content-docs/current/ConfigurationFile.md
+++ b/website/i18n/uk/docusaurus-plugin-content-docs/current/ConfigurationFile.md
@@ -491,6 +491,22 @@ export const config = {
      * @param {GherkinDocument.IFeature} feature  Cucumber feature object
      */
     afterFeature: function (uri, feature) {
+    },
+    /**
+     * Runs before a WebdriverIO assertion library makes an assertion.
+     * @param commandName command name
+     * @param args        arguments that command would receive
+     */
+    beforeAssertion: function (params) {
+    },
+    /**
+     * Runs after a WebdriverIO command gets executed
+     * @param commandName  command name
+     * @param args         arguments that command would receive
+     * @param result       result of the command
+     * @param error        error in case something went wrong
+     */
+    afterAssertion: function (params) {
     }
 }
 ```

--- a/website/i18n/zh/docusaurus-plugin-content-docs/current/Configuration.md
+++ b/website/i18n/zh/docusaurus-plugin-content-docs/current/Configuration.md
@@ -621,3 +621,27 @@ Parameters:
 - `result.error` (`string`): error stack if scenario failed
 - `result.duration` (`number`): duration of scenario in milliseconds
 - `context` (`object`): Cucumber World object
+
+### beforeAssertion
+
+Hook that gets executed before a WebdriverIO assertion happens.
+
+Parameters:
+
+- `params`: assertion information
+- `params.matcherName` (`string`): name of the matcher (e.g. `toHaveTitle`)
+- `params.expectedValue`: value that is passed into the matcher
+- `params.options`: assertion options
+
+### afterAssertion
+
+Hook that gets executed after a WebdriverIO assertion happened.
+
+Parameters:
+
+- `params`: assertion information
+- `params.matcherName` (`string`): name of the matcher (e.g. `toHaveTitle`)
+- `params.expectedValue`: value that is passed into the matcher
+- `params.options`: assertion options
+- `params.result`: assertion results
+

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -28,6 +28,7 @@
     --ifm-table-border-color: #efefef;
     --ifm-navbar-height: 85px;
     --ifm-button-border-width: 0;
+    --ifm-tabs-padding-vertical: 0.5rem;
     --docusaurus-announcement-bar-height: auto!important;
 
     --wdio-spacing-vertical: 60px;
@@ -237,6 +238,10 @@ html[data-theme=dark] div[class^='codeBlockTitle'] {
 }
 div[role="tabpanel"] .prism-code {
     border-top-left-radius: 0;
+}
+
+ul.tabs {
+    margin-bottom: -1rem;
 }
 .tabs__item:hover {
     border-bottom-left-radius: 0;


### PR DESCRIPTION
## Proposed changes

With [`v4.6.0`](https://github.com/webdriverio/expect-webdriverio/releases/tag/v4.6.0) of `expect-webdriverio` we start to support hooks for assertions. This PR integrates this feature to the WebdriverIO test runner. It integrates it in a way that also allows reporter to use the data.

Here is an example:

Given you have the following hooks in your `wdio.conf.js`:

```js
    beforeAssertion: (params) => {
        console.log('beforeAssertion', params)
    },
    afterAssertion: (params) => {
        console.log('afterAssertion', params)
    }
```

and in your tests you have an assertion like this:

```js
await expect(browser).toHaveTitle('WebdriverIO · Next-gen browser and mobile automation test framework for Node.js | WebdriverIO')
```

Then it will log the following data:

```ja
[0-0] beforeAssertion {
[0-0]   matcherName: 'toHaveTitle',
[0-0]   expectedValue: 'WebdriverIO · Next-gen browser and mobile automation test framework for Node.js | WebdriverIO',
[0-0]   options: {
[0-0]     wait: 5000,
[0-0]     interval: 500,
[0-0]     beforeAssertion: [AsyncFunction: beforeAssertion],
[0-0]     afterAssertion: [AsyncFunction: afterAssertion]
[0-0]   }
[0-0] }
[0-0] afterAssertion {
[0-0]   matcherName: 'toHaveTitle',
[0-0]   expectedValue: 'WebdriverIO · Next-gen browser and mobile automation test framework for Node.js | WebdriverIO',
[0-0]   options: {
[0-0]     wait: 5000,
[0-0]     interval: 500,
[0-0]     beforeAssertion: [AsyncFunction: beforeAssertion],
[0-0]     afterAssertion: [AsyncFunction: afterAssertion]
[0-0]   },
[0-0]   result: { pass: true, message: [Function: message] }
[0-0] }
```

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
