### PR TITLE
fix(webdriverio): update puppeteer-core

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12566,9 +12566,9 @@
       "link": true
     },
     "node_modules/devtools-protocol": {
-      "version": "0.0.1327118",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1327118.tgz",
-      "integrity": "sha512-TYdQlql0X6DFdIQbxACCyIvlZ98kxNHlWRllDOKHviQAEXb70+1p/Wvr9JleQxOMkdWie0GFZRxsGSPiCqXYMg=="
+      "version": "0.0.1335233",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1335233.tgz",
+      "integrity": "sha512-bNTJw/m+v0JvQEsaI0l+i6mETHHf7VwZbQzT5GNSveGuYjip8uyjeF/qg84bsIPU+lFypnZr10a+cbcee6I8pg=="
     },
     "node_modules/diff": {
       "version": "5.2.0",
@@ -31257,7 +31257,7 @@
         "@wdio/logger": "8.38.0",
         "@wdio/types": "8.39.0",
         "babel-plugin-istanbul": "^7.0.0",
-        "devtools-protocol": "^0.0.1327118",
+        "devtools-protocol": "^0.0.1335233",
         "istanbul-lib-coverage": "^3.2.0",
         "istanbul-lib-report": "^3.0.0",
         "istanbul-reports": "^3.1.4",
@@ -31757,7 +31757,7 @@
         "aria-query": "^5.0.0",
         "css-shorthand-properties": "^1.1.1",
         "css-value": "^0.0.1",
-        "devtools-protocol": "^0.0.1327118",
+        "devtools-protocol": "^0.0.1335233",
         "grapheme-splitter": "^1.0.2",
         "import-meta-resolve": "^4.0.0",
         "is-plain-obj": "^4.1.0",
@@ -38230,7 +38230,7 @@
         "@wdio/logger": "8.38.0",
         "@wdio/types": "8.39.0",
         "babel-plugin-istanbul": "^7.0.0",
-        "devtools-protocol": "^0.0.1327118",
+        "devtools-protocol": "^0.0.1335233",
         "istanbul-lib-coverage": "^3.2.0",
         "istanbul-lib-report": "^3.0.0",
         "istanbul-reports": "^3.1.4",
@@ -41935,9 +41935,9 @@
       }
     },
     "devtools-protocol": {
-      "version": "0.0.1327118",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1327118.tgz",
-      "integrity": "sha512-TYdQlql0X6DFdIQbxACCyIvlZ98kxNHlWRllDOKHviQAEXb70+1p/Wvr9JleQxOMkdWie0GFZRxsGSPiCqXYMg=="
+      "version": "0.0.1335233",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1335233.tgz",
+      "integrity": "sha512-bNTJw/m+v0JvQEsaI0l+i6mETHHf7VwZbQzT5GNSveGuYjip8uyjeF/qg84bsIPU+lFypnZr10a+cbcee6I8pg=="
     },
     "diff": {
       "version": "5.2.0",
@@ -54834,7 +54834,7 @@
         "aria-query": "^5.0.0",
         "css-shorthand-properties": "^1.1.1",
         "css-value": "^0.0.1",
-        "devtools-protocol": "^0.0.1327118",
+        "devtools-protocol": "^0.0.1335233",
         "got": "^12.6.0",
         "grapheme-splitter": "^1.0.2",
         "import-meta-resolve": "^4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6784,6 +6784,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
       "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+      "dev": true,
       "engines": {
         "node": ">= 10"
       }
@@ -10547,11 +10548,12 @@
       }
     },
     "node_modules/chromium-bidi": {
-      "version": "0.4.9",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.4.9.tgz",
-      "integrity": "sha512-u3DC6XwgLCA9QJ5ak1voPslCmacQdulZNCPsI3qNXxSnEcZS7DFIbww+5RM2bznMEje7cc0oydavRLRvOIZtHw==",
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.5.8.tgz",
+      "integrity": "sha512-blqh+1cEQbHBKmok3rVJkBlBxt9beKBgOsxbFgs7UJcoVbbeZ+K7+6liAsjgpc8l1Xd55cQUy14fXZdGSb4zIw==",
       "dependencies": {
-        "mitt": "3.0.0"
+        "mitt": "3.0.1",
+        "urlpattern-polyfill": "10.0.0"
       },
       "peerDependencies": {
         "devtools-protocol": "*"
@@ -11854,11 +11856,11 @@
       "dev": true
     },
     "node_modules/cross-fetch": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.6.tgz",
-      "integrity": "sha512-riRvo06crlE8HiqOwIpQhxwdOk4fOeR7FVM/wXoxchFEqMNUjvbs3bfo4OTgMEMHzppd4DxFBDbyySj8Cv781g==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
+      "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
       "dependencies": {
-        "node-fetch": "^2.6.11"
+        "node-fetch": "^2.6.12"
       }
     },
     "node_modules/cross-spawn": {
@@ -16410,6 +16412,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
       "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "dev": true,
       "dependencies": {
         "@tootallnate/once": "2",
         "agent-base": "6",
@@ -20611,9 +20614,9 @@
       "dev": true
     },
     "node_modules/mitt": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.0.tgz",
-      "integrity": "sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="
     },
     "node_modules/mkdirp": {
       "version": "1.0.4",
@@ -24443,99 +24446,30 @@
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "20.3.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-20.3.0.tgz",
-      "integrity": "sha512-264pBrIui5bO6NJeOcbJrLa0OCwmA4+WK00JMrLIKTfRiqe2gx8KWTzLsjyw/bizErp3TKS7vt/I0i5fTC+mAw==",
+      "version": "21.11.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.11.0.tgz",
+      "integrity": "sha512-ArbnyA3U5SGHokEvkfWjW+O8hOxV1RSJxOgriX/3A4xZRqixt9ZFHD0yPgZQF05Qj0oAqi8H/7stDorjoHY90Q==",
       "dependencies": {
-        "@puppeteer/browsers": "1.3.0",
-        "chromium-bidi": "0.4.9",
-        "cross-fetch": "3.1.6",
+        "@puppeteer/browsers": "1.9.1",
+        "chromium-bidi": "0.5.8",
+        "cross-fetch": "4.0.0",
         "debug": "4.3.4",
-        "devtools-protocol": "0.0.1120988",
-        "ws": "8.13.0"
+        "devtools-protocol": "0.0.1232444",
+        "ws": "8.16.0"
       },
       "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "typescript": ">= 4.7.4"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+        "node": ">=16.13.2"
       }
