### PR TITLE
feat(wdio-runner): automatically include SoftAssertionService

### DIFF
--- a/__mocks__/expect-webdriverio.ts
+++ b/__mocks__/expect-webdriverio.ts
@@ -3,4 +3,5 @@ process.env.WDIO_ASSERTION_LIB_ACTIVATED = '1'
 const setOptions = vi.fn()
 const expect = vi.fn()
 const matchers = new Map()
-export { setOptions, expect, matchers }
+const SoftAssertionService = vi.fn()
+export { setOptions, expect, matchers, SoftAssertionService }

--- a/e2e/browser-runner/react.test.tsx
+++ b/e2e/browser-runner/react.test.tsx
@@ -21,9 +21,9 @@ describe('React Component Testing', () => {
         const { container } = render(<App />)
         await expect(container).toMatchSnapshot()
         await expect(container).toMatchInlineSnapshot(`
-          "<div>
-            <button>Current theme: light</button>
-          </div>"
-        `)
+"<div>
+  <button>Current theme: light</button>
+</div>"
+`)
     })
 })

--- a/packages/wdio-config/src/constants.ts
+++ b/packages/wdio-config/src/constants.ts
@@ -35,6 +35,7 @@ export const DEFAULT_CONFIGS: () => WebdriverIO.Config = () => ({
     specFileRetries: 0,
     specFileRetriesDelay: 0,
     specFileRetriesDeferred: false,
+    autoAssertOnTestEnd: true,
     reporterSyncInterval: 100,
     reporterSyncTimeout: 5000,
     cucumberFeaturesWithLineNumbers: [],

--- a/packages/wdio-runner/package.json
+++ b/packages/wdio-runner/package.json
@@ -39,7 +39,7 @@
     "@wdio/types": "workspace:*",
     "@wdio/utils": "workspace:*",
     "deepmerge-ts": "^7.0.3",
-    "expect-webdriverio": "^5.1.0",
+    "expect-webdriverio": "^5.3.0",
     "webdriver": "workspace:*",
     "webdriverio": "workspace:*"
   },

--- a/packages/wdio-runner/src/index.ts
+++ b/packages/wdio-runner/src/index.ts
@@ -5,7 +5,7 @@ import logger from '@wdio/logger'
 import { initializeWorkerService, initializePlugin, executeHooksWithArgs } from '@wdio/utils'
 import { ConfigParser } from '@wdio/config/node'
 import { _setGlobal } from '@wdio/globals'
-import { expect, setOptions, SnapshotService } from 'expect-webdriverio'
+import { expect, setOptions, SnapshotService, SoftAssertionService } from 'expect-webdriverio'
 import { attach } from 'webdriverio'
 import type { Selector } from 'webdriverio'
 import type { Options, Capabilities } from '@wdio/types'
@@ -75,11 +75,16 @@ export default class Runner extends EventEmitter {
         /**
          * add built-in services
          */
+        const softAssertionService = new SoftAssertionService({
+            autoAssertOnTestEnd: this._config.autoAssertOnTestEnd || true
+        }, this._caps, this._config)
+
         const snapshotService = SnapshotService.initiate({
             updateState: this._config.updateSnapshots,
             resolveSnapshotPath: this._config.resolveSnapshotPath
         })
         // ToDo(Christian): resolve type incompatibility between v8 and v9
+        this._configParser.addService(softAssertionService as any)
         this._configParser.addService(snapshotService as any)
 
         this._caps = this._isMultiremote

--- a/packages/wdio-runner/tests/index.test.ts
+++ b/packages/wdio-runner/tests/index.test.ts
@@ -6,7 +6,7 @@ import { executeHooksWithArgs } from '@wdio/utils'
 import { ConfigParser } from '@wdio/config/node'
 import { attach } from 'webdriverio'
 import { _setGlobal } from '@wdio/globals'
-import { setOptions, SnapshotService } from 'expect-webdriverio'
+import { setOptions, SnapshotService, SoftAssertionService } from 'expect-webdriverio'
 
 import WDIORunner from '../src/index.js'
 
@@ -18,6 +18,7 @@ vi.mock('util')
 vi.mock('expect-webdriverio', () => ({
     setOptions: vi.fn(),
     expect: vi.fn(),
+    SoftAssertionService: vi.fn(),
     SnapshotService: {
         initiate: vi.fn().mockReturnValue({
             results: ['foobar']

--- a/packages/wdio-types/src/Options.ts
+++ b/packages/wdio-types/src/Options.ts
@@ -247,6 +247,11 @@ export interface Testrunner extends Hooks, WebdriverIO, WebdriverIO.HookFunction
      */
     resolveSnapshotPath?: (testPath: string, snapExtension: string) => string
     /**
+     * If set to true, soft assertions will be automatically asserted at the end of each test.
+     * @default true
+     */
+    autoAssertOnTestEnd?: boolean
+    /**
      * The number of retry attempts for an entire specfile when it fails as a whole.
      */
     specFileRetries?: number

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1197,8 +1197,8 @@ importers:
         specifier: ^7.0.3
         version: 7.1.5
       expect-webdriverio:
-        specifier: ^5.1.0
-        version: 5.1.0(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@packages+webdriverio)
+        specifier: ^5.3.0
+        version: 5.3.0(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@packages+webdriverio)
       webdriver:
         specifier: workspace:*
         version: link:../webdriver
@@ -5492,9 +5492,6 @@ packages:
   '@types/react@19.0.2':
     resolution: {integrity: sha512-USU8ZI/xyKJwFTpjSVIrSeHBVAGagkHQKPNbxeWwql/vDmnTIBgx+TJnhFnj1NXgz8XfprU0egV2dROLGpsBEg==}
 
-  '@types/react@19.1.0':
-    resolution: {integrity: sha512-UaicktuQI+9UKyA4njtDOGBD/67t8YEBt2xdfqu8+gP9hqPUPsiXlNPcpS2gVdjmis5GKPG3fCxbQLVgxsQZ8w==}
-
   '@types/react@19.1.6':
     resolution: {integrity: sha512-JeG0rEWak0N6Itr6QUx+X60uQmN+5t3j9r/OVDtWzFXKaj6kD1BwJzOksD0FF6iWxZlbE1kB0q9vtnU2ekqa1Q==}
 
@@ -5714,6 +5711,9 @@ packages:
   '@vitest/pretty-format@2.1.9':
     resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
 
+  '@vitest/pretty-format@3.2.2':
+    resolution: {integrity: sha512-FY4o4U1UDhO9KMd2Wee5vumwcaHw7Vg4V7yR4Oq6uK34nhEJOmdRYrk3ClburPRUA09lXD/oXWZ8y/Sdma0aUQ==}
+
   '@vitest/runner@2.1.9':
     resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
 
@@ -5722,6 +5722,9 @@ packages:
 
   '@vitest/snapshot@2.1.9':
     resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
+
+  '@vitest/snapshot@3.2.2':
+    resolution: {integrity: sha512-aMEI2XFlR1aNECbBs5C5IZopfi5Lb8QJZGGpzS8ZUHML5La5wCbrbhLOVSME68qwpT05ROEEOAZPRXFpxZV2wA==}
 
   '@vitest/spy@2.1.8':
     resolution: {integrity: sha512-5swjf2q95gXeYPevtW0BLk6H8+bPlMb4Vw/9Em4hFxDcaOxS+e0LOX4yqNxoHzMR2akEB2xfpnWUzkZokmgWDg==}
@@ -6651,10 +6654,6 @@ packages:
 
   ci-info@3.9.0:
     resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
-    engines: {node: '>=8'}
-
-  ci-info@4.1.0:
-    resolution: {integrity: sha512-HutrvTNsF48wnxkzERIXOe5/mlcfFcbfCmwcg6CJnizbSue78AbDt+1cgl26zwn61WFxhcPykPfZrbqjGmBb4A==}
     engines: {node: '>=8'}
 
   ci-info@4.2.0:
@@ -8056,6 +8055,14 @@ packages:
 
   expect-webdriverio@5.1.0:
     resolution: {integrity: sha512-4u3q+Dqx/lXNgvCx1gKia4CfS28z1UxGGfVUkoMNbrsBlTBB2fYqXG+4+YtYoerxvp/XPwIb/+89IGEdyPbDXQ==}
+    engines: {node: '>=18 || >=20 || >=22'}
+    peerDependencies:
+      '@wdio/globals': ^9.0.0
+      '@wdio/logger': ^9.0.0
+      webdriverio: ^9.0.0
+
+  expect-webdriverio@5.3.0:
+    resolution: {integrity: sha512-EUiibBYXWzSn9mJFuF914yeKUxvRxrhR9nImfe0YttG+wVg0v5jY1DPPnRz8sE0wlmoLHyLr155b5/d1+oZmxg==}
     engines: {node: '>=18 || >=20 || >=22'}
     peerDependencies:
       '@wdio/globals': ^9.0.0
@@ -10963,6 +10970,9 @@ packages:
   pathe@2.0.2:
     resolution: {integrity: sha512-15Ztpk+nov8DR524R4BF7uEuzESgzUEAV4Ah7CUMNGXdE5ELuvxElxGXndBl32vMSsWa1jpNf22Z+Er3sKwq+w==}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
   pathval@2.0.0:
     resolution: {integrity: sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==}
     engines: {node: '>= 14.16'}
@@ -12942,6 +12952,10 @@ packages:
     resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
     engines: {node: '>=14.0.0'}
 
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
   tinyspy@3.0.2:
     resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
     engines: {node: '>=14.0.0'}
@@ -14760,7 +14774,7 @@ snapshots:
 
   '@babel/code-frame@7.26.2':
     dependencies:
-      '@babel/helper-validator-identifier': 7.25.9
+      '@babel/helper-validator-identifier': 7.27.1
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
@@ -14858,7 +14872,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.26.8
       '@babel/helper-module-imports': 7.25.9
-      '@babel/helper-validator-identifier': 7.25.9
+      '@babel/helper-validator-identifier': 7.27.1
       '@babel/traverse': 7.26.8
     transitivePeerDependencies:
       - supports-color
@@ -15163,7 +15177,7 @@ snapshots:
       '@babel/core': 7.26.8
       '@babel/helper-module-transforms': 7.26.0(@babel/core@7.26.8)
       '@babel/helper-plugin-utils': 7.25.9
-      '@babel/helper-validator-identifier': 7.25.9
+      '@babel/helper-validator-identifier': 7.27.1
       '@babel/traverse': 7.26.8
     transitivePeerDependencies:
       - supports-color
@@ -15537,17 +15551,17 @@ snapshots:
   '@babel/types@7.26.3':
     dependencies:
       '@babel/helper-string-parser': 7.25.9
-      '@babel/helper-validator-identifier': 7.25.9
+      '@babel/helper-validator-identifier': 7.27.1
 
   '@babel/types@7.26.7':
     dependencies:
       '@babel/helper-string-parser': 7.25.9
-      '@babel/helper-validator-identifier': 7.25.9
+      '@babel/helper-validator-identifier': 7.27.1
 
   '@babel/types@7.26.8':
     dependencies:
       '@babel/helper-string-parser': 7.25.9
-      '@babel/helper-validator-identifier': 7.25.9
+      '@babel/helper-validator-identifier': 7.27.1
 
   '@babel/types@7.27.3':
     dependencies:
@@ -19071,13 +19085,9 @@ snapshots:
   '@types/react-router@5.1.20':
     dependencies:
       '@types/history': 4.7.11
-      '@types/react': 19.1.0
+      '@types/react': 19.1.6
 
   '@types/react@19.0.2':
-    dependencies:
-      csstype: 3.1.3
-
-  '@types/react@19.1.0':
     dependencies:
       csstype: 3.1.3
 
@@ -19364,6 +19374,10 @@ snapshots:
     dependencies:
       tinyrainbow: 1.2.0
 
+  '@vitest/pretty-format@3.2.2':
+    dependencies:
+      tinyrainbow: 2.0.0
+
   '@vitest/runner@2.1.9':
     dependencies:
       '@vitest/utils': 2.1.9
@@ -19380,6 +19394,12 @@ snapshots:
       '@vitest/pretty-format': 2.1.9
       magic-string: 0.30.17
       pathe: 1.1.2
+
+  '@vitest/snapshot@3.2.2':
+    dependencies:
+      '@vitest/pretty-format': 3.2.2
+      magic-string: 0.30.17
+      pathe: 2.0.3
 
   '@vitest/spy@2.1.8':
     dependencies:
@@ -19589,7 +19609,7 @@ snapshots:
 
   '@wdio/globals@9.15.0(@wdio/logger@9.15.0)(puppeteer-core@23.11.1)':
     optionalDependencies:
-      expect-webdriverio: 5.1.0(@wdio/globals@9.15.0(@wdio/logger@9.15.0)(puppeteer-core@23.11.1))(@wdio/logger@9.15.0)(webdriverio@9.15.0(puppeteer-core@23.11.1))
+      expect-webdriverio: 5.3.0(@wdio/globals@9.15.0(@wdio/logger@9.15.0)(puppeteer-core@23.11.1))(@wdio/logger@9.15.0)(webdriverio@9.15.0(puppeteer-core@23.11.1))
       webdriverio: 9.15.0(puppeteer-core@23.11.1)
     transitivePeerDependencies:
       - '@wdio/logger'
@@ -19601,7 +19621,7 @@ snapshots:
 
   '@wdio/globals@9.4.3(@wdio/logger@9.1.3)(puppeteer-core@23.11.1)':
     optionalDependencies:
-      expect-webdriverio: 5.1.0(@wdio/globals@9.4.3(@wdio/logger@9.1.3)(puppeteer-core@23.11.1))(@wdio/logger@9.1.3)(webdriverio@9.4.3(puppeteer-core@23.11.1))
+      expect-webdriverio: 5.3.0(@wdio/globals@9.4.3(@wdio/logger@9.1.3)(puppeteer-core@23.11.1))(@wdio/logger@9.1.3)(webdriverio@9.4.3(puppeteer-core@23.11.1))
       webdriverio: 9.4.3(puppeteer-core@23.11.1)
     transitivePeerDependencies:
       - '@wdio/logger'
@@ -20661,8 +20681,6 @@ snapshots:
   ci-info@2.0.0: {}
 
   ci-info@3.9.0: {}
-
-  ci-info@4.1.0: {}
 
   ci-info@4.2.0: {}
 
@@ -22267,17 +22285,6 @@ snapshots:
       webdriverio: link:packages/webdriverio
     optional: true
 
-  expect-webdriverio@5.1.0(@wdio/globals@9.4.3(@wdio/logger@9.1.3)(puppeteer-core@23.11.1))(@wdio/logger@9.1.3)(webdriverio@9.4.3(puppeteer-core@23.11.1)):
-    dependencies:
-      '@vitest/snapshot': 2.1.9
-      '@wdio/globals': 9.4.3(@wdio/logger@9.1.3)(puppeteer-core@23.11.1)
-      '@wdio/logger': 9.1.3
-      expect: 29.7.0
-      jest-matcher-utils: 29.7.0
-      lodash.isequal: 4.5.0
-      webdriverio: 9.4.3(puppeteer-core@23.11.1)
-    optional: true
-
   expect-webdriverio@5.1.0(@wdio/globals@packages+wdio-globals)(@wdio/logger@9.15.0)(webdriverio@packages+webdriverio):
     dependencies:
       '@vitest/snapshot': 2.1.9
@@ -22301,6 +22308,38 @@ snapshots:
   expect-webdriverio@5.1.0(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@packages+webdriverio):
     dependencies:
       '@vitest/snapshot': 2.1.9
+      '@wdio/globals': link:packages/wdio-globals
+      '@wdio/logger': link:packages/wdio-logger
+      expect: 29.7.0
+      jest-matcher-utils: 29.7.0
+      lodash.isequal: 4.5.0
+      webdriverio: link:packages/webdriverio
+
+  expect-webdriverio@5.3.0(@wdio/globals@9.15.0(@wdio/logger@9.15.0)(puppeteer-core@23.11.1))(@wdio/logger@9.15.0)(webdriverio@9.15.0(puppeteer-core@23.11.1)):
+    dependencies:
+      '@vitest/snapshot': 3.2.2
+      '@wdio/globals': 9.15.0(@wdio/logger@9.15.0)(puppeteer-core@23.11.1)
+      '@wdio/logger': 9.15.0
+      expect: 29.7.0
+      jest-matcher-utils: 29.7.0
+      lodash.isequal: 4.5.0
+      webdriverio: 9.15.0(puppeteer-core@23.11.1)
+    optional: true
+
+  expect-webdriverio@5.3.0(@wdio/globals@9.4.3(@wdio/logger@9.1.3)(puppeteer-core@23.11.1))(@wdio/logger@9.1.3)(webdriverio@9.4.3(puppeteer-core@23.11.1)):
+    dependencies:
+      '@vitest/snapshot': 3.2.2
+      '@wdio/globals': 9.4.3(@wdio/logger@9.1.3)(puppeteer-core@23.11.1)
+      '@wdio/logger': 9.1.3
+      expect: 29.7.0
+      jest-matcher-utils: 29.7.0
+      lodash.isequal: 4.5.0
+      webdriverio: 9.4.3(puppeteer-core@23.11.1)
+    optional: true
+
+  expect-webdriverio@5.3.0(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@packages+webdriverio):
+    dependencies:
+      '@vitest/snapshot': 3.2.2
       '@wdio/globals': link:packages/wdio-globals
       '@wdio/logger': link:packages/wdio-logger
       expect: 29.7.0
@@ -23929,7 +23968,7 @@ snapshots:
       '@jest/types': 30.0.0-alpha.7
       '@types/node': 20.17.57
       chalk: 4.1.2
-      ci-info: 4.1.0
+      ci-info: 4.2.0
       graceful-fs: 4.2.11
       picomatch: 4.0.2
 
@@ -24239,7 +24278,7 @@ snapshots:
 
   libnpmpublish@9.0.9:
     dependencies:
-      ci-info: 4.1.0
+      ci-info: 4.2.0
       normalize-package-data: 6.0.2
       npm-package-arg: 11.0.2
       npm-registry-fetch: 17.1.0
@@ -25998,6 +26037,8 @@ snapshots:
   pathe@1.1.2: {}
 
   pathe@2.0.2: {}
+
+  pathe@2.0.3: {}
 
   pathval@2.0.0: {}
 
@@ -28338,6 +28379,8 @@ snapshots:
   tinypool@1.0.2: {}
 
   tinyrainbow@1.2.0: {}
+
+  tinyrainbow@2.0.0: {}
 
   tinyspy@3.0.2: {}
 

--- a/website/docs/Assertion.md
+++ b/website/docs/Assertion.md
@@ -22,7 +22,7 @@ await expect(await $('.add-to-cart').isClickable()).toBe(true);
 
 ### Advanced Configuration
 
-The SoftAssertionService is now included by default, but you can override its behavior in your wdio.conf.js:
+The SoftAssertionService is included by default (from expect-webdriver 5.2.0), but you can override its behavior in your wdio.conf.js:
 
 ```js
 import { SoftAssertionService } from 'expect-webdriverio'

--- a/website/docs/Assertion.md
+++ b/website/docs/Assertion.md
@@ -5,21 +5,6 @@ title: Assertion
 
 The [WDIO testrunner](https://webdriver.io/docs/clioptions) comes with a built in assertion library that allows you to make powerful assertions on various aspects of the browser or elements within your (web) application. It extends [Jests Matchers](https://jestjs.io/docs/en/using-matchers) functionality with additional, for e2e testing optimized, matchers, e.g.:
 
-## Soft Assertions
-
-WebdriverIO includes soft assertions by default from expect-webdriver(5.2.0). Soft assertions allow your tests to continue execution even when an assertion fails. All failures are collected and reported at the end of the test.
-
-### Usage
-
-```js
-// These won't throw immediately if they fail
-await expect.soft(await $('h1').getText()).toEqual('Basketball Shoes');
-await expect.soft(await $('#price').getText()).toMatch(/€\d+/);
-
-// Regular assertions still throw immediately
-await expect(await $('.add-to-cart').isClickable()).toBe(true);
-```
-
 ```js
 const $button = await $('button')
 await expect($button).toBeDisplayed()
@@ -35,6 +20,21 @@ await expect(selectOptions).toHaveChildren({ gte: 1 })
 ```
 
 For the full list, see the [expect API doc](/docs/api/expect-webdriverio).
+
+## Soft Assertions
+
+WebdriverIO includes soft assertions by default from expect-webdriver(5.2.0). Soft assertions allow your tests to continue execution even when an assertion fails. All failures are collected and reported at the end of the test.
+
+### Usage
+
+```js
+// These won't throw immediately if they fail
+await expect.soft(await $('h1').getText()).toEqual('Basketball Shoes');
+await expect.soft(await $('#price').getText()).toMatch(/€\d+/);
+
+// Regular assertions still throw immediately
+await expect(await $('.add-to-cart').isClickable()).toBe(true);
+```
 
 ## Migrating from Chai
 

--- a/website/docs/Assertion.md
+++ b/website/docs/Assertion.md
@@ -7,7 +7,7 @@ The [WDIO testrunner](https://webdriver.io/docs/clioptions) comes with a built i
 
 ## Soft Assertions
 
-WebdriverIO now includes soft assertions by default. Soft assertions allow your tests to continue execution even when an assertion fails. All failures are collected and reported at the end of the test.
+WebdriverIO includes soft assertions by default from expect-webdriver(5.2.0). Soft assertions allow your tests to continue execution even when an assertion fails. All failures are collected and reported at the end of the test.
 
 ### Usage
 

--- a/website/docs/Assertion.md
+++ b/website/docs/Assertion.md
@@ -5,6 +5,41 @@ title: Assertion
 
 The [WDIO testrunner](https://webdriver.io/docs/clioptions) comes with a built in assertion library that allows you to make powerful assertions on various aspects of the browser or elements within your (web) application. It extends [Jests Matchers](https://jestjs.io/docs/en/using-matchers) functionality with additional, for e2e testing optimized, matchers, e.g.:
 
+## Soft Assertions
+
+WebdriverIO now includes soft assertions by default. Soft assertions allow your tests to continue execution even when an assertion fails. All failures are collected and reported at the end of the test.
+
+### Usage
+
+```js
+// These won't throw immediately if they fail
+await expect.soft(await $('h1').getText()).toEqual('Basketball Shoes');
+await expect.soft(await $('#price').getText()).toMatch(/€\d+/);
+
+// Regular assertions still throw immediately
+await expect(await $('.add-to-cart').isClickable()).toBe(true);
+```
+
+### Advanced Configuration
+
+The SoftAssertionService is now included by default, but you can override its behavior in your wdio.conf.js:
+
+```js
+import { SoftAssertionService } from 'expect-webdriverio'
+
+export const config = {
+  // ...
+  services: [
+    // Override the default settings
+    [SoftAssertionService, {
+      // Disable automatic assertion at the end of tests (default: true)
+      autoAssertOnTestEnd: false
+    }]
+  ],
+  // ...
+}
+```
+
 ```js
 const $button = await $('button')
 await expect($button).toBeDisplayed()

--- a/website/docs/Assertion.md
+++ b/website/docs/Assertion.md
@@ -20,26 +20,6 @@ await expect.soft(await $('#price').getText()).toMatch(/€\d+/);
 await expect(await $('.add-to-cart').isClickable()).toBe(true);
 ```
 
-### Advanced Configuration
-
-The SoftAssertionService is included by default (from expect-webdriver 5.2.0), but you can override its behavior in your wdio.conf.js:
-
-```js
-import { SoftAssertionService } from 'expect-webdriverio'
-
-export const config = {
-  // ...
-  services: [
-    // Override the default settings
-    [SoftAssertionService, {
-      // Disable automatic assertion at the end of tests (default: true)
-      autoAssertOnTestEnd: false
-    }]
-  ],
-  // ...
-}
-```
-
 ```js
 const $button = await $('button')
 await expect($button).toBeDisplayed()

--- a/website/docs/Configuration.md
+++ b/website/docs/Configuration.md
@@ -424,6 +424,13 @@ By default, it is set to `false` so logs are printed in real-time.
 Type: `Boolean`<br />
 Default: `false`
 
+### autoAssertOnTestEnd
+
+Controls whether the SoftAssertionService automatically asserts all soft assertions at the end of each test. When set to `true`, any accumulated soft assertions will be automatically checked and cause the test to fail if any assertions failed. When set to `false`, you must manually call the assert method to check soft assertions.
+
+Type: `Boolean`<br />
+Default: `true`
+
 ### services
 
 Services take over a specific job you don't want to take care of. They enhance your test setup with almost no effort.

--- a/website/docs/Configuration.md
+++ b/website/docs/Configuration.md
@@ -426,7 +426,7 @@ Default: `false`
 
 ### autoAssertOnTestEnd
 
-Controls whether the SoftAssertionService automatically asserts all soft assertions at the end of each test. When set to `true`, any accumulated soft assertions will be automatically checked and cause the test to fail if any assertions failed. When set to `false`, you must manually call the assert method to check soft assertions.
+Controls whether WebdriverIO automatically asserts all soft assertions at the end of each test. When set to `true`, any accumulated soft assertions will be automatically checked and cause the test to fail if any assertions failed. When set to `false`, you must manually call the assert method to check soft assertions.
 
 Type: `Boolean`<br />
 Default: `true`


### PR DESCRIPTION
## Proposed changes

This change integrates the SoftAssertionService from expect-webdriverio 
directly into the wdio-runner package, making soft assertions available 
to all WebdriverIO users without requiring manual configuration.

Users can now use expect.soft() to collect assertion failures without
halting test execution, improving the testing experience by providing
more comprehensive test reports.

With minimal performance impact, adding this feature by default eliminates
an unnecessary configuration step and reduces potential setup errors.

Related to: webdriverio/expect-webdriverio#1836

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
