### PR TITLE
fix(create-wdio): resolve templates from a single path

### DIFF
--- a/packages/create-wdio/src/constants.ts
+++ b/packages/create-wdio/src/constants.ts
@@ -11,8 +11,6 @@ export const colorItBold = chalk.bold.rgb(234, 89, 6)
 export const colorIt = chalk.rgb(234, 89, 6)
 export type PACKAGE_MANAGER = 'npm' | 'pnpm' | 'yarn' | 'bun'
 
-export const TEMPLATE_ROOT_DIR = path.join(__dirname, 'templates', 'exampleFiles')
-
 export const DEFAULT_NPM_TAG = 'latest'
 export const ASCII_ROBOT = `
                  -:...........................-:.

--- a/packages/create-wdio/src/constants.ts
+++ b/packages/create-wdio/src/constants.ts
@@ -11,6 +11,8 @@ export const colorItBold = chalk.bold.rgb(234, 89, 6)
 export const colorIt = chalk.rgb(234, 89, 6)
 export type PACKAGE_MANAGER = 'npm' | 'pnpm' | 'yarn' | 'bun'
 
+export const TEMPLATE_ROOT_DIR = path.join(__dirname, 'templates', 'exampleFiles')
+
 export const DEFAULT_NPM_TAG = 'latest'
 export const ASCII_ROBOT = `
                  -:...........................-:.

--- a/packages/create-wdio/src/utils.ts
+++ b/packages/create-wdio/src/utils.ts
@@ -28,6 +28,8 @@ const __dirname = path.dirname(url.fileURLToPath(import.meta.url))
 
 process.on('SIGINT', () => printAndExit(undefined, 'SIGINT'))
 
+const TEMPLATE_ROOT_DIR = path.join(__dirname, 'templates', 'exampleFiles')
+
 export function runProgram (command: string, args: string[], options: SpawnOptions) {
     const child = spawn(command, args, { stdio: 'inherit', ...options })
     return new Promise<void>((resolve, rejects) => {

--- a/packages/create-wdio/src/utils.ts
+++ b/packages/create-wdio/src/utils.ts
@@ -17,7 +17,7 @@ import type { SpawnOptions } from 'node:child_process'
 
 import spawn from 'cross-spawn'
 
-import { COMMUNITY_PACKAGES_WITH_TS_SUPPORT, DEPENDENCIES_INSTALLATION_MESSAGE, pkg, SUPPORTED_PACKAGE_MANAGERS, QUESTIONNAIRE, TESTING_LIBRARY_PACKAGES, usesSerenity } from './constants.js'
+import { COMMUNITY_PACKAGES_WITH_TS_SUPPORT, DEPENDENCIES_INSTALLATION_MESSAGE, pkg, SUPPORTED_PACKAGE_MANAGERS, QUESTIONNAIRE, TESTING_LIBRARY_PACKAGES, TEMPLATE_ROOT_DIR, usesSerenity } from './constants.js'
 import type { ParsedAnswers, ProjectProps, Questionnair, SupportedPackage } from './types.js'
 import chalk from 'chalk'
 import { getInstallCommand, installPackages } from './install.js'
@@ -27,10 +27,6 @@ const NPM_COMMAND = /^win/.test(process.platform) ? 'npm.cmd' : 'npm'
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url))
 
 process.on('SIGINT', () => printAndExit(undefined, 'SIGINT'))
-
-const TEMPLATE_ROOT_DIR = process.env.NODE_ENV === 'test'
-    ? path.join(__dirname, 'templates', 'exampleFiles')
-    : path.join(__dirname, '..', 'templates', 'exampleFiles')
 
 export function runProgram (command: string, args: string[], options: SpawnOptions) {
     const child = spawn(command, args, { stdio: 'inherit', ...options })
@@ -530,7 +526,7 @@ export function addServiceDeps(names: SupportedPackage[], packages: string[], up
 export async function createWDIOConfig(parsedAnswers: ParsedAnswers) {
     try {
         console.log('Creating a WebdriverIO config file...')
-        const tplPath = path.resolve(__dirname, '..', 'templates', 'wdio.conf.tpl.ejs')
+        const tplPath = path.resolve(TEMPLATE_ROOT_DIR, 'wdio.conf.tpl.ejs')
         const renderedTpl = await renderFile(tplPath, {
             answers: parsedAnswers,
             _: new EjsHelpers({ useEsm: parsedAnswers.esmSupport, useTypeScript: parsedAnswers.isUsingTypeScript })

--- a/packages/create-wdio/src/utils.ts
+++ b/packages/create-wdio/src/utils.ts
@@ -17,7 +17,7 @@ import type { SpawnOptions } from 'node:child_process'
 
 import spawn from 'cross-spawn'
 
-import { COMMUNITY_PACKAGES_WITH_TS_SUPPORT, DEPENDENCIES_INSTALLATION_MESSAGE, pkg, SUPPORTED_PACKAGE_MANAGERS, QUESTIONNAIRE, TESTING_LIBRARY_PACKAGES, TEMPLATE_ROOT_DIR, usesSerenity } from './constants.js'
+import { COMMUNITY_PACKAGES_WITH_TS_SUPPORT, DEPENDENCIES_INSTALLATION_MESSAGE, pkg, SUPPORTED_PACKAGE_MANAGERS, QUESTIONNAIRE, TESTING_LIBRARY_PACKAGES, usesSerenity } from './constants.js'
 import type { ParsedAnswers, ProjectProps, Questionnair, SupportedPackage } from './types.js'
 import chalk from 'chalk'
 import { getInstallCommand, installPackages } from './install.js'


### PR DESCRIPTION
## Proposed changes

Currently the create-wdio is failing to work due to an incorrect path to the templates.

## Types of changes

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

### Reviewers: @webdriverio/project-committers
