### PR TITLE
fix: added filename in file upload

### DIFF
--- a/packages/wdio-browserstack-service/src/launcher.ts
+++ b/packages/wdio-browserstack-service/src/launcher.ts
@@ -433,7 +433,10 @@ export default class BrowserstackLauncherService implements Services.ServiceInst
         log.info(`uploading app ${app.app} ${app.customId? `and custom_id: ${app.customId}` : ''} to browserstack`)
 
         const form = new FormData()
-        if (app.app) form.append('file', fs.createReadStream(app.app))
+        if (app.app) {
+            const fileName = path.basename(app.app)
+            form.append('file', fs.createReadStream(app.app), fileName)
+        }
         if (app.customId) form.append('custom_id', app.customId)
 
         const res = await got.post('https://api-cloud.browserstack.com/app-automate/upload', {


### PR DESCRIPTION
## Proposed changes
 Currently app uploads to browserstack are failing due to uploaded file containing just a blob. Adding filename resolves this issue

Reproducible sample
https://github.com/innovater21/appium-boilerplate

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

## Steps to reproduce

1. clone https://github.com/innovater21/appium-boilerplate
2.  ```sh
      npm install
      npm install --save-dev @wdio/browserstack-service
    ```
3. update user, key and app in `config/browserstack/wdio.android.bs.app.conf.ts`
4. ```sh
    # For iOS
    $ npm run ios.browserstack.app

    # For Android
    $ npm run android.browserstack.app

### Reviewers: @webdriverio/project-committers
