### PR TITLE
fix(webdriver): allow WebdriverIO to handle alerts

### DIFF
--- a/e2e/wdio/headless/test.e2e.ts
+++ b/e2e/wdio/headless/test.e2e.ts
@@ -364,7 +364,7 @@ describe('main suite 1', () => {
         /**
          * fails due to https://github.com/GoogleChromeLabs/chromium-bidi/issues/2556
          */
-        it.skip('should be able to handle dialogs', async () => {
+        it('should be able to handle dialogs', async () => {
             await browser.url('http://guinea-pig.webdriver.io')
             browser.execute(() => alert('123'))
             const dialog = await new Promise<WebdriverIO.Dialog>((resolve) => browser.on('dialog', resolve))

--- a/packages/webdriver/src/utils.ts
+++ b/packages/webdriver/src/utils.ts
@@ -61,7 +61,14 @@ export async function startWebDriverSession (params: RemoteConfig): Promise<{ se
         typeof capabilities.alwaysMatch.browserName === 'string' &&
         capabilities.alwaysMatch.browserName.toLowerCase() !== 'safari'
     ) {
+        /**
+         * opt-into WebDriver Bidi
+         */
         capabilities.alwaysMatch.webSocketUrl = true
+        /**
+         * allow WebdriverIO to handle alerts
+         */
+        capabilities.alwaysMatch.unhandledPromptBehavior = 'ignore'
     }
 
     validateCapabilities(capabilities.alwaysMatch)

--- a/packages/webdriver/tests/__snapshots__/index.test.ts.snap
+++ b/packages/webdriver/tests/__snapshots__/index.test.ts.snap
@@ -13,6 +13,7 @@ exports[`WebDriver > newSession > should allow to create a new session using w3c
       "requestedCapabilities": {
         "alwaysMatch": {
           "browserName": "firefox",
+          "unhandledPromptBehavior": "ignore",
           "webSocketUrl": true,
         },
         "firstMatch": [

--- a/packages/webdriver/tests/index.test.ts
+++ b/packages/webdriver/tests/index.test.ts
@@ -90,7 +90,8 @@ describe('WebDriver', () => {
                     capabilities: {
                         alwaysMatch: {
                             browserName: 'firefox',
-                            webSocketUrl: true
+                            webSocketUrl: true,
+                            unhandledPromptBehavior: 'ignore'
                         },
                         firstMatch: [{}]
                     }
@@ -113,7 +114,8 @@ describe('WebDriver', () => {
                     capabilities: {
                         alwaysMatch: {
                             browserName: 'firefox',
-                            webSocketUrl: true
+                            webSocketUrl: true,
+                            unhandledPromptBehavior: 'ignore'
                         },
                         firstMatch: [{}]
                     }


### PR DESCRIPTION
## Proposed changes

Fix alert handling in WebdriverIO.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
