### PR TITLE
fix: convert npm to pnpm in gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -5,7 +5,11 @@ tasks:
   - name: Unit Test Coverage
     init: gp sync-await installation
     command: |
-      pnpm run test:unit
+      npm run test:unit
+      cd coverage/lcov-report/
+      http-server -p 8000 &
+      cd ../../
+      npx vitest
   - name: Run Documentation Page
     init: |
       cd /workspace/webdriverio/website

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -5,24 +5,20 @@ tasks:
   - name: Unit Test Coverage
     init: gp sync-await installation
     command: |
-      npm run test:unit
-      cd coverage/lcov-report/
-      http-server -p 8000 &
-      cd ../../
-      npx vitest
+      pnpm run test:unit
   - name: Run Documentation Page
     init: |
       cd /workspace/webdriverio/website
-      npm install
+      pnpm install
     command: |
       cd /workspace/webdriverio/website
-      npm start
+      pnpm start
   - name: Setup WebdriverIO Development Environment
     init: |
-      npm install
-      npm run setup
+      pnpm install
+      pnpm run setup
       gp sync-done installation
-    command: npm run watch
+    command: pnpm run watch
   - name: Welcome Bash
     init: gp sync-await installation
     command: node .gitpod/welcome.mjs

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -308,8 +308,6 @@ importers:
 
   e2e/interop: {}
 
-  packages/devtools/build/cjs: {}
-
   packages/eslint-plugin-wdio:
     devDependencies:
       '@types/estree':

--- a/scripts/templates/template.eta
+++ b/scripts/templates/template.eta
@@ -24,7 +24,7 @@ title: <%= it.command %>
 <% if (it.alternativeCommands && it.alternativeCommands.length) { %>
 :::info
 
-This protocol command is embedded in the following convenient method<%= it.alternativeCommands.length > 1 ? 's' : '' %>: <%= it.alternativeCommands.map((command) => `[${command.split('/').pop()}}](/docs/api/${command})`).join(', ') %>. It is recommended to use <%= it.alternativeCommands.length > 1 ? 'these commands' : 'this command' %> instead.
+This protocol command is embedded in the following convenient method<%= it.alternativeCommands.length > 1 ? 's' : '' %>: <%= it.alternativeCommands.map((command) => `[${command.split('/').pop()}](/docs/api/${command})`).join(', ') %>. It is recommended to use <%= it.alternativeCommands.length > 1 ? 'these commands' : 'this command' %> instead.
 
 :::
 <% } %>


### PR DESCRIPTION
## Proposed changes
This change addresses issue #12707. ~~Additionally, I’ve removed the command line for navigating to the coverage folder, which appears to be missing.~~

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
