### PR TITLE
fix(webdriverio): issue generating sample project on V9  (#13413)

### DIFF
--- a/packages/wdio-cli/src/templates/exampleFiles/cucumber/step_definitions/steps.js.ejs
+++ b/packages/wdio-cli/src/templates/exampleFiles/cucumber/step_definitions/steps.js.ejs
@@ -30,7 +30,7 @@ When(/^I login with (\w+) and (.+)$/, async (username, password) => {
 
 Then(/^I should see a flash message saying (.*)$/, async (message) => {
     await expect(SecurePage.flashAlert).toBeExisting();
-    await expect(await SecurePage.flashAlert.getText()).toContain(message);
+    await expect(SecurePage.flashAlert).toHaveText(expect.stringContaining(message));
 });
 <% } else {
 
@@ -50,6 +50,6 @@ When(/^I login with (\w+) and (.+)$/, async (username, password) => {
 
 Then(/^I should see a flash message saying (.*)$/, async (message) => {
     await expect($('#flash')).toBeExisting();
-    await expect(await $('#flash').getText()).toContain(message);
+    await expect($('#flash')).toHaveText(expect.stringContaining(message));
 });
 <% } %>

--- a/packages/wdio-cli/src/templates/exampleFiles/cucumber/step_definitions/steps.js.ejs
+++ b/packages/wdio-cli/src/templates/exampleFiles/cucumber/step_definitions/steps.js.ejs
@@ -6,7 +6,7 @@
     : `const { expect, $ } = require('@wdio/globals')` %>
 <%
 /**
- * step definition without page objects
+ * step definition with page objects
  */
 if (answers.usePageObjects) { %>
 <%- answers.isUsingTypeScript || answers.esmSupport
@@ -30,12 +30,12 @@ When(/^I login with (\w+) and (.+)$/, async (username, password) => {
 
 Then(/^I should see a flash message saying (.*)$/, async (message) => {
     await expect(SecurePage.flashAlert).toBeExisting();
-    await expect(SecurePage.flashAlert).toHaveTextContaining(message);
+    await expect(await SecurePage.flashAlert.getText()).toContain(message);
 });
 <% } else {
 
 /**
- * step definition with page objects
+ * step definition without page objects
  */
 %>
 Given(/^I am on the (\w+) page$/, async (page) => {
@@ -50,6 +50,6 @@ When(/^I login with (\w+) and (.+)$/, async (username, password) => {
 
 Then(/^I should see a flash message saying (.*)$/, async (message) => {
     await expect($('#flash')).toBeExisting();
-    await expect($('#flash')).toHaveTextContaining(message);
+    await expect(await $('#flash').getText()).toContain(message);
 });
 <% } %>


### PR DESCRIPTION
Execution of newly created project using the config wizard reports an error due to the usage of toHaveTextContaining() function.

This fix replaces it with toContain() called on a string.

## Proposed changes

This chances the matchers invoked to validate the text to contain a specific string in the sample project generated with the WDIO config wizard. That's because the function used causes an error (probably deprecated?) 

toHaveTextContaining()  -> toContain()

No tests were added and I believe no tests were present already (I guess otherwise the issue would have been caught)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
