### PR TITLE
fix(webdriverio): wait for element to exist before executing on it

### DIFF
--- a/packages/webdriverio/src/commands/element/execute.ts
+++ b/packages/webdriverio/src/commands/element/execute.ts
@@ -42,5 +42,6 @@ export async function execute<ReturnValue, InnerArguments extends unknown[]> (
     ...args: InnerArguments
 ): Promise<ReturnValue> {
     const browser = getBrowserObject(this)
+    await this.waitForExist()
     return browser.execute(script, this, ...args)
 }

--- a/packages/webdriverio/tests/commands/element/execute.test.ts
+++ b/packages/webdriverio/tests/commands/element/execute.test.ts
@@ -1,5 +1,5 @@
 import path from 'node:path'
-import { expect, describe, it, vi } from 'vitest'
+import { expect, describe, it, vi, beforeEach } from 'vitest'
 import { ELEMENT_KEY } from 'webdriver'
 
 import { remote } from '../../../src/index.js'
@@ -8,6 +8,10 @@ vi.mock('fetch')
 vi.mock('@wdio/logger', () => import(path.join(process.cwd(), '__mocks__', '@wdio/logger')))
 
 describe('execute test', () => {
+    beforeEach(() => {
+        vi.mocked(fetch).mockClear()
+    })
+
     it('should execute the script', async () => {
         const browser = await remote({
             baseUrl: 'http://foobar.com',
@@ -19,10 +23,30 @@ describe('execute test', () => {
         await browser.$('#foo').execute((elem, a, b, c) => (elem.selector as string) + a + b + c, 1, 2, 3)
         expect((vi.mocked(fetch).mock.calls[1][0] as any).pathname)
             .toBe('/session/foobar-123/element')
-        expect(JSON.parse(vi.mocked(fetch).mock.calls[2][1]?.body as string)).toEqual(expect.objectContaining({
+        expect(JSON.parse(vi.mocked(fetch).mock.calls[4][1]?.body as string)).toEqual(expect.objectContaining({
             script: expect.stringContaining('return ((elem, a, b, c) => elem.selector + a + b + c).apply(null, arguments)'),
             args: [{ [ELEMENT_KEY]: 'some-elem-123', ELEMENT: 'some-elem-123' }, 1, 2, 3]
         }))
+    })
+
+    it('should wait for element to exist', async () => {
+        const browser = await remote({
+            baseUrl: 'http://foobar.com',
+            capabilities: {
+                browserName: 'foobar'
+            }
+        })
+
+        await browser.$('#foo').execute((elem) => elem)
+        expect(vi.mocked(fetch).mock.calls.map(call => call[0])).toMatchInlineSnapshot(`
+          [
+            "http://localhost:4321/session",
+            "http://localhost:4321/session/foobar-123/element",
+            "http://localhost:4321/session/foobar-123/elements",
+            "http://localhost:4321/session/foobar-123/element",
+            "http://localhost:4321/session/foobar-123/execute/sync",
+          ]
+        `)
     })
 
     it('should return correct value', async () => {


### PR DESCRIPTION
## Proposed changes

fixes #4801

The following should just work:

```ts
await browser.url('http://guinea-pig.webdriver.io')
const el = await browser.$('.box')
await browser.refresh()
console.log(1111, await el.execute(el => el.outerHTML))
```

This patch adds a `waitForExist` call to ensure the element exist before we call on it.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
