### PR TITLE
fix: Mobile Swipe - percentage calculation issue

### DIFF
--- a/packages/webdriverio/src/commands/mobile/swipe.ts
+++ b/packages/webdriverio/src/commands/mobile/swipe.ts
@@ -137,20 +137,17 @@ async function calculateFromTo({
     //    - left
     //    of the element. These positions will contain the x and y coordinates on where to put the finger
     const { x, y, width, height } = await browser.getElementRect(await scrollableElement?.elementId)
+
+    // calculate the offset
+    const verticalOffset = height - height * swipePercentage
+    const horizontalOffset = width - width * swipePercentage
+
     // It's always advisable to swipe from the center of the element.
     const scrollRectangles = {
-        from: {
-            top: { x: Math.round(x + width / 2), y: Math.round(y + height - height * swipePercentage) },
-            right: { x: Math.round(x + width * swipePercentage), y: Math.round(y + height / 2) },
-            bottom: { x: Math.round(x + width / 2), y: Math.round(y + height * swipePercentage) },
-            left: { x: Math.round(x + width - width * swipePercentage), y: Math.round(y + height / 2) },
-        },
-        to:{
-            top: { x: Math.round(x + width / 2), y: Math.round(y + height) },
-            right: { x: Math.round(x + width), y: Math.round(y + height / 2) },
-            bottom: { x: Math.round(x + width / 2), y: Math.round(y + height) },
-            left: { x: Math.round(x + width), y: Math.round(y + height / 2) },
-        }
+        top: { x: Math.round(x + width / 2), y: Math.round(y + verticalOffset / 2) },
+        right: { x: Math.round(x + width - horizontalOffset / 2), y: Math.round(y + height / 2) },
+        bottom: { x: Math.round(x + width / 2), y: Math.round(y + height - verticalOffset / 2 ) },
+        left: { x: Math.round(x + horizontalOffset / 2), y: Math.round(y + height / 2) },
     }
 
     // 3. Swipe in the given direction
@@ -159,20 +156,20 @@ async function calculateFromTo({
 
     switch (direction) {
     case MobileScrollDirection.Down:
-        from = scrollRectangles.from.top
-        to = scrollRectangles.to.bottom
+        from = scrollRectangles.top
+        to = scrollRectangles.bottom
         break
     case MobileScrollDirection.Left:
-        from = scrollRectangles.from.right
-        to= scrollRectangles.to.left
+        from = scrollRectangles.right
+        to= scrollRectangles.left
         break
     case MobileScrollDirection.Right:
-        from = scrollRectangles.from.left
-        to = scrollRectangles.to.right
+        from = scrollRectangles.left
+        to = scrollRectangles.right
         break
     case MobileScrollDirection.Up:
-        from = scrollRectangles.from.bottom
-        to = scrollRectangles.to.top
+        from = scrollRectangles.bottom
+        to = scrollRectangles.top
         break
     default:
         throw new Error(`Unknown direction: ${direction}`)

--- a/packages/webdriverio/src/commands/mobile/swipe.ts
+++ b/packages/webdriverio/src/commands/mobile/swipe.ts
@@ -139,10 +139,18 @@ async function calculateFromTo({
     const { x, y, width, height } = await browser.getElementRect(await scrollableElement?.elementId)
     // It's always advisable to swipe from the center of the element.
     const scrollRectangles = {
-        top: { x: Math.round(x + width / 2), y: Math.round(y + height - height * swipePercentage) },
-        right: { x: Math.round(x + width * swipePercentage), y: Math.round(y + height / 2) },
-        bottom: { x: Math.round(x + width / 2), y: Math.round(y + height * swipePercentage) },
-        left: { x: Math.round(x + width - width * swipePercentage), y: Math.round(y + height / 2) },
+        from: {
+            top: { x: Math.round(x + width / 2), y: Math.round(y + height - height * swipePercentage) },
+            right: { x: Math.round(x + width * swipePercentage), y: Math.round(y + height / 2) },
+            bottom: { x: Math.round(x + width / 2), y: Math.round(y + height * swipePercentage) },
+            left: { x: Math.round(x + width - width * swipePercentage), y: Math.round(y + height / 2) },
+        },
+        to:{
+            top: { x: Math.round(x + width / 2), y: Math.round(y + height) },
+            right: { x: Math.round(x + width), y: Math.round(y + height / 2) },
+            bottom: { x: Math.round(x + width / 2), y: Math.round(y + height) },
+            left: { x: Math.round(x + width), y: Math.round(y + height / 2) },
+        }
     }
 
     // 3. Swipe in the given direction
@@ -151,20 +159,20 @@ async function calculateFromTo({
 
     switch (direction) {
     case MobileScrollDirection.Down:
-        from = scrollRectangles.top
-        to = scrollRectangles.bottom
+        from = scrollRectangles.from.top
+        to = scrollRectangles.to.bottom
         break
     case MobileScrollDirection.Left:
-        from = scrollRectangles.right
-        to= scrollRectangles.left
+        from = scrollRectangles.from.right
+        to= scrollRectangles.to.left
         break
     case MobileScrollDirection.Right:
-        from = scrollRectangles.left
-        to = scrollRectangles.right
+        from = scrollRectangles.from.left
+        to = scrollRectangles.to.right
         break
     case MobileScrollDirection.Up:
-        from = scrollRectangles.bottom
-        to = scrollRectangles.top
+        from = scrollRectangles.from.bottom
+        to = scrollRectangles.to.top
         break
     default:
         throw new Error(`Unknown direction: ${direction}`)

--- a/packages/webdriverio/tests/commands/mobile/__snapshots__/swipe.test.ts.snap
+++ b/packages/webdriverio/tests/commands/mobile/__snapshots__/swipe.test.ts.snap
@@ -57,7 +57,7 @@ exports[`swipe test > should call a swipe down command with 25% for a scrollable
       "origin": "viewport",
       "type": "pointerMove",
       "x": 250,
-      "y": 500,
+      "y": 350,
     },
     {
       "button": 0,
@@ -73,7 +73,7 @@ exports[`swipe test > should call a swipe down command with 25% for a scrollable
       "origin": "viewport",
       "type": "pointerMove",
       "x": 250,
-      "y": 600,
+      "y": 450,
     },
     {
       "button": 0,
@@ -97,7 +97,7 @@ exports[`swipe test > should call a swipe down command with duration 5000 for a 
       "origin": "viewport",
       "type": "pointerMove",
       "x": 250,
-      "y": 580,
+      "y": 590,
     },
     {
       "button": 0,
@@ -113,7 +113,7 @@ exports[`swipe test > should call a swipe down command with duration 5000 for a 
       "origin": "viewport",
       "type": "pointerMove",
       "x": 250,
-      "y": 600,
+      "y": 210,
     },
     {
       "button": 0,
@@ -136,7 +136,7 @@ exports[`swipe test > should call a swipe left command with 50% for a scrollable
       "duration": 100,
       "origin": "viewport",
       "type": "pointerMove",
-      "x": 250,
+      "x": 325,
       "y": 400,
     },
     {
@@ -152,7 +152,7 @@ exports[`swipe test > should call a swipe left command with 50% for a scrollable
       "duration": 1500,
       "origin": "viewport",
       "type": "pointerMove",
-      "x": 400,
+      "x": 175,
       "y": 400,
     },
     {
@@ -176,7 +176,7 @@ exports[`swipe test > should call a swipe right command with 75% for a scrollabl
       "duration": 100,
       "origin": "viewport",
       "type": "pointerMove",
-      "x": 175,
+      "x": 138,
       "y": 400,
     },
     {
@@ -192,7 +192,7 @@ exports[`swipe test > should call a swipe right command with 75% for a scrollabl
       "duration": 1500,
       "origin": "viewport",
       "type": "pointerMove",
-      "x": 400,
+      "x": 363,
       "y": 400,
     },
     {
@@ -217,7 +217,7 @@ exports[`swipe test > should call a swipe up command with 45% for a scrollable e
       "origin": "viewport",
       "type": "pointerMove",
       "x": 250,
-      "y": 380,
+      "y": 490,
     },
     {
       "button": 0,
@@ -233,7 +233,7 @@ exports[`swipe test > should call a swipe up command with 45% for a scrollable e
       "origin": "viewport",
       "type": "pointerMove",
       "x": 250,
-      "y": 600,
+      "y": 310,
     },
     {
       "button": 0,

--- a/packages/webdriverio/tests/commands/mobile/__snapshots__/swipe.test.ts.snap
+++ b/packages/webdriverio/tests/commands/mobile/__snapshots__/swipe.test.ts.snap
@@ -73,7 +73,7 @@ exports[`swipe test > should call a swipe down command with 25% for a scrollable
       "origin": "viewport",
       "type": "pointerMove",
       "x": 250,
-      "y": 300,
+      "y": 600,
     },
     {
       "button": 0,
@@ -113,7 +113,7 @@ exports[`swipe test > should call a swipe down command with duration 5000 for a 
       "origin": "viewport",
       "type": "pointerMove",
       "x": 250,
-      "y": 220,
+      "y": 600,
     },
     {
       "button": 0,
@@ -128,7 +128,7 @@ exports[`swipe test > should call a swipe down command with duration 5000 for a 
 }
 `;
 
-exports[`swipe test > should call a swipe left command with 75% for a scrollable element 1`] = `
+exports[`swipe test > should call a swipe left command with 50% for a scrollable element 1`] = `
 {
   "actions": [
     {
@@ -136,7 +136,7 @@ exports[`swipe test > should call a swipe left command with 75% for a scrollable
       "duration": 100,
       "origin": "viewport",
       "type": "pointerMove",
-      "x": 325,
+      "x": 250,
       "y": 400,
     },
     {
@@ -152,7 +152,7 @@ exports[`swipe test > should call a swipe left command with 75% for a scrollable
       "duration": 1500,
       "origin": "viewport",
       "type": "pointerMove",
-      "x": 175,
+      "x": 400,
       "y": 400,
     },
     {
@@ -168,7 +168,7 @@ exports[`swipe test > should call a swipe left command with 75% for a scrollable
 }
 `;
 
-exports[`swipe test > should call a swipe right command with 80% for a scrollable element 1`] = `
+exports[`swipe test > should call a swipe right command with 75% for a scrollable element 1`] = `
 {
   "actions": [
     {
@@ -176,7 +176,7 @@ exports[`swipe test > should call a swipe right command with 80% for a scrollabl
       "duration": 100,
       "origin": "viewport",
       "type": "pointerMove",
-      "x": 160,
+      "x": 175,
       "y": 400,
     },
     {
@@ -192,7 +192,7 @@ exports[`swipe test > should call a swipe right command with 80% for a scrollabl
       "duration": 1500,
       "origin": "viewport",
       "type": "pointerMove",
-      "x": 340,
+      "x": 400,
       "y": 400,
     },
     {
@@ -233,7 +233,7 @@ exports[`swipe test > should call a swipe up command with 45% for a scrollable e
       "origin": "viewport",
       "type": "pointerMove",
       "x": 250,
-      "y": 420,
+      "y": 600,
     },
     {
       "button": 0,

--- a/packages/webdriverio/tests/commands/mobile/swipe.test.ts
+++ b/packages/webdriverio/tests/commands/mobile/swipe.test.ts
@@ -108,8 +108,8 @@ describe('swipe test', () => {
         expect(logSpy).toHaveBeenCalledWith('The percentage to swipe should be a number between 0 and 1.')
     })
 
-    const percentages = [0.25, 0.45, 0.75, 0.8]
-    Object.values(MobileScrollDirection) .forEach((direction, index) => {
+    const percentages = [0.25, 0.45, 0.5, 0.75, 0.8]
+    Object.values(MobileScrollDirection).forEach((direction, index) => {
         const percent = percentages[index % percentages.length]
 
         it(`should call a swipe ${direction} command with ${percent * 100}% for a scrollable element`, async () => {


### PR DESCRIPTION
## Proposed changes
Fix for a mobile swipe unexpected behavior when the swipe percentage is <= 0.5. More details https://github.com/webdriverio/webdriverio/issues/14281

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
