### PR TITLE
fix: call afterSession hook on session init failure and guard worker IPC against kill race

### DIFF
--- a/.github/workflows/test-xvfb-e2e.yml
+++ b/.github/workflows/test-xvfb-e2e.yml
@@ -35,11 +35,11 @@ jobs:
 
           # Alpine scenarios
           - distro: alpine
-            version: "3.20"
+            version: "3.23"
             scenario: base
             dockerfile: alpine-base.dockerfile
           - distro: alpine
-            version: "3.20"
+            version: "3.23"
             scenario: with-xvfb
             dockerfile: alpine-with-xvfb.dockerfile
 

--- a/.github/workflows/test-xvfb-e2e.yml
+++ b/.github/workflows/test-xvfb-e2e.yml
@@ -13,11 +13,85 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Alpine with-xvfb only — debugging chromium version detection issue
+          # Ubuntu scenarios
+          - distro: ubuntu
+            version: "24.04"
+            scenario: base
+            dockerfile: ubuntu-base.dockerfile
+          - distro: ubuntu
+            version: "24.04"
+            scenario: with-xvfb
+            dockerfile: ubuntu-with-xvfb.dockerfile
+
+          # Fedora scenarios
+          - distro: fedora
+            version: "40"
+            scenario: base
+            dockerfile: fedora-base.dockerfile
+          - distro: fedora
+            version: "40"
+            scenario: with-xvfb
+            dockerfile: fedora-with-xvfb.dockerfile
+
+          # Alpine scenarios
+          - distro: alpine
+            version: "3.20"
+            scenario: base
+            dockerfile: alpine-base.dockerfile
           - distro: alpine
             version: "3.20"
             scenario: with-xvfb
             dockerfile: alpine-with-xvfb.dockerfile
+
+          # Debian scenarios
+          - distro: debian
+            version: "12"
+            scenario: base
+            dockerfile: debian-base.dockerfile
+          - distro: debian
+            version: "12"
+            scenario: with-xvfb
+            dockerfile: debian-with-xvfb.dockerfile
+
+          # CentOS Stream scenarios (upstream RHEL)
+          - distro: centos-stream
+            version: "9"
+            scenario: base
+            dockerfile: centos-stream-base.dockerfile
+          - distro: centos-stream
+            version: "9"
+            scenario: with-xvfb
+            dockerfile: centos-stream-with-xvfb.dockerfile
+
+          # Arch Linux scenarios
+          - distro: arch
+            version: "latest"
+            scenario: base
+            dockerfile: arch-base.dockerfile
+          - distro: arch
+            version: "latest"
+            scenario: with-xvfb
+            dockerfile: arch-with-xvfb.dockerfile
+
+          # SUSE scenarios
+          - distro: suse
+            version: "15.6"
+            scenario: base
+            dockerfile: suse-base.dockerfile
+          - distro: suse
+            version: "15.6"
+            scenario: with-xvfb
+            dockerfile: suse-with-xvfb.dockerfile
+
+          # Void Linux scenarios
+          - distro: void
+            version: "latest"
+            scenario: base
+            dockerfile: void-base.dockerfile
+          - distro: void
+            version: "latest"
+            scenario: with-xvfb
+            dockerfile: void-with-xvfb.dockerfile
 
     name: "XVFB E2E: ${{ matrix.distro }}:${{ matrix.version }} (${{ matrix.scenario }})"
 
@@ -44,40 +118,6 @@ jobs:
             -f e2e/wdio/xvfb/docker/${{ matrix.dockerfile }} \
             -t xvfb-test:${{ matrix.distro }}-${{ matrix.scenario }} \
             e2e/wdio/xvfb/docker/
