### PR TITLE
fix(@wdio/runner): Respect excludes in capabilities in multiremote case.

### DIFF
--- a/packages/wdio-runner/src/index.ts
+++ b/packages/wdio-runner/src/index.ts
@@ -75,22 +75,19 @@ export default class Runner extends EventEmitter {
         // ToDo(Christian): resolve type incompatibility between v8 and v9
         this._configParser.addService(snapshotService as any)
 
-        let filteredCaps = caps
-        if (this._isMultiremote) {
-            filteredCaps = {}
-            // filters out caps that are excluded in the multiremote capabilities for the current spec
-            Object.entries(caps).forEach(([browserName, browserCaps]) => {
+        this._caps = this._isMultiremote
+            ? Object.entries(caps).reduce((filteredCaps, [browserName, browserCaps]) => {
                 const ex = browserCaps.capabilities['wdio:exclude']
                 if (ex) {
                     const sp = this._configParser?.getSpecs(specs, ex)
                     if (sp && sp.length === 0) {
-                        return
+                        return filteredCaps
                     }
                 }
-                (filteredCaps as Capabilities.RequestedMultiremoteCapabilities)[browserName] = browserCaps
-            })
-        }
-        this._caps = filteredCaps
+                filteredCaps[browserName] = browserCaps
+                return filteredCaps
+            }, {} as Capabilities.RequestedMultiremoteCapabilities)
+            : caps
 
         /**
          * create `browser` stub only if `specFiltering` feature is enabled
@@ -100,46 +97,46 @@ export default class Runner extends EventEmitter {
             // @ts-ignore used in `/packages/webdriverio/src/protocol-stub.ts`
             _automationProtocol: this._config.automationProtocol,
             automationProtocol: './protocol-stub.js'
-        }, filteredCaps)
+        }, this._caps)
 
         /**
          * run `beforeSession` command before framework and browser are initiated
          */
         ;(await initializeWorkerService(
             this._config as Options.Testrunner,
-            filteredCaps as WebdriverIO.Capabilities,
+            this._caps as WebdriverIO.Capabilities,
             args.ignoredWorkerServices
         )).map(this._configParser.addService.bind(this._configParser))
 
-        const beforeSessionParams: BeforeSessionArgs = [this._config, filteredCaps, this._specs, this._cid]
+        const beforeSessionParams: BeforeSessionArgs = [this._config, this._caps, this._specs, this._cid]
         await executeHooksWithArgs('beforeSession', this._config.beforeSession, beforeSessionParams)
 
-        this._reporter = new BaseReporter(this._config, this._cid, { ...filteredCaps })
+        this._reporter = new BaseReporter(this._config, this._cid, { ...this._caps })
         await this._reporter.initReporters()
 
         /**
          * initialize framework
          */
-        this._framework = await this.#initFramework(cid, this._config, filteredCaps, this._reporter, specs)
-        process.send!({ name: 'testFrameworkInit', content: { cid, filteredCaps, specs, hasTests: this._framework.hasTests() } })
+        this._framework = await this.#initFramework(cid, this._config, this._caps, this._reporter, specs)
+        process.send!({ name: 'testFrameworkInit', content: { cid, caps: this._caps, specs, hasTests: this._framework.hasTests() } })
         if (!this._framework.hasTests()) {
             return this._shutdown(0, retries, true)
         }
 
-        browser = await this._initSession(this._config, filteredCaps)
+        browser = await this._initSession(this._config, this._caps)
 
         /**
          * return if session initialization failed
          */
         if (!browser) {
-            const afterArgs: AfterArgs = [1, filteredCaps, this._specs]
+            const afterArgs: AfterArgs = [1, this._caps, this._specs]
             await executeHooksWithArgs('after', this._config.after as Function, afterArgs)
             return this._shutdown(1, retries, true)
         }
 
         this._reporter.caps = browser.capabilities
 
-        const beforeArgs: BeforeArgs = [filteredCaps, this._specs, browser]
+        const beforeArgs: BeforeArgs = [this._caps, this._specs, browser]
         await executeHooksWithArgs('before', this._config.before, beforeArgs)
 
         /**

--- a/packages/wdio-runner/src/index.ts
+++ b/packages/wdio-runner/src/index.ts
@@ -76,6 +76,10 @@ export default class Runner extends EventEmitter {
         this._configParser.addService(snapshotService as any)
 
         this._caps = this._isMultiremote
+            /**
+             * Filter driver instances based on 'wdio:exclude' capability and allow
+             * user to exclude them if not needed for given spec file
+             */
             ? Object.entries(caps).reduce((filteredCaps, [browserName, browserCaps]) => {
                 const ex = browserCaps.capabilities['wdio:exclude']
                 if (ex) {

--- a/tests/multiremote/test-filter1.js
+++ b/tests/multiremote/test-filter1.js
@@ -1,0 +1,7 @@
+import assert from 'node:assert'
+
+describe('smoke test multiremote filter caps', () => {
+    it('should have two instances', async () => {
+        assert.equal(browser.instances.length, 2)
+    })
+})

--- a/tests/multiremote/test-filter2.js
+++ b/tests/multiremote/test-filter2.js
@@ -1,0 +1,7 @@
+import assert from 'node:assert'
+
+describe('smoke test multiremote filter caps', () => {
+    it('should have one instance', async () => {
+        assert.equal(browser.instances.length, 1)
+    })
+})

--- a/tests/smoke.runner.js
+++ b/tests/smoke.runner.js
@@ -547,6 +547,29 @@ const multiremote = async () => {
             }
         }
     })
+
+    const { skippedSpecs, passed, failed } = await launch('multiremote', baseConfig, {
+        specs: [
+            path.resolve(__dirname, 'multiremote', 'test-filter1.js'),
+            path.resolve(__dirname, 'multiremote', 'test-filter2.js')
+        ],
+        capabilities: {
+            browserA: {
+                capabilities: { browserName: 'chrome',  }
+            },
+            browserB: {
+                capabilities: {
+                    browserName: 'chrome',
+                    'wdio:exclude': [
+                        path.resolve(__dirname, 'multiremote', 'test-filter2.js')
+                    ]
+                }
+            }
+        }
+    })
+    assert.strictEqual(skippedSpecs, 0)
+    assert.strictEqual(passed, 2)
+    assert.strictEqual(failed, 0)
 }
 
 /**


### PR DESCRIPTION
Fixes #13875.

When a spec is excluded from some capability there is no point of starting the browser session for it.

## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

When spec is excluded in multiremote the browser sessions are still created for it.

```
specs: [
        'test/example.spec.ts'
    ],

    capabilities: {
        participant1: {
            capabilities: {
                browserName: 'chrome'
            }
        },
        participant2: {
            capabilities: {
                browserName: 'chrome',
                'wdio:exclude': [
                    'test/example.spec.ts'
                ]
            }
        }
    },
```
This will create two browser sessions for the test and the PR will change that to be only one. 

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [ X ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ X ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ X ] I have added the necessary documentation (if appropriate)
- [ X ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [ X ] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

It was discussed in https://github.com/webdriverio/webdriverio/issues/13875

### Reviewers: @webdriverio/project-committers
