### PR TITLE
Missing alerts capability for BrowserStack

### DIFF
--- a/packages/wdio-types/src/Capabilities.ts
+++ b/packages/wdio-types/src/Capabilities.ts
@@ -1202,10 +1202,14 @@ export interface BrowserStackCapabilities {
      */
     autoWait?: number
     /**
-     * https://www.browserstack.com/docs/app-automate/appium/advanced-features/handle-permission-pop-ups
-     * IOS specific. For IOS 13 & above, behavior will flip if popup has more than 2 buttons
+     * iOS specific. For IOS 13 & above, behavior will flip if popup has more than 2 buttons
+     * @see https://www.browserstack.com/docs/app-automate/appium/advanced-features/handle-permission-pop-ups
      */
     autoAcceptAlerts?: boolean
+    /**
+     * iOS specific. For IOS 13 & above, behavior will flip if popup has more than 2 buttons
+     * @see https://www.browserstack.com/docs/app-automate/appium/advanced-features/handle-permission-pop-ups
+     */
     autoDismissAlerts?: boolean
     /**
      * Add a host entry (/etc/hosts) to the remote BrowserStack machine.

--- a/packages/wdio-types/src/Capabilities.ts
+++ b/packages/wdio-types/src/Capabilities.ts
@@ -1202,6 +1202,12 @@ export interface BrowserStackCapabilities {
      */
     autoWait?: number
     /**
+     * https://www.browserstack.com/docs/app-automate/appium/advanced-features/handle-permission-pop-ups
+     * IOS specific. For IOS 13 & above, behavior will flip if popup has more than 2 buttons
+     */
+    autoAcceptAlerts?: boolean
+    autoDismissAlerts?: boolean
+    /**
      * Add a host entry (/etc/hosts) to the remote BrowserStack machine.
      *
      * Format: ip_address domain_name


### PR DESCRIPTION
## Proposed changes

Adding missing alerts capability for BrowserStack. This will be IOS specific. As per the documentation [here](https://www.browserstack.com/docs/app-automate/appium/advanced-features/handle-permission-pop-ups), there should be 2 capabilities `autoAcceptAlerts` and `autoDismissAlerts`. 



## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
