### PR TITLE
chore: update GitHub Actions macOS runner from 13 to 15

### DIFF
--- a/.github/workflows/test-launch.yml
+++ b/.github/workflows/test-launch.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-latest', 'windows-latest', 'macos-13']
+        os: ['ubuntu-latest', 'windows-latest', 'macos-15']
     runs-on: ${{ matrix.os }}
     steps:
       - name: ⬇️ Checkout Code

--- a/.github/workflows/test-multiremote.yml
+++ b/.github/workflows/test-multiremote.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['windows-latest', 'macos-13']
+        os: ['windows-latest', 'macos-15']
     runs-on: ${{ matrix.os }}
     steps:
       - name: ⬇️ Checkout Code

--- a/.github/workflows/test-standalone.yml
+++ b/.github/workflows/test-standalone.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['windows-latest', 'macos-13']
+        os: ['windows-latest', 'macos-15']
     runs-on: ${{ matrix.os }}
     steps:
       - name: ⬇️ Checkout Code

--- a/.github/workflows/test-testrunner.yml
+++ b/.github/workflows/test-testrunner.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['windows-latest', 'macos-13']
+        os: ['windows-latest', 'macos-15']
     runs-on: ${{ matrix.os }}
     steps:
       - name: ⬇️ Checkout Code


### PR DESCRIPTION
## Proposed changes
Updated GitHub Actions workflow files to use `macos-15` runner instead of the deprecated `macos-13` runner. GitHub has deprecated macOS 13 (Ventura) based runner images, and this change ensures our CI workflows continue to run on supported infrastructure.
[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)
UPGRADED MA
## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [x] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
