### PR TITLE
fix(webdriver): lowercase browserName when checking whether to opt-in for bidi

### DIFF
--- a/packages/webdriver/src/utils.ts
+++ b/packages/webdriver/src/utils.ts
@@ -52,11 +52,8 @@ export async function startWebDriverSession (params: RemoteConfig): Promise<{ se
     /**
      * automatically opt-into WebDriver Bid (@ref https://w3c.github.io/webdriver-bidi/)
      */
-    if (!w3cCaps.alwaysMatch['wdio:enforceWebDriverClassic'] && typeof w3cCaps.alwaysMatch.browserName === 'string' && w3cCaps.alwaysMatch.browserName !== 'safari') {
+    if (!w3cCaps.alwaysMatch['wdio:enforceWebDriverClassic'] && typeof w3cCaps.alwaysMatch.browserName === 'string' && w3cCaps.alwaysMatch.browserName.toLowerCase() !== 'safari') {
         w3cCaps.alwaysMatch.webSocketUrl = true
-    }
-    if (!jsonwpCaps['wdio:enforceWebDriverClassic'] && typeof jsonwpCaps.browserName === 'string' && jsonwpCaps.browserName !== 'safari') {
-        jsonwpCaps.webSocketUrl = true
     }
 
     validateCapabilities(w3cCaps.alwaysMatch)

--- a/packages/webdriver/tests/utils.test.ts
+++ b/packages/webdriver/tests/utils.test.ts
@@ -370,6 +370,21 @@ describe('utils', () => {
                 .toBe(undefined)
         })
 
+        it('should not opt-in for Safari as it is not supported', async () => {
+            const params: RemoteConfig = {
+                hostname: 'localhost',
+                port: 4444,
+                path: '/',
+                protocol: 'http',
+                capabilities: {
+                    browserName: 'Safari'
+                }
+            }
+            await startWebDriverSession(params)
+            expect(JSON.parse(mockedFetch.mock.calls[0][1]?.body as string).capabilities.alwaysMatch.webSocketUrl)
+                .toBe(undefined)
+        })
+
         it('should allow to opt-out from bidi when using alwaysMatch', async () => {
             const params: RemoteConfig = {
                 hostname: 'localhost',


### PR DESCRIPTION
## Proposed changes

Currently if someone uses `Safari` as `browserName` WebdriverIO would opt-in to Bidi which would cause a failure as Safaridriver doesn't support it yet. To fix this, we have to lowercase the `browserName` when we do the check.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
