### PR TITLE
fix(webdriver): enable followRedirects for BiDi connections

### DIFF
--- a/packages/webdriver/src/index.ts
+++ b/packages/webdriver/src/index.ts
@@ -11,7 +11,7 @@ import command from './command.js'
 import { DEFAULTS } from './constants.js'
 import type { BidiHandler } from './bidi/handler.js'
 import { environment as environmentValue } from './environment.js'
-import { startWebDriverSession, getPrototype, getEnvironmentVars, setupDirectConnect, initiateBidi, parseBidiMessage } from './utils.js'
+import { startWebDriverSession, getPrototype, getEnvironmentVars, setupDirectConnect, initiateBidi, parseBidiMessage, getBidiRequestOptions } from './utils.js'
 import type { Client, AttachOptions, SessionFlags } from './types.js'
 
 const log = logger('webdriver')
@@ -216,7 +216,7 @@ export default class WebDriver {
          * reconnect to new Bidi session
          */
         if (isBidi(instance.capabilities || {})) {
-            const bidiReqOpts = instance.options.strictSSL ? {} : { rejectUnauthorized: false }
+            const bidiReqOpts = getBidiRequestOptions(instance.options.strictSSL, instance.options.headers)
             await instance._bidiHandler?.reconnect(newSessionCapabilities.webSocketUrl as unknown as string, bidiReqOpts)
             instance._bidiHandler?.socket?.on('message', parseBidiMessage.bind(instance))
         }

--- a/packages/webdriver/src/utils.ts
+++ b/packages/webdriver/src/utils.ts
@@ -9,6 +9,7 @@ import {
 } from '@wdio/protocols'
 import { CAPABILITY_KEYS } from '@wdio/protocols'
 import type { Options } from '@wdio/types'
+import type { ClientOptions } from 'ws'
 
 import command from './command.js'
 import { environment } from './environment.js'
@@ -455,6 +456,20 @@ export const getSessionError = (err: JSONWPCommandError, params: Partial<Options
     return err.message
 }
 
+export function getBidiRequestOptions (
+    strictSSL: boolean = true,
+    headers?: Record<string, string>
+): ClientOptions {
+    const bidiReqOpts: ClientOptions = { followRedirects: true }
+    if (!strictSSL) {
+        bidiReqOpts.rejectUnauthorized = false
+    }
+    if (headers) {
+        bidiReqOpts.headers = headers
+    }
+    return bidiReqOpts
+}
+
 /**
  * Enhance the monad with WebDriver Bidi primitives if a connection can be established successfully
  * @param socketUrl url to bidi interface
@@ -485,10 +500,7 @@ export function initiateBidi (
     }
 
     socketUrl = socketUrl.replace('localhost', '127.0.0.1')
-    const bidiReqOpts: { rejectUnauthorized?: boolean, headers?: Record<string, string> } = strictSSL ? {} : { rejectUnauthorized: false }
-    if (userHeaders) {
-        bidiReqOpts.headers = userHeaders
-    }
+    const bidiReqOpts = getBidiRequestOptions(strictSSL, userHeaders)
     const handler = new BidiHandler(socketUrl, bidiReqOpts)
     handler.connect().then((isConnected) => isConnected && log.info(`Connected to WebDriver Bidi interface at ${socketUrl}`))
 

--- a/packages/webdriver/src/utils.ts
+++ b/packages/webdriver/src/utils.ts
@@ -460,7 +460,7 @@ export function getBidiRequestOptions (
     strictSSL: boolean = true,
     headers?: Record<string, string>
 ): ClientOptions {
-    const bidiReqOpts: ClientOptions = { followRedirects: true }
+    const bidiReqOpts: ClientOptions = { followRedirects: true, maxRedirects: 10 }
     if (!strictSSL) {
         bidiReqOpts.rejectUnauthorized = false
     }

--- a/packages/webdriver/tests/index.test.ts
+++ b/packages/webdriver/tests/index.test.ts
@@ -27,6 +27,7 @@ vi.mock('../src/bidi/core.js', () => {
     return {
         BidiCore: class BidiHandlerMock {
             connect = vi.fn().mockResolvedValue({})
+            reconnect = vi.fn().mockResolvedValue({})
             constructor () {
                 ++initCount
             }
@@ -313,9 +314,22 @@ describe('WebDriver', () => {
                 capabilities: { browserName: 'firefox' }
             })
             vi.mocked(startWebDriver).mockClear()
+            vi.mocked(fetch).mockResolvedValueOnce(Response.json({ value: { webSocketUrl: 'ws://foo/bar' } }))
+            const reconnect = vi.fn().mockResolvedValue(undefined)
+            ;(session as any)._bidiHandler = { reconnect, socket: { on: vi.fn() } }
+            session.options.strictSSL = false
+            session.options.headers = { Authorization: 'OAuth 12345' }
             await WebDriver.reloadSession(session)
             expect(startWebDriver).not.toHaveBeenCalledOnce()
             expect(fetch).toHaveBeenCalledTimes(2)
+            expect(reconnect).toHaveBeenCalledWith(
+                expect.any(String),
+                expect.objectContaining({
+                    followRedirects: true,
+                    rejectUnauthorized: false,
+                    headers: { Authorization: 'OAuth 12345' }
+                })
+            )
         })
 
         it('starts a new driver process if browserName is given', async () => {

--- a/packages/webdriver/tests/utils.test.ts
+++ b/packages/webdriver/tests/utils.test.ts
@@ -6,7 +6,7 @@ import '../src/browser.js'
 
 import {
     isSuccessfulResponse, getPrototype, getSessionError,
-    startWebDriverSession, setupDirectConnect, validateCapabilities
+    startWebDriverSession, setupDirectConnect, validateCapabilities, getBidiRequestOptions
 } from '../src/utils.js'
 import type { Client, RemoteConfig } from '../src/types.js'
 
@@ -94,6 +94,36 @@ describe('utils', () => {
         })
         expect(saucePrototype instanceof Object).toBe(true)
         expect(typeof saucePrototype.getPageLogs.value).toBe('function')
+    })
+
+    describe('getBidiRequestOptions', () => {
+        it('should always include followRedirects', () => {
+            expect(getBidiRequestOptions()).toEqual({ followRedirects: true })
+        })
+
+        it('should include rejectUnauthorized false when strictSSL is false', () => {
+            expect(getBidiRequestOptions(false)).toEqual({
+                followRedirects: true,
+                rejectUnauthorized: false
+            })
+        })
+
+        it('should include provided headers', () => {
+            const headers = { Authorization: 'Bearer token' }
+            expect(getBidiRequestOptions(true, headers)).toEqual({
+                followRedirects: true,
+                headers
+            })
+        })
+
+        it('should include all options when strictSSL is false and headers are passed', () => {
+            const headers = { Authorization: 'Bearer token' }
+            expect(getBidiRequestOptions(false, headers)).toEqual({
+                followRedirects: true,
+                rejectUnauthorized: false,
+                headers
+            })
+        })
     })
 
     describe('setupDirectConnect', () => {


### PR DESCRIPTION
## Proposed changes
FIxes #15125 
Fixes an issue where BiDi connection attempts fail when the websocket URL provided by the driver is redirected (e.g., when a Selenium Grid proxies and redirects `ws://` to `wss://` or another node with an `HTTP 301`).
The ws library rejects HTTP redirects by default. This PR addresses that by explicitly enabling `followRedirects: true` natively for all WebdriverIO BiDi WebSocket connections. This implementation abstracts the websocket configuration into a centralized builder ([getBidiRequestOptions] , ensuring that both initial session connects and session reconnections share the same fallback logic for `strictSSL` and `headers`.

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
