### PR TITLE
fix(wdio-cucumber-framework): filter cucumberFeaturesWithLineNumbers

### DIFF
--- a/infra/compiler/src/index.ts
+++ b/infra/compiler/src/index.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs/promises'
+import { existsSync } from 'node:fs'
 import path from 'node:path'
 import url from 'node:url'
 import { parseArgs } from 'node:util'
@@ -33,7 +34,8 @@ const { values } = parseArgs({ args, options })
  */
 const projects = (await fs.readdir(
     path.resolve(rootDir, 'packages')
-)).filter((dir) => dir !== 'node_modules')
+    // ignore potential stale/empty package directories left over when switching between branches
+)).filter((dir) => dir !== 'node_modules' && existsSync(path.resolve(rootDir, 'packages', dir, 'package.json')))
 
 const packages = (
     await Promise.all(

--- a/packages/wdio-cucumber-framework/src/index.ts
+++ b/packages/wdio-cucumber-framework/src/index.ts
@@ -215,9 +215,11 @@ class CucumberAdapter {
         })
         this._specs = plan?.map((pl) => path.resolve(pl.uri))
 
-        // Filter the specs according to line numbers
+        // Filter features (of which at least some have line numbers) against the already filtered specs
         if (this._config.cucumberFeaturesWithLineNumbers?.length! > 0) {
-            this._specs = this._config.cucumberFeaturesWithLineNumbers!
+            this._specs = this._config.cucumberFeaturesWithLineNumbers!.filter(feature =>
+                this._specs.some(spec => path.resolve(feature).startsWith(spec))
+            )
         }
 
         this._specs = [...new Set(this._specs)]

--- a/tests/cucumber/features/features.given.js
+++ b/tests/cucumber/features/features.given.js
@@ -1,5 +1,5 @@
 import { browser } from '@wdio/globals'
-import { Given } from '../../../packages/wdio-cucumber-framework/build/index.js'
+import { Given } from '@wdio/cucumber-framework'
 
 Given('test1', () => {
     browser.assertExecutingFeatureFileOnce('test1.feature')

--- a/tests/cucumber/features/features.given.js
+++ b/tests/cucumber/features/features.given.js
@@ -1,0 +1,14 @@
+import { browser } from '@wdio/globals'
+import { Given } from '../../../packages/wdio-cucumber-framework/build/index.js'
+
+Given('test1', () => {
+    browser.assertExecutingFeatureFile('test1.feature')
+})
+
+Given('test2', () => {
+    browser.assertExecutingFeatureFile('test2.feature')
+})
+
+Given('test3', () => {
+    browser.assertExecutingFeatureFile('test3.feature')
+})

--- a/tests/cucumber/features/features.given.js
+++ b/tests/cucumber/features/features.given.js
@@ -2,13 +2,13 @@ import { browser } from '@wdio/globals'
 import { Given } from '../../../packages/wdio-cucumber-framework/build/index.js'
 
 Given('test1', () => {
-    browser.assertExecutingFeatureFile('test1.feature')
+    browser.assertExecutingFeatureFileOnce('test1.feature')
 })
 
 Given('test2', () => {
-    browser.assertExecutingFeatureFile('test2.feature')
+    browser.assertExecutingFeatureFileOnce('test2.feature')
 })
 
 Given('test3', () => {
-    browser.assertExecutingFeatureFile('test3.feature')
+    browser.assertExecutingFeatureFileOnce('test3.feature')
 })

--- a/tests/cucumber/features/test1.feature
+++ b/tests/cucumber/features/test1.feature
@@ -1,0 +1,5 @@
+Feature: The first feature
+    As a test script of wdio-cucumber-framework
+
+    Scenario: Executed with line number
+        Given test1

--- a/tests/cucumber/features/test2.feature
+++ b/tests/cucumber/features/test2.feature
@@ -1,0 +1,5 @@
+Feature: The second feature
+    As a test script of wdio-cucumber-framework
+
+    Scenario: Executed with line number
+        Given test2

--- a/tests/cucumber/features/test3.feature
+++ b/tests/cucumber/features/test3.feature
@@ -1,0 +1,5 @@
+Feature: The third feature
+    As a test script of wdio-cucumber-framework
+
+    Scenario: Executed with line number
+        Given test3

--- a/tests/cucumber/features/test3.feature
+++ b/tests/cucumber/features/test3.feature
@@ -3,3 +3,6 @@ Feature: The third feature
 
     Scenario: Executed with line number
         Given test3
+
+    Scenario: Dummy Scenario which ought not be executed
+        Given test1

--- a/tests/cucumber/reporter/reporter.given.js
+++ b/tests/cucumber/reporter/reporter.given.js
@@ -1,4 +1,4 @@
-import { Given, BeforeAll, Before, After, AfterAll } from '../../../packages/wdio-cucumber-framework/build/index.js'
+import { Given, BeforeAll, Before, After, AfterAll } from '@wdio/cucumber-framework'
 
 BeforeAll(() => {})
 Before(function () {})

--- a/tests/cucumber/step-definitions/given.js
+++ b/tests/cucumber/step-definitions/given.js
@@ -1,4 +1,4 @@
-import { Given, BeforeAll, Before, After, AfterAll } from '../../../packages/wdio-cucumber-framework/build/index.js'
+import { Given, BeforeAll, Before, After, AfterAll } from '@wdio/cucumber-framework'
 
 browser.addCommand('rootLevel', () => {
     return true

--- a/tests/cucumber/step-definitions/then.js
+++ b/tests/cucumber/step-definitions/then.js
@@ -1,4 +1,4 @@
-import { Then } from '../../../packages/wdio-cucumber-framework/build/index.js'
+import { Then } from '@wdio/cucumber-framework'
 
 Then(/^the title of the page should be:$/, async (expectedTitle) => {
     const actualTitle = await browser.getTitle()

--- a/tests/helpers/cucumber-features.conf.js
+++ b/tests/helpers/cucumber-features.conf.js
@@ -12,11 +12,16 @@ export const config = Object.assign({}, baseConfig, {
     },
     before: (capabilities, specs, browser) => {
         const specFileName = path.basename(specs[0])
-        browser.assertExecutingFeatureFile = (name) => {
+        browser.assertExecutingFeatureFileOnce = (name) => {
             if (name !== specFileName) {
                 console.error(new Error(`Cucumber executed the wrong feature file! Expected: ${specFileName} Got: ${name}`))
                 process.exit(1)
             }
+            if (global[`Cucumber_Ran_${name}`]) {
+                console.error(new Error(`Cucumber executed feature file ${name} more than once!`))
+                process.exit(1)
+            }
+            global[`Cucumber_Ran_${name}`] = true
         }
     },
 })

--- a/tests/helpers/cucumber-features.conf.js
+++ b/tests/helpers/cucumber-features.conf.js
@@ -1,0 +1,22 @@
+import path from 'node:path'
+import url from 'node:url'
+import { config as baseConfig } from './config.js'
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url))
+
+export const config = Object.assign({}, baseConfig, {
+    framework: 'cucumber',
+    cucumberOpts: {
+        timeout: 5000,
+        require: [path.resolve(__dirname, '..', 'cucumber', 'features', 'features.given.js')]
+    },
+    before: (capabilities, specs, browser) => {
+        const specFileName = path.basename(specs[0])
+        browser.assertExecutingFeatureFile = (name) => {
+            if (name !== specFileName) {
+                console.error(new Error(`Cucumber executed the wrong feature file! Expected: ${specFileName} Got: ${name}`))
+                process.exit(1)
+            }
+        }
+    },
+})

--- a/tests/smoke.runner.js
+++ b/tests/smoke.runner.js
@@ -15,7 +15,7 @@ const noArgConfig = path.resolve(__dirname, 'tests-cli-spec-arg/wdio-with-no-arg
 const severalPassedConfig = path.resolve(__dirname, 'tests-cli-spec-arg/wdio-with-failed.conf.js')
 
 // eslint-disable-next-line no-control-regex
-const specReplaceRegex = /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g
+const ansiColorRegex = /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g
 
 import launch from './helpers/launch.js'
 import {
@@ -195,7 +195,7 @@ const jasmineTimeout = async () => {
         framework: 'jasmine'
     }).catch((err) => err) // error expected
 
-    const specLogs = (await fs.readFile(logFile)).toString().replace(specReplaceRegex, '')
+    const specLogs = (await fs.readFile(logFile)).toString().replace(ansiColorRegex, '')
     assert.ok(
         specLogs.includes('Error: Timeout - Async function did not complete within 1000ms (custom timeout)'),
         'spec was not failing due to timeout error'
@@ -232,7 +232,7 @@ const jasmineAfterAll = async () => {
         framework: 'jasmine'
     }).catch((err) => err) // error expected
 
-    const specLogs = (await fs.readFile(logFile)).toString().replace(specReplaceRegex, '')
+    const specLogs = (await fs.readFile(logFile)).toString().replace(ansiColorRegex, '')
 
     assert.ok(
         specLogs.includes('Testing after all hook'),
@@ -272,7 +272,7 @@ const jasmineFailSpecWithNoExpectations = async () => {
         }
     }).catch((err) => err) // error expected
 
-    const specLogs = (await fs.readFile(logFile)).toString().replace(specReplaceRegex, '')
+    const specLogs = (await fs.readFile(logFile)).toString().replace(ansiColorRegex, '')
     assert.ok(
         specLogs.includes('No assertions found in test'),
         'spec did not fail with the expected check'
@@ -326,7 +326,7 @@ const cucumberTestrunnerByLineNumber = async () => {
                 }]]
         }
     )
-    const specLogs = (await fs.readFile(logFile)).toString().replace(specReplaceRegex, '')
+    const specLogs = (await fs.readFile(logFile)).toString().replace(ansiColorRegex, '')
     assert.ok(
         specLogs.includes('Sync Execution'),
         'scenario not executed in feature by line number'
@@ -342,10 +342,6 @@ const cucumberTestrunnerByLineNumber = async () => {
  */
 const cucumberTestrunnerMultipleByLineNumber = async () => {
     const featureDir = path.resolve(__dirname, 'cucumber', 'features')
-    const log0 = path.resolve(featureDir, 'wdio-0-0-spec-reporter.log')
-    const log1 = path.resolve(featureDir, 'wdio-0-1-spec-reporter.log')
-    const log2 = path.resolve(featureDir, 'wdio-0-2-spec-reporter.log')
-    await Promise.all([fs.rm(log0, { force: true }), fs.rm(log1, { force: true }), fs.rm(log2, { force: true })])
     const { failed, passed, skippedSpecs } = await launch(
         'cucumberTestrunnerMultipleByLineNumber',
         path.resolve(__dirname, 'helpers', 'cucumber-features.conf.js'),
@@ -358,7 +354,7 @@ const cucumberTestrunnerMultipleByLineNumber = async () => {
             ],
             reporters: [
                 ['spec', {
-                    outputDir: featureDir,
+                    outputDir: __dirname,
                     stdout: false,
                 }]]
         }
@@ -366,25 +362,6 @@ const cucumberTestrunnerMultipleByLineNumber = async () => {
     assert.strictEqual(failed, 0)
     assert.strictEqual(passed, 3)
     assert.strictEqual(skippedSpecs, 0)
-    const [spec0, spec1, spec2] = (await Promise.all([fs.readFile(log0), fs.readFile(log1), fs.readFile(log2)]))
-        .map((buf) => buf.toString().replace(specReplaceRegex, ''))
-    const test1 = /Given test1/g
-    const test2 = /Given test2/g
-    const test3 = /Given test3/g
-    const once = (test, spec) => test.exec(spec).length === 1
-    const never = (test, spec) => test.exec(spec) === null
-    assert.ok(
-        once(test1, spec0) && never(test2, spec0) && never(test3, spec0),
-        'worker 0 did not (only) run test1'
-    )
-    assert.ok(
-        never(test1, spec1) && once(test2, spec1) && never(test3, spec1),
-        'worker 1 did not (only) run test2'
-    )
-    assert.ok(
-        never(test1, spec2) && never(test2, spec2) && once(test3, spec2),
-        'worker 2 did not (only) run test3'
-    )
 }
 
 /**
@@ -879,7 +856,7 @@ const jasmineHooksTestrunner = async () => {
             framework: 'jasmine',
         }).catch((err) => err) // error expected
 
-    const specLogs = (await fs.readFile(logFile)).toString().replace(specReplaceRegex, '')
+    const specLogs = (await fs.readFile(logFile)).toString().replace(ansiColorRegex, '')
     assert.ok(
         specLogs.includes('skip test'),
     )

--- a/tests/smoke.runner.js
+++ b/tests/smoke.runner.js
@@ -339,6 +339,31 @@ const cucumberTestrunnerByLineNumber = async () => {
 }
 
 /**
+ * Cucumber wdio testrunner -- run three features (by line number) and verify each only runs once
+ */
+const cucumberTestrunnerMultipleByLineNumber = async () => {
+    const logFile = path.resolve(__dirname, 'cucumber', 'cucumberTestrunnerMultipleByLineNumber.log')
+    await fs.rm(logFile, { force: true })
+    await launch(
+        'cucumberTestrunnerMultipleByLineNumber',
+        path.resolve(__dirname, 'helpers', 'cucumber-features.conf.js'),
+        {
+            spec: [
+                path.resolve(__dirname, 'cucumber', 'features', 'test1.feature:4'),
+                path.resolve(__dirname, 'cucumber', 'features', 'test2.feature'), // deliberately w/o line number
+                path.resolve(__dirname, 'cucumber', 'features', 'test3.feature:4'),
+            ],
+            reporters: [
+                ['spec', {
+                    outputDir: __dirname,
+                    stdout: false,
+                    logFile,
+                }]]
+        }
+    )
+}
+
+/**
  * Cucumber fail due to failAmbiguousDefinitions
  */
 const cucumberFailAmbiguousDefinitions = async () => {
@@ -901,6 +926,7 @@ const jasmineAfterHookArgsValidation = async () => {
         mochaSpecGrouping,
         cucumberTestrunner,
         cucumberTestrunnerByLineNumber,
+        cucumberTestrunnerMultipleByLineNumber,
         cucumberFailAmbiguousDefinitions,
         cucumberReporter,
         standaloneTest,

--- a/tests/smoke.runner.js
+++ b/tests/smoke.runner.js
@@ -14,6 +14,9 @@ const allPassedConfig = path.resolve(__dirname, 'tests-cli-spec-arg/wdio-with-al
 const noArgConfig = path.resolve(__dirname, 'tests-cli-spec-arg/wdio-with-no-arg.conf.js')
 const severalPassedConfig = path.resolve(__dirname, 'tests-cli-spec-arg/wdio-with-failed.conf.js')
 
+// eslint-disable-next-line no-control-regex
+const specReplaceRegex = /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g
+
 import launch from './helpers/launch.js'
 import {
     SERVICE_LOGS,
@@ -192,8 +195,7 @@ const jasmineTimeout = async () => {
         framework: 'jasmine'
     }).catch((err) => err) // error expected
 
-    // eslint-disable-next-line no-control-regex
-    const specLogs = (await fs.readFile(logFile)).toString().replace(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, '')
+    const specLogs = (await fs.readFile(logFile)).toString().replace(specReplaceRegex, '')
     assert.ok(
         specLogs.includes('Error: Timeout - Async function did not complete within 1000ms (custom timeout)'),
         'spec was not failing due to timeout error'
@@ -230,8 +232,7 @@ const jasmineAfterAll = async () => {
         framework: 'jasmine'
     }).catch((err) => err) // error expected
 
-    // eslint-disable-next-line no-control-regex
-    const specLogs = (await fs.readFile(logFile)).toString().replace(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, '')
+    const specLogs = (await fs.readFile(logFile)).toString().replace(specReplaceRegex, '')
 
     assert.ok(
         specLogs.includes('Testing after all hook'),
@@ -271,8 +272,7 @@ const jasmineFailSpecWithNoExpectations = async () => {
         }
     }).catch((err) => err) // error expected
 
-    // eslint-disable-next-line no-control-regex
-    const specLogs = (await fs.readFile(logFile)).toString().replace(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, '')
+    const specLogs = (await fs.readFile(logFile)).toString().replace(specReplaceRegex, '')
     assert.ok(
         specLogs.includes('No assertions found in test'),
         'spec did not fail with the expected check'
@@ -326,8 +326,7 @@ const cucumberTestrunnerByLineNumber = async () => {
                 }]]
         }
     )
-    // eslint-disable-next-line no-control-regex
-    const specLogs = (await fs.readFile(logFile)).toString().replace(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, '')
+    const specLogs = (await fs.readFile(logFile)).toString().replace(specReplaceRegex, '')
     assert.ok(
         specLogs.includes('Sync Execution'),
         'scenario not executed in feature by line number'
@@ -342,24 +341,49 @@ const cucumberTestrunnerByLineNumber = async () => {
  * Cucumber wdio testrunner -- run three features (by line number) and verify each only runs once
  */
 const cucumberTestrunnerMultipleByLineNumber = async () => {
-    const logFile = path.resolve(__dirname, 'cucumber', 'cucumberTestrunnerMultipleByLineNumber.log')
-    await fs.rm(logFile, { force: true })
-    await launch(
+    const featureDir = path.resolve(__dirname, 'cucumber', 'features')
+    const log0 = path.resolve(featureDir, 'wdio-0-0-spec-reporter.log')
+    const log1 = path.resolve(featureDir, 'wdio-0-1-spec-reporter.log')
+    const log2 = path.resolve(featureDir, 'wdio-0-2-spec-reporter.log')
+    await Promise.all([fs.rm(log0, { force: true }), fs.rm(log1, { force: true }), fs.rm(log2, { force: true })])
+    const { failed, passed, skippedSpecs } = await launch(
         'cucumberTestrunnerMultipleByLineNumber',
         path.resolve(__dirname, 'helpers', 'cucumber-features.conf.js'),
         {
             spec: [
-                path.resolve(__dirname, 'cucumber', 'features', 'test1.feature:4'),
-                path.resolve(__dirname, 'cucumber', 'features', 'test2.feature'), // deliberately w/o line number
-                path.resolve(__dirname, 'cucumber', 'features', 'test3.feature:4'),
+                path.resolve(featureDir, 'test1.feature:4'),
+                // deliberately w/o line number to capture more potential bugs
+                path.resolve(featureDir, 'test2.feature'),
+                path.resolve(featureDir, 'test3.feature:4'),
             ],
             reporters: [
                 ['spec', {
-                    outputDir: __dirname,
+                    outputDir: featureDir,
                     stdout: false,
-                    logFile,
                 }]]
         }
+    )
+    assert.strictEqual(failed, 0)
+    assert.strictEqual(passed, 3)
+    assert.strictEqual(skippedSpecs, 0)
+    const [spec0, spec1, spec2] = (await Promise.all([fs.readFile(log0), fs.readFile(log1), fs.readFile(log2)]))
+        .map((buf) => buf.toString().replace(specReplaceRegex, ''))
+    const test1 = /Given test1/g
+    const test2 = /Given test2/g
+    const test3 = /Given test3/g
+    const once = (test, spec) => test.exec(spec).length === 1
+    const never = (test, spec) => test.exec(spec) === null
+    assert.ok(
+        once(test1, spec0) && never(test2, spec0) && never(test3, spec0),
+        'worker 0 did not (only) run test1'
+    )
+    assert.ok(
+        never(test1, spec1) && once(test2, spec1) && never(test3, spec1),
+        'worker 1 did not (only) run test2'
+    )
+    assert.ok(
+        never(test1, spec2) && never(test2, spec2) && once(test3, spec2),
+        'worker 2 did not (only) run test3'
     )
 }
 
@@ -855,8 +879,7 @@ const jasmineHooksTestrunner = async () => {
             framework: 'jasmine',
         }).catch((err) => err) // error expected
 
-    // eslint-disable-next-line no-control-regex
-    const specLogs = (await fs.readFile(logFile)).toString().replace(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, '')
+    const specLogs = (await fs.readFile(logFile)).toString().replace(specReplaceRegex, '')
     assert.ok(
         specLogs.includes('skip test'),
     )


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

Fixes https://github.com/webdriverio/webdriverio/issues/13560. It looks like the `cucumberFeaturesWithLineNumbers` filtering broke some time ago, possibly with https://github.com/webdriverio/webdriverio/pull/11010.

While `_specs` has already been filtered here, `cucumberFeaturesWithLineNumbers`, which just exists to retain the line numbers, still contains all specs as passed on the cmdline or in the config. Therefore, just passing this to cucumber will inevitably execute all specs/features in every worker. To fix this, we only retain those entries within `cucumberFeaturesWithLineNumbers`, for which we can find a fitting entry in the list of already filtered `_spec`s.

Note that `cucumberFeaturesWithLineNumbers` does not really mean "cucumber features with line numbers". It seems to actually mean: "all passed specs, when at least one of them has a line number, or whatever was placed into the `cucumberFeaturesWithLineNumbers` wdio config option."

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
    - [x] Test code which verifies that the correct feature file is executed (fails before the fix) 
    - [x] Test code which verifies that only the correct scenarios are executed
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [x] Back-ported PR at #13563

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

Not 100% sure filtering with `startsWith` works 100% of the time (not sure if the paths could, for example, be relative, in one array, and absolute in the other, but they seem to always be absolute in my testing so far). **edit: now with `path.resolve`**

I wish Cucumber's `loadSources` would just take take whole features instead of just `paths`, but apparently it doesn't.

I'm not entirely sure if the `cucumberFeaturesWithLineNumbers` wdio config option is normalized anywhere. I don't know why it even exists, given that you can just put the features into `specs`, where the line numbers will get filtered out automatically.... It feels like `cucumberFeaturesWithLineNumbers` ought to be internal only.

### Reviewers: @webdriverio/project-committers
