### PR TITLE
docs(eslint-plugin-wdio): fix typo in readme

### DIFF
--- a/packages/eslint-plugin-wdio/README.md
+++ b/packages/eslint-plugin-wdio/README.md
@@ -42,7 +42,7 @@ If you are using the latest version of Eslint with the [flat configuration](http
 
 ```js
 // eslint.config.mjs
-import { config as wdioConfig } from "eslint-plugin-wdio";
+import { configs as wdioConfig } from "eslint-plugin-wdio";
 
 export default [
     {


### PR DESCRIPTION
## Proposed changes

The correct exported const is [`configs`](https://github.com/webdriverio/webdriverio/blob/ea3f50b7780a7f43b230749a98e6c40451ec7f3d/packages/eslint-plugin-wdio/src/index.ts#L47), in the `README.md` it was suggesting `config`.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