-
-      - name: Debug browser environment in container
-        run: |
-          docker run --rm \
-            -e CHROME_BIN=/usr/bin/chromium \
-            xvfb-test:${{ matrix.distro }}-${{ matrix.scenario }} \
-            bash -c "
-              echo '=== which chromium ==='
-              which chromium 2>&1 || echo 'chromium not in PATH'
-              which chromium-browser 2>&1 || echo 'chromium-browser not in PATH'
-              which google-chrome 2>&1 || echo 'google-chrome not in PATH'
-
-              echo '=== chromium --version stdout ==='
-              /usr/bin/chromium --version --no-sandbox 2>/dev/null || echo 'stdout: (empty or error)'
-
-              echo '=== chromium --version stderr ==='
-              /usr/bin/chromium --version --no-sandbox 1>/dev/null 2>&1 || true
-
-              echo '=== chromium --version both streams ==='
-              { /usr/bin/chromium --version --no-sandbox 2>&1 || true; }
-
-              echo '=== CHROME_BIN env ==='
-              echo \"CHROME_BIN=\$CHROME_BIN\"
-
-              echo '=== node version check ==='
-              node -e \"
-                const cp = require('child_process');
-                const result = cp.spawnSync('/usr/bin/chromium', ['--version', '--no-sandbox'], { encoding: 'utf8' });
-                console.log('stdout:', JSON.stringify(result.stdout));
-                console.log('stderr:', JSON.stringify(result.stderr));
-                console.log('error:', result.error ? result.error.message : 'none');
-                console.log('status:', result.status);
-              \"
-            " || true
 
       - name: Run XVFB E2E tests in container
         run: |

--- a/.github/workflows/test-xvfb-e2e.yml
+++ b/.github/workflows/test-xvfb-e2e.yml
@@ -13,85 +13,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Ubuntu scenarios
-          - distro: ubuntu
-            version: "24.04"
-            scenario: base
-            dockerfile: ubuntu-base.dockerfile
-          - distro: ubuntu
-            version: "24.04"
-            scenario: with-xvfb
-            dockerfile: ubuntu-with-xvfb.dockerfile
-
-          # Fedora scenarios
-          - distro: fedora
-            version: "40"
-            scenario: base
-            dockerfile: fedora-base.dockerfile
-          - distro: fedora
-            version: "40"
-            scenario: with-xvfb
-            dockerfile: fedora-with-xvfb.dockerfile
-
-          # Alpine scenarios
-          - distro: alpine
-            version: "3.20"
-            scenario: base
-            dockerfile: alpine-base.dockerfile
+          # Alpine with-xvfb only — debugging chromium version detection issue
           - distro: alpine
             version: "3.20"
             scenario: with-xvfb
             dockerfile: alpine-with-xvfb.dockerfile
-
-          # Debian scenarios
-          - distro: debian
-            version: "12"
-            scenario: base
-            dockerfile: debian-base.dockerfile
-          - distro: debian
-            version: "12"
-            scenario: with-xvfb
-            dockerfile: debian-with-xvfb.dockerfile
-
-          # CentOS Stream scenarios (upstream RHEL)
-          - distro: centos-stream
-            version: "9"
-            scenario: base
-            dockerfile: centos-stream-base.dockerfile
-          - distro: centos-stream
-            version: "9"
-            scenario: with-xvfb
-            dockerfile: centos-stream-with-xvfb.dockerfile
-
-          # Arch Linux scenarios
-          - distro: arch
-            version: "latest"
-            scenario: base
-            dockerfile: arch-base.dockerfile
-          - distro: arch
-            version: "latest"
-            scenario: with-xvfb
-            dockerfile: arch-with-xvfb.dockerfile
-
-          # SUSE scenarios
-          - distro: suse
-            version: "15.6"
-            scenario: base
-            dockerfile: suse-base.dockerfile
-          - distro: suse
-            version: "15.6"
-            scenario: with-xvfb
-            dockerfile: suse-with-xvfb.dockerfile
-
-          # Void Linux scenarios
-          - distro: void
-            version: "latest"
-            scenario: base
-            dockerfile: void-base.dockerfile
-          - distro: void
-            version: "latest"
-            scenario: with-xvfb
-            dockerfile: void-with-xvfb.dockerfile
 
     name: "XVFB E2E: ${{ matrix.distro }}:${{ matrix.version }} (${{ matrix.scenario }})"
 
