### PR TITLE
fix(webdriverio): correct withinViewport check logic for isDisplayed …

### DIFF
--- a/packages/webdriverio/src/scripts/isElementClickable.ts
+++ b/packages/webdriverio/src/scripts/isElementClickable.ts
@@ -111,8 +111,8 @@ export default function isElementClickable (elem: HTMLElement) {
         const windowHeight = (window.innerHeight || document.documentElement.clientHeight)
         const windowWidth = (window.innerWidth || document.documentElement.clientWidth)
 
-        const vertInView = (rect.top <= windowHeight) && ((rect.top + rect.height) > 0)
-        const horInView = (rect.left <= windowWidth) && ((rect.left + rect.width) > 0)
+        const vertInView = (rect.top < windowHeight) && ((rect.top + rect.height) > 0)
+        const horInView = (rect.left < windowWidth) && ((rect.left + rect.width) > 0)
 
         return (vertInView && horInView)
     }

--- a/packages/webdriverio/src/scripts/isElementInViewport.ts
+++ b/packages/webdriverio/src/scripts/isElementInViewport.ts
@@ -16,8 +16,8 @@ export default function isElementInViewport (elem: HTMLElement) {
     const windowHeight = (window.innerHeight || document.documentElement.clientHeight)
     const windowWidth = (window.innerWidth || document.documentElement.clientWidth)
 
-    const vertInView = (rect.top <= windowHeight) && ((rect.top + rect.height) > 0)
-    const horInView = (rect.left <= windowWidth) && ((rect.left + rect.width) > 0)
+    const vertInView = (rect.top < windowHeight) && ((rect.top + rect.height) > 0)
+    const horInView = (rect.left < windowWidth) && ((rect.left + rect.width) > 0)
 
     return (vertInView && horInView)
 }

--- a/packages/webdriverio/tests/scripts/isElementInViewport.test.ts
+++ b/packages/webdriverio/tests/scripts/isElementInViewport.test.ts
@@ -105,8 +105,86 @@ describe('isElementInViewport script', () => {
         expect(isElementInViewport(elemMock)).toBe(false)
     })
 
+    it('should return false if element top equals viewport height (boundary condition)', () => {
+        const elemMock = {
+            getBoundingClientRect: () => ({
+                height: 55,
+                width: 22,
+                top: 600,
+                left: 455
+            })
+        } as unknown as HTMLElement
+
+        expect(isElementInViewport(elemMock)).toBe(false)
+    })
+
+    it('should return false if element left equals viewport width (boundary condition)', () => {
+        const elemMock = {
+            getBoundingClientRect: () => ({
+                height: 55,
+                width: 22,
+                top: 33,
+                left: 800
+            })
+        } as unknown as HTMLElement
+
+        expect(isElementInViewport(elemMock)).toBe(false)
+    })
+
+    it('should return true if element is at the edge of viewport (partially visible)', () => {
+        const elemMock = {
+            getBoundingClientRect: () => ({
+                height: 55,
+                width: 22,
+                top: 599,
+                left: 799
+            })
+        } as unknown as HTMLElement
+
+        expect(isElementInViewport(elemMock)).toBe(true)
+    })
+
+    it('should return false for footer far below small viewport (issue #14855)', () => {
+        // Simulate small viewport like in the bug report: 500x200
+        // @ts-ignore
+        global.window.innerWidth = 500
+        // @ts-ignore
+        global.window.innerHeight = 200
+
+        const elemMock = {
+            getBoundingClientRect: () => ({
+                height: 100,
+                width: 500,
+                top: 1000, // Footer is way below viewport
+                left: 0
+            })
+        } as unknown as HTMLElement
+
+        expect(isElementInViewport(elemMock)).toBe(false)
+    })
+
+    it('should return true for header in small viewport (issue #14855)', () => {
+        // Simulate small viewport like in the bug report: 500x200
+        // @ts-ignore
+        global.window.innerWidth = 500
+        // @ts-ignore
+        global.window.innerHeight = 200
+
+        const elemMock = {
+            getBoundingClientRect: () => ({
+                height: 100,
+                width: 500,
+                top: 50, // Header is visible in viewport
+                left: 0
+            })
+        } as unknown as HTMLElement
+
+        expect(isElementInViewport(elemMock)).toBe(true)
+    })
+
     afterAll(() => {
         // @ts-expect-error
         delete global.window
     })
 })
+


### PR DESCRIPTION
…command

fixes #14855

## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

Changed the boundary comparison operators from `<=` to `<`:

**Fixed Logic:**
```typescript
const vertInView = (rect.top < windowHeight) && ((rect.top + rect.height) > 0)
const horInView = (rect.left < windowWidth) && ((rect.left + rect.width) > 0)
```
## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
