### PR TITLE
Fix watch files documentation

### DIFF
--- a/website/docs/WatchFiles.md
+++ b/website/docs/WatchFiles.md
@@ -9,16 +9,13 @@ With the WDIO testrunner you can watch files while you are working on them. They
 wdio wdio.conf.js --watch
 ```
 
-By default it only watches for changes in your `specs` files. However by setting a `filesToWatch` property in your `wdio.conf.js` that contains a list of file paths (globbing supported) it will also watch for these files to be changed in order to rerun the whole suite. This is useful if you want to automatically rerun all your tests if you have changed your application code, e.g.
+By default it only watches for changes in your `specs` files. However by setting a `filesToWatch` property in your `wdio.conf.js` that contains a list of file paths it will also watch for these files to be changed in order to rerun the whole suite. This is useful if you want to automatically rerun all your tests if you have changed your application code, e.g.
 
 ```js
 // wdio.conf.js
 export const config = {
-    // ...
-    filesToWatch: [
-        // watch for all JS files in my app
-        './src/app/**/*.js'
-    ],
+    // watch for all JS files in my app
+    filesToWatch: glob.sync('./src/app/**/*.js'),
     // ...
 }
 ```


### PR DESCRIPTION
## Proposed changes

Fix documentation to account for change in chokidar not supporting globing anymore.

This was done in this PR: https://github.com/webdriverio/webdriverio/pull/13583

See changelog of chokidar: https://github.com/paulmillr/chokidar/releases/tag/4.0.0

## Types of changes

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

There are other options. You could roll back the change to chokidar, or handle the globing before calling chokidar here: https://github.com/webdriverio/webdriverio/blob/main/packages/wdio-cli/src/watcher.ts#L53.

I do not know enough about the project to know if these options are viable, so I did the minimum which was updating documentation to reflect the current state of the code.

Also didn't know if I should include the call to `glob` in the example, but I don't think there was a better way to still keep an example, even if it depends on a 3rd party library now.

### Reviewers: @webdriverio/project-committers
