### PR TITLE
fix: Fixes isDisplayed to always use default params for checkVisibility.

### DIFF
--- a/packages/webdriverio/src/commands/element/isDisplayed.ts
+++ b/packages/webdriverio/src/commands/element/isDisplayed.ts
@@ -130,7 +130,10 @@ export async function isDisplayed (
     const [isDisplayed, displayProperty] = await Promise.all([
         browser.execute(function checkVisibility (elem, params) {
             return elem.checkVisibility(params)
-        }, this as unknown as HTMLElement, commandParams).catch((err) => {
+        }, this as unknown as HTMLElement, {
+            ...DEFAULT_PARAMS,
+            ...commandParams
+        }).catch((err) => {
             /**
              * Fallback to legacy script if checkVisibility is not available
              */


### PR DESCRIPTION
When waitForDisplayed passes withinViewport only, it skips adding the default params passed to checkVisibility which gives wrong results for elements having visibility: hidden. Always use default params and just allow to be overwritten.

Fixes #14124.

## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
