### PR TITLE
(@wdio/browser-runner): improve performance by less pulling

### DIFF
--- a/packages/wdio-browser-runner/src/browser/frameworks/mocha.ts
+++ b/packages/wdio-browser-runner/src/browser/frameworks/mocha.ts
@@ -169,8 +169,7 @@ export class MochaFramework extends HTMLElement {
         /**
          * propagate results to browser so it can be picked up by the runner
          */
-        window.__wdioEvents__ = this.#runnerEvents
-        window.__wdioFailures__ = failures
+        this.#sendTestReport({ failures, events: this.#runnerEvents })
         console.log(`[WDIO] Finished test suite in ${Date.now() - startTime}ms`)
     }
 
@@ -211,6 +210,13 @@ export class MochaFramework extends HTMLElement {
             type: MESSAGE_TYPES.hookTriggerMessage,
             value: JSON.parse(safeStringify(value))
         }
+    }
+
+    #sendTestReport (value: Workers.BrowserTestResults) {
+        import.meta.hot?.send(WDIO_EVENT_NAME, {
+            type: MESSAGE_TYPES.browserTestResult,
+            value: JSON.parse(safeStringify(value))
+        })
     }
 }
 

--- a/packages/wdio-browser-runner/src/browser/frameworks/mocha.ts
+++ b/packages/wdio-browser-runner/src/browser/frameworks/mocha.ts
@@ -128,17 +128,19 @@ export class MochaFramework extends HTMLElement {
 
         const self = this
         const mochaBeforeHook = globalThis.before || globalThis.suiteSetup
-        mochaBeforeHook(function () {
-            self.#getHook('beforeSuite')({
-                ...this.test?.parent?.suites[0],
+        mochaBeforeHook(async function () {
+            const { title, tests, pending, delayed } = this.test?.parent?.suites[0] || {}
+            await self.#getHook('beforeSuite')({
+                ...({ title, tests, pending, delayed }),
                 file,
             })
         })
 
         const mochaAfterHook = globalThis.after || globalThis.suiteTeardown
-        mochaAfterHook(function () {
-            self.#getHook('afterSuite')({
-                ...this.test?.parent?.suites[0],
+        mochaAfterHook(async function () {
+            const { title, tests, pending, delayed } = this.test?.parent?.suites[0] || {}
+            await self.#getHook('afterSuite')({
+                ...({ title, tests, pending, delayed }),
                 file,
                 duration: Date.now() - startTime
             })

--- a/packages/wdio-browser-runner/src/browser/setup.ts
+++ b/packages/wdio-browser-runner/src/browser/setup.ts
@@ -16,9 +16,6 @@ declare global {
         WDIO_EVENT_NAME: string
         __wdioErrors__: WDIOErrorEvent[]
         __wdioSpec__: string
-        __wdioFailures__: number
-        __wdioEvents__: any[]
-        __wdioConnectPromise__: Promise<WebSocket>
         __wdioMockCache__: Map<string, any>
     }
 }

--- a/packages/wdio-browser-runner/tests/runner.test.ts
+++ b/packages/wdio-browser-runner/tests/runner.test.ts
@@ -126,7 +126,7 @@ describe('BrowserRunner', () => {
                 rootDir: '/foo/bar',
                 framework: 'mocha'
             } as any)
-            expect(await runner['_generateCoverageReports']()).toBe(false)
+            expect(await runner['_generateCoverageReports']()).toBe(true)
             expect(libCoverage.createCoverageMap).toBeCalledTimes(0)
         })
 

