### PR TITLE
Fix  customElement wrapper for custom elements which don't define connectedCallback or disconnectedCallback

### DIFF
--- a/e2e/browser-runner/lit.test.js
+++ b/e2e/browser-runner/lit.test.js
@@ -830,4 +830,18 @@ describe('Lit Component testing', () => {
         const a = new Foo ()
         expect(a.tagName).toBe('X-FOO')
     })
+
+    it('connectedCallback should not fail if no original connectedCallback is defined', () => {
+        class Foo extends HTMLElement {}
+        customElements.define('y-foo', Foo)
+        const a = new Foo ()
+        a.connectedCallback()
+    })
+
+    it('disConnectedCallback should not fail if no original disConnectedCallback is defined', () => {
+        class Foo extends HTMLElement {}
+        customElements.define('z-foo', Foo)
+        const a = new Foo ()
+        a.disconnectedCallback()
+    })
 })

--- a/packages/webdriverio/src/scripts/customElement.ts
+++ b/packages/webdriverio/src/scripts/customElement.ts
@@ -17,13 +17,13 @@ export default function customElementWrapper () {
                 parentNode = parentNode.parentNode
             }
             console.debug('[WDIO]', 'newShadowRoot', this, parentNode, parentNode === document)
-            return origConnectedCallback && origConnectedCallback.call(this)
+            return origConnectedCallback?.call(this)
         }
 
         const origDisconnectedCallback = Constructor.prototype.disconnectedCallback
         Constructor.prototype.disconnectedCallback = function(this: HTMLElement) {
             console.debug('[WDIO]', 'removeShadowRoot', this)
-            return origDisconnectedCallback && origDisconnectedCallback.call(this)
+            return origDisconnectedCallback?.call(this)
         }
         return origFn(name, Constructor, options)
     }

--- a/packages/webdriverio/src/scripts/customElement.ts
+++ b/packages/webdriverio/src/scripts/customElement.ts
@@ -17,13 +17,13 @@ export default function customElementWrapper () {
                 parentNode = parentNode.parentNode
             }
             console.debug('[WDIO]', 'newShadowRoot', this, parentNode, parentNode === document)
-            return origConnectedCallback.call(this)
+            return origConnectedCallback && origConnectedCallback.call(this)
         }
 
         const origDisconnectedCallback = Constructor.prototype.disconnectedCallback
         Constructor.prototype.disconnectedCallback = function(this: HTMLElement) {
             console.debug('[WDIO]', 'removeShadowRoot', this)
-            return origDisconnectedCallback.call(this)
+            return origDisconnectedCallback && origDisconnectedCallback.call(this)
         }
         return origFn(name, Constructor, options)
     }


### PR DESCRIPTION
## Proposed changes
Fixes https://github.com/webdriverio/webdriverio/issues/13524

Starting with v9.0.6 webdriver.io has a bug which causes tests to fail when a custom element doesn't define a connectedCallback or a disconnectedCallback.
The reason is with https://github.com/webdriverio/webdriverio/pull/13430 there is no check anymore if the original function is defined before calling it.

## Types of changes

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Backport Request

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
