### PR TITLE
fix(create-wdio): generate tsconfig consistently even if root config …

### DIFF
--- a/packages/create-wdio/src/utils.ts
+++ b/packages/create-wdio/src/utils.ts
@@ -297,12 +297,9 @@ export async function setupTypeScript(parsedAnswers: ParsedAnswers) {
     }
 
     /**
-     * don't set up TypeScript if a `tsconfig.json` already exists but ensure we install `tsx`
-     * as it is a requirement for running tests with TypeScript
+     * Set up TypeScript if a `tsconfig.json` already exists
+     * We still need to generate it, usually as tsconfig.e2e.json
      */
-    if (parsedAnswers.hasRootTSConfig) {
-        return
-    }
 
     console.log('Setting up TypeScript...')
     const frameworkPackage = convertPackageHashToObject(parsedAnswers.rawAnswers.framework)
@@ -332,7 +329,7 @@ export async function setupTypeScript(parsedAnswers: ParsedAnswers) {
     ]
 
     const preset = getPreset(parsedAnswers)
-    const config = {
+    const config: Record<string, unknown> & { include?: string[] } = {
         compilerOptions: {
             // compiler
             moduleResolution: 'node',
@@ -384,16 +381,51 @@ export async function setupTypeScript(parsedAnswers: ParsedAnswers) {
                     }
                     : {}
             )
-        },
-        include: preset === 'svelte'
-            ? ['src/**/*.d.ts', 'src/**/*.ts', 'src/**/*.js', 'src/**/*.svelte']
-            : preset === 'vue'
-                ? ['src/**/*.ts', 'src/**/*.d.ts', 'src/**/*.tsx', 'src/**/*.vue']
-                : ['test', 'wdio.conf.ts']
+        }
     }
 
+    const tsConfigDir = path.dirname(parsedAnswers.tsConfigFilePath)
+    const getIncludePath = (target: string) => {
+        const p = path.relative(tsConfigDir, path.resolve(parsedAnswers.projectRootDir, target)).replace(/\\/g, '/')
+        return p || '.'
+    }
+
+    if (parsedAnswers.hasRootTSConfig) {
+        config.extends = getIncludePath('tsconfig.json')
+    }
+
+    const defaultSpecInclude = (
+        (parsedAnswers.destSpecRootPath && path.relative(parsedAnswers.projectRootDir, parsedAnswers.destSpecRootPath)) ||
+        (
+            parsedAnswers.specs &&
+            path.dirname(
+                parsedAnswers.specs
+                    .split(/[\\/]/)
+                    .filter((segment) => !segment.includes('*'))
+                    .join(path.sep)
+            )
+        ) ||
+        'test'
+    ).replace(/\\/g, '/')
+
+    const defaultWdioConfigInclude = (
+        (parsedAnswers.wdioConfigPath && path.relative(parsedAnswers.projectRootDir, parsedAnswers.wdioConfigPath)) ||
+        'wdio.conf.ts'
+    ).replace(/\\/g, '/')
+
+    const baseIncludes = preset === 'svelte'
+        ? ['src/**/*.d.ts', 'src/**/*.ts', 'src/**/*.js', 'src/**/*.svelte']
+        : preset === 'vue'
+            ? ['src/**/*.ts', 'src/**/*.d.ts', 'src/**/*.tsx', 'src/**/*.vue']
+            : [
+                defaultSpecInclude && defaultSpecInclude !== '.' ? defaultSpecInclude : 'test',
+                defaultWdioConfigInclude && defaultWdioConfigInclude !== '.' ? defaultWdioConfigInclude : 'wdio.conf.ts'
+            ]
+
+    Object.assign(config, { include: baseIncludes.map(getIncludePath) })
+
     if (parsedAnswers.framework === 'cucumber') {
-        config.include.push('features')
+        config.include!.push(getIncludePath('features'))
     }
 
     await fs.mkdir(path.dirname(parsedAnswers.tsConfigFilePath), { recursive: true })

