### PR TITLE
feat(webdriverio): dialog handler

### DIFF
--- a/e2e/wdio/headless/test.e2e.ts
+++ b/e2e/wdio/headless/test.e2e.ts
@@ -305,4 +305,28 @@ describe('main suite 1', () => {
             expect(request.children!.length).toBe(0)
         })
     })
+
+    describe('dialog handling', () => {
+        it('should automatically accept alerts', async () => {
+            await browser.url('http://guinea-pig.webdriver.io')
+
+            await browser.execute(() => alert('123'))
+
+            /**
+             * in case the alert is not automatically accepted
+             * the following line would time out
+             */
+            await browser.$('div').click()
+        })
+
+        it('should be able to handle dialogs', async () => {
+            await browser.url('http://guinea-pig.webdriver.io')
+            browser.execute(() => alert('123'))
+            const dialog = await new Promise<WebdriverIO.Dialog>((resolve) => browser.on('dialog', resolve))
+
+            expect(dialog.type()).toBe('alert')
+            expect(dialog.message()).toBe('123')
+            await dialog.dismiss()
+        })
+    })
 })

--- a/packages/wdio-utils/src/monad.ts
+++ b/packages/wdio-utils/src/monad.ts
@@ -217,6 +217,20 @@ export default function WebDriver (options: Record<string, any>, modifier?: Func
     for (const eventCommand in EVENTHANDLER_FUNCTIONS) {
         prototype[eventCommand] = function (...args: [any, any]) {
             const method = eventCommand as keyof EventEmitter
+
+            /**
+             * Emit an event when a dialog listener is registered or unregistered.
+             * This is used in `packages/webdriverio/src/dialog.ts`
+             * to decide whether to propagate a `dialog` event to
+             * the user or automatically accept or dismiss the dialog.
+             */
+            if (method === 'on' && args[0] === 'dialog') {
+                eventHandler.emit('_dialogListenerRegistered')
+            }
+            if (method === 'off' && args[0] === 'dialog') {
+                eventHandler.emit('_dialogListenerRemoved')
+            }
+
             eventHandler[method]?.(...args as [never, any])
             return this
         }

--- a/packages/webdriver/src/types.ts
+++ b/packages/webdriver/src/types.ts
@@ -42,10 +42,10 @@ export type BidiEventMap = {
 }
 
 type GetParam<T extends { method: string, params: any }, U extends string> = T extends { method: U } ? T['params'] : never
-type EventMap = {
+export type EventMap = {
     [Event in EventData['method']]: GetParam<EventData, Event>
 } & WebDriverClassicEvents
-export interface BidiEventHandler {
+interface BidiEventHandler {
     on<K extends keyof EventMap>(event: K, listener: (this: Client, param: EventMap[K]) => void): this
     once<K extends keyof EventMap>(event: K, listener: (this: Client, param: EventMap[K]) => void): this
 }

--- a/packages/webdriverio/src/commands/dialog/accept.ts
+++ b/packages/webdriverio/src/commands/dialog/accept.ts
@@ -1,0 +1,13 @@
+/**
+ * Returns when the dialog has been accepted.
+ *
+ * <example>
+    :dialogAccept.js
+    await dialog.accept();
+    await dialog.accept(promptText);
+ * </example>
+ *
+ * @alias dialog.accept
+ * @param {string=} promptText  A text to enter into prompt. Does not cause any effects if the dialog's type is not prompt.
+ */
+// actual implementation is located in packages/webdriverio/src/dialog.ts

--- a/packages/webdriverio/src/commands/dialog/defaultValue.ts
+++ b/packages/webdriverio/src/commands/dialog/defaultValue.ts
@@ -1,0 +1,11 @@
+/**
+ * If dialog is prompt, returns default prompt value. Otherwise, returns empty string.
+ *
+ * <example>
+    :dialogDefaultValue.js
+    const value = await dialog.defaultValue();
+ * </example>
+ *
+ * @alias dialog.defaultValue
+ */
+// actual implementation is located in packages/webdriverio/src/dialog.ts

--- a/packages/webdriverio/src/commands/dialog/dismiss.ts
+++ b/packages/webdriverio/src/commands/dialog/dismiss.ts
@@ -1,0 +1,11 @@
+/**
+ * Returns when the dialog has been dismissed.
+ *
+ * <example>
+    :dialogDismiss.js
+    await dialog.dismiss();
+ * </example>
+ *
+ * @alias dialog.dismiss
+ */
+// actual implementation is located in packages/webdriverio/src/dialog.ts

--- a/packages/webdriverio/src/commands/dialog/message.ts
+++ b/packages/webdriverio/src/commands/dialog/message.ts
@@ -1,0 +1,12 @@
+/**
+ * A message displayed in the dialog.
+ *
+ * <example>
+    :dialogMessage.js
+    const message = await dialog.message();
+ * </example>
+ *
+ * @alias dialog.message
+ * @returns {string}  The message displayed in the dialog.
+ */
+// actual implementation is located in packages/webdriverio/src/dialog.ts

--- a/packages/webdriverio/src/commands/dialog/type.ts
+++ b/packages/webdriverio/src/commands/dialog/type.ts
@@ -1,0 +1,12 @@
+/**
+ * Returns dialog's type, can be one of `alert`, `beforeunload`, `confirm` or `prompt`.
+ *
+ * <example>
+    :dialogType.js
+    const type = await dialog.type();
+ * </example>
+ *
+ * @alias dialog.type
+ * @returns {string}  The type of the dialog
+ */
+// actual implementation is located in packages/webdriverio/src/dialog.ts

--- a/packages/webdriverio/src/dialog.ts
+++ b/packages/webdriverio/src/dialog.ts
@@ -1,0 +1,106 @@
+import { type local } from 'webdriver'
+
+const dialogManager = new Map<WebdriverIO.Browser, DialogManager>()
+
+export function getDialogManager(browser: WebdriverIO.Browser) {
+    const existingDialogManager = dialogManager.get(browser)
+    if (existingDialogManager) {
+        return existingDialogManager
+    }
+
+    const newContext = new DialogManager(browser)
+    dialogManager.set(browser, newContext)
+    return newContext
+}
+
+/**
+ * This class is responsible for managing shadow roots and their elements.
+ * It allows to do deep element lookups and pierce into shadow DOMs across
+ * all components of a page.
+ */
+export class DialogManager {
+    #browser: WebdriverIO.Browser
+    #initialize: Promise<boolean>
+
+    constructor(browser: WebdriverIO.Browser) {
+        this.#browser = browser
+
+        /**
+         * don't run setup when Bidi is not supported or running unit tests
+         */
+        if (!browser.isBidi || process.env.VITEST_WORKER_ID || browser.options?.automationProtocol !== 'webdriver') {
+            this.#initialize = Promise.resolve(true)
+            return
+        }
+
+        /**
+         * listen on required bidi events
+         */
+        this.#initialize = this.#browser.sessionSubscribe({
+            events: ['browsingContext.userPromptOpened']
+        }).then(() => true, () => false)
+        this.#browser.on('browsingContext.userPromptOpened', this.#handleUserPrompt.bind(this))
+    }
+
+    async initialize () {
+        return this.#initialize
+    }
+
+    /**
+     * capture shadow root elements propagated through console.debug
+     */
+    #handleUserPrompt(log: local.BrowsingContextUserPromptOpenedParameters) {
+        const dialog = new Dialog(log, this.#browser)
+        this.#browser.emit('dialog', dialog)
+    }
+}
+
+export class Dialog {
+    #browser: WebdriverIO.Browser
+    #context: string
+    #message: string
+    #defaultValue?: string
+    #type: local.BrowsingContextUserPromptOpenedParameters['type']
+
+    constructor (event: local.BrowsingContextUserPromptOpenedParameters, browser: WebdriverIO.Browser) {
+        this.#message = event.message
+        this.#defaultValue = event.defaultValue
+        this.#type = event.type
+        this.#context = event.context
+        this.#browser = browser
+    }
+
+    message() {
+        return this.#message
+    }
+
+    defaultValue() {
+        return this.#defaultValue
+    }
+
+    type() {
+        return this.#type
+    }
+
+    /**
+     * Returns when the dialog has been accepted.
+     *
+     * @alias dialog.accept
+     * @param {string=} promptText  A text to enter into prompt. Does not cause any effects if the dialog's type is not prompt.
+     * @returns {Promise<void>}
+     */
+    async accept(userText?: string) {
+        await this.#browser.browsingContextHandleUserPrompt({
+            accept: true,
+            context: this.#context,
+            userText
+        })
+    }
+
+    async dismiss() {
+        await this.#browser.browsingContextHandleUserPrompt({
+            accept: false,
+            context: this.#context
+        })
+    }
+}

