### PR TITLE
fix(wdio-utils): rethrow pending/skip errors for Jasmine (#14688)

### DIFF
--- a/packages/wdio-utils/src/test-framework/testFnWrapper.ts
+++ b/packages/wdio-utils/src/test-framework/testFnWrapper.ts
@@ -89,6 +89,7 @@ export const testFrameworkFnWrapper = async function (
     let result
     let error
     let skip = false
+    let autoSkipError: unknown
 
     const testStart = Date.now()
     try {
@@ -116,6 +117,7 @@ export const testFrameworkFnWrapper = async function (
             error = err
         } else {
             skip = true
+            autoSkipError = _err
         }
     }
     const duration = Date.now() - testStart
@@ -137,6 +139,9 @@ export const testFrameworkFnWrapper = async function (
 
     if (error && !error.matcherName) {
         throw error
+    }
+    if (skip && autoSkipError) {
+        throw autoSkipError
     }
     return result
 }


### PR DESCRIPTION
## Proposed changes

Fixes #14688
[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)
Analysis :-  When `pending()` is called inside a Jasmine test, it throws an error containing "marked Pending". The [testFnWrapper] was catching this error and correctly running afterHooks with `skipped: true`, but then returning normally without rethrowing. This caused Jasmine to think the test passed.
Fix: After running afterHooks with the correct skip status, rethrow the skip/pending error so Jasmine can detect and properly report the test as pending.
## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
