### PR TITLE
Updated props to optional for getText and getLocation commands

### DIFF
--- a/packages/webdriverio/src/commands/element/getLocation.ts
+++ b/packages/webdriverio/src/commands/element/getLocation.ts
@@ -4,7 +4,8 @@ import { getElementRect } from '../../utils/index.js'
 export type Location = Pick<RectReturn, 'x' | 'y'>;
 
 export function getLocation (this: WebdriverIO.Element): Promise<Location>
-export function getLocation (this: WebdriverIO.Element, prop?: keyof Location): Promise<number>
+export function getLocation (this: WebdriverIO.Element, prop: keyof Location): Promise<number>
+export function getLocation (this: WebdriverIO.Element, prop?: keyof Location): Promise<Location & number>
 
 /**
  *

--- a/packages/webdriverio/src/commands/element/getLocation.ts
+++ b/packages/webdriverio/src/commands/element/getLocation.ts
@@ -4,7 +4,7 @@ import { getElementRect } from '../../utils/index.js'
 export type Location = Pick<RectReturn, 'x' | 'y'>;
 
 export function getLocation (this: WebdriverIO.Element): Promise<Location>
-export function getLocation (this: WebdriverIO.Element, prop: keyof Location): Promise<number>
+export function getLocation (this: WebdriverIO.Element, prop?: keyof Location): Promise<number>
 
 /**
  *

--- a/packages/webdriverio/src/commands/element/getSize.ts
+++ b/packages/webdriverio/src/commands/element/getSize.ts
@@ -5,7 +5,7 @@ import { getElementRect } from '../../utils/index.js'
 export type Size = Pick<RectReturn, 'width' | 'height'>;
 
 export function getSize (this: WebdriverIO.Element): Promise<Size>;
-export function getSize (this: WebdriverIO.Element, prop: keyof RectReturn): Promise<number>;
+export function getSize (this: WebdriverIO.Element, prop?: keyof RectReturn): Promise<number>;
 
 /**
  *

--- a/packages/webdriverio/src/commands/element/getSize.ts
+++ b/packages/webdriverio/src/commands/element/getSize.ts
@@ -5,7 +5,8 @@ import { getElementRect } from '../../utils/index.js'
 export type Size = Pick<RectReturn, 'width' | 'height'>;
 
 export function getSize (this: WebdriverIO.Element): Promise<Size>;
-export function getSize (this: WebdriverIO.Element, prop?: keyof RectReturn): Promise<number>;
+export function getSize (this: WebdriverIO.Element, prop: keyof RectReturn): Promise<number>;
+export function getSize (this: WebdriverIO.Element, prop?: keyof RectReturn): Promise<Size & number>;
 
 /**
  *

--- a/tests/typings/webdriverio/commands.ts
+++ b/tests/typings/webdriverio/commands.ts
@@ -1,0 +1,21 @@
+import { expectType } from 'tsd'
+import { $ } from '@wdio/globals'
+import type { RectReturn } from '@wdio/protocols'
+
+;(async () => {
+    const el = $('foxo')
+
+    // types validations for getSize command
+    expectType<Pick<RectReturn, 'width' | 'height'>>(await el.getSize())
+    expectType<number>((await el.getSize()).height)
+    expectType<number>((await el.getSize()).width)
+    expectType<number>(await el.getSize('height'))
+    expectType<number>(await el.getSize('width'))
+
+    // types validations for getLocation command
+    expectType<Pick<RectReturn, 'x' | 'y'>>(await el.getLocation())
+    expectType<number>((await el.getLocation()).x)
+    expectType<number>((await el.getLocation()).y)
+    expectType<number>(await el.getLocation('x'))
+    expectType<number>(await el.getLocation('y'))
+})


### PR DESCRIPTION
## Proposed changes
Fixes [#12173](https://github.com/webdriverio/webdriverio/issues/12173)
* Make props as optional parameter for getText and getLocation commands


## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

### Reviewers: @webdriverio/project-committers
