### PR TITLE
Webdriverio: Fix regression in 11711

### DIFF
--- a/packages/webdriverio/src/scripts/isElementDisplayed.ts
+++ b/packages/webdriverio/src/scripts/isElementDisplayed.ts
@@ -210,7 +210,7 @@ export default function isElementDisplayed (element: Element): boolean {
     // This is a partial reimplementation of Selenium's "element is displayed" algorithm.
     // When the W3C specification's algorithm stabilizes, we should implement that.
     // If this command is misdirected to the wrong document (and is NOT inside a shadow root), treat it as not shown.
-    if (!isElementInsideShadowRoot(element) && !document.body.contains(element)) {
+    if (!isElementInsideShadowRoot(element) && !document.contains(element)) {
         return false
     }
 


### PR DESCRIPTION
#11711 was to fix issues with older browsers but also added `body` to a check. It looks like this was added by mistake.

Our tests started failing with this change. I don't have a specific reproducible example because it fails on a custom dropdown that we've built in our codebase.  

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

### Reviewers: @webdriverio/project-committers
