### PR TITLE
feat: Add start options and way to close Shared Store server

### DIFF
--- a/packages/wdio-shared-store-service/src/@types/server.d.ts
+++ b/packages/wdio-shared-store-service/src/@types/server.d.ts
@@ -1,4 +1,4 @@
 interface SharedStoreServer {
     __store: WebdriverIO.JsonObject
-    startServer: () => Promise<{ port: number, app: PolkaInstance }>
+    startServer: (port: number = 0, attach: boolean = false) => Promise<{ port: number, app: PolkaInstance }>
 }

--- a/packages/wdio-shared-store-service/src/client.ts
+++ b/packages/wdio-shared-store-service/src/client.ts
@@ -88,6 +88,15 @@ export const addValueToPool = async (key: string, value: JsonPrimitive | JsonCom
     return res?.body ? (res.body as JsonObject).value : undefined
 }
 
+export const close = async () => {
+    if (!isBaseUrlReady) {
+        throw new Error('Attempting to close server before the it has been initialized.')
+    }
+    const baseUrl = await baseUrlPromise
+    const res = await got.post(`${baseUrl}/action/close`, { json: { }, responseType: 'json' }).catch(errHandler)
+    return res?.body ? (res.body as JsonObject).value : undefined
+}
+
 const errHandler = (err: RequestError) => {
     throw new Error(`${err.response?.body || 'Shared store server threw an error'}`)
 }

--- a/packages/wdio-shared-store-service/src/index.ts
+++ b/packages/wdio-shared-store-service/src/index.ts
@@ -2,7 +2,9 @@ import type { JsonPrimitive, JsonCompatible, JsonArray } from '@wdio/types'
 
 import SharedStoreLauncher from './launcher.js'
 import SharedStoreService from './service.js'
-import type { GetValueOptions } from './types.js'
+import type { GetValueOptions, SharedStoreOptions } from './types.js'
+
+export * as SharedStoreServer from './server.js'
 
 export { getValue, setValue, setResourcePool, getValueFromPool, addValueToPool } from './client.js'
 export default SharedStoreService
@@ -22,5 +24,6 @@ declare global {
     namespace WebdriverIO {
         interface Browser extends BrowserExtension { }
         interface MultiRemoteBrowser extends BrowserExtension { }
+        interface ServiceOption extends SharedStoreOptions {}
     }
 }

--- a/packages/wdio-shared-store-service/src/types.ts
+++ b/packages/wdio-shared-store-service/src/types.ts
@@ -2,3 +2,18 @@ export interface SharedStoreServiceCapabilities extends WebdriverIO.Capabilities
     'wdio:sharedStoreServicePort': number
 }
 export type GetValueOptions = { timeout: Number } | undefined
+
+export type SharedStoreOptions = {
+    /**
+     * The port of the server, takes priority over capability key
+     */
+    port?: number,
+    /**
+     * Does not start a server and instead returns an instance ready to interact with an already created server
+     */
+    attach?: boolean,
+    /**
+     * The server can sometimes produce a 500 Internal Server error, this options ignores these
+     */
+    ignore500?: boolean
+}

--- a/packages/wdio-shared-store-service/tests/service.test.ts
+++ b/packages/wdio-shared-store-service/tests/service.test.ts
@@ -12,6 +12,7 @@ vi.mock('../src/client', () => ({
     getValueFromPool: vi.fn(),
     addValueToPool: vi.fn(),
     setPort: vi.fn(),
+    close: vi.fn(),
 }))
 
 describe('SharedStoreService', () => {
@@ -38,6 +39,14 @@ describe('SharedStoreService', () => {
                 browserB: { capabilities }
             })
             expect(setPort).toBeCalledWith(65209)
+        })
+
+        it('using service options', async () => {
+            new SharedStoreService({ port: 3000 }, {
+                browserA: { capabilities },
+                browserB: { capabilities }
+            })
+            expect(setPort).toBeCalledWith(3000)
         })
     })
 

--- a/packages/wdio-shared-store-service/tsconfig.json
+++ b/packages/wdio-shared-store-service/tsconfig.json
@@ -4,7 +4,7 @@
     "baseUrl": ".",
     "outDir": "./build",
     "rootDir": "./src",
-    "types": ["@wdio/globals/types"]
+    "types": ["@wdio/globals/types", "webdriverio"]
   },
   "include": [
     "src/**/*",


### PR DESCRIPTION
## Proposed changes

Enhances the Share Store service with:

- New `close` command to stop the server
- New service options that allows users to attach to an existing server
- Exports `startServer` command to allow users to start the server outside test automation

These changes enable users to have better control of the server and enhance the performance of test runs in CI when shading tests, for example. Prevents N runners from creating N servers in N `onPrepare` hooks.
## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
- [X] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
