### PR TITLE
catching error from addPreloadScript

### DIFF
--- a/packages/webdriverio/src/session/polyfill.ts
+++ b/packages/webdriverio/src/session/polyfill.ts
@@ -81,6 +81,15 @@ export class PolyfillManager extends SessionManager {
                 ? this.#browser.scriptAddPreloadScript({
                     functionDeclaration,
                     contexts: [context.context]
+                }).catch(() => {
+                    /**
+                     * In case the context is already destroyed before this promise is finished
+                     * For example:
+                     *   - an unsuspecting window (context) is opened
+                     *   - registerScripts is triggered
+                     *   - that window closes before the bidi call starts
+                     *   - bidi call sends the request and gets something like `call rejected because the connection has been closed` error back
+                     */
                 })
                 : Promise.resolve(),
             this.#browser.scriptCallFunction({

--- a/packages/webdriverio/tests/session/polyfill.test.ts
+++ b/packages/webdriverio/tests/session/polyfill.test.ts
@@ -39,7 +39,7 @@ describe('PolyfillManager', () => {
             on: vi.fn(),
             browsingContextGetTree: vi.fn().mockResolvedValue({ contexts: [{ context: '123' }, { context: '456', parent: '789' }] }),
             sessionSubscribe: vi.fn(),
-            scriptAddPreloadScript: vi.fn(),
+            scriptAddPreloadScript: vi.fn().mockResolvedValue({}),
             scriptCallFunction: vi.fn().mockResolvedValue({}),
             isEnabled: vi.fn().mockReturnValue(true),
             options: { automationProtocol: 'webdriver' }


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

Fix for #14326. Seems like the issue is from polyfill -> registerScripts -> scriptAddPreloadScript -> send error not being caught.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

I tried this out with the code from the issue and both standalone and framework went fine. The only part that I was not sure about was the `send` errors were thrown for both standalone and framework, but it only caused standalone to error out from promise uncaught error. The framework (I tried mocha) had `send` error but it kept on going. Maybe the context in which the error was in between the 2 modes were different?

### Reviewers: @webdriverio/project-committers
