### PR TITLE
fix(webdriverio): don't allow to pass in empty array for startNodes

### DIFF
--- a/packages/wdio-browser-runner/src/vite/plugins/testrunner.ts
+++ b/packages/wdio-browser-runner/src/vite/plugins/testrunner.ts
@@ -42,7 +42,7 @@ const resolvedVirtualModuleId = '\0' + virtualModuleId
 const MODULES_TO_MOCK = [
     'import-meta-resolve', 'puppeteer-core', 'archiver', 'glob', 'ws', 'decamelize',
     'geckodriver', 'safaridriver', 'edgedriver', '@puppeteer/browsers', 'locate-app', 'wait-port',
-    'lodash.isequal', '@wdio/repl'
+    'lodash.isequal', '@wdio/repl', 'jszip'
 ]
 
 const POLYFILLS = [

--- a/packages/webdriverio/src/utils/index.ts
+++ b/packages/webdriverio/src/utils/index.ts
@@ -287,10 +287,10 @@ export async function findDeepElement(
 ): Promise<ElementReference | Error> {
     const browser = getBrowserObject(this)
     const shadowRootManager = getShadowRootManager(browser)
-    const handle = await browser.getWindowHandle()
+    const context = await browser.getWindowHandle()
 
     const shadowRoots = shadowRootManager.getShadowElementsByContextId(
-        handle,
+        context,
         (this as WebdriverIO.Element).elementId
     )
     const { using, value } = findStrategy(selector as string, this.isW3C, this.isMobile)
@@ -299,11 +299,12 @@ export async function findDeepElement(
     /**
      * look up selector within document and all shadow roots
      */
-    const deepElementResult = await browser.browsingContextLocateNodes({
-        locator,
-        context: handle,
-        startNodes: shadowRoots.map((shadowRootNodeId) => ({ sharedId: shadowRootNodeId }))
-    }).then(async (result) => {
+    const startNodes = shadowRoots.length > 0
+        ? shadowRoots.map((shadowRootNodeId) => ({ sharedId: shadowRootNodeId }))
+        : (this as WebdriverIO.Element).elementId
+            ? [{ sharedId: (this as WebdriverIO.Element).elementId }]
+            : undefined
+    const deepElementResult = await browser.browsingContextLocateNodes({ locator, context, startNodes }).then(async (result) => {
         const nodes: ExtendedElementReference[] = result.nodes.filter((node) => Boolean(node.sharedId)).map((node) => ({
             [ELEMENT_KEY]: node.sharedId as string,
             locator
@@ -351,10 +352,10 @@ export async function findDeepElements(
 ): Promise<ElementReference[]> {
     const browser = getBrowserObject(this)
     const shadowRootManager = getShadowRootManager(browser)
-    const handle = await browser.getWindowHandle()
+    const context = await browser.getWindowHandle()
 
     const shadowRoots = shadowRootManager.getShadowElementsByContextId(
-        handle,
+        context,
         (this as WebdriverIO.Element).elementId
     )
     const { using, value } = findStrategy(selector as string, this.isW3C, this.isMobile)
@@ -363,11 +364,12 @@ export async function findDeepElements(
     /**
      * look up selector within document and all shadow roots
      */
-    const deepElementResult = await browser.browsingContextLocateNodes({
-        locator,
-        context: handle,
-        startNodes: shadowRoots.map((shadowRootNodeId) => ({ sharedId: shadowRootNodeId }))
-    }).then(async (result) => {
+    const startNodes = shadowRoots.length > 0
+        ? shadowRoots.map((shadowRootNodeId) => ({ sharedId: shadowRootNodeId }))
+        : (this as WebdriverIO.Element).elementId
+            ? [{ sharedId: (this as WebdriverIO.Element).elementId }]
+            : undefined
+    const deepElementResult = await browser.browsingContextLocateNodes({ locator, context, startNodes }).then(async (result) => {
         const nodes: ExtendedElementReference[] = result.nodes.filter((node) => Boolean(node.sharedId)).map((node) => ({
             [ELEMENT_KEY]: node.sharedId as string,
             locator


### PR DESCRIPTION
## Proposed changes

While updating ecosystem packages we have discovered this bug where `startNodes` would be an empty array which appears to not be allowed in Bidi.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
