### PR TITLE
Removing us-east-1 region

### DIFF
--- a/packages/wdio-spec-reporter/src/index.ts
+++ b/packages/wdio-spec-reporter/src/index.ts
@@ -249,11 +249,10 @@ export default class SpecReporter extends WDIOReporter {
             }
 
             // VDC urls can be constructed / be made shared
-            const isUSEast1 = config.headless || (config.hostname?.includes('us-east-1'))
             const isUSEast4 = ['us-east-4'].includes(config?.region || '') || (config.hostname?.includes('us-east-4'))
             const isEUCentral = ['eu', 'eu-central-1'].includes(config?.region || '') || (config.hostname?.includes('eu-central'))
             const isAPAC = ['apac', 'apac-southeast-1'].includes(config?.region || '') || (config.hostname?.includes('apac'))
-            const dc = isUSEast1 ? '.us-east-1' : isUSEast4 ? '.us-east-4' : isEUCentral ? '.eu-central-1' : isAPAC ? '.apac-southeast-1' : ''
+            const dc = isUSEast4 ? '.us-east-4' : isEUCentral ? '.eu-central-1' : isAPAC ? '.apac-southeast-1' : ''
             const sauceLabsSharableLinks = this._sauceLabsSharableLinks
                 ? sauceAuthenticationToken( config.user, config.key, sessionId )
                 : ''

--- a/packages/wdio-spec-reporter/tests/__snapshots__/index.test.ts.snap
+++ b/packages/wdio-spec-reporter/tests/__snapshots__/index.test.ts.snap
@@ -426,7 +426,7 @@ exports[`SpecReporter > printReport > with normal setup > should print link to S
 [loremipsum 50 Windows 10 #0-0] 2) Bar test a failed test with no stack
 [loremipsum 50 Windows 10 #0-0] red expected foo to equal bar
 [loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] Check out job at https://app.us-east-1.saucelabs.com/tests/ba86cbcb70774ef8a0757c1702c3bdf9?auth=364414eae3ee11cb8b8bb3fc3e3b5e12
+[loremipsum 50 Windows 10 #0-0] Check out job at https://app.us-east-4.saucelabs.com/tests/ba86cbcb70774ef8a0757c1702c3bdf9?auth=364414eae3ee11cb8b8bb3fc3e3b5e12
 ",
   ],
 ]

--- a/packages/wdio-spec-reporter/tests/index.test.ts
+++ b/packages/wdio-spec-reporter/tests/index.test.ts
@@ -294,7 +294,7 @@ describe('SpecReporter', () => {
                 printReporter.write.mockClear()
 
                 printReporter.runnerStat.instanceOptions[fakeSessionId] = {
-                    hostname: 'ondemand.us-east-1.saucelabs.com',
+                    hostname: 'ondemand.us-east-4.saucelabs.com',
                     user: 'foobar',
                     key: '123'
                 }

--- a/packages/wdio-types/src/Options.ts
+++ b/packages/wdio-types/src/Options.ts
@@ -143,7 +143,7 @@ export interface WebDriver extends Connection {
     cacheDir?: string
 }
 
-export type SauceRegions = 'us' | 'eu' | 'apac' | 'us-west-1' | 'us-east-1' | 'us-east-4' | 'eu-central-1' | 'apac-southeast-1' | 'staging'
+export type SauceRegions = 'us' | 'eu' | 'apac' | 'us-west-1' | 'us-east-4' | 'eu-central-1' | 'apac-southeast-1' | 'staging'
 
 export interface WebdriverIO extends WebDriver, Pick<Hooks, 'onReload' | 'beforeCommand' | 'afterCommand'> {
     /**
@@ -155,10 +155,6 @@ export interface WebdriverIO extends WebDriver, Pick<Hooks, 'onReload' | 'before
      * US or EU. To change your region to EU, add region: 'eu' to your config.
      */
     region?: SauceRegions
-    /**
-     * Sauce Labs provides a headless offering that allows you to run Chrome and Firefox tests headless.
-     */
-    headless?: boolean
     /**
      * Shorten url command calls by setting a base URL.
      */

--- a/packages/webdriverio/src/utils/detectBackend.ts
+++ b/packages/webdriverio/src/utils/detectBackend.ts
@@ -10,7 +10,6 @@ const REGION_MAPPING = {
     'us': 'us-west-1.', // default endpoint
     'eu': 'eu-central-1.',
     'eu-central-1': 'eu-central-1.',
-    'us-east-1': 'us-east-1.',
     'us-east-4': 'us-east-4.',
     'apac': 'apac-southeast-1.',
     'apac-southeast-1': 'apac-southeast-1',
@@ -23,7 +22,6 @@ interface BackendConfigurations {
     key?: string
     protocol?: string
     region?: Options.SauceRegions
-    headless?: boolean
     path?: string
     capabilities?: Capabilities.RequestedStandaloneCapabilities
 }
@@ -46,7 +44,7 @@ function getSauceEndpoint (
  * helper to detect the Selenium backend according to given capabilities
  */
 export default function detectBackend(options: BackendConfigurations = {}) {
-    const { port, hostname, user, key, protocol, region, headless, path, capabilities } = options
+    const { port, hostname, user, key, protocol, region, path, capabilities } = options
 
     /**
      * browserstack
@@ -86,8 +84,7 @@ export default function detectBackend(options: BackendConfigurations = {}) {
         // Or only RDC or visual
         isVisual
     ) {
-        // Sauce headless is currently only in us-east-1
-        const sauceRegion = headless ? 'us-east-1' : region as keyof typeof REGION_MAPPING
+        const sauceRegion = region as keyof typeof REGION_MAPPING
 
         return {
             protocol: protocol || 'https',

--- a/packages/webdriverio/tests/utils/detectBackend.test.ts
+++ b/packages/webdriverio/tests/utils/detectBackend.test.ts
@@ -173,19 +173,6 @@ describe('detectBackend', () => {
         })
     })
 
-    it('should detect saucelabs headless user', () => {
-        const caps = detectBackend({
-            user: 'foobar',
-            key: '50aa152c-1932-B2f0-9707-18z46q2n1mb0',
-            region: 'eu',
-            headless: true
-        })
-        expect(caps.hostname).toBe('ondemand.us-east-1.saucelabs.com')
-        expect(caps.port).toBe(443)
-        expect(caps.path).toBe('/wd/hub')
-        expect(caps.protocol).toBe('https')
-    })
-
     it('should throw if user and key are given but can not be connected to a cloud', () => {
         expect(() => detectBackend({
             user: 'foobar',


### PR DESCRIPTION
## Proposed changes

I was debugging an issue and noticed the old `us-east-1` region and the `headless` option were present. So, I went ahead and removed this region. I executed all unit tests locally, and they passed. Please let me know if something else is needed.

I will later create another PR for APAC. I just wanted to keep this one as small as possible.

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
