### PR TITLE
fix(webdriverio): prevent waitForExist from swapping valid indexed el…

### DIFF
--- a/packages/webdriverio/tests/commands/element/execute.test.ts
+++ b/packages/webdriverio/tests/commands/element/execute.test.ts
@@ -43,7 +43,7 @@ describe('execute test', () => {
             "http://localhost:4321/session",
             "http://localhost:4321/session/foobar-123/element",
             "http://localhost:4321/session/foobar-123/elements",
-            "http://localhost:4321/session/foobar-123/element",
+            "http://localhost:4321/session/foobar-123/element/some-elem-123/name",
             "http://localhost:4321/session/foobar-123/execute/sync",
           ]
         `)

--- a/packages/webdriverio/tests/commands/element/waitForExist.test.ts
+++ b/packages/webdriverio/tests/commands/element/waitForExist.test.ts
@@ -76,7 +76,24 @@ describe('waitForExists', () => {
         await elem.waitForExist({ timeout })
 
         expect(elem.elementId).toBe('some-elem-456')
-        expect($$Spy).toHaveBeenCalledWith('iframe')
+        expect($Spy).not.toHaveBeenCalled()
+    })
+
+    it('should not swap elementId for indexed elements returned from $$ when accessed via chainable index', async () => {
+        const $$Spy = vi.spyOn(browser, '$$')
+        const $Spy = vi.spyOn(browser, '$')
+
+        const elem = await browser.$$('iframe')[1]
+
+        vi.spyOn(elem, 'isExisting').mockResolvedValue(true)
+        vi.spyOn(elem, 'waitUntil').mockImplementation(async (cond) => cond())
+
+        expect(elem.index).toBe(1)
+        expect(elem.elementId).toBe('some-elem-456')
+
+        await elem.waitForExist({ timeout })
+
+        expect(elem.elementId).toBe('some-elem-456')
         expect($Spy).not.toHaveBeenCalled()
     })
 })


### PR DESCRIPTION
…ements

## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)
Fixes #14249.This PR fixes an issue where \`waitForExist\` would incorrectly switch to a different element reference when using indexed selectors (e.g. \`$$('...')[1]\`) if the DOM structure changed during the wait, even if the original element was still valid
## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
