### PR TITLE
Added default name for tms link to be displayed in allure reports

### DIFF
--- a/packages/wdio-allure-reporter/src/reporter.ts
+++ b/packages/wdio-allure-reporter/src/reporter.ts
@@ -722,7 +722,7 @@ export default class AllureReporter extends WDIOReporter {
 
         this.addLink({
             url: tmsLink,
-            name: linkName,
+            name: linkName || 'tms',
             type: LinkType.TMS
         })
     }


### PR DESCRIPTION
## Proposed changes

Fixes: [https://github.com/webdriverio/webdriverio/issues/12070](12070)

Jenkins Allure plugin doesn't display tms link because wdio  allure plugin creates tms link without a default name parameter. I added the default name for tms link.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
