### PR TITLE
fix(wdio-cli): respect maxInstancesPerCapability for dynamic capabili…

### DIFF
--- a/__mocks__/@wdio/config.ts
+++ b/__mocks__/@wdio/config.ts
@@ -4,7 +4,7 @@ import {
     validateConfig as validateConfigMock
 } from '../../packages/wdio-config/src/utils.js'
 
-export { DEFAULT_CONFIGS } from '../../packages/wdio-config/src/constants.js'
+export { DEFAULT_CONFIGS, DEFAULT_MAX_INSTANCES_PER_CAPABILITY_VALUE } from '../../packages/wdio-config/src/constants.js'
 export const isCloudCapability = vi.fn().mockImplementation(isCloudCapabilityMock)
 export const validateConfig = vi.fn().mockImplementation((defaults, config) => {
     const returnVal = validateConfigMock(defaults, config)

--- a/packages/wdio-cli/src/launcher.ts
+++ b/packages/wdio-cli/src/launcher.ts
@@ -2,7 +2,7 @@ import exitHook from 'async-exit-hook'
 import { resolve } from 'import-meta-resolve'
 
 import logger from '@wdio/logger'
-import { validateConfig } from '@wdio/config'
+import { validateConfig, DEFAULT_MAX_INSTANCES_PER_CAPABILITY_VALUE } from '@wdio/config'
 import { ConfigParser } from '@wdio/config/node'
 import { initializePlugin, initializeLauncherService, sleep, enableFileLogging } from '@wdio/utils'
 import { setupDriver, setupBrowser } from '@wdio/utils/node'
@@ -168,7 +168,7 @@ class Launcher {
     /**
      * initialize launcher by loading `tsx` if needed
      */
-    async initialize () {
+    async initialize() {
         /**
          * only initialize once
          */
@@ -214,7 +214,7 @@ class Launcher {
      * a user can use plugin service, e.g. shared store service is still
      * available running hooks in this order
      */
-    async #runOnCompleteHook (
+    async #runOnCompleteHook(
         config: Required<WebdriverIO.Config>,
         caps: Capabilities.TestrunnerCapabilities,
         exitCode: number
@@ -286,7 +286,7 @@ class Launcher {
                  */
                 const availableInstances = this.isParallelMultiremote ? config.maxInstances || 1 : config.runner === 'browser'
                     ? 1
-                    : (capabilities as WebdriverIO.Capabilities)['wdio:maxInstances'] || config.maxInstancesPerCapability
+                    : (capabilities as WebdriverIO.Capabilities)['wdio:maxInstances'] || config.maxInstancesPerCapability || DEFAULT_MAX_INSTANCES_PER_CAPABILITY_VALUE
 
                 this._schedule.push({
                     cid: cid++,

--- a/packages/wdio-config/src/constants.ts
+++ b/packages/wdio-config/src/constants.ts
@@ -1,6 +1,7 @@
 import type { Services } from '@wdio/types'
 
 const DEFAULT_TIMEOUT = 10000
+const DEFAULT_MAX_INSTANCES_PER_CAPABILITY = 100
 
 /* istanbul ignore next */
 export const DEFAULT_CONFIGS: () => WebdriverIO.Config = () => ({
@@ -20,7 +21,7 @@ export const DEFAULT_CONFIGS: () => WebdriverIO.Config = () => ({
     reporters: [],
     services: [],
     maxInstances: 100,
-    maxInstancesPerCapability: 100,
+    maxInstancesPerCapability: DEFAULT_MAX_INSTANCES_PER_CAPABILITY,
     injectGlobals: true,
     filesToWatch: [],
     connectionRetryTimeout: 120000,
@@ -86,6 +87,8 @@ export const DEFAULT_CONFIGS: () => WebdriverIO.Config = () => ({
     afterScenario: [],
     afterFeature: []
 })
+
+export const DEFAULT_MAX_INSTANCES_PER_CAPABILITY_VALUE = DEFAULT_MAX_INSTANCES_PER_CAPABILITY
 
 export const SUPPORTED_HOOKS: (keyof Services.Hooks)[] = [
     'before', 'beforeSession', 'beforeSuite', 'beforeHook', 'beforeTest', 'beforeCommand',

--- a/packages/wdio-config/src/index.ts
+++ b/packages/wdio-config/src/index.ts
@@ -1,6 +1,6 @@
 /* istanbul ignore file */
 
-import { DEFAULT_CONFIGS } from './constants.js'
+import { DEFAULT_CONFIGS, DEFAULT_MAX_INSTANCES_PER_CAPABILITY_VALUE } from './constants.js'
 import { defineConfig, validateConfig, isCloudCapability } from './utils.js'
 
 export {
@@ -14,7 +14,8 @@ export {
     /**
      * constants
      */
-    DEFAULT_CONFIGS
+    DEFAULT_CONFIGS,
+    DEFAULT_MAX_INSTANCES_PER_CAPABILITY_VALUE
 }
 
 export * from './types.js'

--- a/packages/webdriver/tests/bidi.test.ts
+++ b/packages/webdriver/tests/bidi.test.ts
@@ -85,8 +85,8 @@ describe('BidiCore', () => {
         it('sends and waits for result', async () => {
             const handler = new BidiCore('ws://foo/bar')
             await handler.connect()
-            const [, cb] = vi.mocked(handler.socket?.on)?.mock.calls[1] || [null, () => {}]
-            cb.call(this as  any)
+            const [, cb] = vi.mocked(handler.socket?.on)?.mock.calls[1] || [null, () => { }]
+            cb.call(this as any)
 
             vi.mocked(handler.socket?.on)?.mockClear()
             const promise = handler.send({ method: 'session.new', params: {} })
@@ -101,8 +101,8 @@ describe('BidiCore', () => {
         it('has a proper error stack that contains the line where the command is called', async () => {
             const handler = new BidiCore('ws://foo/bar')
             await handler.connect()
-            const [, cb] = vi.mocked(handler.socket?.on)?.mock.calls[1] || [null, () => {}]
-            cb.call(this as  any)
+            const [, cb] = vi.mocked(handler.socket?.on)?.mock.calls[1] || [null, () => { }]
+            cb.call(this as any)
 
             const promise = handler.send({ method: 'session.new', params: {} })
             setTimeout(
@@ -116,7 +116,7 @@ describe('BidiCore', () => {
 
             const error = await promise.catch((err) => err)
             const errorMessage = 'WebDriver Bidi command "session.new" failed with error: foobar - I am an error!'
-            expect(error.stack).toContain(path.join('packages', 'webdriver', 'tests', 'bidi.test.ts:108:').slice(1))
+            expect(error.stack).toContain(path.join('packages', 'webdriver', 'tests', 'bidi.test.ts:107:').slice(1))
             expect(error.stack).toContain(errorMessage)
             expect(error.message).toBe(errorMessage)
         })
@@ -149,8 +149,8 @@ describe('BidiCore', () => {
         it('can send without getting an result', async () => {
             const handler = new BidiCore('ws://foo/bar')
             await handler.connect()
-            const [, cb] = vi.mocked(handler.socket?.on)?.mock.calls[1] || [null, () => {}]
-            cb.call(this as  any)
+            const [, cb] = vi.mocked(handler.socket?.on)?.mock.calls[1] || [null, () => { }]
+            cb.call(this as any)
 
             expect(handler.sendAsync({ method: 'session.new', params: {} }))
                 .toEqual(1)


### PR DESCRIPTION
…ties

## Proposed changes
Fixes #14730

When capabilities are dynamically added in the `onPrepare` hook, `maxInstancesPerCapability` was being ignored if not explicitly set in the config. This caused the `availableInstances` to be `undefined`, allowing multiple workers to launch on the same device simultaneously, leading to Appium session crashes.

capabilities['wdio:maxInstances'] || config.maxInstancesPerCapability
If both were undefined, availableInstances became undefined, breaking the worker scheduling logic.
Solution: Added a fallback to the default value (100) by:
    Creating a DEFAULT_MAX_INSTANCES_PER_CAPABILITY constant in wdio-config
    Using it as the final fallback in the availableInstances calculation
    Exporting it for reusability across packages
[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
