### PR TITLE
[junit-reporter] Add option to include nodejs console log in junit report

### DIFF
--- a/packages/wdio-junit-reporter/README.md
+++ b/packages/wdio-junit-reporter/README.md
@@ -270,9 +270,9 @@ module.exports = {
 };
 ```
 
-### addConsoleLogs
+### addWorkerLogs
 
-Optional parameter (`false` by default), set this parameter to true in order to attach console logs from step to the reporter.
+Optional parameter, set this parameter to true in order to attach console logs from step to the reporter.
 
 Type: `Boolean`<br />
 Default: `false`<br />
@@ -286,7 +286,7 @@ module.exports = {
         'dot',
         ['junit', {
             outputDir: './',
-            addConsoleLogs: true
+            addWorkerLogs: true
         }]
     ],
     // ...

--- a/packages/wdio-junit-reporter/README.md
+++ b/packages/wdio-junit-reporter/README.md
@@ -270,6 +270,31 @@ module.exports = {
 };
 ```
 
+### addConsoleLogs
+
+Optional parameter (`false` by default), set this parameter to true in order to attach console logs from step to the reporter.
+
+Type: `Boolean`<br />
+Default: `false`<br />
+Example:
+
+```js
+// wdio.conf.js
+module.exports = {
+    // ...
+    reporters: [
+        'dot',
+        ['junit', {
+            outputDir: './',
+            addConsoleLogs: true
+        }]
+    ],
+    // ...
+};
+```
+
+
+
 ## Jenkins Setup
 
 Last but not least you need to tell your CI job (e.g. Jenkins) where it can find the xml file. To do that, add a post-build action to your job that gets executed after the test has run and point Jenkins (or your desired CI system) to your XML test results:

