### PR TITLE
fix(webdriverio): register polyfill on all windows

### DIFF
--- a/packages/webdriverio/src/session/polyfill.ts
+++ b/packages/webdriverio/src/session/polyfill.ts
@@ -20,9 +20,11 @@ export const NAME_POLYFILL = (
  */
 export class PolyfillManager extends SessionManager {
     #initialize: Promise<boolean>
+    #browser: WebdriverIO.Browser
 
     constructor(browser: WebdriverIO.Browser) {
         super(browser, PolyfillManager.name)
+        this.#browser = browser
 
         /**
          * don't run setup when Bidi is not supported or running unit tests
@@ -32,6 +34,28 @@ export class PolyfillManager extends SessionManager {
             return
         }
 
+        /**
+         * apply polyfill script for upcoming as well as current execution context
+         */
+        this.#initialize = Promise.all([
+            this.#registerScripts(),
+            this.#browser.sessionSubscribe({
+                events: ['browsingContext.contextCreated']
+            })
+        ]).then(() => {
+            log.info('polyfill script added')
+            return true
+        }, () => false)
+
+        this.#browser.on('browsingContext.contextCreated', this.#registerScripts.bind(this))
+    }
+
+    removeListeners() {
+        super.removeListeners()
+        this.#browser.off('browsingContext.contextCreated', this.#registerScripts.bind(this))
+    }
+
+    #registerScripts () {
         /**
          * A polyfill to set `__name` to the global scope which is needed for WebdriverIO to properly
          * execute custom (preload) scripts. When using `tsx` Esbuild runs some optimizations which
@@ -45,16 +69,10 @@ export class PolyfillManager extends SessionManager {
             return closure()
         }
 
-        /**
-         * apply polyfill script for upcoming as well as current execution context
-         */
-        this.#initialize = Promise.all([
-            browser.addInitScript(polyfill, NAME_POLYFILL),
-            browser.execute(polyfill, NAME_POLYFILL)
-        ]).then(() => {
-            log.info('polyfill script added')
-            return true
-        }, () => false)
+        return Promise.all([
+            this.#browser.addInitScript(polyfill, NAME_POLYFILL),
+            this.#browser.execute(polyfill, NAME_POLYFILL)
+        ])
     }
 
     async initialize () {

--- a/packages/webdriverio/src/session/session.ts
+++ b/packages/webdriverio/src/session/session.ts
@@ -29,7 +29,7 @@ export class SessionManager {
     }
 
     removeListeners() {
-        this.#browser.off('result', this.#onCommand.bind(this))
+        this.#browser.off('command', this.#onCommand.bind(this))
     }
 
     initialize(): unknown {

--- a/packages/webdriverio/tests/session/polyfill.test.ts
+++ b/packages/webdriverio/tests/session/polyfill.test.ts
@@ -1,0 +1,76 @@
+/// <reference path="../../src/index.ts" />
+import path from 'node:path'
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest'
+
+import { PolyfillManager } from '../../src/session/polyfill.js'
+import {
+    // @ts-expect-error mock
+    instances,
+    type SessionManager
+} from '../../src/session/session.js'
+
+vi.mock('@wdio/logger', () => import(path.join(process.cwd(), '__mocks__', '@wdio/logger')))
+
+vi.mock('../../src/session/session.js', () => {
+    const instances: SessionManager[] = []
+    return {
+        instances,
+        SessionManager: class SessionManagerMock {
+            removeListeners = vi.fn()
+            isEnabled: () => boolean
+
+            constructor(public browser, public name) {
+                instances.push(this as unknown as SessionManager)
+
+                /**
+                 * set isEnabled to whatever is set in the browser
+                 */
+                this.isEnabled = () => browser.isEnabled()
+            }
+        }
+    }
+})
+
+let browser: WebdriverIO.Browser & { on: Mock }
+
+describe('PolyfillManager', () => {
+    beforeEach(() => {
+        browser = {
+            on: vi.fn(),
+            sessionSubscribe: vi.fn(),
+            addInitScript: vi.fn(),
+            execute: vi.fn(),
+            isEnabled: vi.fn().mockReturnValue(true),
+            options: { automationProtocol: 'webdriver' }
+        } as unknown as WebdriverIO.Browser & { on: Mock }
+    })
+
+    it('should not do anything in non Bidi sessions', async () => {
+        // @ts-expect-error mock
+        browser.isEnabled = () => false
+        const manager = new PolyfillManager(browser)
+        expect(browser.on).toBeCalledTimes(0)
+        expect(browser.sessionSubscribe).toBeCalledTimes(0)
+        expect(browser.addInitScript).toBeCalledTimes(0)
+        expect(instances[0].name).toBe('PolyfillManager')
+        expect(await manager.initialize()).toBe(true)
+    })
+
+    it('should register all eventhandlers and scripts', async () => {
+        const manager = new PolyfillManager(browser)
+        expect(browser.on).toBeCalledTimes(1)
+        expect(browser.sessionSubscribe).toBeCalledTimes(1)
+        expect(browser.addInitScript).toBeCalledTimes(1)
+        expect(browser.execute).toBeCalledTimes(1)
+        expect(await manager.initialize()).toBe(true)
+    })
+
+    it('should register scripts when context is created', async () => {
+        const manager = new PolyfillManager(browser)
+        expect(browser.on.mock.calls[0][0]).toBe('browsingContext.contextCreated')
+        browser.on.mock.calls[0][1]()
+        expect(browser.addInitScript).toBeCalledTimes(2)
+        expect(browser.execute).toBeCalledTimes(2)
+        expect(await manager.initialize()).toBe(true)
+    })
+})


### PR DESCRIPTION
## Proposed changes

At the moment the polyfill is not registered in every context that is being created, this causes function executions in other windows to fail. This patch adds a listener on new contexts creations and automatically adds the scripts.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
