### PR TITLE
(wdio-config): check existence of ts-node/esm/transpile-only.mjs & fix a type issue

### DIFF
--- a/packages/wdio-config/src/node/ConfigParser.ts
+++ b/packages/wdio-config/src/node/ConfigParser.ts
@@ -65,6 +65,15 @@ export default class ConfigParser {
         if (_initialConfig.spec) {
             _initialConfig.spec = makeRelativeToCWD(_initialConfig.spec) as string[]
         }
+        /**
+         * the autoCompileOpts.autoCompile CLI argument has to be converted
+         * from type string to type boolean
+         */
+        if (typeof _initialConfig.autoCompileOpts?.autoCompile === 'string') {
+            const strValue = _initialConfig.autoCompileOpts.autoCompile as unknown as string
+            _initialConfig.autoCompileOpts.autoCompile = !!strValue && strValue !== 'false'
+        }
+
         this.merge(_initialConfig, false)
     }
 

--- a/packages/wdio-config/src/node/utils.ts
+++ b/packages/wdio-config/src/node/utils.ts
@@ -1,5 +1,6 @@
 import url from 'node:url'
 import path from 'node:path'
+import { access } from 'node:fs/promises'
 
 import { resolve } from 'import-meta-resolve'
 
@@ -27,6 +28,8 @@ export async function loadTypeScriptCompiler (autoCompileConfig: Options.AutoCom
             throw new Error('test fail')
         }
         await resolve('ts-node', import.meta.url)
+        const loaderPath = await resolve('ts-node/esm/transpile-only.mjs', import.meta.url)
+        await access(new URL(loaderPath))
         process.env.WDIO_LOAD_TS_NODE = '1'
         objectToEnv(autoCompileConfig.tsNodeOpts)
         return true

--- a/packages/wdio-config/tests/node/configparser.test.ts
+++ b/packages/wdio-config/tests/node/configparser.test.ts
@@ -313,13 +313,14 @@ describe('ConfigParser', () => {
 
             it('should just continue without initiation when autoCompile:false', async () => {
                 process.env.THROW_BABEL_REGISTER = '1'
+                const babelRegister = vi.fn()
                 const configParserBuilder = ConfigParserBuilder
                     .withBaseDir(FIXTURES_PATH, FIXTURES_CONF_RDC, {
                         autoCompileOpts: {
                             autoCompile: false
                         }
                     })
-                    .withBabelModule()
+                    .withBabelModule(babelRegister)
                     .withFiles([
                         ...MockedFileSystem_OnlyLoadingConfig(process.cwd(), FIXTURES_CONF_RDC)
                     ])
@@ -327,6 +328,27 @@ describe('ConfigParser', () => {
                 const configParser = configParserBuilder.build()
                 await configParser.initialize()
                 expect(requireMock).not.toHaveBeenCalled()
+                expect(babelRegister).not.toHaveBeenCalled()
+            })
+
+            it('should just continue without initiation with --autoCompileOpts.autoCompile=false', async () => {
+                process.env.THROW_BABEL_REGISTER = '1'
+                const babelRegister = vi.fn()
+                const configParserBuilder = ConfigParserBuilder
+                    .withBaseDir(FIXTURES_PATH, FIXTURES_CONF_RDC, {
+                        autoCompileOpts: {
+                            autoCompile: 'false'
+                        }
+                    })
+                    .withBabelModule(babelRegister)
+                    .withFiles([
+                        ...MockedFileSystem_OnlyLoadingConfig(process.cwd(), FIXTURES_CONF_RDC)
+                    ])
+                const { requireMock } = configParserBuilder.getMocks().modules.getMocks()
+                const configParser = configParserBuilder.build()
+                await configParser.initialize()
+                expect(requireMock).not.toHaveBeenCalled()
+                expect(babelRegister).not.toHaveBeenCalled()
             })
 
             it('should just continue without initiation if @babel/register does not exist', async () => {

--- a/packages/wdio-config/tests/node/utils.test.ts
+++ b/packages/wdio-config/tests/node/utils.test.ts
@@ -1,20 +1,41 @@
 import { describe, beforeEach, it, expect, vi } from 'vitest'
 import { resolve } from 'import-meta-resolve'
+import type fspType from 'node:fs/promises'
+import type { PathLike } from 'node:fs'
 
 import { loadTypeScriptCompiler } from '../../src/node/utils.js'
 
 vi.mock('import-meta-resolve', () => ({
-    resolve: vi.fn().mockResolvedValue('/some/path')
+    resolve: vi.fn().mockResolvedValue('file:///some/path')
 }))
+
+vi.mock('node:fs/promises', async () => {
+    const actualFsp = await vi.importActual<typeof fspType>('node:fs/promises')
+    return {
+        ...actualFsp,
+        access: async (path: PathLike) => {
+            if (path instanceof URL) {
+                if (path.href === 'file:///some/path') {
+                    return undefined
+                }
+                if (path.href === 'file:///some/missing/path') {
+                    throw new Error('ups')
+                }
+            }
+            return actualFsp.access(path)
+        },
+    }
+})
 
 describe('loadTypeScriptCompiler', () => {
     beforeEach(() => {
         vi.mocked(resolve).mockClear()
+        vi.unstubAllEnvs()
     })
 
     it('should return true if tsconfig exists', async () => {
         expect(await loadTypeScriptCompiler({})).toBe(true)
-        expect(resolve).toBeCalledTimes(1)
+        expect(resolve).toBeCalledTimes(2)
     })
 
     it('should return false if tsconfig exists', async () => {
@@ -24,9 +45,22 @@ describe('loadTypeScriptCompiler', () => {
     })
 
     it('should return false if WDIO_WORKER_ID is set', async () => {
-        process.env.WDIO_WORKER_ID = '1'
+        vi.stubEnv('WDIO_WORKER_ID', '1')
         vi.mocked(resolve).mockRejectedValue(new Error('ups'))
         expect(await loadTypeScriptCompiler({})).toBe(false)
         expect(resolve).toBeCalledTimes(0)
+    })
+
+    it('should return false if if ts-node/esm/transpile-only.mjs does not exist', async () => {
+        const mock = vi.mocked(resolve)
+        // resolve the first resolve call to an existing path and the second resolve call to a missing path
+        mock.mockResolvedValue('file:///some/missing/path').mockResolvedValueOnce('file:///some/path')
+        expect(await loadTypeScriptCompiler({})).toBe(false)
+        expect(resolve).toBeCalledTimes(2)
+        expect(mock).toBeCalledTimes(2)
+        expect(mock.mock.calls[0][0]).toBe('ts-node')
+        expect(mock.mock.results[0]).toStrictEqual({ type: 'return', value: 'file:///some/path' })
+        expect(mock.mock.calls[1][0]).toBe('ts-node/esm/transpile-only.mjs')
+        expect(mock.mock.results[1]).toStrictEqual({ type: 'return', value: 'file:///some/missing/path' })
     })
 })


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

Fixes two issues behind https://github.com/webdriverio/webdriverio/issues/12434. The first fix is to check for the existence of the `ts-node/esm/transpile-only.mjs` loader before trying to use it, as it does not exist in ts-node versions <9 (in our case pulled in by a transitive dependency). The 2nd fix is a type issue with the argument `autoCompileConfig.autoCompile=false` which ends up as the string `"false"`. I added a conversion step to take care of this. Note that this CLI argument is already documented in `wdio --help`.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

- [x] Back-ported PR at [`#12437`](https://github.com/webdriverio/webdriverio/pull/12437)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers