### PR TITLE
docs: mention that Chrome DevTools protocol is not installed by default and what package is required

### DIFF
--- a/packages/webdriverio/src/commands/browser/getPuppeteer.ts
+++ b/packages/webdriverio/src/commands/browser/getPuppeteer.ts
@@ -18,7 +18,7 @@ const DEBUG_PIPE_FLAG = 'remote-debugging-pipe'
  * :::info
  *
  * Note that using Puppeteer requires support for Chrome DevTools protocol and e.g.
- * can not be used when running automated tests in the cloud. Chrome DevTools protocol is not installed in v9 by default,
+ * can not be used when running automated tests in the cloud. Chrome DevTools protocol is not installed by default,
  * use `npm install puppeteer-core` to install it.
  * Find out more in the [Automation Protocols](/docs/automationProtocols) section.
  *

--- a/packages/webdriverio/src/commands/browser/getPuppeteer.ts
+++ b/packages/webdriverio/src/commands/browser/getPuppeteer.ts
@@ -18,8 +18,9 @@ const DEBUG_PIPE_FLAG = 'remote-debugging-pipe'
  * :::info
  *
  * Note that using Puppeteer requires support for Chrome DevTools protocol and e.g.
- * can not be used when running automated tests in the cloud. Find out more in the
- * [Automation Protocols](/docs/automationProtocols) section.
+ * can not be used when running automated tests in the cloud. Chrome DevTools protocol is not installed in v9 by default,
+ * use `npm install puppeteer-core` to install it.
+ * Find out more in the [Automation Protocols](/docs/automationProtocols) section.
  *
  * :::
  *

--- a/packages/webdriverio/src/commands/browser/throttleCPU.ts
+++ b/packages/webdriverio/src/commands/browser/throttleCPU.ts
@@ -4,7 +4,7 @@
  * :::info
  *
  * Note that using the `throttleCPU` command requires support for Chrome DevTools protocol and e.g.
- * can not be used when running automated tests in the cloud. Chrome DevTools protocol is not installed in v9 by default,
+ * can not be used when running automated tests in the cloud. Chrome DevTools protocol is not installed by default,
  * use `npm install puppeteer-core` to install it.
  * Find out more in the [Automation Protocols](/docs/automationProtocols) section.
  *

--- a/packages/webdriverio/src/commands/browser/throttleCPU.ts
+++ b/packages/webdriverio/src/commands/browser/throttleCPU.ts
@@ -4,8 +4,9 @@
  * :::info
  *
  * Note that using the `throttleCPU` command requires support for Chrome DevTools protocol and e.g.
- * can not be used when running automated tests in the cloud. Find out more in the
- * [Automation Protocols](/docs/automationProtocols) section.
+ * can not be used when running automated tests in the cloud. Chrome DevTools protocol is not installed in v9 by default,
+ * use `npm install puppeteer-core` to install it.
+ * Find out more in the [Automation Protocols](/docs/automationProtocols) section.
  *
  * :::
  *

--- a/packages/webdriverio/src/commands/browser/throttleNetwork.ts
+++ b/packages/webdriverio/src/commands/browser/throttleNetwork.ts
@@ -12,7 +12,7 @@
  * :::info
  *
  * Note that using the `throttleNetwork` command requires support for Chrome DevTools protocol and e.g.
- * can not be used when running automated tests in the cloud. Chrome DevTools protocol is not installed in v9 by default,
+ * can not be used when running automated tests in the cloud. Chrome DevTools protocol is not installed by default,
  * use `npm install puppeteer-core` to install it.
  * Find out more in the [Automation Protocols](/docs/automationProtocols) section.
  *

--- a/packages/webdriverio/src/commands/browser/throttleNetwork.ts
+++ b/packages/webdriverio/src/commands/browser/throttleNetwork.ts
@@ -12,8 +12,9 @@
  * :::info
  *
  * Note that using the `throttleNetwork` command requires support for Chrome DevTools protocol and e.g.
- * can not be used when running automated tests in the cloud. Find out more in the
- * [Automation Protocols](/docs/automationProtocols) section.
+ * can not be used when running automated tests in the cloud. Chrome DevTools protocol is not installed in v9 by default,
+ * use `npm install puppeteer-core` to install it.
+ * Find out more in the [Automation Protocols](/docs/automationProtocols) section.
  *
  * :::
  *


### PR DESCRIPTION
## Proposed changes

I raised an issue #14253 when I tried to use a few commands that rely on the Chrome DevTools protocol. I agree with Erwin that it is not really a bug, but to be fair I found the Webdriver.io documentation on these commands was incomplete, as they do not mention that Chrome DevTools protocol is not installed by default anymore (in version 9), nor do they indicate which package is required to install to make it work.

The error given when trying to use these commands is a bit more explicit (a package is mentioned, but the name of the package doesn't make it clear that this is the Chrome DevTools protocol for people that are not in the know of such things). So we have two different indications in different places that are correct once put together, but that is not ideal that people have to piece things together. 

So I added a couple of sentences in the documentation on API commands where I found that the Chrome DevTools protocol was required to make things clearer. I mention that the Chrome DevTools protocol is not installed by default in v9 and the name of the package to install to get it.

## Types of changes

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

Let me know if I missed some other commands that requires Chrome DevTools Protocol. The list I came up with was these commands:

- getPupeeter
- throttleCPU
- throttleNetwork

### Reviewers: @webdriverio/project-committers
