### PR TITLE
(webdriverio): fix action pointer parameters mapping

### DIFF
--- a/packages/webdriverio/src/utils/actions/pointer.ts
+++ b/packages/webdriverio/src/utils/actions/pointer.ts
@@ -45,12 +45,6 @@ const MOVE_PARAM_DEFAULTS = {
 type PointerActionParams = Partial<typeof PARAM_DEFAULTS> & Partial<PointerActionUpParams>
 type PointerActionMoveParams = Partial<typeof MOVE_PARAM_DEFAULTS> & PointerActionParams
 
-function mapParams<R, A>(mapFunction: (params: A) => R) {
-    return (params: A) => {
-        return mapFunction(params)
-    }
-}
-
 function mapButton(params: PointerActionParams | ButtonNames | Button) {
     const buttons = {
         left: 0,
@@ -114,7 +108,7 @@ export default class PointerAction extends BaseAction {
     up (params: PointerActionUpParams | ButtonNames = UP_PARAM_DEFAULTS) {
         this.sequence.push({
             type: 'pointerUp',
-            ...mapParams(mapButton)(params)
+            ...mapButton(params)
         })
         return this
     }
@@ -129,7 +123,7 @@ export default class PointerAction extends BaseAction {
         this.sequence.push({
             type: 'pointerDown',
             ...PARAM_DEFAULTS,
-            ...mapParams(mapButton)(params)
+            ...mapButton(params)
         })
         return this
     }

--- a/packages/webdriverio/src/utils/actions/pointer.ts
+++ b/packages/webdriverio/src/utils/actions/pointer.ts
@@ -45,8 +45,8 @@ const MOVE_PARAM_DEFAULTS = {
 type PointerActionParams = Partial<typeof PARAM_DEFAULTS> & Partial<PointerActionUpParams>
 type PointerActionMoveParams = Partial<typeof MOVE_PARAM_DEFAULTS> & PointerActionParams
 
-function mapParams(mapFunction: typeof mapButton) {
-    return (params: PointerActionParams | ButtonNames | Button) => {
+function mapParams<R, A>(mapFunction: (params: A) => R) {
+    return (params: A) => {
         return mapFunction(params)
     }
 }

--- a/packages/webdriverio/src/utils/actions/pointer.ts
+++ b/packages/webdriverio/src/utils/actions/pointer.ts
@@ -45,6 +45,30 @@ const MOVE_PARAM_DEFAULTS = {
 type PointerActionParams = Partial<typeof PARAM_DEFAULTS> & Partial<PointerActionUpParams>
 type PointerActionMoveParams = Partial<typeof MOVE_PARAM_DEFAULTS> & PointerActionParams
 
+function mapParams(mapFunction: typeof mapButton) {
+    return (params: PointerActionParams | ButtonNames | Button) => {
+        return mapFunction(params)
+    }
+}
+
+function mapButton(params: PointerActionParams | ButtonNames | Button) {
+    const buttons = {
+        left: 0,
+        middle: 1,
+        right: 2
+    }
+    if (typeof params === 'number') {
+        return { button: params }
+    }
+    if (typeof params === 'string') {
+        return { button: buttons[params] }
+    }
+    if (typeof params === 'object' && typeof params.button === 'string') {
+        return { ...params, button: buttons[params.button] }
+    }
+    return params
+}
+
 export default class PointerAction extends BaseAction {
     constructor (instance: WebdriverIO.Browser, params: BaseActionParams = {}) {
         if (!params.parameters) {
@@ -90,9 +114,7 @@ export default class PointerAction extends BaseAction {
     up (params: PointerActionUpParams | ButtonNames = UP_PARAM_DEFAULTS) {
         this.sequence.push({
             type: 'pointerUp',
-            button: typeof params === 'string'
-                ? params === 'right' ? 2 : (params === 'middle' ? 1 : 0)
-                : params.button
+            ...mapParams(mapButton)(params)
         })
         return this
     }
@@ -107,10 +129,7 @@ export default class PointerAction extends BaseAction {
         this.sequence.push({
             type: 'pointerDown',
             ...PARAM_DEFAULTS,
-            ...(typeof params === 'string'
-                ? { button: params === 'right' ? 2 : (params === 'middle' ? 1 : 0) }
-                : params
-            )
+            ...mapParams(mapButton)(params)
         })
         return this
     }


### PR DESCRIPTION
## Proposed changes

In another PR I found out that the action pointer parameters are mapped differently and sometimes aren't mapped at all, this PR intends to correct this.

## Types of changes

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

### Reviewers: @webdriverio/project-committers
