### PR TITLE
fix(@wdio/utils): Unset geckodriver when stable is set as browserVersion

### DIFF
--- a/packages/wdio-utils/src/node/manager.ts
+++ b/packages/wdio-utils/src/node/manager.ts
@@ -113,7 +113,11 @@ export async function setupDriver (options: Omit<Options.WebDriver, 'capabilitie
         if (isEdge(cap.browserName)) {
             return setupEdgedriver(cacheDir, cap.browserVersion)
         } else if (isFirefox(cap.browserName)) {
-            // Some Firefox channels are allowed to be set for the browserVersion but not for geckodriver
+            /**
+             * Some Firefox channels are allowed to be set for the browserVersion.
+             * We unset these variables here to make `node-geckodriver` download
+             * the latest driver version.
+             */
             const version = firefoxChannels.includes(cap.browserVersion ?? '')
                 ? undefined
                 : cap.browserVersion

--- a/packages/wdio-utils/src/node/manager.ts
+++ b/packages/wdio-utils/src/node/manager.ts
@@ -17,6 +17,8 @@ enum BrowserDriverTaskLabel {
     DRIVER = 'browser driver'
 }
 
+const firefoxChannels: string[] = ['stable', 'latest'] as const
+
 function mapCapabilities (
     options: Options.WebdriverIO,
     caps: Capabilities.TestrunnerCapabilities,
@@ -111,8 +113,10 @@ export async function setupDriver (options: Omit<Options.WebDriver, 'capabilitie
         if (isEdge(cap.browserName)) {
             return setupEdgedriver(cacheDir, cap.browserVersion)
         } else if (isFirefox(cap.browserName)) {
-            // "latest" works for setting up browser only but not geckodriver
-            const version = cap.browserVersion === 'latest' ? undefined : cap.browserVersion
+            // Some Firefox channels are allowed to be set for the browserVersion but not for geckodriver
+            const version = firefoxChannels.includes(cap.browserVersion ?? '')
+                ? undefined
+                : cap.browserVersion
             return setupGeckodriver(cacheDir, version)
         } else if (isChrome(cap.browserName)) {
             return setupChromedriver(cacheDir, cap.browserVersion)


### PR DESCRIPTION
## Proposed changes

Fixes a crucial bug when downloading Firefox browser for testing:

```ts
DEBUG @wdio/cli:utils: Finished to run "onPrepare" hook in 624ms
INFO @wdio/utils: Setting up browser driver for: chrome@stable - firefox@stable
INFO @wdio/utils: Setting up browser binaries for: chrome@stable - firefox@stable
INFO geckodriver: Downloading Geckodriver from https://github.com/mozilla/geckodriver/releases/download/vstable/geckodriver-vstable-linux64.tar.gz
INFO webdriver: Downloading Chromedriver v131.0.6778.108
INFO webdriver: Setting up firefox vstable_133.0.3
INFO webdriver: Setting up chrome v131.0.6778.108
INFO @wdio/local-runner: Shutting down spawned worker
INFO @wdio/local-runner: Waiting for 0 to shut down gracefully
```

Recently, `@puppeteer/browsers` was upgraded to allow to download Firefox on the `stable` channel, on top of the nightly/latest channel.

That means webdriverIO users can now set the capability
```json
{
  "browserName": "firefox",
  "browserVersion": "stable"
}
```

to test the current latest stable release of Firefox.

But `@wdio/utils` package was only checking for "latest" `browserVersion` to get the correct `geckodriver` URL to download, it now also needs to check for `stable`. In the future, more channels will become available, therefore a `firefoxChannels` array was set, that includes the new stable channel.

Geckodriver now downloads successfully when `browserVersion` is set to "stable" .

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
