### PR TITLE
docs: boilerplate project added to MD

### DIFF
--- a/website/docs/BoilerplateProjects.md
+++ b/website/docs/BoilerplateProjects.md
@@ -345,4 +345,21 @@ PoC project for E2E Multiremote Cucumber tests as well as Data driven Mocha test
     - Test Data ( JSON / XLSX ) handled globally so as to write the data (created on the fly) to a file post test execution
     - Github workflow to run the test and upload the allure report
 
+## [Rondleysg/wdio-multiremote-appium-chromedriver-boilerplate](https://github.com/Rondleysg/wdio-multiremote-appium-chromedriver-boilerplate)
 
+This is a boilerplate project to help show how to run webdriverio multi-remote using appium and chromedriver service with the latest WebdriverIO.
+
+- Frameworks
+  - WebdriverIO (v9)
+  - Appium (v2)
+  - Mocha
+
+- Features
+  - [Page Object](pageobjects) Model
+  - Typescript
+  - Web + Mobile Tests - Multiremote
+  - Native Android and iOS apps
+  - Appium
+  - Chromedriver
+  - ESLint
+  - Tests examples for Login in http://the-internet.herokuapp.com and [WebdriverIO native demo app](https://github.com/webdriverio/native-demo-app)

--- a/website/i18n/ar/docusaurus-plugin-content-docs/current/BoilerplateProjects.md
+++ b/website/i18n/ar/docusaurus-plugin-content-docs/current/BoilerplateProjects.md
@@ -330,6 +330,22 @@ PoC project for E2E Multiremote Cucumber tests as well as Data driven Mocha test
     - Multiple Reports integrated including Allure
     - Test Data ( JSON / XLSX ) handled globally so as to write the data (created on the fly) to a file post test execution
     - Github workflow to run the test and upload the allure report
- 
-      
-      
+
+## [Rondleysg/wdio-multiremote-appium-chromedriver-boilerplate](https://github.com/Rondleysg/wdio-multiremote-appium-chromedriver-boilerplate)
+
+This is a boilerplate project to help show how to run webdriverio multi-remote using appium and chromedriver service with the latest WebdriverIO.
+
+- Frameworks
+  - WebdriverIO (v9)
+  - Appium (v2)
+  - Mocha
+
+- Features
+  - [Page Object](pageobjects) Model
+  - Typescript
+  - Web + Mobile Tests - Multiremote
+  - Native Android and iOS apps
+  - Appium
+  - Chromedriver
+  - ESLint
+  - Tests examples for Login in http://the-internet.herokuapp.com and [WebdriverIO native demo app](https://github.com/webdriverio/native-demo-app)

--- a/website/i18n/bg/docusaurus-plugin-content-docs/current/BoilerplateProjects.md
+++ b/website/i18n/bg/docusaurus-plugin-content-docs/current/BoilerplateProjects.md
@@ -330,6 +330,22 @@ PoC project for E2E Multiremote Cucumber tests as well as Data driven Mocha test
     - Multiple Reports integrated including Allure
     - Test Data ( JSON / XLSX ) handled globally so as to write the data (created on the fly) to a file post test execution
     - Github workflow to run the test and upload the allure report
- 
-      
-      
+
+## [Rondleysg/wdio-multiremote-appium-chromedriver-boilerplate](https://github.com/Rondleysg/wdio-multiremote-appium-chromedriver-boilerplate)
+
+This is a boilerplate project to help show how to run webdriverio multi-remote using appium and chromedriver service with the latest WebdriverIO.
+
+- Frameworks
+  - WebdriverIO (v9)
+  - Appium (v2)
+  - Mocha
+
+- Features
+  - [Page Object](pageobjects) Model
+  - Typescript
+  - Web + Mobile Tests - Multiremote
+  - Native Android and iOS apps
+  - Appium
+  - Chromedriver
+  - ESLint
+  - Tests examples for Login in http://the-internet.herokuapp.com and [WebdriverIO native demo app](https://github.com/webdriverio/native-demo-app)

