### PR TITLE
feat(webdriverio): set cookies via Bidi if supported

### DIFF
--- a/packages/wdio-protocols/src/types.ts
+++ b/packages/wdio-protocols/src/types.ts
@@ -75,7 +75,7 @@ export interface Timeouts {
     script?: number
 }
 
-export type SameSiteOptions = 'Lax' | 'Strict' | 'None'
+export type SameSiteOptions = 'lax' | 'strict' | 'none'
 export interface Cookie {
     /**
      * The name of the cookie.

--- a/packages/webdriverio/src/commands/browser/deleteCookies.ts
+++ b/packages/webdriverio/src/commands/browser/deleteCookies.ts
@@ -1,16 +1,67 @@
+import type { remote } from 'webdriver'
+
 /**
  * Delete cookies visible to the current page. By providing a cookie name it
  * just removes the single cookie or more when multiple names are passed.
  *
  * @alias browser.deleteCookies
- * @param {String | String[]} names  names of cookies to be deleted
- * @uses webdriver/deleteAllCookies,webdriver/deleteCookie
+ * @param {remote.StorageCookieFilter | remote.StorageCookieFilter[]} names  names of cookies to be deleted
  * @example https://github.com/webdriverio/example-recipes/blob/e8b147e88e7a38351b0918b4f7efbd9ae292201d/deleteCookies/example.js#L9-L29
  * @example https://github.com/webdriverio/example-recipes/blob/e8b147e88e7a38351b0918b4f7efbd9ae292201d/deleteCookies/example.js#L31-L35
  */
-export function deleteCookies(
+export async function deleteCookies(
     this: WebdriverIO.Browser,
-    names?: string | string[]
+    filter?: string | string[] | remote.StorageCookieFilter | remote.StorageCookieFilter[]
+): Promise<void> {
+    const filterArray = typeof filter === 'undefined'
+        ? undefined
+        : Array.isArray(filter) ? filter : [filter]
+
+    if (!this.isBidi) {
+        const names = filterArray?.map((f) => {
+            if (typeof f === 'object') {
+                const name = f.name
+                if (!name) {
+                    throw new Error('In WebDriver Classic you can only filter for cookie names')
+                }
+                return name
+            }
+            if (typeof f === 'string') {
+                return f
+            }
+
+            throw new Error(`Invalid value for cookie filter, expected 'string' or 'remote.StorageCookieFilter' but found "${typeof f}"`)
+        })
+        await deleteCookiesClassic.call(this, names)
+        return
+    }
+
+    if (!filterArray) {
+        await this.storageDeleteCookies({})
+        return
+    }
+
+    const bidiFilter = filterArray.map((f) => {
+        if (typeof f === 'string') {
+            return { name: f } as remote.StorageCookieFilter
+        }
+        if (typeof f === 'object') {
+            return f
+        }
+
+        throw new Error(`Invalid value for cookie filter, expected 'string' or 'remote.StorageCookieFilter' but found "${typeof f}"`)
+    })
+
+    await Promise.all(bidiFilter.map((filter) => (
+        this.storageDeleteCookies({ filter })
+    )))
+
+    return
+}
+
+function deleteCookiesClassic(
+    this: WebdriverIO.Browser,
+    names?: string[]
 ) {
     if (names === undefined) {
         return this.deleteAllCookies()

--- a/packages/webdriverio/src/commands/browser/getCookies.ts
+++ b/packages/webdriverio/src/commands/browser/getCookies.ts
@@ -1,4 +1,9 @@
+import logger from '@wdio/logger'
 import type { Cookie } from '@wdio/protocols'
+import type { remote } from 'webdriver'
+
+const log = logger('webdriverio')
+
 /**
  *
  * Retrieve a [cookie](https://w3c.github.io/webdriver/webdriver-spec.html#cookies)
@@ -22,29 +27,90 @@ import type { Cookie } from '@wdio/protocols'
         //    { name: 'test', value: '123' },
         //    { name: 'test2', value: '456' }
         // ]
+
+        // filter cookies by domain
+        const stagingCookies = await browser.getCookies({
+            domain: 'staging.myapplication.com'
+        })
     })
  * </example>
  *
  * @alias browser.getCookies
- * @param {String[]|String}       names  names of requested cookies (if omitted, all cookies will be returned)
- * @return {WebDriverCookie[]}          requested cookies if existing
- * @uses webdriver/getAllCookies
+ * @param {remote.StorageCookieFilter}  filter  an object that allows to filter for cookies with specific attributes
+ * @return {Cookie[]}                           requested cookies
  *
  */
 export async function getCookies(
     this: WebdriverIO.Browser,
-    names?: string | string[]
+    filter?: string | string[] | remote.StorageCookieFilter
 ): Promise<Cookie[]> {
-    if (names === undefined) {
+    /**
+     * check if filter is a string array and let users know that this feature
+     * is deprecated and will be removed in an upcoming version of WebdriverIO
+     */
+    const usesMultipleFilter = Array.isArray(filter) && filter.length > 1
+    if (!this.isBidi || usesMultipleFilter) {
+        return getCookiesClassic.call(this, filter)
+    }
+
+    const cookieFilter = getCookieFilter(filter)
+    const { cookies } = await this.storageGetCookies({ filter: cookieFilter })
+    return cookies.map((cookie) => ({
+        ...cookie,
+        value: cookie.value.type === 'base64' ? atob(cookie.value.value) : cookie.value.value
+    }))
+}
+
+/**
+ * Legacy WebDriver Classic way to fetch cookies
+ */
+async function getCookiesClassic(
+    this: WebdriverIO.Browser,
+    names?: string | string[] | remote.StorageCookieFilter
+): Promise<Cookie[]> {
+    if (!names) {
         return this.getAllCookies()
     }
 
-    const namesList = Array.isArray(names) ? names : [names]
-
-    if (namesList.every(obj => typeof obj !== 'string')) {
-        throw new Error('Invalid input (see https://webdriver.io/docs/api/browser/getCookies for documentation)')
+    const usesMultipleFilter = Array.isArray(names) && names.length > 1
+    if (usesMultipleFilter) {
+        log.warn(
+            'Passing a string array as filter for `getCookies` is deprecated and its ' +
+            'support will be removed in an upcoming version of WebdriverIO!'
+        )
+        const allCookies = await this.getAllCookies()
+        return allCookies.filter(cookie => names.includes(cookie.name))
     }
 
+    const filter = getCookieFilter(names)
     const allCookies = await this.getAllCookies()
-    return allCookies.filter(cookie => namesList.includes(cookie.name))
+    return allCookies.filter(cookie => (
+        !filter ||
+        cookie.name && filter.name === cookie.name ||
+        cookie.value && filter.value?.value === cookie.value ||
+        cookie.path && filter.path === cookie.path ||
+        cookie.domain && filter.domain === cookie.domain ||
+        cookie.sameSite && filter.sameSite === cookie.sameSite ||
+        cookie.expiry && filter.expiry === cookie.expiry ||
+        typeof cookie.httpOnly === 'boolean' && filter.httpOnly === cookie.httpOnly ||
+        typeof cookie.secure === 'boolean' && filter.secure === cookie.secure
+    ))
+}
+
+function getCookieFilter (names?: string | string[] | remote.StorageCookieFilter) {
+    if (!names) {
+        return
+    }
+
+    if (Array.isArray(names) && names.length > 1) {
+        throw new Error('Multiple cookie name filters are not supported')
+    }
+
+    return (Array.isArray(names) ? names : [names]).map((filter) => {
+        if (typeof filter === 'string') {
+            log.warn('Passing string values into `getCookie` is deprecated and its support will be removed in an upcoming version of WebdriverIO!')
+            return { name: filter } as remote.StorageCookieFilter
+        }
+        return filter
+    })[0]
 }

--- a/packages/webdriverio/src/commands/browser/setCookies.ts
+++ b/packages/webdriverio/src/commands/browser/setCookies.ts
@@ -64,8 +64,35 @@ export async function setCookies(
         throw new Error('Invalid input (see https://webdriver.io/docs/api/browser/setCookies for documentation)')
     }
 
-    for (const cookieObj of cookieObjsList) {
-        await this.addCookie(cookieObj)
+    /**
+     * if session doesn't use Bidi, use WebDriver Classic command
+     */
+    if (!this.isBidi) {
+        for (const cookieObj of cookieObjsList) {
+            await this.addCookie(cookieObj)
+        }
+        return
     }
+
+    /**
+     * only fetch current url of browsing context if not all cookies have a domain set
+     */
+    let url = new URL('http://localhost')
+    if (cookieObjsList.some((cookie) => typeof cookie.domain !== 'string')) {
+        url = new URL(await this.getUrl())
+    }
+
+    await Promise.all(cookieObjsList.map((cookie) => (
+        this.storageSetCookie({
+            cookie: {
+                ...cookie,
+                domain: cookie.domain || url.hostname,
+                value: {
+                    type: 'string',
+                    value: cookie.value,
+                }
+            }
+        })
+    )))
     return
 }

--- a/packages/webdriverio/src/commands/browser/setViewport.ts
+++ b/packages/webdriverio/src/commands/browser/setViewport.ts
@@ -1,6 +1,4 @@
 /// <reference path="../../types.ts" />
-import { getBrowserObject } from '@wdio/utils'
-
 import { getContextManager } from '../../context.js'
 
 const minWindowSize = 0
@@ -57,11 +55,10 @@ export async function setViewport(
         throw new Error('setViewport expects devicePixelRatio to be a number in the 0 to 2^31 − 1 range')
     }
 
-    const browser = getBrowserObject(this)
-    const contextManager = getContextManager(browser)
+    const contextManager = getContextManager(this)
     const context = await contextManager.getCurrentContext()
 
-    await browser.browsingContextSetViewport({
+    await this.browsingContextSetViewport({
         context,
         devicePixelRatio: options.devicePixelRatio || 1,
         viewport: {

--- a/packages/webdriverio/tests/commands/browser/deleteCookies.test.ts
+++ b/packages/webdriverio/tests/commands/browser/deleteCookies.test.ts
@@ -1,5 +1,5 @@
 import path from 'node:path'
-import { expect, describe, it, beforeAll, afterEach, vi } from 'vitest'
+import { expect, describe, it, beforeEach, beforeAll, afterEach, vi, type MockInstance } from 'vitest'
 import { remote } from '../../../src/index.js'
 
 vi.mock('fetch')
@@ -8,62 +8,140 @@ vi.mock('@wdio/logger', () => import(path.join(process.cwd(), '__mocks__', '@wdi
 describe('deleteCookies', () => {
     let browser: WebdriverIO.Browser
 
-    beforeAll(async () => {
-        browser = await remote({
-            baseUrl: 'http://foobar.com',
-            capabilities: {
-                browserName: 'foobar'
-            }
+    describe('classic', () => {
+        beforeAll(async () => {
+            browser = await remote({
+                baseUrl: 'http://foobar.com',
+                capabilities: {
+                    browserName: 'foobar'
+                }
+            })
         })
-    })
 
-    it('should delete all cookies', async () => {
-        await browser.deleteCookies()
+        it('should delete all cookies', async () => {
+            await browser.deleteCookies()
 
-        expect(vi.mocked(fetch).mock.calls[1][1]!.method).toBe('DELETE')
-        // @ts-expect-error mock implementation
-        expect(vi.mocked(fetch).mock.calls[1][0]!.pathname)
-            .toBe('/session/foobar-123/cookie')
-    })
-
-    it('should support passing a string', async () => {
-        await browser.deleteCookies('cookie1')
-
-        expect(vi.mocked(fetch).mock.calls[0][1]!.method).toBe('DELETE')
-        // @ts-expect-error mock implementation
-        expect(vi.mocked(fetch).mock.calls[0][0]!.pathname)
-            .toBe('/session/foobar-123/cookie/cookie1')
-    })
-
-    it('should support passing a array with a string', async () => {
-        await browser.deleteCookies(['cookie1'])
-
-        expect(vi.mocked(fetch).mock.calls[0][1]!.method).toBe('DELETE')
-        // @ts-expect-error mock implementation
-        expect(vi.mocked(fetch).mock.calls[0][0]!.pathname)
-            .toBe('/session/foobar-123/cookie/cookie1')
-    })
-
-    it('should delete cookies that match by name', async () => {
-        const cookieNames = ['cookie1', 'cookie2', 'cookie3']
-        await browser.deleteCookies(cookieNames)
-
-        cookieNames.forEach((name, i) => {
-            expect(vi.mocked(fetch).mock.calls[i][1]!.method).toBe('DELETE')
+            expect(vi.mocked(fetch).mock.calls[1][1]!.method).toBe('DELETE')
             // @ts-expect-error mock implementation
-            expect(vi.mocked(fetch).mock.calls[i][0]!.pathname)
-                .toBe(`/session/foobar-123/cookie/${name}`)
+            expect(vi.mocked(fetch).mock.calls[1][0]!.pathname)
+                .toBe('/session/foobar-123/cookie')
+        })
+
+        it('should support passing a string', async () => {
+            await browser.deleteCookies('cookie1')
+
+            expect(vi.mocked(fetch).mock.calls[0][1]!.method).toBe('DELETE')
+            // @ts-expect-error mock implementation
+            expect(vi.mocked(fetch).mock.calls[0][0]!.pathname)
+                .toBe('/session/foobar-123/cookie/cookie1')
+        })
+
+        it('should support passing a array with a string', async () => {
+            await browser.deleteCookies(['cookie1'])
+
+            expect(vi.mocked(fetch).mock.calls[0][1]!.method).toBe('DELETE')
+            // @ts-expect-error mock implementation
+            expect(vi.mocked(fetch).mock.calls[0][0]!.pathname)
+                .toBe('/session/foobar-123/cookie/cookie1')
+        })
+
+        it('should delete cookies that match by name', async () => {
+            const cookieNames = ['cookie1', 'cookie2', 'cookie3']
+            await browser.deleteCookies(cookieNames)
+
+            cookieNames.forEach((name, i) => {
+                expect(vi.mocked(fetch).mock.calls[i][1]!.method).toBe('DELETE')
+                // @ts-expect-error mock implementation
+                expect(vi.mocked(fetch).mock.calls[i][0]!.pathname)
+                    .toBe(`/session/foobar-123/cookie/${name}`)
+            })
+        })
+
+        it('should throw error if invalid arguments are passed', async () => {
+            // @ts-ignore test invalid input
+            await expect(browser.deleteCookies([2]))
+                .rejects
+                .toEqual(new Error('Invalid value for cookie filter, expected \'string\' or \'remote.StorageCookieFilter\' but found "number"'))
+        })
+
+        it('should support remote.StorageCookieFilter in classic if name is used', async () => {
+            await browser.deleteCookies([{ name: 'cookie123' }])
+
+            expect(vi.mocked(fetch).mock.calls[0][1]!.method).toBe('DELETE')
+            // @ts-expect-error mock implementation
+            expect(vi.mocked(fetch).mock.calls[0][0]!.pathname)
+                .toBe('/session/foobar-123/cookie/cookie123')
+        })
+
+        it('should throw if remote.StorageCookieFilter in classic is used with other value than name', async () => {
+            await expect(browser.deleteCookies([{ domain: 'cookie123' }]))
+                .rejects
+                .toEqual(new Error('In WebDriver Classic you can only filter for cookie names'))
+        })
+
+        afterEach(() => {
+            vi.mocked(fetch).mockClear()
         })
     })
 
-    it('should throw error if invalid arguments are passed', async () => {
-        // @ts-ignore test invalid input
-        await expect(browser.deleteCookies([2]))
-            .rejects
-            .toEqual(new Error('Invalid input (see https://webdriver.io/docs/api/browser/deleteCookies for documentation)'))
-    })
+    describe('bidi', () => {
+        let storageDeleteCookies: MockInstance
 
-    afterEach(() => {
-        vi.mocked(fetch).mockClear()
+        beforeAll(async () => {
+            browser = await remote({
+                baseUrl: 'http://foobar.com',
+                capabilities: {
+                    browserName: 'bidi'
+                }
+            })
+            storageDeleteCookies =  vi.spyOn(browser, 'storageDeleteCookies')
+            storageDeleteCookies.mockImplementation((() => {}) as any)
+        })
+
+        beforeEach(() => {
+            storageDeleteCookies.mockClear()
+        })
+
+        it('should delete all cookies', async () => {
+            await browser.deleteCookies()
+            expect(storageDeleteCookies).toBeCalledTimes(1)
+            expect(storageDeleteCookies).toBeCalledWith({})
+        })
+
+        it('should support passing a string', async () => {
+            await browser.deleteCookies('cookie1')
+            expect(storageDeleteCookies).toBeCalledTimes(1)
+            expect(storageDeleteCookies).toBeCalledWith({ filter: { name: 'cookie1' } })
+        })
+
+        it('should support passing an object', async () => {
+            await browser.deleteCookies({ domain: 'foobar.com' })
+            expect(storageDeleteCookies).toBeCalledTimes(1)
+            expect(storageDeleteCookies).toBeCalledWith({ filter: { domain: 'foobar.com' } })
+        })
+
+        it('should support passing a array with a string', async () => {
+            await browser.deleteCookies(['cookie1', 'cookie2'])
+            expect(storageDeleteCookies).toBeCalledTimes(2)
+            expect(storageDeleteCookies).toBeCalledWith({ filter: { name: 'cookie1' } })
+            expect(storageDeleteCookies).toBeCalledWith({ filter: { name: 'cookie2' } })
+        })
+
+        it('should support passing an array of objects', async () => {
+            await browser.deleteCookies([
+                { domain: 'foobar.com' },
+                { domain: 'foobar2.com' }
+            ])
+            expect(storageDeleteCookies).toBeCalledTimes(2)
+            expect(storageDeleteCookies).toBeCalledWith({ filter: { domain: 'foobar.com' } })
+            expect(storageDeleteCookies).toBeCalledWith({ filter: { domain: 'foobar2.com' } })
+        })
+
+        it('should throw error if invalid arguments are passed', async () => {
+            // @ts-ignore test invalid input
+            await expect(browser.deleteCookies([2]))
+                .rejects
+                .toEqual(new Error('Invalid value for cookie filter, expected \'string\' or \'remote.StorageCookieFilter\' but found "number"'))
+        })
     })
 })

--- a/packages/webdriverio/tests/commands/browser/getCookies.test.ts
+++ b/packages/webdriverio/tests/commands/browser/getCookies.test.ts
@@ -1,5 +1,5 @@
 import path from 'node:path'
-import { expect, describe, it, vi, afterEach, beforeAll } from 'vitest'
+import { expect, describe, it, vi, afterEach, beforeEach, beforeAll, type MockInstance } from 'vitest'
 import { remote } from '../../../src/index.js'
 
 vi.mock('fetch')
@@ -8,70 +8,120 @@ vi.mock('@wdio/logger', () => import(path.join(process.cwd(), '__mocks__', '@wdi
 describe('getCookies', () => {
     let browser: WebdriverIO.Browser
 
-    beforeAll(async () => {
-        browser = await remote({
-            baseUrl: 'http://foobar.com',
-            capabilities: {
-                browserName: 'foobar'
-            }
+    describe('classic', () => {
+        beforeAll(async () => {
+            browser = await remote({
+                baseUrl: 'http://foobar.com',
+                capabilities: {
+                    browserName: 'foobar'
+                }
+            })
+        })
+
+        beforeEach(() => {
+            vi.mocked(fetch).mockClear()
+        })
+
+        it('should return all cookies', async () => {
+            const cookies = await browser.getCookies()
+            expect(vi.mocked(fetch).mock.calls[0][1]!.method).toBe('GET')
+            // @ts-expect-error mock implementation
+            expect(vi.mocked(fetch).mock.calls[0][0]!.pathname)
+                .toBe('/session/foobar-123/cookie')
+            expect(cookies).toEqual([
+                { name: 'cookie1', value: 'dummy-value-1' },
+                { name: 'cookie2', value: 'dummy-value-2' },
+                { name: 'cookie3', value: 'dummy-value-3' },
+            ])
+        })
+
+        it('should support passing a string', async () => {
+            const cookies = await browser.getCookies('cookie1')
+
+            expect(vi.mocked(fetch).mock.calls[0][1]!.method).toBe('GET')
+            // @ts-expect-error mock implementation
+            expect(vi.mocked(fetch).mock.calls[0][0]!.pathname)
+                .toBe('/session/foobar-123/cookie')
+            expect(cookies).toEqual([{ name: 'cookie1', value: 'dummy-value-1' }])
+        })
+
+        it('should support passing a array with strings', async () => {
+            const cookies = await browser.getCookies(['cookie1'])
+
+            expect(vi.mocked(fetch).mock.calls[0][1]!.method).toBe('GET')
+            // @ts-expect-error mock implementation
+            expect(vi.mocked(fetch).mock.calls[0][0]!.pathname)
+                .toBe('/session/foobar-123/cookie')
+            expect(cookies).toEqual([{ name: 'cookie1', value: 'dummy-value-1' }])
+        })
+
+        it('should get all cookies and filter out cookies that match by name', async () => {
+            const cookieNames = ['cookie1', 'doesn-not-exist', 'cookie3']
+            const cookies = await browser.getCookies(cookieNames)
+
+            expect(vi.mocked(fetch).mock.calls[0][1]!.method).toBe('GET')
+            // @ts-expect-error mock implementation
+            expect(vi.mocked(fetch).mock.calls[0][0]!.pathname)
+                .toBe('/session/foobar-123/cookie')
+            expect(cookies).toEqual([
+                { name: 'cookie1', value: 'dummy-value-1' },
+                { name: 'cookie3', value: 'dummy-value-3' },
+            ])
+        })
+
+        it('should throw error if invalid arguments are passed', async () => {
+            // @ts-ignore test invalid input
+            const cookies = await browser.getCookies([2])
+            expect(cookies).toEqual([])
+        })
+
+        afterEach(() => {
+            vi.mocked(fetch).mockClear()
         })
     })
 
-    it('should return all cookies', async () => {
-        const cookies = await browser.getCookies()
-        expect(vi.mocked(fetch).mock.calls[1][1]!.method).toBe('GET')
-        // @ts-expect-error mock implementation
-        expect(vi.mocked(fetch).mock.calls[1][0]!.pathname)
-            .toBe('/session/foobar-123/cookie')
-        expect(cookies).toEqual([
-            { name: 'cookie1', value: 'dummy-value-1' },
-            { name: 'cookie2', value: 'dummy-value-2' },
-            { name: 'cookie3', value: 'dummy-value-3' },
-        ])
-    })
+    describe('bidi', () => {
+        let storageGetCookies: MockInstance
 
-    it('should support passing a string', async () => {
-        const cookies = await browser.getCookies('cookie1')
+        beforeAll(async () => {
+            browser = await remote({
+                baseUrl: 'http://foobar.com',
+                capabilities: {
+                    browserName: 'bidi'
+                }
+            })
 
-        expect(vi.mocked(fetch).mock.calls[0][1]!.method).toBe('GET')
-        // @ts-expect-error mock implementation
-        expect(vi.mocked(fetch).mock.calls[0][0]!.pathname)
-            .toBe('/session/foobar-123/cookie')
-        expect(cookies).toEqual([{ name: 'cookie1', value: 'dummy-value-1' }])
-    })
+            storageGetCookies =  vi.spyOn(browser, 'storageGetCookies')
+            storageGetCookies.mockImplementation((() => ({
+                cookies: [{
+                    name: 'cookie',
+                    value: {
+                        type: 'base64',
+                        value: btoa('hello world')
+                    }
+                }]
+            }) as any))
+        })
 
-    it('should support passing a array with strings', async () => {
-        const cookies = await browser.getCookies(['cookie1'])
+        beforeEach(() => {
+            vi.mocked(fetch).mockClear()
+            storageGetCookies.mockClear()
+        })
 
-        expect(vi.mocked(fetch).mock.calls[0][1]!.method).toBe('GET')
-        // @ts-expect-error mock implementation
-        expect(vi.mocked(fetch).mock.calls[0][0]!.pathname)
-            .toBe('/session/foobar-123/cookie')
-        expect(cookies).toEqual([{ name: 'cookie1', value: 'dummy-value-1' }])
-    })
+        it('should return all cookies', async () => {
+            const cookies = await browser.getCookies()
+            expect(storageGetCookies).toBeCalledTimes(1)
+            expect(storageGetCookies).toBeCalledWith({})
+            expect(cookies).toEqual([
+                {
+                    name: 'cookie',
+                    value: 'hello world'
+                }
+            ])
+        })
 
-    it('should get all cookies and filter out cookies that match by name', async () => {
-        const cookieNames = ['cookie1', 'doesn-not-exist', 'cookie3']
-        const cookies = await browser.getCookies(cookieNames)
-
-        expect(vi.mocked(fetch).mock.calls[0][1]!.method).toBe('GET')
-        // @ts-expect-error mock implementation
-        expect(vi.mocked(fetch).mock.calls[0][0]!.pathname)
-            .toBe('/session/foobar-123/cookie')
-        expect(cookies).toEqual([
-            { name: 'cookie1', value: 'dummy-value-1' },
-            { name: 'cookie3', value: 'dummy-value-3' },
-        ])
-    })
-
-    it('should throw error if invalid arguments are passed', async () => {
-        // @ts-ignore test invalid input
-        await expect(browser.getCookies([2]))
-            .rejects
-            .toEqual(new Error('Invalid input (see https://webdriver.io/docs/api/browser/getCookies for documentation)'))
-    })
-
-    afterEach(() => {
-        vi.mocked(fetch).mockClear()
+        afterEach(() => {
+            vi.mocked(fetch).mockClear()
+        })
     })
 })

--- a/packages/webdriverio/tests/commands/browser/setCookies.test.ts
+++ b/packages/webdriverio/tests/commands/browser/setCookies.test.ts
@@ -1,5 +1,5 @@
 import path from 'node:path'
-import { expect, describe, beforeAll, afterEach, it, vi } from 'vitest'
+import { expect, describe, beforeEach, beforeAll, afterEach, it, vi, type MockInstance } from 'vitest'
 
 import { remote } from '../../../src/index.js'
 
@@ -7,84 +7,139 @@ vi.mock('fetch')
 vi.mock('@wdio/logger', () => import(path.join(process.cwd(), '__mocks__', '@wdio/logger')))
 
 describe('setCookies', () => {
+    const cookie1 = { name: 'cookie1', value: 'dummy-value-1' }
+    const cookie2 = { name: 'cookie2', value: 'dummy-value-2' }
+    const cookie3 = { name: 'cookie2', value: 'dummy-value-3' }
     let browser: WebdriverIO.Browser
 
-    beforeAll(async () => {
-        browser = await remote({
-            baseUrl: 'http://foobar.com',
-            capabilities: {
-                browserName: 'foobar'
-            }
+    describe('classic', () => {
+        beforeAll(async () => {
+            browser = await remote({
+                baseUrl: 'http://foobar.com',
+                capabilities: {
+                    browserName: 'foobar'
+                }
+            })
         })
-    })
 
-    it('should output the expected format', async () => {
-        await browser.setCookies([{ name: 'cookie1', value: 'dummy-value-1' }])
-        expect(vi.mocked(fetch).mock.calls).toHaveLength(2!)
-        expect(vi.mocked(fetch).mock.calls[1][1]!.method).toBe('POST')
-        // @ts-expect-error mock implementation
-        expect(vi.mocked(fetch).mock.calls[1][0]!.pathname)
-            .toBe('/session/foobar-123/cookie')
-        expect(vi.mocked(fetch).mock.calls[1][1]!.body)
-            .toEqual(JSON.stringify({ 'cookie': { name: 'cookie1', value: 'dummy-value-1' } }))
-    })
-
-    it('should support passing an object', async () => {
-        await browser.setCookies({ name: 'cookie1', value: 'dummy-value-1' })
-        expect(vi.mocked(fetch).mock.calls).toHaveLength(1!)
-        expect(vi.mocked(fetch).mock.calls[0][1]!.method).toBe('POST')
-        // @ts-expect-error mock implementation
-        expect(vi.mocked(fetch).mock.calls[0][0]!.pathname)
-            .toBe('/session/foobar-123/cookie')
-        expect(vi.mocked(fetch).mock.calls[0][1]!.body)
-            .toEqual(JSON.stringify({ 'cookie': { name: 'cookie1', value: 'dummy-value-1' } }))
-    })
-
-    it('can be called multiple times', async () => {
-        await browser.setCookies({ name: 'cookie1', value: 'dummy-value-1' })
-        await browser.setCookies({ name: 'cookie2', value: 'dummy-value-1' })
-        expect(vi.mocked(fetch).mock.calls).toHaveLength(2!)
-        expect(vi.mocked(fetch).mock.calls[0][1]!.method).toBe('POST')
-        // @ts-expect-error mock implementation
-        expect(vi.mocked(fetch).mock.calls[0][0]!.pathname)
-            .toBe('/session/foobar-123/cookie')
-        expect(vi.mocked(fetch).mock.calls[0][1]!.body)
-            .toEqual(JSON.stringify({ 'cookie': { name: 'cookie1', value: 'dummy-value-1' } }))
-        expect(vi.mocked(fetch).mock.calls[1][1]!.method).toBe('POST')
-        // @ts-expect-error mock implementation
-        expect(vi.mocked(fetch).mock.calls[1][0]!.pathname)
-            .toBe('/session/foobar-123/cookie')
-        expect(vi.mocked(fetch).mock.calls[1][1]!.body)
-            .toEqual(JSON.stringify({ 'cookie': { name: 'cookie2', value: 'dummy-value-1' } }))
-    })
-
-    it('should work with multiple objects passed', async () => {
-        const cookies = [
-            { name: 'cookie1', value: 'dummy-value-1' },
-            { name: 'cookie2', value: 'dummy-value-2' },
-            { name: 'cookie3', value: 'dummy-value-3' }
-        ]
-
-        await browser.setCookies(cookies)
-
-        cookies.forEach((cookie, i) => {
-            expect(vi.mocked(fetch).mock.calls[i][1]!.method).toBe('POST')
+        it('should output the expected format', async () => {
+            await browser.setCookies([cookie1])
+            expect(vi.mocked(fetch).mock.calls).toHaveLength(2!)
+            expect(vi.mocked(fetch).mock.calls[1][1]!.method).toBe('POST')
             // @ts-expect-error mock implementation
-            expect(vi.mocked(fetch).mock.calls[i][0]!.pathname)
+            expect(vi.mocked(fetch).mock.calls[1][0]!.pathname)
                 .toBe('/session/foobar-123/cookie')
-            expect(vi.mocked(fetch).mock.calls[i][1]!.body)
-                .toEqual(JSON.stringify({ 'cookie': cookie }))
+            expect(vi.mocked(fetch).mock.calls[1][1]!.body)
+                .toEqual(JSON.stringify({ 'cookie': cookie1 }))
+        })
+
+        it('should support passing an object', async () => {
+            await browser.setCookies(cookie1)
+            expect(vi.mocked(fetch).mock.calls).toHaveLength(1!)
+            expect(vi.mocked(fetch).mock.calls[0][1]!.method).toBe('POST')
+            // @ts-expect-error mock implementation
+            expect(vi.mocked(fetch).mock.calls[0][0]!.pathname)
+                .toBe('/session/foobar-123/cookie')
+            expect(vi.mocked(fetch).mock.calls[0][1]!.body)
+                .toEqual(JSON.stringify({ 'cookie': cookie1 }))
+        })
+
+        it('can be called multiple times', async () => {
+            await browser.setCookies(cookie1)
+            await browser.setCookies(cookie2)
+            expect(vi.mocked(fetch).mock.calls).toHaveLength(2!)
+            expect(vi.mocked(fetch).mock.calls[0][1]!.method).toBe('POST')
+            // @ts-expect-error mock implementation
+            expect(vi.mocked(fetch).mock.calls[0][0]!.pathname)
+                .toBe('/session/foobar-123/cookie')
+            expect(vi.mocked(fetch).mock.calls[0][1]!.body)
+                .toEqual(JSON.stringify({ 'cookie': cookie1 }))
+            expect(vi.mocked(fetch).mock.calls[1][1]!.method).toBe('POST')
+            // @ts-expect-error mock implementation
+            expect(vi.mocked(fetch).mock.calls[1][0]!.pathname)
+                .toBe('/session/foobar-123/cookie')
+            expect(vi.mocked(fetch).mock.calls[1][1]!.body)
+                .toEqual(JSON.stringify({ 'cookie': cookie2 }))
+        })
+
+        it('should work with multiple objects passed', async () => {
+            const cookies = [cookie1, cookie2, cookie3]
+            await browser.setCookies(cookies)
+
+            cookies.forEach((cookie, i) => {
+                expect(vi.mocked(fetch).mock.calls[i][1]!.method).toBe('POST')
+                // @ts-expect-error mock implementation
+                expect(vi.mocked(fetch).mock.calls[i][0]!.pathname)
+                    .toBe('/session/foobar-123/cookie')
+                expect(vi.mocked(fetch).mock.calls[i][1]!.body)
+                    .toEqual(JSON.stringify({ 'cookie': cookie }))
+            })
+        })
+
+        it('should throw error if invalid arguments are passed', async () => {
+            // @ts-ignore test invalid parameter
+            await expect(browser.setCookies([2]))
+                .rejects
+                .toEqual(new Error('Invalid input (see https://webdriver.io/docs/api/browser/setCookies for documentation)'))
+        })
+
+        afterEach(() => {
+            vi.mocked(fetch).mockClear()
         })
     })
 
-    it('should throw error if invalid arguments are passed', async () => {
-        // @ts-ignore test invalid parameter
-        await expect(browser.setCookies([2]))
-            .rejects
-            .toEqual(new Error('Invalid input (see https://webdriver.io/docs/api/browser/setCookies for documentation)'))
-    })
+    describe('bidi', () => {
+        let storageSetCookie: MockInstance
 
-    afterEach(() => {
-        vi.mocked(fetch).mockClear()
+        beforeAll(async () => {
+            browser = await remote({
+                baseUrl: 'http://foobar.com',
+                capabilities: {
+                    browserName: 'bidi'
+                }
+            })
+
+            storageSetCookie =  vi.spyOn(browser, 'storageSetCookie')
+            storageSetCookie.mockImplementation((() => {}) as any)
+        })
+
+        beforeEach(() => {
+            storageSetCookie.mockClear()
+        })
+
+        it('should support passing an array', async () => {
+            await browser.setCookies([cookie1])
+            expect(storageSetCookie).toBeCalledTimes(1)
+            expect(storageSetCookie).toBeCalledWith({
+                cookie: {
+                    domain: 'webdriver.io',
+                    name: 'cookie1',
+                    value: {
+                        type: 'string',
+                        value: cookie1.value
+                    }
+                }
+            })
+        })
+
+        it('should support passing an object', async () => {
+            await browser.setCookies(cookie1)
+            expect(storageSetCookie).toBeCalledTimes(1)
+            expect(storageSetCookie).toBeCalledWith({
+                cookie: {
+                    domain: 'webdriver.io',
+                    name: 'cookie1',
+                    value: {
+                        type: 'string',
+                        value: cookie1.value
+                    }
+                }
+            })
+        })
+
+        it('can be called multiple times', async () => {
+            await browser.setCookies([cookie1, cookie2, cookie3])
+            expect(storageSetCookie).toBeCalledTimes(3)
+        })
     })
 })

--- a/packages/webdriverio/tests/commands/browser/setViewport.test.ts
+++ b/packages/webdriverio/tests/commands/browser/setViewport.test.ts
@@ -1,5 +1,5 @@
 import path from 'node:path'
-import { expect, describe, it, vi, beforeAll } from 'vitest'
+import { expect, describe, it, vi, beforeEach, beforeAll, type MockInstance } from 'vitest'
 import { remote } from '../../../src/index.js'
 
 vi.mock('fetch')
@@ -7,7 +7,7 @@ vi.mock('@wdio/logger', () => import(path.join(process.cwd(), '__mocks__', '@wdi
 
 describe('setWindowSize', () => {
     let browser: WebdriverIO.Browser
-    const browsingContextSetViewport = vi.fn()
+    let browsingContextSetViewport: MockInstance
 
     beforeAll(async () => {
         browser = await remote({
@@ -16,24 +16,25 @@ describe('setWindowSize', () => {
                 browserName: 'bidi',
             }
         })
-        // @ts-expect-error protocol names are not defined as names to be overwritten but it works
-        browser.overwriteCommand('browsingContextSetViewport', browsingContextSetViewport)
+        browsingContextSetViewport = vi.spyOn(browser, 'browsingContextSetViewport')
+        browsingContextSetViewport.mockImplementation(() => ({}))
+    })
+
+    beforeEach(() => {
+        browsingContextSetViewport.mockClear()
     })
 
     it('should resize W3C browser window', async () => {
         await browser.setViewport({ width: 777, height: 888, devicePixelRatio: 123 })
         expect(browsingContextSetViewport).toBeCalledTimes(1)
-        expect(browsingContextSetViewport).toBeCalledWith(
-            expect.any(Function),
-            {
-                context: 'window-handle-1',
-                viewport: {
-                    width: 777,
-                    height: 888,
-                },
-                devicePixelRatio: 123
-            }
-        )
+        expect(browsingContextSetViewport).toBeCalledWith({
+            context: 'window-handle-1',
+            viewport: {
+                width: 777,
+                height: 888,
+            },
+            devicePixelRatio: 123
+        })
     })
 
     describe('input checks', () => {

--- a/tests/multiremote/test.js
+++ b/tests/multiremote/test.js
@@ -156,8 +156,8 @@ describe('smoke test multiremote', () => {
         it('should throw if promise rejects', async () => {
             await browser.customCommandScenario(Object.keys(browser.instances).length)
             browser.overwriteCommand('deleteCookies', async (origCommand, fail) => {
-                const result = await origCommand()
-                return fail ? Promise.reject(new Error(result)) : result
+                await origCommand()
+                return fail ? Promise.reject(new Error('error')) : 'result'
             })
 
             let err = null
@@ -166,7 +166,7 @@ describe('smoke test multiremote', () => {
             } catch (e) {
                 err = e
             }
-            assert.equal(err.message, 'deleteAllCookies,deleteAllCookies')
+            assert.equal(err.message, 'error')
         })
     })
 })

--- a/tests/typings/webdriverio/async.ts
+++ b/tests/typings/webdriverio/async.ts
@@ -166,7 +166,7 @@ async function bar() {
         domain: '',
         path: '',
         expiry: 1,
-        sameSite: 'Lax',
+        sameSite: 'lax',
         secure: true,
         httpOnly: true
     }])


### PR DESCRIPTION
## Proposed changes

This patch enhances the cookie commands to set/get/delete them via Bidi.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
