### PR TITLE
fix(utils): fix not to judged as screenshot the arg of switch*

### DIFF
--- a/packages/wdio-utils/src/utils.ts
+++ b/packages/wdio-utils/src/utils.ts
@@ -103,7 +103,7 @@ export function commandCallStructure (commandName: string, args: unknown[], unfu
              * "9A562133B0552E0ECB7628F2E8A09E86" a true value which is
              * why we should include a command check in here.
              */
-            !commandName.startsWith('switchToWindow') &&
+            !commandName.startsWith('switch') &&
             isBase64(arg)
         ) {
             arg = SCREENSHOT_REPLACEMENT

--- a/packages/wdio-utils/src/utils.ts
+++ b/packages/wdio-utils/src/utils.ts
@@ -98,6 +98,12 @@ export function commandCallStructure (commandName: string, args: unknown[], unfu
              * include a command check in here.
              */
             !commandName.startsWith('findElement') &&
+            /**
+             * the isBase64 method returns for the argument value like
+             * "9A562133B0552E0ECB7628F2E8A09E86" a true value which is
+             * why we should include a command check in here.
+             */
+            !commandName.startsWith('switchToWindow') &&
             isBase64(arg)
         ) {
             arg = SCREENSHOT_REPLACEMENT

--- a/packages/wdio-utils/tests/utils.test.ts
+++ b/packages/wdio-utils/tests/utils.test.ts
@@ -47,6 +47,8 @@ describe('utils', () => {
             .toBe('findElementsFromElement("/html/body/a")')
         expect(commandCallStructure('switchToWindow', ['9A562133B0552E0ECB7628F2E8A09E86']))
             .toBe('switchToWindow("9A562133B0552E0ECB7628F2E8A09E86")')
+        expect(commandCallStructure('switchFrame', ['9A562133B0552E0ECB7628F2E8A09E86']))
+            .toBe('switchFrame("9A562133B0552E0ECB7628F2E8A09E86")')
     })
 
     it('transformCommandLogResult', () => {

--- a/packages/wdio-utils/tests/utils.test.ts
+++ b/packages/wdio-utils/tests/utils.test.ts
@@ -45,6 +45,8 @@ describe('utils', () => {
             .toBe('findElementFromElement("/html/body/a")')
         expect(commandCallStructure('findElementsFromElement', ['/html/body/a']))
             .toBe('findElementsFromElement("/html/body/a")')
+        expect(commandCallStructure('switchToWindow', ['9A562133B0552E0ECB7628F2E8A09E86']))
+            .toBe('switchToWindow("9A562133B0552E0ECB7628F2E8A09E86")')
     })
 
     it('transformCommandLogResult', () => {


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

When calling a command like:
```
browser.switchToWindow("9A562133B0552E0ECB7628F2E8A09E86")
```

You will see in the logs the following:
```
2025-04-09T02:30:59.864Z INFO webdriver: COMMAND switchToWindow("<Screenshot[base64]>")
2025-04-09T02:30:59.864Z INFO webdriver: [POST] http://localhost:55830/session/4d198ae401db65938c01497afabeb878/window
2025-04-09T02:30:59.864Z INFO webdriver: DATA { handle: '9A562133B0552E0ECB7628F2E8A09E86' }
2025-04-09T02:30:59.865Z INFO webdriver: RESULT null
```

The logs say that the switchToWindow parameter is a base64 screenshot. 
Rather than fixing the fact that the command is judged as BASE64 itself, it would be more appropriate to exclude the command by checking.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