--- a/packages/wdio-junit-reporter/README.md
+++ b/packages/wdio-junit-reporter/README.md
@@ -272,7 +272,7 @@ module.exports = {
 
 ### addWorkerLogs
 
-Optional parameter, set this parameter to true in order to attach console logs from step to the reporter.
+Optional parameter, set this parameter to true in order to attach console logs from the test in the reporter.
 
 Type: `Boolean`<br />
 Default: `false`<br />

--- a/packages/wdio-junit-reporter/src/index.ts
+++ b/packages/wdio-junit-reporter/src/index.ts
@@ -12,6 +12,14 @@ const ansiRegex = new RegExp([
     '(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PR-TZcf-ntqry=><~]))'
 ].join('|'), 'g')
 
+/** Interface to store additional information for a given testcase */
+interface JunitReporterAdditionalInformation {
+    /** uid of the test case */
+    uid: string
+    /** Worker console log for this test. only filled if addWorkerLogs is true */
+    workerConsoleLog: string
+}
+
 /**
  * Reporter that converts test results from a single instance/runner into an XML JUnit report. This class
  * uses junit-report-builder (https://github.com/davidparsson/junit-report-builder) to build report.The report
@@ -25,37 +33,40 @@ class JunitReporter extends WDIOReporter {
     private _fileNameLabel?: string
     private _activeFeature?: any
     private _activeFeatureName?: any
-    private _testToConsoleOutput: { [keys: string]: string }
+    private _testToAdditionalInformation: { [keys: string]: JunitReporterAdditionalInformation }
     private _currentTest?: TestStats
     private _originalStdoutWrite: Function
-    private _addConsoleLogs: boolean
+    private _addWorkerLogs: boolean
 
     constructor(public options: JUnitReporterOptions) {
         super(options)
-        this._addConsoleLogs = options.addConsoleLogs ?? false
-        this._testToConsoleOutput = {}
+        this._addWorkerLogs = options.addWorkerLogs ?? false
+        this._testToAdditionalInformation = {}
         this._originalStdoutWrite = process.stdout.write.bind(process.stdout)
         this._suiteNameRegEx = this.options.suiteNameFormat instanceof RegExp
             ? this.options.suiteNameFormat
             : /[^a-zA-Z0-9@]+/ // Reason for ignoring @ is; reporters like wdio-report-portal will fetch the tags from testcase name given as @foo @bar
 
         const processObj: any = process
-        if (this._addConsoleLogs) {
+        if (this._addWorkerLogs) {
             processObj.stdout.write = this._appendConsoleLog.bind(this)
         }
     }
 
-    onTestRetry (testStats: TestStats) {
+    onTestRetry(testStats: TestStats) {
         testStats.skip('Retry')
     }
 
     onTestStart(test: TestStats) {
         // Reset stdout when a test starts
         this._currentTest = test
-        this._testToConsoleOutput[test.uid] = ''
+        this._testToAdditionalInformation[test.uid] = {
+            workerConsoleLog: '',
+            uid: test.uid
+        }
     }
 
-    onRunnerEnd (runner: RunnerStats) {
+    onRunnerEnd(runner: RunnerStats) {
         const xml = this._buildJunitXml(runner)
         this.write(xml)
     }
@@ -63,13 +74,13 @@ class JunitReporter extends WDIOReporter {
     private _appendConsoleLog(chunk: string, encoding: BufferEncoding, callback: ((err?: Error) => void)) {
         if (this._currentTest?.uid) {
             if (typeof chunk === 'string' && !chunk.includes('mwebdriver')) {
-                this._testToConsoleOutput[this._currentTest.uid] = (this._testToConsoleOutput[this._currentTest.uid] ?? '') + chunk
+                this._testToAdditionalInformation[this._currentTest.uid].workerConsoleLog = (this._testToAdditionalInformation[this._currentTest.uid].workerConsoleLog ?? '') + chunk
             }
         }
         return this._originalStdoutWrite(chunk, encoding, callback)
     }
 
-    private _prepareName (name = 'Skipped test') {
+    private _prepareName(name = 'Skipped test') {
         return name.split(this._suiteNameRegEx).filter(
             (item) => item && item.length
         ).join(' ')
@@ -114,7 +125,7 @@ class JunitReporter extends WDIOReporter {
         } else if (this._activeFeature) {
             let scenario = suite
             const testName = this._prepareName(suite.title)
-            const classNameFormat = this.options.classNameFormat ? this.options.classNameFormat({ packageName: this._packageName, activeFeatureName: this._activeFeatureName }): `${this._packageName}.${this._activeFeatureName}`
+            const classNameFormat = this.options.classNameFormat ? this.options.classNameFormat({ packageName: this._packageName, activeFeatureName: this._activeFeatureName }) : `${this._packageName}.${this._activeFeatureName}`
             const testCase = this._activeFeature.testCase()
                 .className(classNameFormat)
                 .name(`${testName}`)
@@ -218,7 +229,7 @@ class JunitReporter extends WDIOReporter {
                 }
             } else if (test.state === 'failed') {
                 if (test.error) {
-                    if (test.error.message){
+                    if (test.error.message) {
                         test.error.message = test.error.message.replace(ansiRegex, '')
                     }
 
@@ -245,7 +256,7 @@ class JunitReporter extends WDIOReporter {
         return builder
     }
 
-    private _buildJunitXml (runner: RunnerStats) {
+    private _buildJunitXml(runner: RunnerStats) {
         const builder = junit.newBuilder()
         if (runner.config.hostname !== undefined && runner.config.hostname.indexOf('browserstack') > -1) {
             // NOTE: deviceUUID is used to build sanitizedCapabilities resulting in a ever-changing package name in runner.sanitizedCapabilities when running Android tests under Browserstack. (i.e. ht79v1a03938.android.9)
@@ -310,8 +321,8 @@ class JunitReporter extends WDIOReporter {
 
     private _getStandardOutput(test: TestStats) {
         let consoleOutput = ''
-        if (this._addConsoleLogs) {
-            consoleOutput = this._testToConsoleOutput[test.uid] ?? ''
+        if (this._addWorkerLogs) {
+            consoleOutput = this._testToAdditionalInformation[test.uid]?.workerConsoleLog ?? ''
         }
         const commandText = this._getCommandStandardOutput(test)
         let result = ''
@@ -334,7 +345,7 @@ class JunitReporter extends WDIOReporter {
                 standardOutput.push(
                     data.method
                         ? `COMMAND: ${data.method.toUpperCase()} ` +
-                          `${data.endpoint.replace(':sessionId', data.sessionId)} - ${this._format(data.body)}`
+                            `${data.endpoint.replace(':sessionId', data.sessionId)} - ${this._format(data.body)}`
                         : `COMMAND: ${data.command} - ${this._format(data.params)}`
                 )
                 break
@@ -346,7 +357,7 @@ class JunitReporter extends WDIOReporter {
         return standardOutput.length ? standardOutput.join('\n') : ''
     }
 
-    private _format (val: any) {
+    private _format(val: any) {
         return JSON.stringify(limit(val))
     }
 

--- a/packages/wdio-junit-reporter/src/types.ts
+++ b/packages/wdio-junit-reporter/src/types.ts
@@ -115,7 +115,7 @@ export interface JUnitReporterOptions extends Reporters.Options {
     errorOptions?: Record<string, string>
 
     /**
-     * Optional parameter (`false` by default), set this parameter to true in order to attach console logs from step to the reporter.
+     * Optional parameter, set this parameter to true in order to attach console logs from step to the reporter.
      * @default false
      *
      * @example
@@ -128,12 +128,12 @@ export interface JUnitReporterOptions extends Reporters.Options {
      *         'dot',
      *         ['junit', {
      *             outputDir: './',
-     *             addConsoleLogs: true
+     *             addWorkerLogs: true
      *         }]
      *     ],
      *     // ...
      * };
      * ```
      */
-    addConsoleLogs?: boolean
+    addWorkerLogs?: boolean
 }

