### PR TITLE
fix(webdriverio): don't send `desiredCapabilities` anymore when initializing a session

### DIFF
--- a/__mocks__/fetch.ts
+++ b/__mocks__/fetch.ts
@@ -96,14 +96,6 @@ const requestMock: any = vi.fn().mockImplementation((uri, params) => {
         sessionResponse.capabilities.browserName = body.capabilities.alwaysMatch.browserName
     }
 
-    if (
-        body &&
-        body.desiredCapabilities &&
-        body.desiredCapabilities['sauce:options']
-    ) {
-        sessionResponse.capabilities['sauce:options'] = body.desiredCapabilities['sauce:options']
-    }
-
     if (body?.capabilities?.alwaysMatch?.browserName === 'bidi') {
         sessionResponse.capabilities.webSocketUrl = 'ws://webdriver.io'
     }
@@ -111,11 +103,6 @@ const requestMock: any = vi.fn().mockImplementation((uri, params) => {
     switch (uri.pathname) {
     case path:
         value = sessionResponse
-
-        if (body.capabilities.alwaysMatch.browserName && body.capabilities.alwaysMatch.browserName.includes('noW3C')) {
-            value.desiredCapabilities = { browserName: 'mockBrowser' }
-            delete value.capabilities
-        }
 
         if (body.capabilities.alwaysMatch.browserName && body.capabilities.alwaysMatch.browserName.includes('devtools')) {
             value.capabilities['goog:chromeOptions'] = {

--- a/packages/wdio-appium-service/tests/launcher.test.ts
+++ b/packages/wdio-appium-service/tests/launcher.test.ts
@@ -9,7 +9,7 @@ import { Readable, type Writable } from 'node:stream'
 
 import { describe, expect, beforeEach, afterEach, test, vi } from 'vitest'
 import { resolve } from 'import-meta-resolve'
-import type { Capabilities, Options } from '@wdio/types'
+import type { Capabilities } from '@wdio/types'
 
 import AppiumLauncher from '../src/launcher.js'
 
@@ -79,7 +79,7 @@ class MockFailingProcess extends MockProcess {
 class MockProcess2 implements Partial<ChildProcessByStdio<null, Readable, Readable>> {
     pid: number
     exitCode: number | null = null
-    signalCode: null
+    signalCode?: null
     spawnargs: string[] = []
     spawnfile: string = ''
     stdin: null = null
@@ -145,7 +145,7 @@ describe('Appium launcher', () => {
                 command:'path/to/my_custom_appium',
                 args: { address: 'bar', defaultCapabilities: { 'foo': 'bar' } },
             }
-            const capabilities = [{ port: 1234, deviceName: 'baz' }] as (Capabilities.DesiredCapabilities & Options.WebDriver)[]
+            const capabilities = [{ port: 1234, 'appium:deviceName': 'baz' }] as WebdriverIO.Capabilities[]
             const launcher = new AppiumLauncher(options, capabilities, {} as any)
             await launcher.onPrepare()
 
@@ -197,9 +197,9 @@ describe('Appium launcher', () => {
                 command: 'path/to/my_custom_appium',
                 args: { address: 'bar' }
             }
-            const capabilities: Capabilities.MultiRemoteCapabilities = {
-                browserA: { port: 1234, capabilities: { deviceName: 'baz' } },
-                browserB: { capabilities: { deviceName: 'baz' } }
+            const capabilities: Capabilities.RequestedMultiremoteCapabilities = {
+                browserA: { port: 1234, capabilities: { 'appium:deviceName': 'baz' } },
+                browserB: { capabilities: { 'appium:deviceName': 'baz' } }
             }
             const launcher = new AppiumLauncher(options, capabilities, {} as any)
             await launcher.onPrepare()
@@ -219,9 +219,9 @@ describe('Appium launcher', () => {
                 command: 'path/to/my_custom_appium',
                 args: { address: 'bar' }
             }
-            const capabilities: Capabilities.MultiRemoteCapabilities = {
+            const capabilities: Capabilities.RequestedMultiremoteCapabilities = {
                 browserA: { port: 1234, capabilities: { browserName: 'chrome' } },
-                browserB: { capabilities: { deviceName: 'baz' } }
+                browserB: { capabilities: { 'appium:deviceName': 'baz' } }
             }
             const launcher = new AppiumLauncher(options, capabilities, {} as any)
             await launcher.onPrepare()
@@ -241,12 +241,12 @@ describe('Appium launcher', () => {
                 command: 'path/to/my_custom_appium',
                 args: { address: 'bar' }
             }
-            const capabilities: Capabilities.MultiRemoteCapabilities[] = [{
-                browserA: { port: 1234, capabilities: { deviceName: 'baz' } },
-                browserB: { capabilities: { deviceName: 'baz' } }
+            const capabilities: Capabilities.RequestedMultiremoteCapabilities[] = [{
+                browserA: { port: 1234, capabilities: { 'appium:deviceName': 'baz' } },
+                browserB: { capabilities: { 'appium:deviceName': 'baz' } }
             }, {
-                browserC: { port: 5678, capabilities: { deviceName: 'baz' } },
-                browserD: { capabilities: { deviceName: 'baz' } }
+                browserC: { port: 5678, capabilities: { 'appium:deviceName': 'baz' } },
+                browserD: { capabilities: { 'appium:deviceName': 'baz' } }
             }]
             const launcher = new AppiumLauncher(options, capabilities, {} as any)
             await launcher.onPrepare()
@@ -274,8 +274,8 @@ describe('Appium launcher', () => {
                 args : { address: 'foo' },
                 installArgs : { bar : 'bar' },
             }
-            const capabilities: Capabilities.MultiRemoteCapabilities = {
-                browserA: { port: 1234, capabilities: { deviceName: 'baz' } },
+            const capabilities: Capabilities.RequestedMultiremoteCapabilities = {
+                browserA: { port: 1234, capabilities: { 'appium:deviceName': 'baz' } },
                 browserB: { port: 4321, capabilities: { 'bstack:options': {} } }
             }
             const launcher = new AppiumLauncher(options, capabilities, {} as any)
@@ -297,7 +297,7 @@ describe('Appium launcher', () => {
                 command: 'path/to/my_custom_appium',
                 args: { address:'bar', port: 1234 }
             }
-            const capabilities = [{ deviceName: 'baz' } as Capabilities.DesiredCapabilities]
+            const capabilities = [{ 'appium:deviceName': 'baz' }] as WebdriverIO.Capabilities[]
             const launcher = new AppiumLauncher(options, capabilities, {} as any)
             await launcher.onPrepare()
 
@@ -342,7 +342,7 @@ describe('Appium launcher', () => {
         test('should respect random Appium port', async () => {
             vi.mocked(getPort).mockResolvedValueOnce(567567)
 
-            const capabilities = [{ deviceName: 'baz' } as Capabilities.DesiredCapabilities]
+            const capabilities = [{ 'appium:deviceName': 'baz' }] as WebdriverIO.Capabilities[]
             const launcher = new AppiumLauncher({}, capabilities, {} as any)
             await launcher.onPrepare()
 
@@ -387,7 +387,7 @@ describe('Appium launcher', () => {
                 command: 'path/to/my_custom_appium',
                 args: { address: 'bar', port: 1234, basePath: '/foo/bar' }
             }
-            const capabilities = [{ port: 4321, deviceName: 'baz' } as Capabilities.DesiredCapabilities]
+            const capabilities = [{ port: 4321, 'appium:deviceName': 'baz' }] as WebdriverIO.Capabilities[]
             const launcher = new AppiumLauncher(options, capabilities, {} as any)
             await launcher.onPrepare()
 
@@ -598,7 +598,7 @@ describe('Appium launcher', () => {
                 command: 'path/to/my_custom_appium',
                 args: { address: 'bar', port: 1234, basePath: '/foo/bar' }
             }
-            const capabilities = [{ browserName: 'baz' } as Capabilities.DesiredCapabilities]
+            const capabilities = [{ browserName: 'baz' }] as WebdriverIO.Capabilities[]
             const launcher = new AppiumLauncher(options, capabilities, {} as any)
             launcher['_startAppium'] = vi.fn().mockResolvedValue(new MockProcess())
             await launcher.onPrepare()
@@ -617,9 +617,9 @@ describe('Appium launcher', () => {
                 command: 'path/to/my_custom_appium',
                 args: { address: 'bar' }
             }
-            const capabilities: Capabilities.MultiRemoteCapabilities = {
+            const capabilities: Capabilities.RequestedMultiremoteCapabilities = {
                 browserA: { capabilities: { browserName: 'baz' } },
-                browserB: { capabilities: { deviceName: 'baz' } }
+                browserB: { capabilities: { 'appium:deviceName': 'baz' } }
             }
             const launcher = new AppiumLauncher(options, capabilities, {} as any)
             await launcher.onPrepare()
@@ -639,12 +639,12 @@ describe('Appium launcher', () => {
                 command: 'path/to/my_custom_appium',
                 args: { address: 'bar' }
             }
-            const capabilities: Capabilities.MultiRemoteCapabilities[] = [{
-                browserA: { port: 1234, capabilities: { deviceName: 'baz' } },
+            const capabilities: Capabilities.RequestedMultiremoteCapabilities[] = [{
+                browserA: { port: 1234, capabilities: { 'appium:deviceName': 'baz' } },
                 browserB: { capabilities: { browserName: 'baz' } }
             }, {
                 browserC: { port: 5678, capabilities: { browserName: 'baz' } },
-                browserD: { capabilities: { deviceName: 'baz' } }
+                browserD: { capabilities: { 'appium:deviceName': 'baz' } }
             }]
             const launcher = new AppiumLauncher(options, capabilities, {} as any)
             await launcher.onPrepare()

--- a/packages/wdio-sauce-service/tests/launcher.test.ts
+++ b/packages/wdio-sauce-service/tests/launcher.test.ts
@@ -35,12 +35,12 @@ test('onPrepare w/ SauceConnect w/ tunnelIdentifier w/ JWP', async () => {
             tunnelIdentifier: 'my-tunnel'
         }
     }
-    const caps = [{}] as Capabilities.DesiredCapabilities[]
+    const caps = [{}] as WebdriverIO.Capabilities[]
     const config = {
         user: 'foobaruser',
         key: '12345'
     } as Options.Testrunner
-    const service = new SauceServiceLauncher(options, caps, config)
+    const service = new SauceServiceLauncher(options, caps as never, config)
     expect(service['_sauceConnectProcess']).toBeUndefined()
     await service.onPrepare(config, caps)
 
@@ -64,12 +64,12 @@ test('onPrepare w/ SauceConnect w/o tunnelIdentifier w/ JWP', async () => {
             sePort: 4446,
         }
     }
-    const caps = [{}] as Capabilities.DesiredCapabilities[]
+    const caps = [{}] as WebdriverIO.Capabilities[]
     const config = {
         user: 'foobaruser',
         key: '12345'
     } as Options.Testrunner
-    const service = new SauceServiceLauncher(options, caps, config)
+    const service = new SauceServiceLauncher(options, caps as never, config)
     expect(service['_sauceConnectProcess']).toBeUndefined()
     await service.onPrepare(config, caps)
 
@@ -89,12 +89,12 @@ test('onPrepare w/ SauceConnect w/ tunnelIdentifier w/ W3C', async () => {
             tunnelIdentifier: 'my-tunnel'
         }
     }
-    const caps = [{ 'sauce:options': { extendedDebugging: false } }] as Capabilities.DesiredCapabilities[]
+    const caps = [{ 'sauce:options': { extendedDebugging: false } }] as WebdriverIO.Capabilities[]
     const config = {
         user: 'foobaruser',
         key: '12345'
     } as Options.Testrunner
-    const service = new SauceServiceLauncher(options, caps, config)
+    const service = new SauceServiceLauncher(options, caps as never, config)
     expect(service['_sauceConnectProcess']).toBeUndefined()
     await service.onPrepare(config, caps)
 
@@ -113,12 +113,12 @@ test('onPrepare w/ SauceConnect w/o identifier w/ W3C', async () => {
     const options: SauceServiceConfig = {
         sauceConnect: true
     }
-    const caps = [{ 'appium:deviceName': 'Samsung Galaxy S10' }] as Capabilities.DesiredCapabilities[]
+    const caps = [{ 'appium:deviceName': 'Samsung Galaxy S10' }] as WebdriverIO.Capabilities[]
     const config = {
         user: 'foobaruser',
         key: '12345'
     } as Options.Testrunner
-    const service = new SauceServiceLauncher(options, caps, config)
+    const service = new SauceServiceLauncher(options, caps as never, config)
     expect(service['_sauceConnectProcess']).toBeUndefined()
     await service.onPrepare(config, caps)
 
@@ -137,12 +137,12 @@ test('onPrepare w/ SauceConnect w/o scRelay', async () => {
     const options: SauceServiceConfig = {
         sauceConnect: true
     }
-    const caps = [{}] as Capabilities.DesiredCapabilities[]
+    const caps = [{}] as WebdriverIO.Capabilities[]
     const config = {
         user: 'foobaruser',
         key: '12345'
     } as Options.Testrunner
-    const service = new SauceServiceLauncher(options, caps, config)
+    const service = new SauceServiceLauncher(options, caps as never, config)
     expect(service['_sauceConnectProcess']).toBeUndefined()
     await service.onPrepare(config, caps)
 
@@ -158,9 +158,9 @@ test('onPrepare w/ SauceConnect w/ scRelay w/ default port', async () => {
         sauceConnect: true,
         sauceConnectOpts: { tunnelIdentifier: 'test123' }
     }
-    const caps = [{}] as Capabilities.DesiredCapabilities[]
+    const caps = [{}] as WebdriverIO.Capabilities[]
     const config = {} as Options.Testrunner
-    const service = new SauceServiceLauncher(options, caps, config)
+    const service = new SauceServiceLauncher(options, caps as never, config)
     expect(service['_sauceConnectProcess']).toBeUndefined()
     await service.onPrepare(config, caps)
 
@@ -180,13 +180,13 @@ test('onPrepare w/ SauceConnect w/ region EU', async () => {
     const options: SauceServiceConfig = {
         sauceConnect: true
     }
-    const caps = [{}] as Capabilities.DesiredCapabilities[]
+    const caps = [{}] as WebdriverIO.Capabilities[]
     const config = {
         user: 'foobaruser',
         key: '12345',
         region: 'eu'
     } as Options.Testrunner
-    const service = new SauceServiceLauncher(options, caps, config)
+    const service = new SauceServiceLauncher(options, caps as never, config)
     expect(service['_sauceConnectProcess']).toBeUndefined()
     await service.onPrepare(config, caps)
 
@@ -206,7 +206,7 @@ test('onPrepare multiremote', async () => {
             tunnelIdentifier: 'my-tunnel'
         }
     }
-    const caps: Capabilities.MultiRemoteCapabilities = {
+    const caps: Capabilities.RequestedMultiremoteCapabilities = {
         browserA: {
             capabilities: { browserName: 'chrome' }
         },
@@ -221,7 +221,7 @@ test('onPrepare multiremote', async () => {
         user: 'foobaruser',
         key: '12345'
     } as Options.Testrunner
-    const service = new SauceServiceLauncher(options, caps, config)
+    const service = new SauceServiceLauncher(options, caps as never, config)
     expect(service['_sauceConnectProcess']).toBeUndefined()
     await service.onPrepare(config, caps)
 
@@ -251,7 +251,7 @@ test('onPrepare parallel multiremote', async () => {
             tunnelIdentifier: 'my-tunnel'
         }
     }
-    const caps: Capabilities.MultiRemoteCapabilities[] = [{
+    const caps: Capabilities.RequestedMultiremoteCapabilities[] = [{
         browserA: {
             capabilities: { browserName: 'chrome' }
         },
@@ -276,7 +276,7 @@ test('onPrepare parallel multiremote', async () => {
         user: 'foobaruser',
         key: '12345'
     } as Options.Testrunner
-    const service = new SauceServiceLauncher(options, caps, config)
+    const service = new SauceServiceLauncher(options, caps as never, config)
     expect(service['_sauceConnectProcess']).toBeUndefined()
     await service.onPrepare(config, caps)
 
@@ -317,12 +317,12 @@ test('onPrepare if sauceTunnel is not set', async () => {
             tunnelIdentifier: 'my-tunnel'
         }
     }
-    const caps = [{}] as Capabilities.DesiredCapabilities[]
+    const caps = [{}] as WebdriverIO.Capabilities[]
     const config = {
         user: 'foobaruser',
         key: '12345'
     } as Options.Testrunner
-    const service = new SauceServiceLauncher(options, caps, config)
+    const service = new SauceServiceLauncher(options, caps as never, config)
     expect(service['_sauceConnectProcess']).toBeUndefined()
     await service.onPrepare(config, caps)
 
@@ -341,7 +341,7 @@ test('onPrepare multiremote with tunnel identifier and with w3c caps ', async ()
             tunnelIdentifier: 'my-tunnel'
         }
     }
-    const caps: Capabilities.MultiRemoteCapabilities = {
+    const caps: Capabilities.RequestedMultiremoteCapabilities = {
         browserA: {
             capabilities: {
                 browserName: 'chrome',
@@ -364,7 +364,7 @@ test('onPrepare multiremote with tunnel identifier and with w3c caps ', async ()
         user: 'foobaruser',
         key: '12345'
     } as Options.Testrunner
-    const service = new SauceServiceLauncher(options, caps, config)
+    const service = new SauceServiceLauncher(options, caps as never, config)
     expect(service['_sauceConnectProcess']).toBeUndefined()
     await service.onPrepare(config, caps)
 
@@ -391,33 +391,6 @@ test('onPrepare multiremote with tunnel identifier and with w3c caps ', async ()
     expect(service['_sauceConnectProcess']).not.toBeUndefined()
 })
 
-test('onPrepare without tunnel identifier and without w3c caps ', async () => {
-    const options: SauceServiceConfig = {
-        sauceConnect: false
-    }
-    const caps: WebdriverIO.Capabilities[] = [{
-        browserName: 'chrome'
-    }, {
-        browserName: 'firefox',
-        tunnelIdentifier: 'fish'
-    }]
-    const config = {
-        user: 'foobaruser',
-        key: '12345'
-    } as Options.Testrunner
-    const service = new SauceServiceLauncher(options, caps, config)
-    expect(service['_sauceConnectProcess']).toBeUndefined()
-    await service.onPrepare(config, caps)
-
-    expect(caps).toEqual([{
-        browserName: 'chrome'
-    }, {
-        browserName: 'firefox',
-        tunnelIdentifier: 'fish'
-    }])
-    expect(service['_sauceConnectProcess']).toBeUndefined()
-})
-
 test('onPrepare without tunnel identifier and with w3c caps ', async () => {
     const options: SauceServiceConfig = {
         sauceConnect: false
@@ -438,7 +411,7 @@ test('onPrepare without tunnel identifier and with w3c caps ', async () => {
         user: 'foobaruser',
         key: '12345'
     } as Options.Testrunner
-    const service = new SauceServiceLauncher(options, caps, config)
+    const service = new SauceServiceLauncher(options, caps as never, config)
     expect(service['_sauceConnectProcess']).toBeUndefined()
     await service.onPrepare(config, caps)
 
@@ -482,7 +455,7 @@ test('onPrepare with tunnel identifier and with w3c caps ', async () => {
         user: 'foobaruser',
         key: '12345'
     } as Options.Testrunner
-    const service = new SauceServiceLauncher(options, caps, config)
+    const service = new SauceServiceLauncher(options, caps as never, config)
     expect(service['_sauceConnectProcess']).toBeUndefined()
     await service.onPrepare(config, caps)
 
@@ -502,73 +475,6 @@ test('onPrepare with tunnel identifier and with w3c caps ', async () => {
     expect(service['_sauceConnectProcess']).not.toBeUndefined()
 })
 
-test('onPrepare with tunnel identifier and without w3c caps ', async () => {
-    const options: SauceServiceConfig = {
-        sauceConnect: true,
-        scRelay: true,
-        sauceConnectOpts: {
-            sePort: 4446,
-            tunnelIdentifier: 'my-tunnel'
-        }
-    }
-    const caps: WebdriverIO.Capabilities[] = [{
-        browserName: 'internet explorer',
-        platform: 'Windows 7',
-        'sauce:options': { tunnelIdentifier: 'fish' }
-    }, {
-        browserName: 'internet explorer',
-        version: '9'
-    }, {
-        deviceName: 'iPhone',
-        platformName: 'iOS',
-        'sauce:options': { tunnelIdentifier: 'fish-bar' }
-    }, {
-        deviceName: 'iPhone',
-        platformName: 'iOS',
-    }, {
-        deviceName: 'iPhone Simulator',
-        platformName: 'iOS',
-        'sauce:options': { tunnelIdentifier: 'foo-bar' }
-    }, {
-        deviceName: 'iPhone Simulator',
-        platformName: 'iOS',
-    }]
-    const config = {
-        user: 'foobaruser',
-        key: '12345'
-    } as Options.Testrunner
-    const service = new SauceServiceLauncher(options, caps, config)
-    expect(service['_sauceConnectProcess']).toBeUndefined()
-    await service.onPrepare(config, caps)
-
-    expect(caps).toEqual([{
-        browserName: 'internet explorer',
-        platform: 'Windows 7',
-        'sauce:options': { tunnelIdentifier: 'fish' }
-    }, {
-        browserName: 'internet explorer',
-        version: '9',
-        'sauce:options': { tunnelIdentifier: 'my-tunnel' }
-    }, {
-        deviceName: 'iPhone',
-        platformName: 'iOS',
-        'sauce:options': { tunnelIdentifier: 'fish-bar' }
-    }, {
-        deviceName: 'iPhone',
-        platformName: 'iOS',
-        'sauce:options': { tunnelIdentifier: 'my-tunnel' }
-    }, {
-        deviceName: 'iPhone Simulator',
-        platformName: 'iOS',
-        'sauce:options': { tunnelIdentifier: 'foo-bar' }
-    }, {
-        deviceName: 'iPhone Simulator',
-        platformName: 'iOS',
-        'sauce:options': { tunnelIdentifier: 'my-tunnel' }
-    }])
-    expect(service['_sauceConnectProcess']).not.toBeUndefined()
-})
-
 test('startTunnel fail twice and recover', async ()=> {
     const options: SauceServiceConfig = {
         sauceConnect: true,
@@ -576,7 +482,7 @@ test('startTunnel fail twice and recover', async ()=> {
             tunnelIdentifier: 'my-tunnel'
         }
     }
-    const service = new SauceServiceLauncher(options, [{}], {} as Options.Testrunner)
+    const service = new SauceServiceLauncher(options, undefined as never, {} as Options.Testrunner)
     vi.mocked(service['_api'].startSauceConnect)
         .mockRejectedValueOnce(new Error('ENOENT'))
         .mockRejectedValueOnce(new Error('ENOENT'))
@@ -593,7 +499,7 @@ test('startTunnel fail three and throws error', async ()=> {
             tunnelIdentifier: 'my-tunnel'
         }
     }
-    const service = new SauceServiceLauncher(options, [{}], {} as Options.Testrunner)
+    const service = new SauceServiceLauncher(options, undefined as never, {} as Options.Testrunner)
     vi.mocked(service['_api'].startSauceConnect)
         .mockRejectedValueOnce(new Error('ENOENT'))
         .mockRejectedValueOnce(new Error('ENOENT'))
@@ -606,7 +512,7 @@ test('startTunnel fail three and throws error', async ()=> {
 })
 
 test('onComplete', async () => {
-    const service = new SauceServiceLauncher({}, [], {} as Options.Testrunner)
+    const service = new SauceServiceLauncher({}, undefined as never, {} as Options.Testrunner)
     expect(service.onComplete()).toBeUndefined()
 
     service['_sauceConnectProcess'] = { close: vi.fn() } as any

--- a/packages/wdio-testingbot-service/tests/launcher.test.ts
+++ b/packages/wdio-testingbot-service/tests/launcher.test.ts
@@ -99,7 +99,7 @@ describe('wdio-testingbot-service', () => {
             user: 'user',
             key: 'key'
         }
-        const caps: Capabilities.MultiRemoteCapabilities = {
+        const caps: Capabilities.RequestedMultiremoteCapabilities = {
             browserA: {
                 capabilities: {
                     'tb:options': {
@@ -151,7 +151,7 @@ describe('wdio-testingbot-service', () => {
             user: 'user',
             key: 'key'
         }
-        const caps: Capabilities.MultiRemoteCapabilities[] = [{
+        const caps: Capabilities.RequestedMultiremoteCapabilities[] = [{
             browserA: {
                 capabilities: {
                     'tb:options': {
@@ -258,7 +258,7 @@ describe('wdio-testingbot-service', () => {
             user: 'user',
             key: 'key'
         }
-        const caps: Capabilities.MultiRemoteCapabilities = {
+        const caps: Capabilities.RequestedMultiremoteCapabilities = {
             browserA: {
                 capabilities: {}
             },
@@ -273,9 +273,9 @@ describe('wdio-testingbot-service', () => {
         const tbLauncher = new TestingBotLauncher(options)
 
         await tbLauncher.onPrepare(config, caps as any)
-        expect(Object.keys((caps.browserA.capabilities as Capabilities.DesiredCapabilities)['tb:options'] as any))
+        expect(Object.keys((caps.browserA.capabilities as WebdriverIO.Capabilities)['tb:options'] as any))
             .toContain('tunnel-identifier')
-        expect(Object.keys((caps.browserB.capabilities as Capabilities.DesiredCapabilities)['tb:options'] as any))
+        expect(Object.keys((caps.browserB.capabilities as WebdriverIO.Capabilities)['tb:options'] as any))
             .toContain('build')
     })
 

--- a/packages/wdio-utils/src/utils.ts
+++ b/packages/wdio-utils/src/utils.ts
@@ -314,8 +314,17 @@ export const sleep = (ms = 0) => new Promise((r) => setTimeout(r, ms))
 export function isAppiumCapability(caps: WebdriverIO.Capabilities): boolean {
     return Boolean(
         caps &&
-        // @ts-expect-error outdated jsonwp cap
-        (caps.automationName || caps['appium:automationName'] || caps.deviceName || caps.appiumVersion)
+        (
+            // @ts-expect-error outdated jsonwp cap
+            caps.automationName ||
+            caps['appium:automationName'] ||
+            // @ts-expect-error outdated jsonwp cap
+            caps.deviceName ||
+            caps['appium:deviceName'] ||
+            // @ts-expect-error outdated jsonwp cap
+            caps.appiumVersion ||
+            caps['appium:appiumVersion']
+        )
     )
 }
 

--- a/packages/webdriver/src/utils.ts
+++ b/packages/webdriver/src/utils.ts
@@ -39,31 +39,38 @@ export async function startWebDriverSession (params: RemoteConfig): Promise<{ se
      * to check what style the user sent in so we know how to construct the
      * object for the other style
      */
-    const [w3cCaps, jsonwpCaps] = params.capabilities && 'alwaysMatch' in params.capabilities
+    const capabilities = params.capabilities && 'alwaysMatch' in params.capabilities
         /**
          * in case W3C compliant capabilities are provided
          */
-        ? [params.capabilities, params.capabilities.alwaysMatch]
+        ? params.capabilities
         /**
          * otherwise assume they passed in jsonwp-style caps (flat object)
          */
-        : [{ alwaysMatch: params.capabilities, firstMatch: [{}] }, params.capabilities]
+        : { alwaysMatch: params.capabilities, firstMatch: [{}] }
 
     /**
-     * automatically opt-into WebDriver Bid (@ref https://w3c.github.io/webdriver-bidi/)
+     * automatically opt-into WebDriver Bidi (@ref https://w3c.github.io/webdriver-bidi/)
      */
-    if (!w3cCaps.alwaysMatch['wdio:enforceWebDriverClassic'] && typeof w3cCaps.alwaysMatch.browserName === 'string' && w3cCaps.alwaysMatch.browserName.toLowerCase() !== 'safari') {
-        w3cCaps.alwaysMatch.webSocketUrl = true
+    if (
+        /**
+         * except, if user does not want to opt-in
+         */
+        !capabilities.alwaysMatch['wdio:enforceWebDriverClassic'] &&
+        /**
+         * or user requests a Safari session which does not support Bidi
+         */
+        typeof capabilities.alwaysMatch.browserName === 'string' &&
+        capabilities.alwaysMatch.browserName.toLowerCase() !== 'safari'
+    ) {
+        capabilities.alwaysMatch.webSocketUrl = true
     }
 
-    validateCapabilities(w3cCaps.alwaysMatch)
+    validateCapabilities(capabilities.alwaysMatch)
     const sessionRequest = new Request(
         'POST',
         '/session',
-        {
-            capabilities: w3cCaps, // W3C compliant
-            desiredCapabilities: jsonwpCaps // JSONWP compliant
-        }
+        { capabilities }
     )
 
     let response

--- a/packages/webdriver/tests/index.test.ts
+++ b/packages/webdriver/tests/index.test.ts
@@ -93,10 +93,6 @@ describe('WebDriver', () => {
                             webSocketUrl: true
                         },
                         firstMatch: [{}]
-                    },
-                    desiredCapabilities: {
-                        browserName: 'firefox',
-                        webSocketUrl: true
                     }
                 }) })
             )
@@ -120,10 +116,6 @@ describe('WebDriver', () => {
                             webSocketUrl: true
                         },
                         firstMatch: [{}]
-                    },
-                    desiredCapabilities: {
-                        browserName: 'firefox',
-                        webSocketUrl: true
                     }
                 }) })
             )

--- a/packages/webdriverio/tests/addCommand.test.ts
+++ b/packages/webdriverio/tests/addCommand.test.ts
@@ -1,16 +1,16 @@
 import path from 'node:path'
 import { describe, test, expect, vi } from 'vitest'
-import type { Options, Capabilities } from '@wdio/types'
+import type { Capabilities } from '@wdio/types'
 
 import { remote, multiremote } from '../src/index.js'
 
 vi.mock('fetch')
 vi.mock('@wdio/logger', () => import(path.join(process.cwd(), '__mocks__', '@wdio/logger')))
 
-const remoteConfig: Options.WebdriverIO = {
+const remoteConfig: Capabilities.WebdriverIOConfig = {
     baseUrl: 'http://foobar.com',
     capabilities: {
-        browserName: 'foobar-noW3C'
+        browserName: 'foobar'
     }
 }
 
@@ -31,7 +31,7 @@ declare global {
     }
 }
 
-const multiremoteConfig: Capabilities.MultiRemoteCapabilities = {
+const multiremoteConfig: Capabilities.RequestedMultiremoteCapabilities = {
     browserA: {
         logLevel: 'debug',
         capabilities: {

--- a/packages/webdriverio/tests/commands/browser/$.test.ts
+++ b/packages/webdriverio/tests/commands/browser/$.test.ts
@@ -34,7 +34,7 @@ describe('element', () => {
         const browser = await remote({
             baseUrl: 'http://foobar.com',
             capabilities: {
-                browserName: 'foobar-noW3C'
+                browserName: 'foobar'
             }
         })
 

--- a/packages/webdriverio/tests/commands/browser/newWindow.test.ts
+++ b/packages/webdriverio/tests/commands/browser/newWindow.test.ts
@@ -6,8 +6,6 @@ import { expect, describe, beforeEach, afterEach, it, vi } from 'vitest'
 
 import { remote } from '../../../src/index.js'
 
-import type { Capabilities } from '@wdio/types'
-
 vi.mock('fetch')
 vi.mock('@wdio/logger', () => import(path.join(process.cwd(), '__mocks__', '@wdio/logger')))
 
@@ -101,7 +99,7 @@ describe('newWindow', () => {
                 browserName: 'ipad',
                 // @ts-ignore mock feature
                 mobileMode: true
-            } as Capabilities.DesiredCapabilities
+            }
         })
 
         const error = await browser.newWindow('https://webdriver.io', {

--- a/packages/webdriverio/tests/commands/browser/setTimeout.test.ts
+++ b/packages/webdriverio/tests/commands/browser/setTimeout.test.ts
@@ -62,7 +62,7 @@ describe('setTimeout', () => {
         const browser = await remote({
             baseUrl: 'http://foobar.com',
             capabilities: {
-                browserName: 'foobar-noW3C'
+                browserName: 'foobar'
             }
         })
 

--- a/packages/webdriverio/tests/commands/element/$.test.ts
+++ b/packages/webdriverio/tests/commands/element/$.test.ts
@@ -42,7 +42,7 @@ describe('element', () => {
         const browser = await remote({
             baseUrl: 'http://foobar.com',
             capabilities: {
-                browserName: 'foobar-noW3C'
+                browserName: 'foobar'
             }
         })
 

--- a/packages/webdriverio/tests/commands/element/getValue.test.ts
+++ b/packages/webdriverio/tests/commands/element/getValue.test.ts
@@ -27,22 +27,6 @@ describe('getValue', () => {
             .toBe('/session/foobar-123/element/some-elem-123/property/value')
     })
 
-    it('should get the value using getElementAttribute', async () => {
-        const browser = await remote({
-            baseUrl: 'http://foobar.com',
-            capabilities: {
-                browserName: 'foobar'
-            }
-        })
-
-        const elem = await browser.$('#foo')
-
-        await elem.getValue()
-        // @ts-expect-error mock implementation
-        expect(vi.mocked(fetch).mock.calls[2][0].pathname)
-            .toBe('/session/foobar-123/element/some-elem-123/attribute/value')
-    })
-
     it('should get value in mobile mode', async () => {
         const browser = await remote({
             baseUrl: 'http://foobar.com',

--- a/packages/webdriverio/tests/commands/element/getValue.test.ts
+++ b/packages/webdriverio/tests/commands/element/getValue.test.ts
@@ -31,7 +31,7 @@ describe('getValue', () => {
         const browser = await remote({
             baseUrl: 'http://foobar.com',
             capabilities: {
-                browserName: 'foobar-noW3C'
+                browserName: 'foobar'
             }
         })
 

--- a/packages/webdriverio/tests/overwriteCommand.test.ts
+++ b/packages/webdriverio/tests/overwriteCommand.test.ts
@@ -8,7 +8,7 @@ vi.mock('@wdio/logger', () => import(path.join(process.cwd(), '__mocks__', '@wdi
 const remoteConfig = {
     baseUrl: 'http://foobar.com',
     capabilities: {
-        browserName: 'foobar-noW3C'
+        browserName: 'foobar'
     }
 }
 


### PR DESCRIPTION
## Proposed changes

No browser driver is supporting this anymore and since WebdriverIO doesn't provide JSONWP commands we can get rid of this as well.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
