### PR TITLE
Fix update of cucumber pickle data for before/after hooks

### DIFF
--- a/packages/wdio-cucumber-framework/src/cucumberFormatter.ts
+++ b/packages/wdio-cucumber-framework/src/cucumberFormatter.ts
@@ -113,6 +113,11 @@ export default class CucumberFormatter extends Formatter {
         this.failAmbiguousDefinitions = options.parsedArgvOptions._failAmbiguousDefinitions
     }
 
+    updateCurrentPickle(params: HookParams) {
+        this._currentPickle = params
+        this.eventEmitter.emit('getHookParams', params)
+    }
+
     normalizeURI(uri: string) {
         return path.isAbsolute(uri) ? uri : path.resolve(uri)
     }
@@ -270,12 +275,12 @@ export default class CucumberFormatter extends Formatter {
     }
 
     onGherkinDocument(gherkinDocEvent: GherkinDocument) {
-        this._currentPickle = {
+        this.updateCurrentPickle({
             uri: gherkinDocEvent.uri,
             feature: gherkinDocEvent.feature,
-        }
+        })
+
         this._gherkinDocEvents.push(gherkinDocEvent)
-        this.eventEmitter.emit('getHookParams', this._currentPickle)
     }
 
     onHook(hookEvent: Hook) {
@@ -387,7 +392,7 @@ export default class CucumberFormatter extends Formatter {
             )
         }
 
-        this._currentPickle = { uri, feature, scenario }
+        this.updateCurrentPickle({ uri, feature, scenario })
 
         const reporterScenario: ReporterScenario = scenario
         reporterScenario.rule = getRule(
@@ -445,7 +450,7 @@ export default class CucumberFormatter extends Formatter {
                 return
             }
 
-            this._currentPickle = { uri, feature, scenario, step }
+            this.updateCurrentPickle({ uri, feature, scenario, step })
 
             this._testStart = new Date()
             const type = getStepType(step)
@@ -534,7 +539,7 @@ export default class CucumberFormatter extends Formatter {
         )
         const uri = doc?.uri
         const feature = doc?.feature
-        this._currentPickle = { uri, feature, scenario }
+        this.updateCurrentPickle({ uri, feature, scenario })
 
         const payload = {
             uid: scenario.id,

--- a/packages/wdio-cucumber-framework/tests/adapter.test.ts
+++ b/packages/wdio-cucumber-framework/tests/adapter.test.ts
@@ -610,7 +610,7 @@ describe('CucumberAdapter', () => {
         expect(executeHooksWithArgs).toBeCalledTimes(1)
     })
 
-    it('wrapSteps should not call wrapStep if step doesn't has wrapperOptions', async () => {
+    it('wrapSteps should not call wrapStep if step doesn\'t has wrapperOptions', async () => {
         const adapter = await CucumberAdapter.init!('0-0', {}, ['/foo/bar'], {}, {}, {}, false, ['progress'])
         adapter.wrapStep  = vi.fn()
         expect(adapter.wrapStep).toBeCalledTimes(0)

--- a/packages/wdio-cucumber-framework/tests/formatter.test.ts
+++ b/packages/wdio-cucumber-framework/tests/formatter.test.ts
@@ -48,7 +48,7 @@ const wdioReporter = {
 const _eventEmitter = {
     write: vi.fn(),
     emit: vi.fn(),
-    on: vi.fn()
+    on: vi.fn(),
 }
 
 const cid = '0-1'


### PR DESCRIPTION
## Proposed changes
Emit _cucumberPickle data for each event when updated at cucumberFormatter. In this [change](https://github.com/webdriverio/webdriverio/pull/11010/files#diff-e0efb0f89f079be1829b09cfadaf2d248ae64bd988b3a2f940aea3ea13744551R271) we are emitting pickle data only onGherkinDocument, before this we were sending updated pickle data to getHookParams passed to before/after hooks. Which results in step as undefined [here](https://github.com/webdriverio/webdriverio/pull/11010/files#diff-38b3bc00fc303b526589acdf1f7211bab55ad3f92f47e8405909ba5ba1f78239R402).

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
