### PR TITLE
Fix link formatting in babel docs

### DIFF
--- a/website/docs/Babel.md
+++ b/website/docs/Babel.md
@@ -30,7 +30,7 @@ module.exports = {
 When using Babel in a monorepo things can get complicated if you do not follow the documentation steps, so make sure you read the [Babel documentation](https://babeljs.io/docs/config-files#monorepos) thoroughly.
 
 To give you some guidance, here's some things to keep in mind:
-- You have to create a (root `babel.config.json`)[https://babeljs.io/docs/config-files#root-babelconfigjson-file]
+- You have to create a [root babel.config.json](https://babeljs.io/docs/config-files#root-babelconfigjson-file).
 - After you have done so and the project is correctly configured according to the documentation, you will have to make Babel look for the config by updating your wdio config files by adding the example found below.
 
 ```js


### PR DESCRIPTION
## Proposed changes

This fixes a broken link in the documentation for babel.  You can't have preformatted/code text 
 (` `` `) within a link (`[]()`).  The link also switched the bracket/parenthesis symbols.

## Types of changes

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [x] Back-ported PR at #12550

## Further comments

### Reviewers: @webdriverio/project-committers
