### PR TITLE
feat(@wdio/browser-runner): allow to define custom hostname for component tests

### DIFF
--- a/packages/wdio-browser-runner/src/index.ts
+++ b/packages/wdio-browser-runner/src/index.ts
@@ -14,9 +14,8 @@ import type { MaybeMocked, MaybeMockedDeep, MaybePartiallyMocked, MaybePartially
 import type { InlineConfig } from 'vite'
 
 import { ViteServer } from './vite/server.js'
-import {
-    FRAMEWORK_SUPPORT_ERROR, DEFAULT_COVERAGE_REPORTS, SUMMARY_REPORTER, DEFAULT_REPORTS_DIRECTORY
-} from './constants.js'
+import { FRAMEWORK_SUPPORT_ERROR, DEFAULT_COVERAGE_REPORTS, SUMMARY_REPORTER, DEFAULT_REPORTS_DIRECTORY } from './constants.js'
+import { DEFAULT_HOSTNAME } from './vite/constants.js'
 import updateViteConfig from './vite/frameworks/index.js'
 import { ServerWorkerCommunicator } from './communicator.js'
 import { makeHeadless, getCoverageByFactor, adjustWindowInWatchMode } from './utils.js'
@@ -98,7 +97,8 @@ export default class BrowserRunner extends LocalRunner {
 
         try {
             await server.start()
-            runArgs.args.baseUrl = `http://localhost:${server.config.server?.port}`
+            const hostname = this.#options.hostname || DEFAULT_HOSTNAME
+            runArgs.args.baseUrl = `http://${hostname}:${server.config.server?.port}`
         } catch (err: any) {
             throw new Error(`Vite server failed to start: ${err.stack}`)
         }

--- a/packages/wdio-browser-runner/src/types.ts
+++ b/packages/wdio-browser-runner/src/types.ts
@@ -105,6 +105,23 @@ export interface BrowserRunnerOptions {
      * @default ./__mocks__
      */
     automockDir?: string
+    /**
+     * Set a custom hostname for the server hosting the test files (e.g. the system that runs the WebdriverIO process)
+     * in case you are running on a remote grid. Let's say you've set the following capabilities:
+     * ```js
+     * {
+     *   hostname: 'company.grid.com',
+     *   port: 4444,
+     *   path: '/',
+     *   protocol: 'http',
+     * }
+     * ```
+     * In order for the browser to connect to the correct server, you need to set the `hostname` to the IP or hostname
+     * of the machine that runs the WebdriverIO process.
+     *
+     * @default 0.0.0.0
+     */
+    hostname?: string
 }
 
 export interface RunArgs extends Workers.WorkerRunPayload {

--- a/packages/wdio-browser-runner/src/vite/constants.ts
+++ b/packages/wdio-browser-runner/src/vite/constants.ts
@@ -5,6 +5,7 @@ import type { InlineConfig } from 'vite'
 import { codeFrameFix } from './plugins/esbuild.js'
 import type { FrameworkPreset } from '../types.js'
 
+export const DEFAULT_HOSTNAME = '0.0.0.0'
 export const PRESET_DEPENDENCIES: Record<FrameworkPreset, [string, string, any] | undefined> = {
     react: ['@vitejs/plugin-react', 'default', {
         babel: {
@@ -26,7 +27,7 @@ export const PRESET_DEPENDENCIES: Record<FrameworkPreset, [string, string, any] 
 
 export const DEFAULT_VITE_CONFIG: Partial<InlineConfig> = {
     configFile: false,
-    server: { host: 'localhost' },
+    server: { host: DEFAULT_HOSTNAME },
     logLevel: 'silent',
     plugins: [topLevelAwait()],
     build: {

--- a/packages/wdio-browser-runner/src/vite/server.ts
+++ b/packages/wdio-browser-runner/src/vite/server.ts
@@ -81,7 +81,7 @@ export class ViteServer extends EventEmitter {
         const vitePort = await getPort()
         this.#viteConfig = deepmerge(this.#viteConfig, <Partial<InlineConfig>>{
             server: {
-                host: '0.0.0.0',
+                ...this.#viteConfig.server,
                 port: vitePort
             }
         })

--- a/website/docs/ComponentTesting.md
+++ b/website/docs/ComponentTesting.md
@@ -124,6 +124,23 @@ You can now go into the browser or use the command line as REPL
 
 Press `Ctrl` or `Command` + `c` or enter `.exit` to continue with the test.
 
+## Run using a Selenium Grid
+
+If you have a [Selenium Grid](https://www.selenium.dev/documentation/grid/) set up and run your browser through that
+grid, you have to set the `hostname` browser runner option to allow the browser, to access the right host where the
+test files are being served, e.g.:
+
+```ts title=wdio.conf.ts
+export const config: WebdriverIO.Config = {
+    runner: ['browser', {
+        // network IP of the machine that runs the WebdriverIO process
+        hostname: '172.168.0.2'
+    }]
+}
+```
+
+This will ensure the browser correctly opens the right server instance hosted on the instance that runs the WebdriverIO tests.
+
 ## Examples
 
 You can find various examples for testing components using popular component frameworks in our [example repository](https://github.com/webdriverio/component-testing-examples).


### PR DESCRIPTION
## Proposed changes

implements #13206

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [x] Back-ported PR at `#XXXXX`

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
