### PR TITLE
feat: electron download sources for chromedriver

### DIFF
--- a/packages/wdio-utils/package.json
+++ b/packages/wdio-utils/package.json
@@ -37,12 +37,13 @@
     "url": "https://github.com/webdriverio/webdriverio/issues"
   },
   "dependencies": {
-    "@puppeteer/browsers": "^2.2.0",
+    "@puppeteer/browsers": "file:../../../puppeteer/packages/browsers",
     "@wdio/logger": "workspace:*",
     "@wdio/types": "workspace:*",
     "decamelize": "^6.0.0",
     "deepmerge-ts": "^7.0.3",
     "edgedriver": "^6.1.2",
+    "electron-to-chromium": "^1.5.70",
     "geckodriver": "^5.0.0",
     "get-port": "^7.0.0",
     "import-meta-resolve": "^4.0.0",
@@ -54,5 +55,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "devDependencies": {
+    "@types/electron-to-chromium": "^1.5.0"
   }
 }

--- a/packages/wdio-utils/src/node/manager.ts
+++ b/packages/wdio-utils/src/node/manager.ts
@@ -123,7 +123,7 @@ export async function setupDriver (options: Omit<Options.WebDriver, 'capabilitie
                 : cap.browserVersion
             return setupGeckodriver(cacheDir, version)
         } else if (isChrome(cap.browserName)) {
-            return setupChromedriver(cacheDir, cap.browserVersion)
+            return setupChromedriver(cacheDir, cap.browserVersion, cap)
         }
 
         return Promise.resolve()

