### PR TITLE
Dedupe Capabilities (main)

### DIFF
--- a/packages/wdio-config/src/node/ConfigParser.ts
+++ b/packages/wdio-config/src/node/ConfigParser.ts
@@ -12,7 +12,7 @@ import { SUPPORTED_HOOKS, SUPPORTED_FILE_EXTENSIONS, DEFAULT_CONFIGS, NO_NAMED_C
 import type { PathService } from '../types.js'
 
 const log = logger('@wdio/config:ConfigParser')
-const MERGE_DUPLICATION = ['services', 'reporters'] as const
+const MERGE_DUPLICATION = ['services', 'reporters', 'capabilities'] as const
 
 type KeyWithMergeDuplication = (typeof MERGE_DUPLICATION)[number]
 type Spec = string | string[]

--- a/packages/wdio-config/tests/node/configparser.test.ts
+++ b/packages/wdio-config/tests/node/configparser.test.ts
@@ -585,6 +585,25 @@ describe('ConfigParser', () => {
             `)
 
         })
+
+        it('should ensure capabilities are not duped when utilizing launcher', async () => {
+            const configParser = await ConfigParserForTestWithAllFiles(FIXTURES_CONF, {
+                capabilities: [
+                    {
+                        platformName: 'chrome',
+                    },
+                ]
+            })
+            await configParser.initialize({
+                capabilities: [
+                    {
+                        platformName: 'chrome',
+                    },
+                ]
+            })
+            const { capabilities } = configParser.getConfig()
+            expect(capabilities).toHaveLength(1)
+        })
     })
 
     describe('addService', () => {


### PR DESCRIPTION
## Proposed changes

This is an addition to https://github.com/webdriverio/webdriverio/pull/12430.

capabilities are also being duped when initializing WDIO via Launcher. Appears the dev decided not to include this change. More context here: https://github.com/webdriverio/webdriverio/pull/12430#discussion_r1527504299

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [x] Back-ported PR at `#12888`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