-    },
-    "node_modules/puppeteer-core/node_modules/@puppeteer/browsers": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.3.0.tgz",
-      "integrity": "sha512-an3QdbNPkuU6qpxpbssxAbjRLJcF+eP4L8UqIY3+6n0sbaVxw5pz7PiCLy9g32XEZuoamUlV5ZQPnA6FxvkIHA==",
-      "dependencies": {
-        "debug": "4.3.4",
-        "extract-zip": "2.0.1",
-        "http-proxy-agent": "5.0.0",
-        "https-proxy-agent": "5.0.1",
-        "progress": "2.0.3",
-        "proxy-from-env": "1.1.0",
-        "tar-fs": "2.1.1",
-        "unbzip2-stream": "1.4.3",
-        "yargs": "17.7.1"
-      },
-      "bin": {
-        "browsers": "lib/cjs/main-cli.js"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "typescript": ">= 4.7.4"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/puppeteer-core/node_modules/chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
     },
     "node_modules/puppeteer-core/node_modules/devtools-protocol": {
-      "version": "0.0.1120988",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1120988.tgz",
-      "integrity": "sha512-39fCpE3Z78IaIPChJsP6Lhmkbf4dWXOmzLk/KFTdRkNk/0JymRIfUynDVRndV9HoDz8PyalK1UH21ST/ivwW5Q=="
-    },
-    "node_modules/puppeteer-core/node_modules/tar-fs": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-      "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
-      "dependencies": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
-      }
-    },
-    "node_modules/puppeteer-core/node_modules/tar-stream": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
+      "version": "0.0.1232444",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1232444.tgz",
+      "integrity": "sha512-pM27vqEfxSxRkTMnF+XCmxSEb6duO5R+t8A9DEEJgy4Wz2RVanje2mmj99B6A3zv2r/qGfYlOvYznUhuokizmg=="
     },
     "node_modules/puppeteer-core/node_modules/ws": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
+      "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -24550,23 +24484,6 @@
         "utf-8-validate": {
           "optional": true
         }
