### PR TITLE
(wdio-allure-reporter): CompoundError: Also print error message if present [v8]

### DIFF
--- a/packages/wdio-allure-reporter/src/compoundError.ts
+++ b/packages/wdio-allure-reporter/src/compoundError.ts
@@ -11,9 +11,9 @@ export default class CompoundError extends Error {
 
     constructor(...innerErrors: Error[]) {
         const message = ['CompoundError: One or more errors occurred. ---\n'].
-            concat(innerErrors.map(x => x.stack
-                ? `${indentAll(x.stack)}\n--- End of stack trace ---\n`
-                : `   ${x.message}\n--- End of error message ---\n`
+            concat(innerErrors.map(x =>
+                (x.message ? `    ${x.message}\n--- End of error message ---\n` : '') +
+                (x.stack ? `${indentAll(x.stack)}\n--- End of stack trace ---\n` : '')
             )).join('\n')
 
         super(message)

--- a/packages/wdio-allure-reporter/tests/__fixtures__/testState.ts
+++ b/packages/wdio-allure-reporter/tests/__fixtures__/testState.ts
@@ -23,7 +23,7 @@ export function testFailed() {
     const error =
         {
             message: 'AssertionError [ERR_ASSERTION]: foo == bar',
-            stack: 'AssertionError [ERR_ASSERTION]: foo == bar',
+            stack: 'stack trace of AssertionError [ERR_ASSERTION]',
             type: 'AssertionError [ERR_ASSERTION]',
             name: 'Error',
             expected: 'foo',
@@ -37,11 +37,11 @@ export function testFailedWithMultipleErrors() {
     [
         {
             message: 'ReferenceError: All is Dust',
-            stack: 'ReferenceError: All is Dust'
+            stack: 'stack trace of ReferenceError'
         },
         {
             message: 'InternalError: Abandon Hope',
-            stack: 'InternalError: Abandon Hope'
+            stack: 'stack trace of InternalError'
         }
     ]
     return Object.assign(testState(), { errors, state: 'failed', end: '2018-05-14T15:17:21.631Z', _duration: 2730 })

--- a/packages/wdio-allure-reporter/tests/compoundError.test.ts
+++ b/packages/wdio-allure-reporter/tests/compoundError.test.ts
@@ -31,17 +31,22 @@ describe('CompoundError', () => {
         expect(lines).toContain('    Error: I am so sad')
     })
 
-    it('should include stack traces from the errors', () => {
+    it('should include error messages and stack traces from the errors', () => {
         const compoundErr = new CompoundError(e1, e2)
-        const lines = compoundErr.message.split('\n').map(x => x.substr(4))
+        const lines = compoundErr.message.split('\n').map(x => x.substring(4))
 
         // This is a little dense, but essentially, CompoundError's messages look like
         //
         // IntroMessage
-        // EndOfStackMessage
+        // FirstErrorMessage
+        // EndOfErrorMessage
+        // FirstStackTrace
+        // EndOfStackTrace
         // Separator
-        // SecondStack
-        // EndOfStackMessage
+        // SecondErrorMessage
+        // EndOfErrorMessage
+        // SecondStackTrace
+        // EndOfStackTrace
 
         // So we split both the final CompoundError message
         // and the traces that compose it on line separators and then test to make sure that
@@ -49,14 +54,22 @@ describe('CompoundError', () => {
         // We do this rather than hard-coding strings, so we can use actual error stacks (which might be slightly)
         // different depending on how we run the tests.
 
-        const e1split = e1.stack?.split('\n')
-        const e2split = e2.stack?.split('\n')
-        const startOfFirstStack = 2
-        const endOfFirstStack = (e1split?.length || 0) + startOfFirstStack
-        const startOfSecondStack = endOfFirstStack + startOfFirstStack
-        const endOfSecondStack = startOfSecondStack + (e2split?.length || 0)
-        expect(lines.slice(startOfFirstStack, endOfFirstStack)).toEqual(e1split)
-        expect(lines.slice(startOfSecondStack, endOfSecondStack)).toEqual(e2split)
+        const e1message = e1.message
+        const e1stackSplit = e1.stack?.split('\n')
+        const e2message = e2.message
+        const e2stackSplit = e2.stack?.split('\n')
+        const startOfFirstMessage = 2
+        const endOfFirstMessage = startOfFirstMessage + 1
+        const startOfFirstStack = endOfFirstMessage + 1
+        const endOfFirstStack = (e1stackSplit?.length || 0) + startOfFirstStack
+        const startOfSecondMessage = endOfFirstStack + 2
+        const endOfSecondMessage = startOfSecondMessage + 1
+        const startOfSecondStack = endOfSecondMessage + 1
+        const endOfSecondStack = startOfSecondStack + (e2stackSplit?.length || 0)
+        expect(lines.slice(startOfFirstMessage, endOfFirstMessage)).toEqual([e1message])
+        expect(lines.slice(startOfFirstStack, endOfFirstStack)).toEqual(e1stackSplit)
+        expect(lines.slice(startOfSecondMessage, endOfSecondMessage)).toEqual([e2message])
+        expect(lines.slice(startOfSecondStack, endOfSecondStack)).toEqual(e2stackSplit)
     })
 
     it('should include delimiters to indicate where stack traces end', () => {
@@ -80,9 +93,9 @@ describe('CompoundError', () => {
         const lines = error.message.split('\n')
 
         expect(lines[0]).toBe('CompoundError: One or more errors occurred. ---')
-        expect(lines[2]).toBe('   goodbye')
+        expect(lines[2]).toBe('    goodbye')
         expect(lines[3]).toBe('--- End of error message ---')
-        expect(lines[5]).toBe('   hello')
+        expect(lines[5]).toBe('    hello')
         expect(lines[6]).toBe('--- End of error message ---')
     })
 })

--- a/packages/wdio-allure-reporter/tests/suite.test.ts
+++ b/packages/wdio-allure-reporter/tests/suite.test.ts
@@ -318,7 +318,9 @@ describe('Failed tests', () => {
 
         expect(lines[0]).toBe('CompoundError: One or more errors occurred. ---')
         expect(lines[2].trim()).toBe('ReferenceError: All is Dust')
-        expect(lines[5].trim()).toBe('InternalError: Abandon Hope')
+        expect(lines[4].trim()).toBe('stack trace of ReferenceError')
+        expect(lines[7].trim()).toBe('InternalError: Abandon Hope')
+        expect(lines[9].trim()).toBe('stack trace of InternalError')
     })
 
     it('should detect failed test case with Assertion failed from expect-webdriverIO', () => {


### PR DESCRIPTION
## Proposed changes

Currently, the Allure reports only contain the stack traces of inner errors of CompoundErrors. Depending on the environment, stack traces sometimes do not contain error messages. This makes such errors hard to analyze. This change adds error messages, if present.

## Types of changes

- [x] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

### Reviewers: @webdriverio/project-committers
