### PR TITLE
fix(webdriverio): don't fail if getContext is not supported

### DIFF
--- a/packages/wdio-utils/src/envDetector.ts
+++ b/packages/wdio-utils/src/envDetector.ts
@@ -108,9 +108,9 @@ function isMobile(capabilities: WebdriverIO.Capabilities) {
     const browserstackBrowserName = (bsOptions.browserName || '').toLowerCase()
 
     /**
-     * There are cases where sessions with `appium:*` prefixed capabilities do not fully support all "native"-mobile commands.
-     * In this case the `appium:automationName` is set with something else than the
-     * `xcuitest|uiautomator2|flutter|espress|..` value. This can be a browser driver or
+     * There are cases where sessions with `appium:*` prefixed capabilities do not fully support
+     * all "native"-mobile commands. In this case the `appium:automationName` is set with something
+     * else than the `xcuitest|uiautomator2|flutter|espress|..` value. This can be a browser driver or
      * a "wrapped" appium browser-driver. See also https://github.com/webdriverio/webdriverio/issues/13947
      * Return `isMobile:false` for those cases. There we also accepts that specific mobile browser
      * tests (like the FF one on Android) are not seen as a mobile one

--- a/packages/webdriverio/src/context.ts
+++ b/packages/webdriverio/src/context.ts
@@ -1,6 +1,8 @@
+import logger from '@wdio/logger'
 import { getMobileContext, getNativeContext } from './utils/mobile.js'
 
 const contextManager = new Map<WebdriverIO.Browser, ContextManager>()
+const log = logger('webdriverio:context')
 
 export function getContextManager(browser: WebdriverIO.Browser) {
     const existingContextManager = contextManager.get(browser)
@@ -122,11 +124,15 @@ export class ContextManager {
             !this.#isNativeContext &&
             !this.#mobileContext
         ) {
-            const context = await this.#browser.getContext()
-            this.#mobileContext = typeof context === 'string' ?
-                context : typeof context === 'object' ?
-                    context.id :
-                    undefined
+            const context = await this.#browser.getContext().catch((err) => {
+                log.warn(`Error getting context: ${err}`)
+                return undefined
+            })
+            this.#mobileContext = typeof context === 'string'
+                ? context
+                : typeof context === 'object'
+                    ? context.id
+                    : undefined
         }
 
         const windowHandle = this.#mobileContext || await this.#browser.getWindowHandle()

--- a/packages/webdriverio/src/context.ts
+++ b/packages/webdriverio/src/context.ts
@@ -125,7 +125,11 @@ export class ContextManager {
             !this.#mobileContext
         ) {
             const context = await this.#browser.getContext().catch((err) => {
-                log.warn(`Error getting context: ${err}`)
+                log.warn(
+                    `Error getting context: ${err}\n\n` +
+                    `WebDriver capabilities: ${JSON.stringify(this.#browser.capabilities)}\n` +
+                    `Requested WebDriver capabilities: ${JSON.stringify(this.#browser.requestedCapabilities)}`
+                )
                 return undefined
             })
             this.#mobileContext = typeof context === 'string'


### PR DESCRIPTION
## Proposed changes

We've had folks reporting that they get an error like this:

![aaaaa](https://github.com/user-attachments/assets/6aa39d90-d1ff-4f11-95dc-5ee9ba92194d)

This patch mitigates this problem by just catching this error.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
