### PR TITLE
fix(@wdio/cli): improve detection when no capabilities are provided

### DIFF
--- a/packages/wdio-cli/src/launcher.ts
+++ b/packages/wdio-cli/src/launcher.ts
@@ -177,11 +177,24 @@ class Launcher {
     /**
      * run without triggering onPrepare/onComplete hooks
      */
-    private _runMode(config: Required<Options.Testrunner>, caps: Capabilities.TestrunnerCapabilities): Promise<number> {
+    private _runMode(config: Required<Options.Testrunner>, caps?: Capabilities.TestrunnerCapabilities): Promise<number> {
         /**
-         * fail if no caps were found
+         * fail if
          */
-        if (!caps) {
+        if (
+            /**
+             * no caps were provided
+             */
+            !caps ||
+            /**
+             * capability array is empty
+             */
+            (Array.isArray(caps) && caps.length === 0) ||
+            /**
+             * user wants to use multiremote but capability object is empty
+             */
+            (!Array.isArray(caps) && Object.keys(caps).length === 0)
+        ) {
             return new Promise((resolve) => {
                 log.error('Missing capabilities, exiting with failure')
                 return resolve(1)

--- a/packages/wdio-cli/tests/launcher.test.ts
+++ b/packages/wdio-cli/tests/launcher.test.ts
@@ -5,7 +5,7 @@ import { sleep, enableFileLogging } from '@wdio/utils'
 import Launcher from '../src/launcher.js'
 
 const caps: WebdriverIO.Capabilities = {
-    maxInstances: 1,
+    'wdio:maxInstances': 1,
     browserName: 'chrome'
 }
 
@@ -79,7 +79,21 @@ describe('launcher', () => {
 
         it('should fail when no capabilities are set', async () => {
             launcher['_runSpecs'] = vi.fn().mockReturnValue(1)
-            const exitCode = await launcher['_runMode']({ specs: ['./'], shard } as any, undefined as any)
+            const exitCode = await launcher['_runMode']({ specs: ['./'], shard } as any)
+            expect(exitCode).toEqual(1)
+            expect(logger('').error).toBeCalledWith('Missing capabilities, exiting with failure')
+        })
+
+        it('should fail when no capabilities are set (empty capabilities array)', async () => {
+            launcher['_runSpecs'] = vi.fn().mockReturnValue(1)
+            const exitCode = await launcher['_runMode']({ specs: ['./'], shard } as any, [])
+            expect(exitCode).toEqual(1)
+            expect(logger('').error).toBeCalledWith('Missing capabilities, exiting with failure')
+        })
+
+        it('should fail when no capabilities are set (empty capabilities array)', async () => {
+            launcher['_runSpecs'] = vi.fn().mockReturnValue(1)
+            const exitCode = await launcher['_runMode']({ specs: ['./'], shard } as any, {})
             expect(exitCode).toEqual(1)
             expect(logger('').error).toBeCalledWith('Missing capabilities, exiting with failure')
         })


### PR DESCRIPTION
## Proposed changes

If a user doesn't provide any capabilities, the test would fail with:

```
Execution of 0 workers started at 2024-11-04T19:57:43.847Z

2024-11-04T19:57:43.854Z INFO @wdio/cli:launcher: Run onPrepare hook
2024-11-04T19:57:43.855Z ERROR @wdio/cli:launcher: No specs found to run, exiting with failure
2024-11-04T19:57:43.855Z INFO @wdio/cli:launcher: Run onComplete hook

Spec Files:      0 passed, 0 total (0% completed) in 00:00:00

2024-11-04T19:57:43.855Z INFO @wdio/local-runner: Shutting down spawned worker
2024-11-04T19:57:44.107Z INFO @wdio/local-runner: Waiting for 0 to shut down gracefully
2024-11-04T19:57:44.107Z INFO @wdio/local-runner: shutting down
```

This is misleading because the actual reason for this error are missing capabilities.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
