### PR TITLE
chore: Reload session support

### DIFF
--- a/packages/wdio-browserstack-service/src/insights-handler.ts
+++ b/packages/wdio-browserstack-service/src/insights-handler.ts
@@ -26,7 +26,8 @@ import type {
     TestMeta,
     PlatformMeta,
     CurrentRunInfo,
-    StdLog
+    StdLog,
+    CBTData
 } from './types.js'
 import { BStackLogger } from './bstackLogger.js'
 import type { Capabilities } from '@wdio/types'
@@ -49,6 +50,8 @@ class _InsightsHandler {
     }
     private _userCaps?: Capabilities.ResolvedTestrunnerCapabilities = {}
     private listener = Listener.getInstance()
+    private _currentTestId: string | undefined
+    private _cbtQueue: Array<CBTData> = []
 
     constructor (private _browser: WebdriverIO.Browser | WebdriverIO.MultiRemoteBrowser, isAppAutomate?: boolean, private _framework?: string, _userCaps?: Capabilities.ResolvedTestrunnerCapabilities) {
         const caps = (this._browser as WebdriverIO.Browser).capabilities as WebdriverIO.Capabilities
@@ -379,6 +382,7 @@ class _InsightsHandler {
             ...(this._tests[fullTitle] || {}),
             finishedAt: (new Date()).toISOString()
         }
+        this.flushCBTDataQueue()
         this.listener.testFinished(this.getRunData(test, 'TestRunFinished', result))
     }
 
@@ -429,6 +433,7 @@ class _InsightsHandler {
 
     async afterScenario (world: ITestCaseHookParameter) {
         this._cucumberData.scenario = undefined
+        this.flushCBTDataQueue()
         this.listener.testFinished(this.getTestRunDataForCucumber(world, 'TestRunFinished'))
     }
 
@@ -614,6 +619,7 @@ class _InsightsHandler {
         const testMetaData = this._tests[fullTitle]
 
         const filename = test.file || this._suiteFile
+        this._currentTestId = testMetaData.uuid
 
         const testData: TestData = {
             uuid: testMetaData.uuid,
@@ -728,6 +734,7 @@ class _InsightsHandler {
         } else {
             fullNameWithExamples = scenario?.name || ''
         }
+        this._currentTestId = uuid
 
         const testData: TestData = {
             uuid: uuid,
@@ -797,6 +804,36 @@ class _InsightsHandler {
         }
 
         return testData
+    }
+
+    private async flushCBTDataQueue() {
+        if (isUndefined(this._currentTestId)) {return}
+        this._cbtQueue.forEach(cbtData => {
+            cbtData.uuid = this._currentTestId!
+            this.listener.cbtSessionCreated(cbtData)
+        })
+        this._currentTestId = undefined // set undefined for next test
+    }
+
+    async sendCBTInfo() {
+        const integrationsData: any = {}
+
+        if (this._browser && this._platformMeta) {
+            const provider = getCloudProvider(this._browser)
+            integrationsData[provider] = this.getIntegrationsObject()
+        }
+
+        const cbtData: CBTData = {
+            uuid: '',
+            integrations: integrationsData
+        }
+
+        if (this._currentTestId !== undefined) {
+            cbtData.uuid = this._currentTestId
+            this.listener.cbtSessionCreated(cbtData)
+        } else {
+            this._cbtQueue.push(cbtData)
+        }
     }
 
     private getIntegrationsObject () {

--- a/packages/wdio-browserstack-service/src/service.ts
+++ b/packages/wdio-browserstack-service/src/service.ts
@@ -369,6 +369,9 @@ export default class BrowserstackService implements Services.ServiceInstance {
             BStackLogger.info(`Update (reloaded) multiremote job for browser "${browserName}" and sessionId ${oldSessionId}, ${status}`)
         }
 
+        BStackLogger.warn(`Session Reloaded: Old Session Id: ${oldSessionId}, New Session Id: ${newSessionId}`)
+        await this._insightsHandler?.sendCBTInfo()
+
         if (setSessionStatus) {
             await this._update(oldSessionId, {
                 status,

--- a/packages/wdio-browserstack-service/src/types.ts
+++ b/packages/wdio-browserstack-service/src/types.ts
@@ -306,7 +306,7 @@ export interface FeatureStatsOverview {
 
 export interface CBTData {
     uuid: string
-    integrations: IntegrationObject
+    integrations: { [index: string]: IntegrationObject }
 }
 
 export interface TOUsageStats {


### PR DESCRIPTION
## Proposed changes
WebdriverIO provides a new session id in the same browser object, so we are trying to extract all the information and send the updated data to Test Observability, such that we always see the latest sessions id and the data around it

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