--- a/packages/wdio-browser-runner/tests/vite/communicator.test.ts
+++ b/packages/wdio-browser-runner/tests/vite/communicator.test.ts
@@ -29,7 +29,7 @@ describe('ServerWorkerCommunicator', () => {
         await onWorkerMessage({ name: 'sessionEnded', cid: '0-0' }, {}, {})
         expect(SESSIONS.size).toBe(0)
         expect(communicator.coverageMaps).toHaveLength(0)
-        await onWorkerMessage({ name: 'workerEvent', args: { type: 8 } }, {}, {})
+        await onWorkerMessage({ name: 'workerEvent', args: { type: 7 } }, {}, {})
         expect(communicator.coverageMaps).toHaveLength(1)
 
         const onBrowserEvent = server.onBrowserEvent.mock.calls[0][0]

--- a/packages/wdio-runner/src/browser.ts
+++ b/packages/wdio-runner/src/browser.ts
@@ -13,11 +13,13 @@ import type { TestFramework, WorkerResponseMessage } from './types.js'
 
 const log = logger('@wdio/runner')
 const sep = '\n  - '
+const ERROR_CHECK_INTERVAL = 500
 const DEFAULT_TIMEOUT = 60 * 1000
 
 type WDIOErrorEvent = Partial<Pick<ErrorEvent, 'filename' | 'message' | 'error'>> & { hasViteError?: boolean }
 interface TestState {
-    failures?: number | null
+    failures: number
+    events?: any[]
     errors?: WDIOErrorEvent[]
     hasViteError?: boolean
 }
@@ -31,11 +33,10 @@ declare global {
     }
 }
 
-const sleep = (ms = 100) => new Promise((resolve) => setTimeout(resolve, ms))
-
 export default class BrowserFramework implements Omit<TestFramework, 'init'> {
-    #inDebugMode = false
     #runnerOptions: any // `any` here because we don't want to create a dependency to @wdio/browser-runner
+    #testStatePromise: Promise<TestState>
+    #resolveTestStatePromise?: (value: TestState) => void
 
     constructor (
         private _cid: string,
@@ -49,10 +50,18 @@ export default class BrowserFramework implements Omit<TestFramework, 'init'> {
 
         const [, runnerOptions] = Array.isArray(_config.runner) ? _config.runner : []
         this.#runnerOptions = runnerOptions || {}
+
+        /**
+         * create promise to resolve test state which is being sent through the socket
+         * connection from the browser through the main process to the worker
+         */
+        this.#testStatePromise = new Promise((resolve) => {
+            this.#resolveTestStatePromise = resolve
+        })
     }
 
     /**
-     * always return true as it is unrelevant for component testing
+     * always return true as it is irrelevant for component testing
      */
     hasTests () {
         return true
@@ -119,52 +128,20 @@ export default class BrowserFramework implements Omit<TestFramework, 'init'> {
         /**
          * wait for test results or page errors
          */
-        let state: TestState = {}
-        const now = Date.now()
-        await browser.waitUntil(async () => {
-            while (typeof state.failures !== 'number' && (!state.errors || state.errors.length === 0)) {
-                if ((Date.now() - now) > timeout) {
-                    return false
-                }
+        const testTimeout = setTimeout(
+            () => this.#onTestTimeout(`Timed out after ${timeout / 1000}s waiting for test results`),
+            timeout)
 
-                await sleep()
+        /**
+         * run checks for errors here to avoid breakage in communication with the browser
+         */
+        const errorInterval = setInterval(
+            this.#checkForTestError.bind(this),
+            ERROR_CHECK_INTERVAL)
 
-                /**
-                 * don't fetch events if user has called debug command
-                 */
-                if (this.#inDebugMode) {
-                    continue
-                }
-
-                state = await browser?.execute(function fetchExecutionState () {
-                    const failures = window.__wdioEvents__ && window.__wdioEvents__.length > 0
-                        ? window.__wdioFailures__
-                        : null
-                    let viteError
-                    const viteErrorElem = document.querySelector('vite-error-overlay')
-                    if (viteErrorElem && viteErrorElem.shadowRoot) {
-                        const errorElements = Array.from(viteErrorElem.shadowRoot.querySelectorAll('pre'))
-                        if (errorElements.length) {
-                            viteError = [{ message: errorElements.map((elem) => elem.innerText).join('\n') }]
-                        }
-                    }
-                    const loadError = (
-                        typeof window.__wdioErrors__ === 'undefined' &&
-                        document.title !== 'WebdriverIO Browser Test' &&
-                        !document.querySelector('mocha-framework')
-                    )
-                        ?  [{ message: `Failed to load test page (title = "${document.title}", source: ${document.documentElement.innerHTML})` }]
-                        : null
-                    const errors = viteError || window.__wdioErrors__ || loadError
-                    return { failures, errors, hasViteError: Boolean(viteError) }
-                }).catch((err: any) => ({ errors: [{ message: err.message }] }))
-            }
-
-            return true
-        }, {
-            timeoutMsg: 'browser test timed out',
-            timeout
-        })
+        const state: TestState = await this.#testStatePromise
+        clearTimeout(testTimeout)
+        clearInterval(errorInterval)
 
         /**
          * capture coverage if enabled
@@ -183,6 +160,9 @@ export default class BrowserFramework implements Omit<TestFramework, 'init'> {
             process.send(workerEvent)
         }
 
+        /**
+         * let runner fail if we detect an error
+         */
         if (state.errors?.length) {
             const errors = state.errors.map((ev) => state.hasViteError
                 ? `${ev.message}\n${(ev.error ? ev.error.split('\n').slice(1).join('\n') : '')}`
@@ -207,16 +187,10 @@ export default class BrowserFramework implements Omit<TestFramework, 'init'> {
             return 1
         }
 
-        await this.#fetchEvents(browser, spec)
-        return state.failures || 0
-    }
-
-    async #fetchEvents (browser: WebdriverIO.Browser, spec: string) {
         /**
-         * populate events to the reporter
+         * report browser events to WebdriverIO reporter
          */
-        const events = await browser.execute(() => window.__wdioEvents__)
-        for (const ev of events) {
+        for (const ev of (state.events || [])) {
             if ((ev.type === 'suite:start' || ev.type === 'suite:end') && ev.title === '') {
                 continue
             }
@@ -227,6 +201,7 @@ export default class BrowserFramework implements Omit<TestFramework, 'init'> {
                 cid: this._cid
             })
         }
+        return state.failures || 0
     }
 
     async #processMessage (cmd: Workers.WorkerRequest) {
@@ -235,11 +210,6 @@ export default class BrowserFramework implements Omit<TestFramework, 'init'> {
         }
 
         const { message, id } = cmd.args
-        if (message.type === MESSAGE_TYPES.switchDebugState) {
-            this.#inDebugMode = message.value
-            return
-        }
-
         if (message.type === MESSAGE_TYPES.hookTriggerMessage) {
             return this.#handleHook(id, message.value)
         }
@@ -254,6 +224,10 @@ export default class BrowserFramework implements Omit<TestFramework, 'init'> {
 
         if (message.type === MESSAGE_TYPES.expectRequestMessage) {
             return this.#handleExpectation(id, message.value)
+        }
+
+        if (message.type === MESSAGE_TYPES.browserTestResult) {
+            return this.#handleTestFinish(message.value)
         }
     }
 
@@ -313,13 +287,6 @@ export default class BrowserFramework implements Omit<TestFramework, 'init'> {
             return this.#sendWorkerResponse(id, this.#commandResponse({ id: payload.id, error }))
         }
 
-        /**
-         * emit debug state to be enabled to runner so it can be propagated to the worker
-         */
-        if (payload.commandName === 'debug') {
-            this.#inDebugMode = true
-        }
-
         try {
             /**
              * double check if function is registered
@@ -330,13 +297,6 @@ export default class BrowserFramework implements Omit<TestFramework, 'init'> {
 
             const result = await (browser[payload.commandName as keyof typeof browser] as Function)(...payload.args)
             const resultMsg = this.#commandResponse({ id: payload.id, result })
-
-            /**
-             * emit debug state to be disabled to runner so it can be propagated to the worker
-             */
-            if (payload.commandName === 'debug') {
-                this.#inDebugMode = false
-            }
 
             log.debug(`Return command result: ${resultMsg}`)
             return this.#sendWorkerResponse(id, resultMsg)
@@ -402,6 +362,46 @@ export default class BrowserFramework implements Omit<TestFramework, 'init'> {
         return {
             type: MESSAGE_TYPES.expectResponseMessage,
             value
+        }
+    }
+
+    #handleTestFinish (payload: Workers.BrowserTestResults) {
+        this.#resolveTestStatePromise!({ failures: payload.failures })
+    }
+
+    #onTestTimeout (message: string) {
+        return this.#resolveTestStatePromise?.({
+            failures: 1,
+            errors: [{ message }]
+        })
+    }
+
+    async #checkForTestError () {
+        const testError = await browser.execute(function fetchExecutionState () {
+            let viteError
+            const viteErrorElem = document.querySelector('vite-error-overlay')
+            if (viteErrorElem && viteErrorElem.shadowRoot) {
+                const errorElements = Array.from(viteErrorElem.shadowRoot.querySelectorAll('pre'))
+                if (errorElements.length) {
+                    viteError = [{ message: errorElements.map((elem) => elem.innerText).join('\n') }]
+                }
+            }
+            const loadError = (
+                typeof window.__wdioErrors__ === 'undefined' &&
+                document.title !== 'WebdriverIO Browser Test' &&
+                !document.querySelector('mocha-framework')
+            )
+                ?  [{ message: `Failed to load test page (title = "${document.title}", source: ${document.documentElement.innerHTML})` }]
+                : null
+            const errors = viteError || window.__wdioErrors__ || loadError
+            return { errors, hasViteError: Boolean(viteError) }
+        })
+
+        if ((testError.errors && testError.errors.length > 0) || testError.hasViteError) {
+            this.#resolveTestStatePromise?.({
+                failures: 1,
+                ...testError
+            })
         }
     }
 

