### PR TITLE
fix(webdriverio): don't fail if last window is closed

### DIFF
--- a/packages/webdriverio/src/session/context.ts
+++ b/packages/webdriverio/src/session/context.ts
@@ -115,7 +115,7 @@ export class ContextManager extends SessionManager {
          *   > the result of running the remote end steps for the Get Window Handles command, with session, URL variables and parameters.
          */
         if (event.command === 'closeWindow') {
-            const windowHandles = (event.result as { value: string[] }).value
+            const windowHandles = (event.result as { value?: string[] }).value || []
             if (windowHandles.length === 0) {
                 throw new Error('All window handles were removed, causing WebdriverIO to close the session.')
             }

--- a/packages/webdriverio/tests/session/context.test.ts
+++ b/packages/webdriverio/tests/session/context.test.ts
@@ -1,0 +1,78 @@
+import path from 'node:path'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import { getContextManager } from '../../src/session/context.js'
+
+vi.mock('@wdio/logger', () => import(path.join(process.cwd(), '__mocks__', '@wdio/logger')))
+
+type ListenerMap = Record<string, Array<(arg: any) => any>>
+
+function createBrowserStub() {
+    const listeners: ListenerMap = {}
+    const browser = {
+        sessionId: Math.random().toString(36).slice(2),
+        isMobile: false,
+        isBidi: false,
+        capabilities: {},
+        on: vi.fn((event: string, handler: (arg: any) => any) => {
+            listeners[event] ||= []
+            listeners[event].push(handler)
+        }),
+        off: vi.fn(),
+        switchToWindow: vi.fn(),
+        sessionSubscribe: vi.fn(),
+        browsingContextGetTree: vi.fn()
+    } as unknown as WebdriverIO.Browser & { on: any, off: any, switchToWindow: any }
+
+    return {
+        browser,
+        getListeners: () => listeners
+    }
+}
+
+describe('ContextManager', () => {
+    let browser!: WebdriverIO.Browser & { on: any, off: any, switchToWindow: any }
+    let getListeners!: () => ListenerMap
+
+    beforeEach(() => {
+        const stub = createBrowserStub()
+        browser = stub.browser
+        getListeners = stub.getListeners
+        // instantiate to register listeners
+        getContextManager(browser)
+    })
+
+    it('throws a clear error if closeWindow returns no window handles (value undefined)', () => {
+        const resultHandlers = getListeners().result
+        expect(resultHandlers?.length).toBeGreaterThan(0)
+        const handler = resultHandlers![0]
+        expect(() => handler({ command: 'closeWindow', result: {} })).toThrow(
+            'All window handles were removed, causing WebdriverIO to close the session.'
+        )
+    })
+
+    it('throws a clear error if closeWindow returns an empty window handles array', () => {
+        const resultHandlers = getListeners().result
+        const handler = resultHandlers![0]
+        expect(() => handler({ command: 'closeWindow', result: { value: [] } })).toThrow(
+            'All window handles were removed, causing WebdriverIO to close the session.'
+        )
+    })
+
+    it('switches to the first remaining window handle when closing a window', () => {
+        const resultHandlers = getListeners().result
+        const handler = resultHandlers![0]
+        handler({ command: 'closeWindow', result: { value: ['handle-A', 'handle-B'] } })
+        expect(browser.switchToWindow).toHaveBeenCalledWith('handle-A')
+    })
+
+    it('rethrows a meaningful error if closeWindow result contains an error object', () => {
+        const resultHandlers = getListeners().result
+        const handler = resultHandlers![0]
+        const error = new Error('All window handles were removed, causing WebdriverIO to close the session.')
+        expect(() => handler({ command: 'closeWindow', result: { error } })).toThrow(
+            'All window handles were removed, causing WebdriverIO to close the session.'
+        )
+        expect(browser.switchToWindow).not.toHaveBeenCalled()
+    })
+})


### PR DESCRIPTION
## Proposed changes

Handle edge cases for the `closeWindow` command in `ContextManager` where the command result may not include a `value` array (e.g., when an error is returned). The logic now safely treats missing `value` as an empty list and throws a clear, consistent error when no window handles remain. When handles do remain, it switches to the first handle as before.

Also adds unit tests covering:
- `closeWindow` result with no `value` property
- `closeWindow` result with an empty `value` array
- `closeWindow` result containing an `error` object
- Nominal case (switches to the first remaining handle)

This prevents crashes and ensures a consistent error message in both Classic and BiDi sessions for `DELETE /session/:sessionId/window`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Polish (an improvement for an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

- Change in `packages/webdriverio/src/session/context.ts`: tolerate `result.value` being undefined and keep error handling consistent.
- Tests added in `packages/webdriverio/tests/session/context.test.ts` to cover all listed scenarios.

### Reviewers: @webdriverio/project-committers

- Implemented tests for undefined/empty handles and error-only payloads for `closeWindow`.
- Confirmed all unit tests pass locally.

fixes #14678