### PR TITLE
chore(@wdio/spec-reporter): use base name of app path in prefix

### DIFF
--- a/packages/wdio-spec-reporter/src/index.ts
+++ b/packages/wdio-spec-reporter/src/index.ts
@@ -1,5 +1,7 @@
-import prettyMs from 'pretty-ms'
+import path from 'node:path'
 import { format } from 'node:util'
+
+import prettyMs from 'pretty-ms'
 import type { Capabilities } from '@wdio/types'
 import { Chalk, type ChalkInstance } from 'chalk'
 import WDIOReporter, { TestStats } from '@wdio/reporter'
@@ -598,7 +600,12 @@ export default class SpecReporter extends WDIOReporter {
         const device = caps['appium:deviceName']
         // @ts-expect-error outdated JSONWP capabilities
         const app = ((caps['appium:app'] || caps.app) || '').replace('sauce-storage:', '')
-        const appName = app || caps['appium:bundleId'] || caps['appium:appPackage']
+        const appName = (
+            caps['appium:bundleId'] ||
+            caps['appium:appPackage'] ||
+            caps['appium:appActivity'] ||
+            (path.isAbsolute(app) ? path.basename(app) : app)
+        )
         // @ts-expect-error outdated JSONWP capabilities
         const browser = caps.browserName || caps.browser || appName
         /**

--- a/packages/wdio-spec-reporter/tests/index.test.ts
+++ b/packages/wdio-spec-reporter/tests/index.test.ts
@@ -1005,6 +1005,33 @@ describe('SpecReporter', () => {
                 'appium:appActivity': '.MainActivity'
             }, false)).toBe('com.example.android Android')
         })
+
+        it('should prefer bundleId over app path', () => {
+            expect(tmpReporter.getEnviromentCombo({
+                platformName: 'Android',
+                'appium:automationName': 'uiautomator2',
+                'appium:bundleId': 'com.example.android',
+                'appium:appActivity': '.MainActivity',
+                'appium:app': '/foo/bar/loo.apk'
+            }, false)).toBe('com.example.android Android')
+        })
+
+        it('prefers app activity over app path', () => {
+            expect(tmpReporter.getEnviromentCombo({
+                platformName: 'Android',
+                'appium:automationName': 'uiautomator2',
+                'appium:appActivity': '.MainActivity',
+                'appium:app': '/foo/bar/foo/bar/foo/bar/foo/bar/foo/bar/foo/bar/loo.apk'
+            }, false)).toBe('.MainActivity Android')
+        })
+
+        it('uses file name as app path instead of long path', () => {
+            expect(tmpReporter.getEnviromentCombo({
+                platformName: 'Android',
+                'appium:automationName': 'uiautomator2',
+                'appium:app': '/foo/bar/foo/bar/foo/bar/foo/bar/foo/bar/foo/bar/loo.apk'
+            }, false)).toBe('loo.apk Android')
+        })
     })
 
     describe('add real time report', () => {


### PR DESCRIPTION
## Proposed changes

The spec reporter can become unreadable if a user uses an `appium:app` capability with a long path to an application, e.g.:
```
"spec" Reporter:
------------------------------------------------------------------
[/var/folders/w2/s84ng4p93vz2mw5cdc_zkzbc0000kr/T/tmpZFqssp/ios.simulator.wdio.native.app.v1.0.8.zip iOS #0-0] Running: /var/folders/w2/s84ng4p93vz2mw5cdc_zkzbc0000kr/T/tmpZFqssp/ios.simulator.wdio.native.app.v1.0.8.zip on iOS
[/var/folders/w2/s84ng4p93vz2mw5cdc_zkzbc0000kr/T/tmpZFqssp/ios.simulator.wdio.native.app.v1.0.8.zip iOS #0-0] Session ID: c53e5adb93724bd79d5c9b538b8e4258
[/var/folders/w2/s84ng4p93vz2mw5cdc_zkzbc0000kr/T/tmpZFqssp/ios.simulator.wdio.native.app.v1.0.8.zip iOS #0-0]
[/var/folders/w2/s84ng4p93vz2mw5cdc_zkzbc0000kr/T/tmpZFqssp/ios.simulator.wdio.native.app.v1.0.8.zip iOS #0-0] » /tests/integration/specs/general-spec.ts
[/var/folders/w2/s84ng4p93vz2mw5cdc_zkzbc0000kr/T/tmpZFqssp/ios.simulator.wdio.native.app.v1.0.8.zip iOS #0-0] Context
[/var/folders/w2/s84ng4p93vz2mw5cdc_zkzbc0000kr/T/tmpZFqssp/ios.simulator.wdio.native.app.v1.0.8.zip iOS #0-0]    ✓ Native Context Switches correctly
[/var/folders/w2/s84ng4p93vz2mw5cdc_zkzbc0000kr/T/tmpZFqssp/ios.simulator.wdio.native.app.v1.0.8.zip iOS #0-0]
[/var/folders/w2/s84ng4p93vz2mw5cdc_zkzbc0000kr/T/tmpZFqssp/ios.simulator.wdio.native.app.v1.0.8.zip iOS #0-0]       .........Pending Reasons.........
[/var/folders/w2/s84ng4p93vz2mw5cdc_zkzbc0000kr/T/tmpZFqssp/ios.simulator.wdio.native.app.v1.0.8.zip iOS #0-0]          Temporarily disabled with xit
[/var/folders/w2/s84ng4p93vz2mw5cdc_zkzbc0000kr/T/tmpZFqssp/ios.simulator.wdio.native.app.v1.0.8.zip iOS #0-0]    ✓ Webview Context Switches correctly
```

We should just use the file name:

```
"spec" Reporter:
------------------------------------------------------------------
[ios.simulator.wdio.native.app.v1.0.8.zip iOS #0-0] Running: ios.simulator.wdio.native.app.v1.0.8.zip on iOS
[ios.simulator.wdio.native.app.v1.0.8.zip iOS #0-0] Session ID: c53e5adb93724bd79d5c9b538b8e4258
[ios.simulator.wdio.native.app.v1.0.8.zip iOS #0-0]
[ios.simulator.wdio.native.app.v1.0.8.zip iOS #0-0] » /tests/integration/specs/general-spec.ts
[ios.simulator.wdio.native.app.v1.0.8.zip iOS #0-0] Context
[ios.simulator.wdio.native.app.v1.0.8.zip iOS #0-0]    ✓ Native Context Switches correctly
[ios.simulator.wdio.native.app.v1.0.8.zip iOS #0-0]
[ios.simulator.wdio.native.app.v1.0.8.zip iOS #0-0]       .........Pending Reasons.........
[ios.simulator.wdio.native.app.v1.0.8.zip iOS #0-0]          Temporarily disabled with xit
[ios.simulator.wdio.native.app.v1.0.8.zip iOS #0-0]    ✓ Webview Context Switches correctly
```


## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
