### PR TITLE
(@wdio/wdio-browserstack-service) fix: add filename in app upload formData

### DIFF
--- a/packages/wdio-browserstack-service/src/launcher.ts
+++ b/packages/wdio-browserstack-service/src/launcher.ts
@@ -449,7 +449,8 @@ export default class BrowserstackLauncherService implements Services.ServiceInst
 
         const form = new FormData()
         if (app.app) {
-            form.append('file', new FileStream(fs.createReadStream(app.app)))
+            const fileName = path.basename(app.app)
+            form.append('file', new FileStream(fs.createReadStream(app.app)), fileName)
         }
         if (app.customId) {
             form.append('custom_id', app.customId)


### PR DESCRIPTION
## Proposed changes
 Currently app uploads to browserstack are failing due to uploaded file containing just a blob. Adding filename resolves this issue

Reproducible sample
https://github.com/innovater21/appium-boilerplate
## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Steps to reproduce

1. clone https://github.com/innovater21/appium-boilerplate
2.  ```sh
      npm install
      npm install --save-dev @wdio/browserstack-service
    ```
3. update user, key and app in `config/browserstack/wdio.android.bs.app.conf.ts`
4. ```sh
    # For iOS
    $ npm run ios.browserstack.app

    # For Android
    $ npm run android.browserstack.app
   ```
### Reviewers: @webdriverio/project-committers
