### PR TITLE
fix(@wdio/cli): initialize launcher also within watcher

### DIFF
--- a/packages/wdio-cli/src/watcher.ts
+++ b/packages/wdio-cli/src/watcher.ts
@@ -26,7 +26,7 @@ export default class Watcher {
     }
 
     async watch () {
-        await this._launcher.configParser.initialize()
+        await this._launcher.initialize()
         const specs = this._launcher.configParser.getSpecs()
         const capSpecs = this._launcher.isMultiremote
             ? []


### PR DESCRIPTION
## Proposed changes

Currently if you pass in a `--watch` flag within a TS project the WDIO cli fails with `Unknown file extension ".ts" ` as TypeScript support wasn't enabled via `tsx`. We moved this before into the `run` method of the launcher, however the watcher class loads the config file before calling `run`.

This patch ensures we initialise the launcher before working with the config parser.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
