### PR TITLE
Address skipping tests for mocha and jasmine in aftertest

### DIFF
--- a/packages/wdio-utils/tests/test-framework/testFnWrapper-async.test.ts
+++ b/packages/wdio-utils/tests/test-framework/testFnWrapper-async.test.ts
@@ -39,7 +39,8 @@ describe('testFnWrapper', () => {
             retries: {
                 limit: 0,
                 attempts: 0
-            }
+            },
+            skipped: false
         }])
     })
 
@@ -60,7 +61,8 @@ describe('testFnWrapper', () => {
             retries: {
                 limit: 11,
                 attempts: 0
-            }
+            },
+            skipped: false,
         }])
     })
 
@@ -90,7 +92,37 @@ describe('testFnWrapper', () => {
             retries: {
                 limit: 0,
                 attempts: 0
-            }
+            },
+            skipped: false,
+        }])
+    })
+
+    it('should not throw on error on skip test', async () => {
+        const args = buildArgs((mode: string, repeatTest: boolean, arg: any) => {
+            throw new Error('sync skip; aborting execution')
+        }, undefined, () => ['beforeFnArgs'], () => ['afterFnArgs'])
+
+        let error
+        try {
+            // @ts-expect-error
+            await testFnWrapper(...args)
+        } catch (err) {
+            error = err
+        }
+
+        expect(error).toBe(undefined)
+        expect(executeHooksWithArgs).toBeCalledTimes(2)
+        expect(executeHooksWithArgs).toBeCalledWith('beforeFoo', 'beforeFn', ['beforeFnArgs'])
+        expect(executeHooksWithArgs).toBeCalledWith('afterFoo', 'afterFn', ['afterFnArgs', {
+            duration: expect.any(Number),
+            error: undefined,
+            result: undefined,
+            passed: false,
+            retries: {
+                limit: 0,
+                attempts: 0
+            },
+            skipped: true,
         }])
     })
 


### PR DESCRIPTION
## Proposed changes

For #14405. Currently skipping tests in Mocha and Jasmine will result in result.passed = false in afterTest. This is my initial attempt to address that by not letting the test fails if the error thrown is from either Mocha `skip` or Jasmine `pending`. I also added `skipped` field in the result object to differentiate passed/failed vs skipped.

I haven't added to the doc, but if this is good, I can add it to the doc.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
