### PR TITLE
fix(webdriverio): update getHTML docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,8 @@ See [CHANGELOG - v8](https://github.com/webdriverio/webdriverio/blob/v8/CHANGELO
   * [#11942](https://github.com/webdriverio/webdriverio/pull/11942) breaking(*): V9 migrate from got to fetch ([@tamil777selvan](https://github.com/tamil777selvan))
 * `@wdio/protocols`
   * [#12006](https://github.com/webdriverio/webdriverio/pull/12006) breaking(@wdio/protocols): V9 Remove JSONWireProtocol ([@tamil777selvan](https://github.com/tamil777selvan))
+* `webdriverio`
+  * [#12490](https://github.com/webdriverio/webdriverio/pull/12490) allow getHTML to pierce through Shadow DOM ([@christian-bromann](https://github.com/christian-bromann))
 
 #### :rocket: New Feature
 * `webdriverio`

--- a/packages/webdriverio/src/commands/element/getHTML.ts
+++ b/packages/webdriverio/src/commands/element/getHTML.ts
@@ -10,30 +10,6 @@ import getHTMLShadowScript from '../../scripts/getHTMLShadow.js'
 const SHADOW_ID_ATTR_NAME = 'data-wdio-shadow-id'
 const SHADOW_ID_ATTR = `[${SHADOW_ID_ATTR_NAME}]`
 
-export interface GetHTMLOptions {
-    /**
-     * if true, it includes the selector element tag (default: true)
-     * @default true
-     */
-    includeSelectorTag?: boolean
-    /**
-     * if true, it includes content of the shadow roots of all web
-     * components in the DOM (default: true if WebDriver Bidi is enabled)
-     * @default true
-     */
-    pierceShadowRoot?: boolean
-    /**
-     * if true, it removes all comment nodes from the HTML, e.g. `<!--?lit$206212805$--><!--?lit$206212805$-->`
-     * @default true
-     */
-    removeCommentNodes?: boolean
-    /**
-     * if true, the html output will be prettified
-     * @default true
-     */
-    prettify?: boolean
-}
-
 /**
  *
  * Get source code of specified DOM element by selector. By default, it automatically
@@ -55,6 +31,32 @@ export interface GetHTMLOptions {
         console.log(innerHTML);
         // outputs:
         // "<span>Lorem ipsum dolor amet</span>"
+    });
+    :getHTMLShadow.js
+    it('allows to snapshot shadow dom', async () => {
+        await browser.url('https://ionicframework.com/docs/usage/v8/button/basic/demo.html?ionic:mode=md')
+
+        // get snapshot of web component without its styles
+        const snapshot = await $('ion-button').getHTML({ excludeElements: ['style'] })
+
+        // assert snapshot
+        await expect(snapshot).toMatchInlineSnapshot(`
+            <ion-button class="md button button-solid ion-activatable ion-focusable hydrated">Default
+                <template shadowrootmode="open">
+                    <button type="button" class="button-native" part="native">
+                    <span class="button-inner">
+                        <slot name="icon-only"></slot>
+                        <slot name="start"></slot>
+                        <slot></slot>
+                        <slot name="end"></slot>
+                    </span>
+                    <ion-ripple-effect role="presentation" class="md hydrated">
+                        <template shadowrootmode="open"></template>
+                    </ion-ripple-effect>
+                    </button>
+                </template>
+            </ion-button>
+        `)
     });
  * </example>
  *
@@ -85,11 +87,12 @@ export async function getHTML(
         throw new Error('The `getHTML` options parameter must be an object')
     }
 
-    const { includeSelectorTag, pierceShadowRoot, removeCommentNodes, prettify } = Object.assign({
+    const { includeSelectorTag, pierceShadowRoot, removeCommentNodes, prettify, excludeElements } = Object.assign({
         includeSelectorTag: true,
         pierceShadowRoot: true,
         removeCommentNodes: true,
-        prettify: true
+        prettify: true,
+        excludeElements: []
     }, options)
 
     const basicGetHTML = (elementId: string, includeSelectorTag: boolean) => {
@@ -150,7 +153,7 @@ export async function getHTML(
             mode: shadowRootManager.getShadowRootModeById(handle, id) || 'open'
         })))
 
-        return sanitizeHTML($, { removeCommentNodes, prettify })
+        return sanitizeHTML($, { removeCommentNodes, prettify, excludeElements })
     }
 
     const returnHTML = await basicGetHTML(this.elementId, includeSelectorTag)
@@ -203,6 +206,16 @@ function sanitizeHTML ($: CheerioAPI | string, options: GetHTMLOptions = {}): st
      * can cause failures when taking a snapshot of a Shadow DOM element
      */
     const isCheerioObject = $ && typeof $ !== 'string'
+
+    /**
+     * allow user to remove bloated or unwanted elements from the snapshot
+     */
+    if (isCheerioObject) {
+        for (const elemToRemove of (options.excludeElements || [])) {
+            $(elemToRemove).remove()
+        }
+    }
+
     let returnHTML = isCheerioObject ? $('body').html() as string : $
     if (options.removeCommentNodes) {
         returnHTML = returnHTML?.replace(/<!--[\s\S]*?-->/g, '')
@@ -210,4 +223,33 @@ function sanitizeHTML ($: CheerioAPI | string, options: GetHTMLOptions = {}): st
     return options.prettify
         ? prettifyFn(returnHTML)
         : returnHTML
+}
+
+export interface GetHTMLOptions {
+    /**
+     * if true, it includes the selector element tag (default: true)
+     * @default true
+     */
+    includeSelectorTag?: boolean
+    /**
+     * if true, it includes content of the shadow roots of all web
+     * components in the DOM (default: true if WebDriver Bidi is enabled)
+     * @default true
+     */
+    pierceShadowRoot?: boolean
+    /**
+     * if true, it removes all comment nodes from the HTML, e.g. `<!--?lit$206212805$--><!--?lit$206212805$-->`
+     * @default true
+     */
+    removeCommentNodes?: boolean
+    /**
+     * if true, the html output will be prettified
+     * @default true
+     */
+    prettify?: boolean
+    /**
+     * remove certain elements from the output, e.g. style tags or svg elements
+     * @default []
+     */
+    excludeElements?: string[]
 }

--- a/website/blog/2024-08-15-webdriverio-v9-release.md
+++ b/website/blog/2024-08-15-webdriverio-v9-release.md
@@ -233,6 +233,38 @@ const submitButton = await $('button[type="submit"]');
 await submitButton.click(); // automatically waits for the button to become enabled
 ```
 
+### Snapshot Testing of Web Components
+
+If your application uses a lot of web components, using the snapshot feature turned out to be not possible due to the fact that WebdriverIO struggled to look inside the [Shadow Root](https://www.google.com/search?q=shadow+root+mdn&sourceid=chrome&ie=UTF-8). With v9 WebdriverIO has now total visibility into all elements an allows to snapshot open and closed web components by transforming them into a [Declarative Shadow DOM](https://web.dev/articles/declarative-shadow-dom), e.g.:
+
+```ts
+await browser.url('https://ionicframework.com/docs/usage/v8/button/basic/demo.html?ionic:mode=md')
+
+// get snapshot of web component without its styles
+const snapshot = await $('ion-button').getHTML({ excludeElements: ['style'] })
+
+// assert snapshot
+await expect(snapshot).toMatchInlineSnapshot(`
+    <ion-button class="md button button-solid ion-activatable ion-focusable hydrated">Default
+        <template shadowrootmode="open">
+            <button type="button" class="button-native" part="native">
+            <span class="button-inner">
+                <slot name="icon-only"></slot>
+                <slot name="start"></slot>
+                <slot></slot>
+                <slot name="end"></slot>
+            </span>
+            <ion-ripple-effect role="presentation" class="md hydrated">
+                <template shadowrootmode="open"></template>
+            </ion-ripple-effect>
+            </button>
+        </template>
+    </ion-button>
+`)
+```
+
+To enable this feature we enhanced the `getHTML` command and replaced its previous boolean parameter with an object that allows better control about the command behavior. Read more about the new `GetHTMLOptions` options in the [`getHTML`](/docs/api/element/getHTML) command docs.
+
 ## Notable Breaking Changes
 
 We strive to minimize breaking changes to avoid requiring significant time for upgrades to the latest version of WebdriverIO. However, major releases offer an opportunity to remove deprecated interfaces that we no longer recommend using.


### PR DESCRIPTION
## Proposed changes

We missed to properly document the new `getHTML` command that supports piercing shadow roots. While working on the docs fix I discovered that the original PR introduced a new parameter `excludeElements` which was removed later on. I took the opportunity to bring it back as it seem to be useful when testing web components.

fixes #13378

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