--- a/website/i18n/de/docusaurus-plugin-content-docs/current/BoilerplateProjects.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/current/BoilerplateProjects.md
@@ -331,4 +331,21 @@ PoC project for E2E Multiremote Cucumber tests as well as Data driven Mocha test
     - Test Data ( JSON / XLSX ) handled globally so as to write the data (created on the fly) to a file post test execution
     - Github workflow to run the test and upload the allure report
 
+## [Rondleysg/wdio-multiremote-appium-chromedriver-boilerplate](https://github.com/Rondleysg/wdio-multiremote-appium-chromedriver-boilerplate)
 
+This is a boilerplate project to help show how to run webdriverio multi-remote using appium and chromedriver service with the latest WebdriverIO.
+
+- Frameworks
+  - WebdriverIO (v9)
+  - Appium (v2)
+  - Mocha
+
+- Features
+  - [Page Object](pageobjects) Model
+  - Typescript
+  - Web + Mobile Tests - Multiremote
+  - Native Android and iOS apps
+  - Appium
+  - Chromedriver
+  - ESLint
+  - Tests examples for Login in http://the-internet.herokuapp.com and [WebdriverIO native demo app](https://github.com/webdriverio/native-demo-app)

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/BoilerplateProjects.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/BoilerplateProjects.md
@@ -331,4 +331,21 @@ PoC project for E2E Multiremote Cucumber tests as well as Data driven Mocha test
     - Test Data ( JSON / XLSX ) handled globally so as to write the data (created on the fly) to a file post test execution
     - Github workflow to run the test and upload the allure report
 
+## [Rondleysg/wdio-multiremote-appium-chromedriver-boilerplate](https://github.com/Rondleysg/wdio-multiremote-appium-chromedriver-boilerplate)
 
+This is a boilerplate project to help show how to run webdriverio multi-remote using appium and chromedriver service with the latest WebdriverIO.
+
+- Frameworks
+  - WebdriverIO (v9)
+  - Appium (v2)
+  - Mocha
+
+- Features
+  - [Page Object](pageobjects) Model
+  - Typescript
+  - Web + Mobile Tests - Multiremote
+  - Native Android and iOS apps
+  - Appium
+  - Chromedriver
+  - ESLint
+  - Tests examples for Login in http://the-internet.herokuapp.com and [WebdriverIO native demo app](https://github.com/webdriverio/native-demo-app)

--- a/website/i18n/fa/docusaurus-plugin-content-docs/current/BoilerplateProjects.md
+++ b/website/i18n/fa/docusaurus-plugin-content-docs/current/BoilerplateProjects.md
@@ -330,6 +330,22 @@ PoC project for E2E Multiremote Cucumber tests as well as Data driven Mocha test
     - Multiple Reports integrated including Allure
     - Test Data ( JSON / XLSX ) handled globally so as to write the data (created on the fly) to a file post test execution
     - Github workflow to run the test and upload the allure report
- 
-      
-      
+
+## [Rondleysg/wdio-multiremote-appium-chromedriver-boilerplate](https://github.com/Rondleysg/wdio-multiremote-appium-chromedriver-boilerplate)
+
+This is a boilerplate project to help show how to run webdriverio multi-remote using appium and chromedriver service with the latest WebdriverIO.
+
+- Frameworks
+  - WebdriverIO (v9)
+  - Appium (v2)
+  - Mocha
+
+- Features
+  - [Page Object](pageobjects) Model
+  - Typescript
+  - Web + Mobile Tests - Multiremote
+  - Native Android and iOS apps
+  - Appium
+  - Chromedriver
+  - ESLint
+  - Tests examples for Login in http://the-internet.herokuapp.com and [WebdriverIO native demo app](https://github.com/webdriverio/native-demo-app) 

--- a/website/i18n/fr/docusaurus-plugin-content-docs/current/BoilerplateProjects.md
+++ b/website/i18n/fr/docusaurus-plugin-content-docs/current/BoilerplateProjects.md
@@ -330,6 +330,22 @@ PoC project for E2E Multiremote Cucumber tests as well as Data driven Mocha test
     - Multiple Reports integrated including Allure
     - Test Data ( JSON / XLSX ) handled globally so as to write the data (created on the fly) to a file post test execution
     - Github workflow to run the test and upload the allure report
