### PR TITLE
fix: 14084 - displayed method broken after context switching

### DIFF
--- a/packages/webdriverio/src/commands/element/isDisplayed.ts
+++ b/packages/webdriverio/src/commands/element/isDisplayed.ts
@@ -110,8 +110,7 @@ export async function isDisplayed (
      * For mobile sessions with Appium we continue to use the elementDisplayed command
      * as we can't run JS in native apps
      */
-    const isNativeApplication = !(browser.capabilities as WebdriverIO.Capabilities).browserName
-    if (browser.isMobile && isNativeApplication) {
+    if (browser.isMobile && browser.isNativeContext) {
         /**
          * there is no support yet for checking if an element is displayed within the
          * viewport for native apps. We can only check if it's displayed at all.

--- a/packages/webdriverio/tests/commands/element/isDisplayed.test.ts
+++ b/packages/webdriverio/tests/commands/element/isDisplayed.test.ts
@@ -94,7 +94,8 @@ describe('isDisplayed test', () => {
             capabilities: {
                 // @ts-ignore mock feature
                 keepBrowserName: true,
-                mobileMode: true
+                mobileMode: true,
+                nativeAppMode: true,
             } as any
         })
         elem = await browser.$('#foo')
@@ -113,7 +114,8 @@ describe('isDisplayed test', () => {
             capabilities: {
                 // @ts-ignore mock feature
                 keepBrowserName: true,
-                mobileMode: true
+                mobileMode: true,
+                nativeAppMode: true,
             } as any
         })
         elem = await browser.$('#foo')


### PR DESCRIPTION
## Proposed changes

Determining the native conext mode was only done based on the capabilities when the session started. When the context was changed the value was not determined again. This PR fixes this by replacing the native check with the dynamic `browser.isNativeContext`-mode which is updated on context change

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
