### PR TITLE
chore(@wdio/cucumber-framework): better re-export all Cucumber primitives

### DIFF
--- a/packages/wdio-cucumber-framework/src/index.ts
+++ b/packages/wdio-cucumber-framework/src/index.ts
@@ -54,7 +54,7 @@ function getResultObject(
     }
 }
 
-class CucumberAdapter {
+export class CucumberAdapter {
     private _cwd = process.cwd()
     private _newId = IdGenerator.incrementing()
     private _cucumberOpts: Required<CucumberOptions>
@@ -566,7 +566,7 @@ export const publishCucumberReport = async (cucumberMessageDir: string): Promise
 }
 
 const _CucumberAdapter = CucumberAdapter
-const adapterFactory: { init?: Function } = {}
+export const adapterFactory: { init?: Function } = {}
 
 /**
  * tested by smoke tests

--- a/packages/wdio-cucumber-framework/src/index.ts
+++ b/packages/wdio-cucumber-framework/src/index.ts
@@ -15,27 +15,9 @@ import { executeHooksWithArgs, testFnWrapper } from '@wdio/utils'
 import type { Capabilities, Options, Frameworks } from '@wdio/types'
 
 import {
-    After,
-    AfterAll,
-    AfterStep,
-
-    Before,
-    BeforeAll,
-    BeforeStep,
-
-    Given,
-    When,
-    Then,
-
     setDefaultTimeout,
     setDefinitionFunctionWrapper,
     supportCodeLibraryBuilder,
-    setWorldConstructor,
-    defineParameterType,
-    defineStep,
-
-    DataTable,
-    World,
     Status,
 } from '@cucumber/cucumber'
 import Gherkin from '@cucumber/gherkin'
@@ -544,7 +526,7 @@ class CucumberAdapter {
  * @returns {Promise<void>} - A Promise that resolves when the report is successfully published.
  * @throws {Error} - Throws an error if there are issues with file reading or the publishing process.
  */
-const publishCucumberReport = async (cucumberMessageDir: string): Promise<void> => {
+export const publishCucumberReport = async (cucumberMessageDir: string): Promise<void> => {
     const url = process.env.CUCUMBER_PUBLISH_REPORT_URL || 'https://messages.cucumber.io/api/reports'
     const token = process.env.CUCUMBER_PUBLISH_REPORT_TOKEN
     if (!token) {
@@ -598,34 +580,7 @@ adapterFactory.init = async function (...args: any[]) {
 }
 
 export default adapterFactory
-export {
-    CucumberAdapter,
-    adapterFactory,
-
-    After,
-    AfterAll,
-    AfterStep,
-
-    Before,
-    BeforeAll,
-    BeforeStep,
-
-    Given,
-    When,
-    Then,
-
-    DataTable,
-
-    World,
-
-    setDefaultTimeout,
-    setDefinitionFunctionWrapper,
-    setWorldConstructor,
-    defineParameterType,
-    defineStep,
-
-    publishCucumberReport
-}
+export * from '@cucumber/cucumber'
 
 declare global {
     namespace WebdriverIO {

--- a/packages/wdio-cucumber-framework/tests/adapter.test.ts
+++ b/packages/wdio-cucumber-framework/tests/adapter.test.ts
@@ -19,8 +19,11 @@ vi.mock('@wdio/utils')
 vi.mock('@wdio/utils/node')
 vi.mock('expect-webdriverio')
 vi.mock('@cucumber/cucumber', async (orig) => {
-    const origMod = await orig() as typeof Cucumber
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { default: _def, ...origMod } = await orig() as typeof Cucumber
+
     const mod = {
+        ...origMod,
         setDefinitionFunctionWrapper: vi.fn(),
         BeforeAll: vi.fn(),
         AfterAll: vi.fn(),
@@ -106,6 +109,10 @@ describe('CucumberAdapter', () => {
             .toContain('World')
         expect(Object.keys(packageExports))
             .toContain('DataTable')
+        expect(Object.keys(packageExports))
+            .toContain('world')
+        expect(Object.keys(packageExports))
+            .toContain('context')
     })
 
     it('can be initiated with tests', async () => {

--- a/website/docs/Frameworks.md
+++ b/website/docs/Frameworks.md
@@ -480,7 +480,7 @@ import { Given, When, Then } from '@cucumber/cucumber'
 Now, if you use Cucumber already for other types of tests unrelated to WebdriverIO for which you use a specific version you need to import these helpers in your e2e tests from the WebdriverIO Cucumber package, e.g.:
 
 ```js
-import { Given, When, Then } from '@wdio/cucumber-framework'
+import { Given, When, Then, world, context } from '@wdio/cucumber-framework'
 ```
 
 This ensures that you use the right helpers within the WebdriverIO framework and allows you to use an independent Cucumber version for other types of testing.


### PR DESCRIPTION
## Proposed changes

In order to properly re-export all primitives of the Cucumber package, this patch makes sure that we don't import them first to export them. This prevents us from introducing more exports since we can't expect everyone to use the latest Cucumber version.

fixes #13908

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
