### PR TITLE
[WIP] Feature/multiple paralle tests in single process

### DIFF
--- a/examples/wdio/cucumber-lite-local/features/my-feature.feature
+++ b/examples/wdio/cucumber-lite-local/features/my-feature.feature
@@ -1,0 +1,13 @@
+Feature: Example feature
+  As a user of WebdriverIO
+  I should be able to use different commands
+  to get informations about elements on the page
+
+  Scenario: Get size of an element
+    Given I go on the website "https://github.com/"
+    Then  should the element ".header-logged-out a" be 32px wide and 34.5px high
+
+  Rule: Business rule 1
+    Scenario: Get title of website
+      Given I go on the website "https://github.com/"
+      Then  should the title of the page be "GitHub: Let’s build from here · GitHub"

--- a/examples/wdio/cucumber-lite-local/features/other-feature.feature
+++ b/examples/wdio/cucumber-lite-local/features/other-feature.feature
@@ -1,0 +1,15 @@
+Feature: Example feature
+  As a user of WebdriverIO
+  I should be able to use different commands
+  to get informations about elements on the page
+
+  Rule: Business rule 2
+    Scenario: Data Tables
+      Given I go on the website "http://todomvc.com/examples/react/dist/"
+      When  I add the following groceries
+          | Item       | Amount |
+          | Milk       | 2      |
+          | Butter     | 1      |
+          | Noodles    | 1      |
+          | Schocolate | 3      |
+      Then  I should have a list of 4 items

--- a/examples/wdio/cucumber-lite-local/step-definitions.ts
+++ b/examples/wdio/cucumber-lite-local/step-definitions.ts
@@ -1,0 +1,42 @@
+/**
+ * to run these tests you need install Cucumber.js on your machine
+ * take a look at https://github.com/cucumber/cucumber-js for more information
+ *
+ * first, install Cucumber.js via NPM
+ * $ npm install -g cucumber
+ *
+ * then go into the cucumber directory and start the tests with
+ * $ cucumber.js
+ */
+
+import { Given, When, Then } from '@wdio/cucumber-framework'
+import { Key } from 'webdriverio'
+
+Given(/^I go on the website "([^"]*)"$/, async (url) => {
+    await browser.url(url)
+})
+
+When(/^I add the following groceries$/, async (table) => {
+    const newTodo = await $('.new-todo')
+    table.rawTable.shift()
+
+    for (const [item, amount] of table.rawTable) {
+        await newTodo.addValue(`${item} (${amount}x)`)
+        await browser.keys(Key.Enter)
+        await browser.pause(100) // for demo purposes
+    }
+})
+
+Then(/^should the element "([^"]*)" be (\d+(?:\.\d+)?)px wide and (\d+(?:\.\d+)?)px high$/, async (selector, width, height) => {
+    const elemSize = await $(selector).getSize()
+    expect(elemSize.width).toBe(Number(width))
+    expect(elemSize.height).toBe(Number(height))
+})
+
+Then(/^should the title of the page be "([^"]*)"$/, async (expectedTitle) => {
+    await expect(browser).toHaveTitle(expectedTitle)
+})
+
+Then(/^I should have a list of (\d+) items$/, async (items) => {
+    await expect($$('.todo-list li')).toBeElementsArrayOfSize(items)
+})

--- a/examples/wdio/cucumber-lite-local/wdio.conf.ts
+++ b/examples/wdio/cucumber-lite-local/wdio.conf.ts
@@ -1,0 +1,38 @@
+import url from 'node:url'
+import path from 'node:path'
+
+const __dirname = url.fileURLToPath(new URL('.', import.meta.url))
+
+export const config: WebdriverIO.Config = {
+    runner: ['local', {
+        useSingleProcess: true
+    }],
+
+    maxInstances: 2,
+
+    /**
+     * specify test files
+     */
+    specs: [
+        path.resolve(__dirname, 'features', '*.feature')
+    ],
+
+    /**
+     * capabilities
+     */
+    capabilities: [{
+        browserName: 'chrome'
+    }],
+
+    /**
+     * test configurations
+     */
+    logLevel: 'error',
+    framework: 'cucumber',
+
+    reporters: ['spec'],
+
+    cucumberOpts: {
+        require: [path.resolve(__dirname, 'step-definitions.ts')]
+    }
+}

