### PR TITLE
fix(website): ensure footer copyright year is dynamic

### DIFF
--- a/website/i18n/en/docusaurus-theme-classic/footer.json
+++ b/website/i18n/en/docusaurus-theme-classic/footer.json
@@ -63,10 +63,7 @@
     "message": "YouTube",
     "description": "The label of footer link with label=YouTube linking to https://youtube.com/@webdriverio"
   },
-  "copyright": {
-    "message": "Copyright © 2025 OpenJS Foundation",
-    "description": "The footer copyright"
-  },
+
   "logo.alt": {
     "message": "OpenJS Foundation Logo",
     "description": "The alt text of footer logo"

--- a/website/package.json
+++ b/website/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "docusaurus": "docusaurus",
     "start": "cd ../ && npm run generate:bidi && npm run docs:generate && cd website && docusaurus start",
-    "build": "docusaurus build",
+    "build": "docusaurus clear && docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "serve": "docusaurus serve",


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)
#15026 
This PR ensures the website footer copyright year is generated dynamically and stays up-to-date automatically.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments
I have removed copyright key now it will ,force Docusaurus to fallback to base config 
which correctly uses `new Date().getFullYear()`. The cache clear is added as a safety measure for the build pipeline.
[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
