### PR TITLE
fix(webdriver): restore request retries

### DIFF
--- a/packages/wdio-webdriver-mock-service/src/index.ts
+++ b/packages/wdio-webdriver-mock-service/src/index.ts
@@ -68,6 +68,7 @@ export default class WebdriverMockService implements Services.ServiceInstance {
         this._browser.addCommand('parentElementChaining', this.parentNextPreviousElementChaining.bind(this))
         this._browser.addCommand('refetchElementScenario', this.refetchElementScenario.bind(this))
         this._browser.addCommand('executeMemLeakScenario', this.executeMemLeakScenario.bind(this))
+        this._browser.addCommand('requestRetryScenario', this.requestRetryScenario.bind(this))
     }
 
     clickScenario() {
@@ -249,6 +250,13 @@ export default class WebdriverMockService implements Services.ServiceInstance {
         // due to memory leaks in nock, we have to reset it from within the test
         // before measuring our actual memory usage
         return () => this.nockReset()
+    }
+
+    requestRetryScenario() {
+        this.nockReset()
+
+        this._mock.command.navigateTo().times(3).reply(500, {})
+        this._mock.command.navigateTo().reply(200, { value: null })
     }
 
     nockReset() {

--- a/packages/webdriver/src/request/constants.ts
+++ b/packages/webdriver/src/request/constants.ts
@@ -1,0 +1,4 @@
+/**
+ * retrieved from https://github.com/sindresorhus/ky/blob/3ba40cc6333cf1847c02c51744e22ab7c04407f5/source/utils/normalize.ts#L10
+ */
+export const RETRYABLE_STATUS_CODES = [408, 413, 429, 500, 502, 503, 504]

--- a/packages/webdriver/src/utils.ts
+++ b/packages/webdriver/src/utils.ts
@@ -426,7 +426,7 @@ export const getSessionError = (err: JSONWPCommandError, params: Partial<Options
 /**
  * return timeout error with information about the executing command on which the test hangs
  */
-export function getTimeoutError(error: Error, requestOptions: RequestInit, url: URL): Error {
+export function getRequestError(error: Error, requestOptions: RequestInit, url: URL): Error {
     const cmdName = getExecCmdName(url)
     const cmdArgs = getExecCmdArgs(requestOptions)
 

--- a/packages/webdriver/tests/request.test.ts
+++ b/packages/webdriver/tests/request.test.ts
@@ -356,9 +356,9 @@ describe('webdriver request', () => {
                 expect(reqRetryCnt).toBeCalledTimes(retryCnt)
             })
 
-            it('should use error from "getTimeoutError" helper', async () => {
+            it('should use error from "getRequestError" helper', async () => {
                 const timeoutErr = new Error('Timeout')
-                const spy = vi.spyOn(utils, 'getTimeoutError').mockReturnValue(timeoutErr)
+                const spy = vi.spyOn(utils, 'getRequestError').mockReturnValue(timeoutErr)
 
                 const req = new WebDriverRequest('GET', '/timeout', {}, true)
                 req.emit = vi.fn()

--- a/packages/webdriver/tests/utils.test.ts
+++ b/packages/webdriver/tests/utils.test.ts
@@ -8,7 +8,7 @@ import type { Capabilities, Options } from '@wdio/types'
 import {
     isSuccessfulResponse, getPrototype, getSessionError,
     getErrorFromResponseBody, CustomRequestError, startWebDriverSession,
-    getTimeoutError, setupDirectConnect, validateCapabilities
+    getRequestError, setupDirectConnect, validateCapabilities
 } from '../src/utils.js'
 import type { Client, RemoteConfig } from '../src/types.js'
 
@@ -436,7 +436,7 @@ describe('utils', () => {
         })
     })
 
-    describe('getTimeoutError', () => {
+    describe('getRequestError', () => {
         const mkReqOpts = (opts = {}) => {
             return {
                 method: 'GET',
@@ -449,7 +449,7 @@ describe('utils', () => {
                 const err = new Error('Timeout')
                 const reqOpts = mkReqOpts({})
 
-                const timeoutErr = getTimeoutError(err, reqOpts, new URL('https://localhost:4445/wd/hub/session'))
+                const timeoutErr = getRequestError(err, reqOpts, new URL('https://localhost:4445/wd/hub/session'))
 
                 expect(timeoutErr.message).toEqual(expect.stringMatching('when running "https://localhost:4445/wd/hub/session"'))
             })
@@ -458,7 +458,7 @@ describe('utils', () => {
                 const err = new Error('Timeout')
                 const reqOpts = mkReqOpts({})
 
-                const timeoutErr = getTimeoutError(err, reqOpts, new URL('https://localhost:4445/wd/hub/session/abc123/url'))
+                const timeoutErr = getRequestError(err, reqOpts, new URL('https://localhost:4445/wd/hub/session/abc123/url'))
 
                 expect(timeoutErr.message).toEqual(expect.stringMatching('when running "url"'))
             })
@@ -467,7 +467,7 @@ describe('utils', () => {
                 const err = new Error('Timeout')
                 const reqOpts = mkReqOpts({ method: 'GET' })
 
-                const timeoutErr = getTimeoutError(err, reqOpts, new URL('https://localhost:4445/default/method'))
+                const timeoutErr = getRequestError(err, reqOpts, new URL('https://localhost:4445/default/method'))
 
                 expect(timeoutErr.message).toEqual(expect.stringMatching(/when running .+ with method "GET"/))
             })
@@ -477,7 +477,7 @@ describe('utils', () => {
                 const cmdArgs = { foo: 'bar' }
                 const reqOpts = mkReqOpts({ body: cmdArgs })
 
-                const timeoutErr = getTimeoutError(err, reqOpts, new URL('https://localhost:4445/default/method'))
+                const timeoutErr = getRequestError(err, reqOpts, new URL('https://localhost:4445/default/method'))
 
                 expect(timeoutErr.message).toEqual(
                     expect.stringMatching(new RegExp(`when running .+ with method .+ and args "${JSON.stringify(cmdArgs)}"`))
@@ -491,7 +491,7 @@ describe('utils', () => {
                 const cmdArgs = { script: Buffer.from('script').toString('base64') }
                 const reqOpts = mkReqOpts({ body: cmdArgs })
 
-                const timeoutErr = getTimeoutError(err, reqOpts, new URL('https://localhost:4445/default/method'))
+                const timeoutErr = getRequestError(err, reqOpts, new URL('https://localhost:4445/default/method'))
 
                 expect(timeoutErr.message).toEqual(
                     expect.stringMatching(/when running .+ with method .+ and args "<Script\[base64\]>"/)
@@ -503,7 +503,7 @@ describe('utils', () => {
                 const cmdArgs = { script: 'return (function() {\nconsole.log("hi")\n}).apply(null, arguments)' }
                 const reqOpts = mkReqOpts({ body: cmdArgs })
 
-                const timeoutErr = getTimeoutError(err, reqOpts, new URL('https://localhost:4445/default/method'))
+                const timeoutErr = getRequestError(err, reqOpts, new URL('https://localhost:4445/default/method'))
 
                 expect(timeoutErr.message).toEqual(
                     expect.stringMatching(/when running .+ with method .+ and args "function\(\) {\nconsole\.log\("hi"\)\n}/)
@@ -517,7 +517,7 @@ describe('utils', () => {
                 const cmdArgs = { file: Buffer.from('screen').toString('base64') }
                 const reqOpts = mkReqOpts({ body: cmdArgs })
 
-                const timeoutErr = getTimeoutError(err, reqOpts, new URL('https://localhost:4445/default/method'))
+                const timeoutErr = getRequestError(err, reqOpts, new URL('https://localhost:4445/default/method'))
 
                 expect(timeoutErr.message).toEqual(
                     expect.stringMatching(/when running .+ with method .+ and args "<Screenshot\[base64\]>"/)

--- a/tests/mocha/test.ts
+++ b/tests/mocha/test.ts
@@ -338,9 +338,9 @@ describe('Mocha smoke test', () => {
         it('should throw if promise rejects', async () => {
             // @ts-expect-error custom command
             await browser.customCommandScenario()
-            browser.overwriteCommand('deleteCookies', (async (origCommand: Function, fail: boolean) => {
-                const result = await origCommand()
-                return fail ? Promise.reject(new Error(result)) : result
+            browser.overwriteCommand('deleteCookies', (async (origCommand: Function) => {
+                await origCommand()
+                return Promise.reject(new Error('deleteAllCookies'))
             }) as any)
 
             await assert.rejects(
@@ -362,9 +362,9 @@ describe('Mocha smoke test', () => {
         it('should throw if promise rejects (async execution)', async () => {
             // @ts-expect-error custom command
             await browser.customCommandScenario()
-            browser.overwriteCommand('deleteCookies', async (origCommand, fail) => {
-                const result = (await origCommand()) as any as string
-                return fail ? Promise.reject(new Error(result)) : result
+            browser.overwriteCommand('deleteCookies', async (origCommand: Function) => {
+                await origCommand()
+                return Promise.reject(new Error('deleteAllCookies'))
             })
 
             await assert.rejects(
@@ -407,6 +407,14 @@ describe('Mocha smoke test', () => {
             // @ts-expect-error mock feature
             await browser.refetchElementScenario()
             expect(await browser.$$('.foo')[3].getText()).toBe('some element text 4')
+        })
+    })
+
+    describe('request retries', () => {
+        it('should retry request', async () => {
+            // @ts-expect-error mock feature
+            await browser.requestRetryScenario()
+            await browser.url('https://mymockpage.com')
         })
     })
 })

--- a/tests/smoke.runner.js
+++ b/tests/smoke.runner.js
@@ -69,9 +69,9 @@ async function runTests (tests) {
  * Mocha wdio testrunner tests
  */
 const mochaTestrunner = async () => {
-    const { skippedSpecs } = await launch('mochaTestrunner', baseConfig, {
+    const { skippedSpecs, passed } = await launch('mochaTestrunner', baseConfig, {
         specs: [
-            './mocha/test.ts',
+            '../mocha/test.ts',
             path.resolve(__dirname, 'mocha', 'test-middleware.ts'),
             path.resolve(__dirname, 'mocha', 'test-waitForElement.ts'),
             path.resolve(__dirname, 'mocha', 'test-skipped.ts'),
@@ -87,6 +87,7 @@ const mochaTestrunner = async () => {
         return
     }
     assert.strictEqual(skippedSpecs, 1)
+    assert.strictEqual(passed, 4)
 }
 
 /**


### PR DESCRIPTION
## Proposed changes

In v8 we had request retries automatically enabled with `got`. As we switched to `fetch` we lost this capability and now have to restore it by implementing it using already provided primitives by our request class.

fixes #13553

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
