### PR TITLE
(webdriverio): allow getHTML to pierce through Shadow DOM

### DIFF
--- a/e2e/browser-runner/__snapshots__/lit.test.js.snap
+++ b/e2e/browser-runner/__snapshots__/lit.test.js.snap
@@ -1,6 +1,25 @@
 // Snapshot v1
 
-exports[`Lit Component testing > should support snapshot testing 1`] = `"<simple-greeting name="WebdriverIO"></simple-greeting>"`;
+exports[`Lit Component testing > should support snapshot testing 1`] = `
+"<simple-greeting name="WebdriverIO">
+  <shadow-root>
+    <div>
+      <p>Hello Sir, WebdriverIO! Does this work?</p>
+      <button>Good</button>
+      <hr />
+      <em></em>
+      <sub-elem>
+        <shadow-root>
+          <div>
+            <p class="selectMe">I am within another shadow root element</p>
+            <p class="selectMeToo">I am within another shadow root element as well</p>
+          </div>
+        </shadow-root>
+      </sub-elem>
+    </div>
+  </shadow-root>
+</simple-greeting>"
+`;
 
 exports[`Lit Component testing > should support snapshot testing 3`] = `
 {

--- a/e2e/browser-runner/__snapshots__/lit.test.js.snap
+++ b/e2e/browser-runner/__snapshots__/lit.test.js.snap
@@ -1,6 +1,6 @@
 // Snapshot v1
 
-exports[`Lit Component testing > should support snapshot testing 1`] = `
+exports[`snapshot testing > of elements 1`] = `
 "<simple-greeting name="WebdriverIO">
   <shadow-root>
     <div>
@@ -21,7 +21,7 @@ exports[`Lit Component testing > should support snapshot testing 1`] = `
 </simple-greeting>"
 `;
 
-exports[`Lit Component testing > should support snapshot testing 3`] = `
+exports[`snapshot testing > of objects 1`] = `
 {
   "parsed": {
     "alpha": 0,
@@ -34,7 +34,7 @@ exports[`Lit Component testing > should support snapshot testing 3`] = `
 }
 `;
 
-exports[`Lit Component testing > should support snapshot testing 5`] = `
+exports[`snapshot testing > of objects 3`] = `
 {
   "foo": "bar",
 }

--- a/e2e/browser-runner/__snapshots__/lit.test.js.snap
+++ b/e2e/browser-runner/__snapshots__/lit.test.js.snap
@@ -4,7 +4,7 @@ exports[`Lit Component testing > should support snapshot testing 1`] = `
 "<simple-greeting name="WebdriverIO">
   <shadow-root>
     <div>
-      <p>Hello Sir, WebdriverIO! Does this work?</p>
+      <p>Hello Sir, WebdriverIO! How are you today?</p>
       <button>Good</button>
       <hr />
       <em></em>

--- a/e2e/browser-runner/__snapshots__/lit.test.js.snap
+++ b/e2e/browser-runner/__snapshots__/lit.test.js.snap
@@ -4,7 +4,7 @@ exports[`Lit Component testing > should support snapshot testing 1`] = `
 "<simple-greeting name="WebdriverIO">
   <shadow-root>
     <div>
-      <p>Hello Sir, WebdriverIO! How are you today?</p>
+      <p>Hello Sir, WebdriverIO! Does this work?</p>
       <button>Good</button>
       <hr />
       <em></em>

--- a/e2e/browser-runner/__snapshots__/react.test.tsx.snap
+++ b/e2e/browser-runner/__snapshots__/react.test.tsx.snap
@@ -1,3 +1,7 @@
 // Snapshot v1
 
-exports[`React Component Testing > supports snapshot tests 1`] = `"<div><button>Current theme: light</button></div>"`;
+exports[`React Component Testing > supports snapshot tests 1`] = `
+"<div>
+  <button>Current theme: light</button>
+</div>"
+`;

--- a/e2e/browser-runner/__snapshots__/stencil.test.tsx.snap
+++ b/e2e/browser-runner/__snapshots__/stencil.test.tsx.snap
@@ -1,7 +1,45 @@
 // Snapshot v1
 
-exports[`Stencil Component Testing > can auto peirce shadow dom 1`] = `"<nested-component><shadow-root><i>I am a first transparent component!</i><a href="#">I am a link</a></shadow-root></nested-component>"`;
+exports[`Stencil Component Testing > can auto peirce shadow dom 1`] = `
+"<nested-component>
+  <shadow-root>
+    <i>I am a first transparent component!</i>
+    <a href="#">I am a link</a>
+  </shadow-root>
+</nested-component>"
+`;
 
-exports[`Stencil Component Testing > can auto peirce shadow dom 2`] = `"<div class="nested"><nested-component><shadow-root><i>I am a transparent component in a nested context!</i><a href="#">I am a link</a></shadow-root></nested-component></div>"`;
+exports[`Stencil Component Testing > can auto peirce shadow dom 2`] = `
+"<div class="nested">
+  <nested-component>
+    <shadow-root>
+      <i>I am a transparent component in a nested context!</i>
+      <a href="#">I am a link</a>
+    </shadow-root>
+  </nested-component>
+</div>"
+`;
 
-exports[`Stencil Component Testing > can auto peirce shadow dom 3`] = `"<div class="nested second"><nested-component><shadow-root><i>I am a transparent component in a second nested context!</i><a href="#">I am a link</a></shadow-root></nested-component><app-profile><shadow-root><div class="app-profile"><p>Hello! My name is Stencil.</p><nested-component><shadow-root><i>I am a nested component!</i><a href="#">I am a link</a></shadow-root></nested-component></div></shadow-root></app-profile></div>"`;
+exports[`Stencil Component Testing > can auto peirce shadow dom 3`] = `
+"<div class="nested second">
+  <nested-component>
+    <shadow-root>
+      <i>I am a transparent component in a second nested context!</i>
+      <a href="#">I am a link</a>
+    </shadow-root>
+  </nested-component>
+  <app-profile>
+    <shadow-root>
+      <div class="app-profile">
+        <p>Hello! My name is Stencil.</p>
+        <nested-component>
+          <shadow-root>
+            <i>I am a nested component!</i>
+            <a href="#">I am a link</a>
+          </shadow-root>
+        </nested-component>
+      </div>
+    </shadow-root>
+  </app-profile>
+</div>"
+`;

--- a/e2e/browser-runner/__snapshots__/stencil.test.tsx.snap
+++ b/e2e/browser-runner/__snapshots__/stencil.test.tsx.snap
@@ -1,0 +1,5 @@
+// Snapshot v1
+
+exports[`Stencil Component Testing > can auto peirce shadow dom 1`] = `"<div class="nested"><nested-component><shadow-root><i>I am a transparent component in a nested context!</i><a href="#">I am a link</a></shadow-root></nested-component></div>"`;
+
+exports[`Stencil Component Testing > can auto peirce shadow dom 2`] = `"<div class="nested second"><nested-component><shadow-root><i>I am a transparent component in a second nested context!</i><a href="#">I am a link</a></shadow-root></nested-component><app-profile><shadow-root><div class="app-profile"><p>Hello! My name is Stencil.</p><nested-component><shadow-root><i>I am a nested component!</i><a href="#">I am a link</a></shadow-root></nested-component></div></shadow-root></app-profile></div>"`;

--- a/e2e/browser-runner/__snapshots__/stencil.test.tsx.snap
+++ b/e2e/browser-runner/__snapshots__/stencil.test.tsx.snap
@@ -1,5 +1,7 @@
 // Snapshot v1
 
-exports[`Stencil Component Testing > can auto peirce shadow dom 1`] = `"<div class="nested"><nested-component><shadow-root><i>I am a transparent component in a nested context!</i><a href="#">I am a link</a></shadow-root></nested-component></div>"`;
+exports[`Stencil Component Testing > can auto peirce shadow dom 1`] = `"<nested-component><shadow-root><i>I am a first transparent component!</i><a href="#">I am a link</a></shadow-root></nested-component>"`;
 
-exports[`Stencil Component Testing > can auto peirce shadow dom 2`] = `"<div class="nested second"><nested-component><shadow-root><i>I am a transparent component in a second nested context!</i><a href="#">I am a link</a></shadow-root></nested-component><app-profile><shadow-root><div class="app-profile"><p>Hello! My name is Stencil.</p><nested-component><shadow-root><i>I am a nested component!</i><a href="#">I am a link</a></shadow-root></nested-component></div></shadow-root></app-profile></div>"`;
+exports[`Stencil Component Testing > can auto peirce shadow dom 2`] = `"<div class="nested"><nested-component><shadow-root><i>I am a transparent component in a nested context!</i><a href="#">I am a link</a></shadow-root></nested-component></div>"`;
+
+exports[`Stencil Component Testing > can auto peirce shadow dom 3`] = `"<div class="nested second"><nested-component><shadow-root><i>I am a transparent component in a second nested context!</i><a href="#">I am a link</a></shadow-root></nested-component><app-profile><shadow-root><div class="app-profile"><p>Hello! My name is Stencil.</p><nested-component><shadow-root><i>I am a nested component!</i><a href="#">I am a link</a></shadow-root></nested-component></div></shadow-root></app-profile></div>"`;

