### PR TITLE
fix(@wdio/cli): cucumber generated config spec path

### DIFF
--- a/packages/wdio-cli/src/constants.ts
+++ b/packages/wdio-cli/src/constants.ts
@@ -504,7 +504,7 @@ export const QUESTIONNAIRE = [{
         const pattern = isBrowserRunner(answers) ? 'src/**/*.test' : 'test/specs/**/*'
         return getDefaultFiles(answers, pattern)
     },
-    when: /* istanbul ignore next */ (answers: Questionnair) => answers.generateTestFiles && answers.framework.match(/(mocha|jasmine)/)
+    when: /* istanbul ignore next */ (answers: Questionnair) => answers.generateTestFiles && !!answers.framework.match(/(mocha|jasmine)/)
 }, {
     type: 'input',
     name: 'specs',

--- a/packages/wdio-cli/src/constants.ts
+++ b/packages/wdio-cli/src/constants.ts
@@ -504,7 +504,7 @@ export const QUESTIONNAIRE = [{
         const pattern = isBrowserRunner(answers) ? 'src/**/*.test' : 'test/specs/**/*'
         return getDefaultFiles(answers, pattern)
     },
-    when: /* istanbul ignore next */ (answers: Questionnair) => answers.generateTestFiles && !!answers.framework.match(/(mocha|jasmine)/)
+    when: /* istanbul ignore next */ (answers: Questionnair) => answers.generateTestFiles && Boolean(answers.framework.match(/(mocha|jasmine)/))
 }, {
     type: 'input',
     name: 'specs',


### PR DESCRIPTION
## Proposed changes

Solves #13554

After poking around for a few hours, I think that #13348 is to blame.
This comes down to:
```js
{ 
  message: 'What should be the location of your spec files?', // Note: this is NOT the cucumber block
  when: (answers: Questionnair) => answers.generateTestFiles && answers.framework.match(/(mocha|jasmine)/)
  // `answers.framework.match(/(mocha|jasmine)/)` -> returns null
  // `when: () => null` is considered not false, thus true
}
```  
This solution is a quick fix: casting to a boolean, so the `null` becomes `false`.

A few questions:
- Should Dependabot config be reviewed? Automerging + Bumping majors sounds a bit risky to me.
- Should I implement Unit tests? It doesn't seem trivial (no similar test), should I do it in another PR? It also feels that by doing so, we would be testing `Inquirer` instead of the CLI business logic.
- Should we remove the `// @ts-expect-error` [here](https://github.com/webdriverio/webdriverio/blob/1ecf61063a7b16dce5b399eda5a335716149d4af/packages/wdio-cli/src/utils.ts#L568)? I think this bug should not have been caught by a unit test but by the type checking. [Inquirer is expecting a boolean](https://github.com/SBoudrias/Inquirer.js/blob/d2690cc552f6451df30d62b6ca419ead3cea1c9c/packages/inquirer/src/types.mts#L58). This also looks like a big task 😅 , let me know if this is critical for a product pov.


## Types of changes

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
