### PR TITLE
fix(wdio-local-runner): use gracefulExit to avoid synchronous termina…

### DIFF
--- a/packages/wdio-local-runner/src/run.ts
+++ b/packages/wdio-local-runner/src/run.ts
@@ -51,7 +51,7 @@ process.on('message', (m: Workers.WorkerCommand) => {
         }),
         (e: Error) => {
             log.error(`Failed launching test session: ${e.stack}`)
-            setTimeout(() => process.exit(1), 10)
+            setTimeout(() => gracefulExit(1), 10)
         }
     )
 })

--- a/packages/wdio-local-runner/tests/run.test.ts
+++ b/packages/wdio-local-runner/tests/run.test.ts
@@ -83,7 +83,7 @@ test('should exit process if failing to execute', async () => {
     })
     expect((await instances[0]).errorMe).toHaveBeenCalledTimes(1)
     await sleep()
-    expect(process.exit).toBeCalledWith(1)
+    expect(gracefulExitMock).toBeCalledWith(1)
 
 })
 


### PR DESCRIPTION
…tion notice

## Proposed changes
This PR replaces `process.exit(1)` with `gracefulExit(1)` in the `wdio-local-runner` package.
fixes #14647 
[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
