### PR TITLE
fix(types): Fix overwrite command bad typing

### DIFF
--- a/packages/webdriverio/src/commands/browser/custom$.ts
+++ b/packages/webdriverio/src/commands/browser/custom$.ts
@@ -34,7 +34,7 @@ export async function custom$ (
     this: WebdriverIO.Browser,
     strategyName: string,
     ...strategyArguments: unknown[]
-) {
+) : Promise<WebdriverIO.Element> {
     const strategy = this.strategies.get(strategyName) as CustomStrategyFunction
 
     if (!strategy) {

--- a/packages/webdriverio/src/commands/browser/debug.ts
+++ b/packages/webdriverio/src/commands/browser/debug.ts
@@ -34,7 +34,7 @@ import WDIORepl from '@wdio/repl'
 export function debug(
     this: WebdriverIO.Browser,
     commandTimeout = 5000
-) {
+): Promise<void | unknown> {
     const repl = new WDIORepl()
     const { introMessage } = WDIORepl
 

--- a/packages/webdriverio/src/commands/browser/getWindowSize.ts
+++ b/packages/webdriverio/src/commands/browser/getWindowSize.ts
@@ -23,9 +23,9 @@ interface BrowserSize {
  * @type window
  *
  */
-export async function getWindowSize(this: WebdriverIO.Browser) {
+export async function getWindowSize(this: WebdriverIO.Browser): Promise<BrowserSize> {
     const browser = getBrowserObject(this)
 
     const { width, height } = await browser.getWindowRect() as BrowserSize
-    return { width, height } as BrowserSize
+    return { width, height } satisfies BrowserSize
 }

--- a/packages/webdriverio/src/commands/browser/keys.ts
+++ b/packages/webdriverio/src/commands/browser/keys.ts
@@ -26,7 +26,7 @@ import { checkUnicode } from '../../utils/index.js'
 export async function keys (
     this: WebdriverIO.Browser,
     value: string | string[]
-) {
+): Promise<void> {
     let keySequence: string[] = []
 
     /**

--- a/packages/webdriverio/src/commands/browser/mockClearAll.ts
+++ b/packages/webdriverio/src/commands/browser/mockClearAll.ts
@@ -30,7 +30,7 @@ const log = logger('webdriverio:mockClearAll')
  *
  * @alias browser.mockClearAll
  */
-export async function mockClearAll () {
+export async function mockClearAll (): Promise<void> {
     for (const [handle, mocks] of Object.entries(SESSION_MOCKS)) {
         log.trace(`Clearing mocks for ${handle}`)
         for (const mock of mocks) {

--- a/packages/webdriverio/src/commands/browser/mockRestoreAll.ts
+++ b/packages/webdriverio/src/commands/browser/mockRestoreAll.ts
@@ -28,7 +28,7 @@ const log = logger('webdriverio:mockRestoreAll')
  *
  * @alias browser.mockRestoreAll
  */
-export async function mockRestoreAll () {
+export async function mockRestoreAll (): Promise<void> {
     for (const [handle, mocks] of Object.entries(SESSION_MOCKS)) {
         log.trace(`Clearing mocks for ${handle}`)
         for (const mock of mocks) {

--- a/packages/webdriverio/src/commands/browser/pause.ts
+++ b/packages/webdriverio/src/commands/browser/pause.ts
@@ -22,6 +22,6 @@
 export function pause (
     this: WebdriverIO.Browser,
     milliseconds = 1000
-) {
+): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, milliseconds))
 }

--- a/packages/webdriverio/src/commands/browser/react$$.ts
+++ b/packages/webdriverio/src/commands/browser/react$$.ts
@@ -43,7 +43,7 @@ export async function react$$ (
     this: WebdriverIO.Browser,
     selector: string,
     { props = {}, state = {} }: ReactSelectorOptions = {}
-) {
+): Promise<WebdriverIO.ElementArray> {
     await this.executeScript(resqScript, [])
     await this.execute(waitToLoadReact)
     const res = await this.execute(

--- a/packages/webdriverio/src/commands/browser/react$.ts
+++ b/packages/webdriverio/src/commands/browser/react$.ts
@@ -52,7 +52,7 @@ export async function react$ (
     this: WebdriverIO.Browser,
     selector: string,
     { props = {}, state = {} }: ReactSelectorOptions = {}
-) {
+): Promise<WebdriverIO.Element> {
     await this.executeScript(resqScript.toString(), [])
     await this.execute(waitToLoadReact)
     const res = await this.execute(

--- a/packages/webdriverio/src/commands/browser/reloadSession.ts
+++ b/packages/webdriverio/src/commands/browser/reloadSession.ts
@@ -55,7 +55,7 @@ const log = logger('webdriverio')
  * @type utility
  *
  */
-export async function reloadSession (this: WebdriverIO.Browser, newCapabilities?: WebdriverIO.Capabilities) {
+export async function reloadSession (this: WebdriverIO.Browser, newCapabilities?: WebdriverIO.Capabilities): Promise<string> {
     const oldSessionId = (this as WebdriverIO.Browser).sessionId
 
     /**
@@ -91,5 +91,5 @@ export async function reloadSession (this: WebdriverIO.Browser, newCapabilities?
         await Promise.all(options.onReload.map((hook) => hook(oldSessionId, (this as WebdriverIO.Browser).sessionId)))
     }
 
-    return this.sessionId as string
+    return this.sessionId
 }

--- a/packages/webdriverio/src/commands/browser/restore.ts
+++ b/packages/webdriverio/src/commands/browser/restore.ts
@@ -34,7 +34,7 @@ import { restoreFunctions } from '../../constants.js'
 export async function restore (
     this: WebdriverIO.Browser,
     scopes?: SupportedScopes | SupportedScopes[]
-) {
+): Promise<void> {
     const scopeArray = !scopes || Array.isArray(scopes) ? scopes : [scopes]
     const instanceRestoreFunctions = restoreFunctions.get(this)
     if (!instanceRestoreFunctions) {

--- a/packages/webdriverio/src/commands/browser/savePDF.ts
+++ b/packages/webdriverio/src/commands/browser/savePDF.ts
@@ -47,7 +47,7 @@ export async function savePDF (
     this: WebdriverIO.Browser,
     filepath: string,
     options?: PDFPrintOptions
-) {
+): Promise<Buffer<ArrayBuffer>> {
     /**
      * run command implementation based on given environment
      */

--- a/packages/webdriverio/src/commands/browser/saveRecordingScreen.ts
+++ b/packages/webdriverio/src/commands/browser/saveRecordingScreen.ts
@@ -28,7 +28,7 @@ import { environment } from '../../environment.js'
 export async function saveRecordingScreen (
     this: WebdriverIO.Browser,
     filepath: string
-) {
+): Promise<Buffer<ArrayBuffer>> {
     /**
      * run command implementation based on given environment
      */

--- a/packages/webdriverio/src/commands/browser/saveScreenshot.ts
+++ b/packages/webdriverio/src/commands/browser/saveScreenshot.ts
@@ -52,7 +52,7 @@ export async function saveScreenshot (
     this: WebdriverIO.Browser,
     filepath: string,
     options?: SaveScreenshotOptions
-) {
+): Promise<Buffer<ArrayBuffer>> {
     /**
      * run command implementation based on given environment
      */

--- a/packages/webdriverio/src/commands/browser/scroll.ts
+++ b/packages/webdriverio/src/commands/browser/scroll.ts
@@ -29,9 +29,10 @@ export function scroll (
     this: WebdriverIO.Browser,
     x = 0,
     y = 0
-) {
+): Promise<void> {
     if (!x && !y) {
-        return log.warn('"scroll" command was called with no parameters, skipping execution')
+        log.warn('"scroll" command was called with no parameters, skipping execution')
+        return Promise.resolve()
     }
 
     // Appium does not support the "wheel" action

--- a/packages/webdriverio/src/commands/browser/setCookies.ts
+++ b/packages/webdriverio/src/commands/browser/setCookies.ts
@@ -57,7 +57,7 @@ import type { Cookie } from '@wdio/protocols'
 export async function setCookies(
     this: WebdriverIO.Browser,
     cookieObjs: Cookie | Cookie[]
-) {
+): Promise<void> {
     const cookieObjsList = !Array.isArray(cookieObjs) ? [cookieObjs] : cookieObjs
 
     if (cookieObjsList.some(obj => (typeof obj !== 'object'))) {

--- a/packages/webdriverio/src/commands/browser/setViewport.ts
+++ b/packages/webdriverio/src/commands/browser/setViewport.ts
@@ -36,7 +36,7 @@ export interface SetViewportOptions {
 export async function setViewport(
     this: WebdriverIO.Browser,
     options: SetViewportOptions
-) {
+): Promise<void> {
     /**
      * type check
      */

--- a/packages/webdriverio/src/commands/browser/setWindowSize.ts
+++ b/packages/webdriverio/src/commands/browser/setWindowSize.ts
@@ -27,7 +27,7 @@ export async function setWindowSize(
     this: WebdriverIO.Browser,
     width: number,
     height: number
-) {
+): Promise<void> {
     /**
      * type check
      */

--- a/packages/webdriverio/src/commands/browser/switchFrame.ts
+++ b/packages/webdriverio/src/commands/browser/switchFrame.ts
@@ -68,7 +68,7 @@ const log = logger('webdriverio:switchFrame')
 export async function switchFrame (
     this: WebdriverIO.Browser,
     context: WebdriverIO.Element | ChainablePromiseElement | string | null | ((tree: FlatContextTree) => boolean | Promise<boolean>)
-) {
+): Promise<string | void> {
     function isPossiblyUnresolvedElement(input: typeof context): input is WebdriverIO.Element | ChainablePromiseElement {
         return Boolean(input) && typeof input === 'object' && typeof (input as WebdriverIO.Element).getElement === 'function'
     }

--- a/packages/webdriverio/src/commands/browser/switchWindow.ts
+++ b/packages/webdriverio/src/commands/browser/switchWindow.ts
@@ -37,7 +37,7 @@ import { getContextManager } from '../../session/context.js'
 export async function switchWindow (
     this: WebdriverIO.Browser,
     matcher: string | RegExp
-) {
+): Promise<string> {
     /**
      * parameter check
      */

--- a/packages/webdriverio/src/commands/browser/throttle.ts
+++ b/packages/webdriverio/src/commands/browser/throttle.ts
@@ -10,7 +10,7 @@ const log = logger('webdriverio:throttle')
 export async function throttle (
     this: WebdriverIO.Browser,
     params: ThrottleOptions
-) {
+): Promise<void> {
     log.warn('Command "throttle" is deprecated and will be removed with the next major version release! Use `throttleNetwork` instead.')
     const browser = getBrowserObject(this)
     await browser.throttleNetwork(params)

--- a/packages/webdriverio/src/commands/browser/throttleCPU.ts
+++ b/packages/webdriverio/src/commands/browser/throttleCPU.ts
@@ -26,7 +26,7 @@
 export async function throttleCPU (
     this: WebdriverIO.Browser,
     factor: number
-) {
+): Promise<void> {
     if (typeof factor !== 'number') {
         throw new Error('Invalid factor for "throttleCPU". Expected it to be a number (int)')
     }

--- a/packages/webdriverio/src/commands/browser/throttleNetwork.ts
+++ b/packages/webdriverio/src/commands/browser/throttleNetwork.ts
@@ -114,7 +114,7 @@ const NETWORK_PRESET_TYPES = Object.keys(NETWORK_PRESETS)
 export async function throttleNetwork (
     this: WebdriverIO.Browser,
     params: ThrottleOptions
-) {
+): Promise<void> {
     if (
         /**
          * check string parameter
@@ -134,7 +134,7 @@ export async function throttleNetwork (
     if (this.isSauce) {
         const browser = getBrowserObject(this)
         await browser.sauceThrottleNetwork(params)
-        return null
+        return
     }
 
     const failedConnectionMessage = 'No Puppeteer connection could be established which is required to use this command'
@@ -161,5 +161,5 @@ export async function throttleNetwork (
             : params
     )
 
-    return null
+    return
 }

--- a/packages/webdriverio/src/commands/browser/touchAction.ts
+++ b/packages/webdriverio/src/commands/browser/touchAction.ts
@@ -75,6 +75,6 @@ import type { TouchActions } from '../../types.js'
 export function touchAction (
     this: WebdriverIO.Browser,
     actions: TouchActions
-) {
+): Promise<void> {
     return touchActionCommand.call(this, actions)
 }

--- a/packages/webdriverio/src/types.ts
+++ b/packages/webdriverio/src/types.ts
@@ -201,7 +201,7 @@ type OverwriteCommandFnScoped<
     IsElement extends boolean = false
 > = (
     this: IsElement extends true ? WebdriverIO.Element : WebdriverIO.Browser,
-    origCommand: (...args: any[]) => IsElement extends true ? $ElementCommands[ElementKey] : $BrowserCommands[BrowserKey],
+    origCommand: IsElement extends true ? OmitThisParameter<$ElementCommands[ElementKey]> : OmitThisParameter<$BrowserCommands[BrowserKey]>,
     ...args: any[]
 ) => Promise<any>
 
@@ -210,7 +210,7 @@ type OverwriteCommandFn<
     BrowserKey extends keyof $BrowserCommands,
     IsElement extends boolean = false
 > = (
-    origCommand: (...args: any[]) => IsElement extends true ? $ElementCommands[ElementKey] : $BrowserCommands[BrowserKey],
+    origCommand: IsElement extends true ? OmitThisParameter<$ElementCommands[ElementKey]> : OmitThisParameter<$BrowserCommands[BrowserKey]>,
     ...args: any[]
 ) => Promise<any>
 

--- a/packages/webdriverio/src/types.ts
+++ b/packages/webdriverio/src/types.ts
@@ -189,7 +189,7 @@ type AddCommandFnScoped<
     InstanceType = WebdriverIO.Browser,
     IsElement extends boolean = false
 > = (
-    this: IsElement extends true ? Element : InstanceType,
+    this: IsElement extends true ? WebdriverIO.Element : InstanceType,
     ...args: any[]
 ) => any
 
@@ -221,7 +221,7 @@ export interface CustomInstanceCommands<T> {
      */
     addCommand<IsElement extends boolean = false>(
         name: string,
-        func: AddCommandFn | AddCommandFnScoped<T, IsElement>,
+        func: IsElement extends true ? AddCommandFnScoped<T, IsElement> : AddCommandFn,
         attachToElement?: IsElement,
         proto?: Record<string, any>,
         instances?: Record<string, WebdriverIO.Browser | WebdriverIO.MultiRemoteBrowser>
@@ -232,11 +232,31 @@ export interface CustomInstanceCommands<T> {
      */
     overwriteCommand<ElementKey extends keyof $ElementCommands, BrowserKey extends keyof $BrowserCommands, IsElement extends boolean = false>(
         name: IsElement extends true ? ElementKey : BrowserKey,
-        func: OverwriteCommandFn<ElementKey, BrowserKey, IsElement> | OverwriteCommandFnScoped<ElementKey, BrowserKey, IsElement>,
+        func: IsElement extends true ? | OverwriteCommandFnScoped<ElementKey, BrowserKey, IsElement> : OverwriteCommandFn<ElementKey, BrowserKey, IsElement>,
         attachToElement?: IsElement,
         proto?: Record<string, any>,
         instances?: Record<string, WebdriverIO.Browser | WebdriverIO.MultiRemoteBrowser>
     ): void;
+
+    /**
+     * overwrite `browser` command
+     */
+    // overwriteBrowserCommand<ElementKey extends keyof $ElementCommands, BrowserKey extends keyof $BrowserCommands, IsElement extends boolean = false>(
+    //     name: BrowserKey,
+    //     func: OverwriteCommandFn<ElementKey, BrowserKey, IsElement>,
+    //     proto?: Record<string, any>,
+    //     instances?: Record<string, WebdriverIO.Browser | WebdriverIO.MultiRemoteBrowser>
+    // ): void;
+
+    /**
+     * overwrite `element` command
+     */
+    // overwriteElementCommand<ElementKey extends keyof $ElementCommands, BrowserKey extends keyof $BrowserCommands, IsElement extends boolean = true>(
+    //     name: ElementKey,
+    //     func: OverwriteCommandFnScoped<ElementKey, BrowserKey, IsElement>,
+    //     proto?: Record<string, any>,
+    //     instances?: Record<string, WebdriverIO.Browser | WebdriverIO.MultiRemoteBrowser>
+    // ): void;
 
     /**
      * create custom selector

--- a/packages/webdriverio/tests/addCommand.test.ts
+++ b/packages/webdriverio/tests/addCommand.test.ts
@@ -59,6 +59,22 @@ const customCommand = async () => {
 
 describe('addCommand', () => {
     describe('remote', () => {
+
+        test('should resolve the this parameter by inference', async () => {
+            const browser = await remote(remoteConfig)
+            browser.addCommand(
+                'press',
+                async function (this /* Expect to be infer to Element by default */) {
+                    return this.click()
+                },
+                true,
+            )
+
+            const element = await browser.$('.someRandomElement')
+
+            expect(await element.click()).toBeUndefined()
+        })
+
         test('should be able to handle async', async () => {
             const browser = await remote(remoteConfig)
 

--- a/packages/webdriverio/tests/overwriteCommand.test.ts
+++ b/packages/webdriverio/tests/overwriteCommand.test.ts
@@ -54,9 +54,11 @@ describe('overwriteCommand', () => {
                 browser.overwriteCommand(
                     'pause',
                     async function (originalFunction /* (milliseconds?: number | undefined) => Promise<void> */) {
-                        const promise: () => Promise<void> = originalFunction(10)
+                        const promise: Promise<void> = originalFunction(10)
 
-                        return await promise
+                        await promise
+
+                        return
                     },
                     false,
                 )

--- a/packages/webdriverio/tests/overwriteCommand.test.ts
+++ b/packages/webdriverio/tests/overwriteCommand.test.ts
@@ -165,9 +165,7 @@ describe('overwriteCommand', () => {
                     'getText',
                     async function (originalFunction /* Expecting return a Promise<string> */) {
 
-                        console.log('originalFunction', originalFunction)
                         const text: string = await originalFunction()
-                        console.log(text)
                         return text + ' - overwritten'
                     },
                     isElementScope,
@@ -195,6 +193,22 @@ describe('overwriteCommand', () => {
                 const element = await browser.$('.someRandomElement')
 
                 expect(await element.click()).toBeUndefined()
+            })
+
+            test('should resolve the this parameters type by inference automatically', async () => {
+                const browser = await remote(remoteConfig)
+                browser.overwriteCommand(
+                    'click',
+                    async function (this /* Expect to be WebdriverIO.Element */ ) {
+                        return this.getText()
+                    },
+                    isElementScope,
+                )
+
+                const element = await browser.$('.someRandomElement')
+                vi.spyOn(element, 'getElementText').mockResolvedValue('some text')
+
+                expect(await element.click()).toBe('some text')
             })
         })
     })

--- a/packages/webdriverio/tests/overwriteCommand.test.ts
+++ b/packages/webdriverio/tests/overwriteCommand.test.ts
@@ -63,7 +63,7 @@ describe('overwriteCommand', () => {
                     false,
                 )
 
-                expect(browser.pause()).resolves.toBeValid()
+                expect(await browser.pause()).toBeUndefined()
             })
 
             test('should be able to handle async', async () => {
@@ -158,18 +158,23 @@ describe('overwriteCommand', () => {
             })
 
             test('should resolve the return of the original command function type properly', async () => {
+
                 const browser = await remote(remoteConfig)
+
                 browser.overwriteCommand(
                     'getText',
                     async function (originalFunction /* Expecting return a Promise<string> */) {
 
+                        console.log('originalFunction', originalFunction)
                         const text: string = await originalFunction()
-                        return text.concat(' - overwritten')
+                        console.log(text)
+                        return text + ' - overwritten'
                     },
                     isElementScope,
                 )
 
-                const element = browser.$('.someRandomElement')
+                const element = await browser.$('.someRandomElement')
+                vi.spyOn(element, 'getElementText').mockResolvedValue('some text')
 
                 expect(await element.getText()).toBe('some text - overwritten')
             })
@@ -189,7 +194,7 @@ describe('overwriteCommand', () => {
 
                 const element = await browser.$('.someRandomElement')
 
-                expect(element.click()).resolves.toBeValid()
+                expect(await element.click()).toBeUndefined()
             })
         })
     })


### PR DESCRIPTION
## Proposed changes

As exposed in [this issue](https://github.com/webdriverio/webdriverio/issues/14548), when using `overwriteCommand`, the typing is not always correctly inferred.  We attempt to fix a couple of them  and more:

Thing done:
- Have the `this` refer to `WebdriverIO.Element` automatically in the `func` of `overwriteCommand`
- Have the `originalCommandFunction` infer the correct return type by adding the return type explicitly in existing browser commands
- Review documentation to be more verbose and also be more type-safe
- Propose `overwriteBrowserCommand` and `overwriteElementCommand`, instead of using the boolean, which makes the API less clear and typing definition even harder

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

Please let me know about the new API proposal and whether you would like to deprecate the former or keep it.

### Reviewers: @webdriverio/project-committers
