### PR TITLE
fix(browserstack-service): route browserstack_executor commands via HTTP/S in BiDi sessions

### DIFF
--- a/packages/wdio-browserstack-service/src/service.ts
+++ b/packages/wdio-browserstack-service/src/service.ts
@@ -225,26 +225,17 @@ export default class BrowserstackService implements Services.ServiceInstance {
         PerformanceTester.scenarioThatRan = this._scenariosThatRan
 
         if (this._browser) {
-            // redirect browserstack_executor calls from BiDi(execute) WebSocket to HTTP/S(executeScript)
-            if (this._browser.isMultiremote) {
-                const multiRemoteBrowser = this._browser as unknown as WebdriverIO.MultiRemoteBrowser
-                Object.keys(this._caps).forEach((browserName) => {
-                    const instance = multiRemoteBrowser.getInstance(browserName)
-                    instance.overwriteCommand('execute', async (originalExecute, script, ...args) => {
-                        if (typeof script === 'string' && script.startsWith('browserstack_executor:')) {
-                            return instance.executeScript(script, [])
-                        }
-                        return originalExecute(script, ...args)
+            try {
+                if (this._browser.isMultiremote) {
+                    const multiRemoteBrowser = this._browser as unknown as WebdriverIO.MultiRemoteBrowser
+                    Object.keys(this._caps).forEach((browserName) => {
+                        this._routeBidiExecutorToHttp(multiRemoteBrowser.getInstance(browserName))
                     })
-                })
-            } else {
-                const browser = this._browser as WebdriverIO.Browser
-                browser.overwriteCommand('execute', async (originalExecute, script, ...args) => {
-                    if (typeof script === 'string' && script.startsWith('browserstack_executor:')) {
-                        return browser.executeScript(script, [])
-                    }
-                    return originalExecute(script, ...args)
-                })
+                } else {
+                    this._routeBidiExecutorToHttp(this._browser as WebdriverIO.Browser)
+                }
+            } catch (err) {
+                BStackLogger.warn(`Failed to patch execute for BiDi browserstack_executor routing; executor commands may not work in BiDi sessions: ${err}`)
             }
 
             try {
@@ -737,6 +728,19 @@ export default class BrowserstackService implements Services.ServiceInstance {
                 : `Update job with sessionId ${sessionId}`
             )
             return this._update(sessionId, requestBody)
+        })
+    }
+
+    _routeBidiExecutorToHttp (browser: WebdriverIO.Browser) {
+        if (!browser.isBidi) {
+            return
+        }
+
+        browser.overwriteCommand('execute', async (originalExecute, script, ...args) => {
+            if (typeof script === 'string' && script.startsWith('browserstack_executor:')) {
+                return browser.executeScript(script, args)
+            }
+            return originalExecute(script, ...args)
         })
     }
 

--- a/packages/wdio-browserstack-service/src/service.ts
+++ b/packages/wdio-browserstack-service/src/service.ts
@@ -225,6 +225,28 @@ export default class BrowserstackService implements Services.ServiceInstance {
         PerformanceTester.scenarioThatRan = this._scenariosThatRan
 
         if (this._browser) {
+            // redirect browserstack_executor calls from BiDi(execute) WebSocket to HTTP/S(executeScript)
+            if (this._browser.isMultiremote) {
+                const multiRemoteBrowser = this._browser as unknown as WebdriverIO.MultiRemoteBrowser
+                Object.keys(this._caps).forEach((browserName) => {
+                    const instance = multiRemoteBrowser.getInstance(browserName)
+                    instance.overwriteCommand('execute', async (originalExecute, script, ...args) => {
+                        if (typeof script === 'string' && script.startsWith('browserstack_executor:')) {
+                            return instance.executeScript(script, [])
+                        }
+                        return originalExecute(script, ...args)
+                    })
+                })
+            } else {
+                const browser = this._browser as WebdriverIO.Browser
+                browser.overwriteCommand('execute', async (originalExecute, script, ...args) => {
+                    if (typeof script === 'string' && script.startsWith('browserstack_executor:')) {
+                        return browser.executeScript(script, [])
+                    }
+                    return originalExecute(script, ...args)
+                })
+            }
+
             try {
                 const sessionId = this._browser.sessionId
 

--- a/packages/wdio-browserstack-service/tests/service.test.ts
+++ b/packages/wdio-browserstack-service/tests/service.test.ts
@@ -112,6 +112,7 @@ beforeEach(() => {
     browser = {
         execute: vi.fn(),
         executeScript: vi.fn(),
+        overwriteCommand: vi.fn(),
         on: vi.fn(),
         sessionId: sessionId,
         config: {},
@@ -613,6 +614,46 @@ describe('before', () => {
 
         expect(service['_failReasons']).toEqual([])
         expect(service['_sessionBaseUrl']).toEqual('https://api.browserstack.com/automate-turboscale/v1/sessions')
+    })
+    
+    it('should overwrite execute command to route browserstack_executor via executeScript', async () => {
+        const service = new BrowserstackService({} as any, [{}] as any, { user: 'foo', key: 'bar', capabilities: {} })
+        await service.before(service['_config'] as any, [], browser)
+
+        expect(browser.overwriteCommand).toHaveBeenCalledWith('execute', expect.any(Function))
+
+        const overwrite = vi.mocked(browser.overwriteCommand).mock.calls[0][1] as Function
+        const originalExecute = vi.fn()
+
+        await overwrite(originalExecute, 'browserstack_executor: {"action":"annotate"}')
+        expect(browser.executeScript).toHaveBeenCalledWith('browserstack_executor: {"action":"annotate"}', [])
+        expect(originalExecute).not.toHaveBeenCalled()
+
+        await overwrite(originalExecute, 'return document.title')
+        expect(originalExecute).toHaveBeenCalledWith('return document.title')
+    })
+
+    it('should overwrite execute on each instance for multiremote', async () => {
+        const browserA = { executeScript: vi.fn(), overwriteCommand: vi.fn(), sessionId: 'sessionA' }
+        const browserB = { executeScript: vi.fn(), overwriteCommand: vi.fn(), sessionId: 'sessionB' }
+        const multiRemoteBrowser = {
+            ...browser,
+            isMultiremote: true,
+            getInstance: vi.fn().mockImplementation((name: string) => name === 'browserA' ? browserA : browserB)
+        } as unknown as WebdriverIO.MultiRemoteBrowser
+
+        const service = new BrowserstackService({} as any, [{}] as any, {
+            user: 'foo', key: 'bar', capabilities: { browserA: {}, browserB: {} }
+        })
+        await service.before(service['_config'] as any, [], multiRemoteBrowser as any)
+
+        expect(browserA.overwriteCommand).toHaveBeenCalledWith('execute', expect.any(Function))
+        expect(browserB.overwriteCommand).toHaveBeenCalledWith('execute', expect.any(Function))
+
+        const overwriteA = vi.mocked(browserA.overwriteCommand).mock.calls[0][1] as Function
+        await overwriteA(vi.fn(), 'browserstack_executor: {"action":"annotate"}')
+        expect(browserA.executeScript).toHaveBeenCalledWith('browserstack_executor: {"action":"annotate"}', [])
+        expect(browserB.executeScript).not.toHaveBeenCalled()
     })
 })
 

--- a/packages/wdio-browserstack-service/tests/service.test.ts
+++ b/packages/wdio-browserstack-service/tests/service.test.ts
@@ -615,8 +615,9 @@ describe('before', () => {
         expect(service['_failReasons']).toEqual([])
         expect(service['_sessionBaseUrl']).toEqual('https://api.browserstack.com/automate-turboscale/v1/sessions')
     })
-    
+
     it('should overwrite execute command to route browserstack_executor via executeScript', async () => {
+        (browser as any).isBidi = true
         const service = new BrowserstackService({} as any, [{}] as any, { user: 'foo', key: 'bar', capabilities: {} })
         await service.before(service['_config'] as any, [], browser)
 
@@ -631,19 +632,31 @@ describe('before', () => {
 
         await overwrite(originalExecute, 'return document.title')
         expect(originalExecute).toHaveBeenCalledWith('return document.title')
+
+        const extraArg = { key: 'value' }
+        await overwrite(originalExecute, 'return arguments[0]', extraArg)
+        expect(originalExecute).toHaveBeenCalledWith('return arguments[0]', extraArg)
+    })
+
+    it('should not overwrite execute command for non-BiDi sessions', async () => {
+        (browser as any).isBidi = false
+        const service = new BrowserstackService({} as any, [{}] as any, { user: 'foo', key: 'bar', capabilities: {} })
+        await service.before(service['_config'] as any, [], browser)
+
+        expect(browser.overwriteCommand).not.toHaveBeenCalled()
     })
 
     it('should overwrite execute on each instance for multiremote', async () => {
-        const browserA = { executeScript: vi.fn(), overwriteCommand: vi.fn(), sessionId: 'sessionA' }
-        const browserB = { executeScript: vi.fn(), overwriteCommand: vi.fn(), sessionId: 'sessionB' }
+        const browserA = { executeScript: vi.fn(), overwriteCommand: vi.fn(), sessionId: 'sessionA', isBidi: true }
+        const browserB = { executeScript: vi.fn(), overwriteCommand: vi.fn(), sessionId: 'sessionB', isBidi: true }
         const multiRemoteBrowser = {
             ...browser,
             isMultiremote: true,
             getInstance: vi.fn().mockImplementation((name: string) => name === 'browserA' ? browserA : browserB)
         } as unknown as WebdriverIO.MultiRemoteBrowser
 
-        const service = new BrowserstackService({} as any, [{}] as any, {
-            user: 'foo', key: 'bar', capabilities: { browserA: {}, browserB: {} }
+        const service = new BrowserstackService({} as any, { browserA: {}, browserB: {} } as any, {
+            user: 'foo', key: 'bar'
         })
         await service.before(service['_config'] as any, [], multiRemoteBrowser as any)
 
@@ -654,6 +667,11 @@ describe('before', () => {
         await overwriteA(vi.fn(), 'browserstack_executor: {"action":"annotate"}')
         expect(browserA.executeScript).toHaveBeenCalledWith('browserstack_executor: {"action":"annotate"}', [])
         expect(browserB.executeScript).not.toHaveBeenCalled()
+
+        const originalExecuteA = vi.fn()
+        const extraArg = { key: 'value' }
+        await overwriteA(originalExecuteA, 'return arguments[0]', extraArg)
+        expect(originalExecuteA).toHaveBeenCalledWith('return arguments[0]', extraArg)
     })
 })
 


### PR DESCRIPTION
## Proposed changes

Fixes #15207

In BiDi sessions `browser.execute()` routes via `script.callFunction` over WebSocket directly to the browser by bypassing BrowserStack's hub. This causes `browserstack_executor:` commands to fail

This fix overwrites `execute` inside the `before()` hook of `@wdio/browserstack-service` to intercept any `browserstack_executor:` string and redirect it through `executeScript` which is HTTP/S only so it will be intercepted by the BrowserStack hub. All other scripts pass through to the original `execute` path unchanged. The fix covers both single browser and multiremote sessions and is entirely contained within `@wdio/browserstack-service`

## Types of changes

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at

## Further comments

The root cause is that `browser.execute()` in BiDi sessions calls `script.callFunction` over the WebSocket connection, which goes directly to the browser and bypasses BrowserStack's HTTP hub entirely. `executeScript` raw protocol command has no BiDi implementation and is absent from `webdriverBidi.ts` and `BidiHandler` so it always goes via `POST /session/{id}/execute/sync` over HTTP/S which BrowserStack's hub can intercept as expected

### Reviewers: @webdriverio/project-committers