### PR TITLE
fix(bidi-dialog): only dismiss dialogs in active browsing context

### DIFF
--- a/packages/webdriverio/src/session/dialog.ts
+++ b/packages/webdriverio/src/session/dialog.ts
@@ -127,6 +127,13 @@ export class Dialog {
     }
 
     async dismiss() {
+        const contextManager = getContextManager(this.#browser)
+        const context = await contextManager.getCurrentContext()
+
+        if (this.#context !== context) {
+            return
+        }
+
         await this.#browser.browsingContextHandleUserPrompt({
             accept: false,
             context: this.#context

--- a/packages/webdriverio/tests/commands/dialog/dismiss.test.ts
+++ b/packages/webdriverio/tests/commands/dialog/dismiss.test.ts
@@ -42,7 +42,7 @@ describe('dismiss', () => {
 
         // simulate a *different* active context
         mockContextManager.getCurrentContext = vi.fn().mockResolvedValue('ctx-B')
-        await dialog.accept('foo')
+        await dialog.dismiss()
 
         expect(browseStub).not.toHaveBeenCalled()
     })
@@ -65,6 +65,7 @@ describe('dismiss', () => {
             accept: false,
             context: 'ctx-A'
         })
+        expect(browseStub).toHaveBeenCalledTimes(1)
     })
 
     it('should call getCurrentContext once', async () => {
@@ -86,5 +87,6 @@ describe('dismiss', () => {
             accept: false,
             context: 'ctx-A',
         })
+        expect(browseStub).toHaveBeenCalledTimes(1)
     })
 })

--- a/packages/webdriverio/tests/commands/dialog/dismiss.test.ts
+++ b/packages/webdriverio/tests/commands/dialog/dismiss.test.ts
@@ -8,7 +8,7 @@ vi.mock('../../../src/session/context.js', () => ({
 }))
 import { getContextManager } from '../../../src/session/context.js'
 
-describe('accept', () => {
+describe('dismiss', () => {
     let browser: WebdriverIO.Browser
     let dialog: Dialog
     let mockContextManager: { getCurrentContext: () => Promise<string> }
@@ -33,9 +33,9 @@ describe('accept', () => {
     it('should NOT call browsingContextHandleUserPrompt if contexts differ', async () => {
         const fakeEvent = {
             context: 'ctx-A',
-            message: 'ignored',
+            message: 'some message',
             defaultValue: '',
-            type: 'alert',
+            type: 'confirm',
         } as BrowsingContextUserPromptOpenedParameters
 
         dialog = new Dialog(fakeEvent, browser)
@@ -50,25 +50,24 @@ describe('accept', () => {
     it('should call browsingContextHandleUserPrompt if contexts match', async () => {
         const fakeEvent = {
             context: 'ctx-A',
-            message: 'ignored',
+            message: 'some message',
             defaultValue: '',
-            type: 'prompt',
+            type: 'confirm',
         } as BrowsingContextUserPromptOpenedParameters
 
         dialog = new Dialog(fakeEvent, browser)
 
         // simulate *same* active context
         mockContextManager.getCurrentContext = vi.fn().mockResolvedValue('ctx-A')
-        await dialog.accept('my input')
+        await dialog.dismiss()
 
         expect(browseStub).toHaveBeenCalledWith({
-            accept: true,
-            context: 'ctx-A',
-            userText: 'my input'
+            accept: false,
+            context: 'ctx-A'
         })
     })
 
-    it('should call getCurrentContext once and pass undefined userText when none provided', async () => {
+    it('should call getCurrentContext once', async () => {
         const fakeEvent = {
             context: 'ctx-A',
             message: 'msg',
@@ -79,36 +78,13 @@ describe('accept', () => {
         dialog = new Dialog(fakeEvent, browser)
         mockContextManager.getCurrentContext = vi.fn().mockResolvedValue('ctx-A')
 
-        await dialog.accept()
+        await dialog.dismiss()
 
         expect(mockContextManager.getCurrentContext).toHaveBeenCalledTimes(1)
 
         expect(browseStub).toHaveBeenCalledWith({
-            accept: true,
+            accept: false,
             context: 'ctx-A',
-            userText: undefined
         })
-    })
-
-    it('should handle any dialog type the same way when contexts match', async () => {
-        for (const type of ['alert', 'confirm', 'prompt', 'beforeunload'] as const) {
-            const fakeEvent = {
-                context: 'ctx-X',
-                message: 'm',
-                defaultValue: '',
-                type: type,
-            } as BrowsingContextUserPromptOpenedParameters
-
-            dialog = new Dialog(fakeEvent, browser)
-            mockContextManager.getCurrentContext = vi.fn().mockResolvedValue('ctx-X')
-            browseStub.mockClear()
-
-            await dialog.accept('foo')
-            expect(browseStub).toHaveBeenCalledWith({
-                accept: true,
-                context: 'ctx-X',
-                userText: 'foo'
-            })
-        }
     })
 })


### PR DESCRIPTION
## Proposed changes

This PR adds a context check to the dismiss() handler so that we only call browsingContextHandleUserPrompt when the dialog actually belongs to the current browsing context. It uses the ContextManager.getCurrentContext() helper and exits early if this.#context !== context, avoiding "no frame" errors when multiple contexts trigger native dialog events.
I previously added the same check to accept() in #14448  and now I'm adding it to dismiss() which is also required

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

### Reviewers: @webdriverio/project-committers
