### PR TITLE
polish(@wdio/reporter): better display retried scenarios

### DIFF
--- a/examples/wdio/package.json
+++ b/examples/wdio/package.json
@@ -17,6 +17,7 @@
     "@wdio/browser-runner": "workspace:*",
     "@wdio/config": "workspace:*",
     "@wdio/cli": "workspace:*",
+    "@wdio/cucumber-framework": "workspace:*",
     "@wdio/dot-reporter": "workspace:*",
     "@wdio/globals": "workspace:*",
     "@wdio/junit-reporter": "workspace:*",

--- a/packages/wdio-reporter/README.md
+++ b/packages/wdio-reporter/README.md
@@ -178,6 +178,32 @@ SuiteStats {
   end: '2018-02-09T13:30:41.609Z' } }
 ```
 
+##### onSuiteRetry
+
+(Cucumber only)
+
+```js
+SuiteStats {
+  start: 2024-11-13T06:33:21.499Z,
+  end: undefined,
+  type: 'scenario',
+  uid: '0',
+  cid: '0-0',
+  file: '/Users/christian.bromann/Sites/WebdriverIO/projects/webdriverio/examples/wdio/cucumber/features/my-feature.feature',
+  title: 'Get size of an element',
+  fullTitle: 'my-feature.feature:1:1: Get size of an element',
+  tags: [],
+  tests: [],
+  hooks: [],
+  suites: [],
+  parent: 'my-feature.feature:1:1',
+  retries: 1,
+  hooksAndTests: [],
+  description: '',
+  rule: undefined
+}
+```
+
 ##### onHookStart
 
 ```js

--- a/packages/wdio-reporter/src/index.ts
+++ b/packages/wdio-reporter/src/index.ts
@@ -92,6 +92,17 @@ export default class WDIOReporter extends EventEmitter {
             this.onSuiteStart(suite)
         })
 
