### PR TITLE
feat(cucumber): Backport Distinguishing Cucumber PENDING status to v8

### DIFF
--- a/packages/wdio-cucumber-framework/src/utils.ts
+++ b/packages/wdio-cucumber-framework/src/utils.ts
@@ -2,6 +2,7 @@ import path from 'node:path'
 import logger from '@wdio/logger'
 import { isFunctionAsync } from '@wdio/utils'
 import type { supportCodeLibraryBuilder, World } from '@cucumber/cucumber'
+import { Status } from '@cucumber/cucumber'
 
 import type {
     TableRow,
@@ -257,4 +258,22 @@ export function setUserHookNames (options: typeof supportCodeLibraryBuilder) {
             }
         })
     })
+}
+
+/**
+ * Convert Cucumber status to WebdriverIO test status for reporting.
+ * Maps statuses like PASSED, PENDING, etc., to WebdriverIO's shorthand test status values.
+ * @param {TestStepResultStatus} status - The Cucumber status (e.g., 'PENDING')
+ * @returns {'pass' | 'fail' | 'skip' | 'pending'} - The corresponding WebdriverIO test status
+ */
+export function convertStatus(status: TestStepResultStatus): 'pass' | 'fail' | 'skip' | 'pending' {
+    switch (status) {
+    case Status.PASSED: return 'pass'
+    case Status.PENDING: return 'pending'
+    case Status.SKIPPED: return 'skip'
+    case Status.AMBIGUOUS: return 'skip'
+    case Status.FAILED: return 'fail'
+    case Status.UNDEFINED: return 'pass'
+    default: return 'fail'
+    }
 }

--- a/packages/wdio-cucumber-framework/tests/utils.test.ts
+++ b/packages/wdio-cucumber-framework/tests/utils.test.ts
@@ -1,5 +1,6 @@
 import path from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
+import { Status } from '@cucumber/cucumber'
 import {
     createStepArgument,
     formatMessage,
@@ -9,7 +10,8 @@ import {
     getTestStepTitle,
     addKeywordToStep,
     getRule,
-    generateSkipTagsFromCapabilities
+    generateSkipTagsFromCapabilities,
+    convertStatus
 } from '../src/utils.js'
 import { featureWithRules } from './fixtures/features.js'
 
@@ -237,4 +239,16 @@ describe('utils', () => {
         browserName: 'chrome',
     }, [['@skip_local']]))
         .toStrictEqual([])
+
+    describe('convertStatus', () => {
+        it('maps Cucumber statuses to TestStatus', () => {
+            expect(convertStatus(Status.PASSED)).toBe('pass')
+            expect(convertStatus(Status.PENDING)).toBe('pending')
+            expect(convertStatus(Status.SKIPPED)).toBe('skip')
+            expect(convertStatus(Status.AMBIGUOUS)).toBe('skip')
+            expect(convertStatus(Status.FAILED)).toBe('fail')
+            expect(convertStatus(Status.UNDEFINED)).toBe('pass')
+            expect(convertStatus(Status.UNKNOWN)).toBe('fail')
+        })
+    })
 })

--- a/packages/wdio-reporter/src/index.ts
+++ b/packages/wdio-reporter/src/index.ts
@@ -27,7 +27,8 @@ export default class WDIOReporter extends EventEmitter {
         hooks: 0,
         passes: 0,
         skipping: 0,
-        failures: 0
+        failures: 0,
+        pending: 0
     }
     retries = 0
     runnerStat?: RunnerStats
@@ -174,10 +175,17 @@ export default class WDIOReporter extends EventEmitter {
             }
 
             this.tests[currentTest.uid] = currentTest
