### PR TITLE
fix(webdriverio): don't initialize session manager for stub

### DIFF
--- a/e2e/launch/aws.test.ts
+++ b/e2e/launch/aws.test.ts
@@ -38,7 +38,7 @@ test('allow to attach to an existing session', async () => {
         }
     })
 
-    await browser.url('http://guinea-pig.webdriver.io/')
+    await browser.url('https://guinea-pig.webdriver.io/')
 
     const title = await browser.getTitle()
     expect(title).toBe('WebdriverJS Testpage')

--- a/e2e/launch/reloadSession.test.ts
+++ b/e2e/launch/reloadSession.test.ts
@@ -23,7 +23,7 @@ test('can reconnect to WebDriver Bidi session', async () => {
     console.log('\n\nRESTARTED\n\n')
 
     expect(typeof await browser.browsingContextGetTree({})).toBe('object')
-    await browser.url('http://guinea-pig.webdriver.io')
+    await browser.url('https://guinea-pig.webdriver.io')
     expect(await browser.getTitle()).toBe('WebdriverJS Testpage')
     const h1 = await browser.$('h1')
     expect(await h1.getText()).toBe('WebdriverJS Testpage')

--- a/e2e/standalone/attach.test.ts
+++ b/e2e/standalone/attach.test.ts
@@ -12,7 +12,7 @@ import { remote, attach } from 'webdriverio'
 test('allow to attach to an existing session', async () => {
     /**
      * fails in windows due to timeout:
-     * > Command browsingContext.navigate with id 1 (with the following parameter: {"context":"BD746B5679530BC3403539C2FEC5A45A","url":"http://guinea-pig.webdriver.io","wait":"interactive"}) timed out
+     * > Command browsingContext.navigate with id 1 (with the following parameter: {"context":"BD746B5679530BC3403539C2FEC5A45A","url":"https://guinea-pig.webdriver.io","wait":"interactive"}) timed out
      */
     if (os.platform() === 'win32') {
         return
@@ -27,7 +27,7 @@ test('allow to attach to an existing session', async () => {
         }
     })
 
-    await browser.url('http://guinea-pig.webdriver.io')
+    await browser.url('https://guinea-pig.webdriver.io')
     expect(await browser.getTitle()).toBe('WebdriverJS Testpage')
     const origContextTree = await browser.browsingContextGetTree({ maxDepth: 1 })
     expect(origContextTree.contexts).toHaveLength(1)

--- a/e2e/wdio/headless/bidi.e2e.ts
+++ b/e2e/wdio/headless/bidi.e2e.ts
@@ -206,7 +206,7 @@ describe('bidi e2e test', () => {
     })
 
     it('supports execute with bidi on element scope', async () => {
-        await browser.url('http://guinea-pig.webdriver.io')
+        await browser.url('https://guinea-pig.webdriver.io')
         const result = await browser.$('.findme').execute(function (elem, a, b, c, d) {
             return (elem as unknown as HTMLElement).innerText.length + a + b + c + d
         }, 1, 2, 3, 4)
@@ -236,7 +236,7 @@ describe('bidi e2e test', () => {
         })
 
         it('works on element scope', async () => {
-            await browser.url('http://guinea-pig.webdriver.io')
+            await browser.url('https://guinea-pig.webdriver.io')
             const result = await browser.$('.findme').executeAsync(function (elem, a, b, c, d, done) {
                 // browser context - you may not access client or console
                 setTimeout(() => {

--- a/e2e/wdio/headless/classic.e2e.ts
+++ b/e2e/wdio/headless/classic.e2e.ts
@@ -3,7 +3,7 @@ import scripts from './__fixtures__/script.js'
 
 describe('__name polyfill', () => {
     it('suppports __name polyfill for classic sessions', async () => {
-        await browser.url('http://guinea-pig.webdriver.io')
+        await browser.url('https://guinea-pig.webdriver.io')
         expect(await browser.execute(scripts.someScript, 'foo')).toBe('Hello World! foo')
         expect(await browser.executeAsync(scripts.someAsyncScript, 'foo')).toBe('Hello World! foo')
     })

--- a/e2e/wdio/headless/launch.e2e.ts
+++ b/e2e/wdio/headless/launch.e2e.ts
@@ -6,7 +6,7 @@ describe('Launch Test', () => {
         const assertionValue = caps.browserName?.toLowerCase().includes('edge')
             ? 'Edg/'
             : caps.browserName && caps.browserName.includes('chrome') ? 'chrome/' : caps.browserName!.toLowerCase()
-        await browser.url('http://guinea-pig.webdriver.io/')
+        await browser.url('https://guinea-pig.webdriver.io/')
         await expect($('#useragent')).toHaveText(expect.stringContaining(assertionValue), { ignoreCase: true })
 
     // @ts-expect-error

--- a/e2e/wdio/headless/mocking.e2e.ts
+++ b/e2e/wdio/headless/mocking.e2e.ts
@@ -1,13 +1,16 @@
-import { browser, expect } from '@wdio/globals'
+import { browser } from '@wdio/globals'
 
 describe('network mocking', () => {
     it('marks a request as mocked even without overwrites', async () => {
-        const baseUrl = 'http://guinea-pig.webdriver.io/'
+        const baseUrl = 'https://guinea-pig.webdriver.io/'
         const mock = await browser.mock(`${baseUrl}components/hammerjs/hammer.js`, {
             method: 'get',
             statusCode: 200,
         })
         await browser.url(baseUrl)
-        expect(mock.calls.length).toBe(1)
+        await browser.waitUntil(() => mock.calls.length === 1, {
+            timeoutMsg: 'Expected mock to be made',
+            timeout: 2000
+        })
     })
 })

--- a/e2e/wdio/headless/test.e2e.ts
+++ b/e2e/wdio/headless/test.e2e.ts
@@ -9,7 +9,7 @@ const __dirname = path.dirname(url.fileURLToPath(import.meta.url))
 
 describe('main suite 1', () => {
     it('supports snapshot testing', async () => {
-        await browser.url('http://guinea-pig.webdriver.io/')
+        await browser.url('https://guinea-pig.webdriver.io/')
         await expect($('.findme')).toMatchSnapshot()
         await expect($('.findme')).toMatchInlineSnapshot('"<h1 class="findme">Test CSS Attributes</h1>"')
     })
@@ -130,7 +130,7 @@ describe('main suite 1', () => {
         ]
 
         before(async () => {
-            await browser.url('http://guinea-pig.webdriver.io/pointer.html')
+            await browser.url('https://guinea-pig.webdriver.io/pointer.html')
             await browser.$('#parent').waitForExist()
         })
 
@@ -257,7 +257,7 @@ describe('main suite 1', () => {
 
     describe('wdio scrollIntoView behaves like native scrollIntoView', () => {
         beforeEach(async () => {
-            await browser.url('http://guinea-pig.webdriver.io')
+            await browser.url('https://guinea-pig.webdriver.io')
             await browser.setWindowSize(500, 500)
         })
 
@@ -288,7 +288,7 @@ describe('main suite 1', () => {
     })
 
     it('should be able to handle successive scrollIntoView', async () => {
-        await browser.url('http://guinea-pig.webdriver.io')
+        await browser.url('https://guinea-pig.webdriver.io')
         await browser.setWindowSize(500, 500)
         const searchInput = await $('.searchinput')
 
@@ -325,7 +325,7 @@ describe('main suite 1', () => {
         })
 
         it('should return a request object', async () => {
-            const request = await browser.url('http://guinea-pig.webdriver.io/')
+            const request = await browser.url('https://guinea-pig.webdriver.io/')
             if (!request) {
                 throw new Error('Request object is not defined')
             }
@@ -334,7 +334,7 @@ describe('main suite 1', () => {
         })
 
         it('should not contain any children due to "none" wait property', async () => {
-            const request = await browser.url('http://guinea-pig.webdriver.io/', {
+            const request = await browser.url('https://guinea-pig.webdriver.io/', {
                 wait: 'none'
             })
 
@@ -359,7 +359,7 @@ describe('main suite 1', () => {
 
     describe('dialog handling', () => {
         it('should automatically accept alerts', async () => {
-            await browser.url('http://guinea-pig.webdriver.io')
+            await browser.url('https://guinea-pig.webdriver.io')
 
             await browser.execute(() => alert('123'))
 
@@ -374,7 +374,7 @@ describe('main suite 1', () => {
          * fails due to https://github.com/GoogleChromeLabs/chromium-bidi/issues/2556
          */
         it('should be able to handle dialogs', async () => {
-            await browser.url('http://guinea-pig.webdriver.io')
+            await browser.url('https://guinea-pig.webdriver.io')
             browser.execute(() => alert('123'))
             const dialog = await new Promise<WebdriverIO.Dialog>((resolve) => browser.on('dialog', resolve))
 
@@ -418,7 +418,7 @@ describe('main suite 1', () => {
             await browser.emulate('clock', { now })
             expect(await browser.execute(getDateString))
                 .toBe(now.toString())
-            await browser.url('http://guinea-pig.webdriver.io')
+            await browser.url('https://guinea-pig.webdriver.io')
             expect(await browser.execute(getDateString))
                 .toBe(now.toString())
         })
@@ -427,7 +427,7 @@ describe('main suite 1', () => {
             await browser.restore('clock')
             expect(await browser.execute(getDateString))
                 .not.toBe(now.toString())
-            await browser.url('http://guinea-pig.webdriver.io/pointer.html')
+            await browser.url('https://guinea-pig.webdriver.io/pointer.html')
             expect(await browser.execute(getDateString))
                 .not.toBe(now.toString())
         })
@@ -455,7 +455,7 @@ describe('main suite 1', () => {
         }
 
         it('should allow user to switch between contexts', async () => {
-            await browser.url('http://guinea-pig.webdriver.io/')
+            await browser.url('https://guinea-pig.webdriver.io/')
 
             await browser.newWindow('https://webdriver.io')
             await expect($('.hero__subtitle')).toBePresent()
@@ -472,7 +472,7 @@ describe('main suite 1', () => {
 
         it('should not switch window if requested window was not found', async () => {
             await closeAllWindowsButFirst()
-            await browser.navigateTo('http://guinea-pig.webdriver.io/')
+            await browser.navigateTo('https://guinea-pig.webdriver.io/')
             const firstWindowHandle = await browser.getWindowHandle()
 
             await browser.newWindow('https://webdriver.io')
@@ -488,7 +488,7 @@ describe('main suite 1', () => {
 
         it('Should update BiDi browsingContext when performing switchToWindow in WebDriver Classic', async () => {
             await closeAllWindowsButFirst()
-            await browser.url('http://guinea-pig.webdriver.io/')
+            await browser.url('https://guinea-pig.webdriver.io/')
             await $('#newWindow').click()
 
             const handles = await browser.getWindowHandles()
@@ -553,8 +553,8 @@ describe('main suite 1', () => {
 
     describe.only('open resources with different protocols', () => {
         it('http', async () => {
-            browser.url('http://guinea-pig.webdriver.io/')
-            await expect(browser).toHaveUrl('http://guinea-pig.webdriver.io/')
+            browser.url('https://guinea-pig.webdriver.io/')
+            await expect(browser).toHaveUrl('https://guinea-pig.webdriver.io/')
         })
 
         it('https', async () => {

--- a/e2e/wdio/wdio.conf.ts
+++ b/e2e/wdio/wdio.conf.ts
@@ -8,10 +8,10 @@ export const config: WebdriverIO.Config = {
      * specify test files
      */
     specs: [
-        path.join(__dirname, 'headless', 'puppeteer.e2e.ts'),
-        path.join(__dirname, 'headless', 'source-maps.e2e.ts'),
-        path.join(__dirname, 'headless', 'reloadSession.e2e.ts'),
-        path.join(__dirname, 'headless', 'test.e2e.ts'),
+        // path.join(__dirname, 'headless', 'puppeteer.e2e.ts'),
+        // path.join(__dirname, 'headless', 'source-maps.e2e.ts'),
+        // path.join(__dirname, 'headless', 'reloadSession.e2e.ts'),
+        // path.join(__dirname, 'headless', 'test.e2e.ts'),
         path.join(__dirname, 'headless', 'mocking.e2e.ts'),
     ],
 
@@ -21,9 +21,9 @@ export const config: WebdriverIO.Config = {
     capabilities: [{
         browserName: 'chrome',
         browserVersion: 'stable',
-        'goog:chromeOptions': {
-            args: ['headless', 'disable-gpu']
-        }
+        // 'goog:chromeOptions': {
+        //     args: ['headless', 'disable-gpu']
+        // }
     }],
     bail: 1,
     services: ['lighthouse'],

--- a/e2e/wdio/wdio.conf.ts
+++ b/e2e/wdio/wdio.conf.ts
@@ -8,10 +8,10 @@ export const config: WebdriverIO.Config = {
      * specify test files
      */
     specs: [
-        // path.join(__dirname, 'headless', 'puppeteer.e2e.ts'),
-        // path.join(__dirname, 'headless', 'source-maps.e2e.ts'),
-        // path.join(__dirname, 'headless', 'reloadSession.e2e.ts'),
-        // path.join(__dirname, 'headless', 'test.e2e.ts'),
+        path.join(__dirname, 'headless', 'puppeteer.e2e.ts'),
+        path.join(__dirname, 'headless', 'source-maps.e2e.ts'),
+        path.join(__dirname, 'headless', 'reloadSession.e2e.ts'),
+        path.join(__dirname, 'headless', 'test.e2e.ts'),
         path.join(__dirname, 'headless', 'mocking.e2e.ts'),
     ],
 

--- a/packages/webdriver/src/utils.ts
+++ b/packages/webdriver/src/utils.ts
@@ -54,6 +54,8 @@ export async function startWebDriverSession (params: RemoteConfig): Promise<{ se
          */
         : { alwaysMatch: params.capabilities, firstMatch: [{}] }
 
+    console.log(capabilities)
+
     /**
      * automatically opt-into WebDriver Bidi (@ref https://w3c.github.io/webdriver-bidi/)
      */

--- a/packages/webdriverio/src/commands/browser/mockClearAll.ts
+++ b/packages/webdriverio/src/commands/browser/mockClearAll.ts
@@ -17,10 +17,10 @@ const log = logger('webdriverio:mockClearAll')
             headers: { 'Content-Type': 'application/javascript' }
         })
 
-        await browser.url('http://guinea-pig.webdriver.io/')
+        await browser.url('https://guinea-pig.webdriver.io/')
         console.log(docMock.calls.length, jsMock.calls.length) // returns "1 4"
 
-        await browser.url('http://guinea-pig.webdriver.io/')
+        await browser.url('https://guinea-pig.webdriver.io/')
         console.log(docMock.calls.length, jsMock.calls.length) // returns "2 4" (JavaScript comes from cache)
 
         await browser.mockClearAll()

--- a/packages/webdriverio/src/session/index.ts
+++ b/packages/webdriverio/src/session/index.ts
@@ -7,7 +7,15 @@ import { getContextManager } from './context.js'
 /**
  * register all session relevant singletons on the instance
  */
-export function registerSessionManager (instance: WebdriverIO.Browser) {
+export function registerSessionManager(instance: WebdriverIO.Browser) {
+    /**
+     * only register session manager for WebDriver protocol instances
+     * and don't run them for the protocol stub.
+     */
+    if (instance.options.automationProtocol !== 'webdriver') {
+        return
+    }
+
     return Promise.all([
         getPolyfillManager(instance).initialize(),
         getShadowRootManager(instance).initialize(),

--- a/packages/webdriverio/tests/module.test.ts
+++ b/packages/webdriverio/tests/module.test.ts
@@ -12,6 +12,7 @@ vi.mock('@wdio/logger', () => import(path.join(process.cwd(), '__mocks__', '@wdi
 vi.mock('webdriver', () => {
     const client = {
         sessionId: 'foobar-123',
+        options: {},
         addCommand: vi.fn(),
         overwriteCommand: vi.fn(),
         strategies: new Map(),

--- a/packages/webdriverio/tests/session/index.test.ts
+++ b/packages/webdriverio/tests/session/index.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi } from 'vitest'
+
+import { getPolyfillManager } from '../../src/session/polyfill.js'
+import { getShadowRootManager } from '../../src/session/shadowRoot.js'
+import { getNetworkManager } from '../../src/session/networkManager.js'
+import { getDialogManager } from '../../src/session/dialog.js'
+import { getContextManager } from '../../src/session/context.js'
+import { registerSessionManager } from '../../src/session/index.js'
+
+vi.mock('../../src/session/polyfill.js', () => ({
+    getPolyfillManager: vi.fn(() => ({ initialize: vi.fn() }))
+}))
+vi.mock('../../src/session/shadowRoot.js', () => ({
+    getShadowRootManager: vi.fn(() => ({ initialize: vi.fn() }))
+}))
+vi.mock('../../src/session/networkManager.js', () => ({
+    getNetworkManager: vi.fn(() => ({ initialize: vi.fn() }))
+}))
+vi.mock('../../src/session/dialog.js', () => ({
+    getDialogManager: vi.fn(() => ({ initialize: vi.fn() }))
+}))
+vi.mock('../../src/session/context.js', () => ({
+    getContextManager: vi.fn(() => ({ initialize: vi.fn() }))
+}))
+
+describe('webdriverio session manager', () => {
+    it('registers all session manager', async () => {
+        const browser = {
+            options: {
+                automationProtocol: 'webdriver'
+            }
+        } as unknown as WebdriverIO.Browser
+        registerSessionManager(browser)
+        expect(getPolyfillManager).toBeCalledWith(browser)
+        expect(getShadowRootManager).toBeCalledWith(browser)
+        expect(getNetworkManager).toBeCalledWith(browser)
+        expect(getDialogManager).toBeCalledWith(browser)
+        expect(getContextManager).toBeCalledWith(browser)
+    })
+
+    it('does not register for protocol stub', async () => {
+        const browser = {
+            options: {
+                automationProtocol: 'protocol-stub'
+            }
+        } as unknown as WebdriverIO.Browser
+        registerSessionManager(browser)
+        expect(getPolyfillManager).not.toBeCalledWith(browser)
+        expect(getShadowRootManager).not.toBeCalledWith(browser)
+        expect(getNetworkManager).not.toBeCalledWith(browser)
+        expect(getDialogManager).not.toBeCalledWith(browser)
+        expect(getContextManager).not.toBeCalledWith(browser)
+    })
+})

--- a/website/docs/Emulation.md
+++ b/website/docs/Emulation.md
@@ -105,7 +105,7 @@ await clock.restore()
 console.log(await browser.execute(() => (new Date()).toString()))
 // returns "Thu Aug 01 2024 17:59:59 GMT-0700 (Pacific Daylight Time)"
 
-await browser.url('http://guinea-pig.webdriver.io/pointer.html')
+await browser.url('https://guinea-pig.webdriver.io/pointer.html')
 console.log(await browser.execute(() => (new Date()).toString()))
 // returns "Thu Aug 01 2024 17:59:59 GMT-0700 (Pacific Daylight Time)"
 ```

--- a/website/docs/Snapshot.md
+++ b/website/docs/Snapshot.md
@@ -20,7 +20,7 @@ To snapshot a value, you can use the `toMatchSnapshot()` from [`expect()`](/docs
 import { browser, expect } from '@wdio/globals'
 
 it('can take a DOM snapshot', () => {
-    await browser.url('http://guinea-pig.webdriver.io/')
+    await browser.url('https://guinea-pig.webdriver.io/')
     await expect($('.findme')).toMatchSnapshot()
 })
 ```

--- a/website/docs/VisualTesting.md
+++ b/website/docs/VisualTesting.md
@@ -187,7 +187,7 @@ Both methods use the same options as the [`saveFullPageScreen`](https://github.c
 
 #### Example
 
-This is an example of how the tabbing works on our [guinea pig website](http://guinea-pig.webdriver.io/image-compare.html):
+This is an example of how the tabbing works on our [guinea pig website](https://guinea-pig.webdriver.io/image-compare.html):
 
 ![WDIO tabbing example](/img/visual/tabbable-chrome-latest-1366x768.png)
 

--- a/website/docs/visual-testing/test-output.md
+++ b/website/docs/visual-testing/test-output.md
@@ -5,7 +5,7 @@ title: Test Output
 
 :::info
 
-[This WebdriverIO](http://guinea-pig.webdriver.io/image-compare.html) demo site has been used for the example image output.
+[This WebdriverIO](https://guinea-pig.webdriver.io/image-compare.html) demo site has been used for the example image output.
 
 :::
 


### PR DESCRIPTION
## Proposed changes

The WebdriverIO testrunner registers a fake browser instance with a stub protocol to allow load spec files before the session initializes. Currently this stub instance loads all session managers which is not needed and causes issues, see #14083. This patch skips that.

fixes #14083

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
