### PR TITLE
feat(webdriverio): use checkVisibility for display checks

### DIFF
--- a/__mocks__/fetch.ts
+++ b/__mocks__/fetch.ts
@@ -292,6 +292,8 @@ const requestMock: any = vi.fn().mockImplementation((uri, params) => {
             result = true
         } else if (body.script.includes('document.URL')) {
             result = 'https://webdriver.io/?foo=bar'
+        } else if (body.script.includes('function checkVisibility')) {
+            result = true
         } else {
             result = script.apply(this, args)
         }

--- a/packages/webdriverio/src/commands/browser/addInitScript.ts
+++ b/packages/webdriverio/src/commands/browser/addInitScript.ts
@@ -2,35 +2,6 @@ import type { local, remote } from 'webdriver'
 
 import { deserialize } from '../../utils/bidi/index.js'
 
-export interface InitScript<Payload = undefined> {
-    remove: () => Promise<void>
-    on: (event: 'data', listener: (data: Payload) => void) => void
-}
-
-/**
- * Callback to emit data from the browser back to the Node.js environment. In order to receive the
- * data returned by the callback function you have to listen to the `data` event, e.g.
- *
- * ```js
- * const script = await browser.addInitScript((emit) => {
- *    emit('hello')
- * })
- * script.on('data', (data) => {
- *   console.log(data) // prints: hello
- * })
- * ```
- *
- * @param {any} data  The data to emit.
- */
-type InitScriptCallback<Payload> = (data: Payload) => void
-
-type InitScriptFunction<Payload> = ((emit: InitScriptCallback<Payload>) => void | Promise<void>)
-type InitScriptFunctionArg1<Payload, Arg1> = ((arg1: Arg1, emit: InitScriptCallback<Payload>) => void | Promise<void>)
-type InitScriptFunctionArg2<Payload, Arg1, Arg2> = ((arg1: Arg1, arg2: Arg2, emit: InitScriptCallback<Payload>) => void | Promise<void>)
-type InitScriptFunctionArg3<Payload, Arg1, Arg2, Arg3> = ((arg1: Arg1, arg2: Arg2, arg3: Arg3, emit: InitScriptCallback<Payload>) => void | Promise<void>)
-type InitScriptFunctionArg4<Payload, Arg1, Arg2, Arg3, Arg4> = ((arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, emit: InitScriptCallback<Payload>) => void | Promise<void>)
-type InitScriptFunctionArg5<Payload, Arg1, Arg2, Arg3, Arg4, Arg5> = ((arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, emit: InitScriptCallback<Payload>) => void | Promise<void>)
-
 /**
  * Adds a script which would be evaluated in one of the following scenarios:
  *
@@ -186,3 +157,32 @@ export async function addInitScript<Payload, Arg1, Arg2, Arg3, Arg4, Arg5> (
 }
 
 type EventHandlerFunction<Payload> = (data: Payload) => void
+
+/**
+ * Callback to emit data from the browser back to the Node.js environment. In order to receive the
+ * data returned by the callback function you have to listen to the `data` event, e.g.
+ *
+ * ```js
+ * const script = await browser.addInitScript((emit) => {
+ *    emit('hello')
+ * })
+ * script.on('data', (data) => {
+ *   console.log(data) // prints: hello
+ * })
+ * ```
+ *
+ * @param {any} data  The data to emit.
+ */
+type InitScriptCallback<Payload> = (data: Payload) => void
+
+type InitScriptFunction<Payload> = ((emit: InitScriptCallback<Payload>) => void | Promise<void>)
+type InitScriptFunctionArg1<Payload, Arg1> = ((arg1: Arg1, emit: InitScriptCallback<Payload>) => void | Promise<void>)
+type InitScriptFunctionArg2<Payload, Arg1, Arg2> = ((arg1: Arg1, arg2: Arg2, emit: InitScriptCallback<Payload>) => void | Promise<void>)
+type InitScriptFunctionArg3<Payload, Arg1, Arg2, Arg3> = ((arg1: Arg1, arg2: Arg2, arg3: Arg3, emit: InitScriptCallback<Payload>) => void | Promise<void>)
+type InitScriptFunctionArg4<Payload, Arg1, Arg2, Arg3, Arg4> = ((arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, emit: InitScriptCallback<Payload>) => void | Promise<void>)
+type InitScriptFunctionArg5<Payload, Arg1, Arg2, Arg3, Arg4, Arg5> = ((arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, emit: InitScriptCallback<Payload>) => void | Promise<void>)
+
+export interface InitScript<Payload = undefined> {
+    remove: () => Promise<void>
+    on: (event: 'data', listener: (data: Payload) => void) => void
+}

--- a/packages/webdriverio/src/commands/browser/execute.ts
+++ b/packages/webdriverio/src/commands/browser/execute.ts
@@ -77,10 +77,10 @@ export async function execute<ReturnValue, InnerArguments extends unknown[]> (
      * a function parameter, therefore we need to check if it starts with "function () {"
      */
     if (typeof script === 'function') {
-        script = createFunctionDeclarationFromString(`
+        script = `
             ${createFunctionDeclarationFromString(polyfillFn)}
             return (${script}).apply(null, arguments)
-        `)
+        `
     }
 
     return this.executeScript(script, verifyArgsAndStripIfElement(args) as (string | number | boolean)[])

--- a/packages/webdriverio/src/commands/browser/executeAsync.ts
+++ b/packages/webdriverio/src/commands/browser/executeAsync.ts
@@ -1,11 +1,11 @@
 import { getBrowserObject } from '@wdio/utils'
 import type { remote } from 'webdriver'
 
-import { verifyArgsAndStripIfElement } from '../../utils/index.js'
+import { verifyArgsAndStripIfElement, createFunctionDeclarationFromString } from '../../utils/index.js'
 import { LocalValue } from '../../utils/bidi/value.js'
 import { parseScriptResult } from '../../utils/bidi/index.js'
 import { getContextManager } from '../../session/context.js'
-import { NAME_POLYFILL } from '../../session/polyfill.js'
+import { polyfillFn } from '../../session/polyfill.js'
 
 /**
  * :::warning
@@ -102,10 +102,10 @@ export async function executeAsync<ReturnValue, InnerArguments extends unknown[]
      * a function parameter, therefore we need to check if it starts with "function () {"
      */
     if (typeof script === 'function') {
-        script = `
-            ${NAME_POLYFILL}
+        script = createFunctionDeclarationFromString(`
+            ${polyfillFn}
             return (${script}).apply(null, arguments)
-        `
+        `)
     }
 
     return this.executeAsyncScript(script, verifyArgsAndStripIfElement(args) as (string | number | boolean)[])

--- a/packages/webdriverio/src/commands/browser/executeAsync.ts
+++ b/packages/webdriverio/src/commands/browser/executeAsync.ts
@@ -102,10 +102,10 @@ export async function executeAsync<ReturnValue, InnerArguments extends unknown[]
      * a function parameter, therefore we need to check if it starts with "function () {"
      */
     if (typeof script === 'function') {
-        script = createFunctionDeclarationFromString(`
-            ${polyfillFn}
+        script = `
+            ${createFunctionDeclarationFromString(polyfillFn)}
             return (${script}).apply(null, arguments)
-        `)
+        `
     }
 
     return this.executeAsyncScript(script, verifyArgsAndStripIfElement(args) as (string | number | boolean)[])

--- a/packages/webdriverio/src/utils/index.ts
+++ b/packages/webdriverio/src/utils/index.ts
@@ -789,7 +789,8 @@ export const containsHeaderObject = (
 }
 
 export function createFunctionDeclarationFromString (userScript: Function | string) {
-    return new Function(`
-        return (${SCRIPT_PREFIX}${userScript.toString()}${SCRIPT_SUFFIX}).apply(this, arguments);
-    `).toString()
+    if (typeof userScript === 'string') {
+        return `(${SCRIPT_PREFIX}function () {\n${userScript.toString()}\n}${SCRIPT_SUFFIX}).apply(this, arguments);`
+    }
+    return new Function(`return (${SCRIPT_PREFIX}${userScript.toString()}${SCRIPT_SUFFIX}).apply(this, arguments);`).toString()
 }

--- a/packages/webdriverio/src/utils/index.ts
+++ b/packages/webdriverio/src/utils/index.ts
@@ -11,6 +11,7 @@ import * as browserCommands from '../commands/browser.js'
 import * as elementCommands from '../commands/element.js'
 import elementContains from '../scripts/elementContains.js'
 import querySelectorAllDeep from './thirdParty/querySelectorShadowDom.js'
+import { SCRIPT_PREFIX, SCRIPT_SUFFIX } from '../commands/constant.js'
 import { DEEP_SELECTOR, Key } from '../constants.js'
 import { findStrategy } from './findStrategy.js'
 import { getShadowRootManager, type ShadowRootManager } from '../session/shadowRoot.js'
@@ -785,4 +786,10 @@ export const containsHeaderObject = (
     }
 
     return true
+}
+
+export function createFunctionDeclarationFromString (userScript: Function | string) {
+    return new Function(`
+        return (${SCRIPT_PREFIX}${userScript.toString()}${SCRIPT_SUFFIX}).apply(this, arguments);
+    `).toString()
 }

--- a/packages/webdriverio/tests/utils/index.test.ts
+++ b/packages/webdriverio/tests/utils/index.test.ts
@@ -1,7 +1,13 @@
 import { describe, it, expect, vi } from 'vitest'
 import { ELEMENT_KEY, type local } from 'webdriver'
 
-import { findElement, isStaleElementError, elementPromiseHandler, transformClassicToBidiSelector } from '../../src/utils/index.js'
+import {
+    findElement,
+    isStaleElementError,
+    elementPromiseHandler,
+    transformClassicToBidiSelector,
+    createFunctionDeclarationFromString
+} from '../../src/utils/index.js'
 
 vi.mock('is-plain-obj', () => ({
     default: vi.fn().mockReturnValue(false)
@@ -158,5 +164,32 @@ describe('transformClassicToBidiSelector', () => {
         expect(bidiSelector.type).toBe('innerText')
         expect(bidiSelector.value).toBe('new')
         expect((bidiSelector as local.BrowsingContextInnerTextLocator).matchType).toBe('partial')
+    })
+})
+
+describe('createFunctionDeclarationFromString', () => {
+    it('should return a wrapped function string', () => {
+        expect(createFunctionDeclarationFromString((a: string, b: string, c: string) => console.log('foobar' + a + b + c))).toMatchInlineSnapshot(`
+          "function anonymous(
+          ) {
+          return (/* __wdio script__ */(a, b, c) => console.log("foobar" + a + b + c)/* __wdio script end__ */).apply(this, arguments);
+          }"
+        `)
+        function namedFunction (a: string, b: string, c: string) {
+            console.log('foobar' + a + b + c)
+        }
+        expect(createFunctionDeclarationFromString(namedFunction)).toMatchInlineSnapshot(`
+          "function anonymous(
+          ) {
+          return (/* __wdio script__ */function namedFunction(a, b, c) {
+                console.log("foobar" + a + b + c);
+              }/* __wdio script end__ */).apply(this, arguments);
+          }"
+        `)
+        expect(createFunctionDeclarationFromString('console.log("foobar")')).toMatchInlineSnapshot(`
+          "(/* __wdio script__ */function () {
+          console.log("foobar")
+          }/* __wdio script end__ */).apply(this, arguments);"
+        `)
     })
 })


### PR DESCRIPTION
## Proposed changes

The web platform now provides a [`checkVisibility`](https://developer.mozilla.org/en-US/docs/Web/API/Element/checkVisibility#visibilityproperty) function to verify if an element is visible or not. It makes sense to rely on that implementation than maintaining one (that we forked from a different project) ourselves.

Furthermore this tweaks the function execution to expose the function name if available to make it easier to understand which WebdriverIO helper functions were called in the logs.

This "should" be a non breaking change but it is hard to say given that it is not much clear how the custom script worked.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
