### PR TITLE
Browserstack observability reload session fix [v8]

### DIFF
--- a/packages/wdio-browserstack-service/src/insights-handler.ts
+++ b/packages/wdio-browserstack-service/src/insights-handler.ts
@@ -864,12 +864,15 @@ class _InsightsHandler {
     }
 
     private getIntegrationsObject () {
+        const caps = (this._browser as WebdriverIO.Browser)?.capabilities as WebdriverIO.Capabilities
+        const sessionId = (this._browser as WebdriverIO.Browser)?.sessionId
+
         return {
-            capabilities: this._platformMeta?.caps,
-            session_id: this._platformMeta?.sessionId,
-            browser: this._platformMeta?.browserName,
-            browser_version: this._platformMeta?.browserVersion,
-            platform: this._platformMeta?.platformName,
+            capabilities: caps,
+            session_id: sessionId,
+            browser: caps?.browserName,
+            browser_version: caps?.browserVersion,
+            platform: caps?.platformName,
             product: this._platformMeta?.product,
             platform_version: getPlatformVersion(this._userCaps as WebdriverIO.Capabilities)
         }

--- a/packages/wdio-browserstack-service/tests/insights-handler.test.ts
+++ b/packages/wdio-browserstack-service/tests/insights-handler.test.ts
@@ -624,6 +624,18 @@ describe('getIntegrationsObject', () => {
         expect(integrationsObject.platform_version).toEqual('some version')
     })
 
+    it('should fetch latest details', () => {
+        const existingSessionId = browser.sessionId
+        const existingOs = browser.capabilities.os
+        browser.sessionId = 'session-new'
+        browser.capabilities.os = 'Windows'
+        const integrationsObject = insightsHandler['getIntegrationsObject']()
+        expect(integrationsObject.session_id).toEqual('session-new')
+        expect(integrationsObject.capabilities.os).toEqual('Windows')
+        browser.sessionId = existingSessionId
+        browser.capabilities.os = existingOs
+    })
+
     afterAll(() => {
         getPlatformVersionSpy.mockReset()
     })


### PR DESCRIPTION
## Proposed changes
Fix for sending correct session id to Browserstack Observability in case of reloadSession

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
