### PR TITLE
(feat): enable scroll as optional in isClickable script

### DIFF
--- a/packages/webdriverio/src/commands/element/isClickable.ts
+++ b/packages/webdriverio/src/commands/element/isClickable.ts
@@ -3,15 +3,18 @@ import { ELEMENT_KEY } from 'webdriver'
 import { getBrowserObject } from '../../utils/index.js'
 import isElementClickableScript from '../../scripts/isElementClickable.js'
 
+import type { ClickableOptions } from '../../types.js'
 /**
  *
  * Return true if the selected DOM-element:
  *
  * - exists
  * - is visible
- * - is within viewport (if not try scroll to it)
+ * - is within viewport
  * - its center is not overlapped with another element
  * - is not disabled
+ *
+ *By default try to scroll it if not within viewport (can set to false in option)
  *
  * otherwise return false.
  *
@@ -30,18 +33,23 @@ import isElementClickableScript from '../../scripts/isElementClickable.js'
         let clickable = await el.isClickable();
         console.log(clickable); // outputs: true or false
 
+        // is clickable without perform the scroll
+        let clickable = await el.isClickable({ scroll: false });
+
         // wait for element to be clickable
-        await browser.waitUntil(() => el.isClickable())
+        await browser.waitUntil(() => el.isClickable());
     });
  * </example>
  *
  * @alias element.isClickable
  * @return {Boolean}            true if element is clickable
  * @uses protocol/selectorExecute, protocol/timeoutsAsyncScript
+ * @param {ClickableOptions=} options           isClickable command options
+ * @param {scroll=}             options.scroll    try scrolling to element if it's not clickable (default: true)
  * @type state
  *
  */
-export async function isClickable (this: WebdriverIO.Element) {
+export async function isClickable (this: WebdriverIO.Element, { scroll = true }: ClickableOptions = {}) {
     if (!await this.isDisplayed()) {
         return false
     }
@@ -58,5 +66,5 @@ export async function isClickable (this: WebdriverIO.Element) {
     return browser.execute(isElementClickableScript, {
         [ELEMENT_KEY]: this.elementId, // w3c compatible
         ELEMENT: this.elementId // jsonwp compatible
-    } as any as HTMLElement)
+    } as any as HTMLElement, scroll)
 }

--- a/packages/webdriverio/src/commands/element/waitForClickable.ts
+++ b/packages/webdriverio/src/commands/element/waitForClickable.ts
@@ -1,5 +1,7 @@
 import type { WaitForOptions } from '../../types.js'
 
+import type { ClickableOptions } from '../../types.js'
+
 /**
  * Wait for an element for the provided amount of milliseconds to be clickable or not clickable.
  *
@@ -13,12 +15,18 @@ import type { WaitForOptions } from '../../types.js'
  * <example>
     :waitForClickable.js
     it('should detect when element is clickable', async () => {
-        const elem = await $('#elem')
+        const elem = await $('#elem');
         await elem.waitForClickable({ timeout: 3000 });
     });
     it('should detect when element is no longer clickable', async () => {
-        const elem = await $('#elem')
+        const elem = await $('#elem');
         await elem.waitForClickable({ reverse: true });
+    });
+    it('should detect when element is not clickable (without try to scroll), perform an action then should detect when now element is clickable', async () => {
+        const elem = await $('#elem');
+        await elem.waitForClickable({ reverse: true }, { scroll: false });
+        await elem.scrollIntoview();
+        await elem.waitForClickable({ scroll: false });
     });
  * </example>
  *
@@ -28,6 +36,8 @@ import type { WaitForOptions } from '../../types.js'
  * @param {Boolean=}         options.reverse     if true it waits for the opposite (default: false)
  * @param {String=}          options.timeoutMsg  if exists it overrides the default error message
  * @param {Number=}          options.interval    interval between checks (default: `waitforInterval`)
+ * @param {ClickableOptions=}  clickableOptions  waitForClickable options (optional)
+ * @param {scroll=}          clickableOptions.scroll    try scrolling to element if it's not clickable (default: true)
  * @return {Boolean} `true` if element is clickable (or doesn't if flag is set)
  *
  */
