### PR TITLE
fix(webdriverio): allow waitForClickable in native context if browser…

### DIFF
--- a/packages/webdriverio/src/commands/element/waitForClickable.ts
+++ b/packages/webdriverio/src/commands/element/waitForClickable.ts
@@ -44,7 +44,11 @@ export async function waitForClickable (
     }: WaitForOptions = {}
 ) {
     const browser = getBrowserObject(this)
-    if (browser.isMobile && browser.isNativeContext) {
+    if (
+        browser.isMobile &&
+        browser.isNativeContext &&
+        !browser.capabilities?.browserName
+    ) {
         throw new Error('The `waitForClickable` command is only available for desktop and mobile browsers.')
     }
 

--- a/packages/webdriverio/tests/commands/element/waitForClickable.test.ts
+++ b/packages/webdriverio/tests/commands/element/waitForClickable.test.ts
@@ -174,4 +174,31 @@ describe('waitForClickable', () => {
 
         await expect(elem.waitForClickable()).rejects.toThrow('The `waitForClickable` command is only available for desktop and mobile browsers.')
     })
+
+    it('should not throw an error if in native context but has browserName capability', async () => {
+        const browser = await remote({
+            baseUrl: 'http://foobar.com',
+            capabilities: {
+                platformName: 'Android',
+                browserName: 'samsung',
+                mobileMode: true,
+                nativeAppMode: true,
+            } as any
+        })
+        // Force capabilities to ensure test logic works regardless of remote mock implementation
+        Object.assign(browser.capabilities, { browserName: 'samsung' })
+
+        const tmpElem = await browser.$('#foo')
+        const elem = {
+            selector : '#foo',
+            waitForClickable : tmpElem.waitForClickable,
+            elementId : 123,
+            waitUntil : vi.fn().mockResolvedValue(true),
+            isClickable : vi.fn().mockResolvedValue(true),
+            options : { waitforTimeout : 500 },
+            parent: browser
+        } as unknown as WebdriverIO.Element
+
+        await expect(elem.waitForClickable()).resolves.toBe(true)
+    })
 })


### PR DESCRIPTION
…Name is present

## Proposed changes
This PR fixes an issue where 
waitForClickable
 would throw an error "The waitForClickable command is only available for desktop and mobile browsers" when running a web test on a mobile device (e.g., Samsung browser on Android) if the context happened to be reported as "NATIVE_APP" (which causes isNativeContext
 to be true).
The fix involves checking if browser.capabilities.browserName is present in 
waitForClickable

Fixes #14819[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
