### PR TITLE
feat(runner): add logBrowserConsole option to capture browser logs

### DIFF
--- a/packages/wdio-reporter/src/index.ts
+++ b/packages/wdio-reporter/src/index.ts
@@ -11,7 +11,7 @@ import type { Hook } from './stats/hook.js'
 import HookStats from './stats/hook.js'
 import TestStats, { type Test } from './stats/test.js'
 import RunnerStats from './stats/runner.js'
-import type { AfterCommandArgs, BeforeCommandArgs, CommandArgs, Tag, Argument } from './types.js'
+import type { AfterCommandArgs, BeforeCommandArgs, CommandArgs, Tag, Argument, ClientLogArgs } from './types.js'
 
 type CustomWriteStream = { write: (content: unknown) => boolean }
 
@@ -65,7 +65,9 @@ export default class WDIOReporter extends EventEmitter {
         this.on('client:beforeCommand', this.onBeforeCommand.bind(this))
         this.on('client:afterCommand', this.onAfterCommand.bind(this))
         this.on('client:beforeAssertion', this.onBeforeAssertion.bind(this))
+
         this.on('client:afterAssertion', this.onAfterAssertion.bind(this))
+        this.on('client:logEntry', this.onClientLogEntry.bind(this))
 
         this.on('runner:start', (runner: Options.RunnerStart) => {
             rootSuite.cid = runner.cid
@@ -255,6 +257,7 @@ export default class WDIOReporter extends EventEmitter {
             }
             currentTest.output.push(Object.assign(payload, { type: 'result' }))
         })
+
     }
 
     /**
@@ -279,6 +282,7 @@ export default class WDIOReporter extends EventEmitter {
     onAfterCommand(_commandArgs: AfterCommandArgs) { }
     onBeforeAssertion(_assertionArgs: unknown) { }
     onAfterAssertion(_assertionArgs: unknown) { }
+    onClientLogEntry(_logEntryArgs: ClientLogArgs) { }
     onSuiteStart(_suiteStats: SuiteStats) { }
     onHookStart(_hookStat: HookStats) { }
     onHookEnd(_hookStats: HookStats) { }
@@ -314,5 +318,5 @@ function getBrowserName(caps: WebdriverIO.Capabilities) {
 
 export {
     SuiteStats, Tag, HookStats, TestStats, RunnerStats, BeforeCommandArgs,
-    AfterCommandArgs, CommandArgs, Argument, Test, getBrowserName
+    AfterCommandArgs, CommandArgs, Argument, Test, getBrowserName, ClientLogArgs
 }

--- a/packages/wdio-reporter/src/types.ts
+++ b/packages/wdio-reporter/src/types.ts
@@ -38,6 +38,6 @@ export interface Argument {
 }
 
 export interface ClientLogArgs {
-    level: string
+    level: 'debug' | 'info' | 'warn' | 'error' | string
     text: string
 }

--- a/packages/wdio-reporter/src/types.ts
+++ b/packages/wdio-reporter/src/types.ts
@@ -36,3 +36,8 @@ export interface Argument {
         cells: string[]
     }[]
 }
+
+export interface ClientLogArgs {
+    level: string
+    text: string
+}

--- a/packages/wdio-reporter/tests/reporter.test.ts
+++ b/packages/wdio-reporter/tests/reporter.test.ts
@@ -21,7 +21,7 @@ describe('WDIOReporter', () => {
 
     it('constructor', () => {
         new WDIOReporter({ logFile: '/some/logpath' })
-        expect(eventsOnSpy.mock.calls).toHaveLength(20)
+        expect(eventsOnSpy.mock.calls).toHaveLength(21)
         expect(eventsOnSpy).toBeCalledWith('client:beforeCommand', expect.any(Function))
         expect(eventsOnSpy).toBeCalledWith('client:afterCommand', expect.any(Function))
         expect(eventsOnSpy).toBeCalledWith('client:beforeAssertion', expect.any(Function))
@@ -42,6 +42,7 @@ describe('WDIOReporter', () => {
         expect(eventsOnSpy).toBeCalledWith('runner:end', expect.any(Function))
         expect(eventsOnSpy).toBeCalledWith('client:beforeCommand', expect.any(Function))
         expect(eventsOnSpy).toBeCalledWith('client:afterCommand', expect.any(Function))
+        expect(eventsOnSpy).toBeCalledWith('client:logEntry', expect.any(Function))
     })
 
     it('should be by default synchronised', () => {

--- a/packages/wdio-runner/src/index.ts
+++ b/packages/wdio-runner/src/index.ts
@@ -148,6 +148,12 @@ export default class Runner extends EventEmitter {
             return this._shutdown(1, retries, true)
         }
 
+        if (browser?.isBidi && this._config.logBrowserConsole) {
+            browser.on('log.entryAdded', (logEntry: any) => {
+                this._reporter?.emit('client:logEntry', logEntry)
+            })
+        }
+
         this._reporter.caps = browser.capabilities
 
         const beforeArgs: BeforeArgs = [this._caps, this._specs, browser]
@@ -427,6 +433,7 @@ export default class Runner extends EventEmitter {
         } as Options.RunnerEnd)
         try {
             await this._reporter!.waitForSync()
+            this._reporter!.closeStream()
         } catch (err: any) {
             log.error(err)
         }

--- a/packages/wdio-runner/tests/index.test.ts
+++ b/packages/wdio-runner/tests/index.test.ts
@@ -459,12 +459,14 @@ describe('wdio-runner', () => {
             runner['_browser'] = {} as unknown as BrowserObject
             runner['_reporter'] = {
                 waitForSync: vi.fn().mockReturnValue(Promise.resolve()),
-                emit: vi.fn()
+                emit: vi.fn(),
+                closeStream: vi.fn()
             } as any
             runner.emit = vi.fn()
 
             expect(await runner['_shutdown'](123, 123)).toBe(123)
             expect(runner['_reporter']!.waitForSync).toBeCalledTimes(1)
+            expect(runner['_reporter']!.closeStream).toBeCalledTimes(1)
             expect(runner.emit).toBeCalledWith('exit', 1)
         })
 
@@ -476,12 +478,14 @@ describe('wdio-runner', () => {
             runner['_browser'] = {} as unknown as BrowserObject
             runner['_reporter'] = {
                 waitForSync: vi.fn().mockReturnValue(Promise.reject('foo')),
-                emit: vi.fn()
+                emit: vi.fn(),
+                closeStream: vi.fn()
             } as any
             runner.emit = vi.fn()
 
             expect(await runner['_shutdown'](123, 123)).toBe(123)
             expect(runner['_reporter']!.waitForSync).toBeCalledTimes(1)
+            expect(runner['_reporter']!.closeStream).toBeCalledTimes(1)
             expect(runner.emit).toBeCalledWith('exit', 1)
             expect(log.error).toHaveBeenCalledWith('foo')
         })
@@ -493,7 +497,8 @@ describe('wdio-runner', () => {
             runner['_caps'] = { 'browserName': 'safari' }
             runner['_reporter'] = {
                 waitForSync: vi.fn().mockReturnValue(Promise.resolve()),
-                emit: vi.fn()
+                emit: vi.fn(),
+                closeStream: vi.fn()
             } as any
             const reporter = runner['_reporter'] as any
             runner.emit = vi.fn()
@@ -512,6 +517,7 @@ describe('wdio-runner', () => {
             ]
             expect(await runner['_shutdown'](123, 123, true)).toBe(123)
             expect(reporter.emit.mock.calls).toEqual(args)
+            expect(runner['_reporter']!.closeStream).toBeCalledTimes(1)
             expect(runner.emit).toBeCalledWith('exit', 1)
         })
     })

--- a/packages/wdio-spec-reporter/src/index.ts
+++ b/packages/wdio-spec-reporter/src/index.ts
@@ -4,7 +4,7 @@ import prettyMs from 'pretty-ms'
 import type { Capabilities } from '@wdio/types'
 import { Chalk, type ChalkInstance } from 'chalk'
 import WDIOReporter, { TestStats, getBrowserName } from '@wdio/reporter'
-import type { SuiteStats, HookStats, RunnerStats, Argument } from '@wdio/reporter'
+import type { SuiteStats, HookStats, RunnerStats, Argument, ClientLogArgs } from '@wdio/reporter'
 import { buildTableData, printTable, getFormattedRows, sauceAuthenticationToken } from './utils.js'
 import { ChalkColors, type SpecReporterOptions, type TestLink, type StateCount, type Symbols, State } from './types.js'
 
@@ -161,6 +161,10 @@ export default class SpecReporter extends WDIOReporter {
 
     onRunnerEnd (runner: RunnerStats) {
         this.printReport(runner)
+    }
+
+    onClientLogEntry (logEntry: ClientLogArgs) {
+        this._consoleLogs.push(this.setMessageColor(`${logEntry.level}: ${logEntry.text}`, State.PASSED))
     }
 
     /**

--- a/packages/wdio-spec-reporter/src/types.ts
+++ b/packages/wdio-spec-reporter/src/types.ts
@@ -46,6 +46,12 @@ export interface SpecReporterOptions {
      */
     addConsoleLogs?: boolean
     /**
+     * Ability to show console logs from browser in report
+     *
+     * @default: false
+     */
+    addBrowserConsoleLogs?: boolean
+    /**
      * Ability to show test status realtime
      *
      * @default: `false`

--- a/packages/wdio-spec-reporter/tests/index.test.ts
+++ b/packages/wdio-spec-reporter/tests/index.test.ts
@@ -704,6 +704,82 @@ describe('SpecReporter', () => {
         })
     })
 
+    describe('add browser console logs', () => {
+        const options = { addBrowserConsoleLogs: true }
+
+        it('should add browser console log to report for passing test', () => {
+            tmpReporter = new SpecReporter(options)
+            tmpReporter.onSuiteStart(Object.values(SUITES)[0] as any)
+            tmpReporter.onTestStart()
+            tmpReporter['_orderedSuites'] = Object.values(SUITES) as any
+            tmpReporter.onClientLogEntry({
+                level: 'error',
+                text: 'some error from browser'
+            })
+            tmpReporter.onTestPass({
+                title:'test1',
+                state:State.PASSED
+            } as any)
+            expect(tmpReporter.getResultDisplay().toString()).toContain('[browser] red error: some error from browser')
+            tmpReporter.onSuiteEnd()
+            tmpReporter.onRunnerEnd(runnerEnd())
+        })
+
+        it('should add browser console log to report for failing test', () => {
+            tmpReporter = new SpecReporter(options)
+            tmpReporter.onSuiteStart(Object.values(SUITES)[0] as any)
+            tmpReporter.onTestStart()
+            tmpReporter['_orderedSuites'] = Object.values(SUITES) as any
+            tmpReporter.onClientLogEntry({
+                level: 'error',
+                text: 'some error from browser'
+            })
+            tmpReporter.onTestFail({
+                title:'test1',
+                state:State.FAILED
+            } as any)
+            expect(tmpReporter.getResultDisplay().toString()).toContain('[browser] red error: some error from browser')
+            tmpReporter.onSuiteEnd()
+            tmpReporter.onRunnerEnd(runnerEnd())
+        })
+
+        it('should add browser console log to report for skipped test', () => {
+            tmpReporter = new SpecReporter(options)
+            tmpReporter.onSuiteStart(Object.values(SUITES)[0] as any)
+            tmpReporter.onTestStart()
+            tmpReporter['_orderedSuites'] = Object.values(SUITES) as any
+            tmpReporter.onClientLogEntry({
+                level: 'error',
+                text: 'some error from browser'
+            })
+            tmpReporter.onTestSkip({
+                title:'test1',
+                state:State.SKIPPED
+            } as any)
+            expect(tmpReporter.getResultDisplay().toString()).toContain('[browser] red error: some error from browser')
+            tmpReporter.onSuiteEnd()
+            tmpReporter.onRunnerEnd(runnerEnd())
+        })
+
+        it('should NOT add browser console log to report if disabled', () => {
+            tmpReporter = new SpecReporter({ addBrowserConsoleLogs: false })
+            tmpReporter.onSuiteStart(Object.values(SUITES)[0] as any)
+            tmpReporter.onTestStart()
+            tmpReporter['_orderedSuites'] = Object.values(SUITES) as any
+            tmpReporter.onClientLogEntry({
+                level: 'error',
+                text: 'some error from browser'
+            })
+            tmpReporter.onTestPass({
+                title:'test1',
+                state:State.PASSED
+            } as any)
+            expect(tmpReporter.getResultDisplay().toString()).not.toContain('[browser] red error: some error from browser')
+            tmpReporter.onSuiteEnd()
+            tmpReporter.onRunnerEnd(runnerEnd())
+        })
+    })
+
     describe('onlyFailures', () => {
         let printReporter: any = null
         const runner = getRunnerConfig({ hostname: 'localhost' })

--- a/packages/wdio-types/src/Options.ts
+++ b/packages/wdio-types/src/Options.ts
@@ -276,6 +276,14 @@ export interface Testrunner extends Hooks, WebdriverIO, WebdriverIO.HookFunction
      */
     groupLogsByTestSpec?: boolean,
     /**
+     * Add console.logs from browser to your local log output.
+     * These logs will be in the browserconsole namespace and loglevel is according to
+     * the browsers log level.
+     *
+     * @default false
+     */
+    logBrowserConsole?: boolean
+    /**
      * Services take over a specific job you don't want to take care of. They enhance
      * your test setup with almost no effort.
      */

