### PR TITLE
Potential fix for code scanning alert no. 28: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,8 @@
 # This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 name: Test
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/webdriverio/webdriverio/security/code-scanning/28](https://github.com/webdriverio/webdriverio/security/code-scanning/28)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function. Since the workflow appears to involve testing and does not seem to require write access, we will set `contents: read` as a starting point. If any specific jobs require additional permissions, they can be defined individually within those jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