-            currentTest.skip(test.pendingReason!)
-            this.counts.skipping++
-            this.counts.tests++
-            this.onTestSkip(currentTest)
+            if (test.state === 'pending') {
+                currentTest.state = 'pending'
+                this.counts.pending++
+                this.counts.tests++
+                this.onTestPending(currentTest)
+            } else {
+                currentTest.skip(test.pendingReason!)
+                this.counts.skipping++
+                this.counts.tests++
+                this.onTestSkip(currentTest)
+            }
         })
 
         this.on('test:end',  /* istanbul ignore next */(test: Test) => {
@@ -293,6 +301,9 @@ export default class WDIOReporter extends EventEmitter {
     /* istanbul ignore next */
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     onTestSkip(testStats: TestStats) { }
+    /* istanbul ignore next */
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    onTestPending(_testStats: TestStats) { }
     /* istanbul ignore next */
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     onTestEnd(testStats: TestStats) { }

--- a/packages/wdio-reporter/src/stats/test.ts
+++ b/packages/wdio-reporter/src/stats/test.ts
@@ -27,6 +27,7 @@ export interface Test {
     errors?: Error[]
     retries?: number
     argument?: string | Argument
+    state?: string
 }
 
 interface Output {

--- a/packages/wdio-spec-reporter/src/index.ts
+++ b/packages/wdio-spec-reporter/src/index.ts
@@ -33,7 +33,8 @@ export default class SpecReporter extends WDIOReporter {
     private _stateCounts: StateCount = {
         passed: 0,
         failed: 0,
-        skipped: 0
+        skipped: 0,
+        pending: 0
     }
 
     private _symbols: Symbols = {
@@ -128,6 +129,13 @@ export default class SpecReporter extends WDIOReporter {
         this._pendingReasons.push(testStat.pendingReason as string)
         this._consoleLogs.push(this._consoleOutput)
         this._stateCounts.skipped++
+    }
+
+    onTestPending(testStat: TestStats) {
+        this.printCurrentStats(testStat)
+        this._pendingReasons.push(testStat.pendingReason as string)
+        this._consoleLogs.push(this._consoleOutput)
+        this._stateCounts.pending++
     }
 
     onRunnerEnd (runner: RunnerStats) {
@@ -446,6 +454,13 @@ export default class SpecReporter extends WDIOReporter {
             duration = ''
         }
 
+        // Get the pending tests
+        if (this._stateCounts.pending > 0) {
+            const text = `${this._stateCounts.pending} pending ${duration}`.trim()
+            output.push(this.setMessageColor(text, State.PENDING))
+            duration = ''
+        }
+        
         // Get the skipped tests
         if (this._stateCounts.skipped > 0) {
             const text = `${this._stateCounts.skipped} skipped ${duration}`.trim()

--- a/packages/wdio-spec-reporter/src/index.ts
+++ b/packages/wdio-spec-reporter/src/index.ts
@@ -460,7 +460,7 @@ export default class SpecReporter extends WDIOReporter {
             output.push(this.setMessageColor(text, State.PENDING))
             duration = ''
         }
-        
+
         // Get the skipped tests
         if (this._stateCounts.skipped > 0) {
             const text = `${this._stateCounts.skipped} skipped ${duration}`.trim()

--- a/packages/wdio-spec-reporter/src/types.ts
+++ b/packages/wdio-spec-reporter/src/types.ts
@@ -4,6 +4,7 @@ export interface StateCount {
     passed: number
     failed: number
     skipped: number
+    pending: number
 }
 
 export interface Symbols {

--- a/packages/wdio-spec-reporter/tests/index.test.ts
+++ b/packages/wdio-spec-reporter/tests/index.test.ts
@@ -46,6 +46,7 @@ describe('SpecReporter', () => {
             expect(reporter['_stateCounts']).toEqual({
                 passed: 0,
                 skipped: 0,
+                pending: 0,
                 failed: 0,
             })
         })

--- a/tests/cucumber/step-definitions/pending-steps.js
+++ b/tests/cucumber/step-definitions/pending-steps.js
@@ -1,0 +1,5 @@
+import { Given } from '@wdio/cucumber-framework'
+
+Given('a step that returns pending', function () {
+    return 'pending'
+})

--- a/tests/cucumber/test-pending.feature
+++ b/tests/cucumber/test-pending.feature
@@ -1,0 +1,7 @@
+Feature: Pending steps example
+    As a test script of wdio-cucumber-framework
+    I should show pending status
+    when steps return 'pending'
+
+    Scenario: Pending step demonstration
+        Given a step that returns pending

--- a/tests/smoke.runner.js
+++ b/tests/smoke.runner.js
@@ -394,6 +394,42 @@ const cucumberFailAmbiguousDefinitions = async () => {
 }
 
 /**
+ * Cucumber pending status test
+ */
+const cucumberPendingTest = async () => {
+    const logFile = path.resolve(__dirname, 'cucumber', 'cucumberPendingTest.log')
+    await fs.rm(logFile, { force: true })
+
+    await launch(
+        'cucumberPendingTest',
+        path.resolve(__dirname, 'helpers', 'cucumber-hooks.conf.js'),
+        {
+            specs: [
+                path.resolve(__dirname, 'cucumber', 'test-pending.feature')
+            ],
+            reporters: [
+                ['spec', {
+                    outputDir: __dirname,
+                    stdout: false,
+                    logFile
+                }]
+            ],
+            cucumberOpts: {
+                ignoreUndefinedDefinitions: true,
+                scenarioLevelReporter: true
+            }
+        }
+    )
+
+    const specLogs = (await fs.readFile(logFile)).toString().replace(ansiColorRegex, '')
+    const pendingMatch = specLogs.match(/(\d+)\s+pending/)
+    assert.ok(
+        pendingMatch && parseInt(pendingMatch[1], 10) === 1,
+        'Expected exactly 1 pending test in output'
+    )
+}
+
+/**
  * Cucumber reporter
  */
 const cucumberReporter = async () => {
@@ -958,6 +994,7 @@ const jasmineAfterHookArgsValidation = async () => {
         cucumberTestrunnerByLineNumber,
         cucumberTestrunnerMultipleByLineNumber,
         cucumberFailAmbiguousDefinitions,
+        cucumberPendingTest,
         cucumberReporter,
         standaloneTest,
         mochaAsyncTestrunner,


### PR DESCRIPTION
- Added convertStatus in wdio-cucumber-framework to map PENDING to 'pending'
- Updated cucumberFormatter to emit test:pending for PENDING steps
- Modified WDIOReporter to track and handle pending tests
- Extended SpecReporter to display pending count
- Updated types and added unit/smoke tests

Backport of [#14234](https://github.com/webdriverio/webdriverio/pull/14234) for v8 that fixes [#5359](https://github.com/webdriverio/webdriverio/issues/5359)

## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)
No documentation update included, as this is a behavioral enhancement within existing reporter functionality.
Smoke test uses log output validation via launch() to maintain suite consistency.

### Reviewers: @webdriverio/project-committers
