### PR TITLE
@wdio/globals: Declare "expect" global type explicitly

### DIFF
--- a/packages/wdio-globals/types.d.ts
+++ b/packages/wdio-globals/types.d.ts
@@ -11,9 +11,10 @@ declare module NodeJS {
 
 declare function $(...args: Parameters<WebdriverIO.Browser['$']>): ReturnType<WebdriverIO.Browser['$']>
 declare function $$(...args: Parameters<WebdriverIO.Browser['$$']>): ReturnType<WebdriverIO.Browser['$$']>
+declare var multiremotebrowser: WebdriverIO.MultiRemoteBrowser
 declare var browser: WebdriverIO.Browser
 declare var driver: WebdriverIO.Browser
-declare var multiremotebrowser: WebdriverIO.MultiRemoteBrowser
+declare var expect: ExpectType
 
 /**
  * custom environment primitives for WebdriverIO when running in a browser


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

Currently expect-webdriverio is implicitly loading `expect` global type, which is "wrong" since the runtime of expect-webdriverio does not actually load `expect` into the runtime global scope.
https://github.com/webdriverio/expect-webdriverio/pull/1496 fixes this issue but then we need to make sure to load this type in `@wdio/globals`.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [x] Back-ported PR at https://github.com/webdriverio/webdriverio/pull/12502



### Reviewers: @webdriverio/project-committers