@@ -118,6 +44,40 @@ jobs:
             -f e2e/wdio/xvfb/docker/${{ matrix.dockerfile }} \
             -t xvfb-test:${{ matrix.distro }}-${{ matrix.scenario }} \
             e2e/wdio/xvfb/docker/
+
+      - name: Debug browser environment in container
+        run: |
+          docker run --rm \
+            -e CHROME_BIN=/usr/bin/chromium \
+            xvfb-test:${{ matrix.distro }}-${{ matrix.scenario }} \
+            bash -c "
+              echo '=== which chromium ==='
+              which chromium 2>&1 || echo 'chromium not in PATH'
+              which chromium-browser 2>&1 || echo 'chromium-browser not in PATH'
+              which google-chrome 2>&1 || echo 'google-chrome not in PATH'
+
+              echo '=== chromium --version stdout ==='
+              /usr/bin/chromium --version --no-sandbox 2>/dev/null || echo 'stdout: (empty or error)'
+
+              echo '=== chromium --version stderr ==='
+              /usr/bin/chromium --version --no-sandbox 1>/dev/null 2>&1 || true
+
+              echo '=== chromium --version both streams ==='
+              { /usr/bin/chromium --version --no-sandbox 2>&1 || true; }
+
+              echo '=== CHROME_BIN env ==='
+              echo \"CHROME_BIN=\$CHROME_BIN\"
+
+              echo '=== node version check ==='
+              node -e \"
+                const cp = require('child_process');
+                const result = cp.spawnSync('/usr/bin/chromium', ['--version', '--no-sandbox'], { encoding: 'utf8' });
+                console.log('stdout:', JSON.stringify(result.stdout));
+                console.log('stderr:', JSON.stringify(result.stderr));
+                console.log('error:', result.error ? result.error.message : 'none');
+                console.log('status:', result.status);
+              \"
+            " || true
 
       - name: Run XVFB E2E tests in container
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,62 +24,62 @@ jobs:
     name: Build
     uses: ./.github/workflows/build.yml
 
-  static_code_analysis:
-    name: Static Code Analysis
-    uses: ./.github/workflows/test-static.yml
+  # static_code_analysis:
+  #   name: Static Code Analysis
+  #   uses: ./.github/workflows/test-static.yml
 
-  typing_tests:
-    name: Typing Tests
-    needs: [build_core, static_code_analysis]
-    uses: ./.github/workflows/test-typings.yml
+  # typing_tests:
+  #   name: Typing Tests
+  #   needs: [build_core, static_code_analysis]
+  #   uses: ./.github/workflows/test-typings.yml
 
-  interop_tests:
-    name: Interop Tests
-    needs: [build_core, static_code_analysis]
-    uses: ./.github/workflows/test-interop.yml
+  # interop_tests:
+  #   name: Interop Tests
+  #   needs: [build_core, static_code_analysis]
+  #   uses: ./.github/workflows/test-interop.yml
 
-  unit_tests:
-    name: Unit Tests
-    needs: [build_core, static_code_analysis]
-    uses: ./.github/workflows/test-unit.yml
+  # unit_tests:
+  #   name: Unit Tests
+  #   needs: [build_core, static_code_analysis]
+  #   uses: ./.github/workflows/test-unit.yml
 
-  smoke_tests:
-    name: Smoke Tests
-    needs: [build_core, static_code_analysis]
-    uses: ./.github/workflows/test-smoke.yml
+  # smoke_tests:
+  #   name: Smoke Tests
+  #   needs: [build_core, static_code_analysis]
+  #   uses: ./.github/workflows/test-smoke.yml
 
-  component_tests:
-    name: Component Tests
-    needs: [build_core, static_code_analysis]
-    uses: ./.github/workflows/test-component.yml
+  # component_tests:
+  #   name: Component Tests
+  #   needs: [build_core, static_code_analysis]
+  #   uses: ./.github/workflows/test-component.yml
 
