### PR TITLE
Returns full body for mock response

### DIFF
--- a/packages/webdriverio/src/utils/interception/index.ts
+++ b/packages/webdriverio/src/utils/interception/index.ts
@@ -207,11 +207,9 @@ export default class WebDriverInterception {
             if (responseData.body) {
                 this.#responseBodies.set(request.request.request, responseData.body)
             }
-            const bodyToSend = responseData.body?.type === 'string' ? responseData.body.value : responseData.body
             return this.#browser.networkProvideResponse({
                 request: request.request.request,
                 ...responseData,
-                body: bodyToSend as remote.NetworkBytesValue | undefined
             }).catch(this.#handleNetworkProvideResponseError)
         }
 

--- a/packages/webdriverio/tests/utils/interception/index.test.ts
+++ b/packages/webdriverio/tests/utils/interception/index.test.ts
@@ -254,7 +254,7 @@ describe('WebDriverInterception', () => {
         expect(browser.networkProvideResponse).toHaveBeenCalledTimes(1)
         expect(browser.networkProvideResponse).toHaveBeenCalledWith({
             request: 123,
-            body: '{"foo":"bar"}'
+            body: { type: 'string', value: '{"foo":"bar"}' }
         })
         browser.emit('network.responseStarted', {
             isBlocked: true,
@@ -290,7 +290,7 @@ describe('WebDriverInterception', () => {
         expect(browser.networkProvideResponse).toHaveBeenCalledTimes(1)
         expect(browser.networkProvideResponse).toHaveBeenCalledWith({
             request: 123,
-            body: 'hello'
+            body: { type: 'string', value: 'hello' }
         })
         expect(mock.getBinaryResponse('123')).toBeNull()
     })
@@ -358,7 +358,10 @@ describe('WebDriverInterception', () => {
         [
           [
             {
-              "body": "{"data":{"someProperty":123}}",
+              "body": {
+                "type": "string",
+                "value": "{"data":{"someProperty":123}}",
+              },
               "request": "req-123",
             },
           ],


### PR DESCRIPTION
## Proposed changes

For #14409, seemed like not sending the whole body was the issue for type = string. I've tested it using the code in the issue and it was fine.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
