### PR TITLE
chore: add cli arg info

### DIFF
--- a/website/docs/Frameworks.md
+++ b/website/docs/Frameworks.md
@@ -272,6 +272,20 @@ To get up and running quickly with Cucumber, have a look on our [`cucumber-boile
 
 The following options can be applied in your `wdio.conf.js` to configure your Cucumber environment using the `cucumberOpts` property:
 
+:::tip Adjusting options through the command line
+The `cucumberOpts`, such as custom `tags` for filtering tests, can be specified through the command line. This is accomplished by using the `cucumberOpts.{optionName}="value"` format.
+
+For example, if you want to run only the tests that are tagged with `@smoke`, you can use the following command:
+
+```sh
+# When you only want to run tests that hold the tag "@smoke"
+npm run wdio -- --cucumberOpts.tags="@smoke"
+```
+
+This command sets the `tags` option in `cucumberOpts` to `@smoke`, ensuring that only tests with this tag are executed.
+
+:::
+
 #### backtrace
 Show full backtrace for errors.
 

--- a/website/docs/Frameworks.md
+++ b/website/docs/Frameworks.md
@@ -279,7 +279,7 @@ For example, if you want to run only the tests that are tagged with `@smoke`, yo
 
 ```sh
 # When you only want to run tests that hold the tag "@smoke"
-npm run wdio -- --cucumberOpts.tags="@smoke"
+npx wdio ./wdio.conf.js --cucumberOpts.tags="@smoke"
 ```
 
 This command sets the `tags` option in `cucumberOpts` to `@smoke`, ensuring that only tests with this tag are executed.


### PR DESCRIPTION
Make providing options through the cli more clear

![image](https://github.com/webdriverio/webdriverio/assets/11979740/405d778c-93f9-4159-9072-3ae7ab49dbbe)