-  launch_tests:
-    name: E2E Tests
-    needs: [smoke_tests, component_tests, unit_tests, interop_tests, typing_tests]
-    uses: ./.github/workflows/test-launch.yml
+  # launch_tests:
+  #   name: E2E Tests
+  #   needs: [smoke_tests, component_tests, unit_tests, interop_tests, typing_tests]
+  #   uses: ./.github/workflows/test-launch.yml
 
-  cloud_tests:
-    name: E2E Tests
-    needs: [smoke_tests, component_tests, unit_tests, interop_tests, typing_tests]
-    uses: ./.github/workflows/test-cloud.yml
-    secrets: inherit
+  # cloud_tests:
+  #   name: E2E Tests
+  #   needs: [smoke_tests, component_tests, unit_tests, interop_tests, typing_tests]
+  #   uses: ./.github/workflows/test-cloud.yml
+  #   secrets: inherit
 
-  testrunner_tests:
-    name: E2E Tests
-    needs: [smoke_tests, component_tests, unit_tests, interop_tests, typing_tests]
-    uses: ./.github/workflows/test-testrunner.yml
+  # testrunner_tests:
+  #   name: E2E Tests
+  #   needs: [smoke_tests, component_tests, unit_tests, interop_tests, typing_tests]
+  #   uses: ./.github/workflows/test-testrunner.yml
 
-  multiremote_tests:
-    name: E2E Tests
-    needs: [smoke_tests, component_tests, unit_tests, interop_tests, typing_tests]
-    uses: ./.github/workflows/test-multiremote.yml
+  # multiremote_tests:
+  #   name: E2E Tests
+  #   needs: [smoke_tests, component_tests, unit_tests, interop_tests, typing_tests]
+  #   uses: ./.github/workflows/test-multiremote.yml
 
-  standalone_tests:
-    name: E2E Tests
-    needs: [smoke_tests, component_tests, unit_tests, interop_tests, typing_tests]
-    uses: ./.github/workflows/test-standalone.yml
+  # standalone_tests:
+  #   name: E2E Tests
+  #   needs: [smoke_tests, component_tests, unit_tests, interop_tests, typing_tests]
+  #   uses: ./.github/workflows/test-standalone.yml
 
   xvfb_tests:
     name: XVFB E2E Tests
-    needs: [smoke_tests, component_tests, unit_tests, interop_tests, typing_tests]
+    needs: [build_core]
     uses: ./.github/workflows/test-xvfb-e2e.yml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,62 +24,62 @@ jobs:
     name: Build
     uses: ./.github/workflows/build.yml
 
-  # static_code_analysis:
-  #   name: Static Code Analysis
-  #   uses: ./.github/workflows/test-static.yml
+  static_code_analysis:
+    name: Static Code Analysis
+    uses: ./.github/workflows/test-static.yml
 
-  # typing_tests:
-  #   name: Typing Tests
-  #   needs: [build_core, static_code_analysis]
-  #   uses: ./.github/workflows/test-typings.yml
+  typing_tests:
+    name: Typing Tests
+    needs: [build_core, static_code_analysis]
+    uses: ./.github/workflows/test-typings.yml
 
-  # interop_tests:
-  #   name: Interop Tests
-  #   needs: [build_core, static_code_analysis]
-  #   uses: ./.github/workflows/test-interop.yml
+  interop_tests:
+    name: Interop Tests
+    needs: [build_core, static_code_analysis]
+    uses: ./.github/workflows/test-interop.yml
 
-  # unit_tests:
-  #   name: Unit Tests
-  #   needs: [build_core, static_code_analysis]
-  #   uses: ./.github/workflows/test-unit.yml
+  unit_tests:
+    name: Unit Tests
+    needs: [build_core, static_code_analysis]
+    uses: ./.github/workflows/test-unit.yml
 
-  # smoke_tests:
-  #   name: Smoke Tests
-  #   needs: [build_core, static_code_analysis]
-  #   uses: ./.github/workflows/test-smoke.yml
+  smoke_tests:
+    name: Smoke Tests
+    needs: [build_core, static_code_analysis]
+    uses: ./.github/workflows/test-smoke.yml
 
