### PR TITLE
fix(webdriverio): fix types for the WebdriverIO getValue command and Webdriver getElementProperty command

### DIFF
--- a/packages/wdio-protocols/src/protocols/webdriver.ts
+++ b/packages/wdio-protocols/src/protocols/webdriver.ts
@@ -820,7 +820,7 @@ export default {
             ],
             parameters: [],
             returns: {
-                type: 'string',
+                type: 'any',
                 name: 'property',
                 description:
                     'The named property of the element, accessed by calling GetOwnProperty on the element object.',

--- a/packages/webdriverio/src/commands/element/getProperty.ts
+++ b/packages/webdriverio/src/commands/element/getProperty.ts
@@ -15,7 +15,7 @@
  * @param {string} property  name of the element property
  * @return {unknown} the value of the property of the selected element
  */
-export function getProperty (
+export function getProperty(
     this: WebdriverIO.Element,
     property: string
 ): Promise<unknown> {

--- a/packages/webdriverio/src/commands/element/getValue.ts
+++ b/packages/webdriverio/src/commands/element/getValue.ts
@@ -1,3 +1,5 @@
+import { getBrowserObject } from '@wdio/utils'
+
 /**
  *
  * Get the value of a `<textarea>`, `<select>` or text `<input>` found by given selector.
@@ -20,11 +22,13 @@
  * @uses protocol/elements, protocol/elementIdProperty
  *
  */
-export function getValue (this: WebdriverIO.Element) {
+export function getValue<T>(this: WebdriverIO.Element): Promise<T>
+export function getValue(this: WebdriverIO.Element): Promise<string>
+export function getValue<T>(this: WebdriverIO.Element) {
+    const browser = getBrowserObject(this)
     // `!this.isMobile` added to workaround https://github.com/appium/appium/issues/12218
-    if (this.isW3C && !this.isMobile) {
-        return this.getElementProperty(this.elementId, 'value')
+    if (browser.isNativeContext) {
+        return this.getElementAttribute(this.elementId, 'value') as Promise<string>
     }
-
-    return this.getElementAttribute(this.elementId, 'value')
+    return this.getElementProperty(this.elementId, 'value') as Promise<T>
 }

--- a/packages/webdriverio/tests/commands/element/getValue.test.ts
+++ b/packages/webdriverio/tests/commands/element/getValue.test.ts
@@ -11,7 +11,7 @@ describe('getValue', () => {
         vi.mocked(fetch).mockClear()
     })
 
-    it('should get the value using getElementProperty', async () => {
+    it('should get the value using getElementProperty in web mode', async () => {
         const browser = await remote({
             baseUrl: 'http://foobar.com',
             capabilities: {
@@ -22,26 +22,43 @@ describe('getValue', () => {
         const elem = await browser.$('#foo')
 
         await elem.getValue()
-        // @ts-expect-error mock implementation
-        expect(vi.mocked(fetch).mock.calls[2][0].pathname)
+        const url = vi.mocked(fetch).mock.calls[2][0] as URL
+        expect(url.pathname)
             .toBe('/session/foobar-123/element/some-elem-123/property/value')
     })
 
-    it('should get value in mobile mode', async () => {
+    it('should get value using getElementProperty in mobile web mode', async () => {
         const browser = await remote({
             baseUrl: 'http://foobar.com',
             capabilities: {
                 browserName: 'foobar',
-                // @ts-ignore mock feature
                 mobileMode: true
             } as any
         })
         const elem = await browser.$('#foo')
 
         await elem.getValue()
-        // Due to mobileMode being enabled we will have extra calls to fetch
-        // @ts-expect-error mock implementation
-        expect(vi.mocked(fetch).mock.calls[2][0].pathname)
+
+        const url = vi.mocked(fetch).mock.calls[2][0] as URL
+        expect(url.pathname)
+            .toBe('/session/foobar-123/element/some-elem-123/property/value')
+    })
+
+    it('should get value using getElementProperty in mobile native mode', async () => {
+        const browser = await remote({
+            baseUrl: 'http://foobar.com',
+            capabilities: {
+                browserName: 'foobar',
+                mobileMode: true,
+                nativeAppMode: true
+            } as any
+        })
+        const elem = await browser.$('#foo')
+
+        await elem.getValue()
+
+        const url = vi.mocked(fetch).mock.calls[2][0] as URL
+        expect(url.pathname)
             .toBe('/session/foobar-123/element/some-elem-123/attribute/value')
     })
 })


### PR DESCRIPTION
## Proposed changes

Since the getValue command returns the value property (with the exception of native context in which case it will return the value attribute) it can be of any type rather than only a string. This PR fixes this.

## Types of changes

- [x] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

### Reviewers: @webdriverio/project-committers
