### PR TITLE
(@wdio/cli): allow to define path for snapshot file

### DIFF
--- a/examples/wdio/vite-vue-example/package.json
+++ b/examples/wdio/vite-vue-example/package.json
@@ -17,7 +17,7 @@
     "@testing-library/vue": "^8.0.1",
     "@types/mocha": "^10.0.6",
     "@vitejs/plugin-vue": "^5.0.3",
-    "expect-webdriverio": "^4.10.1",
+    "expect-webdriverio": "^4.11.1",
     "mocha": "^10.2.0",
     "typescript": "^5.3.3",
     "vite": "^5.0.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13896,9 +13896,9 @@
       }
     },
     "node_modules/expect-webdriverio": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/expect-webdriverio/-/expect-webdriverio-4.10.1.tgz",
-      "integrity": "sha512-62O5H+io//4vgVsC/m//ept0LyFuyKLVnSJQWByWZ1vdkBv9DQAWouILfis867WMUj9sxrZP6pXyLgp285XIkg==",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/expect-webdriverio/-/expect-webdriverio-4.11.1.tgz",
+      "integrity": "sha512-Py1SyhGqt8zBSmsoD1KnnFxAkOgs/glSs4hF1zOy2+2Z9Jn/2lZvpJN4CaJ43ZYcCVdb8FhKM9uo/d4B283fLg==",
       "dependencies": {
         "@vitest/snapshot": "^1.2.2",
         "expect": "^29.7.0",
@@ -30005,7 +30005,7 @@
         "@wdio/utils": "8.30.0",
         "deepmerge-ts": "^5.0.0",
         "expect": "^29.7.0",
-        "expect-webdriverio": "^4.10.1",
+        "expect-webdriverio": "^4.11.1",
         "get-port": "^7.0.0",
         "import-meta-resolve": "^4.0.0",
         "istanbul-lib-coverage": "^3.2.0",
@@ -30575,7 +30575,7 @@
         "node": "^16.13 || >=18"
       },
       "optionalDependencies": {
-        "expect-webdriverio": "^4.10.1",
+        "expect-webdriverio": "^4.11.1",
         "webdriverio": "8.30.0"
       }
     },
@@ -30589,7 +30589,7 @@
         "@wdio/logger": "8.28.0",
         "@wdio/types": "8.30.0",
         "@wdio/utils": "8.30.0",
-        "expect-webdriverio": "^4.10.1",
+        "expect-webdriverio": "^4.11.1",
         "jasmine": "^5.0.0"
       },
       "devDependencies": {
@@ -30763,7 +30763,7 @@
         "@wdio/types": "8.30.0",
         "@wdio/utils": "8.30.0",
         "deepmerge-ts": "^5.0.0",
-        "expect-webdriverio": "^4.10.1",
+        "expect-webdriverio": "^4.11.1",
         "gaze": "^1.1.2",
         "webdriver": "8.30.0",
         "webdriverio": "8.30.0"
@@ -37061,7 +37061,7 @@
         "@wdio/utils": "8.30.0",
         "deepmerge-ts": "^5.0.0",
         "expect": "^29.7.0",
-        "expect-webdriverio": "^4.10.1",
+        "expect-webdriverio": "^4.11.1",
         "get-port": "^7.0.0",
         "import-meta-resolve": "^4.0.0",
         "istanbul-lib-coverage": "^3.2.0",
@@ -37423,7 +37423,7 @@
     "@wdio/globals": {
       "version": "file:packages/wdio-globals",
       "requires": {
-        "expect-webdriverio": "^4.10.1",
+        "expect-webdriverio": "^4.11.1",
         "webdriverio": "8.30.0"
       }
     },
@@ -37436,7 +37436,7 @@
         "@wdio/logger": "8.28.0",
         "@wdio/types": "8.30.0",
         "@wdio/utils": "8.30.0",
-        "expect-webdriverio": "^4.10.1",
+        "expect-webdriverio": "^4.11.1",
         "jasmine": "^5.0.0"
       }
     },
@@ -37548,7 +37548,7 @@
         "@wdio/types": "8.30.0",
         "@wdio/utils": "8.30.0",
         "deepmerge-ts": "^5.0.0",
-        "expect-webdriverio": "^4.10.1",
+        "expect-webdriverio": "^4.11.1",
         "gaze": "^1.1.2",
         "webdriver": "8.30.0",
         "webdriverio": "8.30.0"
@@ -42323,9 +42323,9 @@
       }
     },
     "expect-webdriverio": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/expect-webdriverio/-/expect-webdriverio-4.10.1.tgz",
