### PR TITLE
Add maskCommands type for `bstack:options` for v8

### DIFF
--- a/packages/wdio-types/src/Capabilities.ts
+++ b/packages/wdio-types/src/Capabilities.ts
@@ -1657,7 +1657,18 @@ export interface BrowserStackCapabilities {
     uploadMedia?: Array<string>
     enablePasscode?: boolean
     deviceLogs?: boolean,
-    resignApp?: boolean
+
+    /**
+     * Disable re-signing of Enterprise signed app uploaded on BrowserStack
+     * @default true
+     */
+    resignApp?: boolean,
+
+    /**
+     * Hides data that you send to or retrieve from the remote browsers through the following commands:
+     * Example: 'setValues, getValues, setCookies, getCookies'
+     */
+    maskCommands?: string
 }
 
 export interface SauceLabsVisualCapabilities {


### PR DESCRIPTION
## Proposed changes

Same as https://github.com/webdriverio/webdriverio/pull/13047, but for v8