### PR TITLE
fix(browserstack): better handle malicious branch names

### DIFF
--- a/packages/wdio-browserstack-service/src/testorchestration/helpers.ts
+++ b/packages/wdio-browserstack-service/src/testorchestration/helpers.ts
@@ -1,9 +1,44 @@
 import os from 'node:os'
 import path from 'node:path'
-import { execSync } from 'node:child_process'
+import { spawnSync } from 'node:child_process'
 import logger from '@wdio/logger'
 
 const log = logger('wdio-browserstack-service:helpers')
+
+/**
+ * Validate that a git ref (branch name, commit hash, etc.) contains only safe characters
+ * to prevent command injection when used in shell commands.
+ *
+ * Git refs can contain alphanumeric characters, forward slashes, dots, underscores, and hyphens.
+ * We explicitly reject any characters that could be used for shell injection.
+ */
+const SAFE_GIT_REF_PATTERN = /^[a-zA-Z0-9_./-]+$/
+
+function isValidGitRef(ref: string): boolean {
+    if (!ref || ref.length === 0 || ref.length > 256) {
+        return false
+    }
+    return SAFE_GIT_REF_PATTERN.test(ref)
+}
+
+/**
+ * Safely execute a git command using spawnSync to avoid shell injection.
+ * This function uses array arguments instead of string interpolation.
+ */
+function safeGitCommand(args: string[], cwd?: string): string {
+    const result = spawnSync('git', args, {
+        cwd,
+        encoding: 'utf-8',
+        maxBuffer: 10 * 1024 * 1024 // 10MB buffer for large diffs
+    })
+    if (result.error) {
+        throw result.error
+    }
+    if (result.status !== 0) {
+        throw new Error(result.stderr || `Git command failed with status ${result.status}`)
+    }
+    return result.stdout.trim()
+}
 
 type GitRemote = {
     name: string
@@ -77,9 +112,13 @@ function getBaseBranch(): string | null {
     try {
         // Try to get the default branch from origin/HEAD symbolic ref (works for most providers)
         try {
-            const originHeadOutput = execSync('git symbolic-ref refs/remotes/origin/HEAD').toString().trim()
+            const originHeadOutput = safeGitCommand(['symbolic-ref', 'refs/remotes/origin/HEAD'])
             if (originHeadOutput.startsWith('refs/remotes/origin/')) {
-                return originHeadOutput.replace('refs/remotes/', '')
+                const branch = originHeadOutput.replace('refs/remotes/', '')
+                if (isValidGitRef(branch)) {
+                    return branch
+                }
+                log.debug(`Invalid branch name detected: ${branch}`)
             }
         } catch {
             log.debug('Could not determine base branch from origin/HEAD')
@@ -87,12 +126,15 @@ function getBaseBranch(): string | null {
 
         // Fallback: use the first branch in local heads
         try {
-            const branchesOutput = execSync('git branch').toString().trim()
+            const branchesOutput = safeGitCommand(['branch'])
             const branches = branchesOutput.split('\n').filter(Boolean)
             if (branches.length > 0) {
                 // Remove the '* ' from current branch if present and return first branch
                 const firstBranch = branches[0].replace(/^\*\s+/, '').trim()
-                return firstBranch
+                if (isValidGitRef(firstBranch)) {
+                    return firstBranch
+                }
+                log.debug(`Invalid branch name detected: ${firstBranch}`)
             }
         } catch {
             log.debug('Could not determine base branch from local branches')
@@ -100,12 +142,15 @@ function getBaseBranch(): string | null {
 
         // Fallback: use the first remote branch if available
         try {
-            const remoteBranchesOutput = execSync('git branch -r').toString().trim()
+            const remoteBranchesOutput = safeGitCommand(['branch', '-r'])
             const remoteBranches = remoteBranchesOutput.split('\n').filter(Boolean)
             for (const branch of remoteBranches) {
                 const cleanBranch = branch.trim()
                 if (cleanBranch.startsWith('origin/') && !cleanBranch.includes('HEAD')) {
-                    return cleanBranch
+                    if (isValidGitRef(cleanBranch)) {
+                        return cleanBranch
+                    }
+                    log.debug(`Invalid branch name detected: ${cleanBranch}`)
                 }
             }
         } catch {
@@ -126,13 +171,25 @@ function getChangedFilesFromCommits(commitHashes: string[]): string[] {
 
     try {
         for (const commit of commitHashes) {
+            // Validate commit hash to prevent injection
+            if (!isValidGitRef(commit)) {
+                log.debug(`Skipping invalid commit hash: ${commit}`)
+                continue
+            }
+
             try {
                 // Check if commit has parents
-                const parentsOutput = execSync(`git log -1 --pretty=%P ${commit}`).toString().trim()
+                const parentsOutput = safeGitCommand(['log', '-1', '--pretty=%P', '--', commit])
                 const parents = parentsOutput.split(' ').filter(Boolean)
 
                 for (const parent of parents) {
-                    const diffOutput = execSync(`git diff --name-only ${parent} ${commit}`).toString().trim()
+                    // Validate parent hash
+                    if (!isValidGitRef(parent)) {
+                        log.debug(`Skipping invalid parent hash: ${parent}`)
+                        continue
+                    }
+
+                    const diffOutput = safeGitCommand(['diff', '--name-only', parent, commit])
                     const files = diffOutput.split('\n').filter(Boolean)
 
                     for (const file of files) {
@@ -188,9 +245,22 @@ export function getGitMetadataForAISelection(folders: string[] | null = []): Git
             process.chdir(folder)
 
             // Get current branch and latest commit
-            const currentBranch = execSync('git rev-parse --abbrev-ref HEAD').toString().trim()
-            const latestCommit = execSync('git rev-parse HEAD').toString().trim()
+            const currentBranch = safeGitCommand(['rev-parse', '--abbrev-ref', 'HEAD'])
+            const latestCommit = safeGitCommand(['rev-parse', 'HEAD'])
             result.prId = latestCommit
+
+            // Validate branch names to prevent command injection
+            if (!isValidGitRef(currentBranch)) {
+                log.warn(`Invalid current branch name detected: ${currentBranch}. Skipping this folder for security reasons.`)
+                process.chdir(originalDir)
+                continue
+            }
+
+            if (!isValidGitRef(latestCommit)) {
+                log.warn(`Invalid commit hash detected: ${latestCommit}. Skipping this folder for security reasons.`)
+                process.chdir(originalDir)
+                continue
+            }
 
             // Find base branch
             const baseBranch = getBaseBranch()
@@ -198,20 +268,21 @@ export function getGitMetadataForAISelection(folders: string[] | null = []): Git
 
             let commits: string[] = []
 
-            if (baseBranch) {
+            if (baseBranch && isValidGitRef(baseBranch)) {
                 try {
                     // Get changed files between base branch and current branch
-                    const changedFilesOutput = execSync(`git diff --name-only ${baseBranch}..${currentBranch}`).toString().trim()
+                    // Using spawnSync with array arguments to prevent command injection
+                    const changedFilesOutput = safeGitCommand(['diff', '--name-only', `${baseBranch}..${currentBranch}`])
                     log.debug(`Changed files between ${baseBranch} and ${currentBranch}: ${changedFilesOutput}`)
                     result.filesChanged = changedFilesOutput.split('\n').filter(f => f.trim())
 
                     // Get commits between base branch and current branch
-                    const commitsOutput = execSync(`git log ${baseBranch}..${currentBranch} --pretty=%H`).toString().trim()
+                    const commitsOutput = safeGitCommand(['log', `${baseBranch}..${currentBranch}`, '--pretty=%H'])
                     commits = commitsOutput.split('\n').filter(Boolean)
                 } catch (error) {
                     log.debug(`Failed to get changed files from branch comparison. Falling back to recent commits. Error: ${error}`)
                     // Fallback to recent commits
-                    const recentCommitsOutput = execSync('git log -10 --pretty=%H').toString().trim()
+                    const recentCommitsOutput = safeGitCommand(['log', '-10', '--pretty=%H'])
                     commits = recentCommitsOutput.split('\n').filter(Boolean)
 
                     if (commits.length > 0) {
@@ -219,8 +290,11 @@ export function getGitMetadataForAISelection(folders: string[] | null = []): Git
                     }
                 }
             } else {
+                if (baseBranch && !isValidGitRef(baseBranch)) {
+                    log.warn(`Invalid base branch name detected: ${baseBranch}. Falling back to recent commits.`)
+                }
                 // Fallback to recent commits
-                const recentCommitsOutput = execSync('git log -10 --pretty=%H').toString().trim()
+                const recentCommitsOutput = safeGitCommand(['log', '-10', '--pretty=%H'])
                 commits = recentCommitsOutput.split('\n').filter(Boolean)
 
                 if (commits.length > 0) {
@@ -235,11 +309,17 @@ export function getGitMetadataForAISelection(folders: string[] | null = []): Git
             // Only process commits if we have them
             if (commits.length > 0) {
                 for (const commit of commits) {
+                    // Validate commit hash
+                    if (!isValidGitRef(commit)) {
+                        log.debug(`Skipping invalid commit hash: ${commit}`)
+                        continue
+                    }
+
                     try {
-                        const commitMessage = execSync(`git log -1 --pretty=%B ${commit}`).toString().trim()
+                        const commitMessage = safeGitCommand(['log', '-1', '--pretty=%B', '--', commit])
                         log.debug(`Processing commit: ${commitMessage}`)
 
-                        const authorName = execSync(`git log -1 --pretty=%an ${commit}`).toString().trim()
+                        const authorName = safeGitCommand(['log', '-1', '--pretty=%an', '--', commit])
                         authorsSet.add(authorName || 'Unknown')
 
                         commitMessages.push({
@@ -256,7 +336,7 @@ export function getGitMetadataForAISelection(folders: string[] | null = []): Git
             if (commits.length === 0 && result.filesChanged.length > 0) {
                 try {
                     // Try to get current git user as fallback
-                    const fallbackAuthor = execSync('git config user.name').toString().trim() || 'Unknown'
+                    const fallbackAuthor = safeGitCommand(['config', 'user.name']) || 'Unknown'
                     authorsSet.add(fallbackAuthor)
                     log.debug(`Added fallback author: ${fallbackAuthor}`)
                 } catch (error) {
@@ -268,16 +348,16 @@ export function getGitMetadataForAISelection(folders: string[] | null = []): Git
             result.authors = Array.from(authorsSet)
             result.commitMessages = commitMessages
 
-            // Get commit date
+            // Get commit date (latestCommit already validated above)
             if (latestCommit) {
-                const commitDate = execSync(`git log -1 --pretty=%cd --date=format:'%Y-%m-%d' ${latestCommit}`).toString().trim()
+                const commitDate = safeGitCommand(['log', '-1', '--pretty=%cd', '--date=format:%Y-%m-%d', '--', latestCommit])
                 result.prDate = commitDate.replace(/'/g, '')
             }
 
             // Set PR title and description from latest commit if not already set
             if ((!result.prTitle || result.prTitle.trim() === '') && latestCommit) {
                 try {
-                    const latestCommitMessage = execSync(`git log -1 --pretty=%B ${latestCommit}`).toString().trim()
+                    const latestCommitMessage = safeGitCommand(['log', '-1', '--pretty=%B', '--', latestCommit])
                     const messageLines = latestCommitMessage.trim().split('\n')
                     result.prTitle = messageLines[0] || ''
 


### PR DESCRIPTION
## Proposed changes

fixes https://github.com/webdriverio/webdriverio/security/advisories/GHSA-5c46-x3qw-q7j7

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
