### PR TITLE
feat(webdriver): support WebSocket options at the BiDi connection

### DIFF
--- a/packages/webdriver/src/browser.ts
+++ b/packages/webdriver/src/browser.ts
@@ -1,5 +1,5 @@
 import logger from '@wdio/logger'
-import type { WebSocket } from 'ws'
+import type { WebSocket, ClientOptions } from 'ws'
 
 import WebDriver from './index.js'
 import { BrowserSocket } from './bidi/socket.js'
@@ -15,7 +15,7 @@ const log = logger('webdriver')
 environment.value = {
     Request: FetchRequest,
     Socket: BrowserSocket,
-    createBidiConnection: (webSocketUrl: string, options: unknown) => {
+    createBidiConnection: (webSocketUrl: string, options: ClientOptions) => {
         log.info(`Connecting to webSocketUrl ${webSocketUrl}`)
         const ws = new BrowserSocket(webSocketUrl, options)
         return new Promise<WebSocket | undefined>((resolve) => {

--- a/packages/webdriver/src/environment.ts
+++ b/packages/webdriver/src/environment.ts
@@ -16,7 +16,7 @@ export interface EnvironmentVariables {
 export interface EnvironmentDependencies {
     Request: typeof FetchRequest,
     Socket: typeof BrowserSocket,
-    createBidiConnection: (wsUrl?: string, options?: unknown) => Promise<WebSocket | undefined>,
+    createBidiConnection: (wsUrl?: string, options?: WebSocket.ClientOptions) => Promise<WebSocket | undefined>,
     variables: EnvironmentVariables
 }
 

--- a/packages/webdriver/src/node/bidi.ts
+++ b/packages/webdriver/src/node/bidi.ts
@@ -4,12 +4,12 @@ import { type LookupAddress } from 'node:dns'
 
 import logger from '@wdio/logger'
 
-import WebSocket from 'ws'
+import WebSocket, { type ClientOptions } from 'ws'
 
 const log = logger('webdriver')
 const CONNECTION_TIMEOUT = 10000
 
-export async function createBidiConnection(webSocketUrl: string, options?: unknown): Promise<WebSocket | undefined> {
+export async function createBidiConnection(webSocketUrl: string, options?: ClientOptions): Promise<WebSocket | undefined> {
     const candidateUrls = await listWebsocketCandidateUrls(webSocketUrl)
     return connectWebsocket(candidateUrls, options)
 }
@@ -54,11 +54,11 @@ interface ConnectionPromise {
  * @param candidateUrls - list of websocket urls to try
  * @returns true if the connection was successful
  */
-export async function connectWebsocket(candidateUrls: string[], _?: unknown): Promise<WebSocket | undefined> {
+export async function connectWebsocket(candidateUrls: string[], options?: ClientOptions): Promise<WebSocket | undefined> {
     const websockets: WebSocket[] = candidateUrls.map((candidateUrl) => {
         log.debug(`Attempt to connect to webSocketUrl ${candidateUrl}`)
         try {
-            const ws = new WebSocket(candidateUrl)
+            const ws = new WebSocket(candidateUrl, options)
             return ws
         } catch {
             return undefined


### PR DESCRIPTION
## Proposed changes
Change to allow options to be specified when connecting a BiDi connection.

Related PR: #14272 ([comment](https://github.com/webdriverio/webdriverio/pull/14272#discussion_r2006572734))

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [X] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
