### PR TITLE
Fix Visual Testing URL path

### DIFF
--- a/packages/create-wdio/src/constants.ts
+++ b/packages/create-wdio/src/constants.ts
@@ -636,7 +636,7 @@ export const QUESTIONNAIRE = [{
 }, {
     type: 'confirm',
     name: 'includeVisualTesting',
-    message: 'Would you like to include Visual Testing to your setup? For more information see https://webdriver.io/docs/visual-testing!',
+    message: 'Would you like to include Visual Testing to your setup? For more information see https://webdriver.io/docs/visual-testing',
     default: false,
     when: /* istanbul ignore next */ (answers: Questionnair) => {
         /**


### PR DESCRIPTION
Updated the message prompt for including Visual Testing to remove the exclamation mark.

Related #15194

## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

N/A

### Reviewers: @webdriverio/project-committers

New Link works, see this :

<img width="1317" height="644" alt="wido fix for Bug 15194" src="https://github.com/user-attachments/assets/a2532184-69f5-4448-bfc6-9fdf38fbd865" />


#QualityWithMillan