--- a/packages/webdriverio/src/index.ts
+++ b/packages/webdriverio/src/index.ts
@@ -14,6 +14,7 @@ import { WDIO_DEFAULTS, SupportedAutomationProtocols, Key as KeyConstant } from 
 import { getPrototype, addLocatorStrategyHandler, isStub } from './utils/index.js'
 import { getShadowRootManager } from './shadowRoot.js'
 import { getNetworkManager } from './networkManager.js'
+import { getDialogManager } from './dialog.js'
 import type { AttachOptions } from './types.js'
 import type * as elementCommands from './commands/element.js'
 
@@ -81,7 +82,8 @@ export const remote = async function(
     instance.addLocatorStrategy = addLocatorStrategyHandler(instance)
     await Promise.all([
         getShadowRootManager(instance).initialize(),
-        getNetworkManager(instance).initialize()
+        getNetworkManager(instance).initialize(),
+        getDialogManager(instance).initialize()
     ])
     return instance
 }
@@ -109,8 +111,13 @@ export const attach = async function (attachOptions: AttachOptions): Promise<Web
 
     driver.addLocatorStrategy = addLocatorStrategyHandler(driver)
     // @ts-expect-error `bidiHandler` is a private property
-    await driver._bidiHandler?.connect().then(
-        () => getShadowRootManager(driver).initialize())
+    await driver._bidiHandler?.connect().then(() => (
+        Promise.all([
+            getShadowRootManager(driver).initialize(),
+            getNetworkManager(driver).initialize(),
+            getDialogManager(driver).initialize()
+        ])
+    ))
     return driver
 }
 

