### PR TITLE
fix(webdriverio): improve typing for execute and executeAsync

### DIFF
--- a/packages/webdriverio/src/commands/browser/execute.ts
+++ b/packages/webdriverio/src/commands/browser/execute.ts
@@ -6,6 +6,7 @@ import { LocalValue } from '../../utils/bidi/value.js'
 import { parseScriptResult } from '../../utils/bidi/index.js'
 import { getContextManager } from '../../session/context.js'
 import { polyfillFn } from '../../session/polyfill.js'
+import type { TransformElement, TransformReturn } from '../../types.js'
 
 /**
  *
@@ -44,9 +45,9 @@ import { polyfillFn } from '../../session/polyfill.js'
  */
 export async function execute<ReturnValue, InnerArguments extends unknown[]> (
     this: WebdriverIO.Browser | WebdriverIO.MultiRemoteBrowser,
-    script: string | ((...innerArgs: InnerArguments) => ReturnValue),
+    script: string | ((...innerArgs: TransformElement<InnerArguments>) => ReturnValue),
     ...args: InnerArguments
-): Promise<ReturnValue> {
+): Promise<TransformReturn<ReturnValue>> {
     /**
      * parameter check
      */

--- a/packages/webdriverio/src/commands/browser/executeAsync.ts
+++ b/packages/webdriverio/src/commands/browser/executeAsync.ts
@@ -6,6 +6,7 @@ import { LocalValue } from '../../utils/bidi/value.js'
 import { parseScriptResult } from '../../utils/bidi/index.js'
 import { getContextManager } from '../../session/context.js'
 import { polyfillFn } from '../../session/polyfill.js'
+import type { TransformElement } from '../../types.js'
 
 /**
  * :::warning
@@ -44,6 +45,15 @@ import { polyfillFn } from '../../session/polyfill.js'
         // node.js context - client and console are available
         console.log(result) // outputs: 10
     });
+
+    :executeAsync.ts
+    // explicitly type the return value of the script to ensure type safety
+    const result: number = await browser.executeAsync(function(a, b, c, d, done) {
+        // browser context - you may not access client or console
+        setTimeout(() => {
+            done(a + b + c + d)
+        }, 3000);
+    }, 1, 2, 3, 4)
  * </example>
  *
  * @param {String|Function} script     The script to execute.
@@ -59,7 +69,12 @@ export async function executeAsync<ReturnValue, InnerArguments extends unknown[]
     this: WebdriverIO.Browser | WebdriverIO.MultiRemoteBrowser,
     script:
         string |
-        ((...args: [...innerArgs: InnerArguments, callback: (result?: ReturnValue) => void]) => void),
+        (
+            (
+                ...args: [...innerArgs: { [K in keyof InnerArguments]: TransformElement<InnerArguments[K]> },
+                callback: (result?: TransformElement<ReturnValue>) => void]
+            ) => void
+        ),
     ...args: InnerArguments
 ): Promise<ReturnValue> {
     /**

--- a/packages/webdriverio/src/commands/element/execute.ts
+++ b/packages/webdriverio/src/commands/element/execute.ts
@@ -38,15 +38,7 @@ import type { TransformElement, TransformReturn } from '../../types.js'
  *
  */
 export async function execute<ReturnValue, InnerArguments extends unknown[]> (
-    /**
-     * `this` has to be typed `unknown` as we can't otherwise assign it to the element, due to:
-     * ```
-     * The 'this' context of type 'ChainablePromiseElement' is not assignable to method's 'this' of type 'Element'.
-     *   Types of property 'parent' are incompatible.
-     *     Type 'Promise<Browser | Element | MultiRemoteBrowser>' is not assignable to type 'Browser | Element'.
-     * ```
-     */
-    this: unknown,
+    this: WebdriverIO.Element,
     script: string | ((...innerArgs: TransformElement<[WebdriverIO.Element, ...InnerArguments]>) => ReturnValue),
     ...args: InnerArguments
 ): Promise<TransformReturn<ReturnValue>> {

--- a/packages/webdriverio/src/commands/element/execute.ts
+++ b/packages/webdriverio/src/commands/element/execute.ts
@@ -1,4 +1,5 @@
 import { getBrowserObject } from '@wdio/utils'
+import type { TransformElement, TransformReturn } from '../../types.js'
 
 /**
  *
@@ -37,11 +38,12 @@ import { getBrowserObject } from '@wdio/utils'
  *
  */
 export async function execute<ReturnValue, InnerArguments extends unknown[]> (
-    this: WebdriverIO.Element,
-    script: string | ((...innerArgs: [WebdriverIO.Element, ...InnerArguments]) => ReturnValue),
+    this: unknown,
+    script: string | ((...innerArgs: TransformElement<[WebdriverIO.Element, ...InnerArguments]>) => ReturnValue),
     ...args: InnerArguments
-): Promise<ReturnValue> {
-    const browser = getBrowserObject(this)
-    await this.waitForExist()
-    return browser.execute(script, this, ...args)
+): Promise<TransformReturn<ReturnValue>> {
+    const scope = this as WebdriverIO.Element
+    const browser = getBrowserObject(scope)
+    await scope.waitForExist()
+    return browser.execute(script, scope, ...args)
 }

--- a/packages/webdriverio/src/commands/element/execute.ts
+++ b/packages/webdriverio/src/commands/element/execute.ts
@@ -38,6 +38,14 @@ import type { TransformElement, TransformReturn } from '../../types.js'
  *
  */
 export async function execute<ReturnValue, InnerArguments extends unknown[]> (
+    /**
+     * `this` has to be typed `unknown` as we can't otherwise assign it to the element, due to:
+     * ```
+     * The 'this' context of type 'ChainablePromiseElement' is not assignable to method's 'this' of type 'Element'.
+     *   Types of property 'parent' are incompatible.
+     *     Type 'Promise<Browser | Element | MultiRemoteBrowser>' is not assignable to type 'Browser | Element'.
+     * ```
+     */
     this: unknown,
     script: string | ((...innerArgs: TransformElement<[WebdriverIO.Element, ...InnerArguments]>) => ReturnValue),
     ...args: InnerArguments

--- a/packages/webdriverio/src/commands/element/executeAsync.ts
+++ b/packages/webdriverio/src/commands/element/executeAsync.ts
@@ -68,6 +68,14 @@ import type { TransformElement } from '../../types.js'
  * @deprecated Please use `execute` instead
  */
 export async function executeAsync<ReturnValue, InnerArguments extends unknown[]> (
+    /**
+     * `this` has to be typed `unknown` as we can't otherwise assign it to the element, due to:
+     * ```
+     * The 'this' context of type 'ChainablePromiseElement' is not assignable to method's 'this' of type 'Element'.
+     *   Types of property 'parent' are incompatible.
+     *     Type 'Promise<Browser | Element | MultiRemoteBrowser>' is not assignable to type 'Browser | Element'.
+     * ```
+     */
     this: unknown,
     script:
         string |

--- a/packages/webdriverio/src/commands/element/executeAsync.ts
+++ b/packages/webdriverio/src/commands/element/executeAsync.ts
@@ -68,15 +68,7 @@ import type { TransformElement } from '../../types.js'
  * @deprecated Please use `execute` instead
  */
 export async function executeAsync<ReturnValue, InnerArguments extends unknown[]> (
-    /**
-     * `this` has to be typed `unknown` as we can't otherwise assign it to the element, due to:
-     * ```
-     * The 'this' context of type 'ChainablePromiseElement' is not assignable to method's 'this' of type 'Element'.
-     *   Types of property 'parent' are incompatible.
-     *     Type 'Promise<Browser | Element | MultiRemoteBrowser>' is not assignable to type 'Browser | Element'.
-     * ```
-     */
-    this: unknown,
+    this: WebdriverIO.Browser | WebdriverIO.Element,
     script:
         string |
         (

--- a/packages/webdriverio/src/commands/element/executeAsync.ts
+++ b/packages/webdriverio/src/commands/element/executeAsync.ts
@@ -1,5 +1,5 @@
 import { getBrowserObject } from '@wdio/utils'
-
+import type { TransformElement } from '../../types.js'
 /**
  * :::warning
  * The `executeAsync` command is deprecated and will be removed in a future version.
@@ -52,12 +52,21 @@ import { getBrowserObject } from '@wdio/utils'
  * @deprecated Please use `execute` instead
  */
 export async function executeAsync<ReturnValue, InnerArguments extends unknown[]> (
-    this: WebdriverIO.Browser | WebdriverIO.Element,
+    this: unknown,
     script:
         string |
-        ((...args: [...innerArgs: [WebdriverIO.Element, ...InnerArguments], callback: (result?: ReturnValue) => void]) => void),
+        (
+            (
+                ...args: [
+                    element: HTMLElement,
+                    ...innerArgs: { [K in keyof InnerArguments]: TransformElement<InnerArguments[K]> },
+                    callback: (result?: TransformElement<ReturnValue>) => void
+                ]
+            ) => void
+        ),
     ...args: InnerArguments
 ): Promise<ReturnValue> {
-    const browser = getBrowserObject(this)
-    return browser.executeAsync(script, this, ...args)
+    const scope = this as WebdriverIO.Element
+    const browser = getBrowserObject(scope)
+    return browser.executeAsync(script, scope, ...args)
 }

--- a/packages/webdriverio/src/commands/element/executeAsync.ts
+++ b/packages/webdriverio/src/commands/element/executeAsync.ts
@@ -36,7 +36,23 @@ import type { TransformElement } from '../../types.js'
                 done(elem.textContent + a + b + c + d)
             }, 3000);
         }, 1, 2, 3, 4);
+
         // node.js context - client and console are available
+        console.log(text); // outputs "Hello World1234"
+    });
+
+    :executeAsync.ts
+    it('should wait for the element to exist, then executes async javascript on the page with the element as first argument', async () => {
+        await browser.setTimeout({ script: 5000 })
+
+        // explicitly type the return value of the script to ensure type safety
+        const text: number = await $('div').execute((elem, a, b, c, d) => {
+            // browser context - you may not access client or console
+            setTimeout(() => {
+                done(elem.textContent + a + b + c + d)
+            }, 3000);
+        }, 1, 2, 3, 4);
+
         // node.js context - client and console are available
         console.log(text); // outputs "Hello World1234"
     });

