### PR TITLE
fix(cli): bring back support for glob pattern in filesToWatch

### DIFF
--- a/packages/wdio-cli/src/watcher.ts
+++ b/packages/wdio-cli/src/watcher.ts
@@ -1,4 +1,5 @@
 import url from 'node:url'
+import path from 'node:path'
 
 import chokidar from 'chokidar'
 import pickBy from 'lodash.pickby'
@@ -53,7 +54,8 @@ export default class Watcher {
         const { filesToWatch } = this._launcher.configParser.getConfig()
         if (filesToWatch.length) {
             const pathService = new FileSystemPathService()
-            const globbedFilesToWatch = filesToWatch.map((file) => pathService.ensureAbsolutePath(file, process.cwd()))
+            const rootDir = path.dirname(path.resolve(process.cwd(), this._configFile))
+            const globbedFilesToWatch = filesToWatch.map((file) => pathService.ensureAbsolutePath(file, rootDir))
             chokidar.watch(globbedFilesToWatch, { ignoreInitial: true })
                 .on('add', this.getFileListener(false))
                 .on('change', this.getFileListener(false))

--- a/packages/wdio-cli/src/watcher.ts
+++ b/packages/wdio-cli/src/watcher.ts
@@ -1,10 +1,12 @@
 import url from 'node:url'
 
 import chokidar from 'chokidar'
-import logger from '@wdio/logger'
 import pickBy from 'lodash.pickby'
 import flattenDeep from 'lodash.flattendeep'
 import union from 'lodash.union'
+
+import logger from '@wdio/logger'
+import { FileSystemPathService } from '@wdio/config/node'
 import type { Capabilities, Workers } from '@wdio/types'
 
 import Launcher from './launcher.js'
@@ -50,7 +52,9 @@ export default class Watcher {
          */
         const { filesToWatch } = this._launcher.configParser.getConfig()
         if (filesToWatch.length) {
-            chokidar.watch(filesToWatch, { ignoreInitial: true })
+            const pathService = new FileSystemPathService()
+            const globbedFilesToWatch = filesToWatch.map((file) => pathService.ensureAbsolutePath(file, process.cwd()))
+            chokidar.watch(globbedFilesToWatch, { ignoreInitial: true })
                 .on('add', this.getFileListener(false))
                 .on('change', this.getFileListener(false))
         }

--- a/packages/wdio-cli/tests/watcher.test.ts
+++ b/packages/wdio-cli/tests/watcher.test.ts
@@ -192,7 +192,7 @@ describe('watcher', () => {
 
         expect(chokidar.watch).toHaveBeenCalledTimes(2)
         expect(chokidar.watch).toBeCalledWith(['/foo', '/bar'], expect.any(Object))
-        expect(chokidar.watch).toBeCalledWith(['./foobar'], expect.any(Object))
+        expect(chokidar.watch).toBeCalledWith([expect.stringContaining('/foobar')], expect.any(Object))
 
     })
 

--- a/packages/wdio-config/src/node/index.ts
+++ b/packages/wdio-config/src/node/index.ts
@@ -1,3 +1,4 @@
 import ConfigParser from './ConfigParser.js'
+import FileSystemPathService from './FileSystemPathService.js'
 
-export { ConfigParser }
+export { ConfigParser, FileSystemPathService }


### PR DESCRIPTION
## Proposed changes

closes #14225

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
