### PR TITLE
fix(@wdio/cli): make 'tsx' a direct dependency

### DIFF
--- a/packages/wdio-cli/package.json
+++ b/packages/wdio-cli/package.json
@@ -67,6 +67,7 @@
     "lodash.union": "^4.6.0",
     "read-pkg-up": "^10.0.0",
     "recursive-readdir": "^2.2.3",
+    "tsx": "^4.7.2",
     "webdriverio": "workspace:*",
     "yargs": "^17.7.2"
   },

--- a/packages/wdio-cli/src/utils.ts
+++ b/packages/wdio-cli/src/utils.ts
@@ -852,14 +852,12 @@ export async function setupTypeScript(parsedAnswers: ParsedAnswers) {
      * as it is a requirement for running tests with TypeScript
      */
     if (parsedAnswers.hasRootTSConfig) {
-        parsedAnswers.packagesToInstall.push('tsx')
         return
     }
 
     console.log('Setting up TypeScript...')
     const frameworkPackage = convertPackageHashToObject(parsedAnswers.rawAnswers.framework)
     const servicePackages = parsedAnswers.rawAnswers.services.map((service) => convertPackageHashToObject(service))
-    parsedAnswers.packagesToInstall.push('tsx')
     const serenityTypes = parsedAnswers.serenityAdapter === 'jasmine' ? ['jasmine'] : []
 
     const types = [

--- a/packages/wdio-cli/tests/utils.test.ts
+++ b/packages/wdio-cli/tests/utils.test.ts
@@ -889,7 +889,6 @@ test('setupTypeScript', async () => {
     } as any
     await setupTypeScript(parsedAnswers)
     expect(vi.mocked(fs.writeFile).mock.calls[0][1]).toMatchSnapshot()
-    expect(parsedAnswers.packagesToInstall).toEqual(['tsx'])
 })
 
 test('setupTypeScript does not create tsconfig.json if TypeScript was not selected', async () => {
@@ -928,7 +927,6 @@ test('setupTypeScript does not create tsconfig.json if there is already one', as
     } as any
     await setupTypeScript(parsedAnswers)
     expect(fs.writeFile).not.toBeCalled()
-    expect(parsedAnswers.packagesToInstall).toEqual(['tsx'])
 })
 
 test('createWDIOConfig', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -726,6 +726,9 @@ importers:
       recursive-readdir:
         specifier: ^2.2.3
         version: 2.2.3
+      tsx:
+        specifier: ^4.7.2
+        version: 4.16.0
       webdriverio:
         specifier: workspace:*
         version: link:../webdriverio


### PR DESCRIPTION
## Proposed changes

Let's not confuse users and require them to have `tsx` installed. Let's just "make it work". Hence, adding `tsx` as direct dependency to the `@wdio/cli` package makes most sense to me IMHO. I don't think the extra impact of having the dependency around makes a big difference.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
