### PR TITLE
fix: avoid starting a timeout if the timer was resolved immediately

### DIFF
--- a/packages/webdriverio/src/utils/Timer.ts
+++ b/packages/webdriverio/src/utils/Timer.ts
@@ -53,6 +53,10 @@ class Timer {
             this._timeoutId = setTimeout(this._tick.bind(this), this._delay)
         }
 
+        if (this._wasConditionExecuted()) {
+            return
+        }
+
         this._mainTimeoutId = setTimeout(() => {
             /**
              * make sure that condition was executed at least once


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

There is a small bug in the timer implementation. If the timer is `leading`, it can resolve the timer immediately. When it does this, it clears the `_timeoutId` and `_mainTimeoutId`, but since if was resolved immediately, the `_mainTimeoutId` is not created yet.

So, the timeout resolves and _always_ creates a 5 seconds timer which hangs the process. This is especially visible when `browser.deleteSession` is called.

I debugged this using the same reproduction from #14639, but called `destroySession` at the end. I expect the process to stop immediately after the promise is resolved, but I always need to wait 5 seconds because the `url` method started a timeout, but never resolved it.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
