### PR TITLE
polish(webdriverio): remove function call before error

### DIFF
--- a/packages/webdriverio/src/commands/browser/switchWindow.ts
+++ b/packages/webdriverio/src/commands/browser/switchWindow.ts
@@ -100,7 +100,5 @@ export async function switchWindow (
         }
     }
 
-    await this.switchToWindow(currentWindow)
-
     throw new Error(`No window found with title, url, name or window handle matching "${matcher}"`)
 }


### PR DESCRIPTION
## Proposed changes

Removed a function call at a place where it should throw an error instead.

## Types of changes

- [x] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

### Reviewers: @webdriverio/project-committers
