### PR TITLE
fix(webdriverio): handle 'no such frame' error in BiDi navigation

### DIFF
--- a/packages/webdriverio/src/commands/browser/url.ts
+++ b/packages/webdriverio/src/commands/browser/url.ts
@@ -229,7 +229,9 @@ export async function url (
                 // Chrome error message
                 err.message.includes('navigation canceled by concurrent navigation') ||
                 // Firefox error message
-                err.message.includes('failed with error: unknown error')
+                err.message.includes('failed with error: unknown error') ||
+                // Race condition where the context is destroyed before navigation
+                err.message.includes('no such frame')
             ) {
                 return this.navigateTo(validateUrl(path))
             }


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)
This is my analysis :-
In WebDriver BiDi mode, the browser.url() command performs a two-step operation: it first resolves the current browsing context ID (via getCurrentContext()) and then issues the browsingContext.navigate command. A race condition occurs if the target browsing context is destroyed (e.g., via window.close() or concurrent navigation) during the latency between ID resolution and command execution. This results in the protocol error: no such frame
In short: You are trying to navigate a "ghost" window.
This is why the error is random: it only happens if the window closes exactly in that tiny gap between checking the ID and using it. My fix handles this by catching that specific "ghost" error and automatically falling back to the "navigate current window" method, which is safer in these situations.
## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