--- a/packages/wdio-types/src/Options.ts
+++ b/packages/wdio-types/src/Options.ts
@@ -276,14 +276,6 @@ export interface Testrunner extends Hooks, WebdriverIO, WebdriverIO.HookFunction
      */
     groupLogsByTestSpec?: boolean,
     /**
-     * Add console.logs from browser to your local log output.
-     * These logs will be in the browserconsole namespace and loglevel is according to
-     * the browsers log level.
-     *
-     * @default false
-     */
-    logBrowserConsole?: boolean
-    /**
      * Services take over a specific job you don't want to take care of. They enhance
      * your test setup with almost no effort.
      */


### PR DESCRIPTION
This feature enables capturing browser logs (via BiDi or classic) and printing them to the worker stdout or log file. Includes safety cleanup for log streams.

## Proposed changes
This PR introduces a new configuration option logBrowserConsole (default: false) to the 
Options.ts
 definition.

When enabled:

Runner: Listens for log.entryAdded events (BiDi support) and emits a client:logEntry event to all reporters.
SpecReporter: Implements 
onClientLogEntry
 to print browser logs directly in the terminal, interleaved with test results for better context (Display).
BaseReporter: Handles file logging. If outputDir is configured, logs are written to a dedicated file wdio-{workerId}-browserconsole.log for debugging (Archival).
WDIOReporter: Defines the event interface allowing any reporter to subscribe to browser logs.
This architecture ensures separation of concerns: the Runner handles data capture, concrete reporters handle display, and the base reporter handles archival. This addresses the need for better visibility into browser-side events during test execution in V9, as discussed in #13663.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments
This implementation aligns with the discussion in #13663 regarding opting-in to browser logs to avoid terminal noise, while providing a dedicated file for debugging when needed. The generated log file is created only if outputDir is specified, ensuring no simplified setups are cluttered. Values for logBrowserConsole are strictly validated to prevent crashes on unknown log levels from the browser.
[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
