### PR TITLE
fix(webdriverio): write polyfill script as ES3

### DIFF
--- a/packages/webdriverio/src/commands/browser/execute.ts
+++ b/packages/webdriverio/src/commands/browser/execute.ts
@@ -5,7 +5,7 @@ import { verifyArgsAndStripIfElement, createFunctionDeclarationFromString } from
 import { LocalValue } from '../../utils/bidi/value.js'
 import { parseScriptResult } from '../../utils/bidi/index.js'
 import { getContextManager } from '../../session/context.js'
-import { polyfillFn } from '../../session/polyfill.js'
+import { polyfillFn } from '../../scripts/polyfill.js'
 
 /**
  *

--- a/packages/webdriverio/src/commands/browser/executeAsync.ts
+++ b/packages/webdriverio/src/commands/browser/executeAsync.ts
@@ -5,7 +5,7 @@ import { verifyArgsAndStripIfElement } from '../../utils/index.js'
 import { LocalValue } from '../../utils/bidi/value.js'
 import { parseScriptResult } from '../../utils/bidi/index.js'
 import { getContextManager } from '../../session/context.js'
-import { polyfillFn } from '../../session/polyfill.js'
+import { polyfillFn } from '../../scripts/polyfill.js'
 
 /**
  * :::warning

--- a/packages/webdriverio/src/scripts/polyfill.ts
+++ b/packages/webdriverio/src/scripts/polyfill.ts
@@ -1,0 +1,19 @@
+/**
+ * A polyfill to set `__name` to the global scope which is needed for WebdriverIO to properly
+ * execute custom (preload) scripts. When using `tsx` Esbuild runs some optimizations which
+ * assume that the file contains these global variables. This is a workaround until this issue
+ * is fixed.
+ *
+ * @see https://github.com/evanw/esbuild/issues/2605
+ */
+export const polyfillFn = function webdriverioPolyfill() {
+    // eslint-disable-next-line no-var
+    var __defProp = Object.defineProperty
+    // eslint-disable-next-line no-var
+    var __name = function (target: unknown, _value: unknown) {
+        return __defProp(target, 'name', { value: _value, configurable: true })
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, no-var
+    var __globalThis = (typeof globalThis === 'object' && globalThis) || (typeof window === 'object' && window) as any
+    __globalThis.__name = __name
+}

--- a/packages/webdriverio/src/session/polyfill.ts
+++ b/packages/webdriverio/src/session/polyfill.ts
@@ -3,30 +3,13 @@ import type { local } from 'webdriver'
 
 import { SessionManager } from './session.js'
 import { createFunctionDeclarationFromString } from '../utils/index.js'
+import { polyfillFn } from '../scripts/polyfill.js'
 
 export function getPolyfillManager(browser: WebdriverIO.Browser) {
     return SessionManager.getSessionManager(browser, PolyfillManager)
 }
 
 const log = logger('webdriverio:PolyfillManager')
-
-/**
- * A polyfill to set `__name` to the global scope which is needed for WebdriverIO to properly
- * execute custom (preload) scripts. When using `tsx` Esbuild runs some optimizations which
- * assume that the file contains these global variables. This is a workaround until this issue
- * is fixed.
- *
- * @see https://github.com/evanw/esbuild/issues/2605
- */
-export const polyfillFn = function webdriverioPolyfill () {
-    const __defProp = Object.defineProperty
-    const __name = function (target: unknown, value: unknown) {
-        return __defProp(target, 'name', { value: value, configurable: true })
-    }
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const __globalThis = (typeof globalThis === 'object' && globalThis) || (typeof window === 'object' && window) as any
-    __globalThis.__name = __name
-}
 
 /**
  * This class is responsible for setting polyfill scripts in the browser.


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

As suggested in https://github.com/webdriverio/webdriverio/issues/14490#issuecomment-2888502371 the polyfill script was moved to the `scripts` folder.

This alone however doesn't resolve the issue.

I've also rewritten the script to use `var` and to avoid `{ value }` object notation.
This does produce the expect output.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
