### PR TITLE
fix(mocha): don't report this.skip() in hooks as failure (#14649)

### DIFF
--- a/packages/wdio-mocha-framework/tests/skip-hook-issue.test.ts
+++ b/packages/wdio-mocha-framework/tests/skip-hook-issue.test.ts
@@ -1,0 +1,113 @@
+import { describe, test, expect, vi } from 'vitest'
+
+import { formatMessage } from '../src/common.js'
+
+/**
+ * Test for GitHub issue #14649
+ * When this.skip() is called in a hook, the hook should not be marked as failed
+ */
+describe('formatMessage - Issue #14649: this.skip() in hooks', () => {
+    test('should NOT include error for sync skip in before all hook', () => {
+        // This is the error that Mocha throws when this.skip() is called
+        const skipError = new Error('sync skip; aborting execution')
+
+        const params = {
+            type: 'test:fail', // Mocha emits 'fail' event when this.skip() is called in hooks
+            payload: {
+                title: '"before all" hook',
+                parent: { title: 'Test Suite' },
+                state: 'failed',
+                duration: 5
+            },
+            err: skipError
+        }
+
+        const message = formatMessage(params as any)
+
+        // FIXED behavior: skip errors should NOT be included as errors
+        expect(message.type).toBe('hook:end')
+        expect(message.error).toBeUndefined() // No error for skip
+    })
+
+    test('should NOT include error for async skip in before each hook', () => {
+        // Async version of skip error
+        const skipError = new Error('async skip; aborting execution')
+
+        const params = {
+            type: 'test:fail',
+            payload: {
+                title: '"before each" hook',
+                parent: { title: 'Test Suite' },
+                state: 'failed',
+                duration: 10
+            },
+            err: skipError
+        }
+
+        const message = formatMessage(params as any)
+
+        // FIXED behavior: skip errors should NOT be included as errors
+        expect(message.type).toBe('hook:end')
+        expect(message.error).toBeUndefined() // No error for skip
+    })
+
+    test('should NOT include error for skip in after all hook', () => {
+        const skipError = new Error('sync skip; aborting execution')
+
+        const params = {
+            type: 'test:fail',
+            payload: {
+                title: '"after all" hook',
+                parent: { title: 'Test Suite' }
+            },
+            err: skipError
+        }
+
+        const message = formatMessage(params as any)
+
+        expect(message.type).toBe('hook:end')
+        expect(message.error).toBeUndefined()
+    })
+
+    test('should properly include error for actual hook failures', () => {
+        // Real error that should be included
+        const realError = new Error('Connection refused')
+
+        const params = {
+            type: 'test:fail',
+            payload: {
+                title: '"before all" hook',
+                parent: { title: 'Test Suite' },
+                state: 'failed'
+            },
+            err: realError
+        }
+
+        const message = formatMessage(params as any)
+
+        // Real errors SHOULD still be included
+        expect(message.type).toBe('hook:end')
+        expect(message.error).toBeDefined()
+        expect(message.error?.message).toBe('Connection refused')
+    })
+
+    test('should include error for skip in non-hook context (regular test)', () => {
+        // Skip in a regular test (not a hook) should still work normally
+        const skipError = new Error('sync skip; aborting execution')
+
+        const params = {
+            type: 'test:fail',
+            payload: {
+                title: 'my test case', // Not a hook title
+                parent: { title: 'Test Suite' }
+            },
+            err: skipError
+        }
+
+        const message = formatMessage(params as any)
+
+        // For non-hook skip, error should still be included (this is handled elsewhere)
+        expect(message.type).toBe('test:fail') // Not converted to hook:end
+        expect(message.error).toBeDefined()
+    })
+})


### PR DESCRIPTION
  ## Proposed changes
  
  [//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)
 `sync skip; aborting execution` (or `async skip`) -> this error was thrown causing the issue handled correctly now  (kindoff corner case)
  ## Types of changes
  
  [//]: # (What types of changes does your code introduce to WebdriverIO?)
  [//]: # (_Put an `x` in the boxes that apply_)
  
  - [ ] Polish (an improvement for an existing feature)
  - [x] Bugfix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] Documentation update (improvements to the project's docs)
  - [ ] Specification changes (updates to WebDriver command specifications)
  - [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)
  
  ## Checklist
  
  [//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)
  
  - [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [ ] I have added the necessary documentation (if appropriate)
  - [ ] I have added proper type definitions for new commands (if appropriate)
  
  ## Backport Request
  
  [//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)
  
  - [x] This change is solely for `v9` and doesn't need to be back-ported
  - [ ] Back-ported PR at `#XXXXX`
  
  ## Further comments
  
  [//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)
  
  ### Reviewers: @webdriverio/project-committers
