### PR TITLE
fix(utils): skip desktop browser download when androidPackage is set

### DIFF
--- a/packages/wdio-types/src/Capabilities.ts
+++ b/packages/wdio-types/src/Capabilities.ts
@@ -476,6 +476,20 @@ export interface ChromeOptions {
      * to <webview> elements, include "webview" in this list.
      */
     windowTypes?: string[]
+    /**
+     * The package name of the Chrome browser to run on Android (e.g. 'com.android.chrome').
+     * When set, chromedriver will connect to the browser on Android over ADB
+     * instead of launching a desktop Chrome.
+     */
+    androidPackage?: string
+    /**
+     * Serial number of the Android device to use (as reported by `adb devices`).
+     */
+    androidDeviceSerial?: string
+    /**
+     * The activity name for the Android activity to launch.
+     */
+    androidActivity?: string
 }
 
 /**
@@ -501,6 +515,20 @@ export interface FirefoxOptions {
     prefs?: {
         [name: string]: string[] | string | number | boolean
     }
+    /**
+     * The package name of the Firefox browser to run on Android (e.g. 'org.mozilla.fenix').
+     * When set, geckodriver will connect to Firefox on Android over ADB
+     * instead of launching a desktop Firefox.
+     */
+    androidPackage?: string
+    /**
+     * Serial number of the Android device to use (as reported by `adb devices`).
+     */
+    androidDeviceSerial?: string
+    /**
+     * The activity name for the Android activity to launch.
+     */
+    androidActivity?: string
 }
 
 // Aerokube Selenoid specific

--- a/packages/wdio-utils/src/node/manager.ts
+++ b/packages/wdio-utils/src/node/manager.ts
@@ -137,6 +137,16 @@ export function setupBrowser (options: Omit<Options.WebDriver, 'capabilities'>, 
             // not yet implemented
             return Promise.resolve()
         } else if (isChrome(cap.browserName) || isFirefox(cap.browserName)) {
+            /**
+             * skip desktop browser download when androidPackage is set,
+             * as the browser runs on the Android device, not the host
+             */
+            const browserOptions = isFirefox(cap.browserName)
+                ? cap['moz:firefoxOptions']
+                : cap['goog:chromeOptions']
+            if (browserOptions?.androidPackage) {
+                return Promise.resolve()
+            }
             return setupPuppeteerBrowser(cacheDir, cap)
         }
 

