### PR TITLE
Add setAnnotation to TestingBot service

### DIFF
--- a/packages/wdio-testingbot-service/src/service.ts
+++ b/packages/wdio-testingbot-service/src/service.ts
@@ -71,8 +71,25 @@ export default class TestingBotService implements Services.ServiceInstance {
              */
             `${test.parent} - ${test.title}`
         )
+        return this.setAnnotation(`tb:test-context=${context}`)
+    }
 
-        this._browser.execute('tb:test-context=' + context)
+    /**
+     * Update the running test on TestingBot with an annotation
+     */
+    async setAnnotation (annotation: string) {
+        if (!this._browser) {
+            return
+        }
+
+        if (this._browser.isMultiremote) {
+            return Promise.all(Object.keys(this._capabilities).map(async (browserName) => {
+                const multiRemoteBrowser = (this._browser as WebdriverIO.MultiRemoteBrowser).getInstance(browserName)
+                return multiRemoteBrowser.executeScript(annotation, [])
+            }))
+        }
+
+        return (this._browser as WebdriverIO.Browser).executeScript(annotation, [])
     }
 
     afterSuite (suite: Frameworks.Suite) {
@@ -106,7 +123,7 @@ export default class TestingBotService implements Services.ServiceInstance {
         }
 
         this._suiteTitle = feature.name
-        this._browser.execute('tb:test-context=Feature: ' + this._suiteTitle)
+        return this.setAnnotation(`tb:test-context=Feature: ${this._suiteTitle}`)
     }
 
     /**
@@ -120,7 +137,7 @@ export default class TestingBotService implements Services.ServiceInstance {
             return
         }
         const scenarioName = world.pickle.name
-        this._browser.execute('tb:test-context=Scenario: ' + scenarioName)
+        return this.setAnnotation(`tb:test-context=Scenario: ${scenarioName}`)
     }
 
     /**


### PR DESCRIPTION
## Proposed changes

While running a test with cucumber-framework and `@wdio/testingbot-service` we noticed an error
```
Invalid left-hand side in assignment
```

This seems similar to https://github.com/webdriverio/webdriverio/issues/13670 so we propose this change where we replace `execute` with `executeScript`.

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