@@ -38,10 +48,11 @@ export async function waitForClickable (
         interval = this.options.waitforInterval,
         reverse = false,
         timeoutMsg = `element ("${this.selector}") still ${reverse ? '' : 'not '}clickable after ${timeout}ms`
-    }: WaitForOptions = {}
+    }: WaitForOptions = {},
+    { scroll = true }: ClickableOptions = {},
 ) {
     return this.waitUntil(
-        async () => reverse !== await this.isClickable(),
+        async () => reverse !== await this.isClickable({ scroll }),
         { timeout, timeoutMsg, interval }
     )
 }

--- a/packages/webdriverio/src/scripts/isElementClickable.ts
+++ b/packages/webdriverio/src/scripts/isElementClickable.ts
@@ -3,7 +3,7 @@
  * @param  {HTMLElement} elem  element to check
  * @return {Boolean}           false if element is not overlapped
  */
-export default function isElementClickable (elem: HTMLElement) {
+export default function isElementClickable (elem: HTMLElement, scroll: boolean = true) {
     if (!elem.getBoundingClientRect || !elem.scrollIntoView || !elem.contains || !elem.getClientRects || !document.elementFromPoint) {
         return false
     }
@@ -127,8 +127,8 @@ export default function isElementClickable (elem: HTMLElement) {
         )
     }
 
-    // scroll to the element if it's not clickable
-    if (!isClickable(elem)) {
+    // scroll to the element if it's not clickable and expected
+    if (!isClickable(elem) && scroll) {
         // works well in dialogs, but the element may be still overlapped by some sticky header/footer
         elem.scrollIntoView(scrollIntoViewFullSupport ? { block: 'nearest', inline: 'nearest' } : false)
 

--- a/packages/webdriverio/src/types.ts
+++ b/packages/webdriverio/src/types.ts
@@ -460,6 +460,10 @@ export type DragAndDropCoordinate = {
     y: number
 }
 
+export type ClickableOptions = {
+    scroll?: boolean
+}
+
 /**
  * WebdriverIO Mock definition
  */

--- a/packages/webdriverio/tests/commands/element/isClickable.test.ts
+++ b/packages/webdriverio/tests/commands/element/isClickable.test.ts
@@ -62,6 +62,16 @@ describe('isClickable test', () => {
         expect(scope.execute).toBeCalledTimes(1)
     })
 
+    it('should not perform the scroll', async () => {
+        await elem.isClickable( { scroll: false } )
+        expect(vi.mocked(got).mock.calls[0][0]!.pathname)
+            .toBe('/session/foobar-123/execute/sync')
+        expect(vi.mocked(got).mock.calls[0][1]!.json.args[0]).toEqual({
+            'element-6066-11e4-a52e-4f735466cecf': 'some-elem-123',
+            ELEMENT: 'some-elem-123'
+        })
+    })
+
     afterEach(() => {
         vi.mocked(got).mockClear()
     })

--- a/packages/webdriverio/tests/commands/element/waitForClickable.test.ts
+++ b/packages/webdriverio/tests/commands/element/waitForClickable.test.ts
@@ -50,6 +50,21 @@ describe('waitForClickable', () => {
         expect(result).toBe(true)
     })
 
+    it('should call isClickable and return true without perform the scroll', async () => {
+        const tmpElem = await browser.$('#foo')
+        const elem = {
+            selector : '#foo',
+            waitForClickable : tmpElem.waitForClickable,
+            elementId : 123,
+            waitUntil : tmpElem.waitUntil,
+            isClickable : vi.fn(() => true),
+            options : { waitforTimeout : 500, waitforInterval: 50 },
+        } as any as WebdriverIO.Element
+        const result = await elem.waitForClickable({ timeout: duration }, { scroll: false })
+
+        expect(result).toBe(true)
+    })
+
     it('should call isClickable and return true if eventually true', async () => {
         const tmpElem = await browser.$('#foo')
         const elem = {


### PR DESCRIPTION
## Proposed changes

Currently, a scroll is perform in isClickable API if the element is not displayed. This is very disruptive in the case where you want to test that the element is not clickable. (a scroll is done wihout asked)
This PR allows to disable the scroll if necessary.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist



- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments
N/A

### Reviewers: @webdriverio/project-committers
