### PR TITLE
Compatibility of ESLint plugin with new flat config

### DIFF
--- a/packages/eslint-plugin-wdio/src/index.ts
+++ b/packages/eslint-plugin-wdio/src/index.ts
@@ -10,13 +10,15 @@ const rules = {
 
 const configs = {
     recommended: {
-        globals: {
-            $: false,
-            $$: false,
-            browser: false,
-            driver: false,
-            expect: false,
-            multiremotebrowser: false,
+        languageOptions: {
+            globals: {
+                $: false,
+                $$: false,
+                browser: false,
+                driver: false,
+                expect: false,
+                multiremotebrowser: false,
+            },
         },
         rules: {
             'wdio/await-expect': 'error',

--- a/packages/eslint-plugin-wdio/src/index.ts
+++ b/packages/eslint-plugin-wdio/src/index.ts
@@ -20,6 +20,11 @@ const configs = {
                 multiremotebrowser: false,
             },
         },
+        plugins: {
+            wdio: {
+                rules,
+            }
+        },
         rules: {
             'wdio/await-expect': 'error',
             'wdio/no-debug': 'error',

--- a/packages/eslint-plugin-wdio/src/index.ts
+++ b/packages/eslint-plugin-wdio/src/index.ts
@@ -29,7 +29,7 @@ const configs = {
             'wdio/await-expect': 'error',
             'wdio/no-debug': 'error',
             'wdio/no-pause': 'error',
-        }
+        } as const
     }
 }
 

--- a/packages/eslint-plugin-wdio/src/index.ts
+++ b/packages/eslint-plugin-wdio/src/index.ts
@@ -33,6 +33,11 @@ const configs = {
     }
 }
 
+export default {
+    rules,
+    configs,
+}
+
 export {
     rules,
     configs,


### PR DESCRIPTION
## Proposed changes

Fixes #12547

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

- Export recommended config, which was adjusted to become compatible with new ESLint flat configuration system.
- Also, add compatibility with typescript-eslint's types-aware `.config()` function. 

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

Both changes were tested locally.
I would want to add typing test for the 2nd change, but typings tests execution is [temporarily disabled](https://github.com/webdriverio/webdriverio/blob/060d9973f2adb7a128db168de3a58f7e2ddef0cf/package.json#L38) and even individual `test:typings:setup` does not work, so it looks broken to me.
While the change slightly modifies the contract of exported TypeScript definitions, I do not think it will break anything. I preserved separate exports of `rules` and `configs`, and the only breaking change I see is changing coordinates of the `globals` object. I think this change should be backported to v8

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
