### PR TITLE
[allure-report] handle case for broken status of tests with retry

### DIFF
--- a/packages/wdio-allure-reporter/src/reporter.ts
+++ b/packages/wdio-allure-reporter/src/reporter.ts
@@ -138,9 +138,14 @@ export default class AllureReporter extends WDIOReporter {
         while (this._state.currentAllureTestOrStep) {
             const currentTest = this._state.pop() as AllureTest | AllureStep
             const isAnyStepFailed = currentTest.wrappedItem.steps.some((step) => step.status === AllureStatus.FAILED)
+            const isAnyStepBroken = currentTest.wrappedItem.steps.some((step) => step.status === AllureStatus.BROKEN)
 
             currentTest.stage = Stage.FINISHED
-            currentTest.status = isAnyStepFailed ? AllureStatus.FAILED : AllureStatus.PASSED
+            currentTest.status = isAnyStepFailed
+                ? AllureStatus.FAILED
+                : isAnyStepBroken
+                    ? AllureStatus.BROKEN
+                    : AllureStatus.PASSED
 
             if (currentTest instanceof AllureTest) {
                 setAllureIds(currentTest, this._state.currentSuite)

--- a/packages/wdio-allure-reporter/tests/__fixtures__/cucumber.ts
+++ b/packages/wdio-allure-reporter/tests/__fixtures__/cucumber.ts
@@ -37,6 +37,12 @@ const error = {
     actual: 'bar'
 }
 
+const nonAssertionError = {
+    message: 'TypeError: Cannot read properties of undefined (reading "foo")',
+    stack: 'TypeError: Cannot read properties of undefined (reading "foo")',
+    name: 'Error'
+}
+
 export function featureStart(featureLabel?: string) {
     const feature = Object.assign(suite('feature'))
     if (featureLabel) {
@@ -52,6 +58,15 @@ export function featureEnd(results = { tests: [], hooks: [] }) {
     return Object.assign(suite('feature'), {
         _duration: 1516,
         suites: [scenarioEnd(results)],
+        end: '2019-07-22T12:21:37.696Z'
+    })
+}
+
+export function featureEndWithRetries(results = [{ tests: [], hooks: [] }]) {
+    const suites = scenarioWithRetries(results)
+    return Object.assign(suite('feature'), {
+        _duration: 1516,
+        suites: suites,
         end: '2019-07-22T12:21:37.696Z'
     })
 }
@@ -74,6 +89,20 @@ export function scenarioEnd({ tests = [], hooks = [] }): SuiteStats {
         tests,
         hooks
     })
+}
+
+function scenarioWithRetries(results = [{ tests: [], hooks: [] }]): Array<SuiteStats>{
+    const allScenarios: SuiteStats[] = []
+    let scenario: SuiteStats = scenarioEnd(results[0])
+    allScenarios.push(scenario)
+
+    for (let i = 1; i < results.length; i++){
+        const nextScenario: SuiteStats = scenarioEnd(results[i])
+        scenario.suites.push(nextScenario)
+        scenario = nextScenario
+    }
+
+    return Object.assign(allScenarios, {})
 }
 
 const hook = () => ({
@@ -165,6 +194,16 @@ export function testFail(): TestStats {
         _duration: 10,
         errors: [error],
         error: error,
+        state: 'failed',
+        end: '2019-07-22T12:21:37.684Z'
+    })
+}
+
+export function testFail2(){
+    return Object.assign(test(), {
+        _duration: 10,
+        errors: [nonAssertionError],
+        error: nonAssertionError,
         state: 'failed',
         end: '2019-07-22T12:21:37.684Z'
     })


### PR DESCRIPTION
## Proposed changes

PR for V8 version

the original PR: https://github.com/webdriverio/webdriverio/pull/12480

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

### Reviewers: @webdriverio/project-committers
