### PR TITLE
(internal): remove dependency to devtools package

### DIFF
--- a/packages/webdriverio/package.json
+++ b/packages/webdriverio/package.json
@@ -79,7 +79,6 @@
     "aria-query": "^5.0.0",
     "css-shorthand-properties": "^1.1.1",
     "css-value": "^0.0.1",
-    "devtools-protocol": "^0.0.1260888",
     "grapheme-splitter": "^1.0.2",
     "import-meta-resolve": "^4.0.0",
     "is-plain-obj": "^4.1.0",

--- a/packages/webdriverio/src/types.ts
+++ b/packages/webdriverio/src/types.ts
@@ -1,5 +1,4 @@
 import type { EventEmitter } from 'node:events'
-import type { Protocol } from 'devtools-protocol'
 import type { SessionFlags, AttachOptions as WebDriverAttachOptions, BidiHandler, BidiEventHandler } from 'webdriver'
 import type { Options, Capabilities, FunctionProperties, ThenArg } from '@wdio/types'
 import type { ElementReference, ProtocolCommands } from '@wdio/protocols'
@@ -8,7 +7,7 @@ import type { Browser as PuppeteerBrowser } from 'puppeteer-core'
 import type * as BrowserCommands from './commands/browser.js'
 import type * as ElementCommands from './commands/element.js'
 import type DevtoolsInterception from './utils/interception/devtools.js'
-import type { Matches } from './utils/interception/types.js'
+import type { Matches, ErrorReason } from './utils/interception/types.js'
 
 export * from './utils/interception/types.js'
 export type RemoteOptions = Options.WebdriverIO & Omit<Options.Testrunner, 'capabilities' | 'rootDir'>
@@ -485,7 +484,7 @@ interface OverwriteEvent {
 
 interface FailEvent {
     requestId: number
-    errorReason: Protocol.Network.ErrorReason
+    errorReason: ErrorReason
 }
 
 interface MockFunctions extends Omit<FunctionProperties<DevtoolsInterception>, 'on'> {

--- a/packages/webdriverio/src/utils/interception/devtools.ts
+++ b/packages/webdriverio/src/utils/interception/devtools.ts
@@ -2,10 +2,9 @@ import fs from 'node:fs/promises'
 import path from 'node:path'
 import logger from '@wdio/logger'
 import type { CDPSession } from 'puppeteer-core'
-import type { Protocol } from 'devtools-protocol'
 
 import Interception from './index.js'
-import type { Matches, MockOverwrite, MockResponseParams } from './types.js'
+import type { Matches, MockOverwrite, MockResponseParams, ErrorReason } from './types.js'
 import { containsHeaderObject } from '../index.js'
 import { ERROR_REASON } from '../../constants.js'
 import { CDP_SESSIONS, SESSION_MOCKS } from '../../commands/browser/mock.js'
@@ -271,7 +270,7 @@ export default class DevtoolsInterception extends Interception {
      * Abort the request with an error code
      * @param {string} errorCode  error code of the response
      */
-    abort (errorReason: Protocol.Network.ErrorReason, sticky: boolean = true) {
+    abort (errorReason: ErrorReason, sticky: boolean = true) {
         this.ensureNotRestored()
         if (typeof errorReason !== 'string' || !ERROR_REASON.includes(errorReason)) {
             throw new Error(`Invalid value for errorReason, allowed are: ${ERROR_REASON.join(', ')}`)
@@ -283,7 +282,7 @@ export default class DevtoolsInterception extends Interception {
      * Abort the request once with an error code
      * @param {string} errorReason  error code of the response
      */
-    abortOnce (errorReason: Protocol.Network.ErrorReason) {
+    abortOnce (errorReason: ErrorReason) {
         this.abort(errorReason, false)
     }
 

--- a/packages/webdriverio/src/utils/interception/index.ts
+++ b/packages/webdriverio/src/utils/interception/index.ts
@@ -4,9 +4,7 @@ import { minimatch } from 'minimatch'
 import Timer from '../Timer.js'
 
 import type { WaitForOptions } from '../../types.js'
-import type { MockFilterOptions, MockOverwrite, MockResponseParams, Matches } from './types.js'
-
-import type { Protocol } from 'devtools-protocol'
+import type { MockFilterOptions, MockOverwrite, MockResponseParams, Matches, ErrorReason } from './types.js'
 
 export default abstract class Interception extends EventEmitter {
     abstract calls: Matches[] | Promise<Matches[]>
@@ -14,14 +12,14 @@ export default abstract class Interception extends EventEmitter {
     abstract restore (): Promise<void>
     abstract respond (overwrite: MockOverwrite, params: MockResponseParams): void
     abstract respondOnce (overwrite: MockOverwrite, params: MockResponseParams): void
-    abstract abort (errorReason: Protocol.Network.ErrorReason, sticky: boolean): void
-    abstract abortOnce (errorReason: Protocol.Network.ErrorReason): void
+    abstract abort (errorReason: ErrorReason, sticky: boolean): void
+    abstract abortOnce (errorReason: ErrorReason): void
 
     respondOverwrites: {
         overwrite?: MockOverwrite
         params?: MockResponseParams
         sticky?: boolean
-        errorReason?: Protocol.Network.ErrorReason
+        errorReason?: ErrorReason
     }[] = []
     matches: Matches[] = []
 

--- a/packages/webdriverio/src/utils/interception/types.ts
+++ b/packages/webdriverio/src/utils/interception/types.ts
@@ -8,6 +8,7 @@ import type { JsonCompatible } from '@wdio/types'
 export type ResourcePriority = 'VeryLow' | 'Low' | 'Medium' | 'High' | 'VeryHigh'
 export type MixedContentType = 'blockable' | 'optionally-blockable' | 'none'
 export type ReferrerPolicy = 'unsafe-url' | 'no-referrer-when-downgrade' | 'no-referrer' | 'origin' | 'origin-when-cross-origin' | 'same-origin' | 'strict-origin' | 'strict-origin-when-cross-origin'
+export type ErrorReason = 'Failed' | 'Aborted' | 'TimedOut' | 'AccessDenied' | 'ConnectionClosed' | 'ConnectionReset' | 'ConnectionRefused' | 'ConnectionAborted' | 'ConnectionFailed' | 'NameNotResolved' | 'InternetDisconnected' | 'AddressUnreachable' | 'BlockedByClient' | 'BlockedByResponse'
 export interface Request {
     /**
      * Request URL (without fragment).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1428,9 +1428,6 @@ importers:
       devtools:
         specifier: ^8.14.0
         version: 8.32.3(typescript@5.3.3)
-      devtools-protocol:
-        specifier: ^0.0.1260888
-        version: 0.0.1260888
       grapheme-splitter:
         specifier: ^1.0.2
         version: 1.0.4


### PR DESCRIPTION
## Proposed changes

Minor improvement: there is no reason to have a whole package as dependency if we only use a single type from it.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
