### PR TITLE
fix(@wdio/runner): retry on Outdated Optimize Dep Vite errors (#13330)

### DIFF
--- a/packages/wdio-runner/src/browser.ts
+++ b/packages/wdio-runner/src/browser.ts
@@ -24,6 +24,13 @@ interface TestState {
     hasViteError?: boolean
 }
 
+interface LogMessage {
+    level: string
+    message: string
+    source: string
+    timestamp: number
+}
+
 declare global {
     interface Window {
         __wdioErrors__: WDIOErrorEvent[]
@@ -34,6 +41,7 @@ declare global {
 }
 
 export default class BrowserFramework implements Omit<TestFramework, 'init'> {
+    #retryOutdatedOptimizeDep = false
     #runnerOptions: any // `any` here because we don't want to create a dependency to @wdio/browser-runner
     #resolveTestStatePromise?: (value: TestState) => void
 
@@ -94,6 +102,7 @@ export default class BrowserFramework implements Omit<TestFramework, 'init'> {
     }
 
     async #runSpec (spec: string, retried = false): Promise<number> {
+        this.#retryOutdatedOptimizeDep = false
         const timeout = this._config.mochaOpts?.timeout || DEFAULT_TIMEOUT
         log.info(`Run spec file ${spec} for cid ${this._cid}`)
 
@@ -426,6 +435,35 @@ export default class BrowserFramework implements Omit<TestFramework, 'init'> {
                 events: [],
                 failures: 1,
                 ...testError
+            })
+        }
+
+        /**
+         * check for outdated optimize dep errors that occasionally happen in Vite
+         */
+        const logs = (await browser.getLogs('browser').catch(() => [])).filter((log: LogMessage) => log.level === 'SEVERE') as LogMessage[]
+        if (logs.length) {
+            if (!this.#retryOutdatedOptimizeDep && logs.some((log) => log.message?.includes('(Outdated Optimize Dep)'))) {
+                log.info('Retry test run due to outdated optimize dep')
+                this.#retryOutdatedOptimizeDep = true
+                return browser.refresh()
+            }
+
+            this.#resolveTestStatePromise?.({
+                events: [],
+                failures: 1,
+                hasViteError: false,
+                /**
+                 * error messages often look like:
+                 * "http://localhost:40167/node_modules/.vite/deps/expect.js?v=bca8e2f3 - Failed to load resource: the server responded with a status of 504 (Outdated Optimize Dep)"
+                 */
+                errors: logs.map((log) => {
+                    const [filename, message] = log.message!.split(' - ')
+                    return {
+                        filename: filename.startsWith('http') ? filename : undefined,
+                        message
+                    }
+                })
             })
         }
     }


### PR DESCRIPTION
## Proposed changes

Sometimes Vite throws this Outdated Optimize Dep error which we should fix by better bundling WebdriverIO. Until we do that, this patch will help resolve these flakiness by just reloading the page which should give Vite the chance to properly optimize the deps. Furthermore this check helps to make sure we fail the process early in cases a network error happens when the testpage is loaded.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
