### PR TITLE
Add file to cucumber options

### DIFF
--- a/packages/wdio-cucumber-framework/src/constants.ts
+++ b/packages/wdio-cucumber-framework/src/constants.ts
@@ -27,7 +27,8 @@ export const DEFAULT_OPTS: CucumberOptions = {
     ignoreUndefinedDefinitions: false,
     failAmbiguousDefinitions: false,
     tagExpression: '',
-    profiles: []
+    profiles: [],
+    file: undefined
 }
 
 export const CUCUMBER_HOOK_DEFINITION_TYPES = [

--- a/packages/wdio-cucumber-framework/src/index.ts
+++ b/packages/wdio-cucumber-framework/src/index.ts
@@ -273,7 +273,7 @@ class CucumberAdapter {
             }
 
             const { runConfiguration } = await loadConfiguration(
-                { profiles: this._cucumberOpts.profiles, provided: this._cucumberOpts as Partial<IConfiguration> },
+                { profiles: this._cucumberOpts.profiles, provided: this._cucumberOpts as Partial<IConfiguration>, file: this._cucumberOpts.file },
                 environment
             )
 

--- a/packages/wdio-cucumber-framework/src/types.ts
+++ b/packages/wdio-cucumber-framework/src/types.ts
@@ -143,6 +143,12 @@ export interface CucumberOptions {
      * @default []
      */
     profiles?: string[];
+    /**
+     * Path to load configuration file from, or `false` to skip.
+     * Not setting this results in undefined which ends up using default cucumber config files
+     * @default undefined
+     */
+    file?: string | false | undefined;
 }
 
 export interface HookParams {

--- a/tests/cucumber/cucumber.js
+++ b/tests/cucumber/cucumber.js
@@ -1,0 +1,10 @@
+import path from 'node:path'
+import url from 'node:url'
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url))
+
+export default {
+    paths: [
+        path.resolve(__dirname, 'test-skipped.feature')
+    ],
+}

--- a/tests/smoke.runner.js
+++ b/tests/smoke.runner.js
@@ -407,6 +407,42 @@ const cucumberReporter = async () => {
 }
 
 /**
+ * Cucumber file option
+ */
+const cucumberFileOption = async () => {
+    const logFile = path.resolve(__dirname, 'cucumber', 'cucumberFileOption.log')
+    await fs.rm(logFile, { force: true })
+    const { passed } = await launch(
+        'cucumberFileOption',
+        path.resolve(__dirname, 'helpers', 'cucumber-hooks.conf.js'),
+        {
+            specs: [
+                path.resolve(__dirname, 'cucumber', 'test.feature'),
+            ],
+            reporters: [
+                ['spec', {
+                    outputDir: __dirname,
+                    stdout: false,
+                    logFile
+                }]],
+            cucumberOpts: {
+                ignoreUndefinedDefinitions: true,
+                scenarioLevelReporter: true,
+                retry: 1,
+                retryTagFilter: '@retry',
+                file: './cucumber/cucumber.js'
+            }
+        }
+    )
+    assert.strictEqual(passed, 1)
+    const specLogs = (await fs.readFile(logFile)).toString().replace(ansiColorRegex, '')
+    assert.ok(
+        specLogs.includes('test-skipped.feature'),
+        'scenario not included according to cucumber config'
+    )
+}
+
+/**
  * wdio test run with custom service
  */
 const customService = async () => {
@@ -929,6 +965,7 @@ const jasmineAfterHookArgsValidation = async () => {
         cucumberTestrunnerMultipleByLineNumber,
         cucumberFailAmbiguousDefinitions,
         cucumberReporter,
+        cucumberFileOption,
         standaloneTest,
         mochaAsyncTestrunner,
         customService,


### PR DESCRIPTION
## Proposed changes

For #13562, adding file to options so that users can choose to ignore (or use different) cucumber config file. I got this from cucumber-js [here](https://github.com/cucumber/cucumber-js/blob/main/src/api/types.ts#L11)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [X] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

Let me know if this is needed. Since the issue is for v9, I only do this for main for now.

- [X] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
