### PR TITLE
Remove unused cli-spinners dependency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -54,7 +54,6 @@ updates:
     - dependency-name: "inquirer"
     - dependency-name: "read-pkg-up"
     - dependency-name: "formdata-node"
-    - dependency-name: "cli-spinners"
     # fails to update and requires investigations
     - dependency-name: "vite"
     - dependency-name: "puppeteer-core"

--- a/packages/wdio-cli/package.json
+++ b/packages/wdio-cli/package.json
@@ -50,7 +50,6 @@
     "async-exit-hook": "^2.0.1",
     "chalk": "^5.2.0",
     "chokidar": "^4.0.0",
-    "cli-spinners": "^3.0.0",
     "dotenv": "^16.3.1",
     "ejs": "^3.1.9",
     "execa": "^9.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -777,9 +777,6 @@ importers:
       chokidar:
         specifier: ^4.0.0
         version: 4.0.0
-      cli-spinners:
-        specifier: ^3.0.0
-        version: 3.2.0
       dotenv:
         specifier: ^16.3.1
         version: 16.4.5


### PR DESCRIPTION
## Proposed changes

The @wdio/cli package has a dependencies on `cli-spinners` and `tsx` however there are no references to these packages in the code. This PR removes the dependencies.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
