### PR TITLE
feat(webdriverio): support more complex selectors in bidi

### DIFF
--- a/packages/webdriver/src/bidi/core.ts
+++ b/packages/webdriver/src/bidi/core.ts
@@ -61,11 +61,11 @@ export class BidiCore {
     #handleResponse (data: RawData) {
         try {
             const payload = JSON.parse(data.toString()) as CommandResponse
-            if (!payload.id) {
+            if (typeof payload.id === 'undefined') {
                 return
             }
 
-            log.debug('BIDI RESULT', data.toString())
+            log.info('BIDI RESULT', JSON.stringify(payload.result))
             this.client?.emit('bidiResult', payload)
             const resolve = this.#pendingCommands.get(payload.id)
             if (!resolve) {

--- a/packages/webdriverio/src/utils/findStrategy.ts
+++ b/packages/webdriverio/src/utils/findStrategy.ts
@@ -248,19 +248,9 @@ export const findStrategy = function (selector: SelectorStrategy, isW3C?: boolea
     }
     case 'xpath extended': {
         using = 'xpath'
-        const match = stringSelector.match(new RegExp(XPATH_SELECTOR_REGEXP.map(rx => rx.source).join('')))
-        if (!match) {
-            throw new Error(`InvalidSelectorMatch: Strategy 'xpath extended' has failed to match '${stringSelector}'`)
-        }
         const PREFIX_NAME: Record<string, string> = { '.': 'class', '#': 'id' }
         const conditions: Array<string> = []
-        const [
-            tag,
-            prefix, name,
-            attrName, attrValue,
-            insensitive,
-            partial, query
-        ] = match.slice(1)
+        const { tag, prefix, name, attrName, attrValue, insensitive, partial, query } = parseExtendedXPathSelector(stringSelector)
 
         if (prefix) {
             if (prefix === '.') {
@@ -343,4 +333,23 @@ const createRoleBaseXpathSelector = (role: ARIARoleDefinitionKey) => {
         xpathLocator += ',' + loc
     })
     return xpathLocator
+}
+
+export function isExtendedXPathSelector (selector: string) {
+    return Boolean(selector.match(new RegExp(XPATH_SELECTOR_REGEXP.map(rx => rx.source).join(''))))
+}
+
+export function parseExtendedXPathSelector (selector: string) {
+    const match = selector.match(new RegExp(XPATH_SELECTOR_REGEXP.map(rx => rx.source).join('')))
+    if (!match) {
+        throw new Error(`InvalidSelectorMatch: Strategy 'xpath extended' has failed to match '${selector}'`)
+    }
+    const [
+        tag,
+        prefix, name,
+        attrName, attrValue,
+        insensitive,
+        partial, query
+    ] = match.slice(1)
+    return { tag, prefix, name, attrName, attrValue, insensitive, partial, query }
 }


### PR DESCRIPTION
## Proposed changes

Enable support for select by text.

We currently have two problems with this:

- with this change, it doesn't make a difference between `span=Hello World` and `i=Hello World`
- we can't use xPath (like in WebDriver classic) because it isn't possible to evaluate it on a document fragment

However it is still better to what we have atm.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
