### PR TITLE
feat(webdriverio): implement auto waiting for element to become inter…

### DIFF
--- a/e2e/browser-runner/lit.test.js
+++ b/e2e/browser-runner/lit.test.js
@@ -235,9 +235,35 @@ describe('Lit Component testing', () => {
         )
 
         const err = await $('input').click().catch((err) => err)
-        expect(err.name).toBe('element not interactable')
-        expect(err.message).toBe('Element <input style="display: none;"> not interactable')
+        expect(err.name).toBe('webdriverio(middleware): element did not become interactable')
+        expect(err.message).toBe('Element <input style="display: none;"> did not become interactable')
         expect(err.stack).toContain('at getErrorFromResponseBody')
+    })
+
+    it('intercepts "element not interactable" errors and waits for the element to be interactable', async () => {
+        render(
+            html`<input style="display: none;" />`,
+            document.body
+        )
+
+        setTimeout(() => {
+            document.querySelector('input').setAttribute('style', '')
+        }, 1000)
+
+        await $('input').click()
+    })
+
+    it('intercepts "element not interactable" errors and waits for the element in array to be interactable', async () => {
+        render(
+            html`<input style="display: none;" />`,
+            document.body
+        )
+
+        setTimeout(() => {
+            document.querySelector('input').setAttribute('style', '')
+        }, 1000)
+
+        await $$('input')[0].click()
     })
 
     it('should allow to auto mock dependencies', () => {

--- a/e2e/wdio/headless/test.e2e.ts
+++ b/e2e/wdio/headless/test.e2e.ts
@@ -94,7 +94,7 @@ describe('main suite 1', () => {
         ])
         expect(sameScrollPosition).toEqual([x, y])
 
-        browser.scroll(0, -y)
+        await browser.scroll(0, -y)
         const oldScrollPosition = await browser.execute(() => [
             window.scrollX, window.scrollY
         ])

--- a/e2e/wdio/headless/test.e2e.ts
+++ b/e2e/wdio/headless/test.e2e.ts
@@ -94,7 +94,7 @@ describe('main suite 1', () => {
         ])
         expect(sameScrollPosition).toEqual([x, y])
 
-        await browser.scroll(0, -y)
+        await browser.scroll(0, Math.floor(-y))
         const oldScrollPosition = await browser.execute(() => [
             window.scrollX, window.scrollY
         ])
@@ -202,8 +202,8 @@ describe('main suite 1', () => {
             expect(value.endsWith('center\n')).toBe(true)
         })
 
-        after(() => {
-            browser.switchToParentFrame()
+        after(async () => {
+            await browser.switchToParentFrame()
         })
     })
 

--- a/packages/webdriverio/src/middlewares.ts
+++ b/packages/webdriverio/src/middlewares.ts
@@ -42,9 +42,14 @@ export const elementErrorHandler = (fn: Function) => (commandName: string, comma
                 return result
             } catch (err: any) {
                 if (err.name === 'element not interactable') {
-                    const elementHTML = await element.getHTML()
-                    err.message = `Element ${elementHTML} not interactable`
-                    err.stack = err.stack ?? Error.captureStackTrace(err)
+                    try {
+                        return await element.waitForClickable()
+                    } catch (error) {
+                        const elementHTML = await element.getHTML()
+                        err.name = 'webdriverio(middleware): element did not become interactable'
+                        err.message = `Element ${elementHTML} did not become interactable`
+                        err.stack = err.stack ?? Error.captureStackTrace(err)
+                    }
                 }
 
                 if (err.name === 'stale element reference' || isStaleElementError(err)) {

--- a/website/docs/AutoWait.md
+++ b/website/docs/AutoWait.md
@@ -3,55 +3,18 @@ id: autowait
 title: Auto-waiting
 ---
 
-One of the most common reasons for flaky tests are interactions with elements that don't exist in your application at the time you want to interact with it. Modern web applications are very dynamic, elements show up and disappear. As a human we are waiting unconsciously for elements but in an automated script we don't consider this as an action. There are two ways to wait on an element to show up.
+When using a command that directly interacts with an element WebdriverIO will automatically wait for the element to be visible and interactable, no manual waits are needed when using the commands (think of click, setValue etc).
+An element is considered interactable when the conditions for [isClickable](https://webdriver.io/docs/api/element/isClickable) are met.
 
-## Implicit vs. Explicit
+While WebdriverIO automatically waits for elements to become interactable, there are rare cases for which you might need to manually wait. For these rare cases we offer commands such as [`waitForDisplayed`](/docs/api/element/waitForDisplayed).
 
-The WebDriver protocol offers [implicit timeouts](https://w3c.github.io/webdriver/#timeouts) that allow specify how long the driver is suppose to wait for an element to show up. By default this timeout is set to `0` and therefore makes the driver return with an `no such element` error immediately if an element could not be found on the page. Increasing this timeout using the [`setTimeout`](/docs/api/browser/setTimeout) would make the driver wait and increases the chances that the element shows up eventually.
+
+## Implicit timeouts (not recommended)
+
+While we do not recommend using this but the WebDriver protocol offers [implicit timeouts](https://w3c.github.io/webdriver/#timeouts) that allow specify how long the driver is suppose to wait for an element to show up. By default this timeout is set to `0` and therefore makes the driver return with an `no such element` error immediately if an element could not be found on the page. Increasing this timeout using the [`setTimeout`](/docs/api/browser/setTimeout) would make the driver wait and increases the chances that the element shows up eventually.
 
 :::note
 
 Read more about WebDriver and framework related timeouts in the [timeouts guide](/docs/timeouts)
 
 :::
-
-A different approach is to use explicit waiting which is built into the WebdriverIO framework in commands such as [`waitForExist`](/docs/api/element/waitForExist). With this technique the framework polls for the element by calling multiple [`findElements`](/docs/api/webdriver#findelements) commands until the timeout is reached.
-
-## Built-in Waiting
-
-Both waiting mechanisms are incompatible with each other and can cause longer wait times. As implicit waits are a global setting it is applied to all elements which is sometimes not the desired behavior. Therefore WebdriverIO provides a built-in wait mechanism that automatically explicitly waits on the element before interacting with it.
-
-:::info Recommendation
-
-We recommend __not__ using implicit waits at all and have WebdriverIO handle element wait actions.
-
-:::
-
-Using implicit waits is also problematic in cases you are interested to wait until an element disappears. WebdriverIO uses polls for the element until it receives an error. Having an implicit wait option set unnecessarily delays the execution of the command and can cause long test durations.
-
-You can set a default value for WebdriverIOs automatic explicit waiting by setting a [`waitforTimeout`](/docs/configuration#waitfortimeout) option in your configuration.
-
-## Limitations
-
-WebdriverIO can only wait for elements when they are implicitly defined. This is always the case when using the [`$`](/docs/api/browser/$) to fetch an element. It however is not supported when fetching a set of elements like this:
-
-```js
-const divs = await $$('div')
-await divs[1].click() // can throw "Cannot read property 'click' of undefined"
-```
-
-It is an absolute legitimate action to fetch a set of elements and click on the nth element of that set. However WebdriverIO doesn't know how many elements you are expecting to show up. As [`$$`](/docs/api/browser/$$) returns an [array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array) of WebdriverIO elements you have to manually check if the return value contains enough items. We recommend using [`waitUntil`](/docs/api/browser/waitUntil) for this, e.g.:
-
-```js
-const div = await browser.waitUntil(async () => {
-    const elems = await $$('div')
-    if (elems.length !== 2) {
-        return false
-    }
-
-    return elems[1]
-}, {
-    timeoutMsg: 'Never found enough div elements'
-})
-await div.click()
-```


### PR DESCRIPTION
Implement auto-waiting for elements to become interactable (only happens when the element isn't interactable).

How it works:

if the element will not become interactable within the time set by the waitforTimeout, it will throw the expected error message with html to notify the user which element did not become interactable.
if the element does become interactable within the time set by the waitforTimeout, it will continue the tests without errors

## Types of changes

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

### Reviewers: @webdriverio/project-committers
