### PR TITLE
Hotfix multiremote cucumber junit reporter

### DIFF
--- a/packages/wdio-junit-reporter/src/index.ts
+++ b/packages/wdio-junit-reporter/src/index.ts
@@ -308,7 +308,7 @@ class JunitReporter extends WDIOReporter {
         } else {
             this._packageName = this.options.packageName || runner.sanitizedCapabilities
         }
-        const isCucumberFrameworkRunner = runner.config.framework === 'cucumber'
+        const isCucumberFrameworkRunner = runner.config.framework === 'cucumber' || Object.values(runner.instanceOptions).some(it => it.framework === "cucumber")
         if (isCucumberFrameworkRunner) {
             this._packageName = `CucumberJUnitReport-${this._packageName}`
             this._suiteTitleLabel = 'featureName'


### PR DESCRIPTION
The runner.config.framework is not set in multiremote. However, it can also be found in the instanceOptions.

## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

Fixes: https://github.com/webdriverio/webdriverio/issues/15109

The generated report is broken when cucumber and multiremote is used. The reason is that the checked framework property is not set (in multiremote).

The real issue might be somewhere in the passed runner object. I'm not sure if it supposed to be that different with multi remote capabilities.

With the proposed change, cucumber framework can also be detected and the generated report is fixed.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
