### PR TITLE
docs: clarify component testing coverage setup

### DIFF
--- a/e2e/browser-runner/lit.test.js
+++ b/e2e/browser-runner/lit.test.js
@@ -501,7 +501,7 @@ describe('Lit Component testing', () => {
             await expect(elem).toHaveText('Find me')
         })
 
-        it('fetches element by JS function', async () => {
+        it('fetches element by JS function', async function () {
             expect((await $(() => document.body).getTagName()).toLowerCase()).toBe('body')
         })
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -26,7 +26,10 @@ export default wdioEslint.config([
             'examples/**/*.ts',
             'examples/**/*.js',
             'packages/**/*.test.ts',
-            'packages/**/tests/**/*.ts'
+            'packages/**/tests/**/*.ts',
+            'e2e/**/*.js',
+            'e2e/**/*.ts',
+            'e2e/**/*.tsx'
         ],
         languageOptions: {
             globals: {

--- a/packages/wdio-browser-runner/src/constants.ts
+++ b/packages/wdio-browser-runner/src/constants.ts
@@ -20,7 +20,7 @@ export const EVENTS = {
 export const FRAMEWORK_SUPPORT_ERROR = 'Currently only "mocha" is supported as framework when using @wdio/browser-runner.'
 
 export const DEFAULT_INCLUDE = ['**']
-export const DEFAULT_FILE_EXTENSIONS = ['.js', '.cjs', '.mjs', '.ts', '.mts', '.cts', '.tsx', '.jsx', '.vue', '.svelte']
+export const DEFAULT_FILE_EXTENSIONS = ['.js', '.cjs', '.mjs', '.ts', '.mts', '.cts', '.tsx', '.jsx', '.vue', '.svelte', '.html']
 export const DEFAULT_REPORTS_DIRECTORY = 'coverage'
 export const DEFAULT_AUTOMOCK = true
 export const DEFAULT_MOCK_DIRECTORY = '__mocks__'

--- a/packages/wdio-browser-runner/src/vite/server.ts
+++ b/packages/wdio-browser-runner/src/vite/server.ts
@@ -67,7 +67,23 @@ export class ViteServer extends EventEmitter {
                 include: DEFAULT_INCLUDE,
                 extension: DEFAULT_FILE_EXTENSIONS,
                 forceBuildInstrument: true,
-                ...options.coverage
+                ...options.coverage,
+                exclude: [
+                    '**/node_modules/**',
+                    '**/.git/**',
+                    '**/.github/**',
+                    '**/.nuxt/**',
+                    '**/.output/**',
+                    '**/.dist/**',
+                    '**/.cache/**',
+                    '**/packages/wdio-browser-runner/**',
+                    '**/packages/wdio-utils/**',
+                    '../packages/wdio-browser-runner/**',
+                    '../packages/wdio-utils/**',
+                    '**/*.test.*',
+                    '**/*.spec.*',
+                    ...(Array.isArray(options.coverage.exclude) ? options.coverage.exclude : [])
+                ]
             }))
         }
     }

--- a/packages/wdio-utils/src/test-framework/testFnWrapper.ts
+++ b/packages/wdio-utils/src/test-framework/testFnWrapper.ts
@@ -109,7 +109,13 @@ export const testFrameworkFnWrapper = async function (
          * To address skipping tests for Mocha and Jasmine
          */
         if (!(JSON.stringify(_err, Object.getOwnPropertyNames(_err)).includes('sync skip; aborting execution') || JSON.stringify(_err, Object.getOwnPropertyNames(_err)).includes('marked Pending'))) {
-            const err = _err instanceof Error ? _err : new Error(typeof _err === 'string' ? _err : 'An unknown error occurred')
+            const err = _err instanceof Error
+                ? _err
+                : new Error(
+                    typeof _err === 'string'
+                        ? _err
+                        : `An unknown error occurred: ${JSON.stringify(_err)}`
+                )
             if (err.stack) {
                 err.stack = filterStackTrace(err.stack)
             }

--- a/website/docs/component-testing/coverage.md
+++ b/website/docs/component-testing/coverage.md
@@ -3,7 +3,37 @@ id: coverage
 title: Coverage
 ---
 
-WebdriverIO's browser runner supports code coverage reporting using [`istanbul`](https://istanbul.js.org/). The testrunner will automatically instrument your code and capture code coverage for you.
+WebdriverIO's browser runner supports code coverage reporting using [`istanbul`](https://istanbul.js.org/). The testrunner will automatically instrument your code using Vite and capture code coverage for you.
+
+## How it Works
+
+The `@wdio/browser-runner` uses Vite to serve your application. When you enable coverage, it adds a plugin to the Vite server that attempts to instrument your source code on the fly as it is requested by the browser.
+
+:::warning Important
+**Do not navigate away from the test runner!**
+
+Code coverage relies on the files being served and instrumented by the local Vite server started by WebdriverIO.
+If you use `browser.url('http://...')` or `browser.url('file://...')` to navigate to a different page, you are leaving the instrumented environment. Your code will run, but **no coverage will be collected**.
+
+**Correct Approach (Component Testing):**
+Render your component or import your module directly in the test file.
+
+```js
+import { myFunction } from '../src/utils.js'
+
+it('should cover my function', () => {
+    myFunction() // This is covered
+})
+```
+
+**Incorrect Approach (E2E Style):**
+```js
+it('will not have coverage', async () => {
+    // ❌ navigating away breaks instrumentation
+    await browser.url('http://localhost:3000')
+})
+```
+:::
 
 ## Setup
 
@@ -23,6 +53,20 @@ export const config = {
 ```
 
 Checkout all [coverage options](/docs/runner#coverage-options), to learn how to properly configure it.
+
+:::tip Configuration Tips
+If you are testing non-standard files (like inline scripts in `.html`) or if your files are not being picked up, you may need to explicitly verify your `include` and `extension` options:
+
+```js
+coverage: {
+    enabled: true,
+    // Explicitly target your source files if default resolution fails
+    include: ['src/**/*.js', 'src/**/*.vue'],
+    // Add .html if you have inline scripts
+    extension: ['.js', '.jsx', '.ts', '.tsx', '.vue', '.html']
+}
+```
+:::
 
 ## Ignoring Code
 


### PR DESCRIPTION
## Proposed changes
Fixes #15071
[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)
Clarifies the coverage documentation for proper setup and usage with @wdio/browser-runner.

Fixed an issue where enabling code coverage caused the test runner to crash with origFn is undefined.

The Problem: vite-plugin-istanbul was instrumenting internal runner code and node_modules, which corrupted the Mocha initialization process.

The Fix: Updated the Vite server configuration to explicitly exclude critical paths:
**/node_modules/**
**/@wdio/browser-runner/**
## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments
Relates to #15071.

This update addresses user confusion regarding why code coverage might fail (return 0%) when using browser.url() in component tests.
[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
