### PR TITLE
fix(webdriverio): use AbortSignal.timeout() instead of an AbortController

### DIFF
--- a/packages/webdriver/src/request/index.ts
+++ b/packages/webdriver/src/request/index.ts
@@ -37,8 +37,6 @@ const DEFAULT_HEADERS = {
 const log = logger('webdriver')
 
 export default abstract class WebDriverRequest extends EventEmitter {
-    #requestTimeout?: NodeJS.Timeout
-
     body?: Record<string, unknown>
     method: string
     endpoint: string
@@ -69,14 +67,9 @@ export default abstract class WebDriverRequest extends EventEmitter {
     }
 
     protected async _createOptions (options: RequestOptions, sessionId?: string, isBrowser: boolean = false): Promise<{url: URL; requestOptions: RequestInit;}> {
-        const controller = new AbortController()
-        this.#requestTimeout = setTimeout(
-            () => controller.abort(),
-            options.connectionRetryTimeout || DEFAULTS.connectionRetryTimeout.default
-        )
-
+        const timeout = options.connectionRetryTimeout || DEFAULTS.connectionRetryTimeout.default as number
         const requestOptions: RequestInit = {
-            signal: controller.signal
+            signal: AbortSignal.timeout(timeout)
         }
 
         const requestHeaders: HeadersInit = new Headers({
@@ -152,10 +145,6 @@ export default abstract class WebDriverRequest extends EventEmitter {
         let response = await this._libRequest(url!, requestLibOptions)
             .catch((err: WebDriverRequestError) => err)
         const durationMillisecond = this._libPerformanceNow() - startTime
-
-        if (this.#requestTimeout) {
-            clearTimeout(this.#requestTimeout)
-        }
 
         /**
          * handle retries for requests


### PR DESCRIPTION
## Proposed changes

use `AbortSignal.timeout(timeout)` instead of initiating an `AbortController`.

fixes #13778

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

@mykola-mokhnach mind checking if this resolves the issue?

### Reviewers: @webdriverio/project-committers
