### PR TITLE
polish(webdriverio): improve error stack of waitUntil command

### DIFF
--- a/packages/webdriverio/src/commands/browser/waitUntil.ts
+++ b/packages/webdriverio/src/commands/browser/waitUntil.ts
@@ -55,19 +55,19 @@ export function waitUntil<ReturnValue>(
         }
 
         const err = new Error(`waitUntil condition failed with the following reason: ${e && e.message || e}`)
-        const origStack = err.stack
-        if (!origStack) {
+        const origStack = e.stack
+        if (!origStack || !err.stack) {
             throw err
         }
 
         /**
          * sanitize error message and clean up stack trace
          */
-        const [errMsg, ...waitUntilErrorStackLines] = origStack.split('\n')
+        const [errMsg, ...waitUntilErrorStackLines] = err.stack.split('\n')
         err.stack = [
             errMsg,
             ...(origStack.split('\n').slice(1)),
-            '\t---',
+            '    ---',
             ...waitUntilErrorStackLines
         ].filter((errorLine) => (
             !errorLine.includes('/node_modules/webdriverio/') &&

--- a/packages/webdriverio/src/commands/browser/waitUntil.ts
+++ b/packages/webdriverio/src/commands/browser/waitUntil.ts
@@ -54,6 +54,26 @@ export function waitUntil<ReturnValue>(
             throw new Error(`waitUntil condition timed out after ${timeout}ms`)
         }
 
-        throw new Error(`waitUntil condition failed with the following reason: ${(e && e.message) || e}`)
+        const err = new Error(`waitUntil condition failed with the following reason: ${e && e.message || e}`)
+        const origStack = err.stack
+        if (!origStack) {
+            throw err
+        }
+
+        /**
+         * sanitize error message and clean up stack trace
+         */
+        const [errMsg, ...waitUntilErrorStackLines] = origStack.split('\n')
+        err.stack = [
+            errMsg,
+            ...(origStack.split('\n').slice(1)),
+            '\t---',
+            ...waitUntilErrorStackLines
+        ].filter((errorLine) => (
+            !errorLine.includes('/node_modules/webdriverio/') &&
+            !errorLine.includes('/node_modules/@wdio/')
+        )).join('\n')
+
+        throw err
     })
 }

--- a/packages/webdriverio/src/utils/Timer.ts
+++ b/packages/webdriverio/src/utils/Timer.ts
@@ -73,20 +73,24 @@ class Timer {
     }
 
     private _tick () {
-        const result = this._fn()
+        try {
+            const result = this._fn()
 
-        if (!result) {
-            return this._checkCondition(new Error(TIMEOUT_ERROR))
+            if (!result) {
+                return this._checkCondition(new Error(TIMEOUT_ERROR))
+            }
+
+            if (typeof result.then !== 'function') {
+                return this._checkCondition(undefined, result)
+            }
+
+            result.then(
+                (res: any) => this._checkCondition(undefined, res),
+                (err: Error) => this._checkCondition(err)
+            )
+        } catch (err: unknown) {
+            return this._checkCondition(err as Error)
         }
-
-        if (typeof result.then !== 'function') {
-            return this._checkCondition(undefined, result)
-        }
-
-        result.then(
-            (res: any) => this._checkCondition(undefined, res),
-            (err: Error) => this._checkCondition(err)
-        )
     }
 
     private _checkCondition (err?: Error, res?: any) {

--- a/packages/webdriverio/tests/commands/browser/waitUntil.test.ts
+++ b/packages/webdriverio/tests/commands/browser/waitUntil.test.ts
@@ -1,3 +1,4 @@
+import path from 'node:path'
 import { expect, describe, it, beforeAll, afterEach, vi } from 'vitest'
 
 import { remote } from '../../../src/index.js'
@@ -82,7 +83,7 @@ describe('waitUntil', () => {
             error = err
         } finally {
             expect(error.message).toContain('waitUntil condition failed with the following reason: foobar')
-            expect(error.stack).toContain('browser/waitUntil.test.ts:72')
+            expect(error.stack).toContain(`browser${path.sep}waitUntil.test.ts:72`)
             expect(val).toBeUndefined()
         }
     })
@@ -106,7 +107,7 @@ describe('waitUntil', () => {
             error = err
         } finally {
             expect(error.message).toContain('waitUntil condition failed with the following reason: foobar')
-            expect(error.stack).toContain('browser/waitUntil.test.ts:98')
+            expect(error.stack).toContain(`browser${path.sep}waitUntil.test.ts:98`)
             expect(val).toBeUndefined()
         }
     })

