### PR TITLE
Vitest framework integration

### DIFF
--- a/__mocks__/@vitest/runner.ts
+++ b/__mocks__/@vitest/runner.ts
@@ -1,0 +1,24 @@
+import { vi } from 'vitest'
+
+export const startTests = vi.fn().mockResolvedValue([])
+
+export const describe = vi.fn()
+export const it = vi.fn()
+export const test = vi.fn()
+export const suite = vi.fn()
+export const beforeAll = vi.fn()
+export const afterAll = vi.fn()
+export const beforeEach = vi.fn()
+export const afterEach = vi.fn()
+
+export const collectTests = vi.fn().mockResolvedValue([])
+
+export const getCurrentSuite = vi.fn()
+export const getCurrentTest = vi.fn()
+export const setFn = vi.fn()
+export const getFn = vi.fn()
+export const setHooks = vi.fn()
+export const getHooks = vi.fn()
+export const updateTask = vi.fn()
+export const createTaskCollector = vi.fn()
+export const recordArtifact = vi.fn()

--- a/packages/wdio-vitest-framework/.npmignore
+++ b/packages/wdio-vitest-framework/.npmignore
@@ -1,0 +1,4 @@
+src
+tests
+tsconfig.json
+tsconfig.prod.json

--- a/packages/wdio-vitest-framework/package.json
+++ b/packages/wdio-vitest-framework/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@wdio/vitest-framework",
+  "version": "9.24.0",
+  "description": "A WebdriverIO plugin. Adapter for Vitest testing framework.",
+  "author": "Christian Bromann <mail@bromann.dev>",
+  "homepage": "https://github.com/webdriverio/webdriverio/tree/main/packages/wdio-vitest-framework",
+  "license": "MIT",
+  "engines": {
+    "node": ">=18.20.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/webdriverio/webdriverio.git",
+    "directory": "packages/wdio-vitest-framework"
+  },
+  "keywords": [
+    "vitest",
+    "webdriver",
+    "wdio",
+    "wdio-plugin",
+    "wdio-framework"
+  ],
+  "bugs": {
+    "url": "https://github.com/webdriverio/webdriverio/issues"
+  },
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./build/index.js",
+      "types": "./build/index.d.ts"
+    },
+    "./package.json": "./package.json"
+  },
+  "types": "./build/index.d.ts",
+  "typeScriptVersion": "3.8.3",
+  "dependencies": {
+    "@vitest/runner": "^4.0.0",
+    "@vitest/utils": "^4.0.0",
+    "@wdio/logger": "workspace:*",
+    "@wdio/types": "workspace:*",
+    "@wdio/utils": "workspace:*"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/wdio-vitest-framework/src/constants.ts
+++ b/packages/wdio-vitest-framework/src/constants.ts
@@ -1,0 +1,5 @@
+export const INTERFACES = ['describe', 'it', 'test', 'beforeAll', 'beforeEach', 'afterAll', 'afterEach'] as const
+
+export const TEST_INTERFACES = ['it', 'test'] as const
+
+export const NOOP = function () { }

--- a/packages/wdio-vitest-framework/src/constants.ts
+++ b/packages/wdio-vitest-framework/src/constants.ts
@@ -1,4 +1,4 @@
-export const INTERFACES = ['describe', 'it', 'test', 'beforeAll', 'beforeEach', 'afterAll', 'afterEach'] as const
+export const INTERFACES = ['it', 'test', 'beforeAll', 'beforeEach', 'afterAll', 'afterEach'] as const
 
 export const TEST_INTERFACES = ['it', 'test'] as const
 

--- a/packages/wdio-vitest-framework/src/index.ts
+++ b/packages/wdio-vitest-framework/src/index.ts
@@ -1,0 +1,230 @@
+import url from 'node:url'
+import type { EventEmitter } from 'node:events'
+
+import logger from '@wdio/logger'
+import { executeHooksWithArgs, wrapGlobalTestMethod } from '@wdio/utils'
+import type { Services } from '@wdio/types'
+import { startTests } from '@vitest/runner'
+import type { VitestRunnerConfig } from '@vitest/runner'
+
+import { WDIOVitestRunner } from './runner.js'
+import { INTERFACES, TEST_INTERFACES } from './constants.js'
+import type { VitestOpts, FrameworkMessage } from './types.js'
+
+const log = logger('@wdio/vitest-framework')
+const FILE_PROTOCOL = 'file://'
+
+interface ParsedConfiguration {
+    rootDir: string
+    vitestOpts: VitestOpts
+    beforeSuite?: Function | Function[]
+    afterSuite?: Function | Function[]
+    beforeTest?: Function | Function[]
+    afterTest?: Function | Function[]
+    beforeHook?: Function | Function[]
+    afterHook?: Function | Function[]
+    before?: Function | Function[]
+    after?: Function | Function[]
+    [key: string]: unknown
+}
+
+/**
+ * Vitest framework adapter for WebdriverIO.
+ *
+ * Uses @vitest/runner to execute tests while integrating with WebdriverIO's
+ * hook system, service lifecycle, and reporter events.
+ */
+class VitestAdapter {
+    private _runner?: WDIOVitestRunner
+    private _hasTests = true
+    private _specLoadError?: Error
+    private _suiteStartDate: number = Date.now()
+
+    constructor(
+        private _cid: string,
+        private _config: ParsedConfiguration,
+        private _specs: string[],
+        private _capabilities: WebdriverIO.Capabilities,
+        private _reporter: EventEmitter
+    ) {
+        this._config = Object.assign({
+            vitestOpts: {}
+        }, _config)
+    }
+
+    async init() {
+        const { vitestOpts } = this._config
+        const runnerConfig = this._buildRunnerConfig(vitestOpts)
+
+        this._runner = new WDIOVitestRunner(
+            runnerConfig,
+            this._cid,
+            this._specs,
+            this._reporter
+        )
+
+        this._setupGlobalTestMethods()
+        await this._loadFiles(vitestOpts)
+        return this
+    }
+
+    hasTests(): boolean {
+        return this._hasTests
+    }
+
+    async run(): Promise<number> {
+        const runner = this._runner!
+
+        let runtimeError: Error | undefined
+
+        try {
+            this._suiteStartDate = Date.now()
+
+            await Promise.resolve(executeHooksWithArgs(
+                'beforeSuite',
+                this._config.beforeSuite as Function,
+                [this._buildSuitePayload('beforeSuite')]
+            )).catch((e: Error) => {
+                log.error(`Error in beforeSuite hook: ${e.stack?.slice(7)}`)
+            })
+
+            const specs = this._specs.map((spec) =>
+                spec.startsWith(FILE_PROTOCOL) ? url.fileURLToPath(spec) : spec
+            )
+
+            await startTests(specs, runner)
+
+            await Promise.resolve(executeHooksWithArgs(
+                'afterSuite',
+                this._config.afterSuite as Function,
+                [this._buildSuitePayload('afterSuite')]
+            )).catch((e: Error) => {
+                log.error(`Error in afterSuite hook: ${e.stack?.slice(7)}`)
+            })
+        } catch (err) {
+            runtimeError = err as Error
+        }
+
+        const result = runtimeError ? 1 : runner.failedCount
+        await Promise.resolve(executeHooksWithArgs(
+            'after',
+            this._config.after as Function,
+            [runtimeError || this._specLoadError || result, this._capabilities, this._specs]
+        ))
+
+        if (runtimeError || this._specLoadError) {
+            throw runtimeError || this._specLoadError
+        }
+
+        return result
+    }
+
+    wrapHook(hookName: keyof Services.HookFunctions) {
+        return () => Promise.resolve(executeHooksWithArgs(
+            hookName,
+            this._config[hookName] as Function,
+            [this._buildSuitePayload(hookName)]
+        )).catch((e: Error) => {
+            log.error(`Error in ${hookName} hook: ${e.stack?.slice(7)}`)
+        })
+    }
+
+    private _buildSuitePayload(hookName: string): FrameworkMessage {
+        const params: FrameworkMessage = { type: hookName }
+        if (hookName === 'afterSuite') {
+            params.duration = Date.now() - this._suiteStartDate
+        }
+        return params
+    }
+
+    private _buildRunnerConfig(opts: VitestOpts): VitestRunnerConfig {
+        const rootDir = this._config.rootDir || process.cwd()
+
+        let testNamePattern: RegExp | undefined
+        if (opts.grep) {
+            testNamePattern = opts.grep instanceof RegExp
+                ? opts.grep
+                : new RegExp(opts.grep)
+        }
+
+        return {
+            root: rootDir,
+            setupFiles: opts.setupFiles || [],
+            passWithNoTests: opts.passWithNoTests ?? false,
+            testNamePattern,
+            allowOnly: true,
+            sequence: {
+                shuffle: false,
+                concurrent: false,
+                seed: Date.now(),
+                hooks: opts.sequence?.hooks ?? 'parallel',
+                setupFiles: 'list',
+            },
+            maxConcurrency: opts.maxConcurrency ?? 5,
+            testTimeout: opts.testTimeout ?? 10000,
+            hookTimeout: opts.hookTimeout ?? 10000,
+            retry: opts.retry ?? 0,
+            includeTaskLocation: false,
+            diffOptions: undefined,
+        }
+    }
+
+    private _setupGlobalTestMethods(): void {
+        const { beforeTest, beforeHook, afterTest, afterHook } = this._config
+
+        const hookArgsFn = (context: unknown) => {
+            return [context]
+        }
+
+        INTERFACES.forEach((fnName: string) => {
+            const isTest = (TEST_INTERFACES as readonly string[]).includes(fnName)
+            wrapGlobalTestMethod(
+                isTest,
+                isTest ? beforeTest as Function : beforeHook as Function,
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                hookArgsFn as any,
+                isTest ? afterTest as Function : afterHook as Function,
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                hookArgsFn as any,
+                fnName,
+                this._cid
+            )
+        })
+    }
+
+    async _loadFiles(_vitestOpts: VitestOpts): Promise<void> {
+        try {
+            for (const spec of this._specs) {
+                const filepath = spec.startsWith(FILE_PROTOCOL)
+                    ? url.fileURLToPath(spec)
+                    : spec
+                await this._runner!.importFile(filepath, 'collect')
+            }
+            this._hasTests = true
+        } catch (err) {
+            const error = '' +
+                'Unable to load spec files quite likely because they rely on `browser` object that is not fully initialized.\n' +
+                '`browser` object has only `capabilities` and some flags like `isMobile`.\n' +
+                'Helper files that use other `browser` commands have to be moved to `before` hook.\n' +
+                `Spec file(s): ${this._specs.join(',')}\n` +
+                `Error: ${(err as Error).stack}`
+            this._specLoadError = new Error(error)
+            this._hasTests = false
+            log.warn(error)
+        }
+    }
+}
+
+const adapterFactory: { init?: Function } = {}
+
+adapterFactory.init = async function (...args: unknown[]) {
+    // @ts-ignore just passing through args
+    const adapter = new VitestAdapter(...args)
+    const instance = await adapter.init()
+    return instance
+}
+
+export default adapterFactory
+export { VitestAdapter, adapterFactory }
+export * from './types.js'
+export type { VitestOpts as VitestOptsConfig } from './types.js'

--- a/packages/wdio-vitest-framework/src/index.ts
+++ b/packages/wdio-vitest-framework/src/index.ts
@@ -2,13 +2,22 @@ import url from 'node:url'
 import type { EventEmitter } from 'node:events'
 
 import logger from '@wdio/logger'
-import { executeHooksWithArgs, wrapGlobalTestMethod } from '@wdio/utils'
+import { executeHooksWithArgs } from '@wdio/utils'
 import type { Services } from '@wdio/types'
-import { startTests } from '@vitest/runner'
+import {
+    startTests,
+    describe as vitestDescribe,
+    it as vitestIt,
+    test as vitestTest,
+    suite as vitestSuite,
+    beforeAll as vitestBeforeAll,
+    afterAll as vitestAfterAll,
+    beforeEach as vitestBeforeEach,
+    afterEach as vitestAfterEach,
+} from '@vitest/runner'
 import type { VitestRunnerConfig } from '@vitest/runner'
 
 import { WDIOVitestRunner } from './runner.js'
-import { INTERFACES, TEST_INTERFACES } from './constants.js'
 import type { VitestOpts, FrameworkMessage } from './types.js'
 
 const log = logger('@wdio/vitest-framework')
@@ -60,7 +69,13 @@ class VitestAdapter {
             runnerConfig,
             this._cid,
             this._specs,
-            this._reporter
+            this._reporter,
+            {
+                beforeTest: this._config.beforeTest,
+                afterTest: this._config.afterTest,
+                beforeHook: this._config.beforeHook,
+                afterHook: this._config.afterHook,
+            }
         )
 
         this._setupGlobalTestMethods()
@@ -170,26 +185,17 @@ class VitestAdapter {
     }
 
     private _setupGlobalTestMethods(): void {
-        const { beforeTest, beforeHook, afterTest, afterHook } = this._config
-
-        const hookArgsFn = (context: unknown) => {
-            return [context]
-        }
-
-        INTERFACES.forEach((fnName: string) => {
-            const isTest = (TEST_INTERFACES as readonly string[]).includes(fnName)
-            wrapGlobalTestMethod(
-                isTest,
-                isTest ? beforeTest as Function : beforeHook as Function,
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                hookArgsFn as any,
-                isTest ? afterTest as Function : afterHook as Function,
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                hookArgsFn as any,
-                fnName,
-                this._cid
-            )
-        })
+        const g = globalThis as Record<string, unknown>
+        g.describe = vitestDescribe
+        g.it = vitestIt
+        g.test = vitestTest
+        g.suite = vitestSuite
+        g.beforeAll = vitestBeforeAll
+        g.afterAll = vitestAfterAll
+        g.beforeEach = vitestBeforeEach
+        g.afterEach = vitestAfterEach
+        g.before = vitestBeforeAll
+        g.after = vitestAfterAll
     }
 
     async _loadFiles(_vitestOpts: VitestOpts): Promise<void> {

--- a/packages/wdio-vitest-framework/src/runner.ts
+++ b/packages/wdio-vitest-framework/src/runner.ts
@@ -2,7 +2,16 @@ import url from 'node:url'
 import type { VitestRunner, VitestRunnerConfig, File, Suite, Test } from '@vitest/runner'
 import type { EventEmitter } from 'node:events'
 
+import { executeHooksWithArgs } from '@wdio/utils'
+
 import type { FrameworkMessage, ErrorInfo } from './types.js'
+
+interface WDIOHooks {
+    beforeTest?: Function | Function[]
+    afterTest?: Function | Function[]
+    beforeHook?: Function | Function[]
+    afterHook?: Function | Function[]
+}
 
 /**
  * Custom VitestRunner implementation that bridges Vitest lifecycle hooks
@@ -13,6 +22,7 @@ export class WDIOVitestRunner implements VitestRunner {
     private _cid: string
     private _specs: string[]
     private _reporter: EventEmitter
+    private _hooks: WDIOHooks
 
     private _level = 0
     private _suiteIds: string[] = ['0']
@@ -24,12 +34,14 @@ export class WDIOVitestRunner implements VitestRunner {
         config: VitestRunnerConfig,
         cid: string,
         specs: string[],
-        reporter: EventEmitter
+        reporter: EventEmitter,
+        hooks: WDIOHooks = {}
     ) {
         this.config = config
         this._cid = cid
         this._specs = specs
         this._reporter = reporter
+        this._hooks = hooks
     }
 
     get failedCount(): number {
@@ -62,13 +74,19 @@ export class WDIOVitestRunner implements VitestRunner {
         }
     }
 
-    onBeforeRunTask(test: Test): void {
+    async onBeforeRunTask(test: Test): Promise<void> {
         const message = this._formatTestMessage('test:start', test)
         message.uid = this._getTestStartUID()
         this._reporter.emit('test:start', message)
+
+        await Promise.resolve(executeHooksWithArgs(
+            'beforeTest',
+            this._hooks.beforeTest as Function,
+            [message, {}]
+        )).catch(() => {})
     }
 
-    onAfterRunTask(test: Test): void {
+    async onAfterRunTask(test: Test): Promise<void> {
         const state = test.result?.state
 
         if (state === 'pass') {
@@ -103,6 +121,16 @@ export class WDIOVitestRunner implements VitestRunner {
         endMessage.uid = this._peekTestUID()
         endMessage.duration = test.result?.duration
         this._reporter.emit('test:end', endMessage)
+
+        await Promise.resolve(executeHooksWithArgs(
+            'afterTest',
+            this._hooks.afterTest as Function,
+            [endMessage, {}, {
+                error: test.result?.errors?.[0],
+                duration: test.result?.duration,
+                passed: test.result?.state === 'pass'
+            }]
+        )).catch(() => {})
     }
 
     private _isFileTask(suite: Suite): boolean {

--- a/packages/wdio-vitest-framework/src/runner.ts
+++ b/packages/wdio-vitest-framework/src/runner.ts
@@ -1,0 +1,206 @@
+import url from 'node:url'
+import type { VitestRunner, VitestRunnerConfig, File, Suite, Test } from '@vitest/runner'
+import type { EventEmitter } from 'node:events'
+
+import type { FrameworkMessage, ErrorInfo } from './types.js'
+
+/**
+ * Custom VitestRunner implementation that bridges Vitest lifecycle hooks
+ * to WebdriverIO reporter events.
+ */
+export class WDIOVitestRunner implements VitestRunner {
+    config: VitestRunnerConfig
+    private _cid: string
+    private _specs: string[]
+    private _reporter: EventEmitter
+
+    private _level = 0
+    private _suiteIds: string[] = ['0']
+    private _suiteCnt: Map<string, number> = new Map()
+    private _testCnt: Map<string, number> = new Map()
+    private _failedCount = 0
+
+    constructor(
+        config: VitestRunnerConfig,
+        cid: string,
+        specs: string[],
+        reporter: EventEmitter
+    ) {
+        this.config = config
+        this._cid = cid
+        this._specs = specs
+        this._reporter = reporter
+    }
+
+    get failedCount(): number {
+        return this._failedCount
+    }
+
+    async importFile(filepath: string, _source: 'collect' | 'setup') {
+        const fileUrl = filepath.startsWith('file://')
+            ? filepath
+            : url.pathToFileURL(filepath).href
+        await import(`${fileUrl}?invalidateCache=${Math.random()}`)
+    }
+
+    onBeforeRunSuite(suite: Suite): void {
+        if (suite.type === 'suite' && !this._isFileTask(suite)) {
+            const message = this._formatSuiteMessage('suite:start', suite)
+            message.uid = this._getSuiteStartUID()
+            this._reporter.emit('suite:start', message)
+        }
+    }
+
+    onAfterRunSuite(suite: Suite): void {
+        if (suite.type === 'suite' && !this._isFileTask(suite)) {
+            const message = this._formatSuiteMessage('suite:end', suite)
+            message.uid = this._getSuiteEndUID()
+            if (suite.result?.duration) {
+                message.duration = suite.result.duration
+            }
+            this._reporter.emit('suite:end', message)
+        }
+    }
+
+    onBeforeRunTask(test: Test): void {
+        const message = this._formatTestMessage('test:start', test)
+        message.uid = this._getTestStartUID()
+        this._reporter.emit('test:start', message)
+    }
+
+    onAfterRunTask(test: Test): void {
+        const state = test.result?.state
+
+        if (state === 'pass') {
+            const message = this._formatTestMessage('test:pass', test)
+            message.uid = this._getTestEndUID()
+            message.passed = true
+            message.duration = test.result?.duration
+            this._reporter.emit('test:pass', message)
+        } else if (state === 'fail') {
+            this._failedCount++
+            const message = this._formatTestMessage('test:fail', test)
+            message.uid = this._getTestEndUID()
+            message.passed = false
+            message.duration = test.result?.duration
+            if (test.result?.errors?.length) {
+                message.error = this._formatError(test.result.errors[0])
+            }
+            this._reporter.emit('test:fail', message)
+        } else if (test.mode === 'skip' || test.mode === 'todo') {
+            const message = this._formatTestMessage('test:pending', test)
+            message.uid = this._getTestEndUID()
+            message.pending = true
+            this._reporter.emit('test:pending', message)
+        } else {
+            const message = this._formatTestMessage('test:end', test)
+            message.uid = this._getTestEndUID()
+            message.duration = test.result?.duration
+            this._reporter.emit('test:end', message)
+        }
+
+        const endMessage = this._formatTestMessage('test:end', test)
+        endMessage.uid = this._peekTestUID()
+        endMessage.duration = test.result?.duration
+        this._reporter.emit('test:end', endMessage)
+    }
+
+    private _isFileTask(suite: Suite): boolean {
+        return 'filepath' in suite
+    }
+
+    private _formatSuiteMessage(type: string, suite: Suite): FrameworkMessage {
+        return {
+            type,
+            cid: this._cid,
+            specs: this._specs,
+            title: suite.name,
+            parent: suite.suite?.name,
+            fullTitle: this._getFullTitle(suite),
+            pending: suite.mode === 'skip' || suite.mode === 'todo',
+            file: (suite.file as File)?.filepath,
+        }
+    }
+
+    private _formatTestMessage(type: string, test: Test): FrameworkMessage {
+        return {
+            type,
+            cid: this._cid,
+            specs: this._specs,
+            title: test.name,
+            parent: test.suite?.name,
+            fullTitle: this._getFullTitle(test),
+            pending: test.mode === 'skip' || test.mode === 'todo',
+            file: test.file?.filepath,
+            body: undefined,
+        }
+    }
+
+    private _getFullTitle(task: Suite | Test): string {
+        const parts: string[] = [task.name]
+        let parent = task.suite
+        while (parent && parent.name && !this._isFileTask(parent)) {
+            parts.unshift(parent.name)
+            parent = parent.suite
+        }
+        return parts.join('.')
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    private _formatError(error: any): ErrorInfo {
+        return {
+            name: error.name || 'Error',
+            message: error.message || String(error),
+            stack: error.stack || error.stackStr || '',
+            type: error.name || 'Error',
+            expected: error.expected,
+            actual: error.actual,
+        }
+    }
+
+    private _getSuiteStartUID(): string {
+        const suiteCnt = this._suiteCnt.has(this._level.toString())
+            ? this._suiteCnt.get(this._level.toString())
+            : 0
+        const suiteId = `suite-${this._level}-${suiteCnt}`
+
+        if (this._suiteCnt.has(this._level.toString())) {
+            this._suiteCnt.set(this._level.toString(), this._suiteCnt.get(this._level.toString())! + 1)
+        } else {
+            this._suiteCnt.set(this._level.toString(), 1)
+        }
+
+        this._suiteIds.push(`${this._level}${suiteCnt}`)
+        this._level++
+        return suiteId
+    }
+
+    private _getSuiteEndUID(): string {
+        this._level--
+        const suiteCnt = this._suiteCnt.get(this._level.toString())! - 1
+        const suiteId = `suite-${this._level}-${suiteCnt}`
+        this._suiteIds.pop()
+        return suiteId
+    }
+
+    private _getTestStartUID(): string {
+        const suiteId = this._suiteIds[this._suiteIds.length - 1]
+        const cnt = this._testCnt.has(suiteId)
+            ? this._testCnt.get(suiteId) || 0
+            : 0
+        this._testCnt.set(suiteId, cnt + 1)
+        return `test-${suiteId}-${cnt}`
+    }
+
+    private _getTestEndUID(): string {
+        const suiteId = this._suiteIds[this._suiteIds.length - 1]
+        const cnt = this._testCnt.get(suiteId)! - 1
+        return `test-${suiteId}-${cnt}`
+    }
+
+    private _peekTestUID(): string {
+        const suiteId = this._suiteIds[this._suiteIds.length - 1]
+        const cnt = this._testCnt.get(suiteId)! - 1
+        return `test-${suiteId}-${cnt}`
+    }
+}

--- a/packages/wdio-vitest-framework/src/types.ts
+++ b/packages/wdio-vitest-framework/src/types.ts
@@ -1,0 +1,75 @@
+export interface VitestOpts {
+    /**
+     * Include globs for test files.
+     */
+    include?: string[]
+    /**
+     * Exclude globs for test files.
+     */
+    exclude?: string[]
+    /**
+     * Test timeout in milliseconds.
+     * @default 10000
+     */
+    testTimeout?: number
+    /**
+     * Hook timeout in milliseconds.
+     * @default 10000
+     */
+    hookTimeout?: number
+    /**
+     * Number of times to retry a failing test.
+     * @default 0
+     */
+    retry?: number
+    /**
+     * Defines how hooks should be ordered.
+     */
+    sequence?: {
+        hooks?: 'stack' | 'list' | 'parallel'
+    }
+    /**
+     * Maximum number of concurrent tests.
+     * @default 5
+     */
+    maxConcurrency?: number
+    /**
+     * Pass with no tests found.
+     * @default false
+     */
+    passWithNoTests?: boolean
+    /**
+     * Glob or regexp pattern to filter test names.
+     */
+    grep?: string | RegExp
+    /**
+     * Setup files to run before tests.
+     */
+    setupFiles?: string[]
+}
+
+export interface FrameworkMessage {
+    type: string
+    cid?: string
+    specs?: string[]
+    uid?: string
+    title?: string
+    parent?: string
+    fullTitle?: string
+    pending?: boolean
+    passed?: boolean
+    file?: string
+    duration?: number
+    error?: ErrorInfo
+    body?: string
+}
+
+export interface ErrorInfo {
+    name: string
+    message: string
+    stack: string
+    type: string
+    expected?: unknown
+    actual?: unknown
+}
+

--- a/packages/wdio-vitest-framework/tests/adapter.test.ts
+++ b/packages/wdio-vitest-framework/tests/adapter.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest'
 import path from 'node:path'
 import logger from '@wdio/logger'
-import { wrapGlobalTestMethod, executeHooksWithArgs } from '@wdio/utils'
+import { executeHooksWithArgs } from '@wdio/utils'
 import { startTests } from '@vitest/runner'
 
 import VitestAdapterFactory, { VitestAdapter } from '../src/index.js'
@@ -57,7 +57,10 @@ test('should properly set up vitest adapter', async () => {
     const result = await adapter.run()
     expect(result).toBe(0)
     expect(vi.mocked(startTests)).toBeCalled()
-    expect(vi.mocked(executeHooksWithArgs).mock.calls).toHaveLength(3)
+    const hookNames = vi.mocked(executeHooksWithArgs).mock.calls.map((c: unknown[]) => c[0])
+    expect(hookNames).toContain('beforeSuite')
+    expect(hookNames).toContain('afterSuite')
+    expect(hookNames).toContain('after')
 })
 
 test('should pass config options to runner', async () => {
@@ -157,10 +160,11 @@ test('should pass spec load error to after hook', async () => {
     await expect(adapter.run()).rejects.toEqual(specError)
 
     const afterCall = vi.mocked(executeHooksWithArgs).mock.calls.find(
-        (c: any) => c[0] === 'after'
+        (c: unknown[]) => c[0] === 'after'
     )
     expect(afterCall).toBeTruthy()
-    expect((afterCall![2] as any)[0]).toBe(specError)
+    const afterArgs = afterCall![2] as unknown[]
+    expect(afterArgs[0]).toBe(specError)
 })
 
 test('wrapHook if successful', async () => {
@@ -175,6 +179,7 @@ test('wrapHook if successful', async () => {
     expect(call[0]).toBe('beforeSuite')
     expect(call[1]).toBe('somehook')
     expect((call[2] as any)[0].type).toBe('beforeSuite')
+    vi.mocked(executeHooksWithArgs).mockReset()
 })
 
 test('wrapHook if failing', async () => {
@@ -189,6 +194,7 @@ test('wrapHook if failing', async () => {
     expect(call[0]).toBe('beforeSuite')
     expect(vi.mocked(logger('').error).mock.calls[0][0]
         .startsWith('Error in beforeSuite hook: uuuups')).toBe(true)
+    vi.mocked(executeHooksWithArgs).mockReset()
 })
 
 describe('hasTests', () => {
@@ -219,7 +225,14 @@ test('should set up global test methods', async () => {
     })
     await adapter.init()
 
-    expect(vi.mocked(wrapGlobalTestMethod).mock.calls.length).toBeGreaterThan(0)
+    const g = globalThis as Record<string, unknown>
+    expect(g.describe).toBeDefined()
+    expect(g.it).toBeDefined()
+    expect(g.test).toBeDefined()
+    expect(g.beforeAll).toBeDefined()
+    expect(g.afterAll).toBeDefined()
+    expect(g.beforeEach).toBeDefined()
+    expect(g.afterEach).toBeDefined()
 })
 
 test('should handle afterSuite duration', async () => {
@@ -286,6 +299,5 @@ test('should return failed count from runner', async () => {
 afterEach(() => {
     vi.mocked(startTests).mockReset()
     vi.mocked(startTests).mockResolvedValue([])
-    vi.mocked(wrapGlobalTestMethod).mockReset()
     vi.mocked(executeHooksWithArgs).mockReset()
 })

--- a/packages/wdio-vitest-framework/tests/adapter.test.ts
+++ b/packages/wdio-vitest-framework/tests/adapter.test.ts
@@ -1,0 +1,291 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest'
+import path from 'node:path'
+import logger from '@wdio/logger'
+import { wrapGlobalTestMethod, executeHooksWithArgs } from '@wdio/utils'
+import { startTests } from '@vitest/runner'
+
+import VitestAdapterFactory, { VitestAdapter } from '../src/index.js'
+import { WDIOVitestRunner } from '../src/runner.js'
+
+vi.mock('@vitest/runner')
+vi.mock('@vitest/runner/utils', () => ({
+    getTests: vi.fn().mockReturnValue([]),
+    getSuites: vi.fn().mockReturnValue([]),
+    hasTests: vi.fn().mockReturnValue(true),
+}))
+vi.mock('@wdio/utils')
+vi.mock('@wdio/logger', () => import(path.join(process.cwd(), '__mocks__', '@wdio/logger')))
+
+vi.spyOn(WDIOVitestRunner.prototype, 'importFile').mockResolvedValue(undefined)
+
+const wdioReporter = {
+    write: vi.fn(),
+    emit: vi.fn(),
+    on: vi.fn()
+} as const
+
+const adapterFactory = (config: any = {}) => new VitestAdapter(
+    '0-2',
+    { rootDir: '/test', ...config },
+    ['/foo/bar.test.js'],
+    { browserName: 'chrome' },
+    wdioReporter as any
+)
+
+beforeEach(() => {
+    wdioReporter.write.mockReset()
+    wdioReporter.emit.mockReset()
+    wdioReporter.on.mockReset()
+})
+
+test('comes with a factory', async () => {
+    expect(typeof VitestAdapterFactory.init).toBe('function')
+    const instance = await VitestAdapterFactory.init!(
+        '0-2',
+        {},
+        ['/foo/bar.test.js'],
+        { browserName: 'chrome' },
+        wdioReporter
+    )
+    const result = await instance.run()
+    expect(result).toBe(0)
+})
+
+test('should properly set up vitest adapter', async () => {
+    const adapter = adapterFactory()
+    await adapter.init()
+    const result = await adapter.run()
+    expect(result).toBe(0)
+    expect(vi.mocked(startTests)).toBeCalled()
+    expect(vi.mocked(executeHooksWithArgs).mock.calls).toHaveLength(3)
+})
+
+test('should pass config options to runner', async () => {
+    const adapter = adapterFactory({
+        vitestOpts: {
+            testTimeout: 30000,
+            hookTimeout: 15000,
+            retry: 2,
+            maxConcurrency: 10,
+            grep: 'my test',
+        }
+    })
+    await adapter.init()
+
+    const runner = adapter['_runner']!
+    expect(runner.config.testTimeout).toBe(30000)
+    expect(runner.config.hookTimeout).toBe(15000)
+    expect(runner.config.retry).toBe(2)
+    expect(runner.config.maxConcurrency).toBe(10)
+    expect(runner.config.testNamePattern).toEqual(/my test/)
+})
+
+test('should use default config when no options provided', async () => {
+    const adapter = adapterFactory()
+    await adapter.init()
+
+    const runner = adapter['_runner']!
+    expect(runner.config.testTimeout).toBe(10000)
+    expect(runner.config.hookTimeout).toBe(10000)
+    expect(runner.config.retry).toBe(0)
+    expect(runner.config.maxConcurrency).toBe(5)
+    expect(runner.config.passWithNoTests).toBe(false)
+    expect(runner.config.testNamePattern).toBeUndefined()
+})
+
+test('should support RegExp grep option', async () => {
+    const adapter = adapterFactory({
+        vitestOpts: {
+            grep: /test pattern/i,
+        }
+    })
+    await adapter.init()
+
+    const runner = adapter['_runner']!
+    expect(runner.config.testNamePattern).toEqual(/test pattern/i)
+})
+
+test('should call beforeSuite and afterSuite hooks', async () => {
+    const adapter = adapterFactory({
+        beforeSuite: vi.fn(),
+        afterSuite: vi.fn(),
+    })
+    await adapter.init()
+    await adapter.run()
+
+    const hookCalls = vi.mocked(executeHooksWithArgs).mock.calls
+    const beforeSuiteCall = hookCalls.find((c: any) => c[0] === 'beforeSuite')
+    const afterSuiteCall = hookCalls.find((c: any) => c[0] === 'afterSuite')
+
+    expect(beforeSuiteCall).toBeTruthy()
+    expect(afterSuiteCall).toBeTruthy()
+})
+
+test('should call after hooks with results', async () => {
+    const adapter = adapterFactory()
+    await adapter.init()
+    await adapter.run()
+
+    const afterCall = vi.mocked(executeHooksWithArgs).mock.calls.find(
+        (c: any) => c[0] === 'after'
+    )
+    expect(afterCall).toBeTruthy()
+    expect(afterCall![2]).toHaveLength(3)
+})
+
+test('should throw runtime error if startTests fails', async () => {
+    const runtimeError = new Error('Runtime failure')
+    vi.mocked(startTests).mockRejectedValueOnce(runtimeError)
+
+    const adapter = adapterFactory()
+    await adapter.init()
+    await expect(adapter.run()).rejects.toEqual(runtimeError)
+})
+
+test('should throw spec load error', async () => {
+    const adapter = adapterFactory()
+    await adapter.init()
+    adapter['_specLoadError'] = new Error('Load error')
+    await expect(adapter.run()).rejects.toEqual(new Error('Load error'))
+})
+
+test('should pass spec load error to after hook', async () => {
+    const specError = new Error('Spec load error')
+    const adapter = adapterFactory()
+    await adapter.init()
+    adapter['_specLoadError'] = specError
+    await expect(adapter.run()).rejects.toEqual(specError)
+
+    const afterCall = vi.mocked(executeHooksWithArgs).mock.calls.find(
+        (c: any) => c[0] === 'after'
+    )
+    expect(afterCall).toBeTruthy()
+    expect((afterCall![2] as any)[0]).toBe(specError)
+})
+
+test('wrapHook if successful', async () => {
+    const config = { beforeSuite: 'somehook' }
+    const adapter = adapterFactory(config)
+    await adapter.init()
+    const wrappedHook = adapter.wrapHook('beforeSuite' as any)
+
+    vi.mocked(executeHooksWithArgs).mockImplementation((...args: any[]) => Promise.resolve(args))
+    await wrappedHook()
+    const call = vi.mocked(executeHooksWithArgs).mock.calls[vi.mocked(executeHooksWithArgs).mock.calls.length - 1]
+    expect(call[0]).toBe('beforeSuite')
+    expect(call[1]).toBe('somehook')
+    expect((call[2] as any)[0].type).toBe('beforeSuite')
+})
+
+test('wrapHook if failing', async () => {
+    const config = { beforeSuite: 'somehook' }
+    const adapter = adapterFactory(config)
+    await adapter.init()
+    const wrappedHook = adapter.wrapHook('beforeSuite' as any)
+
+    vi.mocked(executeHooksWithArgs).mockImplementation(() => Promise.reject(new Error('uuuups')))
+    await wrappedHook()
+    const call = vi.mocked(executeHooksWithArgs).mock.calls[vi.mocked(executeHooksWithArgs).mock.calls.length - 1]
+    expect(call[0]).toBe('beforeSuite')
+    expect(vi.mocked(logger('').error).mock.calls[0][0]
+        .startsWith('Error in beforeSuite hook: uuuups')).toBe(true)
+})
+
+describe('hasTests', () => {
+    test('should return true by default', async () => {
+        const adapter = adapterFactory()
+        await adapter.init()
+        expect(adapter.hasTests()).toBe(true)
+    })
+})
+
+test('should handle file:// protocol in specs', async () => {
+    const adapter = adapterFactory()
+    adapter['_specs'] = ['file:///foo/bar.test.js']
+    await adapter.init()
+    await adapter.run()
+
+    expect(vi.mocked(startTests)).toBeCalled()
+    const specs = vi.mocked(startTests).mock.calls[0][0]
+    expect(specs[0]).toBe('/foo/bar.test.js')
+})
+
+test('should set up global test methods', async () => {
+    const adapter = adapterFactory({
+        beforeTest: vi.fn(),
+        afterTest: vi.fn(),
+        beforeHook: vi.fn(),
+        afterHook: vi.fn(),
+    })
+    await adapter.init()
+
+    expect(vi.mocked(wrapGlobalTestMethod).mock.calls.length).toBeGreaterThan(0)
+})
+
+test('should handle afterSuite duration', async () => {
+    const adapter = adapterFactory()
+    await adapter.init()
+    adapter['_suiteStartDate'] = Date.now() - 5000
+    const payload = adapter['_buildSuitePayload']('afterSuite')
+    expect(payload.type).toBe('afterSuite')
+    expect(payload.duration).toBeDefined()
+    expect(payload.duration! >= 4900).toBeTruthy()
+})
+
+test('should handle _loadFiles error gracefully', async () => {
+    const importError = new Error('Module not found')
+    vi.spyOn(WDIOVitestRunner.prototype, 'importFile').mockRejectedValueOnce(importError)
+
+    const adapter = adapterFactory()
+    await adapter.init()
+
+    expect(adapter.hasTests()).toBe(false)
+    expect(adapter['_specLoadError']).toBeDefined()
+    expect(adapter['_specLoadError']!.message).toContain('Unable to load spec files')
+})
+
+test('should support multiple spec files', async () => {
+    const adapter = new VitestAdapter(
+        '0-2',
+        { rootDir: '/test' } as any,
+        ['/foo/bar.test.js', '/foo/baz.test.js'],
+        { browserName: 'chrome' },
+        wdioReporter as any
+    )
+    await adapter.init()
+    await adapter.run()
+
+    const specArgs = vi.mocked(startTests).mock.calls[0][0]
+    expect(specArgs).toHaveLength(2)
+    expect(specArgs).toContain('/foo/bar.test.js')
+    expect(specArgs).toContain('/foo/baz.test.js')
+})
+
+test('should handle beforeSuite hook error without crashing', async () => {
+    vi.mocked(executeHooksWithArgs).mockRejectedValueOnce(new Error('hook error'))
+
+    const adapter = adapterFactory()
+    await adapter.init()
+    const result = await adapter.run()
+    expect(result).toBe(0)
+})
+
+test('should return failed count from runner', async () => {
+    const adapter = adapterFactory()
+    await adapter.init()
+
+    vi.mocked(startTests).mockImplementationOnce(async (_specs, runner) => {
+        (runner as any)._failedCount = 3
+        return []
+    })
+
+    const result = await adapter.run()
+    expect(result).toBe(3)
+})
+
+afterEach(() => {
+    vi.mocked(startTests).mockReset()
+    vi.mocked(startTests).mockResolvedValue([])
+    vi.mocked(wrapGlobalTestMethod).mockReset()
+    vi.mocked(executeHooksWithArgs).mockReset()
+})

--- a/packages/wdio-vitest-framework/tests/runner.test.ts
+++ b/packages/wdio-vitest-framework/tests/runner.test.ts
@@ -1,0 +1,549 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+import type { VitestRunnerConfig, Suite, Test, File } from '@vitest/runner'
+
+import { WDIOVitestRunner } from '../src/runner.js'
+
+const createRunnerConfig = (overrides: Partial<VitestRunnerConfig> = {}): VitestRunnerConfig => ({
+    root: '/test',
+    setupFiles: [],
+    passWithNoTests: false,
+    allowOnly: true,
+    sequence: {
+        shuffle: false,
+        concurrent: false,
+        seed: 12345,
+        hooks: 'parallel',
+        setupFiles: 'list',
+    },
+    maxConcurrency: 5,
+    testTimeout: 10000,
+    hookTimeout: 10000,
+    retry: 0,
+    includeTaskLocation: false,
+    ...overrides,
+})
+
+const wdioReporter = {
+    emit: vi.fn(),
+    on: vi.fn(),
+    write: vi.fn(),
+}
+
+const createFile = (filepath: string): File => ({
+    type: 'suite' as const,
+    id: 'file-1',
+    name: filepath,
+    fullName: filepath,
+    mode: 'run' as const,
+    meta: {},
+    tasks: [],
+    filepath,
+    projectName: undefined,
+    file: undefined as any,
+})
+
+const createSuite = (name: string, file: File, parent?: Suite): Suite => {
+    const s: Suite = {
+        type: 'suite' as const,
+        id: `suite-${name}`,
+        name,
+        fullName: parent ? `${parent.fullName} > ${name}` : `${file.filepath} > ${name}`,
+        mode: 'run' as const,
+        meta: {},
+        tasks: [],
+        file,
+        suite: parent || file,
+    }
+    return s
+}
+
+const createTest = (name: string, suite: Suite, file: File): Test => ({
+    type: 'test' as const,
+    id: `test-${name}`,
+    name,
+    fullName: `${suite.fullName} > ${name}`,
+    fullTestName: `${suite.name} > ${name}`,
+    mode: 'run' as const,
+    meta: {},
+    file,
+    suite,
+    context: {} as any,
+    timeout: 10000,
+    annotations: [],
+    artifacts: [],
+})
+
+beforeEach(() => {
+    wdioReporter.emit.mockReset()
+    wdioReporter.on.mockReset()
+    wdioReporter.write.mockReset()
+})
+
+describe('WDIOVitestRunner', () => {
+    test('should initialize with config', () => {
+        const config = createRunnerConfig()
+        const runner = new WDIOVitestRunner(config, '0-1', ['/spec.js'], wdioReporter as any)
+        expect(runner.config).toEqual(config)
+        expect(runner.failedCount).toBe(0)
+    })
+
+    test('should import files via dynamic import', async () => {
+        const config = createRunnerConfig()
+        const runner = new WDIOVitestRunner(config, '0-1', ['/spec.js'], wdioReporter as any)
+        // importFile should not throw with a non-existing file in tests
+        // We just verify it attempts to call import
+        await expect(runner.importFile('/non-existent.js', 'collect')).rejects.toThrow()
+    })
+
+    describe('suite events', () => {
+        test('should emit suite:start on onBeforeRunSuite', () => {
+            const config = createRunnerConfig()
+            const runner = new WDIOVitestRunner(config, '0-1', ['/spec.js'], wdioReporter as any)
+            const file = createFile('/spec.js')
+            const s = createSuite('my suite', file)
+
+            runner.onBeforeRunSuite(s)
+
+            expect(wdioReporter.emit).toBeCalledTimes(1)
+            expect(wdioReporter.emit.mock.calls[0][0]).toBe('suite:start')
+            expect(wdioReporter.emit.mock.calls[0][1]).toMatchObject({
+                type: 'suite:start',
+                title: 'my suite',
+                cid: '0-1',
+                specs: ['/spec.js'],
+            })
+        })
+
+        test('should emit suite:end on onAfterRunSuite', () => {
+            const config = createRunnerConfig()
+            const runner = new WDIOVitestRunner(config, '0-1', ['/spec.js'], wdioReporter as any)
+            const file = createFile('/spec.js')
+            const s = createSuite('my suite', file)
+
+            runner.onBeforeRunSuite(s)
+            wdioReporter.emit.mockReset()
+
+            s.result = { state: 'pass', duration: 100 }
+            runner.onAfterRunSuite(s)
+
+            expect(wdioReporter.emit).toBeCalledTimes(1)
+            expect(wdioReporter.emit.mock.calls[0][0]).toBe('suite:end')
+            expect(wdioReporter.emit.mock.calls[0][1]).toMatchObject({
+                type: 'suite:end',
+                title: 'my suite',
+                duration: 100,
+            })
+        })
+
+        test('should not emit events for file-level suites', () => {
+            const config = createRunnerConfig()
+            const runner = new WDIOVitestRunner(config, '0-1', ['/spec.js'], wdioReporter as any)
+            const file = createFile('/spec.js')
+
+            runner.onBeforeRunSuite(file)
+            runner.onAfterRunSuite(file)
+
+            expect(wdioReporter.emit).not.toBeCalled()
+        })
+
+        test('should handle nested suites with correct UIDs', () => {
+            const config = createRunnerConfig()
+            const runner = new WDIOVitestRunner(config, '0-1', ['/spec.js'], wdioReporter as any)
+            const file = createFile('/spec.js')
+            const outer = createSuite('outer', file)
+            const inner = createSuite('inner', file, outer)
+
+            runner.onBeforeRunSuite(outer)
+            expect(wdioReporter.emit.mock.calls[0][1].uid).toBe('suite-0-0')
+
+            runner.onBeforeRunSuite(inner)
+            expect(wdioReporter.emit.mock.calls[1][1].uid).toBe('suite-1-0')
+
+            runner.onAfterRunSuite(inner)
+            expect(wdioReporter.emit.mock.calls[2][1].uid).toBe('suite-1-0')
+
+            runner.onAfterRunSuite(outer)
+            expect(wdioReporter.emit.mock.calls[3][1].uid).toBe('suite-0-0')
+        })
+    })
+
+    describe('test events', () => {
+        test('should emit test:start on onBeforeRunTask', () => {
+            const config = createRunnerConfig()
+            const runner = new WDIOVitestRunner(config, '0-1', ['/spec.js'], wdioReporter as any)
+            const file = createFile('/spec.js')
+            const s = createSuite('suite', file)
+            const t = createTest('my test', s, file)
+
+            runner.onBeforeRunSuite(s)
+            wdioReporter.emit.mockReset()
+
+            runner.onBeforeRunTask(t)
+
+            expect(wdioReporter.emit).toBeCalledTimes(1)
+            expect(wdioReporter.emit.mock.calls[0][0]).toBe('test:start')
+            expect(wdioReporter.emit.mock.calls[0][1]).toMatchObject({
+                type: 'test:start',
+                title: 'my test',
+                cid: '0-1',
+            })
+        })
+
+        test('should emit test:pass on onAfterRunTask when test passes', () => {
+            const config = createRunnerConfig()
+            const runner = new WDIOVitestRunner(config, '0-1', ['/spec.js'], wdioReporter as any)
+            const file = createFile('/spec.js')
+            const s = createSuite('suite', file)
+            const t = createTest('passing test', s, file)
+
+            runner.onBeforeRunSuite(s)
+            runner.onBeforeRunTask(t)
+            wdioReporter.emit.mockReset()
+
+            t.result = { state: 'pass', duration: 50 }
+            runner.onAfterRunTask(t)
+
+            expect(wdioReporter.emit.mock.calls[0][0]).toBe('test:pass')
+            expect(wdioReporter.emit.mock.calls[0][1]).toMatchObject({
+                type: 'test:pass',
+                title: 'passing test',
+                passed: true,
+                duration: 50,
+            })
+            expect(runner.failedCount).toBe(0)
+        })
+
+        test('should emit test:fail on onAfterRunTask when test fails', () => {
+            const config = createRunnerConfig()
+            const runner = new WDIOVitestRunner(config, '0-1', ['/spec.js'], wdioReporter as any)
+            const file = createFile('/spec.js')
+            const s = createSuite('suite', file)
+            const t = createTest('failing test', s, file)
+
+            runner.onBeforeRunSuite(s)
+            runner.onBeforeRunTask(t)
+            wdioReporter.emit.mockReset()
+
+            t.result = {
+                state: 'fail',
+                duration: 30,
+                errors: [{
+                    name: 'AssertionError',
+                    message: 'expected true to be false',
+                    stack: 'Error: expected true to be false\n    at test.js:5:10',
+                    stacks: [],
+                    diff: undefined,
+                    actual: 'true',
+                    expected: 'false',
+                }],
+            }
+            runner.onAfterRunTask(t)
+
+            expect(wdioReporter.emit.mock.calls[0][0]).toBe('test:fail')
+            expect(wdioReporter.emit.mock.calls[0][1]).toMatchObject({
+                type: 'test:fail',
+                title: 'failing test',
+                passed: false,
+            })
+            expect(wdioReporter.emit.mock.calls[0][1].error).toMatchObject({
+                name: 'AssertionError',
+                message: 'expected true to be false',
+            })
+            expect(runner.failedCount).toBe(1)
+        })
+
+        test('should emit test:pending for skipped tests', () => {
+            const config = createRunnerConfig()
+            const runner = new WDIOVitestRunner(config, '0-1', ['/spec.js'], wdioReporter as any)
+            const file = createFile('/spec.js')
+            const s = createSuite('suite', file)
+            const t = createTest('skipped test', s, file)
+            t.mode = 'skip'
+
+            runner.onBeforeRunSuite(s)
+            runner.onBeforeRunTask(t)
+            wdioReporter.emit.mockReset()
+
+            runner.onAfterRunTask(t)
+
+            expect(wdioReporter.emit.mock.calls[0][0]).toBe('test:pending')
+            expect(wdioReporter.emit.mock.calls[0][1]).toMatchObject({
+                type: 'test:pending',
+                title: 'skipped test',
+                pending: true,
+            })
+        })
+
+        test('should emit test:pending for todo tests', () => {
+            const config = createRunnerConfig()
+            const runner = new WDIOVitestRunner(config, '0-1', ['/spec.js'], wdioReporter as any)
+            const file = createFile('/spec.js')
+            const s = createSuite('suite', file)
+            const t = createTest('todo test', s, file)
+            t.mode = 'todo'
+
+            runner.onBeforeRunSuite(s)
+            runner.onBeforeRunTask(t)
+            wdioReporter.emit.mockReset()
+
+            runner.onAfterRunTask(t)
+
+            expect(wdioReporter.emit.mock.calls[0][0]).toBe('test:pending')
+            expect(wdioReporter.emit.mock.calls[0][1].pending).toBe(true)
+        })
+
+        test('should emit test:end after test:pass', () => {
+            const config = createRunnerConfig()
+            const runner = new WDIOVitestRunner(config, '0-1', ['/spec.js'], wdioReporter as any)
+            const file = createFile('/spec.js')
+            const s = createSuite('suite', file)
+            const t = createTest('test', s, file)
+
+            runner.onBeforeRunSuite(s)
+            runner.onBeforeRunTask(t)
+            wdioReporter.emit.mockReset()
+
+            t.result = { state: 'pass', duration: 10 }
+            runner.onAfterRunTask(t)
+
+            const eventTypes = wdioReporter.emit.mock.calls.map((c: any[]) => c[0])
+            expect(eventTypes).toContain('test:pass')
+            expect(eventTypes).toContain('test:end')
+        })
+
+        test('should emit test:end after test:fail', () => {
+            const config = createRunnerConfig()
+            const runner = new WDIOVitestRunner(config, '0-1', ['/spec.js'], wdioReporter as any)
+            const file = createFile('/spec.js')
+            const s = createSuite('suite', file)
+            const t = createTest('test', s, file)
+
+            runner.onBeforeRunSuite(s)
+            runner.onBeforeRunTask(t)
+            wdioReporter.emit.mockReset()
+
+            t.result = {
+                state: 'fail',
+                duration: 10,
+                errors: [{ name: 'Error', message: 'fail', stack: '', stacks: [], diff: undefined }],
+            }
+            runner.onAfterRunTask(t)
+
+            const eventTypes = wdioReporter.emit.mock.calls.map((c: any[]) => c[0])
+            expect(eventTypes).toContain('test:fail')
+            expect(eventTypes).toContain('test:end')
+        })
+
+        test('should increment failed count for each failed test', () => {
+            const config = createRunnerConfig()
+            const runner = new WDIOVitestRunner(config, '0-1', ['/spec.js'], wdioReporter as any)
+            const file = createFile('/spec.js')
+            const s = createSuite('suite', file)
+            const t1 = createTest('fail 1', s, file)
+            const t2 = createTest('fail 2', s, file)
+
+            runner.onBeforeRunSuite(s)
+
+            runner.onBeforeRunTask(t1)
+            t1.result = { state: 'fail', errors: [{ name: 'Error', message: 'e', stack: '', stacks: [], diff: undefined }] }
+            runner.onAfterRunTask(t1)
+
+            runner.onBeforeRunTask(t2)
+            t2.result = { state: 'fail', errors: [{ name: 'Error', message: 'e', stack: '', stacks: [], diff: undefined }] }
+            runner.onAfterRunTask(t2)
+
+            expect(runner.failedCount).toBe(2)
+        })
+    })
+
+    describe('full title computation', () => {
+        test('should compute full title for simple suite', () => {
+            const config = createRunnerConfig()
+            const runner = new WDIOVitestRunner(config, '0-1', ['/spec.js'], wdioReporter as any)
+            const file = createFile('/spec.js')
+            const s = createSuite('my suite', file)
+
+            runner.onBeforeRunSuite(s)
+
+            expect(wdioReporter.emit.mock.calls[0][1].fullTitle).toBe('my suite')
+        })
+
+        test('should compute full title for nested suites', () => {
+            const config = createRunnerConfig()
+            const runner = new WDIOVitestRunner(config, '0-1', ['/spec.js'], wdioReporter as any)
+            const file = createFile('/spec.js')
+            const outer = createSuite('outer', file)
+            const inner = createSuite('inner', file, outer)
+
+            runner.onBeforeRunSuite(outer)
+            runner.onBeforeRunSuite(inner)
+
+            expect(wdioReporter.emit.mock.calls[1][1].fullTitle).toBe('outer.inner')
+        })
+
+        test('should compute full title for test with parent suite', () => {
+            const config = createRunnerConfig()
+            const runner = new WDIOVitestRunner(config, '0-1', ['/spec.js'], wdioReporter as any)
+            const file = createFile('/spec.js')
+            const s = createSuite('suite', file)
+            const t = createTest('my test', s, file)
+
+            runner.onBeforeRunSuite(s)
+            runner.onBeforeRunTask(t)
+
+            const testStartEvent = wdioReporter.emit.mock.calls.find(
+                (c: any) => c[0] === 'test:start'
+            )
+            expect(testStartEvent![1].fullTitle).toBe('suite.my test')
+        })
+    })
+
+    describe('error formatting', () => {
+        test('should format error with all properties', () => {
+            const config = createRunnerConfig()
+            const runner = new WDIOVitestRunner(config, '0-1', ['/spec.js'], wdioReporter as any)
+            const file = createFile('/spec.js')
+            const s = createSuite('suite', file)
+            const t = createTest('test', s, file)
+
+            runner.onBeforeRunSuite(s)
+            runner.onBeforeRunTask(t)
+            wdioReporter.emit.mockReset()
+
+            t.result = {
+                state: 'fail',
+                duration: 10,
+                errors: [{
+                    name: 'AssertionError',
+                    message: 'Expected 1 to equal 2',
+                    stack: 'AssertionError: Expected 1 to equal 2\n    at Context.<anonymous>',
+                    stacks: [],
+                    diff: undefined,
+                    expected: 2,
+                    actual: 1,
+                }],
+            }
+            runner.onAfterRunTask(t)
+
+            const error = wdioReporter.emit.mock.calls[0][1].error
+            expect(error.name).toBe('AssertionError')
+            expect(error.message).toBe('Expected 1 to equal 2')
+            expect(error.stack).toContain('Context.<anonymous>')
+            expect(error.expected).toBe(2)
+            expect(error.actual).toBe(1)
+        })
+
+        test('should handle errors without optional properties', () => {
+            const config = createRunnerConfig()
+            const runner = new WDIOVitestRunner(config, '0-1', ['/spec.js'], wdioReporter as any)
+            const file = createFile('/spec.js')
+            const s = createSuite('suite', file)
+            const t = createTest('test', s, file)
+
+            runner.onBeforeRunSuite(s)
+            runner.onBeforeRunTask(t)
+            wdioReporter.emit.mockReset()
+
+            t.result = {
+                state: 'fail',
+                errors: [{ message: 'simple error', stacks: [], diff: undefined }],
+            }
+            runner.onAfterRunTask(t)
+
+            const error = wdioReporter.emit.mock.calls[0][1].error
+            expect(error.name).toBe('Error')
+            expect(error.message).toBe('simple error')
+        })
+    })
+
+    describe('UID generation', () => {
+        test('should generate unique UIDs for suites', () => {
+            const config = createRunnerConfig()
+            const runner = new WDIOVitestRunner(config, '0-1', ['/spec.js'], wdioReporter as any)
+            const file = createFile('/spec.js')
+            const s1 = createSuite('suite 1', file)
+            const s2 = createSuite('suite 2', file)
+
+            runner.onBeforeRunSuite(s1)
+            runner.onAfterRunSuite(s1)
+            runner.onBeforeRunSuite(s2)
+            runner.onAfterRunSuite(s2)
+
+            const uids = wdioReporter.emit.mock.calls.map((c: any) => c[1].uid)
+            expect(uids[0]).toBe('suite-0-0')
+            expect(uids[1]).toBe('suite-0-0')
+            expect(uids[2]).toBe('suite-0-1')
+            expect(uids[3]).toBe('suite-0-1')
+        })
+
+        test('should generate unique UIDs for tests within suites', () => {
+            const config = createRunnerConfig()
+            const runner = new WDIOVitestRunner(config, '0-1', ['/spec.js'], wdioReporter as any)
+            const file = createFile('/spec.js')
+            const s = createSuite('suite', file)
+            const t1 = createTest('test 1', s, file)
+            const t2 = createTest('test 2', s, file)
+
+            runner.onBeforeRunSuite(s)
+
+            runner.onBeforeRunTask(t1)
+            t1.result = { state: 'pass' }
+            runner.onAfterRunTask(t1)
+
+            runner.onBeforeRunTask(t2)
+            t2.result = { state: 'pass' }
+            runner.onAfterRunTask(t2)
+
+            const testEvents = wdioReporter.emit.mock.calls.filter(
+                (c: any) => c[0] === 'test:start'
+            )
+            expect(testEvents[0][1].uid).toMatch(/^test-/)
+            expect(testEvents[1][1].uid).toMatch(/^test-/)
+            expect(testEvents[0][1].uid).not.toBe(testEvents[1][1].uid)
+        })
+    })
+
+    describe('complete test flow', () => {
+        test('should handle a complete test run with mixed results', () => {
+            const config = createRunnerConfig()
+            const runner = new WDIOVitestRunner(config, '0-1', ['/spec.js'], wdioReporter as any)
+            const file = createFile('/spec.js')
+            const s = createSuite('My Suite', file)
+
+            const t1 = createTest('passes', s, file)
+            const t2 = createTest('fails', s, file)
+            const t3 = createTest('skipped', s, file)
+            t3.mode = 'skip'
+
+            runner.onBeforeRunSuite(s)
+
+            runner.onBeforeRunTask(t1)
+            t1.result = { state: 'pass', duration: 10 }
+            runner.onAfterRunTask(t1)
+
+            runner.onBeforeRunTask(t2)
+            t2.result = {
+                state: 'fail',
+                duration: 5,
+                errors: [{ name: 'Error', message: 'boom', stack: '', stacks: [], diff: undefined }],
+            }
+            runner.onAfterRunTask(t2)
+
+            runner.onBeforeRunTask(t3)
+            runner.onAfterRunTask(t3)
+
+            runner.onAfterRunSuite(s)
+
+            expect(runner.failedCount).toBe(1)
+
+            const events = wdioReporter.emit.mock.calls.map((c: any) => c[0])
+            expect(events).toContain('suite:start')
+            expect(events).toContain('test:start')
+            expect(events).toContain('test:pass')
+            expect(events).toContain('test:fail')
+            expect(events).toContain('test:pending')
+            expect(events).toContain('test:end')
+            expect(events).toContain('suite:end')
+        })
+    })
+})

--- a/packages/wdio-vitest-framework/tsconfig.json
+++ b/packages/wdio-vitest-framework/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "outDir": "./build",
+    "rootDir": "./src"
+  },
+  "include": [
+    "src/**/*",
+    "../../@types"
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1790,6 +1790,9 @@ importers:
       '@wdio/utils':
         specifier: workspace:*
         version: link:../packages/wdio-utils
+      '@wdio/vitest-framework':
+        specifier: workspace:*
+        version: link:../packages/wdio-vitest-framework
       '@wdio/webdriver-mock-service':
         specifier: workspace:*
         version: link:../packages/wdio-webdriver-mock-service
@@ -17276,7 +17279,7 @@ snapshots:
       '@cucumber/ci-environment': 10.0.1
       '@cucumber/cucumber-expressions': 17.1.0
       '@cucumber/gherkin': 28.0.0
-      '@cucumber/gherkin-streams': 5.0.1(@cucumber/gherkin@28.0.0)(@cucumber/message-streams@4.0.1(@cucumber/messages@24.1.0))(@cucumber/messages@24.1.0)
+      '@cucumber/gherkin-streams': 5.0.1(@cucumber/gherkin@28.0.0)(@cucumber/message-streams@4.0.1(@cucumber/messages@26.0.1))(@cucumber/messages@24.1.0)
       '@cucumber/gherkin-utils': 9.0.0
       '@cucumber/html-formatter': 21.6.0(@cucumber/messages@24.1.0)
       '@cucumber/message-streams': 4.0.1(@cucumber/messages@24.1.0)
@@ -17316,7 +17319,7 @@ snapshots:
       yaml: 2.8.0
       yup: 1.2.0
 
-  '@cucumber/gherkin-streams@5.0.1(@cucumber/gherkin@28.0.0)(@cucumber/message-streams@4.0.1(@cucumber/messages@24.1.0))(@cucumber/messages@24.1.0)':
+  '@cucumber/gherkin-streams@5.0.1(@cucumber/gherkin@28.0.0)(@cucumber/message-streams@4.0.1(@cucumber/messages@26.0.1))(@cucumber/messages@24.1.0)':
     dependencies:
       '@cucumber/gherkin': 28.0.0
       '@cucumber/message-streams': 4.0.1(@cucumber/messages@24.1.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1506,6 +1506,24 @@ importers:
         specifier: ^1.1.0
         version: 1.1.0
 
+  packages/wdio-vitest-framework:
+    dependencies:
+      '@vitest/runner':
+        specifier: ^4.0.0
+        version: 4.0.18
+      '@vitest/utils':
+        specifier: ^4.0.0
+        version: 4.0.18
+      '@wdio/logger':
+        specifier: workspace:*
+        version: link:../wdio-logger
+      '@wdio/types':
+        specifier: workspace:*
+        version: link:../wdio-types
+      '@wdio/utils':
+        specifier: workspace:*
+        version: link:../wdio-utils
+
   packages/wdio-webdriver-mock-service:
     dependencies:
       '@types/uuid':
@@ -6778,8 +6796,14 @@ packages:
   '@vitest/pretty-format@4.0.16':
     resolution: {integrity: sha512-eNCYNsSty9xJKi/UdVD8Ou16alu7AYiS2fCPRs0b1OdhJiV89buAXQLpTbe+X8V9L6qrs9CqyvU7OaAopJYPsA==}
 
+  '@vitest/pretty-format@4.0.18':
+    resolution: {integrity: sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==}
+
   '@vitest/runner@3.2.4':
     resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+
+  '@vitest/runner@4.0.18':
+    resolution: {integrity: sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==}
 
   '@vitest/snapshot@2.1.9':
     resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
@@ -6798,6 +6822,9 @@ packages:
 
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+
+  '@vitest/utils@4.0.18':
+    resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
 
   '@volar/language-core@2.4.16':
     resolution: {integrity: sha512-mcoAFkYVQV4iiLYjTlbolbsm9hhDLtz4D4wTG+rwzSCUbEnxEec+KBlneLMlfdVNjkVEh8lUUSsCGNEQR+hFdA==}
@@ -17249,7 +17276,7 @@ snapshots:
       '@cucumber/ci-environment': 10.0.1
       '@cucumber/cucumber-expressions': 17.1.0
       '@cucumber/gherkin': 28.0.0
-      '@cucumber/gherkin-streams': 5.0.1(@cucumber/gherkin@28.0.0)(@cucumber/message-streams@4.0.1(@cucumber/messages@26.0.1))(@cucumber/messages@24.1.0)
+      '@cucumber/gherkin-streams': 5.0.1(@cucumber/gherkin@28.0.0)(@cucumber/message-streams@4.0.1(@cucumber/messages@24.1.0))(@cucumber/messages@24.1.0)
       '@cucumber/gherkin-utils': 9.0.0
       '@cucumber/html-formatter': 21.6.0(@cucumber/messages@24.1.0)
       '@cucumber/message-streams': 4.0.1(@cucumber/messages@24.1.0)
@@ -17289,7 +17316,7 @@ snapshots:
       yaml: 2.8.0
       yup: 1.2.0
 
-  '@cucumber/gherkin-streams@5.0.1(@cucumber/gherkin@28.0.0)(@cucumber/message-streams@4.0.1(@cucumber/messages@26.0.1))(@cucumber/messages@24.1.0)':
+  '@cucumber/gherkin-streams@5.0.1(@cucumber/gherkin@28.0.0)(@cucumber/message-streams@4.0.1(@cucumber/messages@24.1.0))(@cucumber/messages@24.1.0)':
     dependencies:
       '@cucumber/gherkin': 28.0.0
       '@cucumber/message-streams': 4.0.1(@cucumber/messages@24.1.0)
@@ -21825,11 +21852,20 @@ snapshots:
     dependencies:
       tinyrainbow: 3.0.3
 
+  '@vitest/pretty-format@4.0.18':
+    dependencies:
+      tinyrainbow: 3.0.3
+
   '@vitest/runner@3.2.4':
     dependencies:
       '@vitest/utils': 3.2.4
       pathe: 2.0.3
       strip-literal: 3.0.0
+
+  '@vitest/runner@4.0.18':
+    dependencies:
+      '@vitest/utils': 4.0.18
+      pathe: 2.0.3
 
   '@vitest/snapshot@2.1.9':
     dependencies:
@@ -21862,6 +21898,11 @@ snapshots:
       '@vitest/pretty-format': 3.2.4
       loupe: 3.1.4
       tinyrainbow: 2.0.0
+
+  '@vitest/utils@4.0.18':
+    dependencies:
+      '@vitest/pretty-format': 4.0.18
+      tinyrainbow: 3.0.3
 
   '@volar/language-core@2.4.16':
     dependencies:

--- a/tests/helpers/config.js
+++ b/tests/helpers/config.js
@@ -40,5 +40,10 @@ export const config = {
         timeout: 5000,
         requireModule: ['tsx'],
         require: [path.resolve(__dirname, '..', 'cucumber', 'step-definitions', '*.js')]
+    },
+
+    vitestOpts: {
+        testTimeout: 10000,
+        hookTimeout: 10000,
     }
 }

--- a/tests/package.json
+++ b/tests/package.json
@@ -33,6 +33,7 @@
     "@wdio/cucumber-framework": "workspace:*",
     "@wdio/jasmine-framework": "workspace:*",
     "@wdio/mocha-framework": "workspace:*",
+    "@wdio/vitest-framework": "workspace:*",
     "@wdio/smoke-test-reporter": "workspace:*",
     "@wdio/smoke-test-service": "workspace:*",
     "@wdio/smoke-test-cjs-service": "workspace:*",

--- a/tests/smoke.runner.js
+++ b/tests/smoke.runner.js
@@ -1151,6 +1151,70 @@ const jasmineAfterHookArgsValidation = async () => {
 }
 // *** END - Tests for Jasmine ***
 
+// **************************
+// *** Tests for Vitest   ***
+// **************************
+
+/**
+ * Vitest wdio testrunner tests
+ */
+const vitestTestrunner = async () => {
+    const { skippedSpecs, passed } = await launch('vitestTestrunner', baseConfig, {
+        specs: [
+            path.resolve(__dirname, 'vitest', 'test.js'),
+            path.resolve(__dirname, 'vitest', 'test-skipped.js'),
+        ],
+        framework: 'vitest',
+    })
+
+    /**
+     * assertion fails in Windows
+     * ToDo(Christian): fix
+     */
+    if (process.platform === 'win32') {
+        return
+    }
+    assert.strictEqual(skippedSpecs, 0)
+    assert.strictEqual(passed, 2)
+}
+
+/**
+ * Vitest with reporter
+ */
+const vitestReporter = async () => {
+    await launch('vitestReporter', baseConfig, {
+        specs: [path.resolve(__dirname, 'vitest', 'reporter.js')],
+        reporters: [['smoke-test', { foo: 'bar' }]],
+        framework: 'vitest',
+        outputDir: __dirname + '/vitest'
+    }).catch((err) => err) // error expected
+    await sleep(100)
+    const reporterLogsPath = path.resolve(__dirname, 'vitest', 'wdio-0-0-smoke-test-reporter.log')
+    const reporterLogsExist = await fileExists(reporterLogsPath)
+    assert.ok(reporterLogsExist, 'Vitest reporter log file should exist')
+    if (reporterLogsExist) {
+        await fs.unlink(reporterLogsPath)
+    }
+}
+
+/**
+ * Vitest with custom service
+ */
+const vitestCustomService = async () => {
+    await launch('vitestCustomService', baseConfig, {
+        specs: [path.resolve(__dirname, 'vitest', 'service.js')],
+        services: [['smoke-test', { foo: 'bar' }]],
+        framework: 'vitest',
+    })
+    await sleep(100)
+    const serviceLogs = await fs.readFile(path.resolve(__dirname, 'helpers', 'service.log'))
+    assert.equal(serviceLogs.toString(), SERVICE_LOGS)
+    const launcherLogs = await fs.readFile(path.resolve(__dirname, 'helpers', 'launcher.log'))
+    assert.equal(launcherLogs.toString(), LAUNCHER_LOGS)
+}
+
+// *** END - Tests for Vitest ***
+
 (async () => {
     const smokeTests = [
         mochaTestrunner,
@@ -1193,6 +1257,9 @@ const jasmineAfterHookArgsValidation = async () => {
         runSpecsWithFlagNoArg,
         jasmineHooksTestrunner,
         jasmineAfterHookArgsValidation,
+        vitestTestrunner,
+        vitestReporter,
+        vitestCustomService,
         cliExcludeParamValidationAllExcludedByKeyword,
         cliExcludeParamValidationSomeExcludedByKeyword,
         cliExcludeParamValidationSomeExcludedByPath,

--- a/tests/vitest/reporter.js
+++ b/tests/vitest/reporter.js
@@ -1,0 +1,11 @@
+import assert from 'node:assert'
+
+describe('my feature', () => {
+    beforeEach(() => {})
+    afterEach(() => {})
+
+    it('should do stuff', async () => {
+        assert.equal(await browser.getTitle(), 'Mock Page Title')
+        await expect(browser).toHaveTitle('Mock Page Title')
+    })
+})

--- a/tests/vitest/service.js
+++ b/tests/vitest/service.js
@@ -1,0 +1,6 @@
+describe('my feature', () => {
+    it('should do stuff', async () => {
+        expect(await browser.getTitle()).toBe('Mock Page Title')
+        await expect(browser).toHaveTitle('Mock Page Title')
+    })
+})

--- a/tests/vitest/test-empty.js
+++ b/tests/vitest/test-empty.js
@@ -1,0 +1,3 @@
+describe('empty test', () => {
+    it('should not be skipped', () => { })
+})

--- a/tests/vitest/test-skipped.js
+++ b/tests/vitest/test-skipped.js
@@ -1,0 +1,3 @@
+describe('Vitest skipped suite', () => {
+    it('SKIPPED_GREP test', () => {})
+})

--- a/tests/vitest/test.js
+++ b/tests/vitest/test.js
@@ -1,0 +1,89 @@
+import assert from 'node:assert'
+
+describe('Vitest smoke test', () => {
+    it('has globals set up', async () => {
+        expect(global.browser).toBeDefined()
+        expect(global.driver).toBeDefined()
+        expect(global.$).toBeDefined()
+        expect(global.$$).toBeDefined()
+        expect(global.expect).toBeDefined()
+    })
+
+    it('should allow to use WebdriverIO assertions', async () => {
+        await expect(browser).toHaveTitle('Mock Page Title')
+    })
+
+    it('should allow to use asymmetric matchers', async () => {
+        await expect(browser).toHaveTitle(
+            expect.stringContaining('Page'))
+        await expect(browser).toHaveTitle(
+            expect.not.stringContaining('foobar'))
+        await expect(browser).toHaveUrl(
+            expect.stringContaining('mymockpage'))
+        await expect(browser).toHaveUrl(
+            expect.not.stringContaining('mymock_page.'))
+    })
+
+    it('should return async value', async () => {
+        const title = await browser.getTitle()
+        assert.equal(title, 'Mock Page Title')
+    })
+
+    it('should chain properly', async () => {
+        // @ts-expect-error custom command
+        await browser.isExistingScenario()
+
+        const el = browser.$('body')
+        assert.equal(await el.$('.selector-1').isExisting(), true)
+        assert.equal(await el.$('.selector-2').isExisting(), true)
+    })
+
+    it('should allow to reload a session', async () => {
+        const sessionIdBefore = browser.sessionId
+        await browser.reloadSession()
+        expect(sessionIdBefore).not.toBe(browser.sessionId)
+    })
+
+    describe('add customCommands', () => {
+        it('should allow to call nested custom commands', async () => {
+            browser.addCommand('myCustomCommand', async function (param) {
+                const result = {
+                    url: await browser.getUrl(),
+                    title: await browser.getTitle()
+                }
+
+                return { param, ...result }
+            })
+
+            assert.equal(
+                // @ts-expect-error custom command
+                JSON.stringify(await browser.myCustomCommand('foobar')),
+                JSON.stringify({
+                    param: 'foobar',
+                    url: 'https://mymockpage.com',
+                    title: 'Mock Page Title'
+                })
+            )
+        })
+
+        it('allows to create custom commands on elements', async () => {
+            // @ts-expect-error custom command
+            await browser.customCommandScenario()
+            const elem = await $('elem')
+            elem.addCommand('myCustomCommand', async function (param) {
+                const result = await this.getSize()
+                return { selector: this.selector, result, param }
+            })
+
+            assert.equal(
+                // @ts-expect-error custom command
+                JSON.stringify(await elem.myCustomCommand('foobar')),
+                JSON.stringify({
+                    selector: 'elem',
+                    result: { width: 1, height: 2 },
+                    param: 'foobar'
+                })
+            )
+        })
+    })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Proposed changes

This PR introduces a new package, `@wdio/vitest-framework`, providing first-class support for running WebdriverIO tests with the Vitest runner. This addresses a common feature request to allow projects already using Vitest as their primary test runner to avoid integrating and maintaining a separate test runner (like Mocha or Jasmine) solely for WebdriverIO tests, thereby improving toolchain integrity and reducing dependency management overhead.

The new framework integrates with Vitest using the `@vitest/runner` package, enabling users to leverage their existing Vitest ecosystem for browser tests.

## Types of changes

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Backport Request

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

The `@wdio/vitest-framework` package operates similarly to the existing Mocha, Jasmine, and Cucumber framework integrations, running in its own child process and reporting status updates to the main WebdriverIO runner.

**Key Components:**
- **`VitestAdapter`**: The main entry point, responsible for initializing the runner, setting up global test methods (`describe`, `it`, `test`), wrapping WebdriverIO hooks, and orchestrating the test execution.
- **`WDIOVitestRunner`**: A custom implementation of `@vitest/runner` that bridges Vitest's internal events (e.g., `onBeforeRunSuite`, `onAfterRunTask`) to WebdriverIO's event system (`suite:start`, `test:pass`, `test:fail`, etc.). It handles unique ID tracking, error formatting, and filtering of file-level suite events.

The integration supports various Vitest configuration options via `vitestOpts` in the WebdriverIO config, including `testTimeout`, `hookTimeout`, `retry`, `maxConcurrency`, `grep`, and `setupFiles`.

Comprehensive unit tests (42 tests) have been added, covering the adapter's lifecycle, event emission, error handling, and various test states (pass, fail, skip, todo).

### Reviewers: @webdriverio/project-committers

---
<p><a href="https://cursor.com/agents/bc-67cd16cb-74e6-430c-8688-1ff6b1e7b19d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-67cd16cb-74e6-430c-8688-1ff6b1e7b19d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->