### PR TITLE
(wdio-config): change order of the specs when using --multi-run

### DIFF
--- a/packages/wdio-cli/src/commands/run.ts
+++ b/packages/wdio-cli/src/commands/run.ts
@@ -104,8 +104,8 @@ export const cmdArgs = {
         desc: 'exclude certain spec file from the test run - overrides exclude piped from stdin',
         type: 'array'
     },
-    'multi-run': {
-        desc: 'Run individual spec files x amount of times',
+    'repeat': {
+        desc: 'Repeat specific specs and/or suites N times',
         type: 'number'
     },
     mochaOpts: {

--- a/packages/wdio-config/src/node/ConfigParser.ts
+++ b/packages/wdio-config/src/node/ConfigParser.ts
@@ -317,6 +317,7 @@ export default class ConfigParser {
         specs = [...new Set(specs)]
 
         // If the --repeat flag is set, duplicate the specs array N times
+        // Ensure that when --repeat is used that either --spec or --suite is also used
         const hasSubsetOfSpecsDefined = isSpecParamPassed || suites.length > 0
         if (repeat && hasSubsetOfSpecsDefined) {
             specs = Array.from({ length: repeat }, () => specs).flat()

--- a/packages/wdio-config/src/node/ConfigParser.ts
+++ b/packages/wdio-config/src/node/ConfigParser.ts
@@ -271,7 +271,7 @@ export default class ConfigParser {
      * attributes from CLI, config and capabilities
      */
     getSpecs(capSpecs?: Spec[], capExclude?: Spec[]) {
-        const isSpecParamPassed = Array.isArray(this._config.spec) && this._config.spec.length >= 1
+        const isSpecParamPassed = Array.isArray(this._config.spec) && this._config.spec.length > 0
         const multiRun = this._config.multiRun
         // when CLI --spec is explicitly specified, this._config.specs contains the filtered
         // specs matching the passed pattern else the specs defined inside the config are returned
@@ -316,13 +316,9 @@ export default class ConfigParser {
         // Remove any duplicate tests from the final specs array
         specs = [...new Set(specs)]
 
-        // If the --multi-run flag is set, duplicate the specs array
-        // Ensure that when --multi-run is set that either --spec or --suite is also set
-        const hasSubsetOfSpecsDefined = isSpecParamPassed || suites.length > 0
-        if (multiRun && hasSubsetOfSpecsDefined) {
+        // If the --multi-run flag is set, duplicate the specs array N times
+        if (multiRun) {
             specs = specs.flatMap(i => Array.from({ length: multiRun }).fill(i)) as Spec[]
-        } else if (multiRun && !hasSubsetOfSpecsDefined) {
-            throw new Error('The --multi-run flag requires that either the --spec or --suite flag is also set')
         }
 
         return this.shard(

--- a/packages/wdio-config/tests/node/configparser.test.ts
+++ b/packages/wdio-config/tests/node/configparser.test.ts
@@ -853,7 +853,7 @@ describe('ConfigParser', () => {
             expect(specs).toHaveLength(1)
         })
 
-        it('should include specs from suite 3 times with mulit-run', async () => {
+        it('should include specs from suite 3 times with multi-run', async () => {
             const configParser = await ConfigParserForTestWithAllFiles(FIXTURES_CONF)
             await configParser.initialize({ suite: ['functional'], multiRun: 3 })
 
@@ -861,11 +861,12 @@ describe('ConfigParser', () => {
             expect(specs).toHaveLength(3)
         })
 
-        it('should throw an error if multi-run is set but no spec or suite is specified', async () => {
+        it('should allow multi-run to run all tests', async () => {
             const configParser = await ConfigParserForTestWithAllFiles(FIXTURES_CONF)
             await configParser.initialize({ multiRun: 3 })
 
-            expect(() => configParser.getSpecs()).toThrow('The --multi-run flag requires that either the --spec or --suite flag is also set')
+            const specs = configParser.getSpecs()
+            expect(specs).toHaveLength(9)
         })
 
         it('should include spec when specifying a suite unless excluded', async () => {

--- a/packages/wdio-config/tests/node/configparser.test.ts
+++ b/packages/wdio-config/tests/node/configparser.test.ts
@@ -1,5 +1,5 @@
 import url from 'node:url'
-import path, { resolve } from 'node:path'
+import path from 'node:path'
 
 import type { MockedFunction } from 'vitest'
 import { vi, describe, it, expect, beforeEach } from 'vitest'
@@ -862,8 +862,8 @@ describe('ConfigParser', () => {
         })
 
         it('should repeat specs in specific order to fail early', async () => {
-            const spec1 = resolve(__dirname, '../utils.test.ts')
-            const spec2 = resolve(__dirname, 'configparser.test.ts')
+            const spec1 = path.resolve(__dirname, '../utils.test.ts')
+            const spec2 = path.resolve(__dirname, 'configparser.test.ts')
             const configParser = await ConfigParserForTestWithAllFiles(FIXTURES_CONF)
             await configParser.initialize({ spec: [spec1, spec2], repeat: 3 })
 

--- a/packages/wdio-config/tests/node/configparser.test.ts
+++ b/packages/wdio-config/tests/node/configparser.test.ts
@@ -862,12 +862,17 @@ describe('ConfigParser', () => {
         })
 
         it('should repeat specs in specific order to fail early', async () => {
-            const spec = [resolve(__dirname, '../utils.test.ts'), resolve(__dirname, 'configparser.test.ts')]
+            const spec1 = resolve(__dirname, '../utils.test.ts')
+            const spec2 = resolve(__dirname, 'configparser.test.ts')
             const configParser = await ConfigParserForTestWithAllFiles(FIXTURES_CONF)
-            await configParser.initialize({ spec, repeat: 3 })
+            await configParser.initialize({ spec: [spec1, spec2], repeat: 3 })
 
             const specs = configParser.getSpecs()
-            expect(specs).toEqual(Array.from({ length: 3 }, () => spec).flat())
+            expect(specs).toEqual([
+                spec1, spec2,
+                spec1, spec2,
+                spec1, spec2,
+            ])
         })
 
         it('should throw an error if repeat is set but no spec or suite is specified', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
         version: 3.521.0
       '@aws-sdk/lib-storage':
         specifier: ^3.515.0
-        version: 3.515.0(@aws-sdk/client-s3@3.521.0)
+        version: 3.521.0(@aws-sdk/client-s3@3.521.0)
       '@octokit/rest':
         specifier: ^20.0.2
         version: 20.0.2
@@ -2543,8 +2543,8 @@ packages:
       - aws-crt
     dev: true
 
-  /@aws-sdk/lib-storage@3.515.0(@aws-sdk/client-s3@3.521.0):
-    resolution: {integrity: sha512-/7z/3KnMs1ODNS9c8Skj/DFTsy6/v7n17clh1IGOcTYhhioCMA3MIzIZecWFeLjPYcUSkNQHIIjKFQt1nhZkwA==}
+  /@aws-sdk/lib-storage@3.521.0(@aws-sdk/client-s3@3.521.0):
+    resolution: {integrity: sha512-TDkh6j/9dPlHtMeNsv++CCOT+HSWKTAjKkp8A9du3d9axyILE6ukqssehObgkB+8fNu4h776Hq9YJE2QExdrOw==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       '@aws-sdk/client-s3': ^3.0.0

--- a/website/docs/Retry.md
+++ b/website/docs/Retry.md
@@ -158,7 +158,7 @@ export const config = {
 
 ## Run a specific test multiple times
 
-This is to help prevent flaky tests from being introduced in a codebase. By adding the `--multi-run` cli option it will run the specified test(s) or suite(s) x number of times. When using this cli flag the `--spec` or `--suite` flag must also be specified.
+This is to help prevent flaky tests from being introduced in a codebase. By adding the `--multi-run` cli option it will run the specified specs or suites N times. When using this cli flag the `--spec` or `--suite` flag can be specified or you can run all tests.
 
 When adding new tests to a codebase, especially through a CI/CD process the tests could pass and get merged but become flaky later on. This flakiness could come from a number of things like network issues, server load, database size, etc. Using the `--multi-run` flag in your CD/CD process can help catch these flaky tests before they get merged to a main codebase.
 

--- a/website/docs/Retry.md
+++ b/website/docs/Retry.md
@@ -158,13 +158,13 @@ export const config = {
 
 ## Run a specific test multiple times
 
-This is to help prevent flaky tests from being introduced in a codebase. By adding the `--multi-run` cli option it will run the specified specs or suites N times. When using this cli flag the `--spec` or `--suite` flag can be specified or you can run all tests.
+This is to help prevent flaky tests from being introduced in a codebase. By adding the `--repeat` cli option it will run the specified specs or suites N times. When using this cli flag the `--spec` or `--suite` flag must also be specified.
 
-When adding new tests to a codebase, especially through a CI/CD process the tests could pass and get merged but become flaky later on. This flakiness could come from a number of things like network issues, server load, database size, etc. Using the `--multi-run` flag in your CD/CD process can help catch these flaky tests before they get merged to a main codebase.
+When adding new tests to a codebase, especially through a CI/CD process the tests could pass and get merged but become flaky later on. This flakiness could come from a number of things like network issues, server load, database size, etc. Using the `--repeat` flag in your CD/CD process can help catch these flaky tests before they get merged to a main codebase.
 
-One strategy to use is run your tests like regular in your CI/CD process but if you're introducing a new test you can then run another set of tests with the new spec specified in `--spec` along with `--multi-run` so it runs the new test x number of times. If the test fails any of those times then the test will not get merged and will need to be looked at why it failed.
+One strategy to use is run your tests like regular in your CI/CD process but if you're introducing a new test you can then run another set of tests with the new spec specified in `--spec` along with `--repeat` so it runs the new test x number of times. If the test fails any of those times then the test will not get merged and will need to be looked at why it failed.
 
 ```sh
 # This will run the example.e2e.js spec 5 times
-npx wdio run ./wdio.conf.js --spec example.e2e.js --multi-run 5
+npx wdio run ./wdio.conf.js --spec example.e2e.js --repeat 5
 ```

--- a/website/docs/Testrunner.md
+++ b/website/docs/Testrunner.md
@@ -112,14 +112,14 @@ Options:
 --waitforTimeout, -w  timeout for all waitForXXX commands             [number]
 --framework, -f       defines the framework (Mocha, Jasmine or Cucumber) to
                         run the specs                                   [string]
---reporters, -r       reporters to print out the results on stdout     [array]
+--reporters, -r       reporters to print out the results on stdout      [array]
 --suite               overwrites the specs attribute and runs the defined
                         suite                                            [array]
 --spec                run only a certain spec file - overrides specs piped
                         from stdin                                       [array]
 --exclude             exclude spec file(s) from a run - overrides specs piped
                         from stdin                                       [array]
---multi-run           Run one or more specs x amount of times            [number]
+--repeat              Repeat specific specs and/or suites N times        [number]
 --mochaOpts           Mocha options
 --jasmineOpts         Jasmine options
 --cucumberOpts        Cucumber options

--- a/website/i18n/ar/docusaurus-plugin-content-docs/current/Retry.md
+++ b/website/i18n/ar/docusaurus-plugin-content-docs/current/Retry.md
@@ -158,13 +158,13 @@ export const config = {
 
 ## Run a specific test multiple times
 
-This is to help prevent flaky tests from being introduced in a codebase. By adding the `--multi-run` cli option it will run the specified test(s) or suite(s) x number of times. When using this cli flag the `--spec` or `--suite` flag must also be specified.
+This is to help prevent flaky tests from being introduced in a codebase. By adding the `--repeat` cli option it will run the specified test(s) or suite(s) x number of times. When using this cli flag the `--spec` or `--suite` flag must also be specified.
 
-When adding new tests to a codebase, especially through a CI/CD process the tests could pass and get merged but become flaky later on. This flakiness could come from a number of things like network issues, server load, database size, etc. Using the `--multi-run` flag in your CD/CD process can help catch these flaky tests before they get merged to a main codebase.
+When adding new tests to a codebase, especially through a CI/CD process the tests could pass and get merged but become flaky later on. This flakiness could come from a number of things like network issues, server load, database size, etc. Using the `--repeat` flag in your CD/CD process can help catch these flaky tests before they get merged to a main codebase.
 
-One strategy to use is run your tests like regular in your CI/CD process but if you're introducing a new test you can then run another set of tests with the new spec specified in `--spec` along with `--multi-run` so it runs the new test x number of times. If the test fails any of those times then the test will not get merged and will need to be looked at why it failed.
+One strategy to use is run your tests like regular in your CI/CD process but if you're introducing a new test you can then run another set of tests with the new spec specified in `--spec` along with `--repeat` so it runs the new test x number of times. If the test fails any of those times then the test will not get merged and will need to be looked at why it failed.
 
 ```sh
 # This will run the example.e2e.js spec 5 times
-npx wdio run ./wdio.conf.js --spec example.e2e.js --multi-run 5
+npx wdio run ./wdio.conf.js --spec example.e2e.js --repeat 5
 ```

--- a/website/i18n/ar/docusaurus-plugin-content-docs/current/Testrunner.md
+++ b/website/i18n/ar/docusaurus-plugin-content-docs/current/Testrunner.md
@@ -119,7 +119,7 @@ Options:
                         from stdin                                       [array]
 --exclude             exclude spec file(s) from a run - overrides specs piped
                         from stdin                                       [array]
---multi-run           Run one or more specs x amount of times            [number]
+--repeat              Repeat specific specs and/or suites N times        [number]
 --mochaOpts           Mocha options
 --jasmineOpts         Jasmine options
 --cucumberOpts        Cucumber options

--- a/website/i18n/bg/docusaurus-plugin-content-docs/current/Retry.md
+++ b/website/i18n/bg/docusaurus-plugin-content-docs/current/Retry.md
@@ -158,13 +158,13 @@ export const config = {
 
 ## Run a specific test multiple times
 
-This is to help prevent flaky tests from being introduced in a codebase. By adding the `--multi-run` cli option it will run the specified test(s) or suite(s) x number of times. When using this cli flag the `--spec` or `--suite` flag must also be specified.
+This is to help prevent flaky tests from being introduced in a codebase. By adding the `--repeat` cli option it will run the specified test(s) or suite(s) x number of times. When using this cli flag the `--spec` or `--suite` flag must also be specified.
 
-When adding new tests to a codebase, especially through a CI/CD process the tests could pass and get merged but become flaky later on. This flakiness could come from a number of things like network issues, server load, database size, etc. Using the `--multi-run` flag in your CD/CD process can help catch these flaky tests before they get merged to a main codebase.
+When adding new tests to a codebase, especially through a CI/CD process the tests could pass and get merged but become flaky later on. This flakiness could come from a number of things like network issues, server load, database size, etc. Using the `--repeat` flag in your CD/CD process can help catch these flaky tests before they get merged to a main codebase.
 
-One strategy to use is run your tests like regular in your CI/CD process but if you're introducing a new test you can then run another set of tests with the new spec specified in `--spec` along with `--multi-run` so it runs the new test x number of times. If the test fails any of those times then the test will not get merged and will need to be looked at why it failed.
+One strategy to use is run your tests like regular in your CI/CD process but if you're introducing a new test you can then run another set of tests with the new spec specified in `--spec` along with `--repeat` so it runs the new test x number of times. If the test fails any of those times then the test will not get merged and will need to be looked at why it failed.
 
 ```sh
 # This will run the example.e2e.js spec 5 times
-npx wdio run ./wdio.conf.js --spec example.e2e.js --multi-run 5
+npx wdio run ./wdio.conf.js --spec example.e2e.js --repeat 5
 ```

--- a/website/i18n/bg/docusaurus-plugin-content-docs/current/Testrunner.md
+++ b/website/i18n/bg/docusaurus-plugin-content-docs/current/Testrunner.md
@@ -119,7 +119,7 @@ Options:
                         from stdin                                       [array]
 --exclude             exclude spec file(s) from a run - overrides specs piped
                         from stdin                                       [array]
---multi-run           Run one or more specs x amount of times            [number]
+--repeat              Repeat specific specs and/or suites N times        [number]
 --mochaOpts           Mocha options
 --jasmineOpts         Jasmine options
 --cucumberOpts        Cucumber options

--- a/website/i18n/de/docusaurus-plugin-content-docs/current/Retry.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/current/Retry.md
@@ -158,13 +158,13 @@ export const config = {
 
 ## Wiederholen spezifischer Tests
 
-Dadurch soll verhindert werden, dass unzuverlässige Tests in eine Codebasis eingeführt werden. Durch Hinzufügen der Option `--multi-run` cli werden die angegebenen Tests oder Suiten x-mal ausgeführt. Bei Verwendung dieses CLI-Flags muss auch das Flag `--spec` oder `--suite` angegeben werden.
+Dadurch soll verhindert werden, dass unzuverlässige Tests in eine Codebasis eingeführt werden. Durch Hinzufügen der Option `--repeat` cli werden die angegebenen Tests oder Suiten x-mal ausgeführt. Bei Verwendung dieses CLI-Flags muss auch das Flag `--spec` oder `--suite` angegeben werden.
 
-When adding new tests to a codebase, especially through a CI/CD process the tests could pass and get merged but become flaky later on. Diese Fehlerbeständigkeit kann von einer Reihe von Dingen wie Netzwerkproblemen, Serverlast, Datenbankgröße usw. erzeugt werden. Die Verwendung des Flags `--multi-run` in Ihrem CD/CD-Prozess kann dabei helfen, diese fehlerhaften Tests abzufangen, bevor sie zu einer Hauptcodebasis zusammengeführt werden.
+When adding new tests to a codebase, especially through a CI/CD process the tests could pass and get merged but become flaky later on. Diese Fehlerbeständigkeit kann von einer Reihe von Dingen wie Netzwerkproblemen, Serverlast, Datenbankgröße usw. erzeugt werden. Die Verwendung des Flags `--repeat` in Ihrem CD/CD-Prozess kann dabei helfen, diese fehlerhaften Tests abzufangen, bevor sie zu einer Hauptcodebasis zusammengeführt werden.
 
-One strategy to use is run your tests like regular in your CI/CD process but if you're introducing a new test you can then run another set of tests with the new spec specified in `--spec` along with `--multi-run` so it runs the new test x number of times. Wenn der Test in einem dieser Fälle fehlschlägt, muss der Test erst untersucht werden und stabiler gemacht werden.
+One strategy to use is run your tests like regular in your CI/CD process but if you're introducing a new test you can then run another set of tests with the new spec specified in `--spec` along with `--repeat` so it runs the new test x number of times. Wenn der Test in einem dieser Fälle fehlschlägt, muss der Test erst untersucht werden und stabiler gemacht werden.
 
 ```sh
 # This will run the example.e2e.js spec 5 times
-npx wdio run ./wdio.conf.js --spec example.e2e.js --multi-run 5
+npx wdio run ./wdio.conf.js --spec example.e2e.js --repeat 5
 ```

--- a/website/i18n/de/docusaurus-plugin-content-docs/current/Testrunner.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/current/Testrunner.md
@@ -119,7 +119,7 @@ Optionen:
                         from stdin                                       [array]
 --exclude             exclude spec file(s) from a run - overrides specs piped
                         from stdin                                       [array]
---multi-run           Run one or more specs x amount of times            [number]
+--repeat              Run one or more specs x amount of times            [number]
 --mochaOpts           Mocha options
 --jasmineOpts         Jasmine options
 --cucumberOpts        Cucumber options

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/Retry.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/Retry.md
@@ -158,13 +158,13 @@ export const config = {
 
 ## Ejecutar una prueba específica varias veces
 
-Se trata de ayudar a evitar que se introduzcan pruebas falsas en una base de código. Añadiendo la opción de cli `--multi-run` ejecutará la(s) prueba(s) especificada(s) o suite(s) x número de veces. Al usar esta bandera cli la bandera `--spec` o `--suite` también debe ser especificada.
+Se trata de ayudar a evitar que se introduzcan pruebas falsas en una base de código. Añadiendo la opción de cli `--repeat` ejecutará la(s) prueba(s) especificada(s) o suite(s) x número de veces. Al usar esta bandera cli la bandera `--spec` o `--suite` también debe ser especificada.
 
-When adding new tests to a codebase, especially through a CI/CD process the tests could pass and get merged but become flaky later on. Este error podría provenir de una serie de asuntos como problemas de red, carga del servidor, tamaño de la base de datos, etc. Utilizando la bandera `--multi-run` en su proceso de CD/CD puede ayudar a capturar estas pruebas defectuosas antes de que se fusionen en una base de código principal.
+When adding new tests to a codebase, especially through a CI/CD process the tests could pass and get merged but become flaky later on. Este error podría provenir de una serie de asuntos como problemas de red, carga del servidor, tamaño de la base de datos, etc. Utilizando la bandera `--repeat` en su proceso de CD/CD puede ayudar a capturar estas pruebas defectuosas antes de que se fusionen en una base de código principal.
 
-One strategy to use is run your tests like regular in your CI/CD process but if you're introducing a new test you can then run another set of tests with the new spec specified in `--spec` along with `--multi-run` so it runs the new test x number of times. Si la prueba falla cualquiera de esas veces, la prueba no se fusionará y tendrá que ser examinada por qué falló.
+One strategy to use is run your tests like regular in your CI/CD process but if you're introducing a new test you can then run another set of tests with the new spec specified in `--spec` along with `--repeat` so it runs the new test x number of times. Si la prueba falla cualquiera de esas veces, la prueba no se fusionará y tendrá que ser examinada por qué falló.
 
 ```sh
 # This will run the example.e2e.js spec 5 times
-npx wdio run ./wdio.conf.js --spec example.e2e.js --multi-run 5
+npx wdio run ./wdio.conf.js --spec example.e2e.js --repeat 5
 ```

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/Testrunner.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/Testrunner.md
@@ -119,7 +119,7 @@ Opciones:
                         from stdin                                       [array]
 --exclude             exclude spec file(s) from a run - overrides specs piped
                         from stdin                                       [array]
---multi-run           Run one or more specs x amount of times            [number]
+--repeat              Run one or more specs x amount of times            [number]
 --mochaOpts           Mocha options
 --jasmineOpts         Jasmine options
 --cucumberOpts        Cucumber options

--- a/website/i18n/fa/docusaurus-plugin-content-docs/current/Retry.md
+++ b/website/i18n/fa/docusaurus-plugin-content-docs/current/Retry.md
@@ -158,13 +158,13 @@ export const config = {
 
 ## Run a specific test multiple times
 
-This is to help prevent flaky tests from being introduced in a codebase. By adding the `--multi-run` cli option it will run the specified test(s) or suite(s) x number of times. When using this cli flag the `--spec` or `--suite` flag must also be specified.
+This is to help prevent flaky tests from being introduced in a codebase. By adding the `--repeat` cli option it will run the specified test(s) or suite(s) x number of times. When using this cli flag the `--spec` or `--suite` flag must also be specified.
 
-When adding new tests to a codebase, especially through a CI/CD process the tests could pass and get merged but become flaky later on. This flakiness could come from a number of things like network issues, server load, database size, etc. Using the `--multi-run` flag in your CD/CD process can help catch these flaky tests before they get merged to a main codebase.
+When adding new tests to a codebase, especially through a CI/CD process the tests could pass and get merged but become flaky later on. This flakiness could come from a number of things like network issues, server load, database size, etc. Using the `--repeat` flag in your CD/CD process can help catch these flaky tests before they get merged to a main codebase.
 
-One strategy to use is run your tests like regular in your CI/CD process but if you're introducing a new test you can then run another set of tests with the new spec specified in `--spec` along with `--multi-run` so it runs the new test x number of times. If the test fails any of those times then the test will not get merged and will need to be looked at why it failed.
+One strategy to use is run your tests like regular in your CI/CD process but if you're introducing a new test you can then run another set of tests with the new spec specified in `--spec` along with `--repeat` so it runs the new test x number of times. If the test fails any of those times then the test will not get merged and will need to be looked at why it failed.
 
 ```sh
 # This will run the example.e2e.js spec 5 times
-npx wdio run ./wdio.conf.js --spec example.e2e.js --multi-run 5
+npx wdio run ./wdio.conf.js --spec example.e2e.js --repeat 5
 ```

--- a/website/i18n/fa/docusaurus-plugin-content-docs/current/Testrunner.md
+++ b/website/i18n/fa/docusaurus-plugin-content-docs/current/Testrunner.md
@@ -119,7 +119,7 @@ wdio run ./wdio.conf.js --watch
                         from stdin                                       [array]
 --exclude             exclude spec file(s) from a run - overrides specs piped
                         from stdin                                       [array]
---multi-run           Run one or more specs x amount of times            [number]
+--repeat              Run one or more specs x amount of times            [number]
 --mochaOpts           Mocha options
 --jasmineOpts         Jasmine options
 --cucumberOpts        Cucumber options

--- a/website/i18n/fr/docusaurus-plugin-content-docs/current/Retry.md
+++ b/website/i18n/fr/docusaurus-plugin-content-docs/current/Retry.md
@@ -158,13 +158,13 @@ export const config = {
 
 ## Run a specific test multiple times
 
-This is to help prevent flaky tests from being introduced in a codebase. By adding the `--multi-run` cli option it will run the specified test(s) or suite(s) x number of times. When using this cli flag the `--spec` or `--suite` flag must also be specified.
+This is to help prevent flaky tests from being introduced in a codebase. By adding the `--repeat` cli option it will run the specified test(s) or suite(s) x number of times. When using this cli flag the `--spec` or `--suite` flag must also be specified.
 
-When adding new tests to a codebase, especially through a CI/CD process the tests could pass and get merged but become flaky later on. This flakiness could come from a number of things like network issues, server load, database size, etc. Using the `--multi-run` flag in your CD/CD process can help catch these flaky tests before they get merged to a main codebase.
+When adding new tests to a codebase, especially through a CI/CD process the tests could pass and get merged but become flaky later on. This flakiness could come from a number of things like network issues, server load, database size, etc. Using the `--repeat` flag in your CD/CD process can help catch these flaky tests before they get merged to a main codebase.
 
-One strategy to use is run your tests like regular in your CI/CD process but if you're introducing a new test you can then run another set of tests with the new spec specified in `--spec` along with `--multi-run` so it runs the new test x number of times. If the test fails any of those times then the test will not get merged and will need to be looked at why it failed.
+One strategy to use is run your tests like regular in your CI/CD process but if you're introducing a new test you can then run another set of tests with the new spec specified in `--spec` along with `--repeat` so it runs the new test x number of times. If the test fails any of those times then the test will not get merged and will need to be looked at why it failed.
 
 ```sh
 # This will run the example.e2e.js spec 5 times
-npx wdio run ./wdio.conf.js --spec example.e2e.js --multi-run 5
+npx wdio run ./wdio.conf.js --spec example.e2e.js --repeat 5
 ```

--- a/website/i18n/fr/docusaurus-plugin-content-docs/current/Testrunner.md
+++ b/website/i18n/fr/docusaurus-plugin-content-docs/current/Testrunner.md
@@ -119,7 +119,7 @@ Options:
                         from stdin                                       [array]
 --exclude             exclude spec file(s) from a run - overrides specs piped
                         from stdin                                       [array]
---multi-run           Run one or more specs x amount of times            [number]
+--repeat              Run one or more specs x amount of times            [number]
 --mochaOpts           Mocha options
 --jasmineOpts         Jasmine options
 --cucumberOpts        Cucumber options

--- a/website/i18n/hi/docusaurus-plugin-content-docs/current/Retry.md
+++ b/website/i18n/hi/docusaurus-plugin-content-docs/current/Retry.md
@@ -158,13 +158,13 @@ export const config = {
 
 ## एक विशिष्ट परीक्षण कई बार चलाएं
 
-यह परतदार परीक्षणों को कोडबेस में पेश होने से रोकने में मदद करने के लिए है। `--multi-run` cli विकल्प जोड़कर यह निर्दिष्ट परीक्षण(ओं) या सुइट(रों) को x संख्या में चलाएगा। इस cli फ़्लैग का उपयोग करते समय `--spec` या `--suite` फ़्लैग को भी निर्दिष्ट किया जाना चाहिए।
+यह परतदार परीक्षणों को कोडबेस में पेश होने से रोकने में मदद करने के लिए है। `--repeat` cli विकल्प जोड़कर यह निर्दिष्ट परीक्षण(ओं) या सुइट(रों) को x संख्या में चलाएगा। इस cli फ़्लैग का उपयोग करते समय `--spec` या `--suite` फ़्लैग को भी निर्दिष्ट किया जाना चाहिए।
 
-When adding new tests to a codebase, especially through a CI/CD process the tests could pass and get merged but become flaky later on. यह चंचलता कई चीजों से आ सकती है जैसे नेटवर्क समस्याएँ, सर्वर लोड, डेटाबेस आकार, आदि। आपकी सीडी/सीडी प्रक्रिया में `--multi-run` फ़्लैग का उपयोग करने से इन परतदार परीक्षणों को पकड़ने में मदद मिल सकती है, इससे पहले कि वे एक मुख्य कोडबेस में विलय हो जाएँ।
+When adding new tests to a codebase, especially through a CI/CD process the tests could pass and get merged but become flaky later on. यह चंचलता कई चीजों से आ सकती है जैसे नेटवर्क समस्याएँ, सर्वर लोड, डेटाबेस आकार, आदि। आपकी सीडी/सीडी प्रक्रिया में `--repeat` फ़्लैग का उपयोग करने से इन परतदार परीक्षणों को पकड़ने में मदद मिल सकती है, इससे पहले कि वे एक मुख्य कोडबेस में विलय हो जाएँ।
 
-One strategy to use is run your tests like regular in your CI/CD process but if you're introducing a new test you can then run another set of tests with the new spec specified in `--spec` along with `--multi-run` so it runs the new test x number of times. यदि परीक्षण उनमें से किसी भी समय विफल रहता है तो परीक्षण विलय नहीं होगा और यह देखने की आवश्यकता होगी कि यह विफल क्यों हुआ।
+One strategy to use is run your tests like regular in your CI/CD process but if you're introducing a new test you can then run another set of tests with the new spec specified in `--spec` along with `--repeat` so it runs the new test x number of times. यदि परीक्षण उनमें से किसी भी समय विफल रहता है तो परीक्षण विलय नहीं होगा और यह देखने की आवश्यकता होगी कि यह विफल क्यों हुआ।
 
 ```sh
 # This will run the example.e2e.js spec 5 times
-npx wdio run ./wdio.conf.js --spec example.e2e.js --multi-run 5
+npx wdio run ./wdio.conf.js --spec example.e2e.js --repeat 5
 ```

--- a/website/i18n/hi/docusaurus-plugin-content-docs/current/Testrunner.md
+++ b/website/i18n/hi/docusaurus-plugin-content-docs/current/Testrunner.md
@@ -119,7 +119,7 @@ wdio run ./wdio.conf.js --watch
                         from stdin                                       [array]
 --exclude             exclude spec file(s) from a run - overrides specs piped
                         from stdin                                       [array]
---multi-run           Run one or more specs x amount of times            [number]
+--repeat              Run one or more specs x amount of times            [number]
 --mochaOpts           Mocha options
 --jasmineOpts         Jasmine options
 --cucumberOpts        Cucumber options

--- a/website/i18n/it/docusaurus-plugin-content-docs/current/Retry.md
+++ b/website/i18n/it/docusaurus-plugin-content-docs/current/Retry.md
@@ -158,13 +158,13 @@ export const config = {
 
 ## Run a specific test multiple times
 
-This is to help prevent flaky tests from being introduced in a codebase. By adding the `--multi-run` cli option it will run the specified test(s) or suite(s) x number of times. When using this cli flag the `--spec` or `--suite` flag must also be specified.
+This is to help prevent flaky tests from being introduced in a codebase. By adding the `--repeat` cli option it will run the specified test(s) or suite(s) x number of times. When using this cli flag the `--spec` or `--suite` flag must also be specified.
 
-When adding new tests to a codebase, especially through a CI/CD process the tests could pass and get merged but become flaky later on. This flakiness could come from a number of things like network issues, server load, database size, etc. Using the `--multi-run` flag in your CD/CD process can help catch these flaky tests before they get merged to a main codebase.
+When adding new tests to a codebase, especially through a CI/CD process the tests could pass and get merged but become flaky later on. This flakiness could come from a number of things like network issues, server load, database size, etc. Using the `--repeat` flag in your CD/CD process can help catch these flaky tests before they get merged to a main codebase.
 
-One strategy to use is run your tests like regular in your CI/CD process but if you're introducing a new test you can then run another set of tests with the new spec specified in `--spec` along with `--multi-run` so it runs the new test x number of times. If the test fails any of those times then the test will not get merged and will need to be looked at why it failed.
+One strategy to use is run your tests like regular in your CI/CD process but if you're introducing a new test you can then run another set of tests with the new spec specified in `--spec` along with `--repeat` so it runs the new test x number of times. If the test fails any of those times then the test will not get merged and will need to be looked at why it failed.
 
 ```sh
 # This will run the example.e2e.js spec 5 times
-npx wdio run ./wdio.conf.js --spec example.e2e.js --multi-run 5
+npx wdio run ./wdio.conf.js --spec example.e2e.js --repeat 5
 ```

--- a/website/i18n/it/docusaurus-plugin-content-docs/current/Testrunner.md
+++ b/website/i18n/it/docusaurus-plugin-content-docs/current/Testrunner.md
@@ -119,7 +119,7 @@ Options:
                         from stdin                                       [array]
 --exclude             exclude spec file(s) from a run - overrides specs piped
                         from stdin                                       [array]
---multi-run           Run one or more specs x amount of times            [number]
+--repeat              Run one or more specs x amount of times            [number]
 --mochaOpts           Mocha options
 --jasmineOpts         Jasmine options
 --cucumberOpts        Cucumber options

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/Retry.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/Retry.md
@@ -158,13 +158,13 @@ export const config = {
 
 ## Run a specific test multiple times
 
-This is to help prevent flaky tests from being introduced in a codebase. By adding the `--multi-run` cli option it will run the specified test(s) or suite(s) x number of times. When using this cli flag the `--spec` or `--suite` flag must also be specified.
+This is to help prevent flaky tests from being introduced in a codebase. By adding the `--repeat` cli option it will run the specified test(s) or suite(s) x number of times. When using this cli flag the `--spec` or `--suite` flag must also be specified.
 
-When adding new tests to a codebase, especially through a CI/CD process the tests could pass and get merged but become flaky later on. This flakiness could come from a number of things like network issues, server load, database size, etc. Using the `--multi-run` flag in your CD/CD process can help catch these flaky tests before they get merged to a main codebase.
+When adding new tests to a codebase, especially through a CI/CD process the tests could pass and get merged but become flaky later on. This flakiness could come from a number of things like network issues, server load, database size, etc. Using the `--repeat` flag in your CD/CD process can help catch these flaky tests before they get merged to a main codebase.
 
-One strategy to use is run your tests like regular in your CI/CD process but if you're introducing a new test you can then run another set of tests with the new spec specified in `--spec` along with `--multi-run` so it runs the new test x number of times. If the test fails any of those times then the test will not get merged and will need to be looked at why it failed.
+One strategy to use is run your tests like regular in your CI/CD process but if you're introducing a new test you can then run another set of tests with the new spec specified in `--spec` along with `--repeat` so it runs the new test x number of times. If the test fails any of those times then the test will not get merged and will need to be looked at why it failed.
 
 ```sh
 # This will run the example.e2e.js spec 5 times
-npx wdio run ./wdio.conf.js --spec example.e2e.js --multi-run 5
+npx wdio run ./wdio.conf.js --spec example.e2e.js --repeat 5
 ```

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/Testrunner.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/Testrunner.md
@@ -119,7 +119,7 @@ Options:
                         from stdin                                       [array]
 --exclude             exclude spec file(s) from a run - overrides specs piped
                         from stdin                                       [array]
---multi-run           Run one or more specs x amount of times            [number]
+--repeat              Run one or more specs x amount of times            [number]
 --mochaOpts           Mocha options
 --jasmineOpts         Jasmine options
 --cucumberOpts        Cucumber options

--- a/website/i18n/pl/docusaurus-plugin-content-docs/current/Retry.md
+++ b/website/i18n/pl/docusaurus-plugin-content-docs/current/Retry.md
@@ -158,13 +158,13 @@ export const config = {
 
 ## Run a specific test multiple times
 
-This is to help prevent flaky tests from being introduced in a codebase. By adding the `--multi-run` cli option it will run the specified test(s) or suite(s) x number of times. When using this cli flag the `--spec` or `--suite` flag must also be specified.
+This is to help prevent flaky tests from being introduced in a codebase. By adding the `--repeat` cli option it will run the specified test(s) or suite(s) x number of times. When using this cli flag the `--spec` or `--suite` flag must also be specified.
 
-When adding new tests to a codebase, especially through a CI/CD process the tests could pass and get merged but become flaky later on. This flakiness could come from a number of things like network issues, server load, database size, etc. Using the `--multi-run` flag in your CD/CD process can help catch these flaky tests before they get merged to a main codebase.
+When adding new tests to a codebase, especially through a CI/CD process the tests could pass and get merged but become flaky later on. This flakiness could come from a number of things like network issues, server load, database size, etc. Using the `--repeat` flag in your CD/CD process can help catch these flaky tests before they get merged to a main codebase.
 
-One strategy to use is run your tests like regular in your CI/CD process but if you're introducing a new test you can then run another set of tests with the new spec specified in `--spec` along with `--multi-run` so it runs the new test x number of times. If the test fails any of those times then the test will not get merged and will need to be looked at why it failed.
+One strategy to use is run your tests like regular in your CI/CD process but if you're introducing a new test you can then run another set of tests with the new spec specified in `--spec` along with `--repeat` so it runs the new test x number of times. If the test fails any of those times then the test will not get merged and will need to be looked at why it failed.
 
 ```sh
 # This will run the example.e2e.js spec 5 times
-npx wdio run ./wdio.conf.js --spec example.e2e.js --multi-run 5
+npx wdio run ./wdio.conf.js --spec example.e2e.js --repeat 5
 ```

--- a/website/i18n/pl/docusaurus-plugin-content-docs/current/Testrunner.md
+++ b/website/i18n/pl/docusaurus-plugin-content-docs/current/Testrunner.md
@@ -119,7 +119,7 @@ Options:
                         from stdin                                       [array]
 --exclude             exclude spec file(s) from a run - overrides specs piped
                         from stdin                                       [array]
---multi-run           Run one or more specs x amount of times            [number]
+--repeat              Run one or more specs x amount of times            [number]
 --mochaOpts           Mocha options
 --jasmineOpts         Jasmine options
 --cucumberOpts        Cucumber options

--- a/website/i18n/ru/docusaurus-plugin-content-docs/current/Retry.md
+++ b/website/i18n/ru/docusaurus-plugin-content-docs/current/Retry.md
@@ -158,13 +158,13 @@ export const config = {
 
 ## Run a specific test multiple times
 
-This is to help prevent flaky tests from being introduced in a codebase. By adding the `--multi-run` cli option it will run the specified test(s) or suite(s) x number of times. When using this cli flag the `--spec` or `--suite` flag must also be specified.
+This is to help prevent flaky tests from being introduced in a codebase. By adding the `--repeat` cli option it will run the specified test(s) or suite(s) x number of times. When using this cli flag the `--spec` or `--suite` flag must also be specified.
 
-When adding new tests to a codebase, especially through a CI/CD process the tests could pass and get merged but become flaky later on. This flakiness could come from a number of things like network issues, server load, database size, etc. Using the `--multi-run` flag in your CD/CD process can help catch these flaky tests before they get merged to a main codebase.
+When adding new tests to a codebase, especially through a CI/CD process the tests could pass and get merged but become flaky later on. This flakiness could come from a number of things like network issues, server load, database size, etc. Using the `--repeat` flag in your CD/CD process can help catch these flaky tests before they get merged to a main codebase.
 
-One strategy to use is run your tests like regular in your CI/CD process but if you're introducing a new test you can then run another set of tests with the new spec specified in `--spec` along with `--multi-run` so it runs the new test x number of times. If the test fails any of those times then the test will not get merged and will need to be looked at why it failed.
+One strategy to use is run your tests like regular in your CI/CD process but if you're introducing a new test you can then run another set of tests with the new spec specified in `--spec` along with `--repeat` so it runs the new test x number of times. If the test fails any of those times then the test will not get merged and will need to be looked at why it failed.
 
 ```sh
 # This will run the example.e2e.js spec 5 times
-npx wdio run ./wdio.conf.js --spec example.e2e.js --multi-run 5
+npx wdio run ./wdio.conf.js --spec example.e2e.js --repeat 5
 ```

--- a/website/i18n/ru/docusaurus-plugin-content-docs/current/Testrunner.md
+++ b/website/i18n/ru/docusaurus-plugin-content-docs/current/Testrunner.md
@@ -119,7 +119,7 @@ Options:
                         from stdin                                       [array]
 --exclude             exclude spec file(s) from a run - overrides specs piped
                         from stdin                                       [array]
---multi-run           Run one or more specs x amount of times            [number]
+--repeat              Run one or more specs x amount of times            [number]
 --mochaOpts           Mocha options
 --jasmineOpts         Jasmine options
 --cucumberOpts        Cucumber options

--- a/website/i18n/ta/docusaurus-plugin-content-docs/current/Retry.md
+++ b/website/i18n/ta/docusaurus-plugin-content-docs/current/Retry.md
@@ -158,13 +158,13 @@ export const config = {
 
 ## Run a specific test multiple times
 
-This is to help prevent flaky tests from being introduced in a codebase. By adding the `--multi-run` cli option it will run the specified test(s) or suite(s) x number of times. When using this cli flag the `--spec` or `--suite` flag must also be specified.
+This is to help prevent flaky tests from being introduced in a codebase. By adding the `--repeat` cli option it will run the specified test(s) or suite(s) x number of times. When using this cli flag the `--spec` or `--suite` flag must also be specified.
 
-When adding new tests to a codebase, especially through a CI/CD process the tests could pass and get merged but become flaky later on. This flakiness could come from a number of things like network issues, server load, database size, etc. Using the `--multi-run` flag in your CD/CD process can help catch these flaky tests before they get merged to a main codebase.
+When adding new tests to a codebase, especially through a CI/CD process the tests could pass and get merged but become flaky later on. This flakiness could come from a number of things like network issues, server load, database size, etc. Using the `--repeat` flag in your CD/CD process can help catch these flaky tests before they get merged to a main codebase.
 
-One strategy to use is run your tests like regular in your CI/CD process but if you're introducing a new test you can then run another set of tests with the new spec specified in `--spec` along with `--multi-run` so it runs the new test x number of times. If the test fails any of those times then the test will not get merged and will need to be looked at why it failed.
+One strategy to use is run your tests like regular in your CI/CD process but if you're introducing a new test you can then run another set of tests with the new spec specified in `--spec` along with `--repeat` so it runs the new test x number of times. If the test fails any of those times then the test will not get merged and will need to be looked at why it failed.
 
 ```sh
 # This will run the example.e2e.js spec 5 times
-npx wdio run ./wdio.conf.js --spec example.e2e.js --multi-run 5
+npx wdio run ./wdio.conf.js --spec example.e2e.js --repeat 5
 ```

--- a/website/i18n/ta/docusaurus-plugin-content-docs/current/Testrunner.md
+++ b/website/i18n/ta/docusaurus-plugin-content-docs/current/Testrunner.md
@@ -119,7 +119,7 @@ Options:
                         from stdin                                       [array]
 --exclude             exclude spec file(s) from a run - overrides specs piped
                         from stdin                                       [array]
---multi-run           Run one or more specs x amount of times            [number]
+--repeat              Run one or more specs x amount of times            [number]
 --mochaOpts           Mocha options
 --jasmineOpts         Jasmine options
 --cucumberOpts        Cucumber options

--- a/website/i18n/uk/docusaurus-plugin-content-docs/current/Retry.md
+++ b/website/i18n/uk/docusaurus-plugin-content-docs/current/Retry.md
@@ -158,13 +158,13 @@ export const config = {
 
 ## Run a specific test multiple times
 
-This is to help prevent flaky tests from being introduced in a codebase. By adding the `--multi-run` cli option it will run the specified test(s) or suite(s) x number of times. When using this cli flag the `--spec` or `--suite` flag must also be specified.
+This is to help prevent flaky tests from being introduced in a codebase. By adding the `--repeat` cli option it will run the specified test(s) or suite(s) x number of times. When using this cli flag the `--spec` or `--suite` flag must also be specified.
 
-When adding new tests to a codebase, especially through a CI/CD process the tests could pass and get merged but become flaky later on. This flakiness could come from a number of things like network issues, server load, database size, etc. Using the `--multi-run` flag in your CD/CD process can help catch these flaky tests before they get merged to a main codebase.
+When adding new tests to a codebase, especially through a CI/CD process the tests could pass and get merged but become flaky later on. This flakiness could come from a number of things like network issues, server load, database size, etc. Using the `--repeat` flag in your CD/CD process can help catch these flaky tests before they get merged to a main codebase.
 
-One strategy to use is run your tests like regular in your CI/CD process but if you're introducing a new test you can then run another set of tests with the new spec specified in `--spec` along with `--multi-run` so it runs the new test x number of times. If the test fails any of those times then the test will not get merged and will need to be looked at why it failed.
+One strategy to use is run your tests like regular in your CI/CD process but if you're introducing a new test you can then run another set of tests with the new spec specified in `--spec` along with `--repeat` so it runs the new test x number of times. If the test fails any of those times then the test will not get merged and will need to be looked at why it failed.
 
 ```sh
 # This will run the example.e2e.js spec 5 times
-npx wdio run ./wdio.conf.js --spec example.e2e.js --multi-run 5
+npx wdio run ./wdio.conf.js --spec example.e2e.js --repeat 5
 ```

--- a/website/i18n/uk/docusaurus-plugin-content-docs/current/Testrunner.md
+++ b/website/i18n/uk/docusaurus-plugin-content-docs/current/Testrunner.md
@@ -119,7 +119,7 @@ Options:
                         from stdin                                       [array]
 --exclude             exclude spec file(s) from a run - overrides specs piped
                         from stdin                                       [array]
---multi-run           Run one or more specs x amount of times            [number]
+--repeat              Run one or more specs x amount of times            [number]
 --mochaOpts           Mocha options
 --jasmineOpts         Jasmine options
 --cucumberOpts        Cucumber options

--- a/website/i18n/zh/docusaurus-plugin-content-docs/current/Retry.md
+++ b/website/i18n/zh/docusaurus-plugin-content-docs/current/Retry.md
@@ -158,13 +158,13 @@ export const config = {
 
 ## Run a specific test multiple times
 
-This is to help prevent flaky tests from being introduced in a codebase. By adding the `--multi-run` cli option it will run the specified test(s) or suite(s) x number of times. When using this cli flag the `--spec` or `--suite` flag must also be specified.
+This is to help prevent flaky tests from being introduced in a codebase. By adding the `--repeat` cli option it will run the specified test(s) or suite(s) x number of times. When using this cli flag the `--spec` or `--suite` flag must also be specified.
 
-When adding new tests to a codebase, especially through a CI/CD process the tests could pass and get merged but become flaky later on. This flakiness could come from a number of things like network issues, server load, database size, etc. Using the `--multi-run` flag in your CD/CD process can help catch these flaky tests before they get merged to a main codebase.
+When adding new tests to a codebase, especially through a CI/CD process the tests could pass and get merged but become flaky later on. This flakiness could come from a number of things like network issues, server load, database size, etc. Using the `--repeat` flag in your CD/CD process can help catch these flaky tests before they get merged to a main codebase.
 
-One strategy to use is run your tests like regular in your CI/CD process but if you're introducing a new test you can then run another set of tests with the new spec specified in `--spec` along with `--multi-run` so it runs the new test x number of times. If the test fails any of those times then the test will not get merged and will need to be looked at why it failed.
+One strategy to use is run your tests like regular in your CI/CD process but if you're introducing a new test you can then run another set of tests with the new spec specified in `--spec` along with `--repeat` so it runs the new test x number of times. If the test fails any of those times then the test will not get merged and will need to be looked at why it failed.
 
 ```sh
 # This will run the example.e2e.js spec 5 times
-npx wdio run ./wdio.conf.js --spec example.e2e.js --multi-run 5
+npx wdio run ./wdio.conf.js --spec example.e2e.js --repeat 5
 ```

--- a/website/i18n/zh/docusaurus-plugin-content-docs/current/Testrunner.md
+++ b/website/i18n/zh/docusaurus-plugin-content-docs/current/Testrunner.md
@@ -119,7 +119,7 @@ Options:
                         from stdin                                       [array]
 --exclude             exclude spec file(s) from a run - overrides specs piped
                         from stdin                                       [array]
---multi-run           Run one or more specs x amount of times            [number]
+--repeat              Run one or more specs x amount of times            [number]
 --mochaOpts           Mocha options
 --jasmineOpts         Jasmine options
 --cucumberOpts        Cucumber options


### PR DESCRIPTION
## Proposed changes

In order to fail early when using the `--multi-run` flag I changed the order from (example using `--multi-run 3`:
`spec-1, spec-1, spec-1, spec-2, spec-2, spec-2`
to 
`spec-1, spec-2, spec-1, spec-2, spec-1, spec-2`

This way when a test fails, the build breaks earlier than using the previous order.

## Types of changes

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [x] Back-ported PR at #12372

### Reviewers: @webdriverio/project-committers
