### PR TITLE
🐛 Carry on searching for tsconfig.json if parsing the config file fails.

### DIFF
--- a/packages/wdio-cli/src/commands/run.ts
+++ b/packages/wdio-cli/src/commands/run.ts
@@ -241,11 +241,16 @@ export async function handler(argv: RunCommandArguments) {
 }
 
 async function tsConfigPathFromConfigFile(wdioConfPath: string, params: Partial<RunCommandArguments>): Promise<string | void> {
-    const configParser = new ConfigParser(wdioConfPath, params)
-    await configParser.initialize()
-    const { tsConfigPath } = configParser.getConfig()
-    if (tsConfigPath ) {
-        return tsConfigPath
+    try {
+        const configParser = new ConfigParser(wdioConfPath, params)
+        await configParser.initialize()
+        const { tsConfigPath } = configParser.getConfig()
+        if (tsConfigPath) {
+            return tsConfigPath
+        }
+    } catch {
+        console.warn(`Unable to parse config file. If tsConfigPath is set in ${wdioConfPath}, it will be ignored.`)
+        return
     }
     return
 }


### PR DESCRIPTION
Fixes #14801

## Proposed changes

This resolves a bug where a failure by jiti to parse the `wdio.conf.ts` file will stop the cli before it attempts to look for `tsconfig.json` in the same directory as `wdio.conf.js`. 

## Types of changes

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

- [x ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