--- a/packages/wdio-junit-reporter/src/types.ts
+++ b/packages/wdio-junit-reporter/src/types.ts
@@ -115,7 +115,7 @@ export interface JUnitReporterOptions extends Reporters.Options {
     errorOptions?: Record<string, string>
 
     /**
-     * Optional parameter, set this parameter to true in order to attach console logs from step to the reporter.
+     * Optional parameter, set this parameter to true in order to attach console logs from the test in the reporter.
      * @default false
      *
      * @example

--- a/packages/wdio-junit-reporter/src/types.ts
+++ b/packages/wdio-junit-reporter/src/types.ts
@@ -113,4 +113,27 @@ export interface JUnitReporterOptions extends Reporters.Options {
      * ```
      */
     errorOptions?: Record<string, string>
+
+    /**
+     * Optional parameter (`false` by default), set this parameter to true in order to attach console logs from step to the reporter.
+     * @default false
+     *
+     * @example
+     *
+     * ```js
+     * // wdio.conf.js
+     * module.exports = {
+     *     // ...
+     *     reporters: [
+     *         'dot',
+     *         ['junit', {
+     *             outputDir: './',
+     *             addConsoleLogs: true
+     *         }]
+     *     ],
+     *     // ...
+     * };
+     * ```
+     */
+    addConsoleLogs?: boolean
 }

