### PR TITLE
fix: handle binary file busy error at execution (spawn)

### DIFF
--- a/packages/wdio-browserstack-service/src/cli/cliUtils.ts
+++ b/packages/wdio-browserstack-service/src/cli/cliUtils.ts
@@ -27,7 +27,7 @@ import {
 import PerformanceTester from '../instrumentation/performance/performance-tester.js'
 import { EVENTS as PerformanceEvents } from '../instrumentation/performance/constants.js'
 import { BStackLogger as logger } from './cliLogger.js'
-import { UPDATED_CLI_ENDPOINT, BSTACK_SERVICE_VERSION } from '../constants.js'
+import { UPDATED_CLI_ENDPOINT, BSTACK_SERVICE_VERSION, BINARY_BUSY_ERROR_CODES } from '../constants.js'
 import type { Options, Capabilities } from '@wdio/types'
 import type {
     BrowserstackConfig,
@@ -228,9 +228,22 @@ export class CLIUtils {
             sdk_language: this.getSdkLanguage(),
         }
         if (!isNullOrEmpty(existingCliPath)) {
-            queryParams.cli_version = await this.runShellCommand(
+            // If binary is busy (being executed by another process), skip version check
+            // and API call entirely — use existing binary as-is
+            if (this.isBinaryBusy(existingCliPath)) {
+                logger.warn(`Existing binary is currently in use, skipping update: ${existingCliPath}`)
+                PerformanceTester.end(PerformanceEvents.SDK_CLI_CHECK_UPDATE)
+                return existingCliPath
+            }
+            const version = await this.runShellCommand(
                 `${existingCliPath} version`,
             )
+            if (version.toLowerCase().includes('text file busy')) {
+                logger.warn(`Binary busy during version check, skipping update: ${existingCliPath}`)
+                PerformanceTester.end(PerformanceEvents.SDK_CLI_CHECK_UPDATE)
+                return existingCliPath
+            }
+            queryParams.cli_version = version
         }
         const response = await this.requestToUpdateCLI(queryParams, config)
         if (nestedKeyValue(response, ['updated_cli_version'])) {
@@ -369,6 +382,26 @@ export class CLIUtils {
         } catch (err) {
             logger.error(`Error while reading CLI path: ${util.format(err)}`)
             return ''
+        }
+    }
+
+    static isBinaryBusy(binaryPath: string): boolean {
+        if (isNullOrEmpty(binaryPath)) {return false}
+        if (platform() === 'darwin') {return false}
+        if (!fs.existsSync(binaryPath)) {return false}
+
+        try {
+            const fd = fs.openSync(binaryPath, 'r+')
+            fs.closeSync(fd)
+            return false
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } catch (err: any) {
+            if (BINARY_BUSY_ERROR_CODES.includes(err.code)) {
+                logger.debug(`Binary is busy: ${binaryPath}`)
+                return true
+            }
+            logger.debug(`Error checking if binary is busy: ${err.message}`)
+            return false
         }
     }
 
@@ -522,11 +555,15 @@ export class CLIUtils {
         const cleanupTemporaryDownloads = (maxAgeMs = CLI_LOCK_TIMEOUT_MS) => {
             try {
                 const now = Date.now()
+                // Match both download zips (downloaded_file_*.zip) and orphan extract
+                // temp files (<name>.tmp.<pid>) left by crashed peer workers.
+                const tmpExtractRe = /\.tmp\.\d+$/
                 for (const entry of fs.readdirSync(cliDir)) {
-                    if (
-                        !entry.startsWith(CLI_DOWNLOAD_TMP_PREFIX) ||
-                        !entry.endsWith(CLI_DOWNLOAD_TMP_SUFFIX)
-                    ) {
+                    const isDownloadZip =
+                        entry.startsWith(CLI_DOWNLOAD_TMP_PREFIX) &&
+                        entry.endsWith(CLI_DOWNLOAD_TMP_SUFFIX)
+                    const isExtractTmp = tmpExtractRe.test(entry)
+                    if (!isDownloadZip && !isExtractTmp) {
                         continue
                     }
                     const filePath = path.join(cliDir, entry)
@@ -543,13 +580,13 @@ export class CLIUtils {
                         fs.unlinkSync(filePath)
                     } catch (err) {
                         logger.debug(
-                            `Failed to delete temp CLI zip file ${filePath}: ${util.format(err)}`,
+                            `Failed to delete temp CLI file ${filePath}: ${util.format(err)}`,
                         )
                     }
                 }
             } catch (err) {
                 logger.debug(
-                    `Failed to scan temp CLI downloads in ${cliDir}: ${util.format(err)}`,
+                    `Failed to scan temp CLI files in ${cliDir}: ${util.format(err)}`,
                 )
             }
         }
@@ -610,8 +647,6 @@ export class CLIUtils {
             const downloadedFileStream = fs.createWriteStream(zipFilePath)
 
             return new Promise<string | null>((resolve, reject) => {
-                const binaryName = null
-
                 const processDownload = async () => {
                     const abortController = new AbortController()
                     const timeout = setTimeout(
@@ -650,7 +685,6 @@ export class CLIUtils {
                         // Set up the downloadFileStream handler before pipeline
                         CLIUtils.downloadFileStream(
                             downloadedFileStream,
-                            binaryName,
                             zipFilePath,
                             cliDir,
                             (result: string) => {
@@ -688,7 +722,6 @@ export class CLIUtils {
 
     static downloadFileStream(
         downloadedFileStream: fs.WriteStream,
-        binaryName: string | null,
         zipFilePath: string,
         cliDir: string,
         resolve: (path: string) => void,
@@ -703,37 +736,91 @@ export class CLIUtils {
                 const zipfile = await yauzlOpenPromise(zipFilePath, {
                     lazyEntries: true,
                 })
+                let resolvedBinaryPath: string | null = null
+
                 zipfile.readEntry()
                 zipfile.on('entry', async (entry) => {
-                    if (!binaryName) {
-                        binaryName = entry.fileName
-                    }
                     if (/\/$/.test(entry.fileName)) {
-                        // Directory file names end with '/'.
                         zipfile.readEntry()
-                    } else {
-                        // file entry
-                        const writeStream = fs.createWriteStream(
+                        return
+                    }
+
+                    const isBinaryEntry = path.basename(entry.fileName).startsWith('binary-')
+
+                    if (!isBinaryEntry) {
+                        const directStream = fs.createWriteStream(
                             path.join(cliDir, entry.fileName),
                         )
                         const openReadStreamPromise = promisify(
                             zipfile.openReadStream,
                         ).bind(zipfile)
                         try {
-                            const readStream =
-                                await openReadStreamPromise(entry)
+                            const readStream = await openReadStreamPromise(entry)
                             readStream.on('end', function () {
-                                writeStream.close()
-                                zipfile.readEntry()
+                                directStream.end()
+                                directStream.on('close', () => zipfile.readEntry())
                             })
-                            readStream.pipe(writeStream)
+                            readStream.pipe(directStream)
                         } catch (zipErr) {
+                            zipfile.close()
                             reject(zipErr as Error)
                         }
+                        return
+                    }
 
-                        if (entry.fileName === binaryName) {
+                    // Binary entry: extract to PID-scoped temp file, chmod, atomic rename inline.
+                    // Prevents ETXTBSY/EBUSY: the file being executed is never the file being written.
+                    const finalPath = path.join(cliDir, entry.fileName)
+                    const tempPath = path.join(cliDir, `${entry.fileName}.tmp.${process.pid}`)
+
+                    const writeStream = fs.createWriteStream(tempPath)
+
+                    writeStream.on('error', (writeErr) => {
+                        fsp.unlink(tempPath).catch(() => {})
+                        zipfile.close()
+                        reject(writeErr as Error)
+                    })
+
+                    // 'finish' fires on successful flush only; 'error' path won't reach here.
+                    writeStream.on('finish', async () => {
+                        try {
+                            await fsp.chmod(tempPath, '0755')
+                            try {
+                                await fsp.rename(tempPath, finalPath)
+                            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                            } catch (renameErr: any) {
+                                // Narrow fallback to cross-device (EXDEV) only
+                                if (renameErr.code !== 'EXDEV') {
+                                    throw renameErr
+                                }
+                                logger.warn(`Atomic rename failed (cross-device), falling back to copy: ${renameErr.message}`)
+                                await fsp.copyFile(tempPath, finalPath)
+                                await fsp.unlink(tempPath).catch(() => {})
+                            }
+                            if (!resolvedBinaryPath) {
+                                resolvedBinaryPath = finalPath
+                            }
+                            zipfile.readEntry()
+                        } catch (err) {
+                            await fsp.unlink(tempPath).catch(() => {})
                             zipfile.close()
+                            reject(err as Error)
                         }
+                    })
+
+                    const openReadStreamPromise = promisify(
+                        zipfile.openReadStream,
+                    ).bind(zipfile)
+                    try {
+                        const readStream = await openReadStreamPromise(entry)
+                        readStream.on('end', function () {
+                            writeStream.end()
+                        })
+                        readStream.pipe(writeStream)
+                    } catch (zipErr) {
+                        fsp.unlink(tempPath).catch(() => {})
+                        zipfile.close()
+                        reject(zipErr as Error)
                     }
                 })
 
@@ -743,18 +830,16 @@ export class CLIUtils {
 
                 zipfile.once('end', () => {
                     fsp.unlink(zipFilePath).catch(() => {
-                        logger.warn(
-                            `Failed to delete zip file: ${zipFilePath}`,
-                        )
+                        logger.warn(`Failed to delete zip file: ${zipFilePath}`)
                     })
-                    fsp.chmod(`${cliDir}/${binaryName}`, '0755')
-                        .then(() => {
-                            resolve(`${cliDir}/${binaryName}`)
-                        })
-                        .catch((err) => {
-                            reject(err)
-                        })
+
+                    if (!resolvedBinaryPath) {
+                        zipfile.close()
+                        reject(new Error('No binary-* entry found in zip; cannot complete CLI binary extraction'))
+                        return
+                    }
                     zipfile.close()
+                    resolve(resolvedBinaryPath)
                 })
             } catch (err) {
                 reject(err as Error)

--- a/packages/wdio-browserstack-service/src/cli/index.ts
+++ b/packages/wdio-browserstack-service/src/cli/index.ts
@@ -12,7 +12,7 @@ import TestHubModule from './modules/testHubModule.js'
 import type { ChildProcess } from 'node:child_process'
 import type { StartBinSessionResponse } from '@browserstack/wdio-browserstack-service'
 import type BaseModule from './modules/baseModule.js'
-import { BROWSERSTACK_ACCESSIBILITY, BROWSERSTACK_OBSERVABILITY, BROWSERSTACK_TESTHUB_JWT, BROWSERSTACK_TESTHUB_UUID, CLI_STOP_TIMEOUT, TESTOPS_BUILD_COMPLETED_ENV, TESTOPS_SCREENSHOT_ENV } from '../constants.js'
+import { BROWSERSTACK_ACCESSIBILITY, BROWSERSTACK_OBSERVABILITY, BROWSERSTACK_TESTHUB_JWT, BROWSERSTACK_TESTHUB_UUID, CLI_STOP_TIMEOUT, TESTOPS_BUILD_COMPLETED_ENV, TESTOPS_SCREENSHOT_ENV, BINARY_BUSY_ERROR_CODES, MAX_SPAWN_RETRIES, SPAWN_RETRY_DELAY_MS } from '../constants.js'
 import type { Options } from '@wdio/types'
 import TestOpsConfig from '../testOps/testOpsConfig.js'
 import WdioMochaTestFramework from './frameworks/wdioMochaTestFramework.js'
@@ -206,52 +206,105 @@ export class BrowserstackCLI {
         }
 
         const SDK_CLI_BIN_PATH = await this.getCliBinPath()
-        const cmd:Array<string> = [SDK_CLI_BIN_PATH, 'sdk']
-        this.logger.debug(`spawning command='${cmd}'`)
-        // Create a child process
-        this.process = spawn(cmd[0], cmd.slice(1), {
-            env: process.env
-        })
 
-        // Return a promise that resolves when CLI is ready
+        if (!SDK_CLI_BIN_PATH) {
+            throw new Error('Failed to get CLI binary path. CLI setup failed.')
+        }
+
+        const cmd: Array<string> = [SDK_CLI_BIN_PATH, 'sdk']
+        this.logger.debug(`spawning command='${cmd}'`)
+
+        // Defensive retry: atomic rename in CLIUtils prevents ETXTBSY/EBUSY in normal flow,
+        // but retry as a safety net for both synchronous and async spawn failures.
+        for (let attempt = 1; attempt <= MAX_SPAWN_RETRIES; attempt++) {
+            try {
+                await this._spawnAndAwaitReady(cmd)
+                if (attempt > 1) {
+                    this.logger.info(`Spawn succeeded on attempt ${attempt}/${MAX_SPAWN_RETRIES}`)
+                }
+                PerformanceTester.end(PerformanceEvents.SDK_CLI_START)
+                return
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            } catch (err: any) {
+                const isBusy = BINARY_BUSY_ERROR_CODES.includes(err.code) ||
+                    (err.message && (
+                        err.message.toLowerCase().includes('text file busy') ||
+                        err.message.toLowerCase().includes('being used by another process')
+                    ))
+                if (isBusy && attempt < MAX_SPAWN_RETRIES) {
+                    this.logger.warn(
+                        `Spawn attempt ${attempt}/${MAX_SPAWN_RETRIES} failed with busy error, ` +
+                        `retrying in ${SPAWN_RETRY_DELAY_MS}ms: ${err.message}`
+                    )
+                    // Clean up failed process before retry
+                    if (this.process) {
+                        this.process.removeAllListeners()
+                        this.process.stdout?.removeAllListeners()
+                        this.process.stderr?.removeAllListeners()
+                        this.process = null
+                    }
+                    await new Promise((r) => setTimeout(r, SPAWN_RETRY_DELAY_MS))
+                } else {
+                    PerformanceTester.end(PerformanceEvents.SDK_CLI_START, false, err)
+                    throw err
+                }
+            }
+        }
+    }
+
+    /**
+     * Spawn the CLI process and wait until it emits "ready".
+     * Handles both synchronous spawn errors and async error/close events.
+     */
+    private _spawnAndAwaitReady(cmd: Array<string>): Promise<void> {
         return new Promise<void>((resolve, reject) => {
+            let settled = false
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const settle = (fn: typeof resolve | typeof reject, val?: any) => {
+                if (settled) {return}
+                settled = true
+                fn(val)
+            }
+
+            try {
+                this.process = spawn(cmd[0], cmd.slice(1), {
+                    env: process.env
+                })
+            } catch (syncErr) {
+                settle(reject, syncErr)
+                return
+            }
+
             const cliOut: Record<string, string> = {}
 
-            this.process!.stdout!.on('data', (data: Buffer) => {
+            this.process.stdout!.on('data', (data: Buffer) => {
                 const lines = data.toString().trim().split('\n')
-
                 for (const line of lines) {
-                    // Parse key=value pairs
                     if (/^(id|listen|port)=.*$/.test(line)) {
                         const [key, value] = line.split('=', 2)
                         if (value !== undefined) {
                             cliOut[key] = value
                         }
                     }
-
-                    // Check for ready message
                     if (line.toLowerCase().includes('ready')) {
                         this.loadCliParams(cliOut)
-                        PerformanceTester.end(PerformanceEvents.SDK_CLI_START)
-                        resolve()
+                        settle(resolve)
                         return
                     }
                 }
             })
 
-            this.process!.stderr!.on('data', (data: Buffer) => {
+            this.process.stderr!.on('data', (data: Buffer) => {
                 this.logger.error(`CLI stderr: ${data.toString().trim()}`)
             })
 
-            this.process!.on('error', (err: Error) => {
-                cliOut.error = `Error in start: ${err.message}`
-                PerformanceTester.end(PerformanceEvents.SDK_CLI_START, false, err)
-                reject(new Error(`Failed to start CLI process: ${err.message}`))
+            this.process.on('error', (err: Error) => {
+                settle(reject, err)
             })
 
-            this.process!.on('close', (code: number) => {
+            this.process.on('close', (code: number) => {
                 if (code !== 0) {
-                    reject(new Error(`CLI process exited with code ${code}`))
+                    settle(reject, new Error(`CLI process exited with code ${code}`))
                 }
             })
         })

--- a/packages/wdio-browserstack-service/src/constants.ts
+++ b/packages/wdio-browserstack-service/src/constants.ts
@@ -141,6 +141,9 @@ export const GIT_META_DATA_TRUNCATED = '...[TRUNCATED]'
 
 // CLI related constants
 export const CLI_STOP_TIMEOUT = 5000 // 5 seconds
+export const BINARY_BUSY_ERROR_CODES = ['ETXTBSY', 'EBUSY']
+export const MAX_SPAWN_RETRIES = 3
+export const SPAWN_RETRY_DELAY_MS = 1000
 export const WDIO_NAMING_PREFIX = 'WebdriverIO-'
 export const PERF_METRICS_WAIT_TIME = 2000
 

--- a/packages/wdio-browserstack-service/tests/cli/cliUtils.test.ts
+++ b/packages/wdio-browserstack-service/tests/cli/cliUtils.test.ts
@@ -581,7 +581,6 @@ describe('CLIUtils', () => {
 
             CLIUtils.downloadFileStream(
                 mockWriteStream,
-                'binary-1.0.0',
                 mockZipFilePath,
                 mockCliDir,
                 resolve,


### PR DESCRIPTION
## Proposed changes

Fixes a binary file busy (ETXTBSY/EBUSY) error that occurred when the BrowserStack CLI binary was being executed while a new version was being written to the same file path during spawn.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Backport Request

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