-      }
-    },
-    "node_modules/puppeteer-core/node_modules/yargs": {
-      "version": "17.7.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
-      "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
-      "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/qs": {
@@ -28485,7 +28402,7 @@
       "version": "5.4.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
       "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
-      "devOptional": true,
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -28854,6 +28771,11 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/urlpattern-polyfill": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz",
+      "integrity": "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg=="
     },
     "node_modules/userhome": {
       "version": "1.0.0",
@@ -30394,7 +30316,7 @@
         "chrome-launcher": "^1.0.0",
         "edge-paths": "^3.0.5",
         "import-meta-resolve": "^4.0.0",
-        "puppeteer-core": "20.3.0",
+        "puppeteer-core": "^21.11.0",
         "query-selector-shadow-dom": "^1.0.0",
         "ua-parser-js": "^1.0.37",
         "uuid": "^10.0.0",
@@ -31340,7 +31262,7 @@
         "istanbul-lib-report": "^3.0.0",
         "istanbul-reports": "^3.1.4",
         "lighthouse": "8.6.0",
-        "puppeteer-core": "20.3.0",
+        "puppeteer-core": "^21.11.0",
         "webdriverio": "8.39.1"
       },
       "devDependencies": {
@@ -31843,7 +31765,7 @@
         "lodash.clonedeep": "^4.5.0",
         "lodash.zip": "^4.2.0",
         "minimatch": "^9.0.0",
-        "puppeteer-core": "^20.9.0",
+        "puppeteer-core": "^21.11.0",
         "query-selector-shadow-dom": "^1.0.0",
         "resq": "^1.9.1",
         "rgb2hex": "0.2.5",
@@ -31867,193 +31789,6 @@
         "devtools": {
           "optional": true
         }
-      }
-    },
-    "packages/webdriverio/node_modules/@puppeteer/browsers": {
-      "version": "1.4.6",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.4.6.tgz",
-      "integrity": "sha512-x4BEjr2SjOPowNeiguzjozQbsc6h437ovD/wu+JpaenxVLm3jkgzHY2xOslMTp50HoTvQreMjiexiGQw1sqZlQ==",
-      "dependencies": {
-        "debug": "4.3.4",
-        "extract-zip": "2.0.1",
-        "progress": "2.0.3",
-        "proxy-agent": "6.3.0",
-        "tar-fs": "3.0.4",
-        "unbzip2-stream": "1.4.3",
-        "yargs": "17.7.1"
-      },
-      "bin": {
-        "browsers": "lib/cjs/main-cli.js"
-      },
-      "engines": {
-        "node": ">=16.3.0"
-      },
-      "peerDependencies": {
-        "typescript": ">= 4.7.4"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "packages/webdriverio/node_modules/agent-base": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
-      "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
-      "dependencies": {
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "packages/webdriverio/node_modules/cross-fetch": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
-      "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
-      "dependencies": {
-        "node-fetch": "^2.6.12"
-      }
-    },
-    "packages/webdriverio/node_modules/http-proxy-agent": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
-      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-      "dependencies": {
-        "agent-base": "^7.1.0",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "packages/webdriverio/node_modules/https-proxy-agent": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
-      "integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
-      "dependencies": {
-        "agent-base": "^7.0.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "packages/webdriverio/node_modules/lru-cache": {
-      "version": "7.18.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "packages/webdriverio/node_modules/proxy-agent": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.3.0.tgz",
-      "integrity": "sha512-0LdR757eTj/JfuU7TL2YCuAZnxWXu3tkJbg4Oq3geW/qFNT/32T0sp2HnZ9O0lMR4q3vwAt0+xCA8SR0WAD0og==",
-      "dependencies": {
-        "agent-base": "^7.0.2",
-        "debug": "^4.3.4",
-        "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.0",
-        "lru-cache": "^7.14.1",
-        "pac-proxy-agent": "^7.0.0",
-        "proxy-from-env": "^1.1.0",
-        "socks-proxy-agent": "^8.0.1"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "packages/webdriverio/node_modules/puppeteer-core": {
-      "version": "20.9.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-20.9.0.tgz",
-      "integrity": "sha512-H9fYZQzMTRrkboEfPmf7m3CLDN6JvbxXA3qTtS+dFt27tR+CsFHzPsT6pzp6lYL6bJbAPaR0HaPO6uSi+F94Pg==",
-      "dependencies": {
-        "@puppeteer/browsers": "1.4.6",
-        "chromium-bidi": "0.4.16",
-        "cross-fetch": "4.0.0",
-        "debug": "4.3.4",
-        "devtools-protocol": "0.0.1147663",
-        "ws": "8.13.0"
-      },
-      "engines": {
-        "node": ">=16.3.0"
-      },
-      "peerDependencies": {
-        "typescript": ">= 4.7.4"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "packages/webdriverio/node_modules/puppeteer-core/node_modules/chromium-bidi": {
-      "version": "0.4.16",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.4.16.tgz",
-      "integrity": "sha512-7ZbXdWERxRxSwo3txsBjjmc/NLxqb1Bk30mRb0BMS4YIaiV6zvKZqL/UAH+DdqcDYayDWk2n/y8klkBDODrPvA==",
-      "dependencies": {
-        "mitt": "3.0.0"
-      },
-      "peerDependencies": {
-        "devtools-protocol": "*"
-      }
-    },
-    "packages/webdriverio/node_modules/puppeteer-core/node_modules/devtools-protocol": {
-      "version": "0.0.1147663",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1147663.tgz",
-      "integrity": "sha512-hyWmRrexdhbZ1tcJUGpO95ivbRhWXz++F4Ko+n21AY5PNln2ovoJw+8ZMNDTtip+CNFQfrtLVh/w4009dXO/eQ=="
-    },
-    "packages/webdriverio/node_modules/socks-proxy-agent": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.3.tgz",
-      "integrity": "sha512-VNegTZKhuGq5vSD6XNKlbqWhyt/40CgoEw8XxD6dhnm8Jq9IEa3nIa4HwnM8XOqU0CdB0BwWVXusqiFXfHB3+A==",
-      "dependencies": {
-        "agent-base": "^7.1.1",
-        "debug": "^4.3.4",
-        "socks": "^2.7.1"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "packages/webdriverio/node_modules/ws": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
-    "packages/webdriverio/node_modules/yargs": {
-      "version": "17.7.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
-      "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
-      "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "engines": {
-        "node": ">=12"
       }
     }
   },
@@ -37023,7 +36758,8 @@
     "@tootallnate/once": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A=="
+      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+      "dev": true
     },
     "@tootallnate/quickjs-emscripten": {
       "version": "0.23.0",
@@ -38499,7 +38235,7 @@
         "istanbul-lib-report": "^3.0.0",
         "istanbul-reports": "^3.1.4",
         "lighthouse": "8.6.0",
-        "puppeteer-core": "20.3.0",
+        "puppeteer-core": "^21.11.0",
         "webdriverio": "8.39.1"
       }
     },
@@ -40646,11 +40382,12 @@
       }
     },
     "chromium-bidi": {
-      "version": "0.4.9",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.4.9.tgz",
-      "integrity": "sha512-u3DC6XwgLCA9QJ5ak1voPslCmacQdulZNCPsI3qNXxSnEcZS7DFIbww+5RM2bznMEje7cc0oydavRLRvOIZtHw==",
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.5.8.tgz",
+      "integrity": "sha512-blqh+1cEQbHBKmok3rVJkBlBxt9beKBgOsxbFgs7UJcoVbbeZ+K7+6liAsjgpc8l1Xd55cQUy14fXZdGSb4zIw==",
       "requires": {
-        "mitt": "3.0.0"
+        "mitt": "3.0.1",
+        "urlpattern-polyfill": "10.0.0"
       }
     },
     "ci-info": {
@@ -41658,11 +41395,11 @@
       "dev": true
     },
     "cross-fetch": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.6.tgz",
-      "integrity": "sha512-riRvo06crlE8HiqOwIpQhxwdOk4fOeR7FVM/wXoxchFEqMNUjvbs3bfo4OTgMEMHzppd4DxFBDbyySj8Cv781g==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
+      "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
       "requires": {
-        "node-fetch": "^2.6.11"
+        "node-fetch": "^2.6.12"
       }
     },
     "cross-spawn": {
@@ -42190,7 +41927,7 @@
         "chrome-launcher": "^1.0.0",
         "edge-paths": "^3.0.5",
         "import-meta-resolve": "^4.0.0",
-        "puppeteer-core": "20.3.0",
+        "puppeteer-core": "^21.11.0",
         "query-selector-shadow-dom": "^1.0.0",
         "ua-parser-js": "^1.0.37",
         "uuid": "^10.0.0",
@@ -45256,6 +44993,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
       "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "dev": true,
       "requires": {
         "@tootallnate/once": "2",
         "agent-base": "6",
@@ -48413,9 +48151,9 @@
       }
     },
     "mitt": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.0.tgz",
-      "integrity": "sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="
     },
     "mkdirp": {
       "version": "1.0.4",
@@ -51315,86 +51053,28 @@
       }
     },
     "puppeteer-core": {
-      "version": "20.3.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-20.3.0.tgz",
-      "integrity": "sha512-264pBrIui5bO6NJeOcbJrLa0OCwmA4+WK00JMrLIKTfRiqe2gx8KWTzLsjyw/bizErp3TKS7vt/I0i5fTC+mAw==",
+      "version": "21.11.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.11.0.tgz",
+      "integrity": "sha512-ArbnyA3U5SGHokEvkfWjW+O8hOxV1RSJxOgriX/3A4xZRqixt9ZFHD0yPgZQF05Qj0oAqi8H/7stDorjoHY90Q==",
       "requires": {
-        "@puppeteer/browsers": "1.3.0",
-        "chromium-bidi": "0.4.9",
-        "cross-fetch": "3.1.6",
+        "@puppeteer/browsers": "1.9.1",
+        "chromium-bidi": "0.5.8",
+        "cross-fetch": "4.0.0",
         "debug": "4.3.4",
-        "devtools-protocol": "0.0.1120988",
-        "ws": "8.13.0"
+        "devtools-protocol": "0.0.1232444",
+        "ws": "8.16.0"
       },
       "dependencies": {
-        "@puppeteer/browsers": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.3.0.tgz",
-          "integrity": "sha512-an3QdbNPkuU6qpxpbssxAbjRLJcF+eP4L8UqIY3+6n0sbaVxw5pz7PiCLy9g32XEZuoamUlV5ZQPnA6FxvkIHA==",
-          "requires": {
-            "debug": "4.3.4",
-            "extract-zip": "2.0.1",
-            "http-proxy-agent": "5.0.0",
-            "https-proxy-agent": "5.0.1",
-            "progress": "2.0.3",
-            "proxy-from-env": "1.1.0",
-            "tar-fs": "2.1.1",
-            "unbzip2-stream": "1.4.3",
-            "yargs": "17.7.1"
-          }
-        },
-        "chownr": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-          "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
-        },
         "devtools-protocol": {
-          "version": "0.0.1120988",
-          "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1120988.tgz",
-          "integrity": "sha512-39fCpE3Z78IaIPChJsP6Lhmkbf4dWXOmzLk/KFTdRkNk/0JymRIfUynDVRndV9HoDz8PyalK1UH21ST/ivwW5Q=="
-        },
-        "tar-fs": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-          "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
-          "requires": {
-            "chownr": "^1.1.1",
-            "mkdirp-classic": "^0.5.2",
-            "pump": "^3.0.0",
-            "tar-stream": "^2.1.4"
-          }
-        },
-        "tar-stream": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-          "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-          "requires": {
-            "bl": "^4.0.3",
-            "end-of-stream": "^1.4.1",
-            "fs-constants": "^1.0.0",
-            "inherits": "^2.0.3",
-            "readable-stream": "^3.1.1"
-          }
+          "version": "0.0.1232444",
+          "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1232444.tgz",
+          "integrity": "sha512-pM27vqEfxSxRkTMnF+XCmxSEb6duO5R+t8A9DEEJgy4Wz2RVanje2mmj99B6A3zv2r/qGfYlOvYznUhuokizmg=="
         },
         "ws": {
-          "version": "8.13.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-          "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+          "version": "8.16.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
+          "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
           "requires": {}
-        },
-        "yargs": {
-          "version": "17.7.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
-          "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
-          "requires": {
-            "cliui": "^8.0.1",
-            "escalade": "^3.1.1",
-            "get-caller-file": "^2.0.5",
-            "require-directory": "^2.1.1",
-            "string-width": "^4.2.3",
-            "y18n": "^5.0.5",
-            "yargs-parser": "^21.1.1"
-          }
         }
       }
     },
