### PR TITLE
feat: Draft solution to exclude element custom command to implicitWait

### DIFF
--- a/e2e/browser-runner/wdio.conf.js
+++ b/e2e/browser-runner/wdio.conf.js
@@ -112,10 +112,11 @@ export const config = {
         /**
          * only run this test in lit
          */
-        if (process.env.WDIO_PRESET !== 'lit') {
-            return
-        }
+        // TODO dprevost reanable && add a better e2e tests?
+        // if (process.env.WDIO_PRESET !== 'lit') {
+        //     return
+        // }
 
-        browser.addCommand('someCustomCommand', () => 'Hello World')
+        browser.addCommand('someCustomCommand', () => 'Hello World', true, undefined, undefined, true)
     }
 }

--- a/packages/wdio-types/src/Automation.ts
+++ b/packages/wdio-types/src/Automation.ts
@@ -3,7 +3,8 @@ export interface Driver<T> {
         options: T,
         modifier?: (...args: unknown[]) => unknown,
         userPrototype?: Record<string, unknown>,
-        customCommandWrapper?: (...args: unknown[]) => unknown
+        customCommandWrapper?: (...args: unknown[]) => unknown,
+        implicitWaitExclusionList?: string[]
     ): unknown
 
     attachToSession(

--- a/packages/wdio-utils/src/monad.ts
+++ b/packages/wdio-utils/src/monad.ts
@@ -59,7 +59,7 @@ export default function WebDriver(options: object, modifier?: Function, properti
     /**
      * WebDriver monad
      */
-    function unit(this: void, sessionId: string, commandWrapper?: Function) {
+    function unit(this: void, sessionId: string, commandWrapper?: Function, elementCmdImplicitWaitExclusionList?: string[]) {
         /**
          * capabilities attached to the instance prototype not being shown if
          * logging the instance
@@ -116,11 +116,15 @@ export default function WebDriver(options: object, modifier?: Function, properti
             client = modifier(client, options)
         }
 
-        client.addCommand = function (name: string, func: Function, attachToElement = false, proto: Record<string, unknown>, instances?: WebdriverIO.Browser | WebdriverIO.MultiRemoteBrowser) {
+        client.addCommand = function (name: string, func: Function, attachToElement = false, proto: Record<string, unknown>, instances?: WebdriverIO.Browser | WebdriverIO.MultiRemoteBrowser, disableElementImplicitWait?: boolean) {
             const customCommand = typeof commandWrapper === 'function'
                 ? commandWrapper(name, func)
                 : func
             if (attachToElement) {
+                if (disableElementImplicitWait && elementCmdImplicitWaitExclusionList && !elementCmdImplicitWaitExclusionList.includes(name)) {
+                    elementCmdImplicitWaitExclusionList.push(name)
+                }
+
                 /**
                  * add command to every multiremote instance
                  */

--- a/packages/webdriver/src/index.ts
+++ b/packages/webdriver/src/index.ts
@@ -21,7 +21,8 @@ export default class WebDriver {
         options: Capabilities.RemoteConfig,
         modifier?: (...args: any[]) => any,
         userPrototype = {},
-        customCommandWrapper?: (...args: any[]) => any
+        customCommandWrapper?: (...args: any[]) => any,
+        implicitWaitExclusionList: string[] = []
     ): Promise<Client> {
         const envLogLevel = environmentValue.value.variables.WDIO_LOG_LEVEL
         options.logLevel = envLogLevel ?? options.logLevel
@@ -70,7 +71,7 @@ export default class WebDriver {
                 ...bidiPrototype
             }
         )
-        const client = monad(sessionId, customCommandWrapper)
+        const client = monad(sessionId, customCommandWrapper, implicitWaitExclusionList)
 
         /**
          * parse and propagate all Bidi events to the browser instance

--- a/packages/webdriverio/src/index.ts
+++ b/packages/webdriverio/src/index.ts
@@ -18,6 +18,7 @@ import { environment } from './environment.js'
 
 import type { AttachOptions } from './types.js'
 import type * as elementCommands from './commands/element.js'
+import { IMPLICIT_WAIT_EXCLUSION_LIST } from './middlewares.js'
 
 export * from './types.js'
 export const Key = KeyConstant
@@ -63,7 +64,7 @@ export const remote = async function(
 
     const { Driver, options } = await getProtocolDriver({ ...params, ...config })
     const prototype = getPrototype('browser')
-    const instance = await Driver.newSession(options, modifier, prototype, wrapCommand) as WebdriverIO.Browser
+    const instance = await Driver.newSession(options, modifier, prototype, wrapCommand, IMPLICIT_WAIT_EXCLUSION_LIST) as WebdriverIO.Browser
 
     /**
      * we need to overwrite the original addCommand and overwriteCommand
@@ -172,6 +173,7 @@ export const multiremote = async function (
      */
     if (!isStub(automationProtocol)) {
         const origAddCommand = driver.addCommand.bind(driver)
+        // TODO dprevost need to add disableElementImplicitWait here ?
         driver.addCommand = (name: string, fn, attachToElement) => {
             driver.instances.forEach(instanceName =>
                 driver.getInstance(instanceName).addCommand(name, fn, attachToElement)

--- a/packages/webdriverio/src/middlewares.ts
+++ b/packages/webdriverio/src/middlewares.ts
@@ -5,7 +5,7 @@ import refetchElement from './utils/refetchElement.js'
 import implicitWait from './utils/implicitWait.js'
 import { isStaleElementError } from './utils/index.js'
 
-const COMMANDS_TO_SKIP = ['getElement', 'getElements', 'emit']
+export const IMPLICIT_WAIT_EXCLUSION_LIST = ['getElement', 'getElements', 'emit']
 
 /**
  * This method is an command wrapper for elements that checks if a command is called
@@ -16,7 +16,7 @@ const COMMANDS_TO_SKIP = ['getElement', 'getElements', 'emit']
 export const elementErrorHandler = (fn: Function) => (commandName: string, commandFn: Function) => {
     return function elementErrorHandlerCallback (this: WebdriverIO.Element, ...args: unknown[]) {
         return fn(commandName, async function elementErrorHandlerCallbackFn (this: WebdriverIO.Element) {
-            if (COMMANDS_TO_SKIP.includes(commandName)) {
+            if (IMPLICIT_WAIT_EXCLUSION_LIST.includes(commandName)) {
                 return fn(commandName, commandFn).apply(this, args)
             }
 

--- a/packages/webdriverio/src/types.ts
+++ b/packages/webdriverio/src/types.ts
@@ -228,7 +228,8 @@ export interface CustomInstanceCommands<T> {
         func: IsElement extends true ? AddCommandFnScoped<T | Instance, IsElement> : AddCommandFn,
         attachToElement?: IsElement,
         proto?: Record<string, any>,
-        instances?: Record<string, Instances>
+        instances?: Record<string, Instances>,
+        disableElementImplicitWait?: boolean
     ): void;
 
     /**


### PR DESCRIPTION
## Proposed changes

For [this issue](https://github.com/webdriverio/webdriverio/issues/14713), where we want to be able to run an element custom command even when the element does not exist/is not displayed.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [X] Polish (an improvement for an existing feature)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (improvements to the project's docs)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [X] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [X] This change is solely for `v9` and doesn't need to be back-ported

## Further comments

Missing UTs

### Reviewers: @webdriverio/project-committers
