### PR TITLE
fix(ci): hardening security of GH actions

### DIFF
--- a/.github/workflows/actions/get-core-dependencies/action.yml
+++ b/.github/workflows/actions/get-core-dependencies/action.yml
@@ -1,15 +1,13 @@
 name: 'Get Core Dependencies'
 description: 'sets the node version & initializes core dependencies'
-permissions:
-  contents: read # to fetch code (actions/checkout)
 runs:
   using: composite
   steps:
     - name: 📦 Setup pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@7088e561eb65bb68695d245aa206f005ef30921d # v4.1.0
 
     - name: 🐢 Setup Node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version-file: '.nvmrc'
         cache: 'pnpm'

--- a/.github/workflows/authorize.yml
+++ b/.github/workflows/authorize.yml
@@ -7,9 +7,10 @@ on:
 
 jobs:
   authorize:
+    permissions: {}
     runs-on: ubuntu-latest
     steps:
-      - uses: octokit/request-action@v2.4.0
+      - uses: octokit/request-action@dad4362715b7fb2ddedf9772c8670824af564f0d # v2.4.0
         with:
           route: GET /orgs/:organisation/teams/:team/memberships/${{ github.actor }}
           team: technical-steering-committee

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,9 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: read
+      packages: read
     runs-on: ubuntu-latest
     steps:
       - name: ⬇️ Checkout Code

--- a/.github/workflows/cr.yml
+++ b/.github/workflows/cr.yml
@@ -8,6 +8,10 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: write
+      pull-requests: write
+      packages: read
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,7 @@ on: [workflow_dispatch]
 
 permissions:
   contents: read
+  packages: read
 
 jobs:
   deploy:

--- a/.github/workflows/expense.yml
+++ b/.github/workflows/expense.yml
@@ -11,29 +11,29 @@ on:
         required: true
         type: choice
         options:
-          - 15
-          - 25
-          - 35
-          - 50
-          - 100
-          - 150
-          - 200
-          - 250
-          - 300
-          - 350
-          - 400
-          - 450
-          - 500
-          - 550
-          - 600
-          - 650
-          - 700
-          - 750
-          - 800
-          - 850
-          - 900
-          - 950
-          - 1000
+          - '15'
+          - '25'
+          - '35'
+          - '50'
+          - '100'
+          - '150'
+          - '200'
+          - '250'
+          - '300'
+          - '350'
+          - '400'
+          - '450'
+          - '500'
+          - '550'
+          - '600'
+          - '650'
+          - '700'
+          - '750'
+          - '800'
+          - '850'
+          - '900'
+          - '950'
+          - '1000'
 
 jobs:
   authorize:
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run Expense Flow
-        uses: webdriverio/expense-action@v1
+        uses: webdriverio/expense-action@2811799a4c5a0831154784a6021671e62657e289 # v1
         with:
           prNumber: ${{ github.event.inputs.prNumber }}
           amount: ${{ github.event.inputs.amount }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,15 +35,16 @@ jobs:
     permissions:
       contents: write
       id-token: write
+      packages: read
     needs: [authorize]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           ref: 'main'
           fetch-depth: 0
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: pnpm/action-setup@7088e561eb65bb68695d245aa206f005ef30921d # v4.1.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.nvmrc'
           cache: 'pnpm'

--- a/.github/workflows/test-cloud.yml
+++ b/.github/workflows/test-cloud.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   cloud_check:
     name: Cloud Connection Tests
+    permissions:
+      contents: read
     runs-on: 'ubuntu-latest'
     if: github.ref == 'refs/heads/main'
     steps:
@@ -46,7 +48,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
           AWS_DEVICE_FARM_ARN: ${{secrets.AWS_DEVICE_FARM_ARN}}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: failure()
         with:
           name: e2e-cloud-connection-tests-logs

--- a/.github/workflows/test-component.yml
+++ b/.github/workflows/test-component.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   check:
     name: Component Test (${{ matrix.os }}.${{ matrix.node }})
+    permissions:
+      contents: read
+      actions: write
     strategy:
       fail-fast: false
       matrix:
@@ -25,8 +28,8 @@ jobs:
       - name: 🧑‍🔧 Get Core Dependencies
         uses: ./.github/workflows/actions/get-core-dependencies
 
-      - name: Use Node ${{ matrix.node }}
-        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+      - name: 🐢 Setup Node ${{ matrix.node }}
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ matrix.node }}
           cache: 'pnpm'
@@ -49,7 +52,7 @@ jobs:
         if: matrix.os != 'windows-latest'
         uses: ./.github/workflows/actions/check-git-context
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: failure()
         with:
           name: component-tests-${{ matrix.os }}-${{ matrix.node }}-logs

--- a/.github/workflows/test-interop.yml
+++ b/.github/workflows/test-interop.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   check:
     name: CJS Interoperability Tests
+    permissions:
+      contents: read
     runs-on: 'ubuntu-latest'
     steps:
       - name: ⬇️ Checkout Code

