### PR TITLE
Fix Windows Automation on WebDriverIO V9

### DIFF
--- a/packages/wdio-utils/src/envDetector.ts
+++ b/packages/wdio-utils/src/envDetector.ts
@@ -95,14 +95,21 @@ function isFirefox(capabilities?: WebdriverIO.Capabilities) {
     )
 }
 
+// Some drivers (e.g. Appium for Windows) return capabilities with flattened,
+// non-namespaced keys like `automationName` instead of `appium:automationName`.
+// We extend the base type here to safely support those runtime shapes.
+interface ExtendedCapabilities extends WebdriverIO.Capabilities {
+    automationName?: string;
+}
+
 /**
  * get the automation name value of the session
  *
  * @param  {Object}  capabilities  capabilities
  * @return {Boolean}               true if platform is mobile device
  */
-function getAutomationName(capabilities: WebdriverIO.Capabilities) {
-    return capabilities['appium:options']?.automationName || capabilities['appium:automationName']
+function getAutomationName(capabilities: ExtendedCapabilities) {
+    return capabilities['appium:options']?.automationName || capabilities['appium:automationName'] || capabilities['automationName']
 }
 
 /**

--- a/packages/wdio-utils/tests/envDetector.test.ts
+++ b/packages/wdio-utils/tests/envDetector.test.ts
@@ -104,6 +104,28 @@ describe('sessionEnvironmentDetector', () => {
         expect(sessionEnvironmentDetector({ capabilities: chromeHeadlessShellCaps, requestedCapabilities }).isChrome).toBe(true)
     })
 
+    it('isWindowsApp', () => {
+        const requestedCapabilities = { browserName: '' }
+        const capabilities: WebdriverIO.Capabilities = {
+            platformName: 'windows',
+            'appium:automationName': 'windows',
+            'appium:deviceName': 'WindowsPC',
+        }
+        const {
+            isMobile,
+            isWindowsApp,
+            isMacApp,
+            isAndroid,
+            isIOS
+        } = sessionEnvironmentDetector({ capabilities, requestedCapabilities })
+
+        expect(isMobile).toEqual(true)
+        expect(isWindowsApp).toEqual(true)
+        expect(isMacApp).toEqual(false)
+        expect(isAndroid).toEqual(false)
+        expect(isIOS).toEqual(false)
+    })
+
     it('isChromium', () => {
         const requestedCapabilities = { browserName: '' }
         expect(sessionEnvironmentDetector({ capabilities: {}, requestedCapabilities: {} }).isChromium).toBe(false)


### PR DESCRIPTION
## Proposed changes

WebDriverIO V9 completely broke Windows desktop automation.

**Background**
Capabilities for Windows are as follows:

```
capabilities: [{
  platformName: "windows",
  "appium:automationName": "windows",
  "appium:deviceName": "WindowsPC",
}]

```
During session creation, WebDriverIO or the underlying driver (e.g. Appium) normalizes capabilities — removing the "appium:" prefix and flattening them into a plain structure. As a result, the runtime browser.capabilities object often looks like this:

```
{
  "platformName": "windows",
  "automationName": "windows",
  "deviceName": "WindowsPC",
}
```

However, the `getAutomationName()` function only checks the following conditions:

- `capabilities['appium:options']?.automationName`

- `capabilities['appium:automationName']`

`capabilities['appium:automationName']` always returns false because the "appium:" prefix was removed. 

As a result, even though automationName is present and valid, the function returns undefined, causing logic like browser.isWindowsApp to always return false.

**The Fix**
We update `getAutomationName()` to also check capabilities.automationName as a final fallback:

```
interface ExtendedCapabilities extends WebdriverIO.Capabilities {
    automationName?: string;
}

function getAutomationName(capabilities: ExtendedCapabilities) {
    return capabilities['appium:options']?.automationName ||
           capabilities['appium:automationName'] ||
           capabilities.automationName;
}
```

This preserves backward compatibility and ensures accurate automation detection for desktop and non-mobile Appium drivers.

**Alternative Solution Considered**
I considered using a less type-safe fallback:

```
function getAutomationName(capabilities: WebdriverIO.Capabilities) {
    return (capabilities as any)['appium:options']?.automationName ||
           (capabilities as any)['appium:automationName'] ||
           (capabilities as any)['automationName'];
}
```

This approach disables TypeScript’s type checking and introduces risk of typos or fragile code. The final implementation uses a typed interface extension for clarity and safety.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added the necessary documentation (if appropriate)
- [X] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [X] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
