### PR TITLE
fix(@wdio/allure-reporter): Encode HTML entities

### DIFF
--- a/packages/wdio-allure-reporter/package.json
+++ b/packages/wdio-allure-reporter/package.json
@@ -41,6 +41,7 @@
     "@wdio/types": "workspace:*",
     "allure-js-commons": "^2.5.0",
     "csv-stringify": "^6.0.4",
+    "html-entities": "^2.6.0",
     "strip-ansi": "^7.1.0"
   },
   "publishConfig": {

--- a/packages/wdio-allure-reporter/src/reporter.ts
+++ b/packages/wdio-allure-reporter/src/reporter.ts
@@ -1,3 +1,4 @@
+import { encode } from 'html-entities'
 import { stringify } from 'csv-stringify/sync'
 import type {
     SuiteStats, HookStats, RunnerStats, TestStats, BeforeCommandArgs,
@@ -216,12 +217,14 @@ export default class AllureReporter extends WDIOReporter {
         currentSpec.status = status
 
         if (error) {
-            currentSpec.detailsMessage = error.message
-            currentSpec.detailsTrace = error.stack
+            const encodedMessage = encode(error.message)
+            const encodedStack = encode(error.stack)
+            currentSpec.detailsMessage = encodedMessage
+            currentSpec.detailsTrace = encodedStack
 
             // if some step or sub step fails the current test will fails.
             if (this._state.currentTest) {
-                this._state.currentTest.statusDetails = { message: error.message, trace: error.stack }
+                this._state.currentTest.statusDetails = { message: encodedMessage, trace: encodedStack }
             }
         }
 

--- a/packages/wdio-allure-reporter/src/utils.ts
+++ b/packages/wdio-allure-reporter/src/utils.ts
@@ -5,6 +5,7 @@ import type { AllureGroup, AllureStep, AllureTest, ExecutableItemWrapper, Fixtur
 import { LabelName, md5, Stage, Status, Status as AllureStatus } from 'allure-js-commons'
 import CompoundError from './compoundError.js'
 import { allHooks, eachHooks, linkPlaceholder } from './constants.js'
+import { encode } from 'html-entities'
 
 /**
  * Get allure test status by TestStat object
@@ -138,8 +139,8 @@ export const getHookStatus = (newHookStats: HookStats, hookElement: ExecutableIt
         Stage.FINISHED
     // set error detail information
     const formattedError = getErrorFromFailedTest(newHookStats)
-    hookElement.detailsMessage = hookRootStep.detailsMessage = formattedError?.message
-    hookElement.detailsTrace = hookRootStep.detailsTrace = formattedError?.stack
+    hookElement.detailsMessage = hookRootStep.detailsMessage = encode(formattedError?.message)
+    hookElement.detailsTrace = hookRootStep.detailsTrace = encode(formattedError?.stack)
 
     let finalStatus = Status.PASSED
     // set status to hook root step

--- a/packages/wdio-allure-reporter/tests/__fixtures__/testState.ts
+++ b/packages/wdio-allure-reporter/tests/__fixtures__/testState.ts
@@ -96,6 +96,35 @@ export function testFailedWithAssertionErrorFromExpectWebdriverIO() {
     return Object.assign(testState(), { errors, error, state: 'failed', end: '2018-05-14T15:17:21.631Z', _duration: 2730 })
 }
 
+export function testFailedWithHtmlEntities() {
+    const errors =
+    [
+        {
+            // Example is borrowed from testing-library
+            message: `Found multiple elements with the role "list" and name \`/.*/\`·
+Here are the matching elements:·
+Ignored nodes: comments, script, style
+<ul
+  class="some class"
+>`,
+            name: 'Error',
+            stack: '<span>some more html</span>'
+        }
+    ]
+    const error =
+        {
+            message: `Found multiple elements with the role "list" and name \`/.*/\`·
+Here are the matching elements:·
+Ignored nodes: comments, script, style
+<ul
+  class="some class"
+>`,
+            name: 'Error',
+            stack: '<span>some more</span> html'
+        }
+    return Object.assign(testState(), { errors, error, state: 'failed', end: '2018-05-14T15:17:21.631Z', _duration: 2730 })
+}
+
 export function testPending() {
     return Object.assign(testState(), { state: 'pending', end: '2018-05-14T15:17:21.631Z', _duration: 0 })
 }
@@ -140,6 +169,22 @@ export function hookFailed(): WDIOReporter.Hook {
         stack: 'Error: element ("body") still existing after 100ms',
         type: 'Error',
     }
+    return Object.assign(allHookState(), { error, errors: [error], state: 'failed', end: '2018-05-14T15:17:21.631Z', _duration: 2730 })
+}
+
+export function hookFailedWithHtmlEntities(): WDIOReporter.Hook {
+    const error =
+        {
+            message: `Found multiple elements with the role "list" and name \`/.*/\`·
+Here are the matching elements:·
+Ignored nodes: comments, script, style
+<ul
+  class="some class"
+>`,
+            name: 'Error',
+            stack: '<span>some more</span> html'
+        }
+
     return Object.assign(allHookState(), { error, errors: [error], state: 'failed', end: '2018-05-14T15:17:21.631Z', _duration: 2730 })
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -446,7 +446,7 @@ importers:
         version: 5.2.4(vite@5.4.19(@types/node@24.0.11)(terser@5.43.1))(vue@3.5.17(typescript@5.8.3))
       expect-webdriverio:
         specifier: ^5.3.4
-        version: 5.3.4(@wdio/globals@9.17.0)(@wdio/logger@9.18.0)(webdriverio@9.19.0(puppeteer-core@24.12.1))
+        version: 5.3.4(@wdio/globals@9.17.0)(@wdio/logger@9.18.0)(webdriverio@9.19.2(puppeteer-core@24.12.1))
       mocha:
         specifier: ^10.2.0
         version: 10.8.2
@@ -570,6 +570,9 @@ importers:
       csv-stringify:
         specifier: ^6.0.4
         version: 6.5.2
+      html-entities:
+        specifier: ^2.6.0
+        version: 2.6.0
       strip-ansi:
         specifier: ^7.1.0
         version: 7.1.0
@@ -1144,7 +1147,7 @@ importers:
         version: 4.0.0
       expect-webdriverio:
         specifier: ^5.3.4
-        version: 5.3.4(@wdio/globals@9.17.0)(@wdio/logger@packages+wdio-logger)(webdriverio@9.19.0(puppeteer-core@24.12.1))
+        version: 5.3.4(@wdio/globals@9.17.0)(@wdio/logger@packages+wdio-logger)(webdriverio@9.19.2(puppeteer-core@24.12.1))
       split2:
         specifier: ^4.1.0
         version: 4.2.0
@@ -6113,8 +6116,8 @@ packages:
     resolution: {integrity: sha512-fN+Z7SkKjb0u3UUMSxMN4d+CCZQKZhm/tx3eX7Rv+3T78LtpOjlesBYQ7Ax3tQ3tp8hgEo+CoOXU0jHEYubFrg==}
     engines: {node: '>=18.20.0'}
 
-  '@wdio/config@9.19.0':
-    resolution: {integrity: sha512-LMhcI1xj4hfx//IW7WdicbMFhtwkxxaLVbxGS6EVh/yMaQLYZpLD4drJUYQPjy5Rk3DMWIB2OpH+z7f+WDxf4w==}
+  '@wdio/config@9.19.2':
+    resolution: {integrity: sha512-OVCzPQxav0QDk5rktQ6LYARZ5ueUuJXIqTXUpS3A9Jt6PF+ZUI5sbO/y+z+qHQXqDq+LkscmFsmkzgnoHzHcfg==}
     engines: {node: '>=18.20.0'}
 
   '@wdio/dot-reporter@9.16.2':
@@ -6168,8 +6171,8 @@ packages:
     resolution: {integrity: sha512-P86FvM/4XQGpJKwlC2RKF3I21TglPvPOozJGG9HoL0Jmt6jRF20ggO/nRTxU0XiWkRdqESUTmfA87bdCO4GRkQ==}
     engines: {node: '>=18.20.0'}
 
-  '@wdio/types@9.19.0':
-    resolution: {integrity: sha512-prBgfxawncE5NDQdLJlXhoNsC+YPcHGls/fT2mCo0mwYV9zUyTBfLSt+Eo6l+mtvRGAkmMtn5LuQogUWwYHEDg==}
+  '@wdio/types@9.19.2':
+    resolution: {integrity: sha512-fBI7ljL+YcPXSXUhdk2+zVuz7IYP1aDMTq1eVmMme9GY0y67t0dCNPOt6xkCAEdL5dOcV6D2L1r6Cf/M2ifTvQ==}
     engines: {node: '>=18.20.0'}
 
   '@wdio/utils@9.16.2':
@@ -6180,8 +6183,8 @@ packages:
     resolution: {integrity: sha512-M+QH05FUw25aFXZfjb+V16ydKoURgV61zeZrMjQdW2aAiks3F5iiI9pgqYT5kr1kHZcMy8gawGqQQ+RVfKYscQ==}
     engines: {node: '>=18.20.0'}
 
-  '@wdio/utils@9.19.0':
-    resolution: {integrity: sha512-AHcxB1zSVxpe4Ure4MMnWAu2nh7kDVfZT0X4XOINVrQwLxjXSSy05iJ0589BrovqK0tV9lUNn1Rm//5gIiVD4Q==}
+  '@wdio/utils@9.19.2':
+    resolution: {integrity: sha512-caimJiTsxDUfXn/gRAzcYTO3RydSl7XzD+QpjfWZYJjzr8a2XfNnj+Vdmr8gG4BSkiVHirW9mFCZeQp2eTD7rA==}
     engines: {node: '>=18.20.0'}
 
   '@webassemblyjs/ast@1.14.1':
@@ -13810,8 +13813,8 @@ packages:
     resolution: {integrity: sha512-07lC4FLj45lHJo0FvLjUp5qkjzEGWJWKGsxLoe9rQ2Fg88iYsqgr9JfSj8qxHpazBaBd+77+ZtpmMZ2X2D1Zuw==}
     engines: {node: '>=18.20.0'}
 
-  webdriver@9.19.0:
-    resolution: {integrity: sha512-o5ZUvy1IFrlkVuf9hnlwQQnTMVSkEurXQkREb9XXSfcGdzValQejw7vmIrROaPVTgmLcnCq17cNzvirRWkBmgw==}
+  webdriver@9.19.2:
+    resolution: {integrity: sha512-kw6dSwNzimU8/CkGVlM36pqWHZ7BhCwV4/d8fu6rpIYGeQbPwcNc4M90TfJuzYMA7Au3NdrwT/EVQgVLQ9Ju8Q==}
     engines: {node: '>=18.20.0'}
 
   webdriverio@9.16.2:
@@ -13832,8 +13835,8 @@ packages:
       puppeteer-core:
         optional: true
 
-  webdriverio@9.19.0:
-    resolution: {integrity: sha512-4CZ6/1e9tNmLx8C6cK0mwXknFrcafXT0ZwnyMP/ujdXFMfIb7NrQQ3L0kkA/Nq/D+EcpKvFRmOsxnm6FOV9ZIA==}
+  webdriverio@9.19.2:
+    resolution: {integrity: sha512-xP/9odQ9tt2pEuMgo0Oobklhu1lObgL1KmejZeyxVStwnrSTbFmn1AAqPq5pfXizUsyv2PR5+id9frrarx/c4w==}
     engines: {node: '>=18.20.0'}
     peerDependencies:
       puppeteer-core: '>=22.x || <=24.x'
@@ -19515,7 +19518,7 @@ snapshots:
   '@types/react-router@5.1.20':
     dependencies:
       '@types/history': 4.7.11
-      '@types/react': 19.1.8
+      '@types/react': 19.1.9
 
   '@types/react@19.1.8':
     dependencies:
@@ -19968,11 +19971,11 @@ snapshots:
       - bare-buffer
       - supports-color
 
-  '@wdio/config@9.19.0':
+  '@wdio/config@9.19.2':
     dependencies:
       '@wdio/logger': 9.18.0
-      '@wdio/types': 9.19.0
-      '@wdio/utils': 9.19.0
+      '@wdio/types': 9.19.2
+      '@wdio/utils': 9.19.2
       deepmerge-ts: 7.1.5
       glob: 10.4.5
       import-meta-resolve: 4.1.0
@@ -20017,10 +20020,10 @@ snapshots:
       expect-webdriverio: 5.3.4(@wdio/globals@9.17.0)(@wdio/logger@9.18.0)(webdriverio@9.16.2(puppeteer-core@24.12.1))
       webdriverio: 9.16.2(puppeteer-core@24.12.1)
 
-  '@wdio/globals@9.17.0(expect-webdriverio@5.3.4)(webdriverio@9.19.0(puppeteer-core@24.12.1))':
+  '@wdio/globals@9.17.0(expect-webdriverio@5.3.4)(webdriverio@9.19.2(puppeteer-core@24.12.1))':
     dependencies:
-      expect-webdriverio: 5.3.4(@wdio/globals@9.17.0)(@wdio/logger@9.18.0)(webdriverio@9.19.0(puppeteer-core@24.12.1))
-      webdriverio: 9.19.0(puppeteer-core@24.12.1)
+      expect-webdriverio: 5.3.4(@wdio/globals@9.17.0)(@wdio/logger@9.18.0)(webdriverio@9.19.2(puppeteer-core@24.12.1))
+      webdriverio: 9.19.2(puppeteer-core@24.12.1)
 
   '@wdio/logger@9.16.2':
     dependencies:
@@ -20074,7 +20077,7 @@ snapshots:
     dependencies:
       '@types/node': 20.19.10
 
-  '@wdio/types@9.19.0':
+  '@wdio/types@9.19.2':
     dependencies:
       '@types/node': 20.19.10
 
@@ -20117,11 +20120,11 @@ snapshots:
       - bare-buffer
       - supports-color
 
-  '@wdio/utils@9.19.0':
+  '@wdio/utils@9.19.2':
     dependencies:
       '@puppeteer/browsers': 2.10.6
       '@wdio/logger': 9.18.0
-      '@wdio/types': 9.19.0
+      '@wdio/types': 9.19.2
       decamelize: 6.0.0
       deepmerge-ts: 7.1.5
       edgedriver: 6.1.2
@@ -22635,25 +22638,25 @@ snapshots:
       lodash.isequal: 4.5.0
       webdriverio: 9.16.2(puppeteer-core@24.12.1)
 
-  expect-webdriverio@5.3.4(@wdio/globals@9.17.0)(@wdio/logger@9.18.0)(webdriverio@9.19.0(puppeteer-core@24.12.1)):
+  expect-webdriverio@5.3.4(@wdio/globals@9.17.0)(@wdio/logger@9.18.0)(webdriverio@9.19.2(puppeteer-core@24.12.1)):
     dependencies:
       '@vitest/snapshot': 3.2.4
-      '@wdio/globals': 9.17.0(expect-webdriverio@5.3.4)(webdriverio@9.19.0(puppeteer-core@24.12.1))
+      '@wdio/globals': 9.17.0(expect-webdriverio@5.3.4)(webdriverio@9.19.2(puppeteer-core@24.12.1))
       '@wdio/logger': 9.18.0
       expect: 30.0.4
       jest-matcher-utils: 30.0.3
       lodash.isequal: 4.5.0
-      webdriverio: 9.19.0(puppeteer-core@24.12.1)
+      webdriverio: 9.19.2(puppeteer-core@24.12.1)
 
-  expect-webdriverio@5.3.4(@wdio/globals@9.17.0)(@wdio/logger@packages+wdio-logger)(webdriverio@9.19.0(puppeteer-core@24.12.1)):
+  expect-webdriverio@5.3.4(@wdio/globals@9.17.0)(@wdio/logger@packages+wdio-logger)(webdriverio@9.19.2(puppeteer-core@24.12.1)):
     dependencies:
       '@vitest/snapshot': 3.2.4
-      '@wdio/globals': 9.17.0(expect-webdriverio@5.3.4)(webdriverio@9.19.0(puppeteer-core@24.12.1))
+      '@wdio/globals': 9.17.0(expect-webdriverio@5.3.4)(webdriverio@9.19.2(puppeteer-core@24.12.1))
       '@wdio/logger': link:packages/wdio-logger
       expect: 30.0.4
       jest-matcher-utils: 30.0.3
       lodash.isequal: 4.5.0
-      webdriverio: 9.19.0(puppeteer-core@24.12.1)
+      webdriverio: 9.19.2(puppeteer-core@24.12.1)
 
   expect-webdriverio@5.3.4(@wdio/globals@packages+wdio-globals)(@wdio/logger@9.18.0)(webdriverio@packages+webdriverio):
     dependencies:
@@ -23543,7 +23546,7 @@ snapshots:
 
   history@4.10.1:
     dependencies:
-      '@babel/runtime': 7.27.6
+      '@babel/runtime': 7.28.2
       loose-envify: 1.4.0
       resolve-pathname: 3.0.0
       tiny-invariant: 1.3.3
@@ -29398,15 +29401,15 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  webdriver@9.19.0:
+  webdriver@9.19.2:
     dependencies:
       '@types/node': 20.19.10
       '@types/ws': 8.18.1
-      '@wdio/config': 9.19.0
+      '@wdio/config': 9.19.2
       '@wdio/logger': 9.18.0
       '@wdio/protocols': 9.16.2
-      '@wdio/types': 9.19.0
-      '@wdio/utils': 9.19.0
+      '@wdio/types': 9.19.2
+      '@wdio/utils': 9.19.2
       deepmerge-ts: 7.1.5
       https-proxy-agent: 7.0.6
       undici: 6.21.3
@@ -29487,16 +29490,16 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  webdriverio@9.19.0(puppeteer-core@24.12.1):
+  webdriverio@9.19.2(puppeteer-core@24.12.1):
     dependencies:
       '@types/node': 20.19.10
       '@types/sinonjs__fake-timers': 8.1.5
-      '@wdio/config': 9.19.0
+      '@wdio/config': 9.19.2
       '@wdio/logger': 9.18.0
       '@wdio/protocols': 9.16.2
       '@wdio/repl': 9.16.2
-      '@wdio/types': 9.19.0
-      '@wdio/utils': 9.19.0
+      '@wdio/types': 9.19.2
+      '@wdio/utils': 9.19.2
       archiver: 7.0.1
       aria-query: 5.3.2
       cheerio: 1.1.0
@@ -29513,7 +29516,7 @@ snapshots:
       rgb2hex: 0.2.5
       serialize-error: 12.0.0
       urlpattern-polyfill: 10.1.0
-      webdriver: 9.19.0
+      webdriver: 9.19.2
     optionalDependencies:
       puppeteer-core: 24.12.1
     transitivePeerDependencies:


### PR DESCRIPTION
## Proposed changes

Encode HTML entities in the message / stack reported by the allure reporter as otherwise the allure report might completely break (i.e. when using testing-library that includes a stringified DOM tree in its error messages)

## Types of changes

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

none

### Reviewers: @webdriverio/project-committers
