### PR TITLE
Fix `addInitScript` example in v9 blog post

### DIFF
--- a/website/blog/2024-08-15-webdriverio-v9-release.md
+++ b/website/blog/2024-08-15-webdriverio-v9-release.md
@@ -86,7 +86,7 @@ The `addInitScript` command enables you to inject a script into the browser that
 For instance, to get notified whenever an element is added or removed from a node in the application, you can use the following example:
 
 ```ts
-const script = await browser.addInitScript((myParam, callback) => {
+const script = await browser.addInitScript((myParam, emit) => {
     const observer = new MutationObserver((mutations) => {
         for (const mutation of mutations) {
             emit(mutation.target.nodeName)


### PR DESCRIPTION
## Proposed changes

In the blogpost announcing Webdriverio v9, the `addInitScript()` example shows a function that takes `callback` as a parameter, but then calls `emit` instead (after looking at the docs, this is clearly intending to call the parameter named `callback`). I changed the name of the parameter to `emit` to match the examples in [the docs](https://webdriver.io/docs/api/browser/addInitScript), although which name to use is pretty arbitrary.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
