### PR TITLE
fix(webdriver): abort all operation when session closes

### DIFF
--- a/packages/webdriver/src/bidi/core.ts
+++ b/packages/webdriver/src/bidi/core.ts
@@ -126,7 +126,7 @@ export class BidiCore {
              * of the result instead of the raw base64 encoded string
              */
             let resultLog = data.toString()
-            if ('data' in payload.result && typeof payload.result.data === 'string' && base64Regex.test(payload.result.data)) {
+            if (typeof payload.result === 'object' && payload.result && 'data' in payload.result && typeof payload.result.data === 'string' && base64Regex.test(payload.result.data)) {
                 resultLog = JSON.stringify({
                     ...payload.result,
                     data: `Base64 string [${payload.result.data.length} chars]`

--- a/packages/webdriver/src/command.ts
+++ b/packages/webdriver/src/command.ts
@@ -124,10 +124,13 @@ export default function (
         /**
          * Make sure we pass along an abort signal to the request class so we
          * can abort the request as well as any retries in case the session is
-         * deleted
+         * deleted.
+         *
+         * Abort the attempt to make the WebDriver call, except for `deleteSession`
+         * calls which should go through in case we retry the command.
          */
         const { isAborted, abortSignal, cleanup } = manageSessionAbortions.call(this)
-        if (isAborted) {
+        if (isAborted && command !== 'deleteSession') {
             return log.warn(`Trying to run command "${commandCallStructure(command, args)}" after session has been deleted, aborting request without executing it`)
         }
 

--- a/packages/webdriver/src/command.ts
+++ b/packages/webdriver/src/command.ts
@@ -5,10 +5,11 @@ import { WebDriverBidiProtocol, type CommandEndpoint } from '@wdio/protocols'
 import { environment } from './environment.js'
 import type { BidiHandler } from './bidi/handler.js'
 import type { WebDriverResponse } from './request/types.js'
-import type { BaseClient, BidiCommands, BidiResponses } from './types.js'
+import type { BaseClient, BidiCommands, BidiResponses, WebDriverResultEvent } from './types.js'
 
 const log = logger('webdriver')
 const BIDI_COMMANDS: BidiCommands[] = Object.values(WebDriverBidiProtocol).map((def) => def.socket.command)
+const sessionAbortListeners = new Map<string, Set<AbortController> | null>()
 
 export default function (
     method: string,
@@ -120,7 +121,17 @@ export default function (
             body[commandParams[i].name] = arg
         }
 
-        const request = new environment.value.Request(method, endpoint, body, isHubCommand, {
+        /**
+         * Make sure we pass along an abort signal to the request class so we
+         * can abort the request as well as any retries in case the session is
+         * deleted
+         */
+        const { isAborted, abortSignal, cleanup } = manageSessionAbortions.call(this)
+        if (isAborted) {
+            return log.warn(`Trying to run command "${commandCallStructure(command, args)}" after session has been deleted, aborting request without executing it`)
+        }
+
+        const request = new environment.value.Request(method, endpoint, body, abortSignal, isHubCommand, {
             onPerformance: (data) => this.emit('request.performance', data),
             onRequest: (data) => this.emit('request.start', data),
             onResponse: (data) => this.emit('request.end', data),
@@ -193,6 +204,56 @@ export default function (
         }).catch((error) => {
             this.emit('result', { command, method, endpoint, body, result: { error } })
             throw error
+        }).finally(() => {
+            cleanup()
         })
+    }
+}
+
+/**
+ * Manage session abortions, e.g. abort requests after session has been deleted.
+ * @param this - WebDriver client instance
+ * @returns Object with `isAborted`, `abortSignal`, and `cleanup`
+ */
+function manageSessionAbortions (this: BaseClient): {
+    isAborted: boolean
+    abortSignal?: AbortSignal
+    cleanup: () => void
+} {
+    const abort = new AbortController()
+    let abortListenerForCurrentSession = sessionAbortListeners.get(this.sessionId)
+    if (typeof abortListenerForCurrentSession === 'undefined') {
+        abortListenerForCurrentSession = new Set()
+        sessionAbortListeners.set(this.sessionId, abortListenerForCurrentSession)
+    }
+
+    /**
+     * If the session has been deleted, we don't want to run any further commands
+     */
+    if (abortListenerForCurrentSession === null) {
+        return { isAborted: true, abortSignal: undefined, cleanup: () => {} }
+    }
+
+    /**
+     * listen for session deletion and abort all requests
+     */
+    abortListenerForCurrentSession.add(abort)
+    const abortOnSessionEnd = (result: WebDriverResultEvent) => {
+        if (result.command === 'deleteSession') {
+            for (const abortListener of abortListenerForCurrentSession) {
+                abortListener.abort()
+            }
+            abortListenerForCurrentSession.clear()
+            sessionAbortListeners.set(this.sessionId, null)
+        }
+    }
+    this.on('result', abortOnSessionEnd)
+    return {
+        isAborted: false,
+        abortSignal: abort.signal,
+        cleanup: () => {
+            this.off('result', abortOnSessionEnd)
+            abortListenerForCurrentSession?.delete(abort)
+        }
     }
 }

--- a/packages/webdriver/src/request/polyfill.ts
+++ b/packages/webdriver/src/request/polyfill.ts
@@ -1,0 +1,56 @@
+/**
+ * Polyfill for AbortSignal.any()
+ *
+ * Creates a new AbortSignal that aborts when any of the given signals abort.
+ *
+ * @param signals - An array of AbortSignal objects
+ * @returns A new AbortSignal that aborts when any of the input signals abort
+ */
+if (!AbortSignal.any) {
+    AbortSignal.any = function (signals: AbortSignal[]): AbortSignal {
+        // Validate input
+        if (!signals || !Array.isArray(signals)) {
+            throw new TypeError('AbortSignal.any requires an array of AbortSignal objects')
+        }
+
+        // Create a new controller for our combined signal
+        const controller = new AbortController()
+
+        // If any signal is already aborted, abort immediately
+        if (signals.some(signal => signal.aborted)) {
+            controller.abort()
+            return controller.signal
+        }
+
+        // Set up listeners for each signal
+        const listeners = signals.map(signal => {
+            const listener = () => {
+                // When any signal aborts, abort our controller
+                // and forward the abort reason if available
+                if ('reason' in signal && signal.reason !== undefined) {
+                    controller.abort(signal.reason)
+                } else {
+                    controller.abort()
+                }
+
+                // Clean up other listeners when one signal aborts
+                cleanup()
+            }
+
+            signal.addEventListener('abort', listener)
+            return { signal, listener }
+        })
+
+        // Function to remove all event listeners
+        const cleanup = () => {
+            listeners.forEach(({ signal, listener }) => {
+                signal.removeEventListener('abort', listener)
+            })
+        }
+
+        // Make sure to clean up if our combined signal is aborted
+        controller.signal.addEventListener('abort', cleanup)
+
+        return controller.signal
+    }
+}

--- a/packages/webdriver/src/request/request.ts
+++ b/packages/webdriver/src/request/request.ts
@@ -33,14 +33,22 @@ export abstract class WebDriverRequest {
     isHubCommand: boolean
     requiresSessionId: boolean
     eventHandler: RequestEventHandler
-
-    constructor (method: string, endpoint: string, body?: Record<string, unknown>, isHubCommand: boolean = false, eventHandler: RequestEventHandler = {}) {
+    abortSignal?: AbortSignal
+    constructor (
+        method: string,
+        endpoint: string,
+        body?: Record<string, unknown>,
+        abortSignal?: AbortSignal,
+        isHubCommand: boolean = false,
+        eventHandler: RequestEventHandler = {}
+    ) {
         this.body = body
         this.method = method
         this.endpoint = endpoint
         this.isHubCommand = isHubCommand
         this.requiresSessionId = Boolean(this.endpoint.match(/:sessionId/))
         this.eventHandler = eventHandler
+        this.abortSignal = abortSignal
     }
 
     async makeRequest (options: RequestOptions, sessionId?: string) {
@@ -54,7 +62,10 @@ export abstract class WebDriverRequest {
         const requestOptions: RequestInit = {
             method: this.method,
             redirect: 'follow',
-            signal: AbortSignal.timeout(timeout)
+            signal: AbortSignal.any([
+                AbortSignal.timeout(timeout),
+                ...(this.abortSignal ? [this.abortSignal] : [])
+            ])
         }
 
         const requestHeaders: HeadersInit = new Headers({
@@ -198,11 +209,16 @@ export abstract class WebDriverRequest {
             const resError = response as WebDriverRequestError
 
             /**
-             * retry failed requests
+             * retry failed requests, only if:
+             * - the abort signal is not aborted
+             * - the error code or status code is retryable
              */
             if (
-                (resError.code && RETRYABLE_ERROR_CODES.includes(resError.code)) ||
-                (resError.statusCode && RETRYABLE_STATUS_CODES.includes(resError.statusCode))
+                !(this.abortSignal && this.abortSignal.aborted) &&
+                (
+                    (resError.code && RETRYABLE_ERROR_CODES.includes(resError.code)) ||
+                    (resError.statusCode && RETRYABLE_STATUS_CODES.includes(resError.statusCode))
+                )
             ) {
                 return retry(resError)
             }

--- a/packages/webdriver/src/request/request.ts
+++ b/packages/webdriver/src/request/request.ts
@@ -10,6 +10,8 @@ import { isSuccessfulResponse } from '../utils.js'
 import { DEFAULTS } from '../constants.js'
 import pkg from '../../package.json' with { type: 'json' }
 
+import './polyfill.js'
+
 const ERRORS_TO_EXCLUDE_FROM_RETRY = [
     'detached shadow root',
     'move target out of bounds'

--- a/packages/webdriver/src/types.ts
+++ b/packages/webdriver/src/types.ts
@@ -38,9 +38,22 @@ export type BidiResponses = ValueOf<ObtainMethods<Pick<BidiHandler, BidiCommands
 export type RemoteConfig = Options.WebDriver & Capabilities.WithRequestedCapabilities
 
 type BidiInterface = ObtainMethods<Pick<BidiHandler, BidiCommands>>
+export interface WebDriverCommandEvent {
+    command: string
+    method: string
+    endpoint: string
+    body: unknown
+}
+export interface WebDriverResultEvent {
+    command: string
+    method: string
+    endpoint: string
+    body: unknown
+    result: unknown
+}
 type WebDriverClassicEvents = {
-    command: { command: string, method: string, endpoint: string, body: unknown }
-    result: { command: string, method: string, endpoint: string, body: unknown, result: unknown }
+    command: WebDriverCommandEvent
+    result: WebDriverResultEvent
     bidiCommand: Omit<CommandData, 'id'>,
     bidiResult: CommandResponse,
     'request.performance': RequestPerformanceEvent

--- a/packages/webdriver/tests/request.test.ts
+++ b/packages/webdriver/tests/request.test.ts
@@ -124,7 +124,7 @@ describe('webdriver request', () => {
         })
 
         it('ignors path when command is a hub command', async () => {
-            const req = new FetchRequest('POST', '/grid/api/hub', {}, true)
+            const req = new FetchRequest('POST', '/grid/api/hub', {}, undefined, true)
             const options = await req.createOptions({
                 protocol: 'https',
                 hostname: 'localhost',
@@ -221,7 +221,7 @@ describe('webdriver request', () => {
             const expectedResponse = { value: { 'element-6066-11e4-a52e-4f735466cecf': 'some-elem-123' } }
             const onResponse = vi.fn()
             const onPerformance = vi.fn()
-            const req = new FetchRequest('POST', webdriverPath, {}, false, {
+            const req = new FetchRequest('POST', webdriverPath, {}, undefined, false, {
                 onResponse, onPerformance
             })
 
@@ -242,7 +242,7 @@ describe('webdriver request', () => {
         it('should short circuit if request throws a stale element exception', async () => {
             const onResponse = vi.fn()
             const onPerformance = vi.fn()
-            const req = new FetchRequest('POST', 'session/:sessionId/element', {}, false, {
+            const req = new FetchRequest('POST', 'session/:sessionId/element', {}, undefined, false, {
                 onResponse, onPerformance
             })
 
@@ -262,7 +262,7 @@ describe('webdriver request', () => {
         it('should not fail code due to an empty server response', async () => {
             const onResponse = vi.fn()
             const onPerformance = vi.fn()
-            const req = new FetchRequest('POST', webdriverPath, {}, false, {
+            const req = new FetchRequest('POST', webdriverPath, {}, undefined, false, {
                 onResponse, onPerformance
             })
 
@@ -281,7 +281,7 @@ describe('webdriver request', () => {
             const onRetry = vi.fn()
             const onResponse = vi.fn()
             const onPerformance = vi.fn()
-            const req = new FetchRequest('POST', webdriverPath, {}, false, {
+            const req = new FetchRequest('POST', webdriverPath, {}, undefined, false, {
                 onResponse, onPerformance, onRetry
             })
 
@@ -304,7 +304,7 @@ describe('webdriver request', () => {
             const onRetry = vi.fn()
             const onResponse = vi.fn()
             const onPerformance = vi.fn()
-            const req = new FetchRequest('POST', webdriverPath, {}, false, {
+            const req = new FetchRequest('POST', webdriverPath, {}, undefined, false, {
                 onResponse, onPerformance, onRetry
             })
 
@@ -324,7 +324,7 @@ describe('webdriver request', () => {
         })
 
         it('should manage hub commands', async () => {
-            const req = new FetchRequest('POST', '/grid/api/hub', {}, true)
+            const req = new FetchRequest('POST', '/grid/api/hub', {}, undefined, true)
             expect(await req.makeRequest({
                 protocol: 'https',
                 hostname: 'localhost',
@@ -335,7 +335,7 @@ describe('webdriver request', () => {
         })
 
         it('should fail if hub command is called on node', async () => {
-            const req = new FetchRequest('POST', '/grid/api/testsession', {}, true)
+            const req = new FetchRequest('POST', '/grid/api/testsession', {}, undefined, true)
             const result = await req.makeRequest({
                 protocol: 'https',
                 hostname: 'localhost',
@@ -353,7 +353,7 @@ describe('webdriver request', () => {
             it('should throw if timeout happens too often', async () => {
                 const retryCnt = 3
                 const onRetry = vi.fn()
-                const req = new FetchRequest('POST', '/timeout', {}, true, { onRetry })
+                const req = new FetchRequest('POST', '/timeout', {}, undefined, true, { onRetry })
                 const result = await req.makeRequest({
                     protocol: 'https',
                     hostname: 'localhost',
@@ -374,7 +374,7 @@ describe('webdriver request', () => {
                 const onRequest = vi.fn()
                 const onResponse = vi.fn()
                 const onPerformance = vi.fn()
-                const req = new FetchRequest('GET', '/timeout', {}, true, { onRetry, onRequest, onResponse, onPerformance })
+                const req = new FetchRequest('GET', '/timeout', {}, undefined, true, { onRetry, onRequest, onResponse, onPerformance })
                 const reqOpts = {
                     protocol: 'https',
                     hostname: 'localhost',
@@ -395,7 +395,7 @@ describe('webdriver request', () => {
         it('should return proper response if retry passes', async () => {
             const retryCnt = 7
             const onRetry = vi.fn()
-            const req = new FetchRequest('POST', '/timeout', {}, true, { onRetry })
+            const req = new FetchRequest('POST', '/timeout', {}, undefined, true, { onRetry })
             const result = await req.makeRequest({
                 protocol: 'https',
                 hostname: 'localhost',
@@ -414,7 +414,7 @@ describe('webdriver request', () => {
         it('should retry on connection refused error', async () => {
             const retryCnt = 7
             const onRetry = vi.fn()
-            const req = new FetchRequest('POST', '/connectionRefused', {}, false, { onRetry })
+            const req = new FetchRequest('POST', '/connectionRefused', {}, undefined, false, { onRetry })
             const result = await req.makeRequest({
                 protocol: 'https',
                 hostname: 'localhost',
@@ -430,7 +430,8 @@ describe('webdriver request', () => {
         }, 20_000)
 
         it('should throw if request error is unknown', async () => {
-            const req = new FetchRequest('POST', '/sumoerror', {}, true)
+            console.log('TESTING', AbortSignal)
+            const req = new FetchRequest('POST', '/sumoerror', {}, undefined, true)
             const result = await req.makeRequest({
                 protocol: 'https',
                 hostname: 'localhost',

--- a/packages/webdriverio/src/commands/element/waitForDisplayed.ts
+++ b/packages/webdriverio/src/commands/element/waitForDisplayed.ts
@@ -24,7 +24,7 @@ import type { WaitForOptions } from '../../types.js'
  * @example https://github.com/webdriverio/example-recipes/blob/9ac16b4d4cf4bc8ec87f6369439a2d0bcaae4483/waitForDisplayed/waitForDisplayedExample.js#L6-L14
  * @type utility
  */
-export async function waitForDisplayed (
+export function waitForDisplayed (
     this: WebdriverIO.Element,
     {
         timeout = this.options.waitforTimeout,

--- a/packages/webdriverio/tests/commands/browser/reloadSession.test.ts
+++ b/packages/webdriverio/tests/commands/browser/reloadSession.test.ts
@@ -15,12 +15,14 @@ vi.mock('@wdio/utils', async (origMod) => {
 describe('reloadSession test', () => {
     const scenarios = [{
         name: 'should be undefined if sessionId is missing in response',
+        startingSessionId: 'some-session-id-1',
         sessionIdMock: 'ignored if jsonwpMode is false',
         requestMock: [{}, {}],
         newSessionId: undefined,
         jsonwpMode: false
     }, {
         name: 'should be ok if sessionId is in response',
+        startingSessionId: 'some-session-id-2',
         sessionIdMock: 'foobar-234',
         requestMock: [{}, {}],
         newSessionId: 'foobar-234',

--- a/packages/webdriverio/tests/commands/element/waitForClickable.test.ts
+++ b/packages/webdriverio/tests/commands/element/waitForClickable.test.ts
@@ -23,6 +23,8 @@ describe('waitForClickable', () => {
         const tmpElem = await browser.$('#foo')
         const elem = {
             selector : '#foo',
+            on: vi.fn(),
+            off: vi.fn(),
             waitForClickable : tmpElem.waitForClickable,
             elementId : 123,
             waitUntil : vi.fn(((cb))),
@@ -39,6 +41,8 @@ describe('waitForClickable', () => {
         const tmpElem = await browser.$('#foo')
         const elem = {
             selector : '#foo',
+            on: vi.fn(),
+            off: vi.fn(),
             waitForClickable : tmpElem.waitForClickable,
             elementId : 123,
             waitUntil : tmpElem.waitUntil,
@@ -54,6 +58,8 @@ describe('waitForClickable', () => {
         const tmpElem = await browser.$('#foo')
         const elem = {
             selector : '#foo',
+            on: vi.fn(),
+            off: vi.fn(),
             waitForClickable : tmpElem.waitForClickable,
             elementId : 123,
             waitUntil : tmpElem.waitUntil,
@@ -74,6 +80,8 @@ describe('waitForClickable', () => {
         const tmpElem = await browser.$('#foo')
         const elem = {
             selector : '#foo',
+            on: vi.fn(),
+            off: vi.fn(),
             waitForClickable : tmpElem.waitForClickable,
             elementId : 123,
             waitUntil : tmpElem.waitUntil,
@@ -92,7 +100,11 @@ describe('waitForClickable', () => {
         const tmpElem = await browser.$('#foo')
         const elem: any = {
             selector : '#foo',
-            parent: { $: vi.fn(() => { return elem}) },
+            parent: {
+                $: vi.fn(() => { return elem}),
+                on: vi.fn(),
+                off: vi.fn(),
+            },
             waitForClickable : tmpElem.waitForClickable,
             waitUntil : tmpElem.waitUntil,
             isDisplayed : tmpElem.isDisplayed,
@@ -113,6 +125,8 @@ describe('waitForClickable', () => {
         const tmpElem = await browser.$('#foo')
         const elem = {
             selector : '#foo',
+            on: vi.fn(),
+            off: vi.fn(),
             waitForClickable : tmpElem.waitForClickable,
             elementId : 123,
             waitUntil : vi.fn(((cb))),
@@ -131,6 +145,8 @@ describe('waitForClickable', () => {
         const tmpElem = await browser.$('#foo')
         const elem = {
             selector : '#foo',
+            on: vi.fn(),
+            off: vi.fn(),
             waitForClickable : tmpElem.waitForClickable,
             elementId : 123,
             waitUntil : tmpElem.waitUntil,

--- a/packages/webdriverio/tests/commands/element/waitForDisplayed.test.ts
+++ b/packages/webdriverio/tests/commands/element/waitForDisplayed.test.ts
@@ -26,6 +26,8 @@ describe('waitForDisplayed', () => {
         const tmpElem = await browser.$('#foo')
         const elem = {
             selector: '#foo',
+            on: vi.fn(),
+            off: vi.fn(),
             waitForDisplayed: tmpElem.waitForDisplayed,
             elementId: 123,
             waitUntil: vi.fn().mockImplementation(cb),
@@ -51,6 +53,8 @@ describe('waitForDisplayed', () => {
         const tmpElem = await browser.$('#foo')
         const elem = {
             selector: '#foo',
+            on: vi.fn(),
+            off: vi.fn(),
             waitForDisplayed: tmpElem.waitForDisplayed,
             elementId: 123,
             waitUntil: tmpElem.waitUntil,
@@ -71,6 +75,8 @@ describe('waitForDisplayed', () => {
         const tmpElem = await browser.$('#foo')
         const elem = {
             selector: '#foo',
+            on: vi.fn(),
+            off: vi.fn(),
             waitForDisplayed: tmpElem.waitForDisplayed,
             elementId: 123,
             waitUntil: tmpElem.waitUntil,
@@ -91,13 +97,16 @@ describe('waitForDisplayed', () => {
         const tmpElem = await browser.$('#foo')
         const elem = {
             selector: '#foo',
-            parent: { $: vi.fn(() => { return elem}) },
+            parent: {
+                $: vi.fn(() => { return elem}),
+                on: vi.fn(),
+                off: vi.fn(),
+            },
             waitForDisplayed: tmpElem.waitForDisplayed,
             waitUntil: tmpElem.waitUntil,
             isDisplayed: tmpElem.isDisplayed,
             options: { waitforTimeout: 500, waitforInterval: 50 },
         } as unknown as WebdriverIO.Element
-        // @ts-expect-error
         elem.getElement = () => Promise.resolve(elem)
 
         try {
@@ -129,6 +138,8 @@ describe('waitForDisplayed', () => {
         const tmpElem = await browser.$('#foo')
         const elem = {
             selector: '#foo',
+            on: vi.fn(),
+            off: vi.fn(),
             waitForDisplayed: tmpElem.waitForDisplayed,
             elementId: 123,
             waitUntil: tmpElem.waitUntil,

--- a/packages/webdriverio/tests/commands/element/waitForEnabled.test.ts
+++ b/packages/webdriverio/tests/commands/element/waitForEnabled.test.ts
@@ -24,6 +24,8 @@ describe('waitForEnabled', () => {
     it('should wait for the element to exist', async () => {
         const tmpElem = await browser.$('#foo')
         const elem = {
+            on: vi.fn(),
+            off: vi.fn(),
             waitForEnabled : tmpElem.waitForEnabled,
             waitForExist : vi.fn(),
             elementId : null,
@@ -38,6 +40,8 @@ describe('waitForEnabled', () => {
     it('element should already exist on the page', async () => {
         const tmpElem = await browser.$('#foo')
         const elem = {
+            on: vi.fn(),
+            off: vi.fn(),
             waitForEnabled : tmpElem.waitForEnabled,
             waitForExist : vi.fn(),
             elementId : 123,
@@ -54,6 +58,8 @@ describe('waitForEnabled', () => {
         const cb = vi.fn()
         const tmpElem = await browser.$('#foo')
         const elem = {
+            on: vi.fn(),
+            off: vi.fn(),
             selector : '#foo',
             waitForEnabled : tmpElem.waitForEnabled,
             waitForExist : vi.fn(),
@@ -72,6 +78,8 @@ describe('waitForEnabled', () => {
     it('should call isEnabled and return true', async () => {
         const tmpElem = await browser.$('#foo')
         const elem = {
+            on: vi.fn(),
+            off: vi.fn(),
             selector : '#foo',
             waitForEnabled : tmpElem.waitForEnabled,
             waitForExist : vi.fn(),
@@ -88,6 +96,8 @@ describe('waitForEnabled', () => {
     it('should call isEnabled and return false', async () => {
         const tmpElem = await browser.$('#foo')
         const elem = {
+            on: vi.fn(),
+            off: vi.fn(),
             selector : '#foo',
             waitForEnabled : tmpElem.waitForEnabled,
             waitForExist : vi.fn(),
@@ -108,6 +118,8 @@ describe('waitForEnabled', () => {
         const cb = vi.fn()
         const tmpElem = await browser.$('#foo')
         const elem = {
+            on: vi.fn(),
+            off: vi.fn(),
             selector : '#foo',
             waitForEnabled : tmpElem.waitForEnabled,
             waitForExist : vi.fn(),
@@ -124,6 +136,8 @@ describe('waitForEnabled', () => {
     it('should call isEnabled and return false with custom error', async () => {
         const tmpElem = await browser.$('#foo')
         const elem = {
+            on: vi.fn(),
+            off: vi.fn(),
             selector : '#foo',
             waitForEnabled : tmpElem.waitForEnabled,
             waitForExist : vi.fn(),


### PR DESCRIPTION
## Proposed changes

There are scenarios where WebdriverIO continues to run commands, even if a session has already terminated. For example if an element is retried due to stale element exceptions, e.g. outlined in this script:

```ts
await browser.url('http://localhost:8080')

await browser.saveScreenshot('before.png')
try {
    await browser.$('.loading').waitForDisplayed({ reverse: true })
} finally {
    await browser.saveScreenshot('after.png')
    await browser.deleteSession()
}
```

This patch adds a listener for the session close commands and aborts all abort controllers registered for each request. Furthermore the change adds logic to check whether we should even continue making the request if a session was closed before.

fixes #14240

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
