### PR TITLE
fix(junit-reporter): correct handling of skipped tests in JUnit repor…

### DIFF
--- a/packages/wdio-junit-reporter/src/index.ts
+++ b/packages/wdio-junit-reporter/src/index.ts
@@ -321,14 +321,18 @@ class JunitReporter extends WDIOReporter {
         const suiteKeys = Object.keys(this.suites)
 
         if (suiteKeys.length === 0) {
-            const error = this.runnerStat?.error ?? 'No tests found'
+            //const error = this.runnerStat?.error ?? 'No tests found'
             /**
              * Because this function gets called twice for Cucumber, this conditional is to ensure that
              * Cucumber and Mocha generate the same Junit report for empty suites. Otherwise, Cucumber reporter
              * would generate two <testsuite>.
              */
-            if (!isCucumberFrameworkRunner || (isCucumberFrameworkRunner && type === 'feature')) {
-                return builder.testSuite().testCase().className('').name('').failure(error)
+            if (this.runnerStat?.error) {
+                if (!isCucumberFrameworkRunner || (isCucumberFrameworkRunner && type === 'feature')) {
+                    return builder.testSuite().testCase().className('').name('').failure(error)
+                }
+            } else {
+                return builder.testSuite().testCase().className('').name('').skipped('No tests found')
             }
         }
 


### PR DESCRIPTION
…ts for Cucumber and Mocha.

Ensure that tests executed with a specific tag are displayed as 'skipped' rather than 'error' in the report.

Fix for [https://github.com/webdriverio/webdriverio/issues/14374 - ](https://github.com/webdriverio/webdriverio/issues/14374#issuecomment-2915033458)

## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [X] Polish (an improvement for an existing feature)
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [X ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [X] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
