### PR TITLE
fix(webdriverio): define getProperty return type as 'unknown'

### DIFF
--- a/packages/webdriverio/src/commands/element/getProperty.ts
+++ b/packages/webdriverio/src/commands/element/getProperty.ts
@@ -1,5 +1,6 @@
 /**
- * The Get Element Property command will return the result of getting a property of an element.
+ * The Get Element Property command will return the result of getting a property of an
+ * element.
  *
  * <example>
     :getProperty.js
@@ -12,11 +13,11 @@
  *
  * @alias element.getProperty
  * @param {string} property  name of the element property
- * @return {Object|String|Boolean|Number|null} the value of the property of the selected element
+ * @return {unknown} the value of the property of the selected element
  */
 export function getProperty (
     this: WebdriverIO.Element,
     property: string
-) {
+): Promise<unknown> {
     return this.getElementProperty(this.elementId, property)
 }

--- a/tests/typings/webdriverio/async.ts
+++ b/tests/typings/webdriverio/async.ts
@@ -235,6 +235,9 @@ async function bar() {
     expectType<number>(width)
     expectType<number>(height)
 
+    // getProperty return type
+    expectType<unknown>($('#foo').getProperty('bar'))
+
     // protocol command return unmapped object
     const { foo, bar } = await browser.takeHeapSnapshot()
     expectType<any>(foo)


### PR DESCRIPTION
## Proposed changes

fixes #14035

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
