### PR TITLE
fix-v8(@wdio/appium-service): add port to appium start command

### DIFF
--- a/packages/wdio-appium-service/src/launcher.ts
+++ b/packages/wdio-appium-service/src/launcher.ts
@@ -127,18 +127,19 @@ export default class AppiumLauncher implements Services.ServiceInstance {
         if (Array.isArray(this._options.args)) {
             throw new Error('Args should be an object')
         }
-        /**
-         * Append remaining arguments
-         */
-        this._appiumCliArgs.push(...formatCliArgs(this._args))
 
         /**
-         * Get port from service option or use a random port
+         * Use port from service option or get a random port
          */
-        const port = typeof this._args.port === 'number'
-            ? this._args.port
+        this._args.port = typeof this._args.port === 'number' ? this._args.port
             : await getPort({ port: DEFAULT_APPIUM_PORT })
-        this._setCapabilities(port)
+
+        this._setCapabilities(this._args.port)
+
+        /**
+         * Append cli arguments
+         */
+        this._appiumCliArgs.push(...formatCliArgs({ ...this._args }))
 
         /**
          * start Appium

--- a/packages/wdio-appium-service/tests/__snapshots__/launcher.test.ts.snap
+++ b/packages/wdio-appium-service/tests/__snapshots__/launcher.test.ts.snap
@@ -8,6 +8,8 @@ exports[`Appium launcher > onPrepare > should set correct config properties for 
   "/",
   "--address",
   "bar",
+  "--port",
+  "4723",
 ]
 `;
 
@@ -17,6 +19,8 @@ exports[`Appium launcher > onPrepare > should set correct config properties for 
   "/",
   "--address",
   "bar",
+  "--port",
+  "4723",
 ]
 `;
 
@@ -26,5 +30,7 @@ exports[`Appium launcher > onPrepare > should set correct config properties for 
   "/",
   "--address",
   "bar",
+  "--port",
+  "4723",
 ]
 `;

--- a/packages/wdio-appium-service/tests/launcher.test.ts
+++ b/packages/wdio-appium-service/tests/launcher.test.ts
@@ -304,9 +304,9 @@ describe('Appium launcher', () => {
                 expect(spawn).toBeCalledWith(
                     'cmd',
                     [
-                        expect.any(String),
+                        '/c',
                         'node',
-                        '/foo/bar/appium',
+                        expect.any(String),
                         '--base-path',
                         '/',
                         '--port',

--- a/packages/wdio-appium-service/tests/launcher.test.ts
+++ b/packages/wdio-appium-service/tests/launcher.test.ts
@@ -3,6 +3,7 @@ import url from 'node:url'
 import path from 'node:path'
 import { spawn } from 'node:child_process'
 import type cp from 'node:child_process'
+import getPort from 'get-port'
 
 import { describe, expect, beforeEach, afterEach, test, vi } from 'vitest'
 import { resolve } from 'import-meta-resolve'
@@ -115,7 +116,9 @@ describe('Appium launcher', () => {
                         '--address',
                         'bar',
                         '--default-capabilities',
-                        '{"foo":"bar"}'
+                        '{"foo":"bar"}',
+                        '--port',
+                        '4723'
                     ],
                     expect.any(Object)
                 )
@@ -128,7 +131,9 @@ describe('Appium launcher', () => {
                         '--address',
                         'bar',
                         '--default-capabilities',
-                        '{"foo":"bar"}'
+                        '{"foo":"bar"}',
+                        '--port',
+                        '4723'
                     ],
                     expect.any(Object)
                 )
@@ -248,14 +253,85 @@ describe('Appium launcher', () => {
             }
             const capabilities = [{ deviceName: 'baz' } as Capabilities.DesiredCapabilities]
             const launcher = new AppiumLauncher(options, capabilities, {} as any)
-            launcher['_startAppium'] = vi.fn().mockResolvedValue(new MockProcess())
             await launcher.onPrepare()
+
+            if (isWindows) {
+                expect(spawn).toBeCalledWith(
+                    'cmd',
+                    [
+                        expect.any(String),
+                        'path/to/my_custom_appium',
+                        '--base-path',
+                        '/',
+                        '--address',
+                        'bar',
+                        '--port',
+                        '1234'
+                    ],
+                    expect.any(Object)
+                )
+            } else {
+                expect(spawn).toBeCalledWith(
+                    'path/to/my_custom_appium',
+                    [
+                        '--base-path',
+                        '/',
+                        '--address',
+                        'bar',
+                        '--port',
+                        '1234'
+                    ],
+                    expect.any(Object)
+                )
+            }
 
             expect(launcher['_process']).toBeInstanceOf(MockProcess)
             expect(launcher['_logPath']).toBe('./')
             expect(capabilities[0].protocol).toBe('http')
             expect(capabilities[0].hostname).toBe('127.0.0.1')
             expect(capabilities[0].port).toBe(1234)
+            expect(capabilities[0].path).toBe('/')
+        })
+
+        test('should respect random Appium port', async () => {
+            vi.mocked(getPort).mockResolvedValueOnce(567567)
+
+            const capabilities = [{ deviceName: 'baz' } as Capabilities.DesiredCapabilities]
+            const launcher = new AppiumLauncher({}, capabilities, {} as any)
+            await launcher.onPrepare()
+
+            if (isWindows) {
+                expect(spawn).toBeCalledWith(
+                    'cmd',
+                    [
+                        expect.any(String),
+                        'node',
+                        '/foo/bar/appium',
+                        '--base-path',
+                        '/',
+                        '--port',
+                        '567567'
+                    ],
+                    expect.any(Object)
+                )
+            } else {
+                expect(spawn).toBeCalledWith(
+                    'node',
+                    [
+                        '/foo/bar/appium',
+                        '--base-path',
+                        '/',
+                        '--port',
+                        '567567'
+                    ],
+                    expect.any(Object)
+                )
+            }
+
+            expect(launcher['_process']).toBeInstanceOf(MockProcess)
+            expect(capabilities[0].protocol).toBe('http')
+            expect(capabilities[0].hostname).toBe('127.0.0.1')
+            expect(capabilities[0].port).toBe(567567)
             expect(capabilities[0].path).toBe('/')
         })
 
@@ -267,8 +343,37 @@ describe('Appium launcher', () => {
             }
             const capabilities = [{ port: 4321, deviceName: 'baz' } as Capabilities.DesiredCapabilities]
             const launcher = new AppiumLauncher(options, capabilities, {} as any)
-            launcher['_startAppium'] = vi.fn().mockResolvedValue(new MockProcess())
             await launcher.onPrepare()
+
+            if (isWindows) {
+                expect(spawn).toBeCalledWith(
+                    'cmd',
+                    [
+                        expect.any(String),
+                        'path/to/my_custom_appium',
+                        '--base-path',
+                        '/foo/bar',
+                        '--address',
+                        'bar',
+                        '--port',
+                        '1234'
+                    ],
+                    expect.any(Object)
+                )
+            } else {
+                expect(spawn).toBeCalledWith(
+                    'path/to/my_custom_appium',
+                    [
+                        '--base-path',
+                        '/foo/bar',
+                        '--address',
+                        'bar',
+                        '--port',
+                        '1234'
+                    ],
+                    expect.any(Object)
+                )
+            }
 
             expect(launcher['_process']).toBeInstanceOf(MockProcess)
             expect(launcher['_logPath']).toBe('./')
@@ -298,7 +403,9 @@ describe('Appium launcher', () => {
                     '--base-path',
                     '/',
                     '--address',
-                    'bar'
+                    'bar',
+                    '--port',
+                    '4723'
                 ],
                 expect.any(Object)
             )
@@ -338,7 +445,9 @@ describe('Appium launcher', () => {
                         '--base-path',
                         '/',
                         '--address',
-                        'bar'
+                        'bar',
+                        '--port',
+                        '4723'
                     ],
                     expect.any(Object)
                 )
@@ -350,7 +459,9 @@ describe('Appium launcher', () => {
                         '--base-path',
                         '/',
                         '--address',
-                        'bar'
+                        'bar',
+                        '--port',
+                        '4723'
                     ],
                     expect.any(Object)
                 )
@@ -371,7 +482,9 @@ describe('Appium launcher', () => {
                         'node',
                         expect.any(String),
                         '--base-path',
-                        '/'
+                        '/',
+                        '--port',
+                        '4723'
                     ],
                     expect.any(Object)
                 )
@@ -381,7 +494,9 @@ describe('Appium launcher', () => {
                     [
                         '/foo/bar/appium',
                         '--base-path',
-                        '/'
+                        '/',
+                        '--port',
+                        '4723'
                     ],
                     expect.any(Object)
                 )


### PR DESCRIPTION
## Proposed changes
Fix for this PR: **(@wdio/appium-service): make Appium start on a random port** https://github.com/webdriverio/webdriverio/pull/11757. The port value wasn't added in the appium start command. So, no matter what random port was chosen, appium always tries to start it on default, even if it's busy

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
