### PR TITLE
fix(cli): correct isParallelMultiremote check for empty capabilities

### DIFF
--- a/packages/wdio-cli/src/launcher.ts
+++ b/packages/wdio-cli/src/launcher.ts
@@ -74,6 +74,7 @@ class Launcher {
 
         const capabilities = this.configParser.getCapabilities()
         this.isParallelMultiremote = Array.isArray(capabilities) &&
+            capabilities.length > 0 &&
             capabilities.every(cap => Object.values(cap).length > 0 && Object.values(cap).every(c => typeof c === 'object' && (c as { capabilities: WebdriverIO.Capabilities }).capabilities))
         this.isMultiremote = this.isParallelMultiremote || !Array.isArray(capabilities)
         validateConfig(TESTRUNNER_DEFAULTS, { ...config, capabilities })

--- a/packages/wdio-cli/tests/launcher.test.ts
+++ b/packages/wdio-cli/tests/launcher.test.ts
@@ -210,6 +210,36 @@ describe('launcher', () => {
             expect(launcher['_schedule'][0].availableInstances).toBe(11)
             expect(launcher['_schedule'][1].availableInstances).toBe(22)
         })
+
+        it('should apply default maxInstancesPerCapability for dynamically added capabilities without wdio:maxInstances', () => {
+            launcher['_runSpecs'] = vi.fn()
+            launcher['_runMode'](
+                { specs: ['./'], specFileRetries: 2 } as any,
+                [
+                    { browserName: 'chrome', platformName: 'Android' },
+                    { browserName: 'chrome', platformName: 'iOS' }
+                ]
+            )
+
+            expect(launcher['_schedule']).toHaveLength(2)
+            expect(launcher['_schedule'][0].availableInstances).toBe(100)
+            expect(launcher['_schedule'][1].availableInstances).toBe(100)
+        })
+
+        it('should apply config maxInstancesPerCapability for dynamically added capabilities', () => {
+            launcher['_runSpecs'] = vi.fn()
+            launcher['_runMode'](
+                { specs: ['./'], maxInstancesPerCapability: 2 } as any,
+                [
+                    { browserName: 'chrome', platformName: 'Android' },
+                    { browserName: 'chrome', platformName: 'iOS' }
+                ]
+            )
+
+            expect(launcher['_schedule']).toHaveLength(2)
+            expect(launcher['_schedule'][0].availableInstances).toBe(2)
+            expect(launcher['_schedule'][1].availableInstances).toBe(2)
+        })
     })
 
     describe('hasTriggeredExitRoutine', () => {
@@ -322,8 +352,10 @@ describe('launcher', () => {
     describe('exitHandler', () => {
         it('should do nothing if no callback is given', () => {
             launcher['_hasTriggeredExitRoutine'] = false
-            launcher.runner = { shutdown: vi.fn()
-                .mockReturnValue(Promise.resolve()) } as any
+            launcher.runner = {
+                shutdown: vi.fn()
+                    .mockReturnValue(Promise.resolve())
+            } as any
 
             launcher['_exitHandler']()
 
@@ -394,9 +426,11 @@ describe('launcher', () => {
             ]
             // Mock the return value of getSpecs so we are not doing cross
             // module testing
-            launcher.configParser = { getSpecs: vi.fn().mockReturnValue(
-                ['/a.js', ['/b.js', '/c.js', '/d.js'], '/e.js']
-            ) } as any
+            launcher.configParser = {
+                getSpecs: vi.fn().mockReturnValue(
+                    ['/a.js', ['/b.js', '/c.js', '/d.js'], '/e.js']
+                )
+            } as any
             expect(launcher['_formatSpecs'](capabilities as any, specFileRetries)).toStrictEqual(expected)
         })
     })
@@ -407,18 +441,22 @@ describe('launcher', () => {
         })
 
         it('should not start running anything if exit routine is triggered', () => {
-            launcher.configParser = { getConfig: vi.fn().mockReturnValue({
-                maxInstances: 100
-            }) } as any
+            launcher.configParser = {
+                getConfig: vi.fn().mockReturnValue({
+                    maxInstances: 100
+                })
+            } as any
             launcher['_hasTriggeredExitRoutine'] = true
             expect(launcher['_runSpecs']()).toBe(true)
             expect(launcher['_startInstance']).toBeCalledTimes(0)
         })
 
         it('should run all specs', () => {
-            launcher.configParser = { getConfig: vi.fn().mockReturnValue({
-                maxInstances: 100
-            }) } as any
+            launcher.configParser = {
+                getConfig: vi.fn().mockReturnValue({
+                    maxInstances: 100
+                })
+            } as any
             launcher['_schedule'] = [{
                 cid: 0,
                 caps: { browserName: 'chrome' },
@@ -453,9 +491,11 @@ describe('launcher', () => {
         })
 
         it('should run arrayed specs in a single instance', () => {
-            launcher.configParser = { getConfig: vi.fn().mockReturnValue({
-                maxInstances: 100
-            }) } as any
+            launcher.configParser = {
+                getConfig: vi.fn().mockReturnValue({
+                    maxInstances: 100
+                })
+            } as any
             launcher['_schedule'] = [{
                 cid: 0,
                 caps: { browserName: 'chrome' },
@@ -491,10 +531,12 @@ describe('launcher', () => {
 
         it('should not run anything if runner failed', () => {
             launcher['_runnerFailed'] = 2
-            launcher.configParser = { getConfig: vi.fn().mockReturnValue({
-                maxInstances: 100,
-                bail: 1
-            }) } as any
+            launcher.configParser = {
+                getConfig: vi.fn().mockReturnValue({
+                    maxInstances: 100,
+                    bail: 1
+                })
+            } as any
             launcher['_schedule'] = [{
                 cid: 0,
                 caps: { browserName: 'chrome' },
@@ -523,9 +565,11 @@ describe('launcher', () => {
         })
 
         it('should run as much as maxInstances allows', () => {
-            launcher.configParser = { getConfig: vi.fn().mockReturnValue({
-                maxInstances: 5
-            }) } as any
+            launcher.configParser = {
+                getConfig: vi.fn().mockReturnValue({
+                    maxInstances: 5
+                })
+            } as any
             launcher['_schedule'] = [{
                 cid: 0,
                 caps: { browserName: 'chrome' },
@@ -554,9 +598,11 @@ describe('launcher', () => {
         })
 
         it('should not allow to schedule more runner if no instances are available', () => {
-            launcher.configParser = { getConfig: vi.fn().mockReturnValue({
-                maxInstances: 100
-            }) } as any
+            launcher.configParser = {
+                getConfig: vi.fn().mockReturnValue({
+                    maxInstances: 100
+                })
+            } as any
             launcher['_schedule'] = [{
                 cid: 0,
                 caps: { browserName: 'chrome' },
@@ -591,9 +637,11 @@ describe('launcher', () => {
         })
 
         it('should not run if all specs were executed', () => {
-            launcher.configParser = { getConfig: vi.fn().mockReturnValue({
-                maxInstances: 100
-            }) } as any
+            launcher.configParser = {
+                getConfig: vi.fn().mockReturnValue({
+                    maxInstances: 100
+                })
+            } as any
             launcher['_schedule'] = [{
                 cid: 0,
                 caps: { browserName: 'chrome' },
@@ -661,7 +709,7 @@ describe('launcher', () => {
                     args: `--inspect=${hostname}:50000`,
                 }
             })
-            const onWorkerStartMock = vi.fn().mockImplementation((_runnerId, caps)=>{
+            const onWorkerStartMock = vi.fn().mockImplementation((_runnerId, caps) => {
                 caps['goog:chromeOptions'] = {
                     args: `--inspect=${hostname}:50000`
                 }
@@ -696,11 +744,13 @@ describe('launcher', () => {
             const caps = {
                 browserName: 'chrome'
             }
-            launcher.configParser = { getConfig: vi.fn().mockReturnValue({
-                onWorkerStart: onWorkerStartMock,
-                specFileRetries: 2,
-                specFileRetriesDelay: 0.01
-            }) } as any
+            launcher.configParser = {
+                getConfig: vi.fn().mockReturnValue({
+                    onWorkerStart: onWorkerStartMock,
+                    specFileRetries: 2,
+                    specFileRetriesDelay: 0.01
+                })
+            } as any
             launcher['_args'].hostname = '127.0.0.3'
 
             await launcher['_startInstance'](
@@ -728,11 +778,13 @@ describe('launcher', () => {
             const caps = {
                 browserName: 'chrome'
             }
-            launcher.configParser = { getConfig: vi.fn().mockReturnValue({
-                onWorkerStart: onWorkerStartMock,
-                specFileRetries: 4,
-                specFileRetriesDelay: 0.01
-            }) } as any
+            launcher.configParser = {
+                getConfig: vi.fn().mockReturnValue({
+                    onWorkerStart: onWorkerStartMock,
+                    specFileRetries: 4,
+                    specFileRetriesDelay: 0.01
+                })
+            } as any
             launcher['_args'].hostname = '127.0.0.4'
 
             await launcher['_startInstance'](


### PR DESCRIPTION
## Proposed changes
fixes #14730 
[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)
If the capabilities object is empty (like in the repro), the launcher mistakenly thinks it's a “parallel multiremote” run. Because of that, it ignores my new logic and falls back to using the global maxInstances instead.
I fixed it by checking that the array actually has items in it before running that check. Added a test case for this specific scenario so it doesn't slip through again.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
