### PR TITLE
docs: add compareoptions object for visual test docs

### DIFF
--- a/website/docs/visual-testing/service-options.md
+++ b/website/docs/visual-testing/service-options.md
@@ -550,4 +550,11 @@ The width of the line.
 
 ## Compare options
 
+### `compareOptions`
+
+-   **Type:** `object`
+-   **Mandatory:** No
+-   **Default:** See [here](https://github.com/webdriverio/visual-testing/blob/6a988808c9adc58f58c5a66cd74296ae5c1ad6dc/packages/webdriver-image-comparison/src/helpers/options.ts#L46-L60) for all default values
+-   **Supported:** Web, Hybrid App (Webview), Native App (See [Method Compare options](./method-options#compare-check-options) for more information)
+
 The compare options can also be set as service options, they are described in the [Method Compare options](./method-options#compare-check-options)


### PR DESCRIPTION
## Proposed changes

Have a `compareOptions` object mention in the `Visual Service` page, similar to `tabbableOptions` example.

<img width="1156" alt="image" src="https://github.com/user-attachments/assets/51a40964-9cab-4c62-bcc8-197b37dde3cb" />


## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
