### PR TITLE
feat: enhance newWindow function to support 'tab' or 'window' types

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "test:e2e:cloud": "cd ./e2e && npx wdio run ./wdio/wdio.sauce.conf.ts",
     "test:e2e": "run-s test:e2e:* ",
     "dev": "pnpm -r --filter=@wdio/compiler run build --watch",
-    "watch:docs": "pnpm docs:generate && cd website && npm i && npm start",
+    "watch:docs": "pnpm docs:generate && cd website && pnpm i && pnpm start",
     "version": "pnpm changelog && git add CHANGELOG.md",
     "postinstall": "run-s postinstall:*",
     "postinstall:husky": "husky"

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "test:e2e:webdriver": "cd ./e2e && npx wdio run ./wdio/wdio.local.conf.ts",
     "test:e2e:classic": "cd ./e2e && npx wdio run ./wdio/wdio.classic.conf.ts",
     "test:e2e:cloud": "cd ./e2e && npx wdio run ./wdio/wdio.sauce.conf.ts",
+    "test:e2e": "run-s test:e2e:* ",
     "dev": "pnpm -r --filter=@wdio/compiler run build --watch",
     "watch:docs": "pnpm docs:generate && cd website && npm i && npm start",
     "version": "pnpm changelog && git add CHANGELOG.md",