--- a/.github/workflows/test-launch.yml
+++ b/.github/workflows/test-launch.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   launch_check:
     name: E2E Launch Test (${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -31,7 +33,7 @@ jobs:
         run: pnpm run test:e2e:webdriver
         shell: bash
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: failure()
         with:
           name: e2e-launch-tests-logs

--- a/.github/workflows/test-multiremote.yml
+++ b/.github/workflows/test-multiremote.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   multiremote_check:
     name: Testrunner Multiremote Tests (${{ matrix.os }})
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -31,7 +33,7 @@ jobs:
         run: pnpm run test:e2e:multiremote
         shell: bash
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: failure()
         with:
           name: e2e-testrunner-multiremote-tests-logs

--- a/.github/workflows/test-smoke.yml
+++ b/.github/workflows/test-smoke.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   check:
     name: Smoke Test (${{ matrix.os }}.${{ matrix.node }})
+    permissions:
+      contents: read
+      actions: write
     strategy:
       fail-fast: false
       matrix:
@@ -21,23 +24,23 @@ jobs:
       - name: 🧑‍🔧 Get Core Dependencies
         uses: ./.github/workflows/actions/get-core-dependencies
 
-      - name: Use Node ${{ matrix.node }}
-        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+      - name: 🐢 Setup Node ${{ matrix.node }}
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ matrix.node }}
           cache: 'pnpm'
 
-      - name: Download Build Archive
+      - name: 📦 Download Build Archive
         uses: ./.github/workflows/actions/download-archive
         with:
           name: webdriverio
           path: .
           filename: webdriverio-build.zip
 
-      - name: Smoke Tests
+      - name: 🧪 Smoke Tests
         run: pnpm run test:smoke
         shell: bash
 
-      - name: Check Git Context
+      - name: 🔍 Check Git Context
         if: matrix.os != 'windows-latest'
         uses: ./.github/workflows/actions/check-git-context

--- a/.github/workflows/test-standalone.yml
+++ b/.github/workflows/test-standalone.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   standalone_check:
     name: E2E Standalone Tests (${{ matrix.os }})
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-static.yml
+++ b/.github/workflows/test-static.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   check:
     name: Static Code Analysis
+    permissions:
+      contents: read
     runs-on: 'ubuntu-latest'
     steps:
       - name: ⬇️ Checkout Code

--- a/.github/workflows/test-testrunner.yml
+++ b/.github/workflows/test-testrunner.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   testrunner_check:
     name: Testrunner Tests (${{ matrix.os }})
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -33,7 +35,7 @@ jobs:
           pnpm run test:e2e:classic
         shell: bash
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: failure()
         with:
           name: e2e-testrunner-tests-logs

--- a/.github/workflows/test-typings.yml
+++ b/.github/workflows/test-typings.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   check:
     name: Typing Tests
+    permissions:
+      contents: read
     runs-on: 'ubuntu-latest'
     steps:
       - name: ⬇️ Checkout Code

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   check:
     name: Unit Test (${{ matrix.os }}.${{ matrix.node }})
+    permissions:
+      contents: read
+      actions: write
     strategy:
       fail-fast: false
       matrix:
@@ -21,8 +24,8 @@ jobs:
       - name: 🧑‍🔧 Get Core Dependencies
         uses: ./.github/workflows/actions/get-core-dependencies
 
-      - name: Use Node ${{ matrix.node }}
-        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+      - name: 🐢 Setup Node ${{ matrix.node }}
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ matrix.node }}
           cache: 'pnpm'

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Fetch PR metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2.4.0
+        uses: dependabot/fetch-metadata@08eff52f33f11b29792d242ed87062144883395c # v2.4.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -27,7 +27,7 @@ jobs:
         # Don't merge updates to GitHub Actions versions automatically.
         # (Some repos may wish to limit by version range (major/minor/patch), or scope (dep vs dev-dep), too.)
         if: contains(steps.metadata.outputs.package-ecosystem, 'npm')
-        uses: lewagon/wait-on-check-action@v1.3.4
+        uses: lewagon/wait-on-check-action@ccfb013c15c8afb7bf2b7c028fb74dc5a068cccc # v1.3.4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Proposed changes

This pull request enhances the security of our GitHub Actions workflows by implementing several best practices:

-   **Pinning Actions to Commit SHAs**: All external GitHub Actions are now pinned to specific commit SHAs instead of floating versions (e.g., `@v4`). This prevents unexpected or malicious code from being executed if a version tag is updated.
-   **Least-Privilege Permissions**: Each workflow job now has a `permissions` block that specifies the minimum required access for the `GITHUB_TOKEN`. This limits the potential impact of a compromised token.
-   **Updated Actions**: All actions have been updated to their latest stable versions to include the latest features and security fixes.
-   **Workflow Cleanup**: Minor linter issues have been resolved and step names have been made more consistent across various workflows.

These changes collectively harden our CI/CD pipeline against potential supply chain attacks and follow the security guidelines recommended by GitHub.

## Types of changes

-   [ ] Polish (an improvement for an existing feature)
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update (improvements to the project's docs)
-   [ ] Specification changes (updates to WebDriver command specifications)
-   [x] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

-   [ ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added the necessary documentation (if appropriate)
-   [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

-   [x] This change is solely for `v9` and doesn't need to be back-ported
-   [ ] Back-ported PR at `#XXXXX`

## Further comments

This is a foundational security improvement that helps protect the integrity of the project and its dependencies.

### Reviewers: @webdriverio/project-committers