--- a/packages/webdriverio/src/commands/element/getHTML.ts
+++ b/packages/webdriverio/src/commands/element/getHTML.ts
@@ -141,9 +141,8 @@ export async function getHTML(
         /**
          * then get the HTML of the element and its shadow roots
          */
-        const { html, shadowElementHTML } = await browser.execute(
+        const { html, shadowElementHTML } = await this.execute(
             getHTMLShadowScript,
-            { [ELEMENT_KEY]: this.elementId } as unknown as HTMLElement,
             includeSelectorTag,
             elementsWithShadowRootAndIdVerified
         )

--- a/packages/webdriverio/src/commands/element/selectByVisibleText.ts
+++ b/packages/webdriverio/src/commands/element/selectByVisibleText.ts
@@ -60,7 +60,7 @@ export async function selectByVisibleText (
         `./optgroup/option${spaceFormat}`,
     ]
 
-    const optionElement = await this.$(selections.join('|')).getElement()
+    const optionElement = await this.$(selections.join('|'))
     await optionElement.waitForExist({
         timeoutMsg: `Option with text "${text}" not found.`
     })

--- a/packages/webdriverio/src/commands/element/selectByVisibleText.ts
+++ b/packages/webdriverio/src/commands/element/selectByVisibleText.ts
@@ -60,7 +60,7 @@ export async function selectByVisibleText (
         `./optgroup/option${spaceFormat}`,
     ]
 
-    const optionElement = await this.$(selections.join('|'))
+    const optionElement = await this.$(selections.join('|')).getElement()
     await optionElement.waitForExist({
         timeoutMsg: `Option with text "${text}" not found.`
     })

--- a/packages/webdriverio/src/types.ts
+++ b/packages/webdriverio/src/types.ts
@@ -35,9 +35,7 @@ type ChainablePrototype = {
     [K in ElementsQueryCommands]: (...args: Parameters<$ElementCommands[K]>) => ChainablePromiseArray
 }
 
-type AsyncElementProto = {
-    [K in keyof Omit<$ElementCommands, keyof ChainablePrototype>]: OmitThisParameter<$ElementCommands[K]>
-} & ChainablePrototype
+type AsyncElementProto = Omit<$ElementCommands, keyof ChainablePrototype> & ChainablePrototype
 
 interface ChainablePromiseBaseElement {
     /**
@@ -676,6 +674,22 @@ export interface SaveScreenshotOptions {
         height: number
     }
 }
+
+export type TransformElement<T> =
+    T extends WebdriverIO.Element ? HTMLElement :
+        T extends ChainablePromiseElement ? HTMLElement :
+            T extends WebdriverIO.Element[] ? HTMLElement[] :
+                T extends ChainablePromiseArray ? HTMLElement[] :
+                    T extends [infer First, ...infer Rest] ? [TransformElement<First>, ...TransformElement<Rest>] :
+                        T extends Array<infer U> ? Array<TransformElement<U>> :
+                            T
+
+export type TransformReturn<T> =
+    T extends HTMLElement ? WebdriverIO.Element :
+        T extends HTMLElement[] ? WebdriverIO.Element[] :
+            T extends [infer First, ...infer Rest] ? [TransformReturn<First>, ...TransformReturn<Rest>] :
+                T extends Array<infer U> ? Array<TransformReturn<U>> :
+                    T
 
 declare global {
     namespace WebdriverIO {

--- a/packages/webdriverio/src/types.ts
+++ b/packages/webdriverio/src/types.ts
@@ -35,7 +35,9 @@ type ChainablePrototype = {
     [K in ElementsQueryCommands]: (...args: Parameters<$ElementCommands[K]>) => ChainablePromiseArray
 }
 
-type AsyncElementProto = Omit<$ElementCommands, keyof ChainablePrototype> & ChainablePrototype
+type AsyncElementProto = {
+    [K in keyof Omit<$ElementCommands, keyof ChainablePrototype>]: OmitThisParameter<$ElementCommands[K]>
+} & ChainablePrototype
 
 interface ChainablePromiseBaseElement {
     /**

--- a/packages/webdriverio/tests/commands/browser/execute.test-d.ts
+++ b/packages/webdriverio/tests/commands/browser/execute.test-d.ts
@@ -1,0 +1,23 @@
+import { expectTypeOf } from 'vitest'
+import { remote } from '../../../src/index.js'
+
+test('properly transforms element arguments', async () => {
+    const browser = await remote({
+        capabilities: {}
+    })
+    const elem = await browser.$('body')
+    const result = await browser.execute((a, b, c, d) => {
+        expectTypeOf(a).toEqualTypeOf<number>()
+        expectTypeOf(b).toEqualTypeOf<string>()
+        expectTypeOf(c).toEqualTypeOf<boolean>()
+        expectTypeOf(d).toEqualTypeOf<HTMLElement>()
+        return document.body
+    }, 1, '2', true, elem)
+    expectTypeOf(result).toEqualTypeOf<WebdriverIO.Element>()
+
+    const result2 = await browser.execute(() => document.querySelector('div'))
+    expectTypeOf(result2).toEqualTypeOf<WebdriverIO.Element | null>()
+
+    const result3 = await browser.execute(() => 123)
+    expectTypeOf(result3).toEqualTypeOf<number>()
+})

--- a/packages/webdriverio/tests/commands/browser/executeAsync.test-d.ts
+++ b/packages/webdriverio/tests/commands/browser/executeAsync.test-d.ts
@@ -1,0 +1,29 @@
+import { expectTypeOf } from 'vitest'
+import { remote } from '../../../src/index.js'
+
+test('properly transforms element arguments', async () => {
+    const browser = await remote({
+        capabilities: {}
+    })
+    const elem = await browser.$('body')
+
+    const result: WebdriverIO.Element = await browser.executeAsync((a, b, c, d, done) => {
+        expectTypeOf(a).toEqualTypeOf<number>()
+        expectTypeOf(b).toEqualTypeOf<string>()
+        expectTypeOf(c).toEqualTypeOf<boolean>()
+        expectTypeOf(d).toEqualTypeOf<HTMLElement>()
+        done(document.body)
+    }, 1, '2', true, elem)
+    expectTypeOf(result).toEqualTypeOf<WebdriverIO.Element>()
+
+    const el: WebdriverIO.Element | null = await browser.executeAsync((done) => {
+        done(document.querySelector('body'))
+    })
+    expectTypeOf(el).toEqualTypeOf<WebdriverIO.Element | null>()
+
+    const result2: WebdriverIO.Element | null = await browser.executeAsync((done) => done(document.querySelector('div')))
+    expectTypeOf(result2).toEqualTypeOf<WebdriverIO.Element | null>()
+
+    const result3: number = await browser.executeAsync((done) => done(123))
+    expectTypeOf(result3).toEqualTypeOf<number>()
+})

--- a/packages/webdriverio/tests/commands/element/execute.test-d.ts
+++ b/packages/webdriverio/tests/commands/element/execute.test-d.ts
@@ -1,0 +1,24 @@
+import { expectTypeOf } from 'vitest'
+import { remote } from '../../../src/index.js'
+
+test('properly transforms element arguments', async () => {
+    const browser = await remote({
+        capabilities: {}
+    })
+    const elem = await browser.$('body')
+    const result = await elem.execute((el, a, b, c, d) => {
+        expectTypeOf(el).toEqualTypeOf<HTMLElement>()
+        expectTypeOf(a).toEqualTypeOf<number>()
+        expectTypeOf(b).toEqualTypeOf<string>()
+        expectTypeOf(c).toEqualTypeOf<boolean>()
+        expectTypeOf(d).toEqualTypeOf<HTMLElement>()
+        return document.body
+    }, 1, '2', true, elem)
+    expectTypeOf(result).toEqualTypeOf<WebdriverIO.Element>()
+
+    const result2 = await elem.execute(() => document.querySelector('div'))
+    expectTypeOf(result2).toEqualTypeOf<WebdriverIO.Element | null>()
+
+    const result3 = await elem.execute(() => 123)
+    expectTypeOf(result3).toEqualTypeOf<number>()
+})

--- a/packages/webdriverio/tests/commands/element/executeAsync.test-d.ts
+++ b/packages/webdriverio/tests/commands/element/executeAsync.test-d.ts
@@ -1,0 +1,30 @@
+import { expectTypeOf } from 'vitest'
+import { remote } from '../../../src/index.js'
+
+test('properly transforms element arguments', async () => {
+    const browser = await remote({
+        capabilities: {}
+    })
+    const elem = await browser.$('body')
+
+    const result: WebdriverIO.Element = await elem.executeAsync((el, a, b, c, d, done) => {
+        expectTypeOf(el).toEqualTypeOf<HTMLElement>()
+        expectTypeOf(a).toEqualTypeOf<number>()
+        expectTypeOf(b).toEqualTypeOf<string>()
+        expectTypeOf(c).toEqualTypeOf<boolean>()
+        expectTypeOf(d).toEqualTypeOf<HTMLElement>()
+        done(document.body)
+    }, 1, '2', true, elem)
+    expectTypeOf(result).toEqualTypeOf<WebdriverIO.Element>()
+
+    const el: WebdriverIO.Element | null = await elem.executeAsync((el, done) => {
+        done(document.querySelector('body'))
+    })
+    expectTypeOf(el).toEqualTypeOf<WebdriverIO.Element | null>()
+
+    const result2: WebdriverIO.Element | null = await elem.executeAsync((el, done) => done(document.querySelector('div')))
+    expectTypeOf(result2).toEqualTypeOf<WebdriverIO.Element | null>()
+
+    const result3: number = await elem.executeAsync((el, done) => done(123))
+    expectTypeOf(result3).toEqualTypeOf<number>()
+})


### PR DESCRIPTION
## Proposed changes

When using `execute` or `executeAsync` a `WebdriverIO.Element` passed in as argument would be automatically transformed into a `HTMLElement` that it references by the WebDriver protocol. This wasn't reflected in the types.

This patch improves the typing around these 2 commands.

fixes #6486

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

n/a

### Reviewers: @webdriverio/project-committers
