### PR TITLE
feat: do not attach prefs when debuggerAddress is specified (v8)

### DIFF
--- a/packages/wdio-utils/src/node/startWebDriver.ts
+++ b/packages/wdio-utils/src/node/startWebDriver.ts
@@ -16,7 +16,7 @@ import type { InstallOptions } from '@puppeteer/browsers'
 
 import type { Capabilities, Options } from '@wdio/types'
 
-import { parseParams, setupPuppeteerBrowser, setupChromedriver, getCacheDir } from './utils.js'
+import { parseParams, setupPuppeteerBrowser, setupChromedriver, getCacheDir, generateDefaultPrefs } from './utils.js'
 import { isChrome, isFirefox, isEdge, isSafari, isAppiumCapability } from '../utils.js'
 import { DEFAULT_HOSTNAME, SUPPORTED_BROWSERNAMES } from '../constants.js'
 
@@ -80,8 +80,10 @@ export async function startWebDriver (options: Options.WebDriver) {
             ? { executablePath: chromedriverBinary }
             : await setupChromedriver(cacheDir, browserVersion)
 
+        const prefs = generateDefaultPrefs(caps)
         caps['goog:chromeOptions'] = deepmerge(
-            { binary: chromeExecuteablePath, prefs: { 'profile.password_manager_leak_detection': false } },
+            { binary: chromeExecuteablePath },
+            prefs,
             caps['goog:chromeOptions'] || {}
         )
         chromedriverOptions.allowedOrigins = chromedriverOptions.allowedOrigins || ['*']

--- a/packages/wdio-utils/src/node/utils.ts
+++ b/packages/wdio-utils/src/node/utils.ts
@@ -334,3 +334,9 @@ export function setupGeckodriver (cacheDir: string, driverVersion?: string) {
 export function setupEdgedriver (cacheDir: string, driverVersion?: string) {
     return downloadEdgedriver(driverVersion, cacheDir)
 }
+
+export function generateDefaultPrefs(caps: WebdriverIO.Capabilities) {
+    return caps['goog:chromeOptions']?.debuggerAddress
+        ? {}
+        : { prefs: { 'profile.password_manager_leak_detection': false } }
+}

--- a/packages/wdio-utils/tests/node/index.test.ts
+++ b/packages/wdio-utils/tests/node/index.test.ts
@@ -235,7 +235,7 @@ describe('startWebDriver', () => {
         const res = await startWebDriver(options)
         expect(Boolean(res?.stdout)).toBe(true)
         expect(options).toEqual({
-            hostname: 'localhost',
+            hostname: '127.0.0.1',
             port: 1234,
             capabilities: {
                 browserName: 'chrome',

--- a/packages/wdio-utils/tests/node/index.test.ts
+++ b/packages/wdio-utils/tests/node/index.test.ts
@@ -225,6 +225,29 @@ describe('startWebDriver', () => {
         )
     })
 
+    it('should start driver with no prefs if debuggerAddress is set', async () => {
+        const options = {
+            capabilities: {
+                browserName: 'chrome',
+                'goog:chromeOptions': { debuggerAddress: 'localhost:9222' }
+            } as any
+        }
+        const res = await startWebDriver(options)
+        expect(Boolean(res?.stdout)).toBe(true)
+        expect(options).toEqual({
+            hostname: 'localhost',
+            port: 1234,
+            capabilities: {
+                browserName: 'chrome',
+                'goog:chromeOptions': {
+                    // no prefs should be set in this case
+                    binary: expect.any(String),
+                    debuggerAddress: 'localhost:9222'
+                }
+            }
+        })
+    })
+
     it('should start no driver or download chrome if binaries are defined', async () => {
         const options = {
             capabilities: {


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

### Backported PR for https://github.com/webdriverio/webdriverio/pull/14634

Disable attaching prefs object to the 'goog:chromeOptions' when the `debuggerAddress` is specified, because `chrome.prefs` are supposed to be used for a _new_ session, and `debuggerAddress` is used when there is an intention to connect to an _existing_ session.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

Related issue: https://github.com/webdriverio/webdriverio/issues/14591

### Reviewers: @webdriverio/project-committers
