### PR TITLE
fix(ci) group dependabot PRs by version type

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,16 @@ updates:
     # updates to Node.js requires update to .nvmrc
     - dependency-name: "@types/node"
       update-types: ["version-update:semver-major"]
+  groups:
+    patch-deps-updates-main:
+      update-types:
+        - "patch"
+    minor-deps-updates-main:
+      update-types:
+        - "minor"
+    major-deps-updates-main:
+      update-types:
+        - "major"
 - package-ecosystem: npm
   directory: "/"
   target-branch: v8
@@ -50,9 +60,29 @@ updates:
     - dependency-name: "puppeteer-core"
     # requires manual upgrade
     - dependency-name: "allure-js-commons"
+  groups:
+    patch-deps-updates-v8:
+      update-types:
+        - "patch"
+    minor-deps-updates-v8:
+      update-types:
+        - "minor"
+    major-deps-updates-v8:
+      update-types:
+        - "major"
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
     interval: weekly
     time: "11:00"
   open-pull-requests-limit: 10
+  groups:
+    patch-deps-updates:
+      update-types:
+        - "patch"
+    minor-deps-updates:
+      update-types:
+        - "minor"
+    major-deps-updates:
+      update-types:
+        - "major"


### PR DESCRIPTION
## Proposed changes

By default, Dependabot raises a single pull request for each dependency that needs to be updated to a newer version. You can use groups to create sets of dependencies (per package manager), so that Dependabot opens a single pull request to update multiple dependencies at the same time.

More docs [here](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
