### PR TITLE
fix(webdriverio): wait for option to become available before clicking

### DIFF
--- a/e2e/wdio/headless/test.e2e.ts
+++ b/e2e/wdio/headless/test.e2e.ts
@@ -699,4 +699,22 @@ describe('main suite 1', () => {
             })
         }
     })
+
+    describe('selectByVisibleText', () => {
+        it('should wait for the option to be present', async () => {
+            const newOption = 'Option 2'
+            await browser.url('https://guinea-pig.webdriver.io/two.html')
+
+            await browser.execute(() => {
+                const select = document.createElement('select')
+                select.innerHTML = '<option>Option 1</option>'
+                document.body.insertAdjacentElement('beforeend', select)
+                setTimeout(() => select.innerHTML += `<option>${newOption}</option>`, 4000)
+            })
+
+            const $select = browser.$('select')
+            await $select.selectByVisibleText(newOption)
+            await expect($select).toHaveValue(newOption)
+        })
+    })
 })

--- a/e2e/wdio/headless/test.e2e.ts
+++ b/e2e/wdio/headless/test.e2e.ts
@@ -700,21 +700,30 @@ describe('main suite 1', () => {
         }
     })
 
-    describe('selectByVisibleText', () => {
-        it('should wait for the option to be present', async () => {
-            const newOption = 'Option 2'
-            await browser.url('https://guinea-pig.webdriver.io/two.html')
+    describe.only('selectBy*', () => {
+        const scenarios = [
+            ['selectByVisibleText', ['Option 2']],
+            ['selectByIndex', [1]],
+            ['selectByAttribute', ['value', 'someValue1']]
+        ] as const
 
-            await browser.execute(() => {
-                const select = document.createElement('select')
-                select.innerHTML = '<option>Option 1</option>'
-                document.body.insertAdjacentElement('beforeend', select)
-                setTimeout(() => select.innerHTML += `<option>${newOption}</option>`, 4000)
+        for (const [command, args] of scenarios) {
+            it(`${command}: should wait for the option to be present`, async () => {
+                const newOption = 'Option 2'
+                await browser.url('https://guinea-pig.webdriver.io/two.html')
+
+                await browser.execute((newOption) => {
+                    const select = document.createElement('select')
+                    select.innerHTML = '<option value="someValue0">Option 1</option>'
+                    document.body.insertAdjacentElement('beforeend', select)
+                    setTimeout(() => select.innerHTML += `<option value="someValue1">${newOption}</option>`, 2000)
+                }, newOption)
+
+                const $select = browser.$('select')
+                // @ts-expect-error
+                await $select[command](...args)
+                await expect($select).toHaveValue('someValue1')
             })
-
-            const $select = browser.$('select')
-            await $select.selectByVisibleText(newOption)
-            await expect($select).toHaveValue(newOption)
-        })
+        }
     })
 })

--- a/packages/webdriverio/src/commands/element/selectByAttribute.ts
+++ b/packages/webdriverio/src/commands/element/selectByAttribute.ts
@@ -1,3 +1,6 @@
+import { ELEMENT_KEY } from 'webdriver'
+import type { ElementReference } from '@wdio/protocols'
+
 import { getElementFromResponse } from '../../utils/index.js'
 
 /**
@@ -51,15 +54,17 @@ export async function selectByAttribute (
     * find option elememnt using xpath
     */
     const normalized = `[normalize-space(@${attribute.trim()}) = "${value.trim()}"]`
-    const optionElement = await this.findElementFromElement(
-        this.elementId,
-        'xpath',
-        `./option${normalized}|./optgroup/option${normalized}`
-    )
-
-    if (optionElement && (optionElement as unknown as { error: string }).error === 'no such element') {
-        throw new Error(`Option with attribute "${attribute}=${value}" not found.`)
-    }
+    let optionElement: ElementReference | undefined
+    await this.waitUntil(async () => {
+        optionElement = await this.findElementFromElement(
+            this.elementId,
+            'xpath',
+            `./option${normalized}|./optgroup/option${normalized}`
+        )
+        return ELEMENT_KEY in optionElement
+    }, {
+        timeoutMsg: `Option with attribute "${attribute}=${value}" not found.`
+    })
 
     /**
     * select option

--- a/packages/webdriverio/src/commands/element/selectByIndex.ts
+++ b/packages/webdriverio/src/commands/element/selectByIndex.ts
@@ -1,3 +1,4 @@
+import type { ElementReference } from '@wdio/protocols'
 import { getElementFromResponse } from '../../utils/index.js'
 
 /**
@@ -40,18 +41,27 @@ export async function selectByIndex (
         throw new Error('Index needs to be 0 or any other positive number')
     }
 
+    const fetchOptionElements = async () => {
+        return this.findElementsFromElement(this.elementId, 'css selector',  'option')
+    }
+
     /**
     * get option elememnts using css
     */
-    const optionElements = await this.findElementsFromElement(this.elementId, 'css selector',  'option')
+    let optionElements: ElementReference[] = []
+    await this.waitUntil(async () => {
+        optionElements = await fetchOptionElements()
+        return optionElements.length > 0
+    }, {
+        timeoutMsg: 'Select element doesn\'t contain any option element'
+    })
 
-    if (optionElements.length === 0) {
-        throw new Error('Select element doesn\'t contain any option element')
-    }
-
-    if (optionElements.length - 1 < index) {
-        throw new Error(`Option with index "${index}" not found. Select element only contains ${optionElements.length} option elements`)
-    }
+    await this.waitUntil(async () => {
+        optionElements = await fetchOptionElements()
+        return typeof optionElements[index] !== 'undefined'
+    }, {
+        timeoutMsg: `Option with index "${index}" not found. Select element only contains ${optionElements.length} option elements`
+    })
 
     /**
     * select option

--- a/packages/webdriverio/src/commands/element/selectByVisibleText.ts
+++ b/packages/webdriverio/src/commands/element/selectByVisibleText.ts
@@ -60,11 +60,10 @@ export async function selectByVisibleText (
         `./optgroup/option${spaceFormat}`,
     ]
 
-    const optionElement = await this.findElementFromElement(this.elementId, 'xpath', selections.join('|'))
-
-    if (optionElement && (optionElement as unknown as { error: string }).error === 'no such element') {
-        throw new Error(`Option with text "${text}" not found.`)
-    }
+    const optionElement = await this.$(selections.join('|'))
+    await optionElement.waitForExist({
+        timeoutMsg: `Option with text "${text}" not found.`
+    })
 
     /**
     * select option

--- a/packages/webdriverio/src/commands/element/waitForExist.ts
+++ b/packages/webdriverio/src/commands/element/waitForExist.ts
@@ -1,3 +1,4 @@
+import { ELEMENT_KEY } from 'webdriver'
 import type { WaitForOptions } from '../../types.js'
 
 /**
@@ -65,6 +66,7 @@ export async function waitForExist (
      */
     if (!reverse && isExisting && typeof this.selector === 'string') {
         this.elementId = await this.parent.$(this.selector).elementId
+        this[ELEMENT_KEY] = this.elementId
         delete this.error
     }
 

--- a/packages/webdriverio/tests/commands/element/selectByAttribute.test.ts
+++ b/packages/webdriverio/tests/commands/element/selectByAttribute.test.ts
@@ -66,24 +66,19 @@ describe('selectByAttribute test', () => {
     })
 
     it('should throw if option is not found', async () => {
-        // @ts-ignore uses expect-webdriverio
-        expect.hasAssertions()
-
         const mockElem = {
             options: {},
             selector: 'foobar2',
             elementId: 'some-elem-123',
             'element-6066-11e4-a52e-4f735466cecf': 'some-elem-123',
+            waitUntil: vi.fn().mockRejectedValue(new Error('Option with attribute "value=non-existing-value" not found.')),
             findElementFromElement: vi.fn().mockReturnValue(Promise.resolve({ error: 'no such element' }))
         }
         // @ts-ignore mock feature
         mockElem.selectByAttribute = elem.selectByAttribute.bind(mockElem)
 
-        try {
-            // @ts-ignore mock feature
-            await mockElem.selectByAttribute('value', 'non-existing-value')
-        } catch (err: any) {
-            expect(err.toString()).toBe('Error: Option with attribute "value=non-existing-value" not found.')
-        }
+        // @ts-expect-error
+        const err = await mockElem.selectByAttribute('value', 'non-existing-value').catch((err: any) => err)
+        expect(err.toString()).toBe('Error: Option with attribute "value=non-existing-value" not found.')
     })
 })