--- a/packages/webdriverio/tests/commands/browser/waitUntil.test.ts
+++ b/packages/webdriverio/tests/commands/browser/waitUntil.test.ts
@@ -39,7 +39,6 @@ describe('waitUntil', () => {
     it.each([false, '', 0])('Should throw an error when the waitUntil times out e.g. doesnt resolve to a truthy value: %i', async () => {
         let error
         let val
-        // @ts-ignore uses expect-webdriverio
         expect.assertions(2)
         try {
             val = await browser.waitUntil(
@@ -65,12 +64,11 @@ describe('waitUntil', () => {
     it('Should throw an error when the promise is rejected', async () => {
         let error
         let val
-        // @ts-ignore uses expect-webdriverio
-        expect.assertions(2)
+        expect.assertions(3)
         try {
             val = await browser.waitUntil(
                 () => new Promise<boolean>(
-                    (resolve, reject) => setTimeout(
+                    (_, reject) => setTimeout(
                         () => reject(new Error('foobar')),
                         200
                     )
@@ -84,6 +82,31 @@ describe('waitUntil', () => {
             error = err
         } finally {
             expect(error.message).toContain('waitUntil condition failed with the following reason: foobar')
+            expect(error.stack).toContain('browser/waitUntil.test.ts:72')
+            expect(val).toBeUndefined()
+        }
+    })
+
+    it('should throw an error if the condition throws', async () => {
+        let error
+        let val
+        // @ts-ignore uses expect-webdriverio
+        expect.assertions(3)
+        try {
+            val = await browser.waitUntil(
+                () => {
+                    throw new Error('foobar')
+                }, {
+                    timeout: 500,
+                    timeoutMsg: 'Timed Out',
+                    interval: 200
+                }
+            )
+        } catch (err: any) {
+            error = err
+        } finally {
+            expect(error.message).toContain('waitUntil condition failed with the following reason: foobar')
+            expect(error.stack).toContain('browser/waitUntil.test.ts:98')
             expect(val).toBeUndefined()
         }
     })

--- a/packages/webdriverio/tests/commands/browser/waitUntil.test.ts
+++ b/packages/webdriverio/tests/commands/browser/waitUntil.test.ts
@@ -83,7 +83,7 @@ describe('waitUntil', () => {
             error = err
         } finally {
             expect(error.message).toContain('waitUntil condition failed with the following reason: foobar')
-            expect(error.stack).toContain(`browser${path.sep}waitUntil.test.ts:72`)
+            expect(error.stack).toContain(`browser${path.sep}waitUntil.test.ts:73`)
             expect(val).toBeUndefined()
         }
     })
@@ -107,7 +107,7 @@ describe('waitUntil', () => {
             error = err
         } finally {
             expect(error.message).toContain('waitUntil condition failed with the following reason: foobar')
-            expect(error.stack).toContain(`browser${path.sep}waitUntil.test.ts:98`)
+            expect(error.stack).toContain(`browser${path.sep}waitUntil.test.ts:99`)
             expect(val).toBeUndefined()
         }
     })


### PR DESCRIPTION
## Proposed changes

If you would put assertion or anything that would throw an error, it wouldn't be clear where it comes from as the stack trace would only contain the error stack of the `waituntil` command but not what was executed inside the callback, e.g.:

```
Error: waitUntil condition failed with the following reason: TypeError: Cannot read properties of undefined (reading 'provider')
    at <anonymous> (/path/to/project/node_modules/webdriverio/build/index.js:4833:11)
    at Browser.wrapCommandFn (/path/to/project/node_modules/@wdio/utils/build/index.js:884:23)
    at World.<anonymous> (/path/to/project/tests/maps/sample-validations/map-validations.ts:125:5)
```

This patch carries along the original error stack and cleans it up:

```ts
Error: waitUntil condition failed with the following reason: TypeError: Cannot read properties of undefined (reading 'provider')
    at Marker.getCoordinates (/path/to/project/tests/maps/component/marker.ts:55:13)
    at Browser.<anonymous> (/path/to/project/tests/maps/sample-validations/map-validations.ts:126:24)
    at World.<anonymous> (/path/to/project/tests/maps/sample-validations/map-validations.ts:125:5)
```

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
