### PR TITLE
(wdio-allure-reporter): CompoundError: Also print error message if present

### DIFF
--- a/packages/wdio-allure-reporter/src/compoundError.ts
+++ b/packages/wdio-allure-reporter/src/compoundError.ts
@@ -11,9 +11,13 @@ export default class CompoundError extends Error {
 
     constructor(...innerErrors: Error[]) {
         const message = ['CompoundError: One or more errors occurred. ---\n'].
-            concat(innerErrors.map(x => x.stack
-                ? `${indentAll(x.stack)}\n--- End of stack trace ---\n`
-                : `   ${x.message}\n--- End of error message ---\n`
+            concat(innerErrors.map(x =>
+                x.message && x.stack?.includes(x.message)
+                    ? (x.stack ? `${indentAll(x.stack)}\n--- End of stack trace ---\n` : '')
+                    : (
+                        (x.message ? `    ${x.message}\n--- End of error message ---\n` : '') +
+                        (x.stack ? `${indentAll(x.stack)}\n--- End of stack trace ---\n` : '')
+                    )
             )).join('\n')
 
         super(message)

--- a/packages/wdio-allure-reporter/tests/__fixtures__/testState.ts
+++ b/packages/wdio-allure-reporter/tests/__fixtures__/testState.ts
@@ -47,6 +47,21 @@ export function testFailedWithMultipleErrors() {
     return Object.assign(testState(), { errors, state: 'failed', end: '2018-05-14T15:17:21.631Z', _duration: 2730 })
 }
 
+export function testFailedWithMultipleErrorsAndStacksNotContainingMessages() {
+    const errors =
+    [
+        {
+            message: 'ReferenceError: All is Dust',
+            stack: 'stack trace of ReferenceError'
+        },
+        {
+            message: 'InternalError: Abandon Hope',
+            stack: 'stack trace of InternalError'
+        }
+    ]
+    return Object.assign(testState(), { errors, state: 'failed', end: '2018-05-14T15:17:21.631Z', _duration: 2730 })
+}
+
 export function testFailedWithAssertionErrorFromExpectWebdriverIO() {
     const errors =
     [

--- a/packages/wdio-allure-reporter/tests/compoundError.test.ts
+++ b/packages/wdio-allure-reporter/tests/compoundError.test.ts
@@ -80,9 +80,9 @@ describe('CompoundError', () => {
         const lines = error.message.split('\n')
 
         expect(lines[0]).toBe('CompoundError: One or more errors occurred. ---')
-        expect(lines[2]).toBe('   goodbye')
+        expect(lines[2]).toBe('    goodbye')
         expect(lines[3]).toBe('--- End of error message ---')
-        expect(lines[5]).toBe('   hello')
+        expect(lines[5]).toBe('    hello')
         expect(lines[6]).toBe('--- End of error message ---')
     })
 })


### PR DESCRIPTION
## Proposed changes

Currently, the Allure reports only contain the stack traces of inner errors of CompoundErrors. Depending on the environment, stack traces sometimes do not contain error messages. This makes such errors hard to analyze.

This change adds error messages if present and if the stack trace does not already contain the error message.

## Types of changes

- [x] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [x] Back-ported PR at `#12378`

### Reviewers: @webdriverio/project-committers
