### PR TITLE
Allows reloadSession to connect to remote driver

### DIFF
--- a/packages/webdriver/src/index.ts
+++ b/packages/webdriver/src/index.ts
@@ -4,7 +4,6 @@ import logger from '@wdio/logger'
 
 import { webdriverMonad, sessionEnvironmentDetector, startWebDriver } from '@wdio/utils'
 import { validateConfig } from '@wdio/config'
-import { deepmerge } from 'deepmerge-ts'
 import type { Options } from '@wdio/types'
 
 import command from './command.js'
@@ -152,11 +151,18 @@ export default class WebDriver {
      * @returns {string}           the new session id of the browser
      */
     static async reloadSession(instance: Client, newCapabilities?: WebdriverIO.Capabilities) {
-        const capabilities = deepmerge(instance.requestedCapabilities, newCapabilities || {})
-        const params: Options.WebDriver = { ...instance.options, capabilities }
+        const capabilities = newCapabilities ? newCapabilities : instance.requestedCapabilities as WebdriverIO.Capabilities
+        let params: Options.WebDriver = { ...instance.options, capabilities }
+
+        for (const prop of ['protocol', 'hostname', 'port', 'path', 'queryParams', 'user', 'key'] as (keyof Options.Connection)[]) {
+            if (prop in capabilities) {
+                params = { ...params, [prop]: capabilities[prop] }
+                delete capabilities[prop]
+            }
+        }
 
         let driverProcess: ChildProcess | undefined
-        if (newCapabilities?.browserName) {
+        if (params.hostname === DEFAULTS.hostname.default && newCapabilities?.browserName) {
             delete params.port
             delete params.hostname
             driverProcess = await startWebDriver(params)

--- a/packages/webdriver/tests/index.test.ts
+++ b/packages/webdriver/tests/index.test.ts
@@ -298,7 +298,7 @@ describe('WebDriver', () => {
 
         it('starts a new driver process if browserName is given', async () => {
             vi.mocked(startWebDriver).mockImplementation((params) => {
-                params.hostname = 'localhost'
+                params.hostname = '0.0.0.0'
                 params.port = 4444
                 return { pid: 1234 } as any
             })
@@ -310,6 +310,18 @@ describe('WebDriver', () => {
             await WebDriver.reloadSession(session, { browserName: 'chrome' })
             expect(startWebDriver).toHaveBeenCalledOnce()
             expect((session.capabilities as WebdriverIO.Capabilities)['wdio:driverPID']).toBe(1234)
+        })
+
+        it('connects to the new remote', async () => {
+            const session = await WebDriver.newSession({
+                path: '/',
+                capabilities: { browserName: 'firefox' }
+            })
+            vi.mocked(startWebDriver).mockClear()
+            await WebDriver.reloadSession(session, { hostname: '1.1.1.1', port: 5555, browserName: 'chrome' })
+            expect(startWebDriver).not.toHaveBeenCalledOnce()
+            expect(session.options.hostname).toBe('1.1.1.1')
+            expect(session.options.port).toBe(5555)
         })
     })
 

--- a/packages/webdriverio/src/commands/browser/reloadSession.ts
+++ b/packages/webdriverio/src/commands/browser/reloadSession.ts
@@ -11,6 +11,14 @@ const log = logger('webdriverio')
  * Be careful though, this command affects your test time tremendously since spawning
  * new Selenium sessions is very time consuming especially when using cloud services.
  *
+ * Connection parameters such as hostname, port, protocol, etc. can be added along side
+ * browserName when you want to connect to a different remote service. This is useful
+ * in a situation, for example, where you start a test in native app and need to verify
+ * data in web app.
+ *
+ * If you start from remote service, you can pass in 0.0.0.0 for hostname if you want
+ * to switch to local drivers.
+ *
  * <example>
     :reloadSync.js
     it('should reload my session with current capabilities', async () => {
@@ -22,6 +30,18 @@ const log = logger('webdriverio')
     it('should reload my session with new capabilities', async () => {
         console.log(browser.capabilities.browserName) // outputs: chrome
         await browser.reloadSession({
+            browserName: 'firefox'
+        })
+        console.log(browser.capabilities.browserName) // outputs: firefox
+    })
+
+    it('should reload my session with new remote', async () => {
+        console.log(browser.capabilities.browserName) // outputs: chrome
+        await browser.reloadSession({
+            protocol: 'https',
+            host: '0.0.0.1',
+            port: 4444,
+            path: '/wd/hub',
             browserName: 'firefox'
         })
         console.log(browser.capabilities.browserName) // outputs: firefox


### PR DESCRIPTION
## Proposed changes

This change allows reloadSession to connect to remote driver and vice versa. This is useful for some instances, such as when a test starts in mobile native app and then have to validate data in web.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments



### Reviewers: @webdriverio/project-committers
