### PR TITLE
fix(wdio-xvfb): `autoXvfb` should disable xvfb completely

### DIFF
--- a/packages/wdio-local-runner/src/index.ts
+++ b/packages/wdio-local-runner/src/index.ts
@@ -29,6 +29,7 @@ export default class LocalRunner {
     ) {
         // Initialize XvfbManager
         this.xvfbManager = new XvfbManager({
+            enabled: this.config.autoXvfb !== false,
             autoInstall: this.config.xvfbAutoInstall,
             xvfbMaxRetries: this.config.xvfbMaxRetries,
             xvfbRetryDelay: this.config.xvfbRetryDelay

--- a/packages/wdio-local-runner/tests/localRunner.test.ts
+++ b/packages/wdio-local-runner/tests/localRunner.test.ts
@@ -418,3 +418,99 @@ test('should skip xvfb initialization when disabled in config', async () => {
 
     expect(mockInit).not.toHaveBeenCalled()
 })
+
+test('should pass xvfbAutoInstall:true to XvfbManager', async () => {
+    const xvfb = await import('@wdio/xvfb')
+    const runner = new LocalRunner(
+        undefined as never,
+        { xvfbAutoInstall: true } as any
+    )
+
+    // Trigger lazy init to ensure constructor ran
+    await runner.run({
+        cid: 'auto-1',
+        command: 'run',
+        configFile: '/path/to/wdio.conf.js',
+        args: {},
+        caps: {},
+        specs: ['/foo/bar.test.js'],
+        execArgv: [],
+        retries: 0,
+    })
+
+    expect(vi.mocked(xvfb.XvfbManager)).toHaveBeenCalledWith(
+        expect.objectContaining({ autoInstall: true })
+    )
+})
+
+test('should pass xvfbAutoInstall:false to XvfbManager', async () => {
+    const xvfb = await import('@wdio/xvfb')
+    const runner = new LocalRunner(
+        undefined as never,
+        { xvfbAutoInstall: false } as any
+    )
+
+    await runner.run({
+        cid: 'auto-2',
+        command: 'run',
+        configFile: '/path/to/wdio.conf.js',
+        args: {},
+        caps: {},
+        specs: ['/foo/bar.test.js'],
+        execArgv: [],
+        retries: 0,
+    })
+
+    expect(vi.mocked(xvfb.XvfbManager)).toHaveBeenCalledWith(
+        expect.objectContaining({ autoInstall: false })
+    )
+})
+
+test('should pass enabled:true to XvfbManager by default', async () => {
+    const xvfb = await import('@wdio/xvfb')
+    const runner = new LocalRunner(
+        undefined as never,
+        {} as any
+    )
+
+    await runner.run({
+        cid: 'en-1',
+        command: 'run',
+        configFile: '/path/to/wdio.conf.js',
+        args: {},
+        caps: {},
+        specs: ['/foo/bar.test.js'],
+        execArgv: [],
+        retries: 0,
+    })
+
+    expect(vi.mocked(xvfb.XvfbManager)).toHaveBeenCalledWith(
+        expect.objectContaining({ enabled: true })
+    )
+})
+
+test('should pass enabled:false to XvfbManager when autoXvfb is false', async () => {
+    const xvfb = await import('@wdio/xvfb')
+    const runner = new LocalRunner(
+        undefined as never,
+        { autoXvfb: false } as any
+    )
+
+    await runner.run({
+        cid: 'en-2',
+        command: 'run',
+        configFile: '/path/to/wdio.conf.js',
+        args: {},
+        caps: {},
+        specs: ['/foo/bar.test.js'],
+        execArgv: [],
+        retries: 0,
+    })
+
+    expect(vi.mocked(xvfb.XvfbManager)).toHaveBeenCalledWith(
+        expect.objectContaining({ enabled: true })
+    )
+    // first call was default in module mock creation, assert last call
+    const calls = vi.mocked(xvfb.XvfbManager).mock.calls
+    expect(calls[calls.length - 1][0]).toEqual(expect.objectContaining({ enabled: false }))
+})

--- a/packages/wdio-xvfb/README.md
+++ b/packages/wdio-xvfb/README.md
@@ -44,7 +44,9 @@ if (ready) {
 
 ```ts
 interface XvfbOptions {
+    enabled?: boolean;         // Authoritative usage toggle (default: true). If false, never uses Xvfb
     force?: boolean;           // Force Xvfb even on non-Linux systems (for testing)
+    autoInstall?: boolean;     // Opt-in package install if `xvfb-run` is missing (default: false)
     xvfbMaxRetries?: number;   // Number of retry attempts for xvfb failures (default: 3)
     xvfbRetryDelay?: number;   // Base delay between retries in milliseconds (default: 1000)
 }
@@ -96,13 +98,12 @@ const result = await manager.executeWithRetry(async () => {
 The utility automatically detects when Xvfb is needed:
 
 -   ✅ Linux systems without a DISPLAY environment variable
--   ✅ Linux systems in CI environments (uses `is-ci` package for detection)
 -   ✅ Linux systems when headless browser flags are detected:
     - **Chrome/Chromium**: `--headless`, `--headless=new`, `--headless=old`
     - **Firefox**: `--headless`, `-headless`
     - **Edge** (Chromium-based): `--headless`, `--headless=new`, `--headless=old`
 -   ❌ Non-Linux systems (unless `force: true`)
--   ❌ Linux systems with existing DISPLAY (unless in CI or headless flags detected)
+-   ❌ Linux systems with existing DISPLAY (unless headless flags are detected)
 
 ## Features
 
@@ -172,7 +173,7 @@ The utility automatically detects the system's package manager and installs xvfb
 | **`apt`** | `apt-get` | Ubuntu, Debian, Pop!_OS, Mint, Elementary, Zorin, etc. | `xvfb` |
 | **`dnf`** | `dnf` | Fedora, Rocky Linux, AlmaLinux, Nobara, Bazzite, etc. | `xorg-x11-server-Xvfb` |
 | **`yum`** | `yum` | CentOS, RHEL (legacy) | `xorg-x11-server-Xvfb` |
-| **`zypper`** | `zypper` | openSUSE, SUSE Linux Enterprise | `xorg-x11-server-Xvfb xvfb-run` |
+| **`zypper`** | `zypper` | openSUSE, SUSE Linux Enterprise | `xvfb-run` |
 | **`pacman`** | `pacman` | Arch Linux, Manjaro, EndeavourOS, CachyOS, etc. | `xorg-server-xvfb` |
 | **`apk`** | `apk` | Alpine Linux, PostmarketOS | `xvfb-run` |
 | **`xbps`** | `xbps-install` | Void Linux | `xvfb` |
@@ -237,8 +238,8 @@ You can customize xvfb behavior and retry settings:
 // wdio.conf.js - Custom xvfb configuration
 export const config = {
     // Xvfb configuration options (all optional)
-    autoXvfb: true,              // Enable automatic xvfb (default: true)
-    xvfbAutoInstall: false,      // Enable auto-install of xvfb if missing (default: false)
+    autoXvfb: true,              // Authoritative usage toggle (default: true). If false, never uses Xvfb
+    xvfbAutoInstall: false,      // Opt-in install of xvfb packages if missing (default: false)
     xvfbMaxRetries: 5,           // Max retry attempts for xvfb failures (default: 3)
     xvfbRetryDelay: 2000,        // Base delay between retries in ms (default: 1000)
 
@@ -253,7 +254,7 @@ export const config = {
 
 **Configuration Options:**
 
-- **`autoXvfb`** *(boolean, default: true)*: Enable/disable automatic xvfb initialization
+- **`autoXvfb`** *(boolean, default: true)*: Authoritative usage toggle – if `false`, Xvfb is never used
 - **`xvfbAutoInstall`** *(boolean, default: false)*: Install `xvfb` packages automatically if `xvfb-run` is missing
 - **`xvfbMaxRetries`** *(number, default: 3)*: Number of retry attempts when xvfb process fails
 - **`xvfbRetryDelay`** *(number, default: 1000)*: Base delay between retries in milliseconds. Uses progressive delay (delay × attempt number)

--- a/packages/wdio-xvfb/README.md
+++ b/packages/wdio-xvfb/README.md
@@ -232,7 +232,7 @@ export const config = {
 
 #### Advanced WDIO Configuration
 
-You can customize xvfb behavior and retry settings:
+You can customize xvfb behavior and retry settings in your WDIO config file:
 
 ```js
 // wdio.conf.js - Custom xvfb configuration
@@ -252,7 +252,7 @@ export const config = {
 };
 ```
 
-**Configuration Options:**
+**WDIO Testrunner Configuration Options:**
 
 - **`autoXvfb`** *(boolean, default: true)*: Authoritative usage toggle – if `false`, Xvfb is never used
 - **`xvfbAutoInstall`** *(boolean, default: false)*: Install `xvfb` packages automatically if `xvfb-run` is missing

--- a/packages/wdio-xvfb/package.json
+++ b/packages/wdio-xvfb/package.json
@@ -38,11 +38,9 @@
   },
   "typeScriptVersion": "3.8.3",
   "dependencies": {
-    "@wdio/logger": "workspace:*",
-    "is-ci": "^4.1.0"
+    "@wdio/logger": "workspace:*"
   },
   "devDependencies": {
-    "@types/is-ci": "^3.0.4",
     "@types/node": "^20.0.0",
     "@wdio/types": "workspace:*"
   },

--- a/packages/wdio-xvfb/tests/ProcessFactory.test.ts
+++ b/packages/wdio-xvfb/tests/ProcessFactory.test.ts
@@ -83,7 +83,7 @@ describe('ProcessFactory', () => {
             cwd: '/working/dir',
             env: { NODE_ENV: 'test' },
             execArgv: ['--inspect'],
-            stdio: ['inherit', 'pipe', 'pipe', 'ipc'] as const
+            stdio: ['inherit', 'pipe', 'pipe', 'ipc'] as ('inherit' | 'pipe' | 'ignore' | 'ipc')[]
         }
 
         describe('when xvfb should not run', () => {
@@ -105,9 +105,19 @@ describe('ProcessFactory', () => {
                 expect(result).toBe(mockChildProcess)
             })
 
+            it('should not wrap with xvfb-run when explicitly disabled', async () => {
+                mockXvfbManager.shouldRun.mockReturnValue(false) // disabled -> shouldRun false
+                mockExecSync.mockReturnValue('/usr/bin/xvfb-run')
+
+                await processFactory.createWorkerProcess(scriptPath, args, options)
+
+                expect(mockExecSync).not.toHaveBeenCalledWith('which xvfb-run', { stdio: 'ignore' })
+                expect(mockSpawn).not.toHaveBeenCalled()
+                expect(mockFork).toHaveBeenCalled()
+            })
+
             it('should use fork with default execArgv when not provided', async () => {
-                const optionsWithoutExecArgv = { ...options }
-                delete optionsWithoutExecArgv.execArgv
+                const { execArgv: _ignored, ...optionsWithoutExecArgv } = options
 
                 await processFactory.createWorkerProcess(scriptPath, args, optionsWithoutExecArgv)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -446,7 +446,7 @@ importers:
         version: 5.2.4(vite@5.4.19(@types/node@24.0.11)(terser@5.43.1))(vue@3.5.17(typescript@5.8.3))
       expect-webdriverio:
         specifier: ^5.3.4
-        version: 5.3.4(@wdio/globals@9.17.0)(@wdio/logger@9.18.0)(webdriverio@9.18.4(puppeteer-core@24.12.1))
+        version: 5.3.4(@wdio/globals@9.17.0)(@wdio/logger@9.18.0)(webdriverio@9.19.0(puppeteer-core@24.12.1))
       mocha:
         specifier: ^10.2.0
         version: 10.8.2
@@ -1009,7 +1009,7 @@ importers:
         version: link:../wdio-logger
       '@wdio/runner':
         specifier: ^9.16.2
-        version: 9.16.2(expect-webdriverio@5.3.4(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@9.16.2(puppeteer-core@24.12.1)))(webdriverio@9.16.2(puppeteer-core@24.12.1))
+        version: 9.16.2(expect-webdriverio@5.3.4(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@9.18.4(puppeteer-core@24.12.1)))(webdriverio@9.18.4(puppeteer-core@24.12.1))
       '@wdio/types':
         specifier: workspace:*
         version: link:../wdio-types
@@ -1144,7 +1144,7 @@ importers:
         version: 4.0.0
       expect-webdriverio:
         specifier: ^5.3.4
-        version: 5.3.4(@wdio/globals@9.17.0)(@wdio/logger@packages+wdio-logger)(webdriverio@9.18.4(puppeteer-core@24.12.1))
+        version: 5.3.4(@wdio/globals@9.17.0)(@wdio/logger@packages+wdio-logger)(webdriverio@9.19.0(puppeteer-core@24.12.1))
       split2:
         specifier: ^4.1.0
         version: 4.2.0
@@ -1500,13 +1500,7 @@ importers:
       '@wdio/logger':
         specifier: workspace:*
         version: link:../wdio-logger
-      is-ci:
-        specifier: ^4.1.0
-        version: 4.1.0
     devDependencies:
-      '@types/is-ci':
-        specifier: ^3.0.4
-        version: 3.0.4
       '@types/node':
         specifier: ^20.0.0
         version: 20.19.5
@@ -5686,9 +5680,6 @@ packages:
   '@types/ip@1.1.3':
     resolution: {integrity: sha512-64waoJgkXFTYnCYDUWgSATJ/dXEBanVkaP5d4Sbk7P6U7cTTMhxVyROTckc6JKdwCrgnAjZMn0k3177aQxtDEA==}
 
-  '@types/is-ci@3.0.4':
-    resolution: {integrity: sha512-AkCYCmwlXeuH89DagDCzvCAyltI2v9lh3U3DqSg/GrBYoReAaWwxfXCqMx9UV5MajLZ4ZFwZzV4cABGIxk2XRw==}
-
   '@types/is-glob@4.0.4':
     resolution: {integrity: sha512-3mFBtIPQ0TQetKRDe94g8YrxJZxdMillMGegyv6zRBXvq4peRRhf2wLZ/Dl53emtTsC29dQQBwYvovS20yXpiQ==}
 
@@ -6122,6 +6113,10 @@ packages:
     resolution: {integrity: sha512-fN+Z7SkKjb0u3UUMSxMN4d+CCZQKZhm/tx3eX7Rv+3T78LtpOjlesBYQ7Ax3tQ3tp8hgEo+CoOXU0jHEYubFrg==}
     engines: {node: '>=18.20.0'}
 
+  '@wdio/config@9.19.0':
+    resolution: {integrity: sha512-LMhcI1xj4hfx//IW7WdicbMFhtwkxxaLVbxGS6EVh/yMaQLYZpLD4drJUYQPjy5Rk3DMWIB2OpH+z7f+WDxf4w==}
+    engines: {node: '>=18.20.0'}
+
   '@wdio/dot-reporter@9.16.2':
     resolution: {integrity: sha512-JzFegviZdpzgvt8w8uwI0pyJguIuJzfzlkkyWz1WUoqtilH4yrf5IYKzObnm3peh7iQ/y2J1SSeAjKr0Hr5xTg==}
     engines: {node: '>=18.20.0'}
@@ -6173,12 +6168,20 @@ packages:
     resolution: {integrity: sha512-P86FvM/4XQGpJKwlC2RKF3I21TglPvPOozJGG9HoL0Jmt6jRF20ggO/nRTxU0XiWkRdqESUTmfA87bdCO4GRkQ==}
     engines: {node: '>=18.20.0'}
 
+  '@wdio/types@9.19.0':
+    resolution: {integrity: sha512-prBgfxawncE5NDQdLJlXhoNsC+YPcHGls/fT2mCo0mwYV9zUyTBfLSt+Eo6l+mtvRGAkmMtn5LuQogUWwYHEDg==}
+    engines: {node: '>=18.20.0'}
+
   '@wdio/utils@9.16.2':
     resolution: {integrity: sha512-bsRdEUXUTYvznXH/Z+p6HDzHSjMI6I6bnu8WXWTeDDDyqybWK5D8cbZvs8A/kMmGXoz1GZkSBHxy4Z5NTg8OQg==}
     engines: {node: '>=18.20.0'}
 
   '@wdio/utils@9.18.0':
     resolution: {integrity: sha512-M+QH05FUw25aFXZfjb+V16ydKoURgV61zeZrMjQdW2aAiks3F5iiI9pgqYT5kr1kHZcMy8gawGqQQ+RVfKYscQ==}
+    engines: {node: '>=18.20.0'}
+
+  '@wdio/utils@9.19.0':
+    resolution: {integrity: sha512-AHcxB1zSVxpe4Ure4MMnWAu2nh7kDVfZT0X4XOINVrQwLxjXSSy05iJ0589BrovqK0tV9lUNn1Rm//5gIiVD4Q==}
     engines: {node: '>=18.20.0'}
 
   '@webassemblyjs/ast@1.14.1':
@@ -9358,10 +9361,6 @@ packages:
 
   is-ci@3.0.1:
     resolution: {integrity: sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==}
-    hasBin: true
-
-  is-ci@4.1.0:
-    resolution: {integrity: sha512-Ab9bQDQ11lWootZUI5qxgN2ZXwxNI5hTwnsvOc1wyxQ7zQ8OkEDw79mI0+9jI3x432NfwbVRru+3noJfXF6lSQ==}
     hasBin: true
 
   is-core-module@2.16.1:
@@ -13811,6 +13810,10 @@ packages:
     resolution: {integrity: sha512-07lC4FLj45lHJo0FvLjUp5qkjzEGWJWKGsxLoe9rQ2Fg88iYsqgr9JfSj8qxHpazBaBd+77+ZtpmMZ2X2D1Zuw==}
     engines: {node: '>=18.20.0'}
 
+  webdriver@9.19.0:
+    resolution: {integrity: sha512-o5ZUvy1IFrlkVuf9hnlwQQnTMVSkEurXQkREb9XXSfcGdzValQejw7vmIrROaPVTgmLcnCq17cNzvirRWkBmgw==}
+    engines: {node: '>=18.20.0'}
+
   webdriverio@9.16.2:
     resolution: {integrity: sha512-aRcfBZyY+OFqz2DI0ZYmMahGlH3h/clAXXOQSFN5QfrHG4Cjuo5xy3lq4tVfszjEJ813+wwC4HJLbgDmMrPXkA==}
     engines: {node: '>=18.20.0'}
@@ -13822,6 +13825,15 @@ packages:
 
   webdriverio@9.18.4:
     resolution: {integrity: sha512-Q/gghz/Zt7EhTnbDQfLb61WgSwCksXZE60lEzmDXe4fULCH/6Js5IWUsne3W+BRy6nXeVvFscHD/d7S77dbamw==}
+    engines: {node: '>=18.20.0'}
+    peerDependencies:
+      puppeteer-core: '>=22.x || <=24.x'
+    peerDependenciesMeta:
+      puppeteer-core:
+        optional: true
+
+  webdriverio@9.19.0:
+    resolution: {integrity: sha512-4CZ6/1e9tNmLx8C6cK0mwXknFrcafXT0ZwnyMP/ujdXFMfIb7NrQQ3L0kkA/Nq/D+EcpKvFRmOsxnm6FOV9ZIA==}
     engines: {node: '>=18.20.0'}
     peerDependencies:
       puppeteer-core: '>=22.x || <=24.x'
@@ -15949,7 +15961,7 @@ snapshots:
       '@cucumber/ci-environment': 10.0.1
       '@cucumber/cucumber-expressions': 17.1.0
       '@cucumber/gherkin': 28.0.0
-      '@cucumber/gherkin-streams': 5.0.1(@cucumber/gherkin@28.0.0)(@cucumber/message-streams@4.0.1(@cucumber/messages@24.1.0))(@cucumber/messages@24.1.0)
+      '@cucumber/gherkin-streams': 5.0.1(@cucumber/gherkin@28.0.0)(@cucumber/message-streams@4.0.1(@cucumber/messages@26.0.1))(@cucumber/messages@24.1.0)
       '@cucumber/gherkin-utils': 9.0.0
       '@cucumber/html-formatter': 21.6.0(@cucumber/messages@24.1.0)
       '@cucumber/message-streams': 4.0.1(@cucumber/messages@24.1.0)
@@ -15989,7 +16001,7 @@ snapshots:
       yaml: 2.8.0
       yup: 1.2.0
 
-  '@cucumber/gherkin-streams@5.0.1(@cucumber/gherkin@28.0.0)(@cucumber/message-streams@4.0.1(@cucumber/messages@24.1.0))(@cucumber/messages@24.1.0)':
+  '@cucumber/gherkin-streams@5.0.1(@cucumber/gherkin@28.0.0)(@cucumber/message-streams@4.0.1(@cucumber/messages@26.0.1))(@cucumber/messages@24.1.0)':
     dependencies:
       '@cucumber/gherkin': 28.0.0
       '@cucumber/message-streams': 4.0.1(@cucumber/messages@24.1.0)
@@ -19362,10 +19374,6 @@ snapshots:
     dependencies:
       '@types/node': 20.19.5
 
-  '@types/is-ci@3.0.4':
-    dependencies:
-      ci-info: 3.9.0
-
   '@types/is-glob@4.0.4': {}
 
   '@types/istanbul-lib-coverage@2.0.6': {}
@@ -19960,6 +19968,18 @@ snapshots:
       - bare-buffer
       - supports-color
 
+  '@wdio/config@9.19.0':
+    dependencies:
+      '@wdio/logger': 9.18.0
+      '@wdio/types': 9.19.0
+      '@wdio/utils': 9.19.0
+      deepmerge-ts: 7.1.5
+      glob: 10.4.5
+      import-meta-resolve: 4.1.0
+    transitivePeerDependencies:
+      - bare-buffer
+      - supports-color
+
   '@wdio/dot-reporter@9.16.2':
     dependencies:
       '@wdio/reporter': 9.16.2
@@ -19982,10 +20002,10 @@ snapshots:
       - supports-color
       - typescript
 
-  '@wdio/globals@9.16.2(expect-webdriverio@5.3.4(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@9.16.2(puppeteer-core@24.12.1)))(webdriverio@9.16.2(puppeteer-core@24.12.1))':
+  '@wdio/globals@9.16.2(expect-webdriverio@5.3.4(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@9.18.4(puppeteer-core@24.12.1)))(webdriverio@9.18.4(puppeteer-core@24.12.1))':
     dependencies:
-      expect-webdriverio: 5.3.4(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@9.16.2(puppeteer-core@24.12.1))
-      webdriverio: 9.16.2(puppeteer-core@24.12.1)
+      expect-webdriverio: 5.3.4(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@9.18.4(puppeteer-core@24.12.1))
+      webdriverio: 9.18.4(puppeteer-core@24.12.1)
 
   '@wdio/globals@9.16.2(expect-webdriverio@5.3.4(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@packages+webdriverio))(webdriverio@9.16.2(puppeteer-core@24.12.1))':
     dependencies:
@@ -19997,10 +20017,10 @@ snapshots:
       expect-webdriverio: 5.3.4(@wdio/globals@9.17.0)(@wdio/logger@9.18.0)(webdriverio@9.16.2(puppeteer-core@24.12.1))
       webdriverio: 9.16.2(puppeteer-core@24.12.1)
 
-  '@wdio/globals@9.17.0(expect-webdriverio@5.3.4)(webdriverio@9.18.4(puppeteer-core@24.12.1))':
+  '@wdio/globals@9.17.0(expect-webdriverio@5.3.4)(webdriverio@9.19.0(puppeteer-core@24.12.1))':
     dependencies:
-      expect-webdriverio: 5.3.4(@wdio/globals@9.17.0)(@wdio/logger@9.18.0)(webdriverio@9.18.4(puppeteer-core@24.12.1))
-      webdriverio: 9.18.4(puppeteer-core@24.12.1)
+      expect-webdriverio: 5.3.4(@wdio/globals@9.17.0)(@wdio/logger@9.18.0)(webdriverio@9.19.0(puppeteer-core@24.12.1))
+      webdriverio: 9.19.0(puppeteer-core@24.12.1)
 
   '@wdio/logger@9.16.2':
     dependencies:
@@ -20031,19 +20051,19 @@ snapshots:
       diff: 7.0.0
       object-inspect: 1.13.4
 
-  '@wdio/runner@9.16.2(expect-webdriverio@5.3.4(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@9.16.2(puppeteer-core@24.12.1)))(webdriverio@9.16.2(puppeteer-core@24.12.1))':
+  '@wdio/runner@9.16.2(expect-webdriverio@5.3.4(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@9.18.4(puppeteer-core@24.12.1)))(webdriverio@9.18.4(puppeteer-core@24.12.1))':
     dependencies:
       '@types/node': 20.19.5
       '@wdio/config': 9.16.2
       '@wdio/dot-reporter': 9.16.2
-      '@wdio/globals': 9.16.2(expect-webdriverio@5.3.4(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@9.16.2(puppeteer-core@24.12.1)))(webdriverio@9.16.2(puppeteer-core@24.12.1))
+      '@wdio/globals': 9.16.2(expect-webdriverio@5.3.4(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@9.18.4(puppeteer-core@24.12.1)))(webdriverio@9.18.4(puppeteer-core@24.12.1))
       '@wdio/logger': 9.16.2
       '@wdio/types': 9.16.2
       '@wdio/utils': 9.16.2
       deepmerge-ts: 7.1.5
-      expect-webdriverio: 5.3.4(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@9.16.2(puppeteer-core@24.12.1))
+      expect-webdriverio: 5.3.4(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@9.18.4(puppeteer-core@24.12.1))
       webdriver: 9.16.2
-      webdriverio: 9.16.2(puppeteer-core@24.12.1)
+      webdriverio: 9.18.4(puppeteer-core@24.12.1)
     transitivePeerDependencies:
       - bare-buffer
       - bufferutil
@@ -20051,6 +20071,10 @@ snapshots:
       - utf-8-validate
 
   '@wdio/types@9.16.2':
+    dependencies:
+      '@types/node': 20.19.10
+
+  '@wdio/types@9.19.0':
     dependencies:
       '@types/node': 20.19.10
 
@@ -20078,6 +20102,26 @@ snapshots:
       '@puppeteer/browsers': 2.10.6
       '@wdio/logger': 9.18.0
       '@wdio/types': 9.16.2
+      decamelize: 6.0.0
+      deepmerge-ts: 7.1.5
+      edgedriver: 6.1.2
+      geckodriver: 5.0.0
+      get-port: 7.1.0
+      import-meta-resolve: 4.1.0
+      locate-app: 2.5.0
+      mitt: 3.0.1
+      safaridriver: 1.0.0
+      split2: 4.2.0
+      wait-port: 1.1.0
+    transitivePeerDependencies:
+      - bare-buffer
+      - supports-color
+
+  '@wdio/utils@9.19.0':
+    dependencies:
+      '@puppeteer/browsers': 2.10.6
+      '@wdio/logger': 9.18.0
+      '@wdio/types': 9.19.0
       decamelize: 6.0.0
       deepmerge-ts: 7.1.5
       edgedriver: 6.1.2
@@ -22591,25 +22635,25 @@ snapshots:
       lodash.isequal: 4.5.0
       webdriverio: 9.16.2(puppeteer-core@24.12.1)
 
-  expect-webdriverio@5.3.4(@wdio/globals@9.17.0)(@wdio/logger@9.18.0)(webdriverio@9.18.4(puppeteer-core@24.12.1)):
+  expect-webdriverio@5.3.4(@wdio/globals@9.17.0)(@wdio/logger@9.18.0)(webdriverio@9.19.0(puppeteer-core@24.12.1)):
     dependencies:
       '@vitest/snapshot': 3.2.4
-      '@wdio/globals': 9.17.0(expect-webdriverio@5.3.4)(webdriverio@9.18.4(puppeteer-core@24.12.1))
+      '@wdio/globals': 9.17.0(expect-webdriverio@5.3.4)(webdriverio@9.19.0(puppeteer-core@24.12.1))
       '@wdio/logger': 9.18.0
       expect: 30.0.4
       jest-matcher-utils: 30.0.3
       lodash.isequal: 4.5.0
-      webdriverio: 9.18.4(puppeteer-core@24.12.1)
+      webdriverio: 9.19.0(puppeteer-core@24.12.1)
 
-  expect-webdriverio@5.3.4(@wdio/globals@9.17.0)(@wdio/logger@packages+wdio-logger)(webdriverio@9.18.4(puppeteer-core@24.12.1)):
+  expect-webdriverio@5.3.4(@wdio/globals@9.17.0)(@wdio/logger@packages+wdio-logger)(webdriverio@9.19.0(puppeteer-core@24.12.1)):
     dependencies:
       '@vitest/snapshot': 3.2.4
-      '@wdio/globals': 9.17.0(expect-webdriverio@5.3.4)(webdriverio@9.18.4(puppeteer-core@24.12.1))
+      '@wdio/globals': 9.17.0(expect-webdriverio@5.3.4)(webdriverio@9.19.0(puppeteer-core@24.12.1))
       '@wdio/logger': link:packages/wdio-logger
       expect: 30.0.4
       jest-matcher-utils: 30.0.3
       lodash.isequal: 4.5.0
-      webdriverio: 9.18.4(puppeteer-core@24.12.1)
+      webdriverio: 9.19.0(puppeteer-core@24.12.1)
 
   expect-webdriverio@5.3.4(@wdio/globals@packages+wdio-globals)(@wdio/logger@9.18.0)(webdriverio@packages+webdriverio):
     dependencies:
@@ -22620,16 +22664,6 @@ snapshots:
       jest-matcher-utils: 30.0.3
       lodash.isequal: 4.5.0
       webdriverio: link:packages/webdriverio
-
-  expect-webdriverio@5.3.4(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@9.16.2(puppeteer-core@24.12.1)):
-    dependencies:
-      '@vitest/snapshot': 3.2.4
-      '@wdio/globals': link:packages/wdio-globals
-      '@wdio/logger': link:packages/wdio-logger
-      expect: 30.0.4
-      jest-matcher-utils: 30.0.3
-      lodash.isequal: 4.5.0
-      webdriverio: 9.16.2(puppeteer-core@24.12.1)
 
   expect-webdriverio@5.3.4(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@9.18.4(puppeteer-core@24.12.1)):
     dependencies:
@@ -23955,10 +23989,6 @@ snapshots:
   is-ci@3.0.1:
     dependencies:
       ci-info: 3.9.0
-
-  is-ci@4.1.0:
-    dependencies:
-      ci-info: 4.3.0
 
   is-core-module@2.16.1:
     dependencies:
@@ -29368,6 +29398,25 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  webdriver@9.19.0:
+    dependencies:
+      '@types/node': 20.19.10
+      '@types/ws': 8.18.1
+      '@wdio/config': 9.19.0
+      '@wdio/logger': 9.18.0
+      '@wdio/protocols': 9.16.2
+      '@wdio/types': 9.19.0
+      '@wdio/utils': 9.19.0
+      deepmerge-ts: 7.1.5
+      https-proxy-agent: 7.0.6
+      undici: 6.21.3
+      ws: 8.18.3
+    transitivePeerDependencies:
+      - bare-buffer
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   webdriverio@9.16.2(puppeteer-core@24.12.1):
     dependencies:
       '@types/node': 20.19.5
@@ -29430,6 +29479,41 @@ snapshots:
       serialize-error: 12.0.0
       urlpattern-polyfill: 10.1.0
       webdriver: 9.18.0
+    optionalDependencies:
+      puppeteer-core: 24.12.1
+    transitivePeerDependencies:
+      - bare-buffer
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  webdriverio@9.19.0(puppeteer-core@24.12.1):
+    dependencies:
+      '@types/node': 20.19.10
+      '@types/sinonjs__fake-timers': 8.1.5
+      '@wdio/config': 9.19.0
+      '@wdio/logger': 9.18.0
+      '@wdio/protocols': 9.16.2
+      '@wdio/repl': 9.16.2
+      '@wdio/types': 9.19.0
+      '@wdio/utils': 9.19.0
+      archiver: 7.0.1
+      aria-query: 5.3.2
+      cheerio: 1.1.0
+      css-shorthand-properties: 1.1.2
+      css-value: 0.0.1
+      grapheme-splitter: 1.0.4
+      htmlfy: 0.8.1
+      is-plain-obj: 4.1.0
+      jszip: 3.10.1
+      lodash.clonedeep: 4.5.0
+      lodash.zip: 4.2.0
+      query-selector-shadow-dom: 1.0.1
+      resq: 1.11.0
+      rgb2hex: 0.2.5
+      serialize-error: 12.0.0
+      urlpattern-polyfill: 10.1.0
+      webdriver: 9.19.0
     optionalDependencies:
       puppeteer-core: 24.12.1
     transitivePeerDependencies:

--- a/website/_sidebars.json
+++ b/website/_sidebars.json
@@ -77,6 +77,7 @@
       "items": [
         "configurationfile",
         "runner",
+        "headless-and-xvfb",
         "frameworks",
         "assertion",
         "organizingsuites",

--- a/website/docs/HeadlessAndXvfb.md
+++ b/website/docs/HeadlessAndXvfb.md
@@ -1,0 +1,130 @@
+---
+id: headless-and-xvfb
+title: Headless & Xvfb with the Testrunner
+description: How WebdriverIO uses Xvfb for headless testing on Linux, configuration options, CI recipes, and troubleshooting.
+---
+
+This page explains how the WebdriverIO testrunner supports headless execution on Linux using Xvfb (X Virtual Framebuffer). It covers when Xvfb is useful, how to configure it, and how it behaves in CI and Docker.
+
+## When to use Xvfb vs native headless
+
+- Use native headless (e.g., Chrome `--headless=...`) when possible for minimal overhead.
+- Use Xvfb when:
+  - Testing Electron or apps that require a window manager or desktop environment
+  - You rely on GLX or window-manager dependent behaviors
+  - Your tooling expects a display server (`DISPLAY`)
+  - You run into Chromium errors such as:
+    - `session not created: probably user data directory is already in use ...`
+    - `Chrome failed to start: exited abnormally. (DevToolsActivePort file doesn't exist)`
+    The user data directory collision error can be misleading as it is often the result of a browser crash and immediate restart that reuses the same profile directory from the prior instance. Ensuring a stable display (e.g., via Xvfb) often resolves it - if not, you should pass a unique `--user-data-dir` per worker.
+
+## Configuration
+
+Two runner options control Xvfb behavior:
+
+- `autoXvfb` (boolean, default: true)
+  - Authoritative toggle for usage. If `false`, the runner never uses Xvfb.
+  - If `true`, the runner may use Xvfb when needed.
+
+- `xvfbAutoInstall` (boolean, default: false)
+  - Opt-in package installation. If `true` and `xvfb-run` is missing, the runner attempts to install it via the system package manager.
+  - If `false` and `xvfb-run` is missing, the runner warns and continues without Xvfb.
+
+Example:
+
+```ts
+export const config: WebdriverIO.Config = {
+  // Use Xvfb when needed
+  autoXvfb: true,
+
+  // Do not auto-install OS packages by default
+  xvfbAutoInstall: false,
+
+  capabilities: [{
+    browserName: 'chrome',
+    'goog:chromeOptions': { args: ['--headless=new', '--no-sandbox'] }
+  }]
+}
+```
+
+## Detection logic
+
+- The runner considers Xvfb when:
+
+  - Running on Linux
+  - No `DISPLAY` is set (headless environment), or headless browser flags are passed
+
+- If `DISPLAY` is set, the runner won’t force Xvfb by default and will honor your existing X server/window manager.
+
+Notes:
+- `autoXvfb: false` disables Xvfb usage entirely (no wrapping with `xvfb-run`).
+- `xvfbAutoInstall` only affects installation if `xvfb-run` is missing; it does not turn usage on/off.
+
+## Using an existing DISPLAY in CI
+
+If your CI sets up its own X server/window manager (e.g., with `Xvfb :99` and a WM), either:
+
+- Leave `autoXvfb: true` and ensure `DISPLAY` is exported; the runner will honor it and avoid wrapping.
+- Or set `autoXvfb: false` to explicitly disable any Xvfb behavior from the runner.
+
+## CI and Docker recipes
+
+GitHub Actions (using native headless):
+
+```yaml
+- name: Run tests
+  run: npx wdio run ./wdio.conf.ts
+```
+
+GitHub Actions (virtual display via Xvfb if missing and opted in):
+
+```ts
+// wdio.conf.ts
+export const config = {
+  autoXvfb: true,
+  xvfbAutoInstall: true
+}
+```
+
+Docker (Ubuntu/Debian example – preinstall xvfb to avoid auto-install):
+
+```Dockerfile
+RUN apt-get update -qq && apt-get install -y xvfb
+```
+
+For other distributions, adjust the package manager and package name accordingly (e.g., `dnf install xorg-x11-server-Xvfb` on Fedora/RHEL-based, `zypper install xvfb` on openSUSE/SLE).
+
+## Automatic installation support (xvfbAutoInstall)
+
+When `xvfbAutoInstall: true` is enabled, WebdriverIO attempts to install `xvfb` using your system package manager. The following managers and packages are supported:
+
+| Package Manager | Command         | Distributions (examples)                                   | Package Name(s)                 |
+|-----------------|-----------------|-------------------------------------------------------------|----------------------------------|
+| apt             | `apt-get`       | Ubuntu, Debian, Pop!_OS, Mint, Elementary, Zorin, etc.     | `xvfb`                           |
+| dnf             | `dnf`           | Fedora, Rocky Linux, AlmaLinux, Nobara, Bazzite, etc.       | `xorg-x11-server-Xvfb`           |
+| yum             | `yum`           | CentOS, RHEL (legacy)                                       | `xorg-x11-server-Xvfb`           |
+| zypper          | `zypper`        | openSUSE, SUSE Linux Enterprise                             | `xvfb-run`                       |
+| pacman          | `pacman`        | Arch Linux, Manjaro, EndeavourOS, CachyOS, etc.             | `xorg-server-xvfb`               |
+| apk             | `apk`           | Alpine Linux, PostmarketOS                                  | `xvfb-run`                       |
+| xbps-install    | `xbps-install`  | Void Linux                                                  | `xvfb`                           |
+
+Notes:
+- If your environment uses a different package manager, the install will fail with an error; install `xvfb` manually.
+- Package names are distro-specific; the table reflects the common names per family.
+
+## Troubleshooting
+
+- “xvfb-run failed to start”
+  - The runner retries Xvfb-related failures with backoff. Ensure sufficient system packages are present (e.g., `xorg-x11-server-Xvfb` on RPM-based distros).
+
+- Xvfb wrapped unexpectedly in CI
+  - If you have a custom `DISPLAY` / WM setup, set `autoXvfb: false` or ensure `DISPLAY` is exported before the runner starts.
+
+- Missing `xvfb-run`
+  - Keep `xvfbAutoInstall: false` to avoid modifying the environment; install via your base image or set `xvfbAutoInstall: true` to opt in.
+
+## Advanced
+
+- The runner creates processes via a factory that may wrap the node worker with `xvfb-run` if Xvfb is needed and available.
+- Headless browser flags (Chrome/Edge/Firefox) signal headless usage and can trigger Xvfb in environments without a `DISPLAY`.
+


### PR DESCRIPTION
## Proposed changes

Following up from https://github.com/webdriverio/webdriverio/issues/14698, we have an issue with the xvfb feature in that when `autoXvfb` is disabled and xvfb is available, it is used to wrap the WDIO testrunner process, which is not desired behaviour.

Additional changes:

 - CI detection no longer used as CI is too broad a signal for enabling xvfb. Many CI jobs provide a valid DISPLAY or a custom X server/WM. Using isCI forces xvfb even when not needed, which may break these setups.
 - Types improvements
 - Website page under Testrunner documenting WDIO options around headless testing and xvfb.


## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
