### PR TITLE
fix(webdriver): avoid enumerating string request bodies

### DIFF
--- a/packages/webdriver/src/request/request.ts
+++ b/packages/webdriver/src/request/request.ts
@@ -26,6 +26,26 @@ const DEFAULT_HEADERS = {
 
 const log = logger('webdriver')
 
+function hasLoggableBodyContent (body: BodyInit | null | undefined): body is BodyInit {
+    if (!body) {
+        return false
+    }
+
+    if (typeof body === 'string') {
+        return body.length > 0
+    }
+
+    if (body instanceof URLSearchParams || body instanceof FormData) {
+        return Array.from(body.keys()).length > 0
+    }
+
+    if (body instanceof Blob || body instanceof ArrayBuffer || ArrayBuffer.isView(body)) {
+        return body.size ?? body.byteLength > 0
+    }
+
+    return typeof body === 'object' && Object.keys(body).length > 0
+}
+
 export abstract class WebDriverRequest {
     protected abstract fetch(url: URL, opts: RequestInit): Promise<Response>
 
@@ -165,7 +185,7 @@ export abstract class WebDriverRequest {
     ): Promise<WebDriverResponse> {
         log.info(`[${fullRequestOptions.method}] ${(url as URL).href}`)
 
-        if (fullRequestOptions.body && Object.keys(fullRequestOptions.body).length) {
+        if (hasLoggableBodyContent(fullRequestOptions.body)) {
             this.eventHandler.onLogData?.(fullRequestOptions.body)
         }
 

--- a/packages/webdriver/tests/request.test.ts
+++ b/packages/webdriver/tests/request.test.ts
@@ -262,6 +262,19 @@ describe('webdriver request', () => {
             }))
         })
 
+        it('should log string request bodies without enumerating them', async () => {
+            const onLogData = vi.fn()
+            const req = new WebFetchRequest('POST', webdriverPath, {}, undefined, false, {
+                onLogData
+            })
+
+            const url = new URL('/session/foobar-123/element', baseUrl)
+            const opts = { body: JSON.stringify({ file: 'x'.repeat(10_000) }) }
+            await req['_request'](url, opts)
+
+            expect(onLogData).toHaveBeenCalledWith(opts.body)
+        })
+
         it('should short circuit if request throws a stale element exception', async () => {
             const onResponse = vi.fn()
             const onPerformance = vi.fn()


### PR DESCRIPTION
## Summary
- avoid calling `Object.keys()` on stringified request bodies in `FetchRequest._request()`
- keep request body logging for non-empty strings and structured body types
- add a regression test for string request bodies

## Problem
Large `/se/file` upload payloads can throw `RangeError: Too many properties to enumerate` because `_request()` calls `Object.keys(fullRequestOptions.body)` after `createOptions()` has already converted the body to a JSON string.

Fixes #15213.