### PR TITLE
Fix #11937:  Always print error message to terminal when integration package is not found

### DIFF
--- a/packages/wdio-logger/src/node.ts
+++ b/packages/wdio-logger/src/node.ts
@@ -112,7 +112,11 @@ const wdioLoggerMethodFactory = function (this: log.Logger, methodName: log.LogL
                 logCache.clear()
             }
 
-            return logFile.write(logText)
+            if (!logsContainInitPackageError(logText)) {
+                return logFile.write(logText)
+            }
+            // If we get Error during init of integration packages, write logs to both "outputDir" and the terminal
+            logFile.write(logText)
         }
 
         logCache.add(logText)
@@ -214,3 +218,15 @@ getLogger.setLogLevelsConfig = (logLevels: Record<string, log.LogLevelDesc> = {}
 const getLogLevelName = (logName: string) => logName.split(':').shift() as log.LogLevelDesc
 
 export type Logger = LoggerInterface
+
+function logsContainInitPackageError(logText: string) {
+    return ERROR_LOG_VALIDATOR.every(pattern => logText.includes(pattern))
+}
+
+const ERROR_LOG_VALIDATOR = [
+    'Couldn\'t find plugin',
+    'neither as wdio scoped package',
+    'nor as community package',
+    'Please make sure you have it installed'
+]
+


### PR DESCRIPTION
Fix for https://github.com/webdriverio/webdriverio/issues/11937

## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
