### PR TITLE
fix(@wdio/runner): Continue emitting event on the runner even when a reporter throws an error

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,9 @@
     "javascript",
     "typescript",
   ],
+  "editor.codeActionsOnSave": {
+    "source.fixAll": "explicit"
+  },
   // Debugging.
   "debug.javascript.unmapMissingSources": true,
   "files.exclude": {
@@ -43,5 +46,5 @@
     "WDIO",
     "webdriver",
     "webdriverio"
-  ]
+  ],
 }

--- a/packages/wdio-runner/tests/index.test.ts
+++ b/packages/wdio-runner/tests/index.test.ts
@@ -472,7 +472,7 @@ describe('wdio-runner', () => {
             expect(log.error).toHaveBeenCalledWith('foo')
         })
 
-        it('should emit runner:start if the initialisation failed', async () => {
+        it('should emit runner:start if the initialization failed', async () => {
             const runner = new WDIORunner()
             runner['_configParser'] = { getCapabilities: vi.fn().mockReturnValue([{ browserName: 'safari' }]) } as any
             runner['_browser'] = {} as any as BrowserObject

--- a/packages/wdio-runner/tests/reporter.test.ts
+++ b/packages/wdio-runner/tests/reporter.test.ts
@@ -157,7 +157,7 @@ describe('BaseReporter', () => {
         expect(process.send).not.toBeCalled()
     })
 
-    it('should send printFailureMessage', async () => {
+    it('should send printFailureMessage on `test:fail`', async () => {
         const reporter = new BaseReporter({
             outputDir: '/foo/bar',
             reporters: [
@@ -169,12 +169,70 @@ describe('BaseReporter', () => {
 
         const payload = { foo: [1, 2, 3] }
         reporter.emit('test:fail', payload)
-        expect(reporter['_reporters'].map((r) => vi.mocked(r.emit).mock.calls)).toEqual([
-            [['test:fail', Object.assign(payload, { cid: '0-0' })]],
-            [['test:fail', Object.assign(payload, { cid: '0-0' })]]
-        ])
+
+        reporter['_reporters'].forEach((reporter) => {
+            expect(reporter.emit).toHaveBeenCalledWith('test:fail', { ...payload,  cid: '0-0' })
+        })
         expect(process.send).toBeCalledTimes(1)
-        expect(vi.mocked(process.send)!.mock.calls[0][0].name).toBe('printFailureMessage')
+        expect(process.send).toHaveBeenCalledWith(expect.objectContaining({ name: 'printFailureMessage' }))
+    })
+
+    it('should send printFailureMessage on `hook:end`', async () => {
+        const reporter = new BaseReporter({
+            outputDir: '/foo/bar',
+            reporters: [
+                'dot',
+                ['dot', { foo: 'bar' }]
+            ]
+        } as Options.Testrunner, '0-0', capability)
+        await reporter.initReporters()
+        const error = new Error('foobar')
+
+        const payload = { foo: [1, 2, 3], error, title: '"before all" hook' }
+        reporter.emit('hook:end', payload)
+
+        reporter['_reporters'].forEach((reporter) => {
+            expect(reporter.emit).toHaveBeenCalledWith('hook:end', { ...payload,  cid: '0-0' })
+        })
+        expect(process.send).toBeCalledTimes(1)
+        expect(process.send).toHaveBeenCalledWith(expect.objectContaining({ name: 'printFailureMessage' }))
+    })
+
+    it('should send printFailureMessage when reporter throws an error', async () => {
+        const faultyReporter = 'dot'
+        const workingReporter = ['dot', { foo: 'bar' }]
+        const reporter = new BaseReporter({
+            outputDir: '/foo/bar',
+            reporters: [faultyReporter, workingReporter] } as Options.Testrunner, '0-0', capability)
+
+        await reporter.initReporters()
+        const faultyReporterInstance = reporter['_reporters'][0]
+        const workingReporterInstance = reporter['_reporters'][1]
+        vi.spyOn(faultyReporterInstance, 'emit').mockImplementation(() => {
+            throw new Error('Reporter throws an error')
+        })
+
+        const payload = { foo: [1] }
+        reporter.emit('any', payload)
+
+        expect(faultyReporterInstance.emit).toBeCalledTimes(1)
+        expect(workingReporterInstance.emit).toBeCalledTimes(1)
+
+        expect(process.send).toBeCalledTimes(1)
+        expect(process.send).toHaveBeenCalledWith({
+            'content': {
+                'cid': '0-0',
+                'error': {
+                    'message': 'Reporter throws an error',
+                    'stack': expect.stringContaining('Error: Reporter throws an error\n    at DotReporter.<anonymous>')
+
+                },
+                'fullTitle': 'reporter DotReporter',
+            },
+            'name': 'printFailureMessage',
+            'origin': 'reporter',
+        })
+
     })
 
     it('should allow to load custom reporters', async () => {

--- a/packages/wdio-runner/tests/reporter.test.ts
+++ b/packages/wdio-runner/tests/reporter.test.ts
@@ -198,7 +198,7 @@ describe('BaseReporter', () => {
         expect(process.send).toHaveBeenCalledWith(expect.objectContaining({ name: 'printFailureMessage' }))
     })
 
-    it('should send printFailureMessage when reporter throws an error', async () => {
+    it('should send printFailureMessage and continue when reporter throws an error', async () => {
         const faultyReporter = 'dot'
         const workingReporter = ['dot', { foo: 'bar' }]
         const reporter = new BaseReporter({
@@ -217,7 +217,6 @@ describe('BaseReporter', () => {
 
         expect(faultyReporterInstance.emit).toBeCalledTimes(1)
         expect(workingReporterInstance.emit).toBeCalledTimes(1)
-
         expect(process.send).toBeCalledTimes(1)
         expect(process.send).toHaveBeenCalledWith({
             'content': {


### PR DESCRIPTION
## Proposed changes

In [this issue](https://github.com/webdriverio/webdriverio/issues/13915), we discovered we could hang the runner process when processing the reporters with specific conditions. Moreover, after a closer look, when the AllureReporter throws an error, it fails the run, stating that some tests failed when this is not the case. Finally, since we can configure multiple reporters, an error thrown by one should not affect the other reporters.

So, to have more robust test runs and make a better effort at finishing reporting, I propose to try-catch the error after emitting the event to a faulty reporter, output the error in the console, continue to the next reporter, and emit the next event.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [X] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works

## Backport Request

- [X] This change is solely for `v9` and doesn't need to be back-ported

## Further comments
Here is an example where the Allure reporter was throwing an error, but the Spec reporter was not. With the fix, we can now see that the run was successful, but Allure has potential problems due to the error. Weirdly, the second picture shows that the Allure reporting was still working despite the error.

![image](https://github.com/user-attachments/assets/7b393779-945b-4c58-9681-0109b23737a7)

<img width="1016" alt="image" src="https://github.com/user-attachments/assets/82fb211b-48ce-4732-9d30-0debf25cafa8">


### Reviewers: @webdriverio/project-committers