--- a/examples/wdio/package.json
+++ b/examples/wdio/package.json
@@ -8,6 +8,7 @@
     "test:mocha": "wdio run ./mocha/wdio.conf.ts",
     "test:jasmine": "wdio run ./jasmine/wdio.conf.ts",
     "test:cucumber": "wdio run ./cucumber/wdio.conf.ts",
+    "test:cucumberLiteLocal": "wdio run ./cucumber-lite-local/wdio.conf.ts",
     "test:multiremote": "wdio run ./multiremote/wdio.conf.js",
     "test:customReporter": "wdio run ./custom-reporter/wdio.conf.js",
     "test:customService": "wdio run ./custom-service/wdio.conf.js",

--- a/packages/wdio-globals/tests/index.test.ts
+++ b/packages/wdio-globals/tests/index.test.ts
@@ -42,7 +42,7 @@ describe('global handler', () => {
             expect($$('foo')).toBe('barfoo')
             resolver({})
         })
-        await first;
+        await first
         await seccond
     })
 })

--- a/packages/wdio-globals/tests/index.test.ts
+++ b/packages/wdio-globals/tests/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { browser, $, _setGlobal } from '../src/index.js'
+import { browser, $, _setGlobal, _runInGlobalStorage } from '../src/index.js'
 
 describe('global handler', () => {
     it('should allow to import without issues', () => {
@@ -25,5 +25,24 @@ describe('global handler', () => {
         expect(() => $$('foo')).toThrow()
         _setGlobal('$$', (param: string) => `foo${param}`, true)
         expect(() => $$('foo')).not.toThrow()
+    })
+
+    it('can set different global vars to be used by different functions', async () => {
+        let resolver:(value: any) => void
+        const stopper = new Promise(res => resolver = res)
+
+        const first = _runInGlobalStorage(new Map(), async () => {
+            _setGlobal('$$', (param: string) => `foo${param}`, false)
+            expect($$('bar')).toBe('foobar')
+            await stopper
+            expect($$('foo')).toBe('foofoo')
+        })
+        const seccond = _runInGlobalStorage(new Map(), async () => {
+            _setGlobal('$$', (param: string) => `bar${param}`, false)
+            expect($$('foo')).toBe('barfoo')
+            resolver({})
+        })
+        await first;
+        await seccond
     })
 })

--- a/packages/wdio-local-runner/README.md
+++ b/packages/wdio-local-runner/README.md
@@ -3,7 +3,7 @@ WebdriverIO Local Runner
 
 > A WebdriverIO runner to run tests locally within worker processes
 
-The [Local Runner](https://www.npmjs.com/package/@wdio/local-runner) initiates your framework (e.g. Mocha, Jasmine or Cucumber) within worker a process and runs all your test files within your Node.js environment. Every test file is being run in a separate worker process per capability allowing for maximum concurrency. Every worker process uses a single browser instance and therefore runs its own browser session allowing for maximum isolation.
+The [Local Runner](https://www.npmjs.com/package/@wdio/local-runner) initiates your framework (e.g. Mocha, Jasmine or Cucumber) within worker a process and runs all your test files within your Node.js environment. Every test file is being run in a separate worker process per capability allowing for maximum concurrency. Every worker process uses a single browser instance and therefore runs its own browser session allowing for maximum isolation. If you want to change this behaviour and use a single Node.js process and environment for the multiple concurrent sessions, that's possible, just check the setup section on this document.
 
 Given every test is run in its own isolated process, it is not possible to share data across test files. There are two ways to work around this:
 
@@ -33,6 +33,22 @@ export const {
 }
 ```
 
+If you want to use a single Node.js process and environment to execute all the tests in parallel, you can do that by providing an extra configuration to the runner:
+```js
+// wdio.conf.js
+export const {
+    // ...
+    runner: ['local', {
+        useSingleProcess: true
+    }],
+    // ...
+}
+```
+
+Note this might save a lot of memory if you're running tenths of paralel executions, but care should be taken to avoid polluting the global scope. Also some third party wdio services might not work propoerly under this context.
+
 ---
+
+
 
 For more information on WebdriverIO runner, check out the [documentation](https://webdriver.io/docs/runner).

--- a/packages/wdio-local-runner/src/index.ts
+++ b/packages/wdio-local-runner/src/index.ts
@@ -3,6 +3,7 @@ import { WritableStreamBuffer } from 'stream-buffers'
 import type { Options, Workers } from '@wdio/types'
 
 import WorkerInstance from './worker.js'
+import LiteWorkerInstance from './liteWorker.js'
 import { SHUTDOWN_TIMEOUT, BUFFER_OPTIONS } from './constants.js'
 
 const log = logger('@wdio/local-runner')
@@ -15,7 +16,7 @@ export interface RunArgs extends Workers.WorkerRunPayload {
 }
 
 export default class LocalRunner {
-    workerPool: Record<string, WorkerInstance> = {}
+    workerPool: Record<string, WorkerInstance | LiteWorkerInstance> = {}
 
     stdout = new WritableStreamBuffer(BUFFER_OPTIONS)
     stderr = new WritableStreamBuffer(BUFFER_OPTIONS)
@@ -44,7 +45,10 @@ export default class LocalRunner {
             process.stderr.setMaxListeners(workerCnt + 2)
         }
 
-        const worker = new WorkerInstance(this._config, workerOptions, this.stdout, this.stderr)
+        const isLite = Array.isArray(this._config.runner) && this._config.runner[0] === 'local' && this._config.runner[1]?.useSingleProcess
+        const WorkerClass = isLite ? LiteWorkerInstance: WorkerInstance
+
+        const worker = new WorkerClass(this._config, workerOptions, this.stdout, this.stderr)
         this.workerPool[workerOptions.cid] = worker
         worker.postMessage(command, args)
         return worker

--- a/packages/wdio-local-runner/src/liteWorker.ts
+++ b/packages/wdio-local-runner/src/liteWorker.ts
@@ -1,0 +1,235 @@
+import path from 'node:path'
+import { EventEmitter } from 'node:events'
+import type { WritableStreamBuffer } from 'stream-buffers'
+import type { Options, Workers } from '@wdio/types'
+
+import logger from '@wdio/logger'
+
+import runnerTransformStream from './transformStream.js'
+import ReplQueue from './replQueue.js'
+import RunnerStream from './stdStream.js'
+import type { IsolatedProcess } from './runLite.js'
+import { run } from './runLite.js'
+
+const log = logger('@wdio/lite-runner')
+const replQueue = new ReplQueue()
+const ACCEPTABLE_BUSY_COMMANDS = ['workerRequest', 'endSession']
+
+const stdOutStream = new RunnerStream()
+const stdErrStream = new RunnerStream()
+stdOutStream.pipe(process.stdout)
+stdErrStream.pipe(process.stderr)
+
+/**
+ * WorkerInstance
+ * responsible for spawning a sub process to run the framework in and handle its
+ * session lifetime.
+ */
+export default class LiteWorkerInstance extends EventEmitter implements Workers.Worker {
+    cid: string
+    config: Options.Testrunner
+    configFile: string
+    // requestedCapabilities
+    caps: WebdriverIO.Capabilities
+    // actual capabilities returned by driver
+    capabilities: WebdriverIO.Capabilities
+    specs: string[]
+    retries: number
+    stdout: WritableStreamBuffer
+    stderr: WritableStreamBuffer
+    child?: IsolatedProcess
+    sessionId?: string
+    server?: Record<string, any>
+    logsAggregator: string[] = []
+
+    instances?: Record<string, { sessionId: string }>
+    isMultiremote?: boolean
+
+    isBusy = false
+    isKilled = false
+    isSetup: Promise<boolean>
+    isReadyResolver: (value: boolean | PromiseLike<boolean>) => void = () => {}
+    isSetupResolver: (value: boolean | PromiseLike<boolean>) => void = () => {}
+
+    /**
+     * assigns paramters to scope of instance
+     * @param  {object}   config      parsed configuration object
+     * @param  {string}   cid         capability id (e.g. 0-1)
+     * @param  {string}   configFile  path to config file (for sub process to parse)
+     * @param  {object}   caps        capability object
+     * @param  {string[]} specs       list of paths to test files to run in this worker
+     * @param  {number}   retries     number of retries remaining
+     * @param  {object}   execArgv    execution arguments for the test run
+     */
+    constructor(
+        config: Options.Testrunner,
+        { cid, configFile, caps, specs, retries }: Workers.WorkerRunPayload,
+        stdout: WritableStreamBuffer,
+        stderr: WritableStreamBuffer
+    ) {
+        super()
+        this.cid = cid
+        this.config = config
+        this.configFile = configFile
+        this.caps = caps
+        this.capabilities = caps
+        this.specs = specs
+        this.retries = retries
+        this.stdout = stdout
+        this.stderr = stderr
+
+        this.isSetup = new Promise((resolve) => { this.isSetupResolver = resolve })
+    }
+
+    /**
+     * calls wdio-runner
+     */
+    private startProcess() {
+        const { cid } = this
+
+        const runnerEnv = Object.assign({}, process.env, this.config.runnerEnv, {
+            WDIO_WORKER_ID: cid,
+            NODE_ENV: process.env.NODE_ENV || 'test'
+        })
+
+        if (this.config.outputDir) {
+            runnerEnv.WDIO_LOG_PATH = path.join(this.config.outputDir, `wdio-${cid}.log`)
+        }
+
+        log.info(`Start lite worker ${cid}`)
+
+        const child = run(runnerEnv)
+
+        child.emitter.on('send', this._handleMessage.bind(this))
+        child.emitter.on('error', this._handleError.bind(this))
+        child.emitter.on('exit', this._handleExit.bind(this))
+
+        /* istanbul ignore if */
+        if (!process.env.VITEST_WORKER_ID) {
+            if (child.stdout !== null) {
+                if (this.config.groupLogsByTestSpec) {
+                    // Test spec logs are collected only from child stdout stream
+                    // and then printed when the worker exits
+                    // As a result, there is no pipe to parent stdout stream here
+                    runnerTransformStream(cid, child.stdout, this.logsAggregator)
+                } else {
+                    runnerTransformStream(cid, child.stdout).pipe(stdOutStream)
+                }
+            }
+
+            if (child.stderr !== null) {
+                runnerTransformStream(cid, child.stderr).pipe(stdErrStream)
+            }
+        }
+
+        return child
+    }
+
+    private _handleMessage (payload: Workers.WorkerMessage) {
+        const { cid } = this
+
+        /**
+         * resolve pending commands
+         */
+        if (payload.name === 'finishedCommand') {
+            this.isBusy = false
+        }
+
+        /**
+         * mark worker process as ready to receive events
+         */
+        if (payload.name === 'ready') {
+            this.isReadyResolver(true)
+        }
+
+        /**
+         * store sessionId and connection data to worker instance
+         */
+        if (payload.name === 'sessionStarted') {
+            this.isSetupResolver(true)
+            if (payload.content.isMultiremote) {
+                Object.assign(this, payload.content)
+            } else {
+                this.sessionId = payload.content.sessionId
+                this.capabilities = payload.content.capabilities
+                Object.assign(this.config, payload.content)
+            }
+        }
+
+        /**
+         * handle debug command called within worker process
+         */
+        /**TODO: [alfonso-presa] Handle debug
+         *
+        if (child && payload.origin === 'debugger' && payload.name === 'start') {
+            replQueue.add(
+                child,
+                { prompt: `[${cid}] \u203A `, ...payload.params },
+                () => this.emit('message', Object.assign(payload, { cid })),
+                (ev: any) => this.emit('message', ev)
+            )
+            return replQueue.next()
+        }
+
+         */
+
+        /**
+         * handle debugger results
+         */
+        if (replQueue.isRunning && payload.origin === 'debugger' && payload.name === 'result') {
+            replQueue.runningRepl?.onResult(payload.params)
+        }
+
+        this.emit('message', Object.assign(payload, { cid }))
+    }
+
+    private _handleError (payload: Error) {
+        const { cid } = this
+        this.emit('error', Object.assign(payload, { cid }))
+    }
+
+    private _handleExit (exitCode: number) {
+        const { cid, specs, retries } = this
+
+        delete this.child
+        this.isBusy = false
+        this.isKilled = true
+
+        log.debug(`Runner ${cid} finished with exit code ${exitCode}`)
+        this.emit('exit', { cid, exitCode, specs, retries })
+    }
+
+    /**
+     * sends message to sub process to execute functions in wdio-runner
+     * @param  command  method to run in wdio-runner
+     * @param  args     arguments for functions to call
+     */
+    postMessage (command: string, args: Workers.WorkerMessageArgs, requiresSetup = false): void {
+        const { cid, configFile, capabilities, specs, retries, isBusy } = this
+
+        if (isBusy && !ACCEPTABLE_BUSY_COMMANDS.includes(command)) {
+            return log.info(`worker with cid ${cid} already busy and can't take new commands`)
+        }
+
+        /**
+         * start up process if worker hasn't done yet or if child process
+         * closes after running its job
+         */
+        if (!this.child) {
+            this.child = this.startProcess()
+        }
+
+        const cmd: Workers.WorkerCommand = { cid, command, configFile, args, caps: capabilities, specs, retries }
+
+        log.debug(`Send command ${command} to worker with cid "${cid}"`)
+
+        setImmediate(async () => {
+            if (requiresSetup) {
+                this.isSetup
+            }
+            this.child!.emitter.emit('message', cmd)
+        })
+
+        this.isBusy = true
+    }
+}

--- a/packages/wdio-local-runner/src/processProxy.ts
+++ b/packages/wdio-local-runner/src/processProxy.ts
@@ -1,0 +1,19 @@
+import { AsyncLocalStorage } from 'node:async_hooks'
+
+const originalProcess = process
+const processLocals = new AsyncLocalStorage()
+export const patchedProcess = new Proxy(
+    process,
+    {
+        get: (self: never, prop: any) => {
+            const overridenValue = processLocals.getStore() && (processLocals.getStore() as any)[prop]
+            return overridenValue || (originalProcess as any)[prop]
+        }
+    }
+)
+
+globalThis.process = patchedProcess
+
+export function runWithProcessContext(ctx: {[key:string] : string}, callback: () => unknown) {
+    return processLocals.run(ctx, callback)
+}

--- a/packages/wdio-local-runner/src/runLite.ts
+++ b/packages/wdio-local-runner/src/runLite.ts
@@ -1,0 +1,82 @@
+import Runner from '@wdio/runner'
+import logger from '@wdio/logger'
+import type { Workers } from '@wdio/types'
+import EventEmitter from 'node:events'
+import { runWithProcessContext } from './processProxy.js'
+import type { Readable } from 'node:stream'
+import { PassThrough } from 'node:stream'
+import { _runInGlobalStorage } from '@wdio/globals'
+
+const log = logger('@wdio/lite-runner')
+
+/**
+ * ToDo(Christian): remove when @wdio/runner got typed
+ */
+interface RunnerInterface extends NodeJS.EventEmitter {
+    sigintWasCalled: boolean
+    [key: string]: any
+}
+
+export interface IsolatedProcess {
+    emitter: EventEmitter,
+    stdout: Readable,
+    stderr: Readable,
+}
+
+export function run (env: {[key: string]: string}): IsolatedProcess {
+    const stdout = new PassThrough()
+    const stderr = new PassThrough()
+    const emitter = new EventEmitter()
+    const send = function (arg: any) {
+        runWithProcessContext({}, () => emitter.emit('send', arg))
+    }
+    const ctx = {
+        send: (arg: unknown) => {
+            runWithProcessContext({}, () => send(arg))
+        },
+        env,
+        stdout,
+        stderr,
+        kill: (arg: any) => runWithProcessContext({}, () => emitter.emit('exit', arg))
+    } as any
+
+    const runner = new Runner() as unknown as RunnerInterface
+    runner.on('error', ({ name, message, stack }) => send!({
+        origin: 'worker',
+        name: 'error',
+        content: { name, message, stack }
+    }))
+
+    emitter.on('message', (m: Workers.WorkerCommand) => {
+        if (!m || !m.command || !runner[m.command]) {
+            return
+        }
+
+        log.info(`Run worker command: ${m.command}`)
+        runWithProcessContext(ctx, () => {
+            _runInGlobalStorage(new Map(), () => {
+                runner[m.command](m).then(
+                    (result: any) => send!({
+                        origin: 'worker',
+                        name: 'finishedCommand',
+                        content: {
+                            command: m.command,
+                            result
+                        }
+                    }),
+                    (e: Error) => {
+                        log.error(`Failed launching test session: ${e.stack}`)
+                        setTimeout(() => process.exit(1), 10)
+                    }
+                )
+            })
+
+        })
+    })
+
+    return {
+        emitter,
+        stdout,
+        stderr
+    }
+}

--- a/packages/wdio-types/src/Options.ts
+++ b/packages/wdio-types/src/Options.ts
@@ -183,7 +183,7 @@ export interface Testrunner extends Hooks, WebdriverIO, WebdriverIO.HookFunction
      *   running an independant browser session
      * - browser: all spec files are run within the browser
      */
-    runner?: 'local' | 'browser' | ['browser', WebdriverIO.BrowserRunnerOptions] | ['local', never]
+    runner?: 'local' | 'browser' | ['browser', WebdriverIO.BrowserRunnerOptions] | ['local', WebdriverIO.LocalRunnerOptions]
     /**
      * Project root directory path.
      */

--- a/packages/wdio-types/src/index.ts
+++ b/packages/wdio-types/src/index.ts
@@ -76,6 +76,9 @@ declare global {
         interface HookFunctionExtension {}
         interface WDIOVSCodeServiceOptions {}
         interface BrowserRunnerOptions {}
+        interface LocalRunnerOptions {
+            useSingleProcess: boolean
+        }
         interface ChromedriverOptions extends DriverOptions {}
         interface GeckodriverOptions extends DriverOptions {}
         interface EdgedriverOptions extends DriverOptions {}


### PR DESCRIPTION
## Proposed changes

Fixes https://github.com/webdriverio/webdriverio/issues/13217 by using AsyncLocalStorage and proxies to enable the use of a single process for all parallel test executions, saving tons of memory and also speeding thigs up (though, it will be single threaded).

Patching the cucumber-framework was needed in order to reuse the step libraries loaded... the solution is not beautifull at all...

I've created a new cucumber-lite-local example demonstating that this change works.

It's still WIP as REPL is not working right now, and I guess some test coverage would be needed for the new files at the local-runner.

## Types of changes

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Backport Request

I would like this to be backported to v8.... and v7, which is the one we currently rely on.

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

### Reviewers: @webdriverio/project-committers
