### PR TITLE
(webdriver): improve error stack for failing bidi commands

### DIFF
--- a/packages/webdriver/src/bidi/core.ts
+++ b/packages/webdriver/src/bidi/core.ts
@@ -36,6 +36,7 @@ export class BidiCore {
 
     public send (params: Omit<CommandData, 'id'>) {
         const id = this.sendAsync(params)
+        const failError = new Error(`WebDriver Bidi command "${params.method}" failed`)
         return new Promise<CommandResponse>((resolve, reject) => {
             const t = setTimeout(() => {
                 reject(new Error(`Request with id ${id} timed out`))
@@ -50,7 +51,8 @@ export class BidiCore {
                         h.off('message', listener)
                         log.info('BIDI RESULT', JSON.stringify(payload))
                         if (payload.error) {
-                            return reject(new Error(payload.error))
+                            failError.message += ` with error: ${payload.error}`
+                            return reject(failError)
                         }
                         resolve(payload)
                     }

--- a/packages/webdriver/tests/bidi.test.ts
+++ b/packages/webdriver/tests/bidi.test.ts
@@ -62,7 +62,7 @@ describe('BidiCore', () => {
 
             const error = await promise.catch((err) => err)
             const errorMessage = 'WebDriver Bidi command "session.new" failed with error: foobar'
-            expect(error.stack).toContain('/packages/webdriver/tests/bidi.test.ts:')
+            expect(error.stack).toContain(path.join('packages', 'webdriver', 'tests', 'bidi.test.ts:56:'))
             expect(error.stack).toContain(errorMessage)
             expect(error.message).toBe(errorMessage)
         })

--- a/packages/webdriver/tests/bidi.test.ts
+++ b/packages/webdriver/tests/bidi.test.ts
@@ -46,6 +46,26 @@ describe('BidiCore', () => {
             const result = await promise
             expect(result).toEqual({ id: 1, result: 'foobar' })
         })
+
+        it('has a proper error stack that contains the line where the command is called', async () => {
+            const handler = new BidiCore('ws://foo/bar')
+            handler.connect()
+            const [, cb] = vi.mocked(handler.socket.on).mock.calls[0]
+            cb.call(this as  any)
+
+            const promise = handler.send({ method: 'session.new', params: {} })
+            const [, messageCallback] = vi.mocked(handler.socket.on).mock.calls[1]
+            setTimeout(
+                () => messageCallback.call(this as any, Buffer.from(JSON.stringify({ id: 1, error: 'foobar' }))),
+                100
+            )
+
+            const error = await promise.catch((err) => err)
+            const errorMessage = 'WebDriver Bidi command "session.new" failed with error: foobar'
+            expect(error.stack).toContain('/packages/webdriver/tests/bidi.test.ts:')
+            expect(error.stack).toContain(errorMessage)
+            expect(error.message).toBe(errorMessage)
+        })
     })
 
     describe('sendAsync', () => {


### PR DESCRIPTION
## Proposed changes

Right now we are getting not much useful error message in case a Bidi commands fails, an excerpt from our pipeline:

```
Error: no such frame
    at WebSocket.listener (file:///Users/runner/work/***/***/packages/webdriver/src/bidi/core.ts:53:43)
    at WebSocket.emit (node:events:530:35)
    at WebSocket.emit (node:domain:488:12)
    at Receiver.receiverOnMessage (/Users/runner/work/***/***/node_modules/.pnpm/ws@8.16.0/node_modules/ws/lib/websocket.js:1209:20)
    at Receiver.emit (node:events:518:28)
    at Receiver.emit (node:domain:488:12)
    at Receiver.dataMessage (/Users/runner/work/***/***/node_modules/.pnpm/ws@8.16.0/node_modules/ws/lib/receiver.js:603:14)
    at /Users/runner/work/***/***/node_modules/.pnpm/ws@8.16.0/node_modules/ws/lib/receiver.js:534:12
    at /Users/runner/work/***/***/node_modules/.pnpm/ws@8.16.0/node_modules/ws/lib/permessage-deflate.js:[30](https://github.com/webdriverio/webdriverio/actions/runs/8163945562/job/22318215787#step:9:31)9:9
    at /Users/runner/work/***/***/node_modules/.pnpm/ws@8.16.0/node_modules/ws/lib/permessage-deflate.js:392:7
    at afterWrite (node:internal/streams/writable:701:5)
    at onwrite (node:internal/streams/writable:679:7)
    at Zlib.cb (node:internal/streams/transform:191:7)
    at Zlib.processCallback (node:zlib:630:8)
```

This patch creates the error outside if the event handler so that the stack will be much cleaner and allows to reference the origin of the command that was called. Furthermore it improves the error message.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [x] Back-ported PR at `#XXXXX` - will cherry-pick from `main`

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
