### PR TITLE
feat(protocol): extend Appium protocol

### DIFF
--- a/packages/wdio-protocols/src/protocols/appium.ts
+++ b/packages/wdio-protocols/src/protocols/appium.ts
@@ -10,6 +10,19 @@ const chromiumLogCommands = {
 
 export default {
     ...chromiumLogCommands,
+    '/session/:sessionId': {
+        GET: {
+            command: 'getSession',
+            description: 'Retrieve the capabilities of the specified session.',
+            ref: 'https://github.com/appium/appium/blob/master/packages/base-driver/docs/mjsonwp/protocol-methods.md#webdriver-endpoints',
+            parameters: [],
+            returns: {
+                type: 'Object',
+                name: 'capabilities',
+                description: "An object describing the session's capabilities.",
+            },
+        },
+    },
     '/session/:sessionId/context': {
         GET: {
             command: 'getAppiumContext',
@@ -2240,6 +2253,33 @@ export default {
                     XCUITest: '9.3+',
                 },
             },
+        },
+    },
+    '/session/:sessionId/location': {
+        GET: {
+            command: 'getGeoLocation',
+            description: 'Get the current geo location.',
+            ref: 'https://github.com/appium/appium/blob/master/packages/base-driver/docs/mjsonwp/protocol-methods.md#webdriver-endpoints',
+            parameters: [],
+            returns: {
+                type: 'Object',
+                name: 'location',
+                description: 'The current geo location.',
+            },
+        },
+        POST: {
+            command: 'setGeoLocation',
+            description: 'Set the current geo location.',
+            ref: 'https://github.com/appium/appium/blob/master/packages/base-driver/docs/mjsonwp/protocol-methods.md#webdriver-endpoints',
+            parameters: [
+                {
+                    name: 'location',
+                    type: 'object',
+                    description:
+                        'the new location (`{latitude: number, longitude: number, altitude: number}`)',
+                    required: true,
+                },
+            ],
         },
     },
 }

--- a/packages/wdio-protocols/src/protocols/appium.ts
+++ b/packages/wdio-protocols/src/protocols/appium.ts
@@ -13,8 +13,9 @@ export default {
     '/session/:sessionId': {
         GET: {
             command: 'getSession',
-            description: 'Retrieve the capabilities of the specified session.',
+            description: 'Retrieve the capabilities of the current session.',
             ref: 'https://github.com/appium/appium/blob/master/packages/base-driver/docs/mjsonwp/protocol-methods.md#webdriver-endpoints',
+            deprecated: 'Use `getAppiumSessionCapabilities` instead',
             parameters: [],
             returns: {
                 type: 'Object',
@@ -58,6 +59,47 @@ export default {
                 name: 'contexts',
                 description:
                     "an array of strings representing available contexts, e.g. 'WEBVIEW', or 'NATIVE'",
+            },
+        },
+    },
+    '/session/:sessionId/appium/commands': {
+        GET: {
+            command: 'getAppiumCommands',
+            description: 'Retrieve the endpoints and BiDi commands supported in the current session.',
+            ref: 'https://github.com/appium/appium/blob/master/packages/base-driver/lib/protocol/routes.js',
+            parameters: [],
+            returns: {
+                type: 'Object',
+                name: 'commands',
+                description:
+                    'Supported endpoints and BiDi commands, each grouped into common, driver-specific, and plugin-specific endpoints/commands.',
+            },
+        },
+    },
+    '/session/:sessionId/appium/extensions': {
+        GET: {
+            command: 'getAppiumExtensions',
+            description: 'Retrieve the extension commands supported in the current session.',
+            ref: 'https://github.com/appium/appium/blob/master/packages/base-driver/lib/protocol/routes.js',
+            parameters: [],
+            returns: {
+                type: 'Object',
+                name: 'commands',
+                description:
+                    'Supported extension commands, grouped into driver-specific and plugin-specific commands.',
+            },
+        },
+    },
+    '/session/:sessionId/appium/capabilities': {
+        GET: {
+            command: 'getAppiumSessionCapabilities',
+            description: 'Retrieve the capabilities of the current session.',
+            ref: 'https://github.com/appium/appium/blob/master/packages/base-driver/lib/protocol/routes.js',
+            parameters: [],
+            returns: {
+                type: 'Object',
+                name: 'capabilities',
+                description: "An object describing the session's capabilities.",
             },
         },
     },


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)
This PR extends the Appium protocol with several endpoints:

* Endpoints that were part of the JSONWP spec and were removed in WDIO v9, but are still used in Appium:
  * `GET /session/:sessionId`
  * `GET /session/:sessionId/location`
  * `POST /session/:sessionId/location`
* Endpoints added in Appium 2.16:
  * `GET /session/:sessionId/appium/commands`
  * `GET /session/:sessionId/appium/extensions`
  * `GET /session/:sessionId/appium/capabilities`

Note that while `GET /session/:sessionId` is marked as deprecated, it is still needed for compatibility with Appium <2.16.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)
These changes are needed for Appium Inspector, which currently still uses `webdriver` `v7`. [Refer to this issue for more information.](https://github.com/appium/appium-inspector/issues/2099)

### Reviewers: @webdriverio/project-committers
