### PR TITLE
fix Cucumber retries collapsing into single Allure result

### DIFF
--- a/packages/wdio-allure-reporter/src/reporter.ts
+++ b/packages/wdio-allure-reporter/src/reporter.ts
@@ -644,11 +644,70 @@ export default class AllureReporter extends WDIOReporter {
         })
     }
 
-    onSuiteRetry(_suite: SuiteStats): void {
+    onSuiteRetry(suite: SuiteStats): void {
+        const cid = this._currentCid()
+
+        // Mark the first attempt as a retried result so Allure displays it under the "Retries" tab
         this._pushRuntimeMessage({
             type: 'metadata',
             data: { labels: [{ name: LabelName.TAG, value: 'retried' }] },
         })
+
+        // Determine the status of the first (failed) attempt from its accumulated step/hook stats
+        suite.hooks = (suite.hooks || []).map((h: HookStats) => {
+            h.state = h.state || AllureStatusEnum.PASSED
+            return h
+        })
+        const suiteChildren = [...(suite.tests || []), ...(suite.hooks || [])]
+        const isSkipped =
+            suiteChildren.length > 0 &&
+            (suite.tests || []).every((t: TestStats) => [AllureStatusEnum.SKIPPED].includes(t.state as AllureStatus)) &&
+            (suite.hooks || []).every((h: HookStats) => [AllureStatusEnum.PASSED, AllureStatusEnum.SKIPPED].includes(h.state as AllureStatus))
+        const failed = suiteChildren.find((i) => i.state === AllureStatusEnum.FAILED)
+        const status = isSkipped
+            ? AllureStatusEnum.SKIPPED
+            : failed ? getTestStatus(failed) : AllureStatusEnum.FAILED
+        const error = failed ? getErrorFromFailedTest(failed) : undefined
+
+        // Close attempt #1 as a proper (failed/skipped) result
+        this._attachLogs()
+        this._endTest({
+            stage: isSkipped ? AllureStage.PENDING : AllureStage.FINISHED,
+            status,
+            statusDetails: error ? { message: error.message, trace: error.stack } : undefined,
+            stop: Date.now(),
+        })
+
+        // Open a fresh Allure test for the retry attempt.
+        // Sharing the same historyId is intentional: Allure uses it to group
+        // separate result files as retry attempts of the same scenario.
+        this._consoleOutput = ''
+        this._startTest({ name: suite.title, start: Date.now() })
+        this._currentLeafTitleByCid.set(cid, suite.title)
+        const fullTitleForHash = this._mochaFullTitle(cid, suite.title)
+        this._emitHistoryIdsFrom(fullTitleForHash)
+
+        const fullName = toFullName(this._pkgByCid.get(cid)!, fullTitleForHash)
+        this._pushRuntimeMessage({ type: 'allure:test:info', data: { fullName, fullTitle: fullTitleForHash } })
+
+        this._emitBaseLabels(cid)
+
+        convertSuiteTagsToLabels(suite?.tags || []).forEach((lbl) => {
+            switch (lbl.name) {
+            case 'issue':
+                label('issue', lbl.value)
+                break
+            case 'testId':
+                label('testId', lbl.value)
+                break
+            default:
+                label(lbl.name, lbl.value)
+            }
+        })
+
+        if (suite.description) {
+            description(suite.description)
+        }
     }
 
     private _inCucumberStepMode(exec: TestStats | HookStats | SuiteStats): boolean {
@@ -679,6 +738,23 @@ export default class AllureReporter extends WDIOReporter {
         if (this._inCucumberStepMode(test)) {
             this._handleCucumberStepStart(test as TestStats)
             return
+        }
+
+        // Detect a scenarioLevelReporter retry: test:start fires again for a scenario while
+        // a previous scenario test is still open (because testCaseFinished was skipped for
+        // the willBeRetried=true attempt).  End the first attempt explicitly so Allure
+        // generates a separate result file for it before opening the retry result.
+        if (getType(test) === 'scenario' && this._hasPendingTest) {
+            this._pushRuntimeMessage({
+                type: 'metadata',
+                data: { labels: [{ name: LabelName.TAG, value: 'retried' }] },
+            })
+            this._attachLogs()
+            this._endTest({
+                stage: AllureStage.FINISHED,
+                status: AllureStatusEnum.FAILED,
+                stop: Date.now(),
+            })
         }
 
         const cid = this._currentCid()

--- a/packages/wdio-allure-reporter/tests/cucumber.suite.test.ts
+++ b/packages/wdio-allure-reporter/tests/cucumber.suite.test.ts
@@ -902,3 +902,109 @@ describe('reporter option "useCucumberStepReporter" set to true', () => {
         })
     })
 })
