### PR TITLE
fix(@wdio/runner): Handle exception from deleteSession

### DIFF
--- a/packages/wdio-runner/src/index.ts
+++ b/packages/wdio-runner/src/index.ts
@@ -448,7 +448,12 @@ export default class Runner extends EventEmitter {
             })
         }
 
-        await this._browser?.deleteSession()
+        try {
+            await this._browser?.deleteSession()
+        } catch (error) {
+            log.debug('Error deleting session', error)
+        }
+
         process.send!(<SessionEndedMessage>{
             origin: 'worker',
             name: 'sessionEnded',

--- a/packages/wdio-runner/tests/index.test.ts
+++ b/packages/wdio-runner/tests/index.test.ts
@@ -111,6 +111,29 @@ describe('wdio-runner', () => {
             await runner.endSession()
             expect(hook).toBeCalledTimes(0)
         })
+
+        it('should shutdown if deleteSession throws', async () => {
+            const log = logger('wdio-runner')
+            const error = new Error('Session not started or terminated')
+            const hook = vi.fn()
+            const runner = new WDIORunner()
+            runner['_shutdown'] = vi.fn()
+            runner['_browser'] = {
+                deleteSession: vi.fn().mockRejectedValue(error),
+                sessionId: '123',
+                config: { afterSession: [hook] }
+            } as any as BrowserObject
+            runner['_config'] = { logLevel: 'info', afterSession: [hook] } as any
+            await runner.endSession()
+            expect(executeHooksWithArgs).toBeCalledWith(
+                'afterSession',
+                [hook],
+                [{ logLevel: 'info', afterSession: [hook] }, {}, undefined])
+            expect(runner['_browser'].deleteSession).toBeCalledTimes(1)
+            expect(!runner['_browser'].sessionId).toBe(true)
+            expect(runner['_shutdown']).toBeCalledTimes(0)
+            expect(log.debug).toHaveBeenCalledWith('Error deleting session', error)
+        })
     })
 
     describe('run', () => {


### PR DESCRIPTION
Fixes: [#13114](https://github.com/webdriverio/webdriverio/issues/13114)

## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

`deleteSession` can throw and in this case reporters such as  `@wdio/junit-reporter` and `@wdio/spec-reporter` don't receive the `runner:end` event and don't write the report.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [x] Back-ported PR at https://github.com/webdriverio/webdriverio/pull/13176

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
