### PR TITLE
test(cli): fix launcher tests for specFileRetries -1 initialization

### DIFF
--- a/packages/wdio-cli/tests/launcher.test.ts
+++ b/packages/wdio-cli/tests/launcher.test.ts
@@ -107,7 +107,7 @@ describe('launcher', () => {
             )
 
             expect(launcher['_schedule']).toHaveLength(1)
-            expect(launcher['_schedule'][0].specs[0].retries).toBe(2)
+            expect(launcher['_schedule'][0].specs[0].retries).toBe(-1)
 
             expect(typeof launcher['_resolve']).toBe('function')
             expect(launcher['_runSpecs']).toBeCalledTimes(1)
@@ -126,8 +126,8 @@ describe('launcher', () => {
             )
 
             expect(launcher['_schedule']).toHaveLength(2)
-            expect(launcher['_schedule'][0].specs[0].retries).toBe(2)
-            expect(launcher['_schedule'][1].specs[0].retries).toBe(2)
+            expect(launcher['_schedule'][0].specs[0].retries).toBe(-1)
+            expect(launcher['_schedule'][1].specs[0].retries).toBe(-1)
 
             expect(typeof launcher['_resolve']).toBe('function')
             expect(launcher['_runSpecs']).toBeCalledTimes(1)
@@ -142,7 +142,7 @@ describe('launcher', () => {
             )
 
             expect(launcher['_schedule']).toHaveLength(1)
-            expect(launcher['_schedule'][0].specs[0].retries).toBe(2)
+            expect(launcher['_schedule'][0].specs[0].retries).toBe(-1)
 
             expect(typeof launcher['_resolve']).toBe('function')
             expect(launcher['_runSpecs']).toBeCalledTimes(1)
@@ -157,7 +157,7 @@ describe('launcher', () => {
             )
 
             expect(launcher['_schedule']).toHaveLength(1)
-            expect(launcher['_schedule'][0].specs[0].retries).toBe(2)
+            expect(launcher['_schedule'][0].specs[0].retries).toBe(-1)
 
             expect(typeof launcher['_resolve']).toBe('function')
             expect(launcher['_runSpecs']).toBeCalledTimes(1)
@@ -183,7 +183,7 @@ describe('launcher', () => {
             )
 
             expect(launcher['_schedule']).toHaveLength(1)
-            expect(launcher['_schedule'][0].specs[0].retries).toBe(3)
+            expect(launcher['_schedule'][0].specs[0].retries).toBe(-1)
             expect(launcher['_schedule'][0].availableInstances).toBe(4)
 
             expect(launcher['_runSpecs']).toBeCalledTimes(1)


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)
PR #14859 changed specFileRetries initialization to -1 (unknown) to allow the beforeSession hook to override it. However, the launcher tests were not updated and still expected the config values (2, 3), causing test failures.

This updates the test assertions to expect -1, matching the new initialization behavior.
## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