--- a/packages/wdio-junit-reporter/tests/reporter.test.ts
+++ b/packages/wdio-junit-reporter/tests/reporter.test.ts
@@ -374,9 +374,7 @@ describe('wdio-junit-reporter', () => {
         const suite = Object.values(suitesLog)[0] as SuiteStats
         reporter.onSuiteStart(suite)
         const test1 = suite.tests[0]
-        test1.cid = '0-0'
         const test2 = suite.tests[1]
-        test2.cid = '0-1'
         reporter.onTestStart(test1)
         reporter['_appendConsoleLog']('0 - line 0', 'utf-8', () => {})
         reporter['_appendConsoleLog']('0 - line 1', 'utf-8', () => {})

--- a/packages/wdio-junit-reporter/tests/reporter.test.ts
+++ b/packages/wdio-junit-reporter/tests/reporter.test.ts
@@ -367,9 +367,9 @@ describe('wdio-junit-reporter', () => {
         expect(reporter['_sameFileName'](undefined, undefined)).toBeTruthy()
     })
 
-    const options = { stdout: true, addConsoleLogs: true }
+    const options = { stdout: true, addWorkerLogs: true }
 
-    it('addConsoleLogs: should add console log to report for test if activated', () => {
+    it('addWorkerLogs: should add worker console log to report for test if activated', () => {
         reporter = new WDIOJunitReporter(options)
         const suite = Object.values(suitesLog)[0] as SuiteStats
         reporter.onSuiteStart(suite)


### PR DESCRIPTION
by activating the option addConsoleLogs to true
console logs will automatically added to the junit xml

## Proposed changes

This PR adds an option to include nodejs console log in junit reports. This allows to view additional information that is logged during test execution and helps analyze flaky tests easier.

Example output of xml with 1 skipped test, 1 test with console logs and 1 without:

```
Execution of 1 workers started at 2024-09-06T16:46:36.677Z

let's go
[0-0] RUNNING in chrome - file:///mocha/mocha.test.ts
[0-0] Test 1
[0-0] Test 2
[0-0] PASSED in chrome - file:///mocha/mocha.test.ts
that's it

 "junit" Reporter:
<?xml version="1.0" encoding="UTF-8"?>
<testsuites tests="3" failures="0" errors="0" skipped="1">
  <testsuite name="webdriver io page" timestamp="2024-09-06T18:46:39" time="2.255" tests="3" failures="0" errors="0" skipped="1">
    <properties>
      <property name="specId" value="0"/>
      <property name="suiteName" value="webdriver.io page"/>
      <property name="capabilities" value="chrome.128_0_6613_119.linux"/>
      <property name="file" value="file://./mocha/mocha.test.ts"/>
    </properties>
    <testcase classname="chrome.128_0_6613_119.linux.webdriver.io_page" name="should be a pending test" time="0">
      <skipped/>
    </testcase>
    <testcase classname="chrome.128_0_6613_119.linux.webdriver.io_page" name="should have the right title" time="1.409">
      <system-out><![CDATA[
Test 1
Test 2

...command output...

COMMAND: GET /session/d6b83688fd1edb75cc7a8beaebeea91a/window - {}
RESULT: {}
COMMAND: GET /session/d6b83688fd1edb75cc7a8beaebeea91a/window - {}
RESULT: {}
COMMAND: GET /session/d6b83688fd1edb75cc7a8beaebeea91a/window - {}
RESULT: {}
COMMAND: GET /session/d6b83688fd1edb75cc7a8beaebeea91a/window - {}
RESULT: {}
COMMAND: GET /session/d6b83688fd1edb75cc7a8beaebeea91a/title - {}
RESULT: {}
]]></system-out>
    </testcase>
    <testcase classname="chrome.128_0_6613_119.linux.webdriver.io_page" name="should have the right title without console" time="0.844">
      <system-out><![CDATA[
COMMAND: GET /session/d6b83688fd1edb75cc7a8beaebeea91a/window - {}
RESULT: {}
COMMAND: GET /session/d6b83688fd1edb75cc7a8beaebeea91a/window - {}
RESULT: {}
COMMAND: GET /session/d6b83688fd1edb75cc7a8beaebeea91a/window - {}
RESULT: {}
COMMAND: GET /session/d6b83688fd1edb75cc7a8beaebeea91a/window - {}
RESULT: {}
COMMAND: GET /session/d6b83688fd1edb75cc7a8beaebeea91a/title - {}
RESULT: {}
COMMAND: DELETE /session/d6b83688fd1edb75cc7a8beaebeea91a - {}
RESULT: {}
]]></system-out>
    </testcase>
  </testsuite>
</testsuites>

Spec Files:      1 passed, 1 total (100% completed) in 00:00:05
```

closes #13522  

## Types of changes

- [x] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Backport Request

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
