### PR TITLE
fix(@wdio/protocols): Have `options` of appium terminateApp command optional 

### DIFF
--- a/packages/wdio-protocols/src/protocols/appium.ts
+++ b/packages/wdio-protocols/src/protocols/appium.ts
@@ -578,6 +578,7 @@ export default {
                     type: 'object',
                     description:
                         'Command options. E.g. "timeout": (Only Android) Timeout to retry terminate the app (see more in Appium docs)',
+                    required: false,
                 },
             ],
             support: {


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

Since [this PR](https://github.com/webdriverio/webdriverio/pull/14379/files), `terminateApp` requires passing an `options` args which should be optional. The missing `require:false` was making the arguments mandatory.

<img width="665" alt="image" src="https://github.com/user-attachments/assets/848b3a8a-c9b8-4cbe-81bf-abecf94346f2" />


## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

Additionally, we could fix [the generator here](https://github.com/dprevost-LMI/webdriverio/blob/b6c4be917a8d7f4e8822a525dd38fc3df842f05a/infra/compiler/src/type-generation/index.ts#L78) to make it optional when `required` is not found.

Potentially changing:
```ts
                    return `${camelCase(p.name)}${p.required === false ? '?' : ''}: ${paramType}`
```
by
```ts
                    return `${camelCase(p.name)}${p.required !== true ? '?' : ''}: ${paramType}`
```
If accepted, I can add it to this PR

### Reviewers: @webdriverio/project-committers
