### PR TITLE
Fix for doc block with **

### DIFF
--- a/packages/webdriverio/src/commands/mock/waitForResponse.ts
+++ b/packages/webdriverio/src/commands/mock/waitForResponse.ts
@@ -21,5 +21,3 @@
  * @param {String=}          options.timeoutMsg      custom timeout error message
  */
 // actual implementation is located in packages/webdriverio/src/utils/interception
-
-


### PR DESCRIPTION
## Proposed changes

The **/api/** causes the doc block to fail parsing when releasing. Changing the path to make it work.

```
Error: Build failed with 1 error:
error: [webdriverio] Failed to generate d.ts files: TypeScript compilation failed with code 2
Error: src/commands/mock/waitForResponse.ts(7,45): error TS2304: Cannot find name 'api'.

    at failureErrorWithLog (/home/runner/work/webdriverio/webdriverio/node_modules/.pnpm/esbuild@0.25.6/node_modules/esbuild/lib/main.js:1465:15)
    at /home/runner/work/webdriverio/webdriverio/node_modules/.pnpm/esbuild@0.25.6/node_modules/esbuild/lib/main.js:924:25
    at /home/runner/work/webdriverio/webdriverio/node_modules/.pnpm/esbuild@0.25.6/node_modules/esbuild/lib/main.js:1343:9
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5) {
  errors: [Getter/Setter],
  warnings: [Getter/Setter]
```

## Types of changes

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

### Reviewers: @webdriverio/project-committers
