### PR TITLE
(@wdio/appium-service): make Appium start on a random port

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29325,12 +29325,24 @@
         "@wdio/logger": "8.16.17",
         "@wdio/types": "8.24.2",
         "@wdio/utils": "8.24.3",
+        "get-port": "^7.0.0",
         "import-meta-resolve": "^3.0.0",
         "param-case": "^3.0.4",
         "webdriverio": "8.24.3"
       },
       "engines": {
         "node": "^16.13 || >=18"
+      }
+    },
+    "packages/wdio-appium-service/node_modules/get-port": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-7.0.0.tgz",
+      "integrity": "sha512-mDHFgApoQd+azgMdwylJrv2DX47ywGq1i5VFJE7fZ0dttNq3iQMfsU4IvEgBHojA3KqEudyu7Vq+oN8kNaNkWw==",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "packages/wdio-browser-runner": {

--- a/packages/wdio-appium-service/package.json
+++ b/packages/wdio-appium-service/package.json
@@ -37,6 +37,7 @@
     "@wdio/logger": "8.16.17",
     "@wdio/types": "8.24.2",
     "@wdio/utils": "8.24.3",
+    "get-port": "^7.0.0",
     "import-meta-resolve": "^3.0.0",
     "param-case": "^3.0.4",
     "webdriverio": "8.24.3"

--- a/packages/wdio-appium-service/src/launcher.ts
+++ b/packages/wdio-appium-service/src/launcher.ts
@@ -17,8 +17,8 @@ import { getFilePath, formatCliArgs } from './utils.js'
 import type { AppiumServerArguments, AppiumServiceConfig } from './types.js'
 
 const log = logger('@wdio/appium-service')
+const DEFAULT_APPIUM_PORT = 4723
 const DEFAULT_LOG_FILENAME = 'wdio-appium.log'
-
 const DEFAULT_CONNECTION = {
     protocol: 'http',
     hostname: '127.0.0.1',
@@ -109,8 +109,7 @@ export default class AppiumLauncher implements Services.ServiceInstance {
                 Object.assign(
                     cap,
                     DEFAULT_CONNECTION,
-                    'port' in this._args ? { port: this._args.port } : {},
-                    { path: this._args.basePath },
+                    { path: this._args.basePath, port },
                     { ...cap }
                 )
             }
@@ -133,7 +132,9 @@ export default class AppiumLauncher implements Services.ServiceInstance {
         /**
          * Get port from service option or use a random port
          */
-        const port = typeof this._args.port === 'number' ? this._args.port : await getPort()
+        const port = typeof this._args.port === 'number'
+            ? this._args.port
+            : await getPort({ port: DEFAULT_APPIUM_PORT })
         this._setCapabilities(port)
 
         /**


### PR DESCRIPTION
## Proposed changes

This patch makes the Appium service start on a random port instead of always the same default port. This makes using the service a bit simpler as the user might have other Appium processes running unrelated to their test run with the service.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
