### PR TITLE
Add wdio-obsidian-service to docs and cli

### DIFF
--- a/packages/wdio-cli/src/constants.ts
+++ b/packages/wdio-cli/src/constants.ts
@@ -156,7 +156,8 @@ export const SUPPORTED_PACKAGES = {
         { name: 'qmate-service', value: '@sap_oss/wdio-qmate-service$--$qmate-service' },
         { name: 'robonut', value: 'wdio-robonut-service$--$robonut' },
         { name: 'qunit', value: 'wdio-qunit-service$--$qunit' },
-        { name: 'roku', value: 'wdio-roku-service$--$roku' }
+        { name: 'roku', value: 'wdio-roku-service$--$roku' },
+        { name: 'obsidian', value: 'wdio-obsidian-service$--$obsidian' }
     ]
 }
 
@@ -672,7 +673,8 @@ export const COMMUNITY_PACKAGES_WITH_TS_SUPPORT = [
     'wdio-nuxt-service',
     'wdio-vite-service',
     'wdio-gmail-service',
-    'wdio-roku-service'
+    'wdio-roku-service',
+    'wdio-obsidian-service'
 ]
 
 export const TESTRUNNER_DEFAULTS: Options.Definition<Options.Testrunner & { capabilities: unknown }> = {

--- a/scripts/docs-generation/3rd-party/services.json
+++ b/scripts/docs-generation/3rd-party/services.json
@@ -212,5 +212,11 @@
     "title": "QUnit",
     "githubUrl": "https://github.com/mauriciolauffer/wdio-qunit-service",
     "npmUrl": "https://www.npmjs.com/package/wdio-qunit-service"
+  },
+  {
+    "packageName": "wdio-obsidian-service",
+    "title": "Obsidian Plugin Testing",
+    "githubUrl": "https://github.com/jesse-r-s-hines/wdio-obsidian-service",
+    "npmUrl": "https://www.npmjs.com/package/wdio-obsidian-service"
   }
 ]


### PR DESCRIPTION
## Proposed changes

I've created a service to help with testing [Obsidian](https://obsidian.md) plugins, this PR just adds it to the third_party services list.
## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

### Reviewers: @webdriverio/project-committers
