### PR TITLE
chore(webdriver): add unit tests for DNS patch

### DIFF
--- a/packages/webdriver/src/bidi/core.ts
+++ b/packages/webdriver/src/bidi/core.ts
@@ -1,7 +1,5 @@
 import logger from '@wdio/logger'
 import type { ClientOptions, RawData, WebSocket } from 'ws'
-import { isIP } from 'node:net'
-import dns from 'node:dns/promises'
 
 import { environment } from '../environment.js'
 import type * as remote from './remoteTypes.js'
@@ -46,20 +44,19 @@ export class BidiCore {
     }
 
     public async connect () {
+        log.info(`Connecting to webSocketUrl ${this.#webSocketUrl}`)
+
         /**
-         * don't connect and stale unit tests when the websocket url is set to a dummy value
-         * Note: the value is defined in __mocks__/fetch.ts
+         * try to connect to different websocket urls depending on the protocol
          */
-        if (process.env.WDIO_UNIT_TESTS) {
-            this._isConnected = true
-            return
+        this.#ws = await environment.value.createBidiConnection(this.#webSocketUrl, this.#clientOptions)
+        if (!this.#ws) {
+            this._isConnected = false
+            return false
         }
 
-        log.info(`Connecting to webSocketUrl ${this.#webSocketUrl}`)
-        // https://github.com/webdriverio/webdriverio/issues/14039
-        const candidateUrls = await this.#listWebsocketCandidateUrls()
-        this.#waitForConnected = this.#connectWebsocket(candidateUrls)
-        return this.#waitForConnected
+        this._isConnected = true
+        return true
     }
 
     public close () {
@@ -185,75 +182,6 @@ export class BidiCore {
         this.client?.emit('bidiCommand', params)
         this.#ws.send(JSON.stringify({ id, ...params }))
         return id
-    }
-
-    async #listWebsocketCandidateUrls(): Promise<string[]> {
-        const parsedUrl = new URL(this.#webSocketUrl)
-        // https://github.com/webdriverio/webdriverio/issues/14039
-        const candidateUrls: string[] = [this.#webSocketUrl]
-        if (!isIP(parsedUrl.hostname)) {
-            const candidateIps = (await Promise.all([
-                dns.resolve4(parsedUrl.hostname),
-                dns.resolve6(parsedUrl.hostname),
-            ])).flat()
-            // If the host resolves to a single IP address
-            // then it does not make sense to try additional candidates
-            // as the web socket DNS resolver would do exactly the same
-            if (candidateIps.length > 1) {
-                const hostnameMapper = (ip: string) => this.#webSocketUrl.replace(parsedUrl.hostname, ip)
-                candidateUrls.push(...candidateIps.map(hostnameMapper))
-            }
-        }
-        return candidateUrls
-    }
-
-    async #connectWebsocket(candidateUrls: string[]): Promise<boolean> {
-        const wsConnectPromises: Promise<WebSocket | null>[] = []
-        const errorMessages: string[] = []
-        let onFirstWebsocketConnected = () => {}
-        const firstWebsocketConnectedPromise = new Promise<void>((resolve) => {
-            onFirstWebsocketConnected = resolve
-        })
-        const candidateWebsockets: WebSocket[] = []
-        for (const candidateUrl of candidateUrls) {
-            const ws = new environment.value.Socket(candidateUrl, this.#clientOptions) as unknown as WebSocket
-            candidateWebsockets.push(ws)
-            const connectPromise = new Promise<WebSocket | null>((resolve) => {
-                ws.once('open', () => {
-                    if (!this.#ws) {
-                        log.info(`Connected session to Bidi protocol at ${candidateUrl}`)
-                        this.#ws = ws
-                        this.#ws.on('message', this.#handleResponse.bind(this))
-                        onFirstWebsocketConnected()
-                    }
-                    resolve(ws)
-                })
-                ws.once('error', (err) => {
-                    errorMessages.push(`Couldn't connect to Bidi protocol at ${candidateUrl}: ${err.message}`)
-                    resolve(null)
-                })
-            })
-            wsConnectPromises.push(connectPromise)
-        }
-        // We either wait until any web socket is successfully connected
-        // or all of them fail
-        await Promise.race([
-            firstWebsocketConnectedPromise,
-            Promise.all(wsConnectPromises)
-        ])
-        if (this.#ws) {
-            // Cleanup extra opened sockets
-            candidateWebsockets
-                .filter((ws) => ws !== this.#ws)
-                .forEach((ws) => ws.close())
-            this._isConnected = true
-        } else {
-            for (const errorMessage of errorMessages) {
-                log.warn(errorMessage)
-            }
-            this._isConnected = false
-        }
-        return this._isConnected
     }
 }
 

--- a/packages/webdriver/src/browser.ts
+++ b/packages/webdriver/src/browser.ts
@@ -18,7 +18,6 @@ environment.value = {
     createBidiConnection: (webSocketUrl: string, options: unknown) => {
         log.info(`Connecting to webSocketUrl ${webSocketUrl}`)
         const ws = new BrowserSocket(webSocketUrl, options)
-        console.log('!!')
         return new Promise<WebSocket | undefined>((resolve) => {
             ws.on('open', () => {
                 log.info('Connected session to Bidi protocol')

--- a/packages/webdriver/src/browser.ts
+++ b/packages/webdriver/src/browser.ts
@@ -1,3 +1,6 @@
+import logger from '@wdio/logger'
+import type { WebSocket } from 'ws'
+
 import WebDriver from './index.js'
 import { BrowserSocket } from './bidi/socket.js'
 import { FetchRequest } from './request/web.js'
@@ -7,9 +10,26 @@ export * from './index.js'
 
 import { environment } from './environment.js'
 
+const log = logger('webdriver')
+
 environment.value = {
     Request: FetchRequest,
     Socket: BrowserSocket,
+    createBidiConnection: (webSocketUrl: string, options: unknown) => {
+        log.info(`Connecting to webSocketUrl ${webSocketUrl}`)
+        const ws = new BrowserSocket(webSocketUrl, options)
+        console.log('!!')
+        return new Promise<WebSocket | undefined>((resolve) => {
+            ws.on('open', () => {
+                log.info('Connected session to Bidi protocol')
+                resolve(ws as unknown as WebSocket)
+            })
+            ws.on('error', (err) => {
+                const error = err instanceof Error ? err : new Error(String(err))
+                log.warn(`Couldn't connect to Bidi protocol: ${error.message}`)
+                resolve(undefined)
+            })
+        })
+    },
     variables: {}
 }
-

--- a/packages/webdriver/src/environment.ts
+++ b/packages/webdriver/src/environment.ts
@@ -1,3 +1,5 @@
+import type WebSocket from 'ws'
+
 import type { BrowserSocket } from './bidi/socket.js'
 import type { FetchRequest } from './request/web.js'
 
@@ -14,6 +16,7 @@ export interface EnvironmentVariables {
 export interface EnvironmentDependencies {
     Request: typeof FetchRequest,
     Socket: typeof BrowserSocket,
+    createBidiConnection: (wsUrl?: string, options?: unknown) => Promise<WebSocket | undefined>,
     variables: EnvironmentVariables
 }
 
@@ -30,6 +33,9 @@ export const environment: {
         },
         get Socket(): EnvironmentDependencies['Socket'] {
             throw new Error('Socket is not available in this environment')
+        },
+        get createBidiConnection(): EnvironmentDependencies['createBidiConnection'] {
+            throw new Error('createBidiConnection is not available in this environment')
         },
         get variables(): EnvironmentDependencies['variables'] {
             return {}

--- a/packages/webdriver/src/index.ts
+++ b/packages/webdriver/src/index.ts
@@ -149,7 +149,9 @@ export default class WebDriver {
          * parse and propagate all Bidi events to the browser instance
          */
         if (isBidi(options.capabilities || {})) {
-            client._bidiHandler?.socket.on('message', parseBidiMessage.bind(client))
+            client._bidiHandler?.waitForConnected().then(()=>{
+                client._bidiHandler?.socket.on('message', parseBidiMessage.bind(client))
+            })
         }
         return client
     }

--- a/packages/webdriver/src/node.ts
+++ b/packages/webdriver/src/node.ts
@@ -4,6 +4,7 @@ import ws from 'ws'
 import WebDriver from './index.js'
 import { FetchRequest } from './request/node.js'
 import { FetchRequest as WebFetchRequest } from './request/web.js'
+import { createBidiConnection } from './node/bidi.js'
 import type { BrowserSocket } from './bidi/socket.js'
 
 export default WebDriver
@@ -27,6 +28,7 @@ environment.value = {
         process.env.WDIO_UNIT_TESTS
     ) ? WebFetchRequest : FetchRequest,
     Socket: ws as unknown as typeof BrowserSocket,
+    createBidiConnection,
     variables: {
         WEBDRIVER_CACHE_DIR: process.env.WEBDRIVER_CACHE_DIR || os.tmpdir(),
         PROXY_URL: process.env.HTTP_PROXY || process.env.HTTPS_PROXY

--- a/packages/webdriver/src/node/bidi.ts
+++ b/packages/webdriver/src/node/bidi.ts
@@ -6,6 +6,7 @@ import logger from '@wdio/logger'
 import WebSocket from 'ws'
 
 const log = logger('webdriver')
+const CONNECTION_TIMEOUT = 10000
 
 export async function createBidiConnection(webSocketUrl: string, options?: unknown): Promise<WebSocket | undefined> {
     const candidateUrls = await listWebsocketCandidateUrls(webSocketUrl)
@@ -36,54 +37,73 @@ export async function listWebsocketCandidateUrls(webSocketUrl: string): Promise<
     return candidateUrls
 }
 
+interface ConnectionResult {
+    index: number
+    ws: WebSocket
+    isConnected: boolean
+    errorMessage?: string
+}
+
 /**
  * Connect to a websocket
  * @param candidateUrls - list of websocket urls to try
  * @returns true if the connection was successful
  */
 export async function connectWebsocket(candidateUrls: string[], _?: unknown): Promise<WebSocket | undefined> {
-    const wsConnectPromises: Promise<WebSocket | undefined>[] = []
-    const errorMessages: string[] = []
-    let onFirstWebsocketConnected = (_ws: WebSocket) => {}
-    const firstWebsocketConnectedPromise = new Promise<WebSocket>((resolve) => {
-        onFirstWebsocketConnected = resolve
-    })
-    const candidateWebsockets: WebSocket[] = []
-    for (const candidateUrl of candidateUrls) {
+    const websockets: WebSocket[] = candidateUrls.map((candidateUrl) => {
         log.debug(`Attempt to connect to webSocketUrl ${candidateUrl}`)
-        const ws = new WebSocket(candidateUrl) as unknown as WebSocket
-        candidateWebsockets.push(ws)
-        const connectPromise = new Promise<WebSocket | undefined>((resolve) => {
-            ws.once('open', () => {
-                log.info(`Connected session to Bidi protocol at ${candidateUrl}`)
-                onFirstWebsocketConnected(ws)
-                resolve(ws)
-            })
+        return new WebSocket(candidateUrl)
+    })
+
+    const wsConnectPromises: Promise<ConnectionResult>[] = websockets.map((ws, index) => {
+        return new Promise<ConnectionResult>((resolve) => {
+            ws.once('open', () => resolve({ ws, isConnected: true, index }))
             ws.once('error', (err) => {
-                errorMessages.push(`Couldn't connect to Bidi protocol at ${candidateUrl}: ${err.message}`)
-                resolve(undefined)
+                log.debug(`Could not connect to Bidi protocol at ${candidateUrls[index]}: ${err.message}`)
+                resolve({ ws, isConnected: false, errorMessage: err.message, index })
             })
         })
-        wsConnectPromises.push(connectPromise)
-    }
-    // We either wait until any web socket is successfully connected
-    // or all of them fail
-    await Promise.race([
-        firstWebsocketConnectedPromise,
-        Promise.all(wsConnectPromises)
+    })
+
+    const connectionTimeoutPromise = new Promise<undefined>((resolve) => {
+        setTimeout(() => {
+            log.error(`Could not connect to Bidi protocol of any candidate url: "${candidateUrls.join('", "')}"`)
+            return resolve(undefined)
+        }, CONNECTION_TIMEOUT)
+    })
+
+    const ws = await Promise.race([
+        firstResolved(wsConnectPromises),
+        connectionTimeoutPromise,
     ])
 
-    const ws = await firstWebsocketConnectedPromise
-
-    if (ws) {
-        // Cleanup extra opened sockets
-        candidateWebsockets
-            .filter((candidate) => ws !== candidate)
-            .forEach((ws) => ws.close())
-    } else {
-        for (const errorMessage of errorMessages) {
-            log.warn(errorMessage)
-        }
+    const socketsToCleanup = ws ? websockets.filter((_, index) => ws.index !== index) : websockets
+    for (const socket of socketsToCleanup) {
+        socket.removeAllListeners()
+        socket.terminate()
     }
-    return ws
+
+    if (ws?.isConnected) {
+        log.info(`Connected to Bidi protocol at ${candidateUrls[ws.index]}`)
+        return ws.ws
+    }
+
+    return undefined
+}
+
+/**
+ * Race the promises and return the first resolved promise that shows a successful connection
+ * @param promises - list of promises to race
+ * @returns the first resolved promise
+ */
+function firstResolved (promises: Promise<ConnectionResult>[]): Promise<ConnectionResult> {
+    // Race the wrapped promises
+    return Promise.race(promises).then(result => {
+        if (result.isConnected) {
+            return result
+        }
+
+        // If the first result was a rejection, race the remaining promises
+        return firstResolved(promises.filter((_, index) => index !== result.index))
+    })
 }

--- a/packages/webdriver/src/node/bidi.ts
+++ b/packages/webdriver/src/node/bidi.ts
@@ -50,6 +50,7 @@ export async function connectWebsocket(candidateUrls: string[], _?: unknown): Pr
     })
     const candidateWebsockets: WebSocket[] = []
     for (const candidateUrl of candidateUrls) {
+        log.debug(`Attempt to connect to webSocketUrl ${candidateUrl}`)
         const ws = new WebSocket(candidateUrl) as unknown as WebSocket
         candidateWebsockets.push(ws)
         const connectPromise = new Promise<WebSocket | undefined>((resolve) => {

--- a/packages/webdriver/src/node/bidi.ts
+++ b/packages/webdriver/src/node/bidi.ts
@@ -22,15 +22,17 @@ export async function createBidiConnection(webSocketUrl: string, options?: unkno
 export async function listWebsocketCandidateUrls(webSocketUrl: string): Promise<string[]> {
     const parsedUrl = new URL(webSocketUrl)
     const candidateUrls: string[] = [webSocketUrl]
-    if (!isIP(parsedUrl.hostname)) {
-        const candidateIps = await dns.lookup(parsedUrl.hostname, { family:0, all:true })
-        // If the host resolves to a single IP address
-        // then it does not make sense to try additional candidates
-        // as the web socket DNS resolver would do extactly the same
-        if (candidateIps.length > 1) {
-            const hostnameMapper = (result: LookupAddress) => webSocketUrl.replace(parsedUrl.hostname, result.address)
-            candidateUrls.push(...candidateIps.map(hostnameMapper))
-        }
+    if (isIP(parsedUrl.hostname)) {
+        return candidateUrls
+    }
+
+    const candidateIps = await dns.lookup(parsedUrl.hostname, { family:0, all:true })
+    // If the host resolves to a single IP address
+    // then it does not make sense to try additional candidates
+    // as the web socket DNS resolver would do extactly the same
+    if (candidateIps.length > 1) {
+        const hostnameMapper = (result: LookupAddress) => webSocketUrl.replace(parsedUrl.hostname, result.address)
+        candidateUrls.push(...candidateIps.map(hostnameMapper))
     }
     return candidateUrls
 }

--- a/packages/webdriver/src/node/bidi.ts
+++ b/packages/webdriver/src/node/bidi.ts
@@ -1,0 +1,88 @@
+import { isIP } from 'node:net'
+import dns from 'node:dns/promises'
+
+import logger from '@wdio/logger'
+
+import WebSocket from 'ws'
+
+const log = logger('webdriver')
+
+export async function createBidiConnection(webSocketUrl: string, options?: unknown): Promise<WebSocket | undefined> {
+    const candidateUrls = await listWebsocketCandidateUrls(webSocketUrl)
+    return connectWebsocket(candidateUrls, options)
+}
+
+/**
+ * Resolve hostnames to IPv4 and IPv6 addresses
+ * @returns list of websocket urls to try
+ * @see https://github.com/webdriverio/webdriverio/issues/14039
+ */
+export async function listWebsocketCandidateUrls(webSocketUrl: string): Promise<string[]> {
+    const parsedUrl = new URL(webSocketUrl)
+    const candidateUrls: string[] = [webSocketUrl]
+    if (!isIP(parsedUrl.hostname)) {
+        const candidateIps = (await Promise.all([
+            dns.resolve4(parsedUrl.hostname),
+            dns.resolve6(parsedUrl.hostname),
+        ])).flat()
+        // If the host resolves to a single IP address
+        // then it does not make sense to try additional candidates
+        // as the web socket DNS resolver would do extactly the same
+        if (candidateIps.length > 1) {
+            const hostnameMapper = (ip: string) => webSocketUrl.replace(parsedUrl.hostname, ip)
+            candidateUrls.push(...candidateIps.map(hostnameMapper))
+        }
+    }
+    return candidateUrls
+}
+
+/**
+ * Connect to a websocket
+ * @param candidateUrls - list of websocket urls to try
+ * @returns true if the connection was successful
+ */
+export async function connectWebsocket(candidateUrls: string[], _?: unknown): Promise<WebSocket | undefined> {
+    const wsConnectPromises: Promise<WebSocket | undefined>[] = []
+    const errorMessages: string[] = []
+    let onFirstWebsocketConnected = (_ws: WebSocket) => {}
+    const firstWebsocketConnectedPromise = new Promise<WebSocket>((resolve) => {
+        onFirstWebsocketConnected = resolve
+    })
+    const candidateWebsockets: WebSocket[] = []
+    for (const candidateUrl of candidateUrls) {
+        const ws = new WebSocket(candidateUrl) as unknown as WebSocket
+        candidateWebsockets.push(ws)
+        const connectPromise = new Promise<WebSocket | undefined>((resolve) => {
+            ws.once('open', () => {
+                log.info(`Connected session to Bidi protocol at ${candidateUrl}`)
+                onFirstWebsocketConnected(ws)
+                resolve(ws)
+            })
+            ws.once('error', (err) => {
+                errorMessages.push(`Couldn't connect to Bidi protocol at ${candidateUrl}: ${err.message}`)
+                resolve(undefined)
+            })
+        })
+        wsConnectPromises.push(connectPromise)
+    }
+    // We either wait until any web socket is successfully connected
+    // or all of them fail
+    await Promise.race([
+        firstWebsocketConnectedPromise,
+        Promise.all(wsConnectPromises)
+    ])
+
+    const ws = await firstWebsocketConnectedPromise
+
+    if (ws) {
+        // Cleanup extra opened sockets
+        candidateWebsockets
+            .filter((candidate) => ws !== candidate)
+            .forEach((ws) => ws.close())
+    } else {
+        for (const errorMessage of errorMessages) {
+            log.warn(errorMessage)
+        }
+    }
+    return ws
+}

--- a/packages/webdriver/tests/node/bidi.test.ts
+++ b/packages/webdriver/tests/node/bidi.test.ts
@@ -11,8 +11,7 @@ vi.mock('@wdio/logger', () => import(path.join(process.cwd(), '__mocks__', '@wdi
 
 vi.mock('dns/promises', () => ({
     default: {
-        resolve4: vi.fn().mockResolvedValue(['127.0.0.1']),
-        resolve6: vi.fn().mockResolvedValue(['::1'])
+        lookup: vi.fn().mockResolvedValue([{ address: '127.0.0.1' }, { address: '::1' }])
     }
 }))
 

--- a/packages/webdriver/tests/node/bidi.test.ts
+++ b/packages/webdriver/tests/node/bidi.test.ts
@@ -1,0 +1,69 @@
+// @ts-expect-error mock feature
+import { instances } from 'ws'
+import { describe, it, expect, vi } from 'vitest'
+
+import { listWebsocketCandidateUrls, createBidiConnection } from '../../src/node/bidi.js'
+
+vi.mock('dns/promises', () => ({
+    default: {
+        resolve4: vi.fn().mockResolvedValue(['127.0.0.1']),
+        resolve6: vi.fn().mockResolvedValue(['::1'])
+    }
+}))
+
+vi.mock('ws', () => {
+    const instances: WebSocket[] = []
+    return {
+        default: class WebSocketMock {
+            wsUrl: string
+            on = vi.fn()
+            send = vi.fn()
+            once = vi.fn()
+            error = vi.fn()
+            close = vi.fn()
+            terminate = vi.fn()
+
+            constructor(url: string) {
+                instances.push(this as unknown as WebSocket)
+                this.wsUrl = url
+            }
+        },
+        instances
+    }
+})
+
+describe('Bidi Node.js implementation', () => {
+    it('listWebsocketCandidateUrls', async () => {
+        const candidateUrls = await listWebsocketCandidateUrls('ws://foo/bar')
+        expect(candidateUrls).toEqual([
+            'ws://foo/bar',
+            'ws://127.0.0.1/bar',
+            'ws://::1/bar'
+        ])
+    })
+
+    it('createBidiConnection', async () => {
+        const wsPromise = createBidiConnection('ws://foo/bar')
+        await new Promise((resolve) => setTimeout(resolve, 100))
+        expect(instances.length).toBe(3)
+        expect(instances[0].wsUrl).toBe('ws://foo/bar')
+        expect(instances[1].wsUrl).toBe('ws://127.0.0.1/bar')
+        expect(instances[2].wsUrl).toBe('ws://::1/bar')
+        expect(instances[0].once).toHaveBeenCalledWith('open', expect.any(Function))
+        expect(instances[1].once).toHaveBeenCalledWith('open', expect.any(Function))
+        expect(instances[2].once).toHaveBeenCalledWith('open', expect.any(Function))
+
+        console.log(11, instances[0].once.mock.calls[1][1])
+
+        instances[0].once.mock.calls[1][1](new Error('foo')) // error callback
+        instances[1].once.mock.calls[0][1]() // success callback
+        instances[2].once.mock.calls[1][1](new Error('bar')) // error callback
+
+        const ws = await wsPromise as any
+        expect(instances[0].close).toHaveBeenCalled()
+        expect(instances[1].close).not.toHaveBeenCalled()
+        expect(instances[2].close).toHaveBeenCalled()
+
+        expect(ws.wsUrl).toBe('ws://127.0.0.1/bar')
+    })
+})


### PR DESCRIPTION
## Proposed changes

This adds unit tests for #14259. It also moves most of the added logic into a separate file as it is Node.js related and we want to keep basic implementations unrelated to the environment where it is executed in.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

@mykola-mokhnach please review

### Reviewers: @webdriverio/project-committers
