### PR TITLE
WebdriverIO v10 Node.js support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/javascript-node:0-18
+FROM mcr.microsoft.com/devcontainers/javascript-node:0-22
 
 # Installs Firefox ESR
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive && apt-get install -y firefox-esr

--- a/.github/workflows/test-component.yml
+++ b/.github/workflows/test-component.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ['18', '20', '22']
+        node: ['22', '24', '26']
         os: [
           # 'ubuntu-latest',
           'windows-latest',

--- a/.github/workflows/test-smoke.yml
+++ b/.github/workflows/test-smoke.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ['18.20.0', '20', '22']
+        node: ['22', '24', '26']
         os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ['20', '22', '24']
+        node: ['22', '24', '26']
         os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
     runs-on: ${{ matrix.os }}
     steps:

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@types/lodash.zip": "^4.2.9",
     "@types/mime-types": "^3.0.1",
     "@types/mocha": "^10.0.10",
-    "@types/node": "^20.12.7",
+    "@types/node": "^22.0.0",
     "@types/recursive-readdir": "^2.2.4",
     "@types/shelljs": "^0.10.0",
     "@types/split2": "^4.2.3",
@@ -129,6 +129,7 @@
     "vitest": "^3.2.4"
   },
   "engines": {
+    "node": ">=22",
     "pnpm": ">=8.15.3"
   }
 }

