### PR TITLE
Fix problem with tests which had been finished before the parent suite finished 

### DIFF
--- a/packages/wdio-allure-reporter/src/reporter.ts
+++ b/packages/wdio-allure-reporter/src/reporter.ts
@@ -137,6 +137,10 @@ export default class AllureReporter extends WDIOReporter {
 
         while (this._state.currentAllureTestOrStep) {
             const currentTest = this._state.pop() as AllureTest | AllureStep
+            const isAnyStepFailed = currentTest.wrappedItem.steps.some((step) => step.status === AllureStatus.FAILED)
+
+            currentTest.stage = Stage.FINISHED
+            currentTest.status = isAnyStepFailed ? AllureStatus.FAILED : AllureStatus.PASSED
 
             if (currentTest instanceof AllureTest) {
                 setAllureIds(currentTest, this._state.currentSuite)

--- a/packages/wdio-allure-reporter/src/reporter.ts
+++ b/packages/wdio-allure-reporter/src/reporter.ts
@@ -182,14 +182,14 @@ export default class AllureReporter extends WDIOReporter {
         }
     }
 
-    _endTest(status: AllureStatus, error?: Error) {
+    _endTest(status: AllureStatus, error?: Error, stage?: Stage) {
         if (!this._state.currentAllureTestOrStep) {
             return
         }
 
         const currentSpec = this._state.pop() as AllureTest | AllureStep
 
-        currentSpec.stage = Stage.FINISHED
+        currentSpec.stage = stage ?? Stage.FINISHED
         currentSpec.status = status
 
         if (error) {
@@ -353,36 +353,21 @@ export default class AllureReporter extends WDIOReporter {
             })
 
             const suiteChildren = [...suite.tests!, ...suite.hooks]
-
             // A scenario is it skipped if every steps are skipped and hooks are passed or skipped
             const isSkipped = suite.tests.every(item => [AllureStatus.SKIPPED].includes(item.state as AllureStatus)) && suite.hooks.every(item => [AllureStatus.PASSED, AllureStatus.SKIPPED].includes(item.state as AllureStatus))
 
             if (isSkipped) {
-                const currentTest = this._state.pop() as AllureTest
-
-                currentTest.status = AllureStatus.SKIPPED
-                currentTest.stage = Stage.PENDING
-                setAllureIds(currentTest, this._state.currentSuite)
-                currentTest.endTest()
+                this._endTest(AllureStatus.SKIPPED, undefined, Stage.PENDING)
                 return
             }
 
             const isFailed = suiteChildren.find(item => item.state === AllureStatus.FAILED)
 
             if (isFailed) {
-                const currentTest = this._state.pop() as AllureTest
-
-                currentTest.status = getTestStatus(isFailed)
-                currentTest.stage = Stage.FINISHED
+                const testStatus = getTestStatus(isFailed)
                 const error = getErrorFromFailedTest(isFailed)
 
-                if (error) {
-                    currentTest.detailsMessage = error.message
-                    currentTest.detailsTrace = error.stack
-                }
-
-                setAllureIds(currentTest, this._state.currentSuite)
-                currentTest.endTest()
+                this._endTest(testStatus, error)
                 return
             }
 
@@ -391,12 +376,7 @@ export default class AllureReporter extends WDIOReporter {
             const isPartiallySkipped = suiteChildren.every(item => [AllureStatus.PASSED, AllureStatus.SKIPPED].includes(item.state as AllureStatus))
 
             if (isPassed || isPartiallySkipped) {
-                const currentTest = this._state.pop() as AllureTest
-
-                currentTest.status = AllureStatus.PASSED
-                currentTest.stage = Stage.FINISHED
-                setAllureIds(currentTest, this._state.currentSuite)
-                currentTest.endTest()
+                this._endTest(AllureStatus.PASSED)
                 return
             }
 


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

The problem happens, when cucumber feature suite ends before all scenarios and steps finished. In the Allure Report unfinished steps have `unknown` status (original issue https://github.com/allure-framework/allure-js/issues/826).

The PR solves the problem and simplifies the code by reusing `_endTest` method when we need to finish the current test or step.

**Before**

<img width="1337" alt="image" src="https://github.com/webdriverio/webdriverio/assets/13414205/5c8a1e4e-76c6-40cf-93a3-f654c49b1e80">

**After**

<img width="1336" alt="image" src="https://github.com/webdriverio/webdriverio/assets/13414205/754fcba0-9a55-4c77-8144-243c8354375f">



## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