+        /**
+         * This event is currently only supported by Cucumber and is emitted instead of a new
+         * 'suite:start' event when a suite is retried. This is useful for reporters that want to
+         * display the number of times a suite was retried.
+         */
+        this.on('suite:retry', (suite: Suite) => {
+            const suiteStat = this.suites[suite.uid!]
+            suiteStat.retry()
+            this.onSuiteRetry(suiteStat)
+        })
+
         this.on('hook:start', /* istanbul ignore next */ (hook: Hook) => {
             const hookStats = new HookStats(hook)
             const currentSuite = this.currentSuites[this.currentSuites.length - 1]
@@ -296,6 +307,9 @@ export default class WDIOReporter extends EventEmitter {
     /* istanbul ignore next */
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     onTestEnd(testStats: TestStats) { }
+    /* istanbul ignore next */
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    onSuiteRetry(suiteStats: SuiteStats) { }
     /* istanbul ignore next */
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     onSuiteEnd(suiteStats: SuiteStats) { }

--- a/packages/wdio-reporter/src/stats/suite.ts
+++ b/packages/wdio-reporter/src/stats/suite.ts
@@ -17,6 +17,7 @@ export interface Suite {
     tags?: string[] | Tag[]
     description?: string
     rule?: string
+    retries?: number
 }
 
 /**
@@ -33,6 +34,7 @@ export default class SuiteStats extends RunnableStats {
     hooks: HookStats[] = []
     suites: SuiteStats[] = []
     parent?: string
+    retries = 0
     /**
      * an array of hooks and tests stored in order as they happen
      */
@@ -54,5 +56,15 @@ export default class SuiteStats extends RunnableStats {
          */
         this.description = suite.description
         this.rule = suite.rule
+    }
+
+    /**
+     * Mark suite as retried and remove previous history.
+     */
+    retry () {
+        this.retries++
+        this.tests = []
+        this.hooks = []
+        this.hooksAndTests = []
     }
 }

--- a/packages/wdio-reporter/tests/reporter.test.ts
+++ b/packages/wdio-reporter/tests/reporter.test.ts
@@ -21,10 +21,14 @@ describe('WDIOReporter', () => {
 
     it('constructor', () => {
         new WDIOReporter({ logFile: '/some/logpath' })
+        expect(eventsOnSpy.mock.calls).toHaveLength(20)
         expect(eventsOnSpy).toBeCalledWith('client:beforeCommand', expect.any(Function))
         expect(eventsOnSpy).toBeCalledWith('client:afterCommand', expect.any(Function))
+        expect(eventsOnSpy).toBeCalledWith('client:beforeAssertion', expect.any(Function))
+        expect(eventsOnSpy).toBeCalledWith('client:afterAssertion', expect.any(Function))
         expect(eventsOnSpy).toBeCalledWith('runner:start', expect.any(Function))
         expect(eventsOnSpy).toBeCalledWith('suite:start', expect.any(Function))
+        expect(eventsOnSpy).toBeCalledWith('suite:retry', expect.any(Function))
         expect(eventsOnSpy).toBeCalledWith('hook:start', expect.any(Function))
         expect(eventsOnSpy).toBeCalledWith('hook:end', expect.any(Function))
         expect(eventsOnSpy).toBeCalledWith('test:start', expect.any(Function))

--- a/packages/wdio-reporter/tests/stats/__snapshots__/suite.test.ts.snap
+++ b/packages/wdio-reporter/tests/stats/__snapshots__/suite.test.ts.snap
@@ -11,6 +11,7 @@ exports[`should get initialized 1`] = `
   "hooks": [],
   "hooksAndTests": [],
   "parent": "foobar",
+  "retries": 0,
   "rule": undefined,
   "suites": [],
   "tags": [

--- a/packages/wdio-reporter/tests/stats/suite.test.ts
+++ b/packages/wdio-reporter/tests/stats/suite.test.ts
@@ -16,3 +16,23 @@ test('should get initialized', () => {
     expect(snapshot).toMatchSnapshot()
     expect(start instanceof Date).toBe(true)
 })
+
+test('should allow to retry suite', () => {
+    const suite = new SuiteStats({
+        cid: '0-0',
+        title: 'foobar',
+        fullTitle: 'barfoo',
+        file: '/this/is/a/file.txt',
+        description: 'some description',
+        tags: ['foo', 'bar'],
+        parent: 'foobar'
+    })
+    suite.tests = [1, 2, 3] as any
+    suite.hooks = [4, 5, 6] as any
+    suite.hooksAndTests = [7, 8, 9] as any
+    suite.retry()
+    expect(suite.retries).toBe(1)
+    expect(suite.tests).toHaveLength(0)
+    expect(suite.hooks).toHaveLength(0)
+    expect(suite.hooksAndTests).toHaveLength(0)
+})

--- a/packages/wdio-spec-reporter/src/types.ts
+++ b/packages/wdio-spec-reporter/src/types.ts
@@ -4,6 +4,7 @@ export interface StateCount {
     passed: number
     failed: number
     skipped: number
+    retried: number
 }
 
 export interface Symbols {
@@ -11,6 +12,7 @@ export interface Symbols {
     skipped: string
     pending: string
     failed: string
+    retried: string
 }
 
 export interface SpecReporterOptions {
@@ -80,6 +82,7 @@ export enum State {
     PASSED = 'passed',
     PENDING = 'pending',
     SKIPPED = 'skipped',
+    RETRIED = 'retried'
 }
 
 export interface TestLink {

--- a/packages/wdio-spec-reporter/tests/__fixtures__/testdata.ts
+++ b/packages/wdio-spec-reporter/tests/__fixtures__/testdata.ts
@@ -326,7 +326,7 @@ const createTestStatsInstance = (
     return testStat
 }
 
-export const SUITES_WITH_RETRY = {
+export const SUITES_WITH_TEST_RETRY = {
     [suiteIds[0]]: {
         uid: suiteIds[0],
         title: suiteIds[0].slice(0, -1),
@@ -342,7 +342,25 @@ export const SUITES_WITH_RETRY = {
         ],
     },
 }
-Object.values(SUITES_WITH_RETRY).forEach((suite) => {
+Object.values(SUITES_WITH_TEST_RETRY).forEach((suite) => {
+    // @ts-expect-error
+    suite.hooksAndTests = [...suite.tests]
+})
+
+export const SUITES_WITH_RETRIES = {
+    [suiteIds[0]]: {
+        uid: suiteIds[0],
+        title: suiteIds[0].slice(0, -1),
+        file: '/foo/bar/loo.e2e.js',
+        hooks: [],
+        retries: 1,
+        tests: [
+            createTestStatsInstance('foo1', 'foo', 'pass'),
+            createTestStatsInstance('bar1', 'bar', 'pass'),
+        ],
+    },
+}
+Object.values(SUITES_WITH_RETRIES).forEach((suite) => {
     // @ts-expect-error
     suite.hooksAndTests = [...suite.tests]
 })

--- a/packages/wdio-spec-reporter/tests/__snapshots__/index.test.ts.snap
+++ b/packages/wdio-spec-reporter/tests/__snapshots__/index.test.ts.snap
@@ -157,7 +157,7 @@ exports[`SpecReporter > onRetry > should group retried test cases 1`] = `
 [loremipsum 50 Windows 10 #0-0] Foo test
 [loremipsum 50 Windows 10 #0-0]    green ✓ foo
 [loremipsum 50 Windows 10 #0-0]    green ✓ bar
-[loremipsum 50 Windows 10 #0-0]    green ✓ loo (1 retries)
+[loremipsum 50 Windows 10 #0-0]    green ✓ loo yellow (1x retries)
 [loremipsum 50 Windows 10 #0-0]    green ✓ bar
 [loremipsum 50 Windows 10 #0-0]    cyan ? baz
 [loremipsum 50 Windows 10 #0-0]
@@ -592,3 +592,22 @@ exports[`SpecReporter > printReport > with normal setup > should print the repor
 exports[`SpecReporter > showPreface > false 1`] = `[]`;
 
 exports[`SpecReporter > showPreface > true 1`] = `[]`;
+
+exports[`SpecReporter > suite retry > should group retried test suites 1`] = `
+[
+  [
+    "------------------------------------------------------------------
+[loremipsum 50 Windows 10 #0-0] Running: loremipsum (v50) on Windows 10
+[loremipsum 50 Windows 10 #0-0] Session ID: foobar
+[loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] » /foo/bar/loo.e2e.js
+[loremipsum 50 Windows 10 #0-0] Foo testyellow  (1x retries)
+[loremipsum 50 Windows 10 #0-0]    green ✓ foo
+[loremipsum 50 Windows 10 #0-0]    green ✓ bar
+[loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] green 2 passing (5s)
+[loremipsum 50 Windows 10 #0-0] yellow 1 retried
+",
+  ],
+]
+`;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -389,6 +389,9 @@ importers:
       '@wdio/config':
         specifier: workspace:*
         version: link:../../packages/wdio-config
+      '@wdio/cucumber-framework':
+        specifier: workspace:*
+        version: link:../../packages/wdio-cucumber-framework
       '@wdio/dot-reporter':
         specifier: workspace:*
         version: link:../../packages/wdio-dot-reporter


### PR DESCRIPTION
## Proposed changes

This patch enables proper spec reporting when Cucumber scenarios are being retried. Before it would look like:

```
 "spec" Reporter:
------------------------------------------------------------------
[chrome 130.0.6723.117 mac #0-0] Running: chrome (v130.0.6723.117) on mac
[chrome 130.0.6723.117 mac #0-0] Session ID: 6b7e1b42487586c61efffa736922cd76
[chrome 130.0.6723.117 mac #0-0]
[chrome 130.0.6723.117 mac #0-0] » /cucumber/features/my-feature.feature
[chrome 130.0.6723.117 mac #0-0] Example feature
[chrome 130.0.6723.117 mac #0-0] As a user of WebdriverIO
[chrome 130.0.6723.117 mac #0-0] I should be able to use different commands
[chrome 130.0.6723.117 mac #0-0] to get informations about elements on the page
[chrome 130.0.6723.117 mac #0-0]
[chrome 130.0.6723.117 mac #0-0]     Get size of an element
[chrome 130.0.6723.117 mac #0-0]        ✓ Given I go on the website "https://github.com/"
[chrome 130.0.6723.117 mac #0-0]        ✓ Then should the element ".header-logged-out a" be 32px wide and 34.5px high
[chrome 130.0.6723.117 mac #0-0]
[chrome 130.0.6723.117 mac #0-0] 3 passing (2.9s)
[chrome 130.0.6723.117 mac #0-0] 1 failing


Spec Files:      1 passed, 1 total (100% completed) in 00:00:16
```

now it looks like:

```
 "spec" Reporter:
------------------------------------------------------------------
[chrome 130.0.6723.117 mac #0-0] Running: chrome (v130.0.6723.117) on mac
[chrome 130.0.6723.117 mac #0-0] Session ID: 8b549c317945d98b58dfcc1432afdec7
[chrome 130.0.6723.117 mac #0-0]
[chrome 130.0.6723.117 mac #0-0] » /cucumber/features/my-feature.feature
[chrome 130.0.6723.117 mac #0-0] Example feature
[chrome 130.0.6723.117 mac #0-0] As a user of WebdriverIO
[chrome 130.0.6723.117 mac #0-0] I should be able to use different commands
[chrome 130.0.6723.117 mac #0-0] to get informations about elements on the page
[chrome 130.0.6723.117 mac #0-0]
[chrome 130.0.6723.117 mac #0-0] Get size of an element (1x retries)
[chrome 130.0.6723.117 mac #0-0]    ✓ Given I go on the website "https://github.com/"
[chrome 130.0.6723.117 mac #0-0]    ✓ Then should the element ".header-logged-out a" be 32px wide and 34.5px high
[chrome 130.0.6723.117 mac #0-0]
[chrome 130.0.6723.117 mac #0-0] 2 passing (1.9s)
[chrome 130.0.6723.117 mac #0-0] 1 retried


Spec Files:      1 passed, 1 total (100% completed) in 00:00:12
```

fixes #13879

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
