### PR TITLE
feat: display command name for webdriver calls in allure reporter

### DIFF
--- a/packages/wdio-allure-reporter/src/reporter.ts
+++ b/packages/wdio-allure-reporter/src/reporter.ts
@@ -491,11 +491,18 @@ export default class AllureReporter extends WDIOReporter {
         if (disableWebdriverStepsReporting || this._isMultiremote) {
             return
         }
+        const { method, endpoint, command : commandName } = command
+        const formatedEnpoint = method
+            ? `${method} ${endpoint}`
+            : ''
 
-        const stepName = command.method ? `${command.method} ${command.endpoint}` : command.command as string
+        const stepName = formatedEnpoint && commandName
+            ? `${commandName} [${formatedEnpoint}]`
+            : formatedEnpoint || commandName
+
         const payload = command.body || command.params
 
-        this._startStep(stepName)
+        this._startStep(stepName as string)
 
         if (!isEmpty(payload)) {
             this.attachJSON('Request', payload)

--- a/packages/wdio-allure-reporter/src/reporter.ts
+++ b/packages/wdio-allure-reporter/src/reporter.ts
@@ -491,15 +491,9 @@ export default class AllureReporter extends WDIOReporter {
         if (disableWebdriverStepsReporting || this._isMultiremote) {
             return
         }
-        const { method, endpoint, command : commandName } = command
-        const formatedEnpoint = method
-            ? `${method} ${endpoint}`
-            : ''
+        const { method, endpoint } = command
 
-        const stepName = formatedEnpoint && commandName
-            ? `${commandName} [${formatedEnpoint}]`
-            : formatedEnpoint || commandName
-
+        const stepName = command.command ? command.command : `${method} ${endpoint}`
         const payload = command.body || command.params
 
         this._startStep(stepName as string)

--- a/packages/wdio-allure-reporter/tests/allureFeatures.test.ts
+++ b/packages/wdio-allure-reporter/tests/allureFeatures.test.ts
@@ -1054,3 +1054,68 @@ describe('nested suite naming', () => {
         expect(childSuite).not.toBeUndefined()
     })
 })
+
+describe('test step naming', () => {
+    const outputDir = temporaryDirectory()
+    let reporter: any
+
+    beforeEach(() => {
+        clean(outputDir)
+        reporter = new AllureReporter({ outputDir, disableMochaHooks: false })
+    })
+
+    it('when both command name and enpoint are available ', () => {
+        const command = {
+            command: 'SomeCommandStep',
+            method: 'POST',
+            endpoint: '/session/:sessionId/element',
+        }
+        reporter.onRunnerStart(runnerStart())
+        reporter.onSuiteStart(testStart())
+        reporter.onTestStart(testStart())
+        reporter.onBeforeCommand(command)
+        reporter.onAfterCommand(command)
+        reporter.onTestPass()
+        reporter.onSuiteEnd(suiteEnd())
+        reporter.onRunnerEnd(runnerEnd())
+
+        const { results } = getResults(outputDir)
+        const testResult = results.find(
+            (result) => result.name === 'should can do something'
+        )
+
+        expect(results).toHaveLength(1)
+        expect(testResult).not.toBeUndefined()
+        expect(testResult.steps).toHaveLength(1)
+        expect(testResult.steps[0].name).toEqual(
+            'SomeCommandStep [POST /session/:sessionId/element]'
+        )
+    })
+
+    it('when command name is not available ', () => {
+        const command = {
+            method: 'POST',
+            endpoint: '/session/:sessionId/element',
+        }
+        reporter.onRunnerStart(runnerStart())
+        reporter.onSuiteStart(testStart())
+        reporter.onTestStart(testStart())
+        reporter.onBeforeCommand(command)
+        reporter.onAfterCommand(command)
+        reporter.onTestPass()
+        reporter.onSuiteEnd(suiteEnd())
+        reporter.onRunnerEnd(runnerEnd())
+
+        const { results } = getResults(outputDir)
+        const testResult = results.find(
+            (result) => result.name === 'should can do something'
+        )
+
+        expect(results).toHaveLength(1)
+        expect(testResult).not.toBeUndefined()
+        expect(testResult.steps).toHaveLength(1)
+        expect(testResult.steps[0].name).toEqual(
+            'POST /session/:sessionId/element'
+        )
+    })
+})

--- a/packages/wdio-allure-reporter/tests/allureFeatures.test.ts
+++ b/packages/wdio-allure-reporter/tests/allureFeatures.test.ts
@@ -1064,7 +1064,7 @@ describe('test step naming', () => {
         reporter = new AllureReporter({ outputDir, disableMochaHooks: false })
     })
 
-    it('when both command name and enpoint are available ', () => {
+    it('should display command name when both command name and enpoint are available ', () => {
         const command = {
             command: 'SomeCommandStep',
             method: 'POST',
@@ -1088,11 +1088,11 @@ describe('test step naming', () => {
         expect(testResult).not.toBeUndefined()
         expect(testResult.steps).toHaveLength(1)
         expect(testResult.steps[0].name).toEqual(
-            'SomeCommandStep [POST /session/:sessionId/element]'
+            'SomeCommandStep'
         )
     })
 
-    it('when command name is not available ', () => {
+    it('should display the endpoint and method in the absence of command name', () => {
         const command = {
             method: 'POST',
             endpoint: '/session/:sessionId/element',

--- a/packages/webdriver/src/command.ts
+++ b/packages/webdriver/src/command.ts
@@ -118,7 +118,7 @@ export default function (
 
         const request = new Request(method, endpoint, body, isHubCommand)
         request.on('performance', (...args) => this.emit('request.performance', ...args))
-        this.emit('command', { method, endpoint, body })
+        this.emit('command', { command, method, endpoint, body })
         log.info('COMMAND', commandCallStructure(command, args))
         /**
          * use then here so we can better unit test what happens before and after the request
@@ -136,7 +136,7 @@ export default function (
                 log.info('RESULT', resultLog)
             }
 
-            this.emit('result', { method, endpoint, body, result })
+            this.emit('result', { command, method, endpoint, body, result })
 
             if (command === 'deleteSession') {
                 const shutdownDriver = body.deleteSessionOpts?.shutdownDriver !== false


### PR DESCRIPTION
## Proposed changes
Currently the allure reporter will display only the endpoint and method name for all webdriver api calls. As part of the change, i have enabled the command name to be also displayed along with the endpoint. 
Fixes #12926

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [X] Polish (an improvement for an existing feature)
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added the necessary documentation (if appropriate)
- [X] I have added proper type definitions for new commands (if appropriate)


## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
