### PR TITLE
fix `wdio repl` when run with multiremote capabilities

### DIFF
--- a/packages/wdio-cli/src/utils.ts
+++ b/packages/wdio-cli/src/utils.ts
@@ -189,7 +189,7 @@ export async function getCapabilities(arg: ReplCommandArguments) {
             // multi capabilities
             (requiredCaps as (Capabilities.RequestedStandaloneCapabilities)[])[parseInt(arg.capabilities, 10)] ||
             // multiremote
-            (requiredCaps as Capabilities.RequestedMultiremoteCapabilities)[arg.capabilities].capabilities
+            (requiredCaps as Capabilities.RequestedMultiremoteCapabilities)[arg.capabilities]?.capabilities
         )
         const requiredW3CCaps = pickBy(requiredCaps, (_: never, key: string) => CAPABILITY_KEYS.includes(key) || key.includes(':'))
         if (!Object.keys(requiredW3CCaps).length) {

--- a/packages/wdio-cli/tests/__snapshots__/utils.test.ts.snap
+++ b/packages/wdio-cli/tests/__snapshots__/utils.test.ts.snap
@@ -73,6 +73,14 @@ exports[`getCapabilities > should return driver with capabilities for ios 2`] = 
 }
 `;
 
+exports[`getCapabilities > should return driver with capabilities for multiremote config 1`] = `
+{
+  "capabilities": {
+    "browserName": "chrome",
+  },
+}
+`;
+
 exports[`getCapabilities > should through capability not found 1`] = `[Error: No capability found in given config file with the provided capability indexed/named property: 5. Please check the capability in your wdio config file.]`;
 
 exports[`getCapabilities > should throw capability not provided 1`] = `[Error: Please provide index/named property of capability to use from the capabilities array/object in wdio config file]`;

--- a/packages/wdio-cli/tests/utils.test.ts
+++ b/packages/wdio-cli/tests/utils.test.ts
@@ -312,6 +312,25 @@ describe('getCapabilities', () => {
             .toMatchSnapshot()
         expect(autoCompileMock).toBeCalledTimes(1)
     })
+
+    it('should return driver with capabilities for multiremote config', async () => {
+        const getCapabilitiesMock = vi.spyOn(ConfigParser.prototype, 'getCapabilities')
+        getCapabilitiesMock.mockReturnValue({
+            myChromeBrowser: {
+                capabilities: {
+                    browserName: 'chrome'
+                }
+            },
+            myFirefoxBrowser: {
+                capabilities: {
+                    browserName: 'firefox'
+                }
+            }
+        } as WebdriverIO.Capabilities)
+
+        expect(await getCapabilities({ option: '/path/to/config.js', capabilities: 'myChromeBrowser' } as any))
+            .toMatchSnapshot()
+    })
 })
 
 afterEach(() => {


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

Running `wdio repl` with multiremote capabilities fails with the following error:

```
No capability found in given config file with the provided capability indexed/named property: foobar.
```

This PR fixes the issue by reading nested capabilities object.

Fixes #14845




## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)





## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)





## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`




## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)




### Reviewers: @webdriverio/project-committers
