### PR TITLE
fix: Catch requests failure to trigger the `result` and `onAfterCommand` event

### DIFF
--- a/packages/wdio-allure-reporter/src/reporter.ts
+++ b/packages/wdio-allure-reporter/src/reporter.ts
@@ -510,7 +510,7 @@ export default class AllureReporter extends WDIOReporter {
     onAfterCommand(command: AfterCommandArgs) {
         const { disableWebdriverStepsReporting, disableWebdriverScreenshotsReporting } = this._options
 
-        const { value: commandResult } = command?.result || {}
+        const commandResult = command?.result?.value || command?.result.error?.name ||  {}
         const isScreenshot = isScreenshotCommand(command)
         if (!disableWebdriverScreenshotsReporting && isScreenshot && commandResult) {
             this.attachScreenshot('Screenshot', Buffer.from(commandResult, 'base64'))

--- a/packages/wdio-allure-reporter/src/reporter.ts
+++ b/packages/wdio-allure-reporter/src/reporter.ts
@@ -510,7 +510,7 @@ export default class AllureReporter extends WDIOReporter {
     onAfterCommand(command: AfterCommandArgs) {
         const { disableWebdriverStepsReporting, disableWebdriverScreenshotsReporting } = this._options
 
-        const commandResult = command?.result?.value || command?.result.error?.name ||  {}
+        const commandResult = command?.result?.value || command?.result?.error?.name ||  {}
         const isScreenshot = isScreenshotCommand(command)
         if (!disableWebdriverScreenshotsReporting && isScreenshot && commandResult) {
             this.attachScreenshot('Screenshot', Buffer.from(commandResult, 'base64'))

--- a/packages/wdio-allure-reporter/tests/allureFeatures.test.ts
+++ b/packages/wdio-allure-reporter/tests/allureFeatures.test.ts
@@ -1119,3 +1119,60 @@ describe('test step naming', () => {
         )
     })
 })
+
+describe('request fails', () => {
+    const outputDir = temporaryDirectory()
+    let reporter: any
+
+    beforeEach(() => {
+        clean(outputDir)
+        reporter = new AllureReporter({ outputDir, disableMochaHooks: false })
+    })
+
+    it('should attachJSON with error name in onAfterCommand when the command fails', () => {
+        const command = {
+            method: 'POST',
+            endpoint: '/session/:sessionId/element',
+            result : {
+                error: {
+                    name: 'SomeError',
+                }
+            }
+        }
+        const attachJSONSpy = vi.spyOn(reporter, 'attachJSON')
+
+        reporter.onRunnerStart(runnerStart())
+        reporter.onSuiteStart(testStart())
+        reporter.onTestStart(testStart())
+        reporter.onBeforeCommand(command)
+
+        reporter.onAfterCommand(command)
+
+        reporter.onTestPass()
+        reporter.onSuiteEnd(suiteEnd())
+        reporter.onRunnerEnd(runnerEnd())
+
+        expect(attachJSONSpy).toHaveBeenCalledWith('Response', 'SomeError')
+    })
+
+    it('should attachJSON with empty json in onAfterCommand when the command fails', () => {
+        const command = {
+            method: 'POST',
+            endpoint: '/session/:sessionId/element',
+            result : {}
+        }
+        const attachJSONSpy = vi.spyOn(reporter, 'attachJSON')
+        reporter.onRunnerStart(runnerStart())
+        reporter.onSuiteStart(testStart())
+        reporter.onTestStart(testStart())
+        reporter.onBeforeCommand(command)
+
+        reporter.onAfterCommand(command)
+
+        reporter.onTestPass()
+        reporter.onSuiteEnd(suiteEnd())
+        reporter.onRunnerEnd(runnerEnd())
+
+        expect(attachJSONSpy).toHaveBeenCalledWith('Response', {})
+    })
+})

--- a/packages/webdriver/src/command.ts
+++ b/packages/webdriver/src/command.ts
@@ -186,6 +186,9 @@ export default function (
             }
 
             return result.value
+        }).catch((error) => {
+            this.emit('result', { command, method, endpoint, body, result: { error } })
+            throw error
         })
     }
 }


### PR DESCRIPTION
## Proposed changes

As described in https://github.com/webdriverio/webdriverio/issues/13921 and https://github.com/webdriverio/webdriverio/issues/13915, we can trigger `onBeforeCommand` without the expected `onAfterCommand,` resulting, for example, in the case of allure-reporter, in generating more start steps than stopStep and, in the end, making the generator hang in a specific scenario.

Here is a proposition to catch all errors on `request.makeRequest` to ensure we trigger the `result` event, which consequently triggers the `onAfterCommand`. In the end, it now ensures the allure-reporter has the same amount of `startStep` and `endStep`.


## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [X] Polish (an improvement for an existing feature)
- [X] Bugfix (non-breaking change which fixes an issue)
- ~New feature (non-breaking change which adds functionality)~
-  ~Breaking change (fix or feature that would cause existing functionality to not work as expected)~
- ~Documentation update (improvements to the project's docs)~
- ~Specification changes (updates to WebDriver command specifications)~
- ~Internal updates (everything related to internal scripts, governance documentation and CI files)~

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- ~I have added the necessary documentation (if appropriate)~
- ~I have added proper type definitions for new commands (if appropriate)~

## Backport Request

- [X] This change is solely for `v9` and doesn't need to be back-ported
- ~Back-ported PR at `#XXXXX`~

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers

Example in allure report:

![Screenshot 2024-11-26 at 7 30 57 AM](https://github.com/user-attachments/assets/2391476e-d3e9-43c0-8d33-be6c7bcdb804)

