### PR TITLE
Fix avoid misleading BiDi connection failure message

### DIFF
--- a/packages/webdriver/src/node/bidi.ts
+++ b/packages/webdriver/src/node/bidi.ts
@@ -83,7 +83,6 @@ export async function connectWebsocket(candidateUrls: string[], options?: Client
 
     const connectionTimeoutPromise = new Promise<undefined>((resolve) => {
         setTimeout(() => {
-            log.error(`Could not connect to Bidi protocol of any candidate url in time: "${candidateUrls.join('", "')}"`)
             return resolve(undefined)
         }, CONNECTION_TIMEOUT)
     })
@@ -92,6 +91,10 @@ export async function connectWebsocket(candidateUrls: string[], options?: Client
         firstResolved(wsConnectPromises),
         connectionTimeoutPromise,
     ])
+
+    if (typeof wsInfo === 'undefined') {
+        log.error(`Could not connect to Bidi protocol of any candidate url in time: "${candidateUrls.join('", "')}"`)
+    }
 
     const socketsToCleanup = wsInfo ? websockets.filter((_, index) => wsInfo.index !== index) : websockets
     for (const socket of socketsToCleanup) {

--- a/packages/webdriver/src/node/bidi.ts
+++ b/packages/webdriver/src/node/bidi.ts
@@ -81,8 +81,11 @@ export async function connectWebsocket(candidateUrls: string[], options?: Client
         return { promise, index }
     })
 
+    let timeoutId
+
     const connectionTimeoutPromise = new Promise<undefined>((resolve) => {
-        setTimeout(() => {
+        timeoutId = setTimeout(() => {
+            log.error(`Could not connect to Bidi protocol of any candidate url in time: "${candidateUrls.join('", "')}"`)
             return resolve(undefined)
         }, CONNECTION_TIMEOUT)
     })
@@ -92,9 +95,7 @@ export async function connectWebsocket(candidateUrls: string[], options?: Client
         connectionTimeoutPromise,
     ])
 
-    if (typeof wsInfo === 'undefined') {
-        log.error(`Could not connect to Bidi protocol of any candidate url in time: "${candidateUrls.join('", "')}"`)
-    }
+    clearTimeout(timeoutId)
 
     const socketsToCleanup = wsInfo ? websockets.filter((_, index) => wsInfo.index !== index) : websockets
     for (const socket of socketsToCleanup) {


### PR DESCRIPTION
## Proposed changes
This pull request fixes the issue where WDIO always displays the error "ERROR webdriver: Could not connect to Bidi protocol of any candidate url in time" when trying to connect to BiDi. The change was suggested by [tinklern](https://github.com/tinklern) to move the error log below the run and check for an undefined result. This issue was reported in #14430 

## Types of changes

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

### Reviewers: @webdriverio/project-committers
