### PR TITLE
Fix isClickable auto-scroll

### DIFF
--- a/packages/webdriverio/src/scripts/isElementClickable.ts
+++ b/packages/webdriverio/src/scripts/isElementClickable.ts
@@ -129,21 +129,28 @@ export default function isElementClickable (elem: HTMLElement) {
         return isElementInViewport(elem) && !hasOverlaps(elem)
     }
 
+    function getViewportScrollPositions() {
+        return {
+            // Cross-browser compatibility
+            x: window.scrollX ?? window.pageXOffset,
+            y: window.scrollY ?? window.pageYOffset,
+        }
+    }
+
     // scroll the element to the center of the viewport when
     // it is not fully displayed in the viewport or is overlapped by another element
     // to check if it still overlapped/not in the viewport
     // afterwards we scroll back to the original position
     let _isFullyDisplayedInViewport = isFullyDisplayedInViewport(elem)
     if (!_isFullyDisplayedInViewport) {
-        const { x: originalX, y: originalY } = elem.getBoundingClientRect()
+        const { x: originalX, y: originalY } = getViewportScrollPositions()
 
         elem.scrollIntoView(scrollIntoViewFullSupport ? { block: 'center', inline: 'center' } : false)
 
         _isFullyDisplayedInViewport = isFullyDisplayedInViewport(elem)
-
-        const { x, y } = elem.getBoundingClientRect()
-        if (x !== originalX || y !== originalY) {
-            elem.scroll(scrollX, scrollY)
+        const { x: currentX, y: currentY } = getViewportScrollPositions()
+        if (currentX !== originalX || currentY !== originalY) {
+            window.scroll(originalX, originalY)
         }
     }
 

--- a/packages/webdriverio/tests/scripts/isElementClickable.test.ts
+++ b/packages/webdriverio/tests/scripts/isElementClickable.test.ts
@@ -308,7 +308,7 @@ describe('isElementClickable script', () => {
             getBoundingClientRect: () => ({
                 height: 55,
                 width: 22,
-                top: 33,
+                top: 600,
                 left: 999
             }),
             getClientRects: () => [{}],
@@ -317,11 +317,16 @@ describe('isElementClickable script', () => {
         } as unknown as Element
         global.document = { elementFromPoint: () => elemMock } as any
 
-        const originalScrollX = window.scrollX
-        const originalScrollY = window.scrollY
+        // page scrolled passed element scenario
+        window.scroll(5000, 5000)
         isElementClickable(elemMock)
-        expect(window.scrollX).toBe(originalScrollX)
-        expect(window.scrollY).toBe(originalScrollY)
+        expect(window.scrollX).toBe(5000)
+        expect(window.scrollY).toBe(5000)
+        // page scrolled to the beginning scenario
+        window.scroll(0, 0)
+        isElementClickable(elemMock)
+        expect(window.scrollX).toBe(0)
+        expect(window.scrollY).toBe(0)
     })
 
     afterEach(() => {

--- a/packages/webdriverio/tests/scripts/isElementClickable.test.ts
+++ b/packages/webdriverio/tests/scripts/isElementClickable.test.ts
@@ -1,11 +1,74 @@
 import { describe, it, vi, expect, beforeAll, afterEach, afterAll } from 'vitest'
 import isElementClickable from '../../src/scripts/isElementClickable.js'
 
+/**
+* A minimalistic scrollIntoView function that emulates browser behavior
+* to be attached to the Element.prototype
+* @param options - Scroll options or boolean for legacy behavior
+*/
+function scrollIntoView(options?: {
+    block?: 'start' | 'center' | 'end'
+    inline?: 'start' | 'center' | 'end'
+} | boolean): void {
+    const originalRect = this.getBoundingClientRect()
+    const originalScrollY = window.scrollY
+    const originalScrollX = window.scrollX
+
+    // Handle boolean (legacy) parameter or no options
+    const align = typeof options === 'boolean' || !options ?
+        {
+            block: 'start', inline: 'start'
+        } :
+        options
+
+    const getHorizontalScroll = () => {
+        switch (align.inline) {
+        case 'center':
+            return originalScrollX + originalRect.left - window.innerWidth/2 + originalRect.width/2
+        case 'end':
+            return originalScrollX + originalRect.right - window.innerWidth
+        default:
+            return originalScrollX + originalRect.left
+        }
+    }
+
+    const getVerticalScroll = () => {
+        switch (align.inline) {
+        case 'center':
+            return originalScrollY + originalRect.top - window.innerHeight/2 + originalRect.height/2
+        case 'end':
+            return originalScrollY + originalRect.bottom - window.innerHeight
+        default:
+            return originalScrollY + originalRect.top
+        }
+    }
+
+    // Set the scroll position
+    window.scroll(getHorizontalScroll(), getVerticalScroll())
+
+    // Calculate scroll delta
+    const deltaY = originalScrollY - window.scrollY
+    const deltaX = originalScrollX - window.scrollX
+
+    // Update element's apparent position after scrolling
+    this.getBoundingClientRect = () => ({
+        ...originalRect,
+        top: originalRect.top + deltaY,
+        left: originalRect.left + deltaX
+    })
+}
+
 describe('isElementClickable script', () => {
     beforeAll(() => {
         global.window = {
             innerWidth: 800,
-            innerHeight: 600
+            innerHeight: 600,
+            scrollX: 0,
+            scrollY: 0,
+            scroll(x:any, y: any) {
+                this.scrollX = Math.max(0, x)
+                this.scrollY = Math.max(0, y)
+            }
         } as any
     })
 
@@ -223,7 +286,7 @@ describe('isElementClickable script', () => {
         expect(isElementClickable(elemMock)).toBe(false)
     })
 
-    it('should be not clickable if not in viewport', () => {
+    it('should be clickable if not in viewport', () => {
         const elemMock: any = {
             getBoundingClientRect: () => ({
                 height: 55,
@@ -232,12 +295,33 @@ describe('isElementClickable script', () => {
                 left: 999
             }),
             getClientRects: () => [{}],
-            scrollIntoView: () => vi.fn(),
+            scrollIntoView: scrollIntoView,
             contains: () => false
         } as unknown as Element
         global.document = { elementFromPoint: () => elemMock } as any
 
-        expect(isElementClickable(elemMock)).toBe(false)
+        expect(isElementClickable(elemMock)).toBe(true)
+    })
+
+    it('should scroll to the initial position when element not in viewport', () => {
+        const elemMock: any = {
+            getBoundingClientRect: () => ({
+                height: 55,
+                width: 22,
+                top: 33,
+                left: 999
+            }),
+            getClientRects: () => [{}],
+            scrollIntoView: scrollIntoView,
+            contains: () => false
+        } as unknown as Element
+        global.document = { elementFromPoint: () => elemMock } as any
+
+        const originalScrollX = window.scrollX
+        const originalScrollY = window.scrollY
+        isElementClickable(elemMock)
+        expect(window.scrollX).toBe(originalScrollX)
+        expect(window.scrollY).toBe(originalScrollY)
     })
 
     afterEach(() => {


### PR DESCRIPTION
This addresses https://github.com/webdriverio/webdriverio/issues/14289

## Issue
I noticed after a recent version upgrade (from 8.28 to 8.43) that the `isClickable` helper behavior changed and it was causing multiple failures within my project. 
The new behavior which was updated here https://github.com/webdriverio/webdriverio/pull/12491/files, states:
```
scroll the element to the center of the viewport...
afterwards we scroll back to the original position
```
but the scroll back part is not currently happenning.

## Proposed changes
Fix the current `elem.scroll(scrollX, scrollY)` implementation where `scrollX, scrollY` params are not defined, with a straight forward `window.scroll(originalScrollX, originalScrollY)`

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)
After the simple `window.scroll` action fix, i created a mock `elem.scrollIntoView` method to emulate the real https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView to validate this specific use case.
If the page is scrolled on `scrollIntoView` without resetting the scroll position afterwards the new unit test would fail:
![npx vitest  packageswebdriveriotestsscriptsisElementClickable test ts 2025-03-15 at 5 21 42 PM](https://github.com/user-attachments/assets/7e44e17d-326f-4aeb-a6e5-5e56d32d0f6e)


## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
