### PR TITLE
fix(webdriverio): escape scripts in addInitScript

### DIFF
--- a/e2e/wdio/headless/test.e2e.ts
+++ b/e2e/wdio/headless/test.e2e.ts
@@ -430,6 +430,25 @@ describe('main suite 1', () => {
             expect(await browser.execute(() => Math.random())).not.toBe(42)
         })
 
+        it('should escape the init script', async () => {
+            type WindowWithHello = Window & {
+                sayHello?: (name: string) => string;
+            }
+            const script = await browser.addInitScript(() => {
+                (window as WindowWithHello).sayHello = (name) =>
+                    `Hello ${name}`
+            })
+
+            await browser.url('https://webdriver.io')
+            expect(
+                await browser.execute(() =>
+                    (window as WindowWithHello).sayHello!('there'),
+                ),
+            ).toBe('Hello there')
+
+            await script.remove()
+        })
+
         it('passed on callback function', async () => {
             const script = await browser.addInitScript((num, str, bool, emit) => {
                 setTimeout(() => emit(JSON.stringify([num, str, bool])), 500)

--- a/packages/webdriverio/src/commands/browser/addInitScript.ts
+++ b/packages/webdriverio/src/commands/browser/addInitScript.ts
@@ -113,8 +113,9 @@ export async function addInitScript<Payload, Arg1, Arg2, Arg3, Arg4, Arg5> (
 
     const serializedParameters = (args || []).map((arg: unknown) => JSON.stringify(arg))
     const context = await this.getWindowHandle()
+    const src = 'return ' + script.toString()
     const fn = `(emit) => {
-        const closure = new Function(\`return ${script.toString()}\`)
+        const closure = new Function(${JSON.stringify(src)})
         return closure()(${serializedParameters.length ? `${serializedParameters.join(', ')}, emit` : 'emit'})
     }`
     const channel = btoa(fn.toString())


### PR DESCRIPTION
If the script passed to addInitScript contains template literals then we'll run into problems where we try to embed it in another template literal hence we need to escape the script first.

The E2E test added in this patch fails without the corresponding code change.

## Proposed changes

Escapes the source of a passed-in script to `addInitScript` so that scripts that use template literals work.

## Types of changes

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
