### PR TITLE
(@wdio/browser-runner): improved stencil test integration

### DIFF
--- a/e2e/browser-runner/.eslintrc
+++ b/e2e/browser-runner/.eslintrc
@@ -1,10 +1,10 @@
 {
-  "env": {
-    "mocha": true,
-    "browser": true
-  },
-  "globals": {
-    "browser": true,
-    "expect": true
-  }
+    "env": {
+        "mocha": true,
+        "browser": true
+    },
+    "globals": {
+        "browser": true,
+        "expect": true
+    }
 }

--- a/e2e/browser-runner/components/StencilComponent.tsx
+++ b/e2e/browser-runner/components/StencilComponent.tsx
@@ -1,14 +1,15 @@
-import { Component, Prop, h } from '@stencil/core'
+import { Component, Prop } from '@stencil/core'
 import { MatchResults } from '@stencil-community/router'
 
 @Component({
     tag: 'app-profile',
+    styleUrl: 'stencil.css',
     shadow: true,
 })
 export class AppProfile {
-    @Prop() match: MatchResults
+    @Prop() match?: MatchResults
 
-    normalize(name: string): string {
+    normalize(name?: string): string {
         if (name) {
             return name.slice(0, 1).toUpperCase() + name.slice(1).toLowerCase()
         }
@@ -17,8 +18,10 @@ export class AppProfile {
 
     render() {
         return (
-            <div class="app-profile">
+            <div className="app-profile">
                 <p>Hello! My name is {this.normalize(this.match?.params.name)}.</p>
+                {/* @ts-ignore: types don't exist as we don't compile the components with Stencil */}
+                <nested-component id="nested component"></nested-component>
             </div>
         )
     }

--- a/e2e/browser-runner/components/StencilComponentNested.tsx
+++ b/e2e/browser-runner/components/StencilComponentNested.tsx
@@ -1,0 +1,17 @@
+import { Component as foo, Prop } from '@stencil/core'
+
+@foo({
+    tag: 'nested-component',
+    shadow: true,
+})
+export class NestedComponent {
+    @Prop() id?: string
+
+    render() {
+        return (
+            <i>
+                I am a {this.id || 'unknown'}!
+            </i>
+        )
+    }
+}

--- a/e2e/browser-runner/components/stencil.css
+++ b/e2e/browser-runner/components/stencil.css
@@ -1,0 +1,3 @@
+.app-profile {
+    font-weight: bold;
+}

--- a/e2e/browser-runner/stencil.test.tsx
+++ b/e2e/browser-runner/stencil.test.tsx
@@ -17,9 +17,17 @@ describe('Stencil Component Testing', () => {
         await expect($('>>>.app-profile')).toHaveText(
             expect.stringContaining('Hello! My name is Stencil.')
         )
-        await expect($('>>>.app-profile')).toHaveText(
-            expect.stringContaining('I am a nested component!')
-        )
+
+        /**
+         * this assertion for Safari due to: https://github.com/w3c/webdriver/issues/1786
+         */
+        // eslint-disable-next-line no-undef
+        if ((browser.capabilities as WebdriverIO.Capabilities).browserName !== 'safari') {
+            await expect($('>>>.app-profile')).toHaveText(
+                expect.stringContaining('I am a nested component!')
+            )
+        }
+
         await expect($('>>>.app-profile').getCSSProperty('font-weight'))
             .toMatchInlineSnapshot(`
           {

--- a/e2e/browser-runner/stencil.test.tsx
+++ b/e2e/browser-runner/stencil.test.tsx
@@ -2,15 +2,36 @@ import { $, expect } from '@wdio/globals'
 import { render } from '@wdio/browser-runner/stencil'
 
 import { AppProfile } from './components/StencilComponent.jsx'
+import { NestedComponent } from './components/StencilComponentNested.jsx'
 
 describe('Stencil Component Testing', () => {
     it('should render component correctly', async () => {
         render({
-            components: [AppProfile],
+            components: [AppProfile, NestedComponent],
+            autoApplyChanges: true,
             template: () => (
+                // @ts-ignore: types don't exist as we don't compile the components with Stencil
                 <app-profile match={{ params: { name: 'stencil' } }}></app-profile>
             )
         })
-        await expect($('>>>.app-profile')).toHaveText('Hello! My name is Stencil.')
+        await expect($('>>>.app-profile')).toHaveText(
+            expect.stringContaining('Hello! My name is Stencil.')
+        )
+        await expect($('>>>.app-profile')).toHaveText(
+            expect.stringContaining('I am a nested component!')
+        )
+        await expect($('>>>.app-profile').getCSSProperty('font-weight'))
+            .toMatchInlineSnapshot(`
+          {
+            "parsed": {
+              "string": "700",
+              "type": "number",
+              "unit": "",
+              "value": 700,
+            },
+            "property": "font-weight",
+            "value": 700,
+          }
+        `)
     })
 })

--- a/e2e/browser-runner/stencil.test.tsx
+++ b/e2e/browser-runner/stencil.test.tsx
@@ -22,7 +22,7 @@ describe('Stencil Component Testing', () => {
          * this assertion for Safari due to: https://github.com/w3c/webdriver/issues/1786
          */
         // eslint-disable-next-line no-undef
-        if ((browser.capabilities as WebdriverIO.Capabilities).browserName !== 'safari') {
+        if ((browser.capabilities as WebdriverIO.Capabilities).browserName?.toLowerCase() !== 'safari') {
             await expect($('>>>.app-profile')).toHaveText(
                 expect.stringContaining('I am a nested component!')
             )

--- a/packages/wdio-browser-runner/package.json
+++ b/packages/wdio-browser-runner/package.json
@@ -26,7 +26,10 @@
   "types": "./build/index.d.ts",
   "exports": {
     ".": "./build/index.js",
-    "./package.json": "./package.json"
+    "./package.json": "./package.json",
+    "./stencil": {
+      "types": "./stencil/index.d.ts"
+    }
   },
   "typeScriptVersion": "3.8.3",
   "dependencies": {

--- a/packages/wdio-browser-runner/src/vite/frameworks/fixtures/stencil.ts
+++ b/packages/wdio-browser-runner/src/vite/frameworks/fixtures/stencil.ts
@@ -1,5 +1,9 @@
 import { h } from '@stencil/core'
 
+/**
+ * Emulate Node.js `nextTick` function in browser.
+ * This is used by Stencil.js internally.
+ */
 process.nextTick = (cb) => setTimeout(cb, 0)
 
 // @ts-expect-error
@@ -80,7 +84,7 @@ export function render(opts: NewSpecPageOptions): StencilEnvironment {
         win: win,
         doc: doc,
         body: stage as any,
-        styles: styles as Map<string, string>
+        styles
     } as const
 
     const lazyBundles: LazyBundlesRuntimeData = opts.components.map((Cstr: ComponentTestingConstructor) => {
@@ -108,6 +112,11 @@ export function render(opts: NewSpecPageOptions): StencilEnvironment {
             }
         }
         registerModule(bundleId, Cstr)
+
+        /**
+         * Register the component as a custom element
+         */
+        customElements.define(Cstr.COMPILER_META.tagName, Cstr as any)
 
         const lazyBundleRuntimeMeta = formatLazyBundleRuntimeMeta(bundleId, [Cstr.COMPILER_META])
         return lazyBundleRuntimeMeta

--- a/packages/wdio-browser-runner/src/vite/frameworks/stencil.ts
+++ b/packages/wdio-browser-runner/src/vite/frameworks/stencil.ts
@@ -1,7 +1,7 @@
 import path from 'node:path'
 import url from 'node:url'
 
-import { findStaticImports } from 'mlly'
+import { findStaticImports, parseStaticImport } from 'mlly'
 import type { InlineConfig, Plugin } from 'vite'
 
 import { hasFileByExtensions } from '../utils.js'
@@ -9,11 +9,17 @@ import { hasFileByExtensions } from '../utils.js'
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url))
 const STENCIL_IMPORT = '@stencil/core'
 
-export async function isUsingStencilJS (rootDir: string, options: WebdriverIO.BrowserRunnerOptions) {
+interface CompilerOptions {
+    baseUrl?: string
+    paths?: Record<string, string[]>
+    target?: string
+}
+
+export async function isUsingStencilJS(rootDir: string, options: WebdriverIO.BrowserRunnerOptions) {
     return Boolean(options.preset === 'stencil' || await hasFileByExtensions(path.join(rootDir, 'stencil.config')))
 }
 
-export async function optimizeForStencil (rootDir: string) {
+export async function optimizeForStencil(rootDir: string) {
     const stencilConfig = await import(path.join(rootDir, 'stencil.config.ts')).catch(() => ({ config: {} }))
     const stencilPlugins = stencilConfig.config.plugins
     const stencilOptimizations: InlineConfig = {
@@ -39,8 +45,8 @@ export async function optimizeForStencil (rootDir: string) {
     return stencilOptimizations
 }
 
-async function stencilVitePlugin (rootDir: string): Promise<Plugin> {
-    const { transpileSync } = await import('@stencil/core/compiler/stencil.js')
+async function stencilVitePlugin(rootDir: string): Promise<Plugin> {
+    const { transpileSync, ts } = await import('@stencil/core/compiler/stencil.js')
     const stencilHelperPath = path.resolve(__dirname, 'fixtures', 'stencil.js')
     return {
         name: 'wdio-stencil',
@@ -51,43 +57,102 @@ async function stencilVitePlugin (rootDir: string): Promise<Plugin> {
             }
         },
         transform: function (code, id) {
-            const usesStencil = findStaticImports(code).some((imp) => imp.specifier === STENCIL_IMPORT)
-            if (!usesStencil) {
+            const staticImports = findStaticImports(code)
+            const stencilImports = staticImports
+                .filter((imp) => imp.specifier === STENCIL_IMPORT)
+                .map((imp) => parseStaticImport(imp))
+            const isStencilComponent = stencilImports.some((imp) => 'Component' in (imp.namedImports || {}))
+            if (!isStencilComponent) {
                 return { code }
             }
 
+            const tsCompilerOptions = getCompilerOptions(ts, rootDir)
             const opts = {
-                componentExport: 'customelement',
+                componentExport: 'module',
                 componentMetadata: 'compilerstatic',
-                coreImportPath: '@stencil/core/internal/testing',
+                coreImportPath: '@stencil/core/internal/client',
                 currentDirectory: rootDir,
+                file: path.basename(id),
                 module: 'esm',
-                proxy: null,
                 sourceMap: 'inline',
                 style: 'static',
+                proxy: 'defineproperty',
                 styleImportData: 'queryparams',
-                target: 'es2018',
                 transformAliasedImportPaths: process.env.__STENCIL_TRANSPILE_PATHS__ === 'true',
+                target: tsCompilerOptions?.target || 'es2018',
+                paths: tsCompilerOptions?.paths,
+                baseUrl: tsCompilerOptions?.baseUrl,
             }
 
             const transpiledCode = transpileSync(code, opts)
+
+            /**
+             * StencilJS applies only a getter to the component without having a setter defined.
+             * This causes issue in the browser as there is a check that the setter is defined
+             * if the getter is defined. We can work around this by defining a setter.
+             */
+            let transformedCode = transpiledCode.code.replace(
+                'static get style()',
+                'static set style(_) {}\n    static get style()'
+            )
+
+            /**
+             * StencilJS does not import the `h` or `Fragment` function by default. We need to add it so the user
+             * doesn't need to.
+             */
+            const hasRenderFunctionImport = stencilImports.some((imp) => 'h' in (imp.namedImports || {}))
+            if (!hasRenderFunctionImport) {
+                transformedCode = `import { h } from '@stencil/core';\n${transformedCode}`
+            }
+            const hasFragmentImport = stencilImports.some((imp) => 'Fragment' in (imp.namedImports || {}))
+            if (!hasFragmentImport) {
+                transformedCode = `import { Fragment } from '@stencil/core';\n${transformedCode}`
+            }
+
             return {
                 ...transpiledCode,
-                code: transpiledCode.code
-                    // HTMLElement gets imported from StencilJS but is undefined for some reasons
-                    .replace(
-                        'extends HTMLElement {',
-                        // replace it with the original one
-                        'extends window.HTMLElement {' +
-                        // and add a style setter so it won't throw when setting
-                        // style properties
-                        '\n\tstatic set style (ignore) {}\n'
-                    )
-                    // make sure that components are exported properly
-                    // StencilJS removes the export when componentExport is set to 'customelement'
-                    .replace('\nconst', '\nexport const'),
+                code: transformedCode,
                 inputFilePath: id
             }
         }
     }
+}
+
+let _tsCompilerOptions: CompilerOptions | null = null
+
+/**
+ * Read the TypeScript compiler configuration file from disk
+ * @param rootDir the location to search for the config file
+ * @returns the configuration, or `null` if the file cannot be found
+ */
+function getCompilerOptions(ts: any, rootDir: string): CompilerOptions | null {
+    if (_tsCompilerOptions) {
+        return _tsCompilerOptions
+    }
+
+    if (typeof rootDir !== 'string') {
+        return null
+    }
+
+    const tsconfigFilePath = ts.findConfigFile(rootDir, ts.sys.fileExists)
+    if (!tsconfigFilePath) {
+        return null
+    }
+
+    const tsconfigResults = ts.readConfigFile(tsconfigFilePath, ts.sys.readFile)
+
+    if (tsconfigResults.error) {
+        throw new Error(tsconfigResults.error)
+    }
+
+    const parseResult = ts.parseJsonConfigFileContent(
+        tsconfigResults.config,
+        ts.sys,
+        rootDir,
+        undefined,
+        tsconfigFilePath,
+    )
+
+    _tsCompilerOptions = parseResult.options
+    return _tsCompilerOptions
 }

--- a/packages/wdio-browser-runner/tests/vite/frameworks/stencil.test.ts
+++ b/packages/wdio-browser-runner/tests/vite/frameworks/stencil.test.ts
@@ -8,7 +8,28 @@ vi.mock('@stencil/core/compiler/stencil.js', () => ({
     transpileSync: vi.fn().mockReturnValue({
         code: 'the transpiled code',
         inputFilePath: '/foo/bar/StencilComponent.tsx'
-    })
+    }),
+    ts: {
+        findConfigFile: vi.fn().mockReturnValue('/foo/bar/tsconfig.json'),
+        sys: {
+            resolvePath: vi.fn().mockReturnValue('/foo/bar/tsconfig.json'),
+            fileExists: vi.fn().mockReturnValue(true)
+        },
+        readConfigFile: vi.fn().mockReturnValue({
+            config: {
+                compilerOptions: {
+                    baseUrl: './',
+                    paths: {
+                        '@stencil/core': ['node_modules/@stencil/core/dist/types']
+                    },
+                    target: 'es2017'
+                }
+            }
+        }),
+        parseJsonConfigFileContent: vi.fn().mockReturnValue({
+            options: {}
+        })
+    }
 }))
 
 vi.mock('../../../src/vite/utils.js', () => ({
@@ -50,7 +71,7 @@ test('optimizeForStencil', async () => {
         "import { Component, Prop, h } from '@stencil/core'",
         '/foo/bar/StencilComponent.tsx', {})
     ).toEqual({
-        code: 'the transpiled code',
+        code: "import { Fragment } from '@stencil/core';\nthe transpiled code",
         inputFilePath: '/foo/bar/StencilComponent.tsx'
     })
     expect((opt.plugins?.[0] as any).transform(

--- a/packages/wdio-runner/src/browser.ts
+++ b/packages/wdio-runner/src/browser.ts
@@ -346,7 +346,14 @@ export default class BrowserFramework implements Omit<TestFramework, 'init'> {
             const context = payload.element
                 ? Array.isArray(payload.element)
                     ? await browser.$$(payload.element)
-                    : await browser.$(payload.element)
+                    /**
+                     * check if element contains an `elementId` property, if so the element was already
+                     * found, so we can transform it into an `WebdriverIO.Element` object, if not we
+                     * need to find it first, so we pass in the selector.
+                     */
+                    : payload.element.elementId
+                        ? await browser.$(payload.element)
+                        : await browser.$(payload.element.selector)
                 : payload.context || browser
             const result = await matcher.apply(payload.scope, [context, ...payload.args.map(transformExpectArgs)])
             return this.#sendWorkerResponse(id, this.#expectResponse({


### PR DESCRIPTION
## Proposed changes

The original implementation wasn't ideal but did the job. This PR improves the Stencil integration by:

- supporting project `tsconfig.json` options
- better detection on whether a file needs to be transformed by looking for a `Component` import
- auto-import of `h` and `Fragment` functions if missing
- less string replacement of compiled code, we now transform with better options and only need to add the `styles` setter due to a bug in Stencil

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Polish (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
