### PR TITLE
Add maskCommands type for `bstack:options`

### DIFF
--- a/packages/wdio-types/src/Capabilities.ts
+++ b/packages/wdio-types/src/Capabilities.ts
@@ -1657,7 +1657,18 @@ export interface BrowserStackCapabilities {
     uploadMedia?: Array<string>
     enablePasscode?: boolean
     deviceLogs?: boolean,
-    resignApp?: boolean
+
+    /**
+     * Disable re-signing of Enterprise signed app uploaded on BrowserStack
+     * @default true
+     */
+    resignApp?: boolean,
+
+    /**
+     * Hides data that you send to or retrieve from the remote browsers through the following commands:
+     * Example: 'setValues, getValues, setCookies, getCookies'
+     */
+    maskCommands?: string
 }
 
 export interface SauceLabsVisualCapabilities {


### PR DESCRIPTION
## Proposed changes

Add `maskCommands` for `bstack:options`. See https://www.browserstack.com/docs/automate/selenium/hide-sensitive-data#Selenium_4_W3C
Add also doc for `resignApp` that I added previously.

<img width="771" alt="image" src="https://github.com/webdriverio/webdriverio/assets/77302423/56486bd7-2bd7-4d0e-9cdf-be0db2bb3d2e">


## Types of changes

- [x] Polish (an improvement for an existing feature)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc

## Backport Request

- [ ] Back-ported PR at `#XXXXX`

### Reviewers: @webdriverio/project-committers
