### PR TITLE
(webdriver): have a more reliable way to shut down attached session driver

### DIFF
--- a/e2e/attach.test.ts
+++ b/e2e/attach.test.ts
@@ -23,4 +23,8 @@ test('allow to attach to an existing session', async () => {
     expect(await otherBrowser.getTitle()).toBe('WebdriverJS Testpage')
 
     await otherBrowser.deleteSession()
+
+    const error = await browser.status().catch((err) => err)
+    expect(error.message).not.toBe('ChromeDriver ready for new sessions.')
+    expect(error.message).toEqual(expect.stringContaining('ECONNREFUSED'))
 })

--- a/packages/wdio-types/src/Capabilities.ts
+++ b/packages/wdio-types/src/Capabilities.ts
@@ -211,6 +211,10 @@ export interface VendorExtensions extends EdgeCapabilities, AppiumCapabilities, 
 }
 
 export interface WebdriverIOCapabilities {
+    /**
+     * process id of driver attached to given session
+     */
+    'wdio:driverPID'?: number
     'wdio:chromedriverOptions'?: WebdriverIO.ChromedriverOptions
     'wdio:safaridriverOptions'?: WebdriverIO.SafaridriverOptions
     'wdio:geckodriverOptions'?: WebdriverIO.GeckodriverOptions

--- a/packages/webdriver/src/index.ts
+++ b/packages/webdriver/src/index.ts
@@ -33,8 +33,13 @@ export default class WebDriver {
         const environment = sessionEnvironmentDetector({ capabilities, requestedCapabilities })
         const environmentPrototype = getEnvironmentVars(environment)
         const protocolCommands = getPrototype(environment)
-        const driverPrototype: Record<string, PropertyDescriptor> = {
-            _driverProcess: { value: driverProcess, configurable: false, writable: true }
+
+        /**
+         * attach driver process to instance capabilities so we can kill the driver process
+         * even after attaching to this session
+         */
+        if (driverProcess?.pid) {
+            capabilities['wdio:driverPID'] = driverProcess.pid
         }
 
         /**
@@ -53,7 +58,6 @@ export default class WebDriver {
                 ...protocolCommands,
                 ...environmentPrototype,
                 ...userPrototype,
-                ...driverPrototype,
                 ...bidiPrototype
             }
         )


### PR DESCRIPTION
## Proposed changes

The way we currently manage driver shut downs are by attaching the driver process to the instance. This is not the best solution as it requires some limbo with the prototype and also doesn't work when someone attaches to a session and then wants to close it including the driver.

The new approach is attaching the process id as capability via `wdio:driverPID` and use that to shut down the driver process.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Polish (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
