### PR TITLE
fix(docs): remove docs around intercept assertions in jasmine

### DIFF
--- a/website/docs/Frameworks.md
+++ b/website/docs/Frameworks.md
@@ -162,34 +162,6 @@ npm install @wdio/jasmine-framework --save-dev
 
 You can then configure your Jasmine environment by setting a `jasmineOpts` property in your config. A list of all options can be found on the [Jasmine project website](https://jasmine.github.io/api/3.5/Configuration.html).
 
-### Intercept Assertion
-
-The Jasmine framework allows it to intercept each assertion in order to log the state of the application or website, depending on the result.
-
-For example, it is pretty handy to take a screenshot every time an assertion fails. In your `jasmineOpts` you can add a property called `expectationResultHandler` that takes a function to execute. The function’s parameters provide information about the result of the assertion.
-
-The following example demonstrates how to take a screenshot if an assertion fails:
-
-```js
-jasmineOpts: {
-    defaultTimeoutInterval: 10000,
-    expectationResultHandler: function(passed, assertion) {
-        /**
-         * only take screenshot if assertion failed
-         */
-        if(passed) {
-            return
-        }
-
-        browser.saveScreenshot(`assertionError_${assertion.error.message}.png`)
-    }
-},
-```
-
-**Note:** You cannot stop test execution to do something async. It might happen that
-the command takes too much time and the website state has changed. (Though usually, after another 2
-commands the screenshot is taken anyway, which still gives _some_ valuable information about the error.)
-
 ### Jasmine Options
 
 The following options can be applied in your `wdio.conf.js` to configure your Jasmine environment using the `jasmineOpts` property. For more information on these configuration options, check out the [Jasmine docs](https://jasmine.github.io/api/edge/Configuration).
@@ -345,7 +317,7 @@ Paths to where your support code is, for ESM.
 
 Type: `String[]`<br />
 Default: `[]`
-Example: 
+Example:
 
 ```js
 cucumberOpts: {

--- a/website/i18n/ar/docusaurus-plugin-content-docs/current/Frameworks.md
+++ b/website/i18n/ar/docusaurus-plugin-content-docs/current/Frameworks.md
@@ -142,32 +142,6 @@ npm install @wdio/jasmine-framework --save-dev
 
 You can then configure your Jasmine environment by setting a `jasmineOpts` property in your config. A list of all options can be found on the [Jasmine project website](https://jasmine.github.io/api/3.5/Configuration.html).
 
-### Intercept Assertion
-
-The Jasmine framework allows it to intercept each assertion in order to log the state of the application or website, depending on the result.
-
-For example, it is pretty handy to take a screenshot every time an assertion fails. In your `jasmineOpts` you can add a property called `expectationResultHandler` that takes a function to execute. The function’s parameters provide information about the result of the assertion.
-
-The following example demonstrates how to take a screenshot if an assertion fails:
-
-```js
-jasmineOpts: {
-    defaultTimeoutInterval: 10000,
-    expectationResultHandler: function(passed, assertion) {
-        /**
-         * only take screenshot if assertion failed
-         */
-        if(passed) {
-            return
-        }
-
-        browser.saveScreenshot(`assertionError_${assertion.error.message}.png`)
-    }
-},
-```
-
-**Note:** You cannot stop test execution to do something async. It might happen that the command takes too much time and the website state has changed. (Though usually, after another 2 commands the screenshot is taken anyway, which still gives _some_ valuable information about the error.)
-
 ### Jasmine Options
 
 The following options can be applied in your `wdio.conf.js` to configure your Jasmine environment using the `jasmineOpts` property. For more information on these configuration options, check out the [Jasmine docs](https://jasmine.github.io/api/edge/Configuration).

--- a/website/i18n/bg/docusaurus-plugin-content-docs/current/Frameworks.md
+++ b/website/i18n/bg/docusaurus-plugin-content-docs/current/Frameworks.md
@@ -142,32 +142,6 @@ npm install @wdio/jasmine-framework --save-dev
 
 You can then configure your Jasmine environment by setting a `jasmineOpts` property in your config. A list of all options can be found on the [Jasmine project website](https://jasmine.github.io/api/3.5/Configuration.html).
 
-### Intercept Assertion
-
-The Jasmine framework allows it to intercept each assertion in order to log the state of the application or website, depending on the result.
-
-For example, it is pretty handy to take a screenshot every time an assertion fails. In your `jasmineOpts` you can add a property called `expectationResultHandler` that takes a function to execute. The function’s parameters provide information about the result of the assertion.
-
-The following example demonstrates how to take a screenshot if an assertion fails:
-
-```js
-jasmineOpts: {
-    defaultTimeoutInterval: 10000,
-    expectationResultHandler: function(passed, assertion) {
-        /**
-         * only take screenshot if assertion failed
-         */
-        if(passed) {
-            return
-        }
-
-        browser.saveScreenshot(`assertionError_${assertion.error.message}.png`)
-    }
-},
-```
-
-**Note:** You cannot stop test execution to do something async. It might happen that the command takes too much time and the website state has changed. (Though usually, after another 2 commands the screenshot is taken anyway, which still gives _some_ valuable information about the error.)
-
 ### Jasmine Options
 
 The following options can be applied in your `wdio.conf.js` to configure your Jasmine environment using the `jasmineOpts` property. For more information on these configuration options, check out the [Jasmine docs](https://jasmine.github.io/api/edge/Configuration).

--- a/website/i18n/fa/docusaurus-plugin-content-docs/current/Frameworks.md
+++ b/website/i18n/fa/docusaurus-plugin-content-docs/current/Frameworks.md
@@ -142,32 +142,6 @@ npm install @wdio/jasmine-framework --save-dev
 
 You can then configure your Jasmine environment by setting a `jasmineOpts` property in your config. A list of all options can be found on the [Jasmine project website](https://jasmine.github.io/api/3.5/Configuration.html).
 
-### Intercept Assertion
-
-The Jasmine framework allows it to intercept each assertion in order to log the state of the application or website, depending on the result.
-
-For example, it is pretty handy to take a screenshot every time an assertion fails. In your `jasmineOpts` you can add a property called `expectationResultHandler` that takes a function to execute. The function’s parameters provide information about the result of the assertion.
-
-The following example demonstrates how to take a screenshot if an assertion fails:
-
-```js
-jasmineOpts: {
-    defaultTimeoutInterval: 10000,
-    expectationResultHandler: function(passed, assertion) {
-        /**
-         * only take screenshot if assertion failed
-         */
-        if(passed) {
-            return
-        }
-
-        browser.saveScreenshot(`assertionError_${assertion.error.message}.png`)
-    }
-},
-```
-
-**Note:** You cannot stop test execution to do something async. It might happen that the command takes too much time and the website state has changed. (Though usually, after another 2 commands the screenshot is taken anyway, which still gives _some_ valuable information about the error.)
-
 ### Jasmine Options
 
 The following options can be applied in your `wdio.conf.js` to configure your Jasmine environment using the `jasmineOpts` property. For more information on these configuration options, check out the [Jasmine docs](https://jasmine.github.io/api/edge/Configuration).

--- a/website/i18n/fr/docusaurus-plugin-content-docs/current/Frameworks.md
+++ b/website/i18n/fr/docusaurus-plugin-content-docs/current/Frameworks.md
@@ -142,32 +142,6 @@ npm install @wdio/jasmine-framework --save-dev
 
 You can then configure your Jasmine environment by setting a `jasmineOpts` property in your config. A list of all options can be found on the [Jasmine project website](https://jasmine.github.io/api/3.5/Configuration.html).
 
-### Intercept Assertion
-
-The Jasmine framework allows it to intercept each assertion in order to log the state of the application or website, depending on the result.
-
-For example, it is pretty handy to take a screenshot every time an assertion fails. In your `jasmineOpts` you can add a property called `expectationResultHandler` that takes a function to execute. The function’s parameters provide information about the result of the assertion.
-
-The following example demonstrates how to take a screenshot if an assertion fails:
-
-```js
-jasmineOpts: {
-    defaultTimeoutInterval: 10000,
-    expectationResultHandler: function(passed, assertion) {
-        /**
-         * only take screenshot if assertion failed
-         */
-        if(passed) {
-            return
-        }
-
-        browser.saveScreenshot(`assertionError_${assertion.error.message}.png`)
-    }
-},
-```
-
-**Note:** You cannot stop test execution to do something async. It might happen that the command takes too much time and the website state has changed. (Though usually, after another 2 commands the screenshot is taken anyway, which still gives _some_ valuable information about the error.)
-
 ### Jasmine Options
 
 The following options can be applied in your `wdio.conf.js` to configure your Jasmine environment using the `jasmineOpts` property. For more information on these configuration options, check out the [Jasmine docs](https://jasmine.github.io/api/edge/Configuration).

--- a/website/i18n/it/docusaurus-plugin-content-docs/current/Frameworks.md
+++ b/website/i18n/it/docusaurus-plugin-content-docs/current/Frameworks.md
@@ -142,32 +142,6 @@ npm install @wdio/jasmine-framework --save-dev
 
 You can then configure your Jasmine environment by setting a `jasmineOpts` property in your config. A list of all options can be found on the [Jasmine project website](https://jasmine.github.io/api/3.5/Configuration.html).
 
-### Intercept Assertion
-
-The Jasmine framework allows it to intercept each assertion in order to log the state of the application or website, depending on the result.
-
-For example, it is pretty handy to take a screenshot every time an assertion fails. In your `jasmineOpts` you can add a property called `expectationResultHandler` that takes a function to execute. The function’s parameters provide information about the result of the assertion.
-
-The following example demonstrates how to take a screenshot if an assertion fails:
-
-```js
-jasmineOpts: {
-    defaultTimeoutInterval: 10000,
-    expectationResultHandler: function(passed, assertion) {
-        /**
-         * only take screenshot if assertion failed
-         */
-        if(passed) {
-            return
-        }
-
-        browser.saveScreenshot(`assertionError_${assertion.error.message}.png`)
-    }
-},
-```
-
-**Note:** You cannot stop test execution to do something async. It might happen that the command takes too much time and the website state has changed. (Though usually, after another 2 commands the screenshot is taken anyway, which still gives _some_ valuable information about the error.)
-
 ### Jasmine Options
 
 The following options can be applied in your `wdio.conf.js` to configure your Jasmine environment using the `jasmineOpts` property. For more information on these configuration options, check out the [Jasmine docs](https://jasmine.github.io/api/edge/Configuration).

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/Frameworks.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/Frameworks.md
@@ -142,32 +142,6 @@ npm install @wdio/jasmine-framework --save-dev
 
 You can then configure your Jasmine environment by setting a `jasmineOpts` property in your config. A list of all options can be found on the [Jasmine project website](https://jasmine.github.io/api/3.5/Configuration.html).
 
-### Intercept Assertion
-
-The Jasmine framework allows it to intercept each assertion in order to log the state of the application or website, depending on the result.
-
-For example, it is pretty handy to take a screenshot every time an assertion fails. In your `jasmineOpts` you can add a property called `expectationResultHandler` that takes a function to execute. The function’s parameters provide information about the result of the assertion.
-
-The following example demonstrates how to take a screenshot if an assertion fails:
-
-```js
-jasmineOpts: {
-    defaultTimeoutInterval: 10000,
-    expectationResultHandler: function(passed, assertion) {
-        /**
-         * only take screenshot if assertion failed
-         */
-        if(passed) {
-            return
-        }
-
-        browser.saveScreenshot(`assertionError_${assertion.error.message}.png`)
-    }
-},
-```
-
-**Note:** You cannot stop test execution to do something async. It might happen that the command takes too much time and the website state has changed. (Though usually, after another 2 commands the screenshot is taken anyway, which still gives _some_ valuable information about the error.)
-
 ### Jasmine Options
 
 The following options can be applied in your `wdio.conf.js` to configure your Jasmine environment using the `jasmineOpts` property. For more information on these configuration options, check out the [Jasmine docs](https://jasmine.github.io/api/edge/Configuration).

--- a/website/i18n/pl/docusaurus-plugin-content-docs/current/Frameworks.md
+++ b/website/i18n/pl/docusaurus-plugin-content-docs/current/Frameworks.md
@@ -142,32 +142,6 @@ npm install @wdio/jasmine-framework --save-dev
 
 You can then configure your Jasmine environment by setting a `jasmineOpts` property in your config. A list of all options can be found on the [Jasmine project website](https://jasmine.github.io/api/3.5/Configuration.html).
 
-### Intercept Assertion
-
-The Jasmine framework allows it to intercept each assertion in order to log the state of the application or website, depending on the result.
-
-For example, it is pretty handy to take a screenshot every time an assertion fails. In your `jasmineOpts` you can add a property called `expectationResultHandler` that takes a function to execute. The function’s parameters provide information about the result of the assertion.
-
-The following example demonstrates how to take a screenshot if an assertion fails:
-
-```js
-jasmineOpts: {
-    defaultTimeoutInterval: 10000,
-    expectationResultHandler: function(passed, assertion) {
-        /**
-         * only take screenshot if assertion failed
-         */
-        if(passed) {
-            return
-        }
-
-        browser.saveScreenshot(`assertionError_${assertion.error.message}.png`)
-    }
-},
-```
-
-**Note:** You cannot stop test execution to do something async. It might happen that the command takes too much time and the website state has changed. (Though usually, after another 2 commands the screenshot is taken anyway, which still gives _some_ valuable information about the error.)
-
 ### Jasmine Options
 
 The following options can be applied in your `wdio.conf.js` to configure your Jasmine environment using the `jasmineOpts` property. For more information on these configuration options, check out the [Jasmine docs](https://jasmine.github.io/api/edge/Configuration).

--- a/website/i18n/ru/docusaurus-plugin-content-docs/current/Frameworks.md
+++ b/website/i18n/ru/docusaurus-plugin-content-docs/current/Frameworks.md
@@ -142,32 +142,6 @@ npm install @wdio/jasmine-framework --save-dev
 
 You can then configure your Jasmine environment by setting a `jasmineOpts` property in your config. A list of all options can be found on the [Jasmine project website](https://jasmine.github.io/api/3.5/Configuration.html).
 
-### Intercept Assertion
-
-The Jasmine framework allows it to intercept each assertion in order to log the state of the application or website, depending on the result.
-
-For example, it is pretty handy to take a screenshot every time an assertion fails. In your `jasmineOpts` you can add a property called `expectationResultHandler` that takes a function to execute. The function’s parameters provide information about the result of the assertion.
-
-The following example demonstrates how to take a screenshot if an assertion fails:
-
-```js
-jasmineOpts: {
-    defaultTimeoutInterval: 10000,
-    expectationResultHandler: function(passed, assertion) {
-        /**
-         * only take screenshot if assertion failed
-         */
-        if(passed) {
-            return
-        }
-
-        browser.saveScreenshot(`assertionError_${assertion.error.message}.png`)
-    }
-},
-```
-
-**Note:** You cannot stop test execution to do something async. It might happen that the command takes too much time and the website state has changed. (Though usually, after another 2 commands the screenshot is taken anyway, which still gives _some_ valuable information about the error.)
-
 ### Jasmine Options
 
 The following options can be applied in your `wdio.conf.js` to configure your Jasmine environment using the `jasmineOpts` property. For more information on these configuration options, check out the [Jasmine docs](https://jasmine.github.io/api/edge/Configuration).

--- a/website/i18n/ta/docusaurus-plugin-content-docs/current/Frameworks.md
+++ b/website/i18n/ta/docusaurus-plugin-content-docs/current/Frameworks.md
@@ -142,32 +142,6 @@ npm install @wdio/jasmine-framework --save-dev
 
 You can then configure your Jasmine environment by setting a `jasmineOpts` property in your config. A list of all options can be found on the [Jasmine project website](https://jasmine.github.io/api/3.5/Configuration.html).
 
-### Intercept Assertion
-
-The Jasmine framework allows it to intercept each assertion in order to log the state of the application or website, depending on the result.
-
-For example, it is pretty handy to take a screenshot every time an assertion fails. In your `jasmineOpts` you can add a property called `expectationResultHandler` that takes a function to execute. The function’s parameters provide information about the result of the assertion.
-
-The following example demonstrates how to take a screenshot if an assertion fails:
-
-```js
-jasmineOpts: {
-    defaultTimeoutInterval: 10000,
-    expectationResultHandler: function(passed, assertion) {
-        /**
-         * only take screenshot if assertion failed
-         */
-        if(passed) {
-            return
-        }
-
-        browser.saveScreenshot(`assertionError_${assertion.error.message}.png`)
-    }
-},
-```
-
-**Note:** You cannot stop test execution to do something async. It might happen that the command takes too much time and the website state has changed. (Though usually, after another 2 commands the screenshot is taken anyway, which still gives _some_ valuable information about the error.)
-
 ### Jasmine Options
 
 The following options can be applied in your `wdio.conf.js` to configure your Jasmine environment using the `jasmineOpts` property. For more information on these configuration options, check out the [Jasmine docs](https://jasmine.github.io/api/edge/Configuration).

--- a/website/i18n/zh/docusaurus-plugin-content-docs/current/Frameworks.md
+++ b/website/i18n/zh/docusaurus-plugin-content-docs/current/Frameworks.md
@@ -142,32 +142,6 @@ npm install @wdio/jasmine-framework --save-dev
 
 You can then configure your Jasmine environment by setting a `jasmineOpts` property in your config. A list of all options can be found on the [Jasmine project website](https://jasmine.github.io/api/3.5/Configuration.html). You can then configure your Jasmine environment by setting a `jasmineOpts` property in your config. A list of all options can be found on the [Jasmine project website](https://jasmine.github.io/api/3.5/Configuration.html). A list of all options can be found on the [Jasmine project website](https://jasmine.github.io/api/3.5/Configuration.html).
 
-### Intercept Assertion
-
-The Jasmine framework allows it to intercept each assertion in order to log the state of the application or website, depending on the result.
-
-For example, it is pretty handy to take a screenshot every time an assertion fails. In your `jasmineOpts` you can add a property called `expectationResultHandler` that takes a function to execute. The function’s parameters provide information about the result of the assertion.
-
-The following example demonstrates how to take a screenshot if an assertion fails:
-
-```js
-jasmineOpts: {
-    defaultTimeoutInterval: 10000,
-    expectationResultHandler: function(passed, assertion) {
-        /**
-         * only take screenshot if assertion failed
-         */
-        if(passed) {
-            return
-        }
-
-        browser.saveScreenshot(`assertionError_${assertion.error.message}.png`)
-    }
-},
-```
-
-**Note:** You cannot stop test execution to do something async. It might happen that the command takes too much time and the website state has changed. (Though usually, after another 2 commands the screenshot is taken anyway, which still gives _some_ valuable information about the error.) It might happen that the command takes too much time and the website state has changed. (Though usually, after another 2 commands the screenshot is taken anyway, which still gives _some_ valuable information about the error.) It might happen that the command takes too much time and the website state has changed. (Though usually, after another 2 commands the screenshot is taken anyway, which still gives _some_ valuable information about the error.)
-
 ### Jasmine Options
 
 The following options can be applied in your `wdio.conf.js` to configure your Jasmine environment using the `jasmineOpts` property. For more information on these configuration options, check out the [Jasmine docs](https://jasmine.github.io/api/edge/Configuration). For more information on these configuration options, check out the [Jasmine docs](https://jasmine.github.io/api/edge/Configuration). For more information on these configuration options, check out the [Jasmine docs](https://jasmine.github.io/api/edge/Configuration).


### PR DESCRIPTION
## Proposed changes

fixes #13418

This functionality used to work when WebdriverIO would run commands synchronously. Since we moved fully async, it is not feasible to call WebdriverIO commands in Jasmine's `expectationResultHandler`. Instead, users should use `afterTest`.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
