### PR TITLE
fix(shared-store): use 127.0.0.1 instead of localhost (#14761)

### DIFF
--- a/packages/wdio-shared-store-service/src/client.ts
+++ b/packages/wdio-shared-store-service/src/client.ts
@@ -17,7 +17,7 @@ export const setPort = (port: number) => {
      * set as the launcher is called after user hooks. In this case we need
      * to wait until it is set and flush all messages.
      */
-    baseUrlResolve(`http://localhost:${port}`)
+    baseUrlResolve(`http://127.0.0.1:${port}`)
     isBaseUrlReady = true
 }
 

--- a/packages/wdio-shared-store-service/src/server.ts
+++ b/packages/wdio-shared-store-service/src/server.ts
@@ -112,7 +112,7 @@ export const startServer = () => new Promise<{ port: number, app: PolkaInstance 
      * > an arbitrary unused port, which can be retrieved by using `server.address().port`
      * https://nodejs.org/api/net.html#net_server_listen_port_host_backlog_callback
      */
-    app.listen(0, (err: Error) => {
+    app.listen(0, '127.0.0.1', (err: Error) => {
         /* istanbul ignore next */
         if (err) {
             return reject(err)

--- a/packages/wdio-shared-store-service/tests/client.test.ts
+++ b/packages/wdio-shared-store-service/tests/client.test.ts
@@ -21,7 +21,7 @@ vi.spyOn(global, 'fetch').mockImplementation((URL: string | URL | globalThis.Req
 })
 
 const port = 3000
-const baseUrl = `http://localhost:${port}`
+const baseUrl = `http://127.0.0.1:${port}`
 const headers = {
     'Content-Type': 'application/json'
 }


### PR DESCRIPTION
## Proposed changes
Fixes #14761 – Windows Shared Store Service getValue() exception
On Windows Enterprise, localhost can resolve to IPv6 (::1) while the Shared Store server binds only to IPv4. This leads to Not Found errors when calling browser.sharedStore.get() in the beforeSuite hook.

This PR resolves the issue by explicitly using the IPv4 loopback address (127.0.0.1) instead of localhost, ensuring consistent behavior across platforms and Windows configurations.

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
