### PR TITLE
fix(wdio-allure-reporter): properly resolve pending steps and status …

### DIFF
--- a/packages/wdio-allure-reporter/src/reporter.ts
+++ b/packages/wdio-allure-reporter/src/reporter.ts
@@ -870,6 +870,8 @@ export default class AllureReporter extends WDIOReporter {
         const { disableMochaHooks } = this._options
         if (!hook.parent && !this._isGlobalHook(hook)) { return }
         if (disableMochaHooks && !hook.error) { return }
+        const hadPendingTest = this._hasPendingTest
+        const hadPendingHook = this._hasPendingHook
 
         const isCucumber = this._isCucumberHook(hook)
 
@@ -885,7 +887,7 @@ export default class AllureReporter extends WDIOReporter {
 
         const hookType = this._deriveHookType(hook)
 
-        if (hook.error && !this._hasPendingTest && !this._hasPendingHook) {
+        if (hook.error && !hadPendingTest && !hadPendingHook) {
 
             const start = AllureReporter.getTimeOrNow(hook.start)
             this._startTest({ name: hook.title || 'Hook failure', start })
@@ -905,12 +907,12 @@ export default class AllureReporter extends WDIOReporter {
             return
         }
 
-        if (hook.error && this._hasPendingTest && !this._hasPendingHook) {
+        if (hook.error && hadPendingTest && !hadPendingHook) {
             const start = AllureReporter.getTimeOrNow(hook.start)
             this._startHook({ name: hook.title ?? 'Hook', type: hookType, start })
         }
 
-        if (hook.error && !this._hasPendingTest && this._hasPendingHook) {
+        if (hook.error && !hadPendingTest && hadPendingHook) {
             const start = AllureReporter.getTimeOrNow(hook.start)
             this._startTest({ name: hook.title || 'Hook failure', start })
         }
@@ -922,7 +924,7 @@ export default class AllureReporter extends WDIOReporter {
             duration: hook.duration,
         })
 
-        if (hook.error && !this._hasPendingTest && this._hasPendingHook) {
+        if (hook.error && !hadPendingTest && hadPendingHook) {
             this._endTest({
                 status: AllureStatusEnum.BROKEN,
                 stage: AllureStage.FINISHED,

--- a/packages/wdio-allure-reporter/src/state.ts
+++ b/packages/wdio-allure-reporter/src/state.ts
@@ -318,6 +318,16 @@ export class AllureReportState {
                     this._isCapturingPendingHook = false
                     continue
                 }
+                if (this._fixturesStack.length === 0 && this._pendingHookMessages.length > 0 && !this.currentFeature) {
+                    this._pendingHookMessages.push(message)
+                    this._isCapturingPendingHook = false
+                    const testName = this._currentTestName ?? 'unknown test'
+                    await this._attachPendingHookToCurrentTest('before', testName, '')
+                    await this._attachPendingHookToCurrentTest('before', testName, 'each')
+                    await this._attachPendingHookToCurrentTest('after', testName, 'each')
+                    await this._attachPendingHookToCurrentTest('after', testName, '')
+                    continue
+                }
                 await this._endHook(message)
                 continue
 
@@ -381,7 +391,6 @@ export class AllureReportState {
         }
 
         const startMsg = this._pendingHookMessages[startIdx] as WDIOHookStartMessage
-        const endMsg = this._pendingHookMessages[endIdx] as WDIOHookEndMessage
 
         await this._startHook({
             type: 'allure:hook:start',
@@ -409,8 +418,8 @@ export class AllureReportState {
             }
         }
 
+        const endMsg = this._pendingHookMessages[endIdx] as WDIOHookEndMessage
         await this._endHook(endMsg)
-
         this._pendingHookMessages.splice(startIdx, (endIdx - startIdx) + 1)
     }
 }

--- a/packages/wdio-allure-reporter/tests/suite.test.ts
+++ b/packages/wdio-allure-reporter/tests/suite.test.ts
@@ -586,6 +586,40 @@ describe('Hook reporting', () => {
 
         expect(results).toHaveLength(1)
         expect(results[0].name).toEqual('"before all" hook for "should login with valid credentials"')
+        expect(results[0].status).toEqual(Status.BROKEN)
+        expect(results[0].stage).toEqual(Stage.FINISHED)
+    })
+
+    it('should keep before all hook steps on hook failure', async () => {
+        const reporter = new AllureReporter({ outputDir })
+        const runnerEvent = runnerStart()
+
+        delete runnerEvent.capabilities.browserName
+        delete runnerEvent.capabilities.version
+
+        reporter.onRunnerStart(runnerEvent)
+        reporter.onSuiteStart(suiteStart())
+        reporter.onHookStart(hookStart())
+        reporter.addStep({ step: { title: 'Login as Admin', status: Status.PASSED } })
+        reporter.onHookEnd(hookFailed())
+        reporter.onSuiteEnd(suiteEnd())
+        await reporter.onRunnerEnd(runnerEnd())
+
+        const { results, containers } = getResults(outputDir)
+        expect(results).toHaveLength(1)
+        expect(results[0].status).toEqual(Status.BROKEN)
+        expect(results[0].stage).toEqual(Stage.FINISHED)
+
+        const beforeFixtures = containers.flatMap((container: any) =>
+            Array.isArray(container.befores) ? container.befores : []
+        )
+        const hookFixtureWithStep = beforeFixtures.find((fixture: any) =>
+            fixture.name === '"before all" hook for "should login with valid credentials"' &&
+            fixture.steps?.some((step: any) => step.name === 'Login as Admin')
+        )
+
+        expect(hookFixtureWithStep).toBeDefined()
+        expect(hookFixtureWithStep.statusDetails.message).toEqual('element ("body") still existing after 100ms')
     })
 
     it('should report failed before each hook', async () => {


### PR DESCRIPTION
…when hooks fail
fixes #15114 
## Proposed changes
This PR fixes an issue where failing `before()` hooks in Mocha generate an `Unknown` status string instead of `"broken"`, and skip attaching their internal test steps in the Allure reports.

The "Unknown" status and missing steps in Allure reports were caused by a race-like instability in state management during the hook lifecycle. Specifically, the onHookEnd method was mutating the _hasPendingTest flag in the middle of its execution, which caused subsequent conditional checks to fail and skip critical test-ending logic. Simultaneously, when a failing hook forced a test to start and stop dynamically, the state manager was unable to locate a valid endIdx for the execution steps, resulting in orphan steps that never made it into the final report.

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
