### PR TITLE
fix(webdriverio): don't print error when swithcing to an existing window

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,5 @@ website/events.json
 e2e/wdio/headless/*.png
 website/i18n/*
 !website/i18n/en
+
+.pnpm-store

--- a/packages/webdriverio/src/commands/browser/switchWindow.ts
+++ b/packages/webdriverio/src/commands/browser/switchWindow.ts
@@ -45,25 +45,15 @@ export async function switchWindow (
         throw new Error('Unsupported parameter for switchWindow, required is "string" or a RegExp')
     }
 
-    const currentWindow = await this.getWindowHandle()
-        /**
-         * in cases where a browser window was closed by e.g. clicking on a button
-         * this command may throws an "no such window: target window already closed"
-         * error. In this case we return `undefined` and determine the new window
-         * based on the command parameter.
-         */
-        .catch(() => undefined)
-
-    // is the matcher a window handle, and are we in the right window already?
-    if (typeof matcher === 'string' && currentWindow === matcher) {
-        return currentWindow
-    }
-
     const contextManager = getContextManager(this)
     const tabs = await this.getWindowHandles()
 
     // is the matcher a window handle and is it in the list of tabs?
     if (typeof matcher === 'string' && tabs.includes(matcher)) {
+        // are we in the right window already?
+        if (matcher ===  contextManager.getCurrentWindowHandle()) {
+            return matcher
+        }
         await this.switchToWindow(matcher)
         contextManager.setCurrentContext(matcher)
         return matcher

--- a/packages/webdriverio/src/session/index.ts
+++ b/packages/webdriverio/src/session/index.ts
@@ -8,19 +8,23 @@ import { getContextManager } from './context.js'
  * register all session relevant singletons on the instance
  */
 export function registerSessionManager(instance: WebdriverIO.Browser) {
+    // Register ContextManager for all sessions
+    const initializationPromises: Promise<unknown>[] = [
+        getContextManager(instance).initialize(),
+    ]
+
     /**
      * only register session manager for sessions that appear to support
      * WebDriver Bidi
      */
-    if (typeof instance.capabilities.webSocketUrl !== 'string') {
-        return
+    if (typeof instance.capabilities.webSocketUrl === 'string') {
+        initializationPromises.push(
+            getPolyfillManager(instance).initialize(),
+            getShadowRootManager(instance).initialize(),
+            getNetworkManager(instance).initialize(),
+            getDialogManager(instance).initialize()
+        )
     }
 
-    return Promise.all([
-        getPolyfillManager(instance).initialize(),
-        getShadowRootManager(instance).initialize(),
-        getNetworkManager(instance).initialize(),
-        getDialogManager(instance).initialize(),
-        getContextManager(instance).initialize()
-    ])
+    return Promise.all(initializationPromises)
 }

--- a/packages/webdriverio/tests/commands/dialog/accept.test.ts
+++ b/packages/webdriverio/tests/commands/dialog/accept.test.ts
@@ -11,10 +11,17 @@ import { getContextManager } from '../../../src/session/context.js'
 describe('accept', () => {
     let browser: WebdriverIO.Browser
     let dialog: Dialog
-    let mockContextManager: { getCurrentContext: () => Promise<string> }
+    let mockContextManager: { initialize: () => Promise<unknown>, getCurrentContext: () => Promise<string> }
     let browseStub: ReturnType<typeof vi.spyOn>
 
     beforeEach(async () => {
+        mockContextManager = {
+            initialize: vi.fn(),
+            getCurrentContext: vi.fn()
+        };
+
+        (getContextManager as Mock).mockReturnValue(mockContextManager)
+
         browser = await remote({
             baseUrl: 'http://foobar.com',
             capabilities: { browserName: 'dialog' }
@@ -22,12 +29,6 @@ describe('accept', () => {
 
         browseStub = vi.spyOn(browser, 'browsingContextHandleUserPrompt')
             .mockResolvedValue({})
-
-        mockContextManager = {
-            getCurrentContext: vi.fn()
-        };
-
-        (getContextManager as Mock).mockReturnValue(mockContextManager)
     })
 
     it('should NOT call browsingContextHandleUserPrompt if contexts differ', async () => {

--- a/packages/webdriverio/tests/commands/dialog/dismiss.test.ts
+++ b/packages/webdriverio/tests/commands/dialog/dismiss.test.ts
@@ -11,10 +11,17 @@ import { getContextManager } from '../../../src/session/context.js'
 describe('dismiss', () => {
     let browser: WebdriverIO.Browser
     let dialog: Dialog
-    let mockContextManager: { getCurrentContext: () => Promise<string> }
+    let mockContextManager: { initialize: () => Promise<unknown>, getCurrentContext: () => Promise<string> }
     let browseStub: ReturnType<typeof vi.spyOn>
 
     beforeEach(async () => {
+        mockContextManager = {
+            initialize: vi.fn(),
+            getCurrentContext: vi.fn()
+        };
+
+        (getContextManager as Mock).mockReturnValue(mockContextManager)
+
         browser = await remote({
             baseUrl: 'http://foobar.com',
             capabilities: { browserName: 'dialog' }
@@ -22,12 +29,6 @@ describe('dismiss', () => {
 
         browseStub = vi.spyOn(browser, 'browsingContextHandleUserPrompt')
             .mockResolvedValue({})
-
-        mockContextManager = {
-            getCurrentContext: vi.fn()
-        };
-
-        (getContextManager as Mock).mockReturnValue(mockContextManager)
     })
 
     it('should NOT call browsingContextHandleUserPrompt if contexts differ', async () => {

--- a/packages/webdriverio/tests/session/context.test.ts
+++ b/packages/webdriverio/tests/session/context.test.ts
@@ -75,4 +75,29 @@ describe('ContextManager', () => {
         )
         expect(browser.switchToWindow).not.toHaveBeenCalled()
     })
+
+    it('should cache the current window handle on getWindowHandle command', () => {
+        expect(getContextManager(browser).getCurrentWindowHandle()).toBeUndefined()
+        const resultHandlers = getListeners().result
+        const handler = resultHandlers![0]
+        handler({ command: 'getWindowHandle', result: { value: 'current-window-handle' } })
+        expect(getContextManager(browser).getCurrentWindowHandle()).toBe('current-window-handle')
+    })
+
+    it('should cache the current window handle on switchToWindow command success', () => {
+        expect(getContextManager(browser).getCurrentWindowHandle()).toBeUndefined()
+        const resultHandlers = getListeners().result
+        const handler = resultHandlers![0]
+        handler({ command: 'switchToWindow', result: { value: null }, body: { handle: 'current-window-handle' } })
+        expect(getContextManager(browser).getCurrentWindowHandle()).toBe('current-window-handle')
+    })
+
+    it('should not cache the current window handle on switchToWindow command failure', () => {
+        expect(getContextManager(browser).getCurrentWindowHandle()).toBeUndefined()
+        const resultHandlers = getListeners().result
+        const handler = resultHandlers![0]
+        const error = new Error('no such window')
+        handler({ command: 'switchToWindow', result: { error } })
+        expect(getContextManager(browser).getCurrentWindowHandle()).toBeUndefined()
+    })
 })

--- a/packages/webdriverio/tests/session/index.test.ts
+++ b/packages/webdriverio/tests/session/index.test.ts
@@ -47,6 +47,7 @@ describe('webdriverio session manager', () => {
         expect(getShadowRootManager).not.toBeCalledWith(browser)
         expect(getNetworkManager).not.toBeCalledWith(browser)
         expect(getDialogManager).not.toBeCalledWith(browser)
-        expect(getContextManager).not.toBeCalledWith(browser)
+        // ContextManager is always registered for caching current window handle
+        expect(getContextManager).toBeCalledWith(browser)
     })
 })


### PR DESCRIPTION
…dow (#14588)

## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

### Why?

- In `switchWindow`, `getWindleHandle()` is always called.
- When current window is closed by JavaScript `window.close()`, `getWindowHandle()` will fail and log error messages(retry 3 times and take 1.6 secs on my side).
- #14588 : although the test is switching to an available window, `getWindleHandle()` failed and printed errors, causing sub-optimal user experience.

### What?
Introduced a cache for the current window handle, so that we can get current window handle without calling `getWindleHandle()`.

### How?

- Use ContextManager's `onCommandResultBidiAndClassic` hook to cache results of `getWindowHandle` and `switchToWindow` on success.
- Add `ContextManager.getCurrentWindowHandle()` to return the cache.
- Always initialize ContextManager when remote is created, so that it can start capturing `getWindowHandle` and `switchToWindow` commands from the beginning.

### Risk: out of sync
When JavaScript `window.close()` is called, the cache will still return the previous window handle, which is out of sync with reality.

### Why is the fix still valid?
Only `window.close()` can invalidate the cache. However, if the cache value is still included in the results of `getWindowHandles()`, it means the window is not closed and the cache value is still valid.

In switchWindow() command, first call `tabs = getWindowHandles()` to get all open window handles, and only compare `matcher` with `getCurrentWindowHandle()` if `matcher` is included in `tabs`. This guarantees that the value of the cache is valid.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
