### PR TITLE
fix(webdriver): #14622 added ability to proxy websocket connections

### DIFF
--- a/packages/webdriver/package.json
+++ b/packages/webdriver/package.json
@@ -44,6 +44,7 @@
     "@wdio/types": "workspace:*",
     "@wdio/utils": "workspace:*",
     "deepmerge-ts": "^7.0.3",
+    "https-proxy-agent": "^7.0.6",
     "undici": "^6.20.1",
     "ws": "^8.8.0"
   }

--- a/packages/webdriver/tests/node/bidi.test.ts
+++ b/packages/webdriver/tests/node/bidi.test.ts
@@ -7,6 +7,9 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import logger from '@wdio/logger'
 
 import { listWebsocketCandidateUrls, createBidiConnection } from '../../src/node/bidi.js'
+// @ts-expect-error mock feature
+import { proxyUrlValueFn, noProxyValueFn } from '../../src/environment.js'
+import { environment } from '../../build/environment.js'
 
 vi.mock('@wdio/logger', () => import(path.join(process.cwd(), '__mocks__', '@wdio/logger')))
 
@@ -15,6 +18,26 @@ vi.mock('dns/promises', () => ({
         lookup: vi.fn().mockResolvedValue([{ address: '127.0.0.1' }, { address: '::1' }])
     }
 }))
