### PR TITLE
Fix the type exported in configurations genrated by wdio-cli

### DIFF
--- a/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
+++ b/packages/wdio-cli/src/templates/wdio.conf.tpl.ejs
@@ -3,16 +3,12 @@ if (answers.isUsingTypeScript && answers.purpose === 'electron') {
     %>/// <reference types="wdio-electron-service" />
 <% }
 
-if (answers.isUsingTypeScript && !answers.serenityAdapter) {
-    %>import type { Options } from '@wdio/types'
-<% }
-
 if (answers.isUsingTypeScript && answers.serenityAdapter) {
     %>import type { WebdriverIOConfig } from '@serenity-js/webdriverio'
 <% }
 
 if (answers.isUsingTypeScript) {
-    %>export const config: <%= answers.serenityAdapter ? 'WebdriverIOConfig' : 'Options.Testrunner' %> = {<%
+    %>export const config: <%= answers.serenityAdapter ? 'WebdriverIOConfig' : 'WebdriverIO.Config' %> = {<%
 } else if (answers.esmSupport) {
     %>export const config = {<%
 } else {


### PR DESCRIPTION
Change the type exported in the generated wdio.conf.ts files from Options.Testrunner to WebdriverIO.Config.

Fixes #13551

## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

- [x] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
