### PR TITLE
fix(types): correct Promise typings for $ and $$. closes #13945

### DIFF
--- a/packages/webdriverio/src/types.ts
+++ b/packages/webdriverio/src/types.ts
@@ -69,6 +69,7 @@ interface ChainablePromiseBaseElement {
     getElement(): Promise<WebdriverIO.Element>
 }
 export interface ChainablePromiseElement extends
+    Promise<WebdriverIO.Element>,
     ChainablePromiseBaseElement,
     AsyncElementProto,
     Omit<WebdriverIO.Element, keyof ChainablePromiseBaseElement | keyof AsyncElementProto> {}
@@ -95,7 +96,9 @@ interface AsyncIterators<T> {
     entries(): AsyncIterableIterator<[number, WebdriverIO.Element]>;
 }
 
-export interface ChainablePromiseArray extends AsyncIterators<WebdriverIO.Element> {
+export interface ChainablePromiseArray extends
+    Promise<WebdriverIO.Element[]>,
+    AsyncIterators<WebdriverIO.Element> {
     [Symbol.asyncIterator](): AsyncIterableIterator<WebdriverIO.Element>
     [Symbol.iterator](): IterableIterator<WebdriverIO.Element>
 

--- a/tests/typings/webdriverio/async.ts
+++ b/tests/typings/webdriverio/async.ts
@@ -308,12 +308,19 @@ async function bar() {
     const elcResult = await $('foo').$('bar').elementCustomCommand(4)
     expectType<number>(elcResult)
 
+    // Element promise
+    expectType<Promise<WebdriverIO.Element>>(browser.$('foo'))
+
     // $$
     const elems = await $$('').getElements()
     const el4 = elems[0]
     const el5 = await el4.$('')
     expectType<string>(await el4.getAttribute('class'))
     expectType<void|unknown>(await el5.scrollIntoView(false))
+
+    // Element[] promise
+    expectType<Promise<WebdriverIO.Element[]>>(browser.$$('foo'))
+    expectType<number>((await browser.$$('foo')).length)
 
     // async iterator
     const iteratorResult = await $$('').map((el) => el.getText())
@@ -460,6 +467,8 @@ async function bar() {
         await browser.$('foo').$('bar').$$('loo').selector)
     expectType<WebdriverIO.Browser | WebdriverIO.Element | WebdriverIO.MultiRemoteBrowser>(
         await browser.$('foo').$('bar').$$('loo').parent)
+    expectType<Promise<number>>(
+        browser.$('foo').$('bar').$$('loo').length)
 
     // promise chain API
     expectType<string>(


### PR DESCRIPTION
## Proposed changes
Fix TypeScript typings for ChainablePromiseElement and ChainablePromiseArray.

Currently, these interfaces are not seen as proper Promise types by TypeScript.
As a result:

- await does not work correctly on $ / $$ results,

- properties such as .length on arrays are incorrectly inferred (e.g. Promise<number> instead of number).

This PR adjusts the typings so that $ and $$ behave as true Promises in TypeScript, fixing await usage and property inference.

Closes [#13945](https://github.com/webdriverio/webdriverio/issues/13945?utm_source=chatgpt.com)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

This is a minimal fix to typings only, without touching runtime code.
It ensures await works as expected on $ and $$ results, improving DX for TypeScript users without any impact on existing JS code.

### Reviewers: @webdriverio/project-committers
