### PR TITLE
fix(@wdio/browser-runner): sanitize objects to reduce performance burden when stringifying

### DIFF
--- a/packages/wdio-browser-runner/src/browser/frameworks/mocha.ts
+++ b/packages/wdio-browser-runner/src/browser/frameworks/mocha.ts
@@ -213,23 +213,6 @@ export class MochaFramework extends HTMLElement {
                     return arg
                 }
 
-                if ('_runnable' in arg) {
-                    delete arg._runnable
-                }
-
-                if ('test' in arg) {
-                    arg.test = filterTestArgument(arg.test, this.#spec)
-                }
-
-                if ('currentTest' in arg) {
-                    arg.currentTest = filterTestArgument(arg.currentTest, this.#spec)
-                }
-
-                // Check for test argument and file to that argument.
-                if ('type' in arg && 'title' in arg) {
-                    return filterTestArgument(args, this.#spec)
-                }
-
                 // Check for error and convert error class to serializable Object.
                 if ('error' in arg && arg.error instanceof Error) {
                     const errorObject = {
@@ -251,7 +234,12 @@ export class MochaFramework extends HTMLElement {
                     }
                 }
 
-                return arg
+                return {
+                    ...filterTestArgument(arg, this.#spec),
+                    ...('type' in arg && 'title' in arg ? { parent: arg.parent } : {}),
+                    ...('test' in arg && arg.test ? { test: filterTestArgument(arg.test, this.#spec) } : {}),
+                    ...('currentTest' in arg && arg.currentTest ? { currentTest: filterTestArgument(arg.currentTest, this.#spec) } : {})
+                }
             })
             import.meta.hot?.send(WDIO_EVENT_NAME, this.#hookTrigger({ name, id, cid, args }))
         })

--- a/packages/wdio-browser-runner/src/browser/utils.ts
+++ b/packages/wdio-browser-runner/src/browser/utils.ts
@@ -32,7 +32,7 @@ export const showPopupWarning = <T>(name: string, value: T, defaultValue?: T) =>
     return value
 }
 
-export function sanitizeConsoleArgs (args: unknown[]) {
+export function sanitizeConsoleArgs(args: unknown[]) {
     return args.map((arg: any) => {
         if (arg === undefined) {
             return 'undefined'
@@ -68,13 +68,31 @@ export function sanitizeConsoleArgs (args: unknown[]) {
     })
 }
 
+const pick = (keys: string[], obj: any) => {
+    return Object.fromEntries(
+        Object.entries(obj)
+            .filter(([k]) => keys.includes(k))
+    )
+}
+
+const RELEVANT_TEST_PROPS = ['type', 'title', 'body', 'async', 'sync', 'timedOut', 'pending', 'parent', 'test']
+
 /**
  * Filter test argument to only contain relevant information
  * @param arg hook parameter that may contain a test object from Mocha or Jasmine
  * @param file file path of the test
  * @returns test object with only relevant information
  */
-export function filterTestArgument (arg: any, file: string) {
-    const { type, title, body, async, sync, timedOut, pending } = arg
-    return { type, title, body, async, sync, timedOut, pending, file }
+export function filterTestArgument(arg: any, file: string): any {
+    if (!arg) {
+        return arg
+    }
+
+    const newArgs = pick(RELEVANT_TEST_PROPS, arg) as any
+    return {
+        ...newArgs,
+        file: arg.file || file,
+        test: filterTestArgument(newArgs.test, file),
+        parent: filterTestArgument(newArgs.parent, file),
+    }
 }

--- a/packages/wdio-browser-runner/src/browser/utils.ts
+++ b/packages/wdio-browser-runner/src/browser/utils.ts
@@ -67,3 +67,14 @@ export function sanitizeConsoleArgs (args: unknown[]) {
         return arg
     })
 }
+
+/**
+ * Filter test argument to only contain relevant information
+ * @param arg hook parameter that may contain a test object from Mocha or Jasmine
+ * @param file file path of the test
+ * @returns test object with only relevant information
+ */
+export function filterTestArgument (arg: any, file: string) {
+    const { type, title, body, async, sync, timedOut, pending } = arg
+    return { type, title, body, async, sync, timedOut, pending, file }
+}


### PR DESCRIPTION
## Proposed changes

This patch fixes a performance issue we've discovered in the Eslint project. It turns out that we haven't been filtering for large test context objects in the hook wrapper causing performance issues when using hooks in component tests.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [x] Back-ported PR at `#12980`

## Further comments

I tested this on the current Eslint codebase and verified it works. Next step for us should it be to integrate Eslint into our pipeline to avoid these issues from trickling down.

### Reviewers: @webdriverio/project-committers
