### PR TITLE
(webdriverio): make puppeteer a peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31104,7 +31104,6 @@
         "lodash.clonedeep": "^4.5.0",
         "lodash.zip": "^4.2.0",
         "minimatch": "^9.0.0",
-        "puppeteer-core": "^20.9.0",
         "query-selector-shadow-dom": "^1.0.0",
         "resq": "^1.9.1",
         "rgb2hex": "0.2.5",
@@ -31116,16 +31115,21 @@
         "@types/aria-query": "^5.0.0",
         "@types/lodash.clonedeep": "^4.5.6",
         "@types/lodash.zip": "^4.2.6",
-        "got": "^12.6.0"
+        "got": "^12.6.0",
+        "puppeteer-core": "^20.9.0"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "devtools": "^8.14.0"
+        "devtools": "^8.14.0",
+        "puppeteer-core": "^20.9.0"
       },
       "peerDependenciesMeta": {
         "devtools": {
+          "optional": true
+        },
+        "puppeteer-core": {
           "optional": true
         }
       }
@@ -31134,6 +31138,7 @@
       "version": "1.4.6",
       "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.4.6.tgz",
       "integrity": "sha512-x4BEjr2SjOPowNeiguzjozQbsc6h437ovD/wu+JpaenxVLm3jkgzHY2xOslMTp50HoTvQreMjiexiGQw1sqZlQ==",
