### PR TITLE
fix: Allow specFileRetries to be overriden in the beforeSession hook

### DIFF
--- a/packages/wdio-cli/src/launcher.ts
+++ b/packages/wdio-cli/src/launcher.ts
@@ -257,9 +257,10 @@ class Launcher {
         }
 
         /**
-         * avoid retries in watch mode
+         * Avoid retries in watch mode. Otherwise, initialize with -1 which is "unknown". It will be updated when the
+         * worker ends (this allows the value to be read from the config after the beforeSession hook has run).
          */
-        const specFileRetries = this._isWatchMode ? 0 : config.specFileRetries
+        const specFileRetries = this._isWatchMode ? 0 : -1
 
         /**
          * schedule test runs

--- a/packages/wdio-local-runner/src/worker.ts
+++ b/packages/wdio-local-runner/src/worker.ts
@@ -176,6 +176,9 @@ export default class WorkerInstance extends EventEmitter implements Workers.Work
          */
         if (payload.name === 'sessionStarted') {
             this.isSetupResolver(true)
+            if (this.retries === -1 && payload.specFileRetries) {
+                this.retries = payload.specFileRetries - 1
+            }
             if (payload.content.isMultiremote) {
                 Object.assign(this, payload.content)
             } else {

--- a/packages/wdio-runner/src/index.ts
+++ b/packages/wdio-runner/src/index.ts
@@ -61,7 +61,6 @@ export default class Runner extends EventEmitter {
         }
 
         this._config = this._configParser.getConfig()
-        this._specFileRetryAttempts = (this._config.specFileRetries || 0) - (retries || 0)
 
         logger.setLogLevelsConfig(this._config.logLevels, this._config.logLevel)
         if (this._config.maskingPatterns) {
@@ -124,6 +123,7 @@ export default class Runner extends EventEmitter {
 
         const beforeSessionParams: BeforeSessionArgs = [this._config, this._caps, this._specs, this._cid]
         await executeHooksWithArgs('beforeSession', this._config.beforeSession, beforeSessionParams)
+        this._specFileRetryAttempts = (this._config.specFileRetries || 0) - (retries || 0)
 
         this._reporter = new BaseReporter(this._config, this._cid, { ...this._caps })
         await this._reporter.initReporters()
@@ -200,6 +200,7 @@ export default class Runner extends EventEmitter {
         process.send!(<SessionStartedMessage>{
             origin: 'worker',
             name: 'sessionStarted',
+            specFileRetries: this._specFileRetryAttempts,
             content: {
                 automationProtocol, sessionId, isW3C, protocol, hostname, port, path, queryParams, isMultiremote, instances,
                 capabilities: browser.capabilities,

--- a/packages/wdio-types/src/Workers.ts
+++ b/packages/wdio-types/src/Workers.ts
@@ -43,6 +43,7 @@ export interface WorkerEvent {
 
 export interface WorkerMessage {
     name: string
+    specFileRetries?: number
     content: {
         sessionId?: string
         isMultiremote?: boolean


### PR DESCRIPTION
This fixes #14842.

This initializes the launcher's specFileRetries to -1 instead of reading from the config. The worker then reads the value from the config after running the beforeSession hook, and includes the value in the "sessionStarted" message, which is then passed back to the launcher when the worker ends.

