### PR TITLE
wdio-utils: Fitler invalidateCache from stacktraces

### DIFF
--- a/packages/wdio-utils/src/test-framework/testFnWrapper.ts
+++ b/packages/wdio-utils/src/test-framework/testFnWrapper.ts
@@ -121,5 +121,6 @@ export const filterStackTrace = (stack: string): string => {
     return stack
         .split('\n')
         .filter(line => !STACKTRACE_FILTER.some(l => line.includes(l)))
+        .map(line => line.replace(/\?invalidateCache=(\d\.\d+|\d)/g, ''))
         .join('\n')
 }

--- a/packages/wdio-utils/tests/test-framework/testFnWrapper-async.test.ts
+++ b/packages/wdio-utils/tests/test-framework/testFnWrapper-async.test.ts
@@ -133,4 +133,18 @@ describe('filterStackTrace', () => {
             expect(filteredStack).toBe(filterStackTrace(fullStack))
         }
     })
+
+    it('should remove invalidateCache', () => {
+        const stacktrace = `
+            at async Context.<anonymous> (/foo/bar/test/specs/example.e2e.ts:8:9)
+            at Context.testFrameworkFnWrapper (/foo/bar/baz/testFnWrapper.js?invalidateCache=0.2342342342334:50:32)
+        `
+
+        const filteredStack = `
+            at async Context.<anonymous> (/foo/bar/test/specs/example.e2e.ts:8:9)
+            at Context.testFrameworkFnWrapper (/foo/bar/baz/testFnWrapper.js:50:32)
+        `
+
+        expect(filteredStack).toBe(filterStackTrace(stacktrace))
+    })
 })


### PR DESCRIPTION
## Proposed changes

#10975 added invalidateCache to files which are outputted in the stacktraces. This branch removes it from stacktraces since it's not needed and reduces some clutter.

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

### Reviewers: @webdriverio/project-committers
