### PR TITLE
feat: add two new flags

### DIFF
--- a/packages/webdriverio/src/context.ts
+++ b/packages/webdriverio/src/context.ts
@@ -1,3 +1,5 @@
+import type { Capabilities } from '@wdio/types'
+
 const contextManager = new Map<WebdriverIO.Browser, ContextManager>()
 
 export function getContextManager(browser: WebdriverIO.Browser) {
@@ -19,9 +21,15 @@ export function getContextManager(browser: WebdriverIO.Browser) {
 export class ContextManager {
     #browser: WebdriverIO.Browser
     #currentContext?: string
+    #mobileContext?: string
+    #isNativeContext: boolean
 
     constructor(browser: WebdriverIO.Browser) {
         this.#browser = browser
+        const capabilities = this.#browser.capabilities
+        this.#isNativeContext = this.getInitialNativeContext(capabilities)
+        this.#mobileContext = this.getInitialMobileContext(capabilities)
+
         if (!this.#isEnabled()) {
             return
         }
@@ -50,6 +58,13 @@ export class ContextManager {
             ) {
                 this.#currentContext = undefined
             }
+
+            /**
+             * Keep track of the context to which we switch
+             */
+            if (this.#browser.isMobile && event.command === 'switchContext') {
+                this.#mobileContext = event.body.name
+            }
         })
 
         /**
@@ -64,6 +79,19 @@ export class ContextManager {
                 this.#currentContext = (event.result as { value: string[] }).value[0]
                 return this.#browser.switchToWindow(this.#currentContext)
             }
+
+            if (this.#browser.isMobile) {
+                if (event.command === 'getContext') {
+                    this.setCurrentContext(event.result.value)
+                }
+                if (
+                    event.command === 'switchContext' &&
+                    event.result.value === null &&
+                    this.#mobileContext
+                ) {
+                    this.setCurrentContext(this.#mobileContext)
+                }
+            }
         })
     }
 
@@ -71,7 +99,7 @@ export class ContextManager {
      * Only run this session helper if BiDi is enabled and we're not in unit tests.
      */
     #isEnabled () {
-        return !process.env.WDIO_UNIT_TESTS && this.#browser.isBidi
+        return !process.env.WDIO_UNIT_TESTS && (this.#browser.isBidi || this.#browser.isMobile)
     }
 
     /**
@@ -82,13 +110,32 @@ export class ContextManager {
             return ''
         }
 
-        const windowHandle = await this.#browser.getWindowHandle()
+        /**
+         * If we're in a mobile context, we need to get the current context if it's not already set.
+         */
+        if (
+            this.#browser.isMobile &&
+            !this.#isNativeContext &&
+            !this.#mobileContext
+        ) {
+            const context = await this.#browser.getContext()
+            this.#mobileContext = typeof context === 'string' ?
+                context : typeof context === 'object' ?
+                    context.id :
+                    undefined
+        }
+
+        const windowHandle = this.#mobileContext || await this.#browser.getWindowHandle()
         this.setCurrentContext(windowHandle)
         return windowHandle
     }
 
     setCurrentContext (context: string) {
         this.#currentContext = context
+        if (this.#browser.isMobile) {
+            this.#isNativeContext = context ? context === 'NATIVE_APP' : this.#isNativeContext
+            this.#mobileContext = context || undefined
+        }
     }
 
     async getCurrentContext () {
@@ -96,5 +143,37 @@ export class ContextManager {
             return this.initialize()
         }
         return this.#currentContext
+    }
+
+    get isNativeContext() {
+        return this.#isNativeContext
+    }
+
+    get mobileContext() {
+        return this.#mobileContext
+    }
+
+    getInitialNativeContext(capabilities: WebdriverIO.Capabilities): boolean {
+        if (!capabilities || typeof capabilities !== 'object' || !this.#browser.isMobile) {
+            return false // No capabilities provided or invalid format
+        }
+
+        const isAppiumAppCapPresent = (capabilities: Capabilities.RequestedStandaloneCapabilities) => {
+            const appiumKeys = ['app', 'bundleId', 'appPackage', 'appActivity', 'appWaitActivity', 'appWaitPackage']
+            return appiumKeys.some(key => (capabilities as Capabilities.AppiumCapabilities)[key as keyof Capabilities.AppiumCapabilities] !== undefined)
+        }
+        const isBrowserNameFalse = !!capabilities?.browserName === false
+        // @ts-expect-error
+        const isAutoWebviewFalse = capabilities?.autoWebview !== true
+
+        return isBrowserNameFalse && isAppiumAppCapPresent(capabilities) && isAutoWebviewFalse
+    }
+
+    getInitialMobileContext(capabilities: WebdriverIO.Capabilities): string | undefined {
+        return this.#isNativeContext ? 'NATIVE_APP' :
+        // Android webviews are always WEBVIEW_<package_name>, Chrome will always be CHROMIUM
+        // We can only determine it for Android and Chrome, for all other, including iOS, we return undefined
+            this.#browser.isAndroid && capabilities?.browserName?.toLowerCase() === 'chrome' ? 'CHROMIUM' :
+                undefined
     }
 }

