### PR TITLE
chore: Update services.json to add TV Labs service

### DIFF
--- a/packages/create-wdio/src/constants.ts
+++ b/packages/create-wdio/src/constants.ts
@@ -169,6 +169,7 @@ export const SUPPORTED_PACKAGES = {
         // external
         { name: 'eslinter-service', value: 'wdio-eslinter-service$--$eslinter' },
         { name: 'lambdatest', value: 'wdio-lambdatest-service$--$lambdatest' },
+        { name: 'tvlabs', value: '@tvlabs/wdio-service$--$tvlabs' },
         { name: 'zafira-listener', value: 'wdio-zafira-listener-service$--$zafira-listener' },
         { name: 'reportportal', value: 'wdio-reportportal-service$--$reportportal' },
         { name: 'docker', value: 'wdio-docker-service$--$docker' },

--- a/scripts/docs-generation/3rd-party/services.json
+++ b/scripts/docs-generation/3rd-party/services.json
@@ -90,6 +90,13 @@
     "npmUrl": "https://www.npmjs.com/package/wdio-slack-service"
   },
   {
+    "packageName": "@tvlabs/wdio-service",
+    "title": "TV Labs",
+    "branch": "main",
+    "githubUrl": "https://github.com/tv-labs/wdio-tvlabs-service/",
+    "npmUrl": "https://www.npmjs.com/package/@tvlabs/wdio-service"
+  },
+  {
     "packageName": "wdio-lambdatest-service",
     "title": "LambdaTest",
     "branch": "master",


### PR DESCRIPTION
## Proposed changes

Adds the [`@tvlabs/wdio-service`](https://github.com/tv-labs/wdio-tvlabs-service) to services.json and create-wdio service list.

## Types of changes

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Backport Request

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

### Reviewers: @webdriverio/project-committers