--- a/packages/wdio-utils/src/node/startWebDriver.ts
+++ b/packages/wdio-utils/src/node/startWebDriver.ts
@@ -73,6 +73,11 @@ export async function startWebDriver(options: Capabilities.RemoteConfig) {
     if (isChrome(caps.browserName)) {
         /**
          * Chrome
+         *
+         * When goog:chromeOptions.androidPackage is set, chromedriver will launch
+         * Chrome on the Android device over ADB — downloading a desktop Chrome
+         * binary is unnecessary and injecting its path as `binary` conflicts with
+         * `androidPackage` (they are mutually exclusive in chromedriver).
          */
         const chromedriverOptions = caps['wdio:chromedriverOptions'] || ({} as WebdriverIO.ChromedriverOptions)
         /**
@@ -80,36 +85,41 @@ export async function startWebDriver(options: Capabilities.RemoteConfig) {
          * other drivers do as well
          */
         const chromedriverBinary = chromedriverOptions.binary || process.env.CHROMEDRIVER_PATH
-        const { executablePath: chromeExecuteablePath, browserVersion } = await setupPuppeteerBrowser(cacheDir, caps)
+        let browserVersion: string | undefined
+        if (!caps['goog:chromeOptions']?.androidPackage) {
+            const puppeteerResult = await setupPuppeteerBrowser(cacheDir, caps)
+            browserVersion = puppeteerResult.browserVersion
+
+            const prefs = generateDefaultPrefs(caps)
+            caps['goog:chromeOptions'] = deepmerge(
+                { binary: puppeteerResult.executablePath },
+                prefs,
+                caps['goog:chromeOptions'] || {}
+            )
+
+            /**
+             * Add unique user data directory for each worker to prevent
+             * "user data directory is already in use" errors on Windows
+             * when multiple workers start Chrome simultaneously
+             */
+            if (process.platform === 'win32' && process.env.WDIO_WORKER_ID) {
+                const existingArgs = caps['goog:chromeOptions']?.args || []
+                const hasUserDataDir = existingArgs.some(arg =>
+                    typeof arg === 'string' && arg.includes('user-data-dir'))
+
+                if (!hasUserDataDir) {
+                    const userDataDir = path.join(
+                        options.outputDir || os.tmpdir(),
+                        `wdio-chrome-${process.env.WDIO_WORKER_ID}-${Date.now()}`
+                    )
+                    caps['goog:chromeOptions'].args = [...existingArgs, `--user-data-dir=${userDataDir}`]
+                }
+            }
+        }
+
         const { executablePath: chromedriverExcecuteablePath } = chromedriverBinary
             ? { executablePath: chromedriverBinary }
             : await setupChromedriver(cacheDir, browserVersion)
-
-        const prefs = generateDefaultPrefs(caps)
-        caps['goog:chromeOptions'] = deepmerge(
-            { binary: chromeExecuteablePath },
-            prefs,
-            caps['goog:chromeOptions'] || {}
-        )
-
-        /**
-         * Add unique user data directory for each worker to prevent
-         * "user data directory is already in use" errors on Windows
-         * when multiple workers start Chrome simultaneously
-         */
-        if (process.platform === 'win32' && process.env.WDIO_WORKER_ID) {
-            const existingArgs = caps['goog:chromeOptions']?.args || []
-            const hasUserDataDir = existingArgs.some(arg =>
-                typeof arg === 'string' && arg.includes('user-data-dir'))
-
-            if (!hasUserDataDir) {
-                const userDataDir = path.join(
-                    options.outputDir || os.tmpdir(),
-                    `wdio-chrome-${process.env.WDIO_WORKER_ID}-${Date.now()}`
-                )
-                caps['goog:chromeOptions'].args = [...existingArgs, `--user-data-dir=${userDataDir}`]
-            }
-        }
 
         chromedriverOptions.allowedOrigins = chromedriverOptions.allowedOrigins || ['*']
         chromedriverOptions.allowedIps = chromedriverOptions.allowedIps || ['0.0.0.0']
@@ -136,12 +146,19 @@ export async function startWebDriver(options: Capabilities.RemoteConfig) {
     } else if (isFirefox(caps.browserName)) {
         /**
          * Firefox
+         *
+         * When moz:firefoxOptions.androidPackage is set, geckodriver will launch
+         * Firefox on the Android device over ADB — downloading a desktop Firefox
+         * binary is unnecessary and injecting its path as `binary` conflicts with
+         * `androidPackage` (they are mutually exclusive in geckodriver).
          */
-        const { executablePath } = await setupPuppeteerBrowser(cacheDir, caps)
-        caps['moz:firefoxOptions'] = deepmerge(
-            { binary: executablePath },
-            caps['moz:firefoxOptions'] || {}
-        )
+        if (!caps['moz:firefoxOptions']?.androidPackage) {
+            const { executablePath } = await setupPuppeteerBrowser(cacheDir, caps)
+            caps['moz:firefoxOptions'] = deepmerge(
+                { binary: executablePath },
+                caps['moz:firefoxOptions'] || {}
+            )
+        }
 
         /**
          * the "binary" parameter refers to the driver binary in the WebdriverIO.GeckodriverOptions and

--- a/packages/wdio-utils/tests/node/index.test.ts
+++ b/packages/wdio-utils/tests/node/index.test.ts
@@ -388,6 +388,50 @@ describe('startWebDriver', () => {
         )
     })
 
+    it('should skip desktop Firefox download and binary injection when androidPackage is set', async () => {
+        const { setupPuppeteerBrowser } = await import('../../src/node/utils.js')
+        vi.mocked(setupPuppeteerBrowser).mockClear()
+
+        const params = {
+            capabilities: {
+                browserName: 'firefox',
+                'moz:firefoxOptions': {
+                    androidPackage: 'org.mozilla.fenix',
+                    androidDeviceSerial: 'emulator-5554'
+                }
+            } as any
+        }
+        const res = await startWebDriver(params)
+        expect(res).toBe('geckodriver')
+        expect(setupPuppeteerBrowser).not.toBeCalled()
+        expect(params.capabilities['moz:firefoxOptions']).not.toHaveProperty('binary')
+        expect(params.capabilities['moz:firefoxOptions'].androidPackage).toBe('org.mozilla.fenix')
+        expect(startGeckodriver).toBeCalledTimes(1)
+    })
+
+    it('should skip desktop Chrome download and binary injection when androidPackage is set', async () => {
+        const { setupPuppeteerBrowser } = await import('../../src/node/utils.js')
+        vi.mocked(setupPuppeteerBrowser).mockClear()
+        vi.mocked(cp.spawn).mockClear()
+
+        const params = {
+            capabilities: {
+                browserName: 'chrome',
+                'wdio:chromedriverOptions': { binary: '/my/chromedriver' },
+                'goog:chromeOptions': {
+                    androidPackage: 'com.android.chrome',
+                    androidDeviceSerial: 'emulator-5554'
+                }
+            } as any
+        }
+        const res = await startWebDriver(params)
+        expect(Boolean(res?.stdout)).toBe(true)
+        expect(setupPuppeteerBrowser).not.toBeCalled()
+        expect(params.capabilities['goog:chromeOptions']).not.toHaveProperty('binary')
+        expect(params.capabilities['goog:chromeOptions'].androidPackage).toBe('com.android.chrome')
+        expect(cp.spawn).toBeCalledTimes(1)
+    })
+
     it('should not start or download driver for appium capabilities', async () => {
         const options = {
             hostname: 'localhost',

--- a/packages/wdio-utils/tests/node/manager.test.ts
+++ b/packages/wdio-utils/tests/node/manager.test.ts
@@ -379,6 +379,44 @@ describe('setupBrowser', () => {
         })
     })
 
+    test('should skip setupPuppeteerBrowser for Firefox with androidPackage', async () => {
+        vi.mocked(setupPuppeteerBrowser).mockClear()
+        await setupBrowser({}, [{
+            browserName: 'firefox',
+            browserVersion: '5'
+        }, {
+            browserName: 'firefox',
+            'moz:firefoxOptions': {
+                androidPackage: 'org.mozilla.fenix',
+                androidDeviceSerial: 'emulator-5554'
+            }
+        }])
+        expect(setupPuppeteerBrowser).toBeCalledTimes(1)
+        expect(setupPuppeteerBrowser).toBeCalledWith('/foo/bar', {
+            browserName: 'firefox',
+            browserVersion: '5'
+        })
+    })
+
+    test('should skip setupPuppeteerBrowser for Chrome with androidPackage', async () => {
+        vi.mocked(setupPuppeteerBrowser).mockClear()
+        await setupBrowser({}, [{
+            browserName: 'chrome',
+            browserVersion: '1'
+        }, {
+            browserName: 'chrome',
+            'goog:chromeOptions': {
+                androidPackage: 'com.android.chrome',
+                androidDeviceSerial: 'emulator-5554'
+            }
+        }])
+        expect(setupPuppeteerBrowser).toBeCalledTimes(1)
+        expect(setupPuppeteerBrowser).toBeCalledWith('/foo/bar', {
+            browserName: 'chrome',
+            browserVersion: '1'
+        })
+    })
+
     test('with multiremote capabilities series', async () => {
         await setupBrowser({}, [{
             browserA: {


### PR DESCRIPTION
When moz:firefoxOptions.androidPackage or goog:chromeOptions.androidPackage is set, geckodriver/chromedriver launch the browser on an Android device over ADB not a local executable. WDIO was unconditionally calling setupPuppeteerBrowser() and injecting the host-filesystem path as binary into the browser options, causing geckodriver to reject the session with androidPackage and binary are mutually exclusive. This fix guards both startWebDriver and setupBrowser to skip the download and binary injection when androidPackage is present. The driver process still starts normally.

Fixes #15199

## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO `v8`, please raise another PR with the same changes against the `v8` branch.)

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
