### PR TITLE
fix(docs): update footer copyright year to 2026

### DIFF
--- a/website/i18n/en/docusaurus-theme-classic/footer.json
+++ b/website/i18n/en/docusaurus-theme-classic/footer.json
@@ -64,7 +64,7 @@
     "description": "The label of footer link with label=YouTube linking to https://youtube.com/@webdriverio"
   },
   "copyright": {
-    "message": "Copyright © 2025 OpenJS Foundation",
+    "message": "Copyright © 2026 OpenJS Foundation",
     "description": "The footer copyright"
   },
   "logo.alt": {


### PR DESCRIPTION
Fixes -#15026


### What this PR does

- Updates the footer copyright year shown on https://webdriver.io
- Fixes a hardcoded year in the i18n footer translation file

### Context

The footer was still displaying **2025** even though the site and docs are active in 2026.  
The year was coming from a hardcoded value in the footer translation JSON rather than being updated automatically.
