### PR TITLE
(webdriverio): implement deep lookup with Bidi

### DIFF
--- a/e2e/browser-runner/.eslintrc
+++ b/e2e/browser-runner/.eslintrc
@@ -6,5 +6,8 @@
     "globals": {
         "browser": true,
         "expect": true
+    },
+    "rules": {
+        "no-undef": "off"
     }
 }

--- a/e2e/browser-runner/components/StencilComponentNested.tsx
+++ b/e2e/browser-runner/components/StencilComponentNested.tsx
@@ -1,4 +1,4 @@
-import { Component as foo, Prop } from '@stencil/core'
+import { Component as foo, Prop, Host } from '@stencil/core'
 
 @foo({
     tag: 'nested-component',
@@ -9,9 +9,12 @@ export class NestedComponent {
 
     render() {
         return (
-            <i>
-                I am a {this.id || 'unknown'}!
-            </i>
+            <Host>
+                <i>
+                    I am a {this.id || 'unknown'}!
+                </i>
+                <a href="#">I am a link</a>
+            </Host>
         )
     }
 }

--- a/e2e/browser-runner/stencil.test.tsx
+++ b/e2e/browser-runner/stencil.test.tsx
@@ -28,7 +28,7 @@ describe('Stencil Component Testing', () => {
         /**
          * this assertion for Safari due to: https://github.com/w3c/webdriver/issues/1786
          */
-        if (browser.capabilities.browserName?.toLowerCase() !== 'safari') {
+        if ((browser.capabilities as WebdriverIO.Capabilities).browserName?.toLowerCase() !== 'safari') {
             await expect($('>>>.app-profile')).toHaveText(
                 expect.stringContaining('I am a nested component!')
             )
@@ -98,6 +98,9 @@ describe('Stencil Component Testing', () => {
     })
 
     it('can auto peirce shadow dom', async () => {
+        if ((browser.capabilities as WebdriverIO.Capabilities).browserName?.toLowerCase() === 'safari') {
+            return
+        }
         render({
             components: [AppProfile, NestedComponent],
             template: () => (

--- a/e2e/browser-runner/stencil.test.tsx
+++ b/e2e/browser-runner/stencil.test.tsx
@@ -96,4 +96,55 @@ describe('Stencil Component Testing', () => {
         page.unmount()
         await expect(page.root).not.toBeExisting()
     })
+
+    it('can auto peirce shadow dom', async () => {
+        render({
+            components: [AppProfile, NestedComponent],
+            template: () => (
+                <div>
+                    {/* @ts-ignore: types don't exist as we don't compile the components with Stencil */}
+                    <nested-component id="first transparent component"></nested-component>
+                    <div className="nested">
+                        {/* @ts-ignore: types don't exist as we don't compile the components with Stencil */}
+                        <nested-component id="transparent component in a nested context"></nested-component>
+                    </div>
+                    <div className="nested second">
+                        {/* @ts-ignore: types don't exist as we don't compile the components with Stencil */}
+                        <nested-component id="transparent component in a second nested context"></nested-component>
+                        {/* @ts-ignore: types don't exist as we don't compile the components with Stencil */}
+                        <app-profile match={{ params: { name: 'stencil' } }}></app-profile>
+                    </div>
+                </div>
+            )
+        })
+
+        await expect($('i')).toHaveText('I am a first transparent component!')
+        await expect($('.nested i')).not.toBeExisting()
+
+        /**
+         * is able to find element within multiple nested levels of shadow dom
+         * .second > app-profile#shadow-root > nested-component#shadow-root > i
+         */
+        await expect($('.second').$('app-profile').$('i'))
+            .toHaveText('I am a nested component!')
+        /**
+         * finds first <i/> in the first nested component element
+         */
+        await expect($('.nested').$('i'))
+            .toHaveText('I am a transparent component in a nested context!')
+
+        expect(await $$('i').map((el) => el.getText())).toEqual([
+            'I am a first transparent component!',
+            'I am a transparent component in a nested context!',
+            'I am a transparent component in a second nested context!',
+            'I am a nested component!'
+        ])
+        expect(await $('.nested').$$('i').map((el) => el.getText())).toEqual([
+            'I am a transparent component in a nested context!',
+        ])
+        expect(await $('.second').$$('i').map((el) => el.getText())).toEqual([
+            'I am a transparent component in a second nested context!',
+            'I am a nested component!'
+        ])
+    })
 })

--- a/e2e/browser-runner/stencil.test.tsx
+++ b/e2e/browser-runner/stencil.test.tsx
@@ -133,6 +133,12 @@ describe('Stencil Component Testing', () => {
         await expect($('.nested').$('i'))
             .toHaveText('I am a transparent component in a nested context!')
 
+        /**
+         * can combine different selector strategies
+         */
+        await expect($('.nested').$('=I am a link')).toBePresent()
+        await expect($('.nested').$('*=a link')).toBePresent()
+
         expect(await $$('i').map((el) => el.getText())).toEqual([
             'I am a first transparent component!',
             'I am a transparent component in a nested context!',

--- a/e2e/browser-runner/wdio.conf.js
+++ b/e2e/browser-runner/wdio.conf.js
@@ -33,7 +33,7 @@ export const config = {
     capabilities: [
         isMac
             ? { browserName: 'safari' }
-            : { browserName: 'chrome', browserVersion: '122.0.6261.39' }
+            : { browserName: 'chrome', browserVersion: '122.0.6261.39', webSocketUrl: true }
     ],
 
     /**

--- a/packages/wdio-browser-runner/src/browser/driver.ts
+++ b/packages/wdio-browser-runner/src/browser/driver.ts
@@ -4,6 +4,7 @@ import { webdriverMonad, sessionEnvironmentDetector } from '@wdio/utils'
 import { getEnvironmentVars } from 'webdriver'
 import { MESSAGE_TYPES, type Workers } from '@wdio/types'
 import { browser } from '@wdio/globals'
+import safeStringify from 'safe-stringify'
 
 import { getCID, sanitizeConsoleArgs } from './utils.js'
 import { WDIO_EVENT_NAME } from '../constants.js'
@@ -200,7 +201,7 @@ export default class ProxyDriver {
                 import.meta.hot?.send(WDIO_EVENT_NAME, this.#consoleMessage({
                     name: 'consoleEvent',
                     type: method,
-                    args: sanitizeConsoleArgs(args),
+                    args: JSON.parse(safeStringify(sanitizeConsoleArgs(args))),
                     cid
                 }))
                 origCommand(...args)

--- a/packages/wdio-browser-runner/src/browser/utils.ts
+++ b/packages/wdio-browser-runner/src/browser/utils.ts
@@ -1,6 +1,6 @@
 export function getCID() {
     const urlParamString = new URLSearchParams(window.location.search)
-    return (
+    const cid = (
         // initial request contains cid as query parameter
         urlParamString.get('cid') ||
         // if not provided check for document cookie, set by `@wdio/runner` package
@@ -10,6 +10,12 @@ export function getCID() {
             .split('=')
             .pop()
     )
+
+    if (!cid) {
+        throw new Error('"cid" query parameter is missing')
+    }
+
+    return cid
 }
 
 export const showPopupWarning = <T>(name: string, value: T, defaultValue?: T) => (...params: any[]) => {
@@ -29,6 +35,12 @@ export const showPopupWarning = <T>(name: string, value: T, defaultValue?: T) =>
 export function sanitizeConsoleArgs (args: unknown[]) {
     return args.map((arg: any) => {
         try {
+            if (arg && typeof arg.selector === 'string' && arg.error) {
+                return `WebdriverIO.Element<"${arg.selector}">`
+            }
+            if (arg && typeof arg.selector === 'string' && typeof arg.length === 'number') {
+                return `WebdriverIO.Element<${arg.length}x "${arg.selector}">`
+            }
             if (arg && typeof arg.selector === 'string') {
                 return `WebdriverIO.Element<"${arg.selector}">`
             }

--- a/packages/wdio-globals/types.d.ts
+++ b/packages/wdio-globals/types.d.ts
@@ -14,3 +14,26 @@ declare function $$(...args: Parameters<WebdriverIO.Browser['$$']>): ReturnType<
 declare var browser: WebdriverIO.Browser
 declare var driver: WebdriverIO.Browser
 declare var multiremotebrowser: WebdriverIO.MultiRemoteBrowser
+
+/**
+ * custom environment primitives for WebdriverIO when running in a browser
+ */
+declare var wdio: {
+    /**
+     * This command is available when running WebdriverIO tests using `@wdio/browser-runner`.
+     * It allows you to execute a command in Node.js land if desired.
+     * @param command The command to execute
+     * @param args The arguments to pass to the command
+     * @returns The result of the command
+     */
+    execute: <CommandName>(command: CommandName, ...args: any[]) => ReturnType<WebdriverIO.Browser[CommandName]>
+    /**
+     * This command is available when running WebdriverIO tests using `@wdio/browser-runner`.
+     * It allows you to execute a command in Node.js land if desired.
+     * @param command The command to execute
+     * @param scope The element id when the command needs to be executed from an element scope
+     * @param args The arguments to pass to the command
+     * @returns The result of the command
+     */
+    executeWithScope: <CommandName>(commandName: CommandName, scope: string, ...args: any[]) => ReturnType<WebdriverIO.Browser[CommandName]>
+}

--- a/packages/wdio-types/src/Workers.ts
+++ b/packages/wdio-types/src/Workers.ts
@@ -173,6 +173,7 @@ export interface CommandRequestEvent extends MessageWithPendingPromiseId {
     cid: string
     commandName: string
     args: unknown[]
+    scope?: string
 }
 
 export interface CommandResponseEvent extends MessageWithPendingPromiseId {

--- a/packages/webdriver/src/request/index.ts
+++ b/packages/webdriver/src/request/index.ts
@@ -19,6 +19,11 @@ if ('process' in globalThis && globalThis.process.versions?.node) {
 type RequestLibResponse = Options.RequestLibResponse
 type RequestOptions = Omit<Options.WebDriver, 'capabilities'>
 
+const ERRORS_TO_EXCLUDE_FROM_RETRY = [
+    'detached shadow root',
+    'move target out of bounds'
+]
+
 export class RequestLibError extends Error {
     statusCode?: number
     body?: any
@@ -263,10 +268,10 @@ export default abstract class WebDriverRequest extends EventEmitter {
         }
 
         /**
-         * Move out of bounds errors can be excluded from the request retry mechanism as
+         * some errors can be excluded from the request retry mechanism as
          * it likely does not changes anything and the error is handled within the command.
          */
-        if (error.name === 'move target out of bounds') {
+        if (ERRORS_TO_EXCLUDE_FROM_RETRY.includes(error.name)) {
             throw error
         }
 

--- a/packages/webdriverio/src/commands/browser/$$.ts
+++ b/packages/webdriverio/src/commands/browser/$$.ts
@@ -1,7 +1,9 @@
 import type { ElementReference } from '@wdio/protocols'
 
 import { findElements, enhanceElementsArray, isElement, findElement } from '../../utils/index.js'
-import { getElements, findDeepElement } from '../../utils/getElementObject.js'
+import { getElements } from '../../utils/getElementObject.js'
+import { findDeepElements } from '../../utils/index.js'
+import { DEEP_SELECTOR } from '../../constants.js'
 import type { Selector } from '../../types.js'
 
 /**
@@ -47,20 +49,30 @@ import type { Selector } from '../../types.js'
 export async function $$ (
     this: WebdriverIO.Browser | WebdriverIO.Element,
     selector: Selector | ElementReference[] | WebdriverIO.Element[] | HTMLElement[]
-) {
+): Promise<WebdriverIO.ElementArray> {
     /**
-     * do a deep lookup if we are using Bidi and have a string selector
+     * do a deep lookup if
+     * - we are using Bidi
+     * - have a string selector
+     * - that is not a deep selector
      */
-    if (this.isBidi && typeof selector === 'string') {
-        const results = (await findDeepElement.call(this, selector))
-            .filter(Boolean) as ElementReference[]
-
-        if (results.length === 0) {
-            return enhanceElementsArray([], this, selector as Selector) as WebdriverIO.ElementArray
+    if (this.isBidi && typeof selector === 'string' && !selector.startsWith(DEEP_SELECTOR)) {
+        /**
+         * run this in Node.js land if we are using browser runner
+         */
+        if (globalThis.wdio?.execute) {
+            const command = '$$' as const
+            const res = 'elementId' in this
+                ? await globalThis.wdio.executeWithScope(command, this.elementId, selector) as any as ElementReference[]
+                : await globalThis.wdio.execute(command, selector) as any as ElementReference[]
+            const elements = await getElements.call(this, selector as Selector, res)
+            return enhanceElementsArray(elements, this, selector as Selector) as WebdriverIO.ElementArray
         }
 
-        const elements = await getElements.call(this, selector as Selector, results)
-        return enhanceElementsArray(elements, this, selector as Selector) as WebdriverIO.ElementArray
+        const res = await findDeepElements.call(this, selector)
+        const elements = await getElements.call(this, selector as Selector, res)
+        const a = enhanceElementsArray(elements, this, selector as Selector) as WebdriverIO.ElementArray
+        return a
     }
 
     let res: (ElementReference | Error)[] = Array.isArray(selector)

--- a/packages/webdriverio/src/commands/browser/url.ts
+++ b/packages/webdriverio/src/commands/browser/url.ts
@@ -52,7 +52,8 @@ export async function url (
         const context = await this.getWindowHandle()
         const res = await this.browsingContextNavigate({
             context,
-            url: path
+            url: path,
+            wait: 'interactive'
         })
         return res.url
     }

--- a/packages/webdriverio/src/index.ts
+++ b/packages/webdriverio/src/index.ts
@@ -100,6 +100,7 @@ export const attach = async function (attachOptions: AttachOptions): Promise<Web
     ) as WebdriverIO.Browser
 
     driver.addLocatorStrategy = addLocatorStrategyHandler(driver)
+    await getShadowRootManager(driver).initialize()
     return driver
 }
 

--- a/packages/webdriverio/src/index.ts
+++ b/packages/webdriverio/src/index.ts
@@ -12,7 +12,7 @@ import detectBackend from './utils/detectBackend.js'
 import { getProtocolDriver } from './utils/driver.js'
 import { WDIO_DEFAULTS, SupportedAutomationProtocols, Key as KeyConstant } from './constants.js'
 import { getPrototype, addLocatorStrategyHandler, isStub } from './utils/index.js'
-import { getShadowRootManager } from './shadowRootManager.js'
+import { getShadowRootManager } from './shadowRoot.js'
 import type { AttachOptions, RemoteOptions } from './types.js'
 import type * as elementCommands from './commands/element.js'
 

--- a/packages/webdriverio/src/index.ts
+++ b/packages/webdriverio/src/index.ts
@@ -12,6 +12,7 @@ import detectBackend from './utils/detectBackend.js'
 import { getProtocolDriver } from './utils/driver.js'
 import { WDIO_DEFAULTS, SupportedAutomationProtocols, Key as KeyConstant } from './constants.js'
 import { getPrototype, addLocatorStrategyHandler, isStub } from './utils/index.js'
+import { getShadowRootManager } from './shadowRootManager.js'
 import type { AttachOptions, RemoteOptions } from './types.js'
 import type * as elementCommands from './commands/element.js'
 
@@ -74,6 +75,7 @@ export const remote = async function(
     }
 
     instance.addLocatorStrategy = addLocatorStrategyHandler(instance)
+    await getShadowRootManager(instance).initialize()
     return instance
 }
 

--- a/packages/webdriverio/src/scripts/customElement.ts
+++ b/packages/webdriverio/src/scripts/customElement.ts
@@ -1,0 +1,20 @@
+interface EnhancedHTMLElement extends HTMLElement {
+    connectedCallback?(): void;
+}
+
+interface CustomElementConstructor {
+    new (...params: any[]): EnhancedHTMLElement;
+}
+
+export default function customElementWrapper () {
+    const origFn = customElements.define.bind(customElements)
+    customElements.define = function(name: string, Constructor: CustomElementConstructor, options?: ElementDefinitionOptions) {
+        class WdioWrapperElement extends Constructor implements HTMLElement {
+            connectedCallback() {
+                super.connectedCallback && super.connectedCallback()
+                console.debug('[WDIO]', 'newShadowRoot', this.shadowRoot)
+            }
+        }
+        return origFn(name, WdioWrapperElement, options)
+    }
+}

--- a/packages/webdriverio/src/scripts/customElement.ts
+++ b/packages/webdriverio/src/scripts/customElement.ts
@@ -1,5 +1,6 @@
 interface EnhancedHTMLElement extends HTMLElement {
     connectedCallback?(): void;
+    disconnectedCallback?(): void;
 }
 
 interface CustomElementConstructor {
@@ -12,7 +13,11 @@ export default function customElementWrapper () {
         class WdioWrapperElement extends Constructor implements HTMLElement {
             connectedCallback() {
                 super.connectedCallback && super.connectedCallback()
-                console.debug('[WDIO]', 'newShadowRoot', this.shadowRoot)
+                console.debug('[WDIO]', 'newShadowRoot', this.shadowRoot, this)
+            }
+            disconnectedCallback() {
+                super.disconnectedCallback && super.disconnectedCallback()
+                console.debug('[WDIO]', 'removeShadowRoot', this.shadowRoot)
             }
         }
         return origFn(name, WdioWrapperElement, options)

--- a/packages/webdriverio/src/scripts/isDescendant.ts
+++ b/packages/webdriverio/src/scripts/isDescendant.ts
@@ -1,0 +1,3 @@
+export default function isDescandent (context: HTMLElement, element: HTMLElement) {
+    return context.contains(element)
+}

--- a/packages/webdriverio/src/shadowRoot.ts
+++ b/packages/webdriverio/src/shadowRoot.ts
@@ -14,6 +14,11 @@ export function getShadowRootManager(browser: WebdriverIO.Browser) {
     return newContext
 }
 
+/**
+ * This class is responsible for managing shadow roots and their elements.
+ * It allows to do deep element lookups and pierce into shadow DOMs across
+ * all components of a page.
+ */
 export class ShadowRootManager {
     #browser: WebdriverIO.Browser
     #initialize: Promise<boolean>
@@ -26,6 +31,14 @@ export class ShadowRootManager {
 
     constructor(browser: WebdriverIO.Browser) {
         this.#browser = browser
+
+        /**
+         * don't run setup when running unit tests
+         */
+        if (process.env.VITEST_WORKER_ID) {
+            this.#initialize = Promise.resolve(true)
+            return
+        }
 
         /**
          * listen on required bidi events
@@ -70,12 +83,13 @@ export class ShadowRootManager {
             args[1].type !== 'string' // command name, "newShadowRoot" or "removeShadowRoot"
         ) {
             return
+
         }
 
         /**
          * filter for log entry that was created in the right context
          */
-        if (!log.source.context || !this.#shadowRoots.has(log.source.context)) {
+        if (!log.source.context) {
             return
         }
 

--- a/packages/webdriverio/src/shadowRoot.ts
+++ b/packages/webdriverio/src/shadowRoot.ts
@@ -33,9 +33,9 @@ export class ShadowRootManager {
         this.#browser = browser
 
         /**
-         * don't run setup when running unit tests
+         * don't run setup when Bidi is not supported or running unit tests
          */
-        if (process.env.VITEST_WORKER_ID) {
+        if (!browser.isBidi || process.env.VITEST_WORKER_ID) {
             this.#initialize = Promise.resolve(true)
             return
         }

--- a/packages/webdriverio/src/shadowRoot.ts
+++ b/packages/webdriverio/src/shadowRoot.ts
@@ -35,7 +35,7 @@ export class ShadowRootManager {
         /**
          * don't run setup when Bidi is not supported or running unit tests
          */
-        if (!browser.isBidi || process.env.VITEST_WORKER_ID) {
+        if (!browser.isBidi || process.env.VITEST_WORKER_ID || browser.options?.automationProtocol !== 'webdriver') {
             this.#initialize = Promise.resolve(true)
             return
         }

--- a/packages/webdriverio/src/shadowRootManager.ts
+++ b/packages/webdriverio/src/shadowRootManager.ts
@@ -1,0 +1,97 @@
+import type { local } from 'webdriver'
+import customElementWrapper from './scripts/customElement.js'
+
+const shadowRootManager = new Map<WebdriverIO.Browser, ShadowRootManager>()
+
+export function getShadowRootManager(browser: WebdriverIO.Browser) {
+    const existingShadowRootManager = shadowRootManager.get(browser)
+    if (existingShadowRootManager) {
+        return existingShadowRootManager
+    }
+
+    const newContext = new ShadowRootManager(browser)
+    shadowRootManager.set(browser, newContext)
+    return newContext
+}
+
+export class ShadowRootManager {
+    #browser: WebdriverIO.Browser
+    #initialize: Promise<boolean>
+    #shadowRoots = new Map<string, Set<string>>()
+    #currentContext?: string
+
+    constructor(browser: WebdriverIO.Browser) {
+        this.#browser = browser
+
+        /**
+         * listen on required bidi events
+         */
+        this.#initialize = this.#browser.sessionSubscribe({
+            events: ['log.entryAdded', 'browsingContext.load']
+        }).then(() => true, () => false)
+        this.#browser.on('log.entryAdded', this.handleLogEntry.bind(this))
+        this.#browser.on('browsingContext.load', this.handleBrowsingContextLoad.bind(this))
+
+        browser.scriptAddPreloadScript({
+            functionDeclaration: customElementWrapper.toString()
+        })
+    }
+
+    initialize () {
+        return this.#initialize
+    }
+
+    /**
+     * reset list of shadow roots for a specific browsing context
+     */
+    handleBrowsingContextLoad(response: local.BrowsingContextNavigationInfo) {
+        this.#currentContext = response.context
+        this.#shadowRoots.set(response.context, new Set())
+    }
+
+    /**
+     * capture shadow root elements propagated through console.debug
+     */
+    handleLogEntry(log: local.LogEntry) {
+        const args = 'args' in log && log.level === 'debug'
+            ? log.args
+            : undefined
+
+        /**
+         * filter for right log entry type
+         */
+        if (
+            !args ||
+            args.length !== 3 ||
+            args[0].type !== 'string' || args[0].value !== '[WDIO]' ||
+            args[1].type !== 'string' || args[1].value !== 'newShadowRoot' ||
+            args[2].type !== 'node'
+        ) {
+            return
+        }
+
+        /**
+         * filter for log entry that was created in the right context
+         */
+        if (!log.source.context || !this.#shadowRoots.has(log.source.context)) {
+            return
+        }
+
+        const shadowRootForContext = this.#shadowRoots.get(log.source.context)
+        shadowRootForContext?.add(args[2].sharedId as string)
+    }
+
+    /**
+     * get shadow roots for a specific context
+     * @param context context to get shadow roots for (default: current browsing context)
+     * @returns list of shadow root ids for given context
+     */
+    getShadowRootsForContext(context?: string) {
+        const c = context || this.#currentContext
+        if (!c) {
+            return []
+        }
+        const shadowRoots = this.#shadowRoots.get(c)
+        return shadowRoots ? [...shadowRoots] : []
+    }
+}

--- a/packages/webdriverio/src/utils/getElementObject.ts
+++ b/packages/webdriverio/src/utils/getElementObject.ts
@@ -5,6 +5,8 @@ import type { ElementReference } from '@wdio/protocols'
 
 import { getBrowserObject, getPrototype as getWDIOPrototype, getElementFromResponse } from './index.js'
 import { elementErrorHandler } from '../middlewares.js'
+import { findStrategy } from '../utils/findStrategy.js'
+import { getShadowRootManager } from '../shadowRootManager.js'
 import * as browserCommands from '../commands/browser.js'
 import type { Selector, AddCommandFn } from '../types.js'
 
@@ -180,4 +182,38 @@ export const getElements = function getElements(
     })
 
     return elements
+}
+
+function elementPromiseHandler (el: ElementReference) {
+    if ('error' in el) {
+        return
+    }
+    return el as ElementReference
+}
+
+/**
+ * Parallel look up of a selector within multiple shadow roots
+ * @param this WebdriverIO Browser or Element instance
+ * @param selector selector to look up
+ * @param isMulti set to true if you call from `$$` command
+ * @returns a list of element references or undefined if not found
+ */
+export async function findDeepElement(
+    this: WebdriverIO.Browser | WebdriverIO.Element,
+    selector: Selector,
+    isMulti = false
+): Promise<(ElementReference | undefined)[]> {
+    const browser = getBrowserObject(this)
+    const shadowRootManager = getShadowRootManager(browser)
+    const shadowRoots = shadowRootManager.getShadowRootsForContext()
+    const { using, value } = findStrategy(selector as string, this.isW3C, this.isMobile)
+    const documentQuery = isMulti
+        ? browser.findElements(using, value)
+        : browser.findElement(using, value).then(elementPromiseHandler)
+    return (await Promise.all([
+        documentQuery,
+        ...[...shadowRoots].map((id) => (
+            browser.findElementFromShadowRoot(id, using, value).then(elementPromiseHandler)
+        ))
+    ])).flat()
 }

--- a/packages/webdriverio/tests/shadowRoot.test.ts
+++ b/packages/webdriverio/tests/shadowRoot.test.ts
@@ -26,7 +26,7 @@ describe('ShadowRootManager', () => {
     it('registers correct event listeners', async () => {
         const wid = process.env.VITEST_WORKER_ID
         delete process.env.VITEST_WORKER_ID
-        const browser = { ...defaultBrowser, isBidi: true } as any
+        const browser = { ...defaultBrowser, isBidi: true, options: { automationProtocol: 'webdriver' } } as any
         const manager = getShadowRootManager(browser)
         process.env.VITEST_WORKER_ID = wid
         expect(await manager.initialize()).toBe(true)
@@ -37,6 +37,15 @@ describe('ShadowRootManager', () => {
 
     it('should not register event listeners if not in bidi mode', async () => {
         const browser = { ...defaultBrowser } as any
+        const manager = getShadowRootManager(browser)
+        expect(await manager.initialize()).toBe(true)
+        expect(browser.sessionSubscribe).toBeCalledTimes(0)
+        expect(browser.on).toBeCalledTimes(0)
+        expect(browser.scriptAddPreloadScript).toBeCalledTimes(0)
+    })
+
+    it('should not register event listeners if not using webdriver as automation protocol', async () => {
+        const browser = { ...defaultBrowser, isBidi: true, automationProtocol: './protocol-stub.js' } as any
         const manager = getShadowRootManager(browser)
         expect(await manager.initialize()).toBe(true)
         expect(browser.sessionSubscribe).toBeCalledTimes(0)

--- a/packages/webdriverio/tests/shadowRoot.test.ts
+++ b/packages/webdriverio/tests/shadowRoot.test.ts
@@ -26,13 +26,22 @@ describe('ShadowRootManager', () => {
     it('registers correct event listeners', async () => {
         const wid = process.env.VITEST_WORKER_ID
         delete process.env.VITEST_WORKER_ID
-        const browser = { ...defaultBrowser } as any
+        const browser = { ...defaultBrowser, isBidi: true } as any
         const manager = getShadowRootManager(browser)
         process.env.VITEST_WORKER_ID = wid
         expect(await manager.initialize()).toBe(true)
         expect(browser.sessionSubscribe).toBeCalledTimes(1)
         expect(browser.on).toBeCalledTimes(2)
         expect(browser.scriptAddPreloadScript).toBeCalledTimes(1)
+    })
+
+    it('should not register event listeners if not in bidi mode', async () => {
+        const browser = { ...defaultBrowser } as any
+        const manager = getShadowRootManager(browser)
+        expect(await manager.initialize()).toBe(true)
+        expect(browser.sessionSubscribe).toBeCalledTimes(0)
+        expect(browser.on).toBeCalledTimes(0)
+        expect(browser.scriptAddPreloadScript).toBeCalledTimes(0)
     })
 
     it('should reset shadow roots on context load', () => {

--- a/packages/webdriverio/tests/shadowRoot.test.ts
+++ b/packages/webdriverio/tests/shadowRoot.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, vi, expect, beforeEach } from 'vitest'
+
+import { getShadowRootManager } from '../src/shadowRoot.js'
+
+const defaultBrowser = {
+    sessionSubscribe: vi.fn().mockResolvedValue({}),
+    on: vi.fn(),
+    scriptAddPreloadScript: vi.fn(),
+}
+
+describe('ShadowRootManager', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    it('should get shadow root manager per browser session', () => {
+        const browserA = { ...defaultBrowser } as any
+        const browserB = { ...defaultBrowser } as any
+        const managerA = getShadowRootManager(browserA)
+        const managerB = getShadowRootManager(browserB)
+        const managerC = getShadowRootManager(browserA)
+        expect(managerA).not.toBe(managerB)
+        expect(managerA).toBe(managerC)
+    })
+
+    it('registers correct event listeners', async () => {
+        const browser = { ...defaultBrowser } as any
+        const manager = getShadowRootManager(browser)
+        expect(await manager.initialize()).toBe(true)
+        expect(browser.sessionSubscribe).toBeCalledTimes(1)
+        expect(browser.on).toBeCalledTimes(2)
+        expect(browser.scriptAddPreloadScript).toBeCalledTimes(1)
+    })
+
+    it('should reset shadow roots on context load', () => {
+        const browser = { ...defaultBrowser } as any
+        const manager = getShadowRootManager(browser)
+        manager.handleBrowsingContextLoad({ context: 'foobar' } as any)
+        expect(manager.getShadowRootsForContext('foobar')).toEqual([])
+        const manager2 = getShadowRootManager({ ...defaultBrowser } as any)
+        expect(manager2.getShadowRootsForContext()).toEqual([])
+        manager2.deleteShadowRoot('foobar')
+    })
+
+    it('should capture shadow root elements', () => {
+        const browser = { ...defaultBrowser } as any
+        const manager = getShadowRootManager(browser)
+        manager.handleBrowsingContextLoad({ context: 'foobar' } as any)
+        manager.handleLogEntry({
+            level: 'debug',
+            args: [
+                { type: 'string', value: '[WDIO]' },
+                { type: 'string', value: 'newShadowRoot' },
+                { type: 'node', sharedId: 'foobar' },
+                { type: 'node', sharedId: 'barfoo' }
+            ],
+            source: { context: 'foobar' }
+        } as any)
+        expect(manager.getShadowRootsForContext('foobar')).toEqual(['foobar'])
+        expect(manager.getElementWithShadowDOM('foobar')).toBe('barfoo')
+    })
+
+    it('should delete shadow root elements', () => {
+        const browser = { ...defaultBrowser } as any
+        const manager = getShadowRootManager(browser)
+        manager.handleBrowsingContextLoad({ context: 'foobar' } as any)
+        manager.handleLogEntry({
+            level: 'debug',
+            args: [
+                { type: 'string', value: '[WDIO]' },
+                { type: 'string', value: 'newShadowRoot' },
+                { type: 'node', sharedId: 'foobar' },
+                { type: 'node', sharedId: 'barfoo' }
+            ],
+            source: { context: 'foobar' }
+        } as any)
+        manager.handleLogEntry({
+            level: 'debug',
+            args: [
+                { type: 'string', value: '[WDIO]' },
+                { type: 'string', value: 'removeShadowRoot' },
+                { type: 'node', sharedId: 'foobar' }
+            ],
+            source: { context: 'foobar' }
+        } as any)
+        expect(manager.getShadowRootsForContext('foobar')).toEqual([])
+        expect(manager.getElementWithShadowDOM('foobar')).toBe(undefined)
+    })
+
+    it('should ignore log entries that are not of interest', () => {
+        const browser = { ...defaultBrowser } as any
+        const manager = getShadowRootManager(browser)
+        manager.handleBrowsingContextLoad({ context: 'foobar' } as any)
+        manager.handleLogEntry({
+            level: 'debug',
+            args: [
+                { type: 'string', value: 'foobar' },
+                { type: 'string', value: 'newShadowRoot' },
+                { type: 'node', sharedId: 'foobar' },
+                { type: 'node', sharedId: 'barfoo' }
+            ],
+            source: { context: 'foobar' }
+        } as any)
+        expect(manager.getShadowRootsForContext('foobar')).toEqual([])
+    })
+
+    it('should throw if log entry is invalid', () => {
+        const browser = { ...defaultBrowser } as any
+        const manager = getShadowRootManager(browser)
+        manager.handleBrowsingContextLoad({ context: 'foobar' } as any)
+        expect(() => manager.handleLogEntry({
+            level: 'debug',
+            args: [
+                { type: 'string', value: '[WDIO]' },
+                { type: 'string', value: 'foobar' },
+                { type: 'node', sharedId: 'foobar' },
+                { type: 'node', sharedId: 'barfoo' }
+            ],
+            source: { context: 'foobar' }
+        } as any)).toThrow()
+    })
+
+    it('should handle log entries without args or context or with a different context', () => {
+        const browser = { ...defaultBrowser } as any
+        const manager = getShadowRootManager(browser)
+        manager.handleBrowsingContextLoad({ context: 'foobar' } as any)
+        manager.handleLogEntry({
+            level: 'debug',
+            source: { context: 'foobar' }
+        } as any)
+        manager.handleLogEntry({
+            level: 'debug',
+            args: [
+                { type: 'string', value: '[WDIO]' },
+                { type: 'string', value: 'foobar' },
+                { type: 'node', sharedId: 'foobar' },
+                { type: 'node', sharedId: 'barfoo' }
+            ],
+            source: {}
+        } as any)
+        manager.handleLogEntry({
+            level: 'debug',
+            args: [
+                { type: 'string', value: '[WDIO]' },
+                { type: 'string', value: 'newShadowRoot' },
+                { type: 'node', sharedId: 'foobar' },
+                { type: 'node', sharedId: 'barfoo' }
+            ],
+            source: { context: 'barfoo' }
+        } as any)
+        expect(manager.getShadowRootsForContext('foobar')).toEqual([])
+    })
+})

--- a/packages/webdriverio/tests/shadowRoot.test.ts
+++ b/packages/webdriverio/tests/shadowRoot.test.ts
@@ -24,8 +24,11 @@ describe('ShadowRootManager', () => {
     })
 
     it('registers correct event listeners', async () => {
+        const wid = process.env.VITEST_WORKER_ID
+        delete process.env.VITEST_WORKER_ID
         const browser = { ...defaultBrowser } as any
         const manager = getShadowRootManager(browser)
+        process.env.VITEST_WORKER_ID = wid
         expect(await manager.initialize()).toBe(true)
         expect(browser.sessionSubscribe).toBeCalledTimes(1)
         expect(browser.on).toBeCalledTimes(2)


### PR DESCRIPTION
## Proposed changes

With Bidi we can now inject a script to collect all initiated shadow roots in order to do a deep lookup effeciently.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

Thanks @erwinheitzman for coming up with this idea.

### Reviewers: @webdriverio/project-committers