--- a/packages/wdio-utils/src/node/startWebDriver.ts
+++ b/packages/wdio-utils/src/node/startWebDriver.ts
@@ -82,7 +82,7 @@ export async function startWebDriver (options: Capabilities.RemoteConfig) {
         const { executablePath: chromeExecuteablePath, browserVersion } = await setupPuppeteerBrowser(cacheDir, caps)
         const { executablePath: chromedriverExcecuteablePath } = chromedriverBinary
             ? { executablePath: chromedriverBinary }
-            : await setupChromedriver(cacheDir, browserVersion)
+            : await setupChromedriver(cacheDir, browserVersion, caps)
 
         const prefs = generateDefaultPrefs(caps)
         caps['goog:chromeOptions'] = deepmerge(

--- a/packages/wdio-utils/src/node/utils.ts
+++ b/packages/wdio-utils/src/node/utils.ts
@@ -7,12 +7,14 @@ import cp from 'node:child_process'
 import decamelize from 'decamelize'
 import logger from '@wdio/logger'
 import {
-    install, canDownload, resolveBuildId, detectBrowserPlatform, Browser, ChromeReleaseChannel,
-    computeExecutablePath, type InstallOptions
+    install, canDownload, resolveBuildId, detectBrowserPlatform, Browser, BrowserPlatform, ChromeReleaseChannel,
+    computeExecutablePath, type InstalledBrowser,
+    type InstallOptions, type BrowserDownloader, type DownloadOptions
 } from '@puppeteer/browsers'
 import { download as downloadGeckodriver } from 'geckodriver'
 import { download as downloadEdgedriver } from 'edgedriver'
 import { locateChrome, locateFirefox, locateApp } from 'locate-app'
+import { chromiumToElectron } from 'electron-to-chromium'
 import type { EdgedriverParameters } from 'edgedriver'
 import type { Options } from '@wdio/types'
 
@@ -132,8 +134,8 @@ export const downloadProgressCallback = (artifact: string, downloadedBytes: numb
  * @param {InstallOptions & { unpack?: true | undefined }} args - An object containing installation options and an optional `unpack` flag.
  * @returns {Promise<void>} A Promise that resolves once the package is installed and clear the progress log.
  */
-const _install = async (args: InstallOptions & { unpack?: true | undefined }, retry = false): Promise<void> => {
-    await install(args).catch((err) => {
+const _install = async (args: InstallOptions & { unpack?: true | undefined }, retry = false): Promise<string> => {
+    const result = await install(args).catch((err) => {
         const error = `Failed downloading ${args.browser} v${args.buildId} using ${JSON.stringify(args)}: ${err.message}, retrying ...`
         if (retry) {
             err.message += '\n' + error.replace(', retrying ...', '')
@@ -143,6 +145,26 @@ const _install = async (args: InstallOptions & { unpack?: true | undefined }, re
         return _install(args, true)
     })
     log.progress('')
+    // When unpack=true, install returns InstalledBrowser object, extract the path
+    return typeof result === 'string' ? result : result.path
+}
+
+/**
+ * Installs a package and returns the InstalledBrowser object for custom downloader support.
+ * This variant preserves the custom executable path from custom downloaders.
+ */
+const _installWithBrowser = async (args: InstallOptions & { unpack: true }, retry = false): Promise<InstalledBrowser> => {
+    const result = await install(args).catch((err: Error) => {
+        const error = `Failed downloading ${args.browser} v${args.buildId} using ${JSON.stringify(args)}: ${err.message}, retrying ...`
+        if (retry) {
+            err.message += '\n' + error.replace(', retrying ...', '')
+            throw new Error(err.message)
+        }
+        log.error(error)
+        return _installWithBrowser(args, true)
+    })
+    log.progress('')
+    return result
 }
 
 function locateChromeSafely () {
@@ -282,53 +304,128 @@ export function getMajorVersionFromString(fullVersion:string) {
     return prefix && prefix.length > 0 ? prefix[0] : ''
 }
 
-export async function setupChromedriver (cacheDir: string, driverVersion?: string) {
+/**
+ * Extract Electron-related capabilities from WebdriverIO capabilities object.
+ * Handles both direct and W3C capabilities formats.
+ */
+function parseElectronCapabilities(capabilities?: WebdriverIO.Capabilities) {
+    if (!capabilities) {
+        return { chromiumVersion: undefined, electronVersion: undefined }
+    }
+
+    // Type for capabilities with custom properties
+    type CapabilitiesWithCustomProps = Record<string, unknown> & {
+        alwaysMatch?: Record<string, unknown>;
+    }
+
+    // Check direct capabilities
+    const caps = capabilities as CapabilitiesWithCustomProps
+    const chromiumVersion = caps['wdio:chromiumVersion'] as string | undefined
+    const electronVersion = caps['wdio:electronVersion'] as string | undefined
+
+    // Also check for W3C format capabilities
+    const w3cCapabilities = caps.alwaysMatch || caps
+    const w3cChromiumVersion = w3cCapabilities['wdio:chromiumVersion'] as string | undefined
+    const w3cElectronVersion = w3cCapabilities['wdio:electronVersion'] as string | undefined
+
+    // Use the versions found (prefer direct access, fallback to W3C)
+    return {
+        chromiumVersion: chromiumVersion || w3cChromiumVersion,
+        electronVersion: electronVersion || w3cElectronVersion
+    }
+}
+
+/**
+ * Determine the appropriate platform, with ARM Linux override.
+ */
+function resolveChromedriverPlatform(): BrowserPlatform {
     const platform = detectBrowserPlatform()
-    if (!platform) {
+    const actualPlatform = (platform === 'linux' && process.arch === 'arm64') ? BrowserPlatform.LINUX_ARM : platform
+
+    if (actualPlatform !== platform) {
+        log.info(`Overriding platform from ${platform} to ${actualPlatform} for ARM Linux`)
+    }
+
+    if (!actualPlatform) {
         throw new Error('The current platform is not supported.')
     }
-    const version = driverVersion || getBuildIdByChromePath(await locateChromeSafely()) || ChromeReleaseChannel.STABLE
-    const buildId = await resolveBuildId(Browser.CHROMEDRIVER, platform, version)
-    let executablePath = computeExecutablePath({
-        browser: Browser.CHROMEDRIVER,
+
+    return actualPlatform
+}
+
+export async function setupChromedriver (cacheDir: string, driverVersion?: string, capabilities?: WebdriverIO.Capabilities) {
+    const platform = resolveChromedriverPlatform()
+    const { chromiumVersion, electronVersion } = parseElectronCapabilities(capabilities)
+
+    // Determine buildId and downloaders based on capabilities
+    let buildId: string
+    let downloaders: BrowserDownloader[] | undefined
+
+    if (electronVersion) {
+        // Use Electron downloader with Electron version
+        downloaders = [new ElectronDownloader()]
+        buildId = electronVersion
+        log.info(`Using Electron downloader with Electron v${buildId} (Chromium ${chromiumVersion})`)
+    } else if (chromiumVersion) {
+        // Fallback: use Chromium version with Electron downloader
+        downloaders = [new ElectronDownloader()]
+        buildId = chromiumVersion
+        log.info(`Using Electron downloader with Chromium v${buildId}`)
+    } else {
+        // Use standard Chrome chromedriver logic (no Electron downloader)
+        const version = driverVersion || getBuildIdByChromePath(await locateChromeSafely()) || ChromeReleaseChannel.STABLE
+        buildId = await resolveBuildId(Browser.CHROMEDRIVER, platform, version)
+        log.info(`Using standard Chrome chromedriver logic, resolved buildId=${buildId}`)
+    }
+
+    const installOptions = {
+        cacheDir,
         buildId,
         platform,
-        cacheDir
-    })
-    const hasChromedriverInstalled = await fsp.access(executablePath).then(() => true, () => false)
-    if (!hasChromedriverInstalled) {
-        log.info(`Downloading Chromedriver v${buildId}`)
-        const chromedriverInstallOpts: InstallOptions & { unpack?: true } = {
-            cacheDir,
-            buildId,
-            platform,
-            browser: Browser.CHROMEDRIVER,
-            unpack: true,
-            downloadProgressCallback: (downloadedBytes, totalBytes) => downloadProgressCallback('Chromedriver', downloadedBytes, totalBytes)
-        }
-        let knownBuild = buildId
-        if (await canDownload(chromedriverInstallOpts)) {
-            await _install({ ...chromedriverInstallOpts, buildId })
-            log.info(`Download of Chromedriver v${buildId} was successful`)
-        } else {
-            log.warn(`Chromedriver v${buildId} don't exist, trying to find known good version...`)
-            knownBuild = await resolveBuildId(Browser.CHROMEDRIVER, platform, getMajorVersionFromString(version))
-            if (knownBuild) {
-                await _install({ ...chromedriverInstallOpts, buildId: knownBuild })
-                log.info(`Download of Chromedriver v${knownBuild} was successful`)
+        browser: Browser.CHROMEDRIVER,
+        unpack: true,
+        downloadProgressCallback: (downloadedBytes, totalBytes) => downloadProgressCallback('Chromedriver', downloadedBytes, totalBytes),
+        downloaders
+    } satisfies InstallOptions & { unpack: true; downloaders?: BrowserDownloader[] }
+
+    let installedBrowser: Awaited<ReturnType<typeof _installWithBrowser>>
+
+    try {
+        installedBrowser = await _installWithBrowser(installOptions)
+        log.info(`Download of Chromedriver v${buildId} was successful`)
+    } catch (error) {
+        // If the primary download failed and we're using Electron, try a fallback version
+        if (chromiumVersion) {
+            log.warn(`Chromedriver v${buildId} download failed, trying latest compatible version...`)
+            const fallbackVersion = getMajorVersionFromString(chromiumVersion)
+            const fallbackBuildId = await resolveBuildId(Browser.CHROMEDRIVER, platform, fallbackVersion)
+
+            if (fallbackBuildId !== buildId) {
+                log.info(`Trying fallback Chromedriver v${fallbackBuildId}`)
+                try {
+                    installedBrowser = await _installWithBrowser({ ...installOptions, buildId: fallbackBuildId })
+                    log.info(`Download of Chromedriver v${fallbackBuildId} was successful`)
+                    buildId = fallbackBuildId
+                } catch (fallbackError) {
+                    log.error(`Fallback Chromedriver download also failed: ${fallbackError instanceof Error ? fallbackError.message : String(fallbackError)}`)
+                    throw new Error(`Couldn't download Chromedriver v${buildId} or fallback v${fallbackBuildId}`)
+                }
             } else {
-                throw new Error(`Couldn't download any known good version from Chromedriver major v${getMajorVersionFromString(version)}, requested full version - v${version}`)
+                throw new Error(`Couldn't download Chromedriver v${buildId}`)
             }
+        } else {
+            throw error
         }
-        executablePath = computeExecutablePath({
-            browser: Browser.CHROMEDRIVER,
-            buildId: knownBuild,
-            platform,
-            cacheDir
-        })
-    } else {
-        log.info(`Using Chromedriver v${buildId} from cache directory ${cacheDir}`)
     }
+
+    // Use the executable path from InstalledBrowser - this automatically uses
+    // custom paths from downloaders that implement resolveExecutablePath()
+    const executablePath = installedBrowser.executablePath
+
+    if (downloaders?.length) {
+        log.info(`Using custom downloader executable path: ${executablePath}`)
+    }
+
     return { executablePath }
 }
 
@@ -344,4 +441,248 @@ export function generateDefaultPrefs(caps: WebdriverIO.Capabilities) {
     return caps['goog:chromeOptions']?.debuggerAddress
         ? {}
         : { prefs: { 'profile.password_manager_leak_detection': false } }
+}
+
+// ============================================================================
+// Electron Downloader Implementation
+// ============================================================================
+
+type ElectronRelease = {
+    chrome: string;
+    version: string;
+}
+
+/**
+ * Cache for Chromium → Electron version mapping.
+ * Fetched from electronjs.org/headers/index.json on first use.
+ */
+let chromiumToElectronCache: Record<string, string> | null = null
+
+/**
+ * Fetches the Electron releases list and builds a Chromium → Electron mapping.
+ * This provides the most up-to-date version information.
+ */
+async function fetchChromiumToElectronMapping(): Promise<Record<string, string>> {
+    if (chromiumToElectronCache) {
+        return chromiumToElectronCache
+    }
+
+    try {
+        log.debug('Fetching Electron releases for Chromium → Electron version mapping...')
+        const response = await fetch('https://electronjs.org/headers/index.json')
+        const releases = (await response.json()) as ElectronRelease[]
+
+        // Build reverse mapping: Chromium version → Electron version
+        const mapping: Record<string, string> = {}
+        for (const { chrome, version } of releases) {
+            mapping[chrome] = version
+        }
+
+        chromiumToElectronCache = mapping
+        log.debug(`Fetched ${Object.keys(mapping).length} Electron release mappings`)
+        return mapping
+    } catch (error) {
+        log.debug('Failed to fetch Electron releases:', error)
+        throw error
+    }
+}
+
+/**
+ * Maps BrowserPlatform to Electron release platform names.
+ */
+function mapPlatformForElectron(platform: BrowserPlatform): string {
+    const platformMap: Record<BrowserPlatform, string> = {
+        [BrowserPlatform.LINUX]: 'linux-x64',
+        [BrowserPlatform.LINUX_ARM]: 'linux-arm64',
+        [BrowserPlatform.MAC]: 'darwin-x64',
+        [BrowserPlatform.MAC_ARM]: 'darwin-arm64',
+        [BrowserPlatform.WIN32]: 'win32-ia32',
+        [BrowserPlatform.WIN64]: 'win32-x64'
+    }
+
+    const mapped = platformMap[platform]
+    if (!mapped) {
+        throw new Error(`Unsupported platform for Electron: ${platform}`)
+    }
+    return mapped
+}
+
+/**
+ * Resolves a version to an Electron version.
+ * Handles both Electron versions (pass-through) and Chromium versions (mapped).
+ *
+ * Attempts to fetch the latest mappings from electronjs.org first,
+ * then falls back to the electron-to-chromium package.
+ */
+async function resolveElectronVersion(buildId: string, versionMapping?: Record<string, string>): Promise<string | null> {
+    // If it looks like an Electron version (e.g., "33.2.1"), return as-is
+    if (/^\d+\.\d+\.\d+$/.test(buildId)) {
+        return buildId
+    }
+
+    // If custom mapping provided, try that first
+    if (versionMapping && buildId in versionMapping) {
+        return versionMapping[buildId]
+    }
+
+    // Try fetching from electronjs.org for most up-to-date mappings
+    try {
+        const mapping = await fetchChromiumToElectronMapping()
+        if (buildId in mapping) {
+            return mapping[buildId]
+        }
+    } catch (error: unknown) {
+        // Fall through to electron-to-chromium package
+        log.debug('Falling back to electron-to-chromium package', (error as Error).message)
+    }
+
+    // Fall back to electron-to-chromium package for offline/cached lookup
+    const electronVersion = chromiumToElectron(buildId)
+
+    // chromiumToElectron returns either:
+    // - a string (for major version queries)
+    // - an array of strings (for full version queries)
+    // - undefined (if no match)
+    if (Array.isArray(electronVersion)) {
+        // Return the first (latest) matching Electron version
+        return electronVersion[0] || null
+    }
+
+    return electronVersion || null
+}
+
+/**
+ * Options for ElectronDownloader.
+ */
+export interface ElectronDownloaderOptions {
+    /**
+     * Only use Electron downloader for specific platforms.
+     * If not specified, Electron releases will be used for all platforms.
+     *
+     * @example
+     * ```typescript
+     * // Only use for ARM64 Linux, let Chrome for Testing handle others
+     * new ElectronDownloader({ platforms: [BrowserPlatform.LINUX_ARM] })
+     * ```
+     */
+    platforms?: BrowserPlatform[];
+
+    /**
+     * Custom base URL for Electron releases.
+     * @default 'https://github.com/electron/electron/releases/download/'
+     */
+    baseUrl?: string;
+
+    /**
+     * Optional custom version mapping from Chromium version to Electron version.
+     * Has the highest priority in the version resolution fallback chain.
+     *
+     * The version resolution order is:
+     * 1. Custom versionMapping (if provided)
+     * 2. Cached electronjs.org mappings (if initializeElectronMappings() was called)
+     * 3. electron-to-chromium package (always available)
+     *
+     * Only provide this if you need to override specific version mappings.
+     *
+     * @example
+     * ```typescript
+     * new ElectronDownloader({
+     *   versionMapping: {
+     *     '131.0.0.0': '34.0.0' // Override for unreleased versions
+     *   }
+     * })
+     * ```
+     */
+    versionMapping?: Record<string, string>;
+}
+
+/**
+ * Browser downloader that uses Electron releases for Chromedriver.
+ *
+ * This is particularly useful for platforms where Chrome for Testing
+ * doesn't provide binaries, such as Linux ARM64.
+ *
+ * **Version Mapping Strategy:**
+ *
+ * The downloader uses a two-tier fallback for Chromium → Electron version mapping:
+ * 1. **electronjs.org releases API** (most up-to-date, fetched on first use and cached)
+ * 2. **electron-to-chromium package** (offline fallback, may be slightly outdated)
+ *
+ * **Supports two modes:**
+ *
+ * 1. **Electron apps**: Pass Electron version directly (e.g., "33.2.1")
+ * 2. **Non-Electron apps**: Pass Chromium version (e.g., "130.0.6723.2"),
+ *    which gets mapped to an Electron version automatically
+ *
+ * @example
+ * ```typescript
+ * // For Electron apps - pass Electron version
+ * const buildId = electronVersion; // "33.2.1"
+ *
+ * // For non-Electron apps - pass Chromium version, restrict to ARM64
+ * const downloaders = [
+ *   new ElectronDownloader({
+ *     platforms: [BrowserPlatform.LINUX_ARM]
+ *   })
+ * ];
+ * await install({
+ *   browser: Browser.CHROMEDRIVER,
+ *   buildId: '130.0.6723.2', // Chromium version
+ *   downloaders
+ * });
+ * // → Fetches mapping from electronjs.org (cached after first fetch)
+ * // → Maps to Electron v33.2.1
+ * // → Downloads chromedriver from Electron v33.2.1 release
+ * ```
+ */
+export class ElectronDownloader implements BrowserDownloader {
+    readonly #platforms?: BrowserPlatform[]
+    readonly #baseUrl: string
+    readonly #versionMapping?: Record<string, string>
+
+    constructor(options: ElectronDownloaderOptions = {}) {
+        this.#platforms = options.platforms
+        this.#baseUrl = options.baseUrl || 'https://github.com/electron/electron/releases/download/'
+        this.#versionMapping = options.versionMapping
+    }
+
+    async supports(options: DownloadOptions): Promise<boolean> {
+        // Only support Chromedriver
+        if (options.browser !== Browser.CHROMEDRIVER) {
+            return false
+        }
+
+        // Check if we handle this platform
+        if (this.#platforms && !this.#platforms.includes(options.platform)) {
+            return false
+        }
+
+        // Check if we can resolve this version to an Electron version
+        const electronVersion = await resolveElectronVersion(options.buildId, this.#versionMapping)
+        return electronVersion !== null
+    }
+
+    async getDownloadUrl(options: DownloadOptions): Promise<URL | null> {
+        // Resolve buildId to Electron version
+        // (pass-through if already Electron version, map if Chromium version)
+        const electronVersion = await resolveElectronVersion(options.buildId, this.#versionMapping)
+        if (!electronVersion) {
+            return null
+        }
+
+        const electronPlatform = mapPlatformForElectron(options.platform)
+        const urlPath = `v${electronVersion}/chromedriver-v${electronVersion}-${electronPlatform}.zip`
+        return new URL(urlPath, this.#baseUrl)
+    }
+
+    getExecutablePath(options: {
+        browser: Browser
+        buildId: string
+        platform: BrowserPlatform
+    }): string {
+        // Electron chromedriver archives may have different structures.
+        // Try the most common path first.
+        const binaryName = options.platform.includes('win') ? 'chromedriver.exe' : 'chromedriver'
+        return binaryName
+    }
 }

--- a/packages/wdio-utils/tests/node/manager.test.ts
+++ b/packages/wdio-utils/tests/node/manager.test.ts
@@ -79,8 +79,8 @@ describe('setupDriver', () => {
             browserVersion: '6'
         }])
         expect(setupChromedriver).toBeCalledTimes(2)
-        expect(setupChromedriver).toBeCalledWith('/foo/bar', '1')
-        expect(setupChromedriver).toBeCalledWith('/foo/bar', '2')
+        expect(setupChromedriver).toBeCalledWith('/foo/bar', '1', expect.any(Object))
+        expect(setupChromedriver).toBeCalledWith('/foo/bar', '2', expect.any(Object))
         expect(setupEdgedriver).toBeCalledTimes(3)
         expect(setupEdgedriver).toBeCalledWith('/foo/bar', undefined)
         expect(setupEdgedriver).toBeCalledWith('/foo/bar', '3')
@@ -175,8 +175,8 @@ describe('setupDriver', () => {
             }
         })
         expect(setupChromedriver).toBeCalledTimes(2)
-        expect(setupChromedriver).toBeCalledWith('/foo/bar', '1')
-        expect(setupChromedriver).toBeCalledWith('/foo/bar', '2')
+        expect(setupChromedriver).toBeCalledWith('/foo/bar', '1', expect.any(Object))
+        expect(setupChromedriver).toBeCalledWith('/foo/bar', '2', expect.any(Object))
         expect(setupEdgedriver).toBeCalledTimes(2)
         expect(setupEdgedriver).toBeCalledWith('/foo/bar', '3')
         expect(setupEdgedriver).toBeCalledWith('/foo/bar', '4')
@@ -266,8 +266,8 @@ describe('setupDriver', () => {
             }
         }])
         expect(setupChromedriver).toBeCalledTimes(2)
-        expect(setupChromedriver).toBeCalledWith('/foo/bar', '1')
-        expect(setupChromedriver).toBeCalledWith('/foo/bar', '2')
+        expect(setupChromedriver).toBeCalledWith('/foo/bar', '1', expect.any(Object))
+        expect(setupChromedriver).toBeCalledWith('/foo/bar', '2', expect.any(Object))
         expect(setupEdgedriver).toBeCalledTimes(2)
         expect(setupEdgedriver).toBeCalledWith('/foo/bar', '3')
         expect(setupEdgedriver).toBeCalledWith('/foo/bar', '4')

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -446,7 +446,7 @@ importers:
         version: 5.2.4(vite@5.4.19(@types/node@24.0.11)(terser@5.43.1))(vue@3.5.17(typescript@5.8.3))
       expect-webdriverio:
         specifier: ^5.3.4
-        version: 5.3.4(@wdio/globals@9.17.0)(@wdio/logger@9.18.0)(webdriverio@9.18.4(puppeteer-core@24.12.1))
+        version: 5.3.4(@wdio/globals@9.17.0)(@wdio/logger@9.18.0)(webdriverio@9.19.1(puppeteer-core@24.12.1))
       mocha:
         specifier: ^10.2.0
         version: 10.8.2
@@ -1009,7 +1009,7 @@ importers:
         version: link:../wdio-logger
       '@wdio/runner':
         specifier: ^9.16.2
-        version: 9.16.2(expect-webdriverio@5.3.4(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@9.16.2(puppeteer-core@24.12.1)))(webdriverio@9.16.2(puppeteer-core@24.12.1))
+        version: 9.16.2(expect-webdriverio@5.3.4(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@9.18.4(puppeteer-core@24.12.1)))(webdriverio@9.18.4(puppeteer-core@24.12.1))
       '@wdio/types':
         specifier: workspace:*
         version: link:../wdio-types
@@ -1144,7 +1144,7 @@ importers:
         version: 4.0.0
       expect-webdriverio:
         specifier: ^5.3.4
-        version: 5.3.4(@wdio/globals@9.17.0)(@wdio/logger@packages+wdio-logger)(webdriverio@9.18.4(puppeteer-core@24.12.1))
+        version: 5.3.4(@wdio/globals@9.17.0)(@wdio/logger@packages+wdio-logger)(webdriverio@9.19.1(puppeteer-core@24.12.1))
       split2:
         specifier: ^4.1.0
         version: 4.2.0
@@ -1428,8 +1428,8 @@ importers:
   packages/wdio-utils:
     dependencies:
       '@puppeteer/browsers':
-        specifier: ^2.2.0
-        version: 2.10.5
+        specifier: file:../../../puppeteer/packages/browsers
+        version: file:../puppeteer/packages/browsers
       '@wdio/logger':
         specifier: workspace:*
         version: link:../wdio-logger
@@ -1445,6 +1445,9 @@ importers:
       edgedriver:
         specifier: ^6.1.2
         version: 6.1.2
+      electron-to-chromium:
+        specifier: ^1.5.70
+        version: 1.5.178
       geckodriver:
         specifier: ^5.0.0
         version: 5.0.0
@@ -1469,6 +1472,10 @@ importers:
       wait-port:
         specifier: ^1.1.0
         version: 1.1.0
+    devDependencies:
+      '@types/electron-to-chromium':
+        specifier: ^1.5.0
+        version: 1.5.0
 
   packages/wdio-webdriver-mock-service:
     dependencies:
@@ -4790,6 +4797,11 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  '@puppeteer/browsers@file:../puppeteer/packages/browsers':
+    resolution: {directory: ../puppeteer/packages/browsers, type: directory}
+    engines: {node: '>=18'}
+    hasBin: true
+
   '@rolldown/pluginutils@1.0.0-beta.19':
     resolution: {integrity: sha512-3FL3mnMbPu0muGOCaKAhhFEYmqv9eTfPSJRJmANrCwtgK8VuxpsZDGK+m0LYAGoyO8+0j5uRe4PeyPDK1yA/hA==}
 
@@ -5623,6 +5635,9 @@ packages:
   '@types/ejs@3.1.5':
     resolution: {integrity: sha512-nv+GSx77ZtXiJzwKdsASqi+YQ5Z7vwHsTP0JY2SiQgjGckkBRKZnk8nIM+7oUZ1VCtuTz0+By4qVR7fqzp/Dfg==}
 
+  '@types/electron-to-chromium@1.5.0':
+    resolution: {integrity: sha512-DyruYlDaTi6RhdcarT+ppGNg+n2Jr+hvYLdF/RlJhAspSSFk5ptq+lcHgJZ/eQljH1xwZ5NE103oMJcjbDYnzw==}
+
   '@types/eslint-scope@3.7.7':
     resolution: {integrity: sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==}
 
@@ -6122,6 +6137,10 @@ packages:
     resolution: {integrity: sha512-fN+Z7SkKjb0u3UUMSxMN4d+CCZQKZhm/tx3eX7Rv+3T78LtpOjlesBYQ7Ax3tQ3tp8hgEo+CoOXU0jHEYubFrg==}
     engines: {node: '>=18.20.0'}
 
+  '@wdio/config@9.19.1':
+    resolution: {integrity: sha512-BeTB2paSjaij3cf1NXQzX9CZmdj5jz2/xdUhkJlCeGmGn1KjWu5BjMO+exuiy+zln7dOJjev8f0jlg8e8f1EbQ==}
+    engines: {node: '>=18.20.0'}
+
   '@wdio/dot-reporter@9.16.2':
     resolution: {integrity: sha512-JzFegviZdpzgvt8w8uwI0pyJguIuJzfzlkkyWz1WUoqtilH4yrf5IYKzObnm3peh7iQ/y2J1SSeAjKr0Hr5xTg==}
     engines: {node: '>=18.20.0'}
@@ -6173,12 +6192,20 @@ packages:
     resolution: {integrity: sha512-P86FvM/4XQGpJKwlC2RKF3I21TglPvPOozJGG9HoL0Jmt6jRF20ggO/nRTxU0XiWkRdqESUTmfA87bdCO4GRkQ==}
     engines: {node: '>=18.20.0'}
 
+  '@wdio/types@9.19.1':
+    resolution: {integrity: sha512-Q1HVcXiWMHp3ze2NN1BvpsfEh/j6GtAeMHhHW4p2IWUfRZlZqTfiJ+95LmkwXOG2gw9yndT8NkJigAz8v7WVYQ==}
+    engines: {node: '>=18.20.0'}
+
   '@wdio/utils@9.16.2':
     resolution: {integrity: sha512-bsRdEUXUTYvznXH/Z+p6HDzHSjMI6I6bnu8WXWTeDDDyqybWK5D8cbZvs8A/kMmGXoz1GZkSBHxy4Z5NTg8OQg==}
     engines: {node: '>=18.20.0'}
 
   '@wdio/utils@9.18.0':
     resolution: {integrity: sha512-M+QH05FUw25aFXZfjb+V16ydKoURgV61zeZrMjQdW2aAiks3F5iiI9pgqYT5kr1kHZcMy8gawGqQQ+RVfKYscQ==}
+    engines: {node: '>=18.20.0'}
+
+  '@wdio/utils@9.19.1':
+    resolution: {integrity: sha512-wWx5uPCgdZQxFIemAFVk/aa3JLwqrTsvEJsPlV3lCRpLeQ67V8aUPvvNAzE+RhX67qvelwwsvX8RrPdLDfnnYw==}
     engines: {node: '>=18.20.0'}
 
   '@webassemblyjs/ast@1.14.1':
@@ -7530,6 +7557,15 @@ packages:
 
   debug@4.4.1:
     resolution: {integrity: sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
     peerDependencies:
       supports-color: '*'
@@ -12496,6 +12532,11 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  semver@7.7.3:
+    resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   send@0.19.0:
     resolution: {integrity: sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==}
     engines: {node: '>= 0.8.0'}
@@ -13021,6 +13062,9 @@ packages:
 
   tar-fs@3.1.0:
     resolution: {integrity: sha512-5Mty5y/sOF1YWj1J6GiBodjlDc05CUR8PKXrsnFAiSG0xA+GHeWLovaZPYUDXkH/1iKRf2+M5+OrRgzC7O9b7w==}
+
+  tar-fs@3.1.1:
+    resolution: {integrity: sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==}
 
   tar-stream@1.6.2:
     resolution: {integrity: sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==}
@@ -13811,6 +13855,10 @@ packages:
     resolution: {integrity: sha512-07lC4FLj45lHJo0FvLjUp5qkjzEGWJWKGsxLoe9rQ2Fg88iYsqgr9JfSj8qxHpazBaBd+77+ZtpmMZ2X2D1Zuw==}
     engines: {node: '>=18.20.0'}
 
+  webdriver@9.19.1:
+    resolution: {integrity: sha512-cvccIZ3QaUZxxrA81a3rqqgxKt6VzVrZupMc+eX9J40qfGrV3NtdLb/m4AA1PmeTPGN5O3/4KrzDpnVZM4WUnA==}
+    engines: {node: '>=18.20.0'}
+
   webdriverio@9.16.2:
     resolution: {integrity: sha512-aRcfBZyY+OFqz2DI0ZYmMahGlH3h/clAXXOQSFN5QfrHG4Cjuo5xy3lq4tVfszjEJ813+wwC4HJLbgDmMrPXkA==}
     engines: {node: '>=18.20.0'}
@@ -13822,6 +13870,15 @@ packages:
 
   webdriverio@9.18.4:
     resolution: {integrity: sha512-Q/gghz/Zt7EhTnbDQfLb61WgSwCksXZE60lEzmDXe4fULCH/6Js5IWUsne3W+BRy6nXeVvFscHD/d7S77dbamw==}
+    engines: {node: '>=18.20.0'}
+    peerDependencies:
+      puppeteer-core: '>=22.x || <=24.x'
+    peerDependenciesMeta:
+      puppeteer-core:
+        optional: true
+
+  webdriverio@9.19.1:
+    resolution: {integrity: sha512-hpGgK6d9QNi3AaLFWIPQaEMqJhXF048XAIsV5i5mkL0kjghV1opcuhKgbbG+7pcn8JSpiq6mh7o3MDYtapw90w==}
     engines: {node: '>=18.20.0'}
     peerDependencies:
       puppeteer-core: '>=22.x || <=24.x'
@@ -13905,6 +13962,7 @@ packages:
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-mimetype@4.0.0:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
@@ -18301,6 +18359,19 @@ snapshots:
       - bare-buffer
       - supports-color
 
+  '@puppeteer/browsers@file:../puppeteer/packages/browsers':
+    dependencies:
+      debug: 4.4.3
+      extract-zip: 2.0.1
+      progress: 2.0.3
+      proxy-agent: 6.5.0
+      semver: 7.7.3
+      tar-fs: 3.1.1
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - bare-buffer
+      - supports-color
+
   '@rolldown/pluginutils@1.0.0-beta.19': {}
 
   '@rollup/plugin-babel@5.3.1(@babel/core@7.27.7)(@types/babel__core@7.20.5)(rollup@2.79.2)':
@@ -19278,6 +19349,8 @@ snapshots:
 
   '@types/ejs@3.1.5': {}
 
+  '@types/electron-to-chromium@1.5.0': {}
+
   '@types/eslint-scope@3.7.7':
     dependencies:
       '@types/eslint': 9.6.1
@@ -19507,7 +19580,7 @@ snapshots:
   '@types/react-router@5.1.20':
     dependencies:
       '@types/history': 4.7.11
-      '@types/react': 19.1.8
+      '@types/react': 19.1.9
 
   '@types/react@19.1.8':
     dependencies:
@@ -19960,6 +20033,18 @@ snapshots:
       - bare-buffer
       - supports-color
 
+  '@wdio/config@9.19.1':
+    dependencies:
+      '@wdio/logger': 9.18.0
+      '@wdio/types': 9.19.1
+      '@wdio/utils': 9.19.1
+      deepmerge-ts: 7.1.5
+      glob: 10.4.5
+      import-meta-resolve: 4.1.0
+    transitivePeerDependencies:
+      - bare-buffer
+      - supports-color
+
   '@wdio/dot-reporter@9.16.2':
     dependencies:
       '@wdio/reporter': 9.16.2
@@ -19982,10 +20067,10 @@ snapshots:
       - supports-color
       - typescript
 
-  '@wdio/globals@9.16.2(expect-webdriverio@5.3.4(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@9.16.2(puppeteer-core@24.12.1)))(webdriverio@9.16.2(puppeteer-core@24.12.1))':
+  '@wdio/globals@9.16.2(expect-webdriverio@5.3.4(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@9.18.4(puppeteer-core@24.12.1)))(webdriverio@9.18.4(puppeteer-core@24.12.1))':
     dependencies:
-      expect-webdriverio: 5.3.4(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@9.16.2(puppeteer-core@24.12.1))
-      webdriverio: 9.16.2(puppeteer-core@24.12.1)
+      expect-webdriverio: 5.3.4(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@9.18.4(puppeteer-core@24.12.1))
+      webdriverio: 9.18.4(puppeteer-core@24.12.1)
 
   '@wdio/globals@9.16.2(expect-webdriverio@5.3.4(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@packages+webdriverio))(webdriverio@9.16.2(puppeteer-core@24.12.1))':
     dependencies:
@@ -19997,10 +20082,10 @@ snapshots:
       expect-webdriverio: 5.3.4(@wdio/globals@9.17.0)(@wdio/logger@9.18.0)(webdriverio@9.16.2(puppeteer-core@24.12.1))
       webdriverio: 9.16.2(puppeteer-core@24.12.1)
 
-  '@wdio/globals@9.17.0(expect-webdriverio@5.3.4)(webdriverio@9.18.4(puppeteer-core@24.12.1))':
+  '@wdio/globals@9.17.0(expect-webdriverio@5.3.4)(webdriverio@9.19.1(puppeteer-core@24.12.1))':
     dependencies:
-      expect-webdriverio: 5.3.4(@wdio/globals@9.17.0)(@wdio/logger@9.18.0)(webdriverio@9.18.4(puppeteer-core@24.12.1))
-      webdriverio: 9.18.4(puppeteer-core@24.12.1)
+      expect-webdriverio: 5.3.4(@wdio/globals@9.17.0)(@wdio/logger@9.18.0)(webdriverio@9.19.1(puppeteer-core@24.12.1))
+      webdriverio: 9.19.1(puppeteer-core@24.12.1)
 
   '@wdio/logger@9.16.2':
     dependencies:
@@ -20031,19 +20116,19 @@ snapshots:
       diff: 7.0.0
       object-inspect: 1.13.4
 
-  '@wdio/runner@9.16.2(expect-webdriverio@5.3.4(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@9.16.2(puppeteer-core@24.12.1)))(webdriverio@9.16.2(puppeteer-core@24.12.1))':
+  '@wdio/runner@9.16.2(expect-webdriverio@5.3.4(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@9.18.4(puppeteer-core@24.12.1)))(webdriverio@9.18.4(puppeteer-core@24.12.1))':
     dependencies:
       '@types/node': 20.19.5
       '@wdio/config': 9.16.2
       '@wdio/dot-reporter': 9.16.2
-      '@wdio/globals': 9.16.2(expect-webdriverio@5.3.4(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@9.16.2(puppeteer-core@24.12.1)))(webdriverio@9.16.2(puppeteer-core@24.12.1))
+      '@wdio/globals': 9.16.2(expect-webdriverio@5.3.4(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@9.18.4(puppeteer-core@24.12.1)))(webdriverio@9.18.4(puppeteer-core@24.12.1))
       '@wdio/logger': 9.16.2
       '@wdio/types': 9.16.2
       '@wdio/utils': 9.16.2
       deepmerge-ts: 7.1.5
-      expect-webdriverio: 5.3.4(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@9.16.2(puppeteer-core@24.12.1))
+      expect-webdriverio: 5.3.4(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@9.18.4(puppeteer-core@24.12.1))
       webdriver: 9.16.2
-      webdriverio: 9.16.2(puppeteer-core@24.12.1)
+      webdriverio: 9.18.4(puppeteer-core@24.12.1)
     transitivePeerDependencies:
       - bare-buffer
       - bufferutil
@@ -20054,9 +20139,13 @@ snapshots:
     dependencies:
       '@types/node': 20.19.10
 
+  '@wdio/types@9.19.1':
+    dependencies:
+      '@types/node': 20.19.10
+
   '@wdio/utils@9.16.2':
     dependencies:
-      '@puppeteer/browsers': 2.10.5
+      '@puppeteer/browsers': 2.10.6
       '@wdio/logger': 9.16.2
       '@wdio/types': 9.16.2
       decamelize: 6.0.0
@@ -20078,6 +20167,26 @@ snapshots:
       '@puppeteer/browsers': 2.10.6
       '@wdio/logger': 9.18.0
       '@wdio/types': 9.16.2
+      decamelize: 6.0.0
+      deepmerge-ts: 7.1.5
+      edgedriver: 6.1.2
+      geckodriver: 5.0.0
+      get-port: 7.1.0
+      import-meta-resolve: 4.1.0
+      locate-app: 2.5.0
+      mitt: 3.0.1
+      safaridriver: 1.0.0
+      split2: 4.2.0
+      wait-port: 1.1.0
+    transitivePeerDependencies:
+      - bare-buffer
+      - supports-color
+
+  '@wdio/utils@9.19.1':
+    dependencies:
+      '@puppeteer/browsers': 2.10.6
+      '@wdio/logger': 9.18.0
+      '@wdio/types': 9.19.1
       decamelize: 6.0.0
       deepmerge-ts: 7.1.5
       edgedriver: 6.1.2
@@ -21653,6 +21762,10 @@ snapshots:
     optionalDependencies:
       supports-color: 8.1.1
 
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
   decamelize-keys@1.1.1:
     dependencies:
       decamelize: 1.2.0
@@ -22591,25 +22704,25 @@ snapshots:
       lodash.isequal: 4.5.0
       webdriverio: 9.16.2(puppeteer-core@24.12.1)
 
-  expect-webdriverio@5.3.4(@wdio/globals@9.17.0)(@wdio/logger@9.18.0)(webdriverio@9.18.4(puppeteer-core@24.12.1)):
+  expect-webdriverio@5.3.4(@wdio/globals@9.17.0)(@wdio/logger@9.18.0)(webdriverio@9.19.1(puppeteer-core@24.12.1)):
     dependencies:
       '@vitest/snapshot': 3.2.4
-      '@wdio/globals': 9.17.0(expect-webdriverio@5.3.4)(webdriverio@9.18.4(puppeteer-core@24.12.1))
+      '@wdio/globals': 9.17.0(expect-webdriverio@5.3.4)(webdriverio@9.19.1(puppeteer-core@24.12.1))
       '@wdio/logger': 9.18.0
       expect: 30.0.4
       jest-matcher-utils: 30.0.3
       lodash.isequal: 4.5.0
-      webdriverio: 9.18.4(puppeteer-core@24.12.1)
+      webdriverio: 9.19.1(puppeteer-core@24.12.1)
 
-  expect-webdriverio@5.3.4(@wdio/globals@9.17.0)(@wdio/logger@packages+wdio-logger)(webdriverio@9.18.4(puppeteer-core@24.12.1)):
+  expect-webdriverio@5.3.4(@wdio/globals@9.17.0)(@wdio/logger@packages+wdio-logger)(webdriverio@9.19.1(puppeteer-core@24.12.1)):
     dependencies:
       '@vitest/snapshot': 3.2.4
-      '@wdio/globals': 9.17.0(expect-webdriverio@5.3.4)(webdriverio@9.18.4(puppeteer-core@24.12.1))
+      '@wdio/globals': 9.17.0(expect-webdriverio@5.3.4)(webdriverio@9.19.1(puppeteer-core@24.12.1))
       '@wdio/logger': link:packages/wdio-logger
       expect: 30.0.4
       jest-matcher-utils: 30.0.3
       lodash.isequal: 4.5.0
-      webdriverio: 9.18.4(puppeteer-core@24.12.1)
+      webdriverio: 9.19.1(puppeteer-core@24.12.1)
 
   expect-webdriverio@5.3.4(@wdio/globals@packages+wdio-globals)(@wdio/logger@9.18.0)(webdriverio@packages+webdriverio):
     dependencies:
@@ -22620,16 +22733,6 @@ snapshots:
       jest-matcher-utils: 30.0.3
       lodash.isequal: 4.5.0
       webdriverio: link:packages/webdriverio
-
-  expect-webdriverio@5.3.4(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@9.16.2(puppeteer-core@24.12.1)):
-    dependencies:
-      '@vitest/snapshot': 3.2.4
-      '@wdio/globals': link:packages/wdio-globals
-      '@wdio/logger': link:packages/wdio-logger
-      expect: 30.0.4
-      jest-matcher-utils: 30.0.3
-      lodash.isequal: 4.5.0
-      webdriverio: 9.16.2(puppeteer-core@24.12.1)
 
   expect-webdriverio@5.3.4(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@9.18.4(puppeteer-core@24.12.1)):
     dependencies:
@@ -22755,7 +22858,7 @@ snapshots:
 
   extract-zip@2.0.1:
     dependencies:
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.3
       get-stream: 5.2.0
       yauzl: 2.10.0
     optionalDependencies:
@@ -23122,7 +23225,7 @@ snapshots:
     dependencies:
       basic-ftp: 5.0.5
       data-uri-to-buffer: 6.0.2
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -23509,7 +23612,7 @@ snapshots:
 
   history@4.10.1:
     dependencies:
-      '@babel/runtime': 7.27.6
+      '@babel/runtime': 7.28.2
       loose-envify: 1.4.0
       resolve-pathname: 3.0.0
       tiny-invariant: 1.3.3
@@ -26177,7 +26280,7 @@ snapshots:
     dependencies:
       '@tootallnate/quickjs-emscripten': 0.23.0
       agent-base: 7.1.3
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.3
       get-uri: 6.0.4
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
@@ -27036,7 +27139,7 @@ snapshots:
   proxy-agent@6.5.0:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.3
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
       lru-cache: 7.18.3
@@ -27807,6 +27910,8 @@ snapshots:
 
   semver@7.7.2: {}
 
+  semver@7.7.3: {}
+
   send@0.19.0:
     dependencies:
       debug: 2.6.9
@@ -28073,7 +28178,7 @@ snapshots:
   socks-proxy-agent@8.0.5:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.3
       socks: 2.8.5
     transitivePeerDependencies:
       - supports-color
@@ -28482,6 +28587,16 @@ snapshots:
       tar-stream: 2.2.0
 
   tar-fs@3.1.0:
+    dependencies:
+      pump: 3.0.3
+      tar-stream: 3.1.7
+    optionalDependencies:
+      bare-fs: 4.1.5
+      bare-path: 3.0.0
+    transitivePeerDependencies:
+      - bare-buffer
+
+  tar-fs@3.1.1:
     dependencies:
       pump: 3.0.3
       tar-stream: 3.1.7
@@ -29368,6 +29483,25 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  webdriver@9.19.1:
+    dependencies:
+      '@types/node': 20.19.10
+      '@types/ws': 8.18.1
+      '@wdio/config': 9.19.1
+      '@wdio/logger': 9.18.0
+      '@wdio/protocols': 9.16.2
+      '@wdio/types': 9.19.1
+      '@wdio/utils': 9.19.1
+      deepmerge-ts: 7.1.5
+      https-proxy-agent: 7.0.6
+      undici: 6.21.3
+      ws: 8.18.3
+    transitivePeerDependencies:
+      - bare-buffer
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   webdriverio@9.16.2(puppeteer-core@24.12.1):
     dependencies:
       '@types/node': 20.19.5
@@ -29430,6 +29564,41 @@ snapshots:
       serialize-error: 12.0.0
       urlpattern-polyfill: 10.1.0
       webdriver: 9.18.0
+    optionalDependencies:
+      puppeteer-core: 24.12.1
+    transitivePeerDependencies:
+      - bare-buffer
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  webdriverio@9.19.1(puppeteer-core@24.12.1):
+    dependencies:
+      '@types/node': 20.19.10
+      '@types/sinonjs__fake-timers': 8.1.5
+      '@wdio/config': 9.19.1
+      '@wdio/logger': 9.18.0
+      '@wdio/protocols': 9.16.2
+      '@wdio/repl': 9.16.2
+      '@wdio/types': 9.19.1
+      '@wdio/utils': 9.19.1
+      archiver: 7.0.1
+      aria-query: 5.3.2
+      cheerio: 1.1.0
+      css-shorthand-properties: 1.1.2
+      css-value: 0.0.1
+      grapheme-splitter: 1.0.4
+      htmlfy: 0.8.1
+      is-plain-obj: 4.1.0
+      jszip: 3.10.1
+      lodash.clonedeep: 4.5.0
+      lodash.zip: 4.2.0
+      query-selector-shadow-dom: 1.0.1
+      resq: 1.11.0
+      rgb2hex: 0.2.5
+      serialize-error: 12.0.0
+      urlpattern-polyfill: 10.1.0
+      webdriver: 9.19.1
     optionalDependencies:
       puppeteer-core: 24.12.1
     transitivePeerDependencies:


### PR DESCRIPTION
## Proposed changes

This PR adds support for downloading Chromedriver from Electron releases using the new pluggable downloader interface in `@puppeteer/browsers`. This enables Linux ARM64 Chromedriver support where Chrome for Testing doesn't provide binaries.

### Key Changes:

**🔧 New ElectronDownloader Class**
- Implements `BrowserDownloader` interface for Chromedriver downloads from Electron releases
- Maps Chromium versions to Electron versions using `electron-to-chromium` package
- Supports platform-specific downloads (Linux ARM64, macOS, Windows, etc.)

**🖥️ Enhanced Linux ARM64 Support**
- Previously, WebdriverIO couldn't download Chromedriver for Linux ARM64 (Chrome for Testing doesn't provide these binaries)
- Now falls back to Electron releases which do provide ARM64 Chromedriver builds
- Automatic version mapping: Chromium version → Electron version → download URL

**📦 Dependencies Updated**
- Added `electron-to-chromium` for Chromium → Electron version mapping
- Added `@types/electron-to-chromium` for TypeScript support
- Updated `@puppeteer/browsers` to use pluggable downloader interface

**🔄 Version Resolution Strategy**
1. **Custom mapping** (if provided)
2. **Electron releases API** (fetched and cached on first use)
3. **electron-to-chromium package** (offline fallback)

### Example Usage:

```typescript
// For Electron apps - pass Electron version directly
const buildId = '33.2.1'; // Electron version

// For non-Electron apps - pass Chromium version, automatically maps to Electron
const downloaders = [
  new ElectronDownloader({
    platforms: [BrowserPlatform.LINUX_ARM] // Only use for ARM64
  })
];
```

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Backport Request

- [x] This change is solely for `v9` and doesn't need to be back-ported

## Further comments

This addresses the long-standing issue where WebdriverIO couldn't run Chromedriver on Linux ARM64 systems because Chrome for Testing doesn't provide ARM64 binaries. By leveraging Electron releases (which do provide ARM64 Chromedriver builds), we can now support ARM64 Linux environments.

The implementation uses the new pluggable downloader interface from Puppeteer, making it extensible for future browser/driver sources while maintaining backward compatibility.

### Reviewers: @webdriverio/project-committers