### PR TITLE
enhancement: prevent shadow root memory leak in SPA navigation

### DIFF
--- a/e2e/wdio/headless/mocking.e2e.ts
+++ b/e2e/wdio/headless/mocking.e2e.ts
@@ -111,6 +111,10 @@ describe('network mocking', () => {
 
         await browser.url('https://guinea-pig.webdriver.io/')
 
+        await browser.waitUntil(() => mock.calls[0]?.body !== undefined, {
+            timeoutMsg: 'Expected response body to be populated',
+            timeout: 5000
+        })
         expect(mock.calls[0].body).toContain('<title>WebdriverJS Testpage</title>')
     })
 

--- a/packages/webdriverio/src/session/shadowRoot.ts
+++ b/packages/webdriverio/src/session/shadowRoot.ts
@@ -21,6 +21,7 @@ export class ShadowRootManager extends SessionManager {
     #browser: WebdriverIO.Browser
     #initialize: Promise<boolean>
     #shadowRoots = new Map<string, ShadowRootTree>()
+    #currentDocumentIds = new Map<string, string>()
     #documentElement?: remote.ScriptNodeRemoteValue
     #frameDepth = 0
 
@@ -74,6 +75,7 @@ export class ShadowRootManager extends SessionManager {
         }
         const params = command.params as remote.BrowsingContextNavigateParameters
         this.#shadowRoots.delete(params.context)
+        this.#currentDocumentIds.delete(params.context)
     }
 
     /**
@@ -126,6 +128,25 @@ export class ShadowRootManager extends SessionManager {
         const eventType = args[1].value
         if (eventType === 'newShadowRoot' && args[2].type === 'node' && args[3].type === 'node') {
             const [/* [WDIO] */, /* newShadowRoot */, shadowElem, rootElem, isDocument, documentElement] = args
