### PR TITLE
fix(webdriverio): fix wildcard support in browser.mock

### DIFF
--- a/e2e/wdio/headless/mocking.e2e.ts
+++ b/e2e/wdio/headless/mocking.e2e.ts
@@ -1,6 +1,10 @@
 import { browser } from '@wdio/globals'
 
 describe('network mocking', () => {
+    afterEach(async () => {
+        await browser.mockRestoreAll()
+    })
+
     it('marks a request as mocked even without overwrites', async () => {
         const baseUrl = 'https://guinea-pig.webdriver.io/'
         const mock = await browser.mock('https://cdn.jsdelivr.net/npm/hammerjs@1.1.3/hammer.min.js', {
@@ -11,6 +15,110 @@ describe('network mocking', () => {
         await browser.waitUntil(() => mock.calls.length === 1, {
             timeoutMsg: 'Expected mock to be made',
             timeout: 2000
+        })
+    })
+
+    it('should mock with wildcard (*) pattern', async () => {
+        const baseUrl = 'https://guinea-pig.webdriver.io/'
+        const mock = await browser.mock('https://cdn.jsdelivr.net/npm/jquery@3.6.0/*', {
+            method: 'get',
+            statusCode: 200,
+        })
+        await browser.url(baseUrl)
+        await browser.execute(() => {
+            const script = document.createElement('script')
+            script.src = 'https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js'
+            document.body.appendChild(script)
+        })
+        await browser.waitUntil(() => mock.calls.length >= 1, {
+            timeoutMsg: 'Expected wildcard mock to be called',
+            timeout: 5000
+        })
+    })
+
+    it('should mock with double wildcard (**) pattern', async () => {
+        const mock = await browser.mock('https://cdn.jsdelivr.net/npm/vue@2.6.14/**', {
+            method: 'get',
+            statusCode: 200,
+        })
+        await browser.url('https://guinea-pig.webdriver.io/')
+        await browser.execute(() => {
+            const script = document.createElement('script')
+            script.src = 'https://cdn.jsdelivr.net/npm/vue@2.6.14/dist/vue.min.js'
+            document.body.appendChild(script)
+        })
+        await browser.waitUntil(() => mock.calls.length >= 1, {
+            timeoutMsg: 'Expected double wildcard mock to be called',
+            timeout: 5000
+        })
+    })
+
+    it('should mock with wildcard in middle of path', async () => {
+        const mock = await browser.mock('https://cdn.jsdelivr.net/npm/react@17.0.2/*/react.production.min.js', {
+            method: 'get',
+            statusCode: 200,
+        })
+        await browser.url('https://guinea-pig.webdriver.io/')
+        await browser.execute(() => {
+            const script = document.createElement('script')
+            script.src = 'https://cdn.jsdelivr.net/npm/react@17.0.2/umd/react.production.min.js'
+            document.body.appendChild(script)
+        })
+        await browser.waitUntil(() => mock.calls.length >= 1, {
+            timeoutMsg: 'Expected middle wildcard mock to be called',
+            timeout: 5000
+        })
+    })
+
+    it('should mock with hostname wildcard', async () => {
+        const mock = await browser.mock('https://*.jsdelivr.net/npm/lodash@4.17.21/lodash.min.js', {
+            method: 'get',
+            statusCode: 200,
+        })
+        await browser.url('https://guinea-pig.webdriver.io/')
+        await browser.execute(() => {
+            const script = document.createElement('script')
+            script.src = 'https://cdn.jsdelivr.net/npm/lodash@4.17.21/lodash.min.js'
+            document.body.appendChild(script)
+        })
+        await browser.waitUntil(() => mock.calls.length >= 1, {
+            timeoutMsg: 'Expected hostname wildcard mock to be called',
+            timeout: 5000
+        })
+    })
+
+    it('should mock with file extension wildcard', async () => {
+        const mock = await browser.mock('https://cdn.jsdelivr.net/npm/moment@2.29.1/moment.min.*', {
+            method: 'get',
+            statusCode: 200,
+        })
+        await browser.url('https://guinea-pig.webdriver.io/')
+        await browser.execute(() => {
+            const script = document.createElement('script')
+            script.src = 'https://cdn.jsdelivr.net/npm/moment@2.29.1/moment.min.js'
+            document.body.appendChild(script)
+        })
+        await browser.waitUntil(() => mock.calls.length >= 1, {
+            timeoutMsg: 'Expected extension wildcard mock to be called',
+            timeout: 5000
+        })
+    })
+
+    it('should mock with complex mixed wildcards', async () => {
+        // Matches https://cdn.jsdelivr.net/.../bootstrap.min.js
+        const mock = await browser.mock('https://*.jsdelivr.net/**/bootstrap.min.js', {
+            method: 'get',
+            statusCode: 200,
+        })
+        await browser.url('https://guinea-pig.webdriver.io/')
+        await browser.execute(() => {
+            const script = document.createElement('script')
+            script.src = 'https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.min.js'
+            document.body.appendChild(script)
+        })
+        await browser.waitUntil(() => mock.calls.length >= 1, {
+            timeoutMsg: 'Expected complex wildcard mock to be called',
+            timeout: 5000
         })
     })
 })

--- a/packages/webdriverio/src/utils/interception/utils.ts
+++ b/packages/webdriverio/src/utils/interception/utils.ts
@@ -59,7 +59,7 @@ export function parseOverwrite<
         const statusCodeOverwrite = typeof overwrite.statusCode === 'function'
             ? overwrite.statusCode(request as local.NetworkResponseCompletedParameters)
             : overwrite.statusCode
-        ;(result as RespondWithOptions).statusCode = statusCodeOverwrite
+            ; (result as RespondWithOptions).statusCode = statusCodeOverwrite
     }
 
     if ('method' in overwrite) {
@@ -77,8 +77,9 @@ export function parseOverwrite<
     return result
 }
 
-export function getPatternParam (pattern: URLPattern, key: keyof Omit<remote.NetworkUrlPatternPattern, 'type'>) {
-    if (pattern[key] === '*') {
+export function getPatternParam(pattern: URLPattern, key: keyof Omit<remote.NetworkUrlPatternPattern, 'type'>) {
+    const value = pattern[key]
+    if (value === '*' || value.includes('*')) {
         return
     }
 
@@ -86,5 +87,5 @@ export function getPatternParam (pattern: URLPattern, key: keyof Omit<remote.Net
         return pattern.protocol === 'https' ? '443' : '80'
     }
 
-    return pattern[key].replaceAll('*', '\\*')
+    return value
 }


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)
FIXES #14811 
This PR fixes a critical issue where using wildcard patterns (*,**) in \`browser.mock()\` would fail with a "Forbidden characters" error when running with WebDriver Bidi. 

This is extension to the PR https://github.com/webdriverio/webdriverio/pull/14817
## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments
This implementation ensures that `browser.mock` works intuitively with all standard  `URLPattern` wildcard syntaxes while remaining compatible with the strict constraints of the WebDriver Bidi protocol.
[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
