### PR TITLE
(webdriverio): allow to define new capabilities when calling `reloadSession

### DIFF
--- a/__mocks__/@wdio/utils/node.ts
+++ b/__mocks__/@wdio/utils/node.ts
@@ -1,3 +1,4 @@
 import { vi } from 'vitest'
 
 export const canAccess = vi.fn()
+export const startWebDriver = vi.fn().mockResolvedValue({ pid: 42 })

--- a/e2e/wdio/headless/test.e2e.ts
+++ b/e2e/wdio/headless/test.e2e.ts
@@ -10,7 +10,7 @@ describe('main suite 1', () => {
     it('supports snapshot testing', async () => {
         await browser.url('http://guinea-pig.webdriver.io/')
         await expect($('.findme')).toMatchSnapshot()
-        await expect($('.findme')).toMatchInlineSnapshot(`"<h1 class="findme">Test CSS Attributes</h1>"`)
+        await expect($('.findme')).toMatchInlineSnapshot('"<h1 class="findme">Test CSS Attributes</h1>"')
     })
 
     it('should allow to check for PWA', async () => {
@@ -295,5 +295,16 @@ describe('main suite 1', () => {
         const sessionId = browser.sessionId
         await browser.reloadSession()
         expect(browser.sessionId).not.toBe(sessionId)
+    })
+
+    it('can reload a session with new capabilities', async () => {
+        expect((browser.capabilities as WebdriverIO.Capabilities).browserName).toBe('chrome')
+        await browser.reloadSession({
+            browserName: 'firefox',
+            'moz:firefoxOptions': {
+                args: ['-headless']
+            }
+        })
+        expect((browser.capabilities as WebdriverIO.Capabilities).browserName).toBe('firefox')
     })
 })

--- a/e2e/wdio/headless/test.e2e.ts
+++ b/e2e/wdio/headless/test.e2e.ts
@@ -4,7 +4,10 @@ describe('main suite 1', () => {
     it('foobar test', async () => {
         const browserName = (browser.capabilities as WebdriverIO.Capabilities).browserName
         await browser.url('http://guinea-pig.webdriver.io/')
-        await expect((await $('#useragent').getText()).toLowerCase()).toContain(browserName ? browserName.replace(' ', '') : browserName)
+
+        const actualUA = (await $('#useragent').getText()).toLowerCase()
+        const expectedUA = browserName ? browserName.replace(' ', '').replace('-headless-shell', '') : browserName
+        await expect(actualUA).toContain(expectedUA)
     })
 
     it('supports snapshot testing', async () => {
@@ -291,20 +294,22 @@ describe('main suite 1', () => {
         }
     })
 
-    it('can reload a session', async () => {
-        const sessionId = browser.sessionId
-        await browser.reloadSession()
-        expect(browser.sessionId).not.toBe(sessionId)
-    })
-
-    it('can reload a session with new capabilities', async () => {
-        expect((browser.capabilities as WebdriverIO.Capabilities).browserName).toBe('chrome')
-        await browser.reloadSession({
-            browserName: 'firefox',
-            'moz:firefoxOptions': {
-                args: ['-headless']
-            }
+    describe('reloadSession', () => {
+        it('can reload a session', async () => {
+            const sessionId = browser.sessionId
+            await browser.reloadSession()
+            expect(browser.sessionId).not.toBe(sessionId)
         })
-        expect((browser.capabilities as WebdriverIO.Capabilities).browserName).toBe('firefox')
+
+        it('can reload a session with new capabilities', async () => {
+            expect((browser.capabilities as WebdriverIO.Capabilities).browserName).toBe('chrome-headless-shell')
+            await browser.reloadSession({
+                browserName: 'firefox',
+                'moz:firefoxOptions': {
+                    args: ['-headless']
+                }
+            })
+            expect((browser.capabilities as WebdriverIO.Capabilities).browserName).toBe('firefox')
+        })
     })
 })

--- a/e2e/wdio/headless/test.e2e.ts
+++ b/e2e/wdio/headless/test.e2e.ts
@@ -304,12 +304,12 @@ describe('main suite 1', () => {
         it('can reload a session with new capabilities', async () => {
             expect((browser.capabilities as WebdriverIO.Capabilities).browserName).toBe('chrome-headless-shell')
             await browser.reloadSession({
-                browserName: 'firefox',
-                'moz:firefoxOptions': {
-                    args: ['-headless']
+                browserName: 'edge',
+                'ms:edgeOptions': {
+                    args: ['headless', 'disable-gpu']
                 }
             })
-            expect((browser.capabilities as WebdriverIO.Capabilities).browserName).toBe('firefox')
+            expect((browser.capabilities as WebdriverIO.Capabilities).browserName).toBe('edge-headless-shell')
         })
     })
 })

--- a/e2e/wdio/wdio.conf.ts
+++ b/e2e/wdio/wdio.conf.ts
@@ -17,7 +17,9 @@ export const config: Options.Testrunner = {
     capabilities: [{
         browserName: 'chrome',
         browserVersion: 'stable',
-        'wdio:devtoolsOptions': { headless: true, dumpio: true }
+        'goog:chromeOptions': {
+            args: ['headless', 'disable-gpu']
+        }
     }],
     bail: 1,
     services: ['devtools'],

--- a/packages/devtools/src/cjs/index.ts
+++ b/packages/devtools/src/cjs/index.ts
@@ -29,9 +29,9 @@ class Devtools {
      * @param   {Object} instance  the object we get from a new browser session.
      * @returns {string}           the new session id of the browser
      */
-    static async reloadSession (instance: any) {
+    static async reloadSession (instance: any, newCapabilities: any) {
         const Devtools = (await import('../index.js')).default
-        return Devtools.reloadSession(instance)
+        return Devtools.reloadSession(instance, newCapabilities)
     }
 
     static get Devtools () {

--- a/packages/devtools/src/index.ts
+++ b/packages/devtools/src/index.ts
@@ -120,9 +120,12 @@ export default class DevTools {
      * @param   {object} instance  the object we get from a new browser session.
      * @returns {string}           the new session id of the browser
      */
-    static async reloadSession (instance: any): Promise<string> {
+    static async reloadSession (instance: Client, newCapabilities: WebdriverIO.Capabilities): Promise<string> {
         const { session } = sessionMap.get(instance.sessionId)
-        const browser = await launch(instance.requestedCapabilities)
+        const browser = await launch({
+            ...instance.requestedCapabilities as WebdriverIO.Capabilities,
+            ...(newCapabilities || {})
+        })
         const pages = await browser.pages()
         session.initBrowser.call(session, browser, pages)
         instance.puppeteer = browser

--- a/packages/devtools/src/types.ts
+++ b/packages/devtools/src/types.ts
@@ -3,6 +3,7 @@ import type { EventEmitter } from 'node:events'
 import type { Options, Capabilities } from '@wdio/types'
 import type { ProtocolCommands } from '@wdio/protocols'
 import type { LaunchOptions, BrowserLaunchArgumentOptions, BrowserConnectOptions, ConnectOptions } from 'puppeteer-core'
+import type { Browser } from 'puppeteer-core/lib/esm/puppeteer/api/Browser.js'
 import type { EventEmitter as PuppeteerEventEmitter } from 'puppeteer-core/lib/esm/puppeteer/common/EventEmitter.js'
 
 declare global {
@@ -43,7 +44,9 @@ export interface BaseClient extends EventEmitter {
     options: Options.WebDriver
 }
 
-export interface Client extends BaseClient, ProtocolCommands {}
+export interface Client extends BaseClient, ProtocolCommands {
+    puppeteer: Browser
+}
 
 /**
  * Interface keeping together information allowing to remove active listener from emitter.

--- a/packages/wdio-utils/src/startWebDriver.ts
+++ b/packages/wdio-utils/src/startWebDriver.ts
@@ -14,6 +14,9 @@ export async function startWebDriver (options: Options.WebDriver) {
         return
     }
 
+    /**
+     * only import `startWebDriver` when run in Node.js
+     */
     if (globalThis.process) {
         const { startWebDriver } = await import('./node/index.js')
         return startWebDriver(options)

--- a/packages/webdriverio/src/commands/browser/reloadSession.ts
+++ b/packages/webdriverio/src/commands/browser/reloadSession.ts
@@ -18,20 +18,34 @@ const log = logger('webdriverio')
         await browser.reloadSession()
         console.log(browser.sessionId) // outputs: 9a0d9bf9d4864160aa982c50cf18a573
     })
+
+    it('should reload my session with new capabilities', async () => {
+        console.log(browser.capabilities.browserName) // outputs: chrome
+        await browser.reloadSession({
+            browserName: 'firefox'
+        })
+        console.log(browser.capabilities.browserName) // outputs: firefox
+    })
  * </example>
  *
  * @alias browser.reloadSession
+ * @param newCapabilities new capabilities to create a session with
  * @type utility
  *
  */
-export async function reloadSession (this: WebdriverIO.Browser) {
+export async function reloadSession (this: WebdriverIO.Browser, newCapabilities?: WebdriverIO.Capabilities) {
     const oldSessionId = (this as WebdriverIO.Browser).sessionId
+
+    /**
+     * if a new browser name is given we can shut down the driver since we start a new one
+     */
+    const shutdownDriver = Boolean(newCapabilities?.browserName)
 
     /**
      * end current running session, if session already gone suppress exceptions
      */
     try {
-        await this.deleteSession({ shutdownDriver: false })
+        await this.deleteSession({ shutdownDriver })
     } catch (err: any) {
         /**
          * ignoring all exceptions that could be caused by browser.deleteSession()
@@ -47,7 +61,7 @@ export async function reloadSession (this: WebdriverIO.Browser) {
     }
 
     const ProtocolDriver = (await import(this.options.automationProtocol!)).default
-    await ProtocolDriver.reloadSession(this)
+    await ProtocolDriver.reloadSession(this, newCapabilities)
 
     const options = this.options as Options.Testrunner
     if (Array.isArray(options.onReload) && options.onReload.length) {


### PR DESCRIPTION
## Proposed changes

implements #12091

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

Missing pieces:
- ~get #12146 landed and implement driver management~
- ~unit tests~
- ~docs~

### Reviewers: @webdriverio/project-committers