- 
-      
-      
+
+## [Rondleysg/wdio-multiremote-appium-chromedriver-boilerplate](https://github.com/Rondleysg/wdio-multiremote-appium-chromedriver-boilerplate)
+
+This is a boilerplate project to help show how to run webdriverio multi-remote using appium and chromedriver service with the latest WebdriverIO.
+
+- Frameworks
+  - WebdriverIO (v9)
+  - Appium (v2)
+  - Mocha
+
+- Features
+  - [Page Object](pageobjects) Model
+  - Typescript
+  - Web + Mobile Tests - Multiremote
+  - Native Android and iOS apps
+  - Appium
+  - Chromedriver
+  - ESLint
+  - Tests examples for Login in http://the-internet.herokuapp.com and [WebdriverIO native demo app](https://github.com/webdriverio/native-demo-app)

--- a/website/i18n/hi/docusaurus-plugin-content-docs/current/BoilerplateProjects.md
+++ b/website/i18n/hi/docusaurus-plugin-content-docs/current/BoilerplateProjects.md
@@ -331,4 +331,21 @@ PoC project for E2E Multiremote Cucumber tests as well as Data driven Mocha test
     - Test Data ( JSON / XLSX ) handled globally so as to write the data (created on the fly) to a file post test execution
     - Github workflow to run the test and upload the allure report
 
+## [Rondleysg/wdio-multiremote-appium-chromedriver-boilerplate](https://github.com/Rondleysg/wdio-multiremote-appium-chromedriver-boilerplate)
 
+This is a boilerplate project to help show how to run webdriverio multi-remote using appium and chromedriver service with the latest WebdriverIO.
+
+- Frameworks
+  - WebdriverIO (v9)
+  - Appium (v2)
+  - Mocha
+
+- Features
+  - [Page Object](pageobjects) Model
+  - Typescript
+  - Web + Mobile Tests - Multiremote
+  - Native Android and iOS apps
+  - Appium
+  - Chromedriver
+  - ESLint
+  - Tests examples for Login in http://the-internet.herokuapp.com and [WebdriverIO native demo app](https://github.com/webdriverio/native-demo-app)

--- a/website/i18n/it/docusaurus-plugin-content-docs/current/BoilerplateProjects.md
+++ b/website/i18n/it/docusaurus-plugin-content-docs/current/BoilerplateProjects.md
@@ -330,6 +330,22 @@ PoC project for E2E Multiremote Cucumber tests as well as Data driven Mocha test
     - Multiple Reports integrated including Allure
     - Test Data ( JSON / XLSX ) handled globally so as to write the data (created on the fly) to a file post test execution
     - Github workflow to run the test and upload the allure report
- 
-      
-      
+
+## [Rondleysg/wdio-multiremote-appium-chromedriver-boilerplate](https://github.com/Rondleysg/wdio-multiremote-appium-chromedriver-boilerplate)
+
+This is a boilerplate project to help show how to run webdriverio multi-remote using appium and chromedriver service with the latest WebdriverIO.
+
+- Frameworks
+  - WebdriverIO (v9)
+  - Appium (v2)
+  - Mocha
+
+- Features
+  - [Page Object](pageobjects) Model
+  - Typescript
+  - Web + Mobile Tests - Multiremote
+  - Native Android and iOS apps
+  - Appium
+  - Chromedriver
+  - ESLint
+  - Tests examples for Login in http://the-internet.herokuapp.com and [WebdriverIO native demo app](https://github.com/webdriverio/native-demo-app)

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/BoilerplateProjects.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/BoilerplateProjects.md
@@ -330,6 +330,22 @@ PoC project for E2E Multiremote Cucumber tests as well as Data driven Mocha test
     - Multiple Reports integrated including Allure
     - Test Data ( JSON / XLSX ) handled globally so as to write the data (created on the fly) to a file post test execution
     - Github workflow to run the test and upload the allure report
