### PR TITLE
docs(@wdio/junit-reporter): update readme

### DIFF
--- a/packages/wdio-junit-reporter/README.md
+++ b/packages/wdio-junit-reporter/README.md
@@ -261,8 +261,8 @@ The function accepts an object input parameter with the [`packageName`](#package
 (Cucumber only), and `suite` (non-Cucumber only) keys.
 
 Type: `Object`<br />
-Default (Cucumber): ``function (opts) { return `${opts.packageName}${opts.activeFeatureName}` }``<br />
-Default (others): ``function (opts) { return `${opts.packageName}.${(opts.suite.fullTitle || opts.suite.title).replace(/\s/g, '_')}` }``<br />
+Default (Cucumber): ``(opts) => `${opts.packageName}${opts.activeFeatureName}` ``<br />
+Default (others): ``(opts) => `${opts.packageName}.${(opts.suite.fullTitle || opts.suite.title).replace(/\s/g, '_')}` ``<br />
 Example (Cucumber):
 ```js
 // wdio.conf.js


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

This is an enhancement to the `@wdio/junit-reporter` documentation:
* Add missing common options from `@wdio/reporter`: `logFile`, `setLogFile`, `stdout`, `writeStream`
* Add missing `classNameFormat` option
* Add information about function type input parameter for `suiteNameFormat` option
* Add default values for `packageName` option
* Change the `addProperty` paragraph to a dedicated API section for better consistency with `@wdio/allure-reporter`
* Add XML examples for `addFileAttribute` option and `addProperty` function
* Update most `wdio.conf.js` examples

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
