### PR TITLE
chore: update vitest configuration to switch pool type

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
         env: {
             WDIO_SKIP_DRIVER_SETUP: '1'
         },
+        pool: 'threads',
         coverage: {
             enabled: false,
             provider: 'v8',


### PR DESCRIPTION
## Proposed changes
Only CI environment, the Vitest throws an error but exit code is normal.

<img width="2032" alt="image" src="https://github.com/user-attachments/assets/cf673960-4e7c-4a25-bbf7-0f521333b377" />

This could be related to following discussions at `vitest` side.
This PR try to switch pool type taking into account a suggestion at there.
https://github.com/vitest-dev/vitest/discussions/6511

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [X] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments



### Reviewers: @webdriverio/project-committers
