### PR TITLE
fix(allure-reporter): attach cucumber data table to step instead of s…

### DIFF
--- a/packages/wdio-allure-reporter/src/reporter.ts
+++ b/packages/wdio-allure-reporter/src/reporter.ts
@@ -262,6 +262,9 @@ export default class AllureReporter extends WDIOReporter {
     private _handleCucumberStepStart(t: TestStats): void {
         if (!this._hasPendingTest) { return }
 
+        const start = AllureReporter.getTimeOrNow(t.start)
+        this._startStep({ name: t.title, start })
+
         const arg = t.argument as Argument | undefined
         const dataTable = Array.isArray(arg?.rows)
             ? arg!.rows.map((row: { cells: string[] }) => row.cells)
@@ -273,9 +276,6 @@ export default class AllureReporter extends WDIOReporter {
                 contentType: AllureContentType.CSV,
             })
         }
-
-        const start = AllureReporter.getTimeOrNow(t.start)
-        this._startStep({ name: t.title, start })
     }
 
     private _handleCucumberStepEnd(

--- a/packages/wdio-allure-reporter/tests/cucumber.suite.test.ts
+++ b/packages/wdio-allure-reporter/tests/cucumber.suite.test.ts
@@ -797,8 +797,6 @@ describe('reporter option "useCucumberStepReporter" set to true', () => {
             reporter.onHookStart(cucumberHelper.hookStart())
             reporter.onHookEnd(cucumberHelper.hookEnd())
             reporter.onTestStart(cucumberHelper.test3Start())
-            reporter.onBeforeCommand(commandStart())
-            reporter.onAfterCommand(commandEnd())
             reporter.onTestPass(cucumberHelper.testPass())
             reporter.onHookStart(cucumberHelper.hookStart())
             reporter.addAttachment(attachmentHelper.xmlAttachment())
@@ -821,10 +819,16 @@ describe('reporter option "useCucumberStepReporter" set to true', () => {
             clean(outputDir)
         })
 
-        it('should add data table as attachment to test-case', () => {
-            const testCaseStep = allureResult.steps.find((step) => step.name !== 'Hook')
+        it('should add data table as attachment to step', () => {
+            const testCaseStep = allureResult.steps.find((step: any) => step.name === 'I check something')
             expect(testCaseStep).toBeDefined()
-            expect(Array.isArray(testCaseStep!.attachments)).toBe(true)
+            expect(testCaseStep!.attachments).toHaveLength(1)
+            expect(testCaseStep!.attachments[0].name).toBe('Data Table')
+        })
+
+        it('should not add data table as attachment to test-case', () => {
+            const dataTableAttachment = allureResult.attachments.find((attachment: any) => attachment.name === 'Data Table')
+            expect(dataTableAttachment).toBeUndefined()
         })
     })
 


### PR DESCRIPTION
…cenario

Fixes #15039

## Proposed changes
Fix:-
 Reordered the operations in packages/wdio-allure-reporter/src/reporter.ts to ensure  _startStep is called before checking for and attaching Data Tables.
Rootcause :-
In 
_handleCucumberStepStart, the Data Table attachment logic (_attachFile) was executing before the step was started (_startStep). This caused the reporter to attach the table to the currently active scope, which was the Scenario (parent) instead of the new Step.
[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments
The regression appears to have been introduced during the Allure 3 update (around Sep 2025). This fix restores the correct order of operations that existed in previous versions
[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