--- a/packages/wdio-types/src/Workers.ts
+++ b/packages/wdio-types/src/Workers.ts
@@ -85,11 +85,11 @@ export enum MESSAGE_TYPES {
     hookResultMessage,
     expectRequestMessage,
     expectResponseMessage,
-    switchDebugState,
     coverageMap,
     customCommand,
     initiateBrowserStateRequest,
     initiateBrowserStateResponse,
+    browserTestResult
     /**
      * @wdio/runner messages
      * TODO: add runner messages
@@ -109,11 +109,11 @@ export type SocketMessageValue = {
     [MESSAGE_TYPES.hookResultMessage]: HookResultEvent
     [MESSAGE_TYPES.expectRequestMessage]: ExpectRequestEvent
     [MESSAGE_TYPES.expectResponseMessage]: ExpectResponseEvent
-    [MESSAGE_TYPES.switchDebugState]: boolean
     [MESSAGE_TYPES.coverageMap]: any
     [MESSAGE_TYPES.customCommand]: CustomCommandEvent
     [MESSAGE_TYPES.initiateBrowserStateRequest]: BrowserStateRequest
     [MESSAGE_TYPES.initiateBrowserStateResponse]: BrowserState
+    [MESSAGE_TYPES.browserTestResult]: BrowserTestResults
 }
 
 export type SocketMessagePayload<T extends MESSAGE_TYPES> = T extends any
@@ -127,6 +127,11 @@ export interface ConsoleEvent {
     type: 'log' | 'info' | 'warn' | 'debug' | 'error'
     args: unknown[]
     cid: string
+}
+
+export interface BrowserTestResults {
+    failures: number
+    events: any[]
 }
 
 export interface CustomCommandEvent {


### PR DESCRIPTION
## Proposed changes

Some performance improvements in the browser runner. We are using now the new messaging system to push the result to the worker rather than pulling it from a browser global through `execute` command.

Background: it seemed that with a lot of test the execute command always returned the same result e.g. `failures = null` which would cause the test to stale and timeout.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