+
+describe('Cucumber retries (issue #15177)', () => {
+    describe('default mode (no scenarioLevelReporter): onSuiteRetry generates separate result files', () => {
+        let outputDir: string
+        let results: any[]
+
+        beforeAll(async () => {
+            outputDir = temporaryDirectory()
+            const reporter = new AllureReporter({ outputDir, useCucumberStepReporter: true })
+
+            reporter.onRunnerStart(runnerStart())
+            reporter.onSuiteStart(cucumberHelper.featureStart())
+            // ----- Attempt 1 (will be retried) -----
+            reporter.onSuiteStart(cucumberHelper.scenarioStart())
+            reporter.onTestStart(cucumberHelper.testStart())
+            reporter.onTestFail(cucumberHelper.testFail())
+            // suite:retry fires instead of suite:end for willBeRetried attempts
+            const firstAttemptSuite = cucumberHelper.scenarioEnd({ tests: [cucumberHelper.testFail()], hooks: [] })
+            reporter.onSuiteRetry(firstAttemptSuite as any)
+            // ----- Attempt 2 (final) -----
+            reporter.onTestStart(cucumberHelper.testStart())
+            reporter.onTestPass(cucumberHelper.testPass())
+            const secondAttemptResults: any = { tests: [cucumberHelper.testPass()], hooks: [] }
+            reporter.onSuiteEnd(cucumberHelper.scenarioEnd(secondAttemptResults))
+            reporter.onSuiteEnd(cucumberHelper.featureEnd(secondAttemptResults))
+            await reporter.onRunnerEnd(runnerEnd())
+
+            await new Promise(resolve => setTimeout(resolve, 100))
+
+            results = getResults(outputDir).results
+        })
+
+        afterAll(() => clean(outputDir))
+
+        it('should produce two separate Allure result files (one per attempt)', () => {
+            expect(results).toHaveLength(2)
+        })
+
+        it('should assign the same historyId to both attempts so Allure groups them as retries', () => {
+            expect(results[0].historyId).toBeDefined()
+            expect(results[0].historyId).toBe(results[1].historyId)
+        })
+
+        it('attempt 1 should be tagged as "retried" with FAILED status', () => {
+            const attempt1 = results.find((r: any) =>
+                r.labels.some((l: Label) => l.name === LabelName.TAG && l.value === 'retried')
+            )
+            expect(attempt1).toBeDefined()
+            expect(attempt1.status).toBe(Status.FAILED)
+        })
+
+        it('attempt 2 should have PASSED status and no "retried" tag', () => {
+            const attempt2 = results.find((r: any) =>
+                !r.labels.some((l: Label) => l.name === LabelName.TAG && l.value === 'retried')
+            )
+            expect(attempt2).toBeDefined()
+            expect(attempt2.status).toBe(Status.PASSED)
+        })
+    })
+
+    describe('scenarioLevelReporter: separate test:start per attempt generates separate result files', () => {
+        let outputDir: string
+        let results: any[]
+
+        beforeAll(async () => {
+            outputDir = temporaryDirectory()
+            const reporter = new AllureReporter({ outputDir, useCucumberStepReporter: true })
+
+            reporter.onRunnerStart(runnerStart())
+            reporter.onSuiteStart(cucumberHelper.featureStart())
+            // ----- Attempt 1 (willBeRetried=true → no test:fail emitted by cucumberFormatter) -----
+            // test:start fires for the scenario as a whole
+            reporter.onTestStart({ ...cucumberHelper.scenarioStart(), type: 'scenario' } as any)
+            // ----- Attempt 2 (willBeRetried=false) -----
+            // test:start fires again → our fix detects the pending test and closes attempt 1
+            reporter.onTestStart({ ...cucumberHelper.scenarioStart(), type: 'scenario' } as any)
+            // The scenario finally fails (sent by afterTest in cucumberFormatter)
+            reporter.onTestFail(cucumberHelper.testFail())
+            reporter.onSuiteEnd(cucumberHelper.featureEnd({ tests: [cucumberHelper.testFail()], hooks: [] }))
+            await reporter.onRunnerEnd(runnerEnd())
+
+            await new Promise(resolve => setTimeout(resolve, 100))
+
+            results = getResults(outputDir).results
+        })
+
+        afterAll(() => clean(outputDir))
+
+        it('should produce two separate Allure result files', () => {
+            expect(results).toHaveLength(2)
+        })
+
+        it('should assign the same historyId to both attempts', () => {
+            expect(results[0].historyId).toBeDefined()
+            expect(results[0].historyId).toBe(results[1].historyId)
+        })
+
+        it('attempt 1 should be tagged as "retried" with FAILED status (not "unknown")', () => {
+            const attempt1 = results.find((r: any) =>
+                r.labels.some((l: Label) => l.name === LabelName.TAG && l.value === 'retried')
+            )
+            expect(attempt1).toBeDefined()
+            expect(attempt1.status).toBe(Status.FAILED)
+        })
+    })
+})


### PR DESCRIPTION
Closes #15177

## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)
This commit fixes retry handling by gracefully isolating and terminating the aborted first attempt rather than letting it bleed into the second.

In onSuiteRetry, we now accurately deduce the status of the initial attempt, forcibly terminate it with a "retried" tag, and start a fresh Allure test for the next attempt

In onTestStart, I have implemented scenario collision detection to identify orphaned attempts (caused by scenarioLevelReporter), terminating them natively as `FAILED` before initializing Attempt #2.
## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
