### PR TITLE
fix: Ensure getValue returns a string

### DIFF
--- a/packages/webdriverio/src/commands/element/getValue.ts
+++ b/packages/webdriverio/src/commands/element/getValue.ts
@@ -20,11 +20,11 @@
  * @uses protocol/elements, protocol/elementIdProperty
  *
  */
-export function getValue (this: WebdriverIO.Element) {
+export function getValue (this: WebdriverIO.Element): Promise<string> {
     // `!this.isMobile` added to workaround https://github.com/appium/appium/issues/12218
-    if (this.isW3C && !this.isMobile) {
-        return this.getElementProperty(this.elementId, 'value')
-    }
+    const value = this.isW3C && !this.isMobile ?
+        this.getElementProperty(this.elementId, 'value')
+        : this.getElementAttribute(this.elementId, 'value')
 
-    return this.getElementAttribute(this.elementId, 'value')
+    return value.then((res) => typeof res === 'string' ? res : '')
 }

--- a/packages/webdriverio/tests/commands/element/getValue.test.ts
+++ b/packages/webdriverio/tests/commands/element/getValue.test.ts
@@ -44,4 +44,42 @@ describe('getValue', () => {
         expect(vi.mocked(fetch).mock.calls[2][0].pathname)
             .toBe('/session/foobar-123/element/some-elem-123/attribute/value')
     })
+
+    it('should return empty string if value is not a string', async () => {
+        const browser = await remote({
+            baseUrl: 'http://foobar.com',
+            capabilities: {
+                browserName: 'foobar'
+            }
+        })
+        const elem = await browser.$('#foo')
+
+        // mocked return value is an object
+        vi.spyOn(elem, 'getElementProperty').mockResolvedValue({ some: 'object' })
+        expect(await elem.getValue()).toBe('')
+
+        // mocked return value is null
+        vi.spyOn(elem, 'getElementProperty').mockResolvedValue(null)
+        expect(await elem.getValue()).toBe('')
+
+        // mocked return value is undefined
+        vi.spyOn(elem, 'getElementProperty').mockResolvedValue(undefined)
+        expect(await elem.getValue()).toBe('')
+    })
+
+    it('should return empty string if attribute is null or undefined', async () => {
+        const browser = await remote({
+            baseUrl: 'http://foobar.com',
+            capabilities: {
+                browserName: 'foobar',
+                // @ts-ignore mock feature
+                mobileMode: true
+            } as any
+        })
+        const elem = await browser.$('#foo')
+
+        // mocked return value is null
+        vi.spyOn(elem, 'getElementAttribute').mockResolvedValue(null)
+        expect(await elem.getValue()).toBe('')
+    })
 })

--- a/tests/typings/webdriverio/commands.ts
+++ b/tests/typings/webdriverio/commands.ts
@@ -47,4 +47,8 @@ describe('WebdriverIO commands', async () => {
     it('getElementProperty', async () => {
         expectTypeOf(await el.getElementProperty(el.elementId, 'tagName')).toEqualTypeOf<unknown>()
     })
+
+    it('getValue', async () => {
+        expectTypeOf(await el.getValue()).toEqualTypeOf<string>()
+    })
 })


### PR DESCRIPTION
## Proposed changes

Fixes https://github.com/webdriverio/webdriverio/issues/15097 by ensuring that the `element.getValue` always returns a string as documented.

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

As a side effect of having `getElementProperty` return `unknown` in https://github.com/webdriverio/webdriverio/pull/15003, it also changes the return type of `getValue`.

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
