### PR TITLE
fix(cli): properly find ts as default config file

### DIFF
--- a/packages/wdio-cli/src/commands/config.ts
+++ b/packages/wdio-cli/src/commands/config.ts
@@ -214,7 +214,6 @@ export async function canAccessConfigPath(configPath: string) {
  * @param {Function} runConfigCmd   runConfig method to be replaceable for unit testing
  */
 export async function missingConfigurationPrompt(command: string, configPath: string, runConfigCmd = runConfigCommand) {
-
     const message = (
         `Could not execute "${command}" due to missing configuration, file ` +
         `"${path.parse(configPath).name}[.js/.ts]" not found! ` +
@@ -236,9 +235,13 @@ export async function missingConfigurationPrompt(command: string, configPath: st
         console.log(`No WebdriverIO configuration found in "${process.cwd()}"`)
 
         /* istanbul ignore next */
-        return !process.env.WDIO_UNIT_TESTS && process.exit(0)
+        if (!process.env.WDIO_UNIT_TESTS) {
+            process.exit(0)
+        }
+        return configPath
     }
 
     const parsedAnswers = await parseAnswers(false)
     await runConfigCmd(parsedAnswers, 'latest')
+    return configPath
 }

--- a/packages/wdio-cli/src/commands/run.ts
+++ b/packages/wdio-cli/src/commands/run.ts
@@ -180,6 +180,11 @@ export async function handler(argv: RunCommandArguments) {
     if (!confAccess) {
         try {
             await missingConfigurationPrompt('run', wdioConf.fullPathNoExtension)
+            if (process.env.WDIO_UNIT_TESTS) {
+                return
+            }
+
+            return handler(argv)
         } catch {
             process.exit(1)
         }
@@ -196,7 +201,7 @@ export async function handler(argv: RunCommandArguments) {
         process.env.TSX_TSCONFIG_PATH && path.resolve(process.cwd(), process.env.TSX_TSCONFIG_PATH)
     )
     const tsConfigPathFromParams = params.tsConfigPath && path.resolve(process.cwd(), params.tsConfigPath)
-    const tsConfigPathRelativeToWdioConfig = path.join(path.dirname(wdioConf.fullPath), 'tsconfig.json')
+    const tsConfigPathRelativeToWdioConfig = path.join(path.dirname(confAccess), 'tsconfig.json')
     const localTSConfigPath = (
         tsConfigPathFromEnvVar ||
         tsConfigPathFromParams ||
@@ -211,7 +216,7 @@ export async function handler(argv: RunCommandArguments) {
      * if `--watch` param is set, run launcher in watch mode
      */
     if (params.watch) {
-        const watcher = new Watcher(wdioConf.fullPath, params)
+        const watcher = new Watcher(confAccess, params)
         return watcher.watch()
     }
 
@@ -223,12 +228,12 @@ export async function handler(argv: RunCommandArguments) {
      * stdin.isTTY is false when command is from nodes spawn since it's treated as a pipe
      */
     if (process.stdin.isTTY || !process.stdout.isTTY) {
-        return launch(wdioConf.fullPath, params)
+        return launch(confAccess, params)
     }
 
     /*
      * get a list of spec files to run from stdin, overriding any other
      * configuration suite or specs.
      */
-    launchWithStdin(wdioConf.fullPath, params)
+    launchWithStdin(confAccess, params)
 }

--- a/packages/wdio-cli/tests/commands/run.test.ts
+++ b/packages/wdio-cli/tests/commands/run.test.ts
@@ -65,6 +65,12 @@ describe('Command: run', () => {
             .toContain('sample.conf')
     })
 
+    it('should check for js and ts default config files', async () => {
+        vi.mocked(fs.access).mockRejectedValueOnce('not found')
+        const result = await runCmd.handler({ configPath: 'sample.conf.js' } as any)
+        expect(result).toContain('sample.conf.ts')
+    })
+
     it('should use local conf if nothing defined', async () => {
         const launcher = await runCmd.handler({ argv: {} } as any)
         expect(launcher).toContain('wdio.conf.js')


### PR DESCRIPTION
## Proposed changes

fixes #14178

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
