### PR TITLE
Fix stencil test

### DIFF
--- a/e2e/browser-runner/stencil.test.tsx
+++ b/e2e/browser-runner/stencil.test.tsx
@@ -99,7 +99,7 @@ describe('Stencil Component Testing', () => {
 
         expect(page.root.outerHTML).toBe('<no-shadow-component></no-shadow-component>')
         await waitForChanges()
-        expect(page.root.outerHTML).toBe('<no-shadow-component>Hello World!</no-shadow-component>')
+        expect(page.root.outerHTML).toBe('<no-shadow-component class="hydrated">Hello World!</no-shadow-component>')
     })
 
     it('can unmount', async () => {


### PR DESCRIPTION
## Proposed changes

Fix a stencil test that fails in CI

## Types of changes

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [x] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Backport Request

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

I'm not a stencil pro so i hope the change is correct - a bit off googling said the hydrated class is added by stencil, so this should be the expected behaviour.

### Reviewers: @webdriverio/project-committers
