### PR TITLE
docs: fix waitforfontsloaded position in docs

### DIFF
--- a/website/docs/visual-testing/service-options.md
+++ b/website/docs/visual-testing/service-options.md
@@ -410,6 +410,15 @@ returns a string can also be used to set the screenshotPath value:
 
 The padding which needs to be added to the toolbar bar on iOS and Android to do a proper cutout of the viewport.
 
+### `waitForFontsLoaded`
+
+-   **Type:** `boolean`
+-   **Mandatory:** No
+-   **Default:** `true`
+-   **Supported:** Web, Hybrid App (Webview)
+
+Fonts, including third-party fonts, can be loaded synchronously or asynchronously. Asynchronous loading means that fonts might load after WebdriverIO determines that a page has fully loaded. To prevent font rendering issues, this module, by default, will wait for all fonts to be loaded before taking a screenshot.
+
 ## Tabbable Options
 
 :::info NOTE
@@ -538,15 +547,6 @@ The color of the line.
 -   **Supported:** Web
 
 The width of the line.
-
-### `waitForFontsLoaded`
-
--   **Type:** `boolean`
--   **Mandatory:** No
--   **Default:** `true`
--   **Supported:** Web, Hybrid App (Webview)
-
-Fonts, including third-party fonts, can be loaded synchronously or asynchronously. Asynchronous loading means that fonts might load after WebdriverIO determines that a page has fully loaded. To prevent font rendering issues, this module, by default, will wait for all fonts to be loaded before taking a screenshot.
 
 ## Compare options
 


### PR DESCRIPTION
## Proposed changes

`waitForFontsLoaded` is shown as part of the `TabbableOptions` while it should be part of a regular `Default Options`.
I was looking for this features in the docs and got confused because of this.

#### Before

<img width="230" alt="image" src="https://github.com/user-attachments/assets/385707a1-caa5-421e-bdd8-7cc206913d25" />

#### After

<img width="212" alt="image" src="https://github.com/user-attachments/assets/c9b74080-fce4-4bbf-8ae6-f2d5922d792d" />

Notes: I think the TabbableOption is also not correct (ie showing `Tabbable Options > tabbableOptions`), let me know if I should open another PR for this.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
