### PR TITLE
Reduce wait port retry interval

### DIFF
--- a/packages/wdio-utils/src/node/startWebDriver.ts
+++ b/packages/wdio-utils/src/node/startWebDriver.ts
@@ -35,6 +35,7 @@ declare global {
 
 const log = logger('@wdio/utils')
 const DRIVER_WAIT_TIMEOUT = 10 * 1000 // 10s
+const DRIVER_RETRY_INTERVAL = 100
 
 export async function startWebDriver (options: Capabilities.RemoteConfig) {
     /**
@@ -181,7 +182,7 @@ export async function startWebDriver (options: Capabilities.RemoteConfig) {
         driverProcess.stderr?.pipe(split2()).on('data', driverLog.warn.bind(driverLog))
     }
 
-    await waitPort({ port, output: 'silent', timeout: DRIVER_WAIT_TIMEOUT })
+    await waitPort({ port, output: 'silent', timeout: DRIVER_WAIT_TIMEOUT, interval: DRIVER_RETRY_INTERVAL })
         .catch((e) => { throw new Error(`Timed out to connect to ${driver}: ${e.message}`) })
 
     options.hostname = 'localhost'


### PR DESCRIPTION
## Proposed changes

This is a patch for https://github.com/webdriverio/webdriverio/issues/14310

I am currently trying to upgrade to wdio 9 from 8 but it's 10-20% slower.

If we reduce the wait connection retry interval, which is currently set to default (1000ms), the execution will continue much faster.

The 1 sec retry is excessive because the driver process spawn time is ~10ms
```
driverProcess = cp.spawn(chromedriverExcecuteablePath, driverParams, {...})
```

and the time before the port is open and ready to use is another ~10ms
```
await waitPort({ port, output: 'silent', timeout: DRIVER_WAIT_TIMEOUT })
```

Ironically, this delay is more visible on wdio 9 than it is on wdio 8 because the execution time between `driver process spawn -> waitPort` is actually smaller than it is on wdio 8, and during the 1st iteration of `waitPort`, the port is not available, so it waits the default 1 sec.

The tweak presented here is one of the factors which cause the slower overall test execution time.

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
