### PR TITLE
Workaround for chromedriver domain name change

### DIFF
--- a/packages/wdio-utils/src/node/utils.ts
+++ b/packages/wdio-utils/src/node/utils.ts
@@ -212,6 +212,7 @@ export async function setupPuppeteerBrowser(cacheDir: string, caps: WebdriverIO.
         : caps.browserVersion || 'latest'
     const buildId = await resolveBuildId(browserName, platform, tag)
     const installOptions: InstallOptions & { unpack?: true } = {
+        baseUrl: 'https://storage.googleapis.com/chrome-for-testing-public', // TODO: remove this once https://github.com/puppeteer/puppeteer/pull/11923 is backported
         unpack: true,
         cacheDir,
         platform,
@@ -282,6 +283,7 @@ export async function setupChromedriver (cacheDir: string, driverVersion?: strin
     if (!hasChromedriverInstalled) {
         log.info(`Downloading Chromedriver v${buildId}`)
         const chromedriverInstallOpts: InstallOptions & {unpack?: true} = {
+            baseUrl: 'https://storage.googleapis.com/chrome-for-testing-public', // TODO: remove this once https://github.com/puppeteer/puppeteer/pull/11923 is backported
             cacheDir,
             buildId,
             platform,

--- a/packages/wdio-utils/src/node/utils.ts
+++ b/packages/wdio-utils/src/node/utils.ts
@@ -212,7 +212,7 @@ export async function setupPuppeteerBrowser(cacheDir: string, caps: WebdriverIO.
         : caps.browserVersion || 'latest'
     const buildId = await resolveBuildId(browserName, platform, tag)
     const installOptions: InstallOptions & { unpack?: true } = {
-        baseUrl: 'https://storage.googleapis.com/chrome-for-testing-public', // TODO: remove this once https://github.com/puppeteer/puppeteer/pull/11923 is backported
+        baseUrl: 'https://storage.googleapis.com/chrome-for-testing-public', // TODO: remove this once https://github.com/puppeteer/puppeteer/pull/11923 is backported or we update to @puppeteer/browsers >= v2.0.1
         unpack: true,
         cacheDir,
         platform,
@@ -283,7 +283,7 @@ export async function setupChromedriver (cacheDir: string, driverVersion?: strin
     if (!hasChromedriverInstalled) {
         log.info(`Downloading Chromedriver v${buildId}`)
         const chromedriverInstallOpts: InstallOptions & {unpack?: true} = {
-            baseUrl: 'https://storage.googleapis.com/chrome-for-testing-public', // TODO: remove this once https://github.com/puppeteer/puppeteer/pull/11923 is backported
+            baseUrl: 'https://storage.googleapis.com/chrome-for-testing-public', // TODO: remove this once https://github.com/puppeteer/puppeteer/pull/11923 is backported or we update to @puppeteer/browsers >= v2.0.1
             cacheDir,
             buildId,
             platform,


### PR DESCRIPTION
## Proposed changes

Workaround for chromedriver domain name change until https://github.com/puppeteer/puppeteer/pull/11923 is backported or we drop support for Node.js v16 and update to @puppeteer/browsers >= [v2.0.1](https://github.com/puppeteer/puppeteer/releases/tag/browsers-v2.0.1).

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
