### PR TITLE
feat: v8 coverage

### DIFF
--- a/packages/wdio-browser-runner/package.json
+++ b/packages/wdio-browser-runner/package.json
@@ -56,6 +56,7 @@
     "istanbul-reports": "^3.1.5",
     "mlly": "^1.4.0",
     "modern-node-polyfills": "^1.0.0",
+    "monocart-coverage-reports": "^2.7.7",
     "recast": "^0.23.2",
     "safe-stringify": "^1.1.0",
     "source-map-support": "^0.5.21",

--- a/packages/wdio-browser-runner/src/communicator.ts
+++ b/packages/wdio-browser-runner/src/communicator.ts
@@ -6,6 +6,7 @@ import type { WebSocketClient } from 'vite'
 import type { WorkerInstance } from '@wdio/local-runner'
 import { MESSAGE_TYPES, type Options, type Workers } from '@wdio/types'
 import type { SessionStartedMessage, SessionEndedMessage, WorkerResponseMessage } from '@wdio/runner'
+import type { V8CoverageEntry } from 'monocart-coverage-reports'
 
 import { SESSIONS } from './constants.js'
 import { WDIO_EVENT_NAME } from './constants.js'
@@ -36,6 +37,7 @@ export class ServerWorkerCommunicator {
     #pendingMessages = new Map<number, WorkerMessage>()
 
     public coverageMaps: CoverageMap[] = []
+    public coverageList: V8CoverageEntry[] = []
 
     constructor (config: Options.Testrunner) {
         this.#config = config
@@ -66,6 +68,11 @@ export class ServerWorkerCommunicator {
             this.coverageMaps.push(
                 await this.#mapStore.transformCoverage(libCoverage.createCoverageMap(coverageMapData))
             )
+        }
+
+        if (payload.name === 'workerEvent' && payload.args.type === MESSAGE_TYPES.coverageData) {
+            const coverageData = payload.args.value as V8CoverageEntry
+            this.coverageList.push(coverageData)
         }
 
         if (payload.name === 'workerEvent' && payload.args.type === MESSAGE_TYPES.customCommand) {

--- a/packages/wdio-browser-runner/src/types.ts
+++ b/packages/wdio-browser-runner/src/types.ts
@@ -2,6 +2,7 @@ import type { ConfigEnv, InlineConfig } from 'vite'
 import type { Workers, Capabilities, Options } from '@wdio/types'
 import type { MochaOpts } from '@wdio/mocha-framework'
 import type { IstanbulPluginOptions } from 'vite-plugin-istanbul'
+import type { CoverageReportOptions } from 'monocart-coverage-reports'
 
 declare global {
     interface Window {
@@ -13,13 +14,19 @@ declare global {
 export type FrameworkPreset = 'react' | 'preact' | 'vue' | 'svelte' | 'lit' | 'solid' | 'stencil'
 type Arrayable<T> = T | Array<T>
 type CoverageReporter = 'clover' | 'cobertura' | 'html-spa' | 'html' | 'json-summary' | 'json' | 'lcov' | 'lcovonly' | 'none' | 'teamcity' | 'text-lcov' | 'text-summary' | 'text'
-export interface CoverageOptions extends Omit<IstanbulPluginOptions, 'cypress' | 'checkProd' | 'forceBuildInstrument'> {
+export interface IstanbulCoverageOptions extends Omit<IstanbulPluginOptions, 'cypress' | 'checkProd' | 'forceBuildInstrument'> {
     /**
      * Enables coverage collection.
      *
      * @default false
      */
     enabled: boolean
+    /**
+     * Coverage data provider.
+     *
+     * @default istanbul
+     */
+    provider?: 'istanbul'
     /**
      * Directory to write coverage report to.
      *
@@ -71,6 +78,23 @@ export interface CoverageOptions extends Omit<IstanbulPluginOptions, 'cypress' |
      */
     statements?: number
 }
+
+export interface V8CoverageOptions extends CoverageReportOptions {
+    /**
+     * Enables coverage collection.
+     *
+     * @default false
+     */
+    enabled: boolean
+    /**
+     * Coverage data provider.
+     *
+     * @default v8
+     */
+    provider: 'v8'
+}
+
+export type CoverageOptions = IstanbulCoverageOptions | V8CoverageOptions
 
 export interface BrowserRunnerOptions {
     /**

--- a/packages/wdio-browser-runner/src/vite/server.ts
+++ b/packages/wdio-browser-runner/src/vite/server.ts
@@ -58,7 +58,7 @@ export class ViteServer extends EventEmitter {
             ]
         })
 
-        if (options.coverage && options.coverage.enabled) {
+        if (options.coverage && options.coverage.enabled && options.coverage.provider !== 'v8') {
             log.info('Capturing test coverage enabled')
             // @ts-expect-error istanbul plugin seems to incorrectly export
             // its type for our setup

--- a/packages/wdio-runner/src/browser.ts
+++ b/packages/wdio-runner/src/browser.ts
@@ -110,7 +110,7 @@ export default class BrowserFramework implements Omit<TestFramework, 'init'> {
             const puppeteer = await browser.getPuppeteer()
             if (puppeteer) {
                 const page = (await puppeteer.pages())[0]
-                if (page) {
+                if (page && page.coverage) {
                     await Promise.all([
                         page.coverage.startJSCoverage({
                             resetOnNavigation: false,
@@ -170,7 +170,7 @@ export default class BrowserFramework implements Omit<TestFramework, 'init'> {
                 const puppeteer = await browser.getPuppeteer()
                 if (puppeteer) {
                     const page = (await puppeteer.pages())[0]
-                    if (page) {
+                    if (page && page.coverage) {
                         const [jsCoverage, cssCoverage] = await Promise.all([
                             page.coverage.stopJSCoverage(),
                             page.coverage.stopCSSCoverage()

--- a/packages/wdio-types/src/Workers.ts
+++ b/packages/wdio-types/src/Workers.ts
@@ -88,6 +88,7 @@ export enum MESSAGE_TYPES {
     expectMatchersRequest,
     expectMatchersResponse,
     coverageMap,
+    coverageData,
     customCommand,
     initiateBrowserStateRequest,
     initiateBrowserStateResponse,
@@ -114,6 +115,7 @@ export type SocketMessageValue = {
     [MESSAGE_TYPES.expectMatchersRequest]: never
     [MESSAGE_TYPES.expectMatchersResponse]: ExpectMatchersResponse
     [MESSAGE_TYPES.coverageMap]: any
+    [MESSAGE_TYPES.coverageData]: any
     [MESSAGE_TYPES.customCommand]: CustomCommandEvent
     [MESSAGE_TYPES.initiateBrowserStateRequest]: BrowserStateRequest
     [MESSAGE_TYPES.initiateBrowserStateResponse]: BrowserState


### PR DESCRIPTION
@christian-bromann As we discussed issue https://github.com/webdriverio/webdriverio/issues/8050, I tried to create a PR to implement V8 coverage.

However, the e2e test doesn't pass in my local environment (Windows 10 +Node 20) even though it doesn't make any changes. I can't fix it.

So based on this PR, could you help continue implementing V8 coverage?

- Istanbul (default)
```js
runner: ['browser', {
        coverage: {
          enabled: true
        }
}]
```
- V8 
```js
runner: ['browser', {
        coverage: {
          enabled: true,
          provider: 'v8'
        }
}]
```