--- a/packages/webdriverio/src/utils/index.ts
+++ b/packages/webdriverio/src/utils/index.ts
@@ -56,6 +56,27 @@ export const getPrototype = (scope: 'browser' | 'element') => {
         puppeteer: { value: null, writable: true }
     }
 
+    if (scope === 'browser') {
+        /**
+         * Returns a boolean if the current context is the Mobile native context
+         */
+        prototype.isNativeContext = {
+            get: function (this: WebdriverIO.Browser) {
+                const context = getContextManager(this)
+                return context.isNativeContext
+            }
+        }
+        /**
+         * Returns the current mobile context which could be `NATIVE_APP` or `WEBVIEW_***`
+         */
+        prototype.mobileContext = {
+            get: function (this: WebdriverIO.Browser) {
+                const context = getContextManager(this)
+                return context.mobileContext
+            }
+        }
+    }
+
     /**
      * register action commands
      */

--- a/packages/webdriverio/tests/commands/browser.test.ts
+++ b/packages/webdriverio/tests/commands/browser.test.ts
@@ -11,7 +11,11 @@ const files = fs
 
 test(scope + ' commands list and strategies', () => {
     const prototype = Object.keys(getPrototype(scope))
-    const expected = ['puppeteer', ...files, 'strategies']
+    const expected = [
+        'puppeteer', ...files, 'strategies',
+        // Normally the flags are not "returned" because they are added in a different step
+        'isNativeContext', 'mobileContext'
+    ]
     /**
      * ignored commands that are just there for documentation purposes
      */

--- a/packages/webdriverio/tests/module.test.ts
+++ b/packages/webdriverio/tests/module.test.ts
@@ -78,7 +78,7 @@ describe('WebdriverIO module interface', () => {
     describe('remote function', () => {
         it('creates a webdriver session', async () => {
             const options: any = {
-                capabilities: {},
+                capabilities: { browserName: 'chrome' },
                 logLevel: 'trace'
             }
             const browser = await remote(options)
@@ -89,7 +89,7 @@ describe('WebdriverIO module interface', () => {
         it('allows to propagate a modifier', async () => {
             const browser = await remote({
                 automationProtocol: 'webdriver',
-                capabilities: {}
+                capabilities: { browserName: 'chrome' }
             }, (client: any) => {
                 client.foobar = 'barfoo'
                 return client
@@ -104,7 +104,7 @@ describe('WebdriverIO module interface', () => {
                 automationProtocol: 'webdriver',
                 user: 'foo',
                 key: 'bar',
-                capabilities: {}
+                capabilities: { browserName: 'chrome' }
             })
             expect(detectBackend).toBeCalled()
         })
@@ -112,7 +112,7 @@ describe('WebdriverIO module interface', () => {
         it('should attach custom locators to the strategies', async () => {
             const browser = await remote({
                 automationProtocol: 'webdriver',
-                capabilities: {}
+                capabilities: { browserName: 'chrome' }
             })
             const fakeFn = () => { return 'test' as any as HTMLElement }
 
@@ -125,7 +125,7 @@ describe('WebdriverIO module interface', () => {
             expect.assertions(1)
             const browser = await remote({
                 automationProtocol: 'webdriver',
-                capabilities: {}
+                capabilities: { browserName: 'chrome' }
             })
 
             try {

--- a/website/docs/api/Browser.md
+++ b/website/docs/api/Browser.md
@@ -20,9 +20,17 @@ A browser object has the following properties:
 | `sessionId` | `String` | Session id assigned from the remote server. |
 | `options` | `Object` | WebdriverIO [options](/docs/configuration) depending on how the browser object was created. See more [setup types](/docs/setuptypes). |
 | `commandList` | `String[]` | A list of commands registered to the browser instance |
+| `isW3C` | `Boolean` | Indicates if this is a W3C session |
+| `isChrome` | `Boolean` | Indicates if this Chrome instance |
+| `isFirefox` | `Boolean` | Indicates if this Firefox instance |
+| `isBidi` | `Boolean` | Indicates if this session uses Bidi |
+| `isSauce` | `Boolean` | Indicates if this session is Running on Sauce Labs |
 | `isMobile` | `Boolean` | Indicates a mobile session. See more under [Mobile Flags](#mobile-flags). |
 | `isIOS` | `Boolean` | Indicates an iOS session. See more under [Mobile Flags](#mobile-flags). |
 | `isAndroid` | `Boolean` | Indicates an Android session. See more under [Mobile Flags](#mobile-flags). |
+| `isNativeContext` | `Boolean`  | Indicates if the mobile is in the `NATIVE_APP` context. See more under [Mobile Flags](#mobile-flags). |
+| `mobileContext` | `string`  | The will provide the **current** context the driver is in, for example `NATIVE_APP`, `WEBVIEW_<packageName>` for Android or `WEBVIEW_<pid>` for iOS. It will save an extra WebDriver to `driver.getContext()`. See more under [Mobile Flags](#mobile-flags). |
+
 
 ## Methods
 


### PR DESCRIPTION
This PR adds  new session flags called `isNativeContext` and `mobileContext`. These flags will tell you if

- the mobile is in the native context or not
- what the context is

It also reverts the extra WebDriver-call that was added to the `implicitWait` adnd use the `isNativeContext` flag

They will automatically change if the context changes

Given this config:

```js
// wdio.conf.js
export const config = {
    // ...
    capabilities: [
      {
        platformName: 'iOS',
        app: 'net.company.SafariLauncher',
        udid: '123123123123abc',
        deviceName: 'iPhone',
        // ...
      }
    ],
    // ...
}
```

You can access these flags like all other (mobile) flags in your test like so:

```js
console.log(driver.isMobile)        // outputs: true
console.log(driver.isNativeContext) // outputs: true
console.log(driver.mobileContext)   // outputs: NATIVE_APP
```

Because it's attached to the `contextManager` it will also update the status if you do this based on the below config

```js
// wdio.conf.js
export const config = {
    // ...
    capabilities: [
      {
        platform name: 'iOS',
        browserName: 'safari',
        deviceName: 'iPhone',
        // ...
      }
    ],
    // ...
}

```js
//.....
console.log(driver.isNativeContext)   // outputs: false
console.log(driver.mobileContext)     // outputs: WEBVIEW_8919

await driver.switchContext('NATIVE_APP')
console.log(driver.isNativeContext)   // outputs: true
console.log(driver.mobileContext)     // outputs: NATIVE_APP
    
await driver.switchContext('WEBVIEW_8919')
console.log(driver.isNativeContext)   // outputs: false
console.log(driver.mobileContext)     // outputs: WEBVIEW_8919
```

## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
