### PR TITLE
Update docs on selector to warn that aria/ selectors can be slow

### DIFF
--- a/website/docs/Selectors.md
+++ b/website/docs/Selectors.md
@@ -29,7 +29,8 @@ We __do__ and __do not__ recommend the following selectors:
 | `$(() => document.queryElement('button'))` | ⚠️ Sparingly | Effective querying, complex to write. |
 | `$('button[name="submission"]')` | ⚠️ Sparingly | Coupled to the `name` attribute which has HTML semantics. |
 | `$('button[data-testid="submit"]')` | ✅ Good | Requires additional attribute, not connected to a11y. |
-| `$('aria/Submit')` or `$('button=Submit')` | ✅ Always | Best. Resembles how the user interacts with the page. It is recommended to use your frontend's translation files so your tests never fail when the translations are updated |
+| `$('aria/Submit')` | ✅ Good | Good. Resembles how the user interacts with the page. It is recommended to use translation files so your tests don't break when translations are updated. Note: This selector can be slower than others on large pages. |
+| `$('button=Submit')` | ✅ Always | Best. Resembles how the user interacts with the page and is fast. It is recommended to use translation files so your tests don't break when translations are updated. |
 
 ## CSS Query Selector
 


### PR DESCRIPTION
Just an update to the docs to highlight that `aria/` selectors can be slow.

We're discussing the issue and a fix here: #14662