### PR TITLE
chore: improve log formatting for args

### DIFF
--- a/packages/wdio-local-runner/src/worker.ts
+++ b/packages/wdio-local-runner/src/worker.ts
@@ -121,7 +121,7 @@ export default class WorkerInstance extends EventEmitter implements Workers.Work
             runnerEnv.NODE_OPTIONS = (runnerEnv.NODE_OPTIONS || '') + ' --import tsx'
         }
 
-        log.info(`Start worker ${cid} with arg: ${argv}`)
+        log.info(`Start worker ${cid} with arg: ${argv.join(' ')}`)
         const childProcess = this.childProcess = child.fork(path.join(__dirname, 'run.js'), argv, {
             cwd: process.cwd(),
             env: runnerEnv,


### PR DESCRIPTION
## Proposed changes

Currently, when running a local runner we get the following log:
```
2024-09-25T14:51:17.385Z INFO @wdio/local-runner: Start worker 0-0 with arg: run,./wdio.conf.ts
```

I would expect to see:

```
2024-09-25T14:51:17.385Z INFO @wdio/local-runner: Start worker 0-0 with arg: run ./wdio.conf.ts
```

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