+
+vi.mock('../../src/environment.js', () => {
+    const proxyUrlValueFn = vi.fn()
+    const noProxyValueFn = vi.fn()
+
+    return {
+        proxyUrlValueFn,
+        noProxyValueFn,
+        environment: {
+            value: {
+                get variables() {
+                    return {
+                        PROXY_URL: proxyUrlValueFn(),
+                        NO_PROXY: noProxyValueFn()
+                    }
+                }
+            }
+        }
+    }
+})
 
 vi.mock('ws', () => {
     const instances: WebSocket[] = []
@@ -74,12 +97,84 @@ describe('Bidi Node.js implementation', () => {
     })
 
     it('createBidiConnection', async () => {
+        proxyUrlValueFn.mockReturnValue(undefined)
+        noProxyValueFn.mockReturnValue(undefined)
+
         const wsPromise = createBidiConnection('ws://foo/bar')
         await new Promise((resolve) => setTimeout(resolve, 100))
         expect(instances.length).toBe(3)
         expect(instances[0].wsUrl).toBe('ws://foo/bar')
+        expect(instances[0].options).toEqual({})
         expect(instances[1].wsUrl).toBe('ws://127.0.0.1/bar')
+        expect(instances[1].options).toEqual({})
         expect(instances[2].wsUrl).toBe('ws://::1/bar')
+        expect(instances[2].options).toEqual({})
+        expect(instances[0].once).toHaveBeenCalledWith('open', expect.any(Function))
+        expect(instances[1].once).toHaveBeenCalledWith('open', expect.any(Function))
+        expect(instances[2].once).toHaveBeenCalledWith('open', expect.any(Function))
+
+        instances[0].once.mock.calls[1][1](new Error('foo')) // error callback
+        instances[1].once.mock.calls[0][1]() // success callback
+        instances[2].once.mock.calls[1][1](new Error('bar')) // error callback
+
+        const ws = await wsPromise as any
+        expect(instances[0].terminate).toHaveBeenCalled()
+        expect(instances[1].terminate).not.toHaveBeenCalled()
+        expect(instances[2].terminate).toHaveBeenCalled()
+
+        expect(ws.wsUrl).toBe('ws://127.0.0.1/bar')
+        expect(log.info).toHaveBeenCalledWith(
+            'Connected to Bidi protocol at ws://127.0.0.1/bar'
+        )
+        expect(log.error).not.toHaveBeenCalled()
+    })
+
+    it('createBidiConnection with a proxy', async () => {
+        proxyUrlValueFn.mockReturnValue('http://127.0.0.1:8888')
+        noProxyValueFn.mockReturnValue(undefined)
+
+        const wsPromise = createBidiConnection('ws://foo/bar')
+        await new Promise((resolve) => setTimeout(resolve, 100))
+        expect(instances.length).toBe(3)
+        expect(instances[0].wsUrl).toBe('ws://foo/bar')
+        expect(instances[0].options).toEqual({ agent: expect.any(Object) })
+        expect(instances[1].wsUrl).toBe('ws://127.0.0.1/bar')
+        expect(instances[1].options).toEqual({ agent: expect.any(Object) })
+        expect(instances[2].wsUrl).toBe('ws://::1/bar')
+        expect(instances[2].options).toEqual({ agent: expect.any(Object) })
+        expect(instances[0].once).toHaveBeenCalledWith('open', expect.any(Function))
+        expect(instances[1].once).toHaveBeenCalledWith('open', expect.any(Function))
+        expect(instances[2].once).toHaveBeenCalledWith('open', expect.any(Function))
+
+        instances[0].once.mock.calls[1][1](new Error('foo')) // error callback
+        instances[1].once.mock.calls[0][1]() // success callback
+        instances[2].once.mock.calls[1][1](new Error('bar')) // error callback
+
+        const ws = await wsPromise as any
+        expect(instances[0].terminate).toHaveBeenCalled()
+        expect(instances[1].terminate).not.toHaveBeenCalled()
+        expect(instances[2].terminate).toHaveBeenCalled()
+
+        expect(ws.wsUrl).toBe('ws://127.0.0.1/bar')
+        expect(log.info).toHaveBeenCalledWith(
+            'Connected to Bidi protocol at ws://127.0.0.1/bar'
+        )
+        expect(log.error).not.toHaveBeenCalled()
+    })
+
+    it('createBidiConnection and skip the proxy with a no proxy', async () => {
+        proxyUrlValueFn.mockReturnValue('http://127.0.0.1:8888')
+        noProxyValueFn.mockReturnValue(['foo', '127.0.0.1'])
+
+        const wsPromise = createBidiConnection('ws://foo/bar')
+        await new Promise((resolve) => setTimeout(resolve, 100))
+        expect(instances.length).toBe(3)
+        expect(instances[0].wsUrl).toBe('ws://foo/bar')
+        expect(instances[0].options).toEqual({})
+        expect(instances[1].wsUrl).toBe('ws://127.0.0.1/bar')
+        expect(instances[1].options).toEqual({})
+        expect(instances[2].wsUrl).toBe('ws://::1/bar')
+        expect(instances[2].options).toEqual({ agent: expect.any(Object) })
         expect(instances[0].once).toHaveBeenCalledWith('open', expect.any(Function))
         expect(instances[1].once).toHaveBeenCalledWith('open', expect.any(Function))
         expect(instances[2].once).toHaveBeenCalledWith('open', expect.any(Function))
@@ -101,6 +196,9 @@ describe('Bidi Node.js implementation', () => {
     })
 
     it('createBidiConnection with options for the ws', async ()=>{
+        proxyUrlValueFn.mockReturnValue(undefined)
+        noProxyValueFn.mockReturnValue(undefined)
+
         const wsPromise = createBidiConnection('ws://foo/bar', { headers: { 'cf-access-token': 'MY_TOKEN', 'X-Custom': 'xyz' } })
         await new Promise((resolve) => setTimeout(resolve, 100))
         expect(instances.length).toBe(3)
@@ -109,6 +207,9 @@ describe('Bidi Node.js implementation', () => {
     })
 
     it('createBidiConnection returns undefined if no socket connection is established', async () => {
+        proxyUrlValueFn.mockReturnValue(undefined)
+        noProxyValueFn.mockReturnValue(undefined)
+
         const wsPromise = createBidiConnection('ws://foo/bar')
         await new Promise((resolve) => setTimeout(resolve, 100))
         setTimeout(() => instances[0].once.mock.calls[1][1](new Error('foo')), 300) // error callback
@@ -120,6 +221,9 @@ describe('Bidi Node.js implementation', () => {
 
     it('createBidiConnection times out', async () => {
         vi.useFakeTimers()
+        proxyUrlValueFn.mockReturnValue(undefined)
+        noProxyValueFn.mockReturnValue(undefined)
+
         const wsPromise = createBidiConnection('ws://foo/bar')
         vi.runAllTimersAsync()
         expect(await wsPromise).toBeUndefined()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1475,6 +1475,9 @@ importers:
       deepmerge-ts:
         specifier: ^7.0.3
         version: 7.1.5
+      https-proxy-agent:
+        specifier: ^7.0.6
+        version: 7.0.6
       undici:
         specifier: ^6.20.1
         version: 6.21.3
@@ -15609,7 +15612,7 @@ snapshots:
       '@cucumber/ci-environment': 10.0.1
       '@cucumber/cucumber-expressions': 17.1.0
       '@cucumber/gherkin': 28.0.0
-      '@cucumber/gherkin-streams': 5.0.1(@cucumber/gherkin@28.0.0)(@cucumber/message-streams@4.0.1(@cucumber/messages@26.0.1))(@cucumber/messages@24.1.0)
+      '@cucumber/gherkin-streams': 5.0.1(@cucumber/gherkin@28.0.0)(@cucumber/message-streams@4.0.1(@cucumber/messages@24.1.0))(@cucumber/messages@24.1.0)
       '@cucumber/gherkin-utils': 9.0.0
       '@cucumber/html-formatter': 21.6.0(@cucumber/messages@24.1.0)
       '@cucumber/message-streams': 4.0.1(@cucumber/messages@24.1.0)
@@ -15649,7 +15652,7 @@ snapshots:
       yaml: 2.8.0
       yup: 1.2.0
 
-  '@cucumber/gherkin-streams@5.0.1(@cucumber/gherkin@28.0.0)(@cucumber/message-streams@4.0.1(@cucumber/messages@26.0.1))(@cucumber/messages@24.1.0)':
+  '@cucumber/gherkin-streams@5.0.1(@cucumber/gherkin@28.0.0)(@cucumber/message-streams@4.0.1(@cucumber/messages@24.1.0))(@cucumber/messages@24.1.0)':
     dependencies:
       '@cucumber/gherkin': 28.0.0
       '@cucumber/message-streams': 4.0.1(@cucumber/messages@24.1.0)


### PR DESCRIPTION
## Proposed changes

fixes https://github.com/webdriverio/webdriverio/issues/14622

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

This should fix the issue by relying on the existing environment variables. The solution was discussed in https://github.com/webdriverio/webdriverio/issues/14622.

### Reviewers: @webdriverio/project-committers
