### PR TITLE
[backport] @wdio/globals: Declare "expect" global type explicitly

### DIFF
--- a/packages/wdio-globals/types.d.ts
+++ b/packages/wdio-globals/types.d.ts
@@ -11,6 +11,7 @@ declare module NodeJS {
 
 declare function $(...args: Parameters<WebdriverIO.Browser['$']>): ReturnType<WebdriverIO.Browser['$']>
 declare function $$(...args: Parameters<WebdriverIO.Browser['$$']>): ReturnType<WebdriverIO.Browser['$$']>
+declare var multiremotebrowser: WebdriverIO.MultiRemoteBrowser
 declare var browser: WebdriverIO.Browser
 declare var driver: WebdriverIO.Browser
-declare var multiremotebrowser: WebdriverIO.MultiRemoteBrowser
+declare var expect: ExpectType


### PR DESCRIPTION
This is a backport PR against v8 for https://github.com/webdriverio/webdriverio/pull/12499