### PR TITLE
Cache the wd request dispatcher

### DIFF
--- a/packages/webdriver/src/request/node.ts
+++ b/packages/webdriver/src/request/node.ts
@@ -53,7 +53,7 @@ export class FetchRequest extends WebDriverRequest {
     async createOptions (options: RequestOptions, sessionId?: string, isBrowser: boolean = false) {
         const { url, requestOptions } = await super.createOptions(options, sessionId, isBrowser)
 
-        ;(requestOptions as UndiciRequestInit).dispatcher = this.getDispatcher(url, options)
+        ;(requestOptions as UndiciRequestInit).dispatcher = this.getDispatcher(url, options, sessionId)
         return { url, requestOptions }
     }
 }

--- a/packages/webdriver/tests/request.test.ts
+++ b/packages/webdriver/tests/request.test.ts
@@ -7,8 +7,7 @@ import type { Options } from '@wdio/types'
 
 import '../src/browser.js'
 import { FetchRequest as WebFetchRequest } from '../src/request/web.js'
-import { FetchRequest } from '../src/request/node.js'
-import { SESSION_DISPATCHERS } from '../src/request/node.js'
+import { FetchRequest, SESSION_DISPATCHERS } from '../src/request/node.js'
 
 vi.mock('@wdio/logger', () => import(path.join(process.cwd(), '__mocks__', '@wdio/logger')))
 vi.mock('fetch')

--- a/packages/webdriver/tests/request.test.ts
+++ b/packages/webdriver/tests/request.test.ts
@@ -6,10 +6,20 @@ import logger from '@wdio/logger'
 import type { Options } from '@wdio/types'
 
 import '../src/browser.js'
-import { FetchRequest } from '../src/request/web.js'
+import { FetchRequest as WebFetchRequest } from '../src/request/web.js'
+import { FetchRequest } from '../src/request/node.js'
+import { SESSION_DISPATCHERS } from '../src/request/node.js'
 
 vi.mock('@wdio/logger', () => import(path.join(process.cwd(), '__mocks__', '@wdio/logger')))
 vi.mock('fetch')
+vi.mock('undici', () => {
+    return {
+        fetch: vi.fn(async () => ({ ok: true, status: 200, json: async () => ({}) })),
+        Agent: vi.fn().mockImplementation(() => ({ close: vi.fn() })),
+        ProxyAgent: vi.fn().mockImplementation(() => ({ close: vi.fn() })),
+    }
+})
+
 const { warn, error } = logger('test')
 
 const webdriverPath = '/session'
@@ -23,16 +33,17 @@ const baseUrl = `${defaultOptions.protocol}://${defaultOptions.hostname}:${defau
 describe('webdriver request', () => {
     beforeEach(() => {
         vi.mocked(fetch).mockClear()
+        SESSION_DISPATCHERS.clear()
     })
 
     it('should have some default options', () => {
-        const req = new FetchRequest('POST', '/foo/bar', { foo: 'bar' })
+        const req = new WebFetchRequest('POST', '/foo/bar', { foo: 'bar' })
         expect(req.method).toBe('POST')
         expect(req.endpoint).toBe('/foo/bar')
     })
 
     it('should be able to make request', async () => {
-        const req = new FetchRequest('POST', '/foo/bar', { foo: 'bar' })
+        const req = new WebFetchRequest('POST', '/foo/bar', { foo: 'bar' })
         const url =  new URL('/foo/bar', baseUrl)
         req.createOptions = vi.fn().mockImplementation((opts, sessionId) => ({
             url,
@@ -54,7 +65,7 @@ describe('webdriver request', () => {
     })
 
     it('should pick up the fullRequestOptions returned by transformRequest', async () => {
-        const req = new FetchRequest('POST', '/foo/bar', { foo: 'bar' })
+        const req = new WebFetchRequest('POST', '/foo/bar', { foo: 'bar' })
         const transformRequest = vi.fn().mockImplementation((requestOptions) => ({
             ...requestOptions,
             body: { foo: 'baz' }
@@ -75,7 +86,7 @@ describe('webdriver request', () => {
     })
 
     it('should resolve with the body returned by transformResponse', async () => {
-        const req = new FetchRequest('POST', 'session/:sessionId/element', { foo: 'requestBody' })
+        const req = new WebFetchRequest('POST', 'session/:sessionId/element', { foo: 'requestBody' })
 
         const transformResponse = vi.fn().mockImplementation((response) => ({
             ...response,
@@ -100,12 +111,12 @@ describe('webdriver request', () => {
 
     describe('createOptions', () => {
         it('fails if command requires sessionId but none given', async () => {
-            const req = new FetchRequest('POST', `${webdriverPath}/:sessionId/element`, {})
+            const req = new WebFetchRequest('POST', `${webdriverPath}/:sessionId/element`, {})
             await expect(() => req.createOptions({ logLevel: 'warn' })).rejects.toThrow('A sessionId is required')
         })
 
         it('creates proper options set', async () => {
-            const req = new FetchRequest('POST', `${webdriverPath}/:sessionId/element`, {})
+            const req = new WebFetchRequest('POST', `${webdriverPath}/:sessionId/element`, {})
             const { url, requestOptions } = await req.createOptions({
                 protocol: 'https',
                 hostname: 'localhost',
@@ -124,7 +135,7 @@ describe('webdriver request', () => {
         })
 
         it('ignors path when command is a hub command', async () => {
-            const req = new FetchRequest('POST', '/grid/api/hub', {}, undefined, true)
+            const req = new WebFetchRequest('POST', '/grid/api/hub', {}, undefined, true)
             const options = await req.createOptions({
                 protocol: 'https',
                 hostname: 'localhost',
@@ -136,7 +147,7 @@ describe('webdriver request', () => {
         })
 
         it('should add authorization header if user and key is given', async () => {
-            const req = new FetchRequest('POST', webdriverPath, { some: 'body' })
+            const req = new WebFetchRequest('POST', webdriverPath, { some: 'body' })
             const user = 'foo'
             const key = 'bar'
             const { requestOptions } = await req.createOptions({
@@ -151,7 +162,7 @@ describe('webdriver request', () => {
         })
 
         it('sets request body to "undefined" when request object is empty and DELETE is used', async () => {
-            const req = new FetchRequest('DELETE', webdriverPath, {})
+            const req = new WebFetchRequest('DELETE', webdriverPath, {})
             const { requestOptions } = await req.createOptions({
                 ...defaultOptions,
                 path: '/',
@@ -161,7 +172,7 @@ describe('webdriver request', () => {
         })
 
         it('sets request body to "undefined" when request object is empty and GET is used', async () => {
-            const req = new FetchRequest('GET', `${webdriverPath}/title`, {})
+            const req = new WebFetchRequest('GET', `${webdriverPath}/title`, {})
             const { requestOptions } = await req.createOptions({
                 ...defaultOptions,
                 path: '/',
@@ -171,7 +182,7 @@ describe('webdriver request', () => {
         })
 
         it('should attach an empty object body when POST is used', async () => {
-            const req = new FetchRequest('POST', '/status', {})
+            const req = new WebFetchRequest('POST', '/status', {})
             const { requestOptions } = await req.createOptions({
                 ...defaultOptions,
                 path: '/',
@@ -181,7 +192,7 @@ describe('webdriver request', () => {
         })
 
         it('should add the Content-Length header when a request object has a body', async () => {
-            const req = new FetchRequest('POST', webdriverPath, { foo: 'bar' })
+            const req = new WebFetchRequest('POST', webdriverPath, { foo: 'bar' })
             const { requestOptions } = await req.createOptions({
                 ...defaultOptions,
                 path: '/',
@@ -193,7 +204,7 @@ describe('webdriver request', () => {
         })
 
         it('should add Content-Length as well any other header provided in the request options if there is body in the request object', async () => {
-            const req = new FetchRequest('POST', webdriverPath, { foo: 'bar' })
+            const req = new WebFetchRequest('POST', webdriverPath, { foo: 'bar' })
             const { requestOptions } = await req.createOptions({
                 ...defaultOptions, path: '/',
                 headers: { foo: 'bar' },
@@ -204,7 +215,7 @@ describe('webdriver request', () => {
         })
 
         it('should add only the headers provided if the request body is empty', async () => {
-            const req = new FetchRequest('POST', webdriverPath)
+            const req = new WebFetchRequest('POST', webdriverPath)
             const { requestOptions } = await req.createOptions({
                 ...defaultOptions,
                 path: '/',
@@ -221,7 +232,7 @@ describe('webdriver request', () => {
             const expectedResponse = { value: { 'element-6066-11e4-a52e-4f735466cecf': 'some-elem-123' } }
             const onResponse = vi.fn()
             const onPerformance = vi.fn()
-            const req = new FetchRequest('POST', webdriverPath, {}, undefined, false, {
+            const req = new WebFetchRequest('POST', webdriverPath, {}, undefined, false, {
                 onResponse, onPerformance
             })
 
@@ -242,7 +253,7 @@ describe('webdriver request', () => {
         it('should short circuit if request throws a stale element exception', async () => {
             const onResponse = vi.fn()
             const onPerformance = vi.fn()
-            const req = new FetchRequest('POST', 'session/:sessionId/element', {}, undefined, false, {
+            const req = new WebFetchRequest('POST', 'session/:sessionId/element', {}, undefined, false, {
                 onResponse, onPerformance
             })
 
@@ -262,7 +273,7 @@ describe('webdriver request', () => {
         it('should not fail code due to an empty server response', async () => {
             const onResponse = vi.fn()
             const onPerformance = vi.fn()
-            const req = new FetchRequest('POST', webdriverPath, {}, undefined, false, {
+            const req = new WebFetchRequest('POST', webdriverPath, {}, undefined, false, {
                 onResponse, onPerformance
             })
 
@@ -281,7 +292,7 @@ describe('webdriver request', () => {
             const onRetry = vi.fn()
             const onResponse = vi.fn()
             const onPerformance = vi.fn()
-            const req = new FetchRequest('POST', webdriverPath, {}, undefined, false, {
+            const req = new WebFetchRequest('POST', webdriverPath, {}, undefined, false, {
                 onResponse, onPerformance, onRetry
             })
 
@@ -304,7 +315,7 @@ describe('webdriver request', () => {
             const onRetry = vi.fn()
             const onResponse = vi.fn()
             const onPerformance = vi.fn()
-            const req = new FetchRequest('POST', webdriverPath, {}, undefined, false, {
+            const req = new WebFetchRequest('POST', webdriverPath, {}, undefined, false, {
                 onResponse, onPerformance, onRetry
             })
 
@@ -324,7 +335,7 @@ describe('webdriver request', () => {
         })
 
         it('should manage hub commands', async () => {
-            const req = new FetchRequest('POST', '/grid/api/hub', {}, undefined, true)
+            const req = new WebFetchRequest('POST', '/grid/api/hub', {}, undefined, true)
             expect(await req.makeRequest({
                 protocol: 'https',
                 hostname: 'localhost',
@@ -335,7 +346,7 @@ describe('webdriver request', () => {
         })
 
         it('should fail if hub command is called on node', async () => {
-            const req = new FetchRequest('POST', '/grid/api/testsession', {}, undefined, true)
+            const req = new WebFetchRequest('POST', '/grid/api/testsession', {}, undefined, true)
             const result = await req.makeRequest({
                 protocol: 'https',
                 hostname: 'localhost',
@@ -353,7 +364,7 @@ describe('webdriver request', () => {
             it('should throw if timeout happens too often', async () => {
                 const retryCnt = 3
                 const onRetry = vi.fn()
-                const req = new FetchRequest('POST', '/timeout', {}, undefined, true, { onRetry })
+                const req = new WebFetchRequest('POST', '/timeout', {}, undefined, true, { onRetry })
                 const result = await req.makeRequest({
                     protocol: 'https',
                     hostname: 'localhost',
@@ -374,7 +385,7 @@ describe('webdriver request', () => {
                 const onRequest = vi.fn()
                 const onResponse = vi.fn()
                 const onPerformance = vi.fn()
-                const req = new FetchRequest('GET', '/timeout', {}, undefined, true, { onRetry, onRequest, onResponse, onPerformance })
+                const req = new WebFetchRequest('GET', '/timeout', {}, undefined, true, { onRetry, onRequest, onResponse, onPerformance })
                 const reqOpts = {
                     protocol: 'https',
                     hostname: 'localhost',
@@ -395,7 +406,7 @@ describe('webdriver request', () => {
         it('should return proper response if retry passes', async () => {
             const retryCnt = 7
             const onRetry = vi.fn()
-            const req = new FetchRequest('POST', '/timeout', {}, undefined, true, { onRetry })
+            const req = new WebFetchRequest('POST', '/timeout', {}, undefined, true, { onRetry })
             const result = await req.makeRequest({
                 protocol: 'https',
                 hostname: 'localhost',
@@ -414,7 +425,7 @@ describe('webdriver request', () => {
         it('should retry on connection refused error', async () => {
             const retryCnt = 7
             const onRetry = vi.fn()
-            const req = new FetchRequest('POST', '/connectionRefused', {}, undefined, false, { onRetry })
+            const req = new WebFetchRequest('POST', '/connectionRefused', {}, undefined, false, { onRetry })
             const result = await req.makeRequest({
                 protocol: 'https',
                 hostname: 'localhost',
@@ -431,7 +442,7 @@ describe('webdriver request', () => {
 
         it('should throw if request error is unknown', async () => {
             console.log('TESTING', AbortSignal)
-            const req = new FetchRequest('POST', '/sumoerror', {}, undefined, true)
+            const req = new WebFetchRequest('POST', '/sumoerror', {}, undefined, true)
             const result = await req.makeRequest({
                 protocol: 'https',
                 hostname: 'localhost',
@@ -445,6 +456,63 @@ describe('webdriver request', () => {
             )
             expect(result.message).toEqual(expect.stringContaining('ups'))
         })
+
+        it('should validate dispatcher is reused within the same session', async () => {
+            const sessionId = 'reuse-session-id'
+
+            const req1 = new FetchRequest('POST', `/session/${sessionId}/element`, {})
+            const req2 = new FetchRequest('GET', `/session/${sessionId}/cookie`, {})
+            await req1.makeRequest(defaultOptions, sessionId).then((res) => res, (e) => e)
+            await req2.makeRequest(defaultOptions, sessionId).then((res) => res, (e) => e)
+
+            expect(SESSION_DISPATCHERS.has(sessionId)).toBe(true)
+            expect(SESSION_DISPATCHERS.size).toBe(1)
+        })
+
+        it('should validate a new dispatcher is created for each individual session', async () => {
+            const sessionId1 = 'session-id-1'
+            const sessionId2 = 'session-id-2'
+
+            const req1 = new FetchRequest('POST', `/session/${sessionId1}/element`, {})
+            const req2 = new FetchRequest('GET', `/session/${sessionId2}/cookie`, {})
+            await req1.makeRequest(defaultOptions, sessionId1).then((res) => res, (e) => e)
+            await req2.makeRequest(defaultOptions, sessionId2).then((res) => res, (e) => e)
+
+            expect(SESSION_DISPATCHERS.has(sessionId1)).toBe(true)
+            expect(SESSION_DISPATCHERS.has(sessionId2)).toBe(true)
+            expect(SESSION_DISPATCHERS.size).toBe(2)
+        })
+
+        it('should cleanup session dispatcher on DELETE /session/:sessionId', async () => {
+            const sessionId = 'delete-session-id'
+            const deleteSessionRequest = new FetchRequest('DELETE', `/session/${sessionId}`, {})
+            const getElementRequest = new FetchRequest('POST', `/session/${sessionId}/element`, {})
+
+            // initial request to initialize the dispatcher map
+            await getElementRequest.makeRequest(defaultOptions, sessionId).then((res) => res, (e) => e)
+            expect(SESSION_DISPATCHERS.has(sessionId)).toBe(true)
+
+            const currentDispatcher = SESSION_DISPATCHERS.get(sessionId) || { close:undefined }
+            await deleteSessionRequest.makeRequest(defaultOptions, sessionId).then((res) => res, (e) => e)
+
+            expect(currentDispatcher.close).toHaveBeenCalled()
+            expect(SESSION_DISPATCHERS.has(sessionId)).toBe(false)
+            expect(SESSION_DISPATCHERS.size).toBe(0)
+        })
+
+        it('should not cleanup session dispatcher on non delete session DELETE requests', async () => {
+            const sessionId = 'other-delete-session-id'
+            const deleteCookieRequest = new FetchRequest('DELETE', `/session/${sessionId}/cookie`, {})
+
+            await deleteCookieRequest.makeRequest(defaultOptions, sessionId).then((res) => res, (e) => e)
+            expect(SESSION_DISPATCHERS.has(sessionId)).toBe(true)
+
+            const currentDispatcher = SESSION_DISPATCHERS.get(sessionId) || { close:undefined }
+
+            expect(currentDispatcher.close).not.toHaveBeenCalled()
+            expect(SESSION_DISPATCHERS.has(sessionId)).toBe(true)
+            expect(SESSION_DISPATCHERS.size).toBe(1)
+        })
     })
 
     afterEach(() => {
@@ -454,5 +522,7 @@ describe('webdriver request', () => {
         vi.mocked(fetch).mockClear()
         vi.mocked(warn).mockClear()
         vi.mocked(error).mockClear()
+
+        SESSION_DISPATCHERS.clear()
     })
 })


### PR DESCRIPTION
## Proposed changes
I noticed that a new agent is created for each individual wd request. Maybe i am missing something but this seems excessive.

I propose using a cached instance of the dispatcher.

I validated the performance improvement for this change via the performance tests referenced in the issue for this fix - https://github.com/webdriverio/webdriverio/issues/14492



[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

### Reviewers: @webdriverio/project-committers
