### PR TITLE
fix(webdriverio): make command more compatible with v8 behavior

### DIFF
--- a/e2e/browser-runner/__snapshots__/react.test.tsx.snap
+++ b/e2e/browser-runner/__snapshots__/react.test.tsx.snap
@@ -5,3 +5,9 @@ exports[`React Component Testing > supports snapshot tests 1`] = `
   <button>Current theme: light</button>
 </div>"
 `;
+
+exports[`React Component Testing > supports snapshot tests 3`] = `
+"<div>
+  <button>Current theme: light</button>
+</div>"
+`;

--- a/e2e/browser-runner/lit.test.js
+++ b/e2e/browser-runner/lit.test.js
@@ -119,7 +119,7 @@ describe('Lit Component testing', () => {
     })
 
     describe('shadow root piercing', function () {
-        it('should allow to pierce into closed shadow roots', async () => {
+        it('should allow to pierce into closed shadow roots', async function () {
             /**
              * test stopped working on Linux CI machines, skipping for now
              */
@@ -166,7 +166,7 @@ describe('Lit Component testing', () => {
             `)
         })
 
-        it('can fetch multiple elements within various closed shadow roots', async () => {
+        it('can fetch multiple elements within various closed shadow roots', async function () {
             /**
              * test stopped working on Linux CI machines, skipping for now
              */

--- a/e2e/browser-runner/lit.test.js
+++ b/e2e/browser-runner/lit.test.js
@@ -58,7 +58,7 @@ describe('Lit Component testing', () => {
         expect(window.mochaGlobalSetupExecuted).toBe(true)
     })
 
-    it('should render component', async () => {
+    it('should render component', async function () {
         /**
          * only run snapshot tests in non-Safari browsers as shadow dom piercing
          * is not yet supported in Safari
@@ -83,7 +83,7 @@ describe('Lit Component testing', () => {
         expect(await innerElem.getText()).toBe('Hello Sir, WebdriverIO! How are you today?')
     })
 
-    it('should render with mocked component function', async () => {
+    it('should render with mocked component function', async function () {
         /**
          * only run snapshot tests in non-Safari browsers as shadow dom piercing
          * is not yet supported in Safari
@@ -565,7 +565,7 @@ describe('Lit Component testing', () => {
             expect(error.message).toBe('expected bar to be foo')
         })
 
-        it('should support nested element calls', async () => {
+        it('should support nested element calls', async function () {
             /**
              * test stopped working on Linux CI machines, skipping for now
              */
@@ -864,7 +864,7 @@ describe('Lit Component testing', () => {
         expect(a.tagName).toBe('X-FOO')
     })
 
-    it('connectedCallback should not fail if no original connectedCallback is defined', function(){
+    it('connectedCallback should not fail if no original connectedCallback is defined', function () {
         // only in bidi the customElementWrapper is not available
         if (!browser.isBidi || browser.options?.automationProtocol !== 'webdriver') {
             return this.skip()
@@ -876,7 +876,7 @@ describe('Lit Component testing', () => {
         a.connectedCallback()
     })
 
-    it('disConnectedCallback should not fail if no original disConnectedCallback is defined', function() {
+    it('disConnectedCallback should not fail if no original disConnectedCallback is defined', function () {
         // only in bidi the customElementWrapper is not available
         if (!browser.isBidi || browser.options?.automationProtocol !== 'webdriver') {
             return this.skip()

--- a/e2e/browser-runner/lit.test.js
+++ b/e2e/browser-runner/lit.test.js
@@ -1,5 +1,3 @@
-import os from 'node:os'
-
 import { browser, expect, $ } from '@wdio/globals'
 import { spyOn, mock, fn, unmock } from '@wdio/browser-runner'
 import { html, render } from 'lit'
@@ -15,10 +13,6 @@ import { someExport, namedExports, someFunction } from '@testing-library/user-ev
 import stringWidth from 'string-width'
 
 import { SimpleGreeting } from './components/LitComponent.ts'
-
-function isLinuxPlatform () {
-    return !['darwin', 'win32'].includes(os.platform())
-}
 
 const getQuestionFn = spyOn(SimpleGreeting.prototype, 'getQuestion')
 mock('./components/constants.ts', async (mod) => {
@@ -67,13 +61,6 @@ describe('Lit Component testing', () => {
             return
         }
 
-        /**
-         * test stopped working on Linux CI machines, skipping for now
-         */
-        if (isLinuxPlatform()) {
-            return this.skip()
-        }
-
         render(
             html`<simple-greeting name="WebdriverIO" />`,
             document.body
@@ -90,13 +77,6 @@ describe('Lit Component testing', () => {
          */
         if (browser.capabilities.browserName?.toLowerCase() === 'safari') {
             return
-        }
-
-        /**
-         * test stopped working on Linux CI machines, skipping for now
-         */
-        if (isLinuxPlatform()) {
-            return this.skip()
         }
 
         getQuestionFn.mockReturnValue('Does this work?')
@@ -120,13 +100,6 @@ describe('Lit Component testing', () => {
 
     describe('shadow root piercing', function () {
         it('should allow to pierce into closed shadow roots', async function () {
-            /**
-             * test stopped working on Linux CI machines, skipping for now
-             */
-            if (isLinuxPlatform()) {
-                return this.skip()
-            }
-
             /**
              * only run snapshot tests in non-Safari browsers as shadow dom piercing
              * is not yet supported in Safari
@@ -167,13 +140,6 @@ describe('Lit Component testing', () => {
         })
 
         it('can fetch multiple elements within various closed shadow roots', async function () {
-            /**
-             * test stopped working on Linux CI machines, skipping for now
-             */
-            if (isLinuxPlatform()) {
-                return this.skip()
-            }
-
             /**
              * only run snapshot tests in non-Safari browsers as shadow dom piercing
              * is not yet supported in Safari
@@ -573,13 +539,6 @@ describe('Lit Component testing', () => {
         })
 
         it('should support nested element calls', async function () {
-            /**
-             * test stopped working on Linux CI machines, skipping for now
-             */
-            if (isLinuxPlatform()) {
-                return this.skip()
-            }
-
             render(
                 html`<section>
                     <div class="first">

--- a/e2e/browser-runner/lit.test.js
+++ b/e2e/browser-runner/lit.test.js
@@ -119,20 +119,20 @@ describe('Lit Component testing', () => {
     })
 
     describe('shadow root piercing', function () {
-        /**
-         * test stopped working on Linux CI machines, skipping for now
-         */
-        if (isLinuxPlatform()) {
-            return this.skip()
-        }
-
         it('should allow to pierce into closed shadow roots', async () => {
+            /**
+             * test stopped working on Linux CI machines, skipping for now
+             */
+            if (isLinuxPlatform()) {
+                return this.skip()
+            }
+
             /**
              * only run snapshot tests in non-Safari browsers as shadow dom piercing
              * is not yet supported in Safari
              */
             if (browser.capabilities.browserName?.toLowerCase() === 'safari') {
-                return
+                return this.skip()
             }
 
             render(
@@ -168,11 +168,18 @@ describe('Lit Component testing', () => {
 
         it('can fetch multiple elements within various closed shadow roots', async () => {
             /**
+             * test stopped working on Linux CI machines, skipping for now
+             */
+            if (isLinuxPlatform()) {
+                return this.skip()
+            }
+
+            /**
              * only run snapshot tests in non-Safari browsers as shadow dom piercing
              * is not yet supported in Safari
              */
             if (browser.capabilities.browserName?.toLowerCase() === 'safari') {
-                return
+                return this.skip()
             }
 
             render(

--- a/packages/wdio-browser-runner/tests/vite/plugins/testrunner.test.ts
+++ b/packages/wdio-browser-runner/tests/vite/plugins/testrunner.test.ts
@@ -1,16 +1,12 @@
 import os from 'node:os'
 import path from 'node:path'
 import { test, vi, expect } from 'vitest'
-import { resolve } from 'import-meta-resolve'
 
 import { testrunner } from '../../../src/vite/plugins/testrunner.js'
 import { getTemplate, getErrorTemplate } from '../../../src/vite/utils.js'
 import { SESSIONS } from '../../../src/constants.js'
 
 vi.mock('@wdio/logger', () => import(path.join(process.cwd(), '__mocks__', '@wdio/logger')))
-vi.mock('import-meta-resolve', () => ({
-    resolve: vi.fn()
-}))
 vi.mock('../../../src/vite/utils.js', () => ({
     getTemplate: vi.fn(),
     getErrorTemplate: vi.fn(),
@@ -46,10 +42,6 @@ test('resolveId', async () => {
 
     expect(await (plugin[0].resolveId as Function)('@wdio/browser-runner'))
         .toContain(path.join('browser', 'spy.js'))
-
-    vi.mocked(resolve).mockResolvedValue('file:///foo/bar')
-    expect(await (plugin[0].resolveId as Function)('@wdio/config'))
-        .toBe('/foo/bar')
 
     expect(await (plugin[0].resolveId as Function)('node:module'))
         .toContain(path.join('nodelibs', 'browser', 'module.js'))

--- a/packages/wdio-logger/package.json
+++ b/packages/wdio-logger/package.json
@@ -12,8 +12,8 @@
   "exports": {
     ".": {
       "browserSource": "./src/browser.ts",
-      "types": "./build/index.d.ts",
       "browser": "./build/browser.js",
+      "types": "./build/index.d.ts",
       "import": "./build/index.js",
       "require": "./build/index.cjs"
     },

--- a/packages/webdriverio/src/commands/browser/url.ts
+++ b/packages/webdriverio/src/commands/browser/url.ts
@@ -8,52 +8,6 @@ type WaitState = 'none' | 'interactive' | 'networkIdle' | 'complete'
 const DEFAULT_NETWORK_IDLE_TIMEOUT = 5000
 const DEFAULT_WAIT_STATE = 'complete'
 
-interface UrlCommandOptions {
-    /**
-     * The desired state the requested resource should be in before finishing the command.
-     * It supports the following states:
-     *
-     *  - `none`: no wait after the page request is made and the response is received
-     *  - `interactive`: wait until the page is interactive
-     *  - `complete`: wait until the DOM tree of the page is fully loaded
-     *  - `networkIdle`: wait until there are no pending network requests
-     *
-     * @default 'complete'
-     */
-    wait?: WaitState
-    /**
-     * Headers to be sent with the request.
-     * @default {}
-     */
-    headers?: Record<string, string>
-    /**
-     * Basic authentication credentials
-     * Note: this will overwrite the existing `Authorization` header if provided in the `headers` option
-     */
-    auth?: {
-        user: string
-        pass: string
-    }
-    /**
-     * If set to a number, the command will wait for the specified amount of milliseconds for the page to load
-     * all responses before returning.
-     *
-     * Note: for this to have an impact, it requires the `wait` option to be set to `networkIdle`
-     *
-     * @default 5000
-     */
-    timeout?: number
-    /**
-     * A function that is being called before your page has loaded all of its resources. It allows you to easily
-     * mock the environment, e.g. overwrite Web APIs that your application uses.
-     *
-     * Note: the provided function is being serialized and executed in the browser context. You can not pass in variables
-     * from the Node.js context. Furthermore changes to the environment only apply for this specific page load.
-     * Checkout `browser.addPreloadScript` for a more versatile way to mock the environment.
-     */
-    onBeforeLoad?: () => any
-}
-
 /**
  *
  * The `url` command loads an URL in the browser. If a baseUrl is specified in the config,
@@ -196,9 +150,24 @@ export async function url (
             mock.requestOnce({ headers: options.headers })
         }
 
+        /**
+         * WebDriver Classic allowed to provide a `pageLoadStrategy` capability.
+         * To ensure backwards combatibility, we need to map the `pageLoadStrategy`
+         * to the WebDriver Bidi spec.
+         *
+         * see https://www.w3.org/TR/webdriver2/#navigation
+         */
+        const classicPageLoadStrategy = this.capabilities.pageLoadStrategy === 'none'
+            ? 'none'
+            : this.capabilities.pageLoadStrategy === 'normal'
+                ? 'complete'
+                : this.capabilities.pageLoadStrategy === 'eager'
+                    ? 'interactive'
+                    : undefined
+
         const wait = options.wait === 'networkIdle'
             ? 'complete'
-            : options.wait || DEFAULT_WAIT_STATE
+            : options.wait || classicPageLoadStrategy || DEFAULT_WAIT_STATE
         await this.browsingContextNavigate({
             context,
             url: path,
@@ -237,4 +206,50 @@ export async function url (
     }
 
     await this.navigateTo(validateUrl(path))
+}
+
+interface UrlCommandOptions {
+    /**
+     * The desired state the requested resource should be in before finishing the command.
+     * It supports the following states:
+     *
+     *  - `none`: no wait after the page request is made and the response is received
+     *  - `interactive`: wait until the page is interactive
+     *  - `complete`: wait until the DOM tree of the page is fully loaded
+     *  - `networkIdle`: wait until there are no pending network requests
+     *
+     * @default 'complete'
+     */
+    wait?: WaitState
+    /**
+     * Headers to be sent with the request.
+     * @default {}
+     */
+    headers?: Record<string, string>
+    /**
+     * Basic authentication credentials
+     * Note: this will overwrite the existing `Authorization` header if provided in the `headers` option
+     */
+    auth?: {
+        user: string
+        pass: string
+    }
+    /**
+     * If set to a number, the command will wait for the specified amount of milliseconds for the page to load
+     * all responses before returning.
+     *
+     * Note: for this to have an impact, it requires the `wait` option to be set to `networkIdle`
+     *
+     * @default 5000
+     */
+    timeout?: number
+    /**
+     * A function that is being called before your page has loaded all of its resources. It allows you to easily
+     * mock the environment, e.g. overwrite Web APIs that your application uses.
+     *
+     * Note: the provided function is being serialized and executed in the browser context. You can not pass in variables
+     * from the Node.js context. Furthermore changes to the environment only apply for this specific page load.
+     * Checkout `browser.addPreloadScript` for a more versatile way to mock the environment.
+     */
+    onBeforeLoad?: () => any
 }

--- a/packages/webdriverio/src/polyfill.ts
+++ b/packages/webdriverio/src/polyfill.ts
@@ -43,8 +43,8 @@ export class PolyfillManager {
          *
          * @see https://github.com/evanw/esbuild/issues/2605
          */
-        const polyfill = () => {
-            const closure = new Function(NAME_POLYFILL)
+        const polyfill = (polyfill: string) => {
+            const closure = new Function(polyfill)
             return closure()
         }
 
@@ -52,8 +52,8 @@ export class PolyfillManager {
          * apply polyfill script for upcoming as well as current execution context
          */
         this.#initialize = Promise.all([
-            browser.addInitScript(polyfill),
-            browser.execute(polyfill)
+            browser.addInitScript(polyfill, NAME_POLYFILL),
+            browser.execute(polyfill, NAME_POLYFILL)
         ]).then(() => {
             log.info('polyfill script added')
             return true

--- a/packages/webdriverio/src/shadowRoot.ts
+++ b/packages/webdriverio/src/shadowRoot.ts
@@ -194,7 +194,12 @@ export class ShadowRootManager {
             }
         }
 
-        return tree.getAllLookupScopes()
+        const elements = tree.getAllLookupScopes()
+
+        /**
+         * make sure to send back a unique list of elements
+         */
+        return [...new Set(elements).values()]
     }
 
     getShadowElementPairsByContextId (contextId: string, scope?: string): [string, string | undefined][] {


### PR DESCRIPTION
## Proposed changes

This got reported on Discord: a user wanted to inject a script before the page is fully loaded and was using the WebDriver Classic `pageLoadStrategy: 'none'` to achieve this. With v9 we completely ignore this capability as we do page loads with Bidi. This patch will fixes this behavior.

We also had an issue with our `url` docs given that we moved the interface documentation above the command so our docs generation process mistakenly used it as command docs. 

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
