### PR TITLE
fix(webdriver): invoke terminate on all unsuccessful websocket candidates

### DIFF
--- a/packages/webdriver/src/node/bidi.ts
+++ b/packages/webdriver/src/node/bidi.ts
@@ -120,12 +120,7 @@ export async function connectWebsocket(candidateUrls: string[], options?: Client
 
     const socketsToCleanup = wsInfo ? websockets.filter((_, index) => wsInfo.index !== index) : websockets
     for (const socket of socketsToCleanup) {
-        socket.removeAllListeners()
-        if (socket.readyState === WebSocket.OPEN || socket.readyState === WebSocket.CLOSING) {
-            socket.terminate()
-        } else {
-            socket.once('open', () => socket.terminate())
-        }
+        socket.terminate()
     }
 
     if (wsInfo?.isConnected) {


### PR DESCRIPTION
## Proposed changes
Fixes #14742 
Invoke `terminate` on all unsuccessful websocket candidates regardless of their `readyState`.
This change simplifies the cleanup logic and prevents the linked issue from occurring as the [ws library handles](https://github.com/websockets/ws/blob/master/lib/websocket.js#L485-L497) the appropriate way to terminate the connection depending on the ready state.

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)
## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

Instead of an error being thrown a debug message can be seen showing the socket has been closed
`DEBUG webdriver: Could not connect to Bidi protocol at wss://10.166.109.168/session/8be10657e9589a26aa22ea3b67d865ff/se/bidi: WebSocket was closed before the connection was established`

```
[0-0] 2025-09-10T14:45:39.452Z INFO webdriver: Register BiDi handler for session with id 8be10657e9589a26aa22ea3b67d865ff
[0-0] 2025-09-10T14:45:39.452Z INFO webdriver: Connecting to webSocketUrl wss://privatedomain.co.uk/session/8be10657e9589a26aa22ea3b67d865ff/se/bidi
[0-0] 2025-09-10T14:45:39.455Z DEBUG webdriver: Attempt to connect to webSocketUrl wss://privatedomain.co.uk/session/8be10657e9589a26aa22ea3b67d865ff/se/bidi
[0-0] 2025-09-10T14:45:39.457Z DEBUG webdriver: Attempt to connect to webSocketUrl wss://10.166.106.101/session/8be10657e9589a26aa22ea3b67d865ff/se/bidi
[0-0] 2025-09-10T14:45:39.458Z DEBUG webdriver: Attempt to connect to webSocketUrl wss://10.166.109.168/session/8be10657e9589a26aa22ea3b67d865ff/se/bidi
[0-0] 2025-09-10T14:45:39.458Z DEBUG webdriver: Attempt to connect to webSocketUrl wss://10.166.101.206/session/8be10657e9589a26aa22ea3b67d865ff/se/bidi
[0-0] 2025-09-10T14:45:39.550Z DEBUG webdriver: Could not connect to Bidi protocol at wss://10.166.106.101/session/8be10657e9589a26aa22ea3b67d865ff/se/bidi: Unexpected server response: 404
[0-0] 2025-09-10T14:45:39.583Z INFO webdriver: Connected to Bidi protocol at wss://privatedomain.co.uk/session/8be10657e9589a26aa22ea3b67d865ff/se/bidi
[0-0] 2025-09-10T14:45:39.583Z INFO webdriver: Connected to WebDriver Bidi interface at wss://privatedomain.co.uk/session/8be10657e9589a26aa22ea3b67d865ff/se/bidi
[0-0] 2025-09-10T14:45:39.584Z INFO webdriver: BIDI COMMAND session.subscribe {"events":["browsingContext.contextCreated"]}
[0-0] 2025-09-10T14:45:39.584Z INFO webdriver: BIDI COMMAND session.subscribe {"events":["log.entryAdded","browsingContext.navigationStarted"]}
[0-0] 2025-09-10T14:45:39.585Z INFO webdriver: BIDI COMMAND script.addPreloadScript { functionDeclaration: <PreloadScript[1319 bytes]>, contexts: undefined }
[0-0] 2025-09-10T14:45:39.585Z INFO webdriver: BIDI COMMAND session.subscribe {"events":["browsingContext.navigationStarted","browsingContext.fragmentNavigated","network.responseCompleted","network.beforeRequestSent","network.fetchError"]}
[0-0] 2025-09-10T14:45:39.585Z INFO webdriver: BIDI COMMAND session.subscribe {"events":["browsingContext.userPromptOpened"]}
[0-0] 2025-09-10T14:45:39.585Z INFO webdriver: BIDI COMMAND session.subscribe {"events":["browsingContext.navigationStarted"]}
[0-0] 2025-09-10T14:45:39.585Z INFO webdriver: COMMAND getWindowHandle()
[0-0] 2025-09-10T14:45:39.586Z INFO webdriver: BIDI COMMAND browsingContext.getTree {}
[0-0] 2025-09-10T14:45:39.586Z INFO webdriver: [GET] https://privatedomain.co.uk/wd/hub/session/8be10657e9589a26aa22ea3b67d865ff/window
[0-0] 2025-09-10T14:45:39.587Z DEBUG webdriver: Could not connect to Bidi protocol at wss://10.166.109.168/session/8be10657e9589a26aa22ea3b67d865ff/se/bidi: WebSocket was closed before the connection was established
[0-0] 2025-09-10T14:45:39.587Z DEBUG webdriver: Could not connect to Bidi protocol at wss://10.166.101.206/session/8be10657e9589a26aa22ea3b67d865ff/se/bidi: WebSocket was closed before the connection was established

```

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
