### PR TITLE
fix: handle multiple webviews with same package when first is empty (…

### DIFF
--- a/packages/webdriverio/src/commands/mobile/getContexts.ts
+++ b/packages/webdriverio/src/commands/mobile/getContexts.ts
@@ -404,13 +404,15 @@ async function getCurrentContexts({
             packageName,
         })
         // 3. Check if there is a webview that belongs to the app we are testing
-        const androidContext = parsedContexts.find((context) => context.packageName === packageName)
+        const matchingContexts = parsedContexts.filter((context) => context.packageName === packageName)
         // 4. There are cases that no packageName is returned, so we need to check for that
-        isPackageNameMissing = !androidContext?.packageName
+        isPackageNameMissing = matchingContexts.length === 0
         // 5. There are also cases that the androidWebviewData is not returned, so we need to check for that
-        const isAndroidWebviewDataMissing = androidContext && !('androidWebviewData' in androidContext)
+        const hasAndroidWebviewData = matchingContexts.some((context) => Boolean(context.androidWebviewData))
+        const isAndroidWebviewDataMissing = matchingContexts.length > 0 && !hasAndroidWebviewData
         // 6. There are also cases that the androidWebviewData is returned, but the empty property is not returned, so we need to check for that
-        const isAndroidWebviewDataEmpty = androidContext && androidContext.androidWebviewData?.empty
+        const hasNonEmptyAndroidWebviewData = matchingContexts.some((context) => context.androidWebviewData && !context.androidWebviewData.empty)
+        const isAndroidWebviewDataEmpty = matchingContexts.length > 0 && hasAndroidWebviewData && !hasNonEmptyAndroidWebviewData
 
         // If the current app is Chrome we can't wait for the webview to contain pages by checking the androidWebviewData because it will always be empty
         if (packageName === CHROME_PACKAGE_NAME) {

--- a/packages/webdriverio/tests/commands/mobile/getContexts.test.ts
+++ b/packages/webdriverio/tests/commands/mobile/getContexts.test.ts
@@ -434,4 +434,80 @@ describe('getContexts test', () => {
         expect(executeSpy).toHaveBeenCalledTimes(1)
         expect(currentPackageSpy).toHaveBeenCalledTimes(1)
     })
+
+    it('should handle multiple webview pages with same package when first is empty (issue #14755)', async () => {
+        browser = await remote({
+            baseUrl: 'http://foobar.com',
+            capabilities: {
+                browserName: 'foobar',
+                mobileMode: true,
+                platformName: 'Android',
+            } as any
+        })
+
+        const espressoLikeContexts = [
+            {
+                proc: '@webview_devtools_remote_6858',
+                webview: 'WEBVIEW_6858',
+                info: {
+                    'Android-Package': 'com.ismobile.android.blaandroid',
+                    Browser: 'Chrome/124.0.6367.219',
+                    'Protocol-Version': '1.3',
+                    'User-Agent': 'Mozilla/5.0 (Linux; Android 15; sdk_gphone64_arm64 Build/AE3A.240806.043; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/124.0.6367.219 Mobile Safari/537.36',
+                    'V8-Version': '12.4.254.16',
+                    'WebKit-Version': '537.36 (@7741f71cbce3b7dfe3eb5890976d2596364b0733)',
+                    webSocketDebuggerUrl: 'ws://127.0.0.1:10900/devtools/browser'
+                },
+                pages: [
+                    {
+                        description: '{"attached":false,"empty":true,"height":0,"never_attached":true,"screenX":0,"screenY":0,"visible":true,"width":0}',
+                        devtoolsFrontendUrl: 'https://chrome-devtools-frontend.appspot.com/serve_internal_file/@7741f71cbce3b7dfe3eb5890976d2596364b0733/inspector.html?ws=127.0.0.1:10900/devtools/page/B4EF628032DA04BF5D2854F1B8CA7A37',
+                        id: 'B4EF628032DA04BF5D2854F1B8CA7A37',
+                        title: 'about:blank',
+                        type: 'page',
+                        url: 'about:blank',
+                        webSocketDebuggerUrl: 'ws://127.0.0.1:10900/devtools/page/B4EF628032DA04BF5D2854F1B8CA7A37'
+                    },
+                    {
+                        description: '{"attached":true,"empty":false,"height":1984,"never_attached":false,"screenX":0,"screenY":290,"visible":true,"width":1080}',
+                        devtoolsFrontendUrl: 'https://chrome-devtools-frontend.appspot.com/serve_internal_file/@7741f71cbce3b7dfe3eb5890976d2596364b0733/inspector.html?ws=127.0.0.1:10900/devtools/page/B6745CF76C090CEC213E4A2A2B21D228',
+                        faviconUrl: 'http://127.0.0.1:14532/images/icons/bla.ico',
+                        id: 'B6745CF76C090CEC213E4A2A2B21D228',
+                        title: 'Översikt',
+                        type: 'page',
+                        url: 'http://127.0.0.1:14532/Micro?sub=showsummary',
+                        webSocketDebuggerUrl: 'ws://127.0.0.1:10900/devtools/page/B6745CF76C090CEC213E4A2A2B21D228'
+                    }
+                ],
+                webviewName: 'WEBVIEW_com.ismobile.android.blaandroid'
+            }
+        ]
+
+        vi.spyOn(browser, 'execute').mockResolvedValue(espressoLikeContexts as any)
+        vi.spyOn(browser, 'getCurrentPackage').mockResolvedValue('com.ismobile.android.blaandroid')
+
+        const contexts = await browser.getContexts({
+            androidWebviewConnectTimeout: 50,
+            androidWebviewConnectionRetryTime: 1,
+            isAndroidWebviewVisible: false,
+            returnAndroidDescriptionData: true,
+            returnDetailedContexts: true,
+        }) as any
+
+        expect(contexts.some((c: any) => c.id === 'NATIVE_APP')).toBe(true)
+
+        const validContext = contexts.find((c: any) => c.url === 'http://127.0.0.1:14532/Micro?sub=showsummary')
+        expect(validContext).toBeDefined()
+        expect(validContext).toMatchObject({
+            id: 'WEBVIEW_com.ismobile.android.blaandroid',
+            title: 'Översikt',
+            packageName: 'com.ismobile.android.blaandroid',
+            webviewPageId: 'B6745CF76C090CEC213E4A2A2B21D228'
+        })
+
+        const emptyContext = contexts.find((c: any) => c.url === 'about:blank')
+        if (emptyContext) {
+            expect(emptyContext.packageName).toBe('com.ismobile.android.blaandroid')
+        }
+    })
 })


### PR DESCRIPTION
fixes #14755

## Proposed changes
Updated the Android readiness checks in getCurrentContexts to evaluate all matching contexts for the current package and proceed once any non-empty webview page is available. Added a regression test that reproduces the Espresso multi-webview scenario.
[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

the previous implementation only checked the first match which could be an empty  page. The updated logic avoids false negative timeouts by requiring that at least one matching webview page has non-empty andriodwebviewdata

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
