### PR TITLE
fix: add afterEach cleanup to context management E2E tests

### DIFF
--- a/e2e/wdio/headless/test.e2e.ts
+++ b/e2e/wdio/headless/test.e2e.ts
@@ -521,6 +521,10 @@ describe('main suite 1', () => {
             await browser.switchToWindow(allHandles[0])
         }
 
+        afterEach(async () => {
+            await closeAllWindowsButFirst()
+        })
+
         it('should allow user to switch between contexts', async () => {
             await browser.url('https://guinea-pig.webdriver.io/')
 
@@ -570,12 +574,12 @@ describe('main suite 1', () => {
             const elementalSeleniumLink = await $('/html/body/div[3]/div/div/a')
             await elementalSeleniumLink.waitForDisplayed()
             await elementalSeleniumLink.click()
-            await browser.waitUntil(async () => (await browser.getWindowHandles()).length === 3)
+            await browser.waitUntil(async () => (await browser.getWindowHandles()).length === 2)
             await browser.switchWindow('https://elementalselenium.com/')
             await $('#__docusaurus_skipToContent_fallback').waitForDisplayed()
             await browser.closeWindow()
             await $('#__docusaurus_skipToContent_fallback').waitForDisplayed({ reverse: true })
-            await browser.waitUntil(async () => (await browser.getWindowHandles()).length === 2)
+            await browser.waitUntil(async () => (await browser.getWindowHandles()).length === 1)
             await browser.switchWindow('https://the-internet.herokuapp.com/iframe')
         })
     })


### PR DESCRIPTION
## Problem

The `context management` E2E tests in `test.e2e.ts` had no cleanup between tests. When one test timed out (e.g. due to a slow external website), it left extra browser windows open, corrupting the browser state for every subsequent test and causing a **cascade of timeouts** through the `context management`, `switchFrame`, and `open resources` test groups.

This has been causing intermittent CI failures across multiple PRs (e.g. #15119, #15096).

## Root Cause

The `closeAllWindowsButFirst` helper existed but was only called at the **start** of individual tests, not after failures. When a test timed out mid-window-switch:
1. Extra windows remained open
2. The next test inherited a polluted browser state
3. Window count assertions (`length === 3`) would never match because the expected count was based on leftover windows from prior tests

## Fix

1. **Add `afterEach` hook** that calls `closeAllWindowsButFirst()` — ensures each test starts with a clean single-window state, even after failures
2. **Fix window count expectations** in the last test — with cleanup, each test starts from 1 window:
   - After clicking a link that opens a new tab: expect **2** windows (was 3)
   - After closing one window: expect **1** remaining (was 2)