### PR TITLE
(webdriverio): don't fail getContext is not supported, e.g. using Tizen TV driver

### DIFF
--- a/packages/webdriverio/src/commands/element/isClickable.ts
+++ b/packages/webdriverio/src/commands/element/isClickable.ts
@@ -46,7 +46,11 @@ export async function isClickable (this: WebdriverIO.Element) {
         return false
     }
 
-    if (this.isMobile && await this.getContext() === 'NATIVE_APP') {
+    /**
+     * some Appium platforms don't support the `getContext` method, in that case
+     * we can't determine if we are in a native context or not, so we return undefined
+     */
+    if (this.isMobile && await this.getContext().catch(() => undefined) === 'NATIVE_APP') {
         throw new Error('Method not supported in mobile native environment. It is unlikely that you need to use this command.')
     }
 

--- a/packages/webdriverio/src/commands/element/isEqual.ts
+++ b/packages/webdriverio/src/commands/element/isEqual.ts
@@ -37,7 +37,11 @@ export async function isEqual (
 
     // mobile native
     if (browser.isMobile) {
-        const context = await browser.getContext()
+        /**
+         * some Appium platforms don't support the `getContext` method, in that case
+         * we can't determine if we are in a native context or not, so we return undefined
+         */
+        const context = await browser.getContext().catch(() => undefined)
         const contextId = typeof context === 'string'
             ? context
             : context?.id

--- a/packages/webdriverio/tests/commands/element/isClickable.test.ts
+++ b/packages/webdriverio/tests/commands/element/isClickable.test.ts
@@ -50,6 +50,18 @@ describe('isClickable test', () => {
         await expect(() => elem.isClickable.call(scope)).rejects.toThrow()
     })
 
+    it('should not throw if getContext fails', async () => {
+        const scope = {
+            isDisplayed: vi.fn().mockResolvedValue(true),
+            execute: vi.fn(),
+            options: {},
+            isMobile: true,
+            getContext: vi.fn().mockRejectedValue(new Error('command does not exist'))
+        }
+        await elem.isClickable.call(scope)
+        expect(scope.execute).toBeCalledTimes(1)
+    })
+
     afterEach(() => {
         vi.mocked(got).mockClear()
     })


### PR DESCRIPTION
## Proposed changes

fixes #12196

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
