### PR TITLE
fix(browserstack-service): omit unset accessibility config

### DIFF
--- a/packages/wdio-browserstack-service/src/config.ts
+++ b/packages/wdio-browserstack-service/src/config.ts
@@ -21,7 +21,7 @@ class BrowserStackConfig {
     public testObservability: TestOpsConfig
     public percy: boolean
     public percyCaptureMode?: string
-    public accessibility: boolean | null
+    public accessibility?: boolean
     public app?: string | AppConfig
     private static _instance: BrowserStackConfig
     public appAutomate: boolean
@@ -37,7 +37,7 @@ class BrowserStackConfig {
         this.accessKey = config.key
         this.testObservability = new TestOpsConfig(options.testObservability !== false, !isUndefined(options.testObservability))
         this.percy = options.percy || false
-        this.accessibility = options.accessibility !== undefined ? options.accessibility : null
+        this.accessibility = options.accessibility
         this.app = options.app
         this.appAutomate = !isUndefined(options.app)
         this.automate = !this.appAutomate

--- a/packages/wdio-browserstack-service/src/constants.ts
+++ b/packages/wdio-browserstack-service/src/constants.ts
@@ -23,8 +23,7 @@ export const VALID_APP_EXTENSION = [
 export const DEFAULT_OPTIONS: Partial<BrowserstackConfig> = {
     setSessionName: true,
     setSessionStatus: true,
-    testObservability: true,
-    accessibility: false
+    testObservability: true
 }
 
 export const consoleHolder: typeof console = Object.assign({}, console)
@@ -189,4 +188,3 @@ export const MODULE_HOOK_EVENTS = {
     APPAUTOMATE_ON_START: 'MODULE_APPAUTOMATE_ON_START',
     APPAUTOMATE_ON_DRIVER_INIT: 'MODULE_APPAUTOMATE_ON_DRIVER_INIT',
 } as const
-

--- a/packages/wdio-browserstack-service/src/launcher.ts
+++ b/packages/wdio-browserstack-service/src/launcher.ts
@@ -73,7 +73,7 @@ export default class BrowserstackLauncherService implements Services.ServiceInst
     private _projectName?: string
     private _buildTag?: string
     private _buildIdentifier?: string
-    private _accessibilityAutomation?: boolean | null = null
+    private _accessibilityAutomation?: boolean
     private _percy?: Percy
     private _percyBestPlatformCaps?: WebdriverIO.Capabilities
     private readonly browserStackConfig: BrowserStackConfig
@@ -210,7 +210,7 @@ export default class BrowserstackLauncherService implements Services.ServiceInst
         if (!isUndefined(this._options.accessibility)) {
             this._accessibilityAutomation ||= isTrue(this._options.accessibility)
         }
-        this._options.accessibility = this._accessibilityAutomation as boolean
+        this._options.accessibility = this._accessibilityAutomation
 
         // Default is true unless explicitly set to false
         this._options.testObservability = this._options.testObservability !== false
@@ -425,7 +425,7 @@ export default class BrowserstackLauncherService implements Services.ServiceInst
         }
 
         if (buildStartResponse?.accessibility) {
-            if (this._accessibilityAutomation === null) {
+            if (isUndefined(this._accessibilityAutomation)) {
                 this.browserStackConfig.accessibility = buildStartResponse.accessibility.success as boolean
                 this._accessibilityAutomation = buildStartResponse.accessibility.success as boolean
                 this._options.accessibility = buildStartResponse.accessibility.success as boolean
@@ -435,7 +435,7 @@ export default class BrowserstackLauncherService implements Services.ServiceInst
             }
         }
 
-        this.browserStackConfig.accessibility = this._accessibilityAutomation as boolean
+        this.browserStackConfig.accessibility = this._accessibilityAutomation
 
         if (this._accessibilityAutomation && this._options.accessibilityOptions) {
             const filteredOpts = Object.keys(this._options.accessibilityOptions)

--- a/packages/wdio-browserstack-service/src/testHub/utils.ts
+++ b/packages/wdio-browserstack-service/src/testHub/utils.ts
@@ -13,10 +13,10 @@ export interface Errors {
     errors: ErrorType[]
 }
 
-export const getProductMap = (config: BrowserStackConfig): { [key: string]: boolean } => {
+export const getProductMap = (config: BrowserStackConfig): { [key: string]: boolean | undefined } => {
     return {
         observability: config.testObservability.enabled,
-        accessibility: config.accessibility as boolean,
+        accessibility: config.accessibility,
         percy: config.percy,
         automate: config.automate,
         app_automate: config.appAutomate
@@ -73,7 +73,7 @@ export const logBuildError = (error: Errors | null, product: string = ''): void 
     }
 }
 
-export const getProductMapForBuildStartCall = (config: BrowserStackConfig, accessibilityAutomation: boolean | null): { [key: string]: boolean | null } => {
+export const getProductMapForBuildStartCall = (config: BrowserStackConfig, accessibilityAutomation?: boolean): { [key: string]: boolean | undefined } => {
     return {
         observability: config.testObservability.enabled,
         accessibility: accessibilityAutomation,


### PR DESCRIPTION
## Summary
- stop treating an unset BrowserStack accessibility option as a nullable value
- avoid propagating `accessibility: null` through BrowserStack service config and product-map metadata
- preserve explicit accessibility enablement when it is actually configured

## Problem
In WDIO v9 BrowserStack service flows, sessions can fail before creation with an error like:

```text
WebDriverError: The property "#/alwaysMatch/bstack:options/accessibility" of type NilClass did not match one or more of the following types: boolean, string
```

We traced this to `wdio-browserstack-service` carrying accessibility state as `boolean | null` and then serializing that unset state into BrowserStack CLI/session config as `accessibility: null`.

The failure was reproducible in BrowserStack-backed Selenium preprod runs even when the user config did not set any accessibility option.

## Root cause
The regression appears to come from the v9 accessibility auto-enable path introduced in a0bc7107b (`Auto enable accessibility [v9]`).

That change introduced nullable accessibility state and propagated it through:
- `BrowserStackConfig.accessibility`
- launcher `_accessibilityAutomation`
- build start product-map/config generation

Using `undefined` for the unset case is safer here because it omits the field instead of sending `null` to BrowserStack.

## Fix
- make the stored accessibility config optional instead of `boolean | null`
- remove the default `accessibility: false` option from `DEFAULT_OPTIONS`
- avoid writing nullable accessibility state back into launcher/config state
- keep product maps typed to allow `undefined` when accessibility is not configured