-      "integrity": "sha512-62O5H+io//4vgVsC/m//ept0LyFuyKLVnSJQWByWZ1vdkBv9DQAWouILfis867WMUj9sxrZP6pXyLgp285XIkg==",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/expect-webdriverio/-/expect-webdriverio-4.11.1.tgz",
+      "integrity": "sha512-Py1SyhGqt8zBSmsoD1KnnFxAkOgs/glSs4hF1zOy2+2Z9Jn/2lZvpJN4CaJ43ZYcCVdb8FhKM9uo/d4B283fLg==",
       "requires": {
         "@vitest/snapshot": "^1.2.2",
         "@wdio/globals": "^8.29.3",

--- a/packages/wdio-browser-runner/package.json
+++ b/packages/wdio-browser-runner/package.json
@@ -47,7 +47,7 @@
     "@wdio/utils": "8.30.0",
     "deepmerge-ts": "^5.0.0",
     "expect": "^29.7.0",
-    "expect-webdriverio": "^4.10.1",
+    "expect-webdriverio": "^4.11.1",
     "get-port": "^7.0.0",
     "import-meta-resolve": "^4.0.0",
     "istanbul-lib-coverage": "^3.2.0",

--- a/packages/wdio-cli/src/constants.ts
+++ b/packages/wdio-cli/src/constants.ts
@@ -898,6 +898,17 @@ export const TESTRUNNER_DEFAULTS: Options.Definition<Options.Testrunner> = {
         }
     },
     /**
+     * Overrides default snapshot path. For example, to store snapshots next to test files.
+     */
+    resolveSnapshotPath: {
+        type: 'function',
+        validate: (param: Options.Testrunner['resolveSnapshotPath']) => {
+            if (param && typeof param !== 'function') {
+                throw new Error('the "resolveSnapshotPath" options needs to be a function')
+            }
+        }
+    },
+    /**
      * The number of times to retry the entire specfile when it fails as a whole
      */
     specFileRetries: {

--- a/packages/wdio-cli/src/interface.ts
+++ b/packages/wdio-cli/src/interface.ts
@@ -29,7 +29,7 @@ interface CLIInterfaceEvent {
 
 export default class WDIOCLInterface extends EventEmitter {
     #snapshotManager = new SnapshotManager({
-        updateSnapshot: 'new'
+        updateSnapshot: 'new' // ignored in this context
     })
 
     public hasAnsiSupport: boolean

--- a/packages/wdio-globals/package.json
+++ b/packages/wdio-globals/package.json
@@ -42,7 +42,7 @@
     "access": "public"
   },
   "optionalDependencies": {
-    "expect-webdriverio": "^4.10.1",
+    "expect-webdriverio": "^4.11.1",
     "webdriverio": "8.30.0"
   }
 }

--- a/packages/wdio-jasmine-framework/package.json
+++ b/packages/wdio-jasmine-framework/package.json
@@ -37,7 +37,7 @@
     "@wdio/logger": "8.28.0",
     "@wdio/types": "8.30.0",
     "@wdio/utils": "8.30.0",
-    "expect-webdriverio": "^4.10.1",
+    "expect-webdriverio": "^4.11.1",
     "jasmine": "^5.0.0"
   },
   "devDependencies": {

--- a/packages/wdio-runner/package.json
+++ b/packages/wdio-runner/package.json
@@ -36,7 +36,7 @@
     "@wdio/types": "8.30.0",
     "@wdio/utils": "8.30.0",
     "deepmerge-ts": "^5.0.0",
-    "expect-webdriverio": "^4.10.1",
+    "expect-webdriverio": "^4.11.1",
     "gaze": "^1.1.2",
     "webdriver": "8.30.0",
     "webdriverio": "8.30.0"

--- a/packages/wdio-runner/src/index.ts
+++ b/packages/wdio-runner/src/index.ts
@@ -73,7 +73,10 @@ export default class Runner extends EventEmitter {
         /**
          * add built-in services
          */
-        this._snapshotService = SnapshotService.initiate(this._config.updateSnapshots)
+        this._snapshotService = SnapshotService.initiate({
+            updateState: this._config.updateSnapshots,
+            resolveSnapshotPath: this._config.resolveSnapshotPath
+        })
         this._configParser.addService(this._snapshotService)
 
         /**

--- a/packages/wdio-types/src/Options.ts
+++ b/packages/wdio-types/src/Options.ts
@@ -410,6 +410,11 @@ export interface Testrunner extends Hooks, Omit<WebdriverIO, 'capabilities'>, We
      */
     updateSnapshots?: 'all' | 'new' | 'none'
     /**
+     * Overrides default snapshot path. For example, to store snapshots next to test files.
+     * @default __snapshots__ stores snapshot files in __snapshots__ directory next to the test file.
+     */
+    resolveSnapshotPath?: (testPath: string, snapExtension: string) => string
+    /**
      * The number of retry attempts for an entire specfile when it fails as a whole.
      */
     specFileRetries?: number


### PR DESCRIPTION
## Proposed changes

This patch adds support for defining a custom snapshot path. It also bumps the `expect-webdriverio` version which provides improvements on default `updateSnapshot` value.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
