### PR TITLE
Fix moduleLoaderFlag

### DIFF
--- a/packages/wdio-cli/src/commands/run.ts
+++ b/packages/wdio-cli/src/commands/run.ts
@@ -224,7 +224,7 @@ export async function handler(argv: RunCommandArguments) {
         // This switching can be removed once the minimum supported version of Node exceeds 20.6.0 / 18.19.0
         // see https://nodejs.org/api/module.html#customization-hooks
         // and https://tsx.is/node#es-modules-only
-        const moduleLoaderFlag = runCmd.nodeVersion('major') >= 21 || 
+        const moduleLoaderFlag = nodeVersion('major') >= 21 ||
             (nodeVersion('major') === 20 && nodeVersion('minor') >= 6) ||
             (nodeVersion('major') === 18 && nodeVersion('minor') >= 19) ? '--import' : '--loader'
         NODE_OPTIONS += ` ${moduleLoaderFlag} tsx`


### PR DESCRIPTION
Fix `moduleLoaderFlag` being set to deprecated `--loader` instead of `--import` for Node >= 21 where minor version is < 6.

[Previous PR](https://github.com/webdriverio/webdriverio/pull/13768) only fixed the test 🤦 

## Proposed changes

See discussion on what this PR fixes here:
https://github.com/webdriverio/webdriverio/discussions/13664

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers:
@christian-bromann 