### PR TITLE
@wdio/testingbot-service: Update TestingBot Tunnel typings: add noCache and noBump

### DIFF
--- a/packages/wdio-testingbot-service/src/types.ts
+++ b/packages/wdio-testingbot-service/src/types.ts
@@ -23,7 +23,7 @@ export interface TunnelLauncherOptions {
     // Write logging output to this logfile (optional)
     logfile?: string,
 
-    // Change the tunnel version - see versions on https://testingbot.com/support/other/tunnel
+    // Change the tunnel version - see versions on https://testingbot.com/support/other/tunnel/changelog.html
     // "1.19" // or 2.1 (Java 8)
     tunnelVersion?: string,
 
@@ -36,8 +36,14 @@ export interface TunnelLauncherOptions {
     // Use a custom DNS server. For example: 8.8.8.8 (optional)
     dns?: string,
 
-    // Bypass the Caching Proxy running on the TestingBot tunnel VM.
+    // Do not start a local proxy (requires user provided proxy server on port 8087)
     noproxy?: string,
+
+    // Set to true if you do not want TestingBot to override SSL traffic with its own certificate
+    noBump?: boolean;
+
+    // Set to true if you do not want to have static content cached
+    noCache?: boolean;
 }
 
 export interface TestingbotOptions {


### PR DESCRIPTION
Update TestingBot Tunnel typings (`TunnelLauncherOptions`): 
- add `noCache`
- add `noBump`

Thanks!

## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