@@ -54384,7 +54064,7 @@
       "version": "5.4.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
       "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
-      "devOptional": true
+      "dev": true
     },
     "ua-parser-js": {
       "version": "1.0.38",
@@ -54649,6 +54329,11 @@
       "requires": {
         "prepend-http": "^2.0.0"
       }
+    },
+    "urlpattern-polyfill": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz",
+      "integrity": "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg=="
     },
     "userhome": {
       "version": "1.0.0",
@@ -55158,140 +54843,12 @@
         "lodash.clonedeep": "^4.5.0",
         "lodash.zip": "^4.2.0",
         "minimatch": "^9.0.0",
-        "puppeteer-core": "^20.9.0",
+        "puppeteer-core": "^21.11.0",
         "query-selector-shadow-dom": "^1.0.0",
         "resq": "^1.9.1",
         "rgb2hex": "0.2.5",
         "serialize-error": "^11.0.1",
         "webdriver": "8.39.0"
-      },
-      "dependencies": {
-        "@puppeteer/browsers": {
-          "version": "1.4.6",
-          "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.4.6.tgz",
-          "integrity": "sha512-x4BEjr2SjOPowNeiguzjozQbsc6h437ovD/wu+JpaenxVLm3jkgzHY2xOslMTp50HoTvQreMjiexiGQw1sqZlQ==",
-          "requires": {
-            "debug": "4.3.4",
-            "extract-zip": "2.0.1",
-            "progress": "2.0.3",
-            "proxy-agent": "6.3.0",
-            "tar-fs": "3.0.4",
-            "unbzip2-stream": "1.4.3",
-            "yargs": "17.7.1"
-          }
-        },
-        "agent-base": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
-          "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
-          "requires": {
-            "debug": "^4.3.4"
-          }
-        },
-        "cross-fetch": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
-          "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
-          "requires": {
-            "node-fetch": "^2.6.12"
-          }
-        },
-        "http-proxy-agent": {
-          "version": "7.0.2",
-          "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
-          "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-          "requires": {
-            "agent-base": "^7.1.0",
-            "debug": "^4.3.4"
-          }
-        },
-        "https-proxy-agent": {
-          "version": "7.0.4",
-          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
-          "integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
-          "requires": {
-            "agent-base": "^7.0.2",
-            "debug": "4"
-          }
-        },
-        "lru-cache": {
-          "version": "7.18.3",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-          "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="
-        },
-        "proxy-agent": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.3.0.tgz",
-          "integrity": "sha512-0LdR757eTj/JfuU7TL2YCuAZnxWXu3tkJbg4Oq3geW/qFNT/32T0sp2HnZ9O0lMR4q3vwAt0+xCA8SR0WAD0og==",
-          "requires": {
-            "agent-base": "^7.0.2",
-            "debug": "^4.3.4",
-            "http-proxy-agent": "^7.0.0",
-            "https-proxy-agent": "^7.0.0",
-            "lru-cache": "^7.14.1",
-            "pac-proxy-agent": "^7.0.0",
-            "proxy-from-env": "^1.1.0",
-            "socks-proxy-agent": "^8.0.1"
-          }
-        },
-        "puppeteer-core": {
-          "version": "20.9.0",
-          "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-20.9.0.tgz",
-          "integrity": "sha512-H9fYZQzMTRrkboEfPmf7m3CLDN6JvbxXA3qTtS+dFt27tR+CsFHzPsT6pzp6lYL6bJbAPaR0HaPO6uSi+F94Pg==",
-          "requires": {
-            "@puppeteer/browsers": "1.4.6",
-            "chromium-bidi": "0.4.16",
-            "cross-fetch": "4.0.0",
-            "debug": "4.3.4",
-            "devtools-protocol": "0.0.1147663",
-            "ws": "8.13.0"
-          },
-          "dependencies": {
-            "chromium-bidi": {
-              "version": "0.4.16",
-              "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.4.16.tgz",
-              "integrity": "sha512-7ZbXdWERxRxSwo3txsBjjmc/NLxqb1Bk30mRb0BMS4YIaiV6zvKZqL/UAH+DdqcDYayDWk2n/y8klkBDODrPvA==",
-              "requires": {
-                "mitt": "3.0.0"
-              }
-            },
-            "devtools-protocol": {
-              "version": "0.0.1147663",
-              "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1147663.tgz",
-              "integrity": "sha512-hyWmRrexdhbZ1tcJUGpO95ivbRhWXz++F4Ko+n21AY5PNln2ovoJw+8ZMNDTtip+CNFQfrtLVh/w4009dXO/eQ=="
-            }
-          }
-        },
-        "socks-proxy-agent": {
-          "version": "8.0.3",
-          "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.3.tgz",
-          "integrity": "sha512-VNegTZKhuGq5vSD6XNKlbqWhyt/40CgoEw8XxD6dhnm8Jq9IEa3nIa4HwnM8XOqU0CdB0BwWVXusqiFXfHB3+A==",
-          "requires": {
-            "agent-base": "^7.1.1",
-            "debug": "^4.3.4",
-            "socks": "^2.7.1"
-          }
-        },
-        "ws": {
-          "version": "8.13.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-          "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
-          "requires": {}
-        },
-        "yargs": {
-          "version": "17.7.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
-          "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
-          "requires": {
-            "cliui": "^8.0.1",
-            "escalade": "^3.1.1",
-            "get-caller-file": "^2.0.5",
-            "require-directory": "^2.1.1",
-            "string-width": "^4.2.3",
-            "y18n": "^5.0.5",
-            "yargs-parser": "^21.1.1"
-          }
-        }
       }
     },
     "webidl-conversions": {

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -47,7 +47,7 @@
     "chrome-launcher": "^1.0.0",
     "edge-paths": "^3.0.5",
     "import-meta-resolve": "^4.0.0",
-    "puppeteer-core": "20.3.0",
+    "puppeteer-core": "^21.11.0",
     "query-selector-shadow-dom": "^1.0.0",
     "ua-parser-js": "^1.0.37",
     "uuid": "^10.0.0",

--- a/packages/devtools/src/commands/getElementProperty.ts
+++ b/packages/devtools/src/commands/getElementProperty.ts
@@ -20,7 +20,7 @@ export default async function getElementProperty (
         throw getStaleElementError(elementId)
     }
 
-    const jsHandle = await elementHandle.getProperty(name)
+    const jsHandle = await elementHandle.getProperty(name as any)
     if (!jsHandle) {
         return null
     }

--- a/packages/devtools/src/commands/performActions.ts
+++ b/packages/devtools/src/commands/performActions.ts
@@ -1,6 +1,6 @@
 import type { KeyInput } from 'puppeteer-core/lib/esm/puppeteer/common/USKeyboardLayout.js'
 import { _keyDefinitions } from 'puppeteer-core/lib/esm/puppeteer/common/USKeyboardLayout.js'
-import type { Keyboard, Mouse } from 'puppeteer-core/lib/esm/puppeteer/common/Input.js'
+import type { Keyboard, Mouse } from 'puppeteer-core/lib/esm/puppeteer/api/Input.js'
 
 import getElementRect from './getElementRect.js'
 import getWindowRect from './getWindowRect.js'

--- a/packages/devtools/src/commands/switchToFrame.ts
+++ b/packages/devtools/src/commands/switchToFrame.ts
@@ -1,5 +1,5 @@
 import type { Page } from 'puppeteer-core/lib/esm/puppeteer/api/Page.js'
-import type { Frame } from 'puppeteer-core/lib/esm/puppeteer/common/Frame.js'
+import type { Frame } from 'puppeteer-core/lib/esm/puppeteer/api/Frame.js'
 import type { ElementReference } from '@wdio/protocols'
 
 import { ELEMENT_KEY } from '../constants.js'

--- a/packages/devtools/src/commands/switchToParentFrame.ts
+++ b/packages/devtools/src/commands/switchToParentFrame.ts
@@ -1,5 +1,5 @@
 import type { Page } from 'puppeteer-core/lib/esm/puppeteer/api/Page.js'
-import type { Frame } from 'puppeteer-core/lib/esm/puppeteer/common/Frame.js'
+import type { Frame } from 'puppeteer-core/lib/esm/puppeteer/api/Frame.js'
 import type DevToolsDriver from '../devtoolsdriver.js'
 
 /**

--- a/packages/devtools/src/devtoolsdriver.ts
+++ b/packages/devtools/src/devtoolsdriver.ts
@@ -9,10 +9,10 @@ import logger from '@wdio/logger'
 import type { CommandEndpoint } from '@wdio/protocols'
 
 import type { Browser } from 'puppeteer-core/lib/esm/puppeteer/api/Browser.js'
-import type { Dialog } from 'puppeteer-core/lib/esm/puppeteer/common/Dialog.js'
+import type { Dialog } from 'puppeteer-core/lib/esm/puppeteer/api/Dialog.js'
 import type { Page } from 'puppeteer-core/lib/esm/puppeteer/api/Page.js'
-import type { Target } from 'puppeteer-core/lib/esm/puppeteer/common/Target.js'
-import type { Frame } from 'puppeteer-core/lib/esm/puppeteer/common/Frame.js'
+import type { Target } from 'puppeteer-core/lib/esm/puppeteer/api/Target.js'
+import type { Frame } from 'puppeteer-core/lib/esm/puppeteer/api/Frame.js'
 
 import * as commands from './commands/index.js'
 import ElementStore from './elementstore.js'
@@ -300,7 +300,7 @@ export default class DevToolsDriver {
             : false
 
         try {
-            const executionContext = await page.mainFrame().executionContext()
+            const executionContext = await page.mainFrame()
             await executionContext.evaluate('1')
 
             /**

--- a/packages/devtools/src/elementstore.ts
+++ b/packages/devtools/src/elementstore.ts
@@ -1,5 +1,5 @@
 import type { ElementHandle } from 'puppeteer-core/lib/esm/puppeteer/api/ElementHandle.js'
-import type { Frame } from 'puppeteer-core/lib/esm/puppeteer/common/Frame.js'
+import type { Frame } from 'puppeteer-core/lib/esm/puppeteer/api/Frame.js'
 
 export default class ElementStore {
     private _index = 0
@@ -9,7 +9,7 @@ export default class ElementStore {
     set (elementHandle: ElementHandle) {
         const index = `ELEMENT-${++this._index}`
         this._elementMap.set(index, elementHandle)
-        const frame = elementHandle.executionContext()._world?.frame()
+        const frame = elementHandle.frame
         if (frame) {
             let elementIndexes = this._frameMap.get(frame)
             if (!elementIndexes) {

--- a/packages/devtools/src/types.ts
+++ b/packages/devtools/src/types.ts
@@ -53,7 +53,7 @@ export interface Client extends BaseClient, ProtocolCommands {
  */
 export interface ActiveListener {
     /** Event Emitter object emitting to the handler. */
-    emitter: PuppeteerEventEmitter
+    emitter: PuppeteerEventEmitter<any>
     /** Name of the event the handler is attached to. */
     eventName: string
     /** Event function handler, bound to the context of its class instance. */

--- a/packages/devtools/src/utils.ts
+++ b/packages/devtools/src/utils.ts
@@ -12,7 +12,7 @@ import { launch as launchChromeBrowser, type Options } from 'chrome-launcher'
 import type { Logger } from '@wdio/logger'
 import type { ElementHandle } from 'puppeteer-core/lib/esm/puppeteer/api/ElementHandle.js'
 import type { Browser } from 'puppeteer-core/lib/esm/puppeteer/api/Browser.js'
-import type { Frame } from 'puppeteer-core/lib/esm/puppeteer/common/Frame.js'
+import type { Frame } from 'puppeteer-core/lib/esm/puppeteer/api/Frame.js'
 import type { Page } from 'puppeteer-core/lib/esm/puppeteer/api/Page.js'
 
 import cleanUp from './scripts/cleanUpSerializationSelector.js'

--- a/packages/devtools/tests/elementStore.test.ts
+++ b/packages/devtools/tests/elementStore.test.ts
@@ -1,20 +1,18 @@
 import path from 'node:path'
 import { expect, test, vi } from 'vitest'
 import ElementStore from '../src/elementstore.js'
-import type { ElementHandle } from 'puppeteer-core/lib/esm/puppeteer/common/ElementHandle.js'
-import type { Frame } from 'puppeteer-core/lib/esm/puppeteer/common/Frame.js'
+import type { ElementHandle } from 'puppeteer-core/lib/esm/puppeteer/api/ElementHandle.js'
+import type { Frame } from 'puppeteer-core/lib/esm/puppeteer/api/Frame.js'
 
 vi.mock('@wdio/logger', () => import(path.join(process.cwd(), '__mocks__', '@wdio/logger')))
 
 const elementHandleFactory = (
     { isConnected = true, frame = Symbol() }: { isConnected?: boolean, frame?: symbol } = {}
 ) => ({
+    frame,
     id: Math.random(),
     async evaluate(cb: any) {
         return cb({ isConnected })
-    },
-    executionContext() {
-        return { _world: { frame: () => frame } }
     }
 })
 

--- a/packages/wdio-devtools-service/package.json
+++ b/packages/wdio-devtools-service/package.json
@@ -39,7 +39,7 @@
     "@wdio/logger": "8.38.0",
     "@wdio/types": "8.39.0",
     "babel-plugin-istanbul": "^7.0.0",
-    "devtools-protocol": "^0.0.1327118",
+    "devtools-protocol": "^0.0.1335233",
     "istanbul-lib-coverage": "^3.2.0",
     "istanbul-lib-report": "^3.0.0",
     "istanbul-reports": "^3.1.4",

--- a/packages/wdio-devtools-service/package.json
+++ b/packages/wdio-devtools-service/package.json
@@ -44,7 +44,7 @@
     "istanbul-lib-report": "^3.0.0",
     "istanbul-reports": "^3.1.4",
     "lighthouse": "8.6.0",
-    "puppeteer-core": "20.3.0",
+    "puppeteer-core": "^21.11.0",
     "webdriverio": "8.39.1"
   },
   "publishConfig": {

--- a/packages/wdio-devtools-service/src/commands.ts
+++ b/packages/wdio-devtools-service/src/commands.ts
@@ -1,9 +1,8 @@
 import logger from '@wdio/logger'
 
 import type { TraceEvent } from '@tracerbench/trace-event'
-import type { CDPSession } from 'puppeteer-core/lib/esm/puppeteer/common/Connection.js'
+import type { CDPSession } from 'puppeteer-core/lib/esm/puppeteer/api/CDPSession.js'
 import type { Page } from 'puppeteer-core/lib/esm/puppeteer/api/Page.js'
-import type { TracingOptions } from 'puppeteer-core/lib/esm/puppeteer/common/Tracing.js'
 
 import type { RequestPayload } from './handler/network.js'
 import NetworkHandler from './handler/network.js'
@@ -135,7 +134,7 @@ export default class CommandHandler {
         categories = DEFAULT_TRACING_CATEGORIES,
         path,
         screenshots = true
-    }: TracingOptions = {}) {
+    }: any = {}) {
         if (this._isTracing) {
             throw new Error('browser is already being traced')
         }

--- a/packages/wdio-devtools-service/src/gatherer/coverage.ts
+++ b/packages/wdio-devtools-service/src/gatherer/coverage.ts
@@ -10,7 +10,7 @@ import reports from 'istanbul-reports'
 import logger from '@wdio/logger'
 
 import type { Page } from 'puppeteer-core/lib/esm/puppeteer/api/Page.js'
-import type { CDPSession } from 'puppeteer-core/lib/esm/puppeteer/common/Connection.js'
+import type { CDPSession } from 'puppeteer-core/lib/esm/puppeteer/api/CDPSession.js'
 
 import type { CoverageReporterOptions, Coverage } from '../types.js'
 

--- a/packages/wdio-devtools-service/src/gatherer/pwa.ts
+++ b/packages/wdio-devtools-service/src/gatherer/pwa.ts
@@ -8,7 +8,7 @@ import LinkElements from 'lighthouse/lighthouse-core/gather/gatherers/link-eleme
 import ViewportDimensions from 'lighthouse/lighthouse-core/gather/gatherers/viewport-dimensions.js'
 import serviceWorkers from 'lighthouse/lighthouse-core/gather/driver/service-workers.js'
 
-import type { CDPSession } from 'puppeteer-core/lib/esm/puppeteer/common/Connection.js'
+import type { CDPSession } from 'puppeteer-core/lib/esm/puppeteer/api/CDPSession.js'
 import type { Page } from 'puppeteer-core/lib/esm/puppeteer/api/Page.js'
 
 import collectMetaElements from '../scripts/collectMetaElements.js'

--- a/packages/wdio-devtools-service/src/gatherer/trace.ts
+++ b/packages/wdio-devtools-service/src/gatherer/trace.ts
@@ -7,8 +7,8 @@ import logger from '@wdio/logger'
 
 import type { Protocol } from 'devtools-protocol'
 import type { TraceEvent, TraceEventArgs } from '@tracerbench/trace-event'
-import type { HTTPRequest } from 'puppeteer-core/lib/esm/puppeteer/common/HTTPRequest.js'
-import type { CDPSession } from 'puppeteer-core/lib/esm/puppeteer/common/Connection.js'
+import type { HTTPRequest } from 'puppeteer-core/lib/esm/puppeteer/api/HTTPRequest.js'
+import type { CDPSession } from 'puppeteer-core/lib/esm/puppeteer/api/CDPSession.js'
 import type { Page } from 'puppeteer-core/lib/esm/puppeteer/api/Page.js'
 
 import registerPerformanceObserverInPage from '../scripts/registerPerformanceObserverInPage.js'

--- a/packages/wdio-devtools-service/src/handler/network.ts
+++ b/packages/wdio-devtools-service/src/handler/network.ts
@@ -1,4 +1,4 @@
-import type { CDPSession } from 'puppeteer-core/lib/esm/puppeteer/common/Connection.js'
+import type { CDPSession } from 'puppeteer-core/lib/esm/puppeteer/api/CDPSession.js'
 import type { Protocol } from 'devtools-protocol'
 
 import { IGNORED_URLS } from '../constants.js'
@@ -43,8 +43,8 @@ export default class NetworkHandler {
 
     constructor (session: CDPSession) {
         session.on('Network.dataReceived', this.onDataReceived.bind(this))
-        session.on('Network.responseReceived', this.onNetworkResponseReceived.bind(this))
-        session.on('Network.requestWillBeSent', this.onNetworkRequestWillBeSent.bind(this))
+        session.on('Network.responseReceived', this.onNetworkResponseReceived.bind(this) as any)
+        session.on('Network.requestWillBeSent', this.onNetworkRequestWillBeSent.bind(this) as any)
         session.on('Page.frameNavigated', this.onPageFrameNavigated.bind(this))
     }
 

--- a/packages/wdio-devtools-service/src/index.ts
+++ b/packages/wdio-devtools-service/src/index.ts
@@ -169,7 +169,7 @@ export default class DevToolsService implements Services.ServiceInstance {
                     (t) => t.url().includes(url)) :
                 await puppeteer.waitForTarget(
                     /* istanbul ignore next */
-                    (t) => t.type() === 'page' || Boolean(t._getTargetInfo().browserContextId))
+                    (t) => t.type() === 'page' || Boolean(t.browserContext().id))
 
             /* istanbul ignore next */
             if (!target) {

--- a/packages/wdio-devtools-service/src/types.ts
+++ b/packages/wdio-devtools-service/src/types.ts
@@ -1,7 +1,7 @@
 import type { TraceStreamJson } from '@tracerbench/trace-event'
 import type { ReportOptions } from 'istanbul-reports'
 import type { Totals, CoverageSummaryData } from 'istanbul-lib-coverage'
-import type { Viewport } from 'puppeteer-core/lib/esm/puppeteer/common/PuppeteerViewport.js'
+import type { Viewport } from 'puppeteer-core/lib/esm/puppeteer/common/Viewport.js'
 import type { NETWORK_STATES, PWA_AUDITS } from './constants.js'
 
 export interface DevtoolsConfig {

--- a/packages/wdio-devtools-service/src/utils.ts
+++ b/packages/wdio-devtools-service/src/utils.ts
@@ -1,5 +1,5 @@
-import type { CDPSession } from 'puppeteer-core/lib/esm/puppeteer/common/Connection.js'
-import type { Target } from 'puppeteer-core/lib/esm/puppeteer/common/Target.js'
+import type { CDPSession } from 'puppeteer-core/lib/esm/puppeteer/api/CDPSession.js'
+import type { Target } from 'puppeteer-core/lib/esm/puppeteer/api/Target.js'
 import Driver from 'lighthouse/lighthouse-core/gather/driver.js'
 
 import ChromeProtocol from './lighthouse/cri.js'
@@ -68,11 +68,13 @@ export async function getLighthouseDriver (session: CDPSession, target: Target):
     if (!cUrl.pathname.startsWith('/devtools/browser')) {
         await cdpConnection._connectToSocket({
             webSocketDebuggerUrl: connection.url(),
+            // @ts-expect-error
             id: target._targetId
         })
         const { sessionId } = await cdpConnection.sendCommand(
             'Target.attachToTarget',
             undefined,
+            // @ts-expect-error
             { targetId: target._targetId, flatten: true }
         )
         cdpConnection.setSessionId(sessionId)

--- a/packages/webdriverio/package.json
+++ b/packages/webdriverio/package.json
@@ -87,7 +87,7 @@
     "lodash.clonedeep": "^4.5.0",
     "lodash.zip": "^4.2.0",
     "minimatch": "^9.0.0",
-    "puppeteer-core": "^20.9.0",
+    "puppeteer-core": "^21.11.0",
     "query-selector-shadow-dom": "^1.0.0",
     "resq": "^1.9.1",
     "rgb2hex": "0.2.5",

--- a/packages/webdriverio/package.json
+++ b/packages/webdriverio/package.json
@@ -79,7 +79,7 @@
     "aria-query": "^5.0.0",
     "css-shorthand-properties": "^1.1.1",
     "css-value": "^0.0.1",
-    "devtools-protocol": "^0.0.1327118",
+    "devtools-protocol": "^0.0.1335233",
     "grapheme-splitter": "^1.0.2",
     "import-meta-resolve": "^4.0.0",
     "is-plain-obj": "^4.1.0",

--- a/packages/webdriverio/src/commands/browser/mock.ts
+++ b/packages/webdriverio/src/commands/browser/mock.ts
@@ -5,7 +5,7 @@ import DevtoolsNetworkInterception from '../../utils/interception/devtools.js'
 import WebDriverNetworkInterception from '../../utils/interception/webdriver.js'
 import type { Mock } from '../../types.js'
 import type { MockFilterOptions } from '../../utils/interception/types.js'
-import type { CDPSession } from 'puppeteer-core/lib/esm/puppeteer/common/Connection.js'
+import type { CDPSession } from 'puppeteer-core/lib/esm/puppeteer/api/CDPSession.js'
 
 export const SESSION_MOCKS: Record<string, Set<Interception>> = {}
 export const CDP_SESSIONS: Record<string, CDPSession> = {}
@@ -168,7 +168,7 @@ export async function mock (
         client.on(
             'Fetch.requestPaused',
             (NetworkInterception as unknown as typeof DevtoolsNetworkInterception)
-                .handleRequestInterception(client, SESSION_MOCKS[handle])
+                .handleRequestInterception(client, SESSION_MOCKS[handle]) as any
         )
     }
 

--- a/packages/webdriverio/src/utils/interception/devtools.ts
+++ b/packages/webdriverio/src/utils/interception/devtools.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs/promises'
 import path from 'node:path'
 import logger from '@wdio/logger'
-import type { CDPSession } from 'puppeteer-core/lib/esm/puppeteer/common/Connection.js'
+import type { CDPSession } from 'puppeteer-core/lib/esm/puppeteer/api/CDPSession.js'
 import type { Protocol } from 'devtools-protocol'
 
 import Interception from './index.js'

--- a/packages/webdriverio/src/utils/interception/types.ts
+++ b/packages/webdriverio/src/utils/interception/types.ts
@@ -1,4 +1,4 @@
-import type { CDPSession } from 'puppeteer-core/lib/esm/puppeteer/common/Connection.js'
+import type { CDPSession } from 'puppeteer-core/lib/esm/puppeteer/api/CDPSession.js'
 import type { JsonCompatible } from '@wdio/types'
 
 /**


### PR DESCRIPTION
## Proposed changes

There has been a vulnerability detected in `ws` which can be resolved by updating Puppeteer to `21.11.0`. Unfortunately due to the fact that Puppeteer v22 drops support for Node.js v16 there is no way we can update to latest.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
