### PR TITLE
[WDIO8] fixed empty process.execArgv

### DIFF
--- a/packages/wdio-cli/src/launcher.ts
+++ b/packages/wdio-cli/src/launcher.ts
@@ -411,8 +411,8 @@ class Launcher {
         let debugType
         let debugHost = ''
         const debugPort = process.debugPort
-        for (const i in process.execArgv) {
-            const debugArgs = process.execArgv[i].match('--(debug|inspect)(?:-brk)?(?:=(.*):)?')
+        for (const arg of process.execArgv) {
+            const debugArgs = arg.match('--(debug|inspect)(?:-brk)?(?:=(.*):)?')
             if (debugArgs) {
                 const [, type, host] = debugArgs
                 if (type) {


### PR DESCRIPTION
## Proposed changes

WDIO8

I've run into issue when accidentally, i don't know why there is no actions with the option, to array process.execArgv was assigned property 'forEachAsync' like [].forEachAsync that's why the loop is failed in process.execArgv[i] as 'for in' is iterating as with array' item as with array' properties

```
for (const i in process.execArgv) {
   const debugArgs = process.execArgv[i].match('--(debug|inspect)(?:-brk)?(?:=(.*):)?')
}
```

i've changed it to
```
for (const arg of process.execArgv) {
   const debugArgs = arg.match('--(debug|inspect)(?:-brk)?(?:=(.*):)?')
}
```