+
+            /**
+             * Detect document ID changes from sharedId format: f.<frameId>.d.<documentId>.e.<elementId>
+             * When the document changes (full navigation), purge the old tree to prevent unbounded growth.
+             */
+            const ctxId = logEntry.source.context
+            if (shadowElem.sharedId) {
+                const docMatch = shadowElem.sharedId.match(/\.d\.([A-F0-9]+)\./)
+                if (docMatch) {
+                    const newDocId = docMatch[1]
+                    const currentDocId = this.#currentDocumentIds.get(ctxId)
+                    if (currentDocId && currentDocId !== newDocId) {
+                        log.info(`Document changed in context ${ctxId}: ${currentDocId} -> ${newDocId}, purging ${this.#shadowRoots.get(ctxId)?.flat().length ?? 0} stale shadow roots`)
+                        this.#shadowRoots.delete(ctxId)
+                    }
+                    this.#currentDocumentIds.set(ctxId, newDocId)
+                }
+            }
+
             if (!this.#shadowRoots.has(logEntry.source.context)) {
                 /**
                  * initiate shadow tree for context
@@ -310,6 +331,11 @@ export class ShadowRootTree {
         }
 
         if (scope instanceof ShadowRootTree) {
+            for (const child of this.children) {
+                if (child.element === scope.element) {
+                    return
+                }
+            }
             this.children.add(scope)
             return
         }

--- a/packages/webdriverio/src/utils/index.ts
+++ b/packages/webdriverio/src/utils/index.ts
@@ -357,13 +357,13 @@ export async function findDeepElement(
                     try {
                         const connected = await browser.execute((el: Element) => el.isConnected, node as unknown as HTMLElement)
                         if (connected) { return node }
+                        shadowRootManager.deleteShadowRoot(node[ELEMENT_KEY] as string, context)
                     } catch {
-                        // Element reference is stale or garbage collected, try next
+                        shadowRootManager.deleteShadowRoot(node[ELEMENT_KEY] as string, context)
                     }
                 }
-                // All BiDi results are detached, fall back to Classic WebDriver
-                log.warn(`All ${nodes.length} BiDi results for "${value}" are detached, falling back to Classic WebDriver`)
-                return browser.findElement(using, value)
+                log.warn(`All ${nodes.length} BiDi results for "${value}" are detached, removed stale entries from shadow root tree`)
+                return undefined
             }
             return nodes[0]
         }
@@ -392,13 +392,14 @@ export async function findDeepElement(
             try {
                 const connected = await browser.execute((el: Element) => el.isConnected, node as unknown as HTMLElement)
                 if (connected) { return node }
+                shadowRootManager.deleteShadowRoot(node[ELEMENT_KEY] as string, context)
             } catch {
-                // stale, try next
+                shadowRootManager.deleteShadowRoot(node[ELEMENT_KEY] as string, context)
             }
         }
         if (scopedNodes.length > 0) {
-            log.warn(`All ${scopedNodes.length} scoped BiDi results for "${value}" are detached, falling back to Classic WebDriver`)
-            return this.findElementFromElement((this as WebdriverIO.Element).elementId, using, value)
+            log.warn(`All ${scopedNodes.length} scoped BiDi results for "${value}" are detached, removed stale entries from shadow root tree`)
+            return undefined
         }
         return scopedNodes[0]
     }, (err) => {
@@ -471,14 +472,18 @@ export async function findDeepElements(
                 for (const node of nodes) {
                     try {
                         const connected = await browser.execute((el: Element) => el.isConnected, node as unknown as HTMLElement)
-                        if (connected) { validNodes.push(node) }
+                        if (connected) {
+                            validNodes.push(node)
+                        } else {
+                            shadowRootManager.deleteShadowRoot(node[ELEMENT_KEY] as string, context)
+                        }
                     } catch {
-                        // Element reference is stale or garbage collected, skip
+                        shadowRootManager.deleteShadowRoot(node[ELEMENT_KEY] as string, context)
                     }
                 }
                 if (validNodes.length > 0) { return validNodes }
                 // All BiDi results are detached, fall back to Classic WebDriver
-                return browser.findElements(using, value)
+                return []
             }
             return nodes
         }
@@ -507,14 +512,18 @@ export async function findDeepElements(
         for (const node of scopedNodes) {
             try {
                 const connected = await browser.execute((el: Element) => el.isConnected, node as unknown as HTMLElement)
-                if (connected) { connectedScopedNodes.push(node as unknown as (boolean | ElementReference)[]) }
+                if (connected) {
+                    connectedScopedNodes.push(node as unknown as (boolean | ElementReference)[])
+                } else {
+                    shadowRootManager.deleteShadowRoot((node as unknown as Record<string, string>)[ELEMENT_KEY], context)
+                }
             } catch {
-                // stale, skip
+                shadowRootManager.deleteShadowRoot((node as unknown as Record<string, string>)[ELEMENT_KEY], context)
             }
         }
         if (connectedScopedNodes.length > 0) { return connectedScopedNodes }
         if (scopedNodes.length > 0) {
-            return this.findElementsFromElement((this as WebdriverIO.Element).elementId, using, value)
+            return []
         }
         return scopedNodes
     }, (err) => {

--- a/packages/webdriverio/tests/shadowRoot.test.ts
+++ b/packages/webdriverio/tests/shadowRoot.test.ts
@@ -191,6 +191,88 @@ describe('ShadowRootManager', () => {
         } as any)
         expect(manager.getShadowElementsByContextId('removeContext')).not.toContain('shadowA')
     })
+
+    it('should purge old shadow roots when document ID changes', () => {
+        const browser = { ...defaultBrowser } as any
+        const manager = getShadowRootManager(browser)
+        const handleLogEntry = manager.handleLogEntry.bind(manager)
+
+        // Register shadow root with document A
+        handleLogEntry({
+            level: 'debug',
+            source: { context: 'ctx1' },
+            args: [
+                { type: 'string', value: '[WDIO]' },
+                { type: 'string', value: 'newShadowRoot' },
+                { type: 'node', sharedId: 'f.C1.d.AAAA0000AAAA0000AAAA0000AAAA0000.e.100', value: { localName: 'comp-a', shadowRoot: { sharedId: 'f.C1.d.AAAA0000AAAA0000AAAA0000AAAA0000.e.101', value: { nodeType: 11, mode: 'open' } } } },
+                { type: 'node', sharedId: 'f.C1.d.AAAA0000AAAA0000AAAA0000AAAA0000.e.1' },
+                { type: 'boolean', value: true },
+                { type: 'node', sharedId: 'root1' }
+            ]
+        } as any)
+
+        let elements = manager.getShadowElementsByContextId('ctx1')
+        expect(elements.length).toBeGreaterThan(0)
+
+        // Register shadow root with NEW document B → should purge old entries
+        handleLogEntry({
+            level: 'debug',
+            source: { context: 'ctx1' },
+            args: [
+                { type: 'string', value: '[WDIO]' },
+                { type: 'string', value: 'newShadowRoot' },
+                { type: 'node', sharedId: 'f.C1.d.BBBB0000BBBB0000BBBB0000BBBB0000.e.200', value: { localName: 'comp-b', shadowRoot: { sharedId: 'f.C1.d.BBBB0000BBBB0000BBBB0000BBBB0000.e.201', value: { nodeType: 11, mode: 'open' } } } },
+                { type: 'node', sharedId: 'f.C1.d.BBBB0000BBBB0000BBBB0000BBBB0000.e.2' },
+                { type: 'boolean', value: true },
+                { type: 'node', sharedId: 'root2' }
+            ]
+        } as any)
+
+        elements = manager.getShadowElementsByContextId('ctx1')
+        // Should only contain elements from document B, not document A
+        const hasDocA = elements.some(e => e.includes('AAAA0000'))
+        const hasDocB = elements.some(e => e.includes('BBBB0000'))
+        expect(hasDocA).toBe(false)
+        expect(hasDocB).toBe(true)
+    })
+
+    it('should not purge when document ID stays the same', () => {
+        const browser = { ...defaultBrowser } as any
+        const manager = getShadowRootManager(browser)
+        const handleLogEntry = manager.handleLogEntry.bind(manager)
+
+        // Register two shadow roots with same document
+        handleLogEntry({
+            level: 'debug',
+            source: { context: 'ctx1' },
+            args: [
+                { type: 'string', value: '[WDIO]' },
+                { type: 'string', value: 'newShadowRoot' },
+                { type: 'node', sharedId: 'f.C1.d.AAAA0000AAAA0000AAAA0000AAAA0000.e.100', value: { localName: 'comp-a', shadowRoot: { sharedId: 'f.C1.d.AAAA0000AAAA0000AAAA0000AAAA0000.e.101', value: { nodeType: 11, mode: 'open' } } } },
+                { type: 'node', sharedId: 'f.C1.d.AAAA0000AAAA0000AAAA0000AAAA0000.e.1' },
+                { type: 'boolean', value: true },
+                { type: 'node', sharedId: 'root1' }
+            ]
+        } as any)
+
+        handleLogEntry({
+            level: 'debug',
+            source: { context: 'ctx1' },
+            args: [
+                { type: 'string', value: '[WDIO]' },
+                { type: 'string', value: 'newShadowRoot' },
+                { type: 'node', sharedId: 'f.C1.d.AAAA0000AAAA0000AAAA0000AAAA0000.e.200', value: { localName: 'comp-b', shadowRoot: { sharedId: 'f.C1.d.AAAA0000AAAA0000AAAA0000AAAA0000.e.201', value: { nodeType: 11, mode: 'open' } } } },
+                { type: 'node', sharedId: 'f.C1.d.AAAA0000AAAA0000AAAA0000AAAA0000.e.1' },
+                { type: 'boolean', value: false },
+                { type: 'node', sharedId: 'root1' }
+            ]
+        } as any)
+
+        const elements = manager.getShadowElementsByContextId('ctx1')
+        // Should have both elements since same document
+        expect(elements.filter(e => e.includes('AAAA0000')).length).toBeGreaterThanOrEqual(2)
+    })
+
 })
 
 describe('ShadowRootTree', () => {
@@ -234,7 +316,6 @@ describe('ShadowRootTree', () => {
             "17",
             "19",
             "21",
-            "19",
           ]
         `)
         expect(root.find('8')?.getAllLookupScopes()).toMatchInlineSnapshot(`
@@ -260,7 +341,6 @@ describe('ShadowRootTree', () => {
             "17",
             "19",
             "21",
-            "19",
           ]
         `)
     })
@@ -271,9 +351,18 @@ describe('ShadowRootTree', () => {
         expect(child?.getAllLookupScopes()).toMatchInlineSnapshot(`
           [
             "17",
-            "19",
-            "21",
           ]
         `)
     })
+    it('should deduplicate children with same element id', () => {
+        const root = new ShadowRootTree('root1', 'shadow1')
+        const child1 = new ShadowRootTree('elem1', 'shadow-elem1')
+        const child1dup = new ShadowRootTree('elem1', 'shadow-elem1-dup')
+        const child2 = new ShadowRootTree('elem2', 'shadow-elem2')
+        root.addShadowElement(child1)
+        root.addShadowElement(child1dup)  // Duplicate — should be ignored
+        root.addShadowElement(child2)
+        expect(root.flat().length).toBe(3)  // root + child1 + child2 (not child1dup)
+    })
+
 })

--- a/packages/webdriverio/tests/utils/findDeepElement.test.ts
+++ b/packages/webdriverio/tests/utils/findDeepElement.test.ts
@@ -19,6 +19,7 @@ vi.mock('@wdio/utils', async (importOriginal) => {
 vi.mock('../../src/session/shadowRoot.js', () => ({
     getShadowRootManager: vi.fn(() => ({
         getShadowElementsByContextId: mockGetShadowElementsByContextId,
+        deleteShadowRoot: vi.fn(),
     })),
 }))
 
@@ -108,8 +109,9 @@ describe('findDeepElement - isConnected validation', () => {
 
         const result = await findDeepElement.call(browser, '[data-qa="my-btn"]')
 
-        expect(result).toEqual(classicResult)
-        expect(browser.findElement).toHaveBeenCalledWith('css selector', '[data-qa="my-btn"]')
+        // Classic fallback removed - returns undefined for retry
+        expect(result).toBeUndefined()
+        expect(browser.findElement).not.toHaveBeenCalled()
     })
 
     it('should handle execute throwing for stale elements (unscoped)', async () => {
@@ -184,12 +186,8 @@ describe('findDeepElement - isConnected validation', () => {
 
         const result = await findDeepElement.call(element, '.child-selector')
 
-        expect(result).toEqual(classicResult)
-        expect(element.findElementFromElement).toHaveBeenCalledWith(
-            'parent-elem-id',
-            'css selector',
-            '.child-selector'
-        )
+        // Classic fallback removed — returns undefined for retry
+        expect(result).toBeUndefined()
     })
 
     it('should return first connected scoped node (scoped/element context)', async () => {
@@ -283,8 +281,8 @@ describe('findDeepElements - isConnected validation', () => {
 
         const result = await findDeepElements.call(browser, '.card')
 
-        expect(result).toEqual(classicResults)
-        expect(browser.findElements).toHaveBeenCalledWith('css selector', '.card')
+        // Classic fallback removed — returns empty array for retry
+        expect(result).toEqual([])
     })
 
     it('should handle execute throwing for stale elements (unscoped)', async () => {
@@ -359,12 +357,9 @@ describe('findDeepElements - isConnected validation', () => {
 
         const result = await findDeepElements.call(element, '.child')
 
-        expect(result).toEqual(classicResults)
-        expect(element.findElementsFromElement).toHaveBeenCalledWith(
-            'parent-elem',
-            'css selector',
-            '.child'
-        )
+        // Classic fallback removed — returns empty array for retry
+        expect(result).toEqual([])
+        expect(element.findElementsFromElement).not.toHaveBeenCalled()
     })
 
     it('should return connected scoped nodes only (scoped/element context)', async () => {


### PR DESCRIPTION
## Proposed changes

Add 3 fixes to address unbounded shadow root tree growth:

1. Document-based purging: detect documentId changes from sharedId format (f.<frameId>.d.<documentId>.e.<elementId>) and purge stale shadow root tree when document changes (full page navigation). Track current documentId per context via #currentDocumentIds map.
2. Dedup in ShadowRootTree.addShadowElement: prevent duplicate children with same element id from being added to the tree.
3. Lazy cleanup + remove broken Classic fallback: when all BiDi results are detached in findDeepElement/findDeepElements, delete stale entries from shadow root tree and return undefined/[] to let the waitFor retry mechanism work correctly, instead of calling Classic WebDriver which cannot pierce shadow DOM.
## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
