### PR TITLE
fix: Fix skip test filename

### DIFF
--- a/packages/wdio-browserstack-service/src/reporter.ts
+++ b/packages/wdio-browserstack-service/src/reporter.ts
@@ -223,6 +223,9 @@ class _TestReporter extends WDIOReporter {
         const testMetaData: TestMeta = _TestReporter._tests[identifier]
         const scope = testStats.type === 'test' ? (testStats as TestStats).fullTitle : `${this._suites[0].title} - ${testStats.title}`
 
+        // If no describe block present, onSuiteStart doesn't get called. Use specs list for filename
+        const suiteFileName = this._suiteName || (this.specs?.length > 0 ? this.specs[this.specs.length - 1]?.replace('file:', '') : undefined)
+
         await this.configureGit()
         const testData: TestData = {
             uuid: testMetaData ? testMetaData.uuid : uuidv4(),
@@ -235,9 +238,9 @@ class _TestReporter extends WDIOReporter {
             scope: scope,
             scopes: scopes,
             identifier: identifier,
-            file_name: this._suiteName ? path.relative(process.cwd(), this._suiteName) : undefined,
-            location: this._suiteName ? path.relative(process.cwd(), this._suiteName) : undefined,
-            vc_filepath: (this._gitConfigPath && this._suiteName) ? path.relative(this._gitConfigPath, this._suiteName) : undefined,
+            file_name: suiteFileName ? path.relative(process.cwd(), suiteFileName) : undefined,
+            location: suiteFileName ? path.relative(process.cwd(), suiteFileName) : undefined,
+            vc_filepath: (this._gitConfigPath && suiteFileName) ? path.relative(this._gitConfigPath, suiteFileName) : undefined,
             started_at: testStats.start && testStats.start.toISOString(),
             finished_at: testStats.end && testStats.end.toISOString(),
             framework: framework,


### PR DESCRIPTION
## Proposed changes
If no describe block present, onSuiteStart doesn't get called. This sends filename as undefined to browserstack observability. Use specs list for filename

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
