### PR TITLE
fix(wdio-cli): resolve double loading of config file in v9.20.1 Fixes…

### DIFF
--- a/packages/wdio-cli/src/commands/run.ts
+++ b/packages/wdio-cli/src/commands/run.ts
@@ -1,12 +1,11 @@
 import fs from 'node:fs/promises'
 import path from 'node:path'
-import { pathToFileURL } from 'node:url'
 
 import type { Argv } from 'yargs'
 
 import Launcher from '../launcher.js'
 import Watcher from '../watcher.js'
-import { coerceOptsFor,  } from '../utils.js'
+import { coerceOptsFor, } from '../utils.js'
 import { CLI_EPILOGUE } from '../constants.js'
 import type { RunCommandArguments } from '../types.js'
 import { config } from 'create-wdio/config/cli'
@@ -246,7 +245,7 @@ export async function handler(argv: RunCommandArguments) {
 
 async function tsConfigPathFromConfigFile(wdioConfPath: string, params: Partial<RunCommandArguments>): Promise<string | void> {
     try {
-        const configParser = new ConfigParser(cacheBustFilePath(wdioConfPath), params)
+        const configParser = new ConfigParser(wdioConfPath, params)
         await configParser.initialize()
         const { tsConfigPath } = configParser.getConfig()
         if (tsConfigPath) {
@@ -257,14 +256,4 @@ async function tsConfigPathFromConfigFile(wdioConfPath: string, params: Partial<
         return
     }
     return
-}
-
-/**
- * Generates a cross-platform cache-busting URL for module imports.
- */
-function cacheBustFilePath(filePath: string) {
-    const absolutePath = path.resolve(filePath)
-    const fileUrl = pathToFileURL(absolutePath)
-    fileUrl.search = `v=${Date.now()}&log_errors=false`
-    return fileUrl.href
 }


### PR DESCRIPTION
… #14890

## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)
wdio run loads the config file twice using two different import paths:

run.ts → tsConfigPathFromConfigFile
Loads the config using a cache-busted path (?v=timestamp).

Launcher
Loads the same config again using the normal file path.

Because the paths differ, Node treats them as two separate modules, so the config is executed twice. Any shared or global logic in the config ends up running twice as well.

Proposed Fix

Remove the cacheBustFilePath usage in tsConfigPathFromConfigFile.
This ensures both run.ts and Launcher import the config using the same path, allowing Node to reuse the cached module instead of loading it again.
## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
