### PR TITLE
fix(webdriverio): add 'appium:options' when checking for native context

### DIFF
--- a/packages/webdriverio/src/utils/mobile.ts
+++ b/packages/webdriverio/src/utils/mobile.ts
@@ -10,7 +10,7 @@ export function getNativeContext({ capabilities, isMobile }:
 
     const isAppiumAppCapPresent = (capabilities: Capabilities.RequestedStandaloneCapabilities) => {
         const appiumKeys = ['app', 'bundleId', 'appPackage', 'appActivity', 'appWaitActivity', 'appWaitPackage']
-        return appiumKeys.some(key => (capabilities as Capabilities.AppiumCapabilities)[key as keyof Capabilities.AppiumCapabilities] !== undefined)
+        return appiumKeys.some(key => (capabilities as Capabilities.AppiumCapabilities)[key as keyof Capabilities.AppiumCapabilities] !== undefined || capabilities['appium:options']?.[key] !== undefined)
     }
     const isBrowserNameFalse = !!capabilities?.browserName === false
     // @ts-expect-error

--- a/packages/webdriverio/tests/utils/mobile.test.ts
+++ b/packages/webdriverio/tests/utils/mobile.test.ts
@@ -22,6 +22,17 @@ describe('getNativeContext', () => {
         expect(getNativeContext({ capabilities, isMobile: true })).toBe(true)
     })
 
+    it('should return true if Appium app capabilities are present using "appium:options" and valid', () => {
+        const capabilities = {
+            browserName: undefined,
+            autoWebview: false,
+            'appium:options': {
+                app: '/path/to/app.apk'
+            }
+        } as WebdriverIO.Capabilities
+        expect(getNativeContext({ capabilities, isMobile: true })).toBe(true)
+    })
+
     it('should return false if Appium app capabilities are present but `autoWebview` is true', () => {
         const capabilities = {
             app: '/path/to/app.apk',


### PR DESCRIPTION
## Proposed changes

After upgrading to the latest wdio, my tests started to fail; after checking, the reason was because wdio was trying to get the context at start, but since my capabilities use `appium:options`, it was not able to get the native context, which makes it to try to call the getContext before the driver was ready. This PR adds the logic also to check inside `appium:options`

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
