### PR TITLE
Fix appium service caps for multiremote

### DIFF
--- a/packages/wdio-appium-service/src/launcher.ts
+++ b/packages/wdio-appium-service/src/launcher.ts
@@ -77,12 +77,14 @@ export default class AppiumLauncher implements Services.ServiceInstance {
             for (const [, capability] of Object.entries(this._capabilities)) {
                 const cap = (capability.capabilities as Capabilities.W3CCapabilities) || capability
                 const c = (cap as Capabilities.W3CCapabilities).alwaysMatch || cap
-                !isCloudCapability(c) && isAppiumCapability(c) && Object.assign(
-                    capability,
-                    DEFAULT_CONNECTION,
-                    { path: this._args.basePath, port },
-                    { ...capability }
-                )
+                if (!isCloudCapability(c) && isAppiumCapability(c)) {
+                    Object.assign(
+                        capability,
+                        DEFAULT_CONNECTION,
+                        { path: this._args.basePath, port },
+                        { ...capability }
+                    )
+                }
             }
             return
         }

--- a/packages/wdio-appium-service/tests/launcher.test.ts
+++ b/packages/wdio-appium-service/tests/launcher.test.ts
@@ -162,6 +162,28 @@ describe('Appium launcher', () => {
             expect(capabilities.browserB.path).toBe('/')
         })
 
+        test('should set correct config properties of mixed browser and device using multiremote', async () => {
+            const options = {
+                logPath: './',
+                command: 'path/to/my_custom_appium',
+                args: { address: 'bar' }
+            }
+            const capabilities: Capabilities.MultiRemoteCapabilities = {
+                browserA: { port: 1234, capabilities: { browserName: 'chrome' } },
+                browserB: { capabilities: { deviceName: 'baz' } }
+            }
+            const launcher = new AppiumLauncher(options, capabilities, {} as any)
+            await launcher.onPrepare()
+            expect(capabilities.browserA.protocol).toBeUndefined()
+            expect(capabilities.browserA.hostname).toBeUndefined()
+            expect(capabilities.browserA.port).toBe(1234)
+            expect(capabilities.browserA.path).toBeUndefined()
+            expect(capabilities.browserB.protocol).toBe('http')
+            expect(capabilities.browserB.hostname).toBe('127.0.0.1')
+            expect(capabilities.browserB.port).toBe(4723)
+            expect(capabilities.browserB.path).toBe('/')
+        })
+
         test('should set correct config properties using parallel multiremote', async () => {
             const options = {
                 logPath: './',


### PR DESCRIPTION
## Proposed changes

Fixed for [#12382](https://github.com/webdriverio/webdriverio/issues/12382). Related to [pr#12455](https://github.com/webdriverio/webdriverio/pull/12455)

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
