### PR TITLE
feat: add --headless and --headless=false CLI flags for browser runti…

### DIFF
--- a/packages/wdio-cli/src/commands/run.ts
+++ b/packages/wdio-cli/src/commands/run.ts
@@ -117,6 +117,10 @@ export const cmdArgs = {
     coverage: {
         desc: 'Enable coverage for browser runner'
     },
+    headless: {
+        desc: 'run all browser instances in headless mode, overrides capability settings in wdio.conf.js',
+        type: 'boolean'
+    },
     shard: {
         desc: 'Shard tests and execute only the selected shard. Specify in the one-based form like `--shard x/y`, where x is the current and y the total shard.',
         coerce: (shard: string) => {
@@ -135,6 +139,8 @@ export const builder = (yargs: Argv) => {
         .example('$0 run wdio.conf.js --suite foobar', 'Run suite on testsuite "foobar"')
         .example('$0 run wdio.conf.js --spec ./tests/e2e/a.js --spec ./tests/e2e/b.js', 'Run suite on specific specs')
         .example('$0 run wdio.conf.js --shard 1/4', 'Run only the first shard of 4 shards')
+        .example('$0 run wdio.conf.js --headless', 'Run all tests in headless mode')
+        .example('$0 run wdio.conf.js --headless=false', 'Run all tests in headed (non-headless) mode')
         .example('$0 run wdio.conf.js --mochaOpts.timeout 60000', 'Run suite with custom Mocha timeout')
         .example('$0 run wdio.conf.js --tsConfigPath=./configs/bdd-tsconfig.json', 'Run suite with tsx using custom tsconfig.json')
         .epilogue(CLI_EPILOGUE)

--- a/packages/wdio-cli/src/types.ts
+++ b/packages/wdio-cli/src/types.ts
@@ -6,6 +6,7 @@ export type PM = typeof SUPPORTED_PACKAGE_MANAGERS[number]
 
 export interface RunCommandArguments {
     coverage?: boolean
+    headless?: boolean
     watch?: boolean
     hostname?: string
     port?: number

--- a/packages/wdio-config/src/node/ConfigParser.ts
+++ b/packages/wdio-config/src/node/ConfigParser.ts
@@ -6,7 +6,7 @@ import type { Capabilities, Options, Reporters, Services } from '@wdio/types'
 
 import FileSystemPathService from './FileSystemPathService.js'
 import { makeRelativeToCWD } from './utils.js'
-import { removeLineNumbers, isCucumberFeatureWithLineNumber, validObjectOrArray } from '../utils.js'
+import { removeLineNumbers, isCucumberFeatureWithLineNumber, validObjectOrArray, applyHeadlessFlag } from '../utils.js'
 import { SUPPORTED_HOOKS, SUPPORTED_FILE_EXTENSIONS, DEFAULT_CONFIGS, NO_NAMED_CONFIG_EXPORT } from '../constants.js'
 
 import type { PathService } from '../types.js'
@@ -23,6 +23,7 @@ type ImportedConfigModule = ESMImport | DefaultImport
 interface TestrunnerOptionsWithParameters extends Options.Testrunner {
     watch?: boolean
     coverage?: boolean
+    headless?: boolean
     spec?: string[]
     suite?: string[]
     repeat?: number
@@ -100,6 +101,20 @@ export default class ConfigParser {
                     ...(this._config.runner[1] as any).coverage,
                     enabled: this._initialConfig.coverage
                 }
+            }
+        }
+
+        /**
+         * Apply --headless CLI flag: inject or strip headless args from all capabilities
+         */
+        if (typeof this._initialConfig.headless === 'boolean') {
+            const headless = this._initialConfig.headless
+            if (Array.isArray(this._capabilities)) {
+                for (const cap of this._capabilities) {
+                    applyHeadlessFlag(cap as WebdriverIO.Capabilities, headless)
+                }
+            } else if (this._capabilities && typeof this._capabilities === 'object') {
+                log.warn('--headless flag is not supported with object-style capabilities, use array format instead')
             }
         }
 

--- a/packages/wdio-config/src/node/ConfigParser.ts
+++ b/packages/wdio-config/src/node/ConfigParser.ts
@@ -114,7 +114,7 @@ export default class ConfigParser {
                     applyHeadlessFlag(cap as WebdriverIO.Capabilities, headless)
                 }
             } else if (this._capabilities && typeof this._capabilities === 'object') {
-                log.warn('--headless flag is not supported with object-style capabilities, use array format instead')
+                applyHeadlessFlag(this._capabilities as unknown as WebdriverIO.Capabilities, headless)
             }
         }
 

--- a/packages/wdio-config/src/utils.ts
+++ b/packages/wdio-config/src/utils.ts
@@ -5,6 +5,46 @@ export const validObjectOrArray = (object: object): object is object | Array<unk
     (typeof object === 'object' && Object.keys(object).length > 0)
 
 /**
+ * Inject or strip headless CLI args from a single capability object.
+ * Handles Chrome/Chromium, Firefox, and Edge.
+ */
+export function applyHeadlessFlag(caps: WebdriverIO.Capabilities, headless: boolean): WebdriverIO.Capabilities {
+    // W3C capabilities may nest browser settings under `alwaysMatch`
+    const target = (caps as { alwaysMatch?: WebdriverIO.Capabilities }).alwaysMatch || caps
+    const browser = (target.browserName || '').toLowerCase()
+
+    if (browser === 'chrome' || browser === 'chromium') {
+        const opts = (target['goog:chromeOptions'] as { args?: string[] }) || {}
+        const args = opts.args || []
+        target['goog:chromeOptions'] = {
+            ...opts,
+            args: headless
+                ? Array.from(new Set([...args, '--headless', '--disable-gpu']))
+                : args.filter((a: string) => a !== '--headless' && a !== 'headless' && !a.startsWith('--headless='))
+        }
+    } else if (browser === 'firefox') {
+        const opts = (target['moz:firefoxOptions'] as { args?: string[] }) || {}
+        const args = opts.args || []
+        target['moz:firefoxOptions'] = {
+            ...opts,
+            args: headless
+                ? Array.from(new Set([...args, '-headless']))
+                : args.filter((a: string) => a !== '-headless' && a !== '--headless')
+        }
+    } else if (browser === 'microsoftedge' || browser === 'msedge' || browser === 'edge') {
+        const opts = (target['ms:edgeOptions'] as { args?: string[] }) || {}
+        const args = opts.args || []
+        target['ms:edgeOptions'] = {
+            ...opts,
+            args: headless
+                ? Array.from(new Set([...args, '--headless']))
+                : args.filter((a: string) => a !== '--headless' && a !== 'headless' && !a.startsWith('--headless='))
+        }
+    }
+    return caps
+}
+
+/**
  * remove line numbers from file path, ex:
  * `/foo:9` or `c:\bar:14:5`
  * @param   {string} filePath path to spec file

--- a/packages/wdio-config/src/utils.ts
+++ b/packages/wdio-config/src/utils.ts
@@ -13,13 +13,25 @@ export function applyHeadlessFlag(caps: WebdriverIO.Capabilities, headless: bool
     const target = (caps as { alwaysMatch?: WebdriverIO.Capabilities }).alwaysMatch || caps
     const browser = (target.browserName || '').toLowerCase()
 
+    // Multiremote: object whose values are individual capability objects
+    if (!browser && !('alwaysMatch' in caps)) {
+        for (const key of Object.keys(caps)) {
+            const val = (caps as Record<string, unknown>)[key]
+            if (val && typeof val === 'object' && (val as WebdriverIO.Capabilities).browserName) {
+                applyHeadlessFlag(val as WebdriverIO.Capabilities, headless)
+            }
+        }
+        return caps
+    }
+
     if (browser === 'chrome' || browser === 'chromium') {
         const opts = (target['goog:chromeOptions'] as { args?: string[] }) || {}
         const args = opts.args || []
+        const alreadyHasHeadless = args.some((a: string) => a === '--headless' || a === 'headless' || a.startsWith('--headless='))
         target['goog:chromeOptions'] = {
             ...opts,
             args: headless
-                ? Array.from(new Set([...args, '--headless', '--disable-gpu']))
+                ? Array.from(new Set([...args, ...(alreadyHasHeadless ? [] : ['--headless']), '--disable-gpu']))
                 : args.filter((a: string) => a !== '--headless' && a !== 'headless' && !a.startsWith('--headless='))
         }
     } else if (browser === 'firefox') {

--- a/packages/wdio-config/tests/utils.test.ts
+++ b/packages/wdio-config/tests/utils.test.ts
@@ -1,6 +1,54 @@
 import { describe, it, expect } from 'vitest'
 
-import { isCloudCapability, removeLineNumbers, validObjectOrArray } from '../src/utils.js'
+import { isCloudCapability, removeLineNumbers, validObjectOrArray, applyHeadlessFlag } from '../src/utils.js'
+
+describe('applyHeadlessFlag', () => {
+    it('should add headless flags for Chrome', () => {
+        const caps = { browserName: 'chrome', 'goog:chromeOptions': { args: ['--foo'] } }
+        expect(applyHeadlessFlag(caps, true)).toEqual({
+            browserName: 'chrome',
+            'goog:chromeOptions': { args: ['--foo', '--headless', '--disable-gpu'] }
+        })
+    })
+
+    it('should strip headless flags for Chrome', () => {
+        const caps = { browserName: 'chrome', 'goog:chromeOptions': { args: ['--foo', '--headless=new', 'headless', '--disable-gpu'] } }
+        expect(applyHeadlessFlag(caps, false)).toEqual({
+            browserName: 'chrome',
+            'goog:chromeOptions': { args: ['--foo', '--disable-gpu'] }
+        })
+    })
+
+    it('should add headless flag for Firefox', () => {
+        const caps = { browserName: 'firefox', 'moz:firefoxOptions': { args: ['-foo'] } }
+        expect(applyHeadlessFlag(caps, true)).toEqual({
+            browserName: 'firefox',
+            'moz:firefoxOptions': { args: ['-foo', '-headless'] }
+        })
+    })
+
+    it('should strip headless flag for Firefox', () => {
+        const caps = { browserName: 'firefox', 'moz:firefoxOptions': { args: ['-foo', '-headless', '--headless'] } }
+        expect(applyHeadlessFlag(caps, false)).toEqual({
+            browserName: 'firefox',
+            'moz:firefoxOptions': { args: ['-foo'] }
+        })
+    })
+
+    it('should work with Microsoft Edge', () => {
+        const caps = { browserName: 'microsoftedge', 'ms:edgeOptions': { args: ['--foo'] } }
+        expect(applyHeadlessFlag(caps, true)).toEqual({
+            browserName: 'microsoftedge',
+            'ms:edgeOptions': { args: ['--foo', '--headless'] }
+        })
+    })
+
+    it('should handle W3C alwaysMatch capabilities', () => {
+        const caps = { alwaysMatch: { browserName: 'chrome', 'goog:chromeOptions': { args: ['--foo'] } }, firstMatch: [] }
+        applyHeadlessFlag(caps as any, true)
+        expect(caps.alwaysMatch['goog:chromeOptions']).toEqual({ args: ['--foo', '--headless', '--disable-gpu'] })
+    })
+})
 
 describe('utils', () => {
     describe('removeLineNumbers', () => {

--- a/packages/wdio-config/tests/utils.test.ts
+++ b/packages/wdio-config/tests/utils.test.ts
@@ -48,6 +48,34 @@ describe('applyHeadlessFlag', () => {
         applyHeadlessFlag(caps as any, true)
         expect(caps.alwaysMatch['goog:chromeOptions']).toEqual({ args: ['--foo', '--headless', '--disable-gpu'] })
     })
+
+    it('should not add duplicate headless flags when --headless=new is already present for Chrome', () => {
+        const caps = { browserName: 'chrome', 'goog:chromeOptions': { args: ['--foo', '--headless=new'] } }
+        expect(applyHeadlessFlag(caps, true)).toEqual({
+            browserName: 'chrome',
+            'goog:chromeOptions': { args: ['--foo', '--headless=new', '--disable-gpu'] }
+        })
+    })
+
+    it('should apply headless flag to multiremote/object-style capabilities', () => {
+        const caps: any = {
+            chromeBrowser: {
+                browserName: 'chrome',
+                'goog:chromeOptions': { args: ['--foo'] }
+            },
+            firefoxBrowser: {
+                browserName: 'firefox',
+                'moz:firefoxOptions': { args: ['-foo'] }
+            }
+        }
+        applyHeadlessFlag(caps, true)
+        expect(caps.chromeBrowser['goog:chromeOptions']).toEqual({
+            args: ['--foo', '--headless', '--disable-gpu']
+        })
+        expect(caps.firefoxBrowser['moz:firefoxOptions']).toEqual({
+            args: ['-foo', '-headless']
+        })
+    })
 })
 
 describe('utils', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,9 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  axios: ^1.13.5
-
 importers:
 
   .:
@@ -96,11 +93,11 @@ importers:
         specifier: ^8.0.0
         version: 8.0.0
       cddl:
-        specifier: ^0.14.5
-        version: 0.14.5
+        specifier: ^0.12.0
+        version: 0.12.0
       cddl2ts:
-        specifier: ^0.4.1
-        version: 0.4.1
+        specifier: ^0.2.2
+        version: 0.2.2
       chalk:
         specifier: ^5.4.1
         version: 5.6.2
@@ -449,7 +446,7 @@ importers:
         version: 5.2.4(vite@5.4.21(@types/node@25.3.5)(terser@5.43.1))(vue@3.5.29(typescript@5.9.3))
       expect-webdriverio:
         specifier: ^5.6.5
-        version: 5.6.5(@wdio/globals@9.27.1)(@wdio/logger@9.18.0)(webdriverio@9.27.1(puppeteer-core@24.34.0))
+        version: 5.6.5(@wdio/globals@9.27.0)(@wdio/logger@9.18.0)(webdriverio@9.27.0(puppeteer-core@24.34.0))
       mocha:
         specifier: ^10.2.0
         version: 10.8.2
@@ -557,7 +554,7 @@ importers:
         version: 9.39.4(jiti@2.6.1)
       expect-webdriverio:
         specifier: ^5.6.5
-        version: 5.6.5(@wdio/globals@9.27.1)(@wdio/logger@9.18.0)(webdriverio@9.27.1(puppeteer-core@24.34.0))
+        version: 5.6.5(@wdio/globals@9.27.0)(@wdio/logger@9.18.0)(webdriverio@9.27.0(puppeteer-core@24.34.0))
       globals:
         specifier: ^16.5.0
         version: 16.5.0
@@ -795,6 +792,9 @@ importers:
       csv-writer:
         specifier: ^1.6.0
         version: 1.6.0
+      formdata-node:
+        specifier: 5.0.1
+        version: 5.0.1
       git-repo-info:
         specifier: ^2.1.1
         version: 2.1.1
@@ -805,11 +805,11 @@ importers:
         specifier: ^11.0.0
         version: 11.1.0
       tar:
-        specifier: ^7.5.11
-        version: 7.5.13
+        specifier: ^7.5.7
+        version: 7.5.10
       undici:
-        specifier: ^6.24.0
-        version: 6.24.1
+        specifier: ^6.21.3
+        version: 6.23.0
       uuid:
         specifier: ^11.1.0
         version: 11.1.0
@@ -1027,7 +1027,7 @@ importers:
     dependencies:
       expect-webdriverio:
         specifier: ^5.6.5
-        version: 5.6.5(@wdio/globals@9.27.1)(@wdio/logger@9.18.0)(webdriverio@9.16.2(puppeteer-core@24.34.0))
+        version: 5.6.5(@wdio/globals@9.27.0)(@wdio/logger@9.18.0)(webdriverio@9.16.2(puppeteer-core@24.34.0))
       webdriverio:
         specifier: ^9.0.0
         version: 9.16.2(puppeteer-core@24.34.0)
@@ -1180,7 +1180,7 @@ importers:
         version: 4.0.0
       expect-webdriverio:
         specifier: ^5.6.5
-        version: 5.6.5(@wdio/globals@9.27.1)(@wdio/logger@packages+wdio-logger)(webdriverio@9.27.1(puppeteer-core@24.34.0))
+        version: 5.6.5(@wdio/globals@9.27.0)(@wdio/logger@packages+wdio-logger)(webdriverio@9.27.0(puppeteer-core@24.34.0))
       split2:
         specifier: ^4.1.0
         version: 4.2.0
@@ -1679,6 +1679,27 @@ importers:
       safe-stable-stringify:
         specifier: ^2.4.3
         version: 2.5.0
+
+  test-headless-flag:
+    devDependencies:
+      '@wdio/cli':
+        specifier: workspace:*
+        version: link:../packages/wdio-cli
+      '@wdio/local-runner':
+        specifier: workspace:*
+        version: link:../packages/wdio-local-runner
+      '@wdio/mocha-framework':
+        specifier: workspace:*
+        version: link:../packages/wdio-mocha-framework
+      '@wdio/spec-reporter':
+        specifier: workspace:*
+        version: link:../packages/wdio-spec-reporter
+      expect-webdriverio:
+        specifier: ^5.6.5
+        version: 5.6.5(@wdio/globals@9.27.0)(@wdio/logger@9.18.0)(webdriverio@packages+webdriverio)
+      webdriverio:
+        specifier: workspace:*
+        version: link:../packages/webdriverio
 
   tests:
     dependencies:
@@ -6953,8 +6974,8 @@ packages:
     resolution: {integrity: sha512-rcHu0eG16rSEmHL0sEKDcr/vYFmGhQ5GOlmlx54r+1sgh6sf136q+kth4169s16XqviWGW3LjZbUfpTK29pGtw==}
     engines: {node: '>=18.20.0'}
 
-  '@wdio/config@9.27.1':
-    resolution: {integrity: sha512-QVfSCqcpMfVum9KlpxgjaLlSLXkc53UQ2CPJU+IUVBp8LkbSyeX972HQS8V9Hnn6vSPE1dYScItg7wblnJ8RQg==}
+  '@wdio/config@9.27.0':
+    resolution: {integrity: sha512-9y8z7ugIbU6ycKrA2SqCpKh1/hobut2rDq9CLt/BNVzSlebBBVOTMiAt1XroZzcPnA7/ZqpbkpOsbpPUaAQuNQ==}
     engines: {node: '>=18.20.0'}
 
   '@wdio/dot-reporter@9.16.2':
@@ -6971,8 +6992,8 @@ packages:
       expect-webdriverio: ^5.3.2
       webdriverio: ^9.0.0
 
-  '@wdio/globals@9.27.1':
-    resolution: {integrity: sha512-jm6gTQ6Qo3EOBY6PA09U/5Pf17WLEJM1/lTfhc6jzLFE770EuhuhbuphqrInH0hVR9WMyWtSZQ+LRCcLfcmOPQ==}
+  '@wdio/globals@9.27.0':
+    resolution: {integrity: sha512-yT6EAyvEqm+wFD11fg89BMxvFkYLgnIVCihfJx+k73Gm3utL/DfZQpSheQdwrlQzu5p7jHi/JwOD76740F5Peg==}
     engines: {node: '>=18.20.0'}
     peerDependencies:
       expect-webdriverio: ^5.6.5
@@ -6992,8 +7013,8 @@ packages:
   '@wdio/protocols@9.24.0':
     resolution: {integrity: sha512-ozQKYddBLT4TRvU9J+fGrhVUtx3iDAe+KNCJcTDMFMxNSdDMR2xFQdNp8HLHypspk58oXTYCvz6ZYjySthhqsw==}
 
-  '@wdio/protocols@9.27.1':
-    resolution: {integrity: sha512-Ril46AmySoiYX9nuKqFr3SNJqquU3VmF9FzSndQlDib0G3oA4pYx9wcBXvdvkFxRjjmFwQDzmvztKrssAHymgw==}
+  '@wdio/protocols@9.27.0':
+    resolution: {integrity: sha512-rIk69BsY1+6uU2PEN5FiRpI6K7HJ86YHzZRFBe4iRzKXQgGNk1zWzbdVJIuNFoOWsnmYUkK42KSSOT4Le6EmiQ==}
 
   '@wdio/repl@9.16.2':
     resolution: {integrity: sha512-FLTF0VL6+o5BSTCO7yLSXocm3kUnu31zYwzdsz4n9s5YWt83sCtzGZlZpt7TaTzb3jVUfxuHNQDTb8UMkCu0lQ==}
@@ -7018,8 +7039,8 @@ packages:
     resolution: {integrity: sha512-PYYunNl8Uq1r8YMJAK6ReRy/V/XIrCSyj5cpCtR5EqCL6heETOORFj7gt4uPnzidfgbtMBcCru0LgjjlMiH1UQ==}
     engines: {node: '>=18.20.0'}
 
-  '@wdio/types@9.27.1':
-    resolution: {integrity: sha512-EHBNCvLmvpYerln4mb/OBxzKtnavL2wdenjhwuYjzkZMOWHgm/uLXH6sLThM0y6DIbCU72Asth16fo1eDcsofA==}
+  '@wdio/types@9.27.0':
+    resolution: {integrity: sha512-DQJ+OdRBqUBcQ30DN2Z651hEVh3OoxnlDUSRqlWy9An2AY6v9rYWTj825B6zsj5pLLEToYO1tfwWq0ab183pXg==}
     engines: {node: '>=18.20.0'}
 
   '@wdio/utils@9.16.2':
@@ -7030,8 +7051,8 @@ packages:
     resolution: {integrity: sha512-6WhtzC5SNCGRBTkaObX6A07Ofnnyyf+TQH/d/fuhZRqvBknrP4AMMZF+PFxGl1fwdySWdBn+gV2QLE+52Byowg==}
     engines: {node: '>=18.20.0'}
 
-  '@wdio/utils@9.27.1':
-    resolution: {integrity: sha512-s2w1tFrvmpdkZ33LYsIw4ONRdWIIm4MxkyIuibbcG1ILV5fFMS9rU59csHuWIM0KhJoEoLU+fzE3ze9O7TpWhw==}
+  '@wdio/utils@9.27.0':
+    resolution: {integrity: sha512-fUasd5OKJTy2seJfWnYZ9xlxTtY0p/Kyeuh7Tbb8kcofBqmBi2fTvM3sfZlo1tGQX9yCh+IS2N7hlfyFMmuZ+w==}
     engines: {node: '>=18.20.0'}
 
   '@webassemblyjs/ast@1.14.1':
@@ -7082,7 +7103,6 @@ packages:
   '@xmldom/xmldom@0.9.8':
     resolution: {integrity: sha512-p96FSY54r+WJ50FIOsCOjyj/wavs8921hG5+kVMmZgKcvIKxMXHTrjNJvRgWa/zuX3B6t2lijLNFaOyuxUH+2A==}
     engines: {node: '>=14.6'}
-    deprecated: this version has critical issues, please update to the latest version
 
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -7416,6 +7436,9 @@ packages:
   axe-core@4.2.3:
     resolution: {integrity: sha512-pXnVMfJKSIWU2Ml4JHP7pZEPIrgBO1Fd3WGx+fPBsS+KRGhE4vxooD8XBGWbQOIVSZsVK7pUDBBkCicNu80yzQ==}
     engines: {node: '>=4'}
+
+  axios@1.10.0:
+    resolution: {integrity: sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==}
 
   axios@1.13.6:
     resolution: {integrity: sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==}
@@ -7774,10 +7797,6 @@ packages:
     resolution: {integrity: sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==}
     engines: {node: '>=16'}
 
-  camelcase@9.0.0:
-    resolution: {integrity: sha512-TO9xmyXTZ9HUHI8M1OnvExxYB0eYVS/1e5s7IDMTAoIcwUd+aNcFODs6Xk83mobk0velyHFQgA1yIrvYc6wclw==}
-    engines: {node: '>=20'}
-
   caniuse-api@3.0.0:
     resolution: {integrity: sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==}
 
@@ -7790,12 +7809,16 @@ packages:
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
-  cddl2ts@0.4.1:
-    resolution: {integrity: sha512-27wq7kJXUjgUDd4CVvuuf7+zFJ0azyJjVgEK8e/ekPn8HMAkbhnpS/VSS962D7J9TmAsD0cq6NA/ADXhiihclg==}
+  cddl2ts@0.2.2:
+    resolution: {integrity: sha512-aAiow6auAznZgFrBjFCGmPWi6bg4SddxhnMjFrldefERBHjJZ7ZDqtqGiFnYUA8tHLjD5k52F/7ifT8gMLMdAg==}
     hasBin: true
 
-  cddl@0.14.5:
-    resolution: {integrity: sha512-Pvio1zMYXtcs0Oiw42aYVrLmvb4ItpJt22BDP0v7BzBCTMX6xXf7JIXW9p6B0VYAHvz4ONJjzLzcfn+j2IoItw==}
+  cddl@0.12.0:
+    resolution: {integrity: sha512-ZC6S8Kb+AAL8JsMtXUSiXwJftNUwWhdhiluFFN15GQIFkqwC11rKt9dSMUeUdC9USdG2coGFRRSWbElo8GnusA==}
+    hasBin: true
+
+  cddl@0.8.5:
+    resolution: {integrity: sha512-QI16osnIzXgwbDi+/w3QpZLH5Y6HH0SDdGw5Yi54vQIU0bfYfLEK5UUGPrZYe008ETeuR4Fh8VYnOtpln9+36g==}
     hasBin: true
 
   chai@5.2.0:
@@ -7976,10 +7999,6 @@ packages:
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
-
-  cliui@9.0.1:
-    resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
-    engines: {node: '>=20'}
 
   clone-deep@4.0.1:
     resolution: {integrity: sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==}
@@ -9570,6 +9589,15 @@ packages:
       debug:
         optional: true
 
+  follow-redirects@1.15.9:
+    resolution: {integrity: sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
@@ -9593,6 +9621,10 @@ packages:
   format@0.2.2:
     resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
     engines: {node: '>=0.4.x'}
+
+  formdata-node@5.0.1:
+    resolution: {integrity: sha512-8xnIjMYGKPj+rY2BTbAmpqVpi8der/2FT4d9f7J32FlsCpO5EzZPq3C/N56zdv8KweHzVF6TGijsS1JT6r1H2g==}
+    engines: {node: '>= 14.17'}
 
   formdata-polyfill@4.0.10:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
@@ -14266,8 +14298,8 @@ packages:
     engines: {node: '>=10'}
     deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
-  tar@7.5.13:
-    resolution: {integrity: sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==}
+  tar@7.5.10:
+    resolution: {integrity: sha512-8mOPs1//5q/rlkNSPcCegA6hiHJYDmSLEI8aMH/CdSQJNWztHC9WHNam5zdQlfpTwB9Xp7IBEsHfV5LKMJGVAw==}
     engines: {node: '>=18'}
 
   tar@7.5.8:
@@ -14697,10 +14729,6 @@ packages:
     resolution: {integrity: sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==}
     engines: {node: '>=18.17'}
 
-  undici@6.24.1:
-    resolution: {integrity: sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==}
-    engines: {node: '>=18.17'}
-
   undici@7.18.2:
     resolution: {integrity: sha512-y+8YjDFzWdQlSE9N5nzKMT3g4a5UBX1HKowfdXh0uvAnTaqqwqB92Jt4UXBAeKekDs5IaDKyJFR4X1gYVCgXcw==}
     engines: {node: '>=20.18.1'}
@@ -14891,7 +14919,6 @@ packages:
 
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@11.1.0:
@@ -14900,17 +14927,15 @@ packages:
 
   uuid@3.3.2:
     resolution: {integrity: sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+    deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
     hasBin: true
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   validate-npm-package-license@3.0.4:
@@ -15113,6 +15138,10 @@ packages:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
 
+  web-streams-polyfill@4.0.0-beta.3:
+    resolution: {integrity: sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==}
+    engines: {node: '>= 14'}
+
   web-vitals@4.2.4:
     resolution: {integrity: sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==}
 
@@ -15127,8 +15156,8 @@ packages:
     resolution: {integrity: sha512-2R31Ey83NzMsafkl4hdFq6GlIBvOODQMkueLjeRqYAITu3QCYiq9oqBdnWA6CdePuV4dbKlYsKRX0mwMiPclDA==}
     engines: {node: '>=18.20.0'}
 
-  webdriver@9.27.1:
-    resolution: {integrity: sha512-vr6h+RNQ75O2cofgVrdupGxtKjPEBaBYx/lHCHe0giJfAK01oL0U/yrOksJi7kmpev/daN93ldFPhlIlmWtv8Q==}
+  webdriver@9.27.0:
+    resolution: {integrity: sha512-w07ThZND48SIr0b4S7eFougYUyclmoUwdmju8yXvEJiXYjDjeYUpl8wZrYPEYRBylxpSx+sBHfEUBrPQkcTTRQ==}
     engines: {node: '>=18.20.0'}
 
   webdriverio@9.16.2:
@@ -15149,8 +15178,8 @@ packages:
       puppeteer-core:
         optional: true
 
-  webdriverio@9.27.1:
-    resolution: {integrity: sha512-iPaIU/DluYY7zfLiwXDdoLU/6ZW8eup4PNwQikrCzTfvH/ITllRhFUe6NRDTEEePSxxRTeXAn9nehCs98xWGVA==}
+  webdriverio@9.27.0:
+    resolution: {integrity: sha512-Y4FbMf4bKBXpPB0lYpglzQ2GfDDe6uojmMZl85uPyrDx18NW7mqN84ZawGoIg/FRvcLaVhcOzc98WOPo725Rag==}
     engines: {node: '>=18.20.0'}
     peerDependencies:
       puppeteer-core: '>=22.x || <=24.x'
@@ -15387,10 +15416,6 @@ packages:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
     engines: {node: '>=12'}
 
-  wrap-ansi@9.0.2:
-    resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
-    engines: {node: '>=18'}
-
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
@@ -15531,10 +15556,6 @@ packages:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
 
-  yargs-parser@22.0.0:
-    resolution: {integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
-
   yargs-unparser@2.0.0:
     resolution: {integrity: sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==}
     engines: {node: '>=10'}
@@ -15546,10 +15567,6 @@ packages:
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
-
-  yargs@18.0.0:
-    resolution: {integrity: sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
 
   yauzl@2.10.0:
     resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
@@ -16492,7 +16509,7 @@ snapshots:
   '@babel/helper-module-imports@7.27.1':
     dependencies:
       '@babel/traverse': 7.28.5
-      '@babel/types': 7.29.0
+      '@babel/types': 7.28.5
     transitivePeerDependencies:
       - supports-color
 
@@ -17828,7 +17845,7 @@ snapshots:
 
   '@browserstack/ai-sdk-node@1.5.17':
     dependencies:
-      axios: 1.13.6
+      axios: 1.10.0
       uuid: 9.0.1
     transitivePeerDependencies:
       - debug
@@ -18117,7 +18134,7 @@ snapshots:
       '@cucumber/ci-environment': 10.0.1
       '@cucumber/cucumber-expressions': 17.1.0
       '@cucumber/gherkin': 28.0.0
-      '@cucumber/gherkin-streams': 5.0.1(@cucumber/gherkin@28.0.0)(@cucumber/message-streams@4.0.1(@cucumber/messages@24.1.0))(@cucumber/messages@24.1.0)
+      '@cucumber/gherkin-streams': 5.0.1(@cucumber/gherkin@28.0.0)(@cucumber/message-streams@4.0.1(@cucumber/messages@26.0.1))(@cucumber/messages@24.1.0)
       '@cucumber/gherkin-utils': 9.0.0
       '@cucumber/html-formatter': 21.6.0(@cucumber/messages@24.1.0)
       '@cucumber/message-streams': 4.0.1(@cucumber/messages@24.1.0)
@@ -18157,7 +18174,7 @@ snapshots:
       yaml: 2.8.0
       yup: 1.2.0
 
-  '@cucumber/gherkin-streams@5.0.1(@cucumber/gherkin@28.0.0)(@cucumber/message-streams@4.0.1(@cucumber/messages@24.1.0))(@cucumber/messages@24.1.0)':
+  '@cucumber/gherkin-streams@5.0.1(@cucumber/gherkin@28.0.0)(@cucumber/message-streams@4.0.1(@cucumber/messages@26.0.1))(@cucumber/messages@24.1.0)':
     dependencies:
       '@cucumber/gherkin': 28.0.0
       '@cucumber/message-streams': 4.0.1(@cucumber/messages@24.1.0)
@@ -22335,7 +22352,7 @@ snapshots:
 
   '@types/tar@7.0.87':
     dependencies:
-      tar: 7.5.13
+      tar: 7.5.10
 
   '@types/testing-library__jest-dom@5.14.9':
     dependencies:
@@ -22903,11 +22920,11 @@ snapshots:
       - react-native-b4a
       - supports-color
 
-  '@wdio/config@9.27.1':
+  '@wdio/config@9.27.0':
     dependencies:
       '@wdio/logger': 9.18.0
-      '@wdio/types': 9.27.1
-      '@wdio/utils': 9.27.1
+      '@wdio/types': 9.27.0
+      '@wdio/utils': 9.27.0
       deepmerge-ts: 7.1.5
       glob: 10.5.0
       import-meta-resolve: 4.2.0
@@ -22950,15 +22967,20 @@ snapshots:
       expect-webdriverio: 5.6.5(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@packages+webdriverio)
       webdriverio: 9.16.2(puppeteer-core@24.34.0)
 
-  '@wdio/globals@9.27.1(expect-webdriverio@5.6.5)(webdriverio@9.16.2(puppeteer-core@24.34.0))':
+  '@wdio/globals@9.27.0(expect-webdriverio@5.6.5)(webdriverio@9.16.2(puppeteer-core@24.34.0))':
     dependencies:
-      expect-webdriverio: 5.6.5(@wdio/globals@9.27.1)(@wdio/logger@9.18.0)(webdriverio@9.16.2(puppeteer-core@24.34.0))
+      expect-webdriverio: 5.6.5(@wdio/globals@9.27.0)(@wdio/logger@9.18.0)(webdriverio@9.16.2(puppeteer-core@24.34.0))
       webdriverio: 9.16.2(puppeteer-core@24.34.0)
 
-  '@wdio/globals@9.27.1(expect-webdriverio@5.6.5)(webdriverio@9.27.1(puppeteer-core@24.34.0))':
+  '@wdio/globals@9.27.0(expect-webdriverio@5.6.5)(webdriverio@9.27.0(puppeteer-core@24.34.0))':
     dependencies:
-      expect-webdriverio: 5.6.5(@wdio/globals@9.27.1)(@wdio/logger@9.18.0)(webdriverio@9.27.1(puppeteer-core@24.34.0))
-      webdriverio: 9.27.1(puppeteer-core@24.34.0)
+      expect-webdriverio: 5.6.5(@wdio/globals@9.27.0)(@wdio/logger@9.18.0)(webdriverio@9.27.0(puppeteer-core@24.34.0))
+      webdriverio: 9.27.0(puppeteer-core@24.34.0)
+
+  '@wdio/globals@9.27.0(expect-webdriverio@5.6.5)(webdriverio@packages+webdriverio)':
+    dependencies:
+      expect-webdriverio: 5.6.5(@wdio/globals@9.27.0)(@wdio/logger@9.18.0)(webdriverio@packages+webdriverio)
+      webdriverio: link:packages/webdriverio
 
   '@wdio/logger@9.16.2':
     dependencies:
@@ -22979,7 +23001,7 @@ snapshots:
 
   '@wdio/protocols@9.24.0': {}
 
-  '@wdio/protocols@9.27.1': {}
+  '@wdio/protocols@9.27.0': {}
 
   '@wdio/repl@9.16.2':
     dependencies:
@@ -23021,7 +23043,7 @@ snapshots:
     dependencies:
       '@types/node': 20.19.37
 
-  '@wdio/types@9.27.1':
+  '@wdio/types@9.27.0':
     dependencies:
       '@types/node': 20.19.37
 
@@ -23067,11 +23089,11 @@ snapshots:
       - react-native-b4a
       - supports-color
 
-  '@wdio/utils@9.27.1':
+  '@wdio/utils@9.27.0':
     dependencies:
       '@puppeteer/browsers': 2.13.0
       '@wdio/logger': 9.18.0
-      '@wdio/types': 9.27.1
+      '@wdio/types': 9.27.0
       decamelize: 6.0.1
       deepmerge-ts: 7.1.5
       edgedriver: 6.3.0
@@ -23481,6 +23503,14 @@ snapshots:
       possible-typed-array-names: 1.1.0
 
   axe-core@4.2.3: {}
+
+  axios@1.10.0:
+    dependencies:
+      follow-redirects: 1.15.9
+      form-data: 4.0.3
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
 
   axios@1.13.6:
     dependencies:
@@ -23964,8 +23994,6 @@ snapshots:
 
   camelcase@8.0.0: {}
 
-  camelcase@9.0.0: {}
-
   caniuse-api@3.0.0:
     dependencies:
       browserslist: 4.28.1
@@ -23983,17 +24011,21 @@ snapshots:
 
   ccount@2.0.1: {}
 
-  cddl2ts@0.4.1:
+  cddl2ts@0.2.2:
     dependencies:
-      '@babel/parser': 7.29.0
-      camelcase: 9.0.0
-      cddl: 0.14.5
+      '@babel/parser': 7.27.7
+      camelcase: 8.0.0
+      cddl: 0.8.5
       recast: 0.23.11
-      yargs: 18.0.0
+      yargs: 17.7.2
 
-  cddl@0.14.5:
+  cddl@0.12.0:
     dependencies:
-      yargs: 18.0.0
+      yargs: 17.7.2
+
+  cddl@0.8.5:
+    dependencies:
+      yargs: 17.7.2
 
   chai@5.2.0:
     dependencies:
@@ -24212,12 +24244,6 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
-
-  cliui@9.0.1:
-    dependencies:
-      string-width: 7.2.0
-      strip-ansi: 7.2.0
-      wrap-ansi: 9.0.2
 
   clone-deep@4.0.1:
     dependencies:
@@ -25811,35 +25837,45 @@ snapshots:
 
   expect-type@1.2.1: {}
 
-  expect-webdriverio@5.6.5(@wdio/globals@9.27.1)(@wdio/logger@9.18.0)(webdriverio@9.16.2(puppeteer-core@24.34.0)):
+  expect-webdriverio@5.6.5(@wdio/globals@9.27.0)(@wdio/logger@9.18.0)(webdriverio@9.16.2(puppeteer-core@24.34.0)):
     dependencies:
       '@vitest/snapshot': 4.0.16
-      '@wdio/globals': 9.27.1(expect-webdriverio@5.6.5)(webdriverio@9.16.2(puppeteer-core@24.34.0))
+      '@wdio/globals': 9.27.0(expect-webdriverio@5.6.5)(webdriverio@9.16.2(puppeteer-core@24.34.0))
       '@wdio/logger': 9.18.0
       deep-eql: 5.0.2
       expect: 30.2.0
       jest-matcher-utils: 30.2.0
       webdriverio: 9.16.2(puppeteer-core@24.34.0)
 
-  expect-webdriverio@5.6.5(@wdio/globals@9.27.1)(@wdio/logger@9.18.0)(webdriverio@9.27.1(puppeteer-core@24.34.0)):
+  expect-webdriverio@5.6.5(@wdio/globals@9.27.0)(@wdio/logger@9.18.0)(webdriverio@9.27.0(puppeteer-core@24.34.0)):
     dependencies:
       '@vitest/snapshot': 4.0.16
-      '@wdio/globals': 9.27.1(expect-webdriverio@5.6.5)(webdriverio@9.27.1(puppeteer-core@24.34.0))
+      '@wdio/globals': 9.27.0(expect-webdriverio@5.6.5)(webdriverio@9.27.0(puppeteer-core@24.34.0))
       '@wdio/logger': 9.18.0
       deep-eql: 5.0.2
       expect: 30.2.0
       jest-matcher-utils: 30.2.0
-      webdriverio: 9.27.1(puppeteer-core@24.34.0)
+      webdriverio: 9.27.0(puppeteer-core@24.34.0)
 
-  expect-webdriverio@5.6.5(@wdio/globals@9.27.1)(@wdio/logger@packages+wdio-logger)(webdriverio@9.27.1(puppeteer-core@24.34.0)):
+  expect-webdriverio@5.6.5(@wdio/globals@9.27.0)(@wdio/logger@9.18.0)(webdriverio@packages+webdriverio):
     dependencies:
       '@vitest/snapshot': 4.0.16
-      '@wdio/globals': 9.27.1(expect-webdriverio@5.6.5)(webdriverio@9.27.1(puppeteer-core@24.34.0))
+      '@wdio/globals': 9.27.0(expect-webdriverio@5.6.5)(webdriverio@packages+webdriverio)
+      '@wdio/logger': 9.18.0
+      deep-eql: 5.0.2
+      expect: 30.2.0
+      jest-matcher-utils: 30.2.0
+      webdriverio: link:packages/webdriverio
+
+  expect-webdriverio@5.6.5(@wdio/globals@9.27.0)(@wdio/logger@packages+wdio-logger)(webdriverio@9.27.0(puppeteer-core@24.34.0)):
+    dependencies:
+      '@vitest/snapshot': 4.0.16
+      '@wdio/globals': 9.27.0(expect-webdriverio@5.6.5)(webdriverio@9.27.0(puppeteer-core@24.34.0))
       '@wdio/logger': link:packages/wdio-logger
       deep-eql: 5.0.2
       expect: 30.2.0
       jest-matcher-utils: 30.2.0
-      webdriverio: 9.27.1(puppeteer-core@24.34.0)
+      webdriverio: 9.27.0(puppeteer-core@24.34.0)
 
   expect-webdriverio@5.6.5(@wdio/globals@packages+wdio-globals)(@wdio/logger@9.18.0)(webdriverio@packages+webdriverio):
     dependencies:
@@ -26168,6 +26204,8 @@ snapshots:
 
   follow-redirects@1.15.11: {}
 
+  follow-redirects@1.15.9: {}
+
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
@@ -26196,6 +26234,11 @@ snapshots:
       mime-types: 2.1.35
 
   format@0.2.2: {}
+
+  formdata-node@5.0.1:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 4.0.0-beta.3
 
   formdata-polyfill@4.0.10:
     dependencies:
@@ -29106,7 +29149,7 @@ snapshots:
       nopt: 9.0.0
       proc-log: 6.1.0
       semver: 7.7.2
-      tar: 7.5.13
+      tar: 7.5.10
       tinyglobby: 0.2.15
       which: 6.0.1
     transitivePeerDependencies:
@@ -29585,7 +29628,7 @@ snapshots:
       promise-retry: 2.0.1
       sigstore: 4.1.0
       ssri: 12.0.0
-      tar: 7.5.13
+      tar: 7.5.10
     transitivePeerDependencies:
       - supports-color
 
@@ -29607,7 +29650,7 @@ snapshots:
       proc-log: 6.1.0
       sigstore: 4.1.0
       ssri: 13.0.1
-      tar: 7.5.13
+      tar: 7.5.10
     transitivePeerDependencies:
       - supports-color
 
@@ -29732,7 +29775,7 @@ snapshots:
   path-scurry@1.11.1:
     dependencies:
       lru-cache: 10.4.3
-      minipass: 7.1.3
+      minipass: 7.1.2
 
   path-scurry@2.0.1:
     dependencies:
@@ -31995,7 +32038,7 @@ snapshots:
       mkdirp: 1.0.4
       yallist: 4.0.0
 
-  tar@7.5.13:
+  tar@7.5.10:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0
@@ -32396,8 +32439,6 @@ snapshots:
   undici@6.21.3: {}
 
   undici@6.23.0: {}
-
-  undici@6.24.1: {}
 
   undici@7.18.2: {}
 
@@ -32863,6 +32904,8 @@ snapshots:
 
   web-streams-polyfill@3.3.3: {}
 
+  web-streams-polyfill@4.0.0-beta.3: {}
+
   web-vitals@4.2.4: {}
 
   webdriver-bidi-protocol@0.3.10: {}
@@ -32897,7 +32940,7 @@ snapshots:
       '@wdio/utils': 9.24.0
       deepmerge-ts: 7.1.5
       https-proxy-agent: 7.0.6
-      undici: 6.24.1
+      undici: 6.23.0
       ws: 8.19.0
     transitivePeerDependencies:
       - bare-abort-controller
@@ -32907,18 +32950,18 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  webdriver@9.27.1:
+  webdriver@9.27.0:
     dependencies:
       '@types/node': 20.19.37
       '@types/ws': 8.18.1
-      '@wdio/config': 9.27.1
+      '@wdio/config': 9.27.0
       '@wdio/logger': 9.18.0
-      '@wdio/protocols': 9.27.1
-      '@wdio/types': 9.27.1
-      '@wdio/utils': 9.27.1
+      '@wdio/protocols': 9.27.0
+      '@wdio/types': 9.27.0
+      '@wdio/utils': 9.27.0
       deepmerge-ts: 7.1.5
       https-proxy-agent: 7.0.6
-      undici: 6.24.1
+      undici: 6.23.0
       ws: 8.19.0
     transitivePeerDependencies:
       - bare-abort-controller
@@ -33001,16 +33044,16 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  webdriverio@9.27.1(puppeteer-core@24.34.0):
+  webdriverio@9.27.0(puppeteer-core@24.34.0):
     dependencies:
       '@types/node': 20.19.37
       '@types/sinonjs__fake-timers': 8.1.5
-      '@wdio/config': 9.27.1
+      '@wdio/config': 9.27.0
       '@wdio/logger': 9.18.0
-      '@wdio/protocols': 9.27.1
+      '@wdio/protocols': 9.27.0
       '@wdio/repl': 9.16.2
-      '@wdio/types': 9.27.1
-      '@wdio/utils': 9.27.1
+      '@wdio/types': 9.27.0
+      '@wdio/utils': 9.27.0
       archiver: 7.0.1
       aria-query: 5.3.2
       cheerio: 1.1.2
@@ -33027,7 +33070,7 @@ snapshots:
       rgb2hex: 0.2.5
       serialize-error: 12.0.0
       urlpattern-polyfill: 10.1.0
-      webdriver: 9.27.1
+      webdriver: 9.27.0
     optionalDependencies:
       puppeteer-core: 24.34.0
     transitivePeerDependencies:
@@ -33427,12 +33470,6 @@ snapshots:
       string-width: 5.1.2
       strip-ansi: 7.2.0
 
-  wrap-ansi@9.0.2:
-    dependencies:
-      ansi-styles: 6.2.3
-      string-width: 7.2.0
-      strip-ansi: 7.2.0
-
   wrappy@1.0.2: {}
 
   write-file-atomic@2.4.3:
@@ -33526,8 +33563,6 @@ snapshots:
 
   yargs-parser@21.1.1: {}
 
-  yargs-parser@22.0.0: {}
-
   yargs-unparser@2.0.0:
     dependencies:
       camelcase: 6.3.0
@@ -33554,15 +33589,6 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
-
-  yargs@18.0.0:
-    dependencies:
-      cliui: 9.0.1
-      escalade: 3.2.0
-      get-caller-file: 2.0.5
-      string-width: 7.2.0
-      y18n: 5.0.8
-      yargs-parser: 22.0.0
 
   yauzl@2.10.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,6 +11,7 @@ packages:
   - 'examples/cloudservices/**'
   - 'examples/bidi/**'
   - 'examples/appium/**'
+  - 'test-headless-flag'
 
 onlyBuiltDependencies:
   - sharp

--- a/test-headless-flag/package.json
+++ b/test-headless-flag/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "test-headless-flag",
+  "version": "1.0.0",
+  "description": "Test project to verify the --headless CLI flag in WebdriverIO",
+  "type": "module",
+  "scripts": {
+    "test:headless": "wdio run wdio.conf.js --headless",
+    "test:headed": "wdio run wdio.conf.js --headless=false",
+    "test": "wdio run wdio.conf.js"
+  },
+  "devDependencies": {
+    "@wdio/cli": "workspace:*",
+    "@wdio/local-runner": "workspace:*",
+    "@wdio/mocha-framework": "workspace:*",
+    "@wdio/spec-reporter": "workspace:*",
+    "expect-webdriverio": "^5.6.5",
+    "webdriverio": "workspace:*"
+  }
+}

--- a/test-headless-flag/tests/headless.test.js
+++ b/test-headless-flag/tests/headless.test.js
@@ -1,0 +1,38 @@
+/* global describe, it */
+/**
+ * Test file to verify the --headless CLI flag behaviour.
+ *
+ * Usage:
+ *   pnpm --filter test-headless-flag test:headless  → runs Chrome headlessly (no window)
+ *   pnpm --filter test-headless-flag test:headed    → runs Chrome with a visible window
+ *   pnpm --filter test-headless-flag test           → runs as configured in wdio.conf.js (no override)
+ */
+describe('--headless CLI flag', () => {
+    it('should open a page in the browser', async () => {
+        await browser.url('https://www.example.com')
+        const title = await browser.getTitle()
+        console.log('\n  Page title:', title)
+        expect(title).toBeTruthy()
+    })
+
+    it('should log user agent to verify headless mode', async () => {
+        const ua = await browser.execute(() => navigator.userAgent)
+        console.log('\n  User-Agent:', ua)
+
+        // In --headless (Chrome new headless) the UA no longer contains "HeadlessChrome"
+        // but the browser still functions as expected. The key is that no window appears.
+        // For older Chrome headless (pre-112), you'd see "HeadlessChrome" in the UA.
+        const isOldHeadless = ua.includes('HeadlessChrome')
+        console.log('  Old-style headless UA detected:', isOldHeadless)
+    })
+
+    it('should report the effective goog:chromeOptions args via capabilities', async () => {
+        const caps = browser.capabilities
+        const chromeArgs = caps?.['goog:chromeOptions']?.args ?? []
+        console.log('\n  Effective goog:chromeOptions.args:', JSON.stringify(chromeArgs))
+
+        // The test passes regardless of headless state — this is for inspection only.
+        // When run with --headless, you should see "--headless" and "--disable-gpu" in the args.
+        // When run with --headless=false, those args should be absent.
+    })
+})

--- a/test-headless-flag/wdio.conf.js
+++ b/test-headless-flag/wdio.conf.js
@@ -1,0 +1,25 @@
+/**
+ * WebdriverIO config file for testing the --headless CLI flag.
+ *
+ * The capabilities here set headless ON by default (useful for CI).
+ * Run `pnpm test:headed` (--headless=false) to strip the headless args at runtime.
+ * Run `pnpm test:headless` (--headless) to force headless even if you remove the args.
+ */
+export const config = {
+    runner: 'local',
+    specs: ['./tests/*.test.js'],
+    capabilities: [{
+        browserName: 'chrome',
+        // Headless is set here by default — the --headless=false CLI flag will strip it
+        'goog:chromeOptions': {
+            args: ['--no-sandbox', '--disable-dev-shm-usage', '--headless', '--disable-gpu']
+        }
+    }],
+    maxInstances: 1,
+    logLevel: 'warn',
+    framework: 'mocha',
+    reporters: ['spec'],
+    mochaOpts: {
+        timeout: 60000
+    }
+}


### PR DESCRIPTION
…me override

## Proposed changes
Adds a --headless boolean CLI flag that lets users override browser headless mode at runtime without modifying wdio.conf.js. This allows teams to maintain a single config file and toggle headless on/off via the command line — useful for running tests headlessly in CI while being able to quickly switch to headed mode when writing or debugging tests locally.
Closes #15160
The flag injects or strips the appropriate headless arguments per browser (Chrome/Chromium, Firefox, Edge) and takes full precedence over whatever is configured in wdio.conf.js.


[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