- 
-      
-      
+
+## [Rondleysg/wdio-multiremote-appium-chromedriver-boilerplate](https://github.com/Rondleysg/wdio-multiremote-appium-chromedriver-boilerplate)
+
+This is a boilerplate project to help show how to run webdriverio multi-remote using appium and chromedriver service with the latest WebdriverIO.
+
+- Frameworks
+  - WebdriverIO (v9)
+  - Appium (v2)
+  - Mocha
+
+- Features
+  - [Page Object](pageobjects) Model
+  - Typescript
+  - Web + Mobile Tests - Multiremote
+  - Native Android and iOS apps
+  - Appium
+  - Chromedriver
+  - ESLint
+  - Tests examples for Login in http://the-internet.herokuapp.com and [WebdriverIO native demo app](https://github.com/webdriverio/native-demo-app)

--- a/website/i18n/pl/docusaurus-plugin-content-docs/current/BoilerplateProjects.md
+++ b/website/i18n/pl/docusaurus-plugin-content-docs/current/BoilerplateProjects.md
@@ -330,6 +330,22 @@ PoC project for E2E Multiremote Cucumber tests as well as Data driven Mocha test
     - Multiple Reports integrated including Allure
     - Test Data ( JSON / XLSX ) handled globally so as to write the data (created on the fly) to a file post test execution
     - Github workflow to run the test and upload the allure report
- 
-      
-      
+
+## [Rondleysg/wdio-multiremote-appium-chromedriver-boilerplate](https://github.com/Rondleysg/wdio-multiremote-appium-chromedriver-boilerplate)
+
+This is a boilerplate project to help show how to run webdriverio multi-remote using appium and chromedriver service with the latest WebdriverIO.
+
+- Frameworks
+  - WebdriverIO (v9)
+  - Appium (v2)
+  - Mocha
+
+- Features
+  - [Page Object](pageobjects) Model
+  - Typescript
+  - Web + Mobile Tests - Multiremote
+  - Native Android and iOS apps
+  - Appium
+  - Chromedriver
+  - ESLint
+  - Tests examples for Login in http://the-internet.herokuapp.com and [WebdriverIO native demo app](https://github.com/webdriverio/native-demo-app)

--- a/website/i18n/ru/docusaurus-plugin-content-docs/current/BoilerplateProjects.md
+++ b/website/i18n/ru/docusaurus-plugin-content-docs/current/BoilerplateProjects.md
@@ -330,6 +330,22 @@ PoC project for E2E Multiremote Cucumber tests as well as Data driven Mocha test
     - Multiple Reports integrated including Allure
     - Test Data ( JSON / XLSX ) handled globally so as to write the data (created on the fly) to a file post test execution
     - Github workflow to run the test and upload the allure report
- 
-      
-      
+
+## [Rondleysg/wdio-multiremote-appium-chromedriver-boilerplate](https://github.com/Rondleysg/wdio-multiremote-appium-chromedriver-boilerplate)
+
+This is a boilerplate project to help show how to run webdriverio multi-remote using appium and chromedriver service with the latest WebdriverIO.
+
+- Frameworks
+  - WebdriverIO (v9)
+  - Appium (v2)
+  - Mocha
+
+- Features
+  - [Page Object](pageobjects) Model
+  - Typescript
+  - Web + Mobile Tests - Multiremote
+  - Native Android and iOS apps
+  - Appium
+  - Chromedriver
+  - ESLint
+  - Tests examples for Login in http://the-internet.herokuapp.com and [WebdriverIO native demo app](https://github.com/webdriverio/native-demo-app)

--- a/website/i18n/ta/docusaurus-plugin-content-docs/current/BoilerplateProjects.md
+++ b/website/i18n/ta/docusaurus-plugin-content-docs/current/BoilerplateProjects.md
@@ -330,6 +330,22 @@ PoC project for E2E Multiremote Cucumber tests as well as Data driven Mocha test
     - Multiple Reports integrated including Allure
     - Test Data ( JSON / XLSX ) handled globally so as to write the data (created on the fly) to a file post test execution
     - Github workflow to run the test and upload the allure report