--- a/packages/webdriverio/src/types.ts
+++ b/packages/webdriverio/src/types.ts
@@ -278,8 +278,8 @@ type WebdriverIOEventMap = EventMap & {
 }
 
 interface BidiEventHandler {
-    on<K extends keyof WebdriverIOEventMap>(event: K, listener: (this: WebdriverIO.Browser, param: EventMap[K]) => void): this
-    once<K extends keyof WebdriverIOEventMap>(event: K, listener: (this: WebdriverIO.Browser, param: EventMap[K]) => void): this
+    on<K extends keyof WebdriverIOEventMap>(event: K, listener: (this: WebdriverIO.Browser, param: WebdriverIOEventMap[K]) => void): this
+    once<K extends keyof WebdriverIOEventMap>(event: K, listener: (this: WebdriverIO.Browser, param: WebdriverIOEventMap[K]) => void): this
 }
 
 /**

--- a/packages/webdriverio/src/types.ts
+++ b/packages/webdriverio/src/types.ts
@@ -1,9 +1,10 @@
 import type { EventEmitter } from 'node:events'
-import type { remote, SessionFlags, AttachOptions as WebDriverAttachOptions, BidiHandler, BidiEventHandler } from 'webdriver'
+import type { remote, SessionFlags, AttachOptions as WebDriverAttachOptions, BidiHandler, EventMap } from 'webdriver'
 import type { Capabilities, Options, ThenArg } from '@wdio/types'
 import type { ElementReference, ProtocolCommands } from '@wdio/protocols'
 import type { Browser as PuppeteerBrowser } from 'puppeteer-core'
 
+import type { Dialog as DialogImport } from './dialog.js'
 import type * as BrowserCommands from './commands/browser.js'
 import type * as ElementCommands from './commands/element.js'
 import type { Button, ButtonNames } from './utils/actions/pointer.js'
@@ -270,6 +271,15 @@ export interface BrowserBase extends InstanceBase, CustomInstanceCommands<Webdri
      * capabilities of the browser instance
      */
     capabilities: WebdriverIO.Capabilities
+}
+
+type WebdriverIOEventMap = EventMap & {
+    'dialog': WebdriverIO.Dialog
+}
+
+interface BidiEventHandler {
+    on<K extends keyof WebdriverIOEventMap>(event: K, listener: (this: WebdriverIO.Browser, param: EventMap[K]) => void): this
+    once<K extends keyof WebdriverIOEventMap>(event: K, listener: (this: WebdriverIO.Browser, param: EventMap[K]) => void): this
 }
 
 /**
@@ -570,5 +580,14 @@ declare global {
          * @see https://webdriver.io/docs/api/mock
          */
         interface Mock extends WebDriverInterception {}
+        /**
+         * WebdriverIO Dialog object
+         * The dialog object represents a user prompt that was triggered by the browser. It contains
+         * information about the message, type and default value of the prompt.
+         * It can be received using the `on('dialog')` event.
+         *
+         * @see https://webdriver.io/docs/api/dialog
+         */
+        interface Dialog extends DialogImport {}
     }
 }

--- a/scripts/docs-generation/wdioDocs.ts
+++ b/scripts/docs-generation/wdioDocs.ts
@@ -26,7 +26,8 @@ export async function generateWdioDocs (sidebars: any) {
     const COMMANDS = {
         browser: ['api/browser', fs.readdirSync(path.join(COMMAND_DIR, 'browser'))],
         element: ['api/element', fs.readdirSync(path.join(COMMAND_DIR, 'element'))],
-        mock: ['api/mock', fs.readdirSync(path.join(COMMAND_DIR, 'mock'))]
+        mock: ['api/mock', fs.readdirSync(path.join(COMMAND_DIR, 'mock'))],
+        dialog: ['api/dialog', fs.readdirSync(path.join(COMMAND_DIR, 'dialog'))],
     }
 
     const apiDocs: NavbarItem[] = []


### PR DESCRIPTION
## Proposed changes

This patch introduces a new WebdriverIO primitive for handling dialogs. Users can listen on dialogs via `browser.on('dialog')` and handle them manually or if not, they will be handled/dismissed automatically.

I updated the docs:
<img width="1544" alt="Screenshot_2024-07-29_at_10 16 35_PM" src="https://github.com/user-attachments/assets/b42769f8-c6a2-459d-9f0b-ba418233f438">

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
