### PR TITLE
[WDIO8] added supressing for runner's deleteSession

### DIFF
--- a/packages/wdio-runner/src/index.ts
+++ b/packages/wdio-runner/src/index.ts
@@ -516,7 +516,16 @@ export default class Runner extends EventEmitter {
             })
         }
 
-        await this._browser?.deleteSession()
+        try {
+            await this._browser?.deleteSession()
+        } catch (err: any) {
+            /**
+             * ignoring all exceptions that could be caused by browser.deleteSession()
+             * there maybe times where session is ended remotely, browser.deleteSession() will fail in this case)
+             * this can be worked around in code but requires a lot of overhead
+             */
+            log.warn(`Suppressing error closing the session: ${err.message}`)
+        }
         process.send!(<SessionEndedMessage>{
             origin: 'worker',
             name: 'sessionEnded',

--- a/packages/webdriverio/src/commands/browser/reloadSession.ts
+++ b/packages/webdriverio/src/commands/browser/reloadSession.ts
@@ -72,7 +72,7 @@ export async function reloadSession (this: WebdriverIO.Browser, newCapabilities?
          * there maybe times where session is ended remotely, browser.deleteSession() will fail in this case)
          * this can be worked around in code but requires a lot of overhead
          */
-        log.warn(`Suppressing error closing the session: ${err.stack}`)
+        log.warn(`Suppressing error closing the session: ${err.message}`)
     }
 
     if (this.puppeteer?.isConnected()) {


### PR DESCRIPTION
## Proposed changes

Until runner close worker, there is attempt to delete session in the end of worker's execution but if the session has been closed already for some reason whole execution is failed even though all tests are passed. I'd suggest to suppress delete session error as it's just finalizing step and don't relate to tests results

I'd suggest to change err.stack to err.message cause err.stack is redundant, there are lots of reference to internal libs no sure how it's helpful but looking like something important happened