--- a/packages/create-wdio/tests/__snapshots__/utils.test.ts.snap
+++ b/packages/create-wdio/tests/__snapshots__/utils.test.ts.snap
@@ -71,3 +71,38 @@ exports[`setupTypeScript 1`] = `
     ]
 }"
 `;
+
+exports[`setupTypeScript creates tsconfig.json even if there is already one 1`] = `
+"{
+    "compilerOptions": {
+        "moduleResolution": "node",
+        "module": "ESNext",
+        "target": "es2022",
+        "lib": [
+            "es2022",
+            "dom"
+        ],
+        "types": [
+            "node",
+            "@wdio/globals/types",
+            "expect-webdriverio",
+            "foo",
+            "wdio-electron-service"
+        ],
+        "skipLibCheck": true,
+        "noEmit": true,
+        "allowImportingTsExtensions": true,
+        "resolveJsonModule": true,
+        "isolatedModules": true,
+        "strict": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "noFallthroughCasesInSwitch": true
+    },
+    "extends": "tsconfig.json",
+    "include": [
+        "test",
+        "wdio.conf.ts"
+    ]
+}"
+`;

--- a/packages/create-wdio/tests/utils.test.ts
+++ b/packages/create-wdio/tests/utils.test.ts
@@ -628,7 +628,8 @@ test('setupTypeScript', async () => {
             ]
         },
         packagesToInstall: [],
-        tsConfigFilePath: '/foobar/tsconfig.json'
+        tsConfigFilePath: '/foobar/tsconfig.json',
+        projectRootDir: '/foobar'
     } as any
     await setupTypeScript(parsedAnswers)
     expect(vi.mocked(fs.writeFile).mock.calls[0][1]).toMatchSnapshot()
@@ -646,14 +647,15 @@ test('setupTypeScript does not create tsconfig.json if TypeScript was not select
             ]
         },
         packagesToInstall: [],
-        tsConfigFilePath: '/foobar/tsconfig.json'
+        tsConfigFilePath: '/foobar/tsconfig.json',
+        projectRootDir: '/foobar'
     } as any
     await setupTypeScript(parsedAnswers)
     expect(fs.writeFile).not.toBeCalled()
     expect(parsedAnswers.packagesToInstall).toEqual([])
 })
 
-test('setupTypeScript does not create tsconfig.json if there is already one', async () => {
+test('setupTypeScript creates tsconfig.json even if there is already one', async () => {
     const parsedAnswers = {
         isUsingTypeScript: true,
         esmSupport: true,
@@ -666,10 +668,13 @@ test('setupTypeScript does not create tsconfig.json if there is already one', as
         },
         packagesToInstall: [],
         tsConfigFilePath: '/foobar/tsconfig.json',
-        hasRootTSConfig: true
+        hasRootTSConfig: true,
+        projectRootDir: '/foobar'
     } as any
     await setupTypeScript(parsedAnswers)
-    expect(fs.writeFile).not.toBeCalled()
+    const writtenContent = vi.mocked(fs.writeFile).mock.calls[0][1] as string
+    expect(writtenContent).toContain('"extends"')
+    expect(writtenContent).toMatchSnapshot()
 })
 
 describe.skip('createWDIOScript', () => {


### PR DESCRIPTION
## Proposed changes
Fixes #15107
Fixes TypeScript config generation for create-wdio when a project already has a root tsconfig.json, which could lead to missing WebdriverIO.Browser command typings (e.g. url, getTitle) in generated test specs.

This change updates setupTypeScript to always generate the WDIO tsconfig at parsedAnswers.tsConfigFilePath and, when a root tsconfig exists, add "extends": "tsconfig.json" so generated config inherits project defaults.
It also makes default include entries derive from parsed project paths (destSpecRootPath/specs, wdioConfigPath) with safe fallbacks, instead of relying only on hardcoded values.

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [x] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments
This is intentionally a generator-behavior fix. Previously, if a root  tsconfig.json existed, WDIO tsconfig generation was skipped even when tsConfigPath pointed to a non-root file. That could leave tsConfigPath unresolved and break WDIO typing context in specs.
[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
