### PR TITLE
(wdio-config): expand and simplify the --multi-run feature

### DIFF
--- a/packages/wdio-config/src/node/ConfigParser.ts
+++ b/packages/wdio-config/src/node/ConfigParser.ts
@@ -271,7 +271,7 @@ export default class ConfigParser {
      * attributes from CLI, config and capabilities
      */
     getSpecs(capSpecs?: Spec[], capExclude?: Spec[]) {
-        const isSpecParamPassed = Array.isArray(this._config.spec) && this._config.spec.length >= 1
+        const isSpecParamPassed = Array.isArray(this._config.spec) && this._config.spec.length > 0
         const multiRun = this._config.multiRun
         // when CLI --spec is explicitly specified, this._config.specs contains the filtered
         // specs matching the passed pattern else the specs defined inside the config are returned
@@ -316,13 +316,9 @@ export default class ConfigParser {
         // Remove any duplicate tests from the final specs array
         specs = [...new Set(specs)]
 
-        // If the --multi-run flag is set, duplicate the specs array
-        // Ensure that when --multi-run is set that either --spec or --suite is also set
-        const hasSubsetOfSpecsDefined = isSpecParamPassed || suites.length > 0
-        if (multiRun && hasSubsetOfSpecsDefined) {
+        // If the --multi-run flag is set, duplicate the specs array N times
+        if (multiRun) {
             specs = specs.flatMap(i => Array.from({ length: multiRun }).fill(i)) as Spec[]
-        } else if (multiRun && !hasSubsetOfSpecsDefined) {
-            throw new Error('The --multi-run flag requires that either the --spec or --suite flag is also set')
         }
 
         return this.shard(

--- a/packages/wdio-config/tests/node/configparser.test.ts
+++ b/packages/wdio-config/tests/node/configparser.test.ts
@@ -853,7 +853,7 @@ describe('ConfigParser', () => {
             expect(specs).toHaveLength(1)
         })
 
-        it('should include specs from suite 3 times with mulit-run', async () => {
+        it('should include specs from suite 3 times with multi-run', async () => {
             const configParser = await ConfigParserForTestWithAllFiles(FIXTURES_CONF)
             await configParser.initialize({ suite: ['functional'], multiRun: 3 })
 
@@ -861,11 +861,12 @@ describe('ConfigParser', () => {
             expect(specs).toHaveLength(3)
         })
 
-        it('should throw an error if multi-run is set but no spec or suite is specified', async () => {
+        it('should allow multi-run to run all tests', async () => {
             const configParser = await ConfigParserForTestWithAllFiles(FIXTURES_CONF)
             await configParser.initialize({ multiRun: 3 })
 
-            expect(() => configParser.getSpecs()).toThrow('The --multi-run flag requires that either the --spec or --suite flag is also set')
+            const specs = configParser.getSpecs()
+            expect(specs).toHaveLength(9)
         })
 
         it('should include spec when specifying a suite unless excluded', async () => {

--- a/website/docs/Retry.md
+++ b/website/docs/Retry.md
@@ -158,7 +158,7 @@ export const config = {
 
 ## Run a specific test multiple times
 
-This is to help prevent flaky tests from being introduced in a codebase. By adding the `--multi-run` cli option it will run the specified test(s) or suite(s) x number of times. When using this cli flag the `--spec` or `--suite` flag must also be specified.
+This is to help prevent flaky tests from being introduced in a codebase. By adding the `--multi-run` cli option it will run the specified specs or suites N times. When using this cli flag the `--spec` or `--suite` flag can be specified or you can run all tests.
 
 When adding new tests to a codebase, especially through a CI/CD process the tests could pass and get merged but become flaky later on. This flakiness could come from a number of things like network issues, server load, database size, etc. Using the `--multi-run` flag in your CD/CD process can help catch these flaky tests before they get merged to a main codebase.
 


### PR DESCRIPTION
## Proposed changes

At my current project we manually filter our spec files and pass them to webdriverio.
In order to use the --multi-run with our setup I have tested if it is possible to run the following:

- --spec (already worked)
- --suite (already worked)
- --spec with --suite (already worked)
- without any flags (did not work but works now)

## Types of changes

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

### Reviewers: @webdriverio/project-committers
