### PR TITLE
fix for issue #11834 - fixing skip test for jasmine on beforeTest hook

### DIFF
--- a/packages/wdio-utils/src/shim.ts
+++ b/packages/wdio-utils/src/shim.ts
@@ -54,7 +54,7 @@ export async function executeHooksWithArgs<T> (this: any, hookName: string, hook
             * in case of jasmine, when rejecting, we need to pass the message of rejection as well
             */
             if (/^=> marked Pending/.test(e)) {
-                return reject(e);
+                return reject(e)
             }
             log.error(e.stack)
             return resolve(e)

--- a/tests/helpers/jasmine-hooks.conf.js
+++ b/tests/helpers/jasmine-hooks.conf.js
@@ -3,6 +3,6 @@ import { config as baseConfig } from './config.js'
 export const config = Object.assign({}, baseConfig, {
     beforeTest() {
         // this is a global function defined by Jasmine
-        pending()
+        pending('skip test')
     }
 })

--- a/tests/helpers/jasmine-hooks.conf.js
+++ b/tests/helpers/jasmine-hooks.conf.js
@@ -2,6 +2,7 @@ import { config as baseConfig } from './config.js'
 
 export const config = Object.assign({}, baseConfig, {
     beforeTest() {
+        // this is a global function defined by Jasmine
         pending()
     }
 })

--- a/tests/helpers/jasmine-hooks.conf.js
+++ b/tests/helpers/jasmine-hooks.conf.js
@@ -1,0 +1,7 @@
+import { config as baseConfig } from './config.js'
+
+export const config = Object.assign({}, baseConfig, {
+    beforeTest() {
+        pending()
+    }
+})

--- a/tests/jasmine/test-skipped-hooks.ts
+++ b/tests/jasmine/test-skipped-hooks.ts
@@ -1,7 +1,5 @@
-import assert from 'node:assert'
-
 describe('Jasmine smoke test to be skipped via wdio hooks', () => {
     it('should be skipped', async () => {
-        assert.strictEqual(1, 2)
+        expect(true).toBeFalsy()
     })
 })

--- a/tests/jasmine/test-skipped-hooks.ts
+++ b/tests/jasmine/test-skipped-hooks.ts
@@ -2,6 +2,6 @@ import assert from 'node:assert'
 
 describe('Jasmine smoke test to be skipped via wdio hooks', () => {
     it('should be skipped', async () => {
-        assert.strictEqual(1, 1)
+        assert.strictEqual(1, 2)
     })
 })

--- a/tests/jasmine/test-skipped-hooks.ts
+++ b/tests/jasmine/test-skipped-hooks.ts
@@ -1,0 +1,7 @@
+import assert from 'node:assert'
+
+describe('Jasmine smoke test to be skipped via wdio hooks', () => {
+    it('should be skipped', async () => {
+        assert.strictEqual(1, 1)
+    })
+})

--- a/tests/smoke.runner.js
+++ b/tests/smoke.runner.js
@@ -683,6 +683,19 @@ const mochaHooksTestrunner = async () => {
     assert.strictEqual(skippedSpecs, 0)
 }
 
+const jasmineHooksTestrunner = async () => {
+    const { skippedSpecs } = await launch(
+        'jasmineHooksTestrunner',
+        path.resolve(__dirname, 'helpers', 'jasmine-hooks.conf.js'),
+        {
+            specs: [
+                path.resolve(__dirname, 'jasmine', 'test-skipped-hooks.ts'),
+            ]
+        }
+    )
+    assert.strictEqual(skippedSpecs, 0)
+}
+
 (async () => {
     const smokeTests = [
         mochaTestrunner,
@@ -713,7 +726,8 @@ const mochaHooksTestrunner = async () => {
         customReporterObject,
         severeErrorTest,
         nonGlobalTestrunner,
-        mochaHooksTestrunner
+        mochaHooksTestrunner,
+        jasmineHooksTestrunner
     ]
 
     console.log('\nRunning smoke tests...\n')

--- a/tests/smoke.runner.js
+++ b/tests/smoke.runner.js
@@ -684,16 +684,27 @@ const mochaHooksTestrunner = async () => {
 }
 
 const jasmineHooksTestrunner = async () => {
-    const { skippedSpecs } = await launch(
-        'jasmineHooksTestrunner',
+    const logFile = path.join(__dirname, 'jasmineHooksTestrunner.spec.log')
+    await launch('jasmineHooksTestrunner',
         path.resolve(__dirname, 'helpers', 'jasmine-hooks.conf.js'),
         {
-            specs: [
-                path.resolve(__dirname, 'jasmine', 'test-skipped-hooks.ts'),
-            ]
-        }
+            autoCompileOpts: { autoCompile: false },
+            specs: [path.resolve(__dirname, 'jasmine', 'test-skipped-hooks.ts')],
+            reporters: [
+                ['spec', {
+                    outputDir: __dirname,
+                    stdout: false,
+                    logFile
+                }]
+            ],
+            framework: 'jasmine',
+        }).catch((err) => err) // error expected
+
+    // eslint-disable-next-line no-control-regex
+    const specLogs = (await fs.readFile(logFile)).toString().replace(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, '')
+    assert.ok(
+        specLogs.includes('skip test'),
     )
-    assert.strictEqual(skippedSpecs, 0)
 }
 
 (async () => {


### PR DESCRIPTION
## Proposed changes

This is a fix for issue #11834. 
This will enable skipping tests from `beforeTest` hook in config file. just like https://github.com/webdriverio/webdriverio/pull/11158 did for Mocha

the result is that the test is skipped:
![image](https://github.com/HananArgov/webdriverio/assets/48208030/ad1d645b-94f6-45b3-a019-7f39bc00e405)


## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)


- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

this is an implementation based on a previous one for Mocha: (https://github.com/webdriverio/webdriverio/pull/11158)

### Reviewers: @webdriverio/project-committers
