### PR TITLE
Yarn berry fixes

### DIFF
--- a/packages/wdio-cli/src/launcher.ts
+++ b/packages/wdio-cli/src/launcher.ts
@@ -1,5 +1,5 @@
 import exitHook from 'async-exit-hook'
-import { resolve } from 'import-meta-resolve'
+import { createRequire } from 'node:module'
 
 import logger from '@wdio/logger'
 import { validateConfig } from '@wdio/config'
@@ -13,6 +13,7 @@ import { runLauncherHook, runOnCompleteHook, runServiceHook, nodeVersion, type H
 import { TESTRUNNER_DEFAULTS, WORKER_GROUPLOGS_MESSAGES } from './constants.js'
 import type { RunCommandArguments } from './types.js'
 const log = logger('@wdio/cli:launcher')
+const require = createRequire(import.meta.url)
 
 interface Schedule {
     cid: number
@@ -179,7 +180,7 @@ class Launcher {
         /**
          * add tsx to process NODE_OPTIONS so it will be passed along the worker process
          */
-        const tsxPath = resolve('tsx', import.meta.url)
+        const tsxPath = require.resolve('tsx')
         if (!process.env.NODE_OPTIONS || !process.env.NODE_OPTIONS.includes(tsxPath)) {
             /**
              * The `--import` flag is only available in Node 20.6.0 / 18.19.0 and later.


### PR DESCRIPTION
## Proposed changes

Adds support for Yarn Berry by using different require/import constructs in some cases.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