-  # component_tests:
-  #   name: Component Tests
-  #   needs: [build_core, static_code_analysis]
-  #   uses: ./.github/workflows/test-component.yml
+  component_tests:
+    name: Component Tests
+    needs: [build_core, static_code_analysis]
+    uses: ./.github/workflows/test-component.yml
 
-  # launch_tests:
-  #   name: E2E Tests
-  #   needs: [smoke_tests, component_tests, unit_tests, interop_tests, typing_tests]
-  #   uses: ./.github/workflows/test-launch.yml
+  launch_tests:
+    name: E2E Tests
+    needs: [smoke_tests, component_tests, unit_tests, interop_tests, typing_tests]
+    uses: ./.github/workflows/test-launch.yml
 
-  # cloud_tests:
-  #   name: E2E Tests
-  #   needs: [smoke_tests, component_tests, unit_tests, interop_tests, typing_tests]
-  #   uses: ./.github/workflows/test-cloud.yml
-  #   secrets: inherit
+  cloud_tests:
+    name: E2E Tests
+    needs: [smoke_tests, component_tests, unit_tests, interop_tests, typing_tests]
+    uses: ./.github/workflows/test-cloud.yml
+    secrets: inherit
 
-  # testrunner_tests:
-  #   name: E2E Tests
-  #   needs: [smoke_tests, component_tests, unit_tests, interop_tests, typing_tests]
-  #   uses: ./.github/workflows/test-testrunner.yml
+  testrunner_tests:
+    name: E2E Tests
+    needs: [smoke_tests, component_tests, unit_tests, interop_tests, typing_tests]
+    uses: ./.github/workflows/test-testrunner.yml
 
-  # multiremote_tests:
-  #   name: E2E Tests
-  #   needs: [smoke_tests, component_tests, unit_tests, interop_tests, typing_tests]
-  #   uses: ./.github/workflows/test-multiremote.yml
+  multiremote_tests:
+    name: E2E Tests
+    needs: [smoke_tests, component_tests, unit_tests, interop_tests, typing_tests]
+    uses: ./.github/workflows/test-multiremote.yml
 
-  # standalone_tests:
-  #   name: E2E Tests
-  #   needs: [smoke_tests, component_tests, unit_tests, interop_tests, typing_tests]
-  #   uses: ./.github/workflows/test-standalone.yml
+  standalone_tests:
+    name: E2E Tests
+    needs: [smoke_tests, component_tests, unit_tests, interop_tests, typing_tests]
+    uses: ./.github/workflows/test-standalone.yml
 
   xvfb_tests:
     name: XVFB E2E Tests
-    needs: [build_core]
+    needs: [smoke_tests, component_tests, unit_tests, interop_tests, typing_tests]
     uses: ./.github/workflows/test-xvfb-e2e.yml

--- a/e2e/wdio/xvfb/docker/alpine-base.dockerfile
+++ b/e2e/wdio/xvfb/docker/alpine-base.dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.20
+FROM alpine:3.23
 
 # Set environment variables
 ENV CI=true

--- a/e2e/wdio/xvfb/docker/alpine-with-xvfb.dockerfile
+++ b/e2e/wdio/xvfb/docker/alpine-with-xvfb.dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.20
+FROM alpine:3.23
 
 # Set environment variables
 ENV CI=true

--- a/packages/wdio-local-runner/src/worker.ts
+++ b/packages/wdio-local-runner/src/worker.ts
@@ -290,8 +290,10 @@ export default class WorkerInstance extends EventEmitter implements Workers.Work
                 await this.isSetup
             }
 
-            this.childProcess!.send(cmd)
-        })
+            if (this.childProcess) {
+                this.childProcess.send(cmd)
+            }
+        }).catch((err) => log.error(`Failed to send command to worker ${this.cid}: ${err.message}`))
         this.isBusy = true
     }
 }

