### PR TITLE
feat: do not attach prefs when debuggerAddress is specified

### DIFF
--- a/packages/wdio-utils/src/node/startWebDriver.ts
+++ b/packages/wdio-utils/src/node/startWebDriver.ts
@@ -15,7 +15,7 @@ import type { InstallOptions } from '@puppeteer/browsers'
 
 import type { Capabilities } from '@wdio/types'
 
-import { parseParams, setupPuppeteerBrowser, setupChromedriver, getCacheDir } from './utils.js'
+import { parseParams, setupPuppeteerBrowser, setupChromedriver, getCacheDir, generateDefaultPrefs } from './utils.js'
 import { isChrome, isFirefox, isEdge, isSafari, isAppiumCapability } from '../utils.js'
 import { SUPPORTED_BROWSERNAMES } from '../constants.js'
 
@@ -84,8 +84,10 @@ export async function startWebDriver (options: Capabilities.RemoteConfig) {
             ? { executablePath: chromedriverBinary }
             : await setupChromedriver(cacheDir, browserVersion)
 
+        const prefs = generateDefaultPrefs(caps)
         caps['goog:chromeOptions'] = deepmerge(
-            { binary: chromeExecuteablePath, prefs: { 'profile.password_manager_leak_detection': false } },
+            { binary: chromeExecuteablePath },
+            prefs,
             caps['goog:chromeOptions'] || {}
         )
         chromedriverOptions.allowedOrigins = chromedriverOptions.allowedOrigins || ['*']

--- a/packages/wdio-utils/src/node/utils.ts
+++ b/packages/wdio-utils/src/node/utils.ts
@@ -323,3 +323,9 @@ export function setupGeckodriver (cacheDir: string, driverVersion?: string) {
 export function setupEdgedriver (cacheDir: string, driverVersion?: string) {
     return downloadEdgedriver(driverVersion, cacheDir)
 }
+
+export function generateDefaultPrefs(caps: WebdriverIO.Capabilities) {
+    return caps['goog:chromeOptions']?.debuggerAddress
+        ? {}
+        : { prefs: { 'profile.password_manager_leak_detection': false } }
+}

--- a/packages/wdio-utils/tests/node/index.test.ts
+++ b/packages/wdio-utils/tests/node/index.test.ts
@@ -226,6 +226,29 @@ describe('startWebDriver', () => {
         )
     })
 
+    it('should start driver with no prefs if debuggerAddress is set', async () => {
+        const options = {
+            capabilities: {
+                browserName: 'chrome',
+                'goog:chromeOptions': { debuggerAddress: 'localhost:9222' }
+            } as any
+        }
+        const res = await startWebDriver(options)
+        expect(Boolean(res?.stdout)).toBe(true)
+        expect(options).toEqual({
+            hostname: 'localhost',
+            port: 1234,
+            capabilities: {
+                browserName: 'chrome',
+                'goog:chromeOptions': {
+                    // no prefs should be set in this case
+                    binary: expect.any(String),
+                    debuggerAddress: 'localhost:9222'
+                }
+            }
+        })
+    })
+
     it('should start no driver or download chrome if binaries are defined', async () => {
         const options = {
             capabilities: {


### PR DESCRIPTION
## Proposed changes

Disable attaching `prefs` object to the 'goog:chromeOptions' when the `debuggerAddress` is specified, because `chrome.prefs` are supposed to be used for a _new_ session, and `debuggerAddress` is used when there is an intention to connect to an _existing_ session.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [x] Back-ported PR at https://github.com/webdriverio/webdriverio/pull/14635

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

Related issue: https://github.com/webdriverio/webdriverio/issues/14591

### Reviewers: @webdriverio/project-committers
