### PR TITLE
fix(wdio-browserstack-service): Fetching hostname in case of MultiRemote Browser 

### DIFF
--- a/packages/wdio-browserstack-service/src/util.ts
+++ b/packages/wdio-browserstack-service/src/util.ts
@@ -630,12 +630,8 @@ export function getCloudProvider(browser: Browser<'async'> | MultiRemoteBrowser<
                 return 'browserstack'
             }
         }
-    }
-    else {
-        // Single browser instance
-        if (browser.options && browser.options.hostname && browser.options.hostname.includes('browserstack')) {
-            return 'browserstack'
-        }
+    } else if (browser.options && browser.options.hostname && browser.options.hostname.includes('browserstack')) { // Single browser instance
+        return 'browserstack'
     }
     return 'unknown_grid'
 }

--- a/packages/wdio-browserstack-service/src/util.ts
+++ b/packages/wdio-browserstack-service/src/util.ts
@@ -622,8 +622,20 @@ export function getUniqueIdentifierForCucumber(world: ITestCaseHookParameter): s
 }
 
 export function getCloudProvider(browser: Browser<'async'> | MultiRemoteBrowser<'async'>): string {
-    if (browser.options && browser.options.hostname && browser.options.hostname.includes('browserstack')) {
-        return 'browserstack'
+    if (browser && 'instances' in browser) {
+        // Loop through all instances
+        for (const instanceName of browser.instances) {
+            const instance = browser[instanceName]
+            if (instance.options && instance.options.hostname && instance.options.hostname.includes('browserstack')) {
+                return 'browserstack'
+            }
+        }
+    }
+    else {
+        // Single browser instance
+        if (browser.options && browser.options.hostname && browser.options.hostname.includes('browserstack')) {
+            return 'browserstack'
+        }
     }
     return 'unknown_grid'
 }


### PR DESCRIPTION
## Proposed changes

In the case of MultiRemote, the hostname is located in browser.chromeBrowser.options.hostname, while our current [logic](https://github.com/webdriverio/webdriverio/blob/main/packages/wdio-browserstack-service/src/util.ts#L951) retrieves the hostname from browser.options.hostname. This discrepancy is causing the breakage.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
