### PR TITLE
breaking(*): better type definitions for capabilities

### DIFF
--- a/__mocks__/@wdio/config.ts
+++ b/__mocks__/@wdio/config.ts
@@ -7,7 +7,7 @@ import {
     validateConfig as validateConfigMock
 } from '../../packages/wdio-config/src/utils.js'
 
-export const DEFAULT_CONFIGS = DEFAULT_CONFIGS_IMPORT as () => Omit<Options.Testrunner, 'capabilities'>
+export const DEFAULT_CONFIGS = DEFAULT_CONFIGS_IMPORT as () => Options.Testrunner
 export const isCloudCapability = vi.fn().mockImplementation(isCloudCapabilityMock)
 export const validateConfig = vi.fn().mockImplementation((defaults, config) => {
     const returnVal = validateConfigMock(defaults, config)

--- a/packages/wdio-allure-reporter/src/reporter.ts
+++ b/packages/wdio-allure-reporter/src/reporter.ts
@@ -33,7 +33,7 @@ import {
 
 export default class AllureReporter extends WDIOReporter {
     private _allure: AllureRuntime
-    private _capabilities: Capabilities.RemoteCapability
+    private _capabilities: Capabilities.ResolveTestrunnerCaps
     private _isMultiremote?: boolean
     private _config?: Options.Testrunner
     private _options: AllureReporterOptions
@@ -238,17 +238,15 @@ export default class AllureReporter extends WDIOReporter {
         }
 
         if (!this._isMultiremote) {
-            const caps = this._capabilities as Capabilities.DesiredCapabilities
-            const { browserName, desired, device } = caps
-            const deviceName = (desired || {}).deviceName || (desired || {})['appium:deviceName'] || caps.deviceName || caps['appium:deviceName']
-            let targetName = device || browserName || deviceName || cid
+            const caps = this._capabilities as WebdriverIO.Capabilities
+            const deviceName = caps['appium:deviceName']
+            let targetName = caps.browserName || deviceName || cid
             // custom mobile grids can have device information in a `desired` cap
-            if (desired && deviceName && desired['appium:platformVersion']) {
-                targetName = `${device || deviceName} ${desired['appium:platformVersion']}`
+            if (caps['appium:platformVersion']) {
+                targetName = `${deviceName} ${caps['appium:platformVersion']}`
             }
-            const browserstackVersion = caps.os_version || caps.osVersion
-            const version = browserstackVersion || caps.browserVersion || caps.version || caps['appium:platformVersion'] || ''
-            const paramName = (deviceName || device) ? 'device' : 'browser'
+            const version = caps.browserVersion || caps['appium:platformVersion'] || ''
+            const paramName = deviceName ? 'device' : 'browser'
             const paramValue = version ? `${targetName}-${version}` : targetName
 
             if (!paramValue) {

--- a/packages/wdio-allure-reporter/src/reporter.ts
+++ b/packages/wdio-allure-reporter/src/reporter.ts
@@ -33,7 +33,7 @@ import {
 
 export default class AllureReporter extends WDIOReporter {
     private _allure: AllureRuntime
-    private _capabilities: Capabilities.ResolveTestrunnerCaps
+    private _capabilities: Capabilities.ResolvedTestrunnerCapabilities
     private _isMultiremote?: boolean
     private _config?: Options.Testrunner
     private _options: AllureReporterOptions
@@ -238,15 +238,21 @@ export default class AllureReporter extends WDIOReporter {
         }
 
         if (!this._isMultiremote) {
-            const caps = this._capabilities as WebdriverIO.Capabilities
-            const deviceName = caps['appium:deviceName']
-            let targetName = caps.browserName || deviceName || cid
+            const caps = this._capabilities
+            // @ts-expect-error outdated JSONWP capabilities
+            const { browserName, desired, device } = caps
+            // @ts-expect-error outdated JSONWP capabilities
+            const deviceName = (desired || {}).deviceName || (desired || {})['appium:deviceName'] || caps.deviceName || caps['appium:deviceName']
+            let targetName = device || browserName || deviceName || cid
             // custom mobile grids can have device information in a `desired` cap
-            if (caps['appium:platformVersion']) {
-                targetName = `${deviceName} ${caps['appium:platformVersion']}`
+            if (desired && deviceName && desired['appium:platformVersion']) {
+                targetName = `${device || deviceName} ${desired['appium:platformVersion']}`
             }
-            const version = caps.browserVersion || caps['appium:platformVersion'] || ''
-            const paramName = deviceName ? 'device' : 'browser'
+            // @ts-expect-error outdated JSONWP capabilities
+            const browserstackVersion = caps.os_version || caps.osVersion
+            // @ts-expect-error outdated JSONWP capabilities
+            const version = browserstackVersion || caps.browserVersion || caps.version || caps['appium:platformVersion'] || ''
+            const paramName = (deviceName || device) ? 'device' : 'browser'
             const paramValue = version ? `${targetName}-${version}` : targetName
 
             if (!paramValue) {

--- a/packages/wdio-appium-service/src/launcher.ts
+++ b/packages/wdio-appium-service/src/launcher.ts
@@ -34,7 +34,7 @@ export default class AppiumLauncher implements Services.ServiceInstance {
 
     constructor(
         private _options: AppiumServiceConfig,
-        private _capabilities: Capabilities.RemoteCapabilities,
+        private _capabilities: Capabilities.TestrunnerCapabilities,
         private _config?: Options.Testrunner
     ) {
         this._args = {

--- a/packages/wdio-browser-runner/src/index.ts
+++ b/packages/wdio-browser-runner/src/index.ts
@@ -54,8 +54,8 @@ export default class BrowserRunner extends LocalRunner {
          */
         if (this.#config.mochaOpts) {
             this.#config.mochaOpts.require = (this.#config.mochaOpts.require || [])
-                .map((r) => path.join(this.#config.rootDir || process.cwd(), r))
-                .map((r) => url.pathToFileURL(r).pathname)
+                .map((r: 'string') => path.join(this.#config.rootDir || process.cwd(), r))
+                .map((r: 'string') => url.pathToFileURL(r).pathname)
         }
     }
 

--- a/packages/wdio-browser-runner/src/types.ts
+++ b/packages/wdio-browser-runner/src/types.ts
@@ -1,5 +1,5 @@
 import type { ConfigEnv, InlineConfig } from 'vite'
-import type { Workers, Capabilities, Options } from '@wdio/types'
+import type { Workers, Options } from '@wdio/types'
 import type { MochaOpts } from '@wdio/mocha-framework'
 import type { IstanbulPluginOptions } from 'vite-plugin-istanbul'
 
@@ -116,7 +116,7 @@ export interface RunArgs extends Workers.WorkerRunPayload {
 export interface Environment {
     args: MochaOpts
     config: Options.Testrunner
-    capabilities: Capabilities.RemoteCapability
+    capabilities: WebdriverIO.Capabilities
     sessionId: string
     injectGlobals: boolean
 }

--- a/packages/wdio-browser-runner/src/utils.ts
+++ b/packages/wdio-browser-runner/src/utils.ts
@@ -10,7 +10,7 @@ import type { BrowserRunnerOptions, CoverageOptions } from './types.js'
 
 const log = logger('@wdio/browser-runner')
 
-export function makeHeadless (options: BrowserRunnerOptions, caps: Capabilities.RemoteCapability): Capabilities.RemoteCapability {
+export function makeHeadless (options: BrowserRunnerOptions, caps: WebdriverIO.Capabilities): WebdriverIO.Capabilities {
     const capability = (caps as Capabilities.W3CCapabilities).alwaysMatch || caps
     if (!capability.browserName) {
         throw new Error(
@@ -57,7 +57,7 @@ export function makeHeadless (options: BrowserRunnerOptions, caps: Capabilities.
 /**
  * Open with devtools open when in watch mode
  */
-export function adjustWindowInWatchMode (config: Options.Testrunner, caps: Capabilities.RemoteCapability): Capabilities.RemoteCapability {
+export function adjustWindowInWatchMode (config: Options.Testrunner, caps: WebdriverIO.Capabilities): WebdriverIO.Capabilities {
     if (!config.watch) {
         return caps
     }

--- a/packages/wdio-browserstack-service/src/Percy/Percy-Handler.ts
+++ b/packages/wdio-browserstack-service/src/Percy/Percy-Handler.ts
@@ -24,7 +24,7 @@ class _PercyHandler {
     constructor (
         private _percyAutoCaptureMode: string | undefined,
         private _browser: WebdriverIO.Browser | WebdriverIO.MultiRemoteBrowser,
-        private _capabilities: Capabilities.ResolveTestrunnerCaps,
+        private _capabilities: Capabilities.ResolvedTestrunnerCapabilities,
         private _isAppAutomate?: boolean,
         private _framework?: string
     ) {

--- a/packages/wdio-browserstack-service/src/Percy/Percy-Handler.ts
+++ b/packages/wdio-browserstack-service/src/Percy/Percy-Handler.ts
@@ -24,7 +24,7 @@ class _PercyHandler {
     constructor (
         private _percyAutoCaptureMode: string | undefined,
         private _browser: WebdriverIO.Browser | WebdriverIO.MultiRemoteBrowser,
-        private _capabilities: Capabilities.RemoteCapability,
+        private _capabilities: Capabilities.ResolveTestrunnerCaps,
         private _isAppAutomate?: boolean,
         private _framework?: string
     ) {

--- a/packages/wdio-browserstack-service/src/Percy/PercyHelper.ts
+++ b/packages/wdio-browserstack-service/src/Percy/PercyHelper.ts
@@ -23,7 +23,7 @@ export const stopPercy = async (percy: Percy) => {
     return percy.stop()
 }
 
-export const getBestPlatformForPercySnapshot = (capabilities?: Capabilities.RemoteCapabilities) : any => {
+export const getBestPlatformForPercySnapshot = (capabilities?: Capabilities.TestrunnerCapabilities) : any => {
     try {
         const percyBrowserPreference: any = { 'chrome': 0, 'firefox': 1, 'edge': 2, 'safari': 3 }
 
@@ -32,11 +32,15 @@ export const getBestPlatformForPercySnapshot = (capabilities?: Capabilities.Remo
 
         if (Array.isArray(capabilities)) {
             capabilities
-                .flatMap((c: WebdriverIO.Capabilities | Capabilities.MultiRemoteCapabilities) => {
-                    if (Object.values(c).length > 0 && Object.values(c).every(c => typeof c === 'object' && c.capabilities)) {
-                        return Object.values(c).map((o: Options.WebdriverIO) => o.capabilities)
+                .flatMap((c) => {
+                    if ('alwaysMatch' in c) {
+                        return c.alwaysMatch as WebdriverIO.Capabilities
                     }
-                    return c as (Capabilities.DesiredCapabilities)
+
+                    if (Object.values(c).length > 0 && Object.values(c).every(c => typeof c === 'object' && c.capabilities)) {
+                        return Object.values(c).map((o) => o.capabilities) as WebdriverIO.Capabilities[]
+                    }
+                    return c as WebdriverIO.Capabilities
                 }).forEach((capability: WebdriverIO.Capabilities) => {
                     let currBrowserName = capability.browserName
                     if (capability['bstack:options']) {
@@ -52,7 +56,7 @@ export const getBestPlatformForPercySnapshot = (capabilities?: Capabilities.Remo
                 })
             return bestPlatformCaps
         } else if (typeof capabilities === 'object') {
-            Object.entries(capabilities as Capabilities.MultiRemoteCapabilities).forEach(([, caps]) => {
+            Object.entries(capabilities as Capabilities.RequestedMultiremoteCapabilities).forEach(([, caps]) => {
                 let currBrowserName = (caps.capabilities as WebdriverIO.Capabilities).browserName
                 if ((caps.capabilities as WebdriverIO.Capabilities)['bstack:options']) {
                     currBrowserName = (caps.capabilities as WebdriverIO.Capabilities)['bstack:options']?.browserName || currBrowserName

--- a/packages/wdio-browserstack-service/src/Percy/PercyHelper.ts
+++ b/packages/wdio-browserstack-service/src/Percy/PercyHelper.ts
@@ -32,12 +32,12 @@ export const getBestPlatformForPercySnapshot = (capabilities?: Capabilities.Remo
 
         if (Array.isArray(capabilities)) {
             capabilities
-                .flatMap((c: Capabilities.DesiredCapabilities | Capabilities.MultiRemoteCapabilities) => {
+                .flatMap((c: WebdriverIO.Capabilities | Capabilities.MultiRemoteCapabilities) => {
                     if (Object.values(c).length > 0 && Object.values(c).every(c => typeof c === 'object' && c.capabilities)) {
                         return Object.values(c).map((o: Options.WebdriverIO) => o.capabilities)
                     }
                     return c as (Capabilities.DesiredCapabilities)
-                }).forEach((capability: Capabilities.DesiredCapabilities) => {
+                }).forEach((capability: WebdriverIO.Capabilities) => {
                     let currBrowserName = capability.browserName
                     if (capability['bstack:options']) {
                         currBrowserName = capability['bstack:options'].browserName || currBrowserName

--- a/packages/wdio-browserstack-service/src/accessibility-handler.ts
+++ b/packages/wdio-browserstack-service/src/accessibility-handler.ts
@@ -23,7 +23,7 @@ import { BStackLogger } from './bstackLogger.js'
 
 class _AccessibilityHandler {
     private _platformA11yMeta: { [key: string]: any; }
-    private _caps: Capabilities.RemoteCapability
+    private _caps: Capabilities.ResolveTestrunnerCaps
     private _suiteFile?: string
     private _accessibility?: boolean
     private _accessibilityOptions?: { [key: string]: any; }
@@ -33,7 +33,7 @@ class _AccessibilityHandler {
 
     constructor (
         private _browser: WebdriverIO.Browser | WebdriverIO.MultiRemoteBrowser,
-        private _capabilities: Capabilities.RemoteCapability,
+        private _capabilities: Capabilities.ResolveTestrunnerCaps,
         isAppAutomate?: boolean,
         private _framework?: string,
         private _accessibilityAutomation?: boolean | string,
@@ -43,7 +43,8 @@ class _AccessibilityHandler {
 
         this._platformA11yMeta = {
             browser_name: caps.browserName,
-            browser_version: caps?.browserVersion || (caps as Capabilities.DesiredCapabilities)?.version || 'latest',
+            // @ts-expect-error invalid caps property
+            browser_version: caps?.browserVersion || (caps as WebdriverIO.Capabilities)?.version || 'latest',
             os_name: this._getCapabilityValue(_capabilities, 'os', 'os'),
             os_version: this._getCapabilityValue(_capabilities, 'osVersion', 'os_version')
         }
@@ -57,7 +58,7 @@ class _AccessibilityHandler {
         this._suiteFile = filename
     }
 
-    _getCapabilityValue(caps: Capabilities.RemoteCapability, capType: string, legacyCapType: string) {
+    _getCapabilityValue(caps: Capabilities.ResolveTestrunnerCaps, capType: string, legacyCapType: string) {
         if (caps) {
             if (capType === 'accessibility') {
                 if ((caps as WebdriverIO.Capabilities)['bstack:options'] && (isTrue((caps as WebdriverIO.Capabilities)['bstack:options']?.accessibility))) {

--- a/packages/wdio-browserstack-service/src/accessibility-handler.ts
+++ b/packages/wdio-browserstack-service/src/accessibility-handler.ts
@@ -23,7 +23,7 @@ import { BStackLogger } from './bstackLogger.js'
 
 class _AccessibilityHandler {
     private _platformA11yMeta: { [key: string]: any; }
-    private _caps: Capabilities.ResolveTestrunnerCaps
+    private _caps: Capabilities.ResolvedTestrunnerCapabilities
     private _suiteFile?: string
     private _accessibility?: boolean
     private _accessibilityOptions?: { [key: string]: any; }
@@ -33,7 +33,7 @@ class _AccessibilityHandler {
 
     constructor (
         private _browser: WebdriverIO.Browser | WebdriverIO.MultiRemoteBrowser,
-        private _capabilities: Capabilities.ResolveTestrunnerCaps,
+        private _capabilities: Capabilities.ResolvedTestrunnerCapabilities,
         isAppAutomate?: boolean,
         private _framework?: string,
         private _accessibilityAutomation?: boolean | string,
@@ -58,7 +58,7 @@ class _AccessibilityHandler {
         this._suiteFile = filename
     }
 
-    _getCapabilityValue(caps: Capabilities.ResolveTestrunnerCaps, capType: string, legacyCapType: string) {
+    _getCapabilityValue(caps: Capabilities.ResolvedTestrunnerCapabilities, capType: string, legacyCapType: string) {
         if (caps) {
             if (capType === 'accessibility') {
                 if ((caps as WebdriverIO.Capabilities)['bstack:options'] && (isTrue((caps as WebdriverIO.Capabilities)['bstack:options']?.accessibility))) {

--- a/packages/wdio-browserstack-service/src/crash-reporter.ts
+++ b/packages/wdio-browserstack-service/src/crash-reporter.ts
@@ -21,7 +21,7 @@ export default class CrashReporter {
         process.env.CREDENTIALS_FOR_CRASH_REPORTING = JSON.stringify(this.credentialsForCrashReportUpload)
     }
 
-    static setConfigDetails(userConfig: Options.Testrunner, capabilities: Capabilities.RemoteCapability, options: BrowserstackConfig & Options.Testrunner) {
+    static setConfigDetails(userConfig: Options.Testrunner, capabilities: Capabilities.TestrunnerCapabilities, options: BrowserstackConfig & Options.Testrunner) {
         const configWithoutPII = this.filterPII(userConfig)
         const filteredCapabilities = this.filterCapabilities(capabilities)
         this.userConfigForReporting = {
@@ -116,7 +116,7 @@ export default class CrashReporter {
         ['user', 'username', 'key', 'accessKey'].forEach(key => delete obj[key])
     }
 
-    static filterCapabilities(capabilities: Capabilities.RemoteCapability) {
+    static filterCapabilities(capabilities: Capabilities.TestrunnerCapabilities) {
         const capsCopy = JSON.parse(JSON.stringify(capabilities))
         this.recursivelyRedactKeysFromObject(capsCopy, ['extensions'])
         return capsCopy

--- a/packages/wdio-browserstack-service/src/insights-handler.ts
+++ b/packages/wdio-browserstack-service/src/insights-handler.ts
@@ -47,10 +47,10 @@ class _InsightsHandler {
         scenariosStarted: false,
         steps: []
     }
-    private _userCaps?: Capabilities.ResolveTestrunnerCaps = {}
+    private _userCaps?: Capabilities.ResolvedTestrunnerCapabilities = {}
     private listener = Listener.getInstance()
 
-    constructor (private _browser: WebdriverIO.Browser | WebdriverIO.MultiRemoteBrowser, isAppAutomate?: boolean, private _framework?: string, _userCaps?: Capabilities.ResolveTestrunnerCaps) {
+    constructor (private _browser: WebdriverIO.Browser | WebdriverIO.MultiRemoteBrowser, isAppAutomate?: boolean, private _framework?: string, _userCaps?: Capabilities.ResolvedTestrunnerCapabilities) {
         const caps = (this._browser as WebdriverIO.Browser).capabilities as WebdriverIO.Capabilities
         const sessionId = (this._browser as WebdriverIO.Browser).sessionId
 

--- a/packages/wdio-browserstack-service/src/insights-handler.ts
+++ b/packages/wdio-browserstack-service/src/insights-handler.ts
@@ -47,10 +47,10 @@ class _InsightsHandler {
         scenariosStarted: false,
         steps: []
     }
-    private _userCaps?: Capabilities.RemoteCapability = {}
+    private _userCaps?: Capabilities.ResolveTestrunnerCaps = {}
     private listener = Listener.getInstance()
 
-    constructor (private _browser: WebdriverIO.Browser | WebdriverIO.MultiRemoteBrowser, isAppAutomate?: boolean, private _framework?: string, _userCaps?: Capabilities.RemoteCapability) {
+    constructor (private _browser: WebdriverIO.Browser | WebdriverIO.MultiRemoteBrowser, isAppAutomate?: boolean, private _framework?: string, _userCaps?: Capabilities.ResolveTestrunnerCaps) {
         const caps = (this._browser as WebdriverIO.Browser).capabilities as WebdriverIO.Capabilities
         const sessionId = (this._browser as WebdriverIO.Browser).sessionId
 

--- a/packages/wdio-browserstack-service/src/reporter.ts
+++ b/packages/wdio-browserstack-service/src/reporter.ts
@@ -33,7 +33,7 @@ class _TestReporter extends WDIOReporter {
     private _gitConfigured: boolean = false
     private _currentHook: CurrentRunInfo = {}
     private _currentTest: CurrentRunInfo = {}
-    private _userCaps?: Capabilities.RemoteCapability = {}
+    private _userCaps?: Capabilities.ResolveTestrunnerCaps = {}
     private listener = Listener.getInstance()
 
     async onRunnerStart (runnerStats: RunnerStats) {
@@ -49,7 +49,7 @@ class _TestReporter extends WDIOReporter {
     }
 
     private getUserCaps(runnerStats: RunnerStats) {
-        return runnerStats.instanceOptions[runnerStats.sessionId]?.capabilities
+        return runnerStats.capabilities
     }
 
     registerListeners () {

--- a/packages/wdio-browserstack-service/src/reporter.ts
+++ b/packages/wdio-browserstack-service/src/reporter.ts
@@ -33,7 +33,7 @@ class _TestReporter extends WDIOReporter {
     private _gitConfigured: boolean = false
     private _currentHook: CurrentRunInfo = {}
     private _currentTest: CurrentRunInfo = {}
-    private _userCaps?: Capabilities.ResolveTestrunnerCaps = {}
+    private _userCaps?: Capabilities.ResolvedTestrunnerCapabilities = {}
     private listener = Listener.getInstance()
 
     async onRunnerStart (runnerStats: RunnerStats) {

--- a/packages/wdio-browserstack-service/src/service.ts
+++ b/packages/wdio-browserstack-service/src/service.ts
@@ -44,7 +44,7 @@ export default class BrowserstackService implements Services.ServiceInstance {
 
     constructor (
         options: BrowserstackConfig & Options.Testrunner,
-        private _caps: Capabilities.ResolveTestrunnerCaps,
+        private _caps: Capabilities.ResolvedTestrunnerCapabilities,
         private _config: Options.Testrunner
     ) {
         this._options = { ...DEFAULT_OPTIONS, ...options }
@@ -104,7 +104,7 @@ export default class BrowserstackService implements Services.ServiceInstance {
         this._config.key = config.key
     }
 
-    async before(caps: Capabilities.ResolveTestrunnerCaps, specs: string[], browser: WebdriverIO.Browser) {
+    async before(caps: Capabilities.ResolvedTestrunnerCapabilities, specs: string[], browser: WebdriverIO.Browser) {
         // added to maintain backward compatibility with webdriverIO v5
         this._browser = browser ? browser : globalThis.browser
 

--- a/packages/wdio-browserstack-service/src/service.ts
+++ b/packages/wdio-browserstack-service/src/service.ts
@@ -44,7 +44,7 @@ export default class BrowserstackService implements Services.ServiceInstance {
 
     constructor (
         options: BrowserstackConfig & Options.Testrunner,
-        private _caps: Capabilities.RemoteCapability,
+        private _caps: Capabilities.ResolveTestrunnerCaps,
         private _config: Options.Testrunner
     ) {
         this._options = { ...DEFAULT_OPTIONS, ...options }
@@ -78,8 +78,8 @@ export default class BrowserstackService implements Services.ServiceInstance {
         }
     }
 
-    _updateCaps (fn: (caps: WebdriverIO.Capabilities | Capabilities.DesiredCapabilities) => void) {
-        const multiRemoteCap = this._caps as Capabilities.MultiRemoteCapabilities
+    _updateCaps (fn: (caps: WebdriverIO.Capabilities) => void) {
+        const multiRemoteCap = this._caps as Capabilities.RequestedMultiremoteCapabilities
 
         if (multiRemoteCap.capabilities) {
             return Object.entries(multiRemoteCap).forEach(([, caps]) => fn(caps.capabilities as WebdriverIO.Capabilities))
@@ -104,7 +104,7 @@ export default class BrowserstackService implements Services.ServiceInstance {
         this._config.key = config.key
     }
 
-    async before(caps: Capabilities.RemoteCapability, specs: string[], browser: WebdriverIO.Browser) {
+    async before(caps: Capabilities.ResolveTestrunnerCaps, specs: string[], browser: WebdriverIO.Browser) {
         // added to maintain backward compatibility with webdriverIO v5
         this._browser = browser ? browser : globalThis.browser
 
@@ -385,8 +385,8 @@ export default class BrowserstackService implements Services.ServiceInstance {
     }
 
     _isAppAutomate(): boolean {
-        const browserDesiredCapabilities = (this._browser?.capabilities ?? {}) as Capabilities.DesiredCapabilities
-        const desiredCapabilities = (this._caps ?? {})  as Capabilities.DesiredCapabilities
+        const browserDesiredCapabilities = (this._browser?.capabilities ?? {})
+        const desiredCapabilities = (this._caps ?? {})
         return !!browserDesiredCapabilities['appium:app'] || !!desiredCapabilities['appium:app']
     }
 
@@ -412,7 +412,7 @@ export default class BrowserstackService implements Services.ServiceInstance {
         const multiremotebrowser = this._browser as any as WebdriverIO.MultiRemoteBrowser
         return Promise.all(multiremotebrowser.instances
             .filter((browserName: string) => {
-                const cap = getBrowserCapabilities(multiremotebrowser, (this._caps as Capabilities.MultiRemoteCapabilities), browserName)
+                const cap = getBrowserCapabilities(multiremotebrowser, this._caps, browserName)
                 return isBrowserstackCapability(cap)
             })
             .map((browserName: string) => (

--- a/packages/wdio-browserstack-service/src/service.ts
+++ b/packages/wdio-browserstack-service/src/service.ts
@@ -88,7 +88,7 @@ export default class BrowserstackService implements Services.ServiceInstance {
         return fn(this._caps as WebdriverIO.Capabilities)
     }
 
-    beforeSession (config: Omit<Options.Testrunner, 'capabilities'>) {
+    beforeSession (config: Options.Testrunner) {
         // if no user and key is specified even though a browserstack service was
         // provided set user and key with values so that the session request
         // will fail

--- a/packages/wdio-browserstack-service/src/types.ts
+++ b/packages/wdio-browserstack-service/src/types.ts
@@ -122,7 +122,7 @@ export interface BrowserstackConfig {
      */
     sessionNameFormat?: (
         config: Options.Testrunner,
-        capabilities: Capabilities.RemoteCapability,
+        capabilities: Capabilities.ResolveTestrunnerCaps,
         suiteTitle: string,
         testTitle?: string
     ) => string
@@ -255,7 +255,7 @@ export interface LaunchResponse {
 export interface UserConfigforReporting {
   framework?: string,
   services?: any[],
-  capabilities?: Capabilities.RemoteCapability,
+  capabilities?: WebdriverIO.Capabilities,
   env?: {
     'BROWSERSTACK_BUILD': string | undefined,
     'BROWSERSTACK_BUILD_NAME': string | undefined,

--- a/packages/wdio-browserstack-service/src/types.ts
+++ b/packages/wdio-browserstack-service/src/types.ts
@@ -122,7 +122,7 @@ export interface BrowserstackConfig {
      */
     sessionNameFormat?: (
         config: Options.Testrunner,
-        capabilities: Capabilities.ResolveTestrunnerCaps,
+        capabilities: Capabilities.ResolvedTestrunnerCapabilities,
         suiteTitle: string,
         testTitle?: string
     ) => string

--- a/packages/wdio-browserstack-service/src/util.ts
+++ b/packages/wdio-browserstack-service/src/util.ts
@@ -83,7 +83,7 @@ export const COLORS: Record<string, ColorName> = {
  * get browser description for Browserstack service
  * @param cap browser capablities
  */
-export function getBrowserDescription(cap: Capabilities.DesiredCapabilities) {
+export function getBrowserDescription(cap: WebdriverIO.Capabilities) {
     cap = cap || {}
     if (cap['bstack:options']) {
         cap = { ...cap, ...cap['bstack:options'] } as Capabilities.DesiredCapabilities

--- a/packages/wdio-browserstack-service/src/util.ts
+++ b/packages/wdio-browserstack-service/src/util.ts
@@ -86,14 +86,14 @@ export const COLORS: Record<string, ColorName> = {
 export function getBrowserDescription(cap: WebdriverIO.Capabilities) {
     cap = cap || {}
     if (cap['bstack:options']) {
-        cap = { ...cap, ...cap['bstack:options'] } as Capabilities.DesiredCapabilities
+        cap = { ...cap, ...cap['bstack:options'] } as WebdriverIO.Capabilities
     }
 
     /**
      * These keys describe the browser the test was run on
      */
     return BROWSER_DESCRIPTION
-        .map((k: keyof Capabilities.DesiredCapabilities) => cap[k])
+        .map((k) => (cap as any)[k])
         .filter(Boolean)
         .join(' ')
 }
@@ -104,12 +104,12 @@ export function getBrowserDescription(cap: WebdriverIO.Capabilities) {
  * @param caps browser capbilities object. In case of multiremote, the object itself should have a property named 'capabilities'
  * @param browserName browser name in case of multiremote
  */
-export function getBrowserCapabilities(browser: WebdriverIO.Browser | WebdriverIO.MultiRemoteBrowser, caps?: Capabilities.RemoteCapability, browserName?: string) {
+export function getBrowserCapabilities(browser: WebdriverIO.Browser | WebdriverIO.MultiRemoteBrowser, caps?: Capabilities.ResolveTestrunnerCaps, browserName?: string) {
     if (!browser.isMultiremote) {
         return { ...browser.capabilities, ...caps } as WebdriverIO.Capabilities
     }
 
-    const multiCaps = caps as Capabilities.MultiRemoteCapabilities
+    const multiCaps = caps as Capabilities.RequestedMultiremoteCapabilities
     const globalCap = browserName && browser.getInstance(browserName) ? browser.getInstance(browserName).capabilities : {}
     const cap = browserName && multiCaps[browserName] ? multiCaps[browserName].capabilities : {}
     return { ...globalCap, ...cap } as WebdriverIO.Capabilities

--- a/packages/wdio-browserstack-service/src/util.ts
+++ b/packages/wdio-browserstack-service/src/util.ts
@@ -104,7 +104,7 @@ export function getBrowserDescription(cap: WebdriverIO.Capabilities) {
  * @param caps browser capbilities object. In case of multiremote, the object itself should have a property named 'capabilities'
  * @param browserName browser name in case of multiremote
  */
-export function getBrowserCapabilities(browser: WebdriverIO.Browser | WebdriverIO.MultiRemoteBrowser, caps?: Capabilities.ResolveTestrunnerCaps, browserName?: string) {
+export function getBrowserCapabilities(browser: WebdriverIO.Browser | WebdriverIO.MultiRemoteBrowser, caps?: Capabilities.ResolvedTestrunnerCapabilities, browserName?: string) {
     if (!browser.isMultiremote) {
         return { ...browser.capabilities, ...caps } as WebdriverIO.Capabilities
     }

--- a/packages/wdio-cli/src/constants.ts
+++ b/packages/wdio-cli/src/constants.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs/promises'
 import path from 'node:path'
 import { createRequire } from 'node:module'
 import { HOOK_DEFINITION } from '@wdio/utils'
-import type { Options, Services, Reporters, Capabilities } from '@wdio/types'
+import type { Options, Services, Reporters } from '@wdio/types'
 
 import {
     detectCompiler,
@@ -672,7 +672,7 @@ export const COMMUNITY_PACKAGES_WITH_TS_SUPPORT = [
     'wdio-gmail-service'
 ]
 
-export const TESTRUNNER_DEFAULTS: Options.Definition<Options.Testrunner> = {
+export const TESTRUNNER_DEFAULTS: Options.Definition<Options.Testrunner & { capabilities: unknown }> = {
     /**
      * Define specs for test execution. You can either specify a glob
      * pattern to match multiple files at once or wrap a glob or set of
@@ -729,7 +729,7 @@ export const TESTRUNNER_DEFAULTS: Options.Definition<Options.Testrunner> = {
      */
     capabilities: {
         type: 'object',
-        validate: (param: Capabilities.RemoteCapabilities) => {
+        validate: (param: unknown) => {
             /**
              * should be an object
              */

--- a/packages/wdio-cli/src/interface.ts
+++ b/packages/wdio-cli/src/interface.ts
@@ -3,7 +3,7 @@ import chalk, { supportsColor } from 'chalk'
 import logger from '@wdio/logger'
 import { SnapshotManager } from '@vitest/snapshot/manager'
 import type { SnapshotResult } from '@vitest/snapshot'
-import type { Options, Capabilities, Workers } from '@wdio/types'
+import type { Options, Workers } from '@wdio/types'
 
 import { HookError } from './utils.js'
 import { getRunnerName } from './utils.js'
@@ -144,7 +144,7 @@ export default class WDIOCLInterface extends EventEmitter {
     onJobComplete(cid: string, job?: Workers.Job, retries = 0, message = '', _logger: Function = this.log) {
         const details = [`[${cid}]`, message]
         if (job) {
-            details.push('in', getRunnerName(job.caps as Capabilities.DesiredCapabilities), this.getFilenames(job.specs))
+            details.push('in', getRunnerName(job.caps as WebdriverIO.Capabilities), this.getFilenames(job.specs))
         }
         if (retries > 0) {
             details.push(`(${retries} retries)`)

--- a/packages/wdio-cli/src/launcher.ts
+++ b/packages/wdio-cli/src/launcher.ts
@@ -343,7 +343,7 @@ class Launcher {
             const specs = schedulableCaps[0].specs.shift() as NonNullable<WorkerSpecs>
             this._startInstance(
                 specs.files,
-                schedulableCaps[0].caps as Capabilities.ResolveTestrunnerCaps,
+                schedulableCaps[0].caps as Capabilities.ResolvedTestrunnerCapabilities,
                 schedulableCaps[0].cid,
                 specs.rid,
                 specs.retries
@@ -380,7 +380,7 @@ class Launcher {
      */
     private async _startInstance(
         specs: string[],
-        caps: Capabilities.ResolveTestrunnerCaps,
+        caps: Capabilities.ResolvedTestrunnerCapabilities,
         cid: number,
         rid: string | undefined,
         retries: number

--- a/packages/wdio-cli/src/launcher.ts
+++ b/packages/wdio-cli/src/launcher.ts
@@ -82,7 +82,7 @@ class Launcher {
          */
         const totalWorkerCnt = Array.isArray(capabilities)
             ? capabilities
-                .map((c: Capabilities.DesiredCapabilities | Capabilities.MultiRemoteCapabilities) => {
+                .map((c: WebdriverIO.Capabilities | Capabilities.MultiRemoteCapabilities) => {
                     if (this.isParallelMultiremote) {
                         const keys = Object.keys(c as Capabilities.MultiRemoteCapabilities)
                         return this.configParser.getSpecs(((c as Capabilities.MultiRemoteCapabilities)[keys[0]].capabilities as Capabilities.DesiredCapabilities).specs,
@@ -378,7 +378,7 @@ class Launcher {
      */
     private async _startInstance(
         specs: string[],
-        caps: Capabilities.DesiredCapabilities | Capabilities.W3CCapabilities | Capabilities.MultiRemoteCapabilities,
+        caps: WebdriverIO.Capabilities | Capabilities.W3CCapabilities | Capabilities.MultiRemoteCapabilities,
         cid: number,
         rid: string | undefined,
         retries: number

--- a/packages/wdio-cli/src/utils.ts
+++ b/packages/wdio-cli/src/utils.ts
@@ -130,7 +130,7 @@ export async function runLauncherHook(hook: Function | Function[], ...args: any[
 export async function runOnCompleteHook(
     onCompleteHook: Function | Function[],
     config: Options.Testrunner,
-    capabilities: Capabilities.RemoteCapabilities,
+    capabilities: Capabilities.TestrunnerCapabilities,
     exitCode: number,
     results: OnCompleteResult
 ) {
@@ -324,9 +324,9 @@ export async function getCapabilities(arg: ReplCommandArguments) {
         let requiredCaps = config.getCapabilities()
         requiredCaps = (
             // multi capabilities
-            (requiredCaps as (Capabilities.DesiredCapabilities | Capabilities.W3CCapabilities)[])[parseInt(arg.capabilities, 10)] ||
+            (requiredCaps as (Capabilities.RequestedStandaloneCapabilities)[])[parseInt(arg.capabilities, 10)] ||
             // multiremote
-            (requiredCaps as Capabilities.MultiRemoteCapabilities)[arg.capabilities]
+            (requiredCaps as Capabilities.RequestedMultiremoteCapabilities)[arg.capabilities]
         )
         const requiredW3CCaps = pickBy(requiredCaps, (_, key) => CAPABILITY_KEYS.includes(key) || key.includes(':'))
         if (!Object.keys(requiredW3CCaps).length) {

--- a/packages/wdio-cli/src/utils.ts
+++ b/packages/wdio-cli/src/utils.ts
@@ -155,7 +155,7 @@ export async function runOnCompleteHook(
 /**
  * get runner identification by caps
  */
-export function getRunnerName(caps: Capabilities.DesiredCapabilities = {}) {
+export function getRunnerName(caps: WebdriverIO.Capabilities = {}) {
     let runner =
         caps.browserName ||
         caps.platformName ||

--- a/packages/wdio-cli/src/watcher.ts
+++ b/packages/wdio-cli/src/watcher.ts
@@ -31,7 +31,9 @@ export default class Watcher {
         const capSpecs = this._launcher.isMultiremote
             ? []
             : union(flattenDeep(
-                (this._launcher.configParser.getCapabilities() as Capabilities.DesiredCapabilities[]).map(cap => cap.specs || [])
+                (this._launcher.configParser.getCapabilities() as Capabilities.RequestedStandaloneCapabilities[]).map(cap => (
+                    'alwaysMatch' in cap ? cap.alwaysMatch['wdio:specs'] : cap['wdio:specs'] || []
+                ) as string[])
             ))
         this._specs = [...specs, ...capSpecs]
 

--- a/packages/wdio-concise-reporter/src/index.ts
+++ b/packages/wdio-concise-reporter/src/index.ts
@@ -2,7 +2,7 @@ import type { SuiteStats, RunnerStats } from '@wdio/reporter'
 import WDIOReporter from '@wdio/reporter'
 import chalk from 'chalk'
 
-import type { Capabilities, Reporters } from '@wdio/types'
+import type { Reporters } from '@wdio/types'
 
 export default class ConciseReporter extends WDIOReporter {
     // keep track of the order that suites were called
@@ -39,7 +39,7 @@ export default class ConciseReporter extends WDIOReporter {
         const header = chalk.yellow('========= Your concise report ==========')
 
         const output = [
-            this.getEnviromentCombo(runner.capabilities as Capabilities.DesiredCapabilities),
+            this.getEnviromentCombo(runner.capabilities),
             this.getCountDisplay(),
             ...this.getFailureDisplay()
         ]
@@ -102,11 +102,11 @@ export default class ConciseReporter extends WDIOReporter {
      * @param  {Boolean} verbose
      * @return {String}          Enviroment string
      */
-    getEnviromentCombo (caps: Capabilities.DesiredCapabilities) {
-        const device = caps.deviceName
-        const browser = caps.browserName || caps.browser
-        const version = caps.browserVersion || caps.version || caps['appium:platformVersion'] || caps.browser_version
-        const platform = caps.os ? (caps.os + ' ' + caps.os_version) : (caps.platform || caps.platformName)
+    getEnviromentCombo (caps: WebdriverIO.Capabilities) {
+        const device = caps['appium:deviceName']
+        const browser = caps.browserName
+        const version = caps.browserVersion || caps['appium:platformVersion']
+        const platform = caps.platformName
 
         // mobile capabilities
         if (device) {

--- a/packages/wdio-concise-reporter/src/index.ts
+++ b/packages/wdio-concise-reporter/src/index.ts
@@ -103,10 +103,14 @@ export default class ConciseReporter extends WDIOReporter {
      * @return {String}          Enviroment string
      */
     getEnviromentCombo (caps: WebdriverIO.Capabilities) {
-        const device = caps['appium:deviceName']
-        const browser = caps.browserName
-        const version = caps.browserVersion || caps['appium:platformVersion']
-        const platform = caps.platformName
+        // @ts-expect-error `deviceName` and `device` are outdated JSONWP caps
+        const device = caps.deviceName || caps['appium:deviceName'] || caps.device
+        // @ts-expect-error `browser` is an outdated JSONWP cap
+        const browser = caps.browserName || caps.browser
+        // @ts-expect-error `version` and `browser_version` are outdated JSONWP caps
+        const version = caps.browserVersion || caps.version || caps['appium:platformVersion'] || caps.browser_version
+        // @ts-expect-error `os`, `os_version` and `platform` are outdated JSONWP caps
+        const platform = caps.os ? (caps.os + ' ' + caps.os_version) : (caps.platform || caps.platformName)
 
         // mobile capabilities
         if (device) {

--- a/packages/wdio-config/src/constants.ts
+++ b/packages/wdio-config/src/constants.ts
@@ -3,7 +3,7 @@ import type { Options, Services } from '@wdio/types'
 const DEFAULT_TIMEOUT = 10000
 
 /* istanbul ignore next */
-export const DEFAULT_CONFIGS: () => Omit<Options.Testrunner, 'capabilities'> = () => ({
+export const DEFAULT_CONFIGS: () => Options.Testrunner = () => ({
     specs: [],
     suites: {},
     exclude: [],

--- a/packages/wdio-config/src/node/ConfigParser.ts
+++ b/packages/wdio-config/src/node/ConfigParser.ts
@@ -20,13 +20,13 @@ type ESMImport = { config?: TestrunnerOptionsWithParameters }
 type DefaultImport = { default?: { config?: TestrunnerOptionsWithParameters } }
 type ImportedConfigModule = ESMImport | DefaultImport
 
-interface TestrunnerOptionsWithParameters extends Omit<Options.Testrunner, 'capabilities'> {
+interface TestrunnerOptionsWithParameters extends Options.Testrunner {
     watch?: boolean
     coverage?: boolean
     spec?: string[]
     suite?: string[]
     repeat?: number
-    capabilities?: Capabilities.RemoteCapabilities
+    capabilities?: Capabilities.TestrunnerCapabilities
     rootDir: string
     tsConfigPath?: string
 }
@@ -42,7 +42,7 @@ export default class ConfigParser {
     #isInitialised = false
     #configFilePath: string
     private _config: TestrunnerOptionsWithParameters
-    private _capabilities: Capabilities.RemoteCapabilities = []
+    private _capabilities?: Capabilities.TestrunnerCapabilities
 
     constructor(
         configFilePath: string,
@@ -129,6 +129,11 @@ export default class ConfigParser {
                 throw new Error(NO_NAMED_CONFIG_EXPORT)
             }
 
+            const configFileCapabilities = config.capabilities
+            if (!configFileCapabilities) {
+                throw new Error(`No capabilities found in config file: ${filePath}`)
+            }
+
             /**
              * clone the original config
              */
@@ -137,8 +142,7 @@ export default class ConfigParser {
             /**
              * merge capabilities
              */
-            const defaultTo: Capabilities.RemoteCapabilities = Array.isArray(this._capabilities) ? [] : {}
-            this._capabilities = deepmerge(this._capabilities, fileConfig.capabilities || defaultTo)
+            this._capabilities = deepmerge(this._capabilities, fileConfig.capabilities)
             delete fileConfig.capabilities
 
             /**

--- a/packages/wdio-config/src/node/ConfigParser.ts
+++ b/packages/wdio-config/src/node/ConfigParser.ts
@@ -42,7 +42,7 @@ export default class ConfigParser {
     #isInitialised = false
     #configFilePath: string
     private _config: TestrunnerOptionsWithParameters
-    private _capabilities?: Capabilities.TestrunnerCapabilities
+    private _capabilities?: Capabilities.TestrunnerCapabilities = []
 
     constructor(
         configFilePath: string,
@@ -131,7 +131,7 @@ export default class ConfigParser {
 
             const configFileCapabilities = config.capabilities
             if (!configFileCapabilities) {
-                throw new Error(`No capabilities found in config file: ${filePath}`)
+                throw new Error(`No \`capabilities\` property found in WebdriverIO.Config defined in file: ${filePath}`)
             }
 
             /**
@@ -142,7 +142,8 @@ export default class ConfigParser {
             /**
              * merge capabilities
              */
-            this._capabilities = deepmerge(this._capabilities, fileConfig.capabilities)
+            const defaultTo = (Array.isArray(this._capabilities) ? [] : {}) as Capabilities.TestrunnerCapabilities
+            this._capabilities = deepmerge(this._capabilities, fileConfig.capabilities || defaultTo)
             delete fileConfig.capabilities
 
             /**

--- a/packages/wdio-config/tests/node/configparser.test.ts
+++ b/packages/wdio-config/tests/node/configparser.test.ts
@@ -365,7 +365,10 @@ describe('ConfigParser', () => {
                         FileNamed(FIXTURES_LOCAL_CONF).withContents({
                             config: {
                                 hostname: '127.0.0.1',
-                                port: 4444
+                                port: 4444,
+                                capabilities: [{
+                                    browserName: 'chrome'
+                                }]
                             }
                         })
                     ]
@@ -384,7 +387,12 @@ describe('ConfigParser', () => {
             const configParser = ConfigParserBuilder.withBaseDir(FIXTURES_PATH, FIXTURES_DEFAULT_CONF).withFiles([
                 FileNamed(FIXTURES_DEFAULT_CONF).withContents({
                     default: {
-                        config: { foo: 'bar' }
+                        config: {
+                            foo: 'bar',
+                            capabilities: [{
+                                browserName: 'chrome'
+                            }]
+                        }
                     }
                 })
             ]).build()

--- a/packages/wdio-cucumber-framework/src/index.ts
+++ b/packages/wdio-cucumber-framework/src/index.ts
@@ -83,7 +83,7 @@ class CucumberAdapter {
         private _cid: string,
         private _config: Options.Testrunner,
         private _specs: string[],
-        private _capabilities: Capabilities.ResolveTestrunnerCaps,
+        private _capabilities: Capabilities.ResolvedTestrunnerCapabilities,
         private _reporter: EventEmitter,
         private _eventEmitter: EventEmitter,
         private _generateSkipTags: boolean = true,

--- a/packages/wdio-cucumber-framework/src/index.ts
+++ b/packages/wdio-cucumber-framework/src/index.ts
@@ -83,7 +83,7 @@ class CucumberAdapter {
         private _cid: string,
         private _config: Options.Testrunner,
         private _specs: string[],
-        private _capabilities: Capabilities.RemoteCapability,
+        private _capabilities: Capabilities.ResolveTestrunnerCaps,
         private _reporter: EventEmitter,
         private _eventEmitter: EventEmitter,
         private _generateSkipTags: boolean = true,

--- a/packages/wdio-cucumber-framework/src/utils.ts
+++ b/packages/wdio-cucumber-framework/src/utils.ts
@@ -182,7 +182,7 @@ export function addKeywordToStep(steps: ReporterStep[], feature: Feature){
  * @param {string[][]} tags - The original tags of scenarios.
  * @returns {string[]} - An array of generated skip tags in Cucumber tag expression format.
  */
-export function generateSkipTagsFromCapabilities(capabilities: Capabilities.RemoteCapability, tags: string[][]): string[] {
+export function generateSkipTagsFromCapabilities(capabilities: Capabilities.ResolveTestrunnerCaps, tags: string[][]): string[] {
     const generatedTags: string[] = []
 
     const skipTag = /^@skip$|^@skip\((.*)\)$/

--- a/packages/wdio-cucumber-framework/src/utils.ts
+++ b/packages/wdio-cucumber-framework/src/utils.ts
@@ -182,7 +182,7 @@ export function addKeywordToStep(steps: ReporterStep[], feature: Feature){
  * @param {string[][]} tags - The original tags of scenarios.
  * @returns {string[]} - An array of generated skip tags in Cucumber tag expression format.
  */
-export function generateSkipTagsFromCapabilities(capabilities: Capabilities.ResolveTestrunnerCaps, tags: string[][]): string[] {
+export function generateSkipTagsFromCapabilities(capabilities: Capabilities.ResolvedTestrunnerCapabilities, tags: string[][]): string[] {
     const generatedTags: string[] = []
 
     const skipTag = /^@skip$|^@skip\((.*)\)$/

--- a/packages/wdio-devtools-service/src/index.ts
+++ b/packages/wdio-devtools-service/src/index.ts
@@ -18,7 +18,7 @@ export default class DevToolsService implements Services.ServiceInstance {
     constructor (private _options: DevtoolsConfig) {}
 
     async before (
-        caps: Capabilities.RemoteCapability,
+        caps: Capabilities.RequestedStandaloneCapabilities | Capabilities.RequestedMultiremoteCapabilities,
         specs: string[],
         browser: WebdriverIO.Browser | WebdriverIO.MultiRemoteBrowser
     ) {

--- a/packages/wdio-firefox-profile-service/README.md
+++ b/packages/wdio-firefox-profile-service/README.md
@@ -1,7 +1,7 @@
 WDIO Firefox Profile Service
 ============================
 
-You want to run your Firefox browser with a specific extension or need to set couple preferences? Selenium allows you to use a profile for the Firefox browser by passing this profile as `base64` string to the `firefox_profile` property in your desired capabilities. This requires building that profile and converting it into `base64`. This service for the [wdio testrunner](https://webdriver.io/docs/clioptions) takes the work of compiling the profile out of your hand and lets you define your desired options comfortably from the `wdio.conf.js` file.
+You want to run your Firefox browser with a specific extension or need to set a couple preferences? Selenium allows you to use a profile for the Firefox browser by passing this profile as `base64` string to the `moz:firefoxOptions.profile` property in your desired capabilities. This requires building that profile and converting it into `base64`. This service for the [wdio testrunner](https://webdriver.io/docs/clioptions) takes the work of compiling the profile out of your hand and lets you define your desired options comfortably from the `wdio.conf.js` file.
 
 To find all possible options open [about:config](about:config) in your Firefox browser or go to [mozillaZine](http://kb.mozillazine.org/About:config_entries) website to find the whole documentation about each setting. In Addition to that, you can define compiled (as `*.xpi`) Firefox extensions that should get installed before the test starts.
 

--- a/packages/wdio-firefox-profile-service/src/launcher.ts
+++ b/packages/wdio-firefox-profile-service/src/launcher.ts
@@ -84,7 +84,8 @@ export default class FirefoxProfileLauncher {
 
         for (const browser in capabilities) {
             const capability = capabilities[browser].capabilities as Capabilities.RequestedMultiremoteCapabilities[string]['capabilities']
-            if (!capability || (capability as WebdriverIO.Capabilities).browserName !== 'firefox' && (capability as Capabilities.W3CCapabilities).alwaysMatch.browserName !== 'firefox') {
+            const cap = capability && ('alwaysMatch' in capability ? capability.alwaysMatch : capability)
+            if (!capability || cap.browserName !== 'firefox') {
                 continue
             }
 

--- a/packages/wdio-firefox-profile-service/tests/launcher.test.ts
+++ b/packages/wdio-firefox-profile-service/tests/launcher.test.ts
@@ -1,5 +1,4 @@
 import FirefoxProfile from 'firefox-profile'
-import type WebdriverIO from 'webdriverio'
 
 import { describe, expect, test, vi } from 'vitest'
 import Launcher from '../src/launcher.js'
@@ -22,7 +21,7 @@ describe('Firefox profile service', () => {
             const options = {
                 'browser.startup.homepage': 'https://webdriver.io',
             }
-            const capabilities: WebDriver.DesiredCapabilities[] = [{
+            const capabilities: WebdriverIO.Capabilities[] = [{
                 browserName : 'firefox',
             }]
 
@@ -34,36 +33,14 @@ describe('Firefox profile service', () => {
             expect(service['_profile']!.updatePreferences).toHaveBeenCalled()
             expect(service['_profile']!.addExtensions).not.toHaveBeenCalled()
 
-            expect(capabilities[0].firefox_profile).toBe(undefined)
             expect(capabilities[0]['moz:firefoxOptions']).toEqual({ profile : 'foobar' })
-        })
-
-        test('should set preferences with no extensions - legacy', async () => {
-            const options = {
-                'browser.startup.homepage': 'https://webdriver.io',
-                legacy: true
-            }
-            const capabilities: WebDriver.DesiredCapabilities[] = [{
-                browserName : 'firefox',
-            }]
-
-            const service = new Launcher(options)
-            await service.onPrepare({} as never, capabilities)
-
-            expect(service['_profile']!.setPreference).toHaveBeenCalledTimes(1)
-            expect(service['_profile']!.setPreference).toHaveBeenCalledWith('browser.startup.homepage', 'https://webdriver.io')
-            expect(service['_profile']!.updatePreferences).toHaveBeenCalled()
-            expect(service['_profile']!.addExtensions).not.toHaveBeenCalled()
-
-            expect(capabilities[0].firefox_profile).toBe('foobar')
-            expect(capabilities[0]['moz:firefoxOptions']).toEqual(undefined)
         })
 
         test('should amend firefox capabilities', async () => {
             const options = {
                 'browser.startup.homepage': 'https://webdriver.io',
             }
-            const capabilities: WebDriver.DesiredCapabilities[] = [{
+            const capabilities: WebdriverIO.Capabilities[] = [{
                 browserName : 'firefox',
                 'moz:firefoxOptions': {
                     args: ['-headless']
@@ -83,7 +60,7 @@ describe('Firefox profile service', () => {
 
         test('should set preferences with extensions', async () => {
             const options = { extensions : ['/foo/bar.xpi'] }
-            const capabilities: WebDriver.DesiredCapabilities[] = [{ browserName : 'firefox' }]
+            const capabilities: WebdriverIO.Capabilities[] = [{ browserName : 'firefox' }]
 
             const service = new Launcher(options)
             await service.onPrepare({} as never, capabilities)
@@ -96,7 +73,7 @@ describe('Firefox profile service', () => {
             const options = {
                 'browser.startup.homepage': 'https://webdriver.io',
             }
-            const capabilities: WebDriver.DesiredCapabilities[] = [{
+            const capabilities: WebdriverIO.Capabilities[] = [{
                 browserName : 'firefox',
             }, {
                 browserName : 'chrome'
@@ -106,7 +83,6 @@ describe('Firefox profile service', () => {
             await service.onPrepare({} as never, capabilities)
 
             expect(capabilities[0]['moz:firefoxOptions']).toEqual({ profile : 'foobar' })
-            expect(capabilities[1]).not.toHaveProperty('firefox_profile')
             expect(capabilities[1]).not.toHaveProperty('moz:firefoxOptions')
         })
 
@@ -134,7 +110,7 @@ describe('Firefox profile service', () => {
                 'browser.startup.homepage': 'https://webdriver.io',
             }
 
-            const capabilities: WebdriverIO.MultiRemoteCapabilities[] = [{
+            const capabilities: WebdriverIO.MultiremoteConfig['capabilities'] = [{
                 firefox0 : {
                     capabilities : {
                         browserName : 'firefox',
@@ -170,8 +146,6 @@ describe('Firefox profile service', () => {
 
             const service = new Launcher(options)
             await service.onPrepare({} as never, capabilities)
-
-            expect(capabilities.foo.capabilities).not.toHaveProperty('firefox_profile')
             expect(capabilities.foo.capabilities).not.toHaveProperty('moz:firefoxOptions')
         })
 
@@ -181,7 +155,7 @@ describe('Firefox profile service', () => {
                 'browser.startup.homepage': 'https://webdriver.io',
                 proxy : { proxyType: 'direct' as const }
             }
-            const capabilities: WebDriver.DesiredCapabilities[] = [{
+            const capabilities: WebdriverIO.Capabilities[] = [{
                 browserName : 'firefox',
             }]
 
@@ -200,7 +174,7 @@ describe('Firefox profile service', () => {
             const options = {
                 profileDirectory: '/tmp/firefox-profile'
             }
-            const capabilities: WebDriver.DesiredCapabilities[] = [{
+            const capabilities: WebdriverIO.Capabilities[] = [{
                 browserName : 'firefox',
             }]
 
@@ -214,7 +188,7 @@ describe('Firefox profile service', () => {
             const options = {
                 profileDirectory: '/tmp/firefox-profile'
             }
-            const capabilities: WebDriver.DesiredCapabilities[] = [{
+            const capabilities: WebdriverIO.Capabilities[] = [{
                 browserName : 'firefox',
             }]
 

--- a/packages/wdio-jasmine-framework/src/index.ts
+++ b/packages/wdio-jasmine-framework/src/index.ts
@@ -59,7 +59,7 @@ class JasmineAdapter {
         private _cid: string,
         private _config: WebdriverIOJasmineConfig,
         private _specs: string[],
-        private _capabilities: Capabilities.ResolveTestrunnerCaps,
+        private _capabilities: Capabilities.ResolvedTestrunnerCapabilities,
         reporter: EventEmitter
     ) {
         this._jasmineOpts = Object.assign({

--- a/packages/wdio-jasmine-framework/src/index.ts
+++ b/packages/wdio-jasmine-framework/src/index.ts
@@ -59,7 +59,7 @@ class JasmineAdapter {
         private _cid: string,
         private _config: WebdriverIOJasmineConfig,
         private _specs: string[],
-        private _capabilities: Capabilities.RemoteCapabilities,
+        private _capabilities: Capabilities.ResolveTestrunnerCaps,
         reporter: EventEmitter
     ) {
         this._jasmineOpts = Object.assign({

--- a/packages/wdio-json-reporter/src/types.ts
+++ b/packages/wdio-json-reporter/src/types.ts
@@ -11,7 +11,7 @@ export interface SuiteState {
 export interface ResultSet {
     start: Date
     end?: Date
-    capabilities: Capabilities.ResolveTestrunnerCaps
+    capabilities: Capabilities.ResolvedTestrunnerCapabilities
     framework?: string
     mochaOpts?: WebdriverIO.MochaOpts
     jasmineOpts?: WebdriverIO.JasmineOpts

--- a/packages/wdio-json-reporter/src/types.ts
+++ b/packages/wdio-json-reporter/src/types.ts
@@ -11,7 +11,7 @@ export interface SuiteState {
 export interface ResultSet {
     start: Date
     end?: Date
-    capabilities: Capabilities.RemoteCapability
+    capabilities: Capabilities.ResolveTestrunnerCaps
     framework?: string
     mochaOpts?: WebdriverIO.MochaOpts
     jasmineOpts?: WebdriverIO.JasmineOpts

--- a/packages/wdio-junit-reporter/src/index.ts
+++ b/packages/wdio-junit-reporter/src/index.ts
@@ -2,7 +2,6 @@ import url from 'node:url'
 
 import type { RunnerStats, SuiteStats, TestStats } from '@wdio/reporter'
 import WDIOReporter from '@wdio/reporter'
-import type { Capabilities } from '@wdio/types'
 import junit from 'junit-report-builder'
 
 import type { JUnitReporterOptions } from './types.js'
@@ -225,9 +224,12 @@ class JunitReporter extends WDIOReporter {
             // NOTE: deviceUUID is used to build sanitizedCapabilities resulting in a ever-changing package name in runner.sanitizedCapabilities when running Android tests under Browserstack. (i.e. ht79v1a03938.android.9)
             // NOTE: platformVersion is used to build sanitizedCapabilities which can be incorrect and includes a minor version for iOS which is not guaranteed to be the same under Browserstack.
             const browserstackSanitizedCapabilities = [
-                (runner.capabilities as Capabilities.DesiredCapabilities).device,
-                (runner.capabilities as Capabilities.DesiredCapabilities).os,
-                ((runner.capabilities as Capabilities.DesiredCapabilities).os_version || '').replace(/\./g, '_'),
+                // @ts-expect-error capability only exists when running on BrowserStack
+                (runner.capabilities).device,
+                // @ts-expect-error capability only exists when running on BrowserStack
+                (runner.capabilities).os,
+                // @ts-expect-error capability only exists when running on BrowserStack
+                ((runner.capabilities).os_version || '').replace(/\./g, '_'),
             ]
                 .filter(Boolean)
                 .map((capability) => capability!.toLowerCase())

--- a/packages/wdio-local-runner/src/worker.ts
+++ b/packages/wdio-local-runner/src/worker.ts
@@ -4,7 +4,7 @@ import child from 'node:child_process'
 import { EventEmitter } from 'node:events'
 import type { ChildProcess } from 'node:child_process'
 import type { WritableStreamBuffer } from 'stream-buffers'
-import type { Capabilities, Options, Workers } from '@wdio/types'
+import type { Options, Workers } from '@wdio/types'
 
 import logger from '@wdio/logger'
 
@@ -32,9 +32,9 @@ export default class WorkerInstance extends EventEmitter implements Workers.Work
     config: Options.Testrunner
     configFile: string
     // requestedCapabilities
-    caps: Capabilities.RemoteCapability
+    caps: WebdriverIO.Capabilities
     // actual capabilities returned by driver
-    capabilities: Capabilities.RemoteCapability
+    capabilities: WebdriverIO.Capabilities
     specs: string[]
     execArgv: string[]
     retries: number

--- a/packages/wdio-mocha-framework/src/index.ts
+++ b/packages/wdio-mocha-framework/src/index.ts
@@ -7,7 +7,7 @@ import { handleRequires } from 'mocha/lib/cli/run-helpers.js'
 
 import logger from '@wdio/logger'
 import { executeHooksWithArgs } from '@wdio/utils'
-import type { Capabilities, Services, Options } from '@wdio/types'
+import type { Services, Options } from '@wdio/types'
 
 import { formatMessage, setupEnv } from './common.js'
 import { EVENTS, NOOP } from './constants.js'
@@ -43,7 +43,7 @@ class MochaAdapter {
         private _cid: string,
         private _config: ParsedConfiguration,
         private _specs: string[],
-        private _capabilities: Capabilities.RemoteCapability,
+        private _capabilities: WebdriverIO.Capabilities,
         private _reporter: EventEmitter
     ) {
         this._config = Object.assign({

--- a/packages/wdio-reporter/src/stats/runner.ts
+++ b/packages/wdio-reporter/src/stats/runner.ts
@@ -9,7 +9,7 @@ import { sanitizeCaps } from '../utils.js'
  */
 export default class RunnerStats extends RunnableStats {
     cid: string
-    capabilities: Capabilities.ResolveTestrunnerCaps
+    capabilities: Capabilities.ResolvedTestrunnerCapabilities
     sanitizedCapabilities: string
     config: Options.Testrunner
     specs: string[]

--- a/packages/wdio-reporter/src/stats/runner.ts
+++ b/packages/wdio-reporter/src/stats/runner.ts
@@ -9,7 +9,7 @@ import { sanitizeCaps } from '../utils.js'
  */
 export default class RunnerStats extends RunnableStats {
     cid: string
-    capabilities: Capabilities.RemoteCapability
+    capabilities: Capabilities.ResolveTestrunnerCaps
     sanitizedCapabilities: string
     config: Options.Testrunner
     specs: string[]

--- a/packages/wdio-reporter/src/utils.ts
+++ b/packages/wdio-reporter/src/utils.ts
@@ -32,17 +32,21 @@ export function sanitizeCaps (caps?: WebdriverIO.Capabilities) {
     /**
      * mobile caps
      */
-    result = caps['appium:deviceName']
+    // @ts-expect-error outdated JSONWP capabilities
+    result = caps['appium:deviceName'] || caps.deviceName
         ? [
             sanitizeString(caps.platformName),
-            sanitizeString(caps['appium:deviceName']),
+            // @ts-expect-error outdated JSONWP capabilities
+            sanitizeString(caps['appium:deviceName'] || caps.deviceName),
             sanitizeString(caps['appium:platformVersion']),
             sanitizeString(caps['appium:app'])
         ]
         : [
             sanitizeString(caps.browserName),
-            sanitizeString(caps.browserVersion),
-            sanitizeString(caps.platformName),
+            // @ts-expect-error outdated JSONWP capabilities
+            sanitizeString(caps.version || caps.browserVersion),
+            // @ts-expect-error outdated JSONWP capabilities
+            sanitizeString(caps.platform || caps.platformName),
             sanitizeString(caps['appium:app'])
         ]
 

--- a/packages/wdio-reporter/src/utils.ts
+++ b/packages/wdio-reporter/src/utils.ts
@@ -1,5 +1,3 @@
-import type { Capabilities } from '@wdio/types'
-
 import supportsColor from './supportsColor.js'
 import { COLORS } from './constants.js'
 
@@ -24,7 +22,7 @@ export function sanitizeString (str?: string) {
  * formats capability object into sanitized string for e.g.filenames
  * @param {object} caps  Selenium capabilities
  */
-export function sanitizeCaps (caps?: Capabilities.DesiredCapabilities) {
+export function sanitizeCaps (caps?: WebdriverIO.Capabilities) {
     if (!caps) {
         return ''
     }
@@ -34,17 +32,17 @@ export function sanitizeCaps (caps?: Capabilities.DesiredCapabilities) {
     /**
      * mobile caps
      */
-    result = caps.deviceName
+    result = caps['appium:deviceName']
         ? [
             sanitizeString(caps.platformName),
-            sanitizeString(caps.deviceName || caps['appium:deviceName']),
+            sanitizeString(caps['appium:deviceName']),
             sanitizeString(caps['appium:platformVersion']),
             sanitizeString(caps['appium:app'])
         ]
         : [
             sanitizeString(caps.browserName),
-            sanitizeString(caps.version || caps.browserVersion),
-            sanitizeString(caps.platform || caps.platformName),
+            sanitizeString(caps.browserVersion),
+            sanitizeString(caps.platformName),
             sanitizeString(caps['appium:app'])
         ]
 

--- a/packages/wdio-runner/src/browser.ts
+++ b/packages/wdio-runner/src/browser.ts
@@ -6,7 +6,7 @@ import { browser } from '@wdio/globals'
 import { executeHooksWithArgs } from '@wdio/utils'
 import { matchers } from 'expect-webdriverio'
 import { ELEMENT_KEY } from 'webdriver'
-import { type Capabilities, type Workers, type Options, type Services, MESSAGE_TYPES } from '@wdio/types'
+import { type Workers, type Options, type Services, MESSAGE_TYPES } from '@wdio/types'
 
 import { transformExpectArgs } from './utils.js'
 import type BaseReporter from './reporter.js'
@@ -42,7 +42,6 @@ export default class BrowserFramework implements Omit<TestFramework, 'init'> {
         private _cid: string,
         private _config: Options.Testrunner & { sessionId?: string },
         private _specs: string[],
-        private _capabilities: Capabilities.RemoteCapability,
         private _reporter: BaseReporter
     ) {
         // listen on testrunner events
@@ -460,8 +459,8 @@ export default class BrowserFramework implements Omit<TestFramework, 'init'> {
         }
     }
 
-    static init (cid: string, config: any, specs: string[], caps: Capabilities.RemoteCapability, reporter: BaseReporter) {
-        const framework = new BrowserFramework(cid, config, specs, caps, reporter)
+    static init (cid: string, config: any, specs: string[], _: unknown, reporter: BaseReporter) {
+        const framework = new BrowserFramework(cid, config, specs, reporter)
         return framework
     }
 }

--- a/packages/wdio-runner/src/reporter.ts
+++ b/packages/wdio-runner/src/reporter.ts
@@ -18,7 +18,7 @@ export default class BaseReporter {
     constructor(
         private _config: Options.Testrunner,
         private _cid: string,
-        public caps: Capabilities.RemoteCapability
+        public caps: Capabilities.RequestedStandaloneCapabilities | Capabilities.RequestedMultiremoteCapabilities
     ) {}
 
     async initReporters () {
@@ -62,9 +62,9 @@ export default class BaseReporter {
 
     getLogFile (name: string) {
         // clone the config to avoid changing original properties
-        const options = Object.assign({}, this._config) as Omit<Options.Testrunner, 'capabilities'> & {
+        const options = Object.assign({}, this._config) as Options.Testrunner & {
             cid: string
-            capabilities: Capabilities.RemoteCapability
+            capabilities: Capabilities.RequestedStandaloneCapabilities | Capabilities.RequestedMultiremoteCapabilities
         }
         let filename = `wdio-${this._cid}-${name}-reporter.log`
 

--- a/packages/wdio-runner/src/types.ts
+++ b/packages/wdio-runner/src/types.ts
@@ -15,7 +15,7 @@ export type RunParams = {
     cid: string
     args: Args
     specs: string[]
-    caps: Capabilities.RemoteCapability
+    caps: Capabilities.RequestedStandaloneCapabilities | Capabilities.RequestedMultiremoteCapabilities
     configFile: string
     retries: number
 }
@@ -25,16 +25,12 @@ export interface TestFramework {
         cid: string,
         config: Options.Testrunner,
         specs: string[],
-        capabilities: Capabilities.RemoteCapability,
+        capabilities: Capabilities.RequestedStandaloneCapabilities | Capabilities.RequestedMultiremoteCapabilities,
         reporter: BaseReporter
     ) => TestFramework
     run (): Promise<number>
     hasTests (): boolean
 }
-
-type SingleCapability = { capabilities: Capabilities.RemoteCapability }
-export interface SingleConfigOption extends Omit<Options.Testrunner, 'capabilities'>, SingleCapability {}
-export type MultiRemoteCaps = Record<string, (Capabilities.DesiredCapabilities | Capabilities.W3CCapabilities) & { sessionId?: string }>
 
 export interface SessionStartedMessage {
     origin: 'worker'

--- a/packages/wdio-runner/src/utils.ts
+++ b/packages/wdio-runner/src/utils.ts
@@ -1,6 +1,6 @@
 import { deepmerge } from 'deepmerge-ts'
 import logger from '@wdio/logger'
-import { remote, multiremote, attach } from 'webdriverio'
+import { remote, multiremote, attach, type AttachOptions } from 'webdriverio'
 import { DEFAULTS } from 'webdriver'
 import { DEFAULT_CONFIGS } from '@wdio/config'
 import type { AsymmetricMatchers } from 'expect-webdriverio'
@@ -76,8 +76,8 @@ export async function initializeInstance (
             port: caps.port || config.port,
             path: caps.path || config.path
         }
-        const params = { ...config, ...connectionProps, capabilities }
-        return attach({ ...params, options: params } as any)
+        const params = { ...config, ...connectionProps, capabilities } as AttachOptions
+        return attach({ ...params, options: params })
     }
 
     /**

--- a/packages/wdio-sauce-service/src/launcher.ts
+++ b/packages/wdio-sauce-service/src/launcher.ts
@@ -33,8 +33,8 @@ export default class SauceLauncher implements Services.ServiceInstance {
      * modify config and launch sauce connect
      */
     async onPrepare (
-        config: Options.Testrunner,
-        capabilities: Capabilities.RemoteCapabilities
+        _: Options.Testrunner,
+        capabilities: Capabilities.TestrunnerCapabilities
     ) {
         if (!this._options.sauceConnect) {
             return
@@ -70,11 +70,11 @@ export default class SauceLauncher implements Services.ServiceInstance {
                  */
                 if (Object.values(capability).length > 0 && Object.values(capability).every(c => typeof c === 'object' && c.capabilities)) {
                     for (const browserName of Object.keys(capability)) {
-                        const caps = (capability as Capabilities.MultiRemoteCapabilities)[browserName].capabilities
+                        const caps = (capability as Capabilities.RequestedMultiremoteCapabilities)[browserName].capabilities
                         prepareCapability((caps as Capabilities.W3CCapabilities).alwaysMatch || caps)
                     }
                 } else {
-                    prepareCapability(capability as Capabilities.DesiredCapabilities)
+                    prepareCapability(capability as WebdriverIO.Capabilities)
                 }
             }
         } else {

--- a/packages/wdio-sauce-service/src/service.ts
+++ b/packages/wdio-sauce-service/src/service.ts
@@ -40,7 +40,7 @@ export default class SauceService implements Services.ServiceInstance {
 
     constructor (
         options: SauceServiceConfig,
-        private _capabilities: Capabilities.ResolveTestrunnerCaps,
+        private _capabilities: Capabilities.ResolvedTestrunnerCapabilities,
         private _config: Options.Testrunner
     ) {
         this._options = { ...DEFAULT_OPTIONS, ...options }

--- a/packages/wdio-sauce-service/src/service.ts
+++ b/packages/wdio-sauce-service/src/service.ts
@@ -40,7 +40,7 @@ export default class SauceService implements Services.ServiceInstance {
 
     constructor (
         options: SauceServiceConfig,
-        private _capabilities: Capabilities.RemoteCapability,
+        private _capabilities: Capabilities.ResolveTestrunnerCaps,
         private _config: Options.Testrunner
     ) {
         this._options = { ...DEFAULT_OPTIONS, ...options }

--- a/packages/wdio-sauce-service/src/types.ts
+++ b/packages/wdio-sauce-service/src/types.ts
@@ -51,7 +51,7 @@ export interface SauceServiceConfig {
      */
     setJobName?: (
         config: Options.Testrunner,
-        capabilities: Capabilities.ResolveTestrunnerCaps,
+        capabilities: Capabilities.ResolvedTestrunnerCapabilities,
         suiteTitle: string
     ) => string
 }

--- a/packages/wdio-sauce-service/src/types.ts
+++ b/packages/wdio-sauce-service/src/types.ts
@@ -51,7 +51,7 @@ export interface SauceServiceConfig {
      */
     setJobName?: (
         config: Options.Testrunner,
-        capabilities: Capabilities.RemoteCapability,
+        capabilities: Capabilities.ResolveTestrunnerCaps,
         suiteTitle: string
     ) => string
 }

--- a/packages/wdio-sauce-service/src/utils.ts
+++ b/packages/wdio-sauce-service/src/utils.ts
@@ -1,5 +1,3 @@
-import type { Capabilities } from '@wdio/types'
-
 /**
  * Determine if the current instance is a RDC instance. RDC tests are Real Device tests
  * that can be started with different sets of capabilities. A deviceName is not mandatory, the only mandatory cap for
@@ -42,12 +40,10 @@ import type { Capabilities } from '@wdio/types'
  *  deviceContextId: ''
  * }
  */
-export function isRDC (caps: Capabilities.DesiredCapabilities){
-    const { 'appium:deviceName': appiumDeviceName = '', deviceName = '', platformName = '' } = caps
-    const name = appiumDeviceName || deviceName
-
+export function isRDC (caps: WebdriverIO.Capabilities){
+    const { 'appium:deviceName': appiumDeviceName = '', platformName = '' } = caps
     // If the string contains `simulator` or `emulator` it's an EMU/SIM session
-    return !name.match(/(simulator)|(emulator)/gi) && !!platformName.match(/(ios)|(android)/gi)
+    return !appiumDeviceName.match(/(simulator)|(emulator)/gi) && !!platformName.match(/(ios)|(android)/gi)
 }
 
 /**
@@ -55,12 +51,10 @@ export function isRDC (caps: Capabilities.DesiredCapabilities){
  * @param {object} caps
  * @returns {boolean}
  */
-export function isEmuSim (caps: Capabilities.DesiredCapabilities){
-    const { 'appium:deviceName': appiumDeviceName = '', deviceName = '', platformName = '' } = caps
-    const name = appiumDeviceName || deviceName
-
+export function isEmuSim (caps: WebdriverIO.Capabilities){
+    const { 'appium:deviceName': appiumDeviceName = '', platformName = '' } = caps
     // If the string contains `simulator` or `emulator` it's an EMU/SIM session
-    return !!name.match(/(simulator)|(emulator)/gi) && !!platformName.match(/(ios)|(android)/gi)
+    return !!appiumDeviceName.match(/(simulator)|(emulator)/gi) && !!platformName.match(/(ios)|(android)/gi)
 }
 
 /** Ensure capabilities are in the correct format for Sauce Labs
@@ -69,14 +63,13 @@ export function isEmuSim (caps: Capabilities.DesiredCapabilities){
  * @returns {function(object): void} - A function that mutates a single capability
  */
 export function makeCapabilityFactory(tunnelIdentifier: string) {
-    return (capability: Capabilities.DesiredCapabilities) => {
+    return (capability: WebdriverIO.Capabilities) => {
         // If the `sauce:options` are not provided and it is a W3C session then add it
         if (!capability['sauce:options']) {
             capability['sauce:options'] = {}
         }
 
         capability['sauce:options'].tunnelIdentifier = (
-            capability.tunnelIdentifier ||
             capability['sauce:options'].tunnelIdentifier ||
             tunnelIdentifier
         )

--- a/packages/wdio-sauce-service/src/utils.ts
+++ b/packages/wdio-sauce-service/src/utils.ts
@@ -41,9 +41,11 @@
  * }
  */
 export function isRDC (caps: WebdriverIO.Capabilities){
-    const { 'appium:deviceName': appiumDeviceName = '', platformName = '' } = caps
+    // @ts-expect-error outdated JSONWP capabilities
+    const { 'appium:deviceName': appiumDeviceName = '', deviceName = '', platformName = '' } = caps
+    const name = appiumDeviceName || deviceName
     // If the string contains `simulator` or `emulator` it's an EMU/SIM session
-    return !appiumDeviceName.match(/(simulator)|(emulator)/gi) && !!platformName.match(/(ios)|(android)/gi)
+    return !name.match(/(simulator)|(emulator)/gi) && !!platformName.match(/(ios)|(android)/gi)
 }
 
 /**
@@ -52,9 +54,11 @@ export function isRDC (caps: WebdriverIO.Capabilities){
  * @returns {boolean}
  */
 export function isEmuSim (caps: WebdriverIO.Capabilities){
-    const { 'appium:deviceName': appiumDeviceName = '', platformName = '' } = caps
+    // @ts-expect-error outdated JSONWP capabilities
+    const { 'appium:deviceName': appiumDeviceName = '', deviceName = '', platformName = '' } = caps
+    const name = appiumDeviceName || deviceName
     // If the string contains `simulator` or `emulator` it's an EMU/SIM session
-    return !!appiumDeviceName.match(/(simulator)|(emulator)/gi) && !!platformName.match(/(ios)|(android)/gi)
+    return !!name.match(/(simulator)|(emulator)/gi) && !!platformName.match(/(ios)|(android)/gi)
 }
 
 /** Ensure capabilities are in the correct format for Sauce Labs

--- a/packages/wdio-sauce-service/tests/launcher.test.ts
+++ b/packages/wdio-sauce-service/tests/launcher.test.ts
@@ -395,7 +395,7 @@ test('onPrepare without tunnel identifier and without w3c caps ', async () => {
     const options: SauceServiceConfig = {
         sauceConnect: false
     }
-    const caps: Capabilities.DesiredCapabilities[] = [{
+    const caps: WebdriverIO.Capabilities[] = [{
         browserName: 'chrome'
     }, {
         browserName: 'firefox',
@@ -422,7 +422,7 @@ test('onPrepare without tunnel identifier and with w3c caps ', async () => {
     const options: SauceServiceConfig = {
         sauceConnect: false
     }
-    const caps: Capabilities.DesiredCapabilities[] = [{
+    const caps: WebdriverIO.Capabilities[] = [{
         browserName: 'chrome',
         'sauce:options': {
             commandTimeout: 600,
@@ -466,7 +466,7 @@ test('onPrepare with tunnel identifier and with w3c caps ', async () => {
             tunnelIdentifier: 'my-tunnel'
         }
     }
-    const caps: Capabilities.DesiredCapabilities[] = [{
+    const caps: WebdriverIO.Capabilities[] = [{
         browserName: 'chrome',
         'sauce:options': {
             commandTimeout: 600,
@@ -511,7 +511,7 @@ test('onPrepare with tunnel identifier and without w3c caps ', async () => {
             tunnelIdentifier: 'my-tunnel'
         }
     }
-    const caps: Capabilities.DesiredCapabilities[] = [{
+    const caps: WebdriverIO.Capabilities[] = [{
         browserName: 'internet explorer',
         platform: 'Windows 7',
         'sauce:options': { tunnelIdentifier: 'fish' }

--- a/packages/wdio-shared-store-service/src/launcher.ts
+++ b/packages/wdio-shared-store-service/src/launcher.ts
@@ -12,7 +12,7 @@ let server: SharedStoreServer
 export default class SharedStoreLauncher implements Services.HookFunctions {
     private _app?: PolkaInstance
 
-    async onPrepare (_: never, capabilities: Capabilities.RemoteCapabilities) {
+    async onPrepare (_: never, capabilities: Capabilities.TestrunnerCapabilities) {
         /**
          * import during runtime to avoid unnecessary dependency loading
          */
@@ -26,7 +26,7 @@ export default class SharedStoreLauncher implements Services.HookFunctions {
             : Object.values(capabilities).map((multiremoteOption) => multiremoteOption.capabilities)
 
         const caps: Partial<SharedStoreServiceCapabilities>[] = capsList.flatMap((c) => {
-            const multiremote = c as Capabilities.MultiRemoteCapabilities
+            const multiremote = c as Capabilities.RequestedMultiremoteCapabilities
             if (!multiremote.browserName && multiremote[Object.keys(multiremote)[0]].capabilities) {
                 return Object.values(multiremote).map((options) =>
                     (options.capabilities as Capabilities.W3CCapabilities)?.alwaysMatch ||

--- a/packages/wdio-shared-store-service/src/service.ts
+++ b/packages/wdio-shared-store-service/src/service.ts
@@ -8,11 +8,11 @@ import type { GetValueOptions } from './types.js'
 export default class SharedStoreService implements Services.ServiceInstance {
     private _browser?: WebdriverIO.Browser | WebdriverIO.MultiRemoteBrowser
 
-    constructor(_: never, caps: Capabilities.RemoteCapability) {
+    constructor(_: never, caps: Capabilities.ResolveTestrunnerCaps) {
         const port = (
             (caps as SharedStoreServiceCapabilities)[CUSTOM_CAP] ||
             ((caps as Capabilities.W3CCapabilities).alwaysMatch as SharedStoreServiceCapabilities)?.[CUSTOM_CAP] ||
-            (Object.values(caps as Capabilities.MultiRemoteCapabilities)[0]?.capabilities as SharedStoreServiceCapabilities)[CUSTOM_CAP]
+            (Object.values(caps as Capabilities.ResolveTestrunnerCaps)[0]?.capabilities as SharedStoreServiceCapabilities)[CUSTOM_CAP]
         )
 
         if (!port) {

--- a/packages/wdio-shared-store-service/src/service.ts
+++ b/packages/wdio-shared-store-service/src/service.ts
@@ -8,11 +8,11 @@ import type { GetValueOptions } from './types.js'
 export default class SharedStoreService implements Services.ServiceInstance {
     private _browser?: WebdriverIO.Browser | WebdriverIO.MultiRemoteBrowser
 
-    constructor(_: never, caps: Capabilities.ResolveTestrunnerCaps) {
+    constructor(_: never, caps: Capabilities.ResolvedTestrunnerCapabilities) {
         const port = (
             (caps as SharedStoreServiceCapabilities)[CUSTOM_CAP] ||
             ((caps as Capabilities.W3CCapabilities).alwaysMatch as SharedStoreServiceCapabilities)?.[CUSTOM_CAP] ||
-            (Object.values(caps as Capabilities.ResolveTestrunnerCaps)[0]?.capabilities as SharedStoreServiceCapabilities)[CUSTOM_CAP]
+            (Object.values(caps as Capabilities.ResolvedTestrunnerCapabilities)[0]?.capabilities as SharedStoreServiceCapabilities)[CUSTOM_CAP]
         )
 
         if (!port) {

--- a/packages/wdio-spec-reporter/src/index.ts
+++ b/packages/wdio-spec-reporter/src/index.ts
@@ -582,7 +582,7 @@ export default class SpecReporter extends WDIOReporter {
      * @param isMultiremote
      * @return {String}          Enviroment string
      */
-    getEnviromentCombo (capability: Capabilities.ResolveTestrunnerCaps, verbose = true, isMultiremote = false): string {
+    getEnviromentCombo (capability: Capabilities.ResolvedTestrunnerCapabilities, verbose = true, isMultiremote = false): string {
         if (isMultiremote) {
             const browserNames = Object.values(capability).map((c) => c.browserName)
             const browserName = browserNames.length > 1
@@ -592,9 +592,11 @@ export default class SpecReporter extends WDIOReporter {
         }
         const caps = 'alwaysMatch' in capability ? capability.alwaysMatch : capability
         const device = caps['appium:deviceName']
-        const app = ((caps['appium:app'] || (caps as any).app) || '').replace('sauce-storage:', '')
+        // @ts-expect-error outdated JSONWP capabilities
+        const app = ((caps['appium:app'] || caps.app) || '').replace('sauce-storage:', '')
         const appName = app || caps['appium:bundleId'] || (caps as any).bundleId
-        const browser = caps.browserName || appName
+        // @ts-expect-error outdated JSONWP capabilities
+        const browser = caps.browserName || caps.browser || appName
         /**
          * fallback to different capability types:
          * browserVersion: W3C format
@@ -602,14 +604,16 @@ export default class SpecReporter extends WDIOReporter {
          * platformVersion: mobile format
          * browser_version: invalid BS capability
          */
-        const version = caps.browserVersion || caps['appium:platformVersion']
+        // @ts-expect-error outdated JSONWP capabilities
+        const version = caps.browserVersion || caps.version || caps['appium:platformVersion'] || caps.browser_version
         /**
          * fallback to different capability types:
          * platformName: W3C format
          * platform: JSONWP format
          * os, os_version: invalid BS capability
          */
-        const platform = caps.platformName || caps['appium:platformName'] || '(unknown)'
+        // @ts-expect-error outdated JSONWP capabilities
+        const platform = caps.platformName || caps['appium:platformName'] || caps.platform || (caps.os ? caps.os + (caps.os_version ?  ` ${caps.os_version}` : '') : '(unknown)')
 
         // Mobile capabilities
         if (device) {

--- a/packages/wdio-spec-reporter/src/index.ts
+++ b/packages/wdio-spec-reporter/src/index.ts
@@ -231,17 +231,7 @@ export default class SpecReporter extends WDIOReporter {
         const isSauceJob = (
             (config && config.hostname && config.hostname.includes('saucelabs')) ||
             // only show if multiremote is not used
-            capabilities && (
-                // check w3c cap in jsonwp caps
-                (capabilities as Capabilities.DesiredCapabilities)['sauce:options'] ||
-                // check jsonwp caps
-                (capabilities as Capabilities.DesiredCapabilities).tunnelIdentifier ||
-                // check w3c caps
-                (
-                    (capabilities as Capabilities.W3CCapabilities).alwaysMatch &&
-                    (capabilities as Capabilities.W3CCapabilities).alwaysMatch['sauce:options']
-                )
-            )
+            capabilities['sauce:options']
         )
 
         if (isSauceJob && config && config.user && config.key && sessionId) {
@@ -592,7 +582,7 @@ export default class SpecReporter extends WDIOReporter {
      * @param isMultiremote
      * @return {String}          Enviroment string
      */
-    getEnviromentCombo (capability: Capabilities.RemoteCapability, verbose = true, isMultiremote = false): string {
+    getEnviromentCombo (capability: Capabilities.ResolveTestrunnerCaps, verbose = true, isMultiremote = false): string {
         if (isMultiremote) {
             const browserNames = Object.values(capability).map((c) => c.browserName)
             const browserName = browserNames.length > 1
@@ -600,14 +590,11 @@ export default class SpecReporter extends WDIOReporter {
                 : browserNames.pop()
             return `MultiremoteBrowser on ${browserName}`
         }
-        const caps = (
-            ((capability as Capabilities.W3CCapabilities).alwaysMatch as Capabilities.DesiredCapabilities) ||
-            (capability as Capabilities.DesiredCapabilities)
-        )
+        const caps = 'alwaysMatch' in capability ? capability.alwaysMatch : capability
         const device = caps['appium:deviceName']
         const app = ((caps['appium:app'] || (caps as any).app) || '').replace('sauce-storage:', '')
         const appName = app || caps['appium:bundleId'] || (caps as any).bundleId
-        const browser = caps.browserName || caps.browser || appName
+        const browser = caps.browserName || appName
         /**
          * fallback to different capability types:
          * browserVersion: W3C format
@@ -615,14 +602,14 @@ export default class SpecReporter extends WDIOReporter {
          * platformVersion: mobile format
          * browser_version: invalid BS capability
          */
-        const version = caps.browserVersion || caps.version || caps['appium:platformVersion'] || caps.browser_version
+        const version = caps.browserVersion || caps['appium:platformVersion']
         /**
          * fallback to different capability types:
          * platformName: W3C format
          * platform: JSONWP format
          * os, os_version: invalid BS capability
          */
-        const platform = caps.platformName || caps['appium:platformName'] || caps.platform || (caps.os ? caps.os + (caps.os_version ?  ` ${caps.os_version}` : '') : '(unknown)')
+        const platform = caps.platformName || caps['appium:platformName'] || '(unknown)'
 
         // Mobile capabilities
         if (device) {

--- a/packages/wdio-spec-reporter/src/types.ts
+++ b/packages/wdio-spec-reporter/src/types.ts
@@ -83,7 +83,7 @@ export enum State {
 }
 
 export interface TestLink {
-    capabilities: Capabilities.RemoteCapability
+    capabilities: Capabilities.ResolveTestrunnerCaps
     sessionId: string
     isMultiremote: boolean
     instanceName?: string

--- a/packages/wdio-spec-reporter/src/types.ts
+++ b/packages/wdio-spec-reporter/src/types.ts
@@ -83,7 +83,7 @@ export enum State {
 }
 
 export interface TestLink {
-    capabilities: Capabilities.ResolveTestrunnerCaps
+    capabilities: Capabilities.ResolvedTestrunnerCapabilities
     sessionId: string
     isMultiremote: boolean
     instanceName?: string

--- a/packages/wdio-testingbot-service/src/launcher.ts
+++ b/packages/wdio-testingbot-service/src/launcher.ts
@@ -17,7 +17,7 @@ export default class TestingBotLauncher implements Services.ServiceInstance {
         this.options = options
     }
 
-    async onPrepare (config: Options.Testrunner, capabilities: Capabilities.RemoteCapabilities) {
+    async onPrepare (config: Options.Testrunner, capabilities: Capabilities.TestrunnerCapabilities) {
         if (!this.options.tbTunnel || !config.user || !config.key) {
             return
         }
@@ -35,11 +35,11 @@ export default class TestingBotLauncher implements Services.ServiceInstance {
 
         const capabilitiesEntries = Array.isArray(capabilities) ?
             (capabilities as []).every(cap => Object.values(cap).length > 0 && Object.values(cap).every(c => typeof c === 'object' && (c as any).capabilities)) ?
-                capabilities.flatMap((cap: Capabilities.MultiRemoteCapabilities ) => Object.values(cap))
+                capabilities.flatMap((cap: Capabilities.RequestedMultiremoteCapabilities ) => Object.values(cap))
                 : capabilities
             : Object.values(capabilities)
         for (const capability of capabilitiesEntries) {
-            const caps = (capability as Options.WebDriver).capabilities || capability
+            const caps = (capability as Capabilities.WithRequestedCapabilities).capabilities || capability
             const c = (caps as Capabilities.W3CCapabilities).alwaysMatch || caps
 
             if (!c['tb:options']) {

--- a/packages/wdio-testingbot-service/src/service.ts
+++ b/packages/wdio-testingbot-service/src/service.ts
@@ -17,7 +17,7 @@ export default class TestingBotService implements Services.ServiceInstance {
 
     constructor (
         private _options: TestingbotOptions,
-        private _capabilities: Capabilities.ResolveTestrunnerCaps,
+        private _capabilities: Capabilities.ResolvedTestrunnerCapabilities,
         private _config: Options.Testrunner
     ) {
         this._tbUser = this._config.user

--- a/packages/wdio-testingbot-service/src/service.ts
+++ b/packages/wdio-testingbot-service/src/service.ts
@@ -17,8 +17,8 @@ export default class TestingBotService implements Services.ServiceInstance {
 
     constructor (
         private _options: TestingbotOptions,
-        private _capabilities: Capabilities.RemoteCapability,
-        private _config: Omit<Options.Testrunner, 'capabilities'>
+        private _capabilities: Capabilities.ResolveTestrunnerCaps,
+        private _config: Options.Testrunner
     ) {
         this._tbUser = this._config.user
         this._tbSecret = this._config.key

--- a/packages/wdio-types/src/Capabilities.ts
+++ b/packages/wdio-types/src/Capabilities.ts
@@ -113,10 +113,15 @@ export type WebdriverIOMultiremoteConfig = WebDriverIOOptions & { capabilities: 
 
 /**
  * A type referencing all possible capability types when using Testrunner
+ * e.g. everything a user can provide in the `capabilities` property
  */
 export type TestrunnerCapabilities = RequestedStandaloneCapabilities[] | RequestedMultiremoteCapabilities | RequestedMultiremoteCapabilities[]
 
-export type ResolveTestrunnerCaps = WebdriverIO.Capabilities | Record<string, WebdriverIO.Capabilities>
+/**
+ * The capabilities that will be resolved within a worker instance, e.g. either
+ * a single set of capabilities or a single multiremote instance
+ */
+export type ResolvedTestrunnerCapabilities = WebdriverIO.Capabilities | Record<string, WebdriverIO.Capabilities>
 
 /**
  * The `capabilities` property is a required property when using the `remote` method.

--- a/packages/wdio-types/src/Capabilities.ts
+++ b/packages/wdio-types/src/Capabilities.ts
@@ -1,4 +1,5 @@
 import type {
+    WebDriver as WebDriverOptions,
     WebdriverIO as WebDriverIOOptions,
     Connection as ConnectionOptions
 } from './Options.js'
@@ -94,64 +95,181 @@ export interface W3CCapabilities {
     alwaysMatch: WebdriverIO.Capabilities
     firstMatch: WebdriverIO.Capabilities[]
 }
-
-export type RemoteCapabilities = (DesiredCapabilities | W3CCapabilities)[] | MultiRemoteCapabilities | MultiRemoteCapabilities[]
-
-export interface MultiRemoteCapabilities {
-    [instanceName: string]: WebDriverIOOptions
+export type RequestedStandaloneCapabilities = W3CCapabilities | WebdriverIO.Capabilities
+export type RequestedMultiremoteCapabilities = {
+    [instanceName: string]: WebDriverIOOptions & WithRequestedCapabilities
 }
-
-export type RemoteCapability = DesiredCapabilities | W3CCapabilities | MultiRemoteCapabilities
 
 /**
- * @deprecated use `WebdriverIO.Capabilities` instead
+ * Configuration object for the `webdriver` package
  */
-export interface DesiredCapabilities extends WebdriverIO.Capabilities, SauceLabsCapabilities, SauceLabsVisualCapabilities,
-    TestingbotCapabilities, SeleniumRCCapabilities, GeckodriverCapabilities, IECapabilities,
-    AppiumAndroidCapabilities, AppiumCapabilities, VendorExtensions, GridCapabilities,
-    ChromeCapabilities, BrowserStackCapabilities, AppiumXCUITestCapabilities, LambdaTestCapabilities {
+export type RemoteConfig = WebDriverOptions & WithRequestedCapabilities
 
-    // Read-only capabilities
-    cssSelectorsEnabled?: boolean
-    handlesAlerts?: boolean
-    version?: string
-    platform?: string
-    public?: any
+/**
+ * Configuration object for the `webdriverio` package
+ */
+export type WebdriverIOConfig = WebDriverIOOptions & WithRequestedCapabilities
+export type WebdriverIOMultiremoteConfig = WebDriverIOOptions & { capabilities: RequestedMultiremoteCapabilities }
 
-    loggingPrefs?: {
-        browser?: LoggingPreferences
-        driver?: LoggingPreferences
-        server?: LoggingPreferences
-        client?: LoggingPreferences
-    }
+/**
+ * A type referencing all possible capability types when using Testrunner
+ */
+export type TestrunnerCapabilities = RequestedStandaloneCapabilities[] | RequestedMultiremoteCapabilities | RequestedMultiremoteCapabilities[]
 
-    // Read-write capabilities
-    javascriptEnabled?: boolean
-    databaseEnabled?: boolean
-    locationContextEnabled?: boolean
-    applicationCacheEnabled?: boolean
-    browserConnectionEnabled?: boolean
-    webStorageEnabled?: boolean
-    acceptSslCerts?: boolean
-    rotatable?: boolean
-    nativeEvents?: boolean
-    unexpectedAlertBehaviour?: string
-    elementScrollBehavior?: number
+export type ResolveTestrunnerCaps = WebdriverIO.Capabilities | Record<string, WebdriverIO.Capabilities>
 
-    // RemoteWebDriver specific
-    'webdriver.remote.sessionid'?: string
-    'webdriver.remote.quietExceptions'?: boolean
-
-    // Selenese-Backed-WebDriver specific
-    'selenium.server.url'?: string
-
-    // webdriverio specific
-    specs?: string[]
-    exclude?: string[]
-    excludeDriverLogs?: string[]
+/**
+ * The `capabilities` property is a required property when using the `remote` method.
+ */
+export interface WithRequestedCapabilities {
+    /**
+     * Defines the capabilities you want to run in your WebDriver session. Check out the
+     * documentation on [Capabilities](https://webdriver.io/docs/capabilities) for more details.
+     *
+     * @example
+     * ```js
+     * // WebDriver session
+     * const browser = remote({
+     *   capabilities: {
+     *     browserName: 'chrome',
+     *     browserVersion: 86
+     *     platformName: 'Windows 10'
+     *   }
+     * })
+     *
+     * // multiremote session
+     * const browser = remote({
+     *   capabilities: {
+     *     browserA: {
+     *       browserName: 'chrome',
+     *       browserVersion: 86
+     *       platformName: 'Windows 10'
+     *     },
+     *     browserB: {
+     *       browserName: 'firefox',
+     *       browserVersion: 74
+     *       platformName: 'Mac OS X'
+     *     }
+     *   }
+     * })
+     * ```
+     */
+    capabilities: RequestedStandaloneCapabilities
 }
 
-export interface VendorExtensions extends EdgeCapabilities, AppiumCapabilities, WebdriverIOCapabilities, WebdriverIO.WDIOVSCodeServiceOptions {
+/**
+ * The `capabilities` property is a required property when defining a testrunner configuration.
+ */
+export interface WithRequestedTestrunnerCapabilities {
+    /**
+     * Defines a set of capabilities you want to run in your WebDriver session. Check out the
+     * documentation on [Capabilities](https://webdriver.io/docs/capabilities) for more details.
+     *
+     * @example
+     * ```js
+     * // wdio.conf.js
+     * export const config = {
+     *   // define parallel running capabilities
+     *   capabilities: [{
+     *     browserName: 'safari',
+     *     platformName: 'MacOS 10.13',
+     *     ...
+     *   }, {
+     *     browserName: 'microsoftedge',
+     *     platformName: 'Windows 10',
+     *     ...
+     *   }, {
+     *     // using alwaysMatch and firstMatch
+     *   alwaysMatch: {
+     *     browserName: 'chrome',
+     *     browserVersion: 86
+     *      // ...
+     *   },
+     *   firstMatch: [{
+     *     browserName: 'chrome',
+     *      // ...
+     *   }]
+     * }
+     * ```
+     */
+    capabilities: RequestedStandaloneCapabilities[]
+}
+
+/**
+ * The `capabilities` property is a required property when using the `remote` method to initiate a multiremote session.
+ */
+export interface WithRequestedMultiremoteCapabilities {
+    /**
+     * Defines the capabilities for each Multiremote client. Check out the
+     * documentation on [Capabilities](https://webdriver.io/docs/capabilities) for more details.
+     *
+     * @example
+     * ```
+     * // wdio.conf.js
+     * export const config = {
+     *   // multiremote example
+     *   capabilities: {
+     *     browserA: {
+     *       browserName: 'chrome',
+     *       browserVersion: 86
+     *       platformName: 'Windows 10'
+     *     },
+     *     browserB: {
+     *       browserName: 'firefox',
+     *       browserVersion: 74
+     *       platformName: 'Mac OS X'
+     *     }
+     *   }
+     * })
+     * ```
+     * // or with parallel multiremote sessions
+     * ```
+     * // wdio.conf.js
+     * export const config = {
+     *   capabilities: [{
+     *     browserA: {
+     *       port: 4444,
+     *       capabilities: {
+     *         browserName: 'chrome',
+     *         browserVersion: 86
+     *         platformName: 'Windows 10'
+     *       }
+     *     },
+     *     browserB: {
+     *       port: 4444,
+     *       capabilities: {
+     *         browserName: 'firefox',
+     *         browserVersion: 74
+     *         platformName: 'Mac OS X'
+     *       }
+     *     }
+     *   }, {
+     *     browserA: {
+     *       port: 4444,
+     *       capabilities: {
+     *         browserName: 'chrome',
+     *         browserVersion: 86
+     *         platformName: 'Windows 10'
+     *       }
+     *     },
+     *     browserB: {
+     *       port: 4444,
+     *       capabilities: {
+     *         browserName: 'firefox',
+     *         browserVersion: 74
+     *         platformName: 'Mac OS X'
+     *       }
+     *     }
+     *   }]
+     * })
+     * ```
+     */
+    capabilities: RequestedMultiremoteCapabilities | RequestedMultiremoteCapabilities[]
+}
+
+export interface VendorExtensions extends EdgeCapabilities, AppiumCapabilities, WebdriverIOCapabilities,
+    WebdriverIO.WDIOVSCodeServiceOptions, AppiumXCUITestCapabilities, AppiumAndroidCapabilities {
+
     // Aerokube Selenoid specific
     'selenoid:options'?: SelenoidOptions
     // Aerokube Moon specific
@@ -185,8 +303,6 @@ export interface VendorExtensions extends EdgeCapabilities, AppiumCapabilities, 
     // are returned from the driver
     // see https://firefox-source-docs.mozilla.org/testing/geckodriver/Capabilities.html#moz-debuggeraddress
     'moz:debuggerAddress'?: string | number
-    // eslint-disable-next-line
-    firefox_profile?: string
     'ms:edgeOptions'?: MicrosoftEdgeOptions
     'ms:edgeChromium'?: MicrosoftEdgeOptions
 
@@ -203,11 +319,6 @@ export interface VendorExtensions extends EdgeCapabilities, AppiumCapabilities, 
      * Selenium 4.0 Specific
      */
     'se:cdp'?: string
-    /**
-     * @deprecated
-     */
-    // eslint-disable-next-line
-    testobject_api_key?: string
 }
 
 export interface WebdriverIOCapabilities {
@@ -219,15 +330,11 @@ export interface WebdriverIOCapabilities {
     'wdio:safaridriverOptions'?: WebdriverIO.SafaridriverOptions
     'wdio:geckodriverOptions'?: WebdriverIO.GeckodriverOptions
     'wdio:edgedriverOptions'?: WebdriverIO.EdgedriverOptions
+
     /**
     * Maximum number of total parallel running workers (per capability)
     */
     'wdio:maxInstances'?: number
-    /**
-     * Maximum number of total parallel running workers (per capability)
-     * @deprecated please use `wdio:maxInstances` instead
-     */
-    maxInstances?: number
 
     /**
     * Define specs for test execution. You can either specify a glob
@@ -235,23 +342,11 @@ export interface WebdriverIOCapabilities {
     * paths into an array to run them within a single worker process.
     */
     'wdio:specs'?: string[]
-    /**
-     * Define specs for test execution. You can either specify a glob
-     * pattern to match multiple files at once or wrap a glob or set of
-     * paths into an array to run them within a single worker process.
-     * @deprecated please use `wdio:specs` instead
-     */
-    specs?: string[]
 
     /**
      * Exclude specs from test execution.
      */
     'wdio:exclude'?: string[]
-    /**
-     * Exclude specs from test execution.
-     * @deprecated please use `wdio:exclude` instead
-     */
-    exclude?: string[]
 }
 
 export interface ChromeOptions {
@@ -371,17 +466,6 @@ export interface FirefoxLogObject {
     level: FirefoxLogLevels
 }
 
-export interface GeckodriverCapabilities {
-    'firefox_binary'?: string
-    firefoxProfileTemplate?: string
-    captureNetworkTraffic?: boolean
-    addCustomRequestHeaders?: boolean
-    trustAllSSLCertificates?: boolean
-    changeMaxConnections?: boolean
-    profile?: string
-    pageLoadingStrategy?: string
-}
-
 export interface FirefoxOptions {
     debuggerAddress?: string
     binary?: string
@@ -429,25 +513,11 @@ export interface MoonOptions extends SelenoidOptions {
     logLevel?: string
 }
 
-// Selenium Grid specific
-export interface GridCapabilities {
-    // Grid-specific
-    seleniumProtocol?: string
-    maxInstances?: number
-    environment?: string
-}
-
 // Edge specific
 export interface EdgeCapabilities {
     'ms:inPrivate'?: boolean
     'ms:extensionPaths'?: string[]
     'ms:startPage'?: string
-}
-
-// Chrome specific
-export interface ChromeCapabilities {
-    chromeOptions?: ChromeOptions
-    mobileEmulationEnabled?: boolean
 }
 
 /**
@@ -787,31 +857,6 @@ export interface AppiumXCUIProcessArguments {
 
 export interface AppiumXCUICommandTimeouts {
     [key: string]: any
-}
-
-// IE specific
-export interface IECapabilities {
-    'ie.forceCreateProcessApi'?: boolean
-    'ie.browserCommandLineSwitches'?: string
-    'ie.usePerProcessProxy'?: boolean
-    'ie.ensureCleanSession'?: boolean
-    'ie.setProxyByServer'?: boolean
-    'ie.fileUploadDialogTimeout'?: number
-    'ie.edgechromium'?: boolean
-    'ie.edgepath'?: string
-    ignoreProtectedModeSettings?: boolean
-    ignoreZoomSetting?: boolean
-    initialBrowserUrl?: string
-    enablePersistentHover?: boolean
-    enableElementCacheCleanup?: boolean
-    requireWindowFocus?: boolean
-    browserAttachTimeout?: number
-    logFile?: string
-    logLevel?: string
-    host?: string
-    extractPath?: string
-    silent?: string
-    killProcessesByName?: boolean
 }
 
 /**
@@ -1452,7 +1497,7 @@ export interface BrowserStackCapabilities {
     // eslint-disable-next-line
     os_version?: string
     osVersion?: string
-    desired?: DesiredCapabilities
+    desired?: unknown
     device?: string
     platformName?: string
     /**
@@ -1790,21 +1835,4 @@ export interface TestingbotCapabilities {
     'testingbot.geoCountryCode'?: string
     idletimeout?: number
     'load-extension'?: string
-}
-
-export interface SeleniumRCCapabilities {
-    // Selenium RC (1.0) only
-    commandLineFlags?: string
-    executablePath?: string
-    timeoutInSeconds?: number
-    onlyProxySeleniumTraffic?: boolean
-    avoidProxy?: boolean
-    proxyEverything?: boolean
-    proxyRequired?: boolean
-    browserSideLog?: boolean
-    optionsSet?: boolean
-    singleWindow?: boolean
-    dontInjectRegex?: RegExp
-    userJSInjection?: boolean
-    userExtensions?: string
 }

--- a/packages/wdio-types/src/Clients.ts
+++ b/packages/wdio-types/src/Clients.ts
@@ -1,8 +1,0 @@
-import type { DesiredCapabilities } from './Capabilities.js'
-
-export interface Multiremote {
-    sessionId?: string
-    capabilities: DesiredCapabilities
-}
-
-export interface Browser {}

--- a/packages/wdio-types/src/Options.ts
+++ b/packages/wdio-types/src/Options.ts
@@ -1,4 +1,3 @@
-import type { W3CCapabilities, DesiredCapabilities, RemoteCapabilities, RemoteCapability, MultiRemoteCapabilities } from './Capabilities.js'
 import type { Hooks, ServiceEntry } from './Services.js'
 import type { ReporterEntry } from './Reporters.js'
 
@@ -77,41 +76,6 @@ export interface Connection {
 
 export interface WebDriver extends Connection {
     /**
-     * Defines the capabilities you want to run in your WebDriver session. Check out the
-     * [WebDriver Protocol](https://w3c.github.io/webdriver/#capabilities) for more details.
-     * If you want to run multiremote session you need to define an object that has the
-     * browser instance names as string and their capabilities as values.
-     *
-     * @example
-     * ```js
-     * // WebDriver session
-     * const browser = remote({
-     *   capabilities: {
-     *     browserName: 'chrome',
-     *     browserVersion: 86
-     *     platformName: 'Windows 10'
-     *   }
-     * })
-     *
-     * // multiremote session
-     * const browser = remote({
-     *   capabilities: {
-     *     browserA: {
-     *       browserName: 'chrome',
-     *       browserVersion: 86
-     *       platformName: 'Windows 10'
-     *     },
-     *     browserB: {
-     *       browserName: 'firefox',
-     *       browserVersion: 74
-     *       platformName: 'Mac OS X'
-     *     }
-     *   }
-     * })
-     * ```
-     */
-    capabilities: W3CCapabilities | DesiredCapabilities
-    /**
      * Level of logging verbosity.
      *
      * @default 'info'
@@ -179,62 +143,11 @@ export interface WebDriver extends Connection {
     cacheDir?: string
 }
 
-export interface MultiRemoteBrowserOptions {
-    sessionId?: string
-    capabilities: DesiredCapabilities
-}
-
 export type SauceRegions = 'us' | 'eu' | 'apac' | 'us-west-1' | 'us-east-1' | 'us-east-4' | 'eu-central-1' | 'apac-southeast-1' | 'staging'
 
-export interface WebdriverIO extends Omit<WebDriver, 'capabilities'>, Pick<Hooks, 'onReload' | 'beforeCommand' | 'afterCommand'> {
+export interface WebdriverIO extends WebDriver, Pick<Hooks, 'onReload' | 'beforeCommand' | 'afterCommand'> {
     /**
-     * Defines the capabilities you want to run in your WebDriver session. Check out the
-     * [WebDriver Protocol](https://w3c.github.io/webdriver/#capabilities) for more details.
-     * If you want to run a multiremote session you need to define instead of an array of
-     * capabilities an object that has an arbitrary browser instance name as string and its
-     * capabilities as values.
-     *
-     * @example
-     * ```js
-     * // wdio.conf.js
-     * export const config = {
-     *   // ...
-     *   capabilities: {
-     *     browserName: 'safari',
-     *     platformName: 'MacOS 10.13',
-     *     ...
-     *   }
-     * }
-     * ```
-     *
-     * @example
-     * ```
-     * // wdio.conf.js
-     * export const config = {
-     *   // ...
-     *   capabilities: {
-     *     browserA: {
-     *       browserName: 'chrome',
-     *       browserVersion: 86
-     *       platformName: 'Windows 10'
-     *     },
-     *     browserB: {
-     *       browserName: 'firefox',
-     *       browserVersion: 74
-     *       platformName: 'Mac OS X'
-     *     }
-     *   }
-     * })
-     * ```
-     */
-    capabilities: RemoteCapability
-    /**
-     * Define the protocol you want to use for your browser automation.
-     * Currently only [`webdriver`](https://www.npmjs.com/package/webdriver) and
-     * [`devtools`](https://www.npmjs.com/package/devtools) are supported,
-     * as these are the main browser automation technologies available.
-     *
-     * @deprecated this option will be removed in future versions of WebdriverIO. We recommend to use WebDriver for browser or mobile automation.
+     * @private
      */
     automationProtocol?: SupportedProtocols
     /**
@@ -263,52 +176,7 @@ export interface WebdriverIO extends Omit<WebDriver, 'capabilities'>, Pick<Hooks
     waitforInterval?: number
 }
 
-export interface Testrunner extends Hooks, Omit<WebdriverIO, 'capabilities'>, WebdriverIO.HookFunctionExtension {
-    /**
-     * Defines a set of capabilities you want to run in your testrunner session. Check out the
-     * [WebDriver Protocol](https://w3c.github.io/webdriver/#capabilities) for more details.
-     * If you want to run a multiremote session you need to define instead of an array of
-     * capabilities an object that has an arbitrary browser instance name as string and its
-     * capabilities as values.
-     *
-     * @example
-     * ```js
-     * // wdio.conf.js
-     * export const config = {
-     *   // define parallel running capabilities
-     *   capabilities: [{
-     *     browserName: 'safari',
-     *     platformName: 'MacOS 10.13',
-     *     ...
-     *   }, {
-     *     browserName: 'microsoftedge',
-     *     platformName: 'Windows 10',
-     *     ...
-     *   }]
-     * }
-     * ```
-     *
-     * @example
-     * ```
-     * // wdio.conf.js
-     * export const config = {
-     *   // multiremote example
-     *   capabilities: {
-     *     browserA: {
-     *       browserName: 'chrome',
-     *       browserVersion: 86
-     *       platformName: 'Windows 10'
-     *     },
-     *     browserB: {
-     *       browserName: 'firefox',
-     *       browserVersion: 74
-     *       platformName: 'Mac OS X'
-     *     }
-     *   }
-     * })
-     * ```
-     */
-    capabilities: RemoteCapabilities
+export interface Testrunner extends Hooks, WebdriverIO, WebdriverIO.HookFunctionExtension {
     /**
      * Type of runner
      * - local: every spec file group is spawned in its own local process
@@ -464,10 +332,6 @@ export interface TSConfigPathsOptions {
     paths: Record<string, string[]>
     mainFields?: string[]
     addMatchAll?: boolean
-}
-
-export interface MultiRemote extends Omit<Testrunner, 'capabilities'> {
-    capabilities: MultiRemoteCapabilities
 }
 
 export type Definition<T> = {

--- a/packages/wdio-types/src/Reporters.ts
+++ b/packages/wdio-types/src/Reporters.ts
@@ -1,10 +1,11 @@
 import type { WriteStream } from 'node:fs'
 import type { EventEmitter } from 'node:events'
-import type { RemoteCapability } from './Capabilities.js'
+
+import type { RequestedStandaloneCapabilities, RequestedMultiremoteCapabilities } from './Capabilities.js'
 
 interface OutputFileFormatOptions {
     cid: string
-    capabilities: RemoteCapability
+    capabilities: RequestedStandaloneCapabilities | RequestedMultiremoteCapabilities
 }
 
 export interface Options {

--- a/packages/wdio-types/src/Services.ts
+++ b/packages/wdio-types/src/Services.ts
@@ -1,5 +1,5 @@
-import type { DesiredCapabilities, RemoteCapability, RemoteCapabilities } from './Capabilities.js'
 import type { Testrunner as TestrunnerOptions, WebdriverIO as WebdriverIOOptions } from './Options.js'
+import type { RequestedStandaloneCapabilities, RequestedMultiremoteCapabilities, TestrunnerCapabilities } from './Capabilities.js'
 import type { Suite, Test, TestResult } from './Frameworks.js'
 import type { Worker } from './Workers.js'
 
@@ -30,7 +30,7 @@ export interface ServiceOption {
 }
 
 export interface ServiceClass {
-    new(options: ServiceOption, caps: RemoteCapability, config: Omit<WebdriverIOOptions, 'capabilities'>): ServiceInstance
+    new(options: ServiceOption, capabilities: WebdriverIO.Capabilities, config: WebdriverIOOptions): ServiceInstance
 }
 
 export interface ServicePlugin extends ServiceClass {
@@ -40,7 +40,7 @@ export interface ServicePlugin extends ServiceClass {
 
 export interface ServiceInstance extends HookFunctions {
     options?: Record<string, any>,
-    capabilities?: RemoteCapability,
+    capabilities?: WebdriverIO.Capabilities,
     config?: TestrunnerOptions
 }
 
@@ -115,7 +115,7 @@ export interface HookFunctions {
      */
     onPrepare?(
         config: TestrunnerOptions,
-        capabilities: RemoteCapabilities
+        capabilities: TestrunnerCapabilities
     ): unknown | Promise<unknown>
 
     /**
@@ -129,22 +129,22 @@ export interface HookFunctions {
     onComplete?(
         exitCode: number,
         config: Omit<TestrunnerOptions, 'capabilities'>,
-        capabilities: RemoteCapabilities,
+        capabilities: TestrunnerCapabilities,
         results: any // Results
     ): unknown | Promise<unknown>
 
     /**
      * Gets executed before a worker process is spawned and can be used to initialize specific service
      * for that worker as well as modify runtime environments in an async fashion.
-     * @param cid       capability id (e.g 0-0)
-     * @param caps      object containing capabilities for session that will be spawn in the worker
-     * @param specs     specs to be run in the worker process
-     * @param args      object that will be merged with the main configuration once worker is initialized
-     * @param execArgv  list of string arguments passed to the worker process
+     * @param cid           capability id (e.g 0-0)
+     * @param capabilities  object containing capabilities for session that will be spawn in the worker
+     * @param specs         specs to be run in the worker process
+     * @param args          object that will be merged with the main configuration once worker is initialized
+     * @param execArgv      list of string arguments passed to the worker process
      */
     onWorkerStart?(
         cid: string,
-        caps: DesiredCapabilities,
+        capabilities: WebdriverIO.Capabilities,
         specs: string[],
         args: TestrunnerOptions,
         execArgv: string[]
@@ -172,7 +172,7 @@ export interface HookFunctions {
      * @param browser       instance of created browser/device session
      */
     before?(
-        capabilities: RemoteCapability,
+        capabilities: RequestedStandaloneCapabilities | RequestedMultiremoteCapabilities,
         specs: string[],
         browser: any // BrowserObject
     ): unknown | Promise<unknown>
@@ -186,7 +186,7 @@ export interface HookFunctions {
      */
     after?(
         result: number,
-        capabilities: RemoteCapability,
+        capabilities: RequestedStandaloneCapabilities | RequestedMultiremoteCapabilities,
         specs: string[]
     ): unknown | Promise<unknown>
 
@@ -200,7 +200,7 @@ export interface HookFunctions {
      */
     beforeSession?(
         config: Omit<TestrunnerOptions, 'capabilities'>,
-        capabilities: RemoteCapability,
+        capabilities: RequestedStandaloneCapabilities | RequestedMultiremoteCapabilities,
         specs: string[],
         cid: string
     ): unknown | Promise<unknown>
@@ -213,7 +213,7 @@ export interface HookFunctions {
      */
     afterSession?(
         config: TestrunnerOptions,
-        capabilities: RemoteCapability,
+        capabilities: WebdriverIO.Capabilities,
         specs: string[]
     ): unknown | Promise<unknown>
 

--- a/packages/wdio-types/src/Services.ts
+++ b/packages/wdio-types/src/Services.ts
@@ -1,5 +1,5 @@
 import type { Testrunner as TestrunnerOptions, WebdriverIO as WebdriverIOOptions } from './Options.js'
-import type { RequestedStandaloneCapabilities, RequestedMultiremoteCapabilities, TestrunnerCapabilities } from './Capabilities.js'
+import type { RequestedStandaloneCapabilities, RequestedMultiremoteCapabilities, TestrunnerCapabilities, ResolveTestrunnerCaps } from './Capabilities.js'
 import type { Suite, Test, TestResult } from './Frameworks.js'
 import type { Worker } from './Workers.js'
 
@@ -30,7 +30,7 @@ export interface ServiceOption {
 }
 
 export interface ServiceClass {
-    new(options: ServiceOption, capabilities: WebdriverIO.Capabilities, config: WebdriverIOOptions): ServiceInstance
+    new(options: ServiceOption, capabilities: ResolveTestrunnerCaps, config: WebdriverIOOptions): ServiceInstance
 }
 
 export interface ServicePlugin extends ServiceClass {

--- a/packages/wdio-types/src/Services.ts
+++ b/packages/wdio-types/src/Services.ts
@@ -1,5 +1,5 @@
 import type { Testrunner as TestrunnerOptions, WebdriverIO as WebdriverIOOptions } from './Options.js'
-import type { RequestedStandaloneCapabilities, RequestedMultiremoteCapabilities, TestrunnerCapabilities, ResolveTestrunnerCaps } from './Capabilities.js'
+import type { RequestedStandaloneCapabilities, RequestedMultiremoteCapabilities, TestrunnerCapabilities, ResolvedTestrunnerCapabilities } from './Capabilities.js'
 import type { Suite, Test, TestResult } from './Frameworks.js'
 import type { Worker } from './Workers.js'
 
@@ -30,7 +30,7 @@ export interface ServiceOption {
 }
 
 export interface ServiceClass {
-    new(options: ServiceOption, capabilities: ResolveTestrunnerCaps, config: WebdriverIOOptions): ServiceInstance
+    new(options: ServiceOption, capabilities: ResolvedTestrunnerCapabilities, config: WebdriverIOOptions): ServiceInstance
 }
 
 export interface ServicePlugin extends ServiceClass {

--- a/packages/wdio-types/src/Workers.ts
+++ b/packages/wdio-types/src/Workers.ts
@@ -1,14 +1,8 @@
 import type { EventEmitter } from 'node:events'
 import type { Testrunner as TestrunnerOptions } from './Options.js'
-import type {
-    DesiredCapabilities,
-    MultiRemoteCapabilities,
-    RemoteCapability,
-    W3CCapabilities,
-} from './Capabilities.js'
 
 export interface Job {
-    caps: DesiredCapabilities | W3CCapabilities | MultiRemoteCapabilities
+    caps: WebdriverIO.Capabilities
     specs: string[]
     hasTests: boolean
 }
@@ -18,7 +12,7 @@ export type WorkerMessageArgs = Omit<Job, 'caps' | 'specs' | 'hasTests'>
 export interface WorkerRunPayload {
     cid: string
     configFile: string
-    caps: RemoteCapability
+    caps: WebdriverIO.Capabilities
     specs: string[]
     execArgv: string[]
     retries: number
@@ -48,7 +42,7 @@ export interface WorkerMessage {
     content: {
         sessionId?: string
         isMultiremote?: boolean
-        capabilities: RemoteCapability
+        capabilities: WebdriverIO.Capabilities
     }
     origin: string
     params: Record<string, string>
@@ -57,9 +51,9 @@ export interface WorkerMessage {
 export interface Worker
     extends Omit<TestrunnerOptions, 'capabilities' | 'specs' | 'rootDir'>,
         EventEmitter {
-    capabilities: RemoteCapability
+    capabilities: WebdriverIO.Capabilities
     config: TestrunnerOptions,
-    caps: RemoteCapability
+    caps: WebdriverIO.Capabilities
     cid: string
     isBusy?: boolean
     postMessage: (command: string, args: WorkerMessageArgs) => void

--- a/packages/wdio-types/src/index.ts
+++ b/packages/wdio-types/src/index.ts
@@ -1,6 +1,5 @@
 import type * as Automation from './Automation.js'
 import type * as Capabilities from './Capabilities.js'
-import type * as Clients from './Clients.js'
 import type * as Options from './Options.js'
 import type * as Services from './Services.js'
 import type * as Reporters from './Reporters.js'
@@ -12,7 +11,7 @@ import type * as Workers from './Workers.js'
  */
 export { MESSAGE_TYPES } from './Workers.js'
 
-export type { Automation, Capabilities, Clients, Options, Services, Frameworks, Reporters, Workers }
+export type { Automation, Capabilities, Options, Services, Frameworks, Reporters, Workers }
 
 export type JsonPrimitive = string | number | boolean | null
 export type JsonObject = { [x: string]: JsonPrimitive | JsonObject | JsonArray }
@@ -45,7 +44,9 @@ declare global {
         interface CucumberOpts { [key: string]: any }
         interface ServiceOption extends Services.ServiceOption {}
         interface ReporterOption extends Reporters.Options {}
-        interface Config extends Options.Testrunner {}
+        interface Config extends Options.Testrunner, Capabilities.WithRequestedTestrunnerCapabilities {}
+        interface RemoteConfig extends Options.WebdriverIO, Capabilities.WithRequestedCapabilities {}
+        interface MultiremoteConfig extends Options.Testrunner, Capabilities.WithRequestedMultiremoteCapabilities {}
         interface HookFunctionExtension {}
         interface WDIOVSCodeServiceOptions {}
         interface BrowserRunnerOptions {}

--- a/packages/wdio-utils/package.json
+++ b/packages/wdio-utils/package.json
@@ -38,8 +38,8 @@
   },
   "dependencies": {
     "@puppeteer/browsers": "^2.2.0",
-    "@wdio/logger": "workspace:9.0.0-alpha.0",
-    "@wdio/types": "workspace:9.0.0-alpha.0",
+    "@wdio/logger": "workspace:*",
+    "@wdio/types": "workspace:*",
     "decamelize": "^6.0.0",
     "deepmerge-ts": "^7.0.3",
     "edgedriver": "^5.5.0",

--- a/packages/wdio-utils/src/envDetector.ts
+++ b/packages/wdio-utils/src/envDetector.ts
@@ -28,8 +28,6 @@ export function isW3C(capabilities?: WebdriverIO.Capabilities) {
      * - it is an Appium session (since Appium is full W3C compliant)
      */
     const isAppium = Boolean(
-        // @ts-expect-error outdated jsonwp cap
-        capabilities.automationName ||
         capabilities['appium:automationName'] ||
         capabilities['appium:deviceName'] ||
         capabilities['appium:appiumVersion']
@@ -62,7 +60,7 @@ function isChrome(capabilities?: WebdriverIO.Capabilities) {
     if (!capabilities) {
         return false
     }
-    return Boolean(capabilities['goog:chromeOptions'])
+    return Boolean(capabilities['goog:chromeOptions'] && capabilities.browserName === 'chrome')
 }
 
 /**
@@ -219,6 +217,11 @@ function isSeleniumStandalone(capabilities?: WebdriverIO.Capabilities) {
     }
     return (
         /**
+         * Selenium v3 and below
+         */
+        // @ts-expect-error outdated JSONWP capabilities
+        Boolean(capabilities['webdriver.remote.sessionid']) ||
+        /**
          * Selenium v4 and up
          */
         Boolean(capabilities['se:cdp'])
@@ -261,8 +264,13 @@ export function capabilitiesEnvironmentDetector(capabilities: WebdriverIO.Capabi
  * @param  {Object}  requestedCapabilities
  * @return {Object}                         object with environment flags
  */
-export function sessionEnvironmentDetector({ capabilities, requestedCapabilities }:
-    { capabilities: WebdriverIO.Capabilities, requestedCapabilities: Capabilities.WithRequestedCapabilities['capabilities'] }) {
+export function sessionEnvironmentDetector({
+    capabilities,
+    requestedCapabilities
+}: {
+    capabilities: WebdriverIO.Capabilities,
+    requestedCapabilities: Capabilities.RequestedStandaloneCapabilities
+}) {
     return {
         isW3C: isW3C(capabilities),
         isChrome: isChrome(capabilities),

--- a/packages/wdio-utils/src/initializeServices.ts
+++ b/packages/wdio-utils/src/initializeServices.ts
@@ -114,7 +114,7 @@ export async function initializeLauncherService (config: Omit<Options.Testrunner
             const Launcher = (service as Services.ServicePlugin).launcher
             if (typeof Launcher === 'function' && serviceName) {
                 serviceLabelToBeInitialised = `"${serviceName}"`
-                launcherServices.push(new Launcher(serviceConfig, caps as Capabilities.ResolveTestrunnerCaps, config))
+                launcherServices.push(new Launcher(serviceConfig, caps as Capabilities.ResolvedTestrunnerCapabilities, config))
             }
 
             /**
@@ -122,7 +122,7 @@ export async function initializeLauncherService (config: Omit<Options.Testrunner
              */
             if (typeof service === 'function' && !serviceName) {
                 serviceLabelToBeInitialised = `"${service.constructor?.name || service.toString()}"`
-                launcherServices.push(new service(serviceConfig, caps as Capabilities.ResolveTestrunnerCaps, config))
+                launcherServices.push(new service(serviceConfig, caps as Capabilities.ResolvedTestrunnerCapabilities, config))
             }
 
             /**

--- a/packages/wdio-utils/src/initializeServices.ts
+++ b/packages/wdio-utils/src/initializeServices.ts
@@ -1,4 +1,4 @@
-import type { Capabilities, Services, Options } from '@wdio/types'
+import type { Services, Options } from '@wdio/types'
 import logger from '@wdio/logger'
 
 import initializePlugin from './initializePlugin.js'
@@ -91,7 +91,7 @@ function sanitizeServiceArray (service: Services.ServiceEntry): ServiceWithOptio
  *                            as a list of services that don't need to be
  *                            required in the worker
  */
-export async function initializeLauncherService (config: Omit<Options.Testrunner, 'capabilities' | keyof Services.HookFunctions>, caps: Capabilities.DesiredCapabilities) {
+export async function initializeLauncherService (config: Omit<Options.Testrunner, 'capabilities' | keyof Services.HookFunctions>, caps: WebdriverIO.Capabilities) {
     const ignoredWorkerServices = []
     const launcherServices: Services.ServiceInstance[] = []
     let serviceLabelToBeInitialised = 'unknown'
@@ -154,7 +154,7 @@ export async function initializeLauncherService (config: Omit<Options.Testrunner
  */
 export async function initializeWorkerService (
     config: Options.Testrunner,
-    caps: Capabilities.DesiredCapabilities,
+    caps: WebdriverIO.Capabilities,
     ignoredWorkerServices: string[] = []
 ): Promise<Services.ServiceInstance[]> {
     let serviceLabelToBeInitialised = 'unknown'

--- a/packages/wdio-utils/src/initializeServices.ts
+++ b/packages/wdio-utils/src/initializeServices.ts
@@ -1,4 +1,4 @@
-import type { Services, Options } from '@wdio/types'
+import type { Services, Options, Capabilities } from '@wdio/types'
 import logger from '@wdio/logger'
 
 import initializePlugin from './initializePlugin.js'
@@ -91,7 +91,7 @@ function sanitizeServiceArray (service: Services.ServiceEntry): ServiceWithOptio
  *                            as a list of services that don't need to be
  *                            required in the worker
  */
-export async function initializeLauncherService (config: Omit<Options.Testrunner, 'capabilities' | keyof Services.HookFunctions>, caps: WebdriverIO.Capabilities) {
+export async function initializeLauncherService (config: Omit<Options.Testrunner, 'capabilities' | keyof Services.HookFunctions>, caps: Capabilities.TestrunnerCapabilities) {
     const ignoredWorkerServices = []
     const launcherServices: Services.ServiceInstance[] = []
     let serviceLabelToBeInitialised = 'unknown'
@@ -114,7 +114,7 @@ export async function initializeLauncherService (config: Omit<Options.Testrunner
             const Launcher = (service as Services.ServicePlugin).launcher
             if (typeof Launcher === 'function' && serviceName) {
                 serviceLabelToBeInitialised = `"${serviceName}"`
-                launcherServices.push(new Launcher(serviceConfig, caps, config))
+                launcherServices.push(new Launcher(serviceConfig, caps as Capabilities.ResolveTestrunnerCaps, config))
             }
 
             /**
@@ -122,7 +122,7 @@ export async function initializeLauncherService (config: Omit<Options.Testrunner
              */
             if (typeof service === 'function' && !serviceName) {
                 serviceLabelToBeInitialised = `"${service.constructor?.name || service.toString()}"`
-                launcherServices.push(new service(serviceConfig, caps, config))
+                launcherServices.push(new service(serviceConfig, caps as Capabilities.ResolveTestrunnerCaps, config))
             }
 
             /**

--- a/packages/wdio-utils/src/monad.ts
+++ b/packages/wdio-utils/src/monad.ts
@@ -1,5 +1,3 @@
-import type { Clients } from '@wdio/types'
-
 import { EventEmitter } from 'node:events'
 import logger from '@wdio/logger'
 import { MESSAGE_TYPES, type Workers } from '@wdio/types'
@@ -88,7 +86,7 @@ export default function WebDriver (options: Record<string, any>, modifier?: Func
             client = modifier(client, options)
         }
 
-        client.addCommand = function (name: string, func: Function, attachToElement = false, proto: Record<string, any>, instances?: Clients.Multiremote | Clients.Browser) {
+        client.addCommand = function (name: string, func: Function, attachToElement = false, proto: Record<string, any>, instances?: WebdriverIO.Browser | WebdriverIO.MultiRemoteBrowser) {
             const customCommand = typeof commandWrapper === 'function'
                 ? commandWrapper(name, func)
                 : func
@@ -142,7 +140,7 @@ export default function WebDriver (options: Record<string, any>, modifier?: Func
          * @param  {Object=}  proto             prototype to add function to (optional)
          * @param  {Object=}  instances         multiremote instances
          */
-        client.overwriteCommand = function (name: string, func: Function, attachToElement = false, proto: Record<string, any>, instances?: Clients.Multiremote | Clients.Browser) {
+        client.overwriteCommand = function (name: string, func: Function, attachToElement = false, proto: Record<string, any>, instances?: WebdriverIO.Browser | WebdriverIO.MultiRemoteBrowser) {
             const customCommand = typeof commandWrapper === 'function'
                 ? commandWrapper(name, func)
                 : func

--- a/packages/wdio-utils/src/node/manager.ts
+++ b/packages/wdio-utils/src/node/manager.ts
@@ -18,7 +18,7 @@ enum BrowserDriverTaskLabel {
 }
 
 function mapCapabilities (
-    options: Omit<Options.WebdriverIO, 'capabilities'>,
+    options: Options.WebdriverIO,
     caps: Capabilities.TestrunnerCapabilities,
     task: SetupTaskFunction,
     taskItemLabel: string) {
@@ -28,8 +28,13 @@ function mapCapabilities (
                 const w3cCaps = cap as Capabilities.W3CCapabilities
                 const multiremoteCaps = cap as Capabilities.RequestedMultiremoteCapabilities
                 const multiremoteInstanceNames = Object.keys(multiremoteCaps)
-                if (multiremoteCaps[multiremoteInstanceNames[0]]) {
-                    return Object.values(multiremoteCaps).map((c) => 'alwaysMatch' in c ? c.alwaysMatch : c) as WebdriverIO.Capabilities[]
+
+                if (typeof multiremoteCaps[multiremoteInstanceNames[0]] === 'object' && 'capabilities' in multiremoteCaps[multiremoteInstanceNames[0]]) {
+                    return Object.values(multiremoteCaps).map((c: Capabilities.WithRequestedCapabilities) => (
+                        'alwaysMatch' in c.capabilities
+                            ? c.capabilities.alwaysMatch
+                            : c.capabilities
+                    ))
                 }
 
                 if (w3cCaps.alwaysMatch) {

--- a/packages/wdio-utils/src/node/manager.ts
+++ b/packages/wdio-utils/src/node/manager.ts
@@ -19,7 +19,7 @@ enum BrowserDriverTaskLabel {
 
 function mapCapabilities (
     options: Omit<Options.WebdriverIO, 'capabilities'>,
-    caps: Capabilities.WithRequestedCapabilities['capabilities'] | Capabilities.WithRequestedMultiremoteCapabilities['capabilities'],
+    caps: Capabilities.TestrunnerCapabilities,
     task: SetupTaskFunction,
     taskItemLabel: string) {
     const capabilitiesToRequireSetup = (
@@ -98,7 +98,7 @@ function mapCapabilities (
     )
 }
 
-export async function setupDriver (options: Omit<Options.WebDriver, 'capabilities'>, caps: Capabilities.RequestedStandaloneCapabilities | Capabilities.RequestedMultiremoteCapabilities) {
+export async function setupDriver (options: Omit<Options.WebDriver, 'capabilities'>, caps: Capabilities.TestrunnerCapabilities) {
     return mapCapabilities(options, caps, async (cap: WebdriverIO.Capabilities) => {
         const cacheDir = getCacheDir(options, cap)
         if (isEdge(cap.browserName)) {
@@ -115,7 +115,7 @@ export async function setupDriver (options: Omit<Options.WebDriver, 'capabilitie
     }, BrowserDriverTaskLabel.DRIVER)
 }
 
-export function setupBrowser (options: Omit<Options.WebDriver, 'capabilities'>, caps: Capabilities.RequestedStandaloneCapabilities | Capabilities.RequestedMultiremoteCapabilities) {
+export function setupBrowser (options: Omit<Options.WebDriver, 'capabilities'>, caps: Capabilities.TestrunnerCapabilities) {
     return mapCapabilities(options, caps, async (cap: WebdriverIO.Capabilities) => {
         const cacheDir = getCacheDir(options, cap)
         if (isEdge(cap.browserName)) {

--- a/packages/wdio-utils/src/node/startWebDriver.ts
+++ b/packages/wdio-utils/src/node/startWebDriver.ts
@@ -13,7 +13,7 @@ import { start as startGeckodriver, type GeckodriverParameters } from 'geckodriv
 import { start as startEdgedriver, findEdgePath, type EdgedriverParameters } from 'edgedriver'
 import type { InstallOptions } from '@puppeteer/browsers'
 
-import type { Capabilities, Options } from '@wdio/types'
+import type { Capabilities } from '@wdio/types'
 
 import { parseParams, setupPuppeteerBrowser, setupChromedriver, getCacheDir } from './utils.js'
 import { isChrome, isFirefox, isEdge, isSafari, isAppiumCapability } from '../utils.js'
@@ -32,7 +32,7 @@ declare global {
 const log = logger('@wdio/utils')
 const DRIVER_WAIT_TIMEOUT = 10 * 1000 // 10s
 
-export async function startWebDriver (options: Options.WebDriver) {
+export async function startWebDriver (options: Capabilities.RemoteConfig) {
     /**
      * in case we are running unit tests, just return
      */

--- a/packages/wdio-utils/src/shim.ts
+++ b/packages/wdio-utils/src/shim.ts
@@ -1,6 +1,6 @@
 /// <reference types="@wdio/globals/types" />
 import logger from '@wdio/logger'
-import type { Clients, Frameworks } from '@wdio/types'
+import type { Frameworks } from '@wdio/types'
 
 import * as iterators from './pIteration.js'
 import { getBrowserObject } from './utils.js'
@@ -120,9 +120,9 @@ export function wrapCommand<T>(commandName: string, fn: Function): (...args: any
         return commandResult
     }
 
-    function wrapElementFn (promise: Promise<Clients.Browser>, cmd: Function, args: any[], prevInnerArgs?: { prop: string | number, args: any[] }): any {
+    function wrapElementFn (promise: Promise<WebdriverIO.Browser>, cmd: Function, args: any[], prevInnerArgs?: { prop: string | number, args: any[] }): any {
         return new Proxy(
-            Promise.resolve(promise).then((ctx: Clients.Browser) => cmd.call(ctx, ...args)),
+            Promise.resolve(promise).then((ctx: WebdriverIO.Browser) => cmd.call(ctx, ...args)),
             {
                 get: (target, prop: string) => {
                     /**
@@ -160,13 +160,13 @@ export function wrapCommand<T>(commandName: string, fn: Function): (...args: any
                             /**
                              * `this` is an array of WebdriverIO elements
                              */
-                            function (this: WebdriverIO.ElementArray, index: number) {
+                            function (this: any, index: number) {
                                 /**
                                  * if we access an index that is out of bounds we wait for the
                                  * array to get that long, and timeout eventually if it doesn't
                                  */
                                 if (index >= this.length) {
-                                    const browser = getBrowserObject(this)
+                                    const browser = getBrowserObject(this) as any
                                     return browser.waitUntil(async () => {
                                         const elems = await this.parent[this.foundWith as any as '$$'](this.selector)
                                         if (elems.length > index) {
@@ -278,11 +278,11 @@ export function wrapCommand<T>(commandName: string, fn: Function): (...args: any
         )
     }
 
-    function chainElementQuery(this: Promise<Clients.Browser>, ...args: any[]): any {
+    function chainElementQuery(this: Promise<WebdriverIO.Browser>, ...args: any[]): any {
         return wrapElementFn(this, wrapCommandFn, args)
     }
 
-    return function (this: Clients.Browser, ...args: any[]) {
+    return function (this: WebdriverIO.Browser, ...args: any[]) {
         /**
          * if the command suppose to return an element, we apply `chainElementQuery` to allow
          * chaining of these promises.

--- a/packages/wdio-utils/src/startWebDriver.ts
+++ b/packages/wdio-utils/src/startWebDriver.ts
@@ -1,11 +1,11 @@
 import logger from '@wdio/logger'
-import type { Options } from '@wdio/types'
+import type { Capabilities } from '@wdio/types'
 
 import { definesRemoteDriver } from './utils.js'
 
 const log = logger('@wdio/utils')
 
-export async function startWebDriver (options: Options.WebDriver) {
+export async function startWebDriver (options: Capabilities.RemoteConfig) {
     /**
      * if any of the connection parameter are set, don't start any driver
      */

--- a/packages/wdio-utils/src/utils.ts
+++ b/packages/wdio-utils/src/utils.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs/promises'
 import path from 'node:path'
-import type { Options, Services, Clients } from '@wdio/types'
+import type { Options, Services } from '@wdio/types'
 
 import { SUPPORTED_BROWSERNAMES, DEFAULT_PROTOCOL, DEFAULT_HOSTNAME, DEFAULT_PATH } from './constants.js'
 
@@ -45,10 +45,10 @@ export function overwriteElementCommands(propertiesObject: { '__elementOverrides
         const origCommand = propertiesObject[commandName].value
         delete propertiesObject[commandName]
 
-        const newCommand = function (this: Clients.Browser, ...args: any[]) {
+        const newCommand = function (this: WebdriverIO.Browser, ...args: any[]) {
             const element = this
             return userDefinedCommand.apply(element, [
-                function origCommandFunction (this: Clients.Browser) {
+                function origCommandFunction (this: WebdriverIO.Browser) {
                     const context = this || element // respect explicite context binding, use element as default
                     return origCommand.apply(context, arguments)
                 },

--- a/packages/wdio-utils/tests/__fixtures__/edgedriver.response.json
+++ b/packages/wdio-utils/tests/__fixtures__/edgedriver.response.json
@@ -2,24 +2,31 @@
   "value": {
     "sessionId": "867A8C76-537F-4F2B-897C-85F87DF2C995",
     "capabilities": {
-      "ms:inPrivate": false,
-      "browserVersion": "44.17763.1.0",
-      "takesScreenshot": true,
-      "acceptSslCerts": true,
-      "cssSelectorsEnabled": true,
-      "javascriptEnabled": true,
+      "acceptInsecureCerts": false,
       "browserName": "MicrosoftEdge",
-      "locationContextEnabled": true,
-      "platform": "ANY",
-      "takesElementScreenshot": true,
-      "webdriver.remote.sessionid": "199008b1e1e64a039d45e534d71b1e32",
-      "hasMetadata": true,
-      "applicationCacheEnabled": true,
-      "webStorageEnabled": true,
+      "browserVersion": "125.0.2535.92",
+      "fedcm:accounts": true,
+      "ms:edgeOptions": {
+        "debuggerAddress": "localhost:56304"
+      },
+      "msedge": {
+        "msedgedriverVersion": "125.0.2535.92 (d2d4746171db016dca5f4d42bb86454ce4c16da3)",
+        "userDataDir": "/var/folders/rt/1bg19g7s3tn3w25gydr272c80000gn/T/.com.microsoft.edgemac.OJ80Mj"
+      },
+      "networkConnectionEnabled": false,
       "pageLoadStrategy": "normal",
-      "platformName": "windows",
-      "platformVersion": "10",
-      "unhandledPromptBehavior": "dismiss and notify"
+      "platformName": "mac",
+      "proxy": {},
+      "setWindowRect": true,
+      "strictFileInteractability": false,
+      "timeouts": { "implicit": 0, "pageLoad": 300000, "script": 30000 },
+      "unhandledPromptBehavior": "dismiss and notify",
+      "webauthn:extension:credBlob": true,
+      "webauthn:extension:largeBlob": true,
+      "webauthn:extension:minPinLength": true,
+      "webauthn:extension:prf": true,
+      "webauthn:virtualAuthenticators": true,
+      "wdio:driverPID": 87674
     }
   }
 }

--- a/packages/wdio-utils/tests/envDetector.test.ts
+++ b/packages/wdio-utils/tests/envDetector.test.ts
@@ -28,13 +28,13 @@ describe('sessionEnvironmentDetector', () => {
     const safariDockerNpNCaps = safaridriverdockerNpNResponse.value.capabilities as WebdriverIO.Capabilities // absent capability.platformName
     const safariDockerNbVCaps = safaridriverdockerNbVResponse.value.capabilities as WebdriverIO.Capabilities // absent capability.browserVersion
     const safariLegacyCaps = safaridriverLegacyResponse.value as WebdriverIO.Capabilities
-    const standaloneCaps = seleniumstandaloneResponse.value as Capabilities.DesiredCapabilities
-    const standalonev4Caps = seleniumstandalone4Response.value as Capabilities.DesiredCapabilities
+    const standaloneCaps = seleniumstandaloneResponse.value as WebdriverIO.Capabilities
+    const standalonev4Caps = seleniumstandalone4Response.value as WebdriverIO.Capabilities
 
     it('isMobile', () => {
         const requestedCapabilities = { browserName: '' }
-        const appiumReqCaps = { 'appium:options': {} }
-        const appiumW3CCaps = { alwaysMatch: { 'appium:options': {} }, firstMatch: [] }
+        const appiumReqCaps: Capabilities.RequestedStandaloneCapabilities = { 'appium:platformName': 'foo' }
+        const appiumW3CCaps: Capabilities.RequestedStandaloneCapabilities = { alwaysMatch: { 'appium:platformName': 'foo' }, firstMatch: [] }
         expect(sessionEnvironmentDetector({ capabilities: {}, requestedCapabilities: {} }).isMobile).toBe(false)
         expect(sessionEnvironmentDetector({ capabilities: experitestAppiumCaps, requestedCapabilities }).isMobile).toBe(true)
         expect(sessionEnvironmentDetector({ capabilities: appiumCaps, requestedCapabilities }).isMobile).toBe(true)
@@ -65,8 +65,8 @@ describe('sessionEnvironmentDetector', () => {
     it('isW3C', () => {
         const requestedCapabilities = { browserName: '' }
         expect(sessionEnvironmentDetector({ capabilities: {}, requestedCapabilities: {} }).isW3C).toBe(false)
-        expect(sessionEnvironmentDetector({ capabilities: appiumCaps, requestedCapabilities }).isW3C).toBe(true)
-        expect(sessionEnvironmentDetector({ capabilities: experitestAppiumCaps, requestedCapabilities }).isW3C).toBe(true)
+        expect(sessionEnvironmentDetector({ capabilities: appiumCaps, requestedCapabilities }).isW3C).toBe(false)
+        expect(sessionEnvironmentDetector({ capabilities: experitestAppiumCaps, requestedCapabilities }).isW3C).toBe(false)
         expect(sessionEnvironmentDetector({ capabilities: chromeCaps, requestedCapabilities }).isW3C).toBe(true)
         expect(sessionEnvironmentDetector({ capabilities: geckoCaps, requestedCapabilities }).isW3C).toBe(true)
         expect(sessionEnvironmentDetector({ capabilities: safariCaps, requestedCapabilities }).isW3C).toBe(true)
@@ -77,7 +77,7 @@ describe('sessionEnvironmentDetector', () => {
         expect(sessionEnvironmentDetector({ capabilities: phantomCaps, requestedCapabilities }).isW3C).toBe(false)
         expect(sessionEnvironmentDetector({ capabilities: {}, requestedCapabilities }).isW3C).toBe(false)
         expect(sessionEnvironmentDetector({ capabilities: {
-            maxInstances: 7,
+            'wdio:maxInstances': 7,
             platformName: 'WINDOWS',
             'appium:app': 'C:\\Program Files\\App.exe',
             'appium:appArguments': '-noCloseConfirmationPopUp -shouldDisplayDiesToTake',
@@ -121,17 +121,18 @@ describe('sessionEnvironmentDetector', () => {
         expect(sessionEnvironmentDetector({ capabilities: chromeCaps, requestedCapabilities }).isBidi).toBe(false)
         expect(sessionEnvironmentDetector({ capabilities: geckoCaps, requestedCapabilities }).isBidi).toBe(false)
         expect(sessionEnvironmentDetector({ capabilities: phantomCaps, requestedCapabilities }).isBidi).toBe(false)
+        // @ts-expect-error JSON import is not properly typed
         expect(sessionEnvironmentDetector({ capabilities: bidiResponse, requestedCapabilities }).isBidi).toBe(true)
     })
 
     it('isSauce', () => {
         const capabilities = { browserName: 'chrome' }
-        let requestedCapabilities: WebDriver.DesiredCapabilities = {}
+        let requestedCapabilities: WebdriverIO.Capabilities = {}
 
         expect(sessionEnvironmentDetector({ capabilities: {}, requestedCapabilities: {} }).isSauce).toBe(false)
         expect(sessionEnvironmentDetector({ capabilities, requestedCapabilities }).isSauce).toBe(false)
 
-        requestedCapabilities.extendedDebugging = true
+        requestedCapabilities['sauce:options'] = { extendedDebugging: true }
         expect(sessionEnvironmentDetector({ capabilities, requestedCapabilities }).isSauce).toBe(true)
         requestedCapabilities = {}
         expect(sessionEnvironmentDetector({ capabilities, requestedCapabilities }).isSauce).toBe(false)

--- a/packages/wdio-webdriver-mock-service/src/index.ts
+++ b/packages/wdio-webdriver-mock-service/src/index.ts
@@ -37,7 +37,7 @@ export default class WebdriverMockService implements Services.ServiceInstance {
         this._mock.command.getLogTypes().reply(200, { value: [] })
     }
 
-    beforeSession(config: Omit<Options.Testrunner, 'capabilities'>): void {
+    beforeSession(config: Options.Testrunner): void {
         config.hostname = 'localhost'
         config.port = 4444
     }

--- a/packages/webdriver/src/constants.ts
+++ b/packages/webdriver/src/constants.ts
@@ -1,7 +1,8 @@
 import os from 'node:os'
 import type { Options } from '@wdio/types'
+import type { RemoteConfig } from './types.js'
 
-export const DEFAULTS: Options.Definition<Required<Options.WebDriver>> = {
+export const DEFAULTS: Options.Definition<Required<RemoteConfig>> = {
     /**
      * protocol of automation driver
      */

--- a/packages/webdriver/src/index.ts
+++ b/packages/webdriver/src/index.ts
@@ -4,7 +4,12 @@ import logger from '@wdio/logger'
 
 import { webdriverMonad, sessionEnvironmentDetector, startWebDriver } from '@wdio/utils'
 import { validateConfig } from '@wdio/config'
-import type { Options } from '@wdio/types'
+<<<<<<< HEAD
+import type { Capabilities, Options } from '@wdio/types'
+=======
+import { deepmerge } from 'deepmerge-ts'
+import type { Options, Capabilities } from '@wdio/types'
+>>>>>>> 5e5f37dbf (breaking(*): better type definitions for capabilities)
 
 import command from './command.js'
 import { DEFAULTS } from './constants.js'
@@ -15,7 +20,7 @@ const log = logger('webdriver')
 
 export default class WebDriver {
     static async newSession(
-        options: Options.WebDriver,
+        options: Capabilities.RemoteConfig,
         modifier?: (...args: any[]) => any,
         userPrototype = {},
         customCommandWrapper?: (...args: any[]) => any
@@ -122,9 +127,9 @@ export default class WebDriver {
          * initiate WebDriver Bidi
          */
         const bidiPrototype: PropertyDescriptorMap = {}
-        const webSocketUrl = 'alwaysMatch' in options.capabilities!
-            ? options.capabilities.alwaysMatch?.webSocketUrl
-            : options.capabilities!.webSocketUrl
+        const webSocketUrl = 'alwaysMatch' in options.requestedCapabilities
+            ? options.requestedCapabilities.alwaysMatch?.webSocketUrl
+            : options.requestedCapabilities.webSocketUrl
         if (webSocketUrl) {
             log.info(`Register BiDi handler for session with id ${options.sessionId}`)
             Object.assign(bidiPrototype, initiateBidi(webSocketUrl as any as string, options.strictSSL))
@@ -152,7 +157,7 @@ export default class WebDriver {
      */
     static async reloadSession(instance: Client, newCapabilities?: WebdriverIO.Capabilities) {
         const capabilities = newCapabilities ? newCapabilities : instance.requestedCapabilities as WebdriverIO.Capabilities
-        let params: Options.WebDriver = { ...instance.options, capabilities }
+        let params: Capabilities.RemoteConfig = { ...instance.options, capabilities }
 
         for (const prop of ['protocol', 'hostname', 'port', 'path', 'queryParams', 'user', 'key'] as (keyof Options.Connection)[]) {
             if (prop in capabilities) {

--- a/packages/webdriver/src/index.ts
+++ b/packages/webdriver/src/index.ts
@@ -4,12 +4,7 @@ import logger from '@wdio/logger'
 
 import { webdriverMonad, sessionEnvironmentDetector, startWebDriver } from '@wdio/utils'
 import { validateConfig } from '@wdio/config'
-<<<<<<< HEAD
 import type { Capabilities, Options } from '@wdio/types'
-=======
-import { deepmerge } from 'deepmerge-ts'
-import type { Options, Capabilities } from '@wdio/types'
->>>>>>> 5e5f37dbf (breaking(*): better type definitions for capabilities)
 
 import command from './command.js'
 import { DEFAULTS } from './constants.js'
@@ -127,12 +122,10 @@ export default class WebDriver {
          * initiate WebDriver Bidi
          */
         const bidiPrototype: PropertyDescriptorMap = {}
-        const webSocketUrl = options.requestedCapabilities && 'alwaysMatch' in options.requestedCapabilities
-            ? options.requestedCapabilities.alwaysMatch?.webSocketUrl
-            : options.requestedCapabilities?.webSocketUrl
-        if (webSocketUrl) {
+        const webSocketUrl = options.capabilities?.webSocketUrl as unknown as string
+        if (typeof webSocketUrl === 'string') {
             log.info(`Register BiDi handler for session with id ${options.sessionId}`)
-            Object.assign(bidiPrototype, initiateBidi(webSocketUrl as any as string, options.strictSSL))
+            Object.assign(bidiPrototype, initiateBidi(webSocketUrl as unknown as string, options.strictSSL))
         }
 
         const prototype = { ...protocolCommands, ...environmentPrototype, ...userPrototype, ...bidiPrototype }

--- a/packages/webdriver/src/index.ts
+++ b/packages/webdriver/src/index.ts
@@ -127,9 +127,9 @@ export default class WebDriver {
          * initiate WebDriver Bidi
          */
         const bidiPrototype: PropertyDescriptorMap = {}
-        const webSocketUrl = 'alwaysMatch' in options.requestedCapabilities
+        const webSocketUrl = options.requestedCapabilities && 'alwaysMatch' in options.requestedCapabilities
             ? options.requestedCapabilities.alwaysMatch?.webSocketUrl
-            : options.requestedCapabilities.webSocketUrl
+            : options.requestedCapabilities?.webSocketUrl
         if (webSocketUrl) {
             log.info(`Register BiDi handler for session with id ${options.sessionId}`)
             Object.assign(bidiPrototype, initiateBidi(webSocketUrl as any as string, options.strictSSL))

--- a/packages/webdriver/src/types.ts
+++ b/packages/webdriver/src/types.ts
@@ -63,6 +63,10 @@ export interface BaseClient extends EventEmitter, SessionFlags {
 
 export interface Client extends Omit<BaseClient, keyof BidiEventHandler>, ProtocolCommands, BidiHandler, BidiEventHandler {}
 
-export interface AttachOptions extends Pick<BaseClient, 'capabilities' | 'requestedCapabilities'>, Partial<SessionFlags>, Partial<Options.WebDriver> {
+export interface AttachOptions extends Partial<SessionFlags>, Partial<Options.WebDriver> {
     sessionId: string
+    // assigned capabilities by the browser driver / WebDriver server
+    capabilities?: WebdriverIO.Capabilities
+    // original requested capabilities
+    requestedCapabilities?: Capabilities.WithRequestedCapabilities['capabilities']
 }

--- a/packages/webdriver/src/types.ts
+++ b/packages/webdriver/src/types.ts
@@ -29,6 +29,7 @@ type ObtainMethods<T> = { [Prop in keyof T]: T[Prop] extends Fn ? ThenArg<Return
 type WebDriverBidiCommands = typeof WebDriverBidiProtocol
 export type BidiCommands = WebDriverBidiCommands[keyof WebDriverBidiCommands]['socket']['command']
 export type BidiResponses = ValueOf<ObtainMethods<Pick<BidiHandler, BidiCommands>>>
+export type RemoteConfig = Options.WebDriver & Capabilities.WithRequestedCapabilities
 
 type BidiInterface = ObtainMethods<Pick<BidiHandler, BidiCommands>>
 type WebDriverClassicEvents = {
@@ -53,17 +54,15 @@ export interface BaseClient extends EventEmitter, SessionFlags {
     // id of WebDriver session
     sessionId: string
     // assigned capabilities by the browser driver / WebDriver server
-    capabilities: Capabilities.DesiredCapabilities | Capabilities.W3CCapabilities
+    capabilities: WebdriverIO.Capabilities
     // original requested capabilities
-    requestedCapabilities: Capabilities.DesiredCapabilities | Capabilities.W3CCapabilities
+    requestedCapabilities: Capabilities.WithRequestedCapabilities['capabilities']
     // framework options
     options: Options.WebDriver
 }
 
 export interface Client extends Omit<BaseClient, keyof BidiEventHandler>, ProtocolCommands, BidiHandler, BidiEventHandler {}
 
-export interface AttachOptions extends Partial<SessionFlags>, Partial<Options.WebDriver> {
+export interface AttachOptions extends Pick<BaseClient, 'capabilities' | 'requestedCapabilities'>, Partial<SessionFlags>, Partial<Options.WebDriver> {
     sessionId: string
-    capabilities?: Capabilities.DesiredCapabilities | Capabilities.W3CCapabilities
-    isW3C?: boolean
 }

--- a/packages/webdriver/src/utils.ts
+++ b/packages/webdriver/src/utils.ts
@@ -17,7 +17,7 @@ import { BidiHandler } from './bidi/handler.js'
 import type { Event } from './bidi/localTypes.js'
 import { REG_EXPS } from './constants.js'
 import type { WebDriverResponse } from './request/index.js'
-import type { Client, JSONWPCommandError, SessionFlags } from './types.js'
+import type { Client, JSONWPCommandError, SessionFlags, RemoteConfig } from './types.js'
 
 const log = logger('webdriver')
 const deepmerge = deepmergeCustom({ mergeArrays: false })
@@ -32,7 +32,7 @@ const BROWSER_DRIVER_ERRORS = [
 /**
  * start browser session with WebDriver protocol
  */
-export async function startWebDriverSession (params: Options.WebDriver): Promise<{ sessionId: string, capabilities: Capabilities.DesiredCapabilities }> {
+export async function startWebDriverSession (params: RemoteConfig): Promise<{ sessionId: string, capabilities: WebdriverIO.Capabilities }> {
     /**
      * validate capabilities to check if there are no obvious mix between
      * JSONWireProtocol and WebDriver protocol, e.g.
@@ -96,9 +96,9 @@ export async function startWebDriverSession (params: Options.WebDriver): Promise
     /**
      * save actual received session details
      */
-    params.capabilities = response.value.capabilities || response.value
+    params.capabilities = (response.value.capabilities || response.value) as WebdriverIO.Capabilities
 
-    return { sessionId, capabilities: params.capabilities as Capabilities.DesiredCapabilities }
+    return { sessionId, capabilities: params.capabilities }
 }
 
 /**
@@ -306,7 +306,7 @@ export function getEnvironmentVars({ isW3C, isMobile, isIOS, isAndroid, isFirefo
  * @param  {Client} params post-new-session client
  */
 export function setupDirectConnect(client: Client) {
-    const capabilities = client.capabilities as Capabilities.DesiredCapabilities
+    const capabilities = client.capabilities
     const directConnectProtocol = capabilities['appium:directConnectProtocol']
     const directConnectHost = capabilities['appium:directConnectHost']
     const directConnectPath = capabilities['appium:directConnectPath']

--- a/packages/webdriver/tests/utils.test.ts
+++ b/packages/webdriver/tests/utils.test.ts
@@ -178,10 +178,10 @@ describe('utils', () => {
             // @ts-expect-error
             sessionId?: string
             // @ts-expect-error
-            requestedCapabilities?: Capabilities.DesiredCapabilities | Capabilities.W3CCapabilities
+            requestedCapabilities?: WebdriverIO.Capabilities | Capabilities.W3CCapabilities
 
             constructor(
-                public capabilities: Capabilities.DesiredCapabilities | Capabilities.W3CCapabilities,
+                public capabilities: WebdriverIO.Capabilities | Capabilities.W3CCapabilities,
                 public options: Options.WebDriver
             ) {
                 this.capabilities = capabilities

--- a/packages/webdriverio/src/commands/browser/getCookies.ts
+++ b/packages/webdriverio/src/commands/browser/getCookies.ts
@@ -1,3 +1,4 @@
+import type { Cookie } from '@wdio/protocols'
 /**
  *
  * Retrieve a [cookie](https://w3c.github.io/webdriver/webdriver-spec.html#cookies)
@@ -33,7 +34,7 @@
 export async function getCookies(
     this: WebdriverIO.Browser,
     names?: string | string[]
-) {
+): Promise<Cookie[]> {
     if (names === undefined) {
         return this.getAllCookies()
     }

--- a/packages/webdriverio/src/commands/element/click.ts
+++ b/packages/webdriverio/src/commands/element/click.ts
@@ -148,7 +148,7 @@ async function actionClick(element: WebdriverIO.Element, options: Partial<ClickO
         throw new Error('Button type not supported.')
     }
 
-    const browser = getBrowserObject(element)
+    const browser = getBrowserObject(element) as WebdriverIO.Browser
     if (x || y) {
         const { width, height } = await browser.getElementRect(element.elementId)
         if ((x && x < (-Math.floor(width / 2))) || (x && x > Math.floor(width / 2))) {

--- a/packages/webdriverio/src/constants.ts
+++ b/packages/webdriverio/src/constants.ts
@@ -6,7 +6,7 @@ export enum SupportedAutomationProtocols {
     stub = './protocol-stub.js'
 }
 
-export const WDIO_DEFAULTS: Options.Definition<Options.WebdriverIO> = {
+export const WDIO_DEFAULTS: Options.Definition<Capabilities.WebdriverIOConfig> = {
     /**
      * allows to specify automation protocol
      */
@@ -31,7 +31,7 @@ export const WDIO_DEFAULTS: Options.Definition<Options.WebdriverIO> = {
      */
     capabilities: {
         type: 'object',
-        validate: (param: Capabilities.RemoteCapability) => {
+        validate: (param: Capabilities.WebdriverIOConfig['capabilities']) => {
             /**
              * should be an object
              */

--- a/packages/webdriverio/src/index.ts
+++ b/packages/webdriverio/src/index.ts
@@ -13,7 +13,7 @@ import { getProtocolDriver } from './utils/driver.js'
 import { WDIO_DEFAULTS, SupportedAutomationProtocols, Key as KeyConstant } from './constants.js'
 import { getPrototype, addLocatorStrategyHandler, isStub } from './utils/index.js'
 import { getShadowRootManager } from './shadowRoot.js'
-import type { AttachOptions, RemoteOptions } from './types.js'
+import type { AttachOptions } from './types.js'
 import type * as elementCommands from './commands/element.js'
 
 export * from './types.js'
@@ -34,11 +34,11 @@ export const SevereServiceError = SevereServiceErrorImport
  * @see <a href="https://webdriver.io/docs/typescript">Typescript setup</a>
  */
 export const remote = async function(
-    params: RemoteOptions,
+    params: Capabilities.WebdriverIOConfig,
     remoteModifier?: (client: WebDriverTypes.Client, options: Options.WebdriverIO) => WebDriverTypes.Client
 ): Promise<WebdriverIO.Browser> {
-    const keysToKeep = Object.keys(process.env.WDIO_WORKER_ID ? params : DEFAULTS) as (keyof RemoteOptions)[]
-    const config = validateConfig<RemoteOptions>(WDIO_DEFAULTS, params, keysToKeep)
+    const keysToKeep = Object.keys(process.env.WDIO_WORKER_ID ? params : DEFAULTS) as (keyof Capabilities.WebdriverIOConfig)[]
+    const config = validateConfig<Capabilities.WebdriverIOConfig>(WDIO_DEFAULTS, params, keysToKeep)
 
     await enableFileLogging(config.outputDir)
     logger.setLogLevelsConfig(config.logLevels, config.logLevel)
@@ -93,7 +93,7 @@ export const attach = async function (attachOptions: AttachOptions): Promise<Web
         requestedCapabilities: attachOptions.requestedCapabilities
     }
     const prototype = getPrototype('browser')
-    const { Driver } = await getProtocolDriver(params as Options.WebdriverIO)
+    const { Driver } = await getProtocolDriver(params)
 
     const driver = Driver.attachToSession(
         params,
@@ -129,7 +129,7 @@ export const attach = async function (attachOptions: AttachOptions): Promise<Web
  * @see <a href="https://webdriver.io/docs/multiremote">External document and example usage</a>.
  */
 export const multiremote = async function (
-    params: Capabilities.MultiRemoteCapabilities,
+    params: Capabilities.RequestedMultiremoteCapabilities,
     { automationProtocol }: { automationProtocol?: string } = {}
 ): Promise<WebdriverIO.MultiRemoteBrowser> {
     const multibrowser = new MultiRemote()

--- a/packages/webdriverio/src/index.ts
+++ b/packages/webdriverio/src/index.ts
@@ -35,7 +35,7 @@ export const SevereServiceError = SevereServiceErrorImport
  */
 export const remote = async function(
     params: Capabilities.WebdriverIOConfig,
-    remoteModifier?: (client: WebDriverTypes.Client, options: Options.WebdriverIO) => WebDriverTypes.Client
+    remoteModifier?: (client: WebDriverTypes.Client, options: Capabilities.WebdriverIOConfig) => WebDriverTypes.Client
 ): Promise<WebdriverIO.Browser> {
     const keysToKeep = Object.keys(process.env.WDIO_WORKER_ID ? params : DEFAULTS) as (keyof Capabilities.WebdriverIOConfig)[]
     const config = validateConfig<Capabilities.WebdriverIOConfig>(WDIO_DEFAULTS, params, keysToKeep)
@@ -43,7 +43,7 @@ export const remote = async function(
     await enableFileLogging(config.outputDir)
     logger.setLogLevelsConfig(config.logLevels, config.logLevel)
 
-    const modifier = (client: WebDriverTypes.Client, options: Options.WebdriverIO) => {
+    const modifier = (client: WebDriverTypes.Client, options: Capabilities.WebdriverIOConfig) => {
         /**
          * overwrite instance options with default values of the protocol
          * package (without undefined properties)
@@ -86,11 +86,12 @@ export const attach = async function (attachOptions: AttachOptions): Promise<Web
     /**
      * copy instances properties into new object
      */
-    const params = {
+    const params: Capabilities.WebdriverIOConfig & { requestedCapabilities: Capabilities.RequestedStandaloneCapabilities } = {
         automationProtocol: SupportedAutomationProtocols.webdriver,
         ...attachOptions,
         ...detectBackend(attachOptions.options),
-        requestedCapabilities: attachOptions.requestedCapabilities
+        capabilities: attachOptions.capabilities || {},
+        requestedCapabilities: attachOptions.requestedCapabilities || {}
     }
     const prototype = getPrototype('browser')
     const { Driver } = await getProtocolDriver(params)

--- a/packages/webdriverio/src/protocol-stub.ts
+++ b/packages/webdriverio/src/protocol-stub.ts
@@ -63,7 +63,7 @@ function emulateSessionCapabilities (caps: Capabilities.RequestedStandaloneCapab
     // isChrome
     const c = 'alwaysMatch' in caps ? caps.alwaysMatch : caps
     if (c.browserName && c.browserName.toLowerCase() === 'chrome') {
-        capabilities.chrome = true
+        capabilities['goog:chromeOptions'] = {}
     }
 
     return capabilities

--- a/packages/webdriverio/src/protocol-stub.ts
+++ b/packages/webdriverio/src/protocol-stub.ts
@@ -1,15 +1,13 @@
 import { capabilitiesEnvironmentDetector } from '@wdio/utils'
-import type { Capabilities, Options } from '@wdio/types'
+import type { Capabilities } from '@wdio/types'
 
 /**
  * create `browser` object with capabilities and environment flags before session is started
  * so that Mocha/Jasmine users can filter their specs based on flags or use capabilities in test titles
  */
 export default class ProtocolStub {
-    static async newSession (options: Options.WebDriver) {
-        const capabilities = emulateSessionCapabilities(
-            (options.capabilities || {}) as unknown as Capabilities.DesiredCapabilities
-        )
+    static async newSession (options: Capabilities.RemoteConfig) {
+        const capabilities = emulateSessionCapabilities(options.capabilities)
 
         const browser: any = {
             options,
@@ -53,7 +51,7 @@ export default class ProtocolStub {
  * @param   {object} caps user defined capabilities
  * @return  {object}
  */
-function emulateSessionCapabilities (caps: Capabilities.DesiredCapabilities) {
+function emulateSessionCapabilities (caps: Capabilities.RequestedStandaloneCapabilities) {
     const capabilities: Record<string, any> = {}
 
     // remove appium vendor prefix from capabilities
@@ -63,7 +61,8 @@ function emulateSessionCapabilities (caps: Capabilities.DesiredCapabilities) {
     })
 
     // isChrome
-    if (caps.browserName && caps.browserName.toLowerCase() === 'chrome') {
+    const c = 'alwaysMatch' in caps ? caps.alwaysMatch : caps
+    if (c.browserName && c.browserName.toLowerCase() === 'chrome') {
         capabilities.chrome = true
     }
 

--- a/packages/webdriverio/src/types.ts
+++ b/packages/webdriverio/src/types.ts
@@ -468,9 +468,9 @@ export type DragAndDropCoordinate = {
 }
 
 export interface AttachOptions extends Omit<WebDriverAttachOptions, 'capabilities'> {
-    options: Omit<Options.WebdriverIO, 'capabilities'>
-    capabilities: WebDriverAttachOptions['capabilities']
-    requestedCapabilities: WebDriverAttachOptions['capabilities']
+    options?: Options.WebdriverIO
+    capabilities?: WebDriverAttachOptions['capabilities']
+    requestedCapabilities?: WebDriverAttachOptions['capabilities']
 }
 
 export type ThrottlePreset = 'offline' | 'GPRS' | 'Regular2G' | 'Good2G' | 'Regular3G' | 'Good3G' | 'Regular4G' | 'DSL' | 'WiFi' | 'online'

--- a/packages/webdriverio/src/utils/actions/pointer.ts
+++ b/packages/webdriverio/src/utils/actions/pointer.ts
@@ -106,9 +106,10 @@ export default class PointerAction extends BaseAction {
      * Creates an action to release a single key.
      * @param params PointerActionUpParams
      */
+    up (button?: Button): PointerAction
     up (button?: ButtonNames): PointerAction
     up (params?: PointerActionUpParams): PointerAction
-    up (params: PointerActionUpParams | ButtonNames = UP_PARAM_DEFAULTS) {
+    up (params: PointerActionUpParams | ButtonNames | Button = UP_PARAM_DEFAULTS) {
         this.sequence.push({
             type: 'pointerUp',
             ...mapButton(params)
@@ -120,9 +121,10 @@ export default class PointerAction extends BaseAction {
      * Creates an action to press a single key
      * @param params PointerActionParams
      */
+    down (button?: Button): PointerAction
     down (button?: ButtonNames): PointerAction
     down (params?: PointerActionParams): PointerAction
-    down (params: PointerActionParams | ButtonNames = {}) {
+    down (params: PointerActionParams | Button | ButtonNames = {}) {
         this.sequence.push({
             type: 'pointerDown',
             ...PARAM_DEFAULTS,

--- a/packages/webdriverio/src/utils/detectBackend.ts
+++ b/packages/webdriverio/src/utils/detectBackend.ts
@@ -25,7 +25,7 @@ interface BackendConfigurations {
     region?: Options.SauceRegions
     headless?: boolean
     path?: string
-    capabilities?: Capabilities.RemoteCapabilities | Capabilities.RemoteCapability
+    capabilities?: Capabilities.RequestedStandaloneCapabilities
 }
 
 function getSauceEndpoint (
@@ -81,18 +81,17 @@ export default function detectBackend(options: BackendConfigurations = {}) {
      * For Sauce Labs Legacy RDC we only need to determine if the sauce option has a `testobject_api_key`.
      * Same for Sauce Visual where an apiKey can be passed in through the capabilities (soon to be legacy too).
      */
-    const isRDC = Boolean(!Array.isArray(capabilities) && (capabilities as Capabilities.DesiredCapabilities)?.testobject_api_key)
     const isVisual = Boolean(!Array.isArray(capabilities) && capabilities && (capabilities as WebdriverIO.Capabilities)['sauce:visual']?.apiKey)
     if ((typeof user === 'string' && typeof key === 'string' && key.length === 36) ||
         // Or only RDC or visual
-        (isRDC || isVisual)
+        isVisual
     ) {
         // Sauce headless is currently only in us-east-1
         const sauceRegion = headless ? 'us-east-1' : region as keyof typeof REGION_MAPPING
 
         return {
             protocol: protocol || 'https',
-            hostname: hostname || getSauceEndpoint(sauceRegion, { isRDC, isVisual }),
+            hostname: hostname || getSauceEndpoint(sauceRegion, { isVisual }),
             port: port || 443,
             path: path || LEGACY_PATH
         }

--- a/packages/webdriverio/src/utils/driver.ts
+++ b/packages/webdriverio/src/utils/driver.ts
@@ -6,7 +6,7 @@ import { SupportedAutomationProtocols } from '../constants.js'
 
 interface ProtocolDriver {
     Driver: Automation.Driver<Capabilities.RemoteConfig>
-    options: Capabilities.RemoteConfig
+    options: Capabilities.WebdriverIOConfig
 }
 
 let webdriverImport: Automation.Driver<Capabilities.RemoteConfig> | undefined

--- a/packages/webdriverio/src/utils/driver.ts
+++ b/packages/webdriverio/src/utils/driver.ts
@@ -1,23 +1,22 @@
-import type { Automation } from '@wdio/types'
+import type { Automation, Capabilities } from '@wdio/types'
 
 import ProtocolStub from '../protocol-stub.js'
 import detectBackend from './detectBackend.js'
 import { SupportedAutomationProtocols } from '../constants.js'
-import type { RemoteOptions } from '../types.js'
 
 interface ProtocolDriver {
-    Driver: Automation.Driver<RemoteOptions>
-    options: RemoteOptions
+    Driver: Automation.Driver<Capabilities.RemoteConfig>
+    options: Capabilities.RemoteConfig
 }
 
-let webdriverImport: Automation.Driver<RemoteOptions> | undefined
+let webdriverImport: Automation.Driver<Capabilities.RemoteConfig> | undefined
 
 /**
  * get protocol driver
- * @param  {RemoteOptions} options  remote options
+ * @param  {Capabilities.WebdriverIOConfig} options  remote options
  * @return {Automation.Driver}      automation driver
  */
-export async function getProtocolDriver (options: RemoteOptions): Promise<ProtocolDriver> {
+export async function getProtocolDriver (options: Capabilities.WebdriverIOConfig): Promise<ProtocolDriver> {
     /**
      * We still want to be able to inject a stub driver to avoid loading the actual
      * driver package in two places:

--- a/packages/webdriverio/tests/module.test.ts
+++ b/packages/webdriverio/tests/module.test.ts
@@ -5,7 +5,6 @@ import logger from '@wdio/logger'
 import { validateConfig } from '@wdio/config'
 
 import detectBackend from '../src/utils/detectBackend.js'
-import type { RemoteOptions } from '../src/types.js'
 import { remote, multiremote, attach, Key, SevereServiceError } from '../src/index.js'
 import * as cjsExport from '../src/cjs/index.js'
 
@@ -84,8 +83,7 @@ describe('WebdriverIO module interface', () => {
 
     describe('remote function', () => {
         it('creates a webdriver session', async () => {
-            const options: RemoteOptions = {
-                automationProtocol: 'webdriver',
+            const options: any = {
                 capabilities: {},
                 logLevel: 'trace'
             }
@@ -152,7 +150,10 @@ describe('WebdriverIO module interface', () => {
             const browser = await remote({ capabilities: { browserName: 'chrome' } })
 
             expect(browser.sessionId).toBeUndefined()
-            expect(browser.capabilities).toEqual({ browserName: 'chrome', chrome: true })
+            expect(browser.capabilities).toEqual({
+                browserName: 'chrome',
+                'goog:chromeOptions': {}
+            })
 
             const flags: any = {}
             Object.entries(browser).forEach(([key, value]) => {

--- a/packages/webdriverio/tests/utils/detectBackend.test.ts
+++ b/packages/webdriverio/tests/utils/detectBackend.test.ts
@@ -158,32 +158,6 @@ describe('detectBackend', () => {
         expect(caps.protocol).toBe('tcp')
     })
 
-    describe('saucelabs legacy rdc', () => {
-        it('should detect saucelabs rdc user that had not defaulted a region', () => {
-            const caps = detectBackend({ capabilities: { testobject_api_key: '123' } })
-            expect(caps.hostname).toBe('us1.appium.testobject.com')
-            expect(caps.port).toBe(443)
-            expect(caps.path).toBe('/wd/hub')
-            expect(caps.protocol).toBe('https')
-        })
-
-        it('should detect saucelabs us rdc user', () => {
-            const caps = detectBackend({ region: 'us', capabilities: { testobject_api_key: '123' } })
-            expect(caps.hostname).toBe('us1.appium.testobject.com')
-            expect(caps.port).toBe(443)
-            expect(caps.path).toBe('/wd/hub')
-            expect(caps.protocol).toBe('https')
-        })
-
-        it('should detect saucelabs eu rdc user', () => {
-            const caps = detectBackend({ region: 'eu', capabilities: { testobject_api_key: '123' } })
-            expect(caps.hostname).toBe('eu1.appium.testobject.com')
-            expect(caps.port).toBe(443)
-            expect(caps.path).toBe('/wd/hub')
-            expect(caps.protocol).toBe('https')
-        })
-    })
-
     describe('saucelabs visual', () => {
         it('should not detect sauce visual if api key is missing', () => {
             const caps = detectBackend({ capabilities: { 'sauce:visual': {} } })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1292,10 +1292,10 @@ importers:
         specifier: ^2.2.0
         version: 2.2.3
       '@wdio/logger':
-        specifier: workspace:9.0.0-alpha.0
+        specifier: workspace:*
         version: link:../wdio-logger
       '@wdio/types':
-        specifier: workspace:9.0.0-alpha.0
+        specifier: workspace:*
         version: link:../wdio-types
       decamelize:
         specifier: ^6.0.0

--- a/tests/interop/__fixtures__/wdio.conf.js
+++ b/tests/interop/__fixtures__/wdio.conf.js
@@ -1,3 +1,6 @@
 exports.config = {
-    specs: []
+    specs: [],
+    capabilities: [{
+        browserName: 'chrome',
+    }]
 }

--- a/tests/typings/cucumber/config.ts
+++ b/tests/typings/cucumber/config.ts
@@ -7,11 +7,11 @@ const config: WebdriverIO.Config = {
         // @ts-expect-error
         scenarioLevelReporter: 'wrong param',
     },
-    capabilities: {}
+    capabilities: [{}]
 }
 
 const configB: WebdriverIO.Config = {
-    capabilities: {},
+    capabilities: [{}],
     beforeFeature (uri, feature) {
         expectType<string>(uri)
         expectType<string>(feature.children[0].scenario.name)

--- a/tests/typings/jasmine/config.ts
+++ b/tests/typings/jasmine/config.ts
@@ -5,7 +5,7 @@ const config: WebdriverIO.Config = {
         random: 'test wrong parameter',
         stopOnSpecFailure: true
     },
-    capabilities: {}
+    capabilities: [{}]
 }
 
 /**

--- a/tests/typings/mocha/config.ts
+++ b/tests/typings/mocha/config.ts
@@ -4,7 +4,31 @@ const config: WebdriverIO.Config = {
         // @ts-expect-error
         fullTrace: 'wrong param'
     },
+    capabilities: [{}]
+}
+
+const mrconfig: WebdriverIO.MultiremoteConfig = {
+    mochaOpts: {
+        ui: 'qunit',
+        // @ts-expect-error
+        fullTrace: 'wrong param'
+    },
     capabilities: {}
+}
+
+const mrconfig2: WebdriverIO.MultiremoteConfig = {
+    mochaOpts: {
+        ui: 'qunit',
+        // @ts-expect-error
+        fullTrace: 'wrong param'
+    },
+    capabilities: [{
+        chromeBrowser: {
+            capabilities: {
+                browserName: 'chrome'
+            }
+        }
+    }]
 }
 
 /**

--- a/website/docs/CustomServices.md
+++ b/website/docs/CustomServices.md
@@ -89,7 +89,7 @@ export default class CustomWorkerService implements Services.ServiceInstance {
     constructor (
         private _options: MyServiceOptions,
         private _capabilities: Capabilities.RemoteCapability,
-        private _config: Omit<Options.Testrunner, 'capabilities'>
+        private _config: Options.Testrunner
     ) {
         // ...
     }

--- a/website/i18n/ar/docusaurus-plugin-content-docs/current/CustomServices.md
+++ b/website/i18n/ar/docusaurus-plugin-content-docs/current/CustomServices.md
@@ -89,7 +89,7 @@ export default class CustomWorkerService implements Services.ServiceInstance {
     constructor (
         private _options: MyServiceOptions,
         private _capabilities: Capabilities.RemoteCapability,
-        private _config: Omit<Options.Testrunner, 'capabilities'>
+        private _config: Options.Testrunner
     ) {
         // ...
     }

--- a/website/i18n/bg/docusaurus-plugin-content-docs/current/CustomServices.md
+++ b/website/i18n/bg/docusaurus-plugin-content-docs/current/CustomServices.md
@@ -89,7 +89,7 @@ export default class CustomWorkerService implements Services.ServiceInstance {
     constructor (
         private _options: MyServiceOptions,
         private _capabilities: Capabilities.RemoteCapability,
-        private _config: Omit<Options.Testrunner, 'capabilities'>
+        private _config: Options.Testrunner
     ) {
         // ...
     }

--- a/website/i18n/de/docusaurus-plugin-content-docs/current/CustomServices.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/current/CustomServices.md
@@ -89,7 +89,7 @@ export default class CustomWorkerService implements Services.ServiceInstance {
     constructor (
         private _options: MyServiceOptions,
         private _capabilities: Capabilities.RemoteCapability,
-        private _config: Omit<Options.Testrunner, 'capabilities'>
+        private _config: Options.Testrunner
     ) {
         // ...
     }

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/CustomServices.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/CustomServices.md
@@ -89,7 +89,7 @@ export default class CustomWorkerService implements Services.ServiceInstance {
     constructor (
         private _options: MyServiceOptions,
         private _capabilities: Capabilities.RemoteCapability,
-        private _config: Omit<Options.Testrunner, 'capabilities'>
+        private _config: Options.Testrunner
     ) {
         // ...
     }

--- a/website/i18n/fa/docusaurus-plugin-content-docs/current/CustomServices.md
+++ b/website/i18n/fa/docusaurus-plugin-content-docs/current/CustomServices.md
@@ -89,7 +89,7 @@ export default class CustomWorkerService implements Services.ServiceInstance {
     constructor (
         private _options: MyServiceOptions,
         private _capabilities: Capabilities.RemoteCapability,
-        private _config: Omit<Options.Testrunner, 'capabilities'>
+        private _config: Options.Testrunner
     ) {
         // ...
     }

--- a/website/i18n/fr/docusaurus-plugin-content-docs/current/CustomServices.md
+++ b/website/i18n/fr/docusaurus-plugin-content-docs/current/CustomServices.md
@@ -89,7 +89,7 @@ export default class CustomWorkerService implements Services.ServiceInstance {
     constructor (
         private _options: MyServiceOptions,
         private _capabilities: Capabilities.RemoteCapability,
-        private _config: Omit<Options.Testrunner, 'capabilities'>
+        private _config: Options.Testrunner
     ) {
         // ...
     }

--- a/website/i18n/hi/docusaurus-plugin-content-docs/current/CustomServices.md
+++ b/website/i18n/hi/docusaurus-plugin-content-docs/current/CustomServices.md
@@ -89,7 +89,7 @@ export default class CustomWorkerService implements Services.ServiceInstance {
     constructor (
         private _options: MyServiceOptions,
         private _capabilities: Capabilities.RemoteCapability,
-        private _config: Omit<Options.Testrunner, 'capabilities'>
+        private _config: Options.Testrunner
     ) {
         // ...
     }

--- a/website/i18n/it/docusaurus-plugin-content-docs/current/CustomServices.md
+++ b/website/i18n/it/docusaurus-plugin-content-docs/current/CustomServices.md
@@ -89,7 +89,7 @@ export default class CustomWorkerService implements Services.ServiceInstance {
     constructor (
         private _options: MyServiceOptions,
         private _capabilities: Capabilities.RemoteCapability,
-        private _config: Omit<Options.Testrunner, 'capabilities'>
+        private _config: Options.Testrunner
     ) {
         // ...
     }

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/CustomServices.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/CustomServices.md
@@ -89,7 +89,7 @@ export default class CustomWorkerService implements Services.ServiceInstance {
     constructor (
         private _options: MyServiceOptions,
         private _capabilities: Capabilities.RemoteCapability,
-        private _config: Omit<Options.Testrunner, 'capabilities'>
+        private _config: Options.Testrunner
     ) {
         // ...
     }

--- a/website/i18n/pl/docusaurus-plugin-content-docs/current/CustomServices.md
+++ b/website/i18n/pl/docusaurus-plugin-content-docs/current/CustomServices.md
@@ -89,7 +89,7 @@ export default class CustomWorkerService implements Services.ServiceInstance {
     constructor (
         private _options: MyServiceOptions,
         private _capabilities: Capabilities.RemoteCapability,
-        private _config: Omit<Options.Testrunner, 'capabilities'>
+        private _config: Options.Testrunner
     ) {
         // ...
     }

--- a/website/i18n/ru/docusaurus-plugin-content-docs/current/CustomServices.md
+++ b/website/i18n/ru/docusaurus-plugin-content-docs/current/CustomServices.md
@@ -89,7 +89,7 @@ export default class CustomWorkerService implements Services.ServiceInstance {
     constructor (
         private _options: MyServiceOptions,
         private _capabilities: Capabilities.RemoteCapability,
-        private _config: Omit<Options.Testrunner, 'capabilities'>
+        private _config: Options.Testrunner
     ) {
         // ...
     }

--- a/website/i18n/ta/docusaurus-plugin-content-docs/current/CustomServices.md
+++ b/website/i18n/ta/docusaurus-plugin-content-docs/current/CustomServices.md
@@ -89,7 +89,7 @@ export default class CustomWorkerService implements Services.ServiceInstance {
     constructor (
         private _options: MyServiceOptions,
         private _capabilities: Capabilities.RemoteCapability,
-        private _config: Omit<Options.Testrunner, 'capabilities'>
+        private _config: Options.Testrunner
     ) {
         // ...
     }

--- a/website/i18n/uk/docusaurus-plugin-content-docs/current/CustomServices.md
+++ b/website/i18n/uk/docusaurus-plugin-content-docs/current/CustomServices.md
@@ -89,7 +89,7 @@ export default class CustomWorkerService implements Services.ServiceInstance {
     constructor (
         private _options: MyServiceOptions,
         private _capabilities: Capabilities.RemoteCapability,
-        private _config: Omit<Options.Testrunner, 'capabilities'>
+        private _config: Options.Testrunner
     ) {
         // ...
     }

--- a/website/i18n/zh/docusaurus-plugin-content-docs/current/CustomServices.md
+++ b/website/i18n/zh/docusaurus-plugin-content-docs/current/CustomServices.md
@@ -89,7 +89,7 @@ export default class CustomWorkerService implements Services.ServiceInstance {
     constructor (
         private _options: MyServiceOptions,
         private _capabilities: Capabilities.RemoteCapability,
-        private _config: Omit<Options.Testrunner, 'capabilities'>
+        private _config: Options.Testrunner
     ) {
         // ...
     }


### PR DESCRIPTION
## Proposed changes

Our type definitions were often not detailed enough in many cases. Also we still maintain a lot of outdated capabilities that we can remove now.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

supersedes #12400

### Reviewers: @webdriverio/project-committers
