### PR TITLE
chore(@wdio/utils): allow to set spawnOpts for Chromedriver as well

### DIFF
--- a/packages/wdio-utils/src/node/startWebDriver.ts
+++ b/packages/wdio-utils/src/node/startWebDriver.ts
@@ -19,7 +19,11 @@ import { parseParams, setupPuppeteerBrowser, setupChromedriver, getCacheDir } fr
 import { isChrome, isFirefox, isEdge, isSafari, isAppiumCapability } from '../utils.js'
 import { SUPPORTED_BROWSERNAMES } from '../constants.js'
 
-export type ChromedriverParameters = Partial<InstallOptions> & Omit<EdgedriverParameters, 'port' | 'edgeDriverVersion' | 'customEdgeDriverPath'>
+export type ChromedriverParameters = (
+    Partial<InstallOptions> &
+    Omit<EdgedriverParameters, 'port' | 'edgeDriverVersion' | 'customEdgeDriverPath'> &
+    Pick<GeckodriverParameters, 'spawnOpts'>
+)
 declare global {
     namespace WebdriverIO {
         interface ChromedriverOptions extends ChromedriverParameters {}
@@ -90,7 +94,8 @@ export async function startWebDriver (options: Capabilities.RemoteConfig) {
          * Set NODE_OPTIONS empty to avoid passing it to the chromedriver process so that Electron doesn't crash
          */
         driverProcess = cp.spawn(chromedriverExcecuteablePath, driverParams, {
-            env: { ...process.env, NODE_OPTIONS: '' }
+            env: { ...process.env, NODE_OPTIONS: '' },
+            ...(chromedriverOptions.spawnOpts || {})
         })
         driver = `Chromedriver v${browserVersion} with params ${driverParams.join(' ')}`
     } else if (isSafari(caps.browserName)) {

--- a/website/docs/Capabilities.md
+++ b/website/docs/Capabilities.md
@@ -194,6 +194,12 @@ Comma-separated allowlist of request origins which are allowed to connect to Edg
 Type: `string[]`<br />
 Default: `['*']`
 
+##### spawnOpts
+Options to be passed into the driver process.
+
+Type: `SpawnOptionsWithoutStdio | SpawnOptionsWithStdioTuple<StdioOption, StdioOption, StdioOption>`<br />
+Default: `undefined`
+
 </TabItem>
 <TabItem value="firefox">
 


### PR DESCRIPTION
## Proposed changes

This aligns the Chromedriver options with other driver options.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