- 
-      
-      
+
+## [Rondleysg/wdio-multiremote-appium-chromedriver-boilerplate](https://github.com/Rondleysg/wdio-multiremote-appium-chromedriver-boilerplate)
+
+This is a boilerplate project to help show how to run webdriverio multi-remote using appium and chromedriver service with the latest WebdriverIO.
+
+- Frameworks
+  - WebdriverIO (v9)
+  - Appium (v2)
+  - Mocha
+
+- Features
+  - [Page Object](pageobjects) Model
+  - Typescript
+  - Web + Mobile Tests - Multiremote
+  - Native Android and iOS apps
+  - Appium
+  - Chromedriver
+  - ESLint
+  - Tests examples for Login in http://the-internet.herokuapp.com and [WebdriverIO native demo app](https://github.com/webdriverio/native-demo-app)

--- a/website/i18n/uk/docusaurus-plugin-content-docs/current/BoilerplateProjects.md
+++ b/website/i18n/uk/docusaurus-plugin-content-docs/current/BoilerplateProjects.md
@@ -330,6 +330,22 @@ PoC project for E2E Multiremote Cucumber tests as well as Data driven Mocha test
     - Multiple Reports integrated including Allure
     - Test Data ( JSON / XLSX ) handled globally so as to write the data (created on the fly) to a file post test execution
     - Github workflow to run the test and upload the allure report
- 
-      
-      
+
+## [Rondleysg/wdio-multiremote-appium-chromedriver-boilerplate](https://github.com/Rondleysg/wdio-multiremote-appium-chromedriver-boilerplate)
+
+This is a boilerplate project to help show how to run webdriverio multi-remote using appium and chromedriver service with the latest WebdriverIO.
+
+- Frameworks
+  - WebdriverIO (v9)
+  - Appium (v2)
+  - Mocha
+
+- Features
+  - [Page Object](pageobjects) Model
+  - Typescript
+  - Web + Mobile Tests - Multiremote
+  - Native Android and iOS apps
+  - Appium
+  - Chromedriver
+  - ESLint
+  - Tests examples for Login in http://the-internet.herokuapp.com and [WebdriverIO native demo app](https://github.com/webdriverio/native-demo-app)

--- a/website/i18n/zh/docusaurus-plugin-content-docs/current/BoilerplateProjects.md
+++ b/website/i18n/zh/docusaurus-plugin-content-docs/current/BoilerplateProjects.md
@@ -330,6 +330,22 @@ PoC project for E2E Multiremote Cucumber tests as well as Data driven Mocha test
     - Multiple Reports integrated including Allure
     - Test Data ( JSON / XLSX ) handled globally so as to write the data (created on the fly) to a file post test execution
     - Github workflow to run the test and upload the allure report
- 
-      
-      
+
+## [Rondleysg/wdio-multiremote-appium-chromedriver-boilerplate](https://github.com/Rondleysg/wdio-multiremote-appium-chromedriver-boilerplate)
+
+This is a boilerplate project to help show how to run webdriverio multi-remote using appium and chromedriver service with the latest WebdriverIO.
+
+- Frameworks
+  - WebdriverIO (v9)
+  - Appium (v2)
+  - Mocha
+
+- Features
+  - [Page Object](pageobjects) Model
+  - Typescript
+  - Web + Mobile Tests - Multiremote
+  - Native Android and iOS apps
+  - Appium
+  - Chromedriver
+  - ESLint
+  - Tests examples for Login in http://the-internet.herokuapp.com and [WebdriverIO native demo app](https://github.com/webdriverio/native-demo-app)


### PR DESCRIPTION
## Proposed changes

This pull request adds the "wdio-multiremote-appium-chromedriver-boilerplate" project to our boilerplate documentation. The project is designed to demonstrate how to run WebdriverIO multi-remote tests using Appium and the Chromedriver service with the latest version of WebdriverIO. It leverages modern frameworks including WebdriverIO (v9), Appium (v2), and Mocha, while also incorporating advanced features such as the Page Object Model, TypeScript, and ESLint. The boilerplate supports both web and mobile testing, covering native Android and iOS apps, and includes practical test examples for logging in to [the-internet.herokuapp.com](http://the-internet.herokuapp.com/) and the [WebdriverIO native demo app](https://github.com/webdriverio/native-demo-app).

## Types of changes

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

### Reviewers: @webdriverio/project-committers
