### PR TITLE
fix(wdio-jasmine-framework): restore hook data for Jasmine 5.10+

### DIFF
--- a/packages/wdio-jasmine-framework/tests/adapter.test.ts
+++ b/packages/wdio-jasmine-framework/tests/adapter.test.ts
@@ -252,6 +252,38 @@ test('get data from execute hook', async () => {
     expect(adapter['_jrunner']!.executeHook).toBeCalledWith('barfoo')
 })
 
+test('should populate last test data even if jasmine Spec.prototype.execute is undefined', async () => {
+    const adapter = adapterFactory()
+    // simulate Jasmine 5.10+ where this private API is no longer available
+    adapter['_jrunner']!.jasmine.Spec.prototype.execute = undefined as any
+
+    await adapter.init()
+    await adapter.run()
+
+    expect(adapter['_lastTest']).toBeUndefined()
+
+    adapter['_reporter'].specStarted({
+        id: 'test1',
+        description: 'test',
+        fullName: 'test',
+        failedExpectations: [],
+        passedExpectations: [],
+        deprecationWarnings: [],
+        pendingReason: '',
+        duration: null,
+        properties: null,
+        debugLogs: null,
+        status: 'passed',
+        filename: '/foo/bar.test.js'
+    } as any)
+
+    expect(adapter['_lastTest']).toBeDefined()
+    // @ts-ignore outdated types
+    expect(adapter['_lastTest'].id).toBe('test1')
+    // @ts-ignore outdated types
+    expect(typeof adapter['_lastTest'].start).toBe('number')
+})
+
 test('customSpecFilter', () => {
     const specMock = {
         getFullName: () => 'my test @smoke',


### PR DESCRIPTION
Resolves compatibility issue with Jasmine 5.10.0+ where the 'afterTest' hook received an empty test object due to the removal of the private 'jasmine.Spec.prototype.execute' API.

Fixes #14754
In jasmine 5.10.0, the private API jasmine.Spec.prototype.execute was removed. The @wdio/jasmine-framework adapter was monkey-patching this method to capture test information for hooks like afterTest. Since the method no longer exists, _lastTest was never populated, causing the empty {} object issue.

Fix: Used Jasmine's official reporter mechanism (specStarted callback) to capture spec information instead of relying on private APIs.

Tested across the repo mentioned works fine
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
