### PR TITLE
fix: use dns.lookup instead of dns.resolveX

### DIFF
--- a/packages/webdriver/src/index.ts
+++ b/packages/webdriver/src/index.ts
@@ -149,7 +149,9 @@ export default class WebDriver {
          * parse and propagate all Bidi events to the browser instance
          */
         if (isBidi(options.capabilities || {})) {
-            client._bidiHandler?.socket.on('message', parseBidiMessage.bind(client))
+            client._bidiHandler?.waitForConnected().then(()=>{
+                client._bidiHandler?.socket.on('message', parseBidiMessage.bind(client))
+            })
         }
         return client
     }

--- a/packages/webdriver/tests/node/bidi.test.ts
+++ b/packages/webdriver/tests/node/bidi.test.ts
@@ -11,8 +11,7 @@ vi.mock('@wdio/logger', () => import(path.join(process.cwd(), '__mocks__', '@wdi
 
 vi.mock('dns/promises', () => ({
     default: {
-        resolve4: vi.fn().mockResolvedValue(['127.0.0.1']),
-        resolve6: vi.fn().mockResolvedValue(['::1'])
+        lookup: vi.fn().mockResolvedValue([{ address: '127.0.0.1' }, { address: '::1' }])
     }
 }))
 


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

### This Pull request is for #14272

This PR is proposed following changes and related updates for unit test (not changed E2E test).
- use use `dns.lookup` instead of `dns.resolveX`
  `dns.resolveX` is not considering into OS local resolution(e.g. /etc/hosts). (Only resolve with DNS)
   This point causes the error when use the hostname with `localhost` of the URL.
   Generally speaking the `localhost` could no be resolved by DNS.(e.g. Google DNS 8.8.8.8 will be error when resolving the `localhost`)
- Update the cleanup logic for unused web sockets.
  When `ws.readyState` is CONNECTING, the   `ws.terminate()` will cause the error  using   `process.nextTick`.
  So, in the CONNECTING state, the socket is now terminated after it has entered the OPEN state.


## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [X] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
