### PR TITLE
fix(webdriverio): handle Blob serialization in Bidi execute commands

### DIFF
--- a/packages/webdriverio/src/commands/browser/execute.ts
+++ b/packages/webdriverio/src/commands/browser/execute.ts
@@ -4,6 +4,7 @@ import type { remote } from 'webdriver'
 import { verifyArgsAndStripIfElement, createFunctionDeclarationFromString } from '../../utils/index.js'
 import { LocalValue } from '../../utils/bidi/value.js'
 import { parseScriptResult } from '../../utils/bidi/index.js'
+import { createSerializableScript } from '../../utils/bidi/serialize.js'
 import { getContextManager } from '../../session/context.js'
 import { polyfillFn } from '../../scripts/polyfill.js'
 import type { TransformElement, TransformReturn } from '../../types.js'
@@ -60,7 +61,7 @@ export async function execute<ReturnValue, InnerArguments extends unknown[]> (
         const contextManager = getContextManager(browser)
         const context = await contextManager.getCurrentContext()
         const userScript = typeof script === 'string' ? new Function(script) : script
-        const functionDeclaration = createFunctionDeclarationFromString(userScript)
+        const functionDeclaration = createFunctionDeclarationFromString(new Function(createSerializableScript(userScript)))
         const params: remote.ScriptCallFunctionParameters = {
             functionDeclaration,
             awaitPromise: true,

--- a/packages/webdriverio/src/utils/bidi/serialize.ts
+++ b/packages/webdriverio/src/utils/bidi/serialize.ts
@@ -1,0 +1,166 @@
+import { Buffer } from 'node:buffer'
+
+export const SERIALIZED_BLOB_KEY = '__wdioSerializedBlob__'
+export const SERIALIZED_BLOB_KIND_BLOB = 'blob'
+export const SERIALIZED_BLOB_KIND_FILE = 'file'
+
+type SerializedBlobKind = typeof SERIALIZED_BLOB_KIND_BLOB | typeof SERIALIZED_BLOB_KIND_FILE
+
+export interface SerializedBlobValue {
+    [SERIALIZED_BLOB_KEY]: true
+    data: string
+    type?: string
+    size?: number
+    kind?: SerializedBlobKind
+    name?: string
+    lastModified?: number
+}
+
+export const SERIALIZER_HELPER = `
+    const __wdioSerializedBlobKey = ${JSON.stringify(SERIALIZED_BLOB_KEY)};
+    const __wdioSerializedBlobKindBlob = ${JSON.stringify(SERIALIZED_BLOB_KIND_BLOB)};
+    const __wdioSerializedBlobKindFile = ${JSON.stringify(SERIALIZED_BLOB_KIND_FILE)};
+
+    function __wdioIsPlainObject(value) {
+        if (!value || typeof value !== 'object') {
+            return false;
+        }
+        const prototype = Object.getPrototypeOf(value);
+        return prototype === Object.prototype || prototype === null;
+    }
+
+    function __wdioArrayBufferToBase64(buffer) {
+        let binary = '';
+        const bytes = new Uint8Array(buffer);
+        const chunkSize = 0x8000;
+        for (let i = 0; i < bytes.length; i += chunkSize) {
+            const chunk = bytes.subarray(i, i + chunkSize);
+            binary += String.fromCharCode.apply(null, chunk);
+        }
+        const encoder =
+            typeof btoa === 'function'
+                ? btoa
+                : (typeof globalThis !== 'undefined' && typeof globalThis.btoa === 'function'
+                    ? globalThis.btoa
+                    : undefined);
+        if (!encoder) {
+            throw new Error('Unable to encode Blob data: btoa is not available');
+        }
+        return encoder(binary);
+    }
+
+    async function __wdioSerializeBlob(blob) {
+        const arrayBuffer = await blob.arrayBuffer();
+        const base64 = __wdioArrayBufferToBase64(arrayBuffer);
+        const serialized = {
+            [__wdioSerializedBlobKey]: true,
+            data: base64,
+            type: blob.type || '',
+            size: blob.size,
+            kind: __wdioSerializedBlobKindBlob
+        };
+        if (typeof File !== 'undefined' && blob instanceof File) {
+            serialized.kind = __wdioSerializedBlobKindFile;
+            serialized.name = blob.name;
+            serialized.lastModified = blob.lastModified;
+        }
+        return serialized;
+    }
+
+    async function __wdioSerializeValue(value, seen = new WeakSet()) {
+        if (value === null || typeof value !== 'object') {
+            return value;
+        }
+        if (seen.has(value)) {
+            return '[Circular]';
+        }
+        seen.add(value);
+        if (typeof Blob !== 'undefined' && value instanceof Blob) {
+            seen.delete(value);
+            return __wdioSerializeBlob(value);
+        }
+        if (Array.isArray(value)) {
+            const serialized = [];
+            for (const element of value) {
+                serialized.push(await __wdioSerializeValue(element, seen));
+            }
+            seen.delete(value);
+            return serialized;
+        }
+        if (__wdioIsPlainObject(value)) {
+            const entries = [];
+            for (const key of Object.keys(value)) {
+                entries.push([
+                    key,
+                    await __wdioSerializeValue(value[key], seen)
+                ]);
+            }
+            seen.delete(value);
+            return Object.fromEntries(entries);
+        }
+        seen.delete(value);
+        return value;
+    }
+`
+
+function getUserScript (script: string | Function) {
+    if (typeof script === 'string') {
+        return `function () {\n${script}\n}`
+    }
+    return script.toString()
+}
+
+export function createSerializableScript (script: string | Function) {
+    const userScript = getUserScript(script)
+    return `
+        const userScript = ${userScript};
+        ${SERIALIZER_HELPER}
+        return (async () => {
+            const result = await userScript.apply(this, arguments);
+            return __wdioSerializeValue(result);
+        })();
+    `
+}
+
+export function createSerializableAsyncScript (script: string | Function) {
+    const userScript = getUserScript(script)
+    return `
+        const args = Array.from(arguments);
+        const userScript = ${userScript};
+        ${SERIALIZER_HELPER}
+        return new Promise(async (resolve, reject) => {
+            const cb = (result) => resolve(__wdioSerializeValue(result));
+            try {
+                await userScript.apply(this, [...args, cb]);
+            } catch (err) {
+                reject(err);
+            }
+        });
+    `
+}
+
+export function isSerializedBlobValue (value: unknown): value is SerializedBlobValue {
+    if (typeof value !== 'object' || value === null) {
+        return false
+    }
+    const serialized = value as Record<string, unknown>
+    return serialized[SERIALIZED_BLOB_KEY] === true && typeof serialized.data === 'string'
+}
+
+export function createBlobFromSerializedValue (value: SerializedBlobValue) {
+    const data = Buffer.from(value.data, 'base64')
+    const blobParts = [data]
+    const blobOptions = value.type ? { type: value.type } : undefined
+    if (value.kind === SERIALIZED_BLOB_KIND_FILE && typeof File === 'function') {
+        const name = value.name ?? 'file'
+        const lastModified = typeof value.lastModified === 'number' ? value.lastModified : Date.now()
+        return new File(blobParts, name, {
+            type: value.type ?? '',
+            lastModified
+        })
+    }
+    if (typeof Blob === 'function') {
+        return new Blob(blobParts, blobOptions)
+    }
+    return data
+}

--- a/packages/webdriverio/tests/utils/bidi/circular.test.ts
+++ b/packages/webdriverio/tests/utils/bidi/circular.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest'
+import { SERIALIZER_HELPER } from '../../../src/utils/bidi/serialize.js'
+
+describe('Bidi Serialization Circular References', () => {
+    it('should return [Circular] for circular references', async () => {
+        // Evaluate the serializer code in a "browser-like" context (Node.js vm or just new Function)
+        // Since SERIALIZER_HELPER contains __wdioSerializeValue, we can construct a function to use it.
+        const serializerFunction = new Function(`
+            ${SERIALIZER_HELPER}
+            return __wdioSerializeValue(arguments[0]);
+        `)
+
+        const obj: any = { foo: 'bar' }
+        obj.self = obj
+
+        const serialized = await serializerFunction(obj)
+        expect(serialized).toEqual({
+            foo: 'bar',
+            self: '[Circular]'
+        })
+    })
+
+    it('should handle nested circular references', async () => {
+        const serializerFunction = new Function(`
+            ${SERIALIZER_HELPER}
+            return __wdioSerializeValue(arguments[0]);
+        `)
+
+        const a: any = { name: 'a' }
+        const b: any = { name: 'b' }
+        a.child = b
+        b.parent = a
+
+        const serialized = await serializerFunction(a)
+        expect(serialized).toEqual({
+            name: 'a',
+            child: {
+                name: 'b',
+                parent: '[Circular]'
+            }
+        })
+    })
+
+    it('should handle arrays with circular references', async () => {
+        const serializerFunction = new Function(`
+            ${SERIALIZER_HELPER}
+            return __wdioSerializeValue(arguments[0]);
+        `)
+
+        const arr: any[] = []
+        arr.push(arr)
+
+        const serialized = await serializerFunction(arr)
+        expect(serialized).toEqual(['[Circular]'])
+    })
+})

--- a/packages/webdriverio/tests/utils/bidi/serialize.test.ts
+++ b/packages/webdriverio/tests/utils/bidi/serialize.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from 'vitest'
+import { deserialize } from '../../../src/utils/bidi/index.js'
+import { isSerializedBlobValue, createBlobFromSerializedValue, SERIALIZED_BLOB_KEY } from '../../../src/utils/bidi/serialize.js'
+
+describe('Bidi Serialization Fix', () => {
+    it('isSerializedBlobValue should recognize serialized blobs', () => {
+        const serialized = {
+            [SERIALIZED_BLOB_KEY]: true,
+            data: 'base64str',
+            type: 'text/plain'
+        }
+        expect(isSerializedBlobValue(serialized)).toBe(true)
+        expect(isSerializedBlobValue({})).toBe(false)
+        expect(isSerializedBlobValue({ other: 'prop' })).toBe(false)
+    })
+
+    it('deserialize should handle serialized blobs (currently fails/returns object)', () => {
+        // Mock the structure that __wdioSerializeBlob produces and gets sent over Bidi
+        // Bidi sends objects as { type: 'object', value: [...] }
+        const serializedBlob = {
+            type: 'object',
+            value: [
+                ['__wdioSerializedBlob__', { type: 'boolean', value: true }],
+                ['data', { type: 'string', value: 'SGVsbG8gV29ybGQ=' }], // "Hello World" in base64
+                ['type', { type: 'string', value: 'text/plain' }]
+            ]
+        }
+
+        // Current behavior: returns a plain object
+        const result = deserialize(serializedBlob as any)
+
+        // With the fix, it should return a Blob (or primitive if Blob not available, but Node has Blob)
+        expect(result).toBeDefined()
+        // Check if it looks like a Blob (vitest/node Blob)
+        if (typeof Blob !== 'undefined' && result instanceof Blob) {
+            expect(result.type).toBe('text/plain')
+            // Verify content if possible (async text())
+        } else {
+            // Fallback
+            expect(result).toHaveProperty('size')
+            expect(result).toHaveProperty('type', 'text/plain')
+        }
+
+        // This is what we WANT it to do (return a Buffer or Blob if Blob is available)
+        // Since we are in Node, it might be a Buffer or a Blob if global Blob exists (Node 20+ has Blob)
+    })
+
+    it('createBlobFromSerializedValue should create a Blob/Buffer', () => {
+        const payload = {
+            [SERIALIZED_BLOB_KEY]: true,
+            data: 'SGVsbG8gV29ybGQ=',
+            type: 'text/plain'
+        }
+
+        const result = createBlobFromSerializedValue(payload as any)
+
+        // In Node environment, Buffer might be used if Blob is not available, or Blob if it is.
+        // Node 18+ has Blob.
+        expect(result).toBeDefined()
+        if (result instanceof Blob) {
+            expect(result.type).toBe('text/plain')
+            // verify content?
+        } else {
+            // Buffer
+            expect((result as Buffer).toString()).toBe('Hello World')
+        }
+    })
+})


### PR DESCRIPTION
## Proposed changes
Fixes #15082 
[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)
Fixed an issue where browser.execute and browser.executeAsync returning a Blob resulted in an empty object when using WebDriver Bidi.
Below are key devlopments for the PR:- 
1.Implemented createSerializableScript and createSerializableAsyncScript to inject a serializer helper that converts Blob and File objects to a base64 serialized format.
2.Updated deserializeValue in packages/webdriverio/src/utils/bidi/index.ts to detect this serialized format and reconstruct the Blob (or Buffer in Node.js)
3.Added handling for circular references in the serializer to prevent infinite loops, returning [Circular] instead.
## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments
E2E testing was done locally , but haven't added to the code , hit me up if required
[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