+      "dev": true,
       "dependencies": {
         "debug": "4.3.4",
         "extract-zip": "2.0.1",
@@ -31162,6 +31167,7 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
       "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
+      "dev": true,
       "dependencies": {
         "debug": "^4.3.4"
       },
@@ -31173,6 +31179,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
       "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
+      "dev": true,
       "dependencies": {
         "node-fetch": "^2.6.12"
       }
@@ -31181,6 +31188,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.0.tgz",
       "integrity": "sha512-+ZT+iBxVUQ1asugqnD6oWoRiS25AkjNfG085dKJGtGxkdwLQrMKU5wJr2bOOFAXzKcTuqq+7fZlTMgG3SRfIYQ==",
+      "dev": true,
       "dependencies": {
         "agent-base": "^7.1.0",
         "debug": "^4.3.4"
@@ -31193,6 +31201,7 @@
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.2.tgz",
       "integrity": "sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA==",
+      "dev": true,
       "dependencies": {
         "agent-base": "^7.0.2",
         "debug": "4"
@@ -31205,6 +31214,7 @@
       "version": "7.18.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
       "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "dev": true,
       "engines": {
         "node": ">=12"
       }
@@ -31213,6 +31223,7 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.3.0.tgz",
       "integrity": "sha512-0LdR757eTj/JfuU7TL2YCuAZnxWXu3tkJbg4Oq3geW/qFNT/32T0sp2HnZ9O0lMR4q3vwAt0+xCA8SR0WAD0og==",
+      "dev": true,
       "dependencies": {
         "agent-base": "^7.0.2",
         "debug": "^4.3.4",
@@ -31231,6 +31242,7 @@
       "version": "20.9.0",
       "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-20.9.0.tgz",
       "integrity": "sha512-H9fYZQzMTRrkboEfPmf7m3CLDN6JvbxXA3qTtS+dFt27tR+CsFHzPsT6pzp6lYL6bJbAPaR0HaPO6uSi+F94Pg==",
+      "dev": true,
       "dependencies": {
         "@puppeteer/browsers": "1.4.6",
         "chromium-bidi": "0.4.16",
@@ -31255,6 +31267,7 @@
       "version": "0.4.16",
       "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.4.16.tgz",
       "integrity": "sha512-7ZbXdWERxRxSwo3txsBjjmc/NLxqb1Bk30mRb0BMS4YIaiV6zvKZqL/UAH+DdqcDYayDWk2n/y8klkBDODrPvA==",
+      "dev": true,
       "dependencies": {
         "mitt": "3.0.0"
       },
@@ -31265,12 +31278,14 @@
     "packages/webdriverio/node_modules/puppeteer-core/node_modules/devtools-protocol": {
       "version": "0.0.1147663",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1147663.tgz",
-      "integrity": "sha512-hyWmRrexdhbZ1tcJUGpO95ivbRhWXz++F4Ko+n21AY5PNln2ovoJw+8ZMNDTtip+CNFQfrtLVh/w4009dXO/eQ=="
+      "integrity": "sha512-hyWmRrexdhbZ1tcJUGpO95ivbRhWXz++F4Ko+n21AY5PNln2ovoJw+8ZMNDTtip+CNFQfrtLVh/w4009dXO/eQ==",
+      "dev": true
     },
     "packages/webdriverio/node_modules/socks-proxy-agent": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.2.tgz",
       "integrity": "sha512-8zuqoLv1aP/66PHF5TqwJ7Czm3Yv32urJQHrVyhD7mmA6d61Zv8cIXQYPTWwmg6qlupnPvs/QKDmfa4P/qct2g==",
+      "dev": true,
       "dependencies": {
         "agent-base": "^7.0.2",
         "debug": "^4.3.4",
@@ -31284,6 +31299,7 @@
       "version": "8.13.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
       "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+      "dev": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -31304,6 +31320,7 @@
       "version": "17.7.1",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
       "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
+      "dev": true,
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -53932,6 +53949,7 @@
           "version": "1.4.6",
           "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.4.6.tgz",
           "integrity": "sha512-x4BEjr2SjOPowNeiguzjozQbsc6h437ovD/wu+JpaenxVLm3jkgzHY2xOslMTp50HoTvQreMjiexiGQw1sqZlQ==",
+          "dev": true,
           "requires": {
             "debug": "4.3.4",
             "extract-zip": "2.0.1",
@@ -53946,6 +53964,7 @@
           "version": "7.1.0",
           "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
           "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
+          "dev": true,
           "requires": {
             "debug": "^4.3.4"
           }
@@ -53954,6 +53973,7 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
           "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
+          "dev": true,
           "requires": {
             "node-fetch": "^2.6.12"
           }
@@ -53962,6 +53982,7 @@
           "version": "7.0.0",
           "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.0.tgz",
           "integrity": "sha512-+ZT+iBxVUQ1asugqnD6oWoRiS25AkjNfG085dKJGtGxkdwLQrMKU5wJr2bOOFAXzKcTuqq+7fZlTMgG3SRfIYQ==",
+          "dev": true,
           "requires": {
             "agent-base": "^7.1.0",
             "debug": "^4.3.4"
@@ -53971,6 +53992,7 @@
           "version": "7.0.2",
           "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.2.tgz",
           "integrity": "sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA==",
+          "dev": true,
           "requires": {
             "agent-base": "^7.0.2",
             "debug": "4"
@@ -53979,12 +54001,14 @@
         "lru-cache": {
           "version": "7.18.3",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-          "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="
+          "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+          "dev": true
         },
         "proxy-agent": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.3.0.tgz",
           "integrity": "sha512-0LdR757eTj/JfuU7TL2YCuAZnxWXu3tkJbg4Oq3geW/qFNT/32T0sp2HnZ9O0lMR4q3vwAt0+xCA8SR0WAD0og==",
+          "dev": true,
           "requires": {
             "agent-base": "^7.0.2",
             "debug": "^4.3.4",
@@ -54000,6 +54024,7 @@
           "version": "20.9.0",
           "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-20.9.0.tgz",
           "integrity": "sha512-H9fYZQzMTRrkboEfPmf7m3CLDN6JvbxXA3qTtS+dFt27tR+CsFHzPsT6pzp6lYL6bJbAPaR0HaPO6uSi+F94Pg==",
+          "dev": true,
           "requires": {
             "@puppeteer/browsers": "1.4.6",
             "chromium-bidi": "0.4.16",
@@ -54013,6 +54038,7 @@
               "version": "0.4.16",
               "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.4.16.tgz",
               "integrity": "sha512-7ZbXdWERxRxSwo3txsBjjmc/NLxqb1Bk30mRb0BMS4YIaiV6zvKZqL/UAH+DdqcDYayDWk2n/y8klkBDODrPvA==",
+              "dev": true,
               "requires": {
                 "mitt": "3.0.0"
               }
@@ -54020,7 +54046,8 @@
             "devtools-protocol": {
               "version": "0.0.1147663",
               "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1147663.tgz",
-              "integrity": "sha512-hyWmRrexdhbZ1tcJUGpO95ivbRhWXz++F4Ko+n21AY5PNln2ovoJw+8ZMNDTtip+CNFQfrtLVh/w4009dXO/eQ=="
+              "integrity": "sha512-hyWmRrexdhbZ1tcJUGpO95ivbRhWXz++F4Ko+n21AY5PNln2ovoJw+8ZMNDTtip+CNFQfrtLVh/w4009dXO/eQ==",
+              "dev": true
             }
           }
         },
@@ -54028,6 +54055,7 @@
           "version": "8.0.2",
           "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.2.tgz",
           "integrity": "sha512-8zuqoLv1aP/66PHF5TqwJ7Czm3Yv32urJQHrVyhD7mmA6d61Zv8cIXQYPTWwmg6qlupnPvs/QKDmfa4P/qct2g==",
+          "dev": true,
           "requires": {
             "agent-base": "^7.0.2",
             "debug": "^4.3.4",
@@ -54038,12 +54066,14 @@
           "version": "8.13.0",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
           "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+          "dev": true,
           "requires": {}
         },
         "yargs": {
           "version": "17.7.1",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
           "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
+          "dev": true,
           "requires": {
             "cliui": "^8.0.1",
             "escalade": "^3.1.1",

--- a/packages/wdio-cucumber-framework/src/index.ts
+++ b/packages/wdio-cucumber-framework/src/index.ts
@@ -36,13 +36,13 @@ import {
 
     DataTable,
     World,
-    Status
+    Status,
 } from '@cucumber/cucumber'
 import Gherkin from '@cucumber/gherkin'
 import { IdGenerator } from '@cucumber/messages'
 import type { Feature, GherkinDocument } from '@cucumber/messages'
 import type Cucumber from '@cucumber/cucumber'
-import type { IRunEnvironment } from '@cucumber/cucumber/api'
+import type { IConfiguration, IRunEnvironment } from '@cucumber/cucumber/api'
 import { loadConfiguration, loadSources, runCucumber } from '@cucumber/cucumber/api'
 
 import { DEFAULT_OPTS } from './constants.js'
@@ -269,7 +269,7 @@ class CucumberAdapter {
             }
 
             const { runConfiguration } = await loadConfiguration(
-                { profiles: this._cucumberOpts.profiles, provided: this._cucumberOpts },
+                { profiles: this._cucumberOpts.profiles, provided: this._cucumberOpts as Partial<IConfiguration> },
                 environment
             )
 

--- a/packages/wdio-cucumber-framework/src/types.ts
+++ b/packages/wdio-cucumber-framework/src/types.ts
@@ -59,7 +59,7 @@ export interface CucumberOptions {
      * "random" or "random:42" whereas 42 is the seed for randomization
      * @default defined
      */
-    order?: string;
+    order?: 'defined' | 'random' | `random:${string}`;
     /**
      * Publish a report of your test run to https://reports.cucumber.io/
      */

--- a/packages/wdio-cucumber-framework/tests/adapter.test.ts
+++ b/packages/wdio-cucumber-framework/tests/adapter.test.ts
@@ -136,7 +136,7 @@ describe('CucumberAdapter', () => {
     it('can run without errors', async () => {
         const adapter = await CucumberAdapter.init!('0-0', {
             cucumberOpts: { format: [] }
-        }, ['/foo/bar'], {}, {}, {}, false, ['progress'])
+        }, ['/foo/bar'], {}, {}, {}, false, 'progress')
         adapter.registerRequiredModules = vi.fn()
         adapter.addWdioHooks = vi.fn()
         adapter.loadFiles = vi.fn()
@@ -218,7 +218,7 @@ describe('CucumberAdapter', () => {
             {},
             {},
             false,
-            ['progress']
+            'progress'
         )
         adapter.addWdioHooks(
             {
@@ -326,7 +326,7 @@ describe('CucumberAdapter', () => {
             {},
             {},
             false,
-            ['progress']
+            'progress'
         )
 
         expect(adapter._specs).toHaveLength(1)
@@ -354,7 +354,7 @@ describe('CucumberAdapter', () => {
             {},
             {},
             false,
-            ['progress']
+            'progress'
         )
 
         expect(adapter._specs).toHaveLength(1)
@@ -382,7 +382,7 @@ describe('CucumberAdapter', () => {
             {},
             {},
             false,
-            ['progress']
+            'progress'
         )
 
         expect(adapter._specs).toHaveLength(1)
@@ -410,7 +410,7 @@ describe('CucumberAdapter', () => {
             {},
             {},
             false,
-            ['progress']
+            'progress'
         )
 
         expect(adapter._specs).toHaveLength(1)
@@ -438,7 +438,7 @@ describe('CucumberAdapter', () => {
             {},
             {},
             false,
-            ['progress']
+            'progress'
         )
 
         expect(adapter._specs).toHaveLength(0)
@@ -466,7 +466,7 @@ describe('CucumberAdapter', () => {
             {},
             {},
             false,
-            ['progress']
+            'progress'
         )
 
         expect(adapter._specs).toHaveLength(1)
@@ -494,7 +494,7 @@ describe('CucumberAdapter', () => {
             {},
             {},
             false,
-            ['progress']
+            'progress'
         )
 
         expect(adapter._specs).toHaveLength(1)
@@ -521,7 +521,7 @@ describe('CucumberAdapter', () => {
             {},
             {},
             false,
-            ['progress']
+            'progress'
         )
 
         expect(adapter.gherkinParser.tokenMatcher.dialect.name).toBe('Danish')
@@ -539,7 +539,7 @@ describe('CucumberAdapter', () => {
             {},
             {},
             false,
-            ['progress']
+            'progress'
         )
 
         expect(adapter._specs).toHaveLength(2)
@@ -567,7 +567,7 @@ describe('CucumberAdapter', () => {
             {},
             {},
             false,
-            ['progress']
+            'progress'
         )
 
         expect(adapter._specs).toHaveLength(1)
@@ -594,7 +594,7 @@ describe('CucumberAdapter', () => {
             {},
             {},
             true,
-            ['progress']
+            'progress'
         )
 
         expect(adapter._specs).toHaveLength(0)

--- a/packages/wdio-utils/src/index.ts
+++ b/packages/wdio-utils/src/index.ts
@@ -6,7 +6,8 @@ import { startWebDriver } from './startWebDriver.js'
 import { initializeWorkerService, initializeLauncherService } from './initializeServices.js'
 import {
     commandCallStructure, isValidParameter, getArgumentType, safeImport,
-    isFunctionAsync, transformCommandLogResult, sleep, isAppiumCapability
+    isFunctionAsync, transformCommandLogResult, sleep, isAppiumCapability,
+    userImport
 } from './utils.js'
 import { wrapCommand, executeHooksWithArgs, executeAsync } from './shim.js'
 import * as asyncIterators from './pIteration.js'
@@ -31,6 +32,7 @@ export {
     safeImport,
     sleep,
     isAppiumCapability,
+    userImport,
     asyncIterators,
 
     /**

--- a/packages/wdio-utils/src/utils.ts
+++ b/packages/wdio-utils/src/utils.ts
@@ -122,7 +122,7 @@ export function transformCommandLogResult (result: { file?: string, script?: str
 }
 
 /**
- * checks if command argument is valid according to specificiation
+ * checks if command argument is valid according to specification
  *
  * @param  {*}       arg           command argument
  * @param  {Object}  expectedType  parameter type (e.g. `number`, `string[]` or `(number|string)`)
@@ -165,6 +165,25 @@ export function isValidParameter (arg: any, expectedType: string) {
  */
 export function getArgumentType (arg: any) {
     return arg === null ? 'null' : typeof arg
+}
+
+/**
+ * Utility to import modules with user friendly error message
+ * @param moduleName  The name of the module to import
+ * @param namedImport The name of the import to return
+ * @returns          The imported module
+ */
+export async function userImport<T> (moduleName: string, namedImport = 'default'): Promise<T> {
+    try {
+        const mod = await import(moduleName)
+        if (namedImport in mod) {
+            return mod[namedImport]
+        }
+    } catch (err) {
+        throw new Error(`Couldn't import "${moduleName}"! Do you have it installed? If not run "npm install ${moduleName}"!`)
+    }
+
+    throw new Error(`Couldn't find "${namedImport}" in module "${moduleName}"`)
 }
 
 /**

--- a/packages/wdio-utils/tests/utils.test.ts
+++ b/packages/wdio-utils/tests/utils.test.ts
@@ -1,9 +1,11 @@
+import path from 'node:path'
 import type { MockedFunction } from 'vitest'
 import { vi, describe, it, expect } from 'vitest'
 
 import {
     overwriteElementCommands, commandCallStructure, isValidParameter, definesRemoteDriver,
-    getArgumentType, isFunctionAsync, filterSpecArgs, isBase64, transformCommandLogResult
+    getArgumentType, isFunctionAsync, filterSpecArgs, isBase64, transformCommandLogResult,
+    userImport
 } from '../src/utils.js'
 
 describe('utils', () => {
@@ -228,5 +230,26 @@ describe('utils:isBase64', () => {
     it('should throw if input type not a string', () => {
         // @ts-ignore
         expect(() => isBase64(null)).toThrow('Expected string but received invalid type.')
+    })
+})
+
+describe('utils:userImport', () => {
+    it('should import module', async () => {
+        const mod = await userImport('path')
+        expect(mod).toEqual(path)
+        const join = await userImport('path', 'join')
+        expect(join).toEqual(path.join)
+    })
+
+    it('throws error message if named import not found', async () => {
+        await expect(userImport('path', 'foo'))
+            .rejects
+            .toThrow('Couldn\'t find "foo" in module "path"')
+    })
+
+    it('throws error message if module not found', async () => {
+        await expect(userImport('foobar'))
+            .rejects
+            .toThrow('Couldn\'t import "foobar"! Do you have it installed? If not run "npm install foobar"!')
     })
 })

--- a/packages/webdriverio/package.json
+++ b/packages/webdriverio/package.json
@@ -65,7 +65,8 @@
     "@types/aria-query": "^5.0.0",
     "@types/lodash.clonedeep": "^4.5.6",
     "@types/lodash.zip": "^4.2.6",
-    "got": "^12.6.0"
+    "got": "^12.6.0",
+    "puppeteer-core": "^20.9.0"
   },
   "dependencies": {
     "@types/node": "^20.1.0",
@@ -86,7 +87,6 @@
     "lodash.clonedeep": "^4.5.0",
     "lodash.zip": "^4.2.0",
     "minimatch": "^9.0.0",
-    "puppeteer-core": "^20.9.0",
     "query-selector-shadow-dom": "^1.0.0",
     "resq": "^1.9.1",
     "rgb2hex": "0.2.5",
@@ -94,10 +94,14 @@
     "webdriver": "8.29.1"
   },
   "peerDependencies": {
-    "devtools": "^8.14.0"
+    "devtools": "^8.14.0",
+    "puppeteer-core": "^20.9.0"
   },
   "peerDependenciesMeta": {
     "devtools": {
+      "optional": true
+    },
+    "puppeteer-core": {
       "optional": true
     }
   }

--- a/packages/webdriverio/src/commands/browser/getPuppeteer.ts
+++ b/packages/webdriverio/src/commands/browser/getPuppeteer.ts
@@ -1,7 +1,7 @@
-import puppeteer from 'puppeteer-core'
 import logger from '@wdio/logger'
-import type { Browser as PuppeteerBrowser } from 'puppeteer-core/lib/esm/puppeteer/api/Browser.js'
+import { safeImport } from '@wdio/utils'
 import type { Capabilities } from '@wdio/types'
+import type { Puppeteer, Browser as PuppeteerBrowser } from 'puppeteer-core'
 
 import { FF_REMOTE_DEBUG_ARG } from '../../constants.js'
 
@@ -43,6 +43,14 @@ const log = logger('webdriverio')
  * @return {PuppeteerBrowser}  initiated puppeteer instance connected to the browser
  */
 export async function getPuppeteer (this: WebdriverIO.Browser) {
+    const puppeteer = (await safeImport('puppeteer-core'))?.default as unknown as Puppeteer
+    if (!puppeteer) {
+        throw new Error(
+            'You need to install "puppeteer-core" package as a dependency ' +
+            'in order to use the "getPuppeteer" method'
+        )
+    }
+
     /**
      * check if we already connected Puppeteer and if so return
      * that instance

--- a/packages/webdriverio/src/commands/browser/getPuppeteer.ts
+++ b/packages/webdriverio/src/commands/browser/getPuppeteer.ts
@@ -1,5 +1,5 @@
 import logger from '@wdio/logger'
-import { safeImport } from '@wdio/utils'
+import { userImport } from '@wdio/utils'
 import type { Capabilities } from '@wdio/types'
 import type { Puppeteer, Browser as PuppeteerBrowser } from 'puppeteer-core'
 
@@ -43,7 +43,8 @@ const log = logger('webdriverio')
  * @return {PuppeteerBrowser}  initiated puppeteer instance connected to the browser
  */
 export async function getPuppeteer (this: WebdriverIO.Browser) {
-    const puppeteer = (await safeImport('puppeteer-core'))?.default as unknown as Puppeteer
+    const puppeteer = await userImport<Puppeteer>('puppeteer-core')
+
     if (!puppeteer) {
         throw new Error(
             'You need to install "puppeteer-core" package as a dependency ' +

--- a/packages/webdriverio/src/commands/browser/mock.ts
+++ b/packages/webdriverio/src/commands/browser/mock.ts
@@ -1,10 +1,13 @@
-import type Interception from '../../utils/interception/index.js'
+import type { CDPSession } from 'puppeteer-core'
+
 import DevtoolsNetworkInterception from '../../utils/interception/devtools.js'
 import WebDriverNetworkInterception from '../../utils/interception/webdriver.js'
+
 import { getBrowserObject } from '../../utils/index.js'
+
 import type { Mock } from '../../types.js'
 import type { MockFilterOptions } from '../../utils/interception/types.js'
-import type { CDPSession } from 'puppeteer-core/lib/esm/puppeteer/common/Connection.js'
+import type Interception from '../../utils/interception/index.js'
 
 export const SESSION_MOCKS: Record<string, Set<Interception>> = {}
 export const CDP_SESSIONS: Record<string, CDPSession> = {}

--- a/packages/webdriverio/src/types.ts
+++ b/packages/webdriverio/src/types.ts
@@ -3,7 +3,7 @@ import type { Protocol } from 'devtools-protocol'
 import type { SessionFlags, AttachOptions as WebDriverAttachOptions, BidiHandler, BidiEventHandler } from 'webdriver'
 import type { Options, Capabilities, FunctionProperties, ThenArg } from '@wdio/types'
 import type { ElementReference, ProtocolCommands } from '@wdio/protocols'
-import type { Browser as PuppeteerBrowser } from 'puppeteer-core/lib/esm/puppeteer/api/Browser.js'
+import type { Browser as PuppeteerBrowser } from 'puppeteer-core'
 
 import type * as BrowserCommands from './commands/browser.js'
 import type * as ElementCommands from './commands/element.js'

--- a/packages/webdriverio/src/utils/interception/devtools.ts
+++ b/packages/webdriverio/src/utils/interception/devtools.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs/promises'
 import path from 'node:path'
 import logger from '@wdio/logger'
-import type { CDPSession } from 'puppeteer-core/lib/esm/puppeteer/common/Connection.js'
+import type { CDPSession } from 'puppeteer-core'
 import type { Protocol } from 'devtools-protocol'
 
 import Interception from './index.js'

--- a/packages/webdriverio/src/utils/interception/types.ts
+++ b/packages/webdriverio/src/utils/interception/types.ts
@@ -1,4 +1,4 @@
-import type { CDPSession } from 'puppeteer-core/lib/esm/puppeteer/common/Connection.js'
+import type { CDPSession } from 'puppeteer-core'
 import type { JsonCompatible } from '@wdio/types'
 
 /**

--- a/packages/webdriverio/tests/commands/browser/getPuppeteer.test.ts
+++ b/packages/webdriverio/tests/commands/browser/getPuppeteer.test.ts
@@ -7,6 +7,20 @@ import { remote } from '../../../src/index.js'
 
 vi.mock('got')
 vi.mock('puppeteer-core')
+/**
+ * Given that Puppeteer is not a direct dependency of this package, we can't mock
+ * it and dynamically import it. Instead, we mock the "userImport" helper and make
+ * it resolve to the mocked Puppeteer.
+ */
+vi.mock('@wdio/utils', async (origMod) => {
+    const orig = await origMod() as any
+    // resolve the mocked puppeteer-core
+    const puppeteer = await import('puppeteer-core')
+    return {
+        ...orig,
+        userImport: vi.fn().mockResolvedValue(puppeteer.default)
+    }
+})
 vi.mock('@wdio/logger', () => import(path.join(process.cwd(), '__mocks__', '@wdio/logger')))
 
 const puppeteerConnect = vi.mocked(puppeteer.connect)

--- a/packages/webdriverio/tests/commands/browser/throttleCPU.test.ts
+++ b/packages/webdriverio/tests/commands/browser/throttleCPU.test.ts
@@ -8,6 +8,20 @@ import { remote } from '../../../src/index.js'
 
 vi.mock('got')
 vi.mock('puppeteer-core')
+/**
+ * Given that Puppeteer is not a direct dependency of this package, we can't mock
+ * it and dynamically import it. Instead, we mock the "userImport" helper and make
+ * it resolve to the mocked Puppeteer.
+ */
+vi.mock('@wdio/utils', async (origMod) => {
+    const orig = await origMod() as any
+    // resolve the mocked puppeteer-core
+    const puppeteer = await import('puppeteer-core')
+    return {
+        ...orig,
+        userImport: vi.fn().mockResolvedValue(puppeteer.default)
+    }
+})
 vi.mock('@wdio/logger', () => import(path.join(process.cwd(), '__mocks__', '@wdio/logger')))
 
 // @ts-ignore mock feature

--- a/packages/webdriverio/tests/commands/browser/throttleNetwork.test.ts
+++ b/packages/webdriverio/tests/commands/browser/throttleNetwork.test.ts
@@ -8,6 +8,20 @@ import { remote } from '../../../src/index.js'
 
 vi.mock('got')
 vi.mock('puppeteer-core')
+/**
+ * Given that Puppeteer is not a direct dependency of this package, we can't mock
+ * it and dynamically import it. Instead, we mock the "userImport" helper and make
+ * it resolve to the mocked Puppeteer.
+ */
+vi.mock('@wdio/utils', async (origMod) => {
+    const orig = await origMod() as any
+    // resolve the mocked puppeteer-core
+    const puppeteer = await import('puppeteer-core')
+    return {
+        ...orig,
+        userImport: vi.fn().mockResolvedValue(puppeteer.default)
+    }
+})
 vi.mock('@wdio/logger', () => import(path.join(process.cwd(), '__mocks__', '@wdio/logger')))
 
 // @ts-ignore mock feature


### PR DESCRIPTION
## Proposed changes

The `webdriverio` package should not depend on Puppeteer. If the user doesn't use the `getPuppeteer` command there is no need for the dependency to be installed.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

fixes #10726

### Reviewers: @webdriverio/project-committers
