### PR TITLE
chore: Skipping E2e headless tests failing

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -24,7 +24,7 @@ Examples of unacceptable behavior by participants include:
 * Personal insults, particularly those related to gender, sexual orientation, race, religion, or disability.
 * Inappropriate photography or recording.
 * Inappropriate physical contact. You should have someone’s consent before touching them.
-* Unwelcome sexual attention. This includes, sexualized comments or jokes; inappropriate touching, groping, and unwelcomed sexual advances.
+* Unwelcome sexual attention. This includes, sexualized comments or jokes; inappropriate touching, groping, and unwelcome sexual advances.
 * Deliberate intimidation, stalking or following (online or in person).
 * Advocating for, or encouraging, any of the above behavior.
 * Sustained disruption of community events, including talks and presentations.


### PR DESCRIPTION
Skipping E2E is failing on the main branch. A follow-up of https://github.com/webdriverio/webdriverio/pull/14464
I do not understand why it did not fail on the first PR thought.

<img width="1169" alt="image" src="https://github.com/user-attachments/assets/8ac4fa30-d4da-4005-9ac9-422344db2b8a" />
