### PR TITLE
fix(@wdio/sauce-service): set unique values for noSslBumpDomains

### DIFF
--- a/packages/wdio-sauce-service/src/launcher.ts
+++ b/packages/wdio-sauce-service/src/launcher.ts
@@ -46,15 +46,16 @@ export default class SauceLauncher implements Services.ServiceInstance {
              */
             `SC-tunnel-${Math.random().toString().slice(2)}`)
 
+        const noSslBumpDomains = new Set(['127.0.0.1', 'localhost', getLocalIpAddress()])
+        if (this._options.sauceConnectOpts?.noSslBumpDomains) {
+            this._options.sauceConnectOpts.noSslBumpDomains.split(',').forEach((domain) => noSslBumpDomains.add(domain))
+        }
+
         const sauceConnectOpts: SauceConnectOptions = {
             noAutodetect: true,
             tunnelIdentifier: sauceConnectTunnelIdentifier,
             ...this._options.sauceConnectOpts,
-            noSslBumpDomains: `127.0.0.1,localhost,${getLocalIpAddress()}` + (
-                this._options.sauceConnectOpts?.noSslBumpDomains
-                    ? `,${this._options.sauceConnectOpts.noSslBumpDomains}`
-                    : ''
-            ),
+            noSslBumpDomains: Array.from(noSslBumpDomains).join(','),
             logger: this._options.sauceConnectOpts?.logger || ((output) => log.debug(`Sauce Connect Log: ${output}`)),
             ...(!this._options.sauceConnectOpts?.logfile && this._config.outputDir
                 ? { logfile: path.join(this._config.outputDir, 'wdio-sauce-connect-tunnel.log') }

--- a/packages/wdio-sauce-service/tests/launcher.test.ts
+++ b/packages/wdio-sauce-service/tests/launcher.test.ts
@@ -57,6 +57,22 @@ test('onPrepare w/ SauceConnect w/ tunnelIdentifier w/ JWP', async () => {
     expect(service['_sauceConnectProcess']).not.toBeUndefined()
 })
 
+test('onPrepare only sets unique noSslBumpDomains values', async () => {
+    const options: SauceServiceConfig = {
+        sauceConnect: true,
+        sauceConnectOpts: {
+            noSslBumpDomains: 'foo,bar,127.0.0.1,bar'
+        }
+    }
+    const caps = [{}] as WebdriverIO.Capabilities[]
+    const config = {} as Options.Testrunner
+    const service = new SauceServiceLauncher(options, caps as never, config)
+    const startTunnelMock = vi.fn()
+    service.startTunnel = startTunnelMock
+    await service.onPrepare(config, caps)
+    expect(startTunnelMock.mock.calls[0][0].noSslBumpDomains).toBe('127.0.0.1,localhost,foo,bar')
+})
+
 test('onPrepare w/ SauceConnect w/o tunnelIdentifier w/ JWP', async () => {
     const options: SauceServiceConfig = {
         sauceConnect: true,

--- a/packages/wdio-sauce-service/tests/launcher.test.ts
+++ b/packages/wdio-sauce-service/tests/launcher.test.ts
@@ -71,7 +71,7 @@ test('onPrepare only sets unique noSslBumpDomains values', async () => {
     const startTunnelMock = vi.fn()
     service.startTunnel = startTunnelMock
     await service.onPrepare(config, caps)
-    if (os.arch() === 'win32') {
+    if (os.type() === 'Windows_NT') {
         expect(startTunnelMock.mock.calls[0][0].noSslBumpDomains).toBe('127.0.0.1,localhost,::1,foo,bar')
     } else {
         expect(startTunnelMock.mock.calls[0][0].noSslBumpDomains).toBe('127.0.0.1,localhost,foo,bar')

--- a/packages/wdio-sauce-service/tests/launcher.test.ts
+++ b/packages/wdio-sauce-service/tests/launcher.test.ts
@@ -1,3 +1,4 @@
+import os from 'node:os'
 import path from 'node:path'
 import logger from '@wdio/logger'
 import SauceLabs from 'saucelabs'
@@ -70,7 +71,11 @@ test('onPrepare only sets unique noSslBumpDomains values', async () => {
     const startTunnelMock = vi.fn()
     service.startTunnel = startTunnelMock
     await service.onPrepare(config, caps)
-    expect(startTunnelMock.mock.calls[0][0].noSslBumpDomains).toBe('127.0.0.1,localhost,foo,bar')
+    if (os.arch() === 'win32') {
+        expect(startTunnelMock.mock.calls[0][0].noSslBumpDomains).toBe('127.0.0.1,localhost,::1,foo,bar')
+    } else {
+        expect(startTunnelMock.mock.calls[0][0].noSslBumpDomains).toBe('127.0.0.1,localhost,foo,bar')
+    }
 })
 
 test('onPrepare w/ SauceConnect w/o tunnelIdentifier w/ JWP', async () => {


### PR DESCRIPTION
## Proposed changes

Sauce Connect throws if users set same hosts as `noSslBumpDomains` options. This patch filters out the duplicates.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
