### PR TITLE
Add support for Sauce Connect 5, drop support for Sauce Connect 4

### DIFF
--- a/packages/wdio-sauce-service/README.md
+++ b/packages/wdio-sauce-service/README.md
@@ -13,7 +13,7 @@ What else will this service do for you:
 - By default the Sauce Service will update the 'name' of the job when the job starts. This will give you the option to update the name at any given point in time.
 - You can define a `setJobName` parameter and customise the job name according to your capabilities, options and suite title
 - The Sauce Service will also push the error stack of a failed test to the Sauce Labs commands tab
-- It will allow you to automatically configure and spin up [Sauce Connect](https://wiki.saucelabs.com/display/DOCS/Sauce+Connect+Proxy)
+- It will allow you to automatically configure and spin up [Sauce Connect](https://docs.saucelabs.com/secure-connections/)
 - And it will set context points in your command list to identify which commands were executed in what test
 
 ## Installation
@@ -51,17 +51,17 @@ export const config = {
 };
 ```
 
-If you want to use an existing Sauce Connect tunnel you only need to provide a `tunnelIdentifier`, or if you are using a parent tunnel, include the `parentTunnel` in the capabilities like this:
+If you want to use an existing Sauce Connect tunnel you only need to provide a `tunnelName`. If you are using a shared tunnel, and you are not the user who created the tunnel, you must identify the Sauce Labs user who did create the tunnel in order to use it for your test. Include the `tunnelOwner` in the capabilities like this:
 
 
 <Tabs
-  defaultValue="tunnelidentifier"
+  defaultValue="tunnelname"
   values={[
-    {label: 'Tunnel Identifier', value: 'tunnelidentifier'},
-    {label: 'Parent Tunnel', value: 'parenttunnel'}
+    {label: 'Tunnel Name', value: 'tunnelname'},
+    {label: 'Tunnel Owner', value: 'tunnelowner'}
   ]
 }>
-<TabItem value="tunnelidentifier">
+<TabItem value="tunnelname">
 
 ```js
 export const config = {
@@ -72,7 +72,7 @@ export const config = {
         browserVersion: 'latest',
         // Sauce options can be found here https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options
         'sauce:options': {
-            tunnelIdentifier: 'YourTunnelName',
+            tunnelName: 'YourTunnelName',
 
             // Example options
             build: 'your-build-name',
@@ -85,7 +85,7 @@ export const config = {
 ```
 
 </TabItem>
-<TabItem value="parenttunnel">
+<TabItem value="tunnelowner">
 
 ```js
 export const config = {
@@ -96,8 +96,8 @@ export const config = {
         browserVersion: 'latest',
         // Sauce options can be found here https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options
         'sauce:options': {
-            tunnelIdentifier: 'ParentTunnelName',
-            parentTunnel: '<username of parent>,
+            tunnelName: 'TunnelName',
+            tunnelOwner: '<username of owner>,
 
             // Example options
             build: 'your-build-name',
@@ -130,12 +130,12 @@ Type: `Boolean`<br />
 Default: `false`
 
 ### sauceConnectOpts
-Apply Sauce Connect options (e.g. to change port number or logFile settings). See [this list](https://wiki.saucelabs.com/display/DOCS/Sauce+Connect+Proxy+Command-Line+Quick+Reference+Guide) for more information. Per default, the service disables SC proxy auto-detection via `noAutodetect`` as this can be unreliable for some machines.
+Apply Sauce Connect options (e.g. to change port number or logFile settings). See [this list](https://docs.saucelabs.com/dev/cli/sauce-connect-5/run/) for more information.
 
 NOTE: When specifying the options the `--` should be omitted. It can also be turned into camelCase (e.g. `shared-tunnel` or `sharedTunnel`).
 
 Type: `Object`<br />
-Default: `{ noAutodetect: true }`
+Default: `{ }`
 
 ### uploadLogs
 

--- a/packages/wdio-sauce-service/package.json
+++ b/packages/wdio-sauce-service/package.json
@@ -35,7 +35,7 @@
     "@wdio/logger": "workspace:*",
     "@wdio/types": "workspace:*",
     "@wdio/utils": "workspace:*",
-    "saucelabs": "9.0.0",
+    "saucelabs": "^9.0.1",
     "webdriverio": "workspace:*"
   },
   "devDependencies": {

--- a/packages/wdio-sauce-service/package.json
+++ b/packages/wdio-sauce-service/package.json
@@ -35,7 +35,7 @@
     "@wdio/logger": "workspace:*",
     "@wdio/types": "workspace:*",
     "@wdio/utils": "workspace:*",
-    "saucelabs": "8.0.0",
+    "saucelabs": "9.0.0",
     "webdriverio": "workspace:*"
   },
   "devDependencies": {

--- a/packages/wdio-sauce-service/src/constants.ts
+++ b/packages/wdio-sauce-service/src/constants.ts
@@ -3,3 +3,4 @@ import type { SauceServiceConfig } from './types.js'
 export const DEFAULT_OPTIONS: Partial<SauceServiceConfig> = {
     uploadLogs: true
 }
+export const DEFAULT_RUNNER_NAME = 'webdriverio'

--- a/packages/wdio-sauce-service/src/launcher.ts
+++ b/packages/wdio-sauce-service/src/launcher.ts
@@ -52,10 +52,16 @@ export default class SauceLauncher implements Services.ServiceInstance {
             this._options.sauceConnectOpts.tlsPassthroughDomains.split(',').forEach((domain) => tlsPassthroughDomains.add(domain))
         }
 
+        let metadata = this._options.sauceConnectOpts?.metadata || ''
+        if (!metadata.includes('runner=')) {
+            metadata += `runner=${DEFAULT_RUNNER_NAME}`
+        }
+
         const sauceConnectOpts: SauceConnectOptions = {
             tunnelName: sauceConnectTunnelName,
             ...this._options.sauceConnectOpts,
             tlsPassthroughDomains: Array.from(tlsPassthroughDomains).join(','),
+            metadata: metadata,
             logger: this._options.sauceConnectOpts?.logger || ((output) => log.debug(`Sauce Connect Log: ${output}`)),
             ...(!this._options.sauceConnectOpts?.logFile && this._config.outputDir
                 ? { logfile: path.join(this._config.outputDir, 'wdio-sauce-connect-tunnel.log') }

--- a/packages/wdio-sauce-service/src/launcher.ts
+++ b/packages/wdio-sauce-service/src/launcher.ts
@@ -11,6 +11,7 @@ import type { Services, Capabilities, Options } from '@wdio/types'
 
 import { makeCapabilityFactory, getLocalIpAddress } from './utils.js'
 import type { SauceServiceConfig } from './types.js'
+import { DEFAULT_RUNNER_NAME } from './constants.js'
 import path from 'node:path'
 
 const MAX_SC_START_TRIALS = 3
@@ -39,30 +40,29 @@ export default class SauceLauncher implements Services.ServiceInstance {
             return
         }
 
-        const sauceConnectTunnelIdentifier = (
-            this._options.sauceConnectOpts?.tunnelIdentifier ||
+        const sauceConnectTunnelName = (
+            this._options.sauceConnectOpts?.tunnelName ||
             /**
              * generate random identifier if not provided
              */
             `SC-tunnel-${Math.random().toString().slice(2)}`)
 
-        const noSslBumpDomains = new Set(['127.0.0.1', 'localhost', getLocalIpAddress()])
-        if (this._options.sauceConnectOpts?.noSslBumpDomains) {
-            this._options.sauceConnectOpts.noSslBumpDomains.split(',').forEach((domain) => noSslBumpDomains.add(domain))
+        const tlsPassthroughDomains = new Set(['127.0.0.1', 'localhost', getLocalIpAddress()])
+        if (this._options.sauceConnectOpts?.tlsPassthroughDomains) {
+            this._options.sauceConnectOpts.tlsPassthroughDomains.split(',').forEach((domain) => tlsPassthroughDomains.add(domain))
         }
 
         const sauceConnectOpts: SauceConnectOptions = {
-            noAutodetect: true,
-            tunnelIdentifier: sauceConnectTunnelIdentifier,
+            tunnelName: sauceConnectTunnelName,
             ...this._options.sauceConnectOpts,
-            noSslBumpDomains: Array.from(noSslBumpDomains).join(','),
+            tlsPassthroughDomains: Array.from(tlsPassthroughDomains).join(','),
             logger: this._options.sauceConnectOpts?.logger || ((output) => log.debug(`Sauce Connect Log: ${output}`)),
-            ...(!this._options.sauceConnectOpts?.logfile && this._config.outputDir
+            ...(!this._options.sauceConnectOpts?.logFile && this._config.outputDir
                 ? { logfile: path.join(this._config.outputDir, 'wdio-sauce-connect-tunnel.log') }
                 : {}
             )
         }
-        const prepareCapability = makeCapabilityFactory(sauceConnectTunnelIdentifier)
+        const prepareCapability = makeCapabilityFactory(sauceConnectTunnelName)
         if (Array.isArray(capabilities)) {
             for (const capability of capabilities) {
                 /**

--- a/packages/wdio-sauce-service/src/types.ts
+++ b/packages/wdio-sauce-service/src/types.ts
@@ -11,12 +11,12 @@ export interface SauceServiceConfig {
     /**
      * Specify tunnel identifier for Sauce Connect tunnel
      */
-    tunnelIdentifier?: string
+    tunnelName?: string
 
     /**
-     * Specify tunnel identifier for Sauce Connect parent tunnel
+     * Specify tunnel owner
      */
-    parentTunnel?: string
+    tunnelOwner?: string
 
     /**
      * If true it runs Sauce Connect and opens a secure connection between a Sauce Labs virtual
@@ -28,7 +28,7 @@ export interface SauceServiceConfig {
 
     /**
      * Apply Sauce Connect options (e.g. to change port number or logFile settings). See this
-     * list for more information: https://github.com/bermi/sauce-connect-launcher#advanced-usage
+     * list for more information: https://docs.saucelabs.com/dev/cli/sauce-connect-5/run/
      *
      * @default {}
      */
@@ -39,12 +39,6 @@ export interface SauceServiceConfig {
      * @default true
      */
     uploadLogs?: boolean
-
-    /**
-     * Use Sauce Connect as a Selenium Relay. See more [here](https://wiki.saucelabs.com/display/DOCS/Using+the+Selenium+Relay+with+Sauce+Connect+Proxy).
-     * @deprecated
-     */
-    scRelay?: boolean
 
     /**
      * Dynamically control the name of the job

--- a/packages/wdio-sauce-service/src/utils.ts
+++ b/packages/wdio-sauce-service/src/utils.ts
@@ -64,21 +64,18 @@ export function isEmuSim(caps: WebdriverIO.Capabilities) {
 }
 
 /** Ensure capabilities are in the correct format for Sauce Labs
- * @param {string} tunnelIdentifier - The default Sauce Connect tunnel identifier
+ * @param {string} tunnelName - The default Sauce Connect tunnel identifier
  * @param {object} options - Additional options to set on the capability
  * @returns {function(object): void} - A function that mutates a single capability
  */
-export function makeCapabilityFactory(tunnelIdentifier: string) {
+export function makeCapabilityFactory(tunnelName: string) {
     return (capability: WebdriverIO.Capabilities) => {
         // If the `sauce:options` are not provided and it is a W3C session then add it
         if (!capability['sauce:options']) {
             capability['sauce:options'] = {}
         }
 
-        capability['sauce:options'].tunnelIdentifier = (
-            capability['sauce:options'].tunnelIdentifier ||
-            tunnelIdentifier
-        )
+        capability['sauce:options'].tunnelName = (capability['sauce:options'].tunnelName || tunnelName)
     }
 }
 

--- a/packages/wdio-sauce-service/tests/launcher.test.ts
+++ b/packages/wdio-sauce-service/tests/launcher.test.ts
@@ -77,6 +77,20 @@ test('onPrepare only sets unique tlsPassthroughDomains values', async () => {
     }
 })
 
+test('onPrepare sets runner in metadata', async () => {
+    const options: SauceServiceConfig = {
+        sauceConnect: true,
+        sauceConnectOpts: {},
+    }
+    const caps = [{}] as WebdriverIO.Capabilities[]
+    const config = {} as Options.Testrunner
+    const service = new SauceServiceLauncher(options, caps as never, config)
+    const startTunnelMock = vi.fn()
+    service.startTunnel = startTunnelMock
+    await service.onPrepare(config, caps)
+    expect(startTunnelMock.mock.calls[0][0].metadata).toBe('runner=webdriverio')
+})
+
 test('onPrepare w/ SauceConnect w/o tunnelName w/ JWP', async () => {
     const options: SauceServiceConfig = {
         sauceConnect: true,

--- a/packages/wdio-sauce-service/tests/launcher.test.ts
+++ b/packages/wdio-sauce-service/tests/launcher.test.ts
@@ -28,12 +28,11 @@ vi.mock('saucelabs', () => ({
 
 const log = logger('')
 
-test('onPrepare w/ SauceConnect w/ tunnelIdentifier w/ JWP', async () => {
+test('onPrepare w/ SauceConnect w/ tunnelName w/ JWP', async () => {
     const options: SauceServiceConfig = {
         sauceConnect: true,
         sauceConnectOpts: {
-            sePort: 4446,
-            tunnelIdentifier: 'my-tunnel'
+            tunnelName: 'my-tunnel'
         }
     }
     const caps = [{}] as WebdriverIO.Capabilities[]
@@ -47,7 +46,7 @@ test('onPrepare w/ SauceConnect w/ tunnelIdentifier w/ JWP', async () => {
 
     expect(caps).toEqual([{
         'sauce:options': {
-            tunnelIdentifier: 'my-tunnel'
+            tunnelName: 'my-tunnel'
         }
     }])
 
@@ -58,12 +57,12 @@ test('onPrepare w/ SauceConnect w/ tunnelIdentifier w/ JWP', async () => {
     expect(service['_sauceConnectProcess']).not.toBeUndefined()
 })
 
-test('onPrepare only sets unique noSslBumpDomains values', async () => {
+test('onPrepare only sets unique tlsPassthroughDomains values', async () => {
     const options: SauceServiceConfig = {
         sauceConnect: true,
         sauceConnectOpts: {
-            noSslBumpDomains: 'foo,bar,127.0.0.1,bar'
-        }
+            tlsPassthroughDomains: 'foo,bar,127.0.0.1,bar'
+        },
     }
     const caps = [{}] as WebdriverIO.Capabilities[]
     const config = {} as Options.Testrunner
@@ -72,18 +71,16 @@ test('onPrepare only sets unique noSslBumpDomains values', async () => {
     service.startTunnel = startTunnelMock
     await service.onPrepare(config, caps)
     if (os.type() === 'Windows_NT') {
-        expect(startTunnelMock.mock.calls[0][0].noSslBumpDomains).toBe('127.0.0.1,localhost,::1,foo,bar')
+        expect(startTunnelMock.mock.calls[0][0].tlsPassthroughDomains).toBe('127.0.0.1,localhost,::1,foo,bar')
     } else {
-        expect(startTunnelMock.mock.calls[0][0].noSslBumpDomains).toBe('127.0.0.1,localhost,foo,bar')
+        expect(startTunnelMock.mock.calls[0][0].tlsPassthroughDomains).toBe('127.0.0.1,localhost,foo,bar')
     }
 })
 
-test('onPrepare w/ SauceConnect w/o tunnelIdentifier w/ JWP', async () => {
+test('onPrepare w/ SauceConnect w/o tunnelName w/ JWP', async () => {
     const options: SauceServiceConfig = {
         sauceConnect: true,
-        sauceConnectOpts: {
-            sePort: 4446,
-        }
+        sauceConnectOpts: {}
     }
     const caps = [{}] as WebdriverIO.Capabilities[]
     const config = {
@@ -94,7 +91,7 @@ test('onPrepare w/ SauceConnect w/o tunnelIdentifier w/ JWP', async () => {
     expect(service['_sauceConnectProcess']).toBeUndefined()
     await service.onPrepare(config, caps)
 
-    expect(caps[0]['sauce:options']?.tunnelIdentifier).toContain('SC-tunnel-')
+    expect(caps[0]['sauce:options']?.tunnelName).toContain('SC-tunnel-')
 
     // @ts-ignore mock feature
     expect(SauceLabs.default.instances).toHaveLength(1)
@@ -103,11 +100,11 @@ test('onPrepare w/ SauceConnect w/o tunnelIdentifier w/ JWP', async () => {
     expect(service['_sauceConnectProcess']).not.toBeUndefined()
 })
 
-test('onPrepare w/ SauceConnect w/ tunnelIdentifier w/ W3C', async () => {
+test('onPrepare w/ SauceConnect w/ tunnelName w/ W3C', async () => {
     const options: SauceServiceConfig = {
         sauceConnect: true,
         sauceConnectOpts: {
-            tunnelIdentifier: 'my-tunnel'
+            tunnelName: 'my-tunnel'
         }
     }
     const caps = [{ 'sauce:options': { extendedDebugging: false } }] as WebdriverIO.Capabilities[]
@@ -119,7 +116,7 @@ test('onPrepare w/ SauceConnect w/ tunnelIdentifier w/ W3C', async () => {
     expect(service['_sauceConnectProcess']).toBeUndefined()
     await service.onPrepare(config, caps)
 
-    expect(caps[0]['sauce:options']?.tunnelIdentifier).toContain('my-tunnel')
+    expect(caps[0]['sauce:options']?.tunnelName).toContain('my-tunnel')
     expect(service['_sauceConnectProcess']).not.toBeUndefined()
 
     // @ts-ignore mock feature
@@ -143,7 +140,7 @@ test('onPrepare w/ SauceConnect w/o identifier w/ W3C', async () => {
     expect(service['_sauceConnectProcess']).toBeUndefined()
     await service.onPrepare(config, caps)
 
-    expect(caps[0]['sauce:options']?.tunnelIdentifier).toContain('SC-tunnel-')
+    expect(caps[0]['sauce:options']?.tunnelName).toContain('SC-tunnel-')
     expect(service['_sauceConnectProcess']).not.toBeUndefined()
 
     // @ts-ignore mock feature
@@ -154,7 +151,7 @@ test('onPrepare w/ SauceConnect w/o identifier w/ W3C', async () => {
     expect(vi.mocked(log.info).mock.calls[2][0]).toContain('Sauce Connect successfully started after')
 })
 
-test('onPrepare w/ SauceConnect w/o scRelay', async () => {
+test('onPrepare w/ SauceConnect', async () => {
     const options: SauceServiceConfig = {
         sauceConnect: true
     }
@@ -171,30 +168,6 @@ test('onPrepare w/ SauceConnect w/o scRelay', async () => {
     expect(config.port).toBe(undefined)
     expect(config.protocol).toBe(undefined)
     expect(config.hostname).toBe(undefined)
-})
-
-test('onPrepare w/ SauceConnect w/ scRelay w/ default port', async () => {
-    const options: SauceServiceConfig = {
-        scRelay: true,
-        sauceConnect: true,
-        sauceConnectOpts: { tunnelIdentifier: 'test123' }
-    }
-    const caps = [{}] as WebdriverIO.Capabilities[]
-    const config = {} as Options.Testrunner
-    const service = new SauceServiceLauncher(options, caps as never, config)
-    expect(service['_sauceConnectProcess']).toBeUndefined()
-    await service.onPrepare(config, caps)
-
-    expect(service['_sauceConnectProcess']).not.toBeUndefined()
-    // @ts-ignore mock feature
-    expect(SauceLabs.default.instances).toHaveLength(1)
-    // @ts-ignore mock feature
-    expect(SauceLabs.default.instances[0].startSauceConnect).toBeCalledWith({
-        logger: expect.any(Function),
-        noAutodetect: true,
-        noSslBumpDomains: expect.any(String),
-        tunnelIdentifier: 'test123',
-    })
 })
 
 test('onPrepare w/ SauceConnect w/ region EU', async () => {
@@ -221,10 +194,8 @@ test('onPrepare w/ SauceConnect w/ region EU', async () => {
 test('onPrepare multiremote', async () => {
     const options: SauceServiceConfig = {
         sauceConnect: true,
-        scRelay: true,
         sauceConnectOpts: {
-            sePort: 4446,
-            tunnelIdentifier: 'my-tunnel'
+            tunnelName: 'my-tunnel'
         }
     }
     const caps: Capabilities.RequestedMultiremoteCapabilities = {
@@ -234,7 +205,7 @@ test('onPrepare multiremote', async () => {
         browserB: {
             capabilities: {
                 browserName: 'firefox',
-                'sauce:options': { tunnelIdentifier: 'fish' }
+                'sauce:options': { tunnelName: 'fish' }
             }
         }
     }
@@ -250,13 +221,13 @@ test('onPrepare multiremote', async () => {
         browserA: {
             capabilities: {
                 browserName: 'chrome',
-                'sauce:options': { tunnelIdentifier: 'my-tunnel' }
+                'sauce:options': { tunnelName: 'my-tunnel' }
             }
         },
         browserB: {
             capabilities: {
                 browserName: 'firefox',
-                'sauce:options': { tunnelIdentifier: 'fish' }
+                'sauce:options': { tunnelName: 'fish' }
             },
         }
     })
@@ -266,10 +237,8 @@ test('onPrepare multiremote', async () => {
 test('onPrepare parallel multiremote', async () => {
     const options: SauceServiceConfig = {
         sauceConnect: true,
-        scRelay: true,
         sauceConnectOpts: {
-            sePort: 4446,
-            tunnelIdentifier: 'my-tunnel'
+            tunnelName: 'my-tunnel'
         }
     }
     const caps: Capabilities.RequestedMultiremoteCapabilities[] = [{
@@ -279,7 +248,7 @@ test('onPrepare parallel multiremote', async () => {
         browserB: {
             capabilities: {
                 browserName: 'firefox',
-                'sauce:options': { tunnelIdentifier: 'fish' }
+                'sauce:options': { tunnelName: 'fish' }
             }
         }
     }, {
@@ -289,7 +258,7 @@ test('onPrepare parallel multiremote', async () => {
         browserD: {
             capabilities: {
                 browserName: 'firefox',
-                'sauce:options': { tunnelIdentifier: 'fish' }
+                'sauce:options': { tunnelName: 'fish' }
             }
         }
     }]
@@ -305,26 +274,26 @@ test('onPrepare parallel multiremote', async () => {
         browserA: {
             capabilities: {
                 browserName: 'chrome',
-                'sauce:options': { tunnelIdentifier: 'my-tunnel' }
+                'sauce:options': { tunnelName: 'my-tunnel' }
             }
         },
         browserB: {
             capabilities: {
                 browserName: 'firefox',
-                'sauce:options': { tunnelIdentifier: 'fish' }
+                'sauce:options': { tunnelName: 'fish' }
             },
         }
     }, {
         browserC: {
             capabilities: {
                 browserName: 'chrome',
-                'sauce:options': { tunnelIdentifier: 'my-tunnel' }
+                'sauce:options': { tunnelName: 'my-tunnel' }
             }
         },
         browserD: {
             capabilities: {
                 browserName: 'firefox',
-                'sauce:options': { tunnelIdentifier: 'fish' }
+                'sauce:options': { tunnelName: 'fish' }
             },
         }
     }])
@@ -334,8 +303,7 @@ test('onPrepare parallel multiremote', async () => {
 test('onPrepare if sauceTunnel is not set', async () => {
     const options: SauceServiceConfig = {
         sauceConnectOpts: {
-            sePort: 4446,
-            tunnelIdentifier: 'my-tunnel'
+            tunnelName: 'my-tunnel'
         }
     }
     const caps = [{}] as WebdriverIO.Capabilities[]
@@ -359,7 +327,7 @@ test('onPrepare multiremote with tunnel identifier and with w3c caps ', async ()
     const options: SauceServiceConfig = {
         sauceConnect: true,
         sauceConnectOpts: {
-            tunnelIdentifier: 'my-tunnel'
+            tunnelName: 'my-tunnel'
         }
     }
     const caps: Capabilities.RequestedMultiremoteCapabilities = {
@@ -376,7 +344,7 @@ test('onPrepare multiremote with tunnel identifier and with w3c caps ', async ()
                 browserName: 'firefox',
                 'sauce:options': {
                     commandTimeout: 600,
-                    tunnelIdentifier: 'fish'
+                    tunnelName: 'fish'
                 }
             }
         }
@@ -395,7 +363,7 @@ test('onPrepare multiremote with tunnel identifier and with w3c caps ', async ()
                 browserName: 'chrome',
                 'sauce:options': {
                     commandTimeout: 600,
-                    tunnelIdentifier: 'my-tunnel'
+                    tunnelName: 'my-tunnel'
                 }
             }
         },
@@ -404,7 +372,7 @@ test('onPrepare multiremote with tunnel identifier and with w3c caps ', async ()
                 browserName: 'firefox',
                 'sauce:options': {
                     commandTimeout: 600,
-                    tunnelIdentifier: 'fish'
+                    tunnelName: 'fish'
                 }
             }
         }
@@ -420,7 +388,7 @@ test('onPrepare without tunnel identifier and with w3c caps ', async () => {
         browserName: 'chrome',
         'sauce:options': {
             commandTimeout: 600,
-            tunnelIdentifier: 'fish'
+            tunnelName: 'fish'
         }
     }, {
         browserName: 'firefox',
@@ -440,7 +408,7 @@ test('onPrepare without tunnel identifier and with w3c caps ', async () => {
         browserName: 'chrome',
         'sauce:options': {
             commandTimeout: 600,
-            tunnelIdentifier: 'fish'
+            tunnelName: 'fish'
         }
     }, {
         browserName: 'firefox',
@@ -454,17 +422,15 @@ test('onPrepare without tunnel identifier and with w3c caps ', async () => {
 test('onPrepare with tunnel identifier and with w3c caps ', async () => {
     const options: SauceServiceConfig = {
         sauceConnect: true,
-        scRelay: true,
         sauceConnectOpts: {
-            sePort: 4446,
-            tunnelIdentifier: 'my-tunnel'
+            tunnelName: 'my-tunnel'
         }
     }
     const caps: WebdriverIO.Capabilities[] = [{
         browserName: 'chrome',
         'sauce:options': {
             commandTimeout: 600,
-            tunnelIdentifier: 'fish'
+            tunnelName: 'fish'
         }
     }, {
         browserName: 'firefox',
@@ -484,13 +450,13 @@ test('onPrepare with tunnel identifier and with w3c caps ', async () => {
         browserName: 'chrome',
         'sauce:options': {
             commandTimeout: 600,
-            tunnelIdentifier: 'fish'
+            tunnelName: 'fish'
         }
     }, {
         browserName: 'firefox',
         'sauce:options': {
             commandTimeout: 600,
-            tunnelIdentifier: 'my-tunnel'
+            tunnelName: 'my-tunnel'
         }
     }])
     expect(service['_sauceConnectProcess']).not.toBeUndefined()
@@ -500,7 +466,7 @@ test('startTunnel fail twice and recover', async ()=> {
     const options: SauceServiceConfig = {
         sauceConnect: true,
         sauceConnectOpts: {
-            tunnelIdentifier: 'my-tunnel'
+            tunnelName: 'my-tunnel'
         }
     }
     const service = new SauceServiceLauncher(options, undefined as never, {} as Options.Testrunner)
@@ -517,7 +483,7 @@ test('startTunnel fail three and throws error', async ()=> {
     const options: SauceServiceConfig = {
         sauceConnect: true,
         sauceConnectOpts: {
-            tunnelIdentifier: 'my-tunnel'
+            tunnelName: 'my-tunnel'
         }
     }
     const service = new SauceServiceLauncher(options, undefined as never, {} as Options.Testrunner)

--- a/packages/wdio-spec-reporter/tests/index.test.ts
+++ b/packages/wdio-spec-reporter/tests/index.test.ts
@@ -259,7 +259,7 @@ describe('SpecReporter', () => {
             it('should print link to Sauce Labs job details page if run with Sauce Connect (jsonwp)', () => {
                 const runner = getRunnerConfig({
                     capabilities: {
-                        tunnelIdentifier: 'foobar',
+                        tunnelName: 'foobar',
                         ...defaultCaps
                     },
                     sessionId: fakeSessionId

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1218,8 +1218,8 @@ importers:
         specifier: workspace:*
         version: link:../wdio-utils
       saucelabs:
-        specifier: 9.0.0
-        version: 9.0.0
+        specifier: ^9.0.1
+        version: 9.0.1
       webdriverio:
         specifier: workspace:*
         version: link:../webdriverio
@@ -12189,8 +12189,8 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
-  saucelabs@9.0.0:
-    resolution: {integrity: sha512-0IA4Z5Ewlc/SpLG8tvLnSRaiA5xPwova9kBfRM/GMuGUGOgEWo598135u4e0Ot5Vf7i/A8526GfCrx9K+zM8UA==}
+  saucelabs@9.0.1:
+    resolution: {integrity: sha512-RbYYNUxWRciKE5axU8q3paNy7gDFPnzY1Zk9nJHvrJmd8/bxW0LqhdBM0RYy4MVIxl+WWDOGmKY9ARn3vkmGBw==}
     hasBin: true
 
   sax@1.4.1:
@@ -27328,7 +27328,7 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  saucelabs@9.0.0:
+  saucelabs@9.0.1:
     dependencies:
       change-case: 4.1.2
       compressing: 1.10.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -320,7 +320,7 @@ importers:
         version: 3.4.17
       vite:
         specifier: ^5.1.3
-        version: 5.4.12(@types/node@22.10.10)(terser@5.37.0)
+        version: 5.4.12(@types/node@20.17.16)(terser@5.37.0)
       webdriver:
         specifier: workspace:*
         version: link:../packages/webdriver
@@ -437,10 +437,10 @@ importers:
         version: 10.0.10
       '@vitejs/plugin-vue':
         specifier: ^5.0.3
-        version: 5.2.1(vite@5.4.12(@types/node@22.10.10)(terser@5.37.0))(vue@3.5.13(typescript@5.7.3))
+        version: 5.2.1(vite@5.4.12(@types/node@20.17.16)(terser@5.37.0))(vue@3.5.13(typescript@5.7.3))
       expect-webdriverio:
         specifier: 5.0.5
-        version: 5.0.5(@wdio/globals@9.7.1(@wdio/logger@9.4.4)(puppeteer-core@23.11.1))(@wdio/logger@9.4.4)(webdriverio@9.7.1(puppeteer-core@23.11.1))
+        version: 5.0.5(@wdio/globals@9.7.2(@wdio/logger@9.4.4)(puppeteer-core@23.11.1))(@wdio/logger@9.4.4)(webdriverio@9.7.2(puppeteer-core@23.11.1))
       mocha:
         specifier: ^10.2.0
         version: 10.8.2
@@ -449,7 +449,7 @@ importers:
         version: 5.7.3
       vite:
         specifier: ^5.0.12
-        version: 5.4.12(@types/node@22.10.10)(terser@5.37.0)
+        version: 5.4.12(@types/node@20.17.16)(terser@5.37.0)
       vue-tsc:
         specifier: ^2.0.17
         version: 2.2.0(typescript@5.7.3)
@@ -617,13 +617,13 @@ importers:
         version: 0.5.21
       vite:
         specifier: ^5.4.10
-        version: 5.4.12(@types/node@22.10.10)(terser@5.37.0)
+        version: 5.4.12(@types/node@20.17.16)(terser@5.37.0)
       vite-plugin-istanbul:
         specifier: ^6.0.0
-        version: 6.0.2(vite@5.4.12(@types/node@22.10.10)(terser@5.37.0))
+        version: 6.0.2(vite@5.4.12(@types/node@20.17.16)(terser@5.37.0))
       vite-plugin-top-level-await:
         specifier: ^1.4.1
-        version: 1.4.4(rollup@4.31.0)(vite@5.4.12(@types/node@22.10.10)(terser@5.37.0))
+        version: 1.4.4(rollup@4.31.0)(vite@5.4.12(@types/node@20.17.16)(terser@5.37.0))
       webdriver:
         specifier: workspace:*
         version: link:../webdriver
@@ -939,7 +939,7 @@ importers:
     optionalDependencies:
       expect-webdriverio:
         specifier: ^5.0.1
-        version: 5.0.5(@wdio/globals@9.7.1(@wdio/logger@9.4.4)(puppeteer-core@23.11.1))(@wdio/logger@9.4.4)(webdriverio@packages+webdriverio)
+        version: 5.0.5(@wdio/globals@9.7.2(@wdio/logger@9.4.4)(puppeteer-core@23.11.1))(@wdio/logger@9.4.4)(webdriverio@packages+webdriverio)
       webdriverio:
         specifier: workspace:*
         version: link:../webdriverio
@@ -963,7 +963,7 @@ importers:
         version: link:../wdio-utils
       expect-webdriverio:
         specifier: ^5.0.1
-        version: 5.0.5(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@9.7.1(puppeteer-core@23.11.1))
+        version: 5.0.5(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@9.7.2(puppeteer-core@23.11.1))
       jasmine:
         specifier: ^5.0.0
         version: 5.5.0
@@ -1218,8 +1218,8 @@ importers:
         specifier: workspace:*
         version: link:../wdio-utils
       saucelabs:
-        specifier: 8.0.0
-        version: 8.0.0
+        specifier: 9.0.0
+        version: 9.0.0
       webdriverio:
         specifier: workspace:*
         version: link:../webdriverio
@@ -5866,8 +5866,8 @@ packages:
     resolution: {integrity: sha512-8h3SO925efnyIOkKnaNbLbMnJpmvm4wfUWoo26kq8ZPU7DSQsEWvJ7EZ4Hw8RGu+kY4VO7r54ljicnnrFVh/ZA==}
     engines: {node: '>=18.20.0'}
 
-  '@wdio/config@9.6.4':
-    resolution: {integrity: sha512-oTNXVVzaZ0qaM7oX8tyS3YBr4A3ij2py3Umew3ez0IS2vHpRs1LvLfVWoHRSqrhJIVnfjV3+zqcl9BWALNVD/g==}
+  '@wdio/config@9.7.2':
+    resolution: {integrity: sha512-8C4X1gizLLjYJAbrxVOwbudkXNZYD033RPEQAHG4T6CqiqGCMB7Tb3mYUnbHuvjAHj7oJ8FTECkT1a90ZhLMgw==}
     engines: {node: '>=18.20.0'}
 
   '@wdio/eslint@0.0.5':
@@ -5877,8 +5877,8 @@ packages:
     resolution: {integrity: sha512-IyjiS6jtCMCbDedLZNUUaI9IpGAxkItfVKlGUgQ2kNcjOYUyKf/g8MEE0m8lR50yEEVENJ4rEn9IQ+foeFIZjQ==}
     engines: {node: '>=18.20.0'}
 
-  '@wdio/globals@9.7.1':
-    resolution: {integrity: sha512-o3Zaiyi/amH3VF+D2+lB+UXcaksWx44SIIVZjkgYgHsKAnmrv04JfkneQo+x05J/vNc+BM6jwTgTAtmkfF/t5w==}
+  '@wdio/globals@9.7.2':
+    resolution: {integrity: sha512-fn8wwCsMTOID6mZ8ZtNYrdY+/30n6XQ8VVFU1OkrSCyEJ0pin/tIORMIx+ZWTiufzTdWtsHjoXlE+4Zv10G3KA==}
     engines: {node: '>=18.20.0'}
 
   '@wdio/logger@9.1.3':
@@ -5915,8 +5915,8 @@ packages:
     resolution: {integrity: sha512-HIA9bzqADRsTmXZDbVAX3jI0vzFXI9RJ6a92emrkANVG27etEL0KEGXDgoTbdwn7lFLkvY6xp7vY3VR1+Dux0w==}
     engines: {node: '>=18.20.0'}
 
-  '@wdio/utils@9.6.4':
-    resolution: {integrity: sha512-FMI/F5ju0h0HKC4RRQKW/H9So2cgtK6dd0JCmVdBzQ+/LMluEzlZmQva14HYmNd2t2ZmejYRqAJPV3aAsMAMZA==}
+  '@wdio/utils@9.7.2':
+    resolution: {integrity: sha512-DlUY5Gn5wE3Iurlh+LdtzpzNRPIKCAU286NxaxtWjsqD6QSXXALMj5S95k9JDvw6iCXA4XrQa9T5/GBuIuyO2A==}
     engines: {node: '>=18.20.0'}
 
   '@webassemblyjs/ast@1.14.1':
@@ -8814,9 +8814,6 @@ packages:
 
   htmlfy@0.3.2:
     resolution: {integrity: sha512-FsxzfpeDYRqn1emox9VpxMPfGjADoUmmup8D604q497R0VNxiXs4ZZTN2QzkaMA5C9aHGUoe1iQRVSm+HK9xuA==}
-
-  htmlfy@0.5.1:
-    resolution: {integrity: sha512-nb66M9g0zKrvmR3kk/WOM+5tOT3DzO1yJ4yEJXsz2zfZ3gXiCTrlGvbc4lQzTZyylJj7at+XSVDxFvAVH6J6tQ==}
 
   htmlfy@0.6.0:
     resolution: {integrity: sha512-EV1RNjYuG6xIxwA8zDjAUQVeS/SsPE0nhFsdjM8ALopS22ZRAcePocdrhKaaV26PYiTkUrKplJuSZkGRN6Y0Rg==}
@@ -12217,8 +12214,8 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
-  saucelabs@8.0.0:
-    resolution: {integrity: sha512-Rj9m4OCniYk+c4MFuZGqvz64RPX6oRzMqt0bTr9T27IXGnA7Ic7Ms/VHgPtRcJFP6H3sQ169WOzazPZcW4BIAg==}
+  saucelabs@9.0.0:
+    resolution: {integrity: sha512-0IA4Z5Ewlc/SpLG8tvLnSRaiA5xPwova9kBfRM/GMuGUGOgEWo598135u4e0Ot5Vf7i/A8526GfCrx9K+zM8UA==}
     hasBin: true
 
   sax@1.4.1:
@@ -13606,8 +13603,8 @@ packages:
     resolution: {integrity: sha512-aZrJq+FwJFrrSX18PHqFK3iEw+Pdu/cvJwgIiuur4/ffP47jrirwCqabCVaIV3eut+mJBc1nY7IV3Jd3i4MekQ==}
     engines: {node: '>=18.20.0'}
 
-  webdriver@9.7.0:
-    resolution: {integrity: sha512-O/Ce4I7HcsqlP3kx9L0F14olOsarKkXUz+hSunOTC9YxsiVoOu5yIcRrHyWUQziYgA4K5gobZSKrTuAr+edA4Q==}
+  webdriver@9.7.2:
+    resolution: {integrity: sha512-FcPokssrgzwCHL0sQRiiX8H6he30q+W/jy1TvzcUdbQRgpTqnxUPT+hopd6xVhuZecUeHo/KSVXZ1hhcwwJKmQ==}
     engines: {node: '>=18.20.0'}
 
   webdriverio@9.4.3:
@@ -13619,8 +13616,8 @@ packages:
       puppeteer-core:
         optional: true
 
-  webdriverio@9.7.1:
-    resolution: {integrity: sha512-P1roVTpXwtzSgNKl9j92LF4+5i2eGd0n9EMvMRdLNnI0v1ws7dNJOHNgsEAepZqMikYPgh2m+5DyXR1Ygoa+nQ==}
+  webdriverio@9.7.2:
+    resolution: {integrity: sha512-zpGCn+pb63w9ZltCzIeGfEUSLLFwEsr0N4R25BdDFlBPQ5467VugPdSw/hWGTwgx7BzeKSdUgbKHqZMxb77nbQ==}
     engines: {node: '>=18.20.0'}
     peerDependencies:
       puppeteer-core: ^22.3.0
@@ -18873,7 +18870,7 @@ snapshots:
     dependencies:
       '@types/http-cache-semantics': 4.0.4
       '@types/keyv': 3.1.4
-      '@types/node': 22.10.10
+      '@types/node': 20.17.16
       '@types/responselike': 1.0.3
 
   '@types/cheerio@0.22.35':
@@ -19014,7 +19011,7 @@ snapshots:
 
   '@types/keyv@3.1.4':
     dependencies:
-      '@types/node': 22.10.10
+      '@types/node': 20.17.16
 
   '@types/lodash.clonedeep@4.5.9':
     dependencies:
@@ -19137,7 +19134,7 @@ snapshots:
 
   '@types/responselike@1.0.3':
     dependencies:
-      '@types/node': 22.10.10
+      '@types/node': 20.17.16
 
   '@types/retry@0.12.0': {}
 
@@ -19321,9 +19318,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue@5.2.1(vite@5.4.12(@types/node@22.10.10)(terser@5.37.0))(vue@3.5.13(typescript@5.7.3))':
+  '@vitejs/plugin-vue@5.2.1(vite@5.4.12(@types/node@20.17.16)(terser@5.37.0))(vue@3.5.13(typescript@5.7.3))':
     dependencies:
-      vite: 5.4.12(@types/node@22.10.10)(terser@5.37.0)
+      vite: 5.4.12(@types/node@20.17.16)(terser@5.37.0)
       vue: 3.5.13(typescript@5.7.3)
 
   '@vitejs/plugin-vue@5.2.1(vite@5.4.14(@types/node@20.17.16)(terser@5.37.0))(vue@3.5.13(typescript@5.7.3))':
@@ -19521,11 +19518,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@wdio/config@9.6.4':
+  '@wdio/config@9.7.2':
     dependencies:
       '@wdio/logger': 9.4.4
       '@wdio/types': 9.6.3
-      '@wdio/utils': 9.6.4
+      '@wdio/utils': 9.7.2
       deepmerge-ts: 7.1.4
       glob: 10.4.5
       import-meta-resolve: 4.1.0
@@ -19559,10 +19556,10 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@wdio/globals@9.7.1(@wdio/logger@9.4.4)(puppeteer-core@23.11.1)':
+  '@wdio/globals@9.7.2(@wdio/logger@9.4.4)(puppeteer-core@23.11.1)':
     optionalDependencies:
-      expect-webdriverio: 5.0.5(@wdio/globals@9.7.1(@wdio/logger@9.4.4)(puppeteer-core@23.11.1))(@wdio/logger@9.4.4)(webdriverio@9.7.1(puppeteer-core@23.11.1))
-      webdriverio: 9.7.1(puppeteer-core@23.11.1)
+      expect-webdriverio: 5.0.5(@wdio/globals@9.7.2(@wdio/logger@9.4.4)(puppeteer-core@23.11.1))(@wdio/logger@9.4.4)(webdriverio@9.7.2(puppeteer-core@23.11.1))
+      webdriverio: 9.7.2(puppeteer-core@23.11.1)
     transitivePeerDependencies:
       - '@wdio/logger'
       - bare-buffer
@@ -19623,7 +19620,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@wdio/utils@9.6.4':
+  '@wdio/utils@9.7.2':
     dependencies:
       '@puppeteer/browsers': 2.7.0
       '@wdio/logger': 9.4.4
@@ -22225,20 +22222,20 @@ snapshots:
       webdriverio: 9.4.3(puppeteer-core@23.11.1)
     optional: true
 
-  expect-webdriverio@5.0.5(@wdio/globals@9.7.1(@wdio/logger@9.4.4)(puppeteer-core@23.11.1))(@wdio/logger@9.4.4)(webdriverio@9.7.1(puppeteer-core@23.11.1)):
+  expect-webdriverio@5.0.5(@wdio/globals@9.7.2(@wdio/logger@9.4.4)(puppeteer-core@23.11.1))(@wdio/logger@9.4.4)(webdriverio@9.7.2(puppeteer-core@23.11.1)):
     dependencies:
       '@vitest/snapshot': 2.1.8
-      '@wdio/globals': 9.7.1(@wdio/logger@9.4.4)(puppeteer-core@23.11.1)
+      '@wdio/globals': 9.7.2(@wdio/logger@9.4.4)(puppeteer-core@23.11.1)
       '@wdio/logger': 9.4.4
       expect: 29.7.0
       jest-matcher-utils: 29.7.0
       lodash.isequal: 4.5.0
-      webdriverio: 9.7.1(puppeteer-core@23.11.1)
+      webdriverio: 9.7.2(puppeteer-core@23.11.1)
 
-  expect-webdriverio@5.0.5(@wdio/globals@9.7.1(@wdio/logger@9.4.4)(puppeteer-core@23.11.1))(@wdio/logger@9.4.4)(webdriverio@packages+webdriverio):
+  expect-webdriverio@5.0.5(@wdio/globals@9.7.2(@wdio/logger@9.4.4)(puppeteer-core@23.11.1))(@wdio/logger@9.4.4)(webdriverio@packages+webdriverio):
     dependencies:
       '@vitest/snapshot': 2.1.8
-      '@wdio/globals': 9.7.1(@wdio/logger@9.4.4)(puppeteer-core@23.11.1)
+      '@wdio/globals': 9.7.2(@wdio/logger@9.4.4)(puppeteer-core@23.11.1)
       '@wdio/logger': 9.4.4
       expect: 29.7.0
       jest-matcher-utils: 29.7.0
@@ -22256,7 +22253,7 @@ snapshots:
       lodash.isequal: 4.5.0
       webdriverio: link:packages/webdriverio
 
-  expect-webdriverio@5.0.5(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@9.7.1(puppeteer-core@23.11.1)):
+  expect-webdriverio@5.0.5(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@9.7.2(puppeteer-core@23.11.1)):
     dependencies:
       '@vitest/snapshot': 2.1.8
       '@wdio/globals': link:packages/wdio-globals
@@ -22264,7 +22261,7 @@ snapshots:
       expect: 29.7.0
       jest-matcher-utils: 29.7.0
       lodash.isequal: 4.5.0
-      webdriverio: 9.7.1(puppeteer-core@23.11.1)
+      webdriverio: 9.7.2(puppeteer-core@23.11.1)
 
   expect-webdriverio@5.0.5(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@packages+webdriverio):
     dependencies:
@@ -23218,8 +23215,6 @@ snapshots:
       webpack: 5.97.1(@swc/core@1.10.1)
 
   htmlfy@0.3.2: {}
-
-  htmlfy@0.5.1: {}
 
   htmlfy@0.6.0: {}
 
@@ -27393,7 +27388,7 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  saucelabs@8.0.0:
+  saucelabs@9.0.0:
     dependencies:
       change-case: 4.1.2
       compressing: 1.10.1
@@ -28811,7 +28806,7 @@ snapshots:
       - supports-color
       - terser
 
-  vite-plugin-istanbul@6.0.2(vite@5.4.12(@types/node@22.10.10)(terser@5.37.0)):
+  vite-plugin-istanbul@6.0.2(vite@5.4.12(@types/node@20.17.16)(terser@5.37.0)):
     dependencies:
       '@istanbuljs/load-nyc-config': 1.1.0
       espree: 10.3.0
@@ -28819,16 +28814,16 @@ snapshots:
       picocolors: 1.1.1
       source-map: 0.7.4
       test-exclude: 6.0.0
-      vite: 5.4.12(@types/node@22.10.10)(terser@5.37.0)
+      vite: 5.4.12(@types/node@20.17.16)(terser@5.37.0)
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-top-level-await@1.4.4(rollup@4.31.0)(vite@5.4.12(@types/node@22.10.10)(terser@5.37.0)):
+  vite-plugin-top-level-await@1.4.4(rollup@4.31.0)(vite@5.4.12(@types/node@20.17.16)(terser@5.37.0)):
     dependencies:
       '@rollup/plugin-virtual': 3.0.2(rollup@4.31.0)
       '@swc/core': 1.10.1
       uuid: 10.0.0
-      vite: 5.4.12(@types/node@22.10.10)(terser@5.37.0)
+      vite: 5.4.12(@types/node@20.17.16)(terser@5.37.0)
     transitivePeerDependencies:
       - '@swc/helpers'
       - rollup
@@ -28841,13 +28836,13 @@ snapshots:
       source-map: 0.7.4
       stack-trace: 1.0.0-pre2
 
-  vite@5.4.12(@types/node@22.10.10)(terser@5.37.0):
+  vite@5.4.12(@types/node@20.17.16)(terser@5.37.0):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.1
       rollup: 4.31.0
     optionalDependencies:
-      '@types/node': 22.10.10
+      '@types/node': 20.17.16
       fsevents: 2.3.3
       terser: 5.37.0
 
@@ -28973,15 +28968,15 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  webdriver@9.7.0:
+  webdriver@9.7.2:
     dependencies:
       '@types/node': 20.17.16
       '@types/ws': 8.5.14
-      '@wdio/config': 9.6.4
+      '@wdio/config': 9.7.2
       '@wdio/logger': 9.4.4
       '@wdio/protocols': 9.7.0
       '@wdio/types': 9.6.3
-      '@wdio/utils': 9.6.4
+      '@wdio/utils': 9.7.2
       deepmerge-ts: 7.1.4
       undici: 6.21.1
       ws: 8.18.0
@@ -29027,23 +29022,23 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  webdriverio@9.7.1(puppeteer-core@23.11.1):
+  webdriverio@9.7.2(puppeteer-core@23.11.1):
     dependencies:
       '@types/node': 20.17.16
       '@types/sinonjs__fake-timers': 8.1.5
-      '@wdio/config': 9.6.4
+      '@wdio/config': 9.7.2
       '@wdio/logger': 9.4.4
       '@wdio/protocols': 9.7.0
       '@wdio/repl': 9.4.4
       '@wdio/types': 9.6.3
-      '@wdio/utils': 9.6.4
+      '@wdio/utils': 9.7.2
       archiver: 7.0.1
       aria-query: 5.3.2
       cheerio: 1.0.0
       css-shorthand-properties: 1.1.2
       css-value: 0.0.1
       grapheme-splitter: 1.0.4
-      htmlfy: 0.5.1
+      htmlfy: 0.6.0
       import-meta-resolve: 4.1.0
       is-plain-obj: 4.1.0
       jszip: 3.10.1
@@ -29055,7 +29050,7 @@ snapshots:
       rgb2hex: 0.2.5
       serialize-error: 11.0.3
       urlpattern-polyfill: 10.0.0
-      webdriver: 9.7.0
+      webdriver: 9.7.2
     optionalDependencies:
       puppeteer-core: 23.11.1
     transitivePeerDependencies:

--- a/tests/typings/webdriverio/config.ts
+++ b/tests/typings/webdriverio/config.ts
@@ -48,8 +48,7 @@ const config: WebdriverIO.Config = {
             sauceConnectOpts: {
                 directDomains: 'some.domain'
             },
-            scRelay: true,
-            parentTunnel: 123
+            tunnelOwner: 123
         }],
         // @ts-expect-error test wrong parameter
         ['appium', {


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

Sauce Connect 4 is being deprecated and will reach its end-of-life (EOL) on May 5, 2025. This pull request introduces support for Sauce Connect 5, while dropping support for Sauce Connect 4.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
