### PR TITLE
(wdio-browser-runner): fix error response for the wdio-browser-runner

### DIFF
--- a/packages/wdio-browser-runner/src/browser/driver.ts
+++ b/packages/wdio-browser-runner/src/browser/driver.ts
@@ -168,7 +168,8 @@ export default class ProxyDriver {
 
         if (value.error) {
             console.log(`[WDIO] ${(new Date()).toISOString()} - id: ${value.id} - ERROR: ${JSON.stringify(value.error.message)}`)
-            return commandMessage.reject(new Error(value.error.message || 'unknown error'))
+            value.error.message = value.error.message || 'unknown error'
+            return commandMessage.reject(value.error)
         }
         if (commandMessage.commandTimeout) {
             clearTimeout(commandMessage.commandTimeout)

--- a/packages/webdriverio/tests/commands/browser/action.test.ts
+++ b/packages/webdriverio/tests/commands/browser/action.test.ts
@@ -48,9 +48,13 @@ describe('action command', () => {
     })
 
     it('fails if user triggers more than one character', async () => {
-        await expect(async () => browser.action('key').down('foo').perform())
-            .rejects
-            .toMatch(/more than one/)
+        let err
+        try {
+            await browser.action('key').down('foo').perform()
+        } catch (error) {
+            err = error
+        }
+        expect(err.message).toMatch(/more than one/)
     })
 
     it('should trigger command key when Key.Ctrl is used', async () => {


### PR DESCRIPTION
## Proposed changes

Fixes an issue that caused error messages to be different when running browser tests compared to e2e tests

## Types of changes

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

### Reviewers: @webdriverio/project-committers
