### PR TITLE
(wdio-config): add outputDir default

### DIFF
--- a/packages/wdio-config/src/constants.ts
+++ b/packages/wdio-config/src/constants.ts
@@ -7,7 +7,7 @@ export const DEFAULT_CONFIGS: () => Omit<Options.Testrunner, 'capabilities'> = (
     specs: [],
     suites: {},
     exclude: [],
-    outputDir: './.wdio-artifacts/logs',
+    outputDir: '.wdio-artifacts/logs',
     logLevel: 'info' as const,
     logLevels: {},
     groupLogsByTestSpec: false,

--- a/packages/wdio-config/src/constants.ts
+++ b/packages/wdio-config/src/constants.ts
@@ -7,7 +7,7 @@ export const DEFAULT_CONFIGS: () => Omit<Options.Testrunner, 'capabilities'> = (
     specs: [],
     suites: {},
     exclude: [],
-    outputDir: undefined,
+    outputDir: './.wdio-artifacts/logs',
     logLevel: 'info' as const,
     logLevels: {},
     groupLogsByTestSpec: false,


### PR DESCRIPTION
## Proposed changes

By default all the webdriver logs are put into the browser. This PR changes this so that the logs are now stored at `{wdio root}/.wdio-artifacts/logs`, making for a smoother experience and less confusion when people see errors that are not important to them (test passes but there is a webdriver error).

Marked as a breaking change because people could be relying on the logs in some ways that we cannot anticipate.

## Types of changes

- [x] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

### Reviewers: @webdriverio/project-committers