--- a/packages/webdriverio/src/commands/browser/newWindow.ts
+++ b/packages/webdriverio/src/commands/browser/newWindow.ts
@@ -8,23 +8,23 @@ const WAIT_FOR_NEW_HANDLE_TIMEOUT = 3000
 
 /**
  *
- * Open new window in browser. This command is the equivalent function to `window.open()`. This command does not
- * work in mobile environments.
+ * Open new window or tab in browser (defaults to a new window if not specified).
+ * This command is the equivalent function to `window.open()`. This command does not work in mobile environments.
  *
- * __Note:__ When calling this command you automatically switch to the new window.
+ * __Note:__ When calling this command you automatically switch to the new window or tab.
  *
  * <example>
     :newWindowSync.js
-    it('should open a new tab', async () => {
+    it('should open a new window', async () => {
         await browser.url('https://google.com')
         console.log(await browser.getTitle()) // outputs: "Google"
 
-        await browser.newWindow('https://webdriver.io', {
+        const result = await browser.newWindow('https://webdriver.io', {
             windowName: 'WebdriverIO window',
             windowFeature: 'width=420,height=230,resizable,scrollbars=yes,status=1',
         })
         console.log(await browser.getTitle()) // outputs: "WebdriverIO · Next-gen browser and mobile automation test framework for Node.js"
-
+        console.log(result.type) // outputs: "window"
         const handles = await browser.getWindowHandles()
         await browser.switchToWindow(handles[1])
         await browser.closeWindow()
@@ -32,28 +32,60 @@ const WAIT_FOR_NEW_HANDLE_TIMEOUT = 3000
         console.log(await browser.getTitle()) // outputs: "Google"
     });
  * </example>
+ * <example>
+      :newTabSync.js
+      it('should open a new tab', async () => {
+          await browser.url('https://google.com')
+            console.log(await browser.getTitle()) // outputs: "Google"
+
+         await browser.newWindow('https://webdriver.io', {
+              type:'tab',
+              windowName: 'WebdriverIO window',
+              windowFeature: 'width=420,height=230,resizable,scrollbars=yes,status=1',
+          })
+          console.log(await browser.getTitle()) // outputs: "WebdriverIO · Next-gen browser and mobile automation test framework for Node.js"
+          console.log(result.type) // outputs: "tab"
+          const handles = await browser.getWindowHandles()
+          await browser.switchToWindow(handles[1])
+          await browser.closeWindow()
+          await browser.switchToWindow(handles[0])
+          console.log(await browser.getTitle()) // outputs: "Google"
+     });
+ * </example>
  *
  * @param {string}  url      website URL to open
  * @param {NewWindowOptions=} options                newWindow command options
+ * @param {string=}           options.type         type of new window: 'tab' or 'window'
  * @param {String=}           options.windowName     name of the new window
  * @param {String=}           options.windowFeatures features of opened window (e.g. size, position, scrollbars, etc.)
  *
- * @return {String}          id of window handle of new tab
+ * @return {Object}          An object containing the window handle and the type of new window
+ * @return {String}          handle - The ID of the window handle of the new tab or window
+ * @return {String}          type - The type of the new window, either 'tab' or 'window'
+ *
+ * @throws {Error} If `url` is invalid, if the command is used on mobile, or `type` is not 'tab' or 'window'.
  *
  * @uses browser/execute, protocol/getWindowHandles, protocol/switchToWindow
  * @alias browser.newWindow
- * @type window
+ * @type window or tab
  */
 export async function newWindow (
     this: WebdriverIO.Browser,
     url: string,
-    { windowName = '', windowFeatures = '' }: NewWindowOptions = {}
-) {
+    { type = 'window', windowName = '', windowFeatures = '' }: NewWindowOptions = {}
+): Promise<{ handle: string, type: 'tab' | 'window' }> {
     /**
      * parameter check
      */
     if (typeof url !== 'string') {
         throw new Error('number or type of arguments don\'t agree with newWindow command')
+    }
+
+    /**
+    * Validate the 'type' parameter to ensure it is either 'tab' or 'window'
+    */
+    if (!['tab', 'window'].includes(type)) {
+        throw new Error(`Invalid type '${type}' provided to newWindow command. Use either 'tab' or 'window'`)
     }
 
     /**
@@ -67,7 +99,7 @@ export async function newWindow (
 
     if (this.isBidi) {
         const contextManager = getContextManager(this)
-        const { context } = await this.browsingContextCreate({ type: 'window' })
+        const { context } = await this.browsingContextCreate({ type: type })
         contextManager.setCurrentContext(context)
         await this.browsingContextNavigate({ context, url })
     } else {
@@ -95,5 +127,5 @@ export async function newWindow (
     }
 
     await this.switchToWindow(newTab)
-    return newTab
+    return { handle: newTab, type }
 }

--- a/packages/webdriverio/src/commands/browser/newWindow.ts
+++ b/packages/webdriverio/src/commands/browser/newWindow.ts
@@ -104,9 +104,6 @@ export async function newWindow (
     const tabsBefore = await this.getWindowHandles()
 
     if (this.isBidi) {
-        if (windowName || windowFeatures) {
-            log.warn('The "windowName" and "windowFeatures" options are not supported in BiDi mode and will be ignored.')
-        }
         const contextManager = getContextManager(this)
         const { context } = await this.browsingContextCreate({ type: type })
         contextManager.setCurrentContext(context)

--- a/packages/webdriverio/src/commands/browser/newWindow.ts
+++ b/packages/webdriverio/src/commands/browser/newWindow.ts
@@ -57,7 +57,7 @@ const WAIT_FOR_NEW_HANDLE_TIMEOUT = 3000
  *
  * @param {string}  url      website URL to open
  * @param {NewWindowOptions=} options                newWindow command options
- * @param {string=}           options.type         type of new window: 'tab' or 'window'
+ * @param {string=}           options.type           type of new window: 'tab' or 'window'
  * @param {String=}           options.windowName     name of the new window
  * @param {String=}           options.windowFeatures features of opened window (e.g. size, position, scrollbars, etc.)
  *

--- a/packages/webdriverio/src/commands/browser/newWindow.ts
+++ b/packages/webdriverio/src/commands/browser/newWindow.ts
@@ -105,7 +105,7 @@ export async function newWindow (
 
     if (this.isBidi) {
         const contextManager = getContextManager(this)
-        const { context } = await this.browsingContextCreate({ type: type })
+        const { context } = await this.browsingContextCreate({ type })
         contextManager.setCurrentContext(context)
         await this.browsingContextNavigate({ context, url })
     } else {

--- a/packages/webdriverio/src/commands/browser/newWindow.ts
+++ b/packages/webdriverio/src/commands/browser/newWindow.ts
@@ -3,6 +3,8 @@ import { sleep } from '@wdio/utils'
 import newWindowHelper from '../../scripts/newWindow.js'
 import { getContextManager } from '../../context.js'
 import type { NewWindowOptions } from '../../types.js'
+import logger from '@wdio/logger'
+const log = logger('webdriverio:newWindow')
 
 const WAIT_FOR_NEW_HANDLE_TIMEOUT = 3000
 
@@ -88,6 +90,10 @@ export async function newWindow (
         throw new Error(`Invalid type '${type}' provided to newWindow command. Use either 'tab' or 'window'`)
     }
 
+    if (windowFeatures) {
+        log.warn('The "windowFeatures" option is deprecated and will be removed in future versions.')
+    }
+
     /**
      * mobile check
      */
@@ -98,6 +104,9 @@ export async function newWindow (
     const tabsBefore = await this.getWindowHandles()
 
     if (this.isBidi) {
+        if (windowName || windowFeatures) {
+            log.warn('The "windowName" and "windowFeatures" options are not supported in BiDi mode and will be ignored.')
+        }
         const contextManager = getContextManager(this)
         const { context } = await this.browsingContextCreate({ type: type })
         contextManager.setCurrentContext(context)

--- a/packages/webdriverio/src/commands/browser/newWindow.ts
+++ b/packages/webdriverio/src/commands/browser/newWindow.ts
@@ -40,7 +40,7 @@ const WAIT_FOR_NEW_HANDLE_TIMEOUT = 3000
           await browser.url('https://google.com')
             console.log(await browser.getTitle()) // outputs: "Google"
 
-         await browser.newWindow('https://webdriver.io', {
+          await browser.newWindow('https://webdriver.io', {
               type:'tab',
               windowName: 'WebdriverIO window',
               windowFeature: 'width=420,height=230,resizable,scrollbars=yes,status=1',

--- a/packages/webdriverio/src/commands/browser/newWindow.ts
+++ b/packages/webdriverio/src/commands/browser/newWindow.ts
@@ -38,7 +38,7 @@ const WAIT_FOR_NEW_HANDLE_TIMEOUT = 3000
       :newTabSync.js
       it('should open a new tab', async () => {
           await browser.url('https://google.com')
-            console.log(await browser.getTitle()) // outputs: "Google"
+          console.log(await browser.getTitle()) // outputs: "Google"
 
           await browser.newWindow('https://webdriver.io', {
               type:'tab',

--- a/packages/webdriverio/src/commands/browser/newWindow.ts
+++ b/packages/webdriverio/src/commands/browser/newWindow.ts
@@ -90,8 +90,8 @@ export async function newWindow (
         throw new Error(`Invalid type '${type}' provided to newWindow command. Use either 'tab' or 'window'`)
     }
 
-    if (windowFeatures) {
-        log.warn('The "windowFeatures" option is deprecated and will be removed in future versions.')
+    if (windowName || windowFeatures) {
+        log.warn('The "windowName" and "windowFeatures" options are deprecated and only supported in WebDriver Classic sessions.')
     }
 
     /**

--- a/packages/webdriverio/src/types.ts
+++ b/packages/webdriverio/src/types.ts
@@ -488,6 +488,7 @@ export type DragAndDropOptions = {
 }
 
 export type NewWindowOptions = {
+    type?: 'tab' | 'window',
     windowName?: string,
     windowFeatures?: string
 }

--- a/packages/webdriverio/tests/commands/browser/newWindow.test.ts
+++ b/packages/webdriverio/tests/commands/browser/newWindow.test.ts
@@ -42,7 +42,7 @@ describe('newWindow', () => {
             windowName: 'some name',
             windowFeatures: 'some params'
         })
-        expect(newHandle).toBe('new-window-handle')
+        expect(newHandle.handle).toBe('new-window-handle')
         expect(vi.mocked(fetch).mock.calls).toHaveLength(8)
         expect(JSON.parse(vi.mocked(fetch).mock.calls[2][1]?.body as any).args)
             .toEqual(['https://webdriver.io', 'some name', 'some params'])
@@ -108,4 +108,36 @@ describe('newWindow', () => {
         }).catch((err: Error) => err) as Error
         expect(error.message).toContain('not supported on mobile')
     })
+
+    it('should open a new window by default', async () => {
+        const browser = await remote({
+            baseUrl: 'http://foobar.com',
+            capabilities: {
+                browserName: 'foobar'
+            }
+        })
+
+        const newHandle = await browser.newWindow('https://webdriver.io', {
+            windowName: 'some window'
+        })
+
+        expect(newHandle.type).toBe('window')
+    })
+
+    it('should open a new tab when type is tab', async () => {
+        const browser = await remote({
+            baseUrl: 'http://foobar.com',
+            capabilities: {
+                browserName: 'foobar'
+            }
+        })
+
+        const newHandle = await browser.newWindow('https://webdriver.io', {
+            type: 'tab',
+            windowName: 'some tab'
+        })
+
+        expect(newHandle.type).toBe('tab')
+    })
+
 })

--- a/packages/webdriverio/tests/commands/browser/newWindow.test.ts
+++ b/packages/webdriverio/tests/commands/browser/newWindow.test.ts
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  */
 import path from 'node:path'
-import { expect, describe, beforeEach, afterEach, it, vi } from 'vitest'
+import { expect, describe, beforeEach, afterEach, it, vi, type MockInstance } from 'vitest'
 
 import { remote } from '../../../src/index.js'
 
@@ -113,24 +113,41 @@ describe('newWindow', () => {
         const browser = await remote({
             baseUrl: 'http://foobar.com',
             capabilities: {
-                browserName: 'foobar'
+                browserName: 'bidi'
             }
         })
+
+        const browsingContextCreateSpy: MockInstance = vi.spyOn(browser, 'browsingContextCreate')
+        browsingContextCreateSpy.mockImplementation(() => ({ context: 'new-window-handle', type: 'window' }))
+        const browsingContextNavigateSpy: MockInstance = vi.spyOn(browser, 'browsingContextNavigate')
+        browsingContextNavigateSpy.mockImplementation(() => ({}))
 
         const newHandle = await browser.newWindow('https://webdriver.io', {
             windowName: 'some window'
         })
 
         expect(newHandle.type).toBe('window')
+        expect(browsingContextCreateSpy).toHaveBeenCalledTimes(1)
+        expect(browsingContextCreateSpy).toHaveBeenCalledWith({ type: 'window' })
+        expect(browsingContextNavigateSpy).toHaveBeenCalledTimes(1)
+        expect(browsingContextNavigateSpy).toHaveBeenCalledWith({
+            context: 'new-window-handle',
+            url: 'https://webdriver.io'
+        })
     })
 
     it('should open a new tab when type is tab', async () => {
         const browser = await remote({
             baseUrl: 'http://foobar.com',
             capabilities: {
-                browserName: 'foobar'
+                browserName: 'bidi'
             }
         })
+
+        const browsingContextCreateSpy: MockInstance = vi.spyOn(browser, 'browsingContextCreate')
+        browsingContextCreateSpy.mockImplementation(() => ({ context: 'new-tab-handle', type: 'tab' }))
+        const browsingContextNavigateSpy: MockInstance = vi.spyOn(browser, 'browsingContextNavigate')
+        browsingContextNavigateSpy.mockImplementation(() => ({}))
 
         const newHandle = await browser.newWindow('https://webdriver.io', {
             type: 'tab',
@@ -138,6 +155,12 @@ describe('newWindow', () => {
         })
 
         expect(newHandle.type).toBe('tab')
+        expect(browsingContextCreateSpy).toHaveBeenCalledTimes(1)
+        expect(browsingContextCreateSpy).toHaveBeenCalledWith({ type: 'tab' })
+        expect(browsingContextNavigateSpy).toHaveBeenCalledTimes(1)
+        expect(browsingContextNavigateSpy).toHaveBeenCalledWith({
+            context: 'new-tab-handle',
+            url: 'https://webdriver.io'
+        })
     })
-
 })


### PR DESCRIPTION
## Proposed changes

Fixes: https://github.com/webdriverio/webdriverio/issues/13790
- Added 'type' option to newWindow function to specify 'tab' or 'window' (default 'window')
- Updated return value to include both window handle and type
- Improved JSDoc to reflect new behaviour and clarify usage, including combined @throws clause
- Added tests to validate window and tab types

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
