### PR TITLE
fix(wdio-cli): don't apply specFileRetriesDelay on first run when ret…ries sentinel is -1

### DIFF
--- a/packages/wdio-cli/src/launcher.ts
+++ b/packages/wdio-cli/src/launcher.ts
@@ -471,7 +471,8 @@ class Launcher {
         const config = this.configParser.getConfig()
 
         // wait before retrying the spec file
-        if (typeof config.specFileRetriesDelay === 'number' && config.specFileRetries > 0 && config.specFileRetries !== retries) {
+        // retries === -1 means the sentinel "first run" value (specFileRetries unknown until sessionStarted fires)
+        if (typeof config.specFileRetriesDelay === 'number' && config.specFileRetries > 0 && retries >= 0 && config.specFileRetries !== retries) {
             await sleep(config.specFileRetriesDelay * 1000)
         }
 
@@ -596,10 +597,14 @@ class Launcher {
     private async _endHandler({ cid: rid, exitCode, specs, retries }: EndMessage): Promise<void> {
         const passed = this._isWatchModeHalted() || exitCode === 0
 
-        if (!passed && retries > 0) {
+        const config = this.configParser.getConfig()
+        // retries === -1 is the sentinel for "sessionStarted never fired" (e.g. session create failed).
+        // Fall back to config.specFileRetries so the run is still retried the correct number of times.
+        const effectiveRetries = retries === -1 ? config.specFileRetries : retries
+        if (!passed && effectiveRetries > 0) {
             // Default is true, so test for false explicitly
-            const requeue = this.configParser.getConfig().specFileRetriesDeferred ? 'push' : 'unshift'
-            this._schedule[parseInt(rid, 10)].specs[requeue]({ files: specs, retries: retries - 1, rid })
+            const requeue = config.specFileRetriesDeferred ? 'push' : 'unshift'
+            this._schedule[parseInt(rid, 10)].specs[requeue]({ files: specs, retries: effectiveRetries - 1, rid })
         } else {
             this._exitCode = this._isWatchModeHalted() ? 0 : this._exitCode || exitCode
             this._runnerFailed += !passed ? 1 : 0
@@ -622,7 +627,6 @@ class Launcher {
         this._schedule[cid].runningInstances--
 
         log.info('Run onWorkerEnd hook')
-        const config = this.configParser.getConfig()
         await runLauncherHook(config.onWorkerEnd, rid, exitCode, specs, retries)
             .catch((error) => this._workerHookError(error))
         await runServiceHook(this._launcher!, 'onWorkerEnd', rid, exitCode, specs, retries)

--- a/packages/wdio-cli/tests/launcher.test.ts
+++ b/packages/wdio-cli/tests/launcher.test.ts
@@ -389,6 +389,17 @@ describe('launcher', () => {
                 }]
             }])
         })
+
+        it('should reschedule when retries sentinel is -1 (session never started) and config.specFileRetries > 0', async () => {
+            launcher.configParser.getConfig = vi.fn().mockReturnValue({
+                specFileRetries: 2,
+                specFileRetriesDeferred: true,
+                onWorkerEnd: vi.fn()
+            })
+            launcher['_schedule'] = [{ cid: 0, specs: [] }] as any
+            await launcher['_endHandler']({ cid: '0-5', exitCode: 1, retries: -1, specs: ['a.js'] })
+            expect(launcher['_schedule']).toMatchObject([{ cid: 0, specs: [{ rid: '0-5', files: ['a.js'], retries: 1 }] }])
+        })
     })
 
     describe('exitHandler', () => {
@@ -846,6 +857,31 @@ describe('launcher', () => {
                 { hostname: '127.0.0.4' },
                 []
             )
+        })
+
+        it('should not wait when retries sentinel is -1 (session never started)', async () => {
+            const onWorkerStartMock = vi.fn()
+            const caps = {
+                browserName: 'chrome'
+            }
+            launcher.configParser = {
+                getConfig: vi.fn().mockReturnValue({
+                    onWorkerStart: onWorkerStartMock,
+                    specFileRetries: 2,
+                    specFileRetriesDelay: 5
+                })
+            } as any
+            launcher['_args'].hostname = '127.0.0.5'
+
+            await launcher['_startInstance'](
+                ['/foo.test.js'],
+                caps,
+                0,
+                '0-8',
+                -1
+            )
+
+            expect(sleep).not.toHaveBeenCalled()
         })
     })
 


### PR DESCRIPTION

Fixes hang where specFileRetries > 0 + specFileRetriesDelay > 0 caused sleep before first worker spawn. Also fixes retries being skipped when session create fails (sessionStarted never fires, retries stays -1). Fixes #15196

## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
