### PR TITLE
removal of the chainable promise types

### DIFF
--- a/packages/wdio-browser-runner/src/browser/expect.ts
+++ b/packages/wdio-browser-runner/src/browser/expect.ts
@@ -1,7 +1,6 @@
 import { expect, type MatcherContext, type ExpectationResult, type SyncExpectationResult } from 'expect'
 import { MESSAGE_TYPES, type Workers } from '@wdio/types'
 import { $ } from '@wdio/globals'
-import type { ChainablePromiseElement } from 'webdriverio'
 
 import { getCID } from './utils.js'
 import { WDIO_EVENT_NAME } from '../constants.js'
@@ -31,7 +30,7 @@ const COMMAND_TIMEOUT = 30 * 1000 // 30s
  * @returns a matcher result computed in the Node.js environment
  */
 function createMatcher (matcherName: string) {
-    return async function (this: MatcherContext, context: WebdriverIO.Browser | WebdriverIO.Element | ChainablePromiseElement<WebdriverIO.Element> | ChainablePromiseArray, ...args: any[]) {
+    return async function (this: MatcherContext, context: WebdriverIO.Browser | Awaited<WebdriverIO.Element> | Awaited<WebdriverIO.ElementArray>, ...args: any[]) {
         const cid = getCID()
         if (!import.meta.hot || !cid) {
             return {

--- a/packages/webdriverio/src/commands/browser/$$.ts
+++ b/packages/webdriverio/src/commands/browser/$$.ts
@@ -6,7 +6,7 @@ import type { Selector } from '../../types.js'
 
 /**
  * The `$$` command is a short and handy way in order to fetch multiple elements on the page.
- * It returns a `ChainablePromiseArray` containing a set of WebdriverIO elements.
+ * It returns an array containing a set of WebdriverIO elements.
  *
  * Using the wdio testrunner this command is a global variable, see [Globals](https://webdriver.io/docs/api/globals)
  * for more information. Using WebdriverIO within a [standalone](https://webdriver.io/docs/setuptypes#standalone-mode)

--- a/packages/webdriverio/src/commands/element/$$.ts
+++ b/packages/webdriverio/src/commands/element/$$.ts
@@ -1,6 +1,6 @@
 /**
  * The `$$` command is a short and handy way in order to fetch multiple elements on the page.
- * It returns a `ChainablePromiseArray` containing a set of WebdriverIO elements.
+ * It returns an array containing a set of WebdriverIO elements.
  *
  * :::info
  *

--- a/packages/webdriverio/src/commands/element/isExisting.ts
+++ b/packages/webdriverio/src/commands/element/isExisting.ts
@@ -66,5 +66,5 @@ export async function isExisting (this: WebdriverIO.Element) {
         : this.isShadowElement
             ? this.shadow$$.bind(this.parent)
             : this.parent.$$.bind(this.parent)
-    return command(this.selector as string).then((res) => res.length > 0)
+    return (command(this.selector as string) as WebdriverIO.ElementArray & Promise<WebdriverIO.ElementArray>).then((res) => res.length > 0)
 }

--- a/packages/webdriverio/src/types.ts
+++ b/packages/webdriverio/src/types.ts
@@ -18,45 +18,10 @@ type $ElementCommands = typeof ElementCommands
 type ElementQueryCommands = '$' | 'custom$' | 'shadow$' | 'react$'
 type ElementsQueryCommands = '$$' | 'custom$$' | 'shadow$$' | 'react$$'
 type ChainablePrototype = {
-    [K in ElementQueryCommands]: (...args: Parameters<$ElementCommands[K]>) => ChainablePromiseElement<ThenArg<ReturnType<$ElementCommands[K]>>>
+    [K in ElementQueryCommands]: (...args: Parameters<$ElementCommands[K]>) => Awaited<ThenArg<ReturnType<$ElementCommands[K]>>>
 } & {
-    [K in ElementsQueryCommands]: (...args: Parameters<$ElementCommands[K]>) => ChainablePromiseArray<ThenArg<ReturnType<$ElementCommands[K]>>>
+    [K in ElementsQueryCommands]: (...args: Parameters<$ElementCommands[K]>) => Awaited<ThenArg<ReturnType<$ElementCommands[K]>>>
 }
-
-type AsyncElementProto = {
-    [K in keyof Omit<$ElementCommands, keyof ChainablePrototype>]: OmitThisParameter<$ElementCommands[K]>
-} & ChainablePrototype
-
-interface ChainablePromiseBaseElement {
-    /**
-     * WebDriver element reference
-     */
-    elementId: Promise<string>
-    /**
-     * parent of the element if fetched via `$(parent).$(child)`
-     */
-    parent: Promise<WebdriverIO.Element | WebdriverIO.Browser | WebdriverIO.MultiRemoteBrowser>
-    /**
-     * selector used to fetch this element, can be
-     * - undefined if element was created via `$({ 'element-6066-11e4-a52e-4f735466cecf': 'ELEMENT-1' })`
-     * - a string if `findElement` was used and a reference was found
-     * - or a functin if element was found via e.g. `$(() => document.body)`
-     */
-    selector: Promise<Selector>
-    /**
-     * Error message in case element fetch was not successful
-     */
-    error?: Promise<Error>
-    /**
-     * index of the element if fetched with `$$`
-     */
-    index?: Promise<number>
-}
-export interface ChainablePromiseElement<T> extends
-    ChainablePromiseBaseElement,
-    AsyncElementProto,
-    Promise<T>,
-    Omit<WebdriverIO.Element, keyof ChainablePromiseBaseElement | keyof AsyncElementProto> {}
 
 interface AsyncIterators<T> {
     /**
@@ -77,30 +42,6 @@ interface AsyncIterators<T> {
     filter: <T>(callback: (currentValue: WebdriverIO.Element, index: number, array: T[]) => boolean | Promise<boolean>, thisArg?: T) => Promise<WebdriverIO.Element[]>;
     filterSeries: <T>(callback: (currentValue: WebdriverIO.Element, index: number, array: T[]) => boolean | Promise<boolean>, thisArg?: T) => Promise<WebdriverIO.Element[]>;
     reduce: <T, U>(callback: (accumulator: U, currentValue: WebdriverIO.Element, currentIndex: number, array: T[]) => U | Promise<U>, initialValue?: U) => Promise<U>;
-}
-
-export interface ChainablePromiseArray<T> extends Promise<T>, AsyncIterators<T> {
-    [Symbol.asyncIterator](): AsyncIterableIterator<WebdriverIO.Element>
-
-    /**
-     * Amount of element fetched.
-     */
-    length: Promise<number>
-    /**
-     * selector used to fetch this element, can be
-     * - undefined if element was created via `$({ 'element-6066-11e4-a52e-4f735466cecf': 'ELEMENT-1' })`
-     * - a string if `findElement` was used and a reference was found
-     * - or a function if element was found via e.g. `$(() => document.body)`
-     */
-    selector: Promise<Selector>
-    /**
-     * parent of the element if fetched via `$(parent).$(child)`
-     */
-    parent: Promise<WebdriverIO.Element | WebdriverIO.Browser | WebdriverIO.MultiRemoteBrowser>
-    /**
-     * allow to access a specific index of the element set
-     */
-    [n: number]: ChainablePromiseElement<WebdriverIO.Element | undefined>
 }
 
 export type BrowserCommandsType = Omit<$BrowserCommands, keyof ChainablePrototype> & ChainablePrototype

--- a/packages/webdriverio/src/utils/actions/pointer.ts
+++ b/packages/webdriverio/src/utils/actions/pointer.ts
@@ -2,7 +2,6 @@
 import type { ElementReference } from '@wdio/protocols'
 import type { BaseActionParams, KeyActionType } from './base.js'
 import BaseAction from './base.js'
-import type { ChainablePromiseElement } from '../../types.js'
 
 export type ButtonNames = 'left' | 'middle' | 'right'
 export type Button = 0 | 1 | 2
@@ -39,7 +38,7 @@ const MOVE_PARAM_DEFAULTS = {
     x: 0,
     y: 0,
     duration: 100,
-    origin: ORIGIN_DEFAULT as (Origin | ElementReference | ChainablePromiseElement<WebdriverIO.Element> | WebdriverIO.Element)
+    origin: ORIGIN_DEFAULT as (Origin | ElementReference | Awaited<WebdriverIO.Element>)
 }
 
 type PointerActionParams = Partial<typeof PARAM_DEFAULTS> & Partial<PointerActionUpParams>

--- a/packages/webdriverio/src/utils/actions/wheel.ts
+++ b/packages/webdriverio/src/utils/actions/wheel.ts
@@ -1,6 +1,5 @@
 import type { BaseActionParams } from './base.js'
 import BaseAction from './base.js'
-import type { ChainablePromiseElement } from '../../types.js'
 
 export interface ScrollParams {
     /**
@@ -22,7 +21,7 @@ export interface ScrollParams {
     /**
      * element origin
      */
-    origin?: WebdriverIO.Element | ChainablePromiseElement<WebdriverIO.Element>
+    origin?: Awaited<WebdriverIO.Element>
     /**
      * duration ratio be the ratio of time delta and duration
      */


### PR DESCRIPTION
## Proposed changes

Based on a talk I had with Christian and my current team I decided to update our types to reflect that you do not need to `await` the `$` and `$$` commands.

I have replaced the types with TypeScript's `Awaited` utility type: https://www.typescriptlang.org/docs/handbook/utility-types.html#awaitedtype

## Types of changes

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

### Reviewers: @webdriverio/project-committers
