### PR TITLE
fix(webdriverio): make name polyfill compatible with old browsers

### DIFF
--- a/packages/webdriverio/src/polyfill.ts
+++ b/packages/webdriverio/src/polyfill.ts
@@ -5,8 +5,9 @@ const log = logger('webdriverio:PolyfillManager')
 
 export const NAME_POLYFILL = (
     'var __defProp = Object.defineProperty;' +
-    'var __name = (target, value) => __defProp(target, \'name\', { value, configurable: true });' +
-    'globalThis.__name = __name;'
+    'var __name = function (target, value) { return __defProp(target, \'name\', { value: value, configurable: true }); };' +
+    'var __globalThis = (typeof globalThis === \'object\' && globalThis) || (typeof window === \'object\' && window);' +
+    '__globalThis.__name = __name;'
 )
 
 export function getPolyfillManager(browser: WebdriverIO.Browser) {


### PR DESCRIPTION
## Proposed changes

This PR updates the `NAME_POLYFILL` to be compatible with old browsers. It replaces these incompatible features:
* arrow function
* object property name shorthand
* `globalThis`

Resolves https://github.com/webdriverio/webdriverio/issues/13750.

## Types of changes

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Backport Request

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

N/A

### Reviewers: @webdriverio/project-committers