--- a/packages/webdriverio/tests/commands/element/selectByIndex.test.ts
+++ b/packages/webdriverio/tests/commands/element/selectByIndex.test.ts
@@ -27,7 +27,7 @@ describe('selectByIndex test', () => {
         vi.mocked(fetch).mockClear()
     })
 
-    it.only('should select by index', async () => {
+    it('should select by index', async () => {
         await elem.selectByIndex(1)
         // @ts-expect-error mock implementation
         expect(vi.mocked(fetch).mock.calls[1][0]!.pathname)
@@ -44,7 +44,7 @@ describe('selectByIndex test', () => {
         })
     })
 
-    it.only('should throw an error when index < 0', async () => {
+    it('should throw an error when index < 0', async () => {
         // @ts-ignore uses expect-webdriverio
         expect.hasAssertions()
         try {
@@ -54,7 +54,7 @@ describe('selectByIndex test', () => {
         }
     })
 
-    it.only('should throw if there are no options elements', async () => {
+    it('should throw if there are no options elements', async () => {
         // @ts-ignore uses expect-webdriverio
         expect.hasAssertions()
         const mockElem = {
@@ -75,7 +75,7 @@ describe('selectByIndex test', () => {
         }
     })
 
-    it.only('should throw if index is out of range', async () => {
+    it('should throw if index is out of range', async () => {
         const mockElem = {
             options: {},
             selector: 'foobar',
@@ -89,7 +89,7 @@ describe('selectByIndex test', () => {
         expect(err.toString()).toBe('Error: Can\'t call selectByIndex on element with selector "foobar" because element wasn\'t found')
     })
 
-    it.only('should throw if index is out of range', async function () {
+    it('should throw if index is out of range', async function () {
         const err = await elem.selectByIndex(3).catch((err: any) => err)
         expect(err.toString()).toBe('Error: Option with index "3" not found. Select element only contains 3 option elements')
     }, { timeout: 10000 })

--- a/packages/webdriverio/tests/commands/element/selectByIndex.test.ts
+++ b/packages/webdriverio/tests/commands/element/selectByIndex.test.ts
@@ -27,7 +27,7 @@ describe('selectByIndex test', () => {
         vi.mocked(fetch).mockClear()
     })
 
-    it('should select by index', async () => {
+    it.only('should select by index', async () => {
         await elem.selectByIndex(1)
         // @ts-expect-error mock implementation
         expect(vi.mocked(fetch).mock.calls[1][0]!.pathname)
@@ -36,7 +36,7 @@ describe('selectByIndex test', () => {
         expect(vi.mocked(fetch).mock.calls[2][0]!.pathname)
             .toBe('/session/foobar-123/element/some-elem-123/elements')
         // @ts-expect-error mock implementation
-        expect(vi.mocked(fetch).mock.calls[3][0]!.pathname)
+        expect(vi.mocked(fetch).mock.calls[4][0]!.pathname)
             .toBe('/session/foobar-123/element/some-elem-456/click')
         expect(getElementFromResponseSpy).toBeCalledWith({
             [ELEMENT_KEY]: 'some-elem-456',
@@ -44,7 +44,7 @@ describe('selectByIndex test', () => {
         })
     })
 
-    it('should throw an error when index < 0', async () => {
+    it.only('should throw an error when index < 0', async () => {
         // @ts-ignore uses expect-webdriverio
         expect.hasAssertions()
         try {
@@ -54,7 +54,7 @@ describe('selectByIndex test', () => {
         }
     })
 
-    it('should throw if there are no options elements', async () => {
+    it.only('should throw if there are no options elements', async () => {
         // @ts-ignore uses expect-webdriverio
         expect.hasAssertions()
         const mockElem = {
@@ -62,6 +62,7 @@ describe('selectByIndex test', () => {
             selector: 'foobar2',
             elementId: 'some-elem-123',
             'element-6066-11e4-a52e-4f735466cecf': 'some-elem-123',
+            waitUntil: vi.fn().mockRejectedValue(new Error('Select element doesn\'t contain any option element')),
             findElementsFromElement: vi.fn().mockReturnValue(Promise.resolve([]))
         }
         // @ts-ignore mock feature
@@ -74,9 +75,7 @@ describe('selectByIndex test', () => {
         }
     })
 
-    it('should throw if index is out of range', async () => {
-        // @ts-ignore uses expect-webdriverio
-        expect.hasAssertions()
+    it.only('should throw if index is out of range', async () => {
         const mockElem = {
             options: {},
             selector: 'foobar',
@@ -85,21 +84,13 @@ describe('selectByIndex test', () => {
         // @ts-ignore mock feature
         mockElem.selectByIndex = elem.selectByIndex.bind(mockElem)
 
-        try {
-            // @ts-ignore mock feature
-            await mockElem.selectByIndex(2)
-        } catch (err: any) {
-            expect(err.toString()).toBe('Error: Can\'t call selectByIndex on element with selector "foobar" because element wasn\'t found')
-        }
+        // @ts-expect-error
+        const err = await mockElem.selectByIndex(2).catch((err: any) => err)
+        expect(err.toString()).toBe('Error: Can\'t call selectByIndex on element with selector "foobar" because element wasn\'t found')
     })
 
-    it('should throw if index is out of rangew', async () => {
-        // @ts-ignore uses expect-webdriverio
-        expect.hasAssertions()
-        try {
-            await elem.selectByIndex(3)
-        } catch (err: any) {
-            expect(err.toString()).toBe('Error: Option with index "3" not found. Select element only contains 3 option elements')
-        }
-    })
+    it.only('should throw if index is out of range', async function () {
+        const err = await elem.selectByIndex(3).catch((err: any) => err)
+        expect(err.toString()).toBe('Error: Option with index "3" not found. Select element only contains 3 option elements')
+    }, { timeout: 10000 })
 })

--- a/packages/webdriverio/tests/commands/element/selectByVisibleText.test.ts
+++ b/packages/webdriverio/tests/commands/element/selectByVisibleText.test.ts
@@ -42,7 +42,7 @@ describe('selectByVisibleText test', () => {
             `${optionSelection}|${optgroupSelection}`
         )
         // @ts-expect-error mock implementation
-        expect(vi.mocked(fetch).mock.calls[3][0]!.pathname)
+        expect(vi.mocked(fetch).mock.calls[5][0]!.pathname)
             .toBe('/session/foobar-123/element/some-sub-elem-321/click')
         expect(getElementFromResponseSpy).toBeCalledWith({
             [ELEMENT_KEY]: 'some-sub-elem-321'
@@ -62,7 +62,7 @@ describe('selectByVisibleText test', () => {
         expect(JSON.parse(vi.mocked(fetch).mock.calls[2][1]!.body as any).value)
             .toBe(`${optionSelection}|${optgroupSelection}`)
         // @ts-expect-error mock implementation
-        expect(vi.mocked(fetch).mock.calls[3][0]!.pathname)
+        expect(vi.mocked(fetch).mock.calls[5][0]!.pathname)
             .toBe('/session/foobar-123/element/some-sub-elem-321/click')
         expect(getElementFromResponseSpy).toBeCalledWith({
             [ELEMENT_KEY]: 'some-sub-elem-321'
@@ -82,7 +82,7 @@ describe('selectByVisibleText test', () => {
         expect(JSON.parse(vi.mocked(fetch).mock.calls[2][1]!.body as any).value)
             .toBe(`${optionSelection}|${optgroupSelection}`)
         // @ts-expect-error mock implementation
-        expect(vi.mocked(fetch).mock.calls[3][0]!.pathname)
+        expect(vi.mocked(fetch).mock.calls[5][0]!.pathname)
             .toBe('/session/foobar-123/element/some-sub-elem-321/click')
         expect(getElementFromResponseSpy).toBeCalledWith({
             [ELEMENT_KEY]: 'some-sub-elem-321'
@@ -102,7 +102,7 @@ describe('selectByVisibleText test', () => {
         expect(JSON.parse(vi.mocked(fetch).mock.calls[2][1]!.body as any).value)
             .toBe(`${optionSelection}|${optgroupSelection}`)
         // @ts-expect-error mock implementation
-        expect(vi.mocked(fetch).mock.calls[3][0]!.pathname)
+        expect(vi.mocked(fetch).mock.calls[5][0]!.pathname)
             .toBe('/session/foobar-123/element/some-sub-elem-321/click')
         expect(getElementFromResponseSpy).toBeCalledWith({
             [ELEMENT_KEY]: 'some-sub-elem-321'
@@ -122,7 +122,7 @@ describe('selectByVisibleText test', () => {
         expect(JSON.parse(vi.mocked(fetch).mock.calls[2][1]!.body as any).value)
             .toBe(`${optionSelection}|${optgroupSelection}`)
         // @ts-expect-error mock implementation
-        expect(vi.mocked(fetch).mock.calls[3][0]!.pathname)
+        expect(vi.mocked(fetch).mock.calls[5][0]!.pathname)
             .toBe('/session/foobar-123/element/some-sub-elem-321/click')
         expect(getElementFromResponseSpy).toBeCalledWith({
             [ELEMENT_KEY]: 'some-sub-elem-321'
@@ -142,7 +142,7 @@ describe('selectByVisibleText test', () => {
         expect(JSON.parse(vi.mocked(fetch).mock.calls[2][1]!.body as any).value)
             .toBe(`${optionSelection}|${optgroupSelection}`)
         // @ts-expect-error mock implementation
-        expect(vi.mocked(fetch).mock.calls[3][0]!.pathname)
+        expect(vi.mocked(fetch).mock.calls[5][0]!.pathname)
             .toBe('/session/foobar-123/element/some-sub-elem-321/click')
         expect(getElementFromResponseSpy).toBeCalledWith({
             [ELEMENT_KEY]: 'some-sub-elem-321'
@@ -150,10 +150,11 @@ describe('selectByVisibleText test', () => {
     })
 
     it('should throw if option is not found', async () => {
-        // @ts-ignore uses expect-webdriverio
-        expect.hasAssertions()
-
         const mockElem = {
+            $: vi.fn().mockReturnValue(Promise.resolve({
+                waitForExist: vi.fn().mockReturnValue(Promise.reject(new Error('Option with text "non-existing-option" not found.')))
+            })),
+            elementClick: vi.fn().mockReturnValue(Promise.resolve()),
             options: {},
             selector: 'foobar2',
             elementId: 'some-elem-123',
@@ -163,11 +164,8 @@ describe('selectByVisibleText test', () => {
         // @ts-ignore mock feature
         mockElem.selectByVisibleText = elem.selectByVisibleText.bind(mockElem)
 
-        try {
-            // @ts-ignore mock feature
-            await mockElem.selectByVisibleText('non-existing-option')
-        } catch (err: any) {
-            expect(err.toString()).toBe('Error: Option with text "non-existing-option" not found.')
-        }
+        // @ts-expect-error
+        const err = await mockElem.selectByVisibleText('non-existing-option').catch((err: any) => err)
+        expect(err.toString()).toBe('Error: Option with text "non-existing-option" not found.')
     })
 })


### PR DESCRIPTION
## Proposed changes

Fixes an issue described in #14203 where WDIO would not wait for the option to be available. This is problematic if options are dynamically added.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
