### PR TITLE
Copy capability before onWorkerStart is called

### DIFF
--- a/packages/wdio-cli/src/launcher.ts
+++ b/packages/wdio-cli/src/launcher.ts
@@ -513,11 +513,14 @@ class Launcher {
         // bump up worker count
         this._runnerStarted++
 
+        // Prepare to pass different capability objects for each worker
+        const workerCaps = structuredClone(caps)
+
         // run worker hook to allow modify runtime and capabilities of a specific worker
         log.info('Run onWorkerStart hook')
-        await runLauncherHook(config.onWorkerStart, runnerId, caps, specs, this._args, execArgv)
+        await runLauncherHook(config.onWorkerStart, runnerId, workerCaps, specs, this._args, execArgv)
             .catch((error) => this._workerHookError(error))
-        await runServiceHook(this._launcher!, 'onWorkerStart', runnerId, caps, specs, this._args, execArgv)
+        await runServiceHook(this._launcher!, 'onWorkerStart', runnerId, workerCaps, specs, this._args, execArgv)
             .catch((error) => this._workerHookError(error))
 
         // prefer launcher settings in capabilities over general launcher
@@ -534,7 +537,7 @@ class Launcher {
                 user: config.user,
                 key: config.key
             },
-            caps,
+            caps: workerCaps,
             specs,
             execArgv,
             retries


### PR DESCRIPTION
## Proposed changes
This change allows `onWorkerStart` to be used to set different configuration of capability for each worker.
It is naturally possible to reflect the same configuration of capability for all workers, so we do not expect the current behavior to change.

Closes: #14131

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [X] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [X] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments
[`structuredClone`](https://nodejs.org/docs/v20.11.1/api/globals.html#structuredclonevalue-options) is used at this PR. This means that Node version v17 or higher is required (v17 is ended maintenance).

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
