### PR TITLE
fix(webdriver): respect strictSSL setting for bidi connections

### DIFF
--- a/packages/webdriver/src/bidi/core.ts
+++ b/packages/webdriver/src/bidi/core.ts
@@ -3,6 +3,7 @@ import logger from '@wdio/logger'
 
 import type { CommandData } from './remoteTypes.js'
 import type { CommandResponse } from './localTypes.js'
+import type { ClientRequestArgs } from 'node:http'
 
 const log = logger('webdriver')
 const RESPONSE_TIMEOUT = 1000 * 60
@@ -12,9 +13,9 @@ export class BidiCore {
     #ws: WebSocket
     #isConnected = false
 
-    constructor (private _webSocketUrl: string) {
+    constructor (private _webSocketUrl: string, opts?: WebSocket.ClientOptions | ClientRequestArgs) {
         log.info(`Connect to webSocketUrl ${this._webSocketUrl}`)
-        this.#ws = new WebSocket(this._webSocketUrl)
+        this.#ws = new WebSocket(this._webSocketUrl, opts)
     }
 
     public connect () {

--- a/packages/webdriver/src/index.ts
+++ b/packages/webdriver/src/index.ts
@@ -43,7 +43,7 @@ export default class WebDriver {
         const bidiPrototype: PropertyDescriptorMap = {}
         if (capabilities.webSocketUrl) {
             log.info(`Register BiDi handler for session with id ${sessionId}`)
-            Object.assign(bidiPrototype, initiateBidi(capabilities.webSocketUrl as any as string))
+            Object.assign(bidiPrototype, initiateBidi(capabilities.webSocketUrl as any as string, options.strictSSL))
         }
 
         const monad = webdriverMonad(
@@ -121,7 +121,7 @@ export default class WebDriver {
             : options.capabilities!.webSocketUrl
         if (webSocketUrl) {
             log.info(`Register BiDi handler for session with id ${options.sessionId}`)
-            Object.assign(bidiPrototype, initiateBidi(webSocketUrl as any as string))
+            Object.assign(bidiPrototype, initiateBidi(webSocketUrl as any as string, options.strictSSL))
         }
 
         const prototype = { ...protocolCommands, ...environmentPrototype, ...userPrototype, ...bidiPrototype }

--- a/packages/webdriver/src/utils.ts
+++ b/packages/webdriver/src/utils.ts
@@ -419,9 +419,10 @@ function getExecCmdArgs(requestOptions: Options.RequestLibOptions): string {
  * @param socketUrl url to bidi interface
  * @returns prototype with interface for bidi primitives
  */
-export function initiateBidi (socketUrl: string): PropertyDescriptorMap {
+export function initiateBidi (socketUrl: string, strictSSL: boolean = true): PropertyDescriptorMap {
     socketUrl = socketUrl.replace('localhost', '127.0.0.1')
-    const handler = new BidiHandler(socketUrl)
+    const bidiReqOpts = strictSSL ? {} : { rejectUnauthorized: false }
+    const handler = new BidiHandler(socketUrl, bidiReqOpts)
     handler.connect().then(() => log.info(`Connected to WebDriver Bidi interface at ${socketUrl}`))
 
     return {


### PR DESCRIPTION
WebDriver BiDi connections were not made with sensitivity to the `strictSSL` WebDriverIO option. This PR attempts to fix that. Tested locally on a self-signed cert. Not really sure how to add a test in this repo, nor do I really want to figure that out 😉 