### PR TITLE
propagate addCommand to children for multiremote

### DIFF
--- a/packages/webdriverio/src/index.ts
+++ b/packages/webdriverio/src/index.ts
@@ -190,6 +190,10 @@ export const multiremote = async function (
     if (!isStub(automationProtocol)) {
         const origAddCommand = driver.addCommand.bind(driver)
         driver.addCommand = (name: string, fn: (...args: any[]) => any, attachToElement) => {
+            driver.instances.forEach(instance =>
+                driver.getInstance(instance).addCommand(name, fn, attachToElement)
+            )
+
             return origAddCommand(
                 name,
                 fn,

--- a/packages/webdriverio/tests/addCommand.test.ts
+++ b/packages/webdriverio/tests/addCommand.test.ts
@@ -17,6 +17,7 @@ const remoteConfig: Capabilities.WebdriverIOConfig = {
 declare global {
     namespace WebdriverIO {
         interface Browser {
+            myCustomCommand: (arg: any) => Promise<void>
             myOtherCustomCommand: (param: string) => Promise<{ param: string, commandResult: string }>
         }
 
@@ -348,10 +349,24 @@ describe('addCommand', () => {
             })
 
             expect(typeof browser.myCustomCommand).toBe('function')
+            expect(typeof browser.getInstance('browserA').myCustomCommand).toBe('function')
+            expect(typeof browser.getInstance('browserB').myCustomCommand).toBe('function')
             // @ts-expect-error undefined custom command
             const { param, commandResult } = await browser.myCustomCommand('barfoo')
             expect(param).toBe('barfoo')
             expect(commandResult).toEqual(['foobar', 'foobar'])
+
+            const resultA = await browser.getInstance('browserA').myCustomCommand('barfoo')
+            // @ts-expect-error undefined custom command
+            expect(resultA.param).toBe('barfoo')
+            // @ts-expect-error undefined custom command
+            expect(resultA.commandResult).toEqual('foobar')
+
+            const resultB = await browser.getInstance('browserB').myCustomCommand('barfoo')
+            // @ts-expect-error undefined custom command
+            expect(resultB.param).toBe('barfoo')
+            // @ts-expect-error undefined custom command
+            expect(resultB.commandResult).toEqual('foobar')
         })
 
         test('should allow to register custom commands to a single multiremote instance', async () => {

--- a/website/docs/CustomCommands.md
+++ b/website/docs/CustomCommands.md
@@ -97,6 +97,48 @@ Be careful to not overload the `browser` scope with too many custom commands.
 
 We recommend defining custom logic in [page objects](pageobjects), so they are bound to a specific page.
 
+### Multiremote
+
+`addCommand` works in a similar way for multiremote, except the new command will propagate down to the children instances. You have to be mindful when using `this` object since the multiremote `browser` and its children instances have different `this`.
+
+This example shows how to add a new command for multiremote.
+
+```js
+import { multiremotebrowser } from '@wdio/globals'
+
+multiremotebrowser.addCommand('getUrlAndTitle', async function (this: WebdriverIO.MultiRemoteBrowser, customVar: any) {
+    // `this` refers to:
+    //      - MultiRemoteBrowser scope for browser
+    //      - Browser scope for instances
+    return {
+        url: await this.getUrl(),
+        title: await this.getTitle(),
+        customVar: customVar
+    }
+})
+
+multiremotebrowser.getUrlAndTitle()
+/*
+{
+    url: [ 'https://webdriver.io/', 'https://webdriver.io/' ],
+    title: [
+        'WebdriverIO · Next-gen browser and mobile automation test framework for Node.js | WebdriverIO',
+        'WebdriverIO · Next-gen browser and mobile automation test framework for Node.js | WebdriverIO'
+    ],
+    customVar: undefined
+}
+*/
+
+multiremotebrowser.getInstance('browserA').getUrlAndTitle()
+/*
+{
+    url: 'https://webdriver.io/',
+    title: 'WebdriverIO · Next-gen browser and mobile automation test framework for Node.js | WebdriverIO',
+    customVar: undefined
+}
+*/
+```
+
 ## Extend Type Definitions
 
 With TypeScript, it's easy to extend WebdriverIO interfaces. Add types to your custom commands like this:


### PR DESCRIPTION
## Proposed changes

For #13836, pass the new command down to the children instances of multiremote browser.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

### Reviewers: @webdriverio/project-committers
