### PR TITLE
chore(@wdio/spec-reporter): file name print format

### DIFF
--- a/packages/wdio-spec-reporter/README.md
+++ b/packages/wdio-spec-reporter/README.md
@@ -134,12 +134,12 @@ With it set to `false` you will see output as:
 Running: loremipsum (v50) on Windows 10
 Session ID: foobar
 
-» /foo/bar/loo.e2e.js
+» foo/bar/loo.e2e.js
 Foo test
    green ✓ foo
    green ✓ bar
 
-» /bar/foo/loo.e2e.js
+» bar/foo/loo.e2e.js
 Bar test
    green ✓ some test
    red ✖ a failed test
@@ -151,12 +151,12 @@ and with `true` (default) each line will be prefixed with the preface:
 [loremipsum 50 Windows 10 #0-0] Running: loremipsum (v50) on Windows 10
 [loremipsum 50 Windows 10 #0-0] Session ID: foobar
 [loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] » /foo/bar/loo.e2e.js
+[loremipsum 50 Windows 10 #0-0] » foo/bar/loo.e2e.js
 [loremipsum 50 Windows 10 #0-0] Foo test
 [loremipsum 50 Windows 10 #0-0]    green ✓ foo
 [loremipsum 50 Windows 10 #0-0]    green ✓ bar
 [loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] » /bar/foo/loo.e2e.js
+[loremipsum 50 Windows 10 #0-0] » bar/foo/loo.e2e.js
 [loremipsum 50 Windows 10 #0-0] Bar test
 [loremipsum 50 Windows 10 #0-0]    green ✓ some test
 [loremipsum 50 Windows 10 #0-0]    red ✖ a failed test

--- a/packages/wdio-spec-reporter/src/index.ts
+++ b/packages/wdio-spec-reporter/src/index.ts
@@ -380,7 +380,7 @@ export default class SpecReporter extends WDIOReporter {
 
             // Display file path of spec
             if (suite.file && !specFileReferences.includes(suite.file)) {
-                output.push(`${suiteIndent}» ${suite.file.replace(process.cwd(), '')}`)
+                output.push(`${suiteIndent}» ${suite.file.replace(process.cwd(), '').slice(1)}`)
                 specFileReferences.push(suite.file)
             }
 

--- a/packages/wdio-spec-reporter/tests/__snapshots__/index.test.ts.snap
+++ b/packages/wdio-spec-reporter/tests/__snapshots__/index.test.ts.snap
@@ -22,7 +22,7 @@ exports[`SpecReporter > getHeaderDisplay > should validate header output in mult
 
 exports[`SpecReporter > getResultDisplay > should not print if argument is a single line doc string 1`] = `
 [
-  "» /foo/bar/loo.e2e.js",
+  "» foo/bar/loo.e2e.js",
   "Foo test",
   "gray Some important",
   "gray description to read!",
@@ -39,7 +39,7 @@ exports[`SpecReporter > getResultDisplay > should not print if argument is a sin
 
 exports[`SpecReporter > getResultDisplay > should not print if data table is empty 1`] = `
 [
-  "» /foo/bar/loo.e2e.js",
+  "» foo/bar/loo.e2e.js",
   "Foo test",
   "gray Some important",
   "gray description to read!",
@@ -53,7 +53,7 @@ exports[`SpecReporter > getResultDisplay > should not print if data table is emp
 
 exports[`SpecReporter > getResultDisplay > should not print if the argument is undefined 1`] = `
 [
-  "» /foo/bar/loo.e2e.js",
+  "» foo/bar/loo.e2e.js",
   "Foo test",
   "gray Some important",
   "gray description to read!",
@@ -67,7 +67,7 @@ exports[`SpecReporter > getResultDisplay > should not print if the argument is u
 
 exports[`SpecReporter > getResultDisplay > should print data tables 1`] = `
 [
-  "» /foo/bar/loo.e2e.js",
+  "» foo/bar/loo.e2e.js",
   "Foo test",
   "gray Some important",
   "gray description to read!",
@@ -85,7 +85,7 @@ exports[`SpecReporter > getResultDisplay > should print data tables 1`] = `
 
 exports[`SpecReporter > getResultDisplay > should print if the doc string is a blank string 1`] = `
 [
-  "» /foo/bar/loo.e2e.js",
+  "» foo/bar/loo.e2e.js",
   "Foo test",
   "gray Some important",
   "gray description to read!",
@@ -103,7 +103,7 @@ exports[`SpecReporter > getResultDisplay > should print if the doc string is a b
 
 exports[`SpecReporter > getResultDisplay > should print multiple lines doc string 1`] = `
 [
-  "» /foo/bar/loo.e2e.js",
+  "» foo/bar/loo.e2e.js",
   "Foo test",
   "gray Some important",
   "gray description to read!",
@@ -127,18 +127,18 @@ exports[`SpecReporter > getResultDisplay > should print multiple lines doc strin
 
 exports[`SpecReporter > getResultDisplay > should validate the result output with tests 1`] = `
 [
-  "» /foo/bar/loo.e2e.js",
+  "» foo/bar/loo.e2e.js",
   "Foo test",
   "   green ✓ foo",
   "   green ✓ bar",
   "",
-  "» /bar/foo/loo.e2e.js",
+  "» bar/foo/loo.e2e.js",
   "Bar test",
   "   green ✓ some test",
   "   red ✖ a failed test",
   "   red ✖ a failed test with no stack",
   "",
-  "» /bar/loo/foo.e2e.js",
+  "» bar/loo/foo.e2e.js",
   "Baz test",
   "   green ✓ foo bar baz",
   "   cyan - a skipped test",
@@ -153,7 +153,7 @@ exports[`SpecReporter > onRetry > should group retried test cases 1`] = `
 [loremipsum 50 Windows 10 #0-0] Running: loremipsum (v50) on Windows 10
 [loremipsum 50 Windows 10 #0-0] Session ID: foobar
 [loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] » /foo/bar/loo.e2e.js
+[loremipsum 50 Windows 10 #0-0] » foo/bar/loo.e2e.js
 [loremipsum 50 Windows 10 #0-0] Foo test
 [loremipsum 50 Windows 10 #0-0]    green ✓ foo
 [loremipsum 50 Windows 10 #0-0]    green ✓ bar
@@ -173,18 +173,18 @@ exports[`SpecReporter > onlyFailures > false > 0 failures 1`] = `
 [loremipsum 50 Windows 10 #0-0] Running: loremipsum (v50) on Windows 10
 [loremipsum 50 Windows 10 #0-0] Session ID: foobar
 [loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] » /foo/bar/loo.e2e.js
+[loremipsum 50 Windows 10 #0-0] » foo/bar/loo.e2e.js
 [loremipsum 50 Windows 10 #0-0] Foo test
 [loremipsum 50 Windows 10 #0-0]    green ✓ foo
 [loremipsum 50 Windows 10 #0-0]    green ✓ bar
 [loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] » /bar/foo/loo.e2e.js
+[loremipsum 50 Windows 10 #0-0] » bar/foo/loo.e2e.js
 [loremipsum 50 Windows 10 #0-0] Bar test
 [loremipsum 50 Windows 10 #0-0]    green ✓ some test
 [loremipsum 50 Windows 10 #0-0]    red ✖ a failed test
 [loremipsum 50 Windows 10 #0-0]    red ✖ a failed test with no stack
 [loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] » /bar/loo/foo.e2e.js
+[loremipsum 50 Windows 10 #0-0] » bar/loo/foo.e2e.js
 [loremipsum 50 Windows 10 #0-0] Baz test
 [loremipsum 50 Windows 10 #0-0]    green ✓ foo bar baz
 [loremipsum 50 Windows 10 #0-0]    cyan - a skipped test
@@ -208,18 +208,18 @@ exports[`SpecReporter > onlyFailures > false > 1 failure 1`] = `
 [loremipsum 50 Windows 10 #0-0] Running: loremipsum (v50) on Windows 10
 [loremipsum 50 Windows 10 #0-0] Session ID: foobar
 [loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] » /foo/bar/loo.e2e.js
+[loremipsum 50 Windows 10 #0-0] » foo/bar/loo.e2e.js
 [loremipsum 50 Windows 10 #0-0] Foo test
 [loremipsum 50 Windows 10 #0-0]    green ✓ foo
 [loremipsum 50 Windows 10 #0-0]    green ✓ bar
 [loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] » /bar/foo/loo.e2e.js
+[loremipsum 50 Windows 10 #0-0] » bar/foo/loo.e2e.js
 [loremipsum 50 Windows 10 #0-0] Bar test
 [loremipsum 50 Windows 10 #0-0]    green ✓ some test
 [loremipsum 50 Windows 10 #0-0]    red ✖ a failed test
 [loremipsum 50 Windows 10 #0-0]    red ✖ a failed test with no stack
 [loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] » /bar/loo/foo.e2e.js
+[loremipsum 50 Windows 10 #0-0] » bar/loo/foo.e2e.js
 [loremipsum 50 Windows 10 #0-0] Baz test
 [loremipsum 50 Windows 10 #0-0]    green ✓ foo bar baz
 [loremipsum 50 Windows 10 #0-0]    cyan - a skipped test
@@ -245,18 +245,18 @@ exports[`SpecReporter > onlyFailures > true > 1 failure 1`] = `
 [loremipsum 50 Windows 10 #0-0] Running: loremipsum (v50) on Windows 10
 [loremipsum 50 Windows 10 #0-0] Session ID: foobar
 [loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] » /foo/bar/loo.e2e.js
+[loremipsum 50 Windows 10 #0-0] » foo/bar/loo.e2e.js
 [loremipsum 50 Windows 10 #0-0] Foo test
 [loremipsum 50 Windows 10 #0-0]    green ✓ foo
 [loremipsum 50 Windows 10 #0-0]    green ✓ bar
 [loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] » /bar/foo/loo.e2e.js
+[loremipsum 50 Windows 10 #0-0] » bar/foo/loo.e2e.js
 [loremipsum 50 Windows 10 #0-0] Bar test
 [loremipsum 50 Windows 10 #0-0]    green ✓ some test
 [loremipsum 50 Windows 10 #0-0]    red ✖ a failed test
 [loremipsum 50 Windows 10 #0-0]    red ✖ a failed test with no stack
 [loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] » /bar/loo/foo.e2e.js
+[loremipsum 50 Windows 10 #0-0] » bar/loo/foo.e2e.js
 [loremipsum 50 Windows 10 #0-0] Baz test
 [loremipsum 50 Windows 10 #0-0]    green ✓ foo bar baz
 [loremipsum 50 Windows 10 #0-0]    cyan - a skipped test
@@ -296,18 +296,18 @@ exports[`SpecReporter > printReport > with normal setup > should print jobs of a
     "------------------------------------------------------------------
 [MultiremoteBrowser on chrome and firefox #0-0] Running: MultiremoteBrowser on chrome and firefox
 [MultiremoteBrowser on chrome and firefox #0-0]
-[MultiremoteBrowser on chrome and firefox #0-0] » /foo/bar/loo.e2e.js
+[MultiremoteBrowser on chrome and firefox #0-0] » foo/bar/loo.e2e.js
 [MultiremoteBrowser on chrome and firefox #0-0] Foo test
 [MultiremoteBrowser on chrome and firefox #0-0]    green ✓ foo
 [MultiremoteBrowser on chrome and firefox #0-0]    green ✓ bar
 [MultiremoteBrowser on chrome and firefox #0-0]
-[MultiremoteBrowser on chrome and firefox #0-0] » /bar/foo/loo.e2e.js
+[MultiremoteBrowser on chrome and firefox #0-0] » bar/foo/loo.e2e.js
 [MultiremoteBrowser on chrome and firefox #0-0] Bar test
 [MultiremoteBrowser on chrome and firefox #0-0]    green ✓ some test
 [MultiremoteBrowser on chrome and firefox #0-0]    red ✖ a failed test
 [MultiremoteBrowser on chrome and firefox #0-0]    red ✖ a failed test with no stack
 [MultiremoteBrowser on chrome and firefox #0-0]
-[MultiremoteBrowser on chrome and firefox #0-0] » /bar/loo/foo.e2e.js
+[MultiremoteBrowser on chrome and firefox #0-0] » bar/loo/foo.e2e.js
 [MultiremoteBrowser on chrome and firefox #0-0] Baz test
 [MultiremoteBrowser on chrome and firefox #0-0]    green ✓ foo bar baz
 [MultiremoteBrowser on chrome and firefox #0-0]    cyan - a skipped test
@@ -334,18 +334,18 @@ exports[`SpecReporter > printReport > with normal setup > should print link to S
 [loremipsum 50 Windows 10 #0-0] Running: loremipsum (v50) on Windows 10
 [loremipsum 50 Windows 10 #0-0] Session ID: foobar
 [loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] » /foo/bar/loo.e2e.js
+[loremipsum 50 Windows 10 #0-0] » foo/bar/loo.e2e.js
 [loremipsum 50 Windows 10 #0-0] Foo test
 [loremipsum 50 Windows 10 #0-0]    green ✓ foo
 [loremipsum 50 Windows 10 #0-0]    green ✓ bar
 [loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] » /bar/foo/loo.e2e.js
+[loremipsum 50 Windows 10 #0-0] » bar/foo/loo.e2e.js
 [loremipsum 50 Windows 10 #0-0] Bar test
 [loremipsum 50 Windows 10 #0-0]    green ✓ some test
 [loremipsum 50 Windows 10 #0-0]    red ✖ a failed test
 [loremipsum 50 Windows 10 #0-0]    red ✖ a failed test with no stack
 [loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] » /bar/loo/foo.e2e.js
+[loremipsum 50 Windows 10 #0-0] » bar/loo/foo.e2e.js
 [loremipsum 50 Windows 10 #0-0] Baz test
 [loremipsum 50 Windows 10 #0-0]    green ✓ foo bar baz
 [loremipsum 50 Windows 10 #0-0]    cyan - a skipped test
@@ -374,18 +374,18 @@ exports[`SpecReporter > printReport > with normal setup > should print link to S
 [loremipsum 50 Windows 10 #0-0] Running: loremipsum (v50) on Windows 10
 [loremipsum 50 Windows 10 #0-0] Session ID: foobar
 [loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] » /foo/bar/loo.e2e.js
+[loremipsum 50 Windows 10 #0-0] » foo/bar/loo.e2e.js
 [loremipsum 50 Windows 10 #0-0] Foo test
 [loremipsum 50 Windows 10 #0-0]    green ✓ foo
 [loremipsum 50 Windows 10 #0-0]    green ✓ bar
 [loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] » /bar/foo/loo.e2e.js
+[loremipsum 50 Windows 10 #0-0] » bar/foo/loo.e2e.js
 [loremipsum 50 Windows 10 #0-0] Bar test
 [loremipsum 50 Windows 10 #0-0]    green ✓ some test
 [loremipsum 50 Windows 10 #0-0]    red ✖ a failed test
 [loremipsum 50 Windows 10 #0-0]    red ✖ a failed test with no stack
 [loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] » /bar/loo/foo.e2e.js
+[loremipsum 50 Windows 10 #0-0] » bar/loo/foo.e2e.js
 [loremipsum 50 Windows 10 #0-0] Baz test
 [loremipsum 50 Windows 10 #0-0]    green ✓ foo bar baz
 [loremipsum 50 Windows 10 #0-0]    cyan - a skipped test
@@ -413,18 +413,18 @@ exports[`SpecReporter > printReport > with normal setup > should print link to S
     "------------------------------------------------------------------
 [udid-serial-of-device iOS 14.3 #0-0] Running: udid-serial-of-device on iOS 14.3 executing safari
 [udid-serial-of-device iOS 14.3 #0-0]
-[udid-serial-of-device iOS 14.3 #0-0] » /foo/bar/loo.e2e.js
+[udid-serial-of-device iOS 14.3 #0-0] » foo/bar/loo.e2e.js
 [udid-serial-of-device iOS 14.3 #0-0] Foo test
 [udid-serial-of-device iOS 14.3 #0-0]    green ✓ foo
 [udid-serial-of-device iOS 14.3 #0-0]    green ✓ bar
 [udid-serial-of-device iOS 14.3 #0-0]
-[udid-serial-of-device iOS 14.3 #0-0] » /bar/foo/loo.e2e.js
+[udid-serial-of-device iOS 14.3 #0-0] » bar/foo/loo.e2e.js
 [udid-serial-of-device iOS 14.3 #0-0] Bar test
 [udid-serial-of-device iOS 14.3 #0-0]    green ✓ some test
 [udid-serial-of-device iOS 14.3 #0-0]    red ✖ a failed test
 [udid-serial-of-device iOS 14.3 #0-0]    red ✖ a failed test with no stack
 [udid-serial-of-device iOS 14.3 #0-0]
-[udid-serial-of-device iOS 14.3 #0-0] » /bar/loo/foo.e2e.js
+[udid-serial-of-device iOS 14.3 #0-0] » bar/loo/foo.e2e.js
 [udid-serial-of-device iOS 14.3 #0-0] Baz test
 [udid-serial-of-device iOS 14.3 #0-0]    green ✓ foo bar baz
 [udid-serial-of-device iOS 14.3 #0-0]    cyan - a skipped test
@@ -453,18 +453,18 @@ exports[`SpecReporter > printReport > with normal setup > should print link to S
 [loremipsum 50 Windows 10 #0-0] Running: loremipsum (v50) on Windows 10
 [loremipsum 50 Windows 10 #0-0] Session ID: foobar
 [loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] » /foo/bar/loo.e2e.js
+[loremipsum 50 Windows 10 #0-0] » foo/bar/loo.e2e.js
 [loremipsum 50 Windows 10 #0-0] Foo test
 [loremipsum 50 Windows 10 #0-0]    green ✓ foo
 [loremipsum 50 Windows 10 #0-0]    green ✓ bar
 [loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] » /bar/foo/loo.e2e.js
+[loremipsum 50 Windows 10 #0-0] » bar/foo/loo.e2e.js
 [loremipsum 50 Windows 10 #0-0] Bar test
 [loremipsum 50 Windows 10 #0-0]    green ✓ some test
 [loremipsum 50 Windows 10 #0-0]    red ✖ a failed test
 [loremipsum 50 Windows 10 #0-0]    red ✖ a failed test with no stack
 [loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] » /bar/loo/foo.e2e.js
+[loremipsum 50 Windows 10 #0-0] » bar/loo/foo.e2e.js
 [loremipsum 50 Windows 10 #0-0] Baz test
 [loremipsum 50 Windows 10 #0-0]    green ✓ foo bar baz
 [loremipsum 50 Windows 10 #0-0]    cyan - a skipped test
@@ -493,18 +493,18 @@ exports[`SpecReporter > printReport > with normal setup > should print link to S
 [loremipsum 50 Windows 10 #0-0] Running: loremipsum (v50) on Windows 10
 [loremipsum 50 Windows 10 #0-0] Session ID: foobar
 [loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] » /foo/bar/loo.e2e.js
+[loremipsum 50 Windows 10 #0-0] » foo/bar/loo.e2e.js
 [loremipsum 50 Windows 10 #0-0] Foo test
 [loremipsum 50 Windows 10 #0-0]    green ✓ foo
 [loremipsum 50 Windows 10 #0-0]    green ✓ bar
 [loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] » /bar/foo/loo.e2e.js
+[loremipsum 50 Windows 10 #0-0] » bar/foo/loo.e2e.js
 [loremipsum 50 Windows 10 #0-0] Bar test
 [loremipsum 50 Windows 10 #0-0]    green ✓ some test
 [loremipsum 50 Windows 10 #0-0]    red ✖ a failed test
 [loremipsum 50 Windows 10 #0-0]    red ✖ a failed test with no stack
 [loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] » /bar/loo/foo.e2e.js
+[loremipsum 50 Windows 10 #0-0] » bar/loo/foo.e2e.js
 [loremipsum 50 Windows 10 #0-0] Baz test
 [loremipsum 50 Windows 10 #0-0]    green ✓ foo bar baz
 [loremipsum 50 Windows 10 #0-0]    cyan - a skipped test
@@ -533,18 +533,18 @@ exports[`SpecReporter > printReport > with normal setup > should print link to S
 [loremipsum 50 Windows 10 #0-0] Running: loremipsum (v50) on Windows 10
 [loremipsum 50 Windows 10 #0-0] Session ID: foobar
 [loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] » /foo/bar/loo.e2e.js
+[loremipsum 50 Windows 10 #0-0] » foo/bar/loo.e2e.js
 [loremipsum 50 Windows 10 #0-0] Foo test
 [loremipsum 50 Windows 10 #0-0]    green ✓ foo
 [loremipsum 50 Windows 10 #0-0]    green ✓ bar
 [loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] » /bar/foo/loo.e2e.js
+[loremipsum 50 Windows 10 #0-0] » bar/foo/loo.e2e.js
 [loremipsum 50 Windows 10 #0-0] Bar test
 [loremipsum 50 Windows 10 #0-0]    green ✓ some test
 [loremipsum 50 Windows 10 #0-0]    red ✖ a failed test
 [loremipsum 50 Windows 10 #0-0]    red ✖ a failed test with no stack
 [loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] » /bar/loo/foo.e2e.js
+[loremipsum 50 Windows 10 #0-0] » bar/loo/foo.e2e.js
 [loremipsum 50 Windows 10 #0-0] Baz test
 [loremipsum 50 Windows 10 #0-0]    green ✓ foo bar baz
 [loremipsum 50 Windows 10 #0-0]    cyan - a skipped test
@@ -573,18 +573,18 @@ exports[`SpecReporter > printReport > with normal setup > should print the repor
 [loremipsum 50 Windows 10 #0-0] Running: loremipsum (v50) on Windows 10
 [loremipsum 50 Windows 10 #0-0] Session ID: foobar
 [loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] » /foo/bar/loo.e2e.js
+[loremipsum 50 Windows 10 #0-0] » foo/bar/loo.e2e.js
 [loremipsum 50 Windows 10 #0-0] Foo test
 [loremipsum 50 Windows 10 #0-0]    green ✓ foo
 [loremipsum 50 Windows 10 #0-0]    green ✓ bar
 [loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] » /bar/foo/loo.e2e.js
+[loremipsum 50 Windows 10 #0-0] » bar/foo/loo.e2e.js
 [loremipsum 50 Windows 10 #0-0] Bar test
 [loremipsum 50 Windows 10 #0-0]    green ✓ some test
 [loremipsum 50 Windows 10 #0-0]    red ✖ a failed test
 [loremipsum 50 Windows 10 #0-0]    red ✖ a failed test with no stack
 [loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] » /bar/loo/foo.e2e.js
+[loremipsum 50 Windows 10 #0-0] » bar/loo/foo.e2e.js
 [loremipsum 50 Windows 10 #0-0] Baz test
 [loremipsum 50 Windows 10 #0-0]    green ✓ foo bar baz
 [loremipsum 50 Windows 10 #0-0]    cyan - a skipped test
@@ -615,7 +615,7 @@ exports[`SpecReporter > suite retry > should group retried test suites 1`] = `
 [loremipsum 50 Windows 10 #0-0] Running: loremipsum (v50) on Windows 10
 [loremipsum 50 Windows 10 #0-0] Session ID: foobar
 [loremipsum 50 Windows 10 #0-0]
-[loremipsum 50 Windows 10 #0-0] » /foo/bar/loo.e2e.js
+[loremipsum 50 Windows 10 #0-0] » foo/bar/loo.e2e.js
 [loremipsum 50 Windows 10 #0-0] Foo testyellow  (1x retries)
 [loremipsum 50 Windows 10 #0-0]    green ✓ foo
 [loremipsum 50 Windows 10 #0-0]    green ✓ bar


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

Hey! 👋
This PR is for the WebDriver Spec Reporter.

It removes the leading slash from file paths in the report.
Without this, the links to spec files are not clickable in VS Code on macOS and Linux — VS Code says that file not found. It works fine on Windows, but trimming the slash improves cross-platform usability.

https://github.com/user-attachments/assets/f616f9a4-73ce-4ef9-a4cd-af16b2a19929

Let me know if you see any issues with this or something else needs to be updated!

P.S. Vite and other reporters don't have leading slashes.
![image](https://github.com/user-attachments/assets/9f4d92f8-748a-4a58-8a55-8beb7d86160b)


## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)
