### PR TITLE
(@wdio/browser-runner): improved stencil test integration

### DIFF
--- a/e2e/browser-runner/stencil.test.tsx
+++ b/e2e/browser-runner/stencil.test.tsx
@@ -6,7 +6,7 @@ import { NestedComponent } from './components/StencilComponentNested.jsx'
 
 describe('Stencil Component Testing', () => {
     it('should render component correctly', async () => {
-        render({
+        const page = render({
             components: [AppProfile, NestedComponent],
             autoApplyChanges: true,
             template: () => (
@@ -41,5 +41,8 @@ describe('Stencil Component Testing', () => {
             "value": 700,
           }
         `)
+
+        expect(page.container.tagName.toLowerCase()).toBe('stencil-stage')
+        expect(page.root.tagName.toLowerCase()).toBe('app-profile')
     })
 })

--- a/packages/wdio-browser-runner/stencil/index.d.ts
+++ b/packages/wdio-browser-runner/stencil/index.d.ts
@@ -6,7 +6,7 @@ interface RenderOptions {
     /**
      * An array of components to test. Component classes can be imported into the spec file, then their reference should be added to the `component` array in order to be used throughout the test.
      */
-    components: any[];
+    components?: any[];
     /**
      * If `false`, do not flush the render queue on initial test setup.
      */
@@ -65,6 +65,18 @@ interface StencilEnvironment {
      * wait for, and apply the update, call await `flushAll()`.
      */
     flushAll: () => void
+    /**
+     * All styles defined by components.
+     */
+    styles: Record<string, string>
+    /**
+     * Container element in which the template is being rendered.
+     */
+    container: HTMLElement
+    /**
+     * The root component of the template.
+     */
+    root: HTMLElement
 }
 
 export function render(opts: RenderOptions): StencilEnvironment

--- a/packages/wdio-browser-runner/tests/vite/frameworks/stencil.test.ts
+++ b/packages/wdio-browser-runner/tests/vite/frameworks/stencil.test.ts
@@ -81,3 +81,47 @@ test('optimizeForStencil', async () => {
         code: "import { Component, Prop, h } from 'something else'"
     })
 })
+
+test('auto imports "h" from Stencil', async () => {
+    const opt = await optimizeForStencil('/foo/bar')
+    const codeWithoutFragment = `
+    import { some as thing } from '@stencil/core';
+    import { h, foobar } from '@stencil/core';
+    import { render as renderMe } from '@wdio/browser-runner/stencil';
+
+    console.log("Hello");
+    `
+
+    const transformedCode = (opt.plugins?.[0] as any).transform(
+        codeWithoutFragment,
+        '/foo/bar/StencilComponent.tsx', {}
+    )
+    expect(transformedCode).toEqual({
+        code: expect.stringContaining('import { Fragment } from \'@stencil/core\';')
+    })
+    expect(transformedCode).toEqual({
+        code: expect.not.stringContaining('import { h } from \'@stencil/core\';')
+    })
+})
+
+test('auto imports "h" and "Fragment" from Stencil', async () => {
+    const opt = await optimizeForStencil('/foo/bar')
+    const codeWithoutAny = `
+    import { some as thing } from '@stencil/core';
+    import { foobar } from '@stencil/core';
+    import { render as renderMe } from '@wdio/browser-runner/stencil';
+
+    console.log("Hello");
+    `
+
+    const transformedCode = (opt.plugins?.[0] as any).transform(
+        codeWithoutAny,
+        '/foo/bar/StencilComponent.tsx', {}
+    )
+    expect(transformedCode).toEqual({
+        code: expect.stringContaining('import { Fragment } from \'@stencil/core\';')
+    })
+    expect(transformedCode).toEqual({
+        code: expect.stringContaining('import { h } from \'@stencil/core\';')
+    })
+})


### PR DESCRIPTION
## Proposed changes

Some improvements for browser runner and particular running Stencil tests:

- make `testStatePromise` a scoped variable so we can run multiple tests per session
- properly resolve Stencil config if in CJS mode
- auto import `h` and `Fragment`
- allow to keep `components` parameter of render method optional

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
