### PR TITLE
Introducing WebdriverIO Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@
     <a title="Crowdin" target="_blank" href="https://translate.webdriver.io/project/webdriver-io">
         <img src="https://badges.crowdin.net/webdriver-io/localized.svg">
     </a>
+    <a href="https://gurubase.io/g/webdriverio">
+        <img alt="Gurubase" src="https://img.shields.io/badge/Gurubase-Ask%20WebdriverIO%20Guru-006BFF">
+    </a>
     <br />
     <a href="https://discord.webdriver.io">
         <img alt="Support Channel" src="https://img.shields.io/discord/1097401827202445382?color=%234FB898&label=Join%20us%20on%20Discord">


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [WebdriverIO Guru](https://gurubase.io/g/webdriverio) to Gurubase. WebdriverIO Guru uses the data from this repo and data from the [docs](https://webdriver.io/) to answer questions by leveraging the LLM.

In this PR, I showcased the "WebdriverIO Guru", which highlights that WebdriverIO now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable WebdriverIO Guru in Gurubase, just let me know that's totally fine.
