### PR TITLE
reorder shadowroot removal

### DIFF
--- a/packages/webdriverio/src/shadowRoot.ts
+++ b/packages/webdriverio/src/shadowRoot.ts
@@ -339,12 +339,13 @@ export class ShadowRootTree {
     }
 
     remove (element: string): boolean {
-        for (const child of this.children) {
-            if (child.element === element) {
-                return this.children.delete(child)
+        const childArray = Array.from(this.children)
+        for (let i = childArray.length - 1; i >= 0; i--) {
+            if (childArray[i].element === element) {
+                return this.children.delete(childArray[i])
             }
 
-            const wasFound = child.remove(element)
+            const wasFound = childArray[i].remove(element)
             if (wasFound) {
                 return true
             }

--- a/packages/webdriverio/tests/shadowRoot.test.ts
+++ b/packages/webdriverio/tests/shadowRoot.test.ts
@@ -123,6 +123,10 @@ describe('ShadowRootTree', () => {
     root.addShadowElement('8', new ShadowRootTree('10', '11'))
     root.addShadowElement('8', new ShadowRootTree('12', '13'))
     root.addShadowElement('12', new ShadowRootTree('14', '15'))
+    root.addShadowElement(new ShadowRootTree('16', '17'))
+    root.addShadowElement('16', new ShadowRootTree('18', '19'))
+    root.addShadowElement('16', new ShadowRootTree('18', '19'))
+    root.addShadowElement('18', new ShadowRootTree('20', '21'))
 
     it('can find the root of a tree', () => {
         const tree = root.find('8')
@@ -148,6 +152,10 @@ describe('ShadowRootTree', () => {
             "13",
             "15",
             "7",
+            "17",
+            "19",
+            "21",
+            "19",
           ]
         `)
         expect(root.find('8')?.getAllLookupScopes()).toMatchInlineSnapshot(`
@@ -170,6 +178,22 @@ describe('ShadowRootTree', () => {
             "3",
             "5",
             "7",
+            "17",
+            "19",
+            "21",
+            "19",
+          ]
+        `)
+    })
+
+    it('can delete children in the right order', () => {
+        expect(root.remove('18')).toBe(true)
+        const child = root.find('16')
+        expect(child?.getAllLookupScopes()).toMatchInlineSnapshot(`
+          [
+            "17",
+            "19",
+            "21",
           ]
         `)
     })


### PR DESCRIPTION
## Proposed changes

Fix for #13521. So this happens due to the sequence in which shadowRoots are removed. Currently, shadowRoots that are duplicate can be added to the children set and are removed in a first-in-first-out fashion. In the reproducible, the shadowRoot needed to find the element is the child of the first shadowRoot added in the children set. This is followed by a duplicate and a removeShadowRoot entry, which fetches and removes that first child.

For example,
```
root
root.addShadowElement( child('1') )
root.addShadowElement( '1', child('2') )
root.addShadowElement( '1', child('2') ) <-- now there are 2 child 2
root.addShadowElement( '2', child('3') ) <-- child 3 attached to the first child 2
root.remove( '2' ) <-- remove the first child 2 which has child 3 attached and any element that requires child 3 can't be found

```

I fix this by changing the order when removing and make it remove the last one first. I test this with the reproducible example and it works. However, I'm not experienced in how bidi receives shadowRoots and not sure if the current way is the intended way (maybe should have discuss with you first on discord). Let me know how it goes, and if this is not valid, please close this.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

### Reviewers: @webdriverio/project-committers
