### PR TITLE
fix: not add pause for iOS keys

### DIFF
--- a/__mocks__/got.ts
+++ b/__mocks__/got.ts
@@ -90,6 +90,10 @@ const requestMock: any = vi.fn().mockImplementation((uri, params) => {
             }
         }
 
+        if (params.json.capabilities.alwaysMatch.platformName && params.json.capabilities.alwaysMatch.platformName.includes('iOS')) {
+            value.capabilities.platformName = 'iOS'
+        }
+
         break
     case `/session/${sessionId}/element`:
         if (params.json && params.json.value === '#nonexisting') {

--- a/packages/webdriverio/src/commands/browser/keys.ts
+++ b/packages/webdriverio/src/commands/browser/keys.ts
@@ -55,6 +55,10 @@ export async function keys (
      */
     const keyAction = this.action('key')
     keySequence.forEach((value) => keyAction.down(value))
+    /**
+     * XCTest API only allows to send keypresses (e.g. keydown+keyup).
+     * There is no way to "split" them
+     */
     if (!this.isIOS){
         keyAction.pause(10)
     }

--- a/packages/webdriverio/src/commands/browser/keys.ts
+++ b/packages/webdriverio/src/commands/browser/keys.ts
@@ -55,7 +55,9 @@ export async function keys (
      */
     const keyAction = this.action('key')
     keySequence.forEach((value) => keyAction.down(value))
-    keyAction.pause(10)
+    if (!this.isIOS){
+        keyAction.pause(10)
+    }
     keySequence.forEach((value) => keyAction.up(value))
 
     // pass true to skip release of keys as they are already released

--- a/packages/webdriverio/tests/commands/browser/keys.test.ts
+++ b/packages/webdriverio/tests/commands/browser/keys.test.ts
@@ -98,6 +98,21 @@ describe('keys', () => {
         ])
     })
 
+    it('should not send a pause for iOS', async () => {
+        const browser = await remote({
+            baseUrl: 'http://foobar.com',
+            capabilities: {
+                browserName: 'safari',
+                platformName: 'iOS',
+            }
+        })
+        await browser.keys(['c'])
+        expect(vi.mocked(got).mock.calls[1][1].json.actions[0].actions).toEqual([
+            { type: 'keyDown', value: 'c' },
+            { type: 'keyUp', value: 'c' }
+        ])
+    })
+
     afterEach(() => {
         vi.mocked(got).mockClear()
     })


### PR DESCRIPTION
## Proposed changes

This PR fixes the [keys bug](https://github.com/webdriverio/webdriverio/issues/12039) for iOS

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