--- a/packages/wdio-local-runner/tests/worker.test.ts
+++ b/packages/wdio-local-runner/tests/worker.test.ts
@@ -201,4 +201,24 @@ describe('postMessage', () => {
         await worker.isReady
         expect(worker.childProcess!.send).toBeCalledTimes(1)
     })
+
+    it('should not throw unhandled rejection when worker is killed before isReady resolves', async () => {
+        const worker = new Worker({} as any, workerConfig, new WritableStreamBuffer(), new WritableStreamBuffer(), mockXvfbManager as any)
+        worker.childProcess = { send: vi.fn(), kill: vi.fn() } as any
+
+        // postMessage queues send behind isReady (not yet resolved)
+        const postMsgPromise = worker.postMessage('test-message', {})
+
+        // kill() deletes childProcess before isReady resolves
+        worker.kill()
+
+        // resolve isReady — the .then() callback now fires with no childProcess
+        worker.isReadyResolver(true)
+
+        // postMessage itself should resolve without throwing
+        await expect(postMsgPromise).resolves.toBeUndefined()
+
+        // and no unhandled rejection — the send is safely skipped
+        await worker.isReady
+    })
 })

--- a/packages/wdio-runner/src/index.ts
+++ b/packages/wdio-runner/src/index.ts
@@ -146,6 +146,7 @@ export default class Runner extends EventEmitter {
         if (!browser) {
             const afterArgs: AfterArgs = [1, this._caps, this._specs]
             await executeHooksWithArgs('after', this._config.after as Function, afterArgs)
+            await this.endSession()
             return this._shutdown(1, retries, true)
         }
 

--- a/packages/wdio-runner/tests/index.test.ts
+++ b/packages/wdio-runner/tests/index.test.ts
@@ -350,6 +350,41 @@ describe('wdio-runner', () => {
             // browser session is started
             expect(runner['_reporter']?.caps).toEqual(caps)
         })
+
+        it('should call afterSession hook when session initialization fails', async () => {
+            const afterSessionHook = vi.fn()
+            const runner = new WDIORunner()
+            const caps = { browserName: '123' }
+            const specs = ['foobar']
+            const config: any = {
+                framework: 'testNoFailures',
+                reporters: [],
+                beforeSession: [],
+                after: [],
+                afterSession: [afterSessionHook],
+                runner: 'local'
+            }
+            vi.spyOn(ConfigParser.prototype, 'getConfig').mockReturnValue(config)
+            runner['_shutdown'] = vi.fn().mockReturnValue('_shutdown')
+            runner['_initSession'] = vi.fn().mockReturnValue(null)
+
+            await runner.run({
+                args: { reporters: [] },
+                cid: '0-0',
+                caps,
+                specs,
+                configFile: '/foo/bar',
+                retries: 0
+            })
+
+            // afterSession must run to allow services to clean up resources
+            // allocated during beforeSession, even when browser init fails
+            expect(executeHooksWithArgs).toBeCalledWith(
+                'afterSession',
+                [afterSessionHook],
+                expect.any(Array)
+            )
+        })
     })
 
     describe('_initSession', () => {


### PR DESCRIPTION
This PR fixes two independent bugs in the runner lifecycle:

Bug 1: Lifecycle Hook Asymmetry
The Issue: When session initialization fails (_initSession returns null), the runner skips afterSession despite beforeSession having already executed.
The Impact: Creates silent resource leaks (DB connections, ports, mock servers) because the cleanup contract is broken.
The Fix: Awaits endSession() in the failure branch to ensure symmetric hook execution.

Bug 2: Worker IPC Race Condition
The Issue: postMessage queues comands behind isReady without a rejection handler. If a worker is killed before it's ready, childProcess is deleted, causing a TypeError when the queued command finally fires.
The Impact: Triggers unhandled promise rejections that can crash the runner or lead to silent command loss during shutdowns.
The Fix: Implements a null-check guard for send() and adds a .catch() block to handle rejections gracefully.
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
