### PR TITLE
comma can't be typed by keys sequence without extra pause in Electron apps

### DIFF
--- a/packages/webdriverio/src/commands/browser/keys.ts
+++ b/packages/webdriverio/src/commands/browser/keys.ts
@@ -57,7 +57,7 @@ export async function keys (
     keySequence.forEach((value) => {
         if (!this.isIOS && value === ','){
             /**
-             * comma can't be printed within sequence without extra pause here more then 200ms
+             * comma can't be typed within sequence without extra pause here more than 200ms
              */
             keyAction.pause(225)
         }

--- a/packages/webdriverio/src/commands/browser/keys.ts
+++ b/packages/webdriverio/src/commands/browser/keys.ts
@@ -54,7 +54,15 @@ export async function keys (
      * W3C way of handle it key actions
      */
     const keyAction = this.action('key')
-    keySequence.forEach((value) => keyAction.down(value))
+    keySequence.forEach((value) => {
+        if (!this.isIOS && value === ','){
+            /**
+             * comma can't be printed within sequence without extra pause here more then 200ms
+             */
+            keyAction.pause(225)
+        }
+        keyAction.down(value)
+    })
     /**
      * XCTest API only allows to send keypresses (e.g. keydown+keyup).
      * There is no way to "split" them


### PR DESCRIPTION
Bug is browser.keys('something with c,o,m,m,a,s') type it to input as 'something with commas' without commas but have to 'something with c,o,m,m,a,s' in Electron apps