### PR TITLE
fix(bidi-dialog): only accept dialogs in active browsing context

### DIFF
--- a/packages/webdriverio/src/session/dialog.ts
+++ b/packages/webdriverio/src/session/dialog.ts
@@ -115,7 +115,9 @@ export class Dialog {
         const contextManager = getContextManager(this.#browser)
         const context = await contextManager.getCurrentContext()
 
-        if (this.#context !== context) {return}
+        if (this.#context !== context) {
+            return
+        }
 
         await this.#browser.browsingContextHandleUserPrompt({
             accept: true,

--- a/packages/webdriverio/src/session/dialog.ts
+++ b/packages/webdriverio/src/session/dialog.ts
@@ -1,5 +1,6 @@
 import { type local } from 'webdriver'
 import { SessionManager } from './session.js'
+import { getContextManager } from './context.js'
 
 export function getDialogManager(browser: WebdriverIO.Browser) {
     return SessionManager.getSessionManager(browser, DialogManager)
@@ -111,6 +112,11 @@ export class Dialog {
      * @returns {Promise<void>}
      */
     async accept(userText?: string) {
+        const contextManager = getContextManager(this.#browser)
+        const context = await contextManager.getCurrentContext()
+
+        if (this.#context !== context) {return}
+
         await this.#browser.browsingContextHandleUserPrompt({
             accept: true,
             context: this.#context,

--- a/packages/webdriverio/tests/commands/dialog/accept.test.ts
+++ b/packages/webdriverio/tests/commands/dialog/accept.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeEach, vi, type Mock } from 'vitest'
+import { remote } from '../../../src/index.js'
+import { Dialog } from '../../../src/session/dialog.js'
+import type { BrowsingContextUserPromptOpenedParameters } from '../../../../webdriver/build/bidi/localTypes.js'
+
+vi.mock('../../../src/session/context.js', () => ({
+    getContextManager: vi.fn(),
+}))
+import { getContextManager } from '../../../src/session/context.js'
+
+describe('accept', () => {
+    let browser: WebdriverIO.Browser
+    let dialog: Dialog
+    let mockContextManager: { getCurrentContext: () => Promise<string> }
+    let browseStub
+
+    beforeEach(async () => {
+        browser = await remote({
+            baseUrl: 'http://foobar.com',
+            capabilities: { browserName: 'dialog' }
+        })
+
+        browseStub = vi.spyOn(browser, 'browsingContextHandleUserPrompt')
+            .mockResolvedValue({})
+
+        mockContextManager = {
+            getCurrentContext: vi.fn()
+        };
+
+        (getContextManager as Mock).mockReturnValue(mockContextManager)
+    })
+
+    it('should NOT call browsingContextHandleUserPrompt if contexts differ', async () => {
+        const fakeEvent = {
+            context: 'ctx-A',
+            message: 'ignored',
+            defaultValue: '',
+            type: 'alert',
+        } as BrowsingContextUserPromptOpenedParameters
+
+        dialog = new Dialog(fakeEvent, browser)
+
+        // simulate a *different* active context
+        mockContextManager.getCurrentContext = vi.fn().mockResolvedValue('ctx-B')
+        await dialog.accept('foo')
+
+        expect(browseStub).not.toHaveBeenCalled()
+    })
+
+    it('should call browsingContextHandleUserPrompt if contexts match', async () => {
+        const fakeEvent = {
+            context: 'ctx-A',
+            message: 'ignored',
+            defaultValue: '',
+            type: 'prompt',
+        } as BrowsingContextUserPromptOpenedParameters
+
+        dialog = new Dialog(fakeEvent, browser)
+
+        // simulate *same* active context
+        mockContextManager.getCurrentContext = vi.fn().mockResolvedValue('ctx-A')
+        await dialog.accept('my input')
+
+        expect(browseStub).toHaveBeenCalledWith({
+            accept: true,
+            context: 'ctx-A',
+            userText: 'my input'
+        })
+    })
+
+    it('should call getCurrentContext once and pass undefined userText when none provided', async () => {
+        const fakeEvent = {
+            context: 'ctx-A',
+            message: 'msg',
+            defaultValue: '',
+            type: 'prompt',
+        } as BrowsingContextUserPromptOpenedParameters
+
+        dialog = new Dialog(fakeEvent, browser)
+        mockContextManager.getCurrentContext = vi.fn().mockResolvedValue('ctx-A')
+
+        await dialog.accept()
+
+        expect(mockContextManager.getCurrentContext).toHaveBeenCalledTimes(1)
+
+        expect(browseStub).toHaveBeenCalledWith({
+            accept: true,
+            context: 'ctx-A',
+            userText: undefined
+        })
+    })
+
+    it('should handle any dialog type the same way when contexts match', async () => {
+        for (const type of ['alert', 'confirm', 'prompt', 'beforeunload'] as const) {
+            const fakeEvent = {
+                context: 'ctx-X',
+                message: 'm',
+                defaultValue: '',
+                type: type,
+            } as BrowsingContextUserPromptOpenedParameters
+
+            dialog = new Dialog(fakeEvent, browser)
+            mockContextManager.getCurrentContext = vi.fn().mockResolvedValue('ctx-X')
+            browseStub.mockClear()
+
+            await dialog.accept('foo')
+            expect(browseStub).toHaveBeenCalledWith({
+                accept: true,
+                context: 'ctx-X',
+                userText: 'foo'
+            })
+        }
+    })
+})


### PR DESCRIPTION
## Proposed changes

This PR adds a context check in the `accept() `handler so that we only call `dialog.accept() `when the dialog actually belongs to the current browsing context. It uses the `ContextManager.getCurrentContext()` helper and bails out early if `this.#context !== context`, preventing “no such frame” errors when multiple contexts fire native‐dialog events.

## Related issue
Closes #14295

## Types of changes

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)


### Reviewers: @webdriverio/project-committers
