### PR TITLE
docs: document how to retrive browser logs

### DIFF
--- a/website/_sidebars.json
+++ b/website/_sidebars.json
@@ -49,7 +49,8 @@
             "id": "bestpractices"
           },
           "items": [
-            "best-practices/file-download"
+            "best-practices/file-download",
+            "best-practices/browser-logs"
           ]
         },
         "selectors",

--- a/website/docs/best-practices/BrowserLogs.md
+++ b/website/docs/best-practices/BrowserLogs.md
@@ -1,0 +1,80 @@
+---
+id: browser-logs
+title: Browser Logs
+---
+
+When running tests the browser may log important information that you are interested or want to assert against.
+
+<Tabs
+defaultValue="bidi"
+values={[
+    {label: 'Bidi', value: 'bidi'},
+    {label: 'Classic (Deprecated)', value: 'classic'
+}]
+}>
+
+<TabItem value='bidi'>
+
+When using WebDriver Bidi, which is the default way how WebdriverIO automates the browser, you can subscribe to events coming from the browser. For log events you want to listen on `log.entryAdded'`, e.g.:
+
+```ts
+await browser.sessionSubscribe({ events: ['log.entryAdded'] })
+
+/**
+ * returns: {"type":"console","method":"log","realm":null,"args":[{"type":"string","value":"Hello Bidi"}],"level":"info","text":"Hello Bidi","timestamp":1657282076037}
+ */
+browser.on('log.entryAdded', (entryAdded) => console.log('received %s', entryAdded))
+```
+
+In a test you can just push log events to an array an assert that array once your action is done, e.g.:
+
+```ts
+import type { local } from 'webdriver'
+
+describe('should log when doing a certain action', () => {
+    const logs: string[] = []
+
+    function logEvents (event: local.LogEntry) {
+        logs.push(event.text) // add log message to the array
+    }
+
+    before(async () => {
+        await browser.sessionSubscribe({ events: ['log.entryAdded'] })
+        browser.on('log.entryAdded', logEvents)
+    })
+
+    it('should trigger the console event', () => {
+        // trigger the browser send a message to the console
+        ...
+
+        // assert if log was captured
+        expect(logs).toContain('Hello Bidi')
+    })
+
+    // clean up listener afterwards
+    after(() => {
+        browser.off('log.entryAdded', logEvents)
+    })
+})
+```
+
+</TabItem>
+
+<TabItem value='classic'>
+
+If you still use WebDriver Classic or disabled Bidi usage via the `'wdio:enforceWebDriverClassic': true` capability, you can use the `getLogs` JSONWire command to fetch the latest logs. Since WebdriverIO has removed these deprecated commands you will have to use the [JSONWP Service](https://github.com/webdriverio-community/wdio-jsonwp-service) to add the command back to your browser instance.
+
+After you added or initiate the service you can fetch logs via:
+
+```ts
+const logs = await browser.getLogs('browser')
+const logMessage = logs.find((log) => log.message.includes('Hello Bidi'))
+expect(logMessage).toBeTruthy()
+```
+
+Note: the `getLogs` command can only fetch the most recent logs from the browser. It may clean up log messages eventually if they become to old.
+</TabItem>
+
+</Tabs>
+
+Please note that you can use this method to retrieve error messages and verify whether your application has encountered any errors.


### PR DESCRIPTION
## Proposed changes

fixes #9204

<img width="1392" alt="Screenshot 2025-01-08 at 9 44 42 AM" src="https://github.com/user-attachments/assets/ebcda271-888b-449b-8bee-8b6b9eaf4fad" />

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