--- a/e2e/browser-runner/lit.test.js
+++ b/e2e/browser-runner/lit.test.js
@@ -89,8 +89,35 @@ describe('Lit Component testing', () => {
         )
 
         const elem = $('simple-greeting')
-        await expect(elem).toMatchSnapshot()
-        await expect(elem).toMatchInlineSnapshot(`"<simple-greeting name="WebdriverIO" data-wdio-shadow-id="f.9F2C775DA5DB72E134B97FDD40090A63.d.4873A186E45373AB1606DC07D4CB59BC.e.18"></simple-greeting>"`)
+
+        /**
+         * only run snapshot tests in non-Safari browsers as shadow dom piercing
+         * is not yet supported in Safari
+         */
+        if (browser.capabilities.browserName?.toLowerCase() !== 'safari') {
+            await expect(elem).toMatchSnapshot()
+            await expect(elem).toMatchInlineSnapshot(`
+              "<simple-greeting name="WebdriverIO">
+                <shadow-root>
+                  <div>
+                    <p>Hello Sir, WebdriverIO! How are you today?</p>
+                    <button>Good</button>
+                    <hr />
+                    <em></em>
+                    <sub-elem>
+                      <shadow-root>
+                        <div>
+                          <p class="selectMe">I am within another shadow root element</p>
+                          <p class="selectMeToo">I am within another shadow root element as well</p>
+                        </div>
+                      </shadow-root>
+                    </sub-elem>
+                  </div>
+                </shadow-root>
+              </simple-greeting>"
+            `)
+        }
+
         await expect(elem.getCSSProperty('background-color')).toMatchSnapshot()
         await expect(elem.getCSSProperty('background-color')).toMatchInlineSnapshot(`
           {

--- a/e2e/browser-runner/lit.test.js
+++ b/e2e/browser-runner/lit.test.js
@@ -100,7 +100,7 @@ describe('Lit Component testing', () => {
               "<simple-greeting name="WebdriverIO">
                 <shadow-root>
                   <div>
-                    <p>Hello Sir, WebdriverIO! How are you today?</p>
+                    <p>Hello Sir, WebdriverIO! Does this work?</p>
                     <button>Good</button>
                     <hr />
                     <em></em>
@@ -222,6 +222,8 @@ describe('Lit Component testing', () => {
     })
 
     describe('Selector Tests', () => {
+        const getHTMLOptions = { includeSelectorTag: false, prettify: false }
+
         it('fetches element by content correctly', async () => {
             render(
                 html`<div><div><div>Find me</div></div></div>`,
@@ -244,10 +246,10 @@ describe('Lit Component testing', () => {
                 html`<div class="foo" id="#bar"><div><span>Find me</span></div></div>`,
                 document.body
             )
-            expect(await $('div.foo*=me').getHTML(false)).toBe('<div><span>Find me</span></div>')
-            expect(await $('.foo*=me').getHTML(false)).toBe('<div><span>Find me</span></div>')
-            expect(await $('div#bar*=me').getHTML(false)).toBe('<div><span>Find me</span></div>')
-            expect(await $('#bar*=me').getHTML(false)).toBe('<div><span>Find me</span></div>')
+            expect(await $('div.foo*=me').getHTML(getHTMLOptions)).toBe('<div><span>Find me</span></div>')
+            expect(await $('.foo*=me').getHTML(getHTMLOptions)).toBe('<div><span>Find me</span></div>')
+            expect(await $('div#bar*=me').getHTML(getHTMLOptions)).toBe('<div><span>Find me</span></div>')
+            expect(await $('#bar*=me').getHTML(getHTMLOptions)).toBe('<div><span>Find me</span></div>')
         })
 
         const outerClassLists = ['foo', 'bar foo', 'foo bar baz', 'bar foo baz', 'bar baz foo']
@@ -259,7 +261,7 @@ describe('Lit Component testing', () => {
                         html`<div class="${outerClassList}"><div class="${innerClassList}"></div><div><div>Find me</div></div></div>`,
                         document.body
                     )
-                    expect(await $('.foo*=Find').getHTML(false)).toBe(`<div class="${innerClassList}"></div><div><div>Find me</div></div>`)
+                    expect(await $('.foo*=Find').getHTML(getHTMLOptions)).toBe(`<div class="${innerClassList}"></div><div><div>Find me</div></div>`)
                 })
             }
         }
@@ -281,10 +283,10 @@ describe('Lit Component testing', () => {
                 <div class="foo" id="#bar"><div><div class="foo" id="#bar"><div><span>Find me</span></div></div></div></div>`,
                 document.body
             )
-            expect(await $('div.foo*=me').getHTML(false)).toBe('<div><span>Find me</span></div>')
-            expect(await $('.foo*=me').getHTML(false)).toBe('<div><span>Find me</span></div>')
-            expect(await $('div#bar*=me').getHTML(false)).toBe('<div><span>Find me</span></div>')
-            expect(await $('#bar*=me').getHTML(false)).toBe('<div><span>Find me</span></div>')
+            expect(await $('div.foo*=me').getHTML(getHTMLOptions)).toBe('<div><span>Find me</span></div>')
+            expect(await $('.foo*=me').getHTML(getHTMLOptions)).toBe('<div><span>Find me</span></div>')
+            expect(await $('div#bar*=me').getHTML(getHTMLOptions)).toBe('<div><span>Find me</span></div>')
+            expect(await $('#bar*=me').getHTML(getHTMLOptions)).toBe('<div><span>Find me</span></div>')
         })
 
         it('fetches inner element by content correctly with nested attribute selector', async () => {
@@ -304,10 +306,10 @@ describe('Lit Component testing', () => {
                 <div data-testid="foobar"><div><div data-testid="foobar"><div><span>Find me</span></div></div></div></div>`,
                 document.body
             )
-            expect(await $('[data-testid="foobar"]*=me').getHTML(false)).toBe('<div><span>Find me</span></div>')
-            expect(await $('[data-testid]*=me').getHTML(false)).toBe('<div><span>Find me</span></div>')
-            expect(await $('div[data-testid="foobar"]*=me').getHTML(false)).toBe('<div><span>Find me</span></div>')
-            expect(await $('div[data-testid]*=me').getHTML(false)).toBe('<div><span>Find me</span></div>')
+            expect(await $('[data-testid="foobar"]*=me').getHTML(getHTMLOptions)).toBe('<div><span>Find me</span></div>')
+            expect(await $('[data-testid]*=me').getHTML(getHTMLOptions)).toBe('<div><span>Find me</span></div>')
+            expect(await $('div[data-testid="foobar"]*=me').getHTML(getHTMLOptions)).toBe('<div><span>Find me</span></div>')
+            expect(await $('div[data-testid]*=me').getHTML(getHTMLOptions)).toBe('<div><span>Find me</span></div>')
         })
 
         it('fetches the parent element by content correctly', async () => {

--- a/e2e/browser-runner/lit.test.js
+++ b/e2e/browser-runner/lit.test.js
@@ -82,19 +82,24 @@ describe('Lit Component testing', () => {
         expect(Date.now() - start).toBeLessThan(1000)
     })
 
-    it('should support snapshot testing', async () => {
-        render(
-            html`<simple-greeting name="WebdriverIO" />`,
-            document.body
-        )
+    describe('snapshot testing', () => {
+        beforeEach(() => {
+            render(
+                html`<simple-greeting name="WebdriverIO" />`,
+                document.body
+            )
+        })
 
-        const elem = $('simple-greeting')
+        it('of elements', async () => {
+            /**
+             * only run snapshot tests in non-Safari browsers as shadow dom piercing
+             * is not yet supported in Safari
+             */
+            if (browser.capabilities.browserName?.toLowerCase() === 'safari') {
+                return
+            }
 
-        /**
-         * only run snapshot tests in non-Safari browsers as shadow dom piercing
-         * is not yet supported in Safari
-         */
-        if (browser.capabilities.browserName?.toLowerCase() !== 'safari') {
+            const elem = $('simple-greeting')
             await expect(elem).toMatchSnapshot()
             await expect(elem).toMatchInlineSnapshot(`
               "<simple-greeting name="WebdriverIO">
@@ -116,27 +121,30 @@ describe('Lit Component testing', () => {
                 </shadow-root>
               </simple-greeting>"
             `)
-        }
+        })
 
-        await expect(elem.getCSSProperty('background-color')).toMatchSnapshot()
-        await expect(elem.getCSSProperty('background-color')).toMatchInlineSnapshot(`
-          {
-            "parsed": {
-              "alpha": 0,
-              "hex": "#000000",
-              "rgba": "rgba(0,0,0,0)",
-              "type": "color",
-            },
-            "property": "background-color",
-            "value": "rgba(0,0,0,0)",
-          }
-        `)
-        await expect({ foo: 'bar' }).toMatchSnapshot()
-        await expect({ foo: 'bar' }).toMatchInlineSnapshot(`
-          {
-            "foo": "bar",
-          }
-        `)
+        it('of objects', async () => {
+            const elem = $('simple-greeting')
+            await expect(elem.getCSSProperty('background-color')).toMatchSnapshot()
+            await expect(elem.getCSSProperty('background-color')).toMatchInlineSnapshot(`
+              {
+                "parsed": {
+                  "alpha": 0,
+                  "hex": "#000000",
+                  "rgba": "rgba(0,0,0,0)",
+                  "type": "color",
+                },
+                "property": "background-color",
+                "value": "rgba(0,0,0,0)",
+              }
+            `)
+            await expect({ foo: 'bar' }).toMatchSnapshot()
+            await expect({ foo: 'bar' }).toMatchInlineSnapshot(`
+              {
+                "foo": "bar",
+              }
+            `)
+        })
     })
 
     it('should allow to auto mock dependencies', () => {

--- a/e2e/browser-runner/lit.test.js
+++ b/e2e/browser-runner/lit.test.js
@@ -90,7 +90,7 @@ describe('Lit Component testing', () => {
 
         const elem = $('simple-greeting')
         await expect(elem).toMatchSnapshot()
-        await expect(elem).toMatchInlineSnapshot('"<simple-greeting name="WebdriverIO"></simple-greeting>"')
+        await expect(elem).toMatchInlineSnapshot(`"<simple-greeting name="WebdriverIO" data-wdio-shadow-id="f.9F2C775DA5DB72E134B97FDD40090A63.d.4873A186E45373AB1606DC07D4CB59BC.e.18"></simple-greeting>"`)
         await expect(elem.getCSSProperty('background-color')).toMatchSnapshot()
         await expect(elem.getCSSProperty('background-color')).toMatchInlineSnapshot(`
           {

--- a/e2e/browser-runner/react.test.tsx
+++ b/e2e/browser-runner/react.test.tsx
@@ -20,6 +20,10 @@ describe('React Component Testing', () => {
     it('supports snapshot tests', async () => {
         const { container } = render(<App />)
         await expect(container).toMatchSnapshot()
-        await expect(container).toMatchInlineSnapshot('"<div><button>Current theme: light</button></div>"')
+        await expect(container).toMatchInlineSnapshot(`
+          "<div>
+            <button>Current theme: light</button>
+          </div>"
+        `)
     })
 })

--- a/e2e/browser-runner/stencil.test.tsx
+++ b/e2e/browser-runner/stencil.test.tsx
@@ -156,6 +156,7 @@ describe('Stencil Component Testing', () => {
             'I am a nested component!'
         ])
 
+        await expect($('nested-component')).toMatchSnapshot()
         await expect($('.nested')).toMatchSnapshot()
         await expect($('.second')).toMatchSnapshot()
     })

--- a/e2e/browser-runner/stencil.test.tsx
+++ b/e2e/browser-runner/stencil.test.tsx
@@ -155,5 +155,8 @@ describe('Stencil Component Testing', () => {
             'I am a transparent component in a second nested context!',
             'I am a nested component!'
         ])
+
+        await expect($('.nested')).toMatchSnapshot()
+        await expect($('.second')).toMatchSnapshot()
     })
 })

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -63,7 +63,7 @@
     "string-width": "^7.1.0",
     "tailwindcss": "^3.4.1",
     "vite": "^5.1.3",
-    "webdriverio": "^8.32.3"
+    "webdriverio": "workspace:*"
   },
   "dependencies": {
     "@stencil-community/router": "^1.0.2",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -24,7 +24,7 @@
     "test:browser:lit:verifyCoverage": "run-s verifyCoverage",
     "test:browser:lit:verifyScreenshotFile": "test -f ./screenshot.png && rm ./screenshot.png",
     "test:browser:stencil": "run-s test:browser:stencil:*",
-    "test:browser:stencil:wdio": "cross-env WDIO_PRESET=stencil node ../packages/wdio-cli/bin/wdio.js ./browser-runner/wdio.conf.js --spec stencil.test.tsx -s",
+    "test:browser:stencil:wdio": "cross-env WDIO_PRESET=stencil node ../packages/wdio-cli/bin/wdio.js ./browser-runner/wdio.conf.js --spec stencil.test.tsx",
     "test:browser:stencil:verifyCoverage": "run-s verifyCoverage",
     "test:mocha": "node ../packages/wdio-cli/bin/wdio.js ./mocha/wdio.conf.js",
     "test:jasmine": "node ../packages/wdio-cli/bin/wdio.js ./jasmine/wdio.conf.js",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -24,7 +24,7 @@
     "test:browser:lit:verifyCoverage": "run-s verifyCoverage",
     "test:browser:lit:verifyScreenshotFile": "test -f ./screenshot.png && rm ./screenshot.png",
     "test:browser:stencil": "run-s test:browser:stencil:*",
-    "test:browser:stencil:wdio": "cross-env WDIO_PRESET=stencil node ../packages/wdio-cli/bin/wdio.js ./browser-runner/wdio.conf.js --spec stencil.test.tsx",
+    "test:browser:stencil:wdio": "cross-env WDIO_PRESET=stencil node ../packages/wdio-cli/bin/wdio.js ./browser-runner/wdio.conf.js --spec stencil.test.tsx -s",
     "test:browser:stencil:verifyCoverage": "run-s verifyCoverage",
     "test:mocha": "node ../packages/wdio-cli/bin/wdio.js ./mocha/wdio.conf.js",
     "test:jasmine": "node ../packages/wdio-cli/bin/wdio.js ./jasmine/wdio.conf.js",

--- a/packages/wdio-runner/src/browser.ts
+++ b/packages/wdio-runner/src/browser.ts
@@ -306,19 +306,19 @@ export default class BrowserFramework implements Omit<TestFramework, 'init'> {
 
         try {
             /**
-             * double check if function is registered
-             */
-            if (typeof browser[payload.commandName as keyof typeof browser] !== 'function') {
-                throw new Error(`browser.${payload.commandName} is not a function`)
-            }
-
-            /**
              * user either the browser instance or an element based on whether or not
              * a scope property was passed in
              */
             const scope = payload.scope
                 ? await browser.$({ [ELEMENT_KEY]: payload.scope })
                 : browser
+
+            /**
+             * double check if function is registered
+             */
+            if (typeof scope[payload.commandName as keyof typeof scope] !== 'function') {
+                throw new Error(`${payload.scope ? 'element' : 'browser'}.${payload.commandName} is not a function`)
+            }
 
             let result = await (scope[payload.commandName as keyof typeof scope] as Function)(...payload.args)
 

--- a/packages/webdriverio/package.json
+++ b/packages/webdriverio/package.json
@@ -76,6 +76,7 @@
     "@wdio/utils": "9.0.0-alpha.0",
     "archiver": "^7.0.0",
     "aria-query": "^5.0.0",
+    "cheerio": "^1.0.0-rc.12",
     "css-shorthand-properties": "^1.1.1",
     "css-value": "^0.0.1",
     "grapheme-splitter": "^1.0.2",

--- a/packages/webdriverio/package.json
+++ b/packages/webdriverio/package.json
@@ -80,6 +80,7 @@
     "css-shorthand-properties": "^1.1.1",
     "css-value": "^0.0.1",
     "grapheme-splitter": "^1.0.2",
+    "htmlfy": "^0.1.0",
     "import-meta-resolve": "^4.0.0",
     "is-plain-obj": "^4.1.0",
     "lodash.clonedeep": "^4.5.0",

--- a/packages/webdriverio/src/commands/element/getHTML.ts
+++ b/packages/webdriverio/src/commands/element/getHTML.ts
@@ -1,7 +1,24 @@
 import { ELEMENT_KEY } from 'webdriver'
+import type { CheerioAPI } from 'cheerio'
 
 import { getBrowserObject } from '../../utils/index.js'
+import { getShadowRootManager } from '../../shadowRoot.js'
 import getHTMLScript from '../../scripts/getHTML.js'
+import getHTMLShadowScript from '../../scripts/getHTMLShadow.js'
+
+export interface GetHTMLOptions {
+    /**
+     * if true it includes the selector element tag (default: true)
+     * @default true
+     */
+    includeSelectorTag?: boolean
+    /**
+     * if true it includes content of the shadow roots of all web
+     * components in the DOM (default: true)
+     * @default true
+     */
+    pierceShadowRoot?: boolean
+}
 
 /**
  *
@@ -27,19 +44,135 @@ import getHTMLScript from '../../scripts/getHTML.js'
  * </example>
  *
  * @alias element.getHTML
+ * @param {}
  * @param {Boolean=} includeSelectorTag if true it includes the selector element tag (default: true)
  * @return {String}  the HTML of the specified element
  * @uses action/selectorExecute
  * @type property
  *
  */
-export function getHTML (
+export async function getHTML(
     this: WebdriverIO.Element,
-    includeSelectorTag = true
+    {
+        includeSelectorTag = true,
+        pierceShadowRoot = true
+    }: GetHTMLOptions = {}
 ) {
     const browser = getBrowserObject(this)
-    return browser.execute(getHTMLScript, {
-        [ELEMENT_KEY]: this.elementId, // w3c compatible
-        ELEMENT: this.elementId // jsonwp compatible
-    } as any as HTMLElement, includeSelectorTag)
+
+    const basicGetHTML = (elementId: string, includeSelectorTag: boolean) => {
+        return browser.execute(getHTMLScript, {
+            [ELEMENT_KEY]: elementId, // w3c compatible
+            ELEMENT: elementId // jsonwp compatible
+        } as any as HTMLElement, includeSelectorTag)
+    }
+
+    if (pierceShadowRoot) {
+        if (!this.isBidi) {
+            throw new Error('Piercing shadow roots when calling `getHTML()` is only supported when using WebDriver Bidi')
+        }
+
+        /**
+         * ensure command in Node.js world
+         */
+        if (globalThis.wdio) {
+            return globalThis.wdio.executeWithScope('getHTML' as const, this.elementId, includeSelectorTag)
+        }
+
+        const { load } = await import('cheerio')
+        const shadowRootManager = getShadowRootManager(browser)
+        const handle = await browser.getWindowHandle()
+        const shadowRoots = shadowRootManager.getShadowRootsForContext(handle)
+
+        /**
+         * first get all shadow roots and their elements as ElementReference
+         */
+        const elemsWithShadowRootAndId = shadowRoots.map((shadowRootId) => [
+            shadowRootId,
+            { [ELEMENT_KEY]: shadowRootManager.getElementWithShadowDOM(shadowRootId) }
+        ]) as unknown as [string, HTMLElement][]
+
+        /**
+         * then get the HTML of the element and its shadow roots
+         */
+        const { html, shadowElementIdsFound } = await browser.execute(
+            getHTMLShadowScript,
+            { [ELEMENT_KEY]: this.elementId } as any as HTMLElement,
+            includeSelectorTag,
+            elemsWithShadowRootAndId
+        )
+
+        /**
+         * in case the given element has no elements containing a shadow root
+         * we can return the HTML right away
+         */
+        if (shadowElementIdsFound.length === 0) {
+            return html
+        }
+
+        const $ = load(html)
+        await pierceIntoShadowDOM.call(browser, $, elemsWithShadowRootAndId, shadowElementIdsFound)
+
+        /**
+         * delete data-wdio-shadow-id attribute as it contains random ids that
+         * can cause failures when taking a snapshot of a Shadow DOM element
+         */
+        $('shadow-root[id]').each((_, el) => { delete el.attribs.id })
+        $('[data-wdio-shadow-id]').each((_, el) => { delete el.attribs['data-wdio-shadow-id'] })
+
+        return $('body').html()
+    }
+
+    return basicGetHTML(this.elementId, includeSelectorTag)
+}
+
+/**
+ * Recursively pierce into shadow DOMs
+ * @param browser WebdriverIO browser object
+ * @param $ Cheerio object with our virtual DOM we are trying to build up with shadow DOM content
+ * @param elemsWithShadowRootAndId list of all shadow root ids and their elements as ElementReference
+ * @param shadowElementIdsFound list of shadow root ids we want to look up in the next iteration
+ */
+async function pierceIntoShadowDOM (
+    this: WebdriverIO.Browser,
+    $: CheerioAPI,
+    elemsWithShadowRootAndId: [string, HTMLElement][],
+    shadowElementIdsFound: string[]
+): Promise<void> {
+    /**
+     * fetch html of shadow roots
+     */
+    const shadowRootContent = await Promise.all(shadowElementIdsFound.map((sel) => (
+        this.execute(
+            getHTMLShadowScript,
+            { [ELEMENT_KEY]: sel } as any as HTMLElement,
+            false,
+            elemsWithShadowRootAndId
+        ).then(({ html, shadowElementIdsFound }) => (
+            { html, shadowElementIdsFound, shadowRootId: sel }
+        ))
+    )))
+
+    /**
+     * update virtual DOM and inject shadow root content
+     */
+    for (const s of shadowElementIdsFound) {
+        const se = $(`[data-wdio-shadow-id="${s}"]`)
+        if (!se) {
+            continue
+        }
+        const { html } = shadowRootContent.find(({ shadowRootId }) => s === shadowRootId)!
+        se.append(`<shadow-root id="${s}">${html}</shadow-root>`)
+    }
+
+    const elementsToLookup = shadowRootContent.map(({ shadowElementIdsFound }) => shadowElementIdsFound).flat()
+
+    /**
+     * stop recursion if no more shadow roots to look up
+     */
+    if (elementsToLookup.length === 0) {
+        return
+    }
+
+    return pierceIntoShadowDOM.call(this, $, elemsWithShadowRootAndId, elementsToLookup)
 }

--- a/packages/webdriverio/src/commands/element/getHTML.ts
+++ b/packages/webdriverio/src/commands/element/getHTML.ts
@@ -14,7 +14,7 @@ export interface GetHTMLOptions {
     includeSelectorTag?: boolean
     /**
      * if true it includes content of the shadow roots of all web
-     * components in the DOM (default: true)
+     * components in the DOM (default: true if WebDriver Bidi is enabled)
      * @default true
      */
     pierceShadowRoot?: boolean

--- a/packages/webdriverio/src/commands/element/getHTML.ts
+++ b/packages/webdriverio/src/commands/element/getHTML.ts
@@ -101,7 +101,10 @@ export async function getHTML(
          * ensure command in Node.js world
          */
         if (globalThis.wdio) {
-            return globalThis.wdio.executeWithScope('getHTML' as const, this.elementId, includeSelectorTag)
+            return globalThis.wdio.executeWithScope(
+                'getHTML' as const, this.elementId,
+                { includeSelectorTag, pierceShadowRoot, removeCommentNodes, prettify }
+            )
         }
 
         const { load } = await import('cheerio')

--- a/packages/webdriverio/src/commands/element/getHTML.ts
+++ b/packages/webdriverio/src/commands/element/getHTML.ts
@@ -22,7 +22,8 @@ export interface GetHTMLOptions {
 
 /**
  *
- * Get source code of specified DOM element by selector.
+ * Get source code of specified DOM element by selector. By default, it automatically
+ * pierces through all shadow roots of elements contained by the element.
  *
  * <example>
     :index.html
@@ -36,7 +37,7 @@ export interface GetHTMLOptions {
         // outputs:
         // "<div id="test"><span>Lorem ipsum dolor amet</span></div>"
 
-        var innerHTML = await $('#test').getHTML(false);
+        var innerHTML = await $('#test').getHTML({ includeSelectorTag: false });
         console.log(innerHTML);
         // outputs:
         // "<span>Lorem ipsum dolor amet</span>"
@@ -44,8 +45,9 @@ export interface GetHTMLOptions {
  * </example>
  *
  * @alias element.getHTML
- * @param {}
- * @param {Boolean=} includeSelectorTag if true it includes the selector element tag (default: true)
+ * @param {GetHTMLOptions} options                    command options
+ * @param {Boolean=}       options.includeSelectorTag if true it includes the selector element tag (default: true)
+ * @param {Boolean=}       options.pierceShadowRoot   if true it includes content of the shadow roots of all web components in the DOM
  * @return {String}  the HTML of the specified element
  * @uses action/selectorExecute
  * @type property

--- a/packages/webdriverio/src/commands/element/getHTML.ts
+++ b/packages/webdriverio/src/commands/element/getHTML.ts
@@ -59,14 +59,19 @@ export interface GetHTMLOptions {
  */
 export async function getHTML(
     this: WebdriverIO.Element,
-    {
-        includeSelectorTag = true,
-        pierceShadowRoot = true,
-        removeCommentNodes = true
-    }: GetHTMLOptions = {}
+    options: GetHTMLOptions = {}
 ) {
     const browser = getBrowserObject(this)
 
+    if (typeof options !== 'object') {
+        throw new Error('The `getHTML` options parameter must be an object')
+    }
+
+    const {
+        includeSelectorTag = true,
+        pierceShadowRoot = true,
+        removeCommentNodes = true
+    } = options
     const basicGetHTML = (elementId: string, includeSelectorTag: boolean) => {
         return browser.execute(getHTMLScript, {
             [ELEMENT_KEY]: elementId, // w3c compatible

--- a/packages/webdriverio/src/commands/element/getHTML.ts
+++ b/packages/webdriverio/src/commands/element/getHTML.ts
@@ -1,5 +1,6 @@
 import { ELEMENT_KEY } from 'webdriver'
 import type { CheerioAPI } from 'cheerio'
+import { prettify as prettifyFn } from 'htmlfy'
 
 import { getBrowserObject } from '../../utils/index.js'
 import { getShadowRootManager } from '../../shadowRoot.js'
@@ -8,20 +9,26 @@ import getHTMLShadowScript from '../../scripts/getHTMLShadow.js'
 
 export interface GetHTMLOptions {
     /**
-     * if true it includes the selector element tag (default: true)
+     * if true, it includes the selector element tag (default: true)
      * @default true
      */
     includeSelectorTag?: boolean
     /**
-     * if true it includes content of the shadow roots of all web
+     * if true, it includes content of the shadow roots of all web
      * components in the DOM (default: true if WebDriver Bidi is enabled)
      * @default true
      */
     pierceShadowRoot?: boolean
     /**
-     * if true it removes all comment nodes from the HTML, e.g. `<!--?lit$206212805$--><!--?lit$206212805$-->`
+     * if true, it removes all comment nodes from the HTML, e.g. `<!--?lit$206212805$--><!--?lit$206212805$-->`
+     * @default true
      */
     removeCommentNodes?: boolean
+    /**
+     * if true, the html output will be prettified
+     * @default true
+     */
+    prettify?: boolean
 }
 
 /**
@@ -76,7 +83,8 @@ export async function getHTML(
     const {
         includeSelectorTag = true,
         pierceShadowRoot = true,
-        removeCommentNodes = true
+        removeCommentNodes = true,
+        prettify = true
     } = options
     const basicGetHTML = (elementId: string, includeSelectorTag: boolean) => {
         return browser.execute(getHTMLScript, {
@@ -134,11 +142,11 @@ export async function getHTML(
         $('shadow-root[id]').each((_, el) => { delete el.attribs.id })
         $('[data-wdio-shadow-id]').each((_, el) => { delete el.attribs['data-wdio-shadow-id'] })
 
-        let returnHTML = $('body').html()
+        let returnHTML = $('body').html() as string
         if (removeCommentNodes && returnHTML) {
             returnHTML = returnHTML?.replace(/<!--[\s\S]*?-->/g, '')
         }
-        return returnHTML
+        return prettify ? prettifyFn(returnHTML) : returnHTML
     }
 
     let returnHTML = await basicGetHTML(this.elementId, includeSelectorTag)

--- a/packages/webdriverio/src/commands/element/getHTML.ts
+++ b/packages/webdriverio/src/commands/element/getHTML.ts
@@ -217,5 +217,11 @@ function sanitizeHTML ($: CheerioAPI | string, options: GetHTMLOptions = {}): st
     if (options.removeCommentNodes) {
         returnHTML = returnHTML?.replace(/<!--[\s\S]*?-->/g, '')
     }
-    return options.prettify ? prettifyFn(returnHTML) : returnHTML
+    return options.prettify && returnHTML.includes('<')
+        // we have to verify if HTML string starts with `<` and ends with `>` to avoid
+        // https://github.com/j4w8n/htmlfy/issues/3
+        ? prettifyFn(
+            `${returnHTML.startsWith('<') ? '' : ' '}${returnHTML}${returnHTML.endsWith('>') ? '' : ' '}`
+        )
+        : returnHTML
 }

--- a/packages/webdriverio/src/commands/element/getHTML.ts
+++ b/packages/webdriverio/src/commands/element/getHTML.ts
@@ -67,7 +67,7 @@ export async function getHTML(
      * `getHTML` options used to be a string that was the `includeSelectorTag` option
      * and we need to ensure backwards compatibility
      */
-    if (typeof options !== 'object' && typeof options === 'string') {
+    if (typeof options !== 'object' && typeof options === 'boolean') {
         options = { includeSelectorTag: options }
     } else if (typeof options !== 'object') {
         throw new Error('The `getHTML` options parameter must be an object')

--- a/packages/webdriverio/src/commands/element/getHTML.ts
+++ b/packages/webdriverio/src/commands/element/getHTML.ts
@@ -63,7 +63,13 @@ export async function getHTML(
 ) {
     const browser = getBrowserObject(this)
 
-    if (typeof options !== 'object') {
+    /**
+     * `getHTML` options used to be a string that was the `includeSelectorTag` option
+     * and we need to ensure backwards compatibility
+     */
+    if (typeof options !== 'object' && typeof options === 'string') {
+        options = { includeSelectorTag: options }
+    } else if (typeof options !== 'object') {
         throw new Error('The `getHTML` options parameter must be an object')
     }
 

--- a/packages/webdriverio/src/scripts/getHTMLShadow.ts
+++ b/packages/webdriverio/src/scripts/getHTMLShadow.ts
@@ -1,9 +1,10 @@
 /**
- * get HTML of selector element
+ * get HTML of selector element and peirce through all Shadow DOM documents
  *
- * @param  {string}  element             element to get HTML from
- * @param  {Boolean} includeSelectorTag  if true, selector tag gets included (uses outerHTML)
- * @return {String}                      html source
+ * @param  {string}  element               element to get HTML from
+ * @param  {Boolean} includeSelectorTag    if true, selector tag gets included (uses outerHTML)
+ * @param  {Object}  shadowElementIdsFound list of shadow root ids we want to look up in the next iteration
+ * @return {Object}                        html source and list of shadow root ids found
  */
 export default function getHTMLShadow (
     element: HTMLElement,
@@ -13,11 +14,23 @@ export default function getHTMLShadow (
     const shadowElementIdsFound: string[] = []
     const elemsWithShadowRoot = Array.from(element.querySelectorAll('*'))
         .filter((el) => el.shadowRoot)
+
+    /**
+     * make sure to include the root itself
+     */
+    if (element.shadowRoot) {
+        elemsWithShadowRoot.unshift(element)
+    }
+
     for (const elem of elemsWithShadowRoot) {
         if (elem.hasAttribute('data-wdio-shadow-id')) {
             continue
         }
 
+        /**
+         * attach `data-wdio-shadow-id` attribute to the element so we can later
+         * identify it and pierce into its shadow root
+         */
         const shadowElement = shadowElementIds.find(([, sel]) => elem === sel)
         if (shadowElement) {
             shadowElementIdsFound.push(shadowElement[0])

--- a/packages/webdriverio/src/scripts/getHTMLShadow.ts
+++ b/packages/webdriverio/src/scripts/getHTMLShadow.ts
@@ -1,0 +1,32 @@
+/**
+ * get HTML of selector element
+ *
+ * @param  {string}  element             element to get HTML from
+ * @param  {Boolean} includeSelectorTag  if true, selector tag gets included (uses outerHTML)
+ * @return {String}                      html source
+ */
+export default function getHTMLShadow (
+    element: HTMLElement,
+    includeSelectorTag: boolean,
+    shadowElementIds: [string, HTMLElement][] = []
+) {
+    const shadowElementIdsFound: string[] = []
+    const elemsWithShadowRoot = Array.from(element.querySelectorAll('*'))
+        .filter((el) => el.shadowRoot)
+    for (const elem of elemsWithShadowRoot) {
+        if (elem.hasAttribute('data-wdio-shadow-id')) {
+            continue
+        }
+
+        const shadowElement = shadowElementIds.find(([, sel]) => elem === sel)
+        if (shadowElement) {
+            shadowElementIdsFound.push(shadowElement[0])
+            elem.setAttribute('data-wdio-shadow-id', shadowElement[0])
+        }
+    }
+
+    return {
+        html: element[includeSelectorTag ? 'outerHTML' : 'innerHTML'],
+        shadowElementIdsFound
+    }
+}

--- a/packages/webdriverio/src/scripts/getHTMLShadow.ts
+++ b/packages/webdriverio/src/scripts/getHTMLShadow.ts
@@ -23,10 +23,6 @@ export default function getHTMLShadow (
     }
 
     for (const elem of elemsWithShadowRoot) {
-        if (elem.hasAttribute('data-wdio-shadow-id')) {
-            continue
-        }
-
         /**
          * attach `data-wdio-shadow-id` attribute to the element so we can later
          * identify it and pierce into its shadow root

--- a/packages/webdriverio/tests/commands/element/getHTML.test.ts
+++ b/packages/webdriverio/tests/commands/element/getHTML.test.ts
@@ -27,7 +27,7 @@ describe('getHTML test', () => {
             .toBe('/session/foobar-123/execute/sync')
         expect(result).toBe('<some>outer html</some>')
 
-        result = await elem.getHTML(false)
+        result = await elem.getHTML({ includeSelectorTag: false })
         expect(result).toBe('some inner html')
     })
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -301,8 +301,8 @@ importers:
         specifier: ^5.1.3
         version: 5.1.6(@types/node@20.11.26)
       webdriverio:
-        specifier: ^8.32.3
-        version: 8.33.1(typescript@5.4.2)
+        specifier: workspace:*
+        version: link:../packages/webdriverio
 
   e2e/browser-runner: {}
 
@@ -6138,6 +6138,7 @@ packages:
       yargs: 17.7.1
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /@puppeteer/browsers@1.9.1:
     resolution: {integrity: sha512-PuvK6xZzGhKPvlx3fpfdM2kYY3P/hB1URtK8wA7XUJ6prn6pp22zvJHu48th0SGcHL9SutbPHrFuQgfXTFobWA==}
@@ -6153,6 +6154,7 @@ packages:
       yargs: 17.7.2
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /@puppeteer/browsers@2.1.0:
     resolution: {integrity: sha512-xloWvocjvryHdUjDam/ZuGMh7zn4Sn3ZAaV4Ah2e2EwEt90N3XphZlSsU3n0VDc1F7kggCjMuH0UuxfPQ5mD9w==}
@@ -8033,6 +8035,7 @@ packages:
 
   /@types/which@2.0.2:
     resolution: {integrity: sha512-113D3mDkZDjo+EeUEHCFy0qniNc1ZpecGiAU7WSo7YDoSzolZIQKpYFHrPpjkB2nuyahcKfrmLXeQlh7gqJYdw==}
+    dev: false
 
   /@types/ws@8.5.10:
     resolution: {integrity: sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==}
@@ -8403,6 +8406,7 @@ packages:
       import-meta-resolve: 4.0.0
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /@wdio/globals@8.33.1(typescript@5.4.2):
     resolution: {integrity: sha512-1ud9oq7n9MMNywS/FoMRRWqW6uhcoxgnpXoGeLE2Tr+4f937ABOl+sfZgjycXujyvR7yTL8AROOYajp1Yuv1Xg==}
@@ -8428,21 +8432,25 @@ packages:
       loglevel: 1.9.1
       loglevel-plugin-prefix: 0.8.4
       strip-ansi: 7.1.0
+    dev: false
 
   /@wdio/protocols@8.32.0:
     resolution: {integrity: sha512-inLJRrtIGdTz/YPbcsvpSvPlYQFTVtF3OYBwAXhG2FiP1ZwE1CQNLP/xgRGye1ymdGCypGkexRqIx3KBGm801Q==}
+    dev: false
 
   /@wdio/repl@8.24.12:
     resolution: {integrity: sha512-321F3sWafnlw93uRTSjEBVuvWCxTkWNDs7ektQS15drrroL3TMeFOynu4rDrIz0jXD9Vas0HCD2Tq/P0uxFLdw==}
     engines: {node: ^16.13 || >=18}
     dependencies:
       '@types/node': 20.11.26
+    dev: false
 
   /@wdio/types@8.32.4:
     resolution: {integrity: sha512-pDPGcCvq0MQF8u0sjw9m4aMI2gAKn6vphyBB2+1IxYriL777gbbxd7WQ+PygMBvYVprCYIkLPvhUFwF85WakmA==}
     engines: {node: ^16.13 || >=18}
     dependencies:
       '@types/node': 20.11.26
+    dev: false
 
   /@wdio/utils@8.33.1:
     resolution: {integrity: sha512-W0ArrZbs4M23POv8+FPsgHDFxg+wwklfZgLSsjVq2kpCmBCfIPxKSAOgTo/XrcH4We/OnshgBzxLcI+BHDgi4w==}
@@ -8463,6 +8471,7 @@ packages:
       wait-port: 1.1.0
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /@webassemblyjs/ast@1.11.6:
     resolution: {integrity: sha512-IN1xI7PwOvLPgjcf180gC1bqn3q/QaOCwYUahIOhbYUu8KA/3tw2RT/T0Gidi1l7Hhj5D/INhJxiICObqpMu4Q==}
@@ -8598,6 +8607,7 @@ packages:
     engines: {node: '>=6.5'}
     dependencies:
       event-target-shim: 5.0.1
+    dev: false
 
   /accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
@@ -8849,6 +8859,7 @@ packages:
       lodash: 4.17.21
       normalize-path: 3.0.0
       readable-stream: 4.5.2
+    dev: false
 
   /archiver@7.0.1:
     resolution: {integrity: sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==}
@@ -8861,6 +8872,7 @@ packages:
       readdir-glob: 1.1.3
       tar-stream: 3.1.7
       zip-stream: 6.0.1
+    dev: false
 
   /are-we-there-yet@3.0.1:
     resolution: {integrity: sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==}
@@ -9372,6 +9384,7 @@ packages:
   /buffer-crc32@1.0.0:
     resolution: {integrity: sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==}
     engines: {node: '>=8.0.0'}
+    dev: false
 
   /buffer-fill@1.0.0:
     resolution: {integrity: sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ==}
@@ -9402,6 +9415,7 @@ packages:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
+    dev: false
 
   /buffers@0.1.1:
     resolution: {integrity: sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==}
@@ -9827,6 +9841,7 @@ packages:
     dependencies:
       devtools-protocol: 0.0.1147663
       mitt: 3.0.0
+    dev: false
 
   /chromium-bidi@0.5.12(devtools-protocol@0.0.1249869):
     resolution: {integrity: sha512-sZMgEBWKbupD0Q7lyFu8AWkrE+rs5ycE12jFkGwIgD/VS8lDPtelPlXM7LYaq4zrkZ/O2L3f4afHUHL0ICdKog==}
@@ -10080,6 +10095,7 @@ packages:
   /commander@9.5.0:
     resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
     engines: {node: ^12.20.0 || >=14}
+    dev: false
 
   /common-path-prefix@3.0.0:
     resolution: {integrity: sha512-QE33hToZseCH3jS0qN96O/bSh3kaw/h+Tq7ngyY9eWDUnTlTNUyqfqvCXioLe5Na5jFsL78ra/wuBU4iuEgd4w==}
@@ -10105,6 +10121,7 @@ packages:
       is-stream: 2.0.1
       normalize-path: 3.0.0
       readable-stream: 4.5.2
+    dev: false
 
   /compressible@2.0.18:
     resolution: {integrity: sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==}
@@ -10397,6 +10414,7 @@ packages:
     resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
     engines: {node: '>=0.8'}
     hasBin: true
+    dev: false
 
   /crc32-stream@6.0.0:
     resolution: {integrity: sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==}
@@ -10404,6 +10422,7 @@ packages:
     dependencies:
       crc-32: 1.2.2
       readable-stream: 4.5.2
+    dev: false
 
   /create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
@@ -10554,6 +10573,7 @@ packages:
 
   /css-shorthand-properties@1.1.1:
     resolution: {integrity: sha512-Md+Juc7M3uOdbAFwOYlTrccIZ7oCFuzrhKYQjdeUEW/sE1hv17Jp/Bws+ReOPpGVBTYCBoYo+G17V5Qo8QQ75A==}
+    dev: false
 
   /css-tree@1.1.3:
     resolution: {integrity: sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==}
@@ -10571,6 +10591,7 @@ packages:
 
   /css-value@0.0.1:
     resolution: {integrity: sha512-FUV3xaJ63buRLgHrLQVlVgQnQdR4yqdLGaDu7g8CQcWjInDfM9plBTPI9FRfpahju1UBSaMckeb2/46ApS/V1Q==}
+    dev: false
 
   /css-what@6.1.0:
     resolution: {integrity: sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==}
@@ -10697,6 +10718,7 @@ packages:
   /data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
+    dev: false
 
   /data-uri-to-buffer@6.0.2:
     resolution: {integrity: sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==}
@@ -10779,6 +10801,7 @@ packages:
   /decamelize@6.0.0:
     resolution: {integrity: sha512-Fv96DCsdOgB6mdGl67MT5JaTNKRzrzill5OH5s8bjYJXVlcXyPYGyPsUkWyGV5p1TXI5esYIYMMeDJL0hEIwaA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dev: false
 
   /decimal.js@10.4.3:
     resolution: {integrity: sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==}
@@ -10852,6 +10875,7 @@ packages:
   /deepmerge-ts@5.1.0:
     resolution: {integrity: sha512-eS8dRJOckyo9maw9Tu5O5RUi/4inFLrnoLkBe3cPfDMx3WZioXtmOew4TXQaxq7Rhl4xjDtR7c6x8nNTxOvbFw==}
     engines: {node: '>=16.0.0'}
+    dev: false
 
   /deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
@@ -11025,12 +11049,14 @@ packages:
 
   /devtools-protocol@0.0.1147663:
     resolution: {integrity: sha512-hyWmRrexdhbZ1tcJUGpO95ivbRhWXz++F4Ko+n21AY5PNln2ovoJw+8ZMNDTtip+CNFQfrtLVh/w4009dXO/eQ==}
+    dev: false
 
   /devtools-protocol@0.0.1249869:
     resolution: {integrity: sha512-Ctp4hInA0BEavlUoRy9mhGq0i+JSo/AwVyX2EFgZmV1kYB+Zq+EMBAn52QWu6FbRr10hRb6pBl420upbp4++vg==}
 
   /devtools-protocol@0.0.1263784:
     resolution: {integrity: sha512-k0SCZMwj587w4F8QYbP5iIbSonL6sd3q8aVJch036r9Tv2t9b5/Oq7AiJ/FJvRuORm/pJNXZtrdNNWlpRnl56A==}
+    dev: false
 
   /devtools-protocol@0.0.1269399:
     resolution: {integrity: sha512-CVFbZYBunJ+vk3ft+ZsxPqPs1RigTgrMGjCrS/r9Lm9SvKoxrr1FztZ09znTN45d8OgMX4Cz5oETBgHPUxwpLw==}
@@ -11226,6 +11252,7 @@ packages:
     dependencies:
       '@types/which': 2.0.2
       which: 2.0.2
+    dev: false
 
   /edgedriver@5.3.10:
     resolution: {integrity: sha512-RFSHYMNtcF1PjaGZCA2rdQQ8hSTLPZgcYgeY1V6dC+tR4NhZXwFAku+8hCbRYh7ZlwKKrTbVu9FwknjFddIuuw==}
@@ -11238,6 +11265,7 @@ packages:
       node-fetch: 3.3.2
       unzipper: 0.10.14
       which: 4.0.0
+    dev: false
 
   /editorconfig@1.0.4:
     resolution: {integrity: sha512-L9Qe08KWTlqYMVvMcTIvMAdl1cDUubzRNYL+WfA4bLDMHe4nemKkpmYzkznE1FwLKu0EEmy6obgQKzMJrg4x9Q==}
@@ -12081,6 +12109,7 @@ packages:
   /event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
+    dev: false
 
   /eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
@@ -12249,6 +12278,7 @@ packages:
 
   /fast-deep-equal@2.0.1:
     resolution: {integrity: sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==}
+    dev: false
 
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -12327,6 +12357,7 @@ packages:
     dependencies:
       node-domexception: 1.0.0
       web-streams-polyfill: 3.3.3
+    dev: false
 
   /fflate@0.4.8:
     resolution: {integrity: sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==}
@@ -12572,6 +12603,7 @@ packages:
     engines: {node: '>=12.20.0'}
     dependencies:
       fetch-blob: 3.2.0
+    dev: false
 
   /forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
@@ -12706,6 +12738,7 @@ packages:
       which: 4.0.0
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -12761,6 +12794,7 @@ packages:
   /get-port@7.0.0:
     resolution: {integrity: sha512-mDHFgApoQd+azgMdwylJrv2DX47ywGq1i5VFJE7fZ0dttNq3iQMfsU4IvEgBHojA3KqEudyu7Vq+oN8kNaNkWw==}
     engines: {node: '>=16'}
+    dev: false
 
   /get-ready@1.0.0:
     resolution: {integrity: sha512-mFXCZPJIlcYcth+N8267+mghfYN9h3EhsDa6JSnbA3Wrhh/XFpuowviFcsDeYZtKspQyWyJqfs4O6P8CHeTwzw==}
@@ -13106,6 +13140,7 @@ packages:
 
   /grapheme-splitter@1.0.4:
     resolution: {integrity: sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==}
+    dev: false
 
   /graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
@@ -13754,6 +13789,7 @@ packages:
 
   /import-meta-resolve@4.0.0:
     resolution: {integrity: sha512-okYUR7ZQPH+efeuMJGlq4f8ubUgO50kByRPyt/Cy1Io4PSRsPjxME+YlVaCOx+NIToW7hCsZNFJyTPFFKepRSA==}
+    dev: false
 
   /imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
@@ -14692,6 +14728,7 @@ packages:
   /ky@0.33.3:
     resolution: {integrity: sha512-CasD9OCEQSFIam2U8efFK81Yeg8vNMTBUqtMOHlrcWQHqUX3HeCl9Dr31u4toV7emlH8Mymk5+9p0lL6mKb/Xw==}
     engines: {node: '>=14.16'}
+    dev: false
 
   /latest-version@5.1.0:
     resolution: {integrity: sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==}
@@ -14717,6 +14754,7 @@ packages:
     engines: {node: '>= 0.6.3'}
     dependencies:
       readable-stream: 2.3.8
+    dev: false
 
   /lerna-changelog@2.2.0:
     resolution: {integrity: sha512-yjYNAHrbnw8xYFKmYWJEP52Tk4xSdlNmzpYr26+3glbSGDmpe8UMo8f9DlEntjGufL+opup421oVTXcLshwAaQ==}
@@ -15017,6 +15055,7 @@ packages:
       n12: 1.8.26
       type-fest: 2.13.0
       userhome: 1.0.0
+    dev: false
 
   /locate-character@3.0.0:
     resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
@@ -15056,6 +15095,7 @@ packages:
 
   /lodash.clonedeep@4.5.0:
     resolution: {integrity: sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==}
+    dev: false
 
   /lodash.debounce@4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
@@ -15107,6 +15147,7 @@ packages:
 
   /lodash.zip@4.2.0:
     resolution: {integrity: sha512-C7IOaBBK/0gMORRBd8OETNx3kmOkgIWIPvyDpZSCTwUrpYmgZwJkjZeOD8ww4xbOUOs4/attY+pciKvadNfFbg==}
+    dev: false
 
   /lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
@@ -15132,10 +15173,12 @@ packages:
 
   /loglevel-plugin-prefix@0.8.4:
     resolution: {integrity: sha512-WpG9CcFAOjz/FtNht+QJeGpvVl/cdR6P0z6OcXSkr8wFJOsV2GRj2j10JLfjuA4aYkcKCNIEqRGCyTife9R8/g==}
+    dev: false
 
   /loglevel@1.9.1:
     resolution: {integrity: sha512-hP3I3kCrDIMuRwAwHltphhDM1r8i55H33GgqjXbrisuJhF4kRhW1dNuxsRklp4bXl8DSdLaNLuiL4A/LWRfxvg==}
     engines: {node: '>= 0.6.0'}
+    dev: false
 
   /longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
@@ -16209,12 +16252,14 @@ packages:
 
   /mitt@3.0.0:
     resolution: {integrity: sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ==}
+    dev: false
 
   /mitt@3.0.1:
     resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
 
   /mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+    dev: false
 
   /mkdirp@0.5.6:
     resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
@@ -16348,6 +16393,7 @@ packages:
 
   /n12@1.8.26:
     resolution: {integrity: sha512-BUTP59AmN33pLdGLkKphoxhXD8eLi3YCCuEmUXiIPGdmujKEJmyG1T3WL4N7RPr3+t4FdTeGLyejBq/WL0sCWw==}
+    dev: false
 
   /nanoid@3.3.7:
     resolution: {integrity: sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==}
@@ -16404,6 +16450,7 @@ packages:
   /node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
     engines: {node: '>=10.5.0'}
+    dev: false
 
   /node-emoji@2.1.3:
     resolution: {integrity: sha512-E2WEOVsgs7O16zsURJ/eH8BqhF029wGpEOnv7Urwdo2wmQanOACwJQh0devF9D9RhoZru0+9JXIS0dBXIAz+lA==}
@@ -16444,6 +16491,7 @@ packages:
       data-uri-to-buffer: 4.0.1
       fetch-blob: 3.2.0
       formdata-polyfill: 4.0.10
+    dev: false
 
   /node-forge@1.3.1:
     resolution: {integrity: sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==}
@@ -18002,6 +18050,7 @@ packages:
   /process@0.11.10:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
+    dev: false
 
   /progress@2.0.3:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
@@ -18090,6 +18139,7 @@ packages:
       socks-proxy-agent: 8.0.2
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /proxy-agent@6.3.1:
     resolution: {integrity: sha512-Rb5RVBy1iyqOtNl15Cw/llpeLH8bsb37gM1FUfKQ+Wck6xHlbAhWGUFiTRHtkjqGTA5pSHz6+0hrPW/oECihPQ==}
@@ -18105,6 +18155,7 @@ packages:
       socks-proxy-agent: 8.0.2
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /proxy-agent@6.4.0:
     resolution: {integrity: sha512-u0piLU+nCOHMgGjRbimiXmA9kM/L9EHh3zL81xCdp7m+Y2pHIsnmbdDoEDoAz5geaonNR6q6+yOPQs6n4T6sBQ==}
@@ -18188,6 +18239,7 @@ packages:
       - encoding
       - supports-color
       - utf-8-validate
+    dev: false
 
   /puppeteer-core@22.4.1:
     resolution: {integrity: sha512-l9nf8NcirYOHdID12CIMWyy7dqcJCVtgVS+YAiJuUJHg8+9yjgPiG2PcNhojIEEpCkvw3FxvnyITVfKVmkWpjA==}
@@ -18213,6 +18265,7 @@ packages:
 
   /query-selector-shadow-dom@1.0.1:
     resolution: {integrity: sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==}
+    dev: false
 
   /query-string@7.1.3:
     resolution: {integrity: sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==}
@@ -18630,11 +18683,13 @@ packages:
       events: 3.3.0
       process: 0.11.10
       string_decoder: 1.3.0
+    dev: false
 
   /readdir-glob@1.1.3:
     resolution: {integrity: sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==}
     dependencies:
       minimatch: 5.1.6
+    dev: false
 
   /readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
@@ -18958,6 +19013,7 @@ packages:
     resolution: {integrity: sha512-G10EBz+zAAy3zUd/CDoBbXRL6ia9kOo3xRHrMDsHljI0GDkhYlyjwoCx5+3eCC4swi1uCoZQhskuJkj7Gp57Bw==}
     dependencies:
       fast-deep-equal: 2.0.1
+    dev: false
 
   /restore-cursor@3.1.0:
     resolution: {integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==}
@@ -18981,6 +19037,7 @@ packages:
 
   /rgb2hex@0.2.5:
     resolution: {integrity: sha512-22MOP1Rh7sAo1BZpDG6R5RFYzR2lYEgwq7HEmyW2qcsOqR2lQKmn+O//xV3YG/0rrhMC6KVX2hU+ZXuaw9a5bw==}
+    dev: false
 
   /rimraf@2.5.4:
     resolution: {integrity: sha512-Lw7SHMjssciQb/rRz7JyPIy9+bbUshEucPoLRvWqy09vC5zQixl8Uet+Zl+SROBB/JMWHJRdCk1qdxNWHNMvlQ==}
@@ -19112,6 +19169,7 @@ packages:
 
   /safaridriver@0.1.2:
     resolution: {integrity: sha512-4R309+gWflJktzPXBQCobbWEHlzC4aK3a+Ov3tz2Ib2aBxiwd11phkdIBH1l0EO22x24CJMUQkpKFumRriCSRg==}
+    dev: false
 
   /safe-array-concat@1.1.2:
     resolution: {integrity: sha512-vj6RsCsWBCf19jIeHEfkRMw8DPiBb+DMXklQ/1SGDHOMlHdPUkZXFQ2YdplS23zESTijAcurb1aSgJA3AgMu1Q==}
@@ -19301,6 +19359,7 @@ packages:
     engines: {node: '>=14.16'}
     dependencies:
       type-fest: 2.19.0
+    dev: false
 
   /serialize-javascript@4.0.0:
     resolution: {integrity: sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==}
@@ -19728,6 +19787,7 @@ packages:
   /split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
+    dev: false
 
   /split@0.3.3:
     resolution: {integrity: sha512-wD2AeVmxXRBoX44wAycgjVpMhvbwdI2aZjCkvfNcH1YqHQvJVa1duWc73OyVGJUc05fhFaTZeQ/PYsrmyH0JVA==}
@@ -20218,6 +20278,7 @@ packages:
       mkdirp-classic: 0.5.3
       pump: 3.0.0
       tar-stream: 3.1.7
+    dev: false
 
   /tar-fs@3.0.5:
     resolution: {integrity: sha512-JOgGAmZyMgbqpLwct7ZV8VzkEB6pxXFBVErLtb+XCOqzc6w1xiWKI9GVd6bwk68EX7eJ4DWmfXVmq8K2ziZTGg==}
@@ -20708,6 +20769,7 @@ packages:
   /type-fest@2.13.0:
     resolution: {integrity: sha512-lPfAm42MxE4/456+QyIaaVBAwgpJb6xZ8PRu09utnhPdWwcyj9vgy6Sq0Z5yNbJ21EdxB5dRU/Qg8bsyAMtlcw==}
     engines: {node: '>=12.20'}
+    dev: false
 
   /type-fest@2.19.0:
     resolution: {integrity: sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==}
@@ -21086,6 +21148,7 @@ packages:
   /userhome@1.0.0:
     resolution: {integrity: sha512-ayFKY3H+Pwfy4W98yPdtH1VqH4psDeyW8lYYFzfecR9d6hqLpqhecktvYR3SEEXt7vG0S1JEpciI3g94pMErig==}
     engines: {node: '>= 0.8.0'}
+    dev: false
 
   /util-arity@1.1.0:
     resolution: {integrity: sha512-kkyIsXKwemfSy8ZEoaIz06ApApnWsk5hQO0vLjZS6UkBiGiW++Jsyb8vSBoc0WKlffGoGs5yYy/j5pp8zckrFA==}
@@ -21408,6 +21471,7 @@ packages:
       debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /watchpack@2.4.0:
     resolution: {integrity: sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==}
@@ -21432,6 +21496,7 @@ packages:
   /web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
+    dev: false
 
   /web-streams-polyfill@4.0.0-beta.3:
     resolution: {integrity: sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==}
@@ -21457,6 +21522,7 @@ packages:
       - bufferutil
       - supports-color
       - utf-8-validate
+    dev: false
 
   /webdriverio@8.33.1(typescript@5.4.2):
     resolution: {integrity: sha512-1DsF8sx1a46AoVYCUpEwJYU74iBAW/U2H5r6p+60ct7dIiFmxmc4uCbOqtf7NLOTgrIzAOaRnT0EsrRICpg5Qw==}
@@ -21497,6 +21563,7 @@ packages:
       - supports-color
       - typescript
       - utf-8-validate
+    dev: false
 
   /webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -22042,6 +22109,7 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+    dev: false
 
   /ws@8.16.0:
     resolution: {integrity: sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==}
@@ -22164,6 +22232,7 @@ packages:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+    dev: false
 
   /yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
@@ -22226,6 +22295,7 @@ packages:
       archiver-utils: 5.0.2
       compress-commons: 6.0.2
       readable-stream: 4.5.2
+    dev: false
 
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1344,6 +1344,9 @@ importers:
       grapheme-splitter:
         specifier: ^1.0.2
         version: 1.0.4
+      htmlfy:
+        specifier: ^0.1.0
+        version: 0.1.0
       import-meta-resolve:
         specifier: ^4.0.0
         version: 4.0.0
@@ -13525,6 +13528,10 @@ packages:
       pretty-error: 4.0.0
       tapable: 2.2.1
       webpack: 5.90.3
+
+  /htmlfy@0.1.0:
+    resolution: {integrity: sha512-lACWDZJ+RAT+7ieWd3/6O2KScZkMRAkwW83EmkCn/kpudHZ+w01Q6eE9sYgjUorMqi5BdvP24X/2bmp1Aw3JNQ==}
+    dev: false
 
   /htmlparser2@6.1.0:
     resolution: {integrity: sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1332,6 +1332,9 @@ importers:
       aria-query:
         specifier: ^5.0.0
         version: 5.3.0
+      cheerio:
+        specifier: ^1.0.0-rc.12
+        version: 1.0.0-rc.12
       css-shorthand-properties:
         specifier: ^1.1.1
         version: 1.1.1


### PR DESCRIPTION
## Proposed changes

In #12446 we implemented some building blocks that allow us to pierce through the ShadowDOM. This patch enhances on this effort and widens support for piercing to more crucial commands like `getHTML`. Users can now run snapshot tests that include the DOM structure of all underlaying Shadow Roots, e.g.:

```ts
await browser.url('https://sap.github.io/ui5-webcomponents/playground/iframe.html?viewMode=docs&id=main-button--button-overview')
await expect($('ui5-button')).toMatchInlineSnapshot(`
    <ui5-button icon="sap-icon://action" accessible-name="Button with Accessible Name" ui5-button="" has-icon="">
        Button Text
        <shadow-root>
            <button type="button" class="ui5-button-root" data-sap-focus-ref="" part="button" tabindex="0" aria-label="Button with Accessible Name" role="button">
                <ui5-icon class="ui5-button-icon" part="icon" name="sap-icon://action" accessible-role="presentation" ui5-icon="">
                    <shadow-root>
                    <svg class="ui5-icon-root" part="root" focusable="false" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" role="presentation" aria-hidden="true" viewBox="0 0 512 512">
                        <g role="presentation">
                            <path d="M504 109q8 8 8 19t-8 19L395 249q-7 7-17 7-11 0-18.5-7.5T352 230q0-10 8-18l69-65h-52q-21 0-39.5 8T305 177t-22 33-8 40v76q0 11-7 18.5t-18 7.5-18.5-7.5T224 326v-76q0-32 12-60t32.5-49 48.5-33 60-12h38l-55-52q-8-8-8-18 0-11 7.5-18.5T378 0q10 0 17 7zm-50 194q11 0 18.5 7t7.5 18v62q0 38-26 64t-64 26H90q-38 0-64-26T0 390V90q0-38 26-64T90 0h137q11 0 18.5 7.5T253 26t-7.5 18-18.5 7H90q-17 0-28 11T51 90v300q0 17 11 28t28 11h300q17 0 28-11t11-28v-62q0-11 7-18t18-7z"></path>
                        </g>
                    </svg>
                    </shadow-root>
                </ui5-icon>
                <span class="ui5-button-text" id="ui5wc_1-content">
                    <bdi>
                    <slot></slot>
                    </bdi>
                </span>
            </button>
        </shadow-root>
    </ui5-button>
`)
```

When using web components we often see comments like `<!--?lit$206212805$--><!--?lit$206212805$-->` which are used to help the framework hydrate element correctly. Since these are not much helpful when snapshotting the DOM structure of elements, I also added an option that allows users to remove this.

Note: there is a lot more we can do to manipulate and clean up the DOM structure before returning the result. I was thinking of

- `excludeElements`: to remove elements from the snapshot that contain assets, e.g. like the SVG above
- `excludeAttributes`: to remove attributes from elements that contain random values, e.g. like the `id` attribute of `.ui5-button-text` above

I want to raise separate PRs for this.

## Types of changes

This is a breaking change since we changed the interface of `getHTML` and now automatically pierce shadow roots which can impact users existing tests.

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
