### PR TITLE
fix(@wdio/appium-service): don't transform chromedriver_autodownload arg

### DIFF
--- a/packages/wdio-appium-service/src/utils.ts
+++ b/packages/wdio-appium-service/src/utils.ts
@@ -32,6 +32,14 @@ export function formatCliArgs(args: KeyValueArgs): string[] {
             continue
         }
 
+        /**
+         * there are some special options that should not be transformed
+         */
+        if (key === 'chromedriver_autodownload') {
+            cliArgs.push(key)
+            continue
+        }
+
         cliArgs.push(`--${kebabCase(key)}`)
         // Only non-boolean and non-null values are added as option values
         if (typeof value !== 'boolean') {

--- a/packages/wdio-appium-service/tests/utils.test.ts
+++ b/packages/wdio-appium-service/tests/utils.test.ts
@@ -169,4 +169,14 @@ describe('argument formatting', () => {
         expect(args[6]).toBe('\'/Users/frodo/My Projects/the-ring/the-ring.app\'')
         expect(args.length).toBe(7)
     })
+
+    test('it should not format certain other arguments', () => {
+        const args = formatCliArgs({
+            allowInsecure: true,
+            chromedriver_autodownload: true,
+        })
+
+        expect(args[0]).toBe('--allow-insecure')
+        expect(args[1]).toBe('chromedriver_autodownload')
+    })
 })


### PR DESCRIPTION
## Proposed changes

This is an argument for Appium that should not be transformed.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
