### PR TITLE
Upgrade to import-meta-resolve v4.1.0 to avoid node 22 deprecation warning

### DIFF
--- a/packages/wdio-cli/package.json
+++ b/packages/wdio-cli/package.json
@@ -54,7 +54,7 @@
     "dotenv": "^16.3.1",
     "ejs": "^3.1.9",
     "execa": "^9.2.0",
-    "import-meta-resolve": "^4.0.0",
+    "import-meta-resolve": "^4.1.0",
     "inquirer": "^11.0.1",
     "lodash.flattendeep": "^4.4.0",
     "lodash.pickby": "^4.6.0",

--- a/packages/wdio-config/package.json
+++ b/packages/wdio-config/package.json
@@ -42,7 +42,7 @@
     "decamelize": "^6.0.0",
     "deepmerge-ts": "^7.0.3",
     "glob": "^10.2.2",
-    "import-meta-resolve": "^4.0.0"
+    "import-meta-resolve": "^4.1.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/wdio-utils/package.json
+++ b/packages/wdio-utils/package.json
@@ -44,7 +44,7 @@
     "edgedriver": "^5.6.1",
     "geckodriver": "^4.3.3",
     "get-port": "^7.0.0",
-    "import-meta-resolve": "^4.0.0",
+    "import-meta-resolve": "^4.1.0",
     "locate-app": "^2.2.24",
     "safaridriver": "^0.1.2",
     "split2": "^4.2.0",

--- a/packages/webdriverio/package.json
+++ b/packages/webdriverio/package.json
@@ -89,7 +89,7 @@
     "css-value": "^0.0.1",
     "grapheme-splitter": "^1.0.4",
     "htmlfy": "^0.2.1",
-    "import-meta-resolve": "^4.0.0",
+    "import-meta-resolve": "^4.1.0",
     "is-plain-obj": "^4.1.0",
     "jszip": "^3.10.1",
     "lodash.clonedeep": "^4.5.0",


### PR DESCRIPTION
node v22 prints a deprecation warning:
(node:429057) [DEP0180] DeprecationWarning: fs.Stats constructor is deprecated.

The "import-meta-resolve" package was using the deprecated API in 4.0.0 but they stopped using the deprecated API in 4.1.0. This PR upgrades to 4.1.0 for a few packages where webdriverio was using 4.0.0

node v22 will be LTS very very soon so it's nice to clean up this warning

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