--- a/packages/create-wdio/package.json
+++ b/packages/create-wdio/package.json
@@ -31,7 +31,7 @@
   "types": "./build/index.d.ts",
   "typeScriptVersion": "3.8.3",
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/packages/create-wdio/src/constants.ts
+++ b/packages/create-wdio/src/constants.ts
@@ -63,7 +63,7 @@ export const PROGRAM_TITLE = `
 export const UNSUPPORTED_NODE_VERSION = (
     '⚠️  Unsupported Node.js Version Error ⚠️\n' +
     `You are using Node.js ${process.version} which is too old to be used with WebdriverIO.\n` +
-    'Please update to Node.js v20 to continue.\n'
+    'WebdriverIO v10 requires Node.js v22 or later. Please update to Node.js v22 to continue.\n'
 )
 
 export const INSTALL_COMMAND: Record<PACKAGE_MANAGER, string> = {

--- a/packages/create-wdio/src/index.ts
+++ b/packages/create-wdio/src/index.ts
@@ -31,7 +31,7 @@ export async function run(operation = createWebdriverIO) {
     /**
      * ensure right Node.js version is used
      */
-    const unsupportedNodeVersion = !semver.satisfies(process.version, '>=18.18.0')
+    const unsupportedNodeVersion = !semver.satisfies(process.version, '>=22')
     if (unsupportedNodeVersion) {
         console.log(chalk.yellow(UNSUPPORTED_NODE_VERSION))
         return

--- a/packages/create-wdio/tests/index.test.ts
+++ b/packages/create-wdio/tests/index.test.ts
@@ -75,7 +75,7 @@ test('does not run if Node.js version is too low', async () => {
     const op = vi.fn().mockResolvedValue({})
     await run(op)
     expect(op).toBeCalledTimes(0)
-    expect(consoleLog).toBeCalledWith(expect.stringContaining('Please update to Node.js v20 to continue.'))
+    expect(consoleLog).toBeCalledWith(expect.stringContaining('Please update to Node.js v22 to continue.'))
 })
 
 test('createWebdriverIO with Yarn', async () => {

--- a/packages/eslint-plugin-wdio/package.json
+++ b/packages/eslint-plugin-wdio/package.json
@@ -18,7 +18,7 @@
   "type": "module",
   "typeScriptVersion": "3.8.3",
   "engines": {
-    "node": ">=18.20.0"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-allure-reporter/package.json
+++ b/packages/wdio-allure-reporter/package.json
@@ -33,10 +33,10 @@
   },
   "typeScriptVersion": "3.8.3",
   "engines": {
-    "node": ">=18.20.0"
+    "node": ">=22"
   },
   "dependencies": {
-    "@types/node": "^20.1.0",
+    "@types/node": "^22.0.0",
     "@wdio/reporter": "workspace:*",
     "@wdio/types": "workspace:*",
     "allure-js-commons": "^3.3.2",

--- a/packages/wdio-appium-service/package.json
+++ b/packages/wdio-appium-service/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/webdriverio/webdriverio/tree/main/packages/wdio-appium-service",
   "license": "MIT",
   "engines": {
-    "node": ">=18.20.0"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-browser-runner/package.json
+++ b/packages/wdio-browser-runner/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/webdriverio/webdriverio/tree/main/packages/wdio-browser-runner",
   "license": "MIT",
   "engines": {
-    "node": ">=18.20.0"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-browserstack-service/package.json
+++ b/packages/wdio-browserstack-service/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/webdriverio/webdriverio/tree/main/packages/wdio-browserstack-service",
   "license": "MIT",
   "engines": {
-    "node": ">=18.20.0"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",
@@ -62,7 +62,7 @@
     "@wdio/cli": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0"
   },
   "devDependencies": {
-    "@types/node": "^20.1.0",
+    "@types/node": "^22.0.0",
     "@types/tar": "^6.1.13",
     "@types/yauzl": "^2.10.3",
     "@wdio/globals": "workspace:*"

--- a/packages/wdio-cli/package.json
+++ b/packages/wdio-cli/package.json
@@ -9,7 +9,7 @@
     "wdio": "./bin/wdio.js"
   },
   "engines": {
-    "node": ">=18.20.0"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-cli/src/launcher.ts
+++ b/packages/wdio-cli/src/launcher.ts
@@ -9,7 +9,7 @@ import { setupDriver, setupBrowser } from '@wdio/utils/node'
 import type { Capabilities, Services } from '@wdio/types'
 
 import CLInterface from './interface.js'
-import { runLauncherHook, runOnCompleteHook, runServiceHook, nodeVersion, type HookError } from './utils.js'
+import { runLauncherHook, runOnCompleteHook, runServiceHook, type HookError } from './utils.js'
 import { TESTRUNNER_DEFAULTS, WORKER_GROUPLOGS_MESSAGES } from './constants.js'
 import type { RunCommandArguments } from './types.js'
 const log = logger('@wdio/cli:launcher')
@@ -184,15 +184,7 @@ class Launcher {
          */
         const tsxPath = resolve('tsx', import.meta.url)
         if (!process.env.NODE_OPTIONS || !process.env.NODE_OPTIONS.includes(tsxPath)) {
-            /**
-             * The `--import` flag is only available in Node 20.6.0 / 18.19.0 and later.
-             * This switching can be removed once the minimum supported version of Node exceeds 20.6.0 / 18.19.0
-             * see https://nodejs.org/api/module.html#customization-hooks and https://tsx.is/dev-api/node-cli#module-mode-only
-             */
-            const moduleLoaderFlag = nodeVersion('major') >= 21 ||
-                (nodeVersion('major') === 20 && nodeVersion('minor') >= 6) ||
-                (nodeVersion('major') === 18 && nodeVersion('minor') >= 19) ? '--import' : '--loader'
-            process.env.NODE_OPTIONS = `${process.env.NODE_OPTIONS || ''} ${moduleLoaderFlag} ${tsxPath}`
+            process.env.NODE_OPTIONS = `${process.env.NODE_OPTIONS || ''} --import ${tsxPath}`
         }
 
         /**

--- a/packages/wdio-cli/src/utils.ts
+++ b/packages/wdio-cli/src/utils.ts
@@ -298,12 +298,3 @@ export function coerceOptsFor(framework: 'cucumber' | 'mocha' | 'jasmine') {
     throw new Error(`Unsupported framework "${framework}"`)
 }
 
-enum NodeVersion {
-    'major' = 0,
-    'minor' = 1,
-    'patch' = 2
-}
-
-export function nodeVersion(type: keyof typeof NodeVersion): number {
-    return process.versions.node.split('.').map(Number)[NodeVersion[type]]
-}

--- a/packages/wdio-concise-reporter/package.json
+++ b/packages/wdio-concise-reporter/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/webdriverio/webdriverio/tree/main/packages/wdio-concise-reporter",
   "license": "MIT",
   "engines": {
-    "node": ">=18.20.0"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-config/package.json
+++ b/packages/wdio-config/package.json
@@ -20,7 +20,7 @@
   },
   "typeScriptVersion": "3.8.3",
   "engines": {
-    "node": ">=18.20.0"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-cucumber-framework/package.json
+++ b/packages/wdio-cucumber-framework/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/webdriverio/webdriverio/tree/main/packages/wdio-cucumber-framework",
   "license": "MIT",
   "engines": {
-    "node": ">=18.20.0"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",
@@ -42,7 +42,7 @@
     "@cucumber/cucumber": "^10.3.1",
     "@cucumber/gherkin": "29.0.0",
     "@cucumber/messages": "26.0.1",
-    "@types/node": "^20.1.0",
+    "@types/node": "^22.0.0",
     "@wdio/logger": "workspace:*",
     "@wdio/types": "workspace:*",
     "@wdio/utils": "workspace:*",

--- a/packages/wdio-dot-reporter/package.json
+++ b/packages/wdio-dot-reporter/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/webdriverio/webdriverio/tree/main/packages/wdio-dot-reporter",
   "license": "MIT",
   "engines": {
-    "node": ">=18.20.0"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-firefox-profile-service/package.json
+++ b/packages/wdio-firefox-profile-service/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/webdriverio/webdriverio/tree/main/packages/wdio-firefox-profile-service",
   "license": "MIT",
   "engines": {
-    "node": ">=18.20.0"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-globals/package.json
+++ b/packages/wdio-globals/package.json
@@ -21,7 +21,7 @@
   "types": "./build/index.d.ts",
   "typeScriptVersion": "3.8.3",
   "engines": {
-    "node": ">=18.20.0"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-jasmine-framework/package.json
+++ b/packages/wdio-jasmine-framework/package.json
@@ -15,7 +15,7 @@
   },
   "typeScriptVersion": "3.8.3",
   "engines": {
-    "node": ">=18.20.0"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@types/jasmine": "^5.1.13",
-    "@types/node": "^20.1.0",
+    "@types/node": "^22.0.0",
     "@wdio/globals": "workspace:*",
     "@wdio/logger": "workspace:*",
     "@wdio/types": "workspace:*",

--- a/packages/wdio-json-reporter/package.json
+++ b/packages/wdio-json-reporter/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/webdriverio/webdriverio/tree/main/packages/wdio-json-reporter",
   "license": "MIT",
   "engines": {
-    "node": "^16.13 || >=18"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-junit-reporter/package.json
+++ b/packages/wdio-junit-reporter/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/webdriverio/webdriverio/tree/main/packages/wdio-junit-reporter",
   "license": "MIT",
   "engines": {
-    "node": ">=18.20.0"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-lighthouse-service/package.json
+++ b/packages/wdio-lighthouse-service/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/webdriverio/webdriverio/tree/main/packages/wdio-lighthouse-service",
   "license": "MIT",
   "engines": {
-    "node": ">=18.20.0"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",
@@ -42,7 +42,7 @@
   "dependencies": {
     "@babel/core": "^7.18.0",
     "@tracerbench/trace-event": "^8.0.0",
-    "@types/node": "^20.1.0",
+    "@types/node": "^22.0.0",
     "@wdio/logger": "workspace:*",
     "@wdio/types": "workspace:*",
     "babel-plugin-istanbul": "^7.0.0",

--- a/packages/wdio-local-runner/package.json
+++ b/packages/wdio-local-runner/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/webdriverio/webdriverio/tree/main/packages/wdio-local-runner",
   "license": "MIT",
   "engines": {
-    "node": ">=18.20.0"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",
@@ -36,7 +36,7 @@
   },
   "typeScriptVersion": "3.8.3",
   "dependencies": {
-    "@types/node": "^20.1.0",
+    "@types/node": "^22.0.0",
     "@wdio/logger": "workspace:*",
     "@wdio/repl": "workspace:*",
     "@wdio/runner": "workspace:*",

--- a/packages/wdio-logger/package.json
+++ b/packages/wdio-logger/package.json
@@ -21,7 +21,7 @@
   },
   "typeScriptVersion": "3.8.3",
   "engines": {
-    "node": ">=18.20.0"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-mocha-framework/package.json
+++ b/packages/wdio-mocha-framework/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/webdriverio/webdriverio/tree/main/packages/wdio-mocha-framework",
   "license": "MIT",
   "engines": {
-    "node": ">=18.20.0"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",
@@ -37,7 +37,7 @@
   "typeScriptVersion": "3.8.3",
   "dependencies": {
     "@types/mocha": "^10.0.6",
-    "@types/node": "^20.11.28",
+    "@types/node": "^22.0.0",
     "@wdio/logger": "workspace:*",
     "@wdio/types": "workspace:*",
     "@wdio/utils": "workspace:*",

--- a/packages/wdio-protocols/package.json
+++ b/packages/wdio-protocols/package.json
@@ -6,6 +6,9 @@
   "homepage": "https://github.com/webdriverio/webdriverio/tree/main/packages/wdio-protocols",
   "license": "MIT",
   "type": "module",
+  "engines": {
+    "node": ">=22"
+  },
   "types": "./build/index.d.ts",
   "exports": {
     ".": {

--- a/packages/wdio-repl/package.json
+++ b/packages/wdio-repl/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/webdriverio/webdriverio/tree/main/packages/wdio-repl",
   "license": "MIT",
   "engines": {
-    "node": ">=18.20.0"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",
@@ -32,7 +32,7 @@
   },
   "typeScriptVersion": "3.8.3",
   "dependencies": {
-    "@types/node": "^20.1.0"
+    "@types/node": "^22.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/wdio-reporter/package.json
+++ b/packages/wdio-reporter/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/webdriverio/webdriverio/tree/main/packages/wdio-reporter",
   "license": "MIT",
   "engines": {
-    "node": ">=18.20.0"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",
@@ -37,7 +37,7 @@
   },
   "typeScriptVersion": "3.8.3",
   "dependencies": {
-    "@types/node": "^20.1.0",
+    "@types/node": "^22.0.0",
     "@wdio/logger": "workspace:*",
     "@wdio/types": "workspace:*",
     "diff": "^8.0.2",

--- a/packages/wdio-runner/package.json
+++ b/packages/wdio-runner/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/webdriverio/webdriverio/tree/main/packages/wdio-runner",
   "license": "MIT",
   "engines": {
-    "node": ">=18.20.0"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",
@@ -31,7 +31,7 @@
   },
   "typeScriptVersion": "3.8.3",
   "dependencies": {
-    "@types/node": "^20.11.28",
+    "@types/node": "^22.0.0",
     "@wdio/config": "workspace:*",
     "@wdio/dot-reporter": "workspace:*",
     "@wdio/globals": "workspace:*",

--- a/packages/wdio-sauce-service/package.json
+++ b/packages/wdio-sauce-service/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/webdriverio/webdriverio/tree/main/packages/wdio-sauce-service",
   "license": "MIT",
   "engines": {
-    "node": ">=18.20.0"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-shared-store-service/package.json
+++ b/packages/wdio-shared-store-service/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/webdriverio/webdriverio/tree/main/packages/wdio-shared-store-service",
   "license": "MIT",
   "engines": {
-    "node": ">=18.20.0"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-smoke-test-cjs-service/package.json
+++ b/packages/wdio-smoke-test-cjs-service/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/webdriverio/webdriverio/tree/main/packages/wdio-smoke-test-service",
   "license": "MIT",
   "engines": {
-    "node": ">=18.20.0"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",
@@ -25,6 +25,6 @@
   "types": "./build/index.d.ts",
   "typeScriptVersion": "3.8.3",
   "dependencies": {
-    "@types/node": "^20.1.0"
+    "@types/node": "^22.0.0"
   }
 }

--- a/packages/wdio-smoke-test-reporter/package.json
+++ b/packages/wdio-smoke-test-reporter/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/webdriverio/webdriverio/tree/main/packages/wdio-smoke-test-reporter",
   "license": "MIT",
   "engines": {
-    "node": ">=18.20.0"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-smoke-test-service/package.json
+++ b/packages/wdio-smoke-test-service/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/webdriverio/webdriverio/tree/main/packages/wdio-smoke-test-service",
   "license": "MIT",
   "engines": {
-    "node": ">=18.20.0"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",
@@ -29,6 +29,6 @@
   },
   "typeScriptVersion": "3.8.3",
   "dependencies": {
-    "@types/node": "^20.1.0"
+    "@types/node": "^22.0.0"
   }
 }

--- a/packages/wdio-spec-reporter/package.json
+++ b/packages/wdio-spec-reporter/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/webdriverio/webdriverio/tree/main/packages/wdio-spec-reporter",
   "license": "MIT",
   "engines": {
-    "node": ">=18.20.0"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-static-server-service/package.json
+++ b/packages/wdio-static-server-service/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/webdriverio/webdriverio/tree/main/packages/wdio-static-server-service",
   "license": "MIT",
   "engines": {
-    "node": ">=18.20.0"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-sumologic-reporter/package.json
+++ b/packages/wdio-sumologic-reporter/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/webdriverio/webdriverio/tree/main/packages/wdio-sumologic-reporter",
   "license": "MIT",
   "engines": {
-    "node": ">=18.20.0"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-testingbot-service/package.json
+++ b/packages/wdio-testingbot-service/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/webdriverio/webdriverio/tree/main/packages/wdio-testingbot-service",
   "license": "MIT",
   "engines": {
-    "node": ">=18.20.0"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",
@@ -38,7 +38,7 @@
     "webdriverio": "workspace:*"
   },
   "devDependencies": {
-    "@types/node": "^20.1.0",
+    "@types/node": "^22.0.0",
     "@wdio/globals": "workspace:*"
   },
   "publishConfig": {

--- a/packages/wdio-types/package.json
+++ b/packages/wdio-types/package.json
@@ -14,7 +14,7 @@
     }
   },
   "engines": {
-    "node": ">=18.20.0"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",
@@ -32,6 +32,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@types/node": "^20.1.0"
+    "@types/node": "^22.0.0"
   }
 }

--- a/packages/wdio-utils/package.json
+++ b/packages/wdio-utils/package.json
@@ -20,7 +20,7 @@
   "types": "./build/index.d.ts",
   "typeScriptVersion": "3.8.3",
   "engines": {
-    "node": ">=18.20.0"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-webdriver-mock-service/package.json
+++ b/packages/wdio-webdriver-mock-service/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/webdriverio/webdriverio/tree/main/packages/wdio-webdriver-mock-service",
   "license": "MIT",
   "engines": {
-    "node": ">=18.20.0"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/packages/wdio-xvfb/package.json
+++ b/packages/wdio-xvfb/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/webdriverio/webdriverio/tree/main/packages/wdio-xvfb",
   "license": "MIT",
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",
@@ -41,7 +41,7 @@
     "@wdio/logger": "workspace:*"
   },
   "devDependencies": {
-    "@types/node": "^20.0.0",
+    "@types/node": "^22.0.0",
     "@wdio/types": "workspace:*"
   },
   "publishConfig": {

--- a/packages/webdriver/package.json
+++ b/packages/webdriver/package.json
@@ -22,7 +22,7 @@
   "types": "./build/index.d.ts",
   "typeScriptVersion": "3.8.3",
   "engines": {
-    "node": ">=18.20.0"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",
@@ -36,7 +36,7 @@
     "url": "https://github.com/webdriverio/webdriverio/issues"
   },
   "dependencies": {
-    "@types/node": "^20.1.0",
+    "@types/node": "^22.0.0",
     "@types/ws": "^8.5.3",
     "@wdio/config": "workspace:*",
     "@wdio/logger": "workspace:*",

--- a/packages/webdriverio/package.json
+++ b/packages/webdriverio/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/webdriverio/webdriverio/issues"
   },
   "engines": {
-    "node": ">=18.20.0"
+    "node": ">=22"
   },
   "tags": [
     "webdriver",
@@ -75,7 +75,7 @@
     "safe-stable-stringify": "^2.4.3"
   },
   "dependencies": {
-    "@types/node": "^20.11.30",
+    "@types/node": "^22.0.0",
     "@types/sinonjs__fake-timers": "^8.1.5",
     "@wdio/config": "workspace:*",
     "@wdio/logger": "workspace:*",

--- a/website/package.json
+++ b/website/package.json
@@ -36,7 +36,7 @@
     "workbox-strategies": "^7.1.0"
   },
   "engines": {
-    "node": ">=18.0"
+    "node": ">=22"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Proposed changes

This PR updates WebdriverIO to exclusively support Node.js v22, v24, and v26 for the upcoming v10 major release.

Key changes include:
- Updating `engines.node` to `>=22` across all `package.json` files.
- Upgrading `@types/node` to `^22.0.0` where applicable.
- Adjusting Node.js matrices in GitHub Actions CI workflows (`test-smoke.yml`, `test-unit.yml`, `test-component.yml`) to `['22', '24', '26']`.
- Updating runtime Node.js version checks and error messages in `create-wdio`.
- Simplifying `wdio-cli/src/launcher.ts` by removing legacy `--loader` checks and the unused `nodeVersion` utility, as Node.js 22+ natively supports `--import`.
- Updating the `.devcontainer/Dockerfile` base image to `node:0-22`.

## Types of changes

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [x] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

### Reviewers: @webdriverio/project-committers

---
<p><a href="https://cursor.com/agents/bc-8cbc40cf-ff1e-4d33-85ce-fee5d6b5f196"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8cbc40cf-ff1e-4d33-85ce-fee5d6b5f196"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->