### PR TITLE
Fix reloadSession subsequent commands

### DIFF
--- a/packages/webdriver/src/index.ts
+++ b/packages/webdriver/src/index.ts
@@ -151,7 +151,7 @@ export default class WebDriver {
      * @returns {string}           the new session id of the browser
      */
     static async reloadSession(instance: Client, newCapabilities?: WebdriverIO.Capabilities) {
-        const capabilities = newCapabilities ? newCapabilities : instance.requestedCapabilities as WebdriverIO.Capabilities
+        const capabilities = newCapabilities ? newCapabilities : Object.assign({}, instance.requestedCapabilities) as WebdriverIO.Capabilities
         let params: Options.WebDriver = { ...instance.options, capabilities }
 
         for (const prop of ['protocol', 'hostname', 'port', 'path', 'queryParams', 'user', 'key'] as (keyof Options.Connection)[]) {
@@ -178,10 +178,17 @@ export default class WebDriver {
             newSessionCapabilities['wdio:driverPID'] = driverProcess.pid
         }
 
-        instance.options.hostname = params.hostname
-        instance.options.port = params.port
+        for (const prop of ['protocol', 'hostname', 'port', 'path', 'queryParams', 'user', 'key'] as (keyof Options.Connection)[]) {
+            if (prop in params) {
+                (<typeof prop>instance.options[prop]) = params[prop] as typeof prop
+            }
+        }
+        for (const prop in instance.requestedCapabilities) {
+            delete instance.requestedCapabilities[prop as keyof typeof instance.requestedCapabilities]
+        }
         instance.sessionId = sessionId
         instance.capabilities = newSessionCapabilities
+        Object.assign(instance.requestedCapabilities, capabilities)
         return sessionId
     }
 

--- a/packages/webdriver/tests/index.test.ts
+++ b/packages/webdriver/tests/index.test.ts
@@ -318,10 +318,17 @@ describe('WebDriver', () => {
                 capabilities: { browserName: 'firefox' }
             })
             vi.mocked(startWebDriver).mockClear()
-            await WebDriver.reloadSession(session, { hostname: '1.1.1.1', port: 5555, browserName: 'chrome' })
+            await WebDriver.reloadSession(session, { protocol: 'https', hostname: '1.1.1.1', port: 5555, browserName: 'chrome' })
             expect(startWebDriver).not.toHaveBeenCalledOnce()
+            expect(session.options.protocol).toBe('https')
             expect(session.options.hostname).toBe('1.1.1.1')
             expect(session.options.port).toBe(5555)
+
+            await WebDriver.reloadSession(session, { protocol: 'http', hostname: '0.0.0.0', browserName: 'firefox' })
+            expect(startWebDriver).toHaveBeenCalledOnce()
+            expect(session.options.protocol).toBe('http')
+            expect(session.options.hostname).toBe('0.0.0.0')
+            expect((session.requestedCapabilities as WebdriverIO.Capabilities)['browserName']).toBe('firefox')
         })
     })
 


### PR DESCRIPTION
## Proposed changes

A bit of an oversight when I worked on #12957. I found that, because the fields inside instance.options were not properly set at the end of the reloadSession function, creating a new session worked but any subsequent commands (like nagivate, etc.) did not work when any other connection fields aside from hostname and port, like protocol, were changed.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
