### PR TITLE
fix(session): eliminate memory leak in session managers

### DIFF
--- a/packages/webdriverio/src/session/dialog.ts
+++ b/packages/webdriverio/src/session/dialog.ts
@@ -16,6 +16,8 @@ export class DialogManager extends SessionManager {
     #initialize: Promise<boolean>
     #autoHandleDialog = true
 
+    #handleUserPromptListener = this.#handleUserPrompt.bind(this)
+
     constructor(browser: WebdriverIO.Browser) {
         super(browser, DialogManager.name)
         this.#browser = browser
@@ -38,12 +40,12 @@ export class DialogManager extends SessionManager {
         this.#browser.on('_dialogListenerRegistered', () => this.#switchListenerFlag(false))
         // @ts-ignore this is a private event
         this.#browser.on('_dialogListenerRemoved', () => this.#switchListenerFlag(true))
-        this.#browser.on('browsingContext.userPromptOpened', this.#handleUserPrompt.bind(this))
+        this.#browser.on('browsingContext.userPromptOpened', this.#handleUserPromptListener)
     }
 
     removeListeners(): void {
         super.removeListeners()
-        this.#browser.off('browsingContext.userPromptOpened', this.#handleUserPrompt.bind(this))
+        this.#browser.off('browsingContext.userPromptOpened', this.#handleUserPromptListener)
         this.#browser.removeAllListeners('_dialogListenerRegistered')
         this.#browser.removeAllListeners('_dialogListenerRemoved')
     }

--- a/packages/webdriverio/src/session/networkManager.ts
+++ b/packages/webdriverio/src/session/networkManager.ts
@@ -20,6 +20,11 @@ export class NetworkManager extends SessionManager {
     #requests = new Map<Context, WebdriverIO.Request>()
     #lastNetworkId?: string
 
+    #navigationStartedListener = this.#navigationStarted.bind(this)
+    #responseCompletedListener = this.#responseCompleted.bind(this)
+    #beforeRequestSentListener = this.#beforeRequestSent.bind(this)
+    #fetchErrorListener = this.#fetchError.bind(this)
+
     constructor(browser: WebdriverIO.Browser) {
         super(browser, NetworkManager.name)
         this.#browser = browser
@@ -44,20 +49,20 @@ export class NetworkManager extends SessionManager {
                 'network.fetchError'
             ]
         }).then(() => true, () => false)
-        this.#browser.on('browsingContext.navigationStarted', this.#navigationStarted.bind(this))
-        this.#browser.on('browsingContext.fragmentNavigated', this.#navigationStarted.bind(this))
-        this.#browser.on('network.responseCompleted', this.#responseCompleted.bind(this))
-        this.#browser.on('network.beforeRequestSent', this.#beforeRequestSent.bind(this))
-        this.#browser.on('network.fetchError', this.#fetchError.bind(this))
+        this.#browser.on('browsingContext.navigationStarted', this.#navigationStartedListener)
+        this.#browser.on('browsingContext.fragmentNavigated', this.#navigationStartedListener)
+        this.#browser.on('network.responseCompleted', this.#responseCompletedListener)
+        this.#browser.on('network.beforeRequestSent', this.#beforeRequestSentListener)
+        this.#browser.on('network.fetchError', this.#fetchErrorListener)
     }
 
     removeListeners(): void {
         super.removeListeners()
-        this.#browser.off('browsingContext.navigationStarted', this.#navigationStarted.bind(this))
-        this.#browser.off('browsingContext.fragmentNavigated', this.#navigationStarted.bind(this))
-        this.#browser.off('network.responseCompleted', this.#responseCompleted.bind(this))
-        this.#browser.off('network.beforeRequestSent', this.#beforeRequestSent.bind(this))
-        this.#browser.off('network.fetchError', this.#fetchError.bind(this))
+        this.#browser.off('browsingContext.navigationStarted', this.#navigationStartedListener)
+        this.#browser.off('browsingContext.fragmentNavigated', this.#navigationStartedListener)
+        this.#browser.off('network.responseCompleted', this.#responseCompletedListener)
+        this.#browser.off('network.beforeRequestSent', this.#beforeRequestSentListener)
+        this.#browser.off('network.fetchError', this.#fetchErrorListener)
     }
 
     async initialize () {

--- a/packages/webdriverio/src/session/polyfill.ts
+++ b/packages/webdriverio/src/session/polyfill.ts
@@ -19,6 +19,8 @@ export class PolyfillManager extends SessionManager {
     #browser: WebdriverIO.Browser
     #scriptsRegisteredInContexts: Set<string> = new Set()
 
+    #registerScriptsListener = this.#registerScripts.bind(this)
+
     constructor(browser: WebdriverIO.Browser) {
         super(browser, PolyfillManager.name)
         this.#browser = browser
@@ -32,7 +34,7 @@ export class PolyfillManager extends SessionManager {
         }
 
         // start listening for browsingContext.contextCreated
-        this.#browser.on('browsingContext.contextCreated', this.#registerScripts.bind(this))
+        this.#browser.on('browsingContext.contextCreated', this.#registerScriptsListener)
 
         /**
          * apply polyfill script for upcoming as well as current execution context
@@ -50,7 +52,7 @@ export class PolyfillManager extends SessionManager {
     removeListeners() {
         super.removeListeners()
         // stop listening for browsingContext.contextCreated
-        this.#browser.off('browsingContext.contextCreated', this.#registerScripts.bind(this))
+        this.#browser.off('browsingContext.contextCreated', this.#registerScriptsListener)
     }
 
     #registerScripts (context: Pick<local.BrowsingContextInfo, 'context' | 'parent'>) {

--- a/packages/webdriverio/src/session/session.ts
+++ b/packages/webdriverio/src/session/session.ts
@@ -20,10 +20,12 @@ export class SessionManager {
         this.#scope = scope
         const registrationId = `${this.#browser.sessionId}-${this.#scope}`
         if (!listenerRegisteredSession.has(registrationId)) {
-            this.#browser.on('command', this.#onCommand.bind(this))
+            this.#browser.on('command', this.#onCommandListener)
             listenerRegisteredSession.add(registrationId)
         }
     }
+
+    #onCommandListener = this.#onCommand.bind(this)
 
     #onCommand(ev: { command: string }) {
         if (ev.command === 'deleteSession') {
@@ -37,7 +39,7 @@ export class SessionManager {
     }
 
     removeListeners() {
-        this.#browser.off('command', this.#onCommand.bind(this))
+        this.#browser.off('command', this.#onCommandListener)
     }
 
     initialize(): unknown {

--- a/packages/webdriverio/src/session/shadowRoot.ts
+++ b/packages/webdriverio/src/session/shadowRoot.ts
@@ -24,6 +24,10 @@ export class ShadowRootManager extends SessionManager {
     #documentElement?: remote.ScriptNodeRemoteValue
     #frameDepth = 0
 
+    #handleLogEntryListener = this.handleLogEntry.bind(this)
+    #commandResultHandlerListener = this.#commandResultHandler.bind(this)
+    #handleBidiCommandListener = this.#handleBidiCommand.bind(this)
+
     constructor(browser: WebdriverIO.Browser) {
         super(browser, ShadowRootManager.name)
         this.#browser = browser
@@ -42,9 +46,9 @@ export class ShadowRootManager extends SessionManager {
         this.#initialize = this.#browser.sessionSubscribe({
             events: ['log.entryAdded', 'browsingContext.navigationStarted']
         }).then(() => true, () => false)
-        this.#browser.on('log.entryAdded', this.handleLogEntry.bind(this))
-        this.#browser.on('result', this.#commandResultHandler.bind(this))
-        this.#browser.on('bidiCommand', this.#handleBidiCommand.bind(this))
+        this.#browser.on('log.entryAdded', this.#handleLogEntryListener)
+        this.#browser.on('result', this.#commandResultHandlerListener)
+        this.#browser.on('bidiCommand', this.#handleBidiCommandListener)
         this.#browser.scriptAddPreloadScript({
             functionDeclaration: customElementWrapper.toString()
         })
@@ -52,9 +56,9 @@ export class ShadowRootManager extends SessionManager {
 
     removeListeners(): void {
         super.removeListeners()
-        this.#browser.off('log.entryAdded', this.handleLogEntry.bind(this))
-        this.#browser.off('result', this.#commandResultHandler.bind(this))
-        this.#browser.off('bidiCommand', this.#handleBidiCommand.bind(this))
+        this.#browser.off('log.entryAdded', this.#handleLogEntryListener)
+        this.#browser.off('result', this.#commandResultHandlerListener)
+        this.#browser.off('bidiCommand', this.#handleBidiCommandListener)
     }
 
     async initialize () {

--- a/packages/webdriverio/tests/session/session.test.ts
+++ b/packages/webdriverio/tests/session/session.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { SessionManager } from '../../src/session/session.js'
+import { ContextManager } from '../../src/session/context.js'
 
 describe('SessionManager', () => {
     const browser ={
@@ -22,5 +23,53 @@ describe('SessionManager', () => {
         new SessionManager(browser, 'dummy')
         new SessionManager(browser, 'dummy')
         expect(browser.on).toHaveBeenCalledTimes(1)
+    })
+
+    it('should allow to remove event listeners', () => {
+        const browser = {
+            on: vi.fn(),
+            off: vi.fn(),
+            sessionId: '1234'
+        } as any as WebdriverIO.Browser
+        const sm = new SessionManager(browser, 'scope')
+        const listener = vi.mocked(browser.on).mock.calls[0][1]
+        sm.removeListeners()
+        expect(browser.off).toBeCalledWith('command', listener)
+    })
+
+    it('should remove ContextManager listeners using the same references as they were registered', () => {
+        const browser = {
+            sessionId: '1234',
+            capabilities: {},
+            isBidi: false,
+            isMobile: true,
+            isAndroid: false,
+            on: vi.fn(),
+            off: vi.fn(),
+            sessionSubscribe: vi.fn(),
+            browsingContextGetTree: vi.fn(),
+            switchToWindow: vi.fn(),
+        } as any as WebdriverIO.Browser
+
+        const cm = new ContextManager(browser)
+
+        const onCalls = vi.mocked(browser.on).mock.calls
+        const commandListeners = onCalls.filter(([event]) => event === 'command').map(([, listener]) => listener)
+        const resultListeners = onCalls.filter(([event]) => event === 'result').map(([, listener]) => listener)
+        const baseCommandListener = commandListeners[0]
+        const contextCommandListener = commandListeners[1]
+
+        expect(baseCommandListener).toBeTypeOf('function')
+        expect(contextCommandListener).toBeTypeOf('function')
+        expect(resultListeners).toHaveLength(2)
+        expect(resultListeners[0]).toBeTypeOf('function')
+        expect(resultListeners[1]).toBeTypeOf('function')
+
+        cm.removeListeners()
+
+        expect(browser.off).toHaveBeenCalledWith('command', baseCommandListener)
+        expect(browser.off).toHaveBeenCalledWith('command', contextCommandListener)
+        expect(browser.off).toHaveBeenCalledWith('result', resultListeners[0])
+        expect(browser.off).toHaveBeenCalledWith('result', resultListeners[1])
     })
 })


### PR DESCRIPTION
fix #14707

## Proposed changes
Fixed a memory leak in the session management layer where event listeners were not being properly removed during session reload or deletion.
The issue was caused by using Function.prototype.bind() inline when registering and unregistering event listeners (for example, browser.on('event', this.method.bind(this))).
Since .bind() creates a new function reference every time it is called, the reference used during listener removal did not match the one used during registration. As a result, listeners were never removed and accumulated with each reloadSession() call, eventually triggering a MaxListenersExceededWarning.

Refactored SessionManager, ContextManager, NetworkManager, ShadowRootManager, PolyfillManager, and DialogManager.

Stored bound listener functions in private class properties (for example, #onCommandListener) to ensure a stable reference.

Updated removeListeners() in NetworkManager to use these stored references, ensuring successful listener removal.

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
