### PR TITLE
fix(webdriverio): fail implicitly when trying to use Puppeteer with the browser runner

### DIFF
--- a/packages/webdriverio/src/commands/browser/getPuppeteer.ts
+++ b/packages/webdriverio/src/commands/browser/getPuppeteer.ts
@@ -17,9 +17,15 @@ const DEBUG_PIPE_FLAG = 'remote-debugging-pipe'
  *
  * :::info
  *
- * Note that using Puppeteer requires support for Chrome DevTools protocol and e.g.
+ * Note: that using Puppeteer requires support for Chrome DevTools protocol and e.g.
  * can not be used when running automated tests in the cloud. Find out more in the
  * [Automation Protocols](/docs/automationProtocols) section.
+ *
+ * :::
+ *
+ * :::info
+ *
+ * Note: Puppeteer is currently __not__ supported when running [component tests](/docs/component-testing).
  *
  * :::
  *
@@ -44,6 +50,13 @@ const DEBUG_PIPE_FLAG = 'remote-debugging-pipe'
  * @return {PuppeteerBrowser}  initiated puppeteer instance connected to the browser
  */
 export async function getPuppeteer (this: WebdriverIO.Browser): Promise<PuppeteerBrowser> {
+    /**
+     * Tell user that Puppeteer is not supported in browser runner
+     */
+    if (globalThis.wdio) {
+        throw new Error('Puppeteer is not supported in browser runner')
+    }
+
     const puppeteer = await userImport<Puppeteer>('puppeteer-core')
 
     if (!puppeteer) {

--- a/packages/webdriverio/tests/commands/browser/getPuppeteer.test.ts
+++ b/packages/webdriverio/tests/commands/browser/getPuppeteer.test.ts
@@ -55,7 +55,7 @@ describe('attach Puppeteer', () => {
                 }
             },
             requestedCapabilities: {}
-        })
+        } as WebdriverIO.Browser)
         expect(typeof pptr).toBe('object')
         expect(puppeteerConnect.mock.calls).toMatchSnapshot()
     })
@@ -73,7 +73,7 @@ describe('attach Puppeteer', () => {
                     args: ['foo', 'bar', '-remote-debugging-port', 4321, 'barfoo']
                 } as any
             }
-        })
+        } as WebdriverIO.Browser)
         expect(typeof pprt).toBe('object')
         expect(puppeteerConnect.mock.calls).toMatchSnapshot()
     })
@@ -94,7 +94,7 @@ describe('attach Puppeteer', () => {
                     args: []
                 } as any
             }
-        })
+        } as WebdriverIO.Browser)
         expect(typeof pptr).toBe('object')
         expect(puppeteerConnect.mock.calls).toMatchSnapshot()
     })
@@ -113,7 +113,7 @@ describe('attach Puppeteer', () => {
                     args: []
                 } as any
             }
-        })
+        } as WebdriverIO.Browser)
         expect(typeof pptr).toBe('object')
         expect(puppeteerConnect.mock.calls).toMatchSnapshot()
     })
@@ -131,7 +131,7 @@ describe('attach Puppeteer', () => {
                     args: []
                 } as any
             }
-        })).rejects.toThrow('Could\'t find a websocket url')
+        } as WebdriverIO.Browser)).rejects.toThrow('Could\'t find a websocket url')
     })
 
     it('should pass for Edge', async () => {
@@ -145,7 +145,7 @@ describe('attach Puppeteer', () => {
                 }
             },
             requestedCapabilities: {}
-        })
+        } as WebdriverIO.Browser)
         expect(typeof pptr).toBe('object')
         expect(puppeteerConnect.mock.calls).toMatchSnapshot()
     })
@@ -164,7 +164,7 @@ describe('attach Puppeteer', () => {
                 } as any
             }
         // @ts-ignore uses sync command
-        }).catch(err => err)
+        } as WebdriverIO.Browser).catch(err => err)
 
         expect(err.message).toContain('Using DevTools capabilities is not supported for this session.')
     })
@@ -182,7 +182,7 @@ describe('attach Puppeteer', () => {
             puppeteer: {
                 connected: true
             } as any
-        })
+        } as WebdriverIO.Browser)
         expect(typeof pptr).toBe('object')
         expect(puppeteerConnect).toHaveBeenCalledTimes(0)
     })
@@ -194,7 +194,7 @@ describe('attach Puppeteer', () => {
             capabilities: {
                 'se:cdp': 'http://my.grid:1234/session/mytestsession/se/cdp'
             }
-        })
+        } as WebdriverIO.Browser)
         expect(typeof pptr).toBe('object')
         expect(puppeteerConnect.mock.calls).toMatchSnapshot()
     })
@@ -220,7 +220,7 @@ describe('attach Puppeteer', () => {
                     Authorization: 'OAuth token'
                 }
             } as any
-        })
+        } as WebdriverIO.Browser)
         expect(typeof pptr).toBe('object')
         expect(puppeteerConnect.mock.calls).toMatchSnapshot()
     })
@@ -246,9 +246,18 @@ describe('attach Puppeteer', () => {
                     Authorization: 'OAuth token'
                 }
             } as any
-        })
+        } as WebdriverIO.Browser)
         expect(typeof pptr).toBe('object')
         expect(puppeteerConnect.mock.calls).toMatchSnapshot()
     })
 
+    it('should throw an error if Puppeteer is not supported', async () => {
+        // @ts-expect-error
+        globalThis.wdio = true
+        await expect(browser.getPuppeteer.call({
+            ...browser,
+            options: browser.options,
+            capabilities: { browserName: 'chrome' }
+        } as WebdriverIO.Browser)).rejects.toThrow('Puppeteer is not supported in browser runner')
+    })
 })


### PR DESCRIPTION
## Proposed changes

We currently do not support using Puppeteer when running tests in the browser. I think per-se this should be doable but requires additional implementation. To avoid confusion, this patch disables this feature and makes it more clear to the user.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
