### PR TITLE
fix(wdio-protocols): map getActiveElement return type to ElementRefer…

### DIFF
--- a/infra/compiler/src/type-generation/constants.ts
+++ b/infra/compiler/src/type-generation/constants.ts
@@ -32,6 +32,7 @@ export const returnTypeMap = {
     findElementFromShadowRoot: 'ElementReference',
     findElementsFromShadowRoot: 'ElementReference[]',
     getElementShadowRoot: 'ShadowElementReference',
+    getActiveElement: 'ElementReference',
     getAllCookies: 'Cookie[]',
     send: 'BidiResponse',
     getAppiumContext: 'Context',

--- a/tests/typings/webdriverio/commands.ts
+++ b/tests/typings/webdriverio/commands.ts
@@ -1,6 +1,6 @@
 import { expectTypeOf, describe, it } from 'vitest'
 import { $ } from '@wdio/globals'
-import type { RectReturn } from '@wdio/protocols'
+import type { RectReturn, ElementReference } from '@wdio/protocols'
 
 describe('WebdriverIO commands', async () => {
     const chainableEl = $('foo')
@@ -46,5 +46,12 @@ describe('WebdriverIO commands', async () => {
 
     it('getElementProperty', async () => {
         expectTypeOf(await el.getElementProperty(el.elementId, 'tagName')).toEqualTypeOf<unknown>()
+    })
+
+    it('getActiveElement should be compatible with $ (issue #15118)', async () => {
+        const activeEl = await browser.getActiveElement()
+        expectTypeOf(activeEl).toEqualTypeOf<ElementReference>()
+        const chainableElFromActive = $(activeEl)
+        expectTypeOf(chainableElFromActive).toEqualTypeOf(chainableEl)
     })
 })


### PR DESCRIPTION
Fixes #15118

## Proposed changes
This PR fixes a TypeScript type mismatch where the output of getActiveElement() could not be directly passed to the $() command without manual casting (Issue #15118).
The root cause was that getActiveElement was incorrectly returning a generic ProtocolCommandResponse ({ [key: string]: unknown }) instead of ElementReference. Since $() expects a Selector type (which includes ElementReference but not generic objects), this caused a compilation error.

I have updated the type generation constants in infra/compiler/src/type-generation/constants.ts to map getActiveElement to ElementReference, aligning it with other element-returning commands like findElement and findElementFromElement.

This regression was introduced recently in this commit https://github.com/webdriverio/webdriverio/commit/53642c9
[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
