### PR TITLE
fix(webdriverio): reset frame context if refresh command is called

### DIFF
--- a/e2e/wdio/headless/test.e2e.ts
+++ b/e2e/wdio/headless/test.e2e.ts
@@ -513,5 +513,16 @@ describe('main suite 1', () => {
             expect(await browser.execute(() => document.URL))
                 .toBe('https://the-internet.herokuapp.com/frame_right')
         })
+
+        it('should reset the frame when the page is reloaded', async () => {
+            await browser.url('https://the-internet.herokuapp.com/iframe')
+            await expect($('#tinymce')).not.toBePresent()
+            await browser.switchFrame($('iframe'))
+            await expect($('#tinymce')).toBePresent()
+            await browser.refresh()
+            await expect($('#tinymce')).not.toBePresent()
+            await browser.switchFrame($('iframe'))
+            await expect($('#tinymce')).toBePresent()
+        })
     })
 })

--- a/packages/webdriverio/src/commands/browser/switchFrame.ts
+++ b/packages/webdriverio/src/commands/browser/switchFrame.ts
@@ -250,6 +250,9 @@ export async function switchFrame (
      */
     if (typeof context === 'object' && typeof (context as WebdriverIO.Element).getElement === 'function') {
         const element = await context.getElement()
+        await element.waitForExist({
+            timeoutMsg: `Can't switch to frame with selector ${element.selector} because it doesn't exist`
+        })
         return switchToFrameUsingElement(this, element)
     }
 

--- a/packages/webdriverio/src/context.ts
+++ b/packages/webdriverio/src/context.ts
@@ -40,10 +40,14 @@ export class ContextManager {
             }
 
             /**
-             * reset current context if user uses 'switchToParentFrame' which
-             * only impacts WebDriver Classic commands
+             * reset current context if:
+             *   - user uses 'switchToParentFrame' which only impacts WebDriver Classic commands
+             *   - user uses 'refresh' which resets the context in Classic and so should in Bidi
              */
-            if (event.command === 'switchToParentFrame') {
+            if (
+                event.command === 'switchToParentFrame' ||
+                event.command === 'refresh'
+            ) {
                 this.#currentContext = undefined
             }
         })

--- a/packages/webdriverio/tests/commands/browser/switchFrame.test.ts
+++ b/packages/webdriverio/tests/commands/browser/switchFrame.test.ts
@@ -113,6 +113,7 @@ describe('switchFrame command', () => {
             elemExecute.mockResolvedValue({
                 context: '5D4662C2B4465334DFD34239BA1E9E66'
             })
+            vi.spyOn(elem, 'waitForExist').mockResolvedValue({})
 
             await browser.switchFrame(elem)
             expect(contextManager.setCurrentContext).toBeCalledWith('5D4662C2B4465334DFD34239BA1E9E66')


### PR DESCRIPTION
## Proposed changes

When the user calls `refresh`, the previous selected browsing context is being reset for classic commands. This needs to be the same for Bidi, so this patch resets the current frame when that happens.

fixes #13829

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
