### PR TITLE
new eslint rule for deep selector

### DIFF
--- a/packages/eslint-plugin-wdio/README.md
+++ b/packages/eslint-plugin-wdio/README.md
@@ -43,3 +43,4 @@ See [ESLint documentation](https://eslint.org/docs/user-guide/configuring#extend
 | [wdio/await-expect](docs/rules/await-expect.md) | `expect` calls must be prefixed with an `await` |
 | [wdio/no-debug](docs/rules/no-debug.md) | Don't allow `browser.debug()` statements |
 | [wdio/no-pause](docs/rules/no-pause.md) | Don't allow `browser.pause(<number>)` statements |
+| [wdio/await-deep-selector](docs/rules/await-deep-selector.md) | `$('>>>.foo')` calls must be prefixed with an `await` |

--- a/packages/eslint-plugin-wdio/docs/rules/await-deep-selector.md
+++ b/packages/eslint-plugin-wdio/docs/rules/await-deep-selector.md
@@ -10,7 +10,9 @@ Examples of **incorrect** code for this rule:
 describe('my feature', () => {
     it('should do something', async () => {
         const myButton = $('>>>button');
-        expect(myButton).toBeDisplayed();
+         const myButtons = $$('>>>button');
+        await expect(myButton).toBeDisplayed();
+        await expect($('>>>.foo')).toBeDisplayed();
     });
 });
 ```
@@ -21,7 +23,9 @@ Examples of **correct** code for this rule:
 describe('my feature', () => {
     it('should do something', async () => {
         const myButton = await $('>>>button');
-        expect(myButton).toBeDisplayed();
+        const myButtons = await $$('>>>button');
+        await expect(myButton).toBeDisplayed();
+        await expect(await $('>>>.foo')).toBeDisplayed();
     });
 });
 ```

--- a/packages/eslint-plugin-wdio/docs/rules/await-deep-selector.md
+++ b/packages/eslint-plugin-wdio/docs/rules/await-deep-selector.md
@@ -1,0 +1,27 @@
+# Missing await before a deep selector (wdio/await-deep-selector)
+
+`$('>>>selector')` calls must be prefixed with an `await`.
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```js
+describe('my feature', () => {
+    it('should do something', async () => {
+        const myButton = $('>>>button');
+        expect(myButton).toBeDisplayed();
+    });
+});
+```
+
+Examples of **correct** code for this rule:
+
+```js
+describe('my feature', () => {
+    it('should do something', async () => {
+        const myButton = await $('>>>button');
+        expect(myButton).toBeDisplayed();
+    });
+});
+```

--- a/packages/eslint-plugin-wdio/src/rules/await-deep-selector.ts
+++ b/packages/eslint-plugin-wdio/src/rules/await-deep-selector.ts
@@ -19,8 +19,11 @@ const rule: Rule.RuleModule = {
             Identifier(node) {
                 if (
                     node.type === 'Identifier' &&
-                    node.name === '$' &&
+                    (node.name === '$' || node.name === '$$') &&
                     node.parent.parent.type !== 'AwaitExpression' &&
+                    node.parent.parent.type !== 'MemberExpression' &&
+                    node.parent.parent.type !== 'ReturnStatement' &&
+                    node.parent.parent.type !== 'ArrowFunctionExpression' &&
                     'arguments' in node.parent &&
                     node.parent.arguments.some(
                         a => 'value' in a && typeof a.value === 'string' && /.*>>>.*/.test(a.value || '')

--- a/packages/eslint-plugin-wdio/src/rules/await-deep-selector.ts
+++ b/packages/eslint-plugin-wdio/src/rules/await-deep-selector.ts
@@ -1,0 +1,36 @@
+import type { Rule } from 'eslint'
+
+const rule: Rule.RuleModule = {
+    meta: {
+        type: 'problem',
+        docs: {
+            description: 'Await should be used before a deep selector (>>>)',
+            category: 'Possible Errors',
+            url: 'https://github.com/webdriverio/webdriverio/blob/main/packages/eslint-plugin-wdio/docs/rules/await-deep-selector.md',
+            recommended: false,
+        },
+        messages: {
+            missingAwaitDeep: 'Missing await before a deep selector (>>>)'
+        },
+        hasSuggestions: true,
+    },
+    create: function (context: Rule.RuleContext): Rule.RuleListener {
+        return {
+            Identifier(node) {
+                if (
+                    node.type === 'Identifier' &&
+                    node.name === '$' &&
+                    node.parent.parent.type !== 'AwaitExpression' &&
+                    'arguments' in node.parent &&
+                    node.parent.arguments.some(
+                        a => 'value' in a && typeof a.value === 'string' && /.*>>>.*/.test(a.value || '')
+                    )
+                ) {
+                    context.report({ node, messageId: 'missingAwaitDeep' })
+                }
+            },
+        }
+    },
+}
+
+export default rule

--- a/packages/eslint-plugin-wdio/tests/await-deep-selector.test.ts
+++ b/packages/eslint-plugin-wdio/tests/await-deep-selector.test.ts
@@ -1,0 +1,32 @@
+import { RuleTester } from 'eslint'
+import rule from '../src/rules/await-deep-selector.js'
+
+const ruleTester = new RuleTester({
+    parserOptions : {
+        ecmaVersion : 'latest'
+    }
+})
+
+const errors = [{ messageId : 'missingAwaitDeep' }]
+
+ruleTester.run('await-deep-selector-check', rule, {
+    valid : [
+        'it(`bar`, async () => { await expect(await $(`>>>.foo`)).toBeDisplayed(); });',
+        'it(`bar`, async () => { await expect(await $(`>>>.foo`)).toExist(); });',
+        'it(`bar`, async () => { await expect($(`>>>.foo`)).toExist(); });',
+        'it(`bar`, async () => { const foo = await $(`>>>.foo`)); });',
+        'it(`bar`, async () => { const foo = await $(`.foo`)); });',
+        'it(`bar`, async () => expect(`.foo`).toHaveTitle() );',
+        'bar()',
+    ],
+    invalid : [
+        {
+            code : 'it(`foo`, async () => { await expect($(`>>>.foo`)).toBeDisplayed(); });',
+            errors,
+        },
+        {
+            code : 'const foo = $(`>>>.foo`)',
+            errors,
+        }
+    ],
+})

--- a/packages/eslint-plugin-wdio/tests/await-deep-selector.test.ts
+++ b/packages/eslint-plugin-wdio/tests/await-deep-selector.test.ts
@@ -13,9 +13,12 @@ ruleTester.run('await-deep-selector-check', rule, {
     valid : [
         'it(`bar`, async () => { await expect(await $(`>>>.foo`)).toBeDisplayed(); });',
         'it(`bar`, async () => { await expect(await $(`>>>.foo`)).toExist(); });',
-        'it(`bar`, async () => { await expect($(`>>>.foo`)).toExist(); });',
         'it(`bar`, async () => { const foo = await $(`>>>.foo`)); });',
-        'it(`bar`, async () => { const foo = await $(`.foo`)); });',
+        'it(`bar`, async () => { const foo = $(`.foo`)); });',
+        'it(`bar`, async () => { const foo = await $$(`>>>.foo`)); });',
+        'it(`bar`, async () => { const foo = $$(`.foo`)); });',
+        'it(`bar`, async () => { const foo = await browser.$$(`>>>.foo`)); });',
+        'it(`bar`, async () => { const foo = await browser.$(`>>>.foo`)); });',
         'it(`bar`, async () => expect(`.foo`).toHaveTitle() );',
         'bar()',
     ],
@@ -27,6 +30,14 @@ ruleTester.run('await-deep-selector-check', rule, {
         {
             code : 'const foo = $(`>>>.foo`)',
             errors,
-        }
+        },
+        {
+            code : 'it(`foo`, async () => { const foo = $$(`>>>.foo`)); });',
+            errors,
+        },
+        {
+            code : 'it(`foo`, async () => { const foo = browser.$(`>>>.foo`)); });',
+            errors,
+        },
     ],
 })


### PR DESCRIPTION
## Proposed changes

New eslint rules for await before a deep selector. It's necessary if not the asynchrone processing is not completed.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
