### PR TITLE
feat: remove appium commands

### DIFF
--- a/packages/wdio-protocols/src/protocols/jsonwp.ts
+++ b/packages/wdio-protocols/src/protocols/jsonwp.ts
@@ -1215,72 +1215,6 @@ export default {
             ],
         },
     },
-    '/session/:sessionId/touch/down': {
-        POST: {
-            command: 'touchDown',
-            description: 'Finger down on the screen.',
-            ref: 'https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidtouchdown',
-            deprecated: TOUCH_DEPRECATION_NOTICE,
-            parameters: [
-                {
-                    name: 'x',
-                    type: 'number',
-                    description: 'x coordinate on the screen',
-                    required: true,
-                },
-                {
-                    name: 'y',
-                    type: 'number',
-                    description: 'y coordinate on the screen',
-                    required: true,
-                },
-            ],
-        },
-    },
-    '/session/:sessionId/touch/up': {
-        POST: {
-            command: 'touchUp',
-            description: 'Finger up on the screen.',
-            ref: 'https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidtouchup',
-            deprecated: TOUCH_DEPRECATION_NOTICE,
-            parameters: [
-                {
-                    name: 'x',
-                    type: 'number',
-                    description: 'x coordinate on the screen',
-                    required: true,
-                },
-                {
-                    name: 'y',
-                    type: 'number',
-                    description: 'y coordinate on the screen',
-                    required: true,
-                },
-            ],
-        },
-    },
-    '/session/:sessionId/touch/move': {
-        POST: {
-            command: 'touchMove',
-            description: 'Finger move on the screen.',
-            ref: 'https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidtouchmove',
-            deprecated: TOUCH_DEPRECATION_NOTICE,
-            parameters: [
-                {
-                    name: 'x',
-                    type: 'number',
-                    description: 'x coordinate on the screen',
-                    required: true,
-                },
-                {
-                    name: 'y',
-                    type: 'number',
-                    description: 'y coordinate on the screen',
-                    required: true,
-                },
-            ],
-        },
-    },
     '/session/:sessionId/touch/scroll': {
         POST: {
             command: 'touchScroll',
@@ -1321,23 +1255,6 @@ export default {
                     name: 'element',
                     type: 'string',
                     description: 'ID of the element to double tap on',
-                    required: true,
-                },
-            ],
-        },
-    },
-    '/session/:sessionId/touch/longclick': {
-        POST: {
-            command: 'touchLongClick',
-            description:
-                'Long press on the touch screen using finger motion events.',
-            ref: 'https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidtouchlongclick',
-            deprecated: TOUCH_DEPRECATION_NOTICE,
-            parameters: [
-                {
-                    name: 'element',
-                    type: 'string',
-                    description: 'ID of the element to long press on',
                     required: true,
                 },
             ],


### PR DESCRIPTION
The latest `appium-uiautomator2-driver` [3.0.0](https://github.com/appium/appium-uiautomator2-driver/releases/tag/v3.0.0) released removed the following commands

- touchDown
- touchLongClick
- touchMove
- touchUp

They were already deprecated and will now be removed

## Alternatives

### `touchDown`

```ts
// See https://webdriver.io/docs/api/browser/action/
await driver
  // a. Create the event
  .action('pointer')
  // b. Move finger into start position
  .move(x,y) // This can also be written as .move({ x:x, y:y }) which allows you to add more options
  // c. Finger comes down into contact with screen
  .down() // This can also be written as .down({ button:0 }) which allows you to add more options
  // d. Perform the action, in this flow the finger will stay on the screen, this is normally not a good flow because you are "stuck"
   .perform()
```

### `touchUp`

```ts
// See https://webdriver.io/docs/api/browser/action/
// A touchUp is normally the followup from a `touchDown`
await driver
  // a. Create the event
  .action('pointer')
  // b. Move finger into start position
  .move(x,y) // This can also be written as .move({ x:x, y:y }) which allows you to add more options
  // c. Finger comes down into contact with screen
  .down() // This can also be written as .down({ button:0 }) which allows you to add more options
  // d. Pause for a little bit, playing with the pause will make this a "normal" or a longer click action
  .pause(100)
  // e. Finger gets up, off the screen
  .up() // this can also be written as .up({ button:0 }) which allows you to add more options
  // f. Perform the action
  .perform();
```

### `touchLongClick`

```ts
// See https://webdriver.io/docs/api/browser/action/
// The alternative of the `touchLongClick` can be compared with the replacement of the `touchUp` but with a longer pause
await driver
  // a. Create the event
  .action('pointer')
  // b. Move finger into start position
  .move(x,y) // This can also be written as .move({ x:x, y:y }) which allows you to add more options
  // c. Finger comes down into contact with screen
  .down() // This can also be written as .down({ button:0 }) which allows you to add more options
  // d. Pause longer, take for example 1000ms which is 1 second or more
  .pause(3000)
  // e. Finger gets up, off the screen
  .up() // this can also be written as .up({ button:0 }) which allows you to add more options
  // f. Perform the action
  .perform();
```

### `touchMove`

```ts
// See https://webdriver.io/docs/api/browser/action/
// We add an extra `move`
await driver
  // a. Create the event
  .action('pointer')
  // b. Move finger into start position
  .move(from.x, from.y) // This can also be written as .move({ x:from.x, y:from.y }) which allows you to add more options
  // c. Finger comes down into contact with screen
  .down() // This can also be written as .down({ button:0 }) which allows you to add more options
  // d. Pause for a little bit
  .pause(100)
  // e. Finger moves to end position
  // IMPORTANT. The default duration, if you don't provide it, is 100ms. This means that the movement will be so fast that it:
  // - might not be registered
  // - might not have the correct result on longer movements.
  // Short durations will move elements on the screen over longer move coordinates very fast.
  // Play with the duration to make the swipe go slower / faster
  .move({ duration: 1000, x: to.x, y: to.y })
  // f. Finger gets up, off the screen
  .up() // this can also be written as .up({ button:0 }) which allows you to add more options
  // g. Perform the action
  .perform();
```

## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
