### PR TITLE
feat(utils): Fix reduce function to use the initial value parameter

### DIFF
--- a/packages/wdio-utils/src/shim.ts
+++ b/packages/wdio-utils/src/shim.ts
@@ -239,13 +239,13 @@ export function wrapCommand<T>(commandName: string, fn: Function): (...args: unk
                      * ```
                      */
                     if (commandName.endsWith('$$') && typeof iterators[prop as keyof typeof iterators] === 'function') {
-                        return (mapIterator: Function) => wrapElementFn(
+                        return (...iteratorArgs: [Function, ...unknown[]]) => wrapElementFn(
                             target,
-                            function (this: never, mapIterator: Function) {
+                            function (this: never, ...iteratorArgs: [Function, ...unknown[]]) {
                                 // @ts-ignore
-                                return iterators[prop](this, mapIterator)
+                                return iterators[prop](this, ...iteratorArgs)
                             },
-                            [mapIterator]
+                            iteratorArgs
                         )
                     }
 

--- a/packages/wdio-utils/tests/shim-async.test.ts
+++ b/packages/wdio-utils/tests/shim-async.test.ts
@@ -258,6 +258,14 @@ describe('wrapCommand', () => {
             .$$('bar')
             .map((el: any) => el.getTagName())
         ).toEqual(['Yayy0', 'Yayy1', 'Yayy2'])
+
+        expect(await commandA.call(scope(0))
+            .$('foo')
+            .$$('bar')
+            .reduce(async (acc: string, el: any) => {
+                return await el.getTagName() + '_' + acc
+            }, '')
+        ).toEqual('Yayy2_Yayy1_Yayy0_')
     })
 
     it('can access element properties', async () => {


### PR DESCRIPTION
Fixes #14749

## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
