### PR TITLE
Fix for isAndroid outside of test

### DIFF
--- a/packages/wdio-utils/src/envDetector.ts
+++ b/packages/wdio-utils/src/envDetector.ts
@@ -199,13 +199,19 @@ function isAndroid(capabilities?: WebdriverIO.Capabilities) {
         return false
     }
 
-    return Boolean(
+    // Check for explicit Android platform declarations
+    const hasAndroidPlatform = Boolean(
         (capabilities.platformName && capabilities.platformName.match(/Android/i)) ||
         (/Android/i.test(bsOptions.platformName || '')) ||
         (/Android/i.test(bsOptions.browserName || '')) ||
-        (/Samsung/i.test(bsOptions.deviceName || '')) ||
         (capabilities.browserName && capabilities.browserName.match(/Android/i))
     )
+
+    // Check for Android device names (case insensitive)
+    const deviceName = bsOptions.deviceName || ''
+    const hasAndroidDeviceName = /android|galaxy|pixel|nexus|oneplus|lg|htc|motorola|sony|huawei|vivo|oppo|xiaomi|redmi|realme|samsung/i.test(deviceName)
+
+    return Boolean(hasAndroidPlatform || hasAndroidDeviceName)
 }
 
 /**

--- a/packages/wdio-utils/src/envDetector.ts
+++ b/packages/wdio-utils/src/envDetector.ts
@@ -199,7 +199,6 @@ function isAndroid(capabilities?: WebdriverIO.Capabilities) {
         return false
     }
 
-    // Check for explicit Android platform declarations
     const hasAndroidPlatform = Boolean(
         (capabilities.platformName && capabilities.platformName.match(/Android/i)) ||
         (/Android/i.test(bsOptions.platformName || '')) ||
@@ -207,7 +206,6 @@ function isAndroid(capabilities?: WebdriverIO.Capabilities) {
         (capabilities.browserName && capabilities.browserName.match(/Android/i))
     )
 
-    // Check for Android device names (case insensitive)
     const deviceName = bsOptions.deviceName || ''
     const hasAndroidDeviceName = /android|galaxy|pixel|nexus|oneplus|lg|htc|motorola|sony|huawei|vivo|oppo|xiaomi|redmi|realme|samsung/i.test(deviceName)
 

--- a/packages/wdio-utils/tests/envDetector.test.ts
+++ b/packages/wdio-utils/tests/envDetector.test.ts
@@ -223,6 +223,193 @@ describe('sessionEnvironmentDetector', () => {
             const { isAndroid } = sessionEnvironmentDetector({ capabilities, requestedCapabilities })
             expect(isAndroid).toEqual(true)
         })
+
+        it('should detect Android by device name in bstack:options using sessionEnvironmentDetector', () => {
+            expect(sessionEnvironmentDetector({ 
+                capabilities: { 'bstack:options': { deviceName: 'Samsung Galaxy S21' } }, 
+                requestedCapabilities: {} 
+            }).isAndroid).toBe(true)
+            
+            expect(sessionEnvironmentDetector({ 
+                capabilities: { 'bstack:options': { deviceName: 'Google Pixel 7' } }, 
+                requestedCapabilities: {} 
+            }).isAndroid).toBe(true)
+            
+            expect(sessionEnvironmentDetector({ 
+                capabilities: { 'bstack:options': { deviceName: 'OnePlus 9 Pro' } }, 
+                requestedCapabilities: {} 
+            }).isAndroid).toBe(true)
+            
+            expect(sessionEnvironmentDetector({ 
+                capabilities: { 'bstack:options': { deviceName: 'Nexus 5X' } }, 
+                requestedCapabilities: {} 
+            }).isAndroid).toBe(true)
+        })
+
+        it('should detect Android by device name in bstack:options using capabilitiesEnvironmentDetector', () => {
+            expect(capabilitiesEnvironmentDetector({ 
+                'bstack:options': { deviceName: 'Samsung Galaxy S21' }
+            }).isAndroid).toBe(true)
+            
+            expect(capabilitiesEnvironmentDetector({ 
+                'bstack:options': { deviceName: 'Google Pixel 7' }
+            }).isAndroid).toBe(true)
+            
+            expect(capabilitiesEnvironmentDetector({ 
+                'bstack:options': { deviceName: 'OnePlus 9 Pro' }
+            }).isAndroid).toBe(true)
+            
+            expect(capabilitiesEnvironmentDetector({ 
+                'bstack:options': { deviceName: 'Nexus 5X' }
+            }).isAndroid).toBe(true)
+        })
+
+        it('should detect Android by various manufacturer device names with sessionEnvironmentDetector', () => {
+            const androidDevices = [
+                'LG G8',
+                'HTC One',
+                'Motorola Edge',
+                'Sony Xperia',
+                'Huawei P30',
+                'Vivo V21',
+                'Oppo Find X3',
+                'Xiaomi Mi 11',
+                'Redmi Note 10',
+                'Realme GT',
+                'Samsung Galaxy Note'
+            ]
+
+            androidDevices.forEach(deviceName => {
+                expect(sessionEnvironmentDetector({ 
+                    capabilities: { 'bstack:options': { deviceName } }, 
+                    requestedCapabilities: {} 
+                }).isAndroid).toBe(true)
+            })
+        })
+
+        it('should detect Android by various manufacturer device names with capabilitiesEnvironmentDetector', () => {
+            const androidDevices = [
+                'LG G8',
+                'HTC One',
+                'Motorola Edge',
+                'Sony Xperia',
+                'Huawei P30',
+                'Vivo V21',
+                'Oppo Find X3',
+                'Xiaomi Mi 11',
+                'Redmi Note 10',
+                'Realme GT',
+                'Samsung Galaxy Note'
+            ]
+
+            androidDevices.forEach(deviceName => {
+                expect(capabilitiesEnvironmentDetector({ 
+                    'bstack:options': { deviceName }
+                }).isAndroid).toBe(true)
+            })
+        })
+
+        it('should not detect Android for non-Android device names with sessionEnvironmentDetector', () => {
+            const nonAndroidDevices = [
+                'iPhone 13',
+                'iPad Pro',
+                'iPhone SE',
+                'iPad Mini',
+                'Desktop Chrome',
+                'MacBook Pro'
+            ]
+
+            nonAndroidDevices.forEach(deviceName => {
+                expect(sessionEnvironmentDetector({ 
+                    capabilities: { 'bstack:options': { deviceName } }, 
+                    requestedCapabilities: {} 
+                }).isAndroid).toBe(false)
+            })
+        })
+
+        it('should not detect Android for non-Android device names with capabilitiesEnvironmentDetector', () => {
+            const nonAndroidDevices = [
+                'iPhone 13',
+                'iPad Pro',
+                'iPhone SE',
+                'iPad Mini',
+                'Desktop Chrome',
+                'MacBook Pro'
+            ]
+
+            nonAndroidDevices.forEach(deviceName => {
+                expect(capabilitiesEnvironmentDetector({ 
+                    'bstack:options': { deviceName }
+                }).isAndroid).toBe(false)
+            })
+        })
+
+        it('should detect Android case-insensitively by device name with both detectors', () => {
+            expect(sessionEnvironmentDetector({ 
+                capabilities: { 'bstack:options': { deviceName: 'SAMSUNG GALAXY S21' } }, 
+                requestedCapabilities: {} 
+            }).isAndroid).toBe(true)
+            
+            expect(capabilitiesEnvironmentDetector({ 
+                'bstack:options': { deviceName: 'google pixel 7' }
+            }).isAndroid).toBe(true)
+            
+            expect(sessionEnvironmentDetector({ 
+                capabilities: { 'bstack:options': { deviceName: 'Galaxy S22' } }, 
+                requestedCapabilities: {} 
+            }).isAndroid).toBe(true)
+            
+            expect(capabilitiesEnvironmentDetector({ 
+                'bstack:options': { deviceName: 'ONEPLUS 10' }
+            }).isAndroid).toBe(true)
+        })
+
+        it('should detect Android when both platform and device name are present', () => {
+            const capabilities = { 
+                platformName: 'Android',
+                'bstack:options': { deviceName: 'Samsung Galaxy S21' } 
+            }
+            
+            expect(sessionEnvironmentDetector({ 
+                capabilities, 
+                requestedCapabilities: {} 
+            }).isAndroid).toBe(true)
+            
+            expect(capabilitiesEnvironmentDetector(capabilities).isAndroid).toBe(true)
+        })
+
+        it('should detect Android when only device name is present without platform', () => {
+            const capabilities = { 'bstack:options': { deviceName: 'Pixel 7' } }
+            
+            expect(sessionEnvironmentDetector({ 
+                capabilities, 
+                requestedCapabilities: {} 
+            }).isAndroid).toBe(true)
+            
+            expect(capabilitiesEnvironmentDetector(capabilities).isAndroid).toBe(true)
+        })
+
+        it('should handle empty deviceName in bstack:options', () => {
+            const capabilities = { 'bstack:options': { deviceName: '' } }
+            
+            expect(sessionEnvironmentDetector({ 
+                capabilities, 
+                requestedCapabilities: {} 
+            }).isAndroid).toBe(false)
+            
+            expect(capabilitiesEnvironmentDetector(capabilities).isAndroid).toBe(false)
+        })
+
+        it('should handle missing deviceName in bstack:options', () => {
+            const capabilities = { 'bstack:options': {} }
+            
+            expect(sessionEnvironmentDetector({ 
+                capabilities, 
+                requestedCapabilities: {} 
+            }).isAndroid).toBe(false)
+            
+            expect(capabilitiesEnvironmentDetector(capabilities).isAndroid).toBe(false)
+        })
     })
 
     it('isSeleniumStandalone', () => {

--- a/packages/wdio-utils/tests/envDetector.test.ts
+++ b/packages/wdio-utils/tests/envDetector.test.ts
@@ -225,41 +225,41 @@ describe('sessionEnvironmentDetector', () => {
         })
 
         it('should detect Android by device name in bstack:options using sessionEnvironmentDetector', () => {
-            expect(sessionEnvironmentDetector({ 
-                capabilities: { 'bstack:options': { deviceName: 'Samsung Galaxy S21' } }, 
-                requestedCapabilities: {} 
+            expect(sessionEnvironmentDetector({
+                capabilities: { 'bstack:options': { deviceName: 'Samsung Galaxy S21' } },
+                requestedCapabilities: {}
             }).isAndroid).toBe(true)
-            
-            expect(sessionEnvironmentDetector({ 
-                capabilities: { 'bstack:options': { deviceName: 'Google Pixel 7' } }, 
-                requestedCapabilities: {} 
+
+            expect(sessionEnvironmentDetector({
+                capabilities: { 'bstack:options': { deviceName: 'Google Pixel 7' } },
+                requestedCapabilities: {}
             }).isAndroid).toBe(true)
-            
-            expect(sessionEnvironmentDetector({ 
-                capabilities: { 'bstack:options': { deviceName: 'OnePlus 9 Pro' } }, 
-                requestedCapabilities: {} 
+
+            expect(sessionEnvironmentDetector({
+                capabilities: { 'bstack:options': { deviceName: 'OnePlus 9 Pro' } },
+                requestedCapabilities: {}
             }).isAndroid).toBe(true)
-            
-            expect(sessionEnvironmentDetector({ 
-                capabilities: { 'bstack:options': { deviceName: 'Nexus 5X' } }, 
-                requestedCapabilities: {} 
+
+            expect(sessionEnvironmentDetector({
+                capabilities: { 'bstack:options': { deviceName: 'Nexus 5X' } },
+                requestedCapabilities: {}
             }).isAndroid).toBe(true)
         })
 
         it('should detect Android by device name in bstack:options using capabilitiesEnvironmentDetector', () => {
-            expect(capabilitiesEnvironmentDetector({ 
+            expect(capabilitiesEnvironmentDetector({
                 'bstack:options': { deviceName: 'Samsung Galaxy S21' }
             }).isAndroid).toBe(true)
-            
-            expect(capabilitiesEnvironmentDetector({ 
+
+            expect(capabilitiesEnvironmentDetector({
                 'bstack:options': { deviceName: 'Google Pixel 7' }
             }).isAndroid).toBe(true)
-            
-            expect(capabilitiesEnvironmentDetector({ 
+
+            expect(capabilitiesEnvironmentDetector({
                 'bstack:options': { deviceName: 'OnePlus 9 Pro' }
             }).isAndroid).toBe(true)
-            
-            expect(capabilitiesEnvironmentDetector({ 
+
+            expect(capabilitiesEnvironmentDetector({
                 'bstack:options': { deviceName: 'Nexus 5X' }
             }).isAndroid).toBe(true)
         })
@@ -280,9 +280,9 @@ describe('sessionEnvironmentDetector', () => {
             ]
 
             androidDevices.forEach(deviceName => {
-                expect(sessionEnvironmentDetector({ 
-                    capabilities: { 'bstack:options': { deviceName } }, 
-                    requestedCapabilities: {} 
+                expect(sessionEnvironmentDetector({
+                    capabilities: { 'bstack:options': { deviceName } },
+                    requestedCapabilities: {}
                 }).isAndroid).toBe(true)
             })
         })
@@ -303,7 +303,7 @@ describe('sessionEnvironmentDetector', () => {
             ]
 
             androidDevices.forEach(deviceName => {
-                expect(capabilitiesEnvironmentDetector({ 
+                expect(capabilitiesEnvironmentDetector({
                     'bstack:options': { deviceName }
                 }).isAndroid).toBe(true)
             })
@@ -320,9 +320,9 @@ describe('sessionEnvironmentDetector', () => {
             ]
 
             nonAndroidDevices.forEach(deviceName => {
-                expect(sessionEnvironmentDetector({ 
-                    capabilities: { 'bstack:options': { deviceName } }, 
-                    requestedCapabilities: {} 
+                expect(sessionEnvironmentDetector({
+                    capabilities: { 'bstack:options': { deviceName } },
+                    requestedCapabilities: {}
                 }).isAndroid).toBe(false)
             })
         })
@@ -338,76 +338,76 @@ describe('sessionEnvironmentDetector', () => {
             ]
 
             nonAndroidDevices.forEach(deviceName => {
-                expect(capabilitiesEnvironmentDetector({ 
+                expect(capabilitiesEnvironmentDetector({
                     'bstack:options': { deviceName }
                 }).isAndroid).toBe(false)
             })
         })
 
         it('should detect Android case-insensitively by device name with both detectors', () => {
-            expect(sessionEnvironmentDetector({ 
-                capabilities: { 'bstack:options': { deviceName: 'SAMSUNG GALAXY S21' } }, 
-                requestedCapabilities: {} 
+            expect(sessionEnvironmentDetector({
+                capabilities: { 'bstack:options': { deviceName: 'SAMSUNG GALAXY S21' } },
+                requestedCapabilities: {}
             }).isAndroid).toBe(true)
-            
-            expect(capabilitiesEnvironmentDetector({ 
+
+            expect(capabilitiesEnvironmentDetector({
                 'bstack:options': { deviceName: 'google pixel 7' }
             }).isAndroid).toBe(true)
-            
-            expect(sessionEnvironmentDetector({ 
-                capabilities: { 'bstack:options': { deviceName: 'Galaxy S22' } }, 
-                requestedCapabilities: {} 
+
+            expect(sessionEnvironmentDetector({
+                capabilities: { 'bstack:options': { deviceName: 'Galaxy S22' } },
+                requestedCapabilities: {}
             }).isAndroid).toBe(true)
-            
-            expect(capabilitiesEnvironmentDetector({ 
+
+            expect(capabilitiesEnvironmentDetector({
                 'bstack:options': { deviceName: 'ONEPLUS 10' }
             }).isAndroid).toBe(true)
         })
 
         it('should detect Android when both platform and device name are present', () => {
-            const capabilities = { 
+            const capabilities = {
                 platformName: 'Android',
-                'bstack:options': { deviceName: 'Samsung Galaxy S21' } 
+                'bstack:options': { deviceName: 'Samsung Galaxy S21' }
             }
-            
-            expect(sessionEnvironmentDetector({ 
-                capabilities, 
-                requestedCapabilities: {} 
+
+            expect(sessionEnvironmentDetector({
+                capabilities,
+                requestedCapabilities: {}
             }).isAndroid).toBe(true)
-            
+
             expect(capabilitiesEnvironmentDetector(capabilities).isAndroid).toBe(true)
         })
 
         it('should detect Android when only device name is present without platform', () => {
             const capabilities = { 'bstack:options': { deviceName: 'Pixel 7' } }
-            
-            expect(sessionEnvironmentDetector({ 
-                capabilities, 
-                requestedCapabilities: {} 
+
+            expect(sessionEnvironmentDetector({
+                capabilities,
+                requestedCapabilities: {}
             }).isAndroid).toBe(true)
-            
+
             expect(capabilitiesEnvironmentDetector(capabilities).isAndroid).toBe(true)
         })
 
         it('should handle empty deviceName in bstack:options', () => {
             const capabilities = { 'bstack:options': { deviceName: '' } }
-            
-            expect(sessionEnvironmentDetector({ 
-                capabilities, 
-                requestedCapabilities: {} 
+
+            expect(sessionEnvironmentDetector({
+                capabilities,
+                requestedCapabilities: {}
             }).isAndroid).toBe(false)
-            
+
             expect(capabilitiesEnvironmentDetector(capabilities).isAndroid).toBe(false)
         })
 
         it('should handle missing deviceName in bstack:options', () => {
             const capabilities = { 'bstack:options': {} }
-            
-            expect(sessionEnvironmentDetector({ 
-                capabilities, 
-                requestedCapabilities: {} 
+
+            expect(sessionEnvironmentDetector({
+                capabilities,
+                requestedCapabilities: {}
             }).isAndroid).toBe(false)
-            
+
             expect(capabilitiesEnvironmentDetector(capabilities).isAndroid).toBe(false)
         })
     })


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

The change maintains backward compatibility while extending detection to handle BrowserStack's device naming patterns. This should resolve the inconsistency mentioned in the GitHub issue where [isAndroid](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) behaved differently before and after session creation.

ref: https://github.com/webdriverio/webdriverio/issues/14529#issuecomment-2933383489
## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
