### PR TITLE
fix(webdriverio): update listener registration logic of SessionManager

### DIFF
--- a/packages/webdriverio/src/session/session.ts
+++ b/packages/webdriverio/src/session/session.ts
@@ -15,11 +15,12 @@ export class SessionManager {
      */
     constructor(browser: WebdriverIO.Browser, scope: string) {
         this.#browser = browser
-        if (!listenerRegisteredSession.has(this.#browser.sessionId)) {
-            this.#browser.on('command', this.#onCommand.bind(this))
-            listenerRegisteredSession.add(this.#browser.sessionId)
-        }
         this.#scope = scope
+        const registrationId = `${this.#browser.sessionId}-${this.#scope}`
+        if (!listenerRegisteredSession.has(registrationId)) {
+            this.#browser.on('command', this.#onCommand.bind(this))
+            listenerRegisteredSession.add(registrationId)
+        }
     }
 
     #onCommand(ev: { command: string }) {

--- a/packages/webdriverio/src/session/session.ts
+++ b/packages/webdriverio/src/session/session.ts
@@ -1,5 +1,7 @@
 const sessionManager = new Map<string, Map<WebdriverIO.Browser, SessionManager>>()
 
+const listenerRegisteredSession = new Set<string>()
+
 export class SessionManager {
     #browser: WebdriverIO.Browser
     #scope: string
@@ -13,7 +15,10 @@ export class SessionManager {
      */
     constructor(browser: WebdriverIO.Browser, scope: string) {
         this.#browser = browser
-        this.#browser.on('command', this.#onCommand.bind(this))
+        if (!listenerRegisteredSession.has(this.#browser.sessionId)) {
+            this.#browser.on('command', this.#onCommand.bind(this))
+            listenerRegisteredSession.add(this.#browser.sessionId)
+        }
         this.#scope = scope
     }
 

--- a/packages/webdriverio/tests/session/session.test.ts
+++ b/packages/webdriverio/tests/session/session.test.ts
@@ -1,0 +1,26 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { SessionManager } from '../../src/session/session.js'
+
+describe('SessionManager', () => {
+    const browser ={
+        sessionId: '123',
+        on: vi.fn(),
+    } as unknown as WebdriverIO.Browser
+
+    beforeEach(()=>{
+        vi.mocked(browser.on).mockClear()
+    })
+
+    it('should listener registered', ()=>{
+        new SessionManager(browser, 'dummy')
+        expect(browser.on).toHaveBeenCalledTimes(1)
+    })
+
+    it('should listener registered only once when initialized multiple times', ()=>{
+        browser.sessionId = '456'
+        new SessionManager(browser, 'dummy1')
+        new SessionManager(browser, 'dummy2')
+        expect(browser.on).toHaveBeenCalledTimes(1)
+    })
+})

--- a/packages/webdriverio/tests/session/session.test.ts
+++ b/packages/webdriverio/tests/session/session.test.ts
@@ -19,8 +19,8 @@ describe('SessionManager', () => {
 
     it('should listener registered only once when initialized multiple times', ()=>{
         browser.sessionId = '456'
-        new SessionManager(browser, 'dummy1')
-        new SessionManager(browser, 'dummy2')
+        new SessionManager(browser, 'dummy')
+        new SessionManager(browser, 'dummy')
         expect(browser.on).toHaveBeenCalledTimes(1)
     })
 })

--- a/packages/webdriverio/tests/shadowRoot.test.ts
+++ b/packages/webdriverio/tests/shadowRoot.test.ts
@@ -3,6 +3,7 @@ import { describe, it, vi, expect, beforeEach } from 'vitest'
 import { getShadowRootManager, ShadowRootTree } from '../src/session/shadowRoot.js'
 
 const defaultBrowser = {
+    sessionId: '123',
     sessionSubscribe: vi.fn().mockResolvedValue({}),
     on: vi.fn(),
     scriptAddPreloadScript: vi.fn(),
@@ -28,6 +29,7 @@ describe('ShadowRootManager', () => {
         const wid = process.env.WDIO_UNIT_TESTS
         delete process.env.WDIO_UNIT_TESTS
         const browser = { ...defaultBrowser, isBidi: true, options: { capabilities: { webSocketUrl: './' } } } as any
+        browser.sessionId = '234'
         const manager = getShadowRootManager(browser)
         process.env.WDIO_UNIT_TESTS = wid
         expect(await manager.initialize()).toBe(true)
@@ -38,6 +40,7 @@ describe('ShadowRootManager', () => {
 
     it('should not register event listeners if not in bidi mode', async () => {
         const browser = { ...defaultBrowser } as any
+        browser.sessionId = '345'
         const manager = getShadowRootManager(browser)
         expect(await manager.initialize()).toBe(true)
         expect(browser.sessionSubscribe).toBeCalledTimes(0)
@@ -47,6 +50,7 @@ describe('ShadowRootManager', () => {
 
     it('should not register event listeners if not using webdriver as automation protocol', async () => {
         const browser = { ...defaultBrowser, isBidi: true, automationProtocol: './protocol-stub.js' } as any
+        browser.sessionId = '456'
         const manager = getShadowRootManager(browser)
         expect(await manager.initialize()).toBe(true)
         expect(browser.sessionSubscribe).toBeCalledTimes(0)


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

Event listener registration to the browser, which is performed during SessionManager initialisation, is fixed so that it is only performed once for the browser.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [X] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

Closes #14297 

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
