### PR TITLE
chore(webdriver): add exponential backoff to request retries

### DIFF
--- a/packages/webdriver/tests/request.test.ts
+++ b/packages/webdriver/tests/request.test.ts
@@ -397,7 +397,7 @@ describe('webdriver request', () => {
             )
             expect(result).toEqual({ value: {} })
             expect(reqRetryCnt).toBeCalledTimes(5)
-        })
+        }, 20_000)
 
         it('should retry on connection refused error', async () => {
             const retryCnt = 7
@@ -416,7 +416,7 @@ describe('webdriver request', () => {
             )
             expect(result).toEqual({ value: { foo: 'bar' } })
             expect(reqRetryCnt).toBeCalledTimes(5)
-        })
+        }, 20_000)
 
         it('should throw if request error is unknown', async () => {
             const req = new WebDriverRequest('POST', '/sumoerror', {}, true)


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

Fixes: https://github.com/webdriverio/webdriverio/issues/13725

This change adds exponential backoff to request retries.
The first retry has no delay, subsequent retries have increasingly larger and larger delays.

I've added an absolute maximum of 10 seconds in case a caller allows an excessively large number of retries.

I've set numbers which seemed reasonable to me but please adjust if needed.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO \(v8\), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

Is current test coverage sufficient?
I am unsure how to add a test for this that wouldn't be flaky.

### Reviewers: @webdriverio/project-committers
