### PR TITLE
feat(webdriverio): init script improvements

### DIFF
--- a/packages/webdriverio/src/commands/browser/url.ts
+++ b/packages/webdriverio/src/commands/browser/url.ts
@@ -1,5 +1,6 @@
 import { validateUrl } from '../../utils/index.js'
 import { networkManager } from '../../networkManager.js'
+import type { InitScript } from './addInitScript.js'
 
 type WaitState = 'none' | 'interactive' | 'networkIdle' | 'complete'
 
@@ -166,7 +167,7 @@ export async function url (
     }
 
     if (this.isBidi) {
-        let resetPreloadScript: () => Promise<any> = async () => {}
+        let resetPreloadScript: InitScript | undefined
         const context = await this.getWindowHandle()
 
         /**
@@ -223,7 +224,7 @@ export async function url (
          * clear up preload script
          */
         if (resetPreloadScript) {
-            await resetPreloadScript()
+            await resetPreloadScript.remove()
         }
 
         return request

--- a/packages/webdriverio/src/types.ts
+++ b/packages/webdriverio/src/types.ts
@@ -18,6 +18,10 @@ export * from './utils/interception/types.js'
  * re-export action primitives
  */
 export * from './utils/actions/index.js'
+/**
+ * re-export command types
+ */
+export { InitScript } from './commands/browser/addInitScript.js'
 
 type $BrowserCommands = typeof BrowserCommands
 type $ElementCommands = typeof ElementCommands

--- a/packages/webdriverio/src/utils/bidi/index.ts
+++ b/packages/webdriverio/src/utils/bidi/index.ts
@@ -32,11 +32,6 @@ export function parseScriptResult(result: local.ScriptEvaluateResult) {
 export function deserializeValue(result: remote.ScriptLocalValue) {
     // @ts-expect-error
     const { type, value } = result
-    if (value === NonPrimitiveType.Object) {
-        return Object.fromEntries(value.map(([key, value]: [any, any]) => {
-            return [deserializeValue(key), deserializeValue(value)]
-        }))
-    }
     if (type === NonPrimitiveType.RegularExpression) {
         return new RegExp(value.pattern, value.flags)
     }
@@ -73,7 +68,7 @@ export function deserializeValue(result: remote.ScriptLocalValue) {
         return null
     }
     if (type === NonPrimitiveType.Object) {
-        return Object.fromEntries(value.map(([key, value]: [any, any]) => {
+        return Object.fromEntries((value || []).map(([key, value]: [any, any]) => {
             return [typeof key === 'string' ? key : deserializeValue(key), deserializeValue(value)]
         }))
     }


### PR DESCRIPTION
## Proposed changes

This patch improves the functionality of the `initScript` command and incorporates the ability to assign a channel parameter to the script, allowing us to send results back to the Node.js world, e.g.:

```ts
const script = await browser.addInitScript((emit) => {
    const observer = new MutationObserver((mutations) => {
        for (const mutation of mutations) {
            emit(mutation.target.nodeName)
        }
    })
    observer.observe(document, { childList: true, subtree: true })
})

script.on('data', (data) => {
    console.log(data)
})

await browser.url('https://webdriver.io')
```

In this example we get an event every time a change is made to a DOM node.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
