### PR TITLE
change gridProxyDetails request from GET to POST method

### DIFF
--- a/packages/wdio-protocols/src/protocols/selenium.ts
+++ b/packages/wdio-protocols/src/protocols/selenium.ts
@@ -104,7 +104,7 @@ export default {
         },
     },
     '/grid/api/proxy': {
-        GET: {
+        POST: {
             isHubCommand: true,
             command: 'gridProxyDetails',
             description: 'Get proxy details.',


### PR DESCRIPTION
## Proposed changes

This PR fixes a bug related to the browser.gridProxyDetails command:

```bash
file:///<system_path>/wdio-gridproxydetails-bug/node_modules/webdriver/build/node.js:1758
      throw new WebDriverRequestError(err, url, opts);
            ^

WebDriverRequestError: WebDriverError: Request with GET/HEAD method cannot have body. when running "http://localhost:4444/grid/api/proxy" with method "GET" and args "{"id":"http://<ip_address>:64012"}"
    at FetchRequest._libRequest (file:///<system_path>/wdio-gridproxydetails-bug/node_modules/webdriver/build/node.js:1758:13)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async FetchRequest._request (file:///<system_path>/wdio-gridproxydetails-bug/node_modules/webdriver/build/node.js:1768:20)      
    at async Browser.wrapCommandFn (file:///<system_path>/wdio-gridproxydetails-bug/node_modules/@wdio/utils/build/index.js:907:23)    
    at async file:///<system_path>/wdio-gridproxydetails-bug/index.js:26:30
```

You can see the issue reproduced in this GitHub Actions pipeline:
https://github.com/ArtMathArt/wdio-gridproxydetails-bug/actions/runs/14706091466/job/41266809797#step:8:101
or using the minimal reproducible example repository:
https://github.com/ArtMathArt/wdio-gridproxydetails-bug

The issue occurs because the undici library does not accept a body in GET requests, as explained here:
https://github.com/nodejs/undici/issues/4013

Since Selenium Grid 3 also supports POST requests for this endpoint ([selenium-grid2-api documentation](https://github.com/nicegraham/selenium-grid2-api#gridapiproxy)),
I propose switching the request method from GET to POST.

The changes were tested and verified in the following GitHub Actions pipeline:
https://github.com/ArtMathArt/wdio-gridproxydetails-bug/actions/runs/14707097026/job/41270124569#step:11:92

In this pipeline, a custom version of wdio-protocols was built from my fork with the proposed updates and used for testing to confirm the fix.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

Thank you for reviewing this PR!
If any improvements or adjustments are needed, I'm happy to update it based on your feedback.
I'm excited to contribute to WebdriverIO and really appreciate your work maintaining this great project.

### Reviewers: @webdriverio/project-committers
