### PR TITLE
fix(@wdio/sauce-service): don't rely on vulnerable ip package

### DIFF
--- a/packages/wdio-sauce-service/src/launcher.ts
+++ b/packages/wdio-sauce-service/src/launcher.ts
@@ -1,6 +1,5 @@
 import { performance, PerformanceObserver } from 'node:perf_hooks'
 
-import ip from 'ip'
 import {
     default as SauceLabs,
     type SauceLabsOptions,
@@ -10,7 +9,7 @@ import {
 import logger from '@wdio/logger'
 import type { Services, Capabilities, Options } from '@wdio/types'
 
-import { makeCapabilityFactory } from './utils.js'
+import { makeCapabilityFactory, getLocalIpAddress } from './utils.js'
 import type { SauceServiceConfig } from './types.js'
 import path from 'node:path'
 
@@ -51,7 +50,7 @@ export default class SauceLauncher implements Services.ServiceInstance {
             noAutodetect: true,
             tunnelIdentifier: sauceConnectTunnelIdentifier,
             ...this._options.sauceConnectOpts,
-            noSslBumpDomains: `127.0.0.1,localhost,${ip.address()}` + (
+            noSslBumpDomains: `127.0.0.1,localhost,${getLocalIpAddress()}` + (
                 this._options.sauceConnectOpts?.noSslBumpDomains
                     ? `,${this._options.sauceConnectOpts.noSslBumpDomains}`
                     : ''

--- a/packages/wdio-sauce-service/src/utils.ts
+++ b/packages/wdio-sauce-service/src/utils.ts
@@ -1,3 +1,5 @@
+import os from 'node:os'
+
 /**
  * Determine if the current instance is a RDC instance. RDC tests are Real Device tests
  * that can be started with different sets of capabilities. A deviceName is not mandatory, the only mandatory cap for
@@ -40,7 +42,7 @@
  *  deviceContextId: ''
  * }
  */
-export function isRDC (caps: WebdriverIO.Capabilities){
+export function isRDC(caps: WebdriverIO.Capabilities) {
     // @ts-expect-error outdated JSONWP capabilities
     const { 'appium:deviceName': appiumDeviceName = '', deviceName = '', platformName = '' } = caps
     const name = appiumDeviceName || deviceName
@@ -53,7 +55,7 @@ export function isRDC (caps: WebdriverIO.Capabilities){
  * @param {object} caps
  * @returns {boolean}
  */
-export function isEmuSim (caps: WebdriverIO.Capabilities){
+export function isEmuSim(caps: WebdriverIO.Capabilities) {
     // @ts-expect-error outdated JSONWP capabilities
     const { 'appium:deviceName': appiumDeviceName = '', deviceName = '', platformName = '' } = caps
     const name = appiumDeviceName || deviceName
@@ -80,11 +82,22 @@ export function makeCapabilityFactory(tunnelIdentifier: string) {
     }
 }
 
-export function ansiRegex () {
+export function ansiRegex() {
     const pattern = [
         '[\\u001B\\u009B][[\\]()#;?]*(?:(?:(?:[a-zA-Z\\d]*(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]*)*)?\\u0007)',
         '(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PR-TZcf-ntqry=><~]))'
     ].join('|')
 
     return new RegExp(pattern, 'g')
+}
+
+export function getLocalIpAddress(): string {
+    const interfaces = os.networkInterfaces()
+    const internalAddresses = Object.keys(interfaces)
+        .map((nic) => {
+            const addresses = interfaces[nic]?.filter((details) => details.internal) || []
+            return addresses.length ? addresses[0].address : undefined
+        })
+        .filter(Boolean) as string[]
+    return internalAddresses.length ? internalAddresses[0] : '127.0.0.1'
 }


### PR DESCRIPTION
## Proposed changes

This patch removes the dependency of `@wdio/sauce-service` to the `ip` package which has a lot of vulnerabilities (which never impacted any WebdriverIO users) but still causes noises of folks reporting this. 

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
