### PR TITLE
fix(webdriver): stop cloning request so `await response.json()` can abort properly

### DIFF
--- a/packages/webdriver/src/request/request.ts
+++ b/packages/webdriver/src/request/request.ts
@@ -138,13 +138,10 @@ export abstract class WebDriverRequest {
                 ...(dispatcher ? { dispatcher } : {})
             })
 
-            // Cloning the response to prevent body unusable error
-            const resp = response.clone()
-
             return {
-                statusCode: resp.status,
-                body: await resp.json() ?? {},
-            } as Options.RequestLibResponse
+                statusCode: response.status,
+                body: await response.json() ?? {},
+            } satisfies Options.RequestLibResponse
         } catch (err) {
             if (!(err instanceof Error)) {
                 throw new WebDriverRequestError(


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

As demonstrated in [this issue](https://github.com/webdriverio/webdriverio/issues/14457), if we reach the `connectionRetryTimeout` while reading the JSON from the response, using a cloned version throws an empty error since the abort signal data is not properly synced on the cloned version.

However, removing this line removes a potential fix done in [this commit](https://github.com/webdriverio/webdriverio/commit/9aca81ab552bbec28b250bb4ca8fd754bd2a720a) by @tamil777selvan 

At the same time, I do not see why we need to clone the request since it is solely scoped to this code, and cloning means more resources. Is there any filter that also tries to read the stream? If so, it could be the code that clones it before we start the JSON parsing.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
