### PR TITLE
(@wdio/browser-runner): document stencil component testing integration better

### DIFF
--- a/e2e/browser-runner/components/StencilComponentNoShadow.tsx
+++ b/e2e/browser-runner/components/StencilComponentNoShadow.tsx
@@ -1,0 +1,14 @@
+import { Component } from '@stencil/core'
+
+@Component({
+    tag: 'no-shadow-component'
+})
+export class NoShadowComponent {
+    render() {
+        return (
+            <>
+                Hello World!
+            </>
+        )
+    }
+}

--- a/e2e/browser-runner/stencil.test.tsx
+++ b/e2e/browser-runner/stencil.test.tsx
@@ -1,8 +1,9 @@
-import { $, expect } from '@wdio/globals'
-import { render } from '@wdio/browser-runner/stencil'
+import { $, browser, expect } from '@wdio/globals'
+import { render, waitForChanges } from '@wdio/browser-runner/stencil'
 
 import { AppProfile } from './components/StencilComponent.jsx'
 import { NestedComponent } from './components/StencilComponentNested.jsx'
+import { NoShadowComponent } from './components/StencilComponentNoShadow.jsx'
 
 describe('Stencil Component Testing', () => {
     it('should render component correctly', async () => {
@@ -14,6 +15,12 @@ describe('Stencil Component Testing', () => {
                 <app-profile match={{ params: { name: 'stencil' } }}></app-profile>
             )
         })
+
+        expect(page.container.tagName.toLowerCase()).toBe('stencil-stage')
+        expect(page.root.tagName.toLowerCase()).toBe('app-profile')
+        expect(typeof (await page.$container).elementId).toBe('string')
+        expect(typeof (await page.$root).elementId).toBe('string')
+
         await expect($('>>>.app-profile')).toHaveText(
             expect.stringContaining('Hello! My name is Stencil.')
         )
@@ -21,8 +28,7 @@ describe('Stencil Component Testing', () => {
         /**
          * this assertion for Safari due to: https://github.com/w3c/webdriver/issues/1786
          */
-        // eslint-disable-next-line no-undef
-        if ((browser.capabilities as WebdriverIO.Capabilities).browserName?.toLowerCase() !== 'safari') {
+        if (browser.capabilities.browserName?.toLowerCase() !== 'safari') {
             await expect($('>>>.app-profile')).toHaveText(
                 expect.stringContaining('I am a nested component!')
             )
@@ -41,15 +47,11 @@ describe('Stencil Component Testing', () => {
             "value": 700,
           }
         `)
-
-        expect(page.container.tagName.toLowerCase()).toBe('stencil-stage')
-        expect(page.root.tagName.toLowerCase()).toBe('app-profile')
     })
 
     it('can determine root if rendered somewhere nested', async () => {
         const page = render({
             components: [AppProfile, NestedComponent],
-            autoApplyChanges: true,
             template: () => (
                 <div>
                     <div>
@@ -62,5 +64,36 @@ describe('Stencil Component Testing', () => {
 
         expect(page.root.tagName.toLowerCase()).toBe('app-profile')
         expect(page.root.parentElement?.parentElement?.parentElement?.tagName.toLowerCase()).toBe('stencil-stage')
+    })
+
+    it('can render via html', async () => {
+        const page = render({
+            components: [NestedComponent],
+            html: '<nested-component></nested-component>'
+        })
+
+        await expect(page.$root.$('>>> i')).toHaveText('I am a unknown!')
+    })
+
+    it('can wait for changes', async () => {
+        const page = render({
+            components: [NoShadowComponent],
+            html: '<no-shadow-component></no-shadow-component>'
+        })
+
+        expect(page.root.outerHTML).toBe('<no-shadow-component></no-shadow-component>')
+        await waitForChanges()
+        expect(page.root.outerHTML).toBe('<no-shadow-component>Hello World!</no-shadow-component>')
+    })
+
+    it('can unmount', async () => {
+        const page = render({
+            components: [NestedComponent],
+            html: '<nested-component></nested-component>'
+        })
+
+        await expect(page.root).toBeExisting()
+        page.unmount()
+        await expect(page.root).not.toBeExisting()
     })
 })

--- a/packages/wdio-browser-runner/src/browser/driver.ts
+++ b/packages/wdio-browser-runner/src/browser/driver.ts
@@ -4,7 +4,7 @@ import { getEnvironmentVars } from 'webdriver'
 import { MESSAGE_TYPES, type Workers } from '@wdio/types'
 import { browser } from '@wdio/globals'
 
-import { getCID } from './utils.js'
+import { getCID, sanitizeConsoleArgs } from './utils.js'
 import { WDIO_EVENT_NAME } from '../constants.js'
 
 const COMMAND_TIMEOUT = 30 * 1000 // 30s
@@ -185,7 +185,7 @@ export default class ProxyDriver {
                 import.meta.hot?.send(WDIO_EVENT_NAME, this.#consoleMessage({
                     name: 'consoleEvent',
                     type: method,
-                    args,
+                    args: sanitizeConsoleArgs(args),
                     cid
                 }))
                 origCommand(...args)

--- a/packages/wdio-browser-runner/src/browser/utils.ts
+++ b/packages/wdio-browser-runner/src/browser/utils.ts
@@ -25,3 +25,30 @@ export const showPopupWarning = <T>(name: string, value: T, defaultValue?: T) =>
   \`\`\``)
     return value
 }
+
+export function sanitizeConsoleArgs (args: unknown[]) {
+    return args.map((arg: any) => {
+        try {
+            if (arg && typeof arg.elementId === 'string') {
+                return `WebdriverIO.Element<${arg.elementId}>`
+            }
+            if (arg && typeof arg.sessionId === 'string') {
+                return `WebdriverIO.Browser<${arg.sessionId}>`
+            }
+        } catch (err) {
+            // ignore
+        }
+
+        if (
+            arg instanceof HTMLElement ||
+            (arg && typeof arg === 'object' && 'then' in arg && typeof arg.then === 'function') ||
+            typeof arg === 'function'
+        ) {
+            return arg.toString()
+        }
+        if (arg instanceof Error) {
+            return arg.stack
+        }
+        return arg
+    })
+}

--- a/packages/wdio-browser-runner/stencil/index.d.ts
+++ b/packages/wdio-browser-runner/stencil/index.d.ts
@@ -18,31 +18,27 @@ export interface RenderOptions {
      */
     template?: () => any;
     /**
+     * The initial HTML used to generate the test. This can be useful to construct a collection of components working together, and assign HTML attributes.
+     */
+    html?: string;
+    /**
      * Sets the mocked `lang` attribute on `<html>`.
      */
     language?: string;
     /**
      * Useful for debugging hydrating components client-side. Sets that the `html` option already includes annotated prerender attributes and comments.
      */
-    hydrateClientSide?: boolean;
+    // hydrateClientSide?: boolean;
     /**
      * Useful for debugging hydrating components server-side. The output HTML will also include prerender annotations.
      */
-    hydrateServerSide?: boolean;
-    /**
-     * Sets the mocked `document.referrer`.
-     */
-    referrer?: string;
-    /**
-     * Manually set if the mocked document supports Shadow DOM or not. Default is `true`.
-     */
-    supportsShadowDom?: boolean;
+    // hydrateServerSide?: boolean;
     /**
      * When a component is pre-rendered it includes HTML annotations, such as `s-id` attributes and `<!-t.0->` comments. This information is used by clientside hydrating. Default is `false`.
      */
-    includeAnnotations?: boolean;
+    // includeAnnotations?: boolean;
     /**
-     * By default, any changes to component properties and attributes must `page.waitForChanges()` in order to test the updates. As an option, `autoAppluChanges` continuously flushes the queue on the background. Default is `false`.
+     * By default, any changes to component properties and attributes must `page.waitForChanges()` in order to test the updates. As an option, `autoApplyChanges` continuously flushes the queue on the background. Default is `false`.
      */
     autoApplyChanges?: boolean;
     /**
@@ -55,7 +51,7 @@ export interface RenderOptions {
      * When `true` all `BuildConditionals` will be assigned to the global testing `BUILD` object, regardless of their
      * value. When `false`, only `BuildConditionals` with a value of `true` will be assigned to the `BUILD` object.
      */
-    strictBuild?: boolean;
+    // strictBuild?: boolean;
 }
 
 export interface StencilEnvironment {
@@ -74,13 +70,32 @@ export interface StencilEnvironment {
      */
     container: HTMLElement
     /**
+     * The container element as WebdriverIO element.
+     */
+    $container: WebdriverIO.Element
+    /**
      * The root component of the template.
      */
     root: HTMLElement
+    /**
+     * The root component as WebdriverIO element.
+     */
+    $root: WebdriverIO.Element
     /**
      * Removes the container element from the DOM.
      */
     unmount: () => void
 }
 
+/**
+ * Renders a Stencil component for testing into the page.
+ * @param opts options for the test page
+ * @returns a testing environment for the rendered component
+ */
 export function render(opts: RenderOptions): StencilEnvironment
+
+/**
+ * Waits for the next update cycle to complete.
+ * @returns a promise that resolves when the update cycle completes
+ */
+export function waitForChanges(): Promise<void>

--- a/packages/wdio-browser-runner/tests/browser/utils.test.ts
+++ b/packages/wdio-browser-runner/tests/browser/utils.test.ts
@@ -1,5 +1,7 @@
+// @vitest-environment jsdom
+
 import { vi, describe, it, beforeAll, afterAll, expect } from 'vitest'
-import { showPopupWarning } from '../../src/browser/utils.js'
+import { showPopupWarning, sanitizeConsoleArgs } from '../../src/browser/utils.js'
 
 describe('browser utils', () => {
     const consoleWarn = console.warn.bind(console)
@@ -15,6 +17,26 @@ describe('browser utils', () => {
         expect(prompt('test')).toBeNull()
         expect(confirm('test')).toBe(false)
         expect(console.warn).toBeCalledTimes(3)
+    })
+
+    it('sanitizeConsoleArgs', () => {
+        expect(sanitizeConsoleArgs([
+            1,
+            'foo',
+            { foo: 'bar' },
+            { elementId: 'foobar' },
+            { sessionId: 'foobar' },
+            new Error('foobar'),
+            () => {}
+        ])).toEqual([
+            1,
+            'foo',
+            { foo: 'bar' },
+            'WebdriverIO.Element<foobar>',
+            'WebdriverIO.Browser<foobar>',
+            expect.stringContaining('Error: foobar'),
+            '() => {\n      }'
+        ])
     })
 
     afterAll(() => {

--- a/packages/wdio-browser-runner/tests/vite/frameworks/stencil.test.ts
+++ b/packages/wdio-browser-runner/tests/vite/frameworks/stencil.test.ts
@@ -71,7 +71,7 @@ test('optimizeForStencil', async () => {
         "import { Component, Prop, h } from '@stencil/core'",
         '/foo/bar/StencilComponent.tsx', {})
     ).toEqual({
-        code: "import { Fragment } from '@stencil/core';\nthe transpiled code",
+        code: "import { Fragment } from '@stencil/core/internal/client';\nthe transpiled code",
         inputFilePath: '/foo/bar/StencilComponent.tsx'
     })
     expect((opt.plugins?.[0] as any).transform(
@@ -97,7 +97,7 @@ test('auto imports "h" from Stencil', async () => {
         '/foo/bar/StencilComponent.tsx', {}
     )
     expect(transformedCode).toEqual({
-        code: expect.stringContaining('import { Fragment } from \'@stencil/core\';')
+        code: expect.stringContaining('import { Fragment } from \'@stencil/core/internal/client\';')
     })
     expect(transformedCode).toEqual({
         code: expect.not.stringContaining('import { h } from \'@stencil/core\';')
@@ -119,9 +119,9 @@ test('auto imports "h" and "Fragment" from Stencil', async () => {
         '/foo/bar/StencilComponent.tsx', {}
     )
     expect(transformedCode).toEqual({
-        code: expect.stringContaining('import { Fragment } from \'@stencil/core\';')
+        code: expect.stringContaining('import { Fragment } from \'@stencil/core/internal/client\';')
     })
     expect(transformedCode).toEqual({
-        code: expect.stringContaining('import { h } from \'@stencil/core\';')
+        code: expect.stringContaining('import { h } from \'@stencil/core/internal/client\';')
     })
 })

--- a/packages/webdriverio/src/commands/browser/$$.ts
+++ b/packages/webdriverio/src/commands/browser/$$.ts
@@ -58,7 +58,8 @@ export async function $$ (
     if (Array.isArray(selector) && isElement(selector[0])) {
         res = []
         for (const el of selector) {
-            res.push(await findElement.call(this, el))
+            const $el = await findElement.call(this, el)
+            $el && res.push($el)
         }
     }
 

--- a/packages/webdriverio/src/middlewares.ts
+++ b/packages/webdriverio/src/middlewares.ts
@@ -2,7 +2,7 @@ import { ELEMENT_KEY } from 'webdriver'
 
 import refetchElement from './utils/refetchElement.js'
 import implicitWait from './utils/implicitWait.js'
-import { getBrowserObject } from './utils/index.js'
+import { getBrowserObject, isStaleElementError } from './utils/index.js'
 
 /**
  * This method is an command wrapper for elements that checks if a command is called
@@ -37,7 +37,7 @@ export const elementErrorHandler = (fn: Function) => (commandName: string, comma
 
                 return result
             } catch (err: any) {
-                if (err.name === 'stale element reference') {
+                if (err.name === 'stale element reference' || isStaleElementError(err)) {
                     const element = await refetchElement(this, commandName)
                     this.elementId = element.elementId
                     this.parent = element.parent

--- a/packages/webdriverio/src/utils/index.ts
+++ b/packages/webdriverio/src/utils/index.ts
@@ -223,6 +223,17 @@ export function isElement (o: Selector){
     )
 }
 
+export function isStaleElementError (err: Error) {
+    return (
+        // Chrome
+        err.message.includes('stale element reference') ||
+        // Firefox
+        err.message.includes('is no longer attached to the DOM') ||
+        // Safari
+        err.message.includes('Stale element found')
+    )
+}
+
 /**
  * logic to find an element
  */
@@ -297,7 +308,7 @@ export async function findElement(
              * WebDriver throws a stale element reference error if the element is not found
              * and therefor can't be serialized
              */
-            if (err.message.includes('stale element reference')) {
+            if (isStaleElementError(err)) {
                 return undefined
             }
             throw err

--- a/packages/webdriverio/tests/utils/index.test.ts
+++ b/packages/webdriverio/tests/utils/index.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest'
 import { ELEMENT_KEY } from 'webdriver'
 
-import { findElement } from '../../src/utils/index.js'
+import { findElement, isStaleElementError } from '../../src/utils/index.js'
 
 vi.mock('is-plain-obj', () => ({
     default: vi.fn().mockReturnValue(false)
@@ -52,4 +52,15 @@ describe('findElement', () => {
             expect.any(String)
         )
     })
+})
+
+it('isStaleElementError', () => {
+    const staleElementChromeError = new Error('stale element reference: element is not attached to the page document')
+    expect(isStaleElementError(staleElementChromeError)).toBe(true)
+    const staleElementFirefoxError = new Error('The element <nested-component> is no longer attached to the DOM')
+    expect(isStaleElementError(staleElementFirefoxError)).toBe(true)
+    const staleElementSafariError = new Error('A node reference could not be resolved: Stale element found when trying to create the node handle')
+    expect(isStaleElementError(staleElementSafariError)).toBe(true)
+    const otherError = new Error('something else')
+    expect(isStaleElementError(otherError)).toBe(false)
 })

--- a/packages/webdriverio/tests/utils/index.test.ts
+++ b/packages/webdriverio/tests/utils/index.test.ts
@@ -14,7 +14,7 @@ describe('findElement', () => {
             elementId: 'source-elem',
             execute: vi.fn().mockReturnValue(elemRes)
         }
-        expect(await findElement.call(browser, () => 'testme')).toEqual(elemRes)
+        expect(await findElement.call(browser, () => 'testme' as any as HTMLElement)).toEqual(elemRes)
         expect(browser.execute).toBeCalledWith(expect.any(String), browser)
     })
 
@@ -22,12 +22,30 @@ describe('findElement', () => {
         const elemRes = { [ELEMENT_KEY]: 'element-0' }
         const browser: any = {
             elementId: 'source-elem',
-            execute: vi.fn().mockReturnValue(elemRes)
+            execute: vi.fn().mockResolvedValue(elemRes)
         }
-        const domNode = { nodeType: 1, nodeName: 'DivElement' }
+        const domNode = { nodeType: 1, nodeName: 'DivElement' } as HTMLElement
         // @ts-expect-error
         globalThis.window = {}
         expect(await findElement.call(browser, domNode)).toEqual(elemRes)
+        expect(browser.execute).toBeCalledWith(
+            expect.any(String),
+            browser,
+            expect.any(String)
+        )
+    })
+
+    it('should not find element using JS function with referenceId', async () => {
+        const browser: any = {
+            elementId: 'source-elem',
+            execute: vi.fn().mockRejectedValue(new Error('stale element reference: element is not attached to the page document'))
+        }
+        const domNode = { nodeType: 1, nodeName: 'DivElement' } as HTMLElement
+        // @ts-expect-error
+        globalThis.window = {}
+        expect(await findElement.call(browser, domNode)).toEqual(
+            expect.objectContaining({ message: 'DOM Node couldn\'t be found anymore' })
+        )
         expect(browser.execute).toBeCalledWith(
             expect.any(String),
             browser,

--- a/website/docs/component-testing/Stencil.md
+++ b/website/docs/component-testing/Stencil.md
@@ -7,7 +7,7 @@ title: Stencil
 
 ## Setup
 
-To setup WebdriverIO within your Stencil project, follow the [instructions](/docs/component-testing#set-up) in our component testing docs. Make sure to select `stencil` as preset within your runner options, e.g.:
+To set up WebdriverIO within your Stencil project, follow the [instructions](/docs/component-testing#set-up) in our component testing docs. Make sure to select `stencil` as preset within your runner options, e.g.:
 
 ```js
 // wdio.conf.js
@@ -34,7 +34,7 @@ npx wdio run ./wdio.conf.ts
 
 ## Writing Tests
 
-Given you have the following Stencil component:
+Given you have the following Stencil components:
 
 ```tsx title="./components/Component.tsx"
 import { Component, Prop, h } from '@stencil/core'
@@ -63,7 +63,9 @@ export class MyName {
 }
 ```
 
-In your test use the `render` method from `@wdio/browser-runner/stencil` to attach the component to the test page. To interact with the component we recommend to use WebdriverIO commands as they behave more close to actual user interactions, e.g.:
+### `render` Method
+
+In your test use the `render` method from `@wdio/browser-runner/stencil` to attach the component to the test page. To interact with the component we recommend using WebdriverIO commands as they behave closer to actual user interactions, e.g.:
 
 ```tsx title="app.test.tsx"
 import { expect } from '@wdio/globals'
@@ -84,37 +86,106 @@ describe('Stencil Component Testing', () => {
 })
 ```
 
+#### Render Options
+
+The `render` method provides the following options:
+
+##### `components`
+
+An array of components to test. Component classes can be imported into the spec file, then their reference should be added to the `component` array to be used throughout the test.
+
+__Type:__ `CustomElementConstructor[]`<br>
+__Default:__ `[]`
+
+##### `flushQueue`
+
+If `false`, do not flush the render queue on the initial test setup.
+
+__Type:__ `boolean`<br>
+__Default:__ `true`
+
+##### `template`
+
+The initial JSX that is used to generate the test. Use `template` when you want to initialize a component using their properties, instead of their HTML attributes. It will render the specified template (JSX) into `document.body`.
+
+__Type:__ `JSX.Template`
+
+##### `html`
+
+The initial HTML used to generate the test. This can be useful to construct a collection of components working together, and assign HTML attributes.
+
+__Type:__ `string`
+
+##### `language`
+
+Sets the mocked `lang` attribute on `<html>`.
+
+__Type:__ `string`
+
+##### `autoApplyChanges`
+
+By default, any changes to component properties and attributes must `env.waitForChanges()` to test the updates. As an option, `autoApplyChanges` continuously flushes the queue in the background.
+
+__Type:__ `boolean`<br>
+__Default:__ `false`
+
+##### `attachStyles`
+
+By default, styles are not attached to the DOM and they are not reflected in the serialized HTML. Setting this option to `true` will include the component's styles in the serializable output.
+
+__Type:__ `boolean`<br>
+__Default:__ `false`
+
+#### Render Environment
+
+The `render` method returns an environment object that provides certain utility helpers to manage the component's environment.
+
+##### `flushAll`
+
+After changes have been made to a component, such as an update to a property or attribute, the test page does not automatically apply the changes. To wait for, and apply the update, call `await flushAll()`
+
+__Type:__ `() => void`
+
+##### `unmount`
+
+Removes the container element from the DOM.
+
+__Type:__ `() => void`
+
+##### `styles`
+
+All styles defined by components.
+
+__Type:__ `Record<string, string>`
+
+##### `container`
+
+Container element in which the template is being rendered.
+
+__Type:__ `HTMLElement`
+
+##### `$container`
+
+The container element as a WebdriverIO element.
+
+__Type:__ `WebdriverIO.Element`
+
+##### `root`
+
+The root component of the template.
+
+__Type:__ `HTMLElement`
+
+##### `$root`
+
+The root component as a WebdriverIO element.
+
+__Type:__ `WebdriverIO.Element`
+
 ## Element Updates
 
-If you define properties or state in your Stencil component you have to manage when these changes should be applied to the component to be re-rendered. For that use the `flushAll` method that is returned from the `render` method, e.g.:
+If you define properties or states in your Stencil component you have to manage when these changes should be applied to the component to be re-rendered.
 
-```ts
-const { flushAll } = render({
-    components: [AppLogin],
-    template: () => <app-login />
-})
-
-// update component state via
-await $('...').click()
-
-flushAll()
-
-// assert after update
-await expect($('...')).toHaveElementClass('...')
-```
-
-If you prefer to apply changes automatically, set the `autoApplyChanges` flag, e.g.:
-
-```ts
-const { flushAll } = render({
-    components: [AppLogin],
-    template: () => <app-login />,
-    autoApplyChanges: true
-})
-// update component state and assert immediatelly
-await $('...').click()
-await expect($('...')).toHaveElementClass('...')
-```
 
 ## Examples
 

--- a/website/docs/component-testing/Stencil.md
+++ b/website/docs/component-testing/Stencil.md
@@ -63,7 +63,7 @@ export class MyName {
 }
 ```
 
-### `render` Method
+### `render`
 
 In your test use the `render` method from `@wdio/browser-runner/stencil` to attach the component to the test page. To interact with the component we recommend using WebdriverIO commands as they behave closer to actual user interactions, e.g.:
 
@@ -94,14 +94,14 @@ The `render` method provides the following options:
 
 An array of components to test. Component classes can be imported into the spec file, then their reference should be added to the `component` array to be used throughout the test.
 
-__Type:__ `CustomElementConstructor[]`<br>
+__Type:__ `CustomElementConstructor[]`<br />
 __Default:__ `[]`
 
 ##### `flushQueue`
 
 If `false`, do not flush the render queue on the initial test setup.
 
-__Type:__ `boolean`<br>
+__Type:__ `boolean`<br />
 __Default:__ `true`
 
 ##### `template`
@@ -126,14 +126,14 @@ __Type:__ `string`
 
 By default, any changes to component properties and attributes must `env.waitForChanges()` to test the updates. As an option, `autoApplyChanges` continuously flushes the queue in the background.
 
-__Type:__ `boolean`<br>
+__Type:__ `boolean`<br />
 __Default:__ `false`
 
 ##### `attachStyles`
 
 By default, styles are not attached to the DOM and they are not reflected in the serialized HTML. Setting this option to `true` will include the component's styles in the serializable output.
 
-__Type:__ `boolean`<br>
+__Type:__ `boolean`<br />
 __Default:__ `false`
 
 #### Render Environment
@@ -181,6 +181,24 @@ __Type:__ `HTMLElement`
 The root component as a WebdriverIO element.
 
 __Type:__ `WebdriverIO.Element`
+
+### `waitForChanges`
+
+Helper method to wait for the component to be ready.
+
+```ts
+import { render, waitForChanges } from '@wdio/browser-runner/stencil'
+import { MyComponent } from './component.tsx'
+
+const page = render({
+    components: [MyComponent],
+    html: '<my-component></my-component>'
+})
+
+expect(page.root.querySelector('div')).not.toBeDefined()
+await waitForChanges()
+expect(page.root.querySelector('div')).toBeDefined()
+```
 
 ## Element Updates
 


### PR DESCRIPTION
## Proposed changes

Changes include:

- adding `$root` and `$container` convenience objects to the Stencil environment
- introduce `waitForChanges` method
- sanitize some special objects when printing `console.log`
- fix auto Stencil imports
- allow to assert for non existing elements

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
