### PR TITLE
fix for accessibility build error [wdio-browsertstack-service] [v8]

### DIFF
--- a/packages/wdio-browserstack-service/src/util.ts
+++ b/packages/wdio-browserstack-service/src/util.ts
@@ -308,9 +308,11 @@ export const jsonifyAccessibilityArray = (
     return result
 }
 
-export const  processAccessibilityResponse = (response: LaunchResponse) => {
+export const  processAccessibilityResponse = (response: LaunchResponse, options: BrowserstackConfig & Options.Testrunner) => {
     if (!response.accessibility) {
-        handleErrorForAccessibility(null)
+        if (options.accessibility === true) {
+            handleErrorForAccessibility(null)
+        }
         return
     }
     if (!response.accessibility.success) {
@@ -346,7 +348,7 @@ export const processLaunchBuildResponse = (response: LaunchResponse, options: Br
     if (options.testObservability) {
         processTestObservabilityResponse(response)
     }
-    processAccessibilityResponse(response)
+    processAccessibilityResponse(response, options)
 }
 
 export const launchTestSession = PerformanceTester.measureWrapper(PERFORMANCE_SDK_EVENTS.TESTHUB_EVENTS.START, o11yErrorHandler(async function launchTestSession(options: BrowserstackConfig & Options.Testrunner, config: Options.Testrunner, bsConfig: UserConfig, bStackConfig: BrowserStackConfig, accessibilityAutomation: boolean | null) {

--- a/packages/wdio-browserstack-service/tests/util.test.ts
+++ b/packages/wdio-browserstack-service/tests/util.test.ts
@@ -57,6 +57,7 @@ import {
 import * as bstackLogger from '../src/bstackLogger.js'
 import { BROWSERSTACK_OBSERVABILITY, TESTOPS_BUILD_COMPLETED_ENV, BROWSERSTACK_TESTHUB_JWT, BROWSERSTACK_ACCESSIBILITY } from '../src/constants.js'
 import * as testHubUtils from '../src/testHub/utils.js'
+import type { Options } from '@wdio/types'
 
 const log = logger('test')
 
@@ -1382,6 +1383,7 @@ describe('processTestObservabilityResponse', () => {
 
 describe('processAccessibilityResponse', () => {
     let response: LaunchResponse, handleErrorForAccessibilitySpy
+    let options: BrowserstackConfig & Options.Testrunner
     beforeAll(() => {
         response = {
             jwt: 'abc',
@@ -1417,24 +1419,40 @@ describe('processAccessibilityResponse', () => {
                 errors: undefined
             }
         }
+        options = {}
     })
     it ('processAccessibilityResponse should not log an error', function () {
-        processAccessibilityResponse(response)
+        const optionsWithAccessibilityTrue = options
+        optionsWithAccessibilityTrue.accessibility = true
+        processAccessibilityResponse(response, optionsWithAccessibilityTrue)
         expect(process.env[BROWSERSTACK_ACCESSIBILITY]).toEqual('true')
     })
     it ('processAccessibilityResponse should log error if accessibility success is false', function () {
         handleErrorForAccessibilitySpy = vi.spyOn(testHubUtils, 'handleErrorForAccessibility').mockReturnValue({} as any)
         const res = response
         res.accessibility!.success = false
-        processAccessibilityResponse(res)
+        const optionsWithAccessibilityTrue = options
+        optionsWithAccessibilityTrue.accessibility = true
+        processAccessibilityResponse(res, optionsWithAccessibilityTrue)
         expect(handleErrorForAccessibilitySpy).toBeCalled()
     })
     it ('processAccessibilityResponse should log error if accessibility field not found', function () {
         handleErrorForAccessibilitySpy = vi.spyOn(testHubUtils, 'handleErrorForAccessibility').mockReturnValue({} as any)
         const res = response
         res.accessibility = undefined
-        processAccessibilityResponse(res)
+        const optionsWithAccessibilityTrue = options
+        optionsWithAccessibilityTrue.accessibility = true
+        processAccessibilityResponse(res, optionsWithAccessibilityTrue)
         expect(handleErrorForAccessibilitySpy).toBeCalled()
+    })
+    it ('processAccessibilityResponse should not log error if accessibility field not found & accessibility not found in options', function () {
+        handleErrorForAccessibilitySpy = vi.spyOn(testHubUtils, 'handleErrorForAccessibility').mockReturnValue({} as any)
+        const res = response
+        res.accessibility = undefined
+        const optionsWithAccessibilityNull = options
+        optionsWithAccessibilityNull.accessibility = null
+        processAccessibilityResponse(res, optionsWithAccessibilityNull)
+        expect(handleErrorForAccessibilitySpy).toBeCalledTimes(0)
     })
     afterEach(() => {
         handleErrorForAccessibilitySpy?.mockClear()


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)
Fix: Prevent accessibility build error when accessibility config is absent and TestHub returns accessibility: null.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